### PR TITLE
Aus pricing card component

### DIFF
--- a/support-frontend/assets/components/page/heroRoundel.jsx
+++ b/support-frontend/assets/components/page/heroRoundel.jsx
@@ -27,7 +27,7 @@ const heroRoundelStyles = css`
   border-radius: 50%;
   ${headline.xxsmall({ fontWeight: 'bold' })};
 
-  ${from.tablet} {
+  ${from.desktop} {
     width: calc(100% + ${space[6]}px);
     transform: translateY(-50%);
     ${headline.small({ fontWeight: 'bold' })};

--- a/support-frontend/assets/components/page/heroStyles.js
+++ b/support-frontend/assets/components/page/heroStyles.js
@@ -74,7 +74,7 @@ export const heroRoundelContainer = css`
   right: ${space[3]}px;
 
   ${from.tablet} {
-    right: 65px;
+    right: 60px;
   }
 
   ${from.desktop} {

--- a/support-frontend/assets/components/page/heroStyles.js
+++ b/support-frontend/assets/components/page/heroStyles.js
@@ -56,6 +56,10 @@ export const heroImage = css`
   width: 100%;
 
   ${from.tablet} {
+    width: 45%;
+  }
+
+  ${from.desktop} {
     width: 40%;
   }
 
@@ -70,7 +74,11 @@ export const heroRoundelContainer = css`
   right: ${space[3]}px;
 
   ${from.tablet} {
-  right: ${space[12]}px;
+    right: 65px;
+  }
+
+  ${from.desktop} {
+    right: ${space[12]}px;
   }
 `;
 

--- a/support-frontend/assets/components/page/pageTitle.jsx
+++ b/support-frontend/assets/components/page/pageTitle.jsx
@@ -92,9 +92,13 @@ export const pageTitle = css`
   }
 
   ${from.desktop} {
-    ${titlepiece.large({ fontWeight: 'bold' })}
+    ${titlepiece.medium({ fontWeight: 'bold' })}
     margin: 0 auto;
     max-width: 1290px;
+  }
+
+  ${from.leftCol} {
+    ${titlepiece.large({ fontWeight: 'bold' })}
   }
 `;
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroPriceCards.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroPriceCards.jsx
@@ -47,6 +47,11 @@ const roundelContainer = css`
   ${from.tablet} {
     display: none;
   }
+
+  ${until.mobileMedium} {
+    align-items: flex-start;
+    margin-top: 82px;
+  }
 `;
 
 const fitAroundBelow = css`

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroPriceCards.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroPriceCards.jsx
@@ -47,11 +47,6 @@ const roundelContainer = css`
   ${from.tablet} {
     display: none;
   }
-
-  ${until.mobileMedium} {
-    align-items: flex-start;
-    margin-top: 82px;
-  }
 `;
 
 const fitAroundBelow = css`

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithImage.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithImage.jsx
@@ -61,7 +61,6 @@ function HeroWithImage({
             imgType="png"
           />
           }
-          hideRoundelBelow="tablet"
         >
           <section css={heroCopy}>
             <GiftHeadingAnimation />

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithImage.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithImage.jsx
@@ -22,9 +22,7 @@ import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import DefaultRoundel from './defaultRoundel';
 import {
   heroCopy,
-  heroTitle,
   paragraphs,
-  yellowHeading,
   mobileLineBreak,
   circleTextGeneric,
 } from './heroWithImageStyles';
@@ -34,19 +32,6 @@ type PropTypes = {
   countryGroupId: CountryGroupId,
   orderIsAGift: boolean,
 }
-
-const HeroCopyAus = () => (
-  <>
-    <p>
-      With two innovative apps and ad-free reading, a digital subscription gives you the richest experience
-      of Guardian Australia journalism. It also sustains the independent reporting you love.
-    </p>
-    <p>
-      You&apos;ll gain exclusive access to <strong>Australia Weekend</strong>, the new digital
-      edition, providing you with a curated view of the week&apos;s biggest stories, plus early access to
-      essential weekend news.
-    </p>
-  </>);
 
 const GiftCopy = () => (
   <p>
@@ -59,17 +44,13 @@ const GiftCopy = () => (
 function HeroWithImage({
   promotionCopy, countryGroupId, orderIsAGift,
 }: PropTypes) {
-  const title = promotionCopy.title || <>Subscribe for stories<br />
-    <span css={yellowHeading}>that must be told</span></>;
-
   const promoCopy = promotionHTML(promotionCopy.description, { tag: 'div' });
   const roundelText = promotionHTML(promotionCopy.roundel, { css: circleTextGeneric }) || <DefaultRoundel />;
-  const defaultCopy = orderIsAGift ? <GiftCopy /> : <HeroCopyAus />;
-  const copy = promoCopy || defaultCopy;
+  const copy = promoCopy || <GiftCopy />;
 
   return (
     <PageTitle
-      title={orderIsAGift ? 'Give the digital subscription' : 'Digital subscription'}
+      title="Give the digital subscription"
       theme="digital"
     >
       <CentredContainer>
@@ -94,10 +75,7 @@ function HeroWithImage({
           hideRoundelBelow="tablet"
         >
           <section css={heroCopy}>
-            {orderIsAGift ?
-              <GiftHeadingAnimation /> :
-              <h2 css={heroTitle}>{title}</h2>
-            }
+            <GiftHeadingAnimation />
             <div css={paragraphs}>
               {copy}
             </div>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithImage.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithImage.jsx
@@ -10,7 +10,6 @@ import CentredContainer from 'components/containers/centredContainer';
 import GridImage from 'components/gridImage/gridImage';
 import PageTitle from 'components/page/pageTitle';
 import Hero from 'components/page/hero';
-import HeroRoundel from 'components/page/heroRoundel';
 import GiftHeadingAnimation from 'components/animations/giftHeadingAnimation';
 
 import {
@@ -19,18 +18,15 @@ import {
 } from 'helpers/internationalisation/countryGroup';
 import { promotionHTML, type PromotionCopy } from 'helpers/productPrice/promotions';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
-import DefaultRoundel from './defaultRoundel';
 import {
   heroCopy,
   paragraphs,
   mobileLineBreak,
-  circleTextGeneric,
 } from './heroWithImageStyles';
 
 type PropTypes = {
   promotionCopy: PromotionCopy,
   countryGroupId: CountryGroupId,
-  orderIsAGift: boolean,
 }
 
 const GiftCopy = () => (
@@ -42,10 +38,9 @@ const GiftCopy = () => (
 );
 
 function HeroWithImage({
-  promotionCopy, countryGroupId, orderIsAGift,
+  promotionCopy, countryGroupId,
 }: PropTypes) {
   const promoCopy = promotionHTML(promotionCopy.description, { tag: 'div' });
-  const roundelText = promotionHTML(promotionCopy.roundel, { css: circleTextGeneric }) || <DefaultRoundel />;
   const copy = promoCopy || <GiftCopy />;
 
   return (
@@ -65,12 +60,6 @@ function HeroWithImage({
             altText="Digital subscriptions"
             imgType="png"
           />
-          }
-          roundelElement={
-              orderIsAGift ? null :
-              <HeroRoundel>
-                {roundelText}
-              </HeroRoundel>
           }
           hideRoundelBelow="tablet"
         >

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithPriceCards.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithPriceCards.jsx
@@ -12,6 +12,10 @@ import { getTimeboundQuery, getTimeboundCopy } from 'helpers/timeBoundedCopy/tim
 import { HeroPriceCards } from './heroPriceCards';
 import DefaultRoundel from './defaultRoundel';
 import {
+  AUDCountries,
+  type CountryGroupId,
+} from 'helpers/internationalisation/countryGroup';
+import {
   heroCopy,
   heroTitle,
   paragraphs,
@@ -24,6 +28,7 @@ import {
 type PropTypes = {
   promotionCopy: PromotionCopy,
   priceList: any[],
+  countryGroupId: CountryGroupId,
 }
 
 const HeroCopy = () => (
@@ -35,16 +40,28 @@ const HeroCopy = () => (
   </>
 );
 
+const HeroCopyAus = () => (
+  <>
+    <p>
+    With two innovative apps and ad-free reading, a digital subscription gives you the richest experience of
+    Guardian journalism, while helping to sustain vital, independent reporting.
+    </p>
+    <p>
+    Start your free trial today and enjoy exclusive access to the new weekly edition, Australia Weekend.
+    </p>
+  </>);
+
 
 function HeroWithPriceCards({
-  promotionCopy, priceList,
+  promotionCopy, priceList, countryGroupId,
 }: PropTypes) {
   const title = promotionCopy.title || <>Subscribe for stories<br />
     <span css={yellowHeading}>that must be told</span></>;
 
   const promoCopy = promotionHTML(promotionCopy.description, { tag: 'div' });
   const roundelText = promotionHTML(promotionCopy.roundel, { css: circleTextGeneric }) || <DefaultRoundel />;
-  const defaultCopy = getTimeboundCopy('digitalSubscription', getTimeboundQuery() || new Date()) || <HeroCopy />;
+  const nonAusCopy = getTimeboundCopy('digitalSubscription', getTimeboundQuery() || new Date()) || <HeroCopy />;
+  const defaultCopy = countryGroupId === AUDCountries ? <HeroCopyAus /> : nonAusCopy;
   const copy = promoCopy || defaultCopy;
 
   return (

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithPriceCards.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithPriceCards.jsx
@@ -43,11 +43,11 @@ const HeroCopy = () => (
 const HeroCopyAus = () => (
   <>
     <p>
-    With two innovative apps and ad-free reading, a digital subscription gives you the richest experience of
-    Guardian journalism, while helping to sustain vital, independent reporting.
+      <strong>With two innovative apps and ad-free reading,</strong> a digital subscription gives
+      you the richest experience of Guardian journalism, while helping to sustain vital, independent reporting.
     </p>
     <p>
-    Start your free trial today and enjoy exclusive access to the new weekly edition, Australia Weekend.
+      Start your free trial today and enjoy exclusive access to the new weekly edition, Australia Weekend.
     </p>
   </>);
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithPriceCardsStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithPriceCardsStyles.js
@@ -17,6 +17,10 @@ export const heroTitle = css`
   margin-bottom: ${space[3]}px;
 
   ${from.tablet} {
+    ${headline.medium({ fontWeight: 'bold' })};
+  }
+
+  ${from.desktop} {
     ${headline.large({ fontWeight: 'bold' })};
   }
 `;

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -134,7 +134,7 @@ function LandingPage() {
       header={<CountrySwitcherHeader />}
       footer={footer}
     >
-      {countryGroupId === AUDCountries || orderIsAGift ?
+      {orderIsAGift ?
         <HeroWithImage
           orderIsAGift={orderIsAGift}
           countryGroupId={countryGroupId}
@@ -142,6 +142,7 @@ function LandingPage() {
         /> :
         <HeroWithPriceCards
           promotionCopy={sanitisedPromoCopy}
+          countryGroupId={countryGroupId}
           priceList={heroPriceList}
         />
       }

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -136,7 +136,6 @@ function LandingPage() {
     >
       {orderIsAGift ?
         <HeroWithImage
-          orderIsAGift={orderIsAGift}
           countryGroupId={countryGroupId}
           promotionCopy={sanitisedPromoCopy}
         /> :


### PR DESCRIPTION
## What are you doing in this PR?
This work is to update the text in the Australian digital subscriptions hero, and switch it over to the price cards version of the hero (formerly it had packshots). The text has been reduced to make it fit better with the price cards layout.

[**Trello Card**](https://trello.com/c/GLhVZjeO/3723-aus-pricing-card-component)

In addition, I have fixed a small layout issue where the DS gift heading was rolling over the line on desktop (screenshot below).

## Why are you doing this?
The Australian version of the page had been left behind when we switched the hero of this page to the new version with the price cards. The reason (as mentioned above) was that the Australian text was a bit long to fit comfortably with the price cards layout. With this new shorter text, it now fits.

This means that all non-gift digital subscriptions pages now have the price card version of the hero.

## Screenshots
![Screen Shot 2021-05-25 at 10 53 45](https://user-images.githubusercontent.com/16781258/119478179-81075080-bd47-11eb-9305-82ed447406f8.png)

![Screen Shot 2021-05-25 at 12 58 36](https://user-images.githubusercontent.com/16781258/119494216-f6c7e800-bd58-11eb-815d-2191a20baab2.png)

![Screen Shot 2021-05-25 at 10 52 53](https://user-images.githubusercontent.com/16781258/119478229-8c5a7c00-bd47-11eb-9bfd-66fef7251d22.png)

## Layout fix for desktop gift version
![Screen Shot 2021-05-25 at 10 35 58](https://user-images.githubusercontent.com/16781258/119481902-240d9980-bd4b-11eb-9e58-f771574ad1f8.png)

![Screen Shot 2021-05-25 at 11 20 53](https://user-images.githubusercontent.com/16781258/119482050-53240b00-bd4b-11eb-854d-a945e4d280b7.png)

