### PR TITLE
Remove link to paper+digital on subscribe

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -269,7 +269,8 @@ const orderedProducts = (state: State): ProductCopy[] => {
       digital(countryGroupId, state.page.pricingCopy[DigitalPack], true),
       guardianWeekly(countryGroupId, state.page.pricingCopy[GuardianWeekly], false),
       paper(countryGroupId, state.page.pricingCopy[Paper], false),
-      paperAndDigital(countryGroupId, state.common.referrerAcquisitionData, state.common.abParticipations),
+      //Removing the link to the old paper+digital page during the June 21 Sale
+      //paperAndDigital(countryGroupId, state.common.referrerAcquisitionData, state.common.abParticipations),
       premiumApp(countryGroupId),
     ];
   } else if (countryGroupId === EURCountries) {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
During the June newspaper promotional sale we don't want people going to the paper+digital page on subscribe.theguardian.com as this page doesn't support promotions correctly.
To prevent this we are just going to remove the link from the subscriptions landing page for the duration of the sale (and possibly longer if we decide that it is not worth putting it back).

[**Trello Card**](https://trello.com/c/64i2nzMk/3711-print-campaign-remove-paperdigital-section-from-subscriptions-showcase-landing-page)
