### PR TITLE
Revert "Fix issue with spacing on the pricing cards on the print landing page"

### DIFF
--- a/support-frontend/assets/components/product/productOption.jsx
+++ b/support-frontend/assets/components/product/productOption.jsx
@@ -29,7 +29,7 @@ const productOption = css`
   ${textSans.medium()}
   position: relative;
   display: grid;
-  grid-template-rows: 48px minmax(66px, max-content) minmax(100px, 1fr) 72px;
+  grid-template-rows: 48px minmax(66px, 1fr) 100px 86px;
   width: 100%;
   background-color: ${neutral[100]};
   color: ${neutral[7]};
@@ -102,16 +102,18 @@ function ProductOption(props: Product) {
         {props.label && <span css={productOptionHighlight}>{props.label}</span>}
         {props.children && props.children}
       </div>
-      <p css={[productOptionOfferCopy, productOptionUnderline]}>
-        {props.offerCopy}
-      </p>
-      {/* role="text" is non-standardised but works in Safari. Reads the whole section as one text element */}
-      {/* eslint-disable-next-line jsx-a11y/aria-role */}
-      <p role="text" css={productOptionPriceCopy}>
-        <span css={productOptionPrice}>{props.price}</span>
-        {props.priceCopy}
-      </p>
       <div>
+        <p css={[productOptionOfferCopy, productOptionUnderline]}>
+          {props.offerCopy}
+        </p>
+      </div>
+      <div>
+        {/* role="text" is non-standardised but works in Safari. Reads the whole section as one text element */}
+        {/* eslint-disable-next-line jsx-a11y/aria-role */}
+        <p role="text" css={productOptionPriceCopy}>
+          <span css={productOptionPrice}>{props.price}</span>
+          {props.priceCopy}
+        </p>
         <ThemeProvider theme={buttonReaderRevenue}>
           <LinkButton
             href={props.href}


### PR DESCRIPTION
Reverting guardian/support-frontend#3081 whilst we look at an issue it introduced on Safari at the mobile breakpoint:

![IMG_8342](https://user-images.githubusercontent.com/1590704/119805139-e2125e00-bed8-11eb-9fa5-bb80ab73c7ee.PNG)


