### PR TITLE
Fix roundel positioning on GW landing page

### DIFF
--- a/support-frontend/assets/components/page/hero.jsx
+++ b/support-frontend/assets/components/page/hero.jsx
@@ -6,7 +6,6 @@ import {
   hero,
   heroRoundelContainer,
   heroImage,
-  roundelOffset,
   roundelNudgeDown,
   roundelNudgeUp,
   roundelHidingPoints,
@@ -42,7 +41,6 @@ function Hero({
   roundelNudgeDirection = 'up',
   roundelTheme = 'base',
 }: PropTypes) {
-  const useOffset = roundelText && roundelNudgeDirection === 'up';
   const nudgeCSS = roundelNudges[roundelNudgeDirection];
   const hideRoundel = hideRoundelBelow ? roundelHidingPoints[hideRoundelBelow] : '';
 
@@ -60,7 +58,7 @@ function Hero({
           {roundelElement}
         </div>
       }
-      <div css={useOffset ? roundelOffset : ''}>
+      <div>
         {children}
       </div>
       <div css={heroImage}>

--- a/support-frontend/assets/components/page/heroRoundel.jsx
+++ b/support-frontend/assets/components/page/heroRoundel.jsx
@@ -20,12 +20,16 @@ const heroRoundelStyles = css`
   /* Do not remove float! It makes the circle work! See link below */
   float: left;
   transform: translateY(-67%);
-  min-width: ${roundelSizeMob}px;
-  max-width: ${roundelSize}px;
+  min-width: 100px;
+  max-width: ${roundelSizeMob}px;
   width: calc(100% + ${space[3]}px);
   padding: ${space[1]}px;
   border-radius: 50%;
   ${headline.xxsmall({ fontWeight: 'bold' })};
+
+  ${from.mobileMedium} {
+    max-width: ${roundelSize}px;
+  }
 
   ${from.desktop} {
     width: calc(100% + ${space[6]}px);

--- a/support-frontend/assets/components/page/heroRoundel.jsx
+++ b/support-frontend/assets/components/page/heroRoundel.jsx
@@ -22,7 +22,7 @@ const heroRoundelStyles = css`
   transform: translateY(-67%);
   min-width: 100px;
   max-width: ${roundelSizeMob}px;
-  width: calc(100% + ${space[3]}px);
+  width: calc(100% + ${space[1]}px);
   padding: ${space[1]}px;
   border-radius: 50%;
   ${headline.xxsmall({ fontWeight: 'bold' })};

--- a/support-frontend/assets/components/page/heroRoundel.jsx
+++ b/support-frontend/assets/components/page/heroRoundel.jsx
@@ -20,7 +20,7 @@ const heroRoundelStyles = css`
   /* Do not remove float! It makes the circle work! See link below */
   float: left;
   transform: translateY(-67%);
-  min-width: 100px;
+  min-width: ${roundelSizeMob}px;
   max-width: ${roundelSizeMob}px;
   width: calc(100% + ${space[1]}px);
   padding: ${space[1]}px;

--- a/support-frontend/assets/components/page/heroStyles.js
+++ b/support-frontend/assets/components/page/heroStyles.js
@@ -5,7 +5,6 @@ import { brand, neutral } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 import { headline, body } from '@guardian/src-foundations/typography';
-import { roundelSizeMob } from './heroRoundel';
 
 export const hero = css`
   position: relative;
@@ -39,14 +38,6 @@ export const hero = css`
   }
 `;
 
-// On mobile the roundel can overlay and hide the h2 inside the hero
-// This adds a little extra top margin if the roundel is present to keep the headline visible
-export const roundelOffset = css`
-  ${until.tablet} {
-    margin-top: ${(roundelSizeMob / 2) - space[6]}px;
-  }
-`;
-
 export const heroImage = css`
   align-self: flex-end;
   flex-shrink: 0;
@@ -70,8 +61,20 @@ export const heroImage = css`
 
 export const heroRoundelContainer = css`
   position: absolute;
-  top: 0;
-  right: ${space[3]}px;
+  top: ${space[3]}px;
+  right: ${space[5]}px;
+
+  ${from.mobileMedium} {
+    right: ${space[6]}px;
+  }
+
+  ${from.mobileLandscape} {
+    top: 60px;
+  }
+
+  ${from.phablet} {
+    top: ${space[6]}px;
+  }
 
   ${from.tablet} {
     right: 60px;
@@ -79,6 +82,7 @@ export const heroRoundelContainer = css`
 
   ${from.desktop} {
     right: ${space[12]}px;
+    top: 0;
   }
 `;
 

--- a/support-frontend/assets/components/page/pageTitle.jsx
+++ b/support-frontend/assets/components/page/pageTitle.jsx
@@ -2,7 +2,7 @@
 
 import React, { type Node } from 'react';
 import { css } from '@emotion/core';
-import { from, until } from '@guardian/src-foundations/mq';
+import { from } from '@guardian/src-foundations/mq';
 import { brandAlt, neutral } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
 import { titlepiece } from '@guardian/src-foundations/typography';
@@ -79,10 +79,6 @@ export const pageTitle = css`
   z-index: 10;
   padding: ${space[3]}px ${space[3]}px ${space[4]}px;
   width: 100%;
-
-  ${until.tablet} {
-    font-size: 36px;
-  }
 
   ${from.phablet} {
     padding: ${space[4]}px ${space[4]}px ${space[9]}px;

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
@@ -37,11 +37,16 @@ const weeklyHeroCopy = css`
 `;
 
 const weeklyHeroTitle = css`
-  ${headline.medium({ fontWeight: 'bold' })};
+  ${headline.small({ fontWeight: 'bold' })};
   margin-bottom: ${space[3]}px;
+
+  ${from.mobileLandscape} {
+    width: 75%;
+  }
 
   ${from.tablet} {
     ${headline.large({ fontWeight: 'bold' })};
+    width: 100%;
   }
 `;
 
@@ -56,7 +61,12 @@ const weeklyHeroParagraph = css`
 `;
 
 const roundelCentreLine = css`
-  ${headline.small({ fontWeight: 'bold' })}
+  ${headline.xxsmall({ fontWeight: 'bold' })}
+
+  ${from.tablet} {
+    ${headline.medium({ fontWeight: 'bold' })}
+  }
+
   ${from.tablet} {
     ${headline.large({ fontWeight: 'bold' })}
   }
@@ -66,8 +76,16 @@ const giftHeroSubHeading = css`
   font-weight: 700;
 `;
 
+const showOnMobile = css`
+  display: block;
+
+  ${from.mobileLandscape} {
+    display: none;
+  }
+`;
+
 const getRegionalCopyFor = (region: CountryGroupId) => (region === GBPCountries ?
-  <span>Find clarity with The Guardian&apos;s global magazine</span> :
+  <span>Find clarity<br css={showOnMobile} /> with The Guardian&apos;s global magazine</span> :
   <span>Read The Guardian in print</span>);
 
 const getFirstParagraph = (promotionCopy: PromotionCopy, orderIsAGift: boolean) => {

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
@@ -86,7 +86,7 @@ const showOnMobile = css`
 
 const getRegionalCopyFor = (region: CountryGroupId) => (region === GBPCountries ?
   <span>Find clarity<br css={showOnMobile} /> with The Guardian&apos;s global magazine</span> :
-  <span>Read The Guardian in print</span>);
+  <span>Read The<br css={showOnMobile} /> Guardian in print</span>);
 
 const getFirstParagraph = (promotionCopy: PromotionCopy, orderIsAGift: boolean) => {
   if (promotionCopy.description) {


### PR DESCRIPTION
## What are you doing in this PR?
The aim is to fix some slightly strange overlap-y weirdness with the Guardian Weekly landing page hero roundel on mobile breakpoints.

[**Trello Card**](https://trello.com/c/d0iZbHDQ/3740-fix-guardian-weekly-mobile-roundel-position-problem)

## Why are you doing this?
To make the page match the designs.

## Broken
<img width="403" alt="Screenshot 2021-05-27 at 10 00 52" src="https://user-images.githubusercontent.com/16781258/119985793-06466b80-bfbb-11eb-81a9-63ccc25a8b5a.png">

## Fixed
![Screen Shot 2021-05-28 at 13 54 53](https://user-images.githubusercontent.com/16781258/119986910-54a83a00-bfbc-11eb-923b-188d45848840.png)

