### PR TITLE
Fix spacing issue with pricing cards at tablet breakpoint

### DIFF
--- a/support-frontend/assets/components/product/productOption.jsx
+++ b/support-frontend/assets/components/product/productOption.jsx
@@ -29,7 +29,7 @@ const productOption = css`
   ${textSans.medium()}
   position: relative;
   display: grid;
-  grid-template-rows: 48px minmax(66px, 1fr) 100px 86px;
+  grid-template-rows: 48px minmax(66px, max-content) minmax(100px, 1fr) 72px;
   width: 100%;
   background-color: ${neutral[100]};
   color: ${neutral[7]};
@@ -114,6 +114,8 @@ function ProductOption(props: Product) {
           <span css={productOptionPrice}>{props.price}</span>
           {props.priceCopy}
         </p>
+      </div>
+      <div>
         <ThemeProvider theme={buttonReaderRevenue}>
           <LinkButton
             href={props.href}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This actually for real this time fixes the issue where text running over too many lines would become hidden by the pricing card CTA at the tablet breakpoint. This applies the same CSS as used in #3081, reverted in #3088, but without the changes to the HTML structure that caused issues in Safari. 

[**Trello Card**](https://trello.com/c/ZwRqNcnw)

## Screenshots

## Mobile - iOS

**iPhone SE**
![Screenshot 2021-06-03 at 11 40 36](https://user-images.githubusercontent.com/29146931/120635978-fcae7f00-c464-11eb-8663-54826c7080ca.png)

**iPhone 12**
![Screenshot 2021-06-03 at 11 53 49](https://user-images.githubusercontent.com/29146931/120636014-09cb6e00-c465-11eb-8685-c377a50b6c0c.png)

## Tablet

**iPad Mini**
![Screenshot 2021-06-03 at 11 46 37](https://user-images.githubusercontent.com/29146931/120636093-1fd92e80-c465-11eb-86ba-70d6514b231e.png)

**Galaxy Tab S3**
![Screenshot 2021-06-03 at 11 50 15](https://user-images.githubusercontent.com/29146931/120636150-31bad180-c465-11eb-9992-007724a247cc.png)

## Desktop

**macOS - Firefox**
![Screenshot 2021-06-03 at 12-14-02 The Guardian Newspaper Subscription Subscription Card and Home Delivery](https://user-images.githubusercontent.com/29146931/120636246-4e570980-c465-11eb-9f0e-0fc2b36de211.png)
