### PR TITLE
Pass any existing promo code when switching tabs or returning to the paper landing page from the checkout

### DIFF
--- a/support-frontend/assets/helpers/urls/routes.js
+++ b/support-frontend/assets/helpers/urls/routes.js
@@ -50,8 +50,12 @@ function postcodeLookupUrl(postcode: string): string {
   return `${getOrigin() + routes.postcodeLookup}/${postcode}`;
 }
 
-function paperSubsUrl(withDelivery: boolean = false): string {
-  return [getOrigin(), 'uk/subscribe/paper', ...(withDelivery ? ['delivery'] : [])].join('/');
+function paperSubsUrl(withDelivery: boolean = false, promoCode?: Option<string>): string {
+  const baseURL = [getOrigin(), 'uk/subscribe/paper', ...(withDelivery ? ['delivery'] : [])].join('/');
+  if (promoCode) {
+    return `${baseURL}?promoCode=${promoCode}`;
+  }
+  return baseURL;
 }
 
 function digitalSubscriptionLanding(countryGroupId: CountryGroupId, gift: boolean) {

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -15,7 +15,6 @@ import {
   firstError,
   type FormError,
 } from 'helpers/subscriptionsForms/validation';
-import { routes } from 'helpers/urls/routes';
 import Rows from 'components/base/rows';
 import Text from 'components/text/text';
 import Form, { FormSection, FormSectionHiddenUntilSelected } from 'components/checkoutForm/checkoutForm';
@@ -75,6 +74,8 @@ import { options } from 'components/forms/customFields/options';
 import PaperOrderSummary from 'pages/paper-subscription-checkout/components/orderSummary/orderSummary';
 import AddDigiSubCta from 'pages/paper-subscription-checkout/components/addDigiSubCta';
 import { getPriceSummary, sensiblyGenerateDigiSubPrice } from 'pages/paper-subscription-checkout/helpers/orderSummaryText';
+import { paperSubsUrl } from 'helpers/urls/routes';
+import { getQueryParameter } from 'helpers/urls/url';
 
 const marginBottom = css`
   margin-bottom: ${space[6]}px;
@@ -235,7 +236,7 @@ function PaperCheckoutForm(props: PropTypes) {
     digiSubPrice={expandedPricingText}
     startDate={formattedStartDate}
     includesDigiSub={includesDigiSub}
-    changeSubscription={routes.paperSubscriptionProductChoices}
+    changeSubscription={`${paperSubsUrl(false, getQueryParameter('promoCode'))}#subscribe`}
   />);
 
   const homeDeliveryOrderSummary = (<PaperOrderSummary
@@ -251,7 +252,7 @@ function PaperCheckoutForm(props: PropTypes) {
     total={props.total}
     digiSubPrice={expandedPricingText}
     includesDigiSub={includesDigiSub}
-    changeSubscription={routes.paperSubscriptionDeliveryProductChoices}
+    changeSubscription={`${paperSubsUrl(true, getQueryParameter('promoCode'))}#subscribe`}
     productType={Paper}
     paymentStartDate={formattedStartDate}
   />);

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageActions.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageActions.js
@@ -7,6 +7,7 @@ import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
 import { paperSubsUrl } from 'helpers/urls/routes';
+import { getQueryParameter } from 'helpers/urls/url';
 
 // ----- Types ----- //
 export type TabActions = { type: 'SET_TAB', tab: PaperFulfilmentOptions }
@@ -20,7 +21,7 @@ const setTab = (tab: PaperFulfilmentOptions): TabActions => {
     product: 'Paper',
     componentType: 'ACQUISITIONS_BUTTON',
   })();
-  window.history.replaceState({}, null, paperSubsUrl(tab === HomeDelivery));
+  window.history.replaceState({}, null, paperSubsUrl(tab === HomeDelivery, getQueryParameter('promoCode')));
   return { type: 'SET_TAB', tab };
 };
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This amends the behaviour of switching tabs on the paper landing page, and also amends the 'Change' link in the paper checkout order summary, to preserve any promo code that's present on the URL.

[**Trello Card - promo code not retained when switching tabs**](https://trello.com/c/WBcs2fEP)
[**Trello Card - promo code not retained when clicking 'Change'**](https://trello.com/c/xBvTgNly)

## Why are you doing this?

This is to support the June 2021 paper subscriptions sale.
