### PR TITLE
Stop using on identity billing address fields

### DIFF
--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -45,10 +45,10 @@
         firstName: "@firstName",
         lastName: "@lastName",
       }
-      @for(address4 <- user.privateFields.billingAddress4 orElse user.privateFields.address4) {
+      @for(address4 <- user.privateFields.address4) {
         address4: "@address4",
       }
-      @for(country <- user.privateFields.billingCountry orElse user.privateFields.country) {
+      @for(country <- user.privateFields.country) {
         country: "@country",
       }
     };


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

Stop using on identity billing address fields


https://trello.com/c/cKwVxoT8/3036-remove-billingaddress-from-identity

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

We are planning on removing billing address from the Identity user model in preparation for the Identity OKTA migration. This PR implements @paulbrown1982 's advice of using correspondence address for county and country.

## See also
https://github.com/guardian/membership-workflow/pull/295