### PR TITLE
Add new timed copy for Euros special edition

### DIFF
--- a/support-frontend/assets/helpers/timeBoundedCopy/timeBoundedCopy.jsx
+++ b/support-frontend/assets/helpers/timeBoundedCopy/timeBoundedCopy.jsx
@@ -16,15 +16,15 @@ type TimedCopyCollection = { [LandingPage]: TimeBoundCopy[] }
 const timedCopy: TimedCopyCollection = {
   digitalSubscription: [
     {
-      startShowingOn: '2021-05-08',
-      stopShowingOn: '2021-06-04',
+      startShowingOn: '2021-06-11',
+      stopShowingOn: '2021-07-11',
       copy: <>
         <p>
           <strong>With two innovative apps and ad-free reading,</strong> a digital subscription gives
           you the richest experience of Guardian journalism. It also sustains the independent reporting you love.
         </p>
         <p>
-          Plus celebrate our 200th birthday with our special edition, We were there, available for a limited time.
+          Plus take a deeper dive into the Euros with our new special edition, available for a limited time only.
         </p>
       </>,
     },


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds a new line of copy for the Euros special edition, to be live for a month from 11th June.

[**Trello Card**](https://trello.com/c/DR3hIrqY)

## Screenshots

![Screenshot 2021-06-08 at 18-13-52 Support the Guardian The Guardian Digital Subscription](https://user-images.githubusercontent.com/29146931/121229297-aaff5d80-c885-11eb-85e4-6592bb44f549.png)