### PR TITLE
Fix issue with discount rounding

### DIFF
--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
@@ -135,6 +135,6 @@ object PriceSummaryService {
     }
     val numberOfPeriodsDiscounted = Math.ceil(percentageOfPeriodDiscounted)
     val newDiscountPercent = (discountBenefit.amount * percentageOfPeriodDiscounted) / numberOfPeriodsDiscounted
-    BigDecimal(newDiscountPercent).setScale(2, RoundingMode.HALF_DOWN).toDouble
+    BigDecimal(newDiscountPercent).setScale(3, RoundingMode.HALF_DOWN).toDouble
   }
 }

--- a/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
@@ -104,6 +104,7 @@ class PriceSummaryServiceSpec extends AsyncFlatSpec with Matchers {
     checkPrice(discountBenefit, 11.99, 8.99, Monthly)
     checkPrice(discountBenefit, 119.90, 112.41, Annual)
     checkPrice(DiscountBenefit(25, Some(Months.FIVE)), 35.95, 28.46, Quarterly)
+    checkPrice(DiscountBenefit(36.975, Some(Months.TWELVE)), 119, 75, Annual)
 
     //Guardian Weekly domestic
     checkPrice(DiscountBenefit(25, Some(Months.TWO)), 37.50, 31.25, Quarterly)


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We have an issue whereby the amount a user will pay for a subscription after a promotion is applied is slightly different on support-frontend to how it appears in the promo code tool.

It turns out that this is because the discount percentage (after adjustment for the billing period length, see [here for more details](https://github.com/guardian/support-frontend/blob/2978de06f4adb86d99473571775eef7ec24eac46/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala#L127)) was being rounded to two decimal places whereas the promo code tool and most importantly Zuora support at least 3, which is what is needed to be able to target prices at a penny level of granularity.

[**Trello Card**](https://trello.com/c/Dkmk4eNZ/3752-discount-rounding-issue-on-support-frontend)
