### PR TITLE
GW Monthly rate plan

### DIFF
--- a/support-frontend/app/controllers/SubscriptionsController.scala
+++ b/support-frontend/app/controllers/SubscriptionsController.scala
@@ -66,7 +66,7 @@ class SubscriptionsController(
       Map.empty
 
     val fulfilmentOptions = if (countryGroup == CountryGroup.RestOfTheWorld) RestOfWorld else Domestic
-    val weekly = service.getPrices(GuardianWeekly, Nil)(countryGroup)(fulfilmentOptions)(NoProductOptions)(Quarterly)(countryGroup.currency)
+    val weekly = service.getPrices(GuardianWeekly, Nil)(countryGroup)(fulfilmentOptions)(NoProductOptions)(GuardianWeekly.sixForSixBillingPeriod)(countryGroup.currency)
 
     val digitalSubscription = service
       .getPrices(

--- a/support-frontend/app/controllers/SubscriptionsController.scala
+++ b/support-frontend/app/controllers/SubscriptionsController.scala
@@ -67,7 +67,8 @@ class SubscriptionsController(
       Map.empty
 
     val fulfilmentOptions = if (countryGroup == CountryGroup.RestOfTheWorld) RestOfWorld else Domestic
-    val weekly = service.getPrices(GuardianWeekly, Nil)(countryGroup)(fulfilmentOptions)(NoProductOptions)(postIntroductorySixForSixBillingPeriod)(countryGroup.currency)
+    val weekly =
+      service.getPrices(GuardianWeekly, Nil)(countryGroup)(fulfilmentOptions)(NoProductOptions)(postIntroductorySixForSixBillingPeriod)(countryGroup.currency)
 
     val digitalSubscription = service
       .getPrices(

--- a/support-frontend/app/controllers/SubscriptionsController.scala
+++ b/support-frontend/app/controllers/SubscriptionsController.scala
@@ -5,6 +5,7 @@ import admin.settings.{AllSettings, AllSettingsProvider, SettingsSurrogateKeySyn
 import assets.{AssetsResolver, RefPath, StyleContent}
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.Currency.GBP
+import com.gu.support.catalog.GuardianWeekly.postIntroductorySixForSixBillingPeriod
 import com.gu.support.catalog._
 import com.gu.support.encoding.Codec.deriveCodec
 import com.gu.support.pricing.{PriceSummary, PriceSummaryServiceProvider}
@@ -66,7 +67,7 @@ class SubscriptionsController(
       Map.empty
 
     val fulfilmentOptions = if (countryGroup == CountryGroup.RestOfTheWorld) RestOfWorld else Domestic
-    val weekly = service.getPrices(GuardianWeekly, Nil)(countryGroup)(fulfilmentOptions)(NoProductOptions)(GuardianWeekly.sixForSixBillingPeriod)(countryGroup.currency)
+    val weekly = service.getPrices(GuardianWeekly, Nil)(countryGroup)(fulfilmentOptions)(NoProductOptions)(postIntroductorySixForSixBillingPeriod)(countryGroup.currency)
 
     val digitalSubscription = service
       .getPrices(

--- a/support-frontend/assets/helpers/productPrice/__tests__/priceDescriptionsTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/priceDescriptionsTests.js
@@ -3,7 +3,7 @@
 // ----- Imports ----- //
 
 import { getPriceDescription } from 'helpers/productPrice/priceDescriptions';
-import { Annual, Quarterly, SixWeekly } from 'helpers/productPrice/billingPeriods';
+import { Annual, Monthly, Quarterly, SixWeekly } from 'helpers/productPrice/billingPeriods';
 
 jest.mock('ophan', () => {});
 
@@ -31,6 +31,10 @@ describe('getPriceDescription', () => {
     expect(getPriceDescription(gwQuarterly, Quarterly))
       .toEqual('£37.50 per quarter');
 
+    const gwMonthly = { price: 12.5, currency: 'GBP', promotions: [] };
+    expect(getPriceDescription(gwMonthly, Monthly))
+      .toEqual('£12.50 per month');
+
     const gwQuarterlyWithPromo = {
       price: 37.5,
       currency: 'GBP',
@@ -48,7 +52,7 @@ describe('getPriceDescription', () => {
       .toEqual('You\'ll pay £31.87 for 1 quarter, then £37.50 per quarter');
 
     const gwSixWeekly = {
-      price: 81.30,
+      price: 27.50,
       currency: 'USD',
       promotions: [
         {
@@ -59,6 +63,6 @@ describe('getPriceDescription', () => {
         }],
     };
     expect(getPriceDescription(gwSixWeekly, SixWeekly))
-      .toEqual('US$6 for the first 6 issues (then US$81.30 per quarter)');
+      .toEqual('US$6 for the first 6 issues (then US$27.50 per month)');
   });
 });

--- a/support-frontend/assets/helpers/productPrice/billingPeriods.js
+++ b/support-frontend/assets/helpers/productPrice/billingPeriods.js
@@ -12,11 +12,11 @@ const SixForSixBillingPeriod: 'Monthly' = 'Monthly';
 export type BillingPeriod = typeof SixWeekly | typeof Annual | typeof Monthly | typeof Quarterly;
 export type DigitalBillingPeriod = typeof Monthly | typeof Annual;
 export type DigitalGiftBillingPeriod = typeof Annual | typeof Quarterly;
-export type WeeklyBillingPeriod = typeof SixWeekly | typeof SixForSixBillingPeriod | typeof Annual;
+export type WeeklyBillingPeriod = typeof SixWeekly | typeof Monthly | typeof Quarterly | typeof Annual;
 
 export type ContributionBillingPeriod = typeof Monthly | typeof Annual;
 
-const weeklyBillingPeriods = [SixWeekly, SixForSixBillingPeriod, Annual];
+const weeklyBillingPeriods: WeeklyBillingPeriod[] = [SixWeekly, SixForSixBillingPeriod, Annual];
 const weeklyGiftBillingPeriods: WeeklyBillingPeriod[] = [Quarterly, Annual];
 
 function billingPeriodNoun(billingPeriod: BillingPeriod, fixedTerm: boolean = false) {

--- a/support-frontend/assets/helpers/productPrice/billingPeriods.js
+++ b/support-frontend/assets/helpers/productPrice/billingPeriods.js
@@ -7,7 +7,7 @@ const SixWeekly: 'SixWeekly' = 'SixWeekly';
 
 // The value for six for six billing period here must match
 // the value in support-models/src/main/scala/com/gu/support/catalog/Product.scala
-const SixForSixBillingPeriod: 'Monthly' = 'Monthly';
+const postIntroductorySixForSixBillingPeriod: 'Monthly' = 'Monthly';
 
 export type BillingPeriod = typeof SixWeekly | typeof Annual | typeof Monthly | typeof Quarterly;
 export type DigitalBillingPeriod = typeof Monthly | typeof Annual;
@@ -16,7 +16,7 @@ export type WeeklyBillingPeriod = typeof SixWeekly | typeof Monthly | typeof Qua
 
 export type ContributionBillingPeriod = typeof Monthly | typeof Annual;
 
-const weeklyBillingPeriods: WeeklyBillingPeriod[] = [SixWeekly, SixForSixBillingPeriod, Annual];
+const weeklyBillingPeriods: WeeklyBillingPeriod[] = [SixWeekly, postIntroductorySixForSixBillingPeriod, Annual];
 const weeklyGiftBillingPeriods: WeeklyBillingPeriod[] = [Quarterly, Annual];
 
 function billingPeriodNoun(billingPeriod: BillingPeriod, fixedTerm: boolean = false) {
@@ -61,7 +61,7 @@ export {
   Monthly,
   Quarterly,
   SixWeekly,
-  SixForSixBillingPeriod,
+  postIntroductorySixForSixBillingPeriod,
   billingPeriodNoun,
   billingPeriodAdverb,
   billingPeriodTitle,

--- a/support-frontend/assets/helpers/productPrice/billingPeriods.js
+++ b/support-frontend/assets/helpers/productPrice/billingPeriods.js
@@ -4,15 +4,16 @@ const Annual: 'Annual' = 'Annual';
 const Monthly: 'Monthly' = 'Monthly';
 const Quarterly: 'Quarterly' = 'Quarterly';
 const SixWeekly: 'SixWeekly' = 'SixWeekly';
+const SixForSixBillingPeriod: 'Monthly' = 'Monthly';
 
 export type BillingPeriod = typeof SixWeekly | typeof Annual | typeof Monthly | typeof Quarterly;
 export type DigitalBillingPeriod = typeof Monthly | typeof Annual;
 export type DigitalGiftBillingPeriod = typeof Annual | typeof Quarterly;
-export type WeeklyBillingPeriod = typeof SixWeekly | typeof Quarterly | typeof Annual;
+export type WeeklyBillingPeriod = typeof SixWeekly | typeof SixForSixBillingPeriod | typeof Annual;
 
 export type ContributionBillingPeriod = typeof Monthly | typeof Annual;
 
-const weeklyBillingPeriods = [SixWeekly, Quarterly, Annual];
+const weeklyBillingPeriods = [SixWeekly, SixForSixBillingPeriod, Annual];
 const weeklyGiftBillingPeriods: WeeklyBillingPeriod[] = [Quarterly, Annual];
 
 function billingPeriodNoun(billingPeriod: BillingPeriod, fixedTerm: boolean = false) {
@@ -57,6 +58,7 @@ export {
   Monthly,
   Quarterly,
   SixWeekly,
+  SixForSixBillingPeriod,
   billingPeriodNoun,
   billingPeriodAdverb,
   billingPeriodTitle,

--- a/support-frontend/assets/helpers/productPrice/billingPeriods.js
+++ b/support-frontend/assets/helpers/productPrice/billingPeriods.js
@@ -4,6 +4,9 @@ const Annual: 'Annual' = 'Annual';
 const Monthly: 'Monthly' = 'Monthly';
 const Quarterly: 'Quarterly' = 'Quarterly';
 const SixWeekly: 'SixWeekly' = 'SixWeekly';
+
+// The value for six for six billing period here must match
+// the value in support-models/src/main/scala/com/gu/support/catalog/Product.scala
 const SixForSixBillingPeriod: 'Monthly' = 'Monthly';
 
 export type BillingPeriod = typeof SixWeekly | typeof Annual | typeof Monthly | typeof Quarterly;

--- a/support-frontend/assets/helpers/productPrice/priceDescriptions.js
+++ b/support-frontend/assets/helpers/productPrice/priceDescriptions.js
@@ -101,7 +101,12 @@ const getIntroductoryPriceDescription = (
   productPrice: ProductPrice,
   compact: boolean,
 ) => {
-  const standardCopy = standardRate(glyph, productPrice.price, postIntroductorySixForSixBillingPeriod, productPrice.fixedTerm);
+  const standardCopy = standardRate(
+    glyph,
+    productPrice.price,
+    postIntroductorySixForSixBillingPeriod,
+    productPrice.fixedTerm,
+  );
   const separator = compact ? '/' : ' for the first ';
   const periodType = pluralizePeriodType(introPrice.periodLength, introPrice.periodType);
 
@@ -159,7 +164,12 @@ function getSimplifiedPriceDescription(
 
   if (promotion && promotion.introductoryPrice) {
     const introPrice = promotion.introductoryPrice;
-    const standardCopy = standardRate(glyph, productPrice.price, postIntroductorySixForSixBillingPeriod, productPrice.fixedTerm);
+    const standardCopy = standardRate(
+      glyph,
+      productPrice.price,
+      postIntroductorySixForSixBillingPeriod,
+      productPrice.fixedTerm,
+    );
     const periodType = pluralizePeriodType(introPrice.periodLength, introPrice.periodType);
 
     return `for ${introPrice.periodLength} ${periodType} (then ${standardCopy})`;

--- a/support-frontend/assets/helpers/productPrice/priceDescriptions.js
+++ b/support-frontend/assets/helpers/productPrice/priceDescriptions.js
@@ -4,8 +4,8 @@ import { fixDecimals } from 'helpers/productPrice/subscriptions';
 import {
   billingPeriodNoun as upperCaseNoun,
   billingPeriodAdverb,
-  Quarterly,
-  type BillingPeriod, SixForSixBillingPeriod,
+  type BillingPeriod,
+  SixForSixBillingPeriod,
 } from 'helpers/productPrice/billingPeriods';
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import { glyph as shortGlyph, extendedGlyph } from 'helpers/internationalisation/currency';
@@ -101,7 +101,7 @@ const getIntroductoryPriceDescription = (
   productPrice: ProductPrice,
   compact: boolean,
 ) => {
-  const standardCopy = standardRate(glyph, productPrice.price, Quarterly, productPrice.fixedTerm);
+  const standardCopy = standardRate(glyph, productPrice.price, SixForSixBillingPeriod, productPrice.fixedTerm);
   const separator = compact ? '/' : ' for the first ';
   const periodType = pluralizePeriodType(introPrice.periodLength, introPrice.periodType);
 

--- a/support-frontend/assets/helpers/productPrice/priceDescriptions.js
+++ b/support-frontend/assets/helpers/productPrice/priceDescriptions.js
@@ -5,7 +5,7 @@ import {
   billingPeriodNoun as upperCaseNoun,
   billingPeriodAdverb,
   type BillingPeriod,
-  SixForSixBillingPeriod,
+  postIntroductorySixForSixBillingPeriod,
 } from 'helpers/productPrice/billingPeriods';
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import { glyph as shortGlyph, extendedGlyph } from 'helpers/internationalisation/currency';
@@ -101,7 +101,7 @@ const getIntroductoryPriceDescription = (
   productPrice: ProductPrice,
   compact: boolean,
 ) => {
-  const standardCopy = standardRate(glyph, productPrice.price, SixForSixBillingPeriod, productPrice.fixedTerm);
+  const standardCopy = standardRate(glyph, productPrice.price, postIntroductorySixForSixBillingPeriod, productPrice.fixedTerm);
   const separator = compact ? '/' : ' for the first ';
   const periodType = pluralizePeriodType(introPrice.periodLength, introPrice.periodType);
 
@@ -159,7 +159,7 @@ function getSimplifiedPriceDescription(
 
   if (promotion && promotion.introductoryPrice) {
     const introPrice = promotion.introductoryPrice;
-    const standardCopy = standardRate(glyph, productPrice.price, SixForSixBillingPeriod, productPrice.fixedTerm);
+    const standardCopy = standardRate(glyph, productPrice.price, postIntroductorySixForSixBillingPeriod, productPrice.fixedTerm);
     const periodType = pluralizePeriodType(introPrice.periodLength, introPrice.periodType);
 
     return `for ${introPrice.periodLength} ${periodType} (then ${standardCopy})`;

--- a/support-frontend/assets/helpers/productPrice/priceDescriptions.js
+++ b/support-frontend/assets/helpers/productPrice/priceDescriptions.js
@@ -5,7 +5,7 @@ import {
   billingPeriodNoun as upperCaseNoun,
   billingPeriodAdverb,
   Quarterly,
-  type BillingPeriod,
+  type BillingPeriod, SixForSixBillingPeriod,
 } from 'helpers/productPrice/billingPeriods';
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import { glyph as shortGlyph, extendedGlyph } from 'helpers/internationalisation/currency';
@@ -159,7 +159,7 @@ function getSimplifiedPriceDescription(
 
   if (promotion && promotion.introductoryPrice) {
     const introPrice = promotion.introductoryPrice;
-    const standardCopy = standardRate(glyph, productPrice.price, Quarterly, productPrice.fixedTerm);
+    const standardCopy = standardRate(glyph, productPrice.price, SixForSixBillingPeriod, productPrice.fixedTerm);
     const periodType = pluralizePeriodType(introPrice.periodLength, introPrice.periodType);
 
     return `for ${introPrice.periodLength} ${periodType} (then ${standardCopy})`;

--- a/support-frontend/assets/pages/promotion-terms/weeklyTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/weeklyTerms.jsx
@@ -10,7 +10,7 @@ import {
 } from 'helpers/internationalisation/countryGroup';
 import { Domestic, RestOfWorld } from 'helpers/productPrice/fulfilmentOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
-import { Annual, Quarterly } from 'helpers/productPrice/billingPeriods';
+import { Annual, postIntroductorySixForSixBillingPeriod, Quarterly } from 'helpers/productPrice/billingPeriods';
 import { extendedGlyph } from 'helpers/internationalisation/currency';
 import type { CountryGroupPrices } from 'helpers/productPrice/productPrices';
 import { showPrice } from 'helpers/productPrice/productPrices';
@@ -18,14 +18,18 @@ import { showPrice } from 'helpers/productPrice/productPrices';
 type NameAndSaving = {name: CountryGroupName, saving: ?string};
 
 const orderedCountryGroupNames: NameAndSaving[] = [
-  { name: 'United Kingdom', saving: '35%' },
-  { name: 'United States', saving: '31%' },
-  { name: 'Australia', saving: '31%' },
-  { name: 'Europe', saving: '26%' },
-  { name: 'New Zealand', saving: '20%' },
-  { name: 'Canada', saving: '16%' },
+  { name: 'United Kingdom', saving: '34%' },
+  { name: 'United States', saving: '34%' },
+  { name: 'Australia', saving: '30%' },
+  { name: 'Europe', saving: '30%' },
+  { name: 'New Zealand', saving: '19%' },
+  { name: 'Canada', saving: '30%' },
   { name: 'International', saving: null },
 ];
+
+const shortTermDescription = postIntroductorySixForSixBillingPeriod  === Quarterly ?
+  'Quarterly (13 weeks)' :
+  'Monthly (4 weeks)';
 
 export default function WeeklyTerms(props: PromotionTermsPropTypes) {
 
@@ -42,11 +46,11 @@ function getCountryPrice(countryGroupName: CountryGroupName, prices: CountryGrou
   const { currency } = fromCountryGroupName(countryGroupName);
   const currencyGlyph = extendedGlyph(currency);
   const fulfilmentOption = countryGroupName === International ? RestOfWorld : Domestic;
-  const quarterlyPrice = prices[fulfilmentOption][NoProductOptions][Quarterly][currency];
+  const shortTermPrice = prices[fulfilmentOption][NoProductOptions][postIntroductorySixForSixBillingPeriod][currency];
   const annualPrice = prices[fulfilmentOption][NoProductOptions][Annual][currency];
   return {
     currencyGlyph,
-    quarterlyPrice,
+    shortTermPrice,
     annualPrice,
   };
 }
@@ -59,23 +63,25 @@ function getSaving(saving: ?string) {
 }
 
 function StandardCountryPrice(nameAndSaving: NameAndSaving, prices: CountryGroupPrices) {
-  const { quarterlyPrice, annualPrice } = getCountryPrice(nameAndSaving.name, prices);
+  const { shortTermPrice, annualPrice } = getCountryPrice(nameAndSaving.name, prices);
+
   return (
     <SansParagraph>
       <strong>{nameAndSaving.name}:</strong>{' '}
-      Quarterly (13 weeks) subscription rate {showPrice(quarterlyPrice)},
+      {shortTermDescription} subscription rate {showPrice(shortTermPrice)},
       or annual rate {showPrice(annualPrice)}{getSaving(nameAndSaving.saving)}
     </SansParagraph>
   );
 }
 
 function SixForSixCountryPrice(nameAndSaving: NameAndSaving, prices: CountryGroupPrices) {
-  const { currencyGlyph, quarterlyPrice } = getCountryPrice(nameAndSaving.name, prices);
+  const { currencyGlyph, shortTermPrice } = getCountryPrice(nameAndSaving.name, prices);
+
   return (
     <SansParagraph>
       <strong>{nameAndSaving.name}:</strong>{' '}
-      Offer is {currencyGlyph}6 for the first 6 issues followed by quarterly (13 weeks)
-      subscription payments of {showPrice(quarterlyPrice)} thereafter{getSaving(nameAndSaving.saving)}
+      Offer is {currencyGlyph}6 for the first 6 issues followed by {shortTermDescription.toLowerCase()}
+      subscription payments of {showPrice(shortTermPrice)} thereafter{getSaving(nameAndSaving.saving)}
     </SansParagraph>
   );
 }

--- a/support-frontend/assets/pages/promotion-terms/weeklyTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/weeklyTerms.jsx
@@ -27,7 +27,7 @@ const orderedCountryGroupNames: NameAndSaving[] = [
   { name: 'International', saving: null },
 ];
 
-const shortTermDescription = postIntroductorySixForSixBillingPeriod  === Quarterly ?
+const shortTermDescription = postIntroductorySixForSixBillingPeriod === Quarterly ?
   'Quarterly (13 weeks)' :
   'Monthly (4 weeks)';
 

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -31,7 +31,7 @@ import {
   EURCountries,
 } from 'helpers/internationalisation/countryGroup';
 import type { Option } from 'helpers/types/option';
-import { Monthly, Quarterly, type BillingPeriod, SixForSixBillingPeriod } from 'helpers/productPrice/billingPeriods';
+import { Monthly, type BillingPeriod, SixForSixBillingPeriod } from 'helpers/productPrice/billingPeriods';
 import {
   currencies, detect,
   fromCountryGroupId,

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -31,7 +31,7 @@ import {
   EURCountries,
 } from 'helpers/internationalisation/countryGroup';
 import type { Option } from 'helpers/types/option';
-import { Monthly, type BillingPeriod, SixForSixBillingPeriod } from 'helpers/productPrice/billingPeriods';
+import { Monthly, type BillingPeriod, postIntroductorySixForSixBillingPeriod } from 'helpers/productPrice/billingPeriods';
 import {
   currencies, detect,
   fromCountryGroupId,
@@ -143,7 +143,7 @@ const getWeeklyImage = (isTop: boolean) => {
 
 const guardianWeekly = (countryGroupId: CountryGroupId, priceCopy: PriceCopy, isTop: boolean): ProductCopy => ({
   title: 'The Guardian Weekly',
-  subtitle: getDisplayPrice(countryGroupId, priceCopy.price, SixForSixBillingPeriod),
+  subtitle: getDisplayPrice(countryGroupId, priceCopy.price, postIntroductorySixForSixBillingPeriod),
   description: 'A weekly, global magazine from The Guardian, with delivery worldwide',
   offer: getGuardianWeeklyOfferCopy(countryGroupId, priceCopy.discountCopy),
   buttons: [

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -31,7 +31,7 @@ import {
   EURCountries,
 } from 'helpers/internationalisation/countryGroup';
 import type { Option } from 'helpers/types/option';
-import { Monthly, Quarterly, type BillingPeriod } from 'helpers/productPrice/billingPeriods';
+import { Monthly, Quarterly, type BillingPeriod, SixForSixBillingPeriod } from 'helpers/productPrice/billingPeriods';
 import {
   currencies, detect,
   fromCountryGroupId,
@@ -143,7 +143,7 @@ const getWeeklyImage = (isTop: boolean) => {
 
 const guardianWeekly = (countryGroupId: CountryGroupId, priceCopy: PriceCopy, isTop: boolean): ProductCopy => ({
   title: 'The Guardian Weekly',
-  subtitle: getDisplayPrice(countryGroupId, priceCopy.price, Quarterly),
+  subtitle: getDisplayPrice(countryGroupId, priceCopy.price, SixForSixBillingPeriod),
   description: 'A weekly, global magazine from The Guardian, with delivery worldwide',
   offer: getGuardianWeeklyOfferCopy(countryGroupId, priceCopy.discountCopy),
   buttons: [

--- a/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.jsx
@@ -35,7 +35,7 @@ import HeaderWrapper from 'components/subscriptionCheckouts/headerWrapper';
 
 // ----- Redux Store ----- //
 const billingPeriodInUrl = getQueryParameter('period');
-const initialBillingPeriod: WeeklyBillingPeriod = billingPeriodInUrl === 'SixWeekly' || billingPeriodInUrl === 'Quarterly' || billingPeriodInUrl === 'Annual'
+const initialBillingPeriod: WeeklyBillingPeriod = billingPeriodInUrl === 'SixWeekly' || billingPeriodInUrl === 'Monthly' || billingPeriodInUrl === 'Quarterly' || billingPeriodInUrl === 'Annual'
   ? billingPeriodInUrl
   : Quarterly;
 

--- a/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.jsx
@@ -18,7 +18,14 @@ import WeeklyCheckoutFormGifting from './components/weeklyCheckoutFormGifting';
 import type { CommonState } from 'helpers/page/commonReducer';
 import { createWithDeliveryCheckoutReducer } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import { GuardianWeekly } from 'helpers/productPrice/subscriptions';
-import { Quarterly, type WeeklyBillingPeriod } from 'helpers/productPrice/billingPeriods';
+import {
+  Annual,
+  Monthly,
+  Quarterly,
+  SixForSixBillingPeriod,
+  SixWeekly,
+  type WeeklyBillingPeriod,
+} from 'helpers/productPrice/billingPeriods';
 import { getQueryParameter } from 'helpers/urls/url';
 import { getWeeklyDays } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
 import { Domestic } from 'helpers/productPrice/fulfilmentOptions';
@@ -35,9 +42,13 @@ import HeaderWrapper from 'components/subscriptionCheckouts/headerWrapper';
 
 // ----- Redux Store ----- //
 const billingPeriodInUrl = getQueryParameter('period');
-const initialBillingPeriod: WeeklyBillingPeriod = billingPeriodInUrl === 'SixWeekly' || billingPeriodInUrl === 'Monthly' || billingPeriodInUrl === 'Quarterly' || billingPeriodInUrl === 'Annual'
-  ? billingPeriodInUrl
-  : Quarterly;
+const initialBillingPeriod: WeeklyBillingPeriod =
+  billingPeriodInUrl === SixWeekly ||
+  billingPeriodInUrl === Monthly ||
+  billingPeriodInUrl === Quarterly ||
+  billingPeriodInUrl === Annual
+    ? billingPeriodInUrl
+    : SixForSixBillingPeriod;
 
 const startDate = formatMachineDate(getWeeklyDays()[0]);
 const reducer = (commonState: CommonState) => createWithDeliveryCheckoutReducer(

--- a/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.jsx
@@ -19,11 +19,7 @@ import type { CommonState } from 'helpers/page/commonReducer';
 import { createWithDeliveryCheckoutReducer } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import { GuardianWeekly } from 'helpers/productPrice/subscriptions';
 import {
-  Annual,
-  Monthly,
-  Quarterly,
   SixForSixBillingPeriod,
-  SixWeekly,
   type WeeklyBillingPeriod,
 } from 'helpers/productPrice/billingPeriods';
 import { getQueryParameter } from 'helpers/urls/url';
@@ -43,10 +39,10 @@ import HeaderWrapper from 'components/subscriptionCheckouts/headerWrapper';
 // ----- Redux Store ----- //
 const billingPeriodInUrl = getQueryParameter('period');
 const initialBillingPeriod: WeeklyBillingPeriod =
-  billingPeriodInUrl === SixWeekly ||
-  billingPeriodInUrl === Monthly ||
-  billingPeriodInUrl === Quarterly ||
-  billingPeriodInUrl === Annual
+  billingPeriodInUrl === 'SixWeekly' ||
+  billingPeriodInUrl === 'Monthly' ||
+  billingPeriodInUrl === 'Quarterly' ||
+  billingPeriodInUrl === 'Annual'
     ? billingPeriodInUrl
     : SixForSixBillingPeriod;
 

--- a/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.jsx
@@ -19,7 +19,7 @@ import type { CommonState } from 'helpers/page/commonReducer';
 import { createWithDeliveryCheckoutReducer } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import { GuardianWeekly } from 'helpers/productPrice/subscriptions';
 import {
-  SixForSixBillingPeriod,
+  postIntroductorySixForSixBillingPeriod,
   type WeeklyBillingPeriod,
 } from 'helpers/productPrice/billingPeriods';
 import { getQueryParameter } from 'helpers/urls/url';
@@ -44,7 +44,7 @@ const initialBillingPeriod: WeeklyBillingPeriod =
   billingPeriodInUrl === 'Quarterly' ||
   billingPeriodInUrl === 'Annual'
     ? billingPeriodInUrl
-    : SixForSixBillingPeriod;
+    : postIntroductorySixForSixBillingPeriod;
 
 const startDate = formatMachineDate(getWeeklyDays()[0]);
 const reducer = (commonState: CommonState) => createWithDeliveryCheckoutReducer(

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.jsx
@@ -8,7 +8,10 @@ import {
   weeklyGiftBillingPeriods,
   type WeeklyBillingPeriod,
 } from 'helpers/productPrice/billingPeriods';
-import { sendTrackingEventsOnClick, sendTrackingEventsOnView } from 'helpers/productPrice/subscriptions';
+import {
+  sendTrackingEventsOnClick,
+  sendTrackingEventsOnView,
+} from 'helpers/productPrice/subscriptions';
 import {
   getAppliedPromo,
 } from 'helpers/productPrice/promotions';

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.jsx
@@ -8,10 +8,7 @@ import {
   weeklyGiftBillingPeriods,
   type WeeklyBillingPeriod,
 } from 'helpers/productPrice/billingPeriods';
-import {
-  sendTrackingEventsOnClick,
-  sendTrackingEventsOnView,
-} from 'helpers/productPrice/subscriptions';
+import { sendTrackingEventsOnClick, sendTrackingEventsOnView } from 'helpers/productPrice/subscriptions';
 import {
   getAppliedPromo,
 } from 'helpers/productPrice/promotions';

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -174,6 +174,8 @@ case object Paper extends Product {
 }
 
 case object GuardianWeekly extends Product {
+  // The value for six for six billing period here must match
+  // the value in support-frontend/assets/helpers/productPrice/billingPeriods.js
   val sixForSixBillingPeriod: BillingPeriod = Monthly
   private def domestic(
     id: String,

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -174,6 +174,7 @@ case object Paper extends Product {
 }
 
 case object GuardianWeekly extends Product {
+  val sixForSixBillingPeriod: BillingPeriod = Monthly
   private def domestic(
     id: String,
     billingPeriod: BillingPeriod,

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -176,7 +176,7 @@ case object Paper extends Product {
 case object GuardianWeekly extends Product {
   // The value for six for six billing period here must match
   // the value in support-frontend/assets/helpers/productPrice/billingPeriods.js
-  val sixForSixBillingPeriod: BillingPeriod = Monthly
+  val postIntroductorySixForSixBillingPeriod: BillingPeriod = Monthly
   private def domestic(
     id: String,
     billingPeriod: BillingPeriod,

--- a/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
@@ -1,6 +1,7 @@
 package com.gu.support.workers
 
 import com.gu.support.catalog
+import com.gu.support.catalog.GuardianWeekly.postIntroductorySixForSixBillingPeriod
 import com.gu.support.catalog.{Product, ProductRatePlan}
 import com.gu.support.config.TouchPointEnvironment
 import com.gu.support.zuora.api.ReaderType
@@ -13,7 +14,7 @@ object ProductTypeRatePlans {
     environment: TouchPointEnvironment,
     readerType: ReaderType
   ): Option[ProductRatePlan[catalog.GuardianWeekly.type]] = {
-    val postIntroductoryBillingPeriod = if (product.billingPeriod == SixWeekly) catalog.GuardianWeekly.sixForSixBillingPeriod else product.billingPeriod
+    val postIntroductoryBillingPeriod = if (product.billingPeriod == SixWeekly) postIntroductorySixForSixBillingPeriod else product.billingPeriod
     catalog.GuardianWeekly.ratePlans.getOrElse(environment, Nil).find(productRatePlan =>
       productRatePlan.fulfilmentOptions == product.fulfilmentOptions &&
         productRatePlan.billingPeriod == postIntroductoryBillingPeriod &&

--- a/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
@@ -13,7 +13,7 @@ object ProductTypeRatePlans {
     environment: TouchPointEnvironment,
     readerType: ReaderType
   ): Option[ProductRatePlan[catalog.GuardianWeekly.type]] = {
-    val postIntroductoryBillingPeriod = if (product.billingPeriod == SixWeekly) Quarterly else product.billingPeriod
+    val postIntroductoryBillingPeriod = if (product.billingPeriod == SixWeekly) catalog.GuardianWeekly.sixForSixBillingPeriod else product.billingPeriod
     catalog.GuardianWeekly.ratePlans.getOrElse(environment, Nil).find(productRatePlan =>
       productRatePlan.fulfilmentOptions == product.fulfilmentOptions &&
         productRatePlan.billingPeriod == postIntroductoryBillingPeriod &&

--- a/support-services/src/main/scala/com/gu/support/catalog/CatalogService.scala
+++ b/support-services/src/main/scala/com/gu/support/catalog/CatalogService.scala
@@ -1,6 +1,7 @@
 package com.gu.support.catalog
 
 import com.gu.aws.{AwsCloudWatchMetricPut, AwsCloudWatchMetricSetup}
+import com.gu.support.catalog.GuardianWeekly.postIntroductorySixForSixBillingPeriod
 import com.gu.support.config.TouchPointEnvironment
 import com.gu.support.workers.{Annual, BillingPeriod, Quarterly, SixWeekly}
 import com.gu.support.zuora.api.ReaderType
@@ -40,8 +41,8 @@ class CatalogService(val environment: TouchPointEnvironment, jsonProvider: Catal
     // promotion. It is much more use from the point of view of the site to have the subscription
     // price, ie. the quarterly price as the £6 is available through the introductory promotion object
     val ratePlanIdsToSwap = Map(
-      getGWRatePlanId(SixWeekly, Domestic) -> getGWRatePlanId(GuardianWeekly.sixForSixBillingPeriod, Domestic),
-      getGWRatePlanId(SixWeekly, RestOfWorld) -> getGWRatePlanId(GuardianWeekly.sixForSixBillingPeriod, RestOfWorld)
+      getGWRatePlanId(SixWeekly, Domestic) -> getGWRatePlanId(postIntroductorySixForSixBillingPeriod, Domestic),
+      getGWRatePlanId(SixWeekly, RestOfWorld) -> getGWRatePlanId(postIntroductorySixForSixBillingPeriod, RestOfWorld)
     )
 
     Catalog(

--- a/support-services/src/main/scala/com/gu/support/catalog/CatalogService.scala
+++ b/support-services/src/main/scala/com/gu/support/catalog/CatalogService.scala
@@ -40,8 +40,8 @@ class CatalogService(val environment: TouchPointEnvironment, jsonProvider: Catal
     // promotion. It is much more use from the point of view of the site to have the subscription
     // price, ie. the quarterly price as the £6 is available through the introductory promotion object
     val ratePlanIdsToSwap = Map(
-      getGWRatePlanId(SixWeekly, Domestic) -> getGWRatePlanId(Quarterly, Domestic),
-      getGWRatePlanId(SixWeekly, RestOfWorld) -> getGWRatePlanId(Quarterly, RestOfWorld)
+      getGWRatePlanId(SixWeekly, Domestic) -> getGWRatePlanId(GuardianWeekly.sixForSixBillingPeriod, Domestic),
+      getGWRatePlanId(SixWeekly, RestOfWorld) -> getGWRatePlanId(GuardianWeekly.sixForSixBillingPeriod, RestOfWorld)
     )
 
     Catalog(

--- a/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceSpec.scala
@@ -70,7 +70,7 @@ class CatalogServiceSpec extends AsyncFlatSpec with Matchers {
     (for {
       voucherEveryday <- Paper.getProductRatePlan(PROD, Monthly, Collection, Everyday)
       priceList <- serviceWithFixtures.getPriceList(voucherEveryday)
-    } yield priceList.savingVsRetail shouldBe Some(29)).getOrElse(fail())
+    } yield priceList.savingVsRetail shouldBe Some(43)).getOrElse(fail())
 
   }
 }

--- a/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
@@ -137,7 +137,7 @@ class PriceSummaryServiceSpec extends AsyncFlatSpec with Matchers {
   it should "find the retail saving for print products" in {
     val service = new PriceSummaryService(PromotionServiceSpec.serviceWithFixtures, CatalogServiceSpec.serviceWithFixtures)
     val prices = service.getPricesForCountryGroup(Paper, UK, Nil)
-    prices(Collection)(Sixday)(Monthly)(GBP).savingVsRetail shouldBe Some(26)
+    prices(Collection)(Sixday)(Monthly)(GBP).savingVsRetail shouldBe Some(41)
     succeed
   }
 

--- a/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
@@ -5,12 +5,12 @@ import com.gu.support.catalog._
 import com.gu.support.promotions.{DefaultPromotions, PromoCode}
 import com.gu.support.workers.states.SendThankYouEmailState._
 import com.gu.support.workers.states.{SendAcquisitionEventState, SendThankYouEmailState}
-import com.gu.support.workers.{AcquisitionData, AmazonPayPaymentMethod, Annual, BillingPeriod, ClonedDirectDebitPaymentMethod, Contribution, CreditCardReferenceTransaction, DigitalPack, DirectDebitPaymentMethod, SepaPaymentMethod, GuardianWeekly, Monthly, Paper, PayPalReferenceTransaction, PaymentMethod, ProductType, Quarterly, RequestInfo, SixWeekly, StripePaymentType}
+import com.gu.support.workers.{AcquisitionData, AmazonPayPaymentMethod, Annual, BillingPeriod, ClonedDirectDebitPaymentMethod, Contribution, CreditCardReferenceTransaction, DigitalPack, DirectDebitPaymentMethod, GuardianWeekly, Monthly, Paper, PayPalReferenceTransaction, PaymentMethod, ProductType, Quarterly, RequestInfo, SepaPaymentMethod, SixWeekly, StripePaymentType}
 import com.gu.support.zuora.api.ReaderType.{Corporate, Direct, Gift}
 import org.joda.time.{DateTime, DateTimeZone}
-import com.gu.support.acquisitions
+import com.gu.support.{acquisitions, catalog}
 import com.gu.support.acquisitions.AcquisitionType.{Purchase, Redemption}
-import com.gu.support.acquisitions.PaymentProvider.{DirectDebit, PayPal, Stripe, StripeApplePay, StripePaymentRequestButton, StripeSepa, AmazonPay}
+import com.gu.support.acquisitions.PaymentProvider.{AmazonPay, DirectDebit, PayPal, Stripe, StripeApplePay, StripePaymentRequestButton, StripeSepa}
 import com.gu.support.acquisitions.PrintProduct._
 import com.gu.support.acquisitions.{AcquisitionDataRow, AcquisitionProduct, AcquisitionType, PaymentFrequency, PaymentProvider, PrintOptions, PrintProduct}
 import com.gu.support.zuora.api.ReaderType
@@ -59,7 +59,9 @@ object AcquisitionDataRowBuilder {
   private def paymentFrequencyFromBillingPeriod(billingPeriod: BillingPeriod) =
     billingPeriod match {
       case Monthly => PaymentFrequency.Monthly
-      case Quarterly | SixWeekly => PaymentFrequency.Quarterly
+      case Quarterly => PaymentFrequency.Quarterly
+      case SixWeekly if catalog.GuardianWeekly.sixForSixBillingPeriod == Quarterly => PaymentFrequency.Quarterly
+      case SixWeekly => PaymentFrequency.Monthly
       case Annual => PaymentFrequency.Annually
     }
 

--- a/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
@@ -13,6 +13,7 @@ import com.gu.support.acquisitions.AcquisitionType.{Purchase, Redemption}
 import com.gu.support.acquisitions.PaymentProvider.{AmazonPay, DirectDebit, PayPal, Stripe, StripeApplePay, StripePaymentRequestButton, StripeSepa}
 import com.gu.support.acquisitions.PrintProduct._
 import com.gu.support.acquisitions.{AcquisitionDataRow, AcquisitionProduct, AcquisitionType, PaymentFrequency, PaymentProvider, PrintOptions, PrintProduct}
+import com.gu.support.catalog.GuardianWeekly.postIntroductorySixForSixBillingPeriod
 import com.gu.support.zuora.api.ReaderType
 
 
@@ -60,7 +61,7 @@ object AcquisitionDataRowBuilder {
     billingPeriod match {
       case Monthly => PaymentFrequency.Monthly
       case Quarterly => PaymentFrequency.Quarterly
-      case SixWeekly if catalog.GuardianWeekly.sixForSixBillingPeriod == Quarterly => PaymentFrequency.Quarterly
+      case SixWeekly if postIntroductorySixForSixBillingPeriod == Quarterly => PaymentFrequency.Quarterly
       case SixWeekly => PaymentFrequency.Monthly
       case Annual => PaymentFrequency.Annually
     }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendOldAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendOldAcquisitionEvent.scala
@@ -1,7 +1,6 @@
 package com.gu.support.workers.lambdas
 
 import java.util.UUID
-
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.acquisition.model.errors.AnalyticsServiceError
 import com.gu.acquisition.model.{GAData, OphanIds}
@@ -12,6 +11,7 @@ import com.gu.config.Configuration
 import com.gu.i18n.Country
 import com.gu.monitoring.{LambdaExecutionResult, SafeLogger, Success}
 import com.gu.services.{ServiceProvider, Services}
+import com.gu.support.catalog
 import com.gu.support.catalog.{Contribution => _, DigitalPack => _, Paper => _, _}
 import com.gu.support.promotions.{DefaultPromotions, PromoCode}
 import com.gu.support.workers._
@@ -124,7 +124,9 @@ object SendOldAcquisitionEvent {
       // Don't match on this as its not a valid billing period.
         (billingPeriod: @unchecked) match {
           case Monthly => thrift.PaymentFrequency.Monthly
-          case Quarterly | SixWeekly => thrift.PaymentFrequency.Quarterly
+          case Quarterly => thrift.PaymentFrequency.Quarterly
+          case SixWeekly if catalog.GuardianWeekly.sixForSixBillingPeriod == Quarterly => thrift.PaymentFrequency.Quarterly
+          case SixWeekly => thrift.PaymentFrequency.Monthly
           case Annual => thrift.PaymentFrequency.Annually
         }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendOldAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendOldAcquisitionEvent.scala
@@ -12,6 +12,7 @@ import com.gu.i18n.Country
 import com.gu.monitoring.{LambdaExecutionResult, SafeLogger, Success}
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.catalog
+import com.gu.support.catalog.GuardianWeekly.postIntroductorySixForSixBillingPeriod
 import com.gu.support.catalog.{Contribution => _, DigitalPack => _, Paper => _, _}
 import com.gu.support.promotions.{DefaultPromotions, PromoCode}
 import com.gu.support.workers._
@@ -125,7 +126,7 @@ object SendOldAcquisitionEvent {
         (billingPeriod: @unchecked) match {
           case Monthly => thrift.PaymentFrequency.Monthly
           case Quarterly => thrift.PaymentFrequency.Quarterly
-          case SixWeekly if catalog.GuardianWeekly.sixForSixBillingPeriod == Quarterly => thrift.PaymentFrequency.Quarterly
+          case SixWeekly if postIntroductorySixForSixBillingPeriod == Quarterly => thrift.PaymentFrequency.Quarterly
           case SixWeekly => thrift.PaymentFrequency.Monthly
           case Annual => thrift.PaymentFrequency.Annually
         }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We would like to trial a monthly option for Guardian Weekly as there is a belief that it may reduce churn rates from customers coming to the end of the 6 for 6 period.

[**Trello Card**](https://trello.com/c/jShvc0c9/3455-guardian-weekly-replace-quarterly-with-monthly-test)

This PR introduces a new variable `postIntroductorySixForSixBillingPeriod` in both the Javascript code and the Scala code - this are used to determine:
- what rate plan to show alongside Annual
- what rate plan 6 for 6 customers go on to after the introductory offer period

I have tested monthly and 6 for 6 purchases locally and checked the resulting subscription record in Zuora, the thank you email and how it appears in manage my account are all correct.

## Screenshots

![Screen Shot 2021-06-09 at 16 16 01](https://user-images.githubusercontent.com/181371/121381929-10af2080-c93e-11eb-9c86-daa5d9772fd2.png)
![Screen Shot 2021-06-09 at 16 15 42](https://user-images.githubusercontent.com/181371/121381940-1278e400-c93e-11eb-97f6-3ece612f737a.png)
![Screen Shot 2021-06-09 at 16 15 11](https://user-images.githubusercontent.com/181371/121381942-13117a80-c93e-11eb-8f08-993206eeb648.png)
![Screen Shot 2021-06-09 at 16 17 27](https://user-images.githubusercontent.com/181371/121382152-3d633800-c93e-11eb-8a4e-aedfa84795da.png)
