### PR TITLE
Send unmanaged attribute for events test to Braze

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -103,4 +103,27 @@ export const tests: Tests = {
     targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
     seed: 0,
   },
+  // If the name of this test or the variant id changes then the code
+  // in `ZuoraDigitalSubscriptionDirectHandler.subscribe` will need
+  // to change as well.
+  digiSubEventsTest: {
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'variant',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: false,
+    referrerControlled: false,
+    targetPage: pageUrlRegexes.subscriptions.digiSub.nonGiftLandingAndCheckout,
+    seed: 9,
+  },
 };

--- a/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
@@ -36,6 +36,7 @@ object SendThankYouEmailState {
     promoCode: Option[PromoCode],
     accountNumber: String,
     subscriptionNumber: String,
+    isInEventsTest: Option[Boolean],
   ) extends SendThankYouEmailDigitalSubscriptionState
 
   case class SendThankYouEmailDigitalSubscriptionGiftPurchaseState(

--- a/support-models/src/test/scala/com/gu/support/workers/SendThankYouEmailStateSerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/SendThankYouEmailStateSerialisationSpec.scala
@@ -45,6 +45,7 @@ object ProductTypeCreatedTestData {
     None,
     "acno",
     "subno",
+    Some(false),
   )
 
   val digitalSubscriptionGiftPurchaseCreated = SendThankYouEmailDigitalSubscriptionGiftPurchaseState(

--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -272,7 +272,12 @@ class DigitalPackEmailFields(
         date_of_first_payment = formatDate(SubscriptionEmailFieldHelpers.firstPayment(state.paymentSchedule).date),
         trial_period = "14", //TODO: depends on Promo code or zuora config
         paymentFieldsAttributes
-      ), state.user)
+      ),
+        state.user,
+        Some(JsonObject.fromMap(
+          Map("unmanaged_digital_subscription_in_events_test" -> Json.fromBoolean(state.isInEventsTest.getOrElse(false)))
+        ))
+      )
     )
   }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
@@ -65,7 +65,7 @@ object UpdateSupporterProductData {
             ))
           .toRight(())
           .map(Some(_))
-      case SendThankYouEmailDigitalSubscriptionDirectPurchaseState(user, product, _, _, _, _, subscriptionNumber) =>
+      case SendThankYouEmailDigitalSubscriptionDirectPurchaseState(user, product, _, _, _, _, subscriptionNumber, _) =>
         catalogService
           .getProductRatePlan(DigitalPack, product.billingPeriod, NoFulfilmentOptions, NoProductOptions)
           .map(productRatePlan =>

--- a/support-workers/src/main/scala/com/gu/zuora/productHandlers/ZuoraDigitalSubscriptionDirectHandler.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/productHandlers/ZuoraDigitalSubscriptionDirectHandler.scala
@@ -19,7 +19,7 @@ class ZuoraDigitalSubscriptionDirectHandler(
   user: User,
 ) {
 
-  def checkIfUserIsInEventsTest(maybeAbTests: Option[Set[AbTest]]) =
+  def isUserInEventsTest(maybeAbTests: Option[Set[AbTest]]) =
     maybeAbTests.exists(_.toList.exists(test => test.name == "digiSubEventsTest" && test.variant == "variant"))
 
   def subscribe(state: DigitalSubscriptionDirectPurchaseState, maybeAbTests: Option[Set[AbTest]]): Future[SendThankYouEmailState] =
@@ -36,7 +36,7 @@ class ZuoraDigitalSubscriptionDirectHandler(
       state.promoCode,
       account.value,
       sub.value,
-      Some(checkIfUserIsInEventsTest(maybeAbTests)),
+      Some(isUserInEventsTest(maybeAbTests)),
     )
 
 }

--- a/support-workers/src/main/scala/com/gu/zuora/productHandlers/ZuoraDigitalSubscriptionDirectHandler.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/productHandlers/ZuoraDigitalSubscriptionDirectHandler.scala
@@ -8,6 +8,7 @@ import com.gu.support.workers.states.SendThankYouEmailState
 import com.gu.support.workers.states.SendThankYouEmailState.SendThankYouEmailDigitalSubscriptionDirectPurchaseState
 import com.gu.zuora.ZuoraSubscriptionCreator
 import com.gu.zuora.subscriptionBuilders.DigitalSubscriptionDirectPurchaseBuilder
+import ophan.thrift.event.AbTest
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -18,7 +19,10 @@ class ZuoraDigitalSubscriptionDirectHandler(
   user: User,
 ) {
 
-  def subscribe(state: DigitalSubscriptionDirectPurchaseState): Future[SendThankYouEmailState] =
+  def checkIfUserIsInEventsTest(maybeAbTests: Option[Set[AbTest]]) =
+    maybeAbTests.exists(_.toList.exists(test => test.name == "digiSubEventsTest" && test.variant == "variant"))
+
+  def subscribe(state: DigitalSubscriptionDirectPurchaseState, maybeAbTests: Option[Set[AbTest]]): Future[SendThankYouEmailState] =
     for {
       subscribeItem <- Future.fromTry(digitalSubscriptionDirectPurchaseBuilder.build(state).leftMap(BuildSubscribePromoError).toTry)
         .withEventualLogging("subscription data")
@@ -31,7 +35,8 @@ class ZuoraDigitalSubscriptionDirectHandler(
       paymentSchedule,
       state.promoCode,
       account.value,
-      sub.value
+      sub.value,
+      Some(checkIfUserIsInEventsTest(maybeAbTests)),
     )
 
 }

--- a/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
@@ -83,7 +83,10 @@ class DigitalPackEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside
         |  }
         |},
         |"DataExtensionName" : "digipack",
-        |"IdentityUserId" : "1234"
+        |"IdentityUserId" : "1234",
+        |"UserAttributes" : {
+        |   "unmanaged_digital_subscription_in_events_test" : false
+        |}
         |}
         |""".stripMargin)
     val actual = new DigitalPackEmailFields(
@@ -99,6 +102,7 @@ class DigitalPackEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside
         None,
         "acno",
         "A-S00045678",
+        None,
       )
     ).map(_.map(ef => parse(ef.payload)))
     actual.map(inside(_) {

--- a/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
@@ -162,7 +162,7 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
       user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),
     )
 
-    val result = subscriptionCreator.subscribe(state)
+    val result = subscriptionCreator.subscribe(state, None)
 
     result.map { sendThankYouEmailState =>
       withClue(sendThankYouEmailState) {

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -150,6 +150,7 @@ object SendDigitalPackEmail extends App {
       None,
       acno,
       subno,
+      None,
     )
   ))
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We want to run an AB test to measure the appetite for bundling an events benefit with the digital subscription. 

As part of this we will need to add an unmanaged attribute to Braze for all users who fall within the variant cohort - this PR adds code to do that.

For reference the attribute will be called `unmanaged_digital_subscription_in_events_test`


[**Trello Card**](https://trello.com/c/2mB24ver/3733-events-custom-attribute-to-send-to-braze)

I have tested this on CODE and the attribute shows up in Braze as expected.