### PR TITLE
Add special "previous giving" message to the LP

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -185,7 +185,7 @@ class Application(
       ),
       paymentApiUrl = paymentAPIService.paymentAPIUrl,
       paymentApiPayPalEndpoint = paymentAPIService.payPalCreatePaymentEndpoint,
-      existingPaymentOptionsEndpoint = membersDataService.existingPaymentOptionsEndpoint,
+      mdapiUrl = membersDataService.apiUrl,
       idUser = idUser,
       guestAccountCreationToken = guestAccountCreationToken,
       fontLoaderBundle = fontLoaderBundle,

--- a/support-frontend/app/services/MembersDataService.scala
+++ b/support-frontend/app/services/MembersDataService.scala
@@ -40,11 +40,9 @@ object MembersDataService {
   def apply(apiUrl: String)(implicit ec: ExecutionContext, wsClient: WSClient): MembersDataService = new MembersDataService(apiUrl)
 }
 
-class MembersDataService(apiUrl: String)(implicit val ec: ExecutionContext, wsClient: WSClient) {
+class MembersDataService(val apiUrl: String)(implicit val ec: ExecutionContext, wsClient: WSClient) {
 
   import MembersDataService._
-
-  val existingPaymentOptionsEndpoint = s"$apiUrl/user-attributes/me/existing-payment-options"
 
   def userAttributes(implicit accessCredentials: AccessCredentials.Cookies): EitherT[Future, MembersDataServiceError, UserAttributes] =
     get[UserAttributes](s"$apiUrl/user-attributes/me")

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -19,7 +19,7 @@
   paymentMethodConfigs: ContributionsPaymentMethodConfigs,
   paymentApiUrl: String,
   paymentApiPayPalEndpoint: String,
-  existingPaymentOptionsEndpoint: String,
+  mdapiUrl: String,
   idUser: Option[IdUser],
   guestAccountCreationToken: Option[String],
   fontLoaderBundle: Either[RefPath, StyleContent],
@@ -105,7 +105,7 @@
   };
   window.guardian.paymentApiUrl = "@paymentApiUrl";
   window.guardian.paymentApiPayPalEndpoint = "@paymentApiPayPalEndpoint";
-  window.guardian.existingPaymentOptionsEndpoint = "@existingPaymentOptionsEndpoint";
+  window.guardian.mdapiUrl = "@mdapiUrl";
   window.guardian.csrf = { token: "@CSRF.getToken.value" };
 
   @guestAccountCreationToken.map { guestAccountCreationToken =>

--- a/support-frontend/assets/helpers/abTests/lpPreviousGiving.js
+++ b/support-frontend/assets/helpers/abTests/lpPreviousGiving.js
@@ -1,0 +1,50 @@
+// @flow
+
+// ----- Imports ----- //
+
+import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+
+// ----- Consts ----- //
+
+const SUPPORT_AGAIN_HEADER_TEST_NAME = 'header-support-again';
+const SUPPORT_AGAIN_HEADER_VARIANT_NAME = 'control';
+
+// ----- Helpers ----- //
+
+export function getLongMonth(date: Date) {
+  return date.toLocaleDateString('default', { month: 'long' });
+}
+
+function nth(d) {
+  if (d >= 11 && d <= 13) {
+    return 'th';
+  }
+  switch (d % 10) {
+    case 1:
+      return 'st';
+    case 2:
+      return 'nd';
+    case 3:
+      return 'rd';
+    default:
+      return 'th';
+  }
+}
+
+export function getDateWithOrdinal(date: Date) {
+  const dayOfMonth = date.getDate();
+
+  return `${dayOfMonth}${nth(dayOfMonth)}`;
+}
+
+export function isInSupportAgainHeaderVariant(acquisitionData: ReferrerAcquisitionData) {
+  const { abTests } = acquisitionData;
+
+  if (!abTests) {
+    return false;
+  }
+
+  return abTests.some(abTest =>
+    abTest.name === SUPPORT_AGAIN_HEADER_TEST_NAME &&
+      abTest.variant === SUPPORT_AGAIN_HEADER_VARIANT_NAME);
+}

--- a/support-frontend/assets/helpers/customHooks/useLastOneOffContribution.js
+++ b/support-frontend/assets/helpers/customHooks/useLastOneOffContribution.js
@@ -1,0 +1,52 @@
+// @flow
+
+// $FlowIgnore - required for hooks
+import { useState, useEffect } from 'react';
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
+
+const MDAPI_URL = `${window.guardian.mdapiUrl}/user-attributes/me/one-off-contributions`;
+
+export type OneOffContribution = {
+  amount: number,
+  createdAt: Date,
+  currency: IsoCurrency,
+};
+
+type MdapiOneOffContribution = {
+  amount: number,
+  created: number,
+  status: string,
+  currency: string
+};
+
+export function useLastOneOffContribution(): OneOffContribution | null {
+  const [
+    lastOneOffContribution,
+    setlastOneOffContribution,
+  ] = useState<OneOffContribution | null>(null);
+
+  useEffect(() => {
+    fetch(MDAPI_URL, {
+      mode: 'cors',
+      credentials: 'include',
+    })
+      .then(response => response.json())
+      .then((data) => {
+        const contributions = (data: MdapiOneOffContribution[]);
+
+        const latest = contributions
+          .filter(c => c.status.toUpperCase() === 'PAID')
+          .sort((c1, c2) => c2.created - c1.created)[0];
+
+        if (latest) {
+          setlastOneOffContribution({
+            amount: latest.amount,
+            createdAt: new Date(latest.created),
+            currency: latest.currency,
+          });
+        }
+      });
+  }, []);
+
+  return lastOneOffContribution;
+}

--- a/support-frontend/assets/helpers/forms/existingPaymentMethods/existingPaymentMethods.js
+++ b/support-frontend/assets/helpers/forms/existingPaymentMethods/existingPaymentMethods.js
@@ -42,7 +42,7 @@ function sendGetExistingPaymentMethodsRequest(
   storeResponse: ExistingPaymentMethod[] => void,
 ): void {
   fetchJson(
-    `${window.guardian.existingPaymentOptionsEndpoint}?currencyFilter=${isoCurrency}`,
+    `${window.guardian.mdapiUrl}/user-attributes/me/existing-payment-options?currencyFilter=${isoCurrency}`,
     {
       mode: 'cors',
       credentials: 'include',

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormBlurb.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormBlurb.jsx
@@ -1,0 +1,30 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+// ----- Types ----- //
+
+type ContributionFormBlurbProps = {|
+  headerCopy: string | React$Node,
+  bodyCopy: string | React$Node,
+|};
+
+// ----- Component ----- //
+
+export function ContributionFormBlurb({
+  headerCopy,
+  bodyCopy,
+}: ContributionFormBlurbProps) {
+
+  return (
+    <div className="gu-content__blurb">
+      <div className="gu-content__blurb-header-container">
+        <h1 className="gu-content__blurb-header">{headerCopy}</h1>
+      </div>
+
+      <p className="gu-content__blurb-blurb">{bodyCopy}</p>
+    </div>
+  );
+}

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
@@ -12,9 +12,14 @@ import ContributionTicker from 'components/ticker/contributionTicker';
 import { getCampaignSettings } from 'helpers/campaigns/campaigns';
 import { type State } from '../contributionsLandingReducer';
 import { ContributionForm, EmptyContributionForm } from './ContributionForm';
+import { ContributionFormBlurb } from './ContributionFormBlurb';
 import { onThirdPartyPaymentAuthorised, paymentWaiting, setTickerGoalReached } from '../contributionsLandingActions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import SecureTransactionIndicator from 'components/secureTransactionIndicator/secureTransactionIndicator';
+import { useLastOneOffContribution } from 'helpers/customHooks/useLastOneOffContribution';
+import { isInSupportAgainHeaderVariant } from 'helpers/abTests/lpPreviousGiving';
+import { PreviousGivingBodyCopy, PreviousGivingHeaderCopy } from './ContributionsFormBlurbPreviousGiving';
+import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 
 // ----- Types ----- //
@@ -30,6 +35,8 @@ type PropTypes = {|
   campaignCodeParameter: ?string,
   isReturningContributor: boolean,
   countryId: IsoCountry,
+  userName: string | null,
+  referrerAcquisitionData: ReferrerAcquisitionData,
 |};
 
 /* eslint-enable react/no-unused-prop-types */
@@ -40,6 +47,8 @@ const mapStateToProps = (state: State) => ({
   tickerGoalReached: state.page.form.tickerGoalReached,
   isReturningContributor: state.page.user.isReturningContributor,
   countryId: state.common.internationalisation.countryId,
+  userName: state.page.user.firstName,
+  referrerAcquisitionData: state.common.referrerAcquisitionData,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -108,16 +117,24 @@ function withProps(props: PropTypes) {
     );
   }
 
+  const showPreviousGiving = isInSupportAgainHeaderVariant(props.referrerAcquisitionData);
+  const lastOneOffContribution = useLastOneOffContribution();
+
   return (
     <div className="gu-content__content gu-content__content-contributions gu-content__content--flex">
-      <div className="gu-content__blurb">
-        <div className="gu-content__blurb-header-container">
-          <h1 className="gu-content__blurb-header">{countryGroupDetails.headerCopy}</h1>
-        </div>
-        { countryGroupDetails.contributeCopy ?
-          <p className="gu-content__blurb-blurb">{countryGroupDetails.contributeCopy}</p> : null
-        }
-      </div>
+      { showPreviousGiving && lastOneOffContribution && (
+        <ContributionFormBlurb
+          headerCopy={<PreviousGivingHeaderCopy userName={props.userName} />}
+          bodyCopy={<PreviousGivingBodyCopy lastOneOffContribution={lastOneOffContribution} />}
+        />
+      )}
+
+      {!showPreviousGiving && (
+        <ContributionFormBlurb
+          headerCopy={countryGroupDetails.headerCopy}
+          bodyCopy={countryGroupDetails.contributeCopy}
+        />
+      )}
 
       <div className="gu-content__form">
         {showSecureTransactionIndicator()}

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionsFormBlurbPreviousGiving.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionsFormBlurbPreviousGiving.jsx
@@ -1,0 +1,66 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import { css } from '@emotion/core';
+import { brandAlt } from '@guardian/src-foundations/palette';
+import type { OneOffContribution } from 'helpers/customHooks/useLastOneOffContribution';
+import { glyph } from 'helpers/internationalisation/currency';
+import {
+  getLongMonth,
+  getDateWithOrdinal,
+} from 'helpers/abTests/lpPreviousGiving';
+
+// ----- Types ----- //
+
+type PreviousGivingHeaderCopyProps = {|
+  userName: string | null
+|};
+
+type PreviousGivingBodyCopyProps = {|
+  lastOneOffContribution: OneOffContribution
+|};
+
+// ----- Styles ----- //
+
+const bodyStyles = css`
+  line-height: 1.35em;
+`;
+
+const highlightStyles = css`
+  padding: 0 2px;
+  background-color: ${brandAlt[400]};
+`;
+
+// ----- Components ----- //
+
+export function PreviousGivingHeaderCopy({
+  userName,
+}: PreviousGivingHeaderCopyProps) {
+  if (userName) {
+    return <>It's nice to see you again {userName}!</>;
+  }
+
+  return <>It's nice to see you again!</>;
+}
+
+export function PreviousGivingBodyCopy({
+  lastOneOffContribution,
+}: PreviousGivingBodyCopyProps) {
+  const month = getLongMonth(lastOneOffContribution.createdAt);
+  const date = getDateWithOrdinal(lastOneOffContribution.createdAt);
+
+  return (
+    <span css={bodyStyles}>
+      On {month} {date}, you supported us with a{' '}
+      <span css={highlightStyles}>
+        {glyph(lastOneOffContribution.currency)}
+        {lastOneOffContribution.amount} contribution.
+      </span>{' '}
+      We hope you’ll consider the same again today. Every contribution, however
+      big or small, protects the Guardian’s independence, and keeps our
+      high-impact journalism open for all. Thank you.
+    </span>
+  );
+}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Add a special message to the contributions landing page for users that clicked through from the "support again" header (https://github.com/guardian/support-dotcom-components/pull/469)

[**Trello Card**](https://trello.com/c/2jUr2U7V/2637-poc-display-a-custom-message-on-the-lp-based-on-readers-previous-giving)

## Screenshots

<img width="520" alt="Screenshot 2021-06-14 at 14 54 16" src="https://user-images.githubusercontent.com/17720442/121904735-5e060600-cd21-11eb-8ca1-2d0b32dbdb9b.png">