### PR TITLE
Fix issue where the US quarterly price for Guardian Weekly was displayed to ROW on the subs landing page

### DIFF
--- a/support-frontend/app/controllers/SubscriptionsController.scala
+++ b/support-frontend/app/controllers/SubscriptionsController.scala
@@ -65,7 +65,8 @@ class SubscriptionsController(
     else
       Map.empty
 
-    val weekly = service.getPrices(GuardianWeekly, Nil)(countryGroup)(Domestic)(NoProductOptions)(Quarterly)(countryGroup.currency)
+    val weeklyFulfilmentCountry = if (countryGroup == CountryGroup.RestOfTheWorld) RestOfWorld else Domestic
+    val weekly = service.getPrices(GuardianWeekly, Nil)(countryGroup)(weeklyFulfilmentCountry)(NoProductOptions)(Quarterly)(countryGroup.currency)
 
     val digitalSubscription = service
       .getPrices(

--- a/support-frontend/app/controllers/SubscriptionsController.scala
+++ b/support-frontend/app/controllers/SubscriptionsController.scala
@@ -65,8 +65,8 @@ class SubscriptionsController(
     else
       Map.empty
 
-    val weeklyFulfilmentCountry = if (countryGroup == CountryGroup.RestOfTheWorld) RestOfWorld else Domestic
-    val weekly = service.getPrices(GuardianWeekly, Nil)(countryGroup)(weeklyFulfilmentCountry)(NoProductOptions)(Quarterly)(countryGroup.currency)
+    val fulfilmentOptions = if (countryGroup == CountryGroup.RestOfTheWorld) RestOfWorld else Domestic
+    val weekly = service.getPrices(GuardianWeekly, Nil)(countryGroup)(fulfilmentOptions)(NoProductOptions)(Quarterly)(countryGroup.currency)
 
     val digitalSubscription = service
       .getPrices(


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes an issue where the incorrect rate plan was being used to provide the display price for Guardian Weekly on the subscriptions landing page to users in ROW. The rate plan for GW Domestic only includes the US$75 quarterly rate for the USA, and there is a completely separate rate plan for ROW which was not being retrieved.

[**Trello Card**](https://trello.com/c/sWRc0WGy)