### PR TITLE
make sure failing tests in depended projects prevent deployment

### DIFF
--- a/support-workers/build-tc
+++ b/support-workers/build-tc
@@ -25,6 +25,6 @@ popd
 # build scala
 cd ..
 ./sbt "project support-workers" it:assembly \
-"project support-workers" riffRaffUpload \
+"project support-workers" test riffRaffUpload \
 "project it-test-runner" riffRaffUpload \
 "project support-redemptiondb" riffRaffUpload

--- a/supporter-product-data/build-tc
+++ b/supporter-product-data/build-tc
@@ -3,4 +3,4 @@ set -e
 
 # build scala
 cd ..
-./sbt "project supporter-product-data" riffRaffUpload
+./sbt "project supporter-product-data" test riffRaffUpload


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Make it explicitly run the tests for supporter-product-data project
This means that any failures in aggregated projects will prevent the build producing an artifact
https://github.com/guardian/support-frontend/blob/47aa4e818eeb80b96d1a4a921e739b853e33eded/build.sbt#L133

## Why are you doing this?



