### PR TITLE
Turn off PRB design test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -30,26 +30,6 @@ export const pageUrlRegexes = {
 };
 
 export const tests: Tests = {
-  stripeCustomPrbTest: {
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'custom',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    referrerControlled: false,
-    targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
-    seed: 5,
-  },
   editorialVoiceTestPart2: {
     variants: [
       {

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -90,7 +90,6 @@ type PropTypes = {
   setError: (error: ErrorReason, stripeAccount: StripeAccount) => Action,
   setHandleStripe3DS: ((clientSecret: string) => Promise<Stripe3DSResult>) => Action,
   csrf: CsrfState,
-  shouldShowRegularPrb: boolean,
   localCurrencyCountry: ?LocalCurrencyCountry,
   useLocalCurrency: boolean,
 };
@@ -108,7 +107,6 @@ const mapStateToProps = (state: State, ownProps: PropTypes) => ({
   paymentMethod: state.page.form.paymentMethod,
   switches: state.common.settings.switches,
   csrf: state.page.csrf,
-  shouldShowRegularPrb: state.common.abParticipations.stripeCustomPrbTest === 'control',
   localCurrencyCountry: state.common.internationalisation.localCurrencyCountry,
   useLocalCurrency: state.common.internationalisation.useLocalCurrency,
 });
@@ -456,8 +454,7 @@ const PaymentRequestButton = (props: PropTypes) => {
 
   const shouldShowStripePrb =
     prbType === 'APPLE_PAY' ||
-    prbType === 'GOOGLE_PAY' ||
-    props.shouldShowRegularPrb;
+    prbType === 'GOOGLE_PAY';
 
   return (
     <div


### PR DESCRIPTION
## What are you doing in this PR?
Turn off the stripe PRB design test. There was no significant difference between the control and the variant, but we've decided to roll the variant out to 100%.
