### PR TITLE
Restore missing paper subs blue colour

### DIFF
--- a/support-frontend/assets/stylesheets/emotion/colours.js
+++ b/support-frontend/assets/stylesheets/emotion/colours.js
@@ -1,3 +1,5 @@
 export const digitalSubscriptionsBlue = '#00568D';
 
 export const guardianWeeklyBlue = '#66c2e9';
+
+export const paperSubscriptionsBlue = '#90DCFF';

--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -95,7 +95,7 @@ module.exports = (cssFilename, jsFilename, minimizeCss) => ({
     chunkFilename: `webpack/${jsFilename}`,
     filename: `javascripts/${jsFilename}`,
     publicPath: '/assets/',
-    strictModuleErrorHandling: process.env.NODE_ENV === 'production',
+    strictModuleExceptionHandling: process.env.NODE_ENV === 'production',
   },
 
   resolve: {

--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -95,6 +95,7 @@ module.exports = (cssFilename, jsFilename, minimizeCss) => ({
     chunkFilename: `webpack/${jsFilename}`,
     filename: `javascripts/${jsFilename}`,
     publicPath: '/assets/',
+    strictModuleErrorHandling: process.env.NODE_ENV === 'production',
   },
 
   resolve: {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This restores the `paperSubscriptionsBlue` colour that was accidentally deleted, and is required for the paper subs landing page. It also makes the Webpack settting [output.strictModuleErrorHandling](https://webpack.js.org/configuration/output/#outputstrictmoduleerrorhandling) `true` in production builds, in order to catch issues like this in future.