### PR TITLE
java 8 corretto for it test runner

### DIFF
--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -31,7 +31,7 @@ Resources:
         Bucket: support-workers-dist
         Key: !Sub support/${Stage}/it-test-runner/it-test-runner.jar
       MemorySize: 2048
-      Runtime: java8
+      Runtime: java8.al2
       Timeout: 300
       Environment:
         Variables:


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Make the IT tests use the corretto runtime, to check for issues.

## Why are you doing this?

AWS is switching over from July 19th, so we should test in advance.
https://aws.amazon.com/blogs/compute/announcing-migration-of-the-java-8-runtime-in-aws-lambda-to-amazon-corretto/

The IT test runner is about the least consenquential thing we have, however it does use a lot of our code and exercise it, so it should be a good test.

We would need to follow up with support-workers, etc.