### PR TITLE
update contributions FAQs link

### DIFF
--- a/support-frontend/assets/components/footerCompliant/ContributionsFooter.jsx
+++ b/support-frontend/assets/components/footerCompliant/ContributionsFooter.jsx
@@ -40,7 +40,7 @@ const alignmentStyles = css`
 `;
 
 function ContributionsFooter() {
-  const faqsLink = 'https://www.theguardian.com/help/users/faq';
+  const faqsLink = 'https://manage.theguardian.com/help-centre';
   const termsConditionsLink =
     'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions';
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Point to the help centre instead of the outdated FAQs page

## Why are you doing this?

> It was originally created as something to include in our auto-response, but now our auto-response isn't working anyway, plus cases are going to TP in the first instance most of the time.

> The page is still getting some traffic, mostly referrals from other Guardian pages, would it make sense to set up a redirect on the URL to send people directly to the help centre and to take this page down?

> The page is here: https://www.theguardian.com/help/users/faq

------

>This page is not being migrated as it mostly contains information that is already elsewhere on the help centre. I would advise sending people to the help centre instead.

----
re this particulaar page 
> Worth updating that to point directly at the help centre, I'd say.