### PR TITLE
Update aus map URL

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -223,7 +223,7 @@ class Application(
       mainStyleBundle = Left(RefPath("ausMomentMap.css")),
       fontLoaderBundle = fontLoaderBundle,
       description = stringsConfig.contributionsLandingDescription,
-      canonicalLink = Some("https://support.theguardian.com/aus-2020-map"),
+      canonicalLink = Some("https://support.theguardian.com/aus-map"),
       shareImageUrl = Some(
         ausMomentMapSocialImageUrl
       )

--- a/support-frontend/assets/pages/aus-moment-map/components/socialLinks.jsx
+++ b/support-frontend/assets/pages/aus-moment-map/components/socialLinks.jsx
@@ -3,11 +3,11 @@ import React from 'react';
 
 const twitterCopy = 'Hear%20from%20supporters%20across%20Australia%3A%20as%20the%20Guardian%20grows%20its%20community%20and%20reaches%20more%20people%2C%20many%20readers%20have%20shared%20their%20reason%20for%20supporting%20them%20financially.%20Read%20their%20messages%20here';
 const emailHeadline = 'Hear%20from%20Guardian%20supporters%20across%20Australia';
-const emailBody = 'Guardian%20Australia%20is%20growing%20its%20community%20and%20reaching%20more%20people%20than%20ever%20before.%20Many%20readers%20have%20shared%20their%20reason%20for%20supporting%20them%20financially%2C%20and%20you%20can%20read%20their%20messages%20here%3A%0A%0Ahttps%3A%2F%2Fsupport.theguardian.com%2Faus-2020-map';
+const emailBody = 'Guardian%20Australia%20is%20growing%20its%20community%20and%20reaching%20more%20people%20than%20ever%20before.%20Many%20readers%20have%20shared%20their%20reason%20for%20supporting%20them%20financially%2C%20and%20you%20can%20read%20their%20messages%20here%3A%0A%0Ahttps%3A%2F%2Fsupport.theguardian.com%2Faus-map';
 
 const links = {
-  facebook: 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsupport.theguardian.com%2Faus-2020-map',
-  twitter: `https://twitter.com/intent/tweet?url=https%3A%2F%2Fsupport.theguardian.com%2Faus-2020-map&hashtags=supporttheguardian&text=${twitterCopy}`,
+  facebook: 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsupport.theguardian.com%2Faus-map',
+  twitter: `https://twitter.com/intent/tweet?url=https%3A%2F%2Fsupport.theguardian.com%2Faus-map&hashtags=supporttheguardian&text=${twitterCopy}`,
   email: `mailto:?subject=${emailHeadline}&body=${emailBody}?INTCMP=component-social-email`,
 };
 

--- a/support-frontend/assets/pages/contributions-landing/components/AustraliaMapLink.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/AustraliaMapLink.jsx
@@ -19,7 +19,7 @@ const AustraliaMapLink = () => (
         icon={<SvgArrowRightStraight />}
         iconSide="right"
         nudgeIcon
-        href="https://support.theguardian.com/aus-2020-map?INTCMP=thankyou-page-aus-map-cta"
+        href="https://support.theguardian.com/aus-map?INTCMP=thankyou-page-aus-map-cta"
         onClick={() => trackComponentClick('contribution-thankyou-aus-map')}
       >
         View the map

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouAusMap.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouAusMap.jsx
@@ -16,7 +16,7 @@ const buttonContainer = css`
   margin-top: ${space[6]}px;
 `;
 
-const AUS_MAP_URL = 'https://support.theguardian.com/aus-2020-map?INTCMP=thankyou-page-aus-map-cta';
+const AUS_MAP_URL = 'https://support.theguardian.com/aus-map?INTCMP=thankyou-page-aus-map-cta';
 
 const ContributionThankYouAusMap = () => {
 

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -56,6 +56,7 @@ GET  /$country<(uk|us|au|eu|int|nz|ca)>/contribute                 controllers.A
 GET  /$country<(uk|us|au|eu|int|nz|ca)>/contribute/:campaignCode   controllers.Application.contributionsLanding(country: String, campaignCode: String)
 
 GET  /aus-2020-map                                                 controllers.Application.ausMomentMap()
+GET  /aus-map                                                      controllers.Application.ausMomentMap()
 GET  /thank-you-shareable-articles                                 controllers.ArticleShare.getArticles()
 
 GET  /$country<(uk|us|au|eu|int|nz|ca)>/thankyou                   controllers.Application.contributionsLanding(country: String, campaignCode = "")


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Add a new route for the aus map page that doesn't reference the year (`/aus-map`). We're still keeping the old route to avoid breaking existing links.

[**Trello Card**](https://trello.com/c/w39rGCdI/2701-update-aus-map-url)