### PR TITLE
Update lambdas to use amazon java instead of openjdk

### DIFF
--- a/support-lambdas/acquisitions-firehose-transformer/cfn.yaml
+++ b/support-lambdas/acquisitions-firehose-transformer/cfn.yaml
@@ -28,7 +28,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${App}-${Stage}
       Description: A Firehose transformation lambda for serialising the acquisitions event stream to csv
-      Runtime: java8
+      Runtime: java8.al2
       Handler: com.gu.acquisitionFirehoseTransformer.Lambda::handler
       MemorySize: 256
       Timeout: 300

--- a/support-lambdas/stripe-intent/cfn.yaml
+++ b/support-lambdas/stripe-intent/cfn.yaml
@@ -37,7 +37,7 @@ Resources:
         Bucket: support-workers-dist
         Key: !Sub support/${Stage}/stripe-intent/stripe-intent.jar
       MemorySize: 2048
-      Runtime: java8
+      Runtime: java8.al2
       Timeout: 300
       Environment:
         Variables:

--- a/support-workers/cloud-formation/src/templates/lambda.yaml
+++ b/support-workers/cloud-formation/src/templates/lambda.yaml
@@ -10,5 +10,5 @@
     Code:
       S3Bucket: support-workers-dist
       S3Key: !Sub support/${Stage}/support-workers/support-workers.jar
-    Runtime: "java8"
+    Runtime: "java8.al2"
     Timeout: "60"

--- a/supporter-product-data/cloudformation/cfn.yaml
+++ b/supporter-product-data/cloudformation/cfn.yaml
@@ -130,7 +130,7 @@ Resources:
         S3Bucket: supporter-product-data-dist
         S3Key: !Sub support/${Stage}/supporter-product-data/supporter-product-data.jar
       MemorySize: 512
-      Runtime: "java8"
+      Runtime: "java8.al2"
       Timeout: 300
       Environment:
         Variables:
@@ -148,7 +148,7 @@ Resources:
         S3Bucket: supporter-product-data-dist
         S3Key: !Sub support/${Stage}/supporter-product-data/supporter-product-data.jar
       MemorySize: 512
-      Runtime: "java8"
+      Runtime: "java8.al2"
       Timeout: 300
       Environment:
         Variables:
@@ -166,7 +166,7 @@ Resources:
         S3Bucket: supporter-product-data-dist
         S3Key: !Sub support/${Stage}/supporter-product-data/supporter-product-data.jar
       MemorySize: 4096
-      Runtime: "java8"
+      Runtime: "java8.al2"
       Timeout: 600
       Environment:
         Variables:


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR updates all the remaining lambdas to use amazon java

https://trello.com/c/deNeOy6x/3778-switch-over-scala-lambdas-to-corretto

## Why are you doing this?

Following on from https://github.com/guardian/support-frontend/pull/3133 which seems to have had no issues

This is per the amazon announcement they will all move over https://aws.amazon.com/blogs/compute/announcing-migration-of-the-java-8-runtime-in-aws-lambda-to-amazon-corretto/
