### PR TITLE
remove marketing opt in from thank you page for recurring

### DIFF
--- a/support-frontend/.eslintrc
+++ b/support-frontend/.eslintrc
@@ -57,6 +57,7 @@
       }
     ],
     "react/default-props-match-prop-types": [2, { "allowRequiredDefaults": true }],
+    "react/jsx-closing-tag-location": "off"
   },
   "settings": {
     "import/resolver": {

--- a/support-frontend/.eslintrc
+++ b/support-frontend/.eslintrc
@@ -56,8 +56,7 @@
         "ignoreTemplateLiterals": true
       }
     ],
-    "react/default-props-match-prop-types": [2, { "allowRequiredDefaults": true }],
-    "react/jsx-closing-tag-location": "off"
+    "react/default-props-match-prop-types": [2, { "allowRequiredDefaults": true }]
   },
   "settings": {
     "import/resolver": {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -201,7 +201,7 @@ const ContributionThankYou = ({
         csrf={csrf}
       />
     ),
-    shouldShow: true,
+    shouldShow: contributionType === 'ONE_OFF',
   };
   const supportReminderAction = {
     component: (

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.jsx
@@ -124,9 +124,18 @@ const ContributionThankYouHeader = ({
     }
   };
 
-  const additionalCopy = shouldShowLargeDonationMessage
-    ? 'It’s not every day that we receive such a generous contribution – thank you. We would love to stay in touch. So that we can, please pick the add-ons that suit you best. You’ll also receive future communications from us to bring you closer to our journalism and make the most of your Guardian benefits. You can opt out at any time via your account.'
-    : 'To support us further, and enhance your experience with the Guardian, select the add-ons that suit you best. You’ll also receive future communications from us to bring you closer to our journalism and make the most of your Guardian benefits. You can opt out at any time via your account.';
+  const AdditionalCopy = () => (
+    <>
+      { shouldShowLargeDonationMessage ? 'It’s not every day that we receive such a generous contribution – thank you. We would love to stay in touch. So that we can, please pick the add-ons that suit you best. '
+        : 'To support us further, and enhance your experience with the Guardian, select the add-ons that suit you best. '}
+      {contributionType !== 'ONE_OFF' &&
+        <span>
+            As you’re now a valued supporter, we’ll be in touch to bring you closer to our journalism. You can amend your email preferences at any time via <a
+          href="https://manage.theguardian.com">your account</a>.
+        </span>
+      }
+    </>
+  );
 
   return (
     <header css={header}>
@@ -144,7 +153,7 @@ const ContributionThankYouHeader = ({
             <br />
           </>
         )}
-        {additionalCopy}
+        <AdditionalCopy />
       </p>
     </header>
   );

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.jsx
@@ -134,7 +134,8 @@ const ContributionThankYouHeader = ({
           'We’ll be in touch to bring you closer to our journalism. Please select the extra add-ons that suit you best. ' :
           'As you’re now a valued supporter, we’ll be in touch to bring you closer to our journalism. '
         }
-        You can amend your email preferences at any time via <a
+        You can amend your email preferences at any time via{' '}
+        <a
           href="https://manage.theguardian.com"
         >your account
         </a>.

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.jsx
@@ -124,18 +124,31 @@ const ContributionThankYouHeader = ({
     }
   };
 
-  const AdditionalCopy = () => (
-    <>
-      { shouldShowLargeDonationMessage ? 'It’s not every day that we receive such a generous contribution – thank you. We would love to stay in touch. So that we can, please pick the add-ons that suit you best. '
-        : 'To support us further, and enhance your experience with the Guardian, select the add-ons that suit you best. '}
-      {contributionType !== 'ONE_OFF' &&
-        <span>
-            As you’re now a valued supporter, we’ll be in touch to bring you closer to our journalism. You can amend your email preferences at any time via <a
-          href="https://manage.theguardian.com">your account</a>.
-        </span>
-      }
-    </>
-  );
+  const AdditionalCopy = () => {
+    const mainText = shouldShowLargeDonationMessage ? 'It’s not every day that we receive such a generous contribution – thank you. We would love to stay in touch. So that we can, please pick the add-ons that suit you best. '
+      : 'To support us further, and enhance your experience with the Guardian, select the add-ons that suit you best. ';
+
+    const MarketingCopy = () => (
+      <span>
+        { shouldShowLargeDonationMessage ?
+          'We’ll be in touch to bring you closer to our journalism. Please select the extra add-ons that suit you best. ' :
+          'As you’re now a valued supporter, we’ll be in touch to bring you closer to our journalism. '
+        }
+        You can amend your email preferences at any time via <a
+          href="https://manage.theguardian.com"
+        >your account
+        </a>.
+      </span>
+    );
+    return (
+      <>
+        {mainText}
+        { contributionType !== 'ONE_OFF' &&
+          <MarketingCopy />
+        }
+      </>
+    );
+  };
 
   return (
     <header css={header}>


### PR DESCRIPTION
1. Removes the marketing opt in component from the contributions thank you page for recurring
2. Updates the copy about marketing emails in the header copy (see screenshots)

### Single contributions - no change:
![Screen Shot 2021-06-28 at 15 10 29](https://user-images.githubusercontent.com/1513454/123656285-af38ee00-d827-11eb-86b1-aef00c5d8bdf.png)

### Recurring
![Screen Shot 2021-06-28 at 16 09 26](https://user-images.githubusercontent.com/1513454/123660312-76027d00-d82b-11eb-918b-c08c4229e877.png)

### Recurring high contributor
![Screen Shot 2021-06-28 at 16 10 54](https://user-images.githubusercontent.com/1513454/123660319-7733aa00-d82b-11eb-807d-f74b6ea667fa.png)

