### PR TITLE
Extract tracking and A/B test setup from Redux setup and restore them to the subscriptions landing pages

### DIFF
--- a/support-frontend/assets/components/footerCompliant/Footer.jsx
+++ b/support-frontend/assets/components/footerCompliant/Footer.jsx
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 // $FlowIgnore - required for hooks
-import React, { Children, useEffect, type Node } from 'react';
+import React, { Children, useState, useEffect, type Node } from 'react';
 import { ThemeProvider } from 'emotion-theming';
 import { Link, ButtonLink, linkBrand } from '@guardian/src-link';
 import { getGlobal } from 'helpers/globalsAndSwitches/globals';
@@ -30,7 +30,7 @@ type PropTypes = {|
 function Footer({
   centred, children, faqsLink, termsConditionsLink,
 }: PropTypes) {
-  let consentManagementPlatform;
+  const [consentManagementPlatform, setConsentManagementPlatform] = useState(null);
 
   function showPrivacyManager() {
     if (consentManagementPlatform) {
@@ -41,7 +41,7 @@ function Footer({
   useEffect(() => {
     if (!getGlobal('ssr')) {
       import('@guardian/consent-management-platform').then(({ cmp }) => {
-        consentManagementPlatform = cmp;
+        setConsentManagementPlatform(cmp);
       });
     }
   }, []);

--- a/support-frontend/assets/helpers/page/analyticsAndConsent.js
+++ b/support-frontend/assets/helpers/page/analyticsAndConsent.js
@@ -1,0 +1,44 @@
+// @flow
+
+// ----- Imports ----- //
+
+import * as ophan from 'ophan';
+import type { Participations } from 'helpers/abTests/abtest';
+import * as logger from 'helpers/utilities/logger';
+import * as googleTagManager from 'helpers/tracking/googleTagManager';
+import { trackAbTests, setReferrerDataInLocalStorage } from 'helpers/tracking/ophan';
+import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import { getGlobal } from 'helpers/globalsAndSwitches/globals';
+import { isPostDeployUser } from 'helpers/user/user';
+import {
+  type IsoCountry,
+} from 'helpers/internationalisation/country';
+
+// ----- Functions ----- //
+
+// Sets up GA and logging.
+export function analyticsInitialisation(
+  participations: Participations,
+  acquisitionData: ReferrerAcquisitionData,
+): void {
+  setReferrerDataInLocalStorage(acquisitionData);
+  googleTagManager.init(participations);
+  ophan.init();
+  trackAbTests(participations);
+  // Logging.
+  logger.init();
+}
+
+export async function consentInitialisation(country: IsoCountry) {
+  /**
+   * Dynamically load @guardian/consent-management-platform
+   * on condition we're not server side rendering (ssr) the page.
+   * @guardian/consent-management-platform breaks ssr otherwise.
+   */
+  if (!getGlobal('ssr') && !isPostDeployUser()) {
+    const { cmp } = await import('@guardian/consent-management-platform');
+    cmp.init({
+      country,
+    });
+  }
+}

--- a/support-frontend/assets/helpers/page/page.js
+++ b/support-frontend/assets/helpers/page/page.js
@@ -108,15 +108,6 @@ function buildInitialState(
 
 }
 
-// For pages that don't need Redux.
-function statelessInit() {
-  const country: IsoCountry = detectCountry();
-  const countryGroupId: CountryGroupId = detectCountryGroup();
-  const participations: Participations = abTest.init(country, countryGroupId, window.guardian.settings);
-  const acquisitionData = getReferrerAcquisitionData();
-  analyticsInitialisation(participations, acquisitionData);
-}
-
 // Enables redux devtools extension and optional redux-thunk.
 /* eslint-disable no-underscore-dangle */
 function storeEnhancer(thunk: boolean) {
@@ -177,5 +168,4 @@ function init<S, A>(
 
 export {
   init,
-  statelessInit,
 };

--- a/support-frontend/assets/helpers/page/statelessPage.js
+++ b/support-frontend/assets/helpers/page/statelessPage.js
@@ -1,0 +1,28 @@
+// @flow
+
+// ----- Imports ----- //
+
+import type { Participations } from 'helpers/abTests/abtest';
+import * as abTest from 'helpers/abTests/abtest';
+import {
+  detect as detectCountry,
+  type IsoCountry,
+} from 'helpers/internationalisation/country';
+import {
+  getReferrerAcquisitionData,
+} from 'helpers/tracking/acquisitions';
+import {
+  type CountryGroupId,
+  detect as detectCountryGroup,
+} from 'helpers/internationalisation/countryGroup';
+import { analyticsInitialisation, consentInitialisation } from 'helpers/page/analyticsAndConsent';
+
+// For pages that don't need Redux.
+export function setUpTrackingAndConsents() {
+  const country: IsoCountry = detectCountry();
+  const countryGroupId: CountryGroupId = detectCountryGroup();
+  const participations: Participations = abTest.init(country, countryGroupId, window.guardian.settings);
+  const acquisitionData = getReferrerAcquisitionData();
+  analyticsInitialisation(participations, acquisitionData);
+  consentInitialisation(country);
+}

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -213,7 +213,7 @@ function DigitalLandingPage({
   );
 }
 
+setUpTrackingAndConsents();
 const props = digitalLandingProps();
 
-setUpTrackingAndConsents();
 renderPage(<DigitalLandingPage {...props} />, reactElementId[props.countryGroupId]);

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -21,6 +21,7 @@ import {
 } from 'helpers/internationalisation/countryGroup';
 import { routes } from 'helpers/urls/routes';
 import { useHasBeenSeen } from 'helpers/customHooks/useHasBeenSeen';
+import { setUpTrackingAndConsents } from 'helpers/page/statelessPage';
 
 import Page from 'components/page/page';
 import FullWidthContainer from 'components/containers/fullWidthContainer';
@@ -214,4 +215,5 @@ function DigitalLandingPage({
 
 const props = digitalLandingProps();
 
+setUpTrackingAndConsents();
 renderPage(<DigitalLandingPage {...props} />, reactElementId[props.countryGroupId]);

--- a/support-frontend/assets/pages/error/error404.jsx
+++ b/support-frontend/assets/pages/error/error404.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { statelessInit as pageInit } from 'helpers/page/page';
+import { setUpTrackingAndConsents } from 'helpers/page/statelessPage';
 import { renderPage } from 'helpers/rendering/render';
 
 import ErrorPage from './components/errorPage';
@@ -12,7 +12,7 @@ import ErrorPage from './components/errorPage';
 
 // ----- Page Startup ----- //
 
-pageInit();
+setUpTrackingAndConsents();
 
 
 // ----- Render ----- //

--- a/support-frontend/assets/pages/error/error500.jsx
+++ b/support-frontend/assets/pages/error/error500.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { statelessInit as pageInit } from 'helpers/page/page';
+import { setUpTrackingAndConsents } from 'helpers/page/statelessPage';
 import { renderPage } from 'helpers/rendering/render';
 
 import ErrorPage from './components/errorPage';
@@ -12,7 +12,7 @@ import ErrorPage from './components/errorPage';
 
 // ----- Page Startup ----- //
 
-pageInit();
+setUpTrackingAndConsents();
 
 
 // ----- Render ----- //

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -17,6 +17,7 @@ import { tabsTabletSpacing } from './paperSubscriptionLandingStyles';
 import 'stylesheets/skeleton/skeleton.scss';
 import './paperSubscriptionLanding.scss';
 import { getPromotionCopy } from 'helpers/productPrice/promotions';
+import { setUpTrackingAndConsents } from 'helpers/page/statelessPage';
 
 import PaperHero from './components/hero/hero';
 import Tabs from './components/tabs';
@@ -95,6 +96,7 @@ const PaperLandingPage = ({ productPrices, promotionCopy }: PaperLandingPropType
 
 const content = <PaperLandingPage {...paperLandingProps()} />;
 
+setUpTrackingAndConsents();
 renderPage(content, reactElementId);
 
 export { content };

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -94,9 +94,10 @@ const PaperLandingPage = ({ productPrices, promotionCopy }: PaperLandingPropType
   );
 };
 
+setUpTrackingAndConsents();
+
 const content = <PaperLandingPage {...paperLandingProps()} />;
 
-setUpTrackingAndConsents();
 renderPage(content, reactElementId);
 
 export { content };

--- a/support-frontend/assets/pages/paypal-error/payPalError.jsx
+++ b/support-frontend/assets/pages/paypal-error/payPalError.jsx
@@ -9,14 +9,14 @@ import Header from 'components/headers/header/header';
 import Footer from 'components/footer/footer';
 import PageSection from 'components/pageSection/pageSection';
 import QuestionsContact from 'components/questionsContact/questionsContact';
-import { statelessInit as pageInit } from 'helpers/page/page';
+import { setUpTrackingAndConsents } from 'helpers/page/statelessPage';
 import { renderPage } from 'helpers/rendering/render';
 import { detect } from 'helpers/internationalisation/countryGroup';
 import { LinkButton } from '@guardian/src-button';
 
 // ----- Page Startup ----- //
 
-pageInit();
+setUpTrackingAndConsents();
 
 // ----- Render ----- //
 

--- a/support-frontend/assets/pages/showcase/showcase.jsx
+++ b/support-frontend/assets/pages/showcase/showcase.jsx
@@ -64,9 +64,10 @@ const ShowcasePage = () => (
   </Page>
 );
 
+setUpTrackingAndConsents();
+
 const content = <ShowcasePage />;
 
-setUpTrackingAndConsents();
 renderPage(content, 'showcase-landing-page');
 
 export { content };

--- a/support-frontend/assets/pages/showcase/showcase.jsx
+++ b/support-frontend/assets/pages/showcase/showcase.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 
 import { renderPage } from 'helpers/rendering/render';
+import { setUpTrackingAndConsents } from 'helpers/page/statelessPage';
 
 import Page from 'components/page/page';
 
@@ -65,6 +66,7 @@ const ShowcasePage = () => (
 
 const content = <ShowcasePage />;
 
+setUpTrackingAndConsents();
 renderPage(content, 'showcase-landing-page');
 
 export { content };

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -56,4 +56,5 @@ const SubscriptionsLandingPage = ({
 };
 
 setUpTrackingAndConsents();
+
 renderPage(<SubscriptionsLandingPage {...subscriptionsLandingProps()} />, 'subscriptions-landing-page');

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -8,6 +8,7 @@ import Page from 'components/page/page';
 import Footer from 'components/footerCompliant/Footer';
 import { AUDCountries, Canada, EURCountries, GBPCountries, International, NZDCountries, UnitedStates } from 'helpers/internationalisation/countryGroup';
 import headerWithCountrySwitcherContainer from 'components/headers/header/headerWithCountrySwitcher';
+import { setUpTrackingAndConsents } from 'helpers/page/statelessPage';
 
 import { renderPage } from 'helpers/rendering/render';
 import './subscriptionsLanding.scss';
@@ -54,4 +55,5 @@ const SubscriptionsLandingPage = ({
   );
 };
 
+setUpTrackingAndConsents();
 renderPage(<SubscriptionsLandingPage {...subscriptionsLandingProps()} />, 'subscriptions-landing-page');

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -22,6 +22,7 @@ import {
 } from 'helpers/internationalisation/countryGroup';
 import { renderPage } from 'helpers/rendering/render';
 import { routes, promotionTermsUrl } from 'helpers/urls/routes';
+import { setUpTrackingAndConsents } from 'helpers/page/statelessPage';
 
 import FullWidthContainer from 'components/containers/fullWidthContainer';
 import CentredContainer from 'components/containers/centredContainer';
@@ -124,4 +125,5 @@ const WeeklyLandingPage = ({
   );
 };
 
+setUpTrackingAndConsents();
 renderPage(<WeeklyLandingPage {...weeklyLandingProps()} />, reactElementId[countryGroupId]);


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This puts the tracking and CMP back on the subscriptions landing pages where they were mistakenly removed after removing those pages' Redux dependency. I've done a little bit of reorganisation too and given the 'stateless init' function a hopefully clearer name and moved it into a separate file, which should keep Redux out of the bundle for pages that aren't using it.

## Why are you doing this?

We noticed a drop off in the analytics at around the time the PR removing the Redux dependency was merged; there may be other causes but it seems pretty likely that this issue is at least part of it.