### PR TITLE
Restore initialise step for pages without Redux

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -21,7 +21,6 @@ import {
 } from 'helpers/internationalisation/countryGroup';
 import { routes } from 'helpers/urls/routes';
 import { useHasBeenSeen } from 'helpers/customHooks/useHasBeenSeen';
-
 import Page from 'components/page/page';
 import FullWidthContainer from 'components/containers/fullWidthContainer';
 import CentredContainer from 'components/containers/centredContainer';
@@ -40,6 +39,7 @@ import FeedbackWidget from 'pages/digital-subscription-landing/components/feedba
 import { getHeroCtaProps } from './components/paymentSelection/helpers/paymentSelection';
 import EventsModule from 'pages/digital-subscription-landing/components/events/eventsModule';
 import { digitalLandingProps, type DigitalLandingPropTypes } from './digitalSubscriptionLandingProps';
+import { initPageWithoutRedux } from 'helpers/page/page';
 
 // ----- Styles ----- //
 import 'stylesheets/skeleton/skeleton.scss';
@@ -211,6 +211,9 @@ function DigitalLandingPage({
     </Page>
   );
 }
+
+// ----- Page Startup without Redux ----- //
+initPageWithoutRedux();
 
 const props = digitalLandingProps();
 

--- a/support-frontend/assets/pages/error/error404.jsx
+++ b/support-frontend/assets/pages/error/error404.jsx
@@ -4,16 +4,14 @@
 
 import React from 'react';
 
-import { statelessInit as pageInit } from 'helpers/page/page';
+import { initPageWithoutRedux } from 'helpers/page/page';
 import { renderPage } from 'helpers/rendering/render';
 
 import ErrorPage from './components/errorPage';
 
 
-// ----- Page Startup ----- //
-
-pageInit();
-
+// ----- Page Startup without Redux ----- //
+initPageWithoutRedux();
 
 // ----- Render ----- //
 

--- a/support-frontend/assets/pages/error/error500.jsx
+++ b/support-frontend/assets/pages/error/error500.jsx
@@ -4,15 +4,14 @@
 
 import React from 'react';
 
-import { statelessInit as pageInit } from 'helpers/page/page';
+import { initPageWithoutRedux } from 'helpers/page/page';
 import { renderPage } from 'helpers/rendering/render';
 
 import ErrorPage from './components/errorPage';
 
 
-// ----- Page Startup ----- //
-
-pageInit();
+// ----- Page Startup without Redux ----- //
+initPageWithoutRedux();
 
 
 // ----- Render ----- //

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -30,6 +30,7 @@ import { Collection, HomeDelivery } from 'helpers/productPrice/fulfilmentOptions
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 
 import { paperLandingProps, type PaperLandingPropTypes } from './paperSubscriptionLandingProps';
+import { initPageWithoutRedux } from 'helpers/page/page';
 
 // ----- Collection or delivery ----- //
 
@@ -92,6 +93,9 @@ const PaperLandingPage = ({ productPrices, promotionCopy }: PaperLandingPropType
     </Page>
   );
 };
+
+// ----- Page Startup without Redux ----- //
+initPageWithoutRedux();
 
 const content = <PaperLandingPage {...paperLandingProps()} />;
 

--- a/support-frontend/assets/pages/paypal-error/payPalError.jsx
+++ b/support-frontend/assets/pages/paypal-error/payPalError.jsx
@@ -9,14 +9,13 @@ import Header from 'components/headers/header/header';
 import Footer from 'components/footer/footer';
 import PageSection from 'components/pageSection/pageSection';
 import QuestionsContact from 'components/questionsContact/questionsContact';
-import { statelessInit as pageInit } from 'helpers/page/page';
+import { initPageWithoutRedux } from 'helpers/page/page';
 import { renderPage } from 'helpers/rendering/render';
 import { detect } from 'helpers/internationalisation/countryGroup';
 import { LinkButton } from '@guardian/src-button';
 
-// ----- Page Startup ----- //
-
-pageInit();
+// ----- Page Startup without Redux ----- //
+initPageWithoutRedux();
 
 // ----- Render ----- //
 

--- a/support-frontend/assets/pages/showcase/showcase.jsx
+++ b/support-frontend/assets/pages/showcase/showcase.jsx
@@ -25,6 +25,7 @@ import CtaSubscribe from './components/ctaSubscribe';
 import CtaContribute from './components/ctaContribute';
 import OtherProducts from './components/otherProducts';
 import './showcase.scss';
+import { initPageWithoutRedux } from 'helpers/page/page';
 
 // ----- Internationalisation ----- //
 
@@ -62,6 +63,9 @@ const ShowcasePage = () => (
     {countryGroupId === 'GBPCountries' && <OtherProducts />}
   </Page>
 );
+
+// ----- Page Startup without Redux ----- //
+initPageWithoutRedux();
 
 const content = <ShowcasePage />;
 

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -14,6 +14,7 @@ import './subscriptionsLanding.scss';
 
 import SubscriptionLandingContent from './components/subscriptionsLandingContent';
 import { subscriptionsLandingProps, type SubscriptionsLandingPropTypes } from './subscriptionsLandingProps';
+import { initPageWithoutRedux } from 'helpers/page/page';
 
 // ----- Render ----- //
 
@@ -53,5 +54,8 @@ const SubscriptionsLandingPage = ({
     </Page>
   );
 };
+
+// ----- Page Startup without Redux ----- //
+initPageWithoutRedux();
 
 renderPage(<SubscriptionsLandingPage {...subscriptionsLandingProps()} />, 'subscriptions-landing-page');

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -41,6 +41,7 @@ import { promoQueryParam, getPromotionCopy } from 'helpers/productPrice/promotio
 import { getQueryParameter } from 'helpers/urls/url';
 
 import { weeklyLandingProps, type WeeklyLandingPropTypes } from './weeklySubscriptionLandingProps';
+import { initPageWithoutRedux } from 'helpers/page/page';
 
 // ----- Internationalisation ----- //
 
@@ -123,5 +124,8 @@ const WeeklyLandingPage = ({
     </Page>
   );
 };
+
+// ----- Page Startup without Redux ----- //
+initPageWithoutRedux();
 
 renderPage(<WeeklyLandingPage {...weeklyLandingProps()} />, reactElementId[countryGroupId]);


### PR DESCRIPTION
## What are you doing in this PR?

In https://github.com/guardian/support-frontend/pull/3072 we removed Redux from the following landing pages:

- pages/digital-subscription-landing/digitalSubscriptionLanding.jsx 
- pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx 
- pages/showcase/showcase.jsx 
- pages/subscriptions-landing/subscriptionsLanding.jsx 
- pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx 

In doing so we removed `import { init as pageInit } from 'helpers/page/page'` from each of these files as the Redux set-up steps in the function `pageInt` were no longer required. However `pageInt` not only contained Redux set-up steps it also initialised the CMP. By no longer calling `pageInt` the CMP was no longer initialised and as a result none of the tracking dependent on the CMP being initialised was triggered, this includes calls to GA.

To address this I've pulled out the code which initialises the CMP in `helpers/page/page.js` into a function called `cmpInitialisation`, this function will be called from either `init` (used for pages with Redux) or `initPageWithoutRedux` (used for pages without Redux and FKA as `statelessInit`).

I'm now importing `initPageWithoutRedux` in the 5 pages listed above, and I've also renamed the import in the following pages, which previously referred to it as `statelessInit`:

- support-frontend/assets/pages/error/error404.jsx 
- support-frontend/assets/pages/error/error500.jsx 
- support-frontend/assets/pages/paypal-error/payPalError.jsx 

This means the CMP is now initialised on pages with and without Redux.