### PR TITLE
Update nonGiftLandingNotAusNotUS regex to omit gift checkouts

### DIFF
--- a/support-frontend/assets/helpers/abTests/__tests__/abtestTest.js
+++ b/support-frontend/assets/helpers/abTests/__tests__/abtestTest.js
@@ -13,7 +13,7 @@ import { GBPCountries, UnitedStates } from '../../internationalisation/countryGr
 import { pageUrlRegexes } from 'helpers/abTests/abtestDefinitions';
 
 const { subsShowcaseAndDigiSubPages, digiSub } = pageUrlRegexes.subscriptions;
-const { nonGiftLandingNotAusNotUS } = digiSub;
+const { nonGiftLandingNotAusNotUS, nonGiftLandingAndCheckout } = digiSub;
 
 jest.mock('ophan', () => ({
   record: () => null,
@@ -594,20 +594,22 @@ describe('Correct allocation in a multi test environment', () => {
 
 });
 
-describe('targetPage matching for the digital pack product page and showcase page test', () => {
-  it('targetPageMatches returns expected result', () => {
-    expect(targetPageMatches('/uk/subscribe/paper', subsShowcaseAndDigiSubPages)).toEqual(false);
-    expect(targetPageMatches('/uk/subscribe/digital/checkout', subsShowcaseAndDigiSubPages)).toEqual(false);
-    expect(targetPageMatches('/us/subscribe', subsShowcaseAndDigiSubPages)).toEqual(true);
-    expect(targetPageMatches('/us/subscribe/digital', subsShowcaseAndDigiSubPages)).toEqual(true);
-    const withAcquisitionParams = '/uk/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B"componentType"%3A"ACQUISITIONS_HEADER"%2C"componentId"%3A"header_support_subscribe"%2C"source"%3A"GUARDIAN_WEB"%2C"referrerPageviewId"%3A"k8heft91k5c3tnnnmwjd"%2C"referrerUrl"%3A"https%3A%2F%2Fwww.theguardian.com%2Fuk"%7D';
-    expect(targetPageMatches(withAcquisitionParams, subsShowcaseAndDigiSubPages)).toEqual(true);
-    expect(targetPageMatches('/us/subscribe/digital?test=blah', subsShowcaseAndDigiSubPages)).toEqual(true);
-    // Test nonGiftLandingNotAusNotUS regex
-    expect(targetPageMatches('/uk/subscribe/digital', nonGiftLandingNotAusNotUS)).toEqual(true);
-    expect(targetPageMatches('/subscribe/digital/checkout', nonGiftLandingNotAusNotUS)).toEqual(true);
-    expect(targetPageMatches('/us/subscribe/digital', nonGiftLandingNotAusNotUS)).toEqual(false);
-    expect(targetPageMatches('/au/subscribe/digital', nonGiftLandingNotAusNotUS)).toEqual(false);
-    expect(targetPageMatches('/uk/subscribe/digital/gift', nonGiftLandingNotAusNotUS)).toEqual(false);
-  });
+it('targetPage matching', () => {
+  expect(targetPageMatches('/uk/subscribe/paper', subsShowcaseAndDigiSubPages)).toEqual(false);
+  expect(targetPageMatches('/uk/subscribe/digital/checkout', subsShowcaseAndDigiSubPages)).toEqual(false);
+  expect(targetPageMatches('/us/subscribe', subsShowcaseAndDigiSubPages)).toEqual(true);
+  expect(targetPageMatches('/us/subscribe/digital', subsShowcaseAndDigiSubPages)).toEqual(true);
+  const withAcquisitionParams = '/uk/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B"componentType"%3A"ACQUISITIONS_HEADER"%2C"componentId"%3A"header_support_subscribe"%2C"source"%3A"GUARDIAN_WEB"%2C"referrerPageviewId"%3A"k8heft91k5c3tnnnmwjd"%2C"referrerUrl"%3A"https%3A%2F%2Fwww.theguardian.com%2Fuk"%7D';
+  expect(targetPageMatches(withAcquisitionParams, subsShowcaseAndDigiSubPages)).toEqual(true);
+  expect(targetPageMatches('/us/subscribe/digital?test=blah', subsShowcaseAndDigiSubPages)).toEqual(true);
+ // Test nonGiftLandingAndCheckout regex
+ expect(targetPageMatches('/uk/subscribe/digital', nonGiftLandingAndCheckout)).toEqual(true);
+ expect(targetPageMatches('/subscribe/digital/checkout', nonGiftLandingAndCheckout)).toEqual(true);
+ expect(targetPageMatches('/uk/subscribe/digital/gift', nonGiftLandingAndCheckout)).toEqual(false);
+  // Test nonGiftLandingNotAusNotUS regex
+  expect(targetPageMatches('/uk/subscribe/digital', nonGiftLandingNotAusNotUS)).toEqual(true);
+  expect(targetPageMatches('/subscribe/digital/checkout', nonGiftLandingNotAusNotUS)).toEqual(true);
+  expect(targetPageMatches('/us/subscribe/digital', nonGiftLandingNotAusNotUS)).toEqual(false);
+  expect(targetPageMatches('/au/subscribe/digital', nonGiftLandingNotAusNotUS)).toEqual(false);
+  expect(targetPageMatches('/uk/subscribe/digital/gift', nonGiftLandingNotAusNotUS)).toEqual(false);
 });

--- a/support-frontend/assets/helpers/abTests/__tests__/abtestTest.js
+++ b/support-frontend/assets/helpers/abTests/__tests__/abtestTest.js
@@ -12,7 +12,8 @@ import type { Participations } from '../abtest';
 import { GBPCountries, UnitedStates } from '../../internationalisation/countryGroup';
 import { pageUrlRegexes } from 'helpers/abTests/abtestDefinitions';
 
-const { subsShowcaseAndDigiSubPages } = pageUrlRegexes.subscriptions;
+const { subsShowcaseAndDigiSubPages, digiSub } = pageUrlRegexes.subscriptions;
+const { nonGiftLandingNotAusNotUS } = digiSub;
 
 jest.mock('ophan', () => ({
   record: () => null,
@@ -594,11 +595,19 @@ describe('Correct allocation in a multi test environment', () => {
 });
 
 describe('targetPage matching for the digital pack product page and showcase page test', () => {
-  expect(targetPageMatches('/uk/subscribe/paper', subsShowcaseAndDigiSubPages)).toEqual(false);
-  expect(targetPageMatches('/uk/subscribe/digital/checkout', subsShowcaseAndDigiSubPages)).toEqual(false);
-  expect(targetPageMatches('/us/subscribe', subsShowcaseAndDigiSubPages)).toEqual(true);
-  expect(targetPageMatches('/us/subscribe/digital', subsShowcaseAndDigiSubPages)).toEqual(true);
-  const withAcquisitionParams = '/uk/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B"componentType"%3A"ACQUISITIONS_HEADER"%2C"componentId"%3A"header_support_subscribe"%2C"source"%3A"GUARDIAN_WEB"%2C"referrerPageviewId"%3A"k8heft91k5c3tnnnmwjd"%2C"referrerUrl"%3A"https%3A%2F%2Fwww.theguardian.com%2Fuk"%7D';
-  expect(targetPageMatches(withAcquisitionParams, subsShowcaseAndDigiSubPages)).toEqual(true);
-  expect(targetPageMatches('/us/subscribe/digital?test=blah', subsShowcaseAndDigiSubPages)).toEqual(true);
+  it('targetPageMatches returns expected result', () => {
+    expect(targetPageMatches('/uk/subscribe/paper', subsShowcaseAndDigiSubPages)).toEqual(false);
+    expect(targetPageMatches('/uk/subscribe/digital/checkout', subsShowcaseAndDigiSubPages)).toEqual(false);
+    expect(targetPageMatches('/us/subscribe', subsShowcaseAndDigiSubPages)).toEqual(true);
+    expect(targetPageMatches('/us/subscribe/digital', subsShowcaseAndDigiSubPages)).toEqual(true);
+    const withAcquisitionParams = '/uk/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B"componentType"%3A"ACQUISITIONS_HEADER"%2C"componentId"%3A"header_support_subscribe"%2C"source"%3A"GUARDIAN_WEB"%2C"referrerPageviewId"%3A"k8heft91k5c3tnnnmwjd"%2C"referrerUrl"%3A"https%3A%2F%2Fwww.theguardian.com%2Fuk"%7D';
+    expect(targetPageMatches(withAcquisitionParams, subsShowcaseAndDigiSubPages)).toEqual(true);
+    expect(targetPageMatches('/us/subscribe/digital?test=blah', subsShowcaseAndDigiSubPages)).toEqual(true);
+    // Test nonGiftLandingNotAusNotUS regex
+    expect(targetPageMatches('/uk/subscribe/digital', nonGiftLandingNotAusNotUS)).toEqual(true);
+    expect(targetPageMatches('/subscribe/digital/checkout', nonGiftLandingNotAusNotUS)).toEqual(true);
+    expect(targetPageMatches('/us/subscribe/digital', nonGiftLandingNotAusNotUS)).toEqual(false);
+    expect(targetPageMatches('/au/subscribe/digital', nonGiftLandingNotAusNotUS)).toEqual(false);
+    expect(targetPageMatches('/uk/subscribe/digital/gift', nonGiftLandingNotAusNotUS)).toEqual(false);
+  });
 });

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -25,7 +25,7 @@ export const pageUrlRegexes = {
       giftLandingAndCheckout: /\/subscribe\/digital(\/checkout)?\/gift(\?.*)?$/,
       // Requires /subscribe/digital, allows /checkout, allows any query string
       nonGiftLandingAndCheckout: /\/subscribe\/digital(\/checkout)?(\?.*)?$/,
-      nonGiftLandingNotAusNotUS: /((uk|ca|eu|nz|int)\/subscribe\/digital?(\\?.*)?$)|(\/subscribe\/digital\/checkout?(\\?.*)?$)/,
+      nonGiftLandingNotAusNotUS: /((uk|ca|eu|nz|int)\/subscribe\/digital(?!\/gift).?(\\?.*)?$)|(\/subscribe\/digital\/checkout?(\\?.*)?$)/,
     },
   },
 };


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

We don't watch to show the `digiSubEventsTest` AB test on the Digital Subs Gifting landing page,  however the current `nonGiftLandingNotAusNotUS` regex still matches the gifting URL "https://support.theguardian.com/uk/subscribe/digital/gift", as can be seen here: https://regex101.com/r/HO8nZC/1

This PR updates the `nonGiftLandingNotAusNotUS` regex to omit the gifting landing page URLs, as can be seen here: https://regex101.com/r/OCYfxg/1

I've also included some unit tests to validate this.