### PR TITLE
fix SendAcquisitionEventSpec 

### DIFF
--- a/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
+++ b/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
@@ -6,7 +6,7 @@ import com.amazon.pay.response.ipn.model.{Notification, NotificationType, Refund
 import com.amazon.pay.response.model.{AuthorizationDetails, OrderReferenceDetails, Status}
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync
 import com.amazonaws.services.sqs.model.SendMessageResult
-import com.gu.support.acquisitions.{AcquisitionsStreamEc2OrLocalConfig, AcquisitionsStreamService, BigQueryConfig, BigQueryService}
+import com.gu.support.acquisitions.{AcquisitionsStreamEc2OrLocalConfig, AcquisitionsStreamService, AcquisitionsStreamServiceImpl, BigQueryConfig, BigQueryService}
 import com.typesafe.scalalogging.StrictLogging
 import conf.BigQueryConfigLoader.bigQueryConfigParameterStoreLoadable
 import conf.AcquisitionsStreamConfigLoader.acquisitionsStreamec2OrLocalConfigLoader
@@ -195,7 +195,7 @@ object AmazonPayBackend {
         .map(new BigQueryService(_)): InitializationResult[BigQueryService],
       configLoader
         .loadConfig[Environment, AcquisitionsStreamEc2OrLocalConfig](env)
-        .map(new AcquisitionsStreamService(_)): InitializationResult[AcquisitionsStreamService],
+        .map(new AcquisitionsStreamServiceImpl(_)): InitializationResult[AcquisitionsStreamService],
       configLoader
         .loadConfig[Environment, EmailConfig](env)
         .andThen(EmailService.fromEmailConfig): InitializationResult[EmailService],

--- a/support-payment-api/src/main/scala/backend/PaypalBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaypalBackend.scala
@@ -6,7 +6,7 @@ import cats.syntax.apply._
 import cats.syntax.either._
 import cats.syntax.validated._
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync
-import com.gu.support.acquisitions.{BigQueryConfig, BigQueryService, AcquisitionsStreamService, AcquisitionsStreamEc2OrLocalConfig}
+import com.gu.support.acquisitions.{AcquisitionsStreamEc2OrLocalConfig, AcquisitionsStreamService, AcquisitionsStreamServiceImpl, BigQueryConfig, BigQueryService}
 import com.paypal.api.payments.Payment
 import com.typesafe.scalalogging.StrictLogging
 import conf.BigQueryConfigLoader.bigQueryConfigParameterStoreLoadable
@@ -222,7 +222,7 @@ object PaypalBackend {
         .map(new BigQueryService(_)): InitializationResult[BigQueryService],
       configLoader
         .loadConfig[Environment, AcquisitionsStreamEc2OrLocalConfig](env)
-        .map(new AcquisitionsStreamService(_)): InitializationResult[AcquisitionsStreamService],
+        .map(new AcquisitionsStreamServiceImpl(_)): InitializationResult[AcquisitionsStreamService],
       configLoader
         .loadConfig[Environment, EmailConfig](env)
         .andThen(EmailService.fromEmailConfig): InitializationResult[EmailService],

--- a/support-payment-api/src/main/scala/backend/StripeBackend.scala
+++ b/support-payment-api/src/main/scala/backend/StripeBackend.scala
@@ -8,7 +8,7 @@ import cats.syntax.validated._
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs.model.SendMessageResult
-import com.gu.support.acquisitions.{BigQueryConfig, BigQueryService, AcquisitionsStreamService, AcquisitionsStreamEc2OrLocalConfig}
+import com.gu.support.acquisitions.{AcquisitionsStreamEc2OrLocalConfig, AcquisitionsStreamService, AcquisitionsStreamServiceImpl, BigQueryConfig, BigQueryService}
 import com.stripe.model.{Charge, PaymentIntent}
 import com.typesafe.scalalogging.StrictLogging
 import conf.BigQueryConfigLoader.bigQueryConfigParameterStoreLoadable
@@ -322,7 +322,7 @@ object StripeBackend {
         .map(new BigQueryService(_)): InitializationResult[BigQueryService],
       configLoader
         .loadConfig[Environment, AcquisitionsStreamEc2OrLocalConfig](env)
-        .map(new AcquisitionsStreamService(_)): InitializationResult[AcquisitionsStreamService],
+        .map(new AcquisitionsStreamServiceImpl(_)): InitializationResult[AcquisitionsStreamService],
       configLoader
         .loadConfig[Environment, EmailConfig](env)
         .andThen(EmailService.fromEmailConfig): InitializationResult[EmailService],

--- a/support-workers/src/main/scala/com/gu/services/Services.scala
+++ b/support-workers/src/main/scala/com/gu/services/Services.scala
@@ -8,7 +8,7 @@ import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.paypal.PayPalService
 import com.gu.salesforce.SalesforceService
 import com.gu.stripe.StripeService
-import com.gu.support.acquisitions.BigQueryService
+import com.gu.support.acquisitions.{AcquisitionsStreamLambdaConfig, AcquisitionsStreamService, AcquisitionsStreamServiceImpl, BigQueryService}
 import com.gu.support.catalog.CatalogService
 import com.gu.support.config.Stages.{CODE, DEV, PROD}
 import com.gu.support.config.TouchPointEnvironments
@@ -18,11 +18,9 @@ import com.gu.support.redemption.gifting.generator.GiftCodeGeneratorService
 import com.gu.zuora.{ZuoraGiftService, ZuoraService}
 import com.gu.supporterdata.model.Stage.{DEV => DynamoStageDEV, PROD => DynamoStagePROD, UAT => DynamoStageUAT}
 import com.gu.supporterdata.services.SupporterDataDynamoService
-import com.gu.support.acquisitions.{AcquisitionsStreamService, AcquisitionsStreamLambdaConfig}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import com.gu.support.acquisitions.AcquisitionsStreamLambdaConfig
 
 trait ServiceProvider {
   private lazy val config = Configuration.load()
@@ -48,7 +46,7 @@ class Services(isTestUser: Boolean, val config: Configuration) {
   lazy val catalogService = CatalogService(TouchPointEnvironments.fromStage(stage, isTestUser))
   lazy val giftCodeGenerator = new GiftCodeGeneratorService
   lazy val bigQueryService = new BigQueryService(bigQueryConfigProvider.get(isTestUser))
-  lazy val acquisitionsStreamService = new AcquisitionsStreamService(AcquisitionsStreamLambdaConfig(config.acquisitionsKinesisStreamName))
+  lazy val acquisitionsStreamService: AcquisitionsStreamService = new AcquisitionsStreamServiceImpl(AcquisitionsStreamLambdaConfig(config.acquisitionsKinesisStreamName))
   val supporterDynamoStage = (Configuration.stage, isTestUser) match {
     case (DEV, false) => DynamoStageDEV
     case (CODE, false) => DynamoStageDEV

--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/SendAcquisitionEventSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/SendAcquisitionEventSpec.scala
@@ -48,6 +48,13 @@ class SendAcquisitionEventSpec extends AsyncLambdaSpec with MockContext {
 
 object MockAcquisitionHelper extends MockitoSugar {
 
+  val mockAcquisitionsStreamService = new AcquisitionsStreamService {
+    def putAcquisition(acquisition: AcquisitionDataRow): EitherT[Future, String, Unit] =
+      EitherT(Future.successful(
+        Right(()): Either[String,Unit]
+      ))
+  }
+
   lazy val mockServices = {
     val configuration = Configuration.load()
     //Mock the Acquisition service
@@ -56,16 +63,9 @@ object MockAcquisitionHelper extends MockitoSugar {
     val acquisitionService = AcquisitionServiceBuilder.build(isTestService = true)
     val bigQueryService = new BigQueryService(configuration.bigQueryConfigProvider.get())
 
-    val acquisitionsStreamService = mock[AcquisitionsStreamService]
-    val acquisitionsStreamServiceResult = EitherT(Future.successful(
-      Right(()): Either[List[String],Unit]
-    ))
-    when(acquisitionsStreamService.putAcquisitionWithRetry(any[AcquisitionDataRow], any[Int])(any[ExecutionContext]))
-      .thenReturn(acquisitionsStreamServiceResult)
-
     when(services.acquisitionService).thenReturn(acquisitionService)
     when(services.bigQueryService).thenReturn(bigQueryService)
-    when(services.acquisitionsStreamService).thenReturn(acquisitionsStreamService)
+    when(services.acquisitionsStreamService).thenReturn(mockAcquisitionsStreamService)
     when(serviceProvider.forUser(any[Boolean])).thenReturn(services)
     serviceProvider
   }


### PR DESCRIPTION
The `AcquisitionsStreamService` was introduced as a service in a previous PR, and this test is now failing.
I've added a mock implementation that always succeeds