### PR TITLE
Enable amount selection from the url

### DIFF
--- a/support-frontend/assets/helpers/forms/checkouts.js
+++ b/support-frontend/assets/helpers/forms/checkouts.js
@@ -76,6 +76,10 @@ function getContributionTypeFromUrl(): ?ContributionType {
   return toContributionType(getQueryParameter('selected-contribution-type'));
 }
 
+function getAmountFromUrl(): ?number {
+  return parseInt(getQueryParameter('selected-amount'), 10);
+}
+
 // Returns an array of Payment Methods, in the order of preference,
 // i.e the first element in the array will be the default option
 function getPaymentMethods(
@@ -233,6 +237,7 @@ export {
   getValidContributionTypesFromUrlOrElse,
   getContributionTypeFromSession,
   getContributionTypeFromUrl,
+  getAmountFromUrl,
   toHumanReadableContributionType,
   getValidPaymentMethods,
   getPaymentMethodToSelect,


### PR DESCRIPTION
e.g.
`?selected-amount=15&selected-contribution-type=monthly`

If the selected amount is available in the set of configured amounts then this will be selected. If it's not available, we set it as the 'other' amount.

E.g. an amount is available:
![Screen Shot 2021-07-05 at 12 15 31](https://user-images.githubusercontent.com/1513454/124463447-d002c580-dd8a-11eb-9edf-a306987bd5c0.png)


An amount is not available:
![Screen Shot 2021-07-05 at 12 15 42](https://user-images.githubusercontent.com/1513454/124463454-d2fdb600-dd8a-11eb-8b07-eb7f6059b916.png)
