### PR TITLE
Update payment selection logic to use country rather than currency

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
@@ -8,16 +8,15 @@ import {
   SvgDirectDebit,
   SvgPayPal,
 } from '@guardian/src-icons';
-
+import type { IsoCountry } from 'helpers/internationalisation/country';
 import Rows from 'components/base/rows';
 import { type Option } from 'helpers/types/option';
 import { DirectDebit, PayPal, Stripe, type PaymentMethod } from 'helpers/forms/paymentMethods';
 import { supportedPaymentMethods } from 'helpers/subscriptionsForms/countryPaymentMethods';
-import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { ErrorMessage } from 'helpers/subscriptionsForms/validation';
 
 type PropTypes = {|
-  currencyId: IsoCurrency,
+  country: IsoCountry,
   paymentMethod: Option<PaymentMethod>,
   setPaymentMethod: Function,
   validationError: Option<ErrorMessage>,
@@ -51,7 +50,7 @@ const RadioWithImage = (props: RadioWithImagePropTypes) => (
 );
 
 function PaymentMethodSelector(props: PropTypes) {
-  const paymentMethods = supportedPaymentMethods(props.currencyId);
+  const paymentMethods = supportedPaymentMethods(props.country);
 
   return (
     <Rows gap="large">

--- a/support-frontend/assets/helpers/subscriptionsForms/countryPaymentMethods.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/countryPaymentMethods.js
@@ -2,10 +2,10 @@
 
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import { DirectDebit, PayPal, Stripe } from 'helpers/forms/paymentMethods';
-import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import type { IsoCountry } from 'helpers/internationalisation/country';
 
-function supportedPaymentMethods(currencyId: IsoCurrency): PaymentMethod[] {
-  const countrySpecific: PaymentMethod[] = currencyId === 'GBP' ? [DirectDebit, Stripe, PayPal] : [Stripe, PayPal];
+function supportedPaymentMethods(country: IsoCountry): PaymentMethod[] {
+  const countrySpecific: PaymentMethod[] = country === 'GB' ? [DirectDebit, Stripe, PayPal] : [Stripe, PayPal];
 
   return countrySpecific;
 }

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -195,7 +195,7 @@ function DigitalCheckoutForm(props: PropTypes) {
           {paymentMethods.length > 1 ?
             <FormSection title="How would you like to pay?">
               <PaymentMethodSelector
-                currencyId={props.currencyId}
+                country={props.country}
                 paymentMethod={props.paymentMethod}
                 setPaymentMethod={props.setPaymentMethod}
                 validationError={firstError('paymentMethod', props.formErrors)}

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.jsx
@@ -236,7 +236,7 @@ function DigitalCheckoutFormGift(props: PropTypes) {
           {paymentMethods.length > 1 ?
             <FormSection title="How would you like to pay?">
               <PaymentMethodSelector
-                currencyId={props.currencyId}
+                country={props.country}
                 paymentMethod={props.paymentMethod}
                 setPaymentMethod={props.setPaymentMethod}
                 validationError={firstError('paymentMethod', props.formErrors)}

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -385,7 +385,7 @@ function PaperCheckoutForm(props: PropTypes) {
           {paymentMethods.length > 1 ?
             <FormSection cssOverrides={removeTopBorder} title="How would you like to pay?">
               <PaymentMethodSelector
-                currencyId="GBP"
+                country={props.country}
                 paymentMethod={props.paymentMethod}
                 setPaymentMethod={props.setPaymentMethod}
                 validationError={firstError('paymentMethod', props.formErrors)}

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -312,7 +312,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
           {paymentMethods.length > 1 ?
             <FormSection title="How would you like to pay?">
               <PaymentMethodSelector
-                currencyId={props.currencyId}
+                country={props.billingCountry}
                 paymentMethod={props.paymentMethod}
                 setPaymentMethod={props.setPaymentMethod}
                 validationError={firstError('paymentMethod', props.formErrors)}

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
@@ -338,7 +338,7 @@ function WeeklyCheckoutFormGifting(props: PropTypes) {
           {paymentMethods.length > 1 ?
             <FormSection title="How would you like to pay?">
               <PaymentMethodSelector
-                currencyId={props.currencyId}
+                country={props.billingCountry}
                 paymentMethod={props.paymentMethod}
                 setPaymentMethod={props.setPaymentMethod}
                 validationError={firstError('paymentMethod', props.formErrors)}


### PR DESCRIPTION
## What are you doing in this PR?
This changes the payment selection logic so we show direct debit as an option if the country is GB rather than if the currency is GBP.

[**Trello Card**](https://trello.com/c/OaMMxRYL/3782-only-enable-direct-debit-where-countryid-gb)

## Why are you doing this?
We've had a few errors where people from the Isle of Man try to pay with direct debit (which is an option presented to them) and their payments can't be processed because they're not in GB.

## Is this an AB test?
- [ ] Yes
- [x] No

