### PR TITLE
Set isRecurringContributor using MDAPI

### DIFF
--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -130,10 +130,6 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     dispatch(setPostDeploymentTestUser(true));
   }
 
-  if (getCookie('gu_recurring_contributor') === 'true') {
-    dispatch(setIsRecurringContributor());
-  }
-
   if (getCookie('gu.contributions.contrib-timestamp')) {
     dispatch(setIsReturningContributor(true));
   }
@@ -149,6 +145,17 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     dispatch(setStateField(window.guardian.user.address4 || window.guardian.geoip.stateCode));
     dispatch(setIsSignedIn(true));
     dispatch(setEmailValidated(getEmailValidatedFromUserCookie(cookie.get('GU_U'))));
+
+    fetch(`${window.guardian.mdapiUrl}/user-attributes/me`, {
+      mode: 'cors',
+      credentials: 'include',
+    }).then(response => response.json())
+      .then((attributes) => {
+        if (attributes.recurringContributionPaymentPlan) {
+          dispatch(setIsRecurringContributor());
+        }
+      });
+
   } else if (userAppearsLoggedIn) { // TODO - remove in another PR as this condition is deprecated
     fetch(routes.oneOffContribAutofill, { credentials: 'include' }).then((response) => {
       if (response.ok) {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
@@ -41,7 +41,6 @@ type PropTypes = {|
   billingState: StateProvince | null,
   checkoutFormHasBeenSubmitted: boolean,
   isSignedIn: boolean,
-  isRecurringContributor: boolean,
   userTypeFromIdentityResponse: UserTypeFromIdentityResponse,
   updateFirstName: (Event) => void,
   updateLastName: (Event) => void,
@@ -65,7 +64,6 @@ const mapStateToProps = (state: State) => ({
   checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
   billingState: getCheckoutFormValue(state.page.form.formData.billingState, state.page.user.stateField),
   isSignedIn: state.page.user.isSignedIn,
-  isRecurringContributor: state.page.user.isRecurringContributor,
   userTypeFromIdentityResponse: state.page.form.userTypeFromIdentityResponse,
   contributionType: state.page.form.contributionType,
 });

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -355,7 +355,6 @@ const sendFormSubmitEventForPayPalRecurring = () =>
       flowPrefix: 'npf',
       form: getForm('form--contribution'),
       isSignedIn: state.page.user.isSignedIn,
-      isRecurringContributor: state.page.user.isRecurringContributor,
       setFormIsValid: (isValid: boolean) => dispatch(setFormIsValid(isValid)),
       setCheckoutFormHasBeenSubmitted: () => dispatch(setCheckoutFormHasBeenSubmitted()),
     };


### PR DESCRIPTION
The `gu_recurring_contributor` cookie is used for 2 things:
1. on dotcom: to hide support messaging,
2. on the contributions landing page: to prevent people from creating more than one recurring contribution.

The second use is problematic because the cookie is set when support-workers runs. This means if it fails during/after then the user cannot retry unless they delete the cookie.
With this PR, the landing page instead queries MDAPI to find out if the user has a recurring contribution. This does mean that non-signed-in users will not have this check.

Separately, we should delay setting the cookie until support-workers completes or hits the timeout.