### PR TITLE
Aus moment social share

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -225,6 +225,7 @@ const ContributionThankYou = ({
           campaignSettings && campaignSettings.createReferralCodes
         }
         campaignCode={campaignSettings && campaignSettings.campaignCode}
+        countryId={countryId}
       />
     ),
     shouldShow: true,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSocialShare.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSocialShare.jsx
@@ -22,6 +22,7 @@ import {
   OPHAN_COMPONENT_ID_SOCIAL_EMAIL,
 } from './utils/ophan';
 import { trackComponentClick, trackComponentLoad } from 'helpers/tracking/behaviour';
+import type { IsoCountry } from 'helpers/internationalisation/country';
 import { generateReferralCode } from '../../../../helpers/campaigns/campaignReferralCodes';
 import { css } from '@emotion/core';
 import { space } from '@guardian/src-foundations';
@@ -37,13 +38,15 @@ const buttonsContainer = css`
 type ContributionThankYouSocialShareProps = {|
   email: string,
   createReferralCodes: boolean,
-  campaignCode: ?string
+  campaignCode: ?string,
+  countryId: IsoCountry,
 |};
 
 const ContributionThankYouSocialShare = ({
   email,
   createReferralCodes,
   campaignCode,
+  countryId,
 }: ContributionThankYouSocialShareProps) => {
   useEffect(() => {
     trackComponentLoad(OPHAN_COMPONENT_ID_SOCIAL);
@@ -54,17 +57,21 @@ const ContributionThankYouSocialShare = ({
       ? generateReferralCode(email, campaignCode)
       : null;
 
+  const copy = countryId === 'AU' ?
+    'Your voice matters. By sharing a message of support for Guardian Australia, you can help us grow our community. ' +
+    'Together, we can make a difference.' :
+    'Invite your followers to support the Guardian’s open, independent reporting.';
+
   const actionIcon = <SvgShare />;
   const actionHeader = <ActionHeader title="Share your support" />;
   const actionBody = (
     <ActionBody>
       <p>
-        Invite your followers to support the Guardian’s open, independent
-        reporting.
+        {copy}
       </p>
       <div css={buttonsContainer}>
         <LinkButton
-          href={getFacebookShareLink(referralCode)}
+          href={getFacebookShareLink(campaignCode, referralCode)}
           onClick={() =>
             trackComponentClick(OPHAN_COMPONENT_ID_SOCIAL_FACEBOOK)
           }
@@ -76,7 +83,7 @@ const ContributionThankYouSocialShare = ({
           hideLabel
         />
         <LinkButton
-          href={getTwitterShareLink(referralCode)}
+          href={getTwitterShareLink(countryId, campaignCode, referralCode)}
           onClick={() => trackComponentClick(OPHAN_COMPONENT_ID_SOCIAL_TWITTER)}
           target="_blank"
           rel="noopener noreferrer"
@@ -98,7 +105,7 @@ const ContributionThankYouSocialShare = ({
           hideLabel
         />
         <LinkButton
-          href={getEmailShareLink(referralCode)}
+          href={getEmailShareLink(campaignCode, referralCode)}
           onClick={() => trackComponentClick(OPHAN_COMPONENT_ID_SOCIAL_EMAIL)}
           target="_blank"
           rel="noopener noreferrer"

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/utils/social.js
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/utils/social.js
@@ -1,5 +1,7 @@
 // @flow
 
+import type { IsoCountry } from 'helpers/internationalisation/country';
+
 const appendReferralCode = (
   url: string,
   platform: string,
@@ -13,38 +15,47 @@ const INTCMP_FACEBOOK = 'component-share-facebook';
 const INTCMP_TWITTER = 'component-share-twitter';
 const INTCMP_MAIL = 'component-share-mail';
 const LANDING_PAGE_URL = 'https://support.theguardian.com/contribute';
-const LANDING_PAGE_URL_FACEBOOK = `${LANDING_PAGE_URL}?INTCMP=${INTCMP_FACEBOOK}`;
-const LANDING_PAGE_URL_TWITTER = `${LANDING_PAGE_URL}?INTCMP=${INTCMP_TWITTER}`;
 
-const emailLandingPageUrl = (referralCode: ?string) =>
-  appendReferralCode(
-    `${LANDING_PAGE_URL}?INTCMP=${INTCMP_MAIL}`,
+const emailLandingPageUrl = (campaignCode: ?string, referralCode: ?string): string => {
+  const intcmp = campaignCode ? `${INTCMP_MAIL}-${campaignCode}` : INTCMP_MAIL;
+  return appendReferralCode(
+    `${LANDING_PAGE_URL}?INTCMP=${intcmp}`,
     'email',
     referralCode,
   );
+};
 
 const TWITTER_TEXT_COPY =
   'Join me and over one million others in supporting a different model for open, independent journalism. Together we can help safeguard The Guardian’s future – so more people, across the world, can keep accessing factual information for free';
-const EMAIL_SUBJECT_COPY = 'Join me in supporting open, independent journalism';
-const emailBodyCopy = (referralCode: ?string) =>
-  `Join me and over one million others in supporting a different model for open, independent journalism. Together we can help safeguard The Guardian’s future – so more people, across the world, can keep accessing factual information for free: ${emailLandingPageUrl(referralCode)}`;
+const TWITTER_TEXT_COPY_AU =
+  'I support Guardian Australia because I believe in rigorous, independent journalism that’s open for everyone to read. Join me by making a contribution and together we can be a voice for change. #supportGuardianAustralia';
 
-export const getFacebookShareLink = (referralCode: ?string): string => {
+const EMAIL_SUBJECT_COPY = 'Join me in supporting open, independent journalism';
+const emailBodyCopy = (campaignCode: ?string, referralCode: ?string) =>
+  `Join me and over one million others in supporting a different model for open, independent journalism. Together we can help safeguard The Guardian’s future – so more people, across the world, can keep accessing factual information for free: ${emailLandingPageUrl(campaignCode, referralCode)}`;
+
+export const getFacebookShareLink = (campaignCode: ?string, referralCode: ?string): string => {
+  const intcmp = campaignCode ? `${INTCMP_FACEBOOK}-${campaignCode}` : INTCMP_FACEBOOK;
+  const landingPageUrl = `${LANDING_PAGE_URL}?INTCMP=${intcmp}`;
+
   const encodedUrl = appendReferralCode(
-    LANDING_PAGE_URL_FACEBOOK,
+    landingPageUrl,
     'facebook',
     referralCode,
   );
   return `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`;
 };
 
-export const getTwitterShareLink = (referralCode: ?string): string => {
+export const getTwitterShareLink = (countryId: IsoCountry, campaignCode: ?string, referralCode: ?string): string => {
+  const intcmp = campaignCode ? `${INTCMP_TWITTER}-${campaignCode}` : INTCMP_TWITTER;
+  const landingPageUrl = `${LANDING_PAGE_URL}?INTCMP=${intcmp}`;
+
   const encodedUrl = appendReferralCode(
-    LANDING_PAGE_URL_TWITTER,
+    landingPageUrl,
     'twitter',
     referralCode,
   );
-  const encodedText = encodeURI(TWITTER_TEXT_COPY);
+  const encodedText = encodeURI(countryId === 'AU' ? TWITTER_TEXT_COPY_AU : TWITTER_TEXT_COPY);
   return `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedText}`;
 };
 
@@ -57,8 +68,8 @@ export const getLinkedInShareLink = (referralCode: ?string): string => {
   return `https://www.linkedin.com/shareArticle?mini=true&url=${encodedUrl}`;
 };
 
-export const getEmailShareLink = (referralCode: ?string): string => {
+export const getEmailShareLink = (campaignCode: ?string, referralCode: ?string): string => {
   const encodedSubject = encodeURI(EMAIL_SUBJECT_COPY);
-  const encodedBody = encodeURI(emailBodyCopy(referralCode));
+  const encodedBody = encodeURI(emailBodyCopy(campaignCode, referralCode));
   return `mailto:?subject=${encodedSubject}&body=${encodedBody}`;
 };


### PR DESCRIPTION
1. Different copy in the social share component
2. Add campaign code to the INTCMP (facebook/twitter/email)
3. Different copy for twitter

![Screen Shot 2021-07-13 at 08 40 46](https://user-images.githubusercontent.com/1513454/125412173-90edf900-e3b6-11eb-8169-f54b72279a12.png)

Facebook:
`https://www.facebook.com/sharer/sharer.php?u=https://support.theguardian.com/contribute?INTCMP=component-share-facebook-Aus_moment_2021`

Twitter:
`https://twitter.com/intent/tweet?url=https://support.theguardian.com/contribute?INTCMP=component-share-twitter-Aus_moment_2021&text=I%20support%20Guardian%20Australia%20because%20I%20believe%20in%20rigorous,%20independent%20journalism%20that%E2%80%99s%20open%20for%20everyone%20to%20read.%20Join%20me%20by%20making%20a%20contribution%20and%20together%20we%20can%20be%20a%20voice%20for%20change.%20#supportGuardianAustralia`

Email:
`mailto:?subject=Join%20me%20in%20supporting%20open,%20independent%20journalism&body=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open,%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people,%20across%20the%20world,%20can%20keep%20accessing%20factual%20information%20for%20free:%20https://support.theguardian.com/contribute?INTCMP=component-share-mail-Aus_moment_2021`