### PR TITLE
Remove tickets offer from comparison table

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/comparison/tableContents.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/comparison/tableContents.jsx
@@ -12,7 +12,6 @@ import { type TableRow } from './comparisonTable';
 import { SvgNews } from 'components/icons/news';
 import { SvgAdFree } from 'components/icons/adFree';
 import { SvgEditionsIcon, SvgLiveAppIcon } from 'components/icons/appsIcon';
-import { SvgTicket } from 'components/icons/ticket';
 import { SvgOffline } from 'components/icons/offlineReading';
 import { SvgCrosswords } from 'components/icons/crosswords';
 import { SvgFreeTrial } from 'components/icons/freeTrial';
@@ -158,13 +157,6 @@ export const tableContent: Array<TableRow> = [
       <span css={[hideOnVerySmall, noWrap]}>;&nbsp;</span>
       <span css={hideOnVerySmall}>Live and Discover</span></>,
     ariaLabel: 'The Guardian app with premium features, Live and Discover',
-    free: <Padlock />,
-    paid: <Checkmark />,
-  },
-  {
-    icon: <div css={iconContainer}><SvgTicket /></div>,
-    description: 'Six free tickets to Guardian events',
-    ariaLabel: 'Six free tickets to Guardian events',
     free: <Padlock />,
     paid: <Checkmark />,
   },


### PR DESCRIPTION
## What are you doing in this PR?
Removing the comparison table line that says that we are offering six free tickets to events, as this was not meant to be in the test version, this was just for the qual tests.

This is to fix an issue from this PR: https://github.com/guardian/support-frontend/pull/3145

## Why are you doing this?
To correct the content of the new comparison table.

## Screenshots
![Screen Shot 2021-07-14 at 16 30 42](https://user-images.githubusercontent.com/16781258/125650139-36158a99-7e75-4a6d-b60a-a795225f3bd3.png)

![Screen Shot 2021-07-14 at 16 31 20](https://user-images.githubusercontent.com/16781258/125650203-299e76c0-7c50-4e6b-90ff-cbeb0043252e.png)
