### PR TITLE
Swap out marked for snarkdown

### DIFF
--- a/support-frontend/assets/helpers/productPrice/__tests__/promotionsTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/promotionsTests.js
@@ -1,0 +1,28 @@
+import { getPromotionCopy } from '../promotions';
+
+const sanitisablePromotionCopy = {
+  title: 'The Guardian Weekly',
+  description: 'The Guardian Weekly magazine:\n- is a round-up of the [world news opinion and long reads that have shaped the week.](https://www.theguardian.com/about/journalism)\n- with striking photography and insightful companion pieces, all handpicked from The Guardian and The Observer.',
+  roundel: '**Save _25%_ for a year!**',
+};
+
+describe('getPromotionCopy', () => {
+  it('should return promotion copy if it exists', () => {
+
+    expect(getPromotionCopy()).toEqual({});
+
+    expect(getPromotionCopy(sanitisablePromotionCopy)).not.toEqual({});
+
+  });
+
+  it('should return a santised html string when sanitisable promotion copy is provided', () => {
+
+    expect(getPromotionCopy(sanitisablePromotionCopy).title).toEqual(sanitisablePromotionCopy.title);
+
+    expect(getPromotionCopy(sanitisablePromotionCopy).description).toEqual('The Guardian Weekly magazine:<ul><li>is a round-up of the <a href="https://www.theguardian.com/about/journalism">world news opinion and long reads that have shaped the week.</a></li><li>with striking photography and insightful companion pieces, all handpicked from The Guardian and The Observer.</li></ul>');
+
+    expect(getPromotionCopy(sanitisablePromotionCopy).roundel).toEqual('<strong>Save <em>25%</em> for a year!</strong>');
+
+  });
+
+});

--- a/support-frontend/assets/helpers/productPrice/promotions.jsx
+++ b/support-frontend/assets/helpers/productPrice/promotions.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import marked from 'marked';
+import snarkdown from 'snarkdown';
 import DOMPurify from 'dompurify';
 
 import { getQueryParameter } from 'helpers/urls/url';
@@ -118,7 +118,7 @@ function getPromotion(
 function getSanitisedHtml(markdownString: string) {
   // ensure we don't accidentally inject dangerous html into the page
   return DOMPurify.sanitize(
-    marked(markdownString),
+    snarkdown(markdownString),
     { ALLOWED_TAGS: ['em', 'strong', 'ul', 'li', 'a', 'p'] },
   );
 }

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -82,7 +82,7 @@
     "@emotion/react": "^11.1.5",
     "@emotion/serialize": "^0.11.16",
     "@guardian/consent-management-platform": "^6.7.4",
-    "@guardian/pasteup": "^1.0.0-alpha.7",
+    "@guardian/pasteup": "1.0.0-alpha.7",
     "@guardian/src-accordion": "^3.2.0",
     "@guardian/src-button": "^2.8.2",
     "@guardian/src-checkbox": "^2.7.1",

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -105,7 +105,6 @@
     "emotion-theming": "^10.0.27",
     "framer-motion": "^1.11.1",
     "lodash.debounce": "^4.0.6",
-    "marked": "^1.1.0",
     "ophan-tracker-js": "^1.3.23",
     "react-day-picker": "^7.4.8",
     "react-redux": "^5.1.1",
@@ -113,6 +112,7 @@
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "seedrandom": "^2.4.3",
+    "snarkdown": "^2.0.0",
     "uuid": "^3.2.1"
   },
   "devDependencies": {

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -2952,7 +2952,7 @@
     puppeteer "^1.11.0"
     puppeteer-cluster "^0.12.1"
 
-"@guardian/pasteup@^1.0.0-alpha.7":
+"@guardian/pasteup@1.0.0-alpha.7":
   version "1.0.0-alpha.7"
   resolved "https://registry.yarnpkg.com/@guardian/pasteup/-/pasteup-1.0.0-alpha.7.tgz#680656b92632006d736d0378ae19f8c6943769c8"
   integrity sha512-WSa3gnRYxciFas3QYhtTk8unvj5N9K5IB61LL1CP3bVCJ2euXR13xRRHafI/Vy1dnrDwPa80SaE+apTcwipvpA==
@@ -15925,6 +15925,11 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
+
+snarkdown@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/snarkdown/-/snarkdown-2.0.0.tgz#b1feb4db91b9f94a8ebbd7a50f3e99aee18b1e03"
+  integrity sha512-MgL/7k/AZdXCTJiNgrO7chgDqaB9FGM/1Tvlcenenb7div6obaDATzs16JhFyHHBGodHT3B7RzRc5qk8pFhg3A==
 
 sntp@2.x.x:
   version "2.0.2"

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -11784,11 +11784,6 @@ markdown-to-jsx@^6.11.4:
     prop-types "^15.6.2"
     unquote "^1.1.0"
 
-marked@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.1.1.tgz#e5d61b69842210d5df57b05856e0c91572703e6a"
-  integrity sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==
-
 material-colors@^1.2.1:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"


### PR DESCRIPTION
## What are you doing in this PR?
This pr removes the markdown library `marked` and replaces it with `snarkdown`.

[**Trello Card**](https://trello.com/c/NCxiJcmU/3719-swap-out-marked-for-snarkdown-on-support-frontend)

## Why are you doing this?
We rely on the marked library to parse markdown coming from the promo code tool. However we only support a limited amount of markdown styling, and don't need to include a full markdown parser on every page. Marked is about 10KiB gzipped and is one of the largest single dependencies on our landing pages whilst Snarkdown is considerably smaller.

## Is this an AB test?
- [ ] Yes
- [x] No