### PR TITLE
Add border to free column checkmark and fix resulting spacing issues

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/comparison/comparisonTable.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/comparison/comparisonTable.jsx
@@ -32,9 +32,6 @@ const container = css`
 const columnHeading = css`
   border-left: ${borderStyle};
   border-top: ${borderStyle};
-  ${from.mobileLandscape} {
-    width: 60px;
-  }
 `;
 
 const columnHeadingLast = css`

--- a/support-frontend/assets/pages/digital-subscription-landing/components/comparison/tableContents.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/comparison/tableContents.jsx
@@ -16,6 +16,7 @@ import { SvgOffline } from 'components/icons/offlineReading';
 import { SvgCrosswords } from 'components/icons/crosswords';
 import { SvgFreeTrial } from 'components/icons/freeTrial';
 import { SvgPadlock } from 'components/icons/padlock';
+import type { Option } from 'helpers/types/option';
 
 const iconSizeMobile = 28;
 const iconSizeDesktop = 34;
@@ -112,8 +113,8 @@ const hideOnVerySmall = css`
   }
 `;
 
-const noWrap = css`
-  white-space: nowrap;
+const borderLeft = css`
+  border-left: ${borderStyle};
 `;
 
 const Padlock = () => (
@@ -122,11 +123,19 @@ const Padlock = () => (
   </div>
 );
 
-const Checkmark = () => (
-  <div aria-label="Included" css={[indicators, checkmark, yellowBackground]}>
-    <SvgCheckmark />
-  </div>
-);
+const Checkmark = (props: {borderLeft?: Option<string>}) => {
+  const checkMarkStyles = props.borderLeft ?
+    [indicators, checkmark, yellowBackground, props.borderLeft] :
+    [indicators, checkmark, yellowBackground];
+  return (
+    <div aria-label="Included" css={checkMarkStyles}>
+      <SvgCheckmark />
+    </div>);
+};
+
+Checkmark.defaultProps = {
+  borderLeft: null,
+};
 
 
 export const tableContent: Array<TableRow> = [
@@ -134,7 +143,7 @@ export const tableContent: Array<TableRow> = [
     icon: <div css={iconContainer}><SvgNews /></div>,
     description: 'Access to The Guardian\'s quality, open journalism',
     ariaLabel: 'Access to The Guardian\'s quality, open journalism',
-    free: <Checkmark />,
+    free: <Checkmark borderLeft={borderLeft} />,
     paid: <Checkmark />,
   },
   {
@@ -153,8 +162,7 @@ export const tableContent: Array<TableRow> = [
   },
   {
     icon: <div css={iconContainer}><SvgLiveAppIcon /></div>,
-    description: <>The Guardian app with premium features
-      <span css={[hideOnVerySmall, noWrap]}>;&nbsp;</span>
+    description: <>The Guardian app with premium features;{' '}
       <span css={hideOnVerySmall}>Live and Discover</span></>,
     ariaLabel: 'The Guardian app with premium features, Live and Discover',
     free: <Padlock />,


### PR DESCRIPTION
## What are you doing in this PR?
Adding a border to a yellow square in the comparison table and fixing the spacing issue that resulted from adding this border.

This is a fix relating to this PR: https://github.com/guardian/support-frontend/pull/3145

## Why are you doing this?
Dipa asked me to add it! 

## Screenshots
![Screen Shot 2021-07-19 at 17 01 55](https://user-images.githubusercontent.com/16781258/126193048-247e975e-085a-4dd8-a782-9813531651f8.png)

![Screen Shot 2021-07-19 at 17 01 30](https://user-images.githubusercontent.com/16781258/126193076-2f7b8fbe-e2eb-4b2c-ae9d-eb65c4e5778f.png)
