### PR TITLE
Allow spaces in IBAN

### DIFF
--- a/support-frontend/assets/helpers/forms/formValidation.js
+++ b/support-frontend/assets/helpers/forms/formValidation.js
@@ -115,5 +115,6 @@ export const checkStateIfApplicable: ((string | null), CountryGroupId, Contribut
   return true;
 };
 
+// ignores all spaces
 export const isValidIban = (iban: string | null): boolean =>
-  !!iban && /[a-zA-Z]{2}[0-9]{2}[a-zA-Z0-9]{4}[0-9]{7}([a-zA-Z0-9]?){0,16}/.test(iban);
+  !!iban && /[a-zA-Z]{2}[0-9]{2}[a-zA-Z0-9]{4}[0-9]{7}([a-zA-Z0-9]?){0,16}/.test(iban.replace(/ /g, ''));

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.js
@@ -236,7 +236,7 @@ function regularPaymentFieldsFromAuthorisation(authorisation: PaymentAuthorisati
     case Sepa:
       return {
         accountHolderName: authorisation.accountHolderName,
-        iban: authorisation.iban,
+        iban: authorisation.iban.replace(/ /g, ''),
       };
     case ExistingCard:
     case ExistingDirectDebit:

--- a/support-frontend/assets/pages/contributions-landing/components/SepaForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/SepaForm.jsx
@@ -34,6 +34,7 @@ type SepaFormProps = {|
   checkoutFormHasBeenSubmitted: boolean,
 |};
 
+
 export function SepaForm({
   iban,
   accountHolderName,
@@ -63,7 +64,7 @@ export function SepaForm({
         <div>
           <TextInput
             label="IBAN"
-            pattern="[0-9A-Z]*"
+            pattern="[0-9A-Z ]*"
             minLength="6"
             maxLength="34"
             value={iban}


### PR DESCRIPTION
IBANs are sometimes entered with spaces within. This PR allows users to include spaces, and only removes them when it posts the form to the backend

Both of these are ok:
![Screen Shot 2021-07-21 at 10 12 58](https://user-images.githubusercontent.com/1513454/126463763-eee63757-2291-4d45-9d76-d53beca294dc.png)
![Screen Shot 2021-07-21 at 10 13 21](https://user-images.githubusercontent.com/1513454/126463769-05c25485-a72b-4cd3-8cb0-48453152934f.png)
