### PR TITLE
trim name and email before sending to backend

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -171,10 +171,10 @@ function buildRegularPaymentRequest(
 
   return {
     title,
-    firstName,
-    lastName,
+    firstName: firstName.trim(),
+    lastName: lastName.trim(),
     ...addresses,
-    email,
+    email: email.trim(),
     ...giftRecipient,
     telephoneNumber: telephone,
     product,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -449,9 +449,9 @@ function regularPaymentRequestFromAuthorisation(
   const { billingCountry, billingState } = getBillingCountryAndState(authorisation, state);
 
   return {
-    firstName: state.page.form.formData.firstName || '',
-    lastName: state.page.form.formData.lastName || '',
-    email: state.page.form.formData.email || '',
+    firstName: (state.page.form.formData.firstName || '').trim(),
+    lastName: (state.page.form.formData.lastName || '').trim(),
+    email: (state.page.form.formData.email || '').trim(),
     billingAddress: {
       lineOne: null, // required go cardless field
       lineTwo: null, // required go cardless field


### PR DESCRIPTION
We've had some recurring contributions fail because identity doesn't allow whitespace before or after the name fields.
This change trims these fields client-side before posting to the backend.