### PR TITLE
change IT test alarms to 15 minute period

### DIFF
--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -119,11 +119,11 @@ Resources:
                 - Name: Stage
                   Value: !Ref Stage
             Stat: Sum
-            Period: 60
+            Period: 900
             Unit: Count
       ComparisonOperator: GreaterThanThreshold
       Threshold: 0
-      EvaluationPeriods: 130
+      EvaluationPeriods: 9
       DatapointsToAlarm: 3
       TreatMissingData: breaching
 
@@ -155,7 +155,7 @@ Resources:
                 - Name: Stage
                   Value: !Ref Stage
             Stat: Sum
-            Period: 60
+            Period: 900
             Unit: Count
         - Id: m2
           ReturnData: false
@@ -167,10 +167,10 @@ Resources:
                 - Name: Stage
                   Value: !Ref Stage
             Stat: Sum
-            Period: 60
+            Period: 900
             Unit: Count
       ComparisonOperator: LessThanThreshold
       Threshold: 100
-      EvaluationPeriods: 70
-      DatapointsToAlarm: 70
+      EvaluationPeriods: 9
+      DatapointsToAlarm: 9
       TreatMissingData: breaching


### PR DESCRIPTION
Following on from https://github.com/guardian/support-frontend/pull/3188
The alarm period could be 15 minutes, this will make it group together data points from slower runs, this making it less likely to trigger.
I ahve also extended the range of the "not running" alarm to make sure it isn't running for 2 hours before going off.