### PR TITLE
Retain query params for paper landing page

### DIFF
--- a/support-frontend/assets/helpers/urls/routes.js
+++ b/support-frontend/assets/helpers/urls/routes.js
@@ -52,7 +52,7 @@ function postcodeLookupUrl(postcode: string): string {
 
 function paperSubsUrl(withDelivery: boolean = false, promoCode?: Option<string>): string {
   const baseURL = [getOrigin(), 'uk/subscribe/paper', ...(withDelivery ? ['delivery'] : [])].join('/');
-  const queryParams = [...getAllQueryParams(), (promoCode ? ['promoCode', promoCode] : [])];
+  const queryParams = [...getAllQueryParams(), ...(promoCode ? [['promoCode', promoCode]] : [])];
   const queryParamsString = queryParams.map(keyValuePair => keyValuePair.join('=')).join('&');
   if (queryParamsString) {
     return `${baseURL}?${queryParamsString}`;

--- a/support-frontend/assets/helpers/urls/routes.js
+++ b/support-frontend/assets/helpers/urls/routes.js
@@ -50,7 +50,7 @@ function postcodeLookupUrl(postcode: string): string {
   return `${getOrigin() + routes.postcodeLookup}/${postcode}`;
 }
 
-function paperSubsUrl(withDelivery: boolean = false, promoCode?: Option<string> = 'yopromo'): string {
+function paperSubsUrl(withDelivery: boolean = false, promoCode?: Option<string>): string {
   const baseURL = [getOrigin(), 'uk/subscribe/paper', ...(withDelivery ? ['delivery'] : [])].join('/');
   const queryParams = [...getAllQueryParams(), (promoCode ? ['promoCode', promoCode] : [])];
   const queryParamsString = queryParams.map(keyValuePair => keyValuePair.join('=')).join('&');

--- a/support-frontend/assets/helpers/urls/routes.js
+++ b/support-frontend/assets/helpers/urls/routes.js
@@ -3,7 +3,7 @@
 // ----- Routes ----- //
 
 import { countryGroups, type CountryGroupId } from '../internationalisation/countryGroup';
-import { getOrigin, isProd } from './url';
+import { getAllQueryParams, getOrigin, isProd } from './url';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
 import { type Option } from 'helpers/types/option';
@@ -50,10 +50,12 @@ function postcodeLookupUrl(postcode: string): string {
   return `${getOrigin() + routes.postcodeLookup}/${postcode}`;
 }
 
-function paperSubsUrl(withDelivery: boolean = false, promoCode?: Option<string>): string {
+function paperSubsUrl(withDelivery: boolean = false, promoCode?: Option<string> = 'yopromo'): string {
   const baseURL = [getOrigin(), 'uk/subscribe/paper', ...(withDelivery ? ['delivery'] : [])].join('/');
-  if (promoCode) {
-    return `${baseURL}?promoCode=${promoCode}`;
+  const queryParams = [...getAllQueryParams(), (promoCode ? ['promoCode', promoCode] : [])];
+  const queryParamsString = queryParams.map(keyValuePair => keyValuePair.join('=')).join('&');
+  if (queryParamsString) {
+    return `${baseURL}?${queryParamsString}`;
   }
   return baseURL;
 }

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -3,7 +3,7 @@
 // ----- Imports ----- //
 
 // $FlowIgnore
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
 import Page from 'components/page/page';
 import Header from 'components/headers/header/header';
@@ -60,14 +60,17 @@ const PaperLandingPage = ({ productPrices, promotionCopy }: PaperLandingPropType
     return null;
   }
 
-  useEffect(() => {
+  function handleSetTabAction(newTab: PaperFulfilmentOptions) {
+    setSelectedTab(newTab);
+
     sendTrackingEventsOnClick({
-      id: `Paper_${selectedTab}-tab`, // eg. Paper_Collection-tab or Paper_HomeDelivery-tab
+      id: `Paper_${newTab}-tab`, // eg. Paper_Collection-tab or Paper_HomeDelivery-tab
       product: 'Paper',
       componentType: 'ACQUISITIONS_BUTTON',
     })();
-    window.history.replaceState({}, null, paperSubsUrl(selectedTab === HomeDelivery));
-  }, [selectedTab]);
+
+    window.history.replaceState({}, null, paperSubsUrl(newTab === HomeDelivery));
+  }
 
   return (
     <Page
@@ -80,7 +83,7 @@ const PaperLandingPage = ({ productPrices, promotionCopy }: PaperLandingPropType
         <CentredContainer>
           <Block>
             <div css={tabsTabletSpacing}>
-              <Tabs selectedTab={selectedTab} setTabAction={setSelectedTab} />
+              <Tabs selectedTab={selectedTab} setTabAction={handleSetTabAction} />
             </div>
           </Block>
         </CentredContainer>


### PR DESCRIPTION
## What are you doing in this PR?
This PR prevents query parameters from being stripped out of the newspaper landing page url as well as ensuring that tracking information for the landing page is only sent on click are not being sent on initial page load. 

[**Trello Card**](https://trello.com/c/mxxVFqnJ/3810-paper-landing-page-loses-tracking-params)

## Why are you doing this?
Marketing use certain query parameters to attribute traffic etc to their campaigns.

## Is this an AB test?
- [ ] Yes
- [x] No
