### PR TITLE
Disallow non ASCII characters in submission validators 

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.jsx
+++ b/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.jsx
@@ -19,7 +19,7 @@ import Form from './components/form';
 import Playback from './components/playback';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type ErrorReason } from 'helpers/forms/errorReasons';
-
+import { nonSillyCharacters } from 'helpers/subscriptionsForms/validation';
 
 // ---- Types ----- //
 
@@ -123,7 +123,8 @@ class DirectDebitForm extends Component<PropTypes, StateTypes> {
         error: '',
         message: 'Please enter a valid account name',
         // Regex matches a string with any character that is not a digit
-        rule: accountHolderName => accountHolderName.match(/^\D+$/),
+        rule: accountHolderName => accountHolderName.match(/^\D+$/) &&
+          nonSillyCharacters(accountHolderName),
       },
       sortCodeString: {
         error: '',

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
@@ -12,6 +12,7 @@ import {
   notNull,
   removeError,
   validate,
+  nonSillyCharacters,
 } from 'helpers/subscriptionsForms/validation';
 import { type RegularPaymentRequestAddress } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
 import { type Scoped } from 'helpers/subscriptionsForms/scoped';
@@ -95,15 +96,16 @@ export const isHomeDeliveryInM25 = (
 
 const applyBillingAddressRules = (fields: FormFields, addressType: AddressType): FormError<FormField>[] => validate([
   {
-    rule: nonEmptyString(fields.lineOne),
+    rule: nonEmptyString(fields.lineOne) && nonSillyCharacters(fields.lineOne),
     error: formError('lineOne', `Please enter a ${addressType} address.`),
   },
   {
-    rule: nonEmptyString(fields.city),
+    rule: nonEmptyString(fields.city) && nonSillyCharacters(fields.city),
     error: formError('city', `Please enter a ${addressType} city.`),
   },
   {
-    rule: isPostcodeOptional(fields.country) || nonEmptyString(fields.postCode),
+    rule: isPostcodeOptional(fields.country) ||
+    (nonEmptyString(fields.postCode) && nonSillyCharacters(fields.postCode)),
     error: formError('postCode', `Please enter a ${addressType} postcode.`),
   },
   {

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
@@ -96,38 +96,77 @@ export const isHomeDeliveryInM25 = (
 
 const applyBillingAddressRules = (fields: FormFields, addressType: AddressType): FormError<FormField>[] => validate([
   {
-    rule: nonEmptyString(fields.lineOne) && nonSillyCharacters(fields.lineOne),
+    rule: nonEmptyString(fields.lineOne),
     error: formError('lineOne', `Please enter a ${addressType} address.`),
   },
   {
-    rule: nonEmptyString(fields.city) && nonSillyCharacters(fields.city),
+    rule: nonSillyCharacters(fields.lineOne),
+    error: formError(
+      'lineOne',
+      'Please use only letters, numbers and punctuation.',
+    ),
+  },
+  {
+    rule: nonSillyCharacters(fields.lineTwo),
+    error: formError(
+      'lineTwo',
+      'Please use only letters, numbers and punctuation.',
+    ),
+  },
+  {
+    rule: nonEmptyString(fields.city),
     error: formError('city', `Please enter a ${addressType} city.`),
   },
   {
-    rule: isPostcodeOptional(fields.country) ||
-    (nonEmptyString(fields.postCode) && nonSillyCharacters(fields.postCode)),
+    rule: nonSillyCharacters(fields.city),
+    error: formError(
+      'city',
+      'Please use only letters, numbers and punctuation.',
+    ),
+  },
+  {
+    rule:
+        isPostcodeOptional(fields.country) ||
+        (nonEmptyString(fields.postCode) &&
+          nonSillyCharacters(fields.postCode)),
     error: formError('postCode', `Please enter a ${addressType} postcode.`),
   },
   {
+    rule: nonSillyCharacters(fields.postCode),
+    error: formError(
+      'postCode',
+      'Please use only letters, numbers and punctuation.',
+    ),
+  },
+  {
     rule: checkLength(fields.postCode, 20),
-    error: formError('postCode', `Please enter a ${addressType} postcode no longer than 20 characters.`),
+    error: formError(
+      'postCode',
+      `Please enter a ${addressType} postcode no longer than 20 characters.`,
+    ),
   },
   {
     rule: notNull(fields.country),
     error: formError('country', `Please select a ${addressType} country.`),
   },
   {
-    rule: isStateNullable(fields.country) || (notNull(fields.state) && nonEmptyString(fields.state)),
+    rule:
+        isStateNullable(fields.country) ||
+        (notNull(fields.state) && nonEmptyString(fields.state)),
     error: formError(
       'state',
-      fields.country === 'CA' ? `Please select a ${addressType} province/territory.` : `Please select a ${addressType} state.`,
+      fields.country === 'CA'
+        ? `Please select a ${addressType} province/territory.`
+        : `Please select a ${addressType} state.`,
     ),
   },
   {
     rule: checkLength(fields.state, 40),
     error: formError(
       'state',
-      fields.country === 'CA' ? `Please enter a ${addressType} province/territory no longer than 40 characters` : `Please enter a ${addressType} state name no longer than 40 characters`,
+      fields.country === 'CA'
+        ? `Please enter a ${addressType} province/territory no longer than 40 characters`
+        : `Please enter a ${addressType} state name no longer than 40 characters`,
     ),
   },
 ]);

--- a/support-frontend/assets/helpers/subscriptionsForms/__tests__/validationTest.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/__tests__/validationTest.js
@@ -8,12 +8,27 @@ import {
   firstError,
   formError,
   validate,
+  nonSillyCharacters,
 } from '../validation';
 
 
 // ----- Tests ----- //
 
 describe('validation', () => {
+
+  describe('non silly characters', () => {
+
+    it('should return false if string contains a silly character', () => {
+      expect(nonSillyCharacters('😊')).toBe(false);
+      expect(nonSillyCharacters('jane✅')).toBe(false);
+      expect(nonSillyCharacters('𝒢℞à©ℨ')).toBe(false);
+    });
+
+    it('should return true if string does not contain silly characters', () => {
+      expect(nonSillyCharacters('joe')).toBe(true);
+    });
+
+  });
 
   describe('nonEmptyString', () => {
 

--- a/support-frontend/assets/helpers/subscriptionsForms/rules.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/rules.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { formError, nonEmptyString, notNull, validate } from './validation';
+import { formError, nonEmptyString, notNull, nonSillyCharacters, validate } from './validation';
 import type { FormField, FormFields } from './formFields';
 import type { FormError } from './validation';
 import { checkOptionalEmail, checkEmail, checkGiftStartDate } from 'helpers/forms/formValidation';
@@ -13,8 +13,20 @@ function applyCheckoutRules(fields: FormFields): FormError<FormField>[] {
       error: formError('firstName', 'Please enter a first name.'),
     },
     {
+      rule: nonSillyCharacters(fields.firstName),
+      error: formError('firstName', 'Please use only letters, numbers and punctuation.'),
+    },
+    {
       rule: nonEmptyString(fields.lastName),
       error: formError('lastName', 'Please enter a last name.'),
+    },
+    {
+      rule: nonSillyCharacters(fields.lastName),
+      error: formError('lastName', 'Please use only letters, numbers and punctuation.'),
+    },
+    {
+      rule: nonSillyCharacters(fields.telephone),
+      error: formError('telephone', 'Please use only letters, numbers and punctuation.'),
     },
     {
       rule: notNull(fields.paymentMethod),
@@ -28,11 +40,19 @@ function applyCheckoutRules(fields: FormFields): FormError<FormField>[] {
         error: formError('firstNameGiftRecipient', 'Please enter the recipient\'s first name.'),
       },
       {
+        rule: nonSillyCharacters(fields.firstNameGiftRecipient),
+        error: formError('firstNameGiftRecipient', 'Please use only letters, numbers and punctuation.'),
+      },
+      {
         rule: nonEmptyString(fields.lastNameGiftRecipient),
         error: formError('lastNameGiftRecipient', 'Please enter the recipient\'s last name.'),
       },
       {
-        rule: checkEmail(fields.emailGiftRecipient),
+        rule: nonSillyCharacters(fields.lastNameGiftRecipient),
+        error: formError('lastNameGiftRecipient', 'Please use only letters, numbers and punctuation.'),
+      },
+      {
+        rule: checkEmail(fields.emailGiftRecipient) && nonSillyCharacters(fields.emailGiftRecipient),
         error: formError('emailGiftRecipient', 'Please use a valid email address for the recipient.'),
       },
       {
@@ -50,7 +70,11 @@ function applyCheckoutRules(fields: FormFields): FormError<FormField>[] {
         error: formError('lastNameGiftRecipient', 'Please enter the recipient\'s last name.'),
       },
       {
-        rule: checkOptionalEmail(fields.emailGiftRecipient),
+        rule: nonSillyCharacters(fields.lastNameGiftRecipient),
+        error: formError('lastNameGiftRecipient', 'Please use only letters, numbers and punctuation.'),
+      },
+      {
+        rule: checkOptionalEmail(fields.emailGiftRecipient) && nonSillyCharacters(fields.emailGiftRecipient),
         error: formError('emailGiftRecipient', 'Please use a valid email address for the recipient.'),
       },
     ];

--- a/support-frontend/assets/helpers/subscriptionsForms/rules.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/rules.js
@@ -66,6 +66,10 @@ function applyCheckoutRules(fields: FormFields): FormError<FormField>[] {
         error: formError('firstNameGiftRecipient', 'Please enter the recipient\'s first name.'),
       },
       {
+        rule: nonSillyCharacters(fields.firstNameGiftRecipient),
+        error: formError('firstNameGiftRecipient', 'Please use only letters, numbers and punctuation.'),
+      },
+      {
         rule: nonEmptyString(fields.lastNameGiftRecipient),
         error: formError('lastNameGiftRecipient', 'Please enter the recipient\'s last name.'),
       },

--- a/support-frontend/assets/helpers/subscriptionsForms/validation.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/validation.js
@@ -25,6 +25,14 @@ function notNull<A>(value: A): boolean {
   return value !== null;
 }
 
+function nonSillyCharacters(s: ?string): boolean {
+  const nonAsciiRegex = (/[^\x20-\x7E]/g);
+  if (!s) {
+    return true;
+  }
+  return !nonAsciiRegex.test(s);
+}
+
 // ----- Functions ----- //
 
 function firstError<FieldType>(field: FieldType, errors: FormError<FieldType>[]): Option<ErrorMessage> {
@@ -56,4 +64,5 @@ export {
   formError,
   removeError,
   validate,
+  nonSillyCharacters,
 };

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -212,7 +212,7 @@ function DigitalCheckoutForm(props: PropTypes) {
               country={props.country}
               isTestUser={props.isTestUser}
               submitForm={props.submitForm}
-              allErrors={[...props.addressErrors]}
+              allErrors={[...props.addressErrors, ...props.formErrors]}
               setStripePaymentMethod={props.setStripePaymentMethod}
               validateForm={props.validateForm}
               buttonText="Start your free trial now"

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.jsx
@@ -103,7 +103,7 @@ describe('Digital checkout form', () => {
       fireEvent.click(creditDebit);
       const freeTrialButton = await screen.findByRole('button', { name: 'Start your free trial now' }, { timeout: 2000 });
       fireEvent.click(freeTrialButton);
-      expect(await screen.queryByText('Please use only letters, numbers and punctuation.')).toBeInTheDocument();
+      expect(await screen.queryAllByText('Please use only letters, numbers and punctuation.')).toBeTruthy();
     });
   });
 });

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.jsx
@@ -1,4 +1,6 @@
 /* eslint-disable react/prop-types */
+import '__mocks__/stripeMock';
+
 import React from 'react';
 import { applyMiddleware, createStore, combineReducers, compose } from 'redux';
 import { Provider } from 'react-redux';
@@ -74,6 +76,10 @@ describe('Digital checkout form', () => {
       },
     };
 
+    window.fetch = async () => ({
+      json: async () => ({ client_secret: 'super secret' }),
+    });
+
     renderWithStore(<DigitalCheckoutForm />, { initialState });
   });
 
@@ -86,6 +92,18 @@ describe('Digital checkout form', () => {
       const countrySelect = await screen.findByLabelText('Country');
       fireEvent.change(countrySelect, { target: { value: 'US' } });
       expect(await screen.queryByText('Direct debit')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Validation', () => {
+    it('should display an error if a silly character is entered into an input field', async () => {
+      const firstNameInput = await screen.findByLabelText('First name');
+      fireEvent.change(firstNameInput, { target: { value: 'jane✅' } });
+      const creditDebit = await screen.findByLabelText('Credit/Debit card');
+      fireEvent.click(creditDebit);
+      const freeTrialButton = await screen.findByRole('button', { name: 'Start your free trial now' }, { timeout: 2000 });
+      fireEvent.click(freeTrialButton);
+      expect(await screen.queryByText('Please use only letters, numbers and punctuation.')).toBeInTheDocument();
     });
   });
 });

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.jsx
@@ -1,4 +1,6 @@
 /* eslint-disable react/prop-types */
+import '__mocks__/stripeMock';
+
 import React from 'react';
 import { applyMiddleware, createStore, combineReducers, compose } from 'redux';
 import { Provider } from 'react-redux';
@@ -84,6 +86,10 @@ describe('Newspaper checkout form', () => {
       },
     };
 
+    window.fetch = async () => ({
+      json: async () => ({ client_secret: 'super secret' }),
+    });
+
     renderWithStore(<PaperCheckoutForm />, { initialState });
   });
 
@@ -104,6 +110,18 @@ describe('Newspaper checkout form', () => {
       const allCountrySelects = await screen.findAllByLabelText('Country');
       fireEvent.change(allCountrySelects[1], { target: { value: 'IM' } });
       expect(await screen.queryByText('Direct debit')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Validation', () => {
+    it('should display an error if a silly character is entered into an input field', async () => {
+      const firstNameInput = await screen.findByLabelText('First name');
+      fireEvent.change(firstNameInput, { target: { value: 'jane✅' } });
+      const creditDebit = await screen.findByLabelText('Credit/Debit card');
+      fireEvent.click(creditDebit);
+      const payNowButton = await screen.findByRole('button', { name: 'Pay now' }, { timeout: 2000 });
+      fireEvent.click(payNowButton);
+      expect(await screen.queryAllByText('Please use only letters, numbers and punctuation.')).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
## What are you doing in this PR?
This adds a validation rule to the relevant text input fields in the digital, GW and newspaper checkouts which prevents a user from submitting the form if they have included non ASCII characters. The user will now be shown an error message prompting them to change their input value.

[**Trello Card**](https://trello.com/c/Iyyimr7j/3094-disallow-funny-characters-in-submission-validators-80)

## Why are you doing this?
When people put emojis or font changes into their checkout submissions, it causes a zuora repeated failure followed by eventual timeout.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

|  |  |
| ------------- | ------------- |
| <img width="1170" alt="Screenshot 2021-08-02 at 10 21 22" src="https://user-images.githubusercontent.com/44685872/127837626-41c82c1c-c2ea-453d-86f8-7291d8005ba4.png"> | <img width="1170" alt="Screenshot 2021-08-02 at 10 21 47" src="https://user-images.githubusercontent.com/44685872/127837902-6efc8b4a-9474-4d82-94a9-f04de8156620.png"> |
