### PR TITLE
Turn off comparison table A/B test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -102,7 +102,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: true,
+    isActive: false,
     referrerControlled: false,
     targetPage: pageUrlRegexes.subscriptions.digiSub.nonGiftLandingAndCheckout,
     seed: 10,


### PR DESCRIPTION
## What are you doing in this PR?
This turns off the comparison table A/B test. We may use it again later, so for now the test and related components will remain in the codebase in an inactive state.