### PR TITLE
Events email referrer controlled A/B test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -87,7 +87,7 @@ export const tests: Tests = {
   // If the name of this test or the variant id changes then the code
   // in `ZuoraDigitalSubscriptionDirectHandler.subscribe` will need
   // to change as well.
-  digiSubEventsTest: {
+  emailDigiSubEventsTest: {
     variants: [
       {
         id: 'control',
@@ -102,11 +102,10 @@ export const tests: Tests = {
         size: 0,
       },
     },
-    isActive: true,
-    referrerControlled: false,
+    isActive: false,
+    referrerControlled: true,
     targetPage: pageUrlRegexes.subscriptions.digiSub.nonGiftLandingNotAusNotUS,
     seed: 10,
-    optimizeId: '-2DJ0JTsSVaskWwTm9Je4A',
   },
   comparisonTableTest: {
     variants: [

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -102,10 +102,11 @@ export const tests: Tests = {
         size: 0,
       },
     },
-    isActive: false,
+    isActive: true,
     referrerControlled: true,
     targetPage: pageUrlRegexes.subscriptions.digiSub.nonGiftLandingNotAusNotUS,
     seed: 10,
+    // optimizeId: tbc
   },
   comparisonTableTest: {
     variants: [

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -104,7 +104,6 @@ export const tests: Tests = {
     },
     isActive: true,
     referrerControlled: true,
-    targetPage: pageUrlRegexes.subscriptions.digiSub.nonGiftLandingNotAusNotUS,
     seed: 10,
     // optimizeId: tbc
   },

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouContent.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouContent.jsx
@@ -43,7 +43,7 @@ const getEmailCopy = (paymentMethod: Option<PaymentMethod>, includePaymentCopy: 
 };
 
 function ThankYouContent(props: PropTypes) {
-  const showEventsContent = props.participations && props.participations.digiSubEventsTest === 'variant';
+  const showEventsContent = props.participations && props.participations.emailDigiSubEventsTest === 'variant';
   return (
     <div className="thank-you-stage">
       <ThankYouHero

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -118,7 +118,7 @@ function DigitalLandingPage({
   }
 
   const isGift = orderIsAGift || false;
-  const showEventsComponent = participations.digiSubEventsTest === 'variant';
+  const showEventsComponent = participations.emailDigiSubEventsTest === 'variant';
   const showComparisonTable = participations.comparisonTableTest === 'variant';
 
   const path = orderIsAGift ? routes.digitalSubscriptionLandingGift : routes.digitalSubscriptionLanding;

--- a/support-workers/src/main/scala/com/gu/zuora/productHandlers/ZuoraDigitalSubscriptionDirectHandler.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/productHandlers/ZuoraDigitalSubscriptionDirectHandler.scala
@@ -20,7 +20,7 @@ class ZuoraDigitalSubscriptionDirectHandler(
 ) {
 
   def isUserInEventsTest(maybeAbTests: Option[Set[AbTest]]) =
-    maybeAbTests.exists(_.toList.exists(test => test.name == "digiSubEventsTest" && test.variant == "variant"))
+    maybeAbTests.exists(_.toList.exists(test => test.name == "emailDigiSubEventsTest" && test.variant == "variant"))
 
   def subscribe(state: DigitalSubscriptionDirectPurchaseState, maybeAbTests: Option[Set[AbTest]]): Future[SendThankYouEmailState] =
     for {


### PR DESCRIPTION
## What are you doing in this PR?
This PR sets up a referrer controlled 0% A/B test for the Events module on the digital subscriptions landing page. 

NB: The Events module component is due to be updated in a subsequent PR and the `emailDigiSubEventsTest` A/B test is yet to be set up in Optimize.

To view the existing Events module component you can use the following endpoint to force the variant: /subscribe/digital#ab-emailDigiSubEventsTest=variant

[**Trello Card**](https://trello.com/c/4QY6ub1H/3823-set-up-a-referrercontrolled-abtest-for-the-events-email-ab-test)

## Why are you doing this?
We want to test whether user's in our email distribution lists will be encouraged to subscribe by the Digi Subs + Events offer of 6 free tickets to events and masterclasses.

## Screenshots
The current Events module:

| Desktop  | Mobile |
| ------------- | ------------- |
| <img width="871" alt="Screenshot 2021-08-05 at 11 45 20" src="https://user-images.githubusercontent.com/44685872/128337856-073244a0-7695-44ac-87b7-b2d46cffb896.png"> | <img width="239" alt="Screenshot 2021-08-05 at 11 46 30" src="https://user-images.githubusercontent.com/44685872/128337931-facc9306-2679-4d2e-bcf6-df9e2c57dae5.png"> |
