### PR TITLE
Identify PPC sources in acquisitions data

### DIFF
--- a/support-frontend/assets/helpers/tracking/acquisitions.js
+++ b/support-frontend/assets/helpers/tracking/acquisitions.js
@@ -290,8 +290,6 @@ function getReferrerAcquisitionData(): ReferrerAcquisitionData {
     ? deserialiseReferralData(getQueryParameter(REFERRAL_DATA_PARAM) || '')
     : deserialiseJsonObject(getQueryParameter(ACQUISITIONS_PARAM) || '');
 
-  debugger;
-
   // Read from param, or read from sessionStorage, or build minimal version.
   const referrerAcquisitionData = buildReferrerAcquisitionData(paramData || readReferrerAcquisitionData() || {});
   storeReferrerAcquisitionData(referrerAcquisitionData);

--- a/support-frontend/assets/helpers/tracking/acquisitions.js
+++ b/support-frontend/assets/helpers/tracking/acquisitions.js
@@ -188,7 +188,7 @@ function buildReferrerAcquisitionData(acquisitionData: Object): ReferrerAcquisit
     acquisitionData.queryParameters ||
     toAcquisitionQueryParameters(getAllQueryParamsWithExclusions(parameterExclusions));
 
-  const establishedSource = ((campaignCode && /\bPPC\b/i.test(campaignCode)) || getQueryParameter('glcid')) ? 'PPC' : acquisitionData.source;
+  const establishedSource = ((campaignCode && /^PPC_/i.test(campaignCode)) || getQueryParameter('gclid')) ? 'PPC' : acquisitionData.source;
 
   return {
     referrerPageviewId,
@@ -289,6 +289,8 @@ function getReferrerAcquisitionData(): ReferrerAcquisitionData {
   const paramData = getQueryParameter(REFERRAL_DATA_PARAM)
     ? deserialiseReferralData(getQueryParameter(REFERRAL_DATA_PARAM) || '')
     : deserialiseJsonObject(getQueryParameter(ACQUISITIONS_PARAM) || '');
+
+  debugger;
 
   // Read from param, or read from sessionStorage, or build minimal version.
   const referrerAcquisitionData = buildReferrerAcquisitionData(paramData || readReferrerAcquisitionData() || {});

--- a/support-frontend/assets/helpers/tracking/acquisitions.js
+++ b/support-frontend/assets/helpers/tracking/acquisitions.js
@@ -179,7 +179,7 @@ function buildReferrerAcquisitionData(acquisitionData: Object): ReferrerAcquisit
 
   // This was how referrer pageview id used to be passed.
   const campaignCode =
-    getCampaignCode() || acquisitionData.campaignCode || getQueryParameter('INTCMP');
+    getCampaignCode() || acquisitionData.campaignCode || getQueryParameter('INTCMP') || getQueryParameter('CMP');
 
   const parameterExclusions =
     ['REFPVID', 'INTCMP', 'acquisitionData', 'contributionValue', 'contribType', 'currency'];
@@ -188,13 +188,15 @@ function buildReferrerAcquisitionData(acquisitionData: Object): ReferrerAcquisit
     acquisitionData.queryParameters ||
     toAcquisitionQueryParameters(getAllQueryParamsWithExclusions(parameterExclusions));
 
+  const establishedSource = (/\bPPC\b/i.test(campaignCode) || getQueryParameter('glcid')) ? 'PPC' : acquisitionData.source;
+
   return {
     referrerPageviewId,
     campaignCode,
     referrerUrl: acquisitionData.referrerUrl,
     componentId: acquisitionData.componentId,
     componentType: acquisitionData.componentType,
-    source: acquisitionData.source,
+    source: establishedSource,
     abTests: acquisitionData.abTest ? [acquisitionData.abTest] : acquisitionData.abTests,
     queryParameters: queryParameters.length > 0 ? queryParameters : [],
     labels: acquisitionData.labels,

--- a/support-frontend/assets/helpers/tracking/acquisitions.js
+++ b/support-frontend/assets/helpers/tracking/acquisitions.js
@@ -188,7 +188,7 @@ function buildReferrerAcquisitionData(acquisitionData: Object): ReferrerAcquisit
     acquisitionData.queryParameters ||
     toAcquisitionQueryParameters(getAllQueryParamsWithExclusions(parameterExclusions));
 
-  const establishedSource = (/\bPPC\b/i.test(campaignCode) || getQueryParameter('glcid')) ? 'PPC' : acquisitionData.source;
+  const establishedSource = ((campaignCode && /\bPPC\b/i.test(campaignCode)) || getQueryParameter('glcid')) ? 'PPC' : acquisitionData.source;
 
   return {
     referrerPageviewId,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/AJVCpH2a)

## Why are you doing this?

The Support website does not attribute inbound links from search engine pay-per-click sources (e.g. Google Ads) as having a `source` of `PPC`, even though that enum is supported. As a consequence, acquisitions made via this journey are attributed the same as if the user had visited the site via organic search or by just typing support.theguardian.com/* in their address bar.

I've solved this by:

- Including the value from &CMP= in the hierarchy of values which identify a campaign code. This adds only additive tracking benefits from what I can understand.
- Adding a tiny parser of that to identify the link as coming from a search engine pay-per-click. This is driven by the assumption that inbound links from Bing have an `&CMP=ppc_*` param and inbound links from Google have `&gclid=*`. Chris is going to try and add `&CMP=` to future Google links, but that may take some time. I don't expect this parser to generate false positives, it's more likely to miss, and be no different to now.

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [x] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots
N/A
