### PR TITLE
remove line from build.sbt that prevented snyk finding any deps/issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,6 @@ lazy val release = Seq[ReleaseStep](
 inThisBuild(Seq(
   organization := "com.gu",
   scalaVersion := "2.13.5",
-  dependencyTree / aggregate := false,
   // https://www.scala-sbt.org/1.x/docs/Cached-Resolution.html
   updateOptions := updateOptions.value.withCachedResolution(true),
   resolvers ++= Seq(Resolver.sonatypeRepo("releases")), // libraries that haven't yet synced to maven central


### PR DESCRIPTION
This PR makes dependencyTree work on all subprojects in the multi module build.  Previously it was prevented in this PR which was probably a mistaken commited line: https://github.com/guardian/support-frontend/pull/2111/files#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91R54

This should make snyk work properly in future.  We are not sure how long it ws broken for, as the old snyk monitor system was a bit spammy.

After this there are 18 vulnerabilities reported so we can fix them.  Tom has separately deleted all the old teamcity snyk steps and the old snyk "projects" so there should only be one from now on.

