### PR TITLE
Update Events module for Email Digi Subs + Events AB test

### DIFF
--- a/support-frontend/assets/components/icons/clock.jsx
+++ b/support-frontend/assets/components/icons/clock.jsx
@@ -1,5 +1,0 @@
-export const SvgClock = () => (
-  <svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path fillRule="evenodd" clipRule="evenodd" d="M10 5C10 7.76136 7.76136 10 5 10C2.23864 10 0 7.76136 0 5C0 2.23864 2.23864 0 5 0C7.76136 0 10 2.23864 10 5ZM5.54547 4.84091L5.21592 0.909094H4.77274L4.43183 5.17046L5.01138 5.75L8.18183 5.45455V5L5.54547 4.84091Z" fill="#007ABC" />
-  </svg>
-);

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -109,7 +109,7 @@ export const tests: Tests = {
     isActive: true,
     referrerControlled: true,
     seed: 10,
-    // optimizeId: tbc
+    optimizeId: 'dQCXBc3QQIW7M1Di_qSCHw',
   },
   comparisonTableTest: {
     variants: [

--- a/support-frontend/assets/helpers/images/imageCatalogue.json
+++ b/support-frontend/assets/helpers/images/imageCatalogue.json
@@ -51,6 +51,7 @@
   "weeklyCampaignBenefitsImg": "340db3a4561cbd502dc59b764ab8d93433511103/0_255_1972_1183",
   "weeklyCampaignHeroImg": "d2baab9f40e198459a02c30d86c774e79096e43e/0_0_1158_954",
   "weeklyLandingHero": "87e6e2d907b9de594c73239bae0b49f2f811173c/738_0_6362_3008",
-  "jessPhillips": "4ea76856f99f62b26cd07f87e4ca24e7f4f7645f/0_731_5464_3278",
-  "robbieAnderson": "89a3278a6503624ec4f1851caccf55a7ce6a6076/0_182_5472_3283"
+  "keirStarmer": "48dd5abbefdc9319a42c6200b9315cfa2ed638b4/0_192_5760_3456",
+  "felicityCloake": "855a409989bc1898aba80e8600a8e6ca8e01ca3a/0_0_500_300",
+  "woleSoyinka": "7a24fd9a5293314cf0ed51445443220c30d88d4d/0_0_2667_1600"
 }

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/thankYou/eventsModule.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/thankYou/eventsModule.jsx
@@ -19,7 +19,7 @@ const EventsModule = () => (
     <SvgTicket />
     <Text title="Guardian digital events">
       <p>
-      Enjoy 6 free tickets to Guardian digital events in the first 3 months of your subscription.
+      Enjoy 6 free tickets to Guardian digital events in the first 6 months of your subscription.
       You will be sent your unique redemption code by email shortly, enter your code 6 times at
       the checkout for your chosen events to receive your free tickets.
       </p>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/events/eventCard.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/events/eventCard.jsx
@@ -7,13 +7,11 @@ import { from } from '@guardian/src-foundations/mq';
 import { border } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
 import { SvgCalendar } from 'components/icons/calendar';
-import { SvgClock } from 'components/icons/clock';
 
 type PropTypes = {
   eventType: string,
   eventImage: Node,
   eventDate: string,
-  eventTime: string,
   eventColour: string,
   eventSectionText: string,
   eventDescription: string,
@@ -97,10 +95,10 @@ const EventCard = (props: PropTypes) => {
 `;
 
   const svgFillColour = css`
-  svg path {
-    fill: ${props.eventColour};
-  }
-`;
+    svg path {
+      fill: ${props.eventColour};
+    }
+  `;
 
   return (
     <section>
@@ -111,9 +109,6 @@ const EventCard = (props: PropTypes) => {
           <div>
             <div css={[infoLine, svgFillColour]} aria-label="The event date is">
               <SvgCalendar />{props.eventDate}
-            </div>
-            <div css={[infoLine, svgFillColour]} aria-label="The event will be held at">
-              <SvgClock />{props.eventTime}
             </div>
           </div>
           <p css={eventDescriptionText}>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/events/eventCard.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/events/eventCard.jsx
@@ -26,7 +26,7 @@ const cardContent = css`
   }
 
   ${from.tablet} {
-    grid-template-rows: 1fr 1.8fr;
+    grid-template-rows: 1fr 1.6fr;
   }
 
   ${from.leftCol} {

--- a/support-frontend/assets/pages/digital-subscription-landing/components/events/eventsImages.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/events/eventsImages.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import GridImage from 'components/gridImage/gridImage';
 
-const jessPhillips = (
+const keirStarmerImage = (
   <GridImage
     classModifiers={['']}
-    gridId="jessPhillips"
+    gridId="keirStarmer"
     srcSizes={[140, 500, 1000]}
     sizes="(max-width: 480px) 100px,
             (max-width: 740px) 100%,
@@ -14,20 +14,34 @@ const jessPhillips = (
   />
 );
 
-const robbieAndersonImage = (
+const felicityCloakeImage = (
   <GridImage
     classModifiers={['']}
-    gridId="robbieAnderson"
-    srcSizes={[140, 500, 1000]}
+    gridId="felicityCloake"
+    srcSizes={[140, 500]}
     sizes="(max-width: 480px) 100px,
             (max-width: 740px) 100%,
             (max-width: 1067px) 150%,
             560px"
     imgType="jpg"
+  />
+);
+
+const woleSoyinkaImage = (
+  <GridImage
+    classModifiers={['']}
+    gridId="woleSoyinka"
+    srcSizes={[140, 500, 1000]}
+    sizes="(max-width: 480px) 100px,
+            (max-width: 740px) 100%,
+            (max-width: 1067px) 150%,
+            560px"
+    imgType="png"
   />
 );
 
 export {
-  jessPhillips,
-  robbieAndersonImage,
+  keirStarmerImage,
+  felicityCloakeImage,
+  woleSoyinkaImage,
 };

--- a/support-frontend/assets/pages/digital-subscription-landing/components/events/eventsModule.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/events/eventsModule.jsx
@@ -8,8 +8,9 @@ import { background, border, lifestyle, news } from '@guardian/src-foundations/p
 import { headline, body, textSans } from '@guardian/src-foundations/typography';
 import { SvgTicket } from 'components/icons/ticket';
 import EventCard from './eventCard';
-import { keirStarmerImage, felicityCloakeImage } from './eventsImages';
+import { keirStarmerImage, felicityCloakeImage, woleSoyinkaImage } from './eventsImages';
 import BlockLabel from 'components/blockLabel/blockLabel';
+import { detect as detectCountry } from 'helpers/internationalisation/country';
 
 const container = css`
   box-sizing: border-box;
@@ -167,6 +168,33 @@ const eventCardContainer = css`
   }
 `;
 
+const countryId = detectCountry();
+console.log(countryId);
+
+const FeaturedEventCardUK = (
+  <EventCard
+    eventType="Featured event"
+    eventImage={keirStarmerImage}
+    eventDate="20 Sept 2021"
+    eventColour={news[400]}
+    eventSectionText="Politics"
+    eventDescription="Guardian Newsroom: Are the Labour Party electable?"
+  />
+);
+
+const FeaturedEventCardUS = (
+  <EventCard
+    eventType="Featured event"
+    eventImage={woleSoyinkaImage}
+    eventDate="28 Sept 2021"
+    eventColour={news[400]}
+    eventSectionText="Politics"
+    eventDescription="Wole Soyinka in conversation"
+  />
+);
+
+const featuredEvent = ((countryId === 'US' ? FeaturedEventCardUS : FeaturedEventCardUK));
+
 const EventsModule = () => (
   <>
     <BlockLabel tag="h2" cssOverrides={label}>Special offer</BlockLabel>
@@ -183,18 +211,11 @@ const EventsModule = () => (
           </p>
         </div>
         <div css={eventCardContainer}>
-          <EventCard
-            eventType="Featured event"
-            eventImage={keirStarmerImage}
-            eventDate="21 July 2021"
-            eventColour={news[400]}
-            eventSectionText="Politics"
-            eventDescription="Guardian Newsroom: Are the Labour Party electable?"
-          />
+          {featuredEvent}
           <EventCard
             eventType="Featured masterclass"
             eventImage={felicityCloakeImage}
-            eventDate="22 July 2021"
+            eventDate="22 Sept 2021"
             eventColour={lifestyle[400]}
             eventSectionText="Food"
             eventDescription="How to write about food with Felicity Cloake"

--- a/support-frontend/assets/pages/digital-subscription-landing/components/events/eventsModule.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/events/eventsModule.jsx
@@ -175,7 +175,7 @@ const EventsModule = () => (
         <div css={textContentContainer}>
           <SvgTicket />
           <h3 css={cardTitle}>Enjoy 6 free tickets to digital Guardian events</h3>
-          <p css={para}>In the <span css={bold}>first 3 months</span> of your subscription</p>
+          <p css={para}>In the <span css={bold}>first 6 months</span> of your subscription</p>
           <p css={paraSecond}>
             Join interactive Live conversations with journalists, political leaders and cultural
             icons. Or get inspired to learn a new skill in selected Masterclasses. With events

--- a/support-frontend/assets/pages/digital-subscription-landing/components/events/eventsModule.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/events/eventsModule.jsx
@@ -169,7 +169,6 @@ const eventCardContainer = css`
 `;
 
 const countryId = detectCountry();
-console.log(countryId);
 
 const FeaturedEventCardUK = (
   <EventCard

--- a/support-frontend/assets/pages/digital-subscription-landing/components/events/eventsModule.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/events/eventsModule.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { css } from '@emotion/core';
 import { from } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
-import { background, border, lifestyle, news } from '@guardian/src-foundations/palette';
+import { background, border, lifestyle, news, culture } from '@guardian/src-foundations/palette';
 import { headline, body, textSans } from '@guardian/src-foundations/typography';
 import { SvgTicket } from 'components/icons/ticket';
 import EventCard from './eventCard';
@@ -187,8 +187,8 @@ const FeaturedEventCardUS = (
     eventType="Featured event"
     eventImage={woleSoyinkaImage}
     eventDate="28 Sept 2021"
-    eventColour={news[400]}
-    eventSectionText="Politics"
+    eventColour={culture[400]}
+    eventSectionText="Culture"
     eventDescription="Wole Soyinka in conversation"
   />
 );
@@ -217,7 +217,7 @@ const EventsModule = () => (
             eventImage={felicityCloakeImage}
             eventDate="22 Sept 2021"
             eventColour={lifestyle[400]}
-            eventSectionText="Food"
+            eventSectionText="Lifestyle"
             eventDescription="How to write about food with Felicity Cloake"
           />
         </div>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/events/eventsModule.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/events/eventsModule.jsx
@@ -4,11 +4,11 @@ import React from 'react';
 import { css } from '@emotion/core';
 import { from } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
-import { background, border, sport, news } from '@guardian/src-foundations/palette';
+import { background, border, lifestyle, news } from '@guardian/src-foundations/palette';
 import { headline, body, textSans } from '@guardian/src-foundations/typography';
 import { SvgTicket } from 'components/icons/ticket';
 import EventCard from './eventCard';
-import { jessPhillips, robbieAndersonImage } from './eventsImages';
+import { keirStarmerImage, felicityCloakeImage } from './eventsImages';
 import BlockLabel from 'components/blockLabel/blockLabel';
 
 const container = css`
@@ -112,7 +112,7 @@ const paraTiny = css`
   ${from.tablet} {
     margin: 0;
     position: absolute;
-    bottom: 40px;
+    bottom: 15px;
   }
 
   ${from.desktop} {
@@ -185,21 +185,19 @@ const EventsModule = () => (
         <div css={eventCardContainer}>
           <EventCard
             eventType="Featured event"
-            eventImage={jessPhillips}
+            eventImage={keirStarmerImage}
             eventDate="21 July 2021"
-            eventTime="8-9pm BST"
             eventColour={news[400]}
             eventSectionText="Politics"
-            eventDescription="Everything you really need to know about politics, with Jess Phillips MP"
+            eventDescription="Guardian Newsroom: Are the Labour Party electable?"
           />
           <EventCard
             eventType="Featured masterclass"
-            eventImage={robbieAndersonImage}
+            eventImage={felicityCloakeImage}
             eventDate="22 July 2021"
-            eventTime="6.30-8pm BST"
-            eventColour={sport[400]}
-            eventSectionText="Sport"
-            eventDescription="How to apply sports psychology to your life with Dr Robbie Anderson"
+            eventColour={lifestyle[400]}
+            eventSectionText="Food"
+            eventDescription="How to write about food with Felicity Cloake"
           />
         </div>
         <p css={paraTiny}>See full Terms &amp; Conditions below</p>


### PR DESCRIPTION
## What are you doing in this PR?
This follows a previous PR which set up a referrer controlled 0% A/B test for the Events module on the digital subscriptions landing page, which can be found [here](https://github.com/guardian/support-frontend/pull/3202). This PR updates the images and copy for the events shown in the Events module component.

[**Trello Card**](https://trello.com/c/191FZirU/3802-update-events-module-component-for-email-digi-subs-events-ab-test)

## Why are you doing this?
So when the Events module component is rendered we show appropriate up-to-date events information.

## Is this an AB test?
- [x] Yes
- [ ] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home/#/accounts/1368065808/containers/6827913/experiments/497)

## Accessibility test checklist
 - [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots
| Left col  | Mobile medium |
| ------------- | ------------- |
| <img width="903" alt="Screenshot 2021-08-13 at 09 50 09" src="https://user-images.githubusercontent.com/44685872/129331484-3167cc62-ed29-4885-bea2-e088fb7c8937.png"> | <img width="280" alt="Screenshot 2021-08-13 at 09 50 41" src="https://user-images.githubusercontent.com/44685872/129331394-05890ef7-ddbe-4927-8d15-12934924dd39.png"> |