### PR TITLE
Remove snyk check from branches

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -7,6 +7,8 @@ on:
   schedule:
     - cron: '0 6 * * *'
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -16,21 +18,15 @@ jobs:
       SNYK_COMMAND: test
     steps:
       - name: Checkout branch
-        if: github.ref == 'refs/heads/main'
         uses: actions/checkout@v2
 
-      - name: Set command to monitor
-        if: github.ref == 'refs/heads/main'
-        run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
-
       - name: Run Snyk to check for vulnerabilities
-        if: github.ref == 'refs/heads/main'
         uses: snyk/actions/scala@0.3.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --org=the-guardian-cuu --project-name=${{ github.repository }} --file=./build.sbt
-          command: ${{ env.SNYK_COMMAND }}
+          command: monitor
 
   node-security:
     runs-on: ubuntu-latest
@@ -38,18 +34,12 @@ jobs:
       SNYK_COMMAND: test
     steps:
       - name: Checkout branch
-        if: github.ref == 'refs/heads/main'
         uses: actions/checkout@v2
 
-      - name: Set command to monitor
-        if: github.ref == 'refs/heads/main'
-        run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
-
       - name: Run Snyk to check for vulnerabilities
-        if: github.ref == 'refs/heads/main'
         uses: snyk/actions/node@0.3.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --org=the-guardian-cuu --project-name=${{ github.repository }} --file=./support-frontend/yarn.lock
-          command: ${{ env.SNYK_COMMAND }}
+          command: monitor

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -16,6 +16,7 @@ jobs:
       SNYK_COMMAND: test
     steps:
       - name: Checkout branch
+        if: github.ref == 'refs/heads/main'
         uses: actions/checkout@v2
 
       - name: Set command to monitor
@@ -23,6 +24,7 @@ jobs:
         run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
 
       - name: Run Snyk to check for vulnerabilities
+        if: github.ref == 'refs/heads/main'
         uses: snyk/actions/scala@0.3.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -36,6 +38,7 @@ jobs:
       SNYK_COMMAND: test
     steps:
       - name: Checkout branch
+        if: github.ref == 'refs/heads/main'
         uses: actions/checkout@v2
 
       - name: Set command to monitor
@@ -43,6 +46,7 @@ jobs:
         run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
 
       - name: Run Snyk to check for vulnerabilities
+        if: github.ref == 'refs/heads/main'
         uses: snyk/actions/node@0.3.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
It marks all branches as failed, which isn't helpful.
We have a snyk rota for addressing these issues