### PR TITLE
acquisitions-firehose-transformer: GBP conversion

### DIFF
--- a/support-lambdas/acquisitions-firehose-transformer/build.sbt
+++ b/support-lambdas/acquisitions-firehose-transformer/build.sbt
@@ -5,10 +5,9 @@ name := "acquisitions-firehose-transformer"
 description:= "A Firehose transformation lambda for serialising the acquisitions event stream to csv"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.4",
   "software.amazon.awssdk" % "auth" % "2.17.19",
-  "software.amazon.awssdk" % "dynamodb" % "2.16.84",
+  "software.amazon.awssdk" % "dynamodb" % "2.17.19",
   "ch.qos.logback" % "logback-classic" % "1.1.7",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
   "io.circe" %% "circe-core" % circeVersion,

--- a/support-lambdas/acquisitions-firehose-transformer/build.sbt
+++ b/support-lambdas/acquisitions-firehose-transformer/build.sbt
@@ -18,6 +18,7 @@ libraryDependencies ++= Seq(
 assemblyMergeStrategy in assembly := {
   case x if x.endsWith("module-info.class") => MergeStrategy.discard
   case str if str.contains("simulacrum") => MergeStrategy.first
+  case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
   case y =>
     val oldStrategy = (assemblyMergeStrategy in assembly).value
     oldStrategy(y)

--- a/support-lambdas/acquisitions-firehose-transformer/build.sbt
+++ b/support-lambdas/acquisitions-firehose-transformer/build.sbt
@@ -6,8 +6,6 @@ description:= "A Firehose transformation lambda for serialising the acquisitions
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.4",
-  "software.amazon.awssdk" % "auth" % "2.17.19",
-  "software.amazon.awssdk" % "dynamodb" % "2.17.19",
   "ch.qos.logback" % "logback-classic" % "1.1.7",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
   "io.circe" %% "circe-core" % circeVersion,

--- a/support-lambdas/acquisitions-firehose-transformer/build.sbt
+++ b/support-lambdas/acquisitions-firehose-transformer/build.sbt
@@ -7,6 +7,7 @@ description:= "A Firehose transformation lambda for serialising the acquisitions
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.4",
+  "software.amazon.awssdk" % "auth" % "2.17.19",
   "software.amazon.awssdk" % "dynamodb" % "2.16.84",
   "ch.qos.logback" % "logback-classic" % "1.1.7",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",

--- a/support-lambdas/acquisitions-firehose-transformer/build.sbt
+++ b/support-lambdas/acquisitions-firehose-transformer/build.sbt
@@ -7,11 +7,13 @@ description:= "A Firehose transformation lambda for serialising the acquisitions
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.4",
+  "software.amazon.awssdk" % "dynamodb" % "2.16.84",
   "ch.qos.logback" % "logback-classic" % "1.1.7",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
-  "com.gu" %% "acquisitions-value-calculator-client" % "2.0.5"
+  "com.gu" %% "acquisitions-value-calculator-client" % "2.0.5",
+  "org.scanamo" %% "scanamo" % "1.0.0-M15"
 )
 assemblyMergeStrategy in assembly := {
   case x if x.endsWith("module-info.class") => MergeStrategy.discard

--- a/support-lambdas/acquisitions-firehose-transformer/cfn.yaml
+++ b/support-lambdas/acquisitions-firehose-transformer/cfn.yaml
@@ -50,4 +50,9 @@ Resources:
           Action: sts:AssumeRole
           Resource:
             Ref: OphanRole
-
+      - Statement:
+          Effect: Allow
+          Action: dynamodb:*
+          Resource:
+            - !Sub arn:aws:dynamodb:*:${AWS::AccountId}:table/fixer-io-cache
+            - !Sub arn:aws:dynamodb:*:${AWS::AccountId}:table/fixer-io-cache/index/*

--- a/support-lambdas/acquisitions-firehose-transformer/riff-raff.yaml
+++ b/support-lambdas/acquisitions-firehose-transformer/riff-raff.yaml
@@ -9,3 +9,9 @@ deployments:
       functionNames: [acquisitions-firehose-transformer-]
       fileName: acquisitions-firehose-transformer.jar
       prefixStack: false
+    dependencies: [ cfn ]
+  cfn:
+    type: cloud-formation
+    app: acquisitions-firehose-transformer
+    parameters:
+      templatePath: cfn.yaml

--- a/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/AcquisitionToJson.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/AcquisitionToJson.scala
@@ -18,6 +18,7 @@ object AcquisitionToJson {
     countryCode: String,
     amount: BigDecimal,
     annualisedValue: Double,
+    annualisedValueGBP: Double,
     currency: String,
     timestamp: String,
     campaignCode: String,
@@ -28,12 +29,13 @@ object AcquisitionToJson {
     labels: List[String]
   )
 
-  def apply(amount: BigDecimal, annualisedValue: Double, acquisition: AcquisitionDataRow): Json = {
+  def apply(amount: BigDecimal, annualisedValue: Double, annualisedValueGBP: Double,acquisition: AcquisitionDataRow): Json = {
     AcquisitionOutput(
       acquisition.paymentFrequency.value,
       acquisition.country.alpha2,
       amount,
       annualisedValue,
+      annualisedValueGBP,
       acquisition.currency.iso,
       dtFormatter.print(acquisition.eventTimeStamp),
       acquisition.campaignCode.getOrElse(""),

--- a/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/GBPConversionService.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/GBPConversionService.scala
@@ -16,7 +16,7 @@ trait GBPConversionService {
 object GBPConversionServiceImpl extends GBPConversionService {
   private case class ConversionData(base: String, eventDate: String, rates: Map[String,Float])
 
-  private val dynamoDb = DynamoDbClient.builder().region(Region.EU_WEST_1).build()
+  private val dynamoDb = DynamoDbClient.builder().region(Region.EU_WEST_1).endpointDiscoveryEnabled(true).build()
   private val scanamo: Scanamo = Scanamo(dynamoDb)
   private val table: Table[ConversionData] = Table("fixer-io-cache")
 

--- a/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/GBPConversionService.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/GBPConversionService.scala
@@ -7,7 +7,7 @@ import org.joda.time.format.ISODateTimeFormat
 import org.scanamo.generic.auto._
 import org.scanamo.syntax._
 import org.scanamo.{Scanamo, Table}
-import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, EnvironmentVariableCredentialsProvider, InstanceProfileCredentialsProvider, ProfileCredentialsProvider}
+import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, EnvironmentVariableCredentialsProvider, ProfileCredentialsProvider}
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
@@ -18,19 +18,16 @@ trait GBPConversionService {
 object GBPConversionServiceImpl extends GBPConversionService {
   private case class ConversionData(base: String, eventDate: String, rates: Map[String,Float])
 
-  val chain = AwsCredentialsProviderChain.builder()
+  private val providerChain = AwsCredentialsProviderChain.builder()
     .addCredentialsProvider(EnvironmentVariableCredentialsProvider.create())
     .addCredentialsProvider(ProfileCredentialsProvider.create("membership"))
-    .addCredentialsProvider(ProfileCredentialsProvider.create())
-    .addCredentialsProvider(InstanceProfileCredentialsProvider.create())
     .build()
 
-  val dynamoDb = DynamoDbClient.builder()
-    .credentialsProvider(chain)
+  private val dynamoDb = DynamoDbClient.builder()
+    .credentialsProvider(providerChain)
     .region(Region.EU_WEST_1)
     .build()
 
-//  private val dynamoDb = DynamoDbClient.builder().region(Region.EU_WEST_1).endpointDiscoveryEnabled(true).build()
   private val scanamo: Scanamo = Scanamo(dynamoDb)
   private val table: Table[ConversionData] = Table("fixer-io-cache")
 

--- a/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/GBPConversionService.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/GBPConversionService.scala
@@ -1,0 +1,38 @@
+package com.gu.acquisitionFirehoseTransformer
+
+import com.gu.i18n.Currency
+import org.joda.time.DateTime
+import org.joda.time.format.ISODateTimeFormat
+import org.scanamo.generic.auto._
+import org.scanamo.syntax._
+import org.scanamo.{Scanamo, Table}
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+
+trait GBPConversionService {
+  def convert(currency: Currency, amount: Double, dateTime: DateTime): Either[String,Double]
+}
+
+class GBPConversionServiceImpl() extends GBPConversionService {
+  private case class ConversionData(base: String, eventDate: String, rates: Map[String,Float])
+
+  private val dynamoDb = DynamoDbClient.builder().build()
+  private val scanamo: Scanamo = Scanamo(dynamoDb)
+  private val table: Table[ConversionData] = Table("fixer-io-cache")
+
+  def convert(currency: Currency, amount: Double, dateTime: DateTime): Either[String,Double] = {
+    val date = ISODateTimeFormat.date().print(dateTime)
+    scanamo
+      .exec(
+        table.query("eventDate" === date and ("base" === "GBP"))
+      )
+      .headOption.toRight(s"No results found in dynamodb for $date")
+      .flatMap {
+        case Right(conversionData) =>
+          conversionData.rates.get(currency.iso) match {
+            case Some(rate) => Right(amount / rate)
+            case None => Left(s"Cannot find rate for currency ${currency.iso}")
+          }
+        case Left(error) => Left(error.toString)
+      }
+  }
+}

--- a/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/GBPConversionService.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/GBPConversionService.scala
@@ -6,6 +6,7 @@ import org.joda.time.format.ISODateTimeFormat
 import org.scanamo.generic.auto._
 import org.scanamo.syntax._
 import org.scanamo.{Scanamo, Table}
+import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 trait GBPConversionService {
@@ -15,7 +16,7 @@ trait GBPConversionService {
 object GBPConversionServiceImpl extends GBPConversionService {
   private case class ConversionData(base: String, eventDate: String, rates: Map[String,Float])
 
-  private val dynamoDb = DynamoDbClient.builder().build()
+  private val dynamoDb = DynamoDbClient.builder().region(Region.EU_WEST_1).build()
   private val scanamo: Scanamo = Scanamo(dynamoDb)
   private val table: Table[ConversionData] = Table("fixer-io-cache")
 

--- a/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/GBPConversionService.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/GBPConversionService.scala
@@ -19,8 +19,8 @@ object GBPConversionServiceImpl extends GBPConversionService {
   private case class ConversionData(base: String, eventDate: String, rates: Map[String,Float])
 
   private val providerChain = AwsCredentialsProviderChain.builder()
-    .addCredentialsProvider(EnvironmentVariableCredentialsProvider.create())
-    .addCredentialsProvider(ProfileCredentialsProvider.create("membership"))
+    .addCredentialsProvider(EnvironmentVariableCredentialsProvider.create())  // For running in lambda
+    .addCredentialsProvider(ProfileCredentialsProvider.create("membership"))  // For running locally
     .build()
 
   private val dynamoDb = DynamoDbClient.builder()

--- a/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/GBPConversionService.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/GBPConversionService.scala
@@ -12,7 +12,7 @@ trait GBPConversionService {
   def convert(currency: Currency, amount: Double, dateTime: DateTime): Either[String,Double]
 }
 
-class GBPConversionServiceImpl() extends GBPConversionService {
+object GBPConversionServiceImpl extends GBPConversionService {
   private case class ConversionData(base: String, eventDate: String, rates: Map[String,Float])
 
   private val dynamoDb = DynamoDbClient.builder().build()

--- a/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/Lambda.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/Lambda.scala
@@ -66,7 +66,7 @@ object Lambda extends LazyLogging {
             av <- getAnnualisedValue(amount, acquisition)
             avGBP <- gbpService.convert(acquisition.currency, av, conversionDate)
           } yield {
-            val outputJson = AcquisitionToJson(amount, avGBP, acquisition).noSpaces +"\n"
+            val outputJson = AcquisitionToJson(amount, av, avGBP, acquisition).noSpaces +"\n"
             new Record(recordId, Result.Ok, ByteBuffer.wrap(outputJson.getBytes))
           }
       }.sequence

--- a/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/Lambda.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/Lambda.scala
@@ -20,7 +20,7 @@ case class AcquisitionWithRecordId(val acquisition: AcquisitionDataRow, recordId
 object Lambda extends LazyLogging {
 
   def handler(event: KinesisFirehoseEvent): KinesisAnalyticsInputPreprocessingResponse = {
-    processEvent(event, new AnnualisedValueServiceImpl(), new GBPConversionServiceImpl())
+    processEvent(event, new AnnualisedValueServiceImpl(), GBPConversionServiceImpl)
   }
 
   def processEvent(

--- a/support-lambdas/acquisitions-firehose-transformer/src/test/scala/com/gu/acquisitionFirehoseTransformer/LambdaSpec.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/test/scala/com/gu/acquisitionFirehoseTransformer/LambdaSpec.scala
@@ -3,7 +3,6 @@ package com.gu.acquisitionFirehoseTransformer
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 
-import com.gu.support.acquisitions
 import com.gu.support.acquisitions.models._
 import com.amazonaws.services.lambda.runtime.events.KinesisFirehoseEvent
 
@@ -12,7 +11,7 @@ import org.joda.time.DateTime
 import com.gu.i18n.{Country, Currency}
 import com.gu.support.zuora.api.ReaderType
 import java.nio.ByteBuffer
-import collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import com.gu.acquisitionsValueCalculatorClient.model.AcquisitionModel
 import scala.concurrent.ExecutionContext
 

--- a/support-lambdas/acquisitions-firehose-transformer/src/test/scala/com/gu/acquisitionFirehoseTransformer/LambdaSpec.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/test/scala/com/gu/acquisitionFirehoseTransformer/LambdaSpec.scala
@@ -41,10 +41,10 @@ class LambdaSpec extends AnyFlatSpec with Matchers {
     val jsons = records.toList.map { record => new String(record.getData().array()) }
 
     jsons(0) should be(
-      """{"paymentFrequency":"MONTHLY","countryCode":"GB","amount":10.0,"annualisedValue":144.0,"currency":"GBP","timestamp":"2018-12-13 14:15:04","campaignCode":"MY_CAMPAIGN_CODE","componentId":"MY_COMPONENT_ID","product":"RECURRING_CONTRIBUTION","paymentProvider":"STRIPE","referrerUrl":"referrer-url","labels":[]}""" + '\n',
+      """{"paymentFrequency":"MONTHLY","countryCode":"GB","amount":10.0,"annualisedValue":120.0,"annualisedValueGBP":144.0,"currency":"USD","timestamp":"2018-12-13 14:15:04","campaignCode":"MY_CAMPAIGN_CODE","componentId":"MY_COMPONENT_ID","product":"RECURRING_CONTRIBUTION","paymentProvider":"STRIPE","referrerUrl":"referrer-url","labels":[]}""" + '\n',
     )
     jsons(1) should be(
-      """{"paymentFrequency":"MONTHLY","countryCode":"GB","amount":20.0,"annualisedValue":288.0,"currency":"GBP","timestamp":"2018-12-13 14:15:04","campaignCode":"MY_CAMPAIGN_CODE","componentId":"MY_COMPONENT_ID","product":"RECURRING_CONTRIBUTION","paymentProvider":"STRIPE","referrerUrl":"referrer-url","labels":[]}""" + '\n',
+      """{"paymentFrequency":"MONTHLY","countryCode":"GB","amount":20.0,"annualisedValue":240.0,"annualisedValueGBP":288.0,"currency":"USD","timestamp":"2018-12-13 14:15:04","campaignCode":"MY_CAMPAIGN_CODE","componentId":"MY_COMPONENT_ID","product":"RECURRING_CONTRIBUTION","paymentProvider":"STRIPE","referrerUrl":"referrer-url","labels":[]}""" + '\n',
     )
   }
 
@@ -69,7 +69,7 @@ class LambdaSpec extends AnyFlatSpec with Matchers {
       product = AcquisitionProduct.RecurringContribution,
       amount = amount,
       country = Country.UK,
-      currency = Currency.GBP,
+      currency = Currency.USD,
       componentId = Some("MY_COMPONENT_ID"),
       componentType = None,
       campaignCode = Some("MY_CAMPAIGN_CODE"),

--- a/support-lambdas/acquisitions-firehose-transformer/src/test/scala/com/gu/acquisitionFirehoseTransformer/LambdaSpec.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/test/scala/com/gu/acquisitionFirehoseTransformer/LambdaSpec.scala
@@ -20,7 +20,11 @@ import scala.concurrent.ExecutionContext
 class LambdaSpec extends AnyFlatSpec with Matchers {
 
   val mockAVService = new AnnualisedValueServiceWrapper {
-    def getAV(acquisitionModel: AcquisitionModel, accountName: String)(implicit executionContext: ExecutionContext): Either[String,Double] = Right(50)
+    def getAV(acquisitionModel: AcquisitionModel, accountName: String)(implicit executionContext: ExecutionContext): Either[String,Double] = Right(acquisitionModel.amount*12)
+  }
+
+  val mockGBPService = new GBPConversionService {
+    override def convert(currency: Currency, amount: Double, dateTime: DateTime): Either[String, Double] = Right(amount * 1.2)
   }
 
   it should "successfully process a valid batch of acquisitions, filtering out ones without an amount" in {
@@ -29,7 +33,7 @@ class LambdaSpec extends AnyFlatSpec with Matchers {
     val r3 = buildRecord("3", None)
     val event = buildEvent(List(r1, r2, r3))
 
-    val result = Lambda.processEvent(event, mockAVService)
+    val result = Lambda.processEvent(event, mockAVService, mockGBPService)
 
     val records = result.getRecords.asScala
 
@@ -38,10 +42,10 @@ class LambdaSpec extends AnyFlatSpec with Matchers {
     val jsons = records.toList.map { record => new String(record.getData().array()) }
 
     jsons(0) should be(
-      """{"paymentFrequency":"MONTHLY","countryCode":"GB","amount":10.0,"annualisedValue":50.0,"currency":"GBP","timestamp":"2018-12-13 14:15:04","campaignCode":"MY_CAMPAIGN_CODE","componentId":"MY_COMPONENT_ID","product":"RECURRING_CONTRIBUTION","paymentProvider":"STRIPE","referrerUrl":"referrer-url","labels":[]}""" + '\n',
+      """{"paymentFrequency":"MONTHLY","countryCode":"GB","amount":10.0,"annualisedValue":144.0,"currency":"GBP","timestamp":"2018-12-13 14:15:04","campaignCode":"MY_CAMPAIGN_CODE","componentId":"MY_COMPONENT_ID","product":"RECURRING_CONTRIBUTION","paymentProvider":"STRIPE","referrerUrl":"referrer-url","labels":[]}""" + '\n',
     )
     jsons(1) should be(
-      """{"paymentFrequency":"MONTHLY","countryCode":"GB","amount":20.0,"annualisedValue":50.0,"currency":"GBP","timestamp":"2018-12-13 14:15:04","campaignCode":"MY_CAMPAIGN_CODE","componentId":"MY_COMPONENT_ID","product":"RECURRING_CONTRIBUTION","paymentProvider":"STRIPE","referrerUrl":"referrer-url","labels":[]}""" + '\n',
+      """{"paymentFrequency":"MONTHLY","countryCode":"GB","amount":20.0,"annualisedValue":288.0,"currency":"GBP","timestamp":"2018-12-13 14:15:04","campaignCode":"MY_CAMPAIGN_CODE","componentId":"MY_COMPONENT_ID","product":"RECURRING_CONTRIBUTION","paymentProvider":"STRIPE","referrerUrl":"referrer-url","labels":[]}""" + '\n',
     )
   }
 
@@ -49,7 +53,7 @@ class LambdaSpec extends AnyFlatSpec with Matchers {
     val r = buildInvalidRecord("1")
     val event = buildEvent(List(r))
 
-    assertThrows[Exception] { Lambda.processEvent(event, mockAVService) }
+    assertThrows[Exception] { Lambda.processEvent(event, mockAVService, mockGBPService) }
   }
 
 


### PR DESCRIPTION
This lambda uses the `AnnualisedValueService` to calculate AV before writing to S3.
But despite taking currency as a parameter, this service does not calculate AV in GBP!
The `fixer-io-cache` dynamodb table has daily currency conversions rates.

I used a scala library called scanamo for querying dynamodb as the java sdk is not great.

An event in athena:
![Screen Shot 2021-08-16 at 10 36 31](https://user-images.githubusercontent.com/1513454/129543192-26f9b45d-a6ce-49fb-9460-e30aceba345b.png)
