### PR TITLE
Add prototype for interactive table for future digi subs A/B test

### DIFF
--- a/support-frontend/assets/components/interactiveTable/interactiveTable.jsx
+++ b/support-frontend/assets/components/interactiveTable/interactiveTable.jsx
@@ -1,0 +1,211 @@
+// @flow
+// $FlowIgnore
+import React, { useState, type Node } from 'react';
+import { css } from '@emotion/core';
+import { space } from '@guardian/src-foundations';
+import { SvgChevronDownSingle } from '@guardian/src-icons';
+import { Button } from '@guardian/src-button';
+import { neutral, sport } from '@guardian/src-foundations/palette';
+import { visuallyHidden as _visuallyHidden } from '@guardian/src-foundations/accessibility';
+
+const visuallyHidden = css`
+  ${_visuallyHidden}
+`;
+
+const table = css`
+  width: 100%;
+`;
+
+const tableRow = css`
+  position: relative;
+  width: 100%;
+  display: flex;
+  flex-flow: row wrap;
+  text-align: left;
+  background-color: ${neutral[100]};
+  max-height: 72px;
+  transition: all 0.2s ease-in-out;
+
+  :not(:first-of-type) {
+    margin-top: ${space[2]}px;
+  }
+
+  td, th {
+    display: block;
+    flex: 1 1 25%;
+    height: 72px;
+  }
+`;
+
+const tableRowOpen = css`
+  background-color: ${sport[800]};
+  max-height: 300px;
+`;
+
+const tableCell = css`
+  padding: ${space[4]}px;
+`;
+
+const expandableButtonCell = css`
+  order: -1;
+  padding: 0;
+`;
+
+const detailsCell = css`
+  flex: 1 1 100%;
+`;
+
+const detailsHidden = css`
+  display: none;
+`;
+
+const detailsVisible = css`
+  display: block;
+`;
+
+const toggleButton = css`
+  position: absolute;
+  left: ${space[4]}px;
+  right: ${space[4]}px;
+  width: calc(100% - 32px);
+  /* Allows space for the 5px focus box shadow */
+  height: 62px;
+  justify-content: flex-start;
+
+  svg {
+    fill: currentColor;
+    height: ${space[4]}px;
+    max-width: ${space[5]}px;
+    transition: transform 0.2s ease-in-out;
+  }
+`;
+
+const toggleButtonOpen = css`
+  svg {
+    transform: rotate(180deg);
+  }
+`;
+
+
+type CellData = {|
+  content: Node;
+  isPrimary?: boolean;
+|}
+
+type RowData = {|
+  rowId: string;
+  columns: CellData[];
+  details: Node;
+|}
+
+function InteractiveTableRow({
+  rowId, columns, details,
+}: RowData) {
+  const [showDetails, setShowDetails] = useState<boolean>(false);
+
+  return (
+    <tr role="row" css={[tableRow, showDetails ? tableRowOpen : '']}>
+      {columns.map((column) => {
+        if (column.isPrimary) {
+          return (
+            <th scope="row" role="rowHeader" css={tableCell}>
+              {column.content}
+            </th>
+          );
+        }
+        return <td role="cell" css={tableCell}>{column.content}</td>;
+      })}
+      <td role="cell" css={expandableButtonCell}>
+        <Button
+          hideLabel
+          priority="subdued"
+          icon={<SvgChevronDownSingle />}
+          css={[toggleButton, showDetails ? toggleButtonOpen : '']}
+          aria-expanded={showDetails ? 'true' : 'false'}
+          aria-controls={`${rowId}-details`}
+          onClick={() => setShowDetails(!showDetails)}
+        >
+          Show more details
+        </Button>
+      </td>
+      <td
+        role="cell"
+        hidden={!showDetails}
+        id={`${rowId}-details`}
+        css={[tableCell, detailsCell, showDetails ? detailsVisible : detailsHidden]}
+      >
+        {details}
+      </td>
+    </tr>
+  );
+}
+
+const rows: RowData[] = [
+  {
+    rowId: 'row1',
+    columns: [
+      {
+        content: 'Nice journalism',
+        isPrimary: true,
+      },
+      {
+        content: 'Yes',
+      },
+      {
+        content: 'Yes',
+      },
+    ],
+    details: 'It\'s really very very good journalism',
+  },
+  {
+    rowId: 'row2',
+    columns: [
+      {
+        content: 'A free pony',
+        isPrimary: true,
+      },
+      {
+        content: 'Yes',
+      },
+      {
+        content: 'No',
+      },
+    ],
+    details: 'You will need your own stable',
+  },
+];
+
+function InteractiveTable() {
+  return (
+    <table css={table}>
+      <caption css={visuallyHidden}>What&apos;s included in a paid digital subscription</caption>
+      <thead>
+        <tr role="row" css={tableRow}>
+          <th scope="col" role="columnHeader"><span css={visuallyHidden}>Benefits</span></th>
+          <th scope="col" role="columnHeader" css={tableCell}>Paid</th>
+          <th scope="col" role="columnHeader" css={tableCell}>Free</th>
+          <th scope="col" role="columnHeader"><span css={visuallyHidden}>Actions</span></th>
+          <th scope="col" role="columnHeader"><span css={visuallyHidden}>Details</span></th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(({ rowId, columns, details }) =>
+          (<InteractiveTableRow
+            rowId={rowId}
+            columns={columns}
+            details={details}
+          />))
+        }
+      </tbody>
+      <tfoot>
+        <tr role="row" css={tableRow}>
+          <td role="cell" colSpan="5" css={tableCell}>
+            <div><span>Plus 14 day free trial</span></div>
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  );
+}
+
+export default InteractiveTable;

--- a/support-frontend/assets/components/interactiveTable/interactiveTable.jsx
+++ b/support-frontend/assets/components/interactiveTable/interactiveTable.jsx
@@ -86,7 +86,6 @@ const toggleButtonOpen = css`
   }
 `;
 
-
 type CellData = {|
   content: Node;
   isPrimary?: boolean;
@@ -125,7 +124,7 @@ function InteractiveTableRow({
           aria-controls={`${rowId}-details`}
           onClick={() => setShowDetails(!showDetails)}
         >
-          Show more details
+          {`${showDetails ? 'Hide' : 'Show'} more details`}
         </Button>
       </td>
       <td
@@ -184,8 +183,8 @@ function InteractiveTable() {
           <th scope="col" role="columnHeader"><span css={visuallyHidden}>Benefits</span></th>
           <th scope="col" role="columnHeader" css={tableCell}>Paid</th>
           <th scope="col" role="columnHeader" css={tableCell}>Free</th>
-          <th scope="col" role="columnHeader"><span css={visuallyHidden}>Actions</span></th>
-          <th scope="col" role="columnHeader"><span css={visuallyHidden}>Details</span></th>
+          <th scope="col" role="columnHeader" css={expandableButtonCell}><span css={visuallyHidden}>Actions</span></th>
+          <th scope="col" role="columnHeader"><span css={visuallyHidden}>More details</span></th>
         </tr>
       </thead>
       <tbody>
@@ -198,8 +197,8 @@ function InteractiveTable() {
         }
       </tbody>
       <tfoot>
-        <tr role="row" css={tableRow}>
-          <td role="cell" colSpan="5" css={tableCell}>
+        <tr role="row">
+          <td role="cell" colSpan="5" aria-colspan="5" css={tableCell}>
             <div><span>Plus 14 day free trial</span></div>
           </td>
         </tr>

--- a/support-frontend/stories/content.jsx
+++ b/support-frontend/stories/content.jsx
@@ -9,6 +9,7 @@ import { List, ListWithSubText } from 'components/list/list';
 import Tabs from 'components/tabs/tabs';
 import Quote from 'components/quote/quote';
 import BlockLabel from 'components/blockLabel/blockLabel';
+import InteractiveTable from 'components/interactiveTable/interactiveTable';
 
 const stories = storiesOf('Content components', module)
   .addDecorator(withKnobs({
@@ -115,3 +116,5 @@ stories.add('Quote', () => {
 });
 
 stories.add('Block label', () => <BlockLabel>Use this for stand-out labels on other content</BlockLabel>);
+
+stories.add('Interactive table', () => <InteractiveTable />);


### PR DESCRIPTION
## What are you doing in this PR?

This adds the interactive table component built as an exploratory spike, ahead of the more specific A/B test work to add it to the digi subs landing page.

[**Trello Card**](https://trello.com/c/jGZVS2Om)

## Why are you doing this?

This component is by no means ready for production, but merging it means the prototype will be ready to go for future dev work.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)