### PR TITLE
convert query params in GCL case to the correct format for the backend

### DIFF
--- a/support-frontend/assets/helpers/tracking/acquisitions.js
+++ b/support-frontend/assets/helpers/tracking/acquisitions.js
@@ -303,7 +303,7 @@ function getAcquisitionDataFromPPCParams(): ?Object {
     return {
       source: 'PPC',
       campaignCode: 'Google_Adwords',
-      queryParameters: getAllQueryParams(),
+      queryParameters: toAcquisitionQueryParameters(getAllQueryParams()),
     };
   }
   return null;


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR converts the queryParameters in the referrerAcquisitionData into the correct format.
Before it was
![image](https://user-images.githubusercontent.com/7304387/130830864-c0ed4be8-f60f-4c7a-a709-adae594af6be.png)
...which caused a 400 bad request due to a backend deserialisation error

This will change it to 
```json
[
  {
     "name": "thekey",
     "value":"thevalue"
  }
... more pairs here
]
```

This is a fix to this PR: https://github.com/guardian/support-frontend/pull/3204

## Why are you doing this?

Stop the failed signups from happening.
