### PR TITLE
Update product price tests

### DIFF
--- a/support-frontend/assets/helpers/productPrice/__tests__/paperProductPricesTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/paperProductPricesTests.js
@@ -1,0 +1,178 @@
+// @flow
+
+// ----- Imports ----- //
+import { getMaxSavingVsRetail } from 'helpers/productPrice/paperProductPrices';
+
+const productPrices = {
+  'United Kingdom': {
+    Collection: {
+      SixdayPlus: {
+        Monthly: {
+          GBP: {
+            price: 27.36, savingVsRetail: 35, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      SundayPlus: {
+        Monthly: {
+          GBP: {
+            price: 22.06, savingVsRetail: 15, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      SaturdayPlus: {
+        Monthly: {
+          GBP: {
+            price: 21.62, savingVsRetail: 16, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      Saturday: {
+        Monthly: {
+          GBP: {
+            price: 10.36, savingVsRetail: 13, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      Sixday: {
+        Monthly: {
+          GBP: {
+            price: 41.12, savingVsRetail: 26, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      Weekend: {
+        Monthly: {
+          GBP: {
+            price: 20.76, savingVsRetail: 20, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      Sunday: {
+        Monthly: {
+          GBP: {
+            price: 10.79, savingVsRetail: 13, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      WeekendPlus: {
+        Monthly: {
+          GBP: {
+            price: 12.56, savingVsRetail: 26, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      Everyday: {
+        Monthly: {
+          GBP: {
+            price: 47.62, savingVsRetail: 29, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      EverydayPlus: {
+        Monthly: {
+          GBP: {
+            price: 29.20, savingVsRetail: 41, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+    },
+    HomeDelivery: {
+      SixdayPlus: {
+        Monthly: {
+          GBP: {
+            price: 30.36, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      SundayPlus: {
+        Monthly: {
+          GBP: {
+            price: 26.39, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      SaturdayPlus: {
+        Monthly: {
+          GBP: {
+            price: 25.96, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      Saturday: {
+        Monthly: {
+          GBP: {
+            price: 14.69, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      Sixday: {
+        Monthly: {
+          GBP: {
+            price: 54.12, savingVsRetail: 5, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      Weekend: {
+        Monthly: {
+          GBP: {
+            price: 25.09, savingVsRetail: 2, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      Sunday: {
+        Monthly: {
+          GBP: {
+            price: 15.12,
+            currency: 'GBP',
+            fixedTerm: false,
+            promotions: [{
+              name: 'examplePromo',
+              description: 'an example promotion',
+              promoCode: 1234,
+              introductoryPrice: {
+                price: 6.99,
+                periodLength: 3,
+                periodType: 'issue',
+              },
+            }],
+          },
+        },
+      },
+      WeekendPlus: {
+        Monthly: {
+          GBP: {
+            price: 12.57, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      Everyday: {
+        Monthly: {
+          GBP: {
+            price: 62.79, savingVsRetail: 9, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+      EverydayPlus: {
+        Monthly: {
+          GBP: {
+            price: 29.19, currency: 'GBP', fixedTerm: false, promotions: [],
+          },
+        },
+      },
+    },
+  },
+};
+
+// ----- Tests ----- //
+
+jest.mock('ophan', () => {});
+
+
+describe('getMaxSavingVsRetail', () => {
+
+  it('should return the maximum savings for a fulfilment option vs retail', () => {
+    expect(getMaxSavingVsRetail(productPrices)).toEqual(29);
+  });
+
+});

--- a/support-frontend/assets/helpers/productPrice/__tests__/paperProductPricesTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/paperProductPricesTests.js
@@ -1,7 +1,9 @@
 // @flow
 
 // ----- Imports ----- //
-import { getMaxSavingVsRetail } from 'helpers/productPrice/paperProductPrices';
+import { getMaxSavingVsRetail, getProductPrice } from 'helpers/productPrice/paperProductPrices';
+import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import type { ProductOptions } from 'helpers/productPrice/productOptions';
 
 const productPrices = {
   'United Kingdom': {
@@ -162,7 +164,14 @@ const productPrices = {
       },
     },
   },
+  // No fulfilment options
 };
+
+const homeDelivery: FulfilmentOptions = 'HomeDelivery';
+// const noFulfilmentOptions: FulfilmentOptions = 'NoFulfilmentOptions';
+
+const weekend: ProductOptions = 'Weekend';
+// const noProductOptions: ProductOptions = 'NoProductOptions';
 
 // ----- Tests ----- //
 
@@ -173,6 +182,33 @@ describe('getMaxSavingVsRetail', () => {
 
   it('should return the maximum savings for a fulfilment option vs retail', () => {
     expect(getMaxSavingVsRetail(productPrices)).toEqual(29);
+  });
+
+});
+
+describe('getProductPrice', () => {
+
+  it('should return product price details if valid fulfilment and product options are provided', () => {
+    expect(getProductPrice(productPrices, homeDelivery, weekend)).toEqual({
+      currency: 'GBP',
+      fixedTerm: false,
+      price: 25.09,
+      promotions: [],
+      savingVsRetail: 2,
+    });
+
+    // it('should...', () => {
+    // expect(getProductPrice(productPrices, homeDelivery, noProductOptions)).toEqual();
+    // });
+
+    // it('should...', () => {
+    // expect(getProductPrice(productPrices, noFulfilmentOptions, sunday)).toEqual();
+    // });
+
+    // it('should...', () => {
+    // expect(getProductPrice(productPrices, noFulfilmentOptions, noProductOptions)).toEqual();
+    // });
+
   });
 
 });

--- a/support-frontend/assets/helpers/productPrice/__tests__/paperProductPricesTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/paperProductPricesTests.js
@@ -1,7 +1,7 @@
 // @flow
 
 // ----- Imports ----- //
-import { getMaxSavingVsRetail, getProductPrice } from 'helpers/productPrice/paperProductPrices';
+import { getMaxSavingVsRetail, getProductPrice, finalPrice } from 'helpers/productPrice/paperProductPrices';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
 
@@ -171,6 +171,7 @@ const homeDelivery: FulfilmentOptions = 'HomeDelivery';
 // const noFulfilmentOptions: FulfilmentOptions = 'NoFulfilmentOptions';
 
 const weekend: ProductOptions = 'Weekend';
+const sunday: ProductOptions = 'Sunday';
 // const noProductOptions: ProductOptions = 'NoProductOptions';
 
 // ----- Tests ----- //
@@ -209,6 +210,20 @@ describe('getProductPrice', () => {
     // expect(getProductPrice(productPrices, noFulfilmentOptions, noProductOptions)).toEqual();
     // });
 
+  });
+
+});
+
+describe('finalPrice', () => {
+  it('should return the final price with any discounts applied', () => {
+    expect(finalPrice(productPrices, homeDelivery, sunday)).toEqual({
+      currency: 'GBP',
+      fixedTerm: false,
+      price: 6.99,
+      promotions: [{
+        description: 'an example promotion', introductoryPrice: { periodLength: 3, periodType: 'issue', price: 6.99 }, name: 'examplePromo', promoCode: 1234,
+      }],
+    });
   });
 
 });

--- a/support-frontend/assets/helpers/productPrice/__tests__/paperProductPricesTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/paperProductPricesTests.js
@@ -164,15 +164,12 @@ const productPrices = {
       },
     },
   },
-  // No fulfilment options
 };
 
 const homeDelivery: FulfilmentOptions = 'HomeDelivery';
-// const noFulfilmentOptions: FulfilmentOptions = 'NoFulfilmentOptions';
 
 const weekend: ProductOptions = 'Weekend';
 const sunday: ProductOptions = 'Sunday';
-// const noProductOptions: ProductOptions = 'NoProductOptions';
 
 // ----- Tests ----- //
 
@@ -180,15 +177,12 @@ jest.mock('ophan', () => {});
 
 
 describe('getMaxSavingVsRetail', () => {
-
   it('should return the maximum savings for a fulfilment option vs retail', () => {
     expect(getMaxSavingVsRetail(productPrices)).toEqual(29);
   });
-
 });
 
 describe('getProductPrice', () => {
-
   it('should return product price details if valid fulfilment and product options are provided', () => {
     expect(getProductPrice(productPrices, homeDelivery, weekend)).toEqual({
       currency: 'GBP',
@@ -198,20 +192,6 @@ describe('getProductPrice', () => {
       savingVsRetail: 2,
     });
   });
-
-
-  // it('should...', () => {
-  //   expect(getProductPrice(productPrices, homeDelivery, noProductOptions)).toEqual();
-  // });
-
-  // it('should...', () => {
-  //   expect(getProductPrice(productPrices, noFulfilmentOptions, sunday)).toEqual();
-  // });
-
-  // it('should...', () => {
-  //   expect(getProductPrice(productPrices)).toEqual();
-  // });
-
 });
 
 // as finalPrice and getPriceWithDiscount perform the same action
@@ -227,7 +207,6 @@ describe('finalPrice', () => {
       }],
     });
   });
-
 });
 
 describe('getPriceWithDiscount', () => {
@@ -241,5 +220,4 @@ describe('getPriceWithDiscount', () => {
       }],
     });
   });
-
 });

--- a/support-frontend/assets/helpers/productPrice/__tests__/paperProductPricesTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/paperProductPricesTests.js
@@ -1,7 +1,7 @@
 // @flow
 
 // ----- Imports ----- //
-import { getMaxSavingVsRetail, getProductPrice, finalPrice } from 'helpers/productPrice/paperProductPrices';
+import { getMaxSavingVsRetail, getProductPrice, finalPrice, getPriceWithDiscount } from 'helpers/productPrice/paperProductPrices';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
 
@@ -197,26 +197,42 @@ describe('getProductPrice', () => {
       promotions: [],
       savingVsRetail: 2,
     });
+  });
 
-    // it('should...', () => {
-    // expect(getProductPrice(productPrices, homeDelivery, noProductOptions)).toEqual();
-    // });
 
-    // it('should...', () => {
-    // expect(getProductPrice(productPrices, noFulfilmentOptions, sunday)).toEqual();
-    // });
+  // it('should...', () => {
+  //   expect(getProductPrice(productPrices, homeDelivery, noProductOptions)).toEqual();
+  // });
 
-    // it('should...', () => {
-    // expect(getProductPrice(productPrices, noFulfilmentOptions, noProductOptions)).toEqual();
-    // });
+  // it('should...', () => {
+  //   expect(getProductPrice(productPrices, noFulfilmentOptions, sunday)).toEqual();
+  // });
 
+  // it('should...', () => {
+  //   expect(getProductPrice(productPrices)).toEqual();
+  // });
+
+});
+
+// as finalPrice and getPriceWithDiscount perform the same action
+// one will be removed and the related code updated in a subsequent PR
+describe('finalPrice', () => {
+  it('should return the final price with any discounts applied', () => {
+    expect(finalPrice(productPrices, homeDelivery, sunday)).toEqual({
+      currency: 'GBP',
+      fixedTerm: false,
+      price: 6.99,
+      promotions: [{
+        description: 'an example promotion', introductoryPrice: { periodLength: 3, periodType: 'issue', price: 6.99 }, name: 'examplePromo', promoCode: 1234,
+      }],
+    });
   });
 
 });
 
-describe('finalPrice', () => {
+describe('getPriceWithDiscount', () => {
   it('should return the final price with any discounts applied', () => {
-    expect(finalPrice(productPrices, homeDelivery, sunday)).toEqual({
+    expect(getPriceWithDiscount(productPrices, homeDelivery, sunday)).toEqual({
       currency: 'GBP',
       fixedTerm: false,
       price: 6.99,

--- a/support-frontend/assets/helpers/productPrice/__tests__/productPricesTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/productPricesTests.js
@@ -1,7 +1,18 @@
 // @flow
 
 // ----- Imports ----- //
-import { isNumeric } from 'helpers/productPrice/productPrices';
+import
+{
+  getProductPrice,
+  // getFirstValidPrice,
+  // finalPrice,
+  // getCurrency,
+  // getCountryGroup,
+  // showPrice,
+  // displayPrice,
+  isNumeric,
+} from 'helpers/productPrice/productPrices';
+
 
 // ----- Tests ----- //
 
@@ -16,5 +27,66 @@ describe('isNumeric', () => {
     expect(isNumeric(0)).toEqual(true);
     expect(isNumeric(50)).toEqual(true);
 
+  });
+});
+
+describe('getProductPrice', () => {
+  const productPrices = {
+    'United Kingdom': {
+      Collection: {
+        Weekend: {
+          Monthly: {
+            GBP: {
+              price: 20.76, savingVsRetail: 20, currency: 'GBP', fixedTerm: false, promotions: [],
+            },
+          },
+        },
+        NoProductOptions: {
+          Monthly: {
+            GBP: {
+              price: 11.95, savingVsRetail: 5, currency: 'GBP', fixedTerm: false, promotions: [],
+            },
+          },
+        },
+      },
+      NoFulfilmentOptions: {
+        NoProductOptions: {
+          Monthly: {
+            GBP: {
+              price: 15.95, savingVsRetail: 10, currency: 'GBP', fixedTerm: false, promotions: [],
+            },
+          },
+        },
+      },
+    },
+  };
+
+  it('should return product price information for a given currency', () => {
+    expect(getProductPrice(productPrices, 'United Kingdom', 'Monthly', 'Collection', 'Weekend'))
+      .toEqual({
+        currency: 'GBP',
+        fixedTerm: false,
+        price: 20.76,
+        promotions: [],
+        savingVsRetail: 20,
+      });
+
+    expect(getProductPrice(productPrices, 'United Kingdom', 'Monthly', 'Collection'))
+      .toEqual({
+        currency: 'GBP',
+        fixedTerm: false,
+        price: 11.95,
+        promotions: [],
+        savingVsRetail: 5,
+      });
+
+    expect(getProductPrice(productPrices, 'United Kingdom', 'Monthly'))
+      .toEqual({
+        currency: 'GBP',
+        fixedTerm: false,
+        price: 15.95,
+        promotions: [],
+        savingVsRetail: 10,
+      });
   });
 });

--- a/support-frontend/assets/helpers/productPrice/__tests__/productPricesTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/productPricesTests.js
@@ -4,13 +4,15 @@
 import
 {
   getProductPrice,
-  // getFirstValidPrice,
-  // finalPrice,
-  // getCurrency,
-  // getCountryGroup,
-  // showPrice,
-  // displayPrice,
+  getFirstValidPrice,
+  finalPrice,
+  getCurrency,
+  getCountryGroup,
+  showPrice,
+  displayPrice,
   isNumeric,
+  type ProductPrice,
+  type ProductPrices,
 } from 'helpers/productPrice/productPrices';
 
 
@@ -88,5 +90,128 @@ describe('getProductPrice', () => {
         promotions: [],
         savingVsRetail: 10,
       });
+  });
+});
+
+describe('finalPrice', () => {
+  const productPrices = {
+    'United Kingdom': {
+      Collection: {
+        Sunday: {
+          Monthly: {
+            GBP: {
+              price: 15.99,
+              currency: 'GBP',
+              fixedTerm: false,
+              promotions: [{
+                name: 'examplePromo',
+                description: 'an example promotion',
+                promoCode: 1234,
+                introductoryPrice: {
+                  price: 6.99,
+                  periodLength: 3,
+                  periodType: 'issue',
+                },
+              }],
+            },
+          },
+        },
+      },
+    },
+  };
+
+  it('should return the final price with any discounts applied', () => {
+    expect(finalPrice(productPrices, 'United Kingdom', 'Monthly', 'Collection', 'Sunday')).toEqual({
+      currency: 'GBP',
+      fixedTerm: false,
+      price: 6.99,
+      promotions: [{
+        description: 'an example promotion',
+        introductoryPrice: {
+          periodLength: 3,
+          periodType: 'issue',
+          price: 6.99,
+        },
+        name: 'examplePromo',
+        promoCode: 1234,
+      }],
+    });
+  });
+});
+
+describe('getFirstValidPrice', () => {
+  it('should return the first valid numeric price', () => {
+    expect(getFirstValidPrice(6.99, 8.99, 11.99)).toEqual(6.99);
+    expect(getFirstValidPrice(null, undefined, '8.99', 11.99)).toEqual('8.99');
+  });
+});
+
+describe('getCurrency', () => {
+  it('should return an ISO currency code', () => {
+    expect(getCurrency('GB')).toEqual('GBP');
+    expect(getCurrency('US')).toEqual('USD');
+    expect(getCurrency('AU')).toEqual('AUD');
+    expect(getCurrency('NZ')).toEqual('NZD');
+  });
+});
+
+describe('getCountryGroup', () => {
+  it('should return a country group given a valid ISO country code', () => {
+    expect(getCountryGroup('GB')).toEqual({
+      countries: [
+        'GB',
+        'FK',
+        'GI',
+        'GG',
+        'IM',
+        'JE',
+        'SH',
+      ],
+      currency: 'GBP',
+      name: 'United Kingdom',
+      supportInternationalisationId: 'uk',
+    });
+
+    expect(getCountryGroup('CA')).toEqual({
+      countries: [
+        'CA',
+      ],
+      currency: 'CAD',
+      name: 'Canada',
+      supportInternationalisationId: 'ca',
+    });
+  });
+});
+
+describe('showPrice', () => {
+  const productPrice: ProductPrice = {
+    currency: 'USD',
+    fixedTerm: true,
+    price: 6.99,
+  };
+
+  it('should return the price prepended with a glyph', () => {
+    expect(showPrice(productPrice)).toEqual('US$6.99');
+    expect(showPrice(productPrice, false)).toEqual('$6.99');
+  });
+});
+
+describe('displayPrice', () => {
+  const productPrices: ProductPrices = {
+    'United Kingdom': {
+      Collection: {
+        Weekend: {
+          Monthly: {
+            GBP: {
+              price: 20.76, savingVsRetail: 20, currency: 'GBP', fixedTerm: false, promotions: [],
+            },
+          },
+        },
+      },
+    },
+  };
+
+  it('should return the price prepended with a glyph', () => {
+    expect(displayPrice(productPrices, 'United Kingdom', 'Monthly', 'Collection', 'Weekend')).toEqual('£20.76');
   });
 });

--- a/support-frontend/assets/helpers/productPrice/__tests__/productPricesTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/productPricesTests.js
@@ -2,187 +2,19 @@
 
 // ----- Imports ----- //
 import { isNumeric } from 'helpers/productPrice/productPrices';
-import { hasDiscount } from 'helpers/productPrice/promotions';
-import { getMaxSavingVsRetail } from 'helpers/productPrice/paperProductPrices';
 
 // ----- Tests ----- //
 
 jest.mock('ophan', () => {});
 
 
-describe('productPrices', () => {
+describe('isNumeric', () => {
+  it('should return true if a number is provided', () => {
 
-  describe('isNumeric', () => {
     expect(isNumeric(null)).toEqual(false);
     expect(isNumeric(undefined)).toEqual(false);
     expect(isNumeric(0)).toEqual(true);
     expect(isNumeric(50)).toEqual(true);
+
   });
-
-  describe('getMaxSavingVsRetail', () => {
-    const productPrices = {
-      'United Kingdom': {
-        Collection: {
-          SixdayPlus: {
-            Monthly: {
-              GBP: {
-                price: 27.36, savingVsRetail: 35, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          SundayPlus: {
-            Monthly: {
-              GBP: {
-                price: 22.06, savingVsRetail: 15, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          SaturdayPlus: {
-            Monthly: {
-              GBP: {
-                price: 21.62, savingVsRetail: 16, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          Saturday: {
-            Monthly: {
-              GBP: {
-                price: 10.36, savingVsRetail: 13, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          Sixday: {
-            Monthly: {
-              GBP: {
-                price: 41.12, savingVsRetail: 26, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          Weekend: {
-            Monthly: {
-              GBP: {
-                price: 20.76, savingVsRetail: 20, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          Sunday: {
-            Monthly: {
-              GBP: {
-                price: 10.79, savingVsRetail: 13, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          WeekendPlus: {
-            Monthly: {
-              GBP: {
-                price: 12.56, savingVsRetail: 26, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          Everyday: {
-            Monthly: {
-              GBP: {
-                price: 47.62, savingVsRetail: 29, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          EverydayPlus: {
-            Monthly: {
-              GBP: {
-                price: 29.20, savingVsRetail: 41, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-        },
-        HomeDelivery: {
-          SixdayPlus: {
-            Monthly: {
-              GBP: {
-                price: 30.36, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          SundayPlus: {
-            Monthly: {
-              GBP: {
-                price: 26.39, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          SaturdayPlus: {
-            Monthly: {
-              GBP: {
-                price: 25.96, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          Saturday: {
-            Monthly: {
-              GBP: {
-                price: 14.69, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          Sixday: {
-            Monthly: {
-              GBP: {
-                price: 54.12, savingVsRetail: 5, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          Weekend: {
-            Monthly: {
-              GBP: {
-                price: 25.09, savingVsRetail: 2, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          Sunday: {
-            Monthly: {
-              GBP: {
-                price: 15.12, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          WeekendPlus: {
-            Monthly: {
-              GBP: {
-                price: 12.57, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          Everyday: {
-            Monthly: {
-              GBP: {
-                price: 62.79, savingVsRetail: 9, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-          EverydayPlus: {
-            Monthly: {
-              GBP: {
-                price: 29.19, currency: 'GBP', fixedTerm: false, promotions: [],
-              },
-            },
-          },
-        },
-      },
-    };
-
-    expect(getMaxSavingVsRetail(productPrices)).toEqual(29);
-  });
-
-  describe('hasDiscount', () => {
-
-    it('should cope with all the possible values for promotion.discountPrice', () => {
-      expect(hasDiscount(null)).toEqual(false);
-      expect(hasDiscount(undefined)).toEqual(false);
-      expect(hasDiscount({})).toEqual(false);
-      expect(hasDiscount({ discountedPrice: null })).toEqual(false);
-      expect(hasDiscount({ discountedPrice: 50 })).toEqual(true);
-      expect(hasDiscount({ discountedPrice: 0 })).toEqual(true);
-
-    });
-  });
-
 });

--- a/support-frontend/assets/helpers/productPrice/__tests__/promotionsTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/promotionsTests.js
@@ -1,28 +1,28 @@
-import { getPromotionCopy, hasDiscount } from '../promotions';
-
-const sanitisablePromotionCopy = {
-  title: 'The Guardian Weekly',
-  description: 'The Guardian Weekly magazine:\n- is a round-up of the [world news opinion and long reads that have shaped the week.](https://www.theguardian.com/about/journalism)\n- with striking photography and insightful companion pieces, all handpicked from the Guardian and the Observer.',
-  roundel: '**Save _25%_ for a year!**',
-};
+import {
+  getAppliedPromo,
+  applyDiscount,
+  hasIntroductoryPrice,
+  hasDiscount,
+  getPromotionCopy,
+  promotionHTML,
+} from '../promotions';
 
 describe('getPromotionCopy', () => {
+  const sanitisablePromotionCopy = {
+    title: 'The Guardian Weekly',
+    description: 'The Guardian Weekly magazine:\n- is a round-up of the [world news opinion and long reads that have shaped the week.](https://www.theguardian.com/about/journalism)\n- with striking photography and insightful companion pieces, all handpicked from the Guardian and the Observer.',
+    roundel: '**Save _25%_ for a year!**',
+  };
+
   it('should return promotion copy if it exists', () => {
-
     expect(getPromotionCopy()).toEqual({});
-
     expect(getPromotionCopy(sanitisablePromotionCopy)).not.toEqual({});
-
   });
 
   it('should return a santised html string when sanitisable promotion copy is provided', () => {
-
     expect(getPromotionCopy(sanitisablePromotionCopy).title).toEqual(sanitisablePromotionCopy.title);
-
     expect(getPromotionCopy(sanitisablePromotionCopy).description).toEqual('The Guardian Weekly magazine:<ul><li>is a round-up of the <a href="https://www.theguardian.com/about/journalism">world news opinion and long reads that have shaped the week.</a></li><li>with striking photography and insightful companion pieces, all handpicked from the Guardian and the Observer.</li></ul>');
-
     expect(getPromotionCopy(sanitisablePromotionCopy).roundel).toEqual('<strong>Save <em>25%</em> for a year!</strong>');
-
   });
 });
 
@@ -37,3 +37,116 @@ describe('hasDiscount', () => {
   });
 });
 
+describe('getAppliedPromo', () => {
+  const promotions = [{
+    name: 'examplePromo1',
+    description: 'example promotion1',
+    promoCode: 1234,
+    discountedPrice: 5.99,
+  }, {
+    name: 'examplePromo2',
+    description: 'example promotion2',
+    promoCode: 5678,
+    introductoryPrice: {
+      price: 6.99,
+      periodLength: 3,
+      periodType: 'issue',
+    },
+  }];
+
+  it('should return the applied promotion based on inputs', () => {
+    expect(getAppliedPromo(promotions)).toEqual({
+      description: 'example promotion2',
+      introductoryPrice: {
+        periodLength: 3,
+        periodType: 'issue',
+        price: 6.99,
+      },
+      name: 'examplePromo2',
+      promoCode: 5678,
+    });
+
+    expect(getAppliedPromo()).toEqual(null);
+  });
+});
+
+describe('applyDiscount', () => {
+  const productWithIntroductoryPrice = {
+    price: 12.99,
+    currency: 'EUR',
+    fixedTerm: false,
+    promotions: [{
+      name: 'Sept 2019 Discount',
+      description: '50% off for 3 months',
+      promoCode: 'GH86H9J',
+      introductoryPrice: { price: 6.99, periodLength: 6, periodType: 'issue' },
+    }],
+  };
+
+  const productWithDiscountedPrice = {
+    price: 12.99,
+    currency: 'EUR',
+    fixedTerm: false,
+    promotions: [{
+      name: 'Sept 2019 Discount',
+      description: '25% off',
+      promoCode: 'GH86H9J',
+      discountedPrice: 8.99,
+    }],
+  };
+
+  it('should return an updated price with a discount applied', () => {
+    expect(applyDiscount(productWithIntroductoryPrice, productWithIntroductoryPrice.promotions[0])).toEqual({
+      currency: 'EUR',
+      fixedTerm: false,
+      price: 6.99,
+      promotions: [{
+        name: 'Sept 2019 Discount',
+        description: '50% off for 3 months',
+        promoCode: 'GH86H9J',
+        introductoryPrice: { price: 6.99, periodLength: 6, periodType: 'issue' },
+      }],
+    });
+
+    expect(applyDiscount(productWithDiscountedPrice, productWithDiscountedPrice.promotions[0])).toEqual({
+      currency: 'EUR',
+      fixedTerm: false,
+      price: 8.99,
+      promotions: [{
+        name: 'Sept 2019 Discount',
+        description: '25% off',
+        promoCode: 'GH86H9J',
+        discountedPrice: 8.99,
+      }],
+    });
+  });
+});
+
+describe('hasIntroductoryPrice', () => {
+  const promotionWithIntroductoryPrice = {
+    name: 'Sept 2019 Discount',
+    description: '50% off for 3 months',
+    promoCode: 'GH86H9J',
+    introductoryPrice: { price: 6.99, periodLength: 6, periodType: 'issue' },
+  };
+
+  const promotionWithoutIntroductoryPrice = {
+    name: 'Sept 2019 Discount',
+    description: '50% off for 3 months',
+    promoCode: 'GH86H9J',
+  };
+
+  it('should return true if there is an introductory price', () => {
+    expect(hasIntroductoryPrice(promotionWithIntroductoryPrice)).toEqual(true);
+    expect(hasIntroductoryPrice(promotionWithoutIntroductoryPrice)).toEqual(false);
+    expect(hasIntroductoryPrice()).toEqual(false);
+  });
+});
+
+describe('promotionHTML', () => {
+  it('should return promotion html if present', () => {
+    expect(promotionHTML()).toEqual(null);
+    expect(promotionHTML('Get 25% off').props).toEqual({ __EMOTION_TYPE_PLEASE_DO_NOT_USE__: 'span', css: '', dangerouslySetInnerHTML: { __html: 'Get 25% off' } });
+    expect(promotionHTML('Get 20% off', { tag: 'div' }).props).toEqual({ __EMOTION_TYPE_PLEASE_DO_NOT_USE__: 'div', css: '', dangerouslySetInnerHTML: { __html: 'Get 20% off' } });
+  });
+});

--- a/support-frontend/assets/helpers/productPrice/__tests__/promotionsTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/promotionsTests.js
@@ -1,4 +1,4 @@
-import { getPromotionCopy } from '../promotions';
+import { getPromotionCopy, hasDiscount } from '../promotions';
 
 const sanitisablePromotionCopy = {
   title: 'The Guardian Weekly',
@@ -24,5 +24,16 @@ describe('getPromotionCopy', () => {
     expect(getPromotionCopy(sanitisablePromotionCopy).roundel).toEqual('<strong>Save <em>25%</em> for a year!</strong>');
 
   });
-
 });
+
+describe('hasDiscount', () => {
+  it('should cope with all the possible values for promotion.discountPrice', () => {
+    expect(hasDiscount(null)).toEqual(false);
+    expect(hasDiscount(undefined)).toEqual(false);
+    expect(hasDiscount({})).toEqual(false);
+    expect(hasDiscount({ discountedPrice: null })).toEqual(false);
+    expect(hasDiscount({ discountedPrice: 50 })).toEqual(true);
+    expect(hasDiscount({ discountedPrice: 0 })).toEqual(true);
+  });
+});
+

--- a/support-frontend/assets/helpers/productPrice/paperProductPrices.js
+++ b/support-frontend/assets/helpers/productPrice/paperProductPrices.js
@@ -37,6 +37,8 @@ function getProductPrice(
   );
 }
 
+// finalPrice and getPriceWithDiscount perform the same action
+// so one will be removed and the related code updated in a subsequent PR
 function finalPrice(
   productPrices: ProductPrices,
   fulfilmentOption: ?FulfilmentOptions,


### PR DESCRIPTION
## What are you doing in this PR?

This pr adds tests for a number of files in the `productPrice` folder that handle the way we access pricing information and the text about them.

## Why are you doing this?

These tests will prevent regressions when modifying code within the `productPrice` folder. We will soon be separating the work of getting the correct price from the text about the price, as they are currently intertwined in a way that makes it difficult to make the nimble text changes that we increasingly need to make. 

[**Trello Card**](https://trello.com/c/t6CiFUA6/3753-write-tests-for-price-text-and-price-calculation-code-90)

## Is this an AB test?
- [ ] Yes
- [x] No
