### PR TITLE
change DS alarm back to 3h

### DIFF
--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -345,7 +345,7 @@ Resources:
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-      AlarmName: !Sub URGENT 9-5 - ${Stage} support-workers No successful Digital Subscription checkouts in 2h
+      AlarmName: !Sub URGENT 9-5 - ${Stage} support-workers No successful Digital Subscription checkouts in 3h
       Metrics:
         - Id: e1
           Expression: "SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0)])"
@@ -403,7 +403,7 @@ Resources:
           ReturnData: false
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 0
-      EvaluationPeriods: 24
+      EvaluationPeriods: 36
       TreatMissingData: breaching
     DependsOn: SupportWorkersPROD
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR changes the DS alarm back to 3h


## Why are you doing this?
I changed it to 2h as an opportunity in this PR
https://github.com/guardian/support-frontend/pull/3221/files#r695752789

However, it seems it went off fairly soon after, so I was a bit optimistic (I only checked back a week or so to ensure no false alarms would happen)