### PR TITLE
track paypal submissions for weekly + paper subs

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -48,7 +48,7 @@ import {
   getBillingAddress,
   getDeliveryAddress,
 } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
-import { submitWithDeliveryForm } from 'helpers/subscriptionsForms/submit';
+import { submitWithDeliveryForm, trackSubmitAttempt } from 'helpers/subscriptionsForms/submit';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { Stripe, DirectDebit, PayPal } from 'helpers/forms/paymentMethods';
 import { validateWithDeliveryForm } from 'helpers/subscriptionsForms/formValidation';
@@ -60,8 +60,13 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { withDeliveryFormIsValid } from 'helpers/subscriptionsForms/formValidation';
 import { setupSubscriptionPayPalPayment } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 import DirectDebitForm from 'components/directDebit/directDebitProgressiveDisclosure/directDebitForm';
-import { paperProductsWithDigital, paperProductsWithoutDigital, type ActivePaperProducts } from 'helpers/productPrice/productOptions';
-import { Paper } from 'helpers/productPrice/subscriptions';
+import {
+  paperProductsWithDigital,
+  paperProductsWithoutDigital,
+  type ActivePaperProducts,
+  NoProductOptions,
+} from 'helpers/productPrice/productOptions';
+import { DigitalPack, Paper } from 'helpers/productPrice/subscriptions';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import DirectDebitPaymentTerms from 'components/subscriptionCheckouts/directDebit/directDebitPaymentTerms';
 import { getPaymentStartDate, getFormattedStartDate } from 'pages/paper-subscription-checkout/helpers/subsCardDays';
@@ -164,6 +169,12 @@ function mapDispatchToProps() {
     validateForm: () => (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) => {
       const state = getState();
       validateWithDeliveryForm(dispatch, state);
+      // We need to track PayPal payment attempts here because PayPal behaves
+      // differently to other payment methods. All others are tracked in submit.js
+      const { paymentMethod } = state.page.checkout;
+      if (paymentMethod === PayPal) {
+        trackSubmitAttempt(PayPal, DigitalPack, NoProductOptions);
+      }
     },
     setupRecurringPayPalPayment: setupSubscriptionPayPalPayment,
     signOut,

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -64,9 +64,8 @@ import {
   paperProductsWithDigital,
   paperProductsWithoutDigital,
   type ActivePaperProducts,
-  NoProductOptions,
 } from 'helpers/productPrice/productOptions';
-import { DigitalPack, Paper } from 'helpers/productPrice/subscriptions';
+import { Paper } from 'helpers/productPrice/subscriptions';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import DirectDebitPaymentTerms from 'components/subscriptionCheckouts/directDebit/directDebitPaymentTerms';
 import { getPaymentStartDate, getFormattedStartDate } from 'pages/paper-subscription-checkout/helpers/subsCardDays';
@@ -173,7 +172,7 @@ function mapDispatchToProps() {
       // differently to other payment methods. All others are tracked in submit.js
       const { paymentMethod } = state.page.checkout;
       if (paymentMethod === PayPal) {
-        trackSubmitAttempt(PayPal, DigitalPack, NoProductOptions);
+        trackSubmitAttempt(PayPal, Paper, state.page.checkout.productOption);
       }
     },
     setupRecurringPayPalPayment: setupSubscriptionPayPalPayment,

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -53,7 +53,7 @@ import {
   getDeliveryAddress,
 } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import { getWeeklyDays } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
-import { submitWithDeliveryForm } from 'helpers/subscriptionsForms/submit';
+import { submitWithDeliveryForm, trackSubmitAttempt } from 'helpers/subscriptionsForms/submit';
 import { formatMachineDate, formatUserDate } from 'helpers/utilities/dateConversions';
 import { routes } from 'helpers/urls/routes';
 import { BillingPeriodSelector } from 'components/subscriptionCheckouts/billingPeriodSelector';
@@ -80,6 +80,8 @@ import { Select, Option as OptionForSelect } from '@guardian/src-select';
 import { options } from 'components/forms/customFields/options';
 import { currencyFromCountryCode } from 'helpers/internationalisation/currency';
 import type { Participations } from 'helpers/abTests/abtest';
+import { DigitalPack } from 'helpers/productPrice/subscriptions';
+import { NoProductOptions } from 'helpers/productPrice/productOptions';
 
 
 // ----- Styles ----- //
@@ -150,6 +152,12 @@ function mapDispatchToProps() {
     validateForm: () => (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) => {
       const state = getState();
       validateWithDeliveryForm(dispatch, state);
+      // We need to track PayPal payment attempts here because PayPal behaves
+      // differently to other payment methods. All others are tracked in submit.js
+      const { paymentMethod } = state.page.checkout;
+      if (paymentMethod === PayPal) {
+        trackSubmitAttempt(PayPal, DigitalPack, NoProductOptions);
+      }
     },
     setupRecurringPayPalPayment: setupSubscriptionPayPalPayment,
   };

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -80,7 +80,7 @@ import { Select, Option as OptionForSelect } from '@guardian/src-select';
 import { options } from 'components/forms/customFields/options';
 import { currencyFromCountryCode } from 'helpers/internationalisation/currency';
 import type { Participations } from 'helpers/abTests/abtest';
-import { DigitalPack } from 'helpers/productPrice/subscriptions';
+import { GuardianWeekly } from 'helpers/productPrice/subscriptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
 
 
@@ -156,7 +156,7 @@ function mapDispatchToProps() {
       // differently to other payment methods. All others are tracked in submit.js
       const { paymentMethod } = state.page.checkout;
       if (paymentMethod === PayPal) {
-        trackSubmitAttempt(PayPal, DigitalPack, NoProductOptions);
+        trackSubmitAttempt(PayPal, GuardianWeekly, NoProductOptions);
       }
     },
     setupRecurringPayPalPayment: setupSubscriptionPayPalPayment,

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
@@ -53,7 +53,7 @@ import {
   getDeliveryAddress,
 } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import { getWeeklyDays } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
-import { submitWithDeliveryForm } from 'helpers/subscriptionsForms/submit';
+import { submitWithDeliveryForm, trackSubmitAttempt } from 'helpers/subscriptionsForms/submit';
 import { formatMachineDate, formatUserDate } from 'helpers/utilities/dateConversions';
 import { routes } from 'helpers/urls/routes';
 import { getWeeklyFulfilmentOption } from 'helpers/productPrice/fulfilmentOptions';
@@ -81,6 +81,8 @@ import { titles } from 'helpers/user/details';
 import { Select, Option as OptionForSelect } from '@guardian/src-select';
 import { options } from 'components/forms/customFields/options';
 import { currencyFromCountryCode } from 'helpers/internationalisation/currency';
+import { DigitalPack } from 'helpers/productPrice/subscriptions';
+import { NoProductOptions } from 'helpers/productPrice/productOptions';
 
 // ----- Styles ----- //
 
@@ -150,6 +152,12 @@ function mapDispatchToProps() {
     validateForm: () => (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) => {
       const state = getState();
       validateWithDeliveryForm(dispatch, state);
+      // We need to track PayPal payment attempts here because PayPal behaves
+      // differently to other payment methods. All others are tracked in submit.js
+      const { paymentMethod } = state.page.checkout;
+      if (paymentMethod === PayPal) {
+        trackSubmitAttempt(PayPal, DigitalPack, NoProductOptions);
+      }
     },
     setupRecurringPayPalPayment: setupSubscriptionPayPalPayment,
   };

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
@@ -81,7 +81,7 @@ import { titles } from 'helpers/user/details';
 import { Select, Option as OptionForSelect } from '@guardian/src-select';
 import { options } from 'components/forms/customFields/options';
 import { currencyFromCountryCode } from 'helpers/internationalisation/currency';
-import { DigitalPack } from 'helpers/productPrice/subscriptions';
+import { GuardianWeekly } from 'helpers/productPrice/subscriptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
 
 // ----- Styles ----- //
@@ -156,7 +156,7 @@ function mapDispatchToProps() {
       // differently to other payment methods. All others are tracked in submit.js
       const { paymentMethod } = state.page.checkout;
       if (paymentMethod === PayPal) {
-        trackSubmitAttempt(PayPal, DigitalPack, NoProductOptions);
+        trackSubmitAttempt(PayPal, GuardianWeekly, NoProductOptions);
       }
     },
     setupRecurringPayPalPayment: setupSubscriptionPayPalPayment,


### PR DESCRIPTION
@johnduffell and I noticed that `subs-checkout-submit-` componentEvent for paypal is missing in the pageview table.
This is because we have to handle paypal differently, which we do for digisub: https://github.com/guardian/support-frontend/blob/main/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx#L136