### PR TITLE
Turn off emailDigiSubEventsTest AB test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -106,7 +106,7 @@ export const tests: Tests = {
         size: 0,
       },
     },
-    isActive: true,
+    isActive: false,
     referrerControlled: true,
     seed: 10,
     optimizeId: 'dQCXBc3QQIW7M1Di_qSCHw',


### PR DESCRIPTION
## What are you doing in this PR?

The `emailDigiSubEventsTest` has come to an end, this PR turns off the test in `abtestDefinitions.js` so members of the public will no longer be able to enter the test. A follow-up PR will remove the Event component and any other associated logic required to support the test.