### PR TITLE
Add spacing in the bottom of patrons text

### DIFF
--- a/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -62,6 +62,7 @@ function TermsPrivacy(props: PropTypes) {
         If you would like to support us at a higher level, from {getRegionalAmountString()} a month,
         you can join us as a Guardian Patron. {patronsLink}
       </p>
+      <br />
     </div>
   );
 


### PR DESCRIPTION
Add a line break after the patrons text to give spacing at the bottom

**before**
![image](https://user-images.githubusercontent.com/47318984/132832736-b3ec975b-2408-456a-8ec6-8d80e7d23c1e.png)

**after**
![image](https://user-images.githubusercontent.com/47318984/132832697-cc27e81c-57e7-4587-842e-4c96220f5d46.png)
