### PR TITLE
Paper product pricing cards with Saturday plan 

### DIFF
--- a/support-frontend/assets/components/product/productInfoChip.jsx
+++ b/support-frontend/assets/components/product/productInfoChip.jsx
@@ -3,7 +3,7 @@
 import React, { type Node } from 'react';
 import { css } from '@emotion/core';
 import { space } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/typography';
+import { body } from '@guardian/src-foundations/typography';
 
 type PropTypes = {|
   children: Node,
@@ -11,7 +11,8 @@ type PropTypes = {|
 |};
 
 const infoChip = css`
-  ${textSans.medium()}
+  display: flex;
+  ${body.medium()}
 
   &:not(:last-of-type) {
     margin-bottom: ${space[4]}px;

--- a/support-frontend/assets/components/product/productOption.jsx
+++ b/support-frontend/assets/components/product/productOption.jsx
@@ -29,7 +29,12 @@ const productOption = css`
   ${textSans.medium()}
   position: relative;
   display: grid;
-  grid-template-rows: 48px minmax(66px, max-content) minmax(100px, 1fr) 72px;
+  grid-template-columns: 2fr 1fr;
+  grid-template-rows: 1fr 1fr 1fr;
+  grid-template-areas:
+    '. priceCopy'
+    '. priceCopy'
+    '. .';
   width: 100%;
   background-color: ${neutral[100]};
   color: ${neutral[7]};
@@ -37,6 +42,9 @@ const productOption = css`
   ${from.tablet} {
     min-height: 272px;
     width: 300px;
+    grid-template-columns: none;
+    grid-template-rows: 48px minmax(66px, max-content) minmax(100px, 1fr) 72px;
+    grid-template-areas: none;
   }
 `;
 
@@ -91,6 +99,12 @@ const buttonCopyTabletToDesktop = css`
     }
 `;
 
+const priceCopyGridPlacement = css`
+  ${until.tablet} {
+    grid-area: priceCopy;
+  }
+`;
+
 function ProductOption(props: Product) {
   const [hasBeenSeen, setElementToObserve] = useHasBeenSeen({
     threshold: 0.5,
@@ -135,7 +149,7 @@ function ProductOption(props: Product) {
           {props.offerCopy}
         </p>
       </div>
-      <div>
+      <div css={priceCopyGridPlacement}>
         {/* role="text" is non-standardised but works in Safari. Reads the whole section as one text element */}
         {/* eslint-disable-next-line jsx-a11y/aria-role */}
         <p role="text" css={productOptionPriceCopy}>

--- a/support-frontend/assets/components/product/productOption.jsx
+++ b/support-frontend/assets/components/product/productOption.jsx
@@ -7,7 +7,7 @@ import { css } from '@emotion/core';
 import { brandAlt, neutral } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
-import { from } from '@guardian/src-foundations/mq';
+import { from, between } from '@guardian/src-foundations/mq';
 import { LinkButton, buttonReaderRevenue } from '@guardian/src-button';
 import { useHasBeenSeen } from 'helpers/customHooks/useHasBeenSeen';
 
@@ -76,6 +76,21 @@ const productOptionHighlight = css`
   padding: ${space[2]}px ${space[3]}px;
   ${headline.xxsmall({ fontWeight: 'bold' })};
 `;
+
+const buttonCopy = css`
+  display: inline-flex;
+  ${between.tablet.and.leftCol} {
+    display: none;
+    }
+`;
+
+const buttonCopyTabletToDesktop = css`
+  display: none;
+  ${between.tablet.and.leftCol} {
+    display: inline-flex;
+    }
+`;
+
 function ProductOption(props: Product) {
   const [hasBeenSeen, setElementToObserve] = useHasBeenSeen({
     threshold: 0.5,
@@ -118,11 +133,20 @@ function ProductOption(props: Product) {
       <div>
         <ThemeProvider theme={buttonReaderRevenue}>
           <LinkButton
+            css={buttonCopy}
             href={props.href}
             onClick={props.onClick}
             aria-label={`${props.title}- ${props.buttonCopy}`}
           >
             {props.buttonCopy}
+          </LinkButton>
+          <LinkButton
+            css={buttonCopyTabletToDesktop}
+            href={props.href}
+            onClick={props.onClick}
+            aria-label={`${props.title}- Subscribe`}
+          >
+            Subscribe
           </LinkButton>
         </ThemeProvider>
       </div>

--- a/support-frontend/assets/components/product/productOption.jsx
+++ b/support-frontend/assets/components/product/productOption.jsx
@@ -30,7 +30,7 @@ const productOption = css`
   position: relative;
   display: grid;
   grid-template-columns: 2fr 1fr;
-  grid-template-rows: 1fr 1fr 1fr;
+  grid-template-rows: min-content 1fr min-content;
   grid-template-areas:
     '. priceCopy'
     '. priceCopy'
@@ -64,23 +64,51 @@ const productOptionVerticalLine = css`
 
 const productOptionTitle = css`
   ${headline.xsmall({ fontWeight: 'bold' })};
-  padding-bottom: ${space[4]}px;
-  margin-bottom: ${space[2]}px;
+  padding-bottom: ${space[5]}px;
+  ${from.tablet} {
+    margin-bottom: ${space[2]}px;
+  }
+  ${between.tablet.and.desktop} {
+    ${headline.xxxsmall({ fontWeight: 'bold' })};
+  }
 `;
 
 const productOptionOfferCopy = css`
-  height: 100%;
-  padding-bottom: ${space[2]}px;
+  ${textSans.medium()};
+  ${from.tablet} {
+    height: 100%;
+    padding-bottom: ${space[2]}px;
+  }
+  ${between.tablet.and.desktop} {
+    ${textSans.small()};
+  }
 `;
 
 const productOptionPrice = css`
   display: block;
-  ${headline.large({ fontWeight: 'bold' })};
+  padding-bottom: ${space[5]}px;
+  ${headline.xsmall({ fontWeight: 'bold' })};
+  ${between.tablet.and.desktop} {
+    ${headline.small({ fontWeight: 'bold' })};
+  }
+  ${from.desktop} {
+    ${headline.large({ fontWeight: 'bold' })};
+    padding-bottom: 0;
+  }
 `;
 
 const productOptionPriceCopy = css`
-  height: 100%;
-  margin-bottom: ${space[4]}px;
+  ${textSans.xsmall()};
+  ${from.tablet} {
+    height: 100%;
+    margin-bottom: ${space[4]}px;
+  }
+  ${between.phablet.and.desktop} {
+    ${textSans.small()};
+  }
+  ${from.desktop} {
+    ${textSans.medium()};
+  }
 `;
 
 const productOptionHighlight = css`

--- a/support-frontend/assets/components/product/productOption.jsx
+++ b/support-frontend/assets/components/product/productOption.jsx
@@ -34,7 +34,7 @@ const productOption = css`
   grid-template-areas:
     '. priceCopy'
     '. priceCopy'
-    '. .';
+    'button button';
   width: 100%;
   background-color: ${neutral[100]};
   color: ${neutral[7]};
@@ -123,6 +123,33 @@ const productOptionHighlight = css`
   ${headline.xxsmall({ fontWeight: 'bold' })};
 `;
 
+const buttonDiv = css`
+  grid-area: button;
+  padding: ${space[3]}px 0;
+  ${between.mobileMedium.and.tablet} {
+    grid-area: 3 / 1 / span 1 / span 1;
+    border-right: 1px solid ${neutral[86]};
+    margin-right: ${space[3]}px;
+    padding-right: ${space[3]}px;
+  }
+  ${from.tablet} {
+    grid-area: auto;
+    padding: 0;
+  }
+`;
+
+const button = css`
+  display: flex;
+  justify-content: center;
+  ${from.mobileMedium} {
+    grid-area: priceCopy;
+  }
+  ${from.tablet} {
+    grid-area: auto;
+    display: inline-flex;
+  }
+`;
+
 const buttonCopySpan = css`
   ${between.tablet.and.leftCol} {
     display: none;
@@ -187,9 +214,10 @@ function ProductOption(props: Product) {
           {props.priceCopy}
         </p>
       </div>
-      <div>
+      <div css={buttonDiv}>
         <ThemeProvider theme={buttonReaderRevenue}>
           <LinkButton
+            css={button}
             href={props.href}
             onClick={props.onClick}
             aria-label={`${props.title}- ${props.buttonCopy} now`}

--- a/support-frontend/assets/components/product/productOption.jsx
+++ b/support-frontend/assets/components/product/productOption.jsx
@@ -123,18 +123,10 @@ const productOptionHighlight = css`
   ${headline.xxsmall({ fontWeight: 'bold' })};
 `;
 
-const buttonCopy = css`
-  display: inline-flex;
+const buttonCopySpan = css`
   ${between.tablet.and.leftCol} {
     display: none;
   }
-`;
-
-const buttonCopyTabletToDesktop = css`
-  display: none;
-  ${between.tablet.and.leftCol} {
-    display: inline-flex;
-    }
 `;
 
 const priceCopyGridPlacement = css`
@@ -198,20 +190,11 @@ function ProductOption(props: Product) {
       <div>
         <ThemeProvider theme={buttonReaderRevenue}>
           <LinkButton
-            css={buttonCopy}
             href={props.href}
             onClick={props.onClick}
-            aria-label={`${props.title}- ${props.buttonCopy}`}
+            aria-label={`${props.title}- ${props.buttonCopy} now`}
           >
-            {props.buttonCopy}
-          </LinkButton>
-          <LinkButton
-            css={buttonCopyTabletToDesktop}
-            href={props.href}
-            onClick={props.onClick}
-            aria-label={`${props.title}- Subscribe`}
-          >
-            Subscribe
+            {props.buttonCopy}<span css={buttonCopySpan}>&nbsp;now</span>
           </LinkButton>
         </ThemeProvider>
       </div>

--- a/support-frontend/assets/components/product/productOption.jsx
+++ b/support-frontend/assets/components/product/productOption.jsx
@@ -68,7 +68,7 @@ const productOptionTitle = css`
   ${from.tablet} {
     margin-bottom: ${space[2]}px;
   }
-  ${between.tablet.and.desktop} {
+  ${between.tablet.and.leftCol} {
     ${headline.xxxsmall({ fontWeight: 'bold' })};
   }
 `;
@@ -79,7 +79,7 @@ const productOptionOfferCopy = css`
     height: 100%;
     padding-bottom: ${space[2]}px;
   }
-  ${between.tablet.and.desktop} {
+  ${between.tablet.and.leftCol} {
     ${textSans.small()};
   }
 `;
@@ -88,10 +88,10 @@ const productOptionPrice = css`
   display: block;
   padding-bottom: ${space[5]}px;
   ${headline.xsmall({ fontWeight: 'bold' })};
-  ${between.tablet.and.desktop} {
+  ${between.tablet.and.leftCol} {
     ${headline.small({ fontWeight: 'bold' })};
   }
-  ${from.desktop} {
+  ${from.leftCol} {
     ${headline.large({ fontWeight: 'bold' })};
     padding-bottom: 0;
   }
@@ -103,10 +103,10 @@ const productOptionPriceCopy = css`
     height: 100%;
     margin-bottom: ${space[4]}px;
   }
-  ${between.phablet.and.desktop} {
+  ${between.phablet.and.leftCol} {
     ${textSans.small()};
   }
-  ${from.desktop} {
+  ${from.leftCol} {
     ${textSans.medium()};
   }
 `;
@@ -126,7 +126,7 @@ const productOptionHighlight = css`
 const buttonDiv = css`
   grid-area: button;
   padding: ${space[3]}px 0;
-  ${between.mobileMedium.and.tablet} {
+  ${between.mobileLandscape.and.tablet} {
     grid-area: 3 / 1 / span 1 / span 1;
     border-right: 1px solid ${neutral[86]};
     margin-right: ${space[3]}px;
@@ -141,8 +141,9 @@ const buttonDiv = css`
 const button = css`
   display: flex;
   justify-content: center;
-  ${from.mobileMedium} {
+  ${from.mobileLandscape} {
     grid-area: priceCopy;
+    display: inline-flex;
   }
   ${from.tablet} {
     grid-area: auto;

--- a/support-frontend/assets/components/product/productOption.jsx
+++ b/support-frontend/assets/components/product/productOption.jsx
@@ -49,7 +49,17 @@ const productOption = css`
 `;
 
 const productOptionUnderline = css`
-  border-bottom: 1px solid ${neutral[86]};
+  ${from.tablet} {
+    border-bottom: 1px solid ${neutral[86]};
+  }
+`;
+
+const productOptionVerticalLine = css`
+  ${until.tablet} {
+    border-right: 1px solid ${neutral[86]};
+    margin-right: ${space[3]}px;
+    padding-right: ${space[3]}px;
+  }
 `;
 
 const productOptionTitle = css`
@@ -89,7 +99,7 @@ const buttonCopy = css`
   display: inline-flex;
   ${between.tablet.and.leftCol} {
     display: none;
-    }
+  }
 `;
 
 const buttonCopyTabletToDesktop = css`
@@ -139,12 +149,12 @@ function ProductOption(props: Product) {
 
   return (
     <div ref={setElementToObserve} css={[productOption, props.cssOverrides, productOptionMargin]}>
-      <div>
+      <div css={productOptionVerticalLine}>
         <h3 css={[productOptionTitle, productOptionUnderline]}>{props.title}</h3>
         {props.label && <span css={productOptionHighlight}>{props.label}</span>}
         {props.children && props.children}
       </div>
-      <div>
+      <div css={productOptionVerticalLine}>
         <p css={[productOptionOfferCopy, productOptionUnderline]}>
           {props.offerCopy}
         </p>

--- a/support-frontend/assets/components/product/productOption.jsx
+++ b/support-frontend/assets/components/product/productOption.jsx
@@ -7,7 +7,7 @@ import { css } from '@emotion/core';
 import { brandAlt, neutral } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
-import { from, between } from '@guardian/src-foundations/mq';
+import { from, between, until } from '@guardian/src-foundations/mq';
 import { LinkButton, buttonReaderRevenue } from '@guardian/src-button';
 import { useHasBeenSeen } from 'helpers/customHooks/useHasBeenSeen';
 
@@ -110,8 +110,21 @@ function ProductOption(props: Product) {
     }
   }, [hasBeenSeen]);
 
+  const productOptionMargin = props.label && css`
+  ${until.tablet} {
+    /* calculation belows are based on productOptionHighlight text size, line height and padding */
+    &:first-of-type {
+      margin-top: calc((20px * 1.5) + 8px) !important;
+    }
+    /* 16px alloted for margin between product options when a label is present */
+    &:not(first-of-type) {
+      margin-top: calc((20px * 1.5) + 8px + 16px) !important;
+    }
+    }
+  `;
+
   return (
-    <div ref={setElementToObserve} css={[productOption, props.cssOverrides]}>
+    <div ref={setElementToObserve} css={[productOption, props.cssOverrides, productOptionMargin]}>
       <div>
         <h3 css={[productOptionTitle, productOptionUnderline]}>{props.title}</h3>
         {props.label && <span css={productOptionHighlight}>{props.label}</span>}

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/linkTo.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/linkTo.jsx
@@ -4,6 +4,10 @@
 
 import React, { type Node } from 'react';
 import { css } from '@emotion/core';
+import { space } from '@guardian/src-foundations';
+import { neutral } from '@guardian/src-foundations/palette';
+import { body } from '@guardian/src-foundations/typography';
+import { from } from '@guardian/src-foundations/mq';
 import { Link } from '@guardian/src-link';
 
 import { paperSubsUrl } from 'helpers/urls/routes';
@@ -14,16 +18,30 @@ const linkColor = css`
   color: inherit;
 `;
 
+const linkStyles = (tab, activeTab) => css`
+  color: ${neutral[100]};
+  ${body.small({ fontWeight: 'bold' })};
+  text-decoration: none;
+  padding: ${space[3]}px ${space[3]}px ${space[2]}px;
+  border-bottom: ${space[1]}px solid ${(tab === activeTab) ? neutral[100] : 'transparent'};
+  width: 50%;
+  ${from.tablet} {
+    width: initial;
+  }
+`;
+
 function LinkTo({
-  setTabAction, tab, children,
+  setTabAction, tab, children, activeTab, isPricesTabLink,
 }: {|
   setTabAction: (PaperFulfilmentOptions) => void,
   tab: PaperFulfilmentOptions,
-  children: Node
+  children: Node,
+  activeTab?: PaperFulfilmentOptions | null,
+  isPricesTabLink?: boolean
 |}) {
   return (
     <Link
-      css={linkColor}
+      css={isPricesTabLink ? linkStyles(tab, activeTab) : linkColor}
       href={paperSubsUrl(tab === 'delivery')}
       onClick={(ev) => {
         ev.preventDefault();
@@ -34,5 +52,10 @@ function LinkTo({
     </Link>
   );
 }
+
+LinkTo.defaultProps = {
+  activeTab: null,
+  isPricesTabLink: false,
+};
 
 export default LinkTo;

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/linkTo.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/linkTo.jsx
@@ -43,6 +43,7 @@ function LinkTo({
     <Link
       css={isPricesTabLink ? linkStyles(tab, activeTab) : linkColor}
       href={paperSubsUrl(tab === 'delivery')}
+      aria-current={tab === activeTab}
       onClick={(ev) => {
         ev.preventDefault();
         setTabAction(tab);

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/prices.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/prices.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { css } from '@emotion/core';
 import { space } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
+import { brand } from '@guardian/src-foundations/palette';
 import { from, between } from '@guardian/src-foundations/mq';
 import { SvgInfo } from '@guardian/src-icons';
 
@@ -75,6 +76,12 @@ const pricesInfo = css`
   margin-top: ${space[6]}px;
 `;
 
+const pricesTabs = css`
+  margin-top: ${space[6]}px;
+  display: flex;
+  border-bottom: 1px solid ${brand[600]};
+`;
+
 function Prices({
   activeTab, setTabAction, products,
 }: PropTypes) {
@@ -98,14 +105,13 @@ function Prices({
           />
         ))}
       </FlexContainer>
-      <div css={pricesInfo}>
-        {
-            activeTab === Collection ?
-              <LinkTo tab={HomeDelivery} setTabAction={setTabAction}>Switch to Delivery</LinkTo> :
-              <LinkTo tab={Collection} setTabAction={setTabAction}>
-                  Switch to Subscription card
-              </LinkTo>
-          }
+      <div css={pricesTabs}>
+        <LinkTo tab={Collection} setTabAction={setTabAction} activeTab={activeTab} isPricesTabLink>
+          Subscription card
+        </LinkTo>
+        <LinkTo tab={HomeDelivery} setTabAction={setTabAction} activeTab={activeTab} isPricesTabLink>
+          Home Delivery
+        </LinkTo>
       </div>
       <div css={pricesInfo}>
         <ProductInfoChip icon={<SvgInfo />}>

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/prices.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/prices.jsx
@@ -28,8 +28,8 @@ const pricesSection = css`
 const priceBoxes = css`
   margin-top: ${space[6]}px;
   justify-content: flex-start;
-  ${from.desktop} {
-    margin-top: ${space[9]}px;
+  ${from.tablet} {
+    margin-top: ${space[12]}px;
   }
 `;
 

--- a/support-frontend/assets/pages/paper-subscription-landing/components/paperPrices.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/paperPrices.jsx
@@ -81,7 +81,7 @@ const getPlans = (
       href: paperCheckoutUrl(fulfilmentOption, productOption, promoCode, isUsingGuestCheckout),
       onClick: sendTrackingEventsOnClick(trackingProperties),
       onView: sendTrackingEventsOnView(trackingProperties),
-      buttonCopy: 'Subscribe now',
+      buttonCopy: 'Subscribe',
       priceCopy: getPriceCopyString(nonDiscountedPrice, copy[fulfilmentOption][productOption]),
       offerCopy: getOfferText(priceAfterPromosApplied),
       label: '',


### PR DESCRIPTION
## What are you doing in this PR?
This pr implements the design changes to the paper pricing cards with the inclusion of the Saturday plan

[**Trello Card**](https://trello.com/c/5ROhF0di/3845-paper-campaign-support-5th-pricing-card-saturday-subscription60)

## Why are you doing this?
These changes are necessary for when we enable the Saturday paper subscription pricing card.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots
| mobile | mobileMedium | mobileLandscape | phablet | tablet | leftCol | wide |
|--------|--------------|-----------------|---------|--------|---------|------|
| ![mobile](https://user-images.githubusercontent.com/44685872/132847463-09c5a705-6486-4f45-b98f-24762432fd9c.png) | ![mobileMedium](https://user-images.githubusercontent.com/44685872/132847630-b588326e-7f9a-456f-a903-d78b5e5fd3e0.png) | ![mobileLandscape](https://user-images.githubusercontent.com/44685872/132847710-e3608cd1-5449-4f75-aa7b-087577af92a4.png) | ![phablet](https://user-images.githubusercontent.com/44685872/132847776-f20f047a-f4a7-4fb0-ab40-0da0c71174ad.png) | ![tablet](https://user-images.githubusercontent.com/44685872/132847959-5442ecdb-3f58-4aad-9d88-8deaf01ca9e2.png) | ![leftCol](https://user-images.githubusercontent.com/44685872/132848018-a2a8eb23-aa19-4cb7-920b-fe9102769267.png) | ![wide](https://user-images.githubusercontent.com/44685872/132848136-427db918-7d3d-43d6-884c-5fff3b448143.png) |


