### PR TITLE
if a create request fails for any reason, alarm immediately

### DIFF
--- a/support-frontend/app/controllers/RegularContributions.scala
+++ b/support-frontend/app/controllers/RegularContributions.scala
@@ -37,14 +37,15 @@ class RegularContributions(
 
   implicit val a: AssetsResolver = assets
 
-  def create: Action[CreateSupportWorkersRequest] = maybeAuthenticatedAction().async(new LoggingCirceParser(components).requestParser) {
-    implicit request =>
-      request.user.fold {
-        createContributorAndUser()
-      } { fullUser =>
-        createContributorWithUser(fullUser)
-      }
-  }
+  def create: EssentialAction =
+    alarmOnFailure(maybeAuthenticatedAction().async(new LoggingCirceParser(components).requestParser) {
+      implicit request =>
+        request.user.fold {
+          createContributorAndUser()
+        } { fullUser =>
+          createContributorWithUser(fullUser)
+        }
+    })
 
   private def createContributorWithUser(fullUser: AuthenticatedIdUser)(implicit request: OptionalAuthRequest[CreateSupportWorkersRequest]) = {
     val billingPeriod = request.body.product.billingPeriod

--- a/support-frontend/app/wiring/ActionBuilders.scala
+++ b/support-frontend/app/wiring/ActionBuilders.scala
@@ -14,6 +14,7 @@ trait ActionBuilders {
     cc = controllerComponents,
     addToken = csrfAddToken,
     checkToken = csrfCheck,
-    csrfConfig = csrfConfig
+    csrfConfig = csrfConfig,
+    stage = appConfig.stage
   )
 }

--- a/support-frontend/cloud-formation/cfn.yaml
+++ b/support-frontend/cloud-formation/cfn.yaml
@@ -545,3 +545,30 @@ Resources:
       TreatMissingData: notBreaching
     DependsOn:
     - StateMachineUnavailableMetric
+
+  ServerSideCreateFailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProdResources
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+      AlarmName: !Join
+        - ' '
+        - - !FindInMap [ Constants, Alarm, Urgent ]
+          - !Ref 'Stage'
+          - 'support-frontend create subscription call failed'
+      AlarmDescription: !Join
+        - ' '
+        - - 'Impact - Someone pressed buy on a subscription but received an error.'
+          - !FindInMap [ Constants, Alarm, Process ]
+      MetricName: ServerSideCreateFailure
+      Namespace: support-frontend
+      Dimensions:
+        - Name: Stage
+          Value: PROD
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 1
+      Period: 60
+      EvaluationPeriods: 1
+      Statistic: Sum
+      TreatMissingData: notBreaching

--- a/support-frontend/test/actions/ActionRefinerTest.scala
+++ b/support-frontend/test/actions/ActionRefinerTest.scala
@@ -1,5 +1,6 @@
 package actions
 
+import com.gu.support.config.{Stage, Stages}
 import config.Configuration.IdentityUrl
 import fixtures.TestCSRFComponents
 import org.mockito.ArgumentMatchers._
@@ -22,6 +23,7 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
   val supportUrl = "https://support-url.local"
   val path = "/test-path"
   val fakeRequest = FakeRequest("GET", path)
+  val stage = Stages.DEV
 
   trait Mocks {
     val asyncAuthenticationService = mock[AsyncAuthenticationService]
@@ -31,7 +33,7 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
 
     "include Cache-control: no-cache, private" in new Mocks {
       val actionRefiner =
-        new CustomActionBuilders(asyncAuthenticationService,IdentityUrl(""), "", stubControllerComponents(), csrfAddToken, csrfCheck, csrfConfig)
+        new CustomActionBuilders(asyncAuthenticationService,IdentityUrl(""), "", stubControllerComponents(), csrfAddToken, csrfCheck, csrfConfig, stage)
       val result = actionRefiner.PrivateAction(Ok("")).apply(FakeRequest())
       header("Cache-Control", result) mustBe Some("no-cache, private")
     }
@@ -46,7 +48,7 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
         .thenReturn(Future.successful(mock[AuthenticatedIdUser]))
 
       val actionRefiner = new CustomActionBuilders(
-        asyncAuthenticationService, IdentityUrl(""), "", stubControllerComponents(), csrfAddToken, csrfCheck, csrfConfig
+        asyncAuthenticationService, IdentityUrl(""), "", stubControllerComponents(), csrfAddToken, csrfCheck, csrfConfig, stage
       )
       val result = actionRefiner.authenticatedAction()(Ok("authentication-test")).apply(fakeRequest)
       status(result) mustEqual Status.OK
@@ -63,7 +65,8 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
         cc = stubControllerComponents(),
         addToken = csrfAddToken,
         checkToken = csrfCheck,
-        csrfConfig = csrfConfig
+        csrfConfig = csrfConfig,
+        stage = stage
       )
       val result = actionRefiner.authenticatedAction()(Ok("authentication-test")).apply(fakeRequest)
 
@@ -87,7 +90,8 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
         cc = stubControllerComponents(),
         addToken = csrfAddToken,
         checkToken = csrfCheck,
-        csrfConfig = csrfConfig
+        csrfConfig = csrfConfig,
+        stage = stage
       )
       val result = actionRefiner.authenticatedAction()(Ok("authentication-test")).apply(fakeRequest)
       header("Cache-Control", result) mustBe Some("no-cache, private")
@@ -102,7 +106,8 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
         cc = stubControllerComponents(),
         addToken = csrfAddToken,
         checkToken = csrfCheck,
-        csrfConfig = csrfConfig
+        csrfConfig = csrfConfig,
+        stage = stage
       )
       val result = actionRefiner.authenticatedAction()(Ok("authentication-test")).apply(fakeRequest)
       header("Cache-Control", result) mustBe Some("no-cache, private")
@@ -131,7 +136,8 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
         cc = stubControllerComponents(),
         addToken = csrfAddToken,
         checkToken = csrfCheck,
-        csrfConfig = csrfConfig
+        csrfConfig = csrfConfig,
+        stage = stage
       )
       val result = actionRefiner.authenticatedTestUserAction()(Ok("authentication-test")).apply(fakeRequest)
       status(result) mustEqual Status.OK
@@ -149,7 +155,8 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
         cc = stubControllerComponents(),
         addToken = csrfAddToken,
         checkToken = csrfCheck,
-        csrfConfig = csrfConfig
+        csrfConfig = csrfConfig,
+        stage = stage
       )
       val result = actionRefiner.authenticatedTestUserAction()(Ok("authentication-test")).apply(fakeRequest)
 
@@ -167,7 +174,7 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
       when(asyncAuthenticationService.authenticateTestUser(any())).thenReturn(Future.failed(new RuntimeException))
 
       val actionRefiner =
-          new CustomActionBuilders(asyncAuthenticationService, IdentityUrl(""), "", stubControllerComponents(), csrfAddToken, csrfCheck, csrfConfig)
+          new CustomActionBuilders(asyncAuthenticationService, IdentityUrl(""), "", stubControllerComponents(), csrfAddToken, csrfCheck, csrfConfig, stage)
       val result = actionRefiner.authenticatedTestUserAction()(Ok("authentication-test")).apply(fakeRequest)
       header("Cache-Control", result) mustBe Some("no-cache, private")
     }

--- a/support-frontend/test/controllers/ApplicationTest.scala
+++ b/support-frontend/test/controllers/ApplicationTest.scala
@@ -10,7 +10,7 @@ import config.{Configuration, RecaptchaConfigProvider, StringsConfig}
 import fixtures.TestCSRFComponents
 import org.scalatestplus.mockito.MockitoSugar.mock
 import services._
-import com.gu.support.config.{AmazonPayConfigProvider, PayPalConfigProvider, Stage, StripeConfigProvider}
+import com.gu.support.config.{AmazonPayConfigProvider, PayPalConfigProvider, Stage, Stages, StripeConfigProvider}
 import config.Configuration.{GuardianDomain, IdentityUrl}
 
 import scala.concurrent.ExecutionContext
@@ -22,6 +22,7 @@ import org.scalatest.matchers.must.Matchers
 class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents {
 
   implicit val timeout = Timeout(2.seconds)
+  val stage = Stages.DEV
 
   val actionRefiner = new CustomActionBuilders(
     asyncAuthenticationService = mock[AsyncAuthenticationService],
@@ -30,7 +31,8 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
     cc = stubControllerComponents(),
     addToken = csrfAddToken,
     checkToken = csrfCheck,
-    csrfConfig = csrfConfig
+    csrfConfig = csrfConfig,
+    stage = stage
   )
 
   "/healthcheck" should {

--- a/support-frontend/test/controllers/SiteMapTest.scala
+++ b/support-frontend/test/controllers/SiteMapTest.scala
@@ -5,6 +5,7 @@ import actions.CustomActionBuilders
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{status, stubControllerComponents}
 import akka.util.Timeout
+import com.gu.support.config.Stages
 import org.scalatestplus.mockito.MockitoSugar.mock
 import config.Configuration.IdentityUrl
 import services.AsyncAuthenticationService
@@ -12,13 +13,13 @@ import services.AsyncAuthenticationService
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
-
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.must.Matchers
 
 class SiteMapTest extends AnyWordSpec with Matchers with TestCSRFComponents {
 
   implicit val timeout = Timeout(2.seconds)
+  val stage = Stages.DEV
 
   val actionRefiner = new CustomActionBuilders(
     asyncAuthenticationService = mock[AsyncAuthenticationService],
@@ -27,7 +28,8 @@ class SiteMapTest extends AnyWordSpec with Matchers with TestCSRFComponents {
     cc = stubControllerComponents(),
     addToken = csrfAddToken,
     checkToken = csrfCheck,
-    csrfConfig = csrfConfig
+    csrfConfig = csrfConfig,
+    stage = stage
   )
 
   "GET /sitemap.xml" should {

--- a/support-frontend/test/fixtures/DisplayFormMocks.scala
+++ b/support-frontend/test/fixtures/DisplayFormMocks.scala
@@ -14,6 +14,7 @@ import play.api.mvc.RequestHeader
 import play.api.Environment
 import assets.{AssetsResolver, RefPath}
 import com.gu.identity.model.{PublicFields, User => IdUser}
+import com.gu.support.config.Stages
 import config.Configuration.IdentityUrl
 import services._
 import services.MembersDataService._
@@ -43,6 +44,8 @@ trait DisplayFormMocks extends TestCSRFComponents {
 
   val asyncAuthenticationService = mock[AsyncAuthenticationService]
 
+  val stage = Stages.DEV
+
   val loggedInActionRefiner = new CustomActionBuilders(
     asyncAuthenticationService,
     idWebAppUrl = IdentityUrl(""),
@@ -50,7 +53,8 @@ trait DisplayFormMocks extends TestCSRFComponents {
     cc = stubControllerComponents(),
     addToken = csrfAddToken,
     checkToken = csrfCheck,
-    csrfConfig = csrfConfig
+    csrfConfig = csrfConfig,
+    stage = stage
   )
 
   val loggedOutActionRefiner = new CustomActionBuilders(
@@ -60,7 +64,8 @@ trait DisplayFormMocks extends TestCSRFComponents {
     cc = stubControllerComponents(),
     addToken = csrfAddToken,
     checkToken = csrfCheck,
-    csrfConfig = csrfConfig
+    csrfConfig = csrfConfig,
+    stage = stage
   )
 
   def mockedMembersDataService(data: (AccessCredentials.Cookies, Either[MembersDataServiceError, UserAttributes])): MembersDataService = {

--- a/support-frontend/test/selenium/subscriptions/pages/GuardianWeeklyGiftCheckout.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/GuardianWeeklyGiftCheckout.scala
@@ -21,7 +21,7 @@ class GuardianWeeklyGiftCheckout(implicit val webDriver: WebDriver) extends Chec
   private val billingPostcode = id("billing-postcode")
   private val billingCountry = id("billing-country")
 
-  def fillForm() {
+  def fillForm(): Unit = {
     setValue(gifteeFirstName, "Gifty")
     setValue(gifteeLastName, "McGiftface")
     setValue(deliveryCountry, "United Kingdom")

--- a/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
+++ b/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
@@ -44,11 +44,10 @@ object AwsCloudWatchMetricSetup {
       )
     )
 
-  def serverSideValidationFailure(stage: Stage, product: String): MetricRequest =
+  def serverSideCreateFailure(stage: Stage): MetricRequest =
     getMetricRequest(
-      MetricName("ServerSideValidationFailure"),
+      MetricName("ServerSideCreateFailure"),
       Map(
-        MetricDimensionName("Product") -> MetricDimensionValue(product),
         MetricDimensionName("Stage") -> MetricDimensionValue(stage.toString)
       )
     )


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

The server side create endpoint is the final step in creating a subscription, after the client side work has been done.
This PR makes us get an alarm if there's any non 2xx response from the create endpoint on the server side.

Tested locally with Digi sub and contribution (positive and negative cases)

https://trello.com/c/RzkGDEbI/3849-alarm-on-a-single-deserialisation-failure-on-acquisition

## Why are you doing this?

This is needed in response to an incident where some subscribe requests did not validate on the server side, but no alarms were able to detect that, as it was rejected immediately by the parser.  See retro doc here https://docs.google.com/document/d/10K8VFm2oUv6SOu6U49B1rUPtHQPwGyZB2pV8Cfam_dE/edit#
This tries to capture all errors between the request header being read in to the server and available as a ByteString, and the response being returned.


![image](https://user-images.githubusercontent.com/7304387/134212761-e6a18df6-6249-4c5b-9d20-5bedf991b461.png)
https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metricsV2:graph=~(metrics~(~(~'support-frontend~'ServerSideCreateFailure~'Stage~'DEV))~view~'timeSeries~stacked~false~region~'eu-west-1~start~'-PT3H~end~'P0D~stat~'Sum~period~60~yAxis~(left~(min~0)));query=~'*7bsupport-frontend*2cStage*7d