### PR TITLE
also alarm on failed futures on the create endpoints

### DIFF
--- a/support-frontend/app/services/HttpIdentityService.scala
+++ b/support-frontend/app/services/HttpIdentityService.scala
@@ -180,7 +180,7 @@ class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient:
       wsClient.url(s"$apiUrl/$endpoint")
         .withHttpHeaders(headers: _*)
         .withQueryStringParameters(parameters: _*)
-        .withRequestTimeout(1.second)
+        .withRequestTimeout(3.seconds)
         .withMethod("GET")
     )(func)
   }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Follwing on from https://github.com/guardian/support-frontend/pull/3246
It became clear that failed futures can be returned by an action and cause a 5xx in place of the Result object.
This PR traps them too and also pushes an alarm if it fails.


## Why are you doing this?

We want to know when things are going wrong right at the end of the process of purchasing, so we can make the experience better. And avoid losing money.
