### PR TITLE
don't submit stripe errors to the backend as a payment method

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -148,7 +148,7 @@ const StripeForm = (props: StripeFormPropTypes) => {
     return stripe.handleCardSetup(clientSecret, cardElement).then((result) => {
       if (result.error) {
         handleStripeError(result.error);
-        return Promise.resolve(result.error);
+        return Promise.reject(result.error);
       }
       return result.setupIntent.payment_method;
 


### PR DESCRIPTION
## What are you doing in this PR?

This PR makes sure a stripe error is logged as a rejected promise rather than the error being used to resolve the promise.  This means it doesn't get submitted to the back end as a valid payment id.

https://trello.com/c/hR0Sn4K3/3870-dont-submit-client-side-stripe-error-as-payment-details-to-back-end

## Why are you doing this?

This is needed to reduce the number of alarms that go off, and make the error message clearer.

Before the user used to see:
![image](https://user-images.githubusercontent.com/7304387/134380186-c9f361a1-7db2-4c05-b91e-67e1e95d84ae.png)
and this extra request:
![image](https://user-images.githubusercontent.com/7304387/134380289-a997a7bb-4b70-47dc-9d1b-adcf9f8187c2.png)

Now they will see:
![image](https://user-images.githubusercontent.com/7304387/134379870-446ec38d-2465-45b7-8b7a-95ae0910f7aa.png)
