### PR TITLE
Remove querystring switch for SEPA

### DIFF
--- a/support-frontend/assets/helpers/forms/checkouts.js
+++ b/support-frontend/assets/helpers/forms/checkouts.js
@@ -100,7 +100,7 @@ function getPaymentMethods(
       return [Stripe, PayPal, AmazonPay];
     }
     return [Stripe, PayPal];
-  } else if (contributionType !== 'ONE_OFF' && countryGroupId === 'EURCountries' && getQueryParameter('sepa') === 'true') {
+  } else if (contributionType !== 'ONE_OFF' && countryGroupId === 'EURCountries') {
     return [Sepa, Stripe, PayPal];
   }
   return [Stripe, PayPal];


### PR DESCRIPTION
currently you can only see SEPA if you add `?sepa=true` to the url.
This PR removes this.
After this PR is merged all EUR users will see SEPA. The RRCP switchboard has a switch for SEPA if we need to disable it.

To be merged on Monday.