### PR TITLE
fix ipaddress field in zuora request

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -150,7 +150,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       BankTransferAccountName = sepa.accountHolderName,
       BankTransferAccountNumber = sepa.iban,
       Email = user.primaryEmailAddress,
-      IPAddress = ipAddress,
+      IPAddress = ipAddress.take(15), // zuora doesn't support ipv6
       GatewayOptionData = GatewayOptionData(List(GatewayOption("UserAgent", userAgent)))
     ))
   }


### PR DESCRIPTION
A sepa recurring contribution failed at the zuora step with:
`The length of IP Address can not be longer than 15 characters`
This doesn't work for ipv6