### PR TITLE
Remove newspaper guest checkout test

### DIFF
--- a/support-frontend/app/controllers/PaperSubscriptionForm.scala
+++ b/support-frontend/app/controllers/PaperSubscriptionForm.scala
@@ -40,21 +40,7 @@ class PaperSubscriptionForm(
   implicit val a: AssetsResolver = assets
 
 
-  def displayForm(): Action[AnyContent] =
-    authenticatedAction(subscriptionsClientId).async { implicit request =>
-      implicit val settings: AllSettings = settingsProvider.getAllSettings()
-      identityService.getUser(request.user.minimalUser).fold(
-        error => {
-          SafeLogger.error(scrub"Failed to display paper subscriptions form for ${request.user.minimalUser.id} due to error from identityService: $error")
-          Future.successful(InternalServerError)
-        },
-        user => {
-          Future.successful(Ok(paperSubscriptionFormHtml(Some(user))))
-        }
-      ).flatten.map(_.withSettingsSurrogateKey)
-    }
-
-  def displayGuestForm(): Action[AnyContent] = {
+  def displayForm(): Action[AnyContent] = {
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     maybeAuthenticatedAction().async{ implicit request =>
         val maybeIdUser: EitherT[Future, String, Option[IdUser]] = request.user match {

--- a/support-frontend/assets/components/csr/csrMode.js
+++ b/support-frontend/assets/components/csr/csrMode.js
@@ -1,13 +1,10 @@
 // $FlowIgnore - required for hooks
 import { useEffect, useState } from 'react';
-import { getQueryParameter } from 'helpers/urls/url';
 
 const domains = ['https://gnmtouchpoint.my.salesforce.com', 'https://gnmtouchpoint--dev1--c.cs88.visual.force.com'];
 const isSalesforceDomain = domain => domains.find(element => element === domain);
 
 const isInCsrMode = () => window.location !== window.parent.location;
-
-const hasCsrQueryParam = () => getQueryParameter('csr', '0') === '1';
 
 const useCsrDetails = () => {
   const [csrUsername, setCsrUsername] = useState('');
@@ -24,4 +21,4 @@ const useCsrDetails = () => {
   return csrUsername;
 };
 
-export { isInCsrMode, useCsrDetails, hasCsrQueryParam };
+export { isInCsrMode, useCsrDetails };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -1,6 +1,5 @@
 // @flow
 import type { Tests } from './abtest';
-import { hasCsrQueryParam } from 'components/csr/csrMode';
 
 // ----- Tests ----- //
 
@@ -132,28 +131,6 @@ export const tests: Tests = {
     targetPage: pageUrlRegexes.subscriptions.digiSub.nonGiftLandingAndCheckoutWithGuest,
     seed: 10,
     optimizeId: 'YlwEboxsQ4qmv03tF4lRvQ',
-  },
-  subscriptionsGuestCheckoutTest: {
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'variant',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    canRun: () => !hasCsrQueryParam(),
-    isActive: true,
-    referrerControlled: false,
-    targetPage: pageUrlRegexes.subscriptions.paper.paperLandingWithGuestCheckout,
-    seed: 3,
-    optimizeId: 'tn3FveQmTeiTS4JtSUyzig',
   },
   productSetTest: {
     variants: [

--- a/support-frontend/assets/helpers/urls/routes.js
+++ b/support-frontend/assets/helpers/urls/routes.js
@@ -75,7 +75,7 @@ function paperCheckoutUrl(
   productOptions: ProductOptions,
   promoCode?: Option<string>,
 ) {
-  const url = `${getOrigin()}/subscribe/paper/checkout/guest`;
+  const url = `${getOrigin()}/subscribe/paper/checkout`;
 
   return addQueryParamsToURL(url, { promoCode, fulfilmentOption, productOptions });
 }

--- a/support-frontend/assets/helpers/urls/routes.js
+++ b/support-frontend/assets/helpers/urls/routes.js
@@ -3,7 +3,7 @@
 // ----- Routes ----- //
 
 import { countryGroups, type CountryGroupId } from '../internationalisation/countryGroup';
-import { addQueryParamsToURL, getAllQueryParams, getOrigin, getQueryParameter, isProd } from './url';
+import { addQueryParamsToURL, getAllQueryParams, getOrigin, isProd } from './url';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
 import { type Option } from 'helpers/types/option';
@@ -74,13 +74,10 @@ function paperCheckoutUrl(
   fulfilmentOption: FulfilmentOptions,
   productOptions: ProductOptions,
   promoCode?: Option<string>,
-  isUsingGuestCheckout: boolean,
 ) {
-  const url = isUsingGuestCheckout ?
-    `${getOrigin()}/subscribe/paper/checkout/guest?fulfilment=${fulfilmentOption}&product=${productOptions}`
-    : `${getOrigin()}/subscribe/paper/checkout?fulfilment=${fulfilmentOption}&product=${productOptions}`;
+  const url = `${getOrigin()}/subscribe/paper/checkout/guest`;
 
-  return addQueryParamsToURL(url, { promoCode, csr: getQueryParameter('csr') });
+  return addQueryParamsToURL(url, { promoCode, fulfilmentOption, productOptions });
 }
 
 // If the user cancels before completing the payment flow, send them back to the contribute page.

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -81,7 +81,6 @@ import { paperSubsUrl } from 'helpers/urls/routes';
 import { getQueryParameter } from 'helpers/urls/url';
 import type { Participations } from 'helpers/abTests/abtest';
 import { checkIfEmailHasPassword } from 'helpers/subscriptionsForms/guestCheckout';
-import { hasCsrQueryParam } from 'components/csr/csrMode';
 import { setupSubscriptionPayPalPaymentNoShipping } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 
 const marginBottom = css`
@@ -219,7 +218,6 @@ function PaperCheckoutForm(props: PropTypes) {
   const priceHasRedundantFloat = simplePrice.split('.')[1] === '00'; // checks whether price is something like '£10.00'
   const cleanedPrice = priceHasRedundantFloat ? simplePrice.replace(/\.(.*)/, '') : simplePrice; // removes decimal point if there are no pence
   const expandedPricingText = `${cleanedPrice} per month`;
-  const isUsingGuestCheckout = props.participations.subscriptionsGuestCheckoutTest === 'variant' || hasCsrQueryParam();
 
   function addDigitalSubscription(event: SyntheticInputEvent<HTMLInputElement>) {
     setIncludesDigiSub(event.target.checked);
@@ -313,7 +311,7 @@ function PaperCheckoutForm(props: PropTypes) {
               setTelephone={props.setTelephone}
               formErrors={props.formErrors}
               signOut={props.signOut}
-              isUsingGuestCheckout={isUsingGuestCheckout}
+              isUsingGuestCheckout
             />
           </FormSection>
 

--- a/support-frontend/assets/pages/paper-subscription-landing/components/paperPrices.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/paperPrices.jsx
@@ -58,7 +58,6 @@ const copy = {
 const getPlans = (
   fulfilmentOption: PaperFulfilmentOptions,
   productPrices: ProductPrices,
-  isUsingGuestCheckout: boolean,
 ) =>
   ActivePaperProductTypes.map((productOption) => {
     const priceAfterPromosApplied = finalPrice(productPrices, fulfilmentOption, productOption);
@@ -80,7 +79,7 @@ const getPlans = (
     return {
       title: getTitle(productOption),
       price: showPrice(priceAfterPromosApplied),
-      href: paperCheckoutUrl(fulfilmentOption, productOption, promoCode, isUsingGuestCheckout),
+      href: paperCheckoutUrl(fulfilmentOption, productOption, promoCode),
       onClick: sendTrackingEventsOnClick(trackingProperties),
       onView: sendTrackingEventsOnView(trackingProperties),
       buttonCopy: 'Subscribe',
@@ -94,16 +93,15 @@ const getPlans = (
     productPrices: ?ProductPrices,
     tab: PaperFulfilmentOptions,
     setTabAction: (PaperFulfilmentOptions) => void,
-    isUsingGuestCheckout: boolean,
 |}
 
 function PaperProductPrices({
-  productPrices, tab, setTabAction, isUsingGuestCheckout,
+  productPrices, tab, setTabAction,
 }: PaperProductPricesProps) {
   if (!productPrices) {
     return null;
   }
-  const products = getPlans(tab, productPrices, isUsingGuestCheckout);
+  const products = getPlans(tab, productPrices);
 
   return <Prices activeTab={tab} products={products} setTabAction={setTabAction} />;
 }

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -31,7 +31,6 @@ import { Collection, HomeDelivery } from 'helpers/productPrice/fulfilmentOptions
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 
 import { paperLandingProps, type PaperLandingPropTypes } from './paperSubscriptionLandingProps';
-import { hasCsrQueryParam } from 'components/csr/csrMode';
 
 // ----- Collection or delivery ----- //
 
@@ -51,10 +50,9 @@ const paperSubsFooter = (
 const pageQaId = 'qa-paper-subscriptions';
 
 
-const PaperLandingPage = ({ productPrices, promotionCopy, participations }: PaperLandingPropTypes) => {
+const PaperLandingPage = ({ productPrices, promotionCopy }: PaperLandingPropTypes) => {
   const sanitisedPromoCopy = getPromotionCopy(promotionCopy);
   const fulfilment: PaperFulfilmentOptions = window.location.pathname.includes('delivery') ? HomeDelivery : Collection;
-  const isUsingGuestCheckout = participations.subscriptionsGuestCheckoutTest === 'variant' || hasCsrQueryParam();
 
   const [selectedTab, setSelectedTab] = useState<PaperFulfilmentOptions>(fulfilment);
 
@@ -96,7 +94,6 @@ const PaperLandingPage = ({ productPrices, promotionCopy, participations }: Pape
             productPrices={productPrices}
             tab={selectedTab}
             setTabAction={setSelectedTab}
-            isUsingGuestCheckout={isUsingGuestCheckout}
           />
         </CentredContainer>
       </FullWidthContainer>

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingProps.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingProps.js
@@ -1,21 +1,15 @@
 // @flow
 
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
-import { getProductPrices, getPromotionCopy, getSettings } from 'helpers/globalsAndSwitches/globals';
+import { getProductPrices, getPromotionCopy } from 'helpers/globalsAndSwitches/globals';
 import type { PromotionCopy } from 'helpers/productPrice/promotions';
-import { init as initAbTests } from 'helpers/abTests/abtest';
-import { GBPCountries } from 'helpers/internationalisation/countryGroup';
-import { detect } from 'helpers/internationalisation/country';
-import type { Participations } from 'helpers/abTests/abtest';
 
 export type PaperLandingPropTypes = {|
   productPrices: ?ProductPrices;
   promotionCopy: ?PromotionCopy;
-  participations: Participations;
 |}
 
 export const paperLandingProps = (): PaperLandingPropTypes => ({
   productPrices: getProductPrices(),
   promotionCopy: getPromotionCopy(),
-  participations: initAbTests(detect(GBPCountries), GBPCountries, getSettings()),
 });

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -182,7 +182,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
     props.setBillingCountry(props.deliveryCountry);
   };
   const paymentMethods = supportedPaymentMethods(props.currencyId, props.billingCountry);
-  const isUsingGuestCheckout = props.participations.subscriptionsGuestCheckoutTest === 'variant';
+  const isUsingGuestCheckout = false;
 
   return (
     <Content modifierClasses={['your-details']}>

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -113,7 +113,6 @@ GET  /subscribe/paper                                              controllers.P
 GET  /subscribe/paper/delivery                                     controllers.PaperSubscriptionController.paperMethodRedirect(withDelivery: Boolean = true)
 GET  /uk/subscribe/paper                                           controllers.PaperSubscriptionController.paper()
 GET  /uk/subscribe/paper/delivery                                  controllers.PaperSubscriptionController.paper()
-GET  /subscribe/paper/checkout/guest                               controllers.PaperSubscriptionForm.displayGuestForm()
 GET  /subscribe/paper/checkout                                     controllers.PaperSubscriptionForm.displayForm()
 
 # redemptions


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR removes the [ab test for newspaper guest checkout](https://github.com/guardian/support-frontend/pull/3232) and rolls guest checkout out to 100% of users.

[**Trello Card**](https://trello.com/c/j4hh5Kw4/3887-release-the-newspaper-guest-checkout-to-100-of-the-audience-stop-test)


## Is this an AB test?
- [ ] Yes
- [x] No

[**Link to the test results in Optimize**](https://optimize.google.com/optimize/home/#/accounts/1368065808/containers/6827913/experiments/496/report)

