### PR TITLE
Fix assembly by applying merge strategy to execution.interceptors

### DIFF
--- a/supporter-product-data/build.sbt
+++ b/supporter-product-data/build.sbt
@@ -35,6 +35,7 @@ assemblyMergeStrategy in assembly := {
   case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
   case x if x.endsWith("module-info.class") => MergeStrategy.discard
   case "mime.types" => MergeStrategy.first
+  case name if name.endsWith("execution.interceptors") => MergeStrategy.filterDistinctLines
   case y =>
     val oldStrategy = (assemblyMergeStrategy in assembly).value
     oldStrategy(y)


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

The supporter product data build has been failing in TeamCity for a while because of a merge problem in the assembly step of the build. This PR fixes it.

