### PR TITLE
optimistically extend identity timeout further

### DIFF
--- a/support-frontend/app/services/HttpIdentityService.scala
+++ b/support-frontend/app/services/HttpIdentityService.scala
@@ -180,7 +180,7 @@ class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient:
       wsClient.url(s"$apiUrl/$endpoint")
         .withHttpHeaders(headers: _*)
         .withQueryStringParameters(parameters: _*)
-        .withRequestTimeout(3.seconds)
+        .withRequestTimeout(5.seconds)
         .withMethod("GET")
     )(func)
   }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR extends the IDAPI timeoiut from 3 to 5s in order to reduce the number of 5xx errors due to identity timeout on the recurring product create endpoint.

## Why are you doing this?

The timeout was 1s and we were getting errors, so I increased to 3 in this PR
https://github.com/guardian/support-frontend/pull/3247/files#diff-de948b533ed461aa9f0a28870a991d90798894d20fb7295a129a60965c90851eR183

I had a chat with identity but they didn't see any issues at their end.

However it's still timing out every day so I have extended again (optimisticvally)

My feeling is it's a network issue and it won't recover even in 5s, but it is worth a try.  Failing that it might be worth seeing if we can get rid of the call, as all we are doing is getting the displayname and email address for support-workers, which may already be available.
