### PR TITLE
Fix state bug

### DIFF
--- a/support-frontend/assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.jsx
+++ b/support-frontend/assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.jsx
@@ -46,6 +46,8 @@ const updateStore = (dispatch: Dispatch<Action>, payPalUserDetails: PayPalUserDe
     setAddressLineOne, setTownCity, setPostcode, setState, setCountry,
   } = addressActionCreatorsFor('billing');
 
+  // $FlowIgnore stoopid flow
+  dispatch(setCountry(payPalUserDetails.shipToCountryCode));
   dispatch(setEmail(payPalUserDetails.email));
   dispatch(setFirstName(payPalUserDetails.firstName));
   dispatch(setLastName(payPalUserDetails.lastName));
@@ -55,8 +57,6 @@ const updateStore = (dispatch: Dispatch<Action>, payPalUserDetails: PayPalUserDe
     dispatch(setState(payPalUserDetails.shipToState));
   }
   dispatch(setPostcode(payPalUserDetails.shipToZip));
-  // $FlowIgnore stoopid flow
-  dispatch(setCountry(payPalUserDetails.shipToCountryCode));
 };
 
 function mapStateToProps(state: CheckoutState, ownProps) {

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -174,6 +174,6 @@ export const tests: Tests = {
     referrerControlled: false,
     targetPage: pageUrlRegexes.subscriptions.digiSub.nonGiftLandingAndCheckoutWithGuest,
     seed: 11,
-    optimizeId: 'vkNaA-56TTeQBN8DB5YyZw',
+    optimizeId: 'mB8kTh9ySPCAtwHHrVWkQw',
   },
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -152,7 +152,7 @@ export const tests: Tests = {
     targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
     seed: 13,
   },
-  payPalOneClickTest: {
+  payPalOneClickTestV2: {
     variants: [
       {
         id: 'control',


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
There was a bug with the #3249 test affecting users in countries where state is a required field:

When we retrieved the address information from PayPal we set the `state` field in Redux before `country`, however changing the value of `country` then sets `state` back to `null` see: https://github.com/guardian/support-frontend/blob/7f81d37da9a377d2fc304f2d50e228abe6a86dca/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx#L283

This PR fixes this by setting the `country` field before the `state` field.

Unfortunately this means that we will have to restart the PayPal one click test

[**Trello Card**](https://trello.com/c/X6JZVvOe/3892-paypal-one-click-users-in-the-us-have-null-state)

## Is this an AB test?
- [x] Yes
- [ ] No


If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home/#/accounts/1368065808/containers/6827913/experiments/507)
