### PR TITLE
update footer faq link to the help centre

### DIFF
--- a/support-frontend/assets/components/footerCompliant/ContributionsFooter.jsx
+++ b/support-frontend/assets/components/footerCompliant/ContributionsFooter.jsx
@@ -40,14 +40,13 @@ const alignmentStyles = css`
 `;
 
 function ContributionsFooter() {
-  const faqsLink = 'https://manage.theguardian.com/help-centre';
   const termsConditionsLink =
     'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions';
 
   return (
     <div css={containerStyles}>
       <div css={alignmentStyles}>
-        <Footer faqsLink={faqsLink} termsConditionsLink={termsConditionsLink}>
+        <Footer termsConditionsLink={termsConditionsLink}>
           <p>
             The ultimate owner of the Guardian is The Scott Trust Limited, whose
             role it is to secure the editorial and financial independence of the

--- a/support-frontend/assets/components/footerCompliant/DigitalFooter.jsx
+++ b/support-frontend/assets/components/footerCompliant/DigitalFooter.jsx
@@ -69,7 +69,7 @@ const GiftLinks = (props: LinkTypes) => {
 
 function DigitalFooter({ productPrices, orderIsAGift, country }: PropTypes) {
   const faqsLink = orderIsAGift ? 'https://www.theguardian.com/help/2020/nov/23/guardian-gift-digital-subscription-faqs' :
-    'https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions';
+    'https://manage.theguardian.com/help-centre';
   const termsConditionsLink = orderIsAGift ?
     'https://www.theguardian.com/help/2020/nov/24/gift-digital-subscriptions-terms-and-conditions' :
     'https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions';

--- a/support-frontend/assets/components/footerCompliant/DigitalFooter.jsx
+++ b/support-frontend/assets/components/footerCompliant/DigitalFooter.jsx
@@ -68,14 +68,11 @@ const GiftLinks = (props: LinkTypes) => {
 };
 
 function DigitalFooter({ productPrices, orderIsAGift, country }: PropTypes) {
-  const faqsLink = orderIsAGift ? 'https://www.theguardian.com/help/2020/nov/23/guardian-gift-digital-subscription-faqs' :
-    'https://manage.theguardian.com/help-centre';
   const termsConditionsLink = orderIsAGift ?
     'https://www.theguardian.com/help/2020/nov/24/gift-digital-subscriptions-terms-and-conditions' :
     'https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions';
   return (
     <Footer
-      faqsLink={faqsLink}
       termsConditionsLink={termsConditionsLink}
     >
       <h3

--- a/support-frontend/assets/components/footerCompliant/Footer.jsx
+++ b/support-frontend/assets/components/footerCompliant/Footer.jsx
@@ -19,7 +19,6 @@ import { BackToTop } from './BackToTop';
 
 type PropTypes = {|
   centred: boolean,
-  faqsLink: string,
   termsConditionsLink: string,
   children: Node,
 |};
@@ -28,7 +27,7 @@ type PropTypes = {|
 // ----- Component ----- //
 
 function Footer({
-  centred, children, faqsLink, termsConditionsLink,
+  centred, children, termsConditionsLink,
 }: PropTypes) {
   const [consentManagementPlatform, setConsentManagementPlatform] = useState(null);
 
@@ -60,11 +59,9 @@ function Footer({
       }
         <FooterContent appearance={{ border: true, centred }}>
           <ul css={linksList}>
-            {faqsLink &&
-              <li css={link}>
-                <Link subdued href={faqsLink}>FAQs</Link>
-              </li>
-            }
+            <li css={link}>
+              <Link subdued href="https://manage.theguardian.com/help-centre">Help Centre</Link>
+            </li>
             <li css={link}>
               <Link subdued href="https://www.theguardian.com/help/contact-us">Contact us</Link>
             </li>
@@ -98,7 +95,6 @@ function Footer({
 
 Footer.defaultProps = {
   centred: false,
-  faqsLink: '',
   termsConditionsLink: '',
   children: [],
 };

--- a/support-frontend/assets/components/footerCompliant/WeeklyFooter.jsx
+++ b/support-frontend/assets/components/footerCompliant/WeeklyFooter.jsx
@@ -12,7 +12,6 @@ export default function WeeklyFooter({ promoTermsLink, centred }: PropTypes) {
   return (
     <Footer
       centred={centred}
-      faqsLink="https://www.theguardian.com/help/2012/jan/19/guardian-weekly-faqs"
       termsConditionsLink="https://www.theguardian.com/info/2014/jul/10/guardian-weekly-print-subscription-services-terms-conditions"
     >
       <h3 css={footerTextHeading}>Promotion terms and conditions</h3>

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouExisting.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouExisting.jsx
@@ -39,7 +39,7 @@ const content = (
       header={<Header countryGroupId={countryGroupId} />}
       footer={
         <Footer
-          faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
+          faqsLink="https://manage.theguardian.com/help-centre"
           termsConditionsLink="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions"
         />}
     >

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouExisting.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouExisting.jsx
@@ -38,10 +38,7 @@ const content = (
     <Page
       header={<Header countryGroupId={countryGroupId} />}
       footer={
-        <Footer
-          faqsLink="https://manage.theguardian.com/help-centre"
-          termsConditionsLink="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions"
-        />}
+        <Footer termsConditionsLink="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions" />}
     >
       <div className="thank-you-stage">
         <HeroWrapper appearance="custom">

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouPendingContent.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouPendingContent.jsx
@@ -48,26 +48,15 @@ function ThankYouPendingContent(props: PropTypes) {
             our {(
               <a
                 onClick={sendTrackingEventsOnClick({
-                  id: 'faq',
-                  product: 'DigitalPack',
-                  componentType: 'ACQUISITIONS_BUTTON',
-                })}
-                href="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
-              >
-              FAQs page
-              </a>
-            )} to find answers to common user issues. Alternatively, you can also
-            visit our {(
-              <a
-                onClick={sendTrackingEventsOnClick({
                   id: 'help',
                   product: 'DigitalPack',
                   componentType: 'ACQUISITIONS_BUTTON',
                 })}
-                href="https://www.theguardian.com/help"
-              >Help page
+                href="https://manage.theguardian.com/help-centre"
+              >
+              Help Centre
               </a>
-            )} for customer support.
+            )} to find answers to common user issues and get customer support.
           </p>
         </Text>
       </Content>

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
@@ -62,7 +62,7 @@ const content = (
       header={<HeaderWrapper />}
       footer={
         <Footer
-          faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
+          faqsLink="https://manage.theguardian.com/help-centre"
           termsConditionsLink="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions"
         >
           <p>By proceeding, you agree to our{' '}

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
@@ -61,10 +61,7 @@ const content = (
     <Page
       header={<HeaderWrapper />}
       footer={
-        <Footer
-          faqsLink="https://manage.theguardian.com/help-centre"
-          termsConditionsLink="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions"
-        >
+        <Footer termsConditionsLink="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions">
           <p>By proceeding, you agree to our{' '}
             <a href="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions">Terms &amp; Conditions</a>.{' '}
             We will share your contact and subscription details with our fulfilment partners to provide you with your subscription card.{' '}

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -39,10 +39,7 @@ const reactElementId = 'paper-subscription-landing-page';
 // ----- Redux Store ----- //
 
 const paperSubsFooter = (
-  <Footer
-    faqsLink="https://manage.theguardian.com/help-centre"
-    termsConditionsLink="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions"
-  />);
+  <Footer termsConditionsLink="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions" />);
 
 // ----- Render ----- //
 

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -40,7 +40,7 @@ const reactElementId = 'paper-subscription-landing-page';
 
 const paperSubsFooter = (
   <Footer
-    faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
+    faqsLink="https://manage.theguardian.com/help-centre"
     termsConditionsLink="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions"
   />);
 

--- a/support-frontend/assets/pages/promotion-terms/promotionTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/promotionTerms.jsx
@@ -38,7 +38,7 @@ const PromotionTermsPage = (props: State) => (
     <Page
       header={<Header countryGroupId={detect()} />}
       footer={<Footer
-        faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
+        faqsLink="https://manage.theguardian.com/help-centre"
         termsConditionsLink={getTermsConditionsLink(props.page.promotionTerms)}
       />}
     >

--- a/support-frontend/assets/pages/promotion-terms/promotionTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/promotionTerms.jsx
@@ -37,10 +37,7 @@ const PromotionTermsPage = (props: State) => (
   <Provider store={store}>
     <Page
       header={<Header countryGroupId={detect()} />}
-      footer={<Footer
-        faqsLink="https://manage.theguardian.com/help-centre"
-        termsConditionsLink={getTermsConditionsLink(props.page.promotionTerms)}
-      />}
+      footer={<Footer termsConditionsLink={getTermsConditionsLink(props.page.promotionTerms)} />}
     >
       <PromoDetails {...props.page.promotionTerms} />
       <LegalTerms {...props.page} />

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -42,7 +42,7 @@ const SubscriptionsLandingPage = ({
     <Page
       header={<Header />}
       footer={
-        <Footer faqsLink="https://manage.theguardian.com/help-centre" centred />
+        <Footer centred />
         }
     >
       <SubscriptionLandingContent

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -42,7 +42,7 @@ const SubscriptionsLandingPage = ({
     <Page
       header={<Header />}
       footer={
-        <Footer faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions" centred />
+        <Footer faqsLink="https://manage.theguardian.com/help-centre" centred />
         }
     >
       <SubscriptionLandingContent

--- a/support-frontend/assets/pages/subscriptions-redemption/subscriptionsRedemption.jsx
+++ b/support-frontend/assets/pages/subscriptions-redemption/subscriptionsRedemption.jsx
@@ -38,10 +38,7 @@ const content = (
     <Page
       header={<Header display="guardianLogo" countryGroupId="GBPCountries" />}
       footer={
-        <Footer
-          faqsLink="https://manage.theguardian.com/help-centre"
-          termsConditionsLink="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions"
-        />}
+        <Footer termsConditionsLink="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions" />}
     >
       <CheckoutStage
         checkoutForm={<RedemptionForm />}

--- a/support-frontend/assets/pages/subscriptions-redemption/subscriptionsRedemption.jsx
+++ b/support-frontend/assets/pages/subscriptions-redemption/subscriptionsRedemption.jsx
@@ -39,7 +39,7 @@ const content = (
       header={<Header display="guardianLogo" countryGroupId="GBPCountries" />}
       footer={
         <Footer
-          faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
+          faqsLink="https://manage.theguardian.com/help-centre"
           termsConditionsLink="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions"
         />}
     >

--- a/support-frontend/stories/footer.jsx
+++ b/support-frontend/stories/footer.jsx
@@ -21,7 +21,7 @@ stories.add('Footer', () => {
     <FullWidthContainer theme="brand">
       <CentredContainer>
         <Footer
-          faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
+          faqsLink="https://manage.theguardian.com/help-centre"
           termsConditionsLink="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions"
         >
           {contents &&

--- a/support-frontend/stories/footer.jsx
+++ b/support-frontend/stories/footer.jsx
@@ -20,10 +20,7 @@ stories.add('Footer', () => {
   return (
     <FullWidthContainer theme="brand">
       <CentredContainer>
-        <Footer
-          faqsLink="https://manage.theguardian.com/help-centre"
-          termsConditionsLink="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions"
-        >
+        <Footer termsConditionsLink="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions">
           {contents &&
           <>
             Terms and conditions may (or may not) apply


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR updates the footer FAQs link to point to the Help Centre.

## Why are you doing this?

We got this message pointing out the change needed

>I've noticed that through the footer on the support.theguardian.com platform you can access this set of FAQs.

>This should really be pointing at the help centre instead. The long list of Subscription FAQs that's currently on there has a very high bounce rate and is also difficult to maintain as it's managed on a separate platform. 

>If there's anything on the long list of Subscription FAQs that's currently not on the help centre can you please let me know so that I can add it, so that everything is in the same place. Then we should change all FAQ links on the support.theguardian.com to point to the help centre.

