### PR TITLE
Fix issue with query string param on Newspaper LP

### DIFF
--- a/support-frontend/assets/helpers/urls/routes.js
+++ b/support-frontend/assets/helpers/urls/routes.js
@@ -77,7 +77,7 @@ function paperCheckoutUrl(
 ) {
   const url = `${getOrigin()}/subscribe/paper/checkout`;
 
-  return addQueryParamsToURL(url, { promoCode, fulfilmentOption, productOptions });
+  return addQueryParamsToURL(url, { promoCode, fulfilment: fulfilmentOption, product: productOptions });
 }
 
 // If the user cancels before completing the payment flow, send them back to the contribute page.


### PR DESCRIPTION
## What are you doing in this PR?

Investigated an issue with @rupertbates and @johnduffell where the Newspaper checkout form was always displaying Subs Card as selected product, even if Home Delivery had been selected. This was down to an issue with the way we construct the URL and query params.  

Incorrect: https://support.theguardian.com/subscribe/paper/checkout?fulfilmentOption=HomeDelivery&productOptions=Everyday

Correct: https://support.theguardian.com/subscribe/paper/checkout?fulfilment=HomeDelivery&product=Everyday