### PR TITLE
make the guest checkout identity timeout 5 seconds

### DIFF
--- a/support-frontend/app/services/HttpIdentityService.scala
+++ b/support-frontend/app/services/HttpIdentityService.scala
@@ -153,7 +153,7 @@ class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient:
       wsClient.url(s"$apiUrl/guest")
         .withHttpHeaders(postHeaders(req): _*)
         .withBody(body)
-        .withRequestTimeout(1.second)
+        .withRequestTimeout(5.seconds)
         .withMethod("POST")
         .withQueryStringParameters(("accountVerificationEmail", "true"))
     ) { resp =>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR makes the identity timeout for guest checkout also 5 seconds.

This is to put it in line with the user-get timeout in https://github.com/guardian/support-frontend/pull/3258

## Why are you doing this?

We get occasional identity timeouts, it makes sense to be generous.  I think the real issue is a network issue, so we should probably use a retry if it still happens often.
