### PR TITLE
Enable Guardian Weekly guest checkout

### DIFF
--- a/support-frontend/app/controllers/WeeklySubscriptionForm.scala
+++ b/support-frontend/app/controllers/WeeklySubscriptionForm.scala
@@ -45,7 +45,7 @@ class WeeklySubscriptionForm(
     val maybeIdUser: EitherT[Future, String, Option[IdUser]] = request.user match {
       case Some(user) =>
         identityService.getUser(user.minimalUser).map(Some(_))
-      case _ => EitherT.rightT(None)
+      case None => EitherT.rightT(None)
     }
     maybeIdUser.fold(
       error => {

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetails.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetails.jsx
@@ -37,7 +37,7 @@ export type PropTypes = {
   setEmail: Function,
   confirmEmail?: Option<string>,
   setConfirmEmail?: Option<Function>,
-  checkIfEmailHasPassword?: Option<Function>,
+  fetchAndStoreUserType?: Option<Function>,
   isSignedIn: boolean,
   telephone: Option<string>,
   setTelephone: Function,
@@ -87,8 +87,8 @@ export default function PersonalDetails(props: PropTypes) {
     if (props.setEmail) { props.setEmail(e.target.value); }
   };
 
-  const maybeCheckEmail = (e) => {
-    if (props.checkIfEmailHasPassword) { props.checkIfEmailHasPassword(e.target.value); }
+  const maybeFetchAndStoreUsertype = (e) => {
+    if (props.fetchAndStoreUserType) { props.fetchAndStoreUserType(e.target.value); }
   };
 
   const maybeSetConfirmEmail = (e) => {
@@ -135,7 +135,7 @@ export default function PersonalDetails(props: PropTypes) {
         type="email"
         value={props.email}
         onInput={maybeSetEmail}
-        onChange={maybeCheckEmail}
+        onChange={maybeFetchAndStoreUsertype}
         error={firstError('email', props.formErrors)}
         pattern={emailRegexPattern}
         disabled={!props.isUsingGuestCheckout || props.isSignedIn}
@@ -159,5 +159,5 @@ export default function PersonalDetails(props: PropTypes) {
 PersonalDetails.defaultProps = {
   confirmEmail: null,
   setConfirmEmail: null,
-  checkIfEmailHasPassword: null,
+  fetchAndStoreUserType: null,
 };

--- a/support-frontend/assets/helpers/subscriptionsForms/guestCheckout.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/guestCheckout.js
@@ -1,12 +1,12 @@
 // @flow
 
-import type { CheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
+import type { CheckoutState, WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import { getUserTypeFromIdentity } from 'helpers/identityApis';
 import type { UserTypeFromIdentityResponse } from 'helpers/identityApis';
 import { setUserTypeFromIdentityResponse } from 'helpers/subscriptionsForms/formActions';
 
 export const checkIfEmailHasPassword = (email: string) =>
-  (dispatch: Function, getState: () => CheckoutState): void => {
+  (dispatch: Function, getState: () => CheckoutState | WithDeliveryCheckoutState): void => {
     const state = getState();
     const { csrf } = state.page;
     const { isSignedIn } = state.page.checkout;

--- a/support-frontend/assets/helpers/subscriptionsForms/guestCheckout.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/guestCheckout.js
@@ -5,7 +5,7 @@ import { getUserTypeFromIdentity } from 'helpers/identityApis';
 import type { UserTypeFromIdentityResponse } from 'helpers/identityApis';
 import { setUserTypeFromIdentityResponse } from 'helpers/subscriptionsForms/formActions';
 
-export const checkIfEmailHasPassword = (email: string) =>
+export const fetchAndStoreUserType = (email: string) =>
   (dispatch: Function, getState: () => CheckoutState | WithDeliveryCheckoutState): void => {
     const state = getState();
     const { csrf } = state.page;

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -64,7 +64,7 @@ import type { Participations } from 'helpers/abTests/abtest';
 import { PayPalSubmitButton } from 'components/subscriptionCheckouts/payPalSubmitButton';
 import { supportedPaymentMethods } from 'helpers/subscriptionsForms/countryPaymentMethods';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
-import { checkIfEmailHasPassword } from 'helpers/subscriptionsForms/guestCheckout';
+import { fetchAndStoreUserType } from 'helpers/subscriptionsForms/guestCheckout';
 
 // ----- Types ----- //
 
@@ -78,7 +78,7 @@ type PropTypes = {|
   productPrices: ProductPrices,
   currencyId: IsoCurrency,
   ...FormActionCreators,
-  checkIfEmailHasPassword: Function,
+  fetchAndStoreUserType: Function,
   csrf: Csrf,
   payPalHasLoaded: boolean,
   isTestUser: boolean,
@@ -121,8 +121,8 @@ function mapStateToProps(state: CheckoutState) {
 function mapDispatchToProps() {
   return {
     ...formActionCreators,
-    checkIfEmailHasPassword: email => (dispatch: Dispatch<Action>, getState: () => CheckoutState) => {
-      checkIfEmailHasPassword(email)(dispatch, getState);
+    fetchAndStoreUserType: email => (dispatch: Dispatch<Action>, getState: () => CheckoutState) => {
+      fetchAndStoreUserType(email)(dispatch, getState);
     },
     formIsValid: () => (dispatch: Dispatch<Action>, getState: () => CheckoutState) => checkoutFormIsValid(getState()),
     submitForm: () => (dispatch: Dispatch<Action>, getState: () => CheckoutState) =>
@@ -195,7 +195,7 @@ function DigitalCheckoutForm(props: PropTypes) {
               confirmEmail={props.confirmEmail}
               setConfirmEmail={props.setConfirmEmail}
               isSignedIn={props.isSignedIn}
-              checkIfEmailHasPassword={props.checkIfEmailHasPassword}
+              fetchAndStoreUserType={props.fetchAndStoreUserType}
               telephone={props.telephone}
               setTelephone={props.setTelephone}
               formErrors={props.formErrors}

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -80,7 +80,7 @@ import { getPriceSummary, sensiblyGenerateDigiSubPrice } from 'pages/paper-subsc
 import { paperSubsUrl } from 'helpers/urls/routes';
 import { getQueryParameter } from 'helpers/urls/url';
 import type { Participations } from 'helpers/abTests/abtest';
-import { checkIfEmailHasPassword } from 'helpers/subscriptionsForms/guestCheckout';
+import { fetchAndStoreUserType } from 'helpers/subscriptionsForms/guestCheckout';
 import { setupSubscriptionPayPalPaymentNoShipping } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 
 const marginBottom = css`
@@ -106,7 +106,7 @@ type PropTypes = {|
   submissionError: ErrorReason | null,
   productPrices: ProductPrices,
   ...FormActionCreators,
-  checkIfEmailHasPassword: Function,
+  fetchAndStoreUserType: Function,
   submitForm: Function,
   billingAddressErrors: Array<Object>,
   deliveryAddressErrors: Array<Object>,
@@ -158,8 +158,8 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
 function mapDispatchToProps() {
   return {
     ...formActionCreators,
-    checkIfEmailHasPassword: email => (dispatch: Dispatch<Action>, getState: () => CheckoutState) => {
-      checkIfEmailHasPassword(email)(dispatch, getState);
+    fetchAndStoreUserType: email => (dispatch: Dispatch<Action>, getState: () => CheckoutState) => {
+      fetchAndStoreUserType(email)(dispatch, getState);
     },
     formIsValid: () =>
       (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) => withDeliveryFormIsValid(getState()),
@@ -306,7 +306,7 @@ function PaperCheckoutForm(props: PropTypes) {
               confirmEmail={props.confirmEmail}
               setConfirmEmail={props.setConfirmEmail}
               isSignedIn={props.isSignedIn}
-              checkIfEmailHasPassword={props.checkIfEmailHasPassword}
+              fetchAndStoreUserType={props.fetchAndStoreUserType}
               telephone={props.telephone}
               setTelephone={props.setTelephone}
               formErrors={props.formErrors}

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -47,7 +47,7 @@ import type {
   FormActionCreators,
 } from 'helpers/subscriptionsForms/formActions';
 import { formActionCreators } from 'helpers/subscriptionsForms/formActions';
-import type { WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
+import type { CheckoutState, WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import {
   getBillingAddress,
   getDeliveryAddress,
@@ -82,6 +82,7 @@ import type { Participations } from 'helpers/abTests/abtest';
 import { GuardianWeekly } from 'helpers/productPrice/subscriptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
 import { setupSubscriptionPayPalPaymentNoShipping } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
+import { checkIfEmailHasPassword } from 'helpers/subscriptionsForms/guestCheckout';
 
 
 // ----- Styles ----- //
@@ -102,6 +103,7 @@ type PropTypes = {|
   submissionError: ErrorReason | null,
   productPrices: ProductPrices,
   ...FormActionCreators,
+  checkIfEmailHasPassword: Function,
   submitForm: Function,
   setBillingCountry: Function,
   billingAddressErrors: Array<Object>,
@@ -142,6 +144,9 @@ function mapDispatchToProps() {
   const { setCountry } = addressActionCreatorsFor('billing');
   return {
     ...formActionCreators,
+    checkIfEmailHasPassword: email => (dispatch: Dispatch<Action>, getState: () => CheckoutState) => {
+      checkIfEmailHasPassword(email)(dispatch, getState);
+    },
     formIsValid: () =>
       (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) => withDeliveryFormIsValid(getState()),
     submitForm: () => (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) =>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -47,7 +47,7 @@ import type {
   FormActionCreators,
 } from 'helpers/subscriptionsForms/formActions';
 import { formActionCreators } from 'helpers/subscriptionsForms/formActions';
-import type { CheckoutState, WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
+import type { WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import {
   getBillingAddress,
   getDeliveryAddress,
@@ -144,7 +144,7 @@ function mapDispatchToProps() {
   const { setCountry } = addressActionCreatorsFor('billing');
   return {
     ...formActionCreators,
-    checkIfEmailHasPassword: email => (dispatch: Dispatch<Action>, getState: () => CheckoutState) => {
+    checkIfEmailHasPassword: email => (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) => {
       checkIfEmailHasPassword(email)(dispatch, getState);
     },
     formIsValid: () =>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -82,7 +82,7 @@ import type { Participations } from 'helpers/abTests/abtest';
 import { GuardianWeekly } from 'helpers/productPrice/subscriptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
 import { setupSubscriptionPayPalPaymentNoShipping } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
-import { checkIfEmailHasPassword } from 'helpers/subscriptionsForms/guestCheckout';
+import { fetchAndStoreUserType } from 'helpers/subscriptionsForms/guestCheckout';
 
 
 // ----- Styles ----- //
@@ -103,7 +103,7 @@ type PropTypes = {|
   submissionError: ErrorReason | null,
   productPrices: ProductPrices,
   ...FormActionCreators,
-  checkIfEmailHasPassword: Function,
+  fetchAndStoreUserType: Function,
   submitForm: Function,
   setBillingCountry: Function,
   billingAddressErrors: Array<Object>,
@@ -144,8 +144,8 @@ function mapDispatchToProps() {
   const { setCountry } = addressActionCreatorsFor('billing');
   return {
     ...formActionCreators,
-    checkIfEmailHasPassword: email => (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) => {
-      checkIfEmailHasPassword(email)(dispatch, getState);
+    fetchAndStoreUserType: email => (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) => {
+      fetchAndStoreUserType(email)(dispatch, getState);
     },
     formIsValid: () =>
       (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) => withDeliveryFormIsValid(getState()),
@@ -237,7 +237,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
               confirmEmail={props.confirmEmail}
               setConfirmEmail={props.setConfirmEmail}
               isSignedIn={props.isSignedIn}
-              checkIfEmailHasPassword={props.checkIfEmailHasPassword}
+              fetchAndStoreUserType={props.fetchAndStoreUserType}
               telephone={props.telephone}
               setTelephone={props.setTelephone}
               formErrors={props.formErrors}

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -182,7 +182,6 @@ function WeeklyCheckoutForm(props: PropTypes) {
     props.setBillingCountry(props.deliveryCountry);
   };
   const paymentMethods = supportedPaymentMethods(props.currencyId, props.billingCountry);
-  const isUsingGuestCheckout = false;
 
   return (
     <Content modifierClasses={['your-details']}>
@@ -230,12 +229,15 @@ function WeeklyCheckoutForm(props: PropTypes) {
               setLastName={props.setLastName}
               email={props.email}
               setEmail={props.setEmail}
+              confirmEmail={props.confirmEmail}
+              setConfirmEmail={props.setConfirmEmail}
               isSignedIn={props.isSignedIn}
+              checkIfEmailHasPassword={props.checkIfEmailHasPassword}
               telephone={props.telephone}
               setTelephone={props.setTelephone}
               formErrors={props.formErrors}
               signOut={props.signOut}
-              isUsingGuestCheckout={isUsingGuestCheckout}
+              isUsingGuestCheckout
             />
           </FormSection>
           <FormSection title="Where should we deliver your magazine?">

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
@@ -83,7 +83,7 @@ import { currencyFromCountryCode } from 'helpers/internationalisation/currency';
 import { GuardianWeekly } from 'helpers/productPrice/subscriptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
 import { setupSubscriptionPayPalPaymentNoShipping } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
-import { checkIfEmailHasPassword } from 'helpers/subscriptionsForms/guestCheckout';
+import { fetchAndStoreUserType } from 'helpers/subscriptionsForms/guestCheckout';
 
 // ----- Styles ----- //
 
@@ -102,7 +102,7 @@ type PropTypes = {|
   submissionError: ErrorReason | null,
   productPrices: ProductPrices,
   ...FormActionCreators,
-  checkIfEmailHasPassword: Function,
+  fetchAndStoreUserType: Function,
   submitForm: Function,
   setBillingCountry: Function,
   billingAddressErrors: Array<Object>,
@@ -144,8 +144,8 @@ function mapDispatchToProps() {
   const { setCountry } = addressActionCreatorsFor('billing');
   return {
     ...formActionCreators,
-    checkIfEmailHasPassword: email => (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) => {
-      checkIfEmailHasPassword(email)(dispatch, getState);
+    fetchAndStoreUserType: email => (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) => {
+      fetchAndStoreUserType(email)(dispatch, getState);
     },
     formIsValid: () =>
       (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) => withDeliveryFormIsValid(getState()),
@@ -310,7 +310,7 @@ function WeeklyCheckoutFormGifting(props: PropTypes) {
               setEmail={props.setEmail}
               setConfirmEmail={props.setConfirmEmail}
               isSignedIn={props.isSignedIn}
-              checkIfEmailHasPassword={props.checkIfEmailHasPassword}
+              fetchAndStoreUserType={props.fetchAndStoreUserType}
               telephone={props.telephone}
               setTelephone={props.setTelephone}
               formErrors={props.formErrors}

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
@@ -303,12 +303,14 @@ function WeeklyCheckoutFormGifting(props: PropTypes) {
               setLastName={props.setLastName}
               email={props.email}
               setEmail={props.setEmail}
+              setConfirmEmail={props.setConfirmEmail}
               isSignedIn={props.isSignedIn}
+              checkIfEmailHasPassword={props.checkIfEmailHasPassword}
               telephone={props.telephone}
               setTelephone={props.setTelephone}
               formErrors={props.formErrors}
               signOut={props.signOut}
-              isUsingGuestCheckout={false}
+              isUsingGuestCheckout
             />
           </FormSection>
           <FormSection title="Is the billing address the same as the recipient's address?">

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
@@ -47,7 +47,7 @@ import type {
   FormActionCreators,
 } from 'helpers/subscriptionsForms/formActions';
 import { formActionCreators } from 'helpers/subscriptionsForms/formActions';
-import type { CheckoutState, WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
+import type { WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import {
   getBillingAddress,
   getDeliveryAddress,
@@ -144,7 +144,7 @@ function mapDispatchToProps() {
   const { setCountry } = addressActionCreatorsFor('billing');
   return {
     ...formActionCreators,
-    checkIfEmailHasPassword: email => (dispatch: Dispatch<Action>, getState: () => CheckoutState) => {
+    checkIfEmailHasPassword: email => (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) => {
       checkIfEmailHasPassword(email)(dispatch, getState);
     },
     formIsValid: () =>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
@@ -47,7 +47,7 @@ import type {
   FormActionCreators,
 } from 'helpers/subscriptionsForms/formActions';
 import { formActionCreators } from 'helpers/subscriptionsForms/formActions';
-import type { WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
+import type { CheckoutState, WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import {
   getBillingAddress,
   getDeliveryAddress,
@@ -83,6 +83,7 @@ import { currencyFromCountryCode } from 'helpers/internationalisation/currency';
 import { GuardianWeekly } from 'helpers/productPrice/subscriptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
 import { setupSubscriptionPayPalPaymentNoShipping } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
+import { checkIfEmailHasPassword } from 'helpers/subscriptionsForms/guestCheckout';
 
 // ----- Styles ----- //
 
@@ -101,6 +102,7 @@ type PropTypes = {|
   submissionError: ErrorReason | null,
   productPrices: ProductPrices,
   ...FormActionCreators,
+  checkIfEmailHasPassword: Function,
   submitForm: Function,
   setBillingCountry: Function,
   billingAddressErrors: Array<Object>,
@@ -142,6 +144,9 @@ function mapDispatchToProps() {
   const { setCountry } = addressActionCreatorsFor('billing');
   return {
     ...formActionCreators,
+    checkIfEmailHasPassword: email => (dispatch: Dispatch<Action>, getState: () => CheckoutState) => {
+      checkIfEmailHasPassword(email)(dispatch, getState);
+    },
     formIsValid: () =>
       (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) => withDeliveryFormIsValid(getState()),
     submitForm: () => (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) =>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR removes the requirement to sign in before purchasing a GW sub or gift sub


[**Trello Card**](https://trello.com/c/YB2VSB5h/3880-implement-gw-gifting-and-non-gifting-guest-checkout-not-an-ab-test)

## Why are you doing this?
- To remove friction from the checkout process
- Changes to the Identity sign up process mean that users can no longer be logged in until they verify their email. This would make the old flow completely impractical
- It allows customer service representatives (CSRs) to use these checkouts to purchase subscriptions for customers rather than having to use the subscribe site

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [x] No

