### PR TITLE
Override no-default-export rule in our ESLint config for the migration

### DIFF
--- a/support-frontend/migration/.eslintrc.js
+++ b/support-frontend/migration/.eslintrc.js
@@ -1,5 +1,9 @@
 module.exports = {
   extends: '@guardian/eslint-config-typescript',
+  rules: {
+    // TODO: update this to 'warn' or delete once the post-migration fixing process is done
+    "import/no-default-export": "off",
+  },
   settings: {
     'import/resolver': {
       typescript: {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This tweaks our future ESLint config, which otherwise just extends the Guardian TS config, to allow default exports from files.

## Why are you doing this?

We are currently using default exports all over the codebase, and fixing errors arising from this rule will mean having to touch multiple other files every time you try and fix the TS/lint errors in a single file, which will then cause any other lint errors in _those_ files to fail the ESLint check in the pre-commit hook.

Overriding this rule for now will make the gradual fix process a lot easier. We can then revisit this in future to better align with the existing shared config, perhaps switching to a warning first.