### PR TITLE
Fix PayPal test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -152,7 +152,7 @@ export const tests: Tests = {
     targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
     seed: 13,
   },
-  payPalOneClickTestV2: {
+  payPalOneClickTestV3: {
     variants: [
       {
         id: 'control',
@@ -174,6 +174,6 @@ export const tests: Tests = {
     referrerControlled: false,
     targetPage: pageUrlRegexes.subscriptions.digiSub.nonGiftLandingAndCheckoutWithGuest,
     seed: 11,
-    optimizeId: 'mB8kTh9ySPCAtwHHrVWkQw',
+    optimizeId: 'dDHS42cERbuQb0BXe85-4g',
   },
 };

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -156,8 +156,8 @@ function DigitalCheckoutForm(props: PropTypes) {
   const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Sorry there was a problem' :
     'Sorry we could not process your payment';
   const paymentMethods = supportedPaymentMethods(props.currencyId, props.country);
-  const isUsingGuestCheckout = props.participations.payPalOneClickTest === 'payPal' ||
-    props.participations.payPalOneClickTest === 'guestCheckout';
+  const isUsingGuestCheckout = props.participations.payPalOneClickTestV3 === 'payPal' ||
+    props.participations.payPalOneClickTestV3 === 'guestCheckout';
 
   return (
     <Content>

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -203,8 +203,8 @@ function DigitalLandingComponent({
 
   const showEventsComponent = participations.emailDigiSubEventsTest === 'variant';
   const showComparisonTable = participations.comparisonTableTest2 === 'variant';
-  const showPayPalButton = participations.payPalOneClickTest === 'payPal';
-  const isUsingGuestCheckout = showPayPalButton || participations.payPalOneClickTest === 'guestCheckout';
+  const showPayPalButton = participations.payPalOneClickTestV3 === 'payPal';
+  const isUsingGuestCheckout = showPayPalButton || participations.payPalOneClickTestV3 === 'guestCheckout';
   const giftNonGiftLink = orderIsAGift ? routes.digitalSubscriptionLanding : routes.digitalSubscriptionLandingGift;
   const sanitisedPromoCopy = getPromotionCopy(promotionCopy);
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
The PayPal one click test launched in #3249 had a bug in it which meant that even people who were in the `payPal` variant would not see the one click option. This fixes that and restarts the test.


[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [x] Yes
- [ ] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home/#/accounts/1368065808/containers/6827913/experiments/510)
