### PR TITLE
Roll out `productSetTest` variant to 100%

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -132,26 +132,6 @@ export const tests: Tests = {
     seed: 10,
     optimizeId: 'unfNP7eZTLW4245wJOcxiw',
   },
-  productSetTest: {
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'variant',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    referrerControlled: false,
-    targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
-    seed: 13,
-  },
   payPalOneClickTestV3: {
     variants: [
       {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -37,7 +37,6 @@ type PropTypes = {|
   stripePaymentRequestButtonClicked: boolean,
   localCurrencyCountry: ?LocalCurrencyCountry,
   useLocalCurrency: boolean,
-  productSetAbTestVariant: boolean,
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -107,7 +106,6 @@ function ContributionAmount(props: PropTypes) {
         selectedAmounts={props.selectedAmounts}
         selectAmount={props.selectAmount}
         shouldShowFrequencyButtons={props.contributionType !== 'ONE_OFF'}
-        productSetAbTestVariant={props.productSetAbTestVariant}
       />
 
       { showOther &&

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmountChoices.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmountChoices.jsx
@@ -13,35 +13,10 @@ import {
 import { formatAmount } from 'helpers/forms/checkouts';
 import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
 import ContributionAmountChoicesChoiceLabel from './ContributionAmountChoicesChoiceLabel';
-import { from, until } from '@guardian/src-foundations/mq';
+import { until } from '@guardian/src-foundations/mq';
 import { css } from '@emotion/core';
 
-const choiceCardGroupOverrides = css`
-  > div {
-    ${until.leftCol} {
-      flex-wrap: wrap;
-    }
-    margin-top: -8px;
-  }
-
-  > div > label {
-    ${from.tablet} {
-      max-width: 100px;
-    }
-    margin-top: 8px !important;
-  }
-`;
-
-const choiceCardGrid = css`
-  ${from.mobileLandscape} {
-    width: 100%;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-gap: 8px;
-  }
-`;
-
-const choiceCardGridProductSetAbTestStyles = css`
+const choiceCardGridStyles = css`
   ${until.mobileLandscape} {
     > div {
       width: 100%;
@@ -56,8 +31,8 @@ const choiceCardGridProductSetAbTestStyles = css`
   }
 `;
 
-const choiceCardGridProductSetAbTestFullWithOtherStyles = css`
-${choiceCardGridProductSetAbTestStyles}
+const choiceCardGridFullWidthOtherStyles = css`
+${choiceCardGridStyles}
 
 > div > label:last-of-type {
   grid-column-start: 1;
@@ -80,8 +55,6 @@ type ContributionAmountChoicesProps = {|
     ContributionType
   ) => () => void,
   shouldShowFrequencyButtons: boolean,
-  // eslint-disable-next-line react/no-unused-prop-types
-  productSetAbTestVariant: boolean, // this is actually being used but eslint doesn't seem to know that
 |};
 
 const isSelected = (
@@ -99,120 +72,7 @@ const isSelected = (
   return amount === defaultAmount;
 };
 
-const ContributionAmountChoices = (props: ContributionAmountChoicesProps) => {
-  if (props.productSetAbTestVariant) {
-    return <ContributionAmountChoicesProductSetAbTest {...props} />;
-  } else if (props.shouldShowFrequencyButtons) {
-    return <ContributionAmountChoicesTwoColumnAfterMobile {...props} />;
-  }
-  return <ContributionAmountChoicesDefault {...props} />;
-};
-
-const ContributionAmountChoicesDefault = ({
-  validAmounts,
-  defaultAmount,
-  countryGroupId,
-  contributionType,
-  showOther,
-  selectAmount,
-  selectedAmounts,
-  currency,
-  shouldShowFrequencyButtons,
-}: ContributionAmountChoicesProps) => (
-  <ChoiceCardGroup name="amounts" css={choiceCardGroupOverrides}>
-    {validAmounts.map((amount: number) => (
-      <ChoiceCard
-        id={`contributionAmount-${amount}`}
-        name="contributionAmount"
-        value={amount}
-        checked={isSelected(
-          amount,
-          selectedAmounts,
-          contributionType,
-          defaultAmount,
-        )}
-        onChange={selectAmount(amount, countryGroupId, contributionType)}
-        label={
-          <ContributionAmountChoicesChoiceLabel
-            formattedAmount={formatAmount(
-              currencies[currency],
-              spokenCurrencies[currency],
-              amount,
-              false,
-            )}
-            shouldShowFrequencyButtons={shouldShowFrequencyButtons}
-            contributionType={contributionType}
-          />
-        }
-      />
-    ))}
-    <ChoiceCard
-      id="contributionAmount-other"
-      name="contributionAmount"
-      value="other"
-      checked={showOther}
-      onChange={selectAmount('other', countryGroupId, contributionType)}
-      label="Other"
-    />
-  </ChoiceCardGroup>
-);
-
-const ContributionAmountChoicesTwoColumnAfterMobile = ({
-  validAmounts,
-  defaultAmount,
-  countryGroupId,
-  contributionType,
-  showOther,
-  selectAmount,
-  selectedAmounts,
-  currency,
-  shouldShowFrequencyButtons,
-}: ContributionAmountChoicesProps) => (
-  <ChoiceCardGroup name="amounts">
-    <div css={choiceCardGrid}>
-      {validAmounts.map((amount: number) => (
-        <div>
-          <ChoiceCard
-            id={`contributionAmount-${amount}`}
-            name="contributionAmount"
-            value={amount}
-            checked={isSelected(
-              amount,
-              selectedAmounts,
-              contributionType,
-              defaultAmount,
-            )}
-            onChange={selectAmount(amount, countryGroupId, contributionType)}
-            label={
-              <ContributionAmountChoicesChoiceLabel
-                formattedAmount={formatAmount(
-                  currencies[currency],
-                  spokenCurrencies[currency],
-                  amount,
-                  false,
-                )}
-                shouldShowFrequencyButtons={shouldShowFrequencyButtons}
-                contributionType={contributionType}
-              />
-            }
-          />
-        </div>
-      ))}
-      <div>
-        <ChoiceCard
-          id="contributionAmount-other"
-          name="contributionAmount"
-          value="other"
-          checked={showOther}
-          onChange={selectAmount('other', countryGroupId, contributionType)}
-          label="Other"
-        />
-      </div>
-    </div>
-  </ChoiceCardGroup>
-);
-
-const ContributionAmountChoicesProductSetAbTest = ({
+const ContributionAmountChoices = ({
   validAmounts,
   defaultAmount,
   countryGroupId,
@@ -226,7 +86,7 @@ const ContributionAmountChoicesProductSetAbTest = ({
   const isOtherAmountFullWidth = validAmounts.length % 2 === 0;
 
   return (
-    <ChoiceCardGroup name="amounts" columns={2} cssOverrides={isOtherAmountFullWidth ? choiceCardGridProductSetAbTestFullWithOtherStyles : choiceCardGridProductSetAbTestStyles}>
+    <ChoiceCardGroup name="amounts" columns={2} cssOverrides={isOtherAmountFullWidth ? choiceCardGridFullWidthOtherStyles : choiceCardGridStyles}>
       {validAmounts.map((amount: number) => (
         <ChoiceCard
           id={`contributionAmount-${amount}`}

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -306,8 +306,8 @@ function ContributionForm(props: PropTypes) {
     <form onSubmit={onSubmit(props)} className={classNameWithModifiers(baseClass, classModifiers)} noValidate>
       <h2 className="hidden-heading">Make a contribution</h2>
       <div className="contributions-form-selectors">
-        <ContributionTypeTabs productSetAbTestVariant={props.productSetAbTestVariant} />
-        <ContributionAmount productSetAbTestVariant={props.productSetAbTestVariant} />
+        <ContributionTypeTabs />
+        <ContributionAmount />
         {props.localCurrencyCountry && props.contributionType === 'ONE_OFF' && (
           <CheckboxGroup cssOverrides="margin-top:16px;">
             <Checkbox

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -36,7 +36,6 @@ type PropTypes = {|
   contributionTypes: ContributionTypes,
   onSelectContributionType: (ContributionType, Switches, IsoCountry, CountryGroupId, boolean) => void,
   useLocalCurrency: boolean,
-  productSetAbTestVariant: boolean,
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -69,7 +68,7 @@ const mapDispatchToProps = (dispatch: Function) => ({
   },
 });
 
-const tabGroupStyles = (checkedContributionType: ContributionType) => css`
+const groupStyles = css`
   > div {
     display: flex;
 
@@ -77,28 +76,12 @@ const tabGroupStyles = (checkedContributionType: ContributionType) => css`
     position: relative;
     z-index: 0;
 
-    label:nth-of-type(1) {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-      /* This is to override a margin that is added by source */
-      margin-right: 0;
-
-      z-index: ${checkedContributionType === 'ONE_OFF' ? 100 : 1}
+    label {
+      margin: 0 8px 0 0;
     }
 
-    label:nth-of-type(2) {
-      border-radius: 0;
-      margin-left: -1px;
-      margin-right: -1px;
-
-      z-index: ${checkedContributionType === 'MONTHLY' ? 100 : 1}
-    }
-
-    label:nth-of-type(3) {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
-
-      z-index: ${checkedContributionType === 'ANNUAL' ? 100 : 1}
+    label:last-of-type {
+      margin: 0;
     }
   }
 `;
@@ -111,7 +94,7 @@ function ContributionTypeTabs(props: PropTypes) {
   const renderChoiceCards = () => (
     <ChoiceCardGroup
       name="contributionTypes"
-      cssOverrides={props.productSetAbTestVariant ? tabGroupStyles(props.contributionType) : null}
+      cssOverrides={groupStyles}
     >
       {contributionTypes.map((contributionTypeSetting: ContributionTypeSetting) => {
       const { contributionType } = contributionTypeSetting;


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Roll out productSetTest variant to 100%. We've also made a slight tweak to the variant to add some spacing between the options at mobile. This means the design is essentially identical on desktop to the control, but still with the condensed layout on mobile. 

[**Trello Card**](https://trello.com/c/s3ni0Xx4/2810-roll-out-product-set-test-amended-variant)

**NB**: As a separate piece of work, we should revisit the markup we use here for the contribution frequency. Semantically they are tabs and there are established best practices for writting [accessible tab components](https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-2/tabs.html). I've made a [demo repo](https://github.com/TomPretty/accessible-tabs/blob/main/src/App.tsx) for this that reimplements those best practices in `typescript` + `React`. I've also discussed with Simon from the DS team about implementing this component in source. 

## Screenshots

### Mobile
<img width="335" alt="Screenshot 2021-10-07 at 14 17 35" src="https://user-images.githubusercontent.com/17720442/136392410-b4017dad-48b2-4241-aef8-3ca801e85ab0.png">

### Desktop
<img width="396" alt="Screenshot 2021-10-07 at 14 17 54" src="https://user-images.githubusercontent.com/17720442/136392414-2e5370af-8912-42b9-952b-6403991011b9.png">

