### PR TITLE
Fix typo and errors

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionArticleCount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionArticleCount.jsx
@@ -453,7 +453,7 @@ export function ArticleCountHeaderCopy({
   if (userName) {
     return (
       <>
-        Hi {userName}! You have read {numArticles} in the last 12 months
+        Hi {userName}! You have read {numArticles} articles in the last 12 months
       </>
     );
   }

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
@@ -202,7 +202,7 @@ function withProps(props: PropTypes) {
         />
       )}
 
-      { isArticleCountTest && numArticles ? (
+      { isArticleCountTest && numArticles && numArticles >= 5 ? (
         <ContributionFormBlurb
           headerCopy={<ContributionsArticleCountWithOptOut
             numArticles={numArticles}


### PR DESCRIPTION
This PR fixes the error where article count header in the landing page was not correctly rendering when article count is below 5

