### PR TITLE
Adding extra logging for SEPA

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -146,6 +146,12 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
   }
 
   def createSepaPaymentMethod(sepa: SepaPaymentFields, user: User, ipAddress: String, userAgent: String): Future[SepaPaymentMethod] = {
+    if (ipAddress.length() > 15) {
+      SafeLogger.warn(s"IPv6 Address: ${ipAddress} will be truncated to 15 characters")
+    }
+    if (userAgent.length() > 255) {
+      SafeLogger.warn(s"User Agent: ${userAgent} will be truncated to 255 characters")
+    }
     Future.successful(SepaPaymentMethod(
       BankTransferAccountName = sepa.accountHolderName,
       BankTransferAccountNumber = sepa.iban,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Adding extra logging to highlight when the payment method and user agent gets truncated. This is so that we can establish if Stripe is not accepting the payment. I've not been able to find anything through searching Stripe's or `com.gu.support.workers.lambdas.CreateZuoraSubscription`s logs.

## Is this an AB test?
- [ ] Yes
- [x] No

Ref: https://github.com/guardian/support-frontend/pull/3252