### PR TITLE
correct name for gifting stripe test

### DIFF
--- a/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
@@ -40,7 +40,7 @@ class CheckoutsSpec extends AnyFeatureSpec
   }
 
   Feature("Digital Pack gift checkout") {
-    Scenario("User already logged in - Direct Debit checkout") {
+    Scenario("User already logged in - Stripe checkout") {
       testCheckout("Digital Pack gift", new DigitalPackGiftCheckout, new DigitalPackGiftProductPage, payWithStripe)
     }
   }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR corrects the name of the test.

## Other info

Interestingly, the test failure that brought my attention to this, we attempted to fix the issue by switching the payment method.  However clearly there is an underlying issue that makes this test unreliable, perhaps the window of race condition is smaller with stripe, but still present?
https://github.com/guardian/support-frontend/pull/2916
