### PR TITLE
Do not truncate IP address in zuora request

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -147,7 +147,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
 
   def createSepaPaymentMethod(sepa: SepaPaymentFields, user: User, ipAddress: String, userAgent: String): Future[SepaPaymentMethod] = {
     if (ipAddress.length() > 15) {
-      SafeLogger.warn(s"IPv6 Address: ${ipAddress} will be truncated to 15 characters")
+      SafeLogger.warn(s"IPv6 Address: ${ipAddress} is longer than 15 characters")
     }
     if (userAgent.length() > 255) {
       SafeLogger.warn(s"User Agent: ${userAgent} will be truncated to 255 characters")
@@ -156,7 +156,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       BankTransferAccountName = sepa.accountHolderName,
       BankTransferAccountNumber = sepa.iban,
       Email = user.primaryEmailAddress,
-      IPAddress = ipAddress.take(15), // zuora doesn't support ipv6
+      IPAddress = ipAddress,
       GatewayOptionData = GatewayOptionData(List(
         GatewayOption(
           "UserAgent",


### PR DESCRIPTION
Currently Stripe rejects requests from zuora if an ipv6 address is truncated. This causes `CreateZuoraSubscription` to fail, but support-workers 'succeeds' and the user sees a payment failure message.

This PR removes the truncation. This means the request to zuora will fail, and support-workers will fail. The user will still see a payment failure error.

We're waiting for zuora to fix this.