### PR TITLE
Update contributions social share image to new design

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -138,11 +138,8 @@ class Application(
   }
 
   private def shareImageUrl(settings: AllSettings): String = {
-    // Standard image
-    // "https://i.guim.co.uk/img/media/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/1000.png?quality=85&s=4b52891c0a86da6c08f2dc6e8308d211"
-
-    // AUS 2021 appeal image
-    "https://i.guim.co.uk/img/media/8b9e82bb323f76edbfec5cf5f0e2ccd3c7e00b12/0_1_1000_525/1000.png?quality=85&s=a77669466491c22436d12f058d352a72"
+    // Autumn 2021 generic image
+    "https://i.guim.co.uk/img/media/5366cacfd2081e5a4af259318238b3f82610d32e/0_0_1000_525/1000.png?quality=85&s=966978166c0983aef68828559ede40d8"
   }
 
   private def contributionsHtml(countryCode: String, geoData: GeoData, idUser: Option[IdUser],


### PR DESCRIPTION
## What are you doing in this PR?
This updates the social share image for the contributions landing page 

[**Trello Card**](https://trello.com/c/H1zxuruc)

## Why are you doing this?
The previous image was from an older campaign and no longer relevant.

## Is this an AB test?
- [ ] Yes
- [x] No

## Screenshots
Using [Open Graph Preview](https://addons.mozilla.org/en-GB/firefox/addon/open-graph-preview-and-debug/)

<img width="534" alt="Screenshot 2021-10-18 at 14 21 20" src="https://user-images.githubusercontent.com/29146931/137739668-ecdd2e33-cdfe-43fc-816a-f12de4d75005.png">