### PR TITLE
remove fezziwig dependency

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -21,7 +21,6 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-lambda" % awsClientVersion,
   "org.typelevel" %% "cats-core" % catsVersion,
   "com.dripower" %% "play-circe" % playCirceVersion,
-  "com.gu" %% "fezziwig" % "1.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % circeVersion,


### PR DESCRIPTION
this isn't used anymore, we used to need it for the json serialization of the ophan thrift models