### PR TITLE
Strip full path from error messages

### DIFF
--- a/support-frontend/scripts/ts-log-errors.js
+++ b/support-frontend/scripts/ts-log-errors.js
@@ -22,7 +22,7 @@ exec(tscCmd, (error, stdout) => {
 
       const errorInstance = {
         path: errorPath,
-        message: shortenFullPathToRelativePath(errorMessage),
+        message: shortenFullPathsToRelativePaths(errorMessage),
       };
 
       const errorInstances = accumulator[errorCode]
@@ -110,9 +110,9 @@ exec(tscCmd, (error, stdout) => {
 });
 
 
-const FULL_PATH_REGEX = /'\/.*\/(?<relativePath>)support-frontend\/.* ' /gm
+const FULL_PATH_REGEX = /'\/.*\/(?<relativePath>support-frontend\/[^ ]+)'/gm
 
-function shortenFullPathToRelativePath(errorMessage) {
+function shortenFullPathsToRelativePaths(errorMessage) {
   const caputureGroups = FULL_PATH_REGEX.exec(errorMessage);
 
   if (!caputureGroups || !caputureGroups.groups) {
@@ -121,5 +121,5 @@ function shortenFullPathToRelativePath(errorMessage) {
 
   const { relativePath } = caputureGroups.groups;
 
-  return errorMessage.replace(FULL_PATH_REGEX, relativePath);
+  return errorMessage.replace(FULL_PATH_REGEX, `'${relativePath}'`);
 }

--- a/support-frontend/typescript-errors.json
+++ b/support-frontend/typescript-errors.json
@@ -4709,39 +4709,39 @@
     "TS7016": [
         {
             "path": "assets/components/paypalExpressButton/PayPalExpressButton.tsx",
-            "message": "Could not find a declaration file for module 'react-dom'. '/Users/tom_pretty/code/support-frontend/support-frontend/node_modules/react-dom/index.js' implicitly has an 'any' type."
+            "message": "Could not find a declaration file for module 'react-dom'. 'support-frontend/node_modules/react-dom/index.js' implicitly has an 'any' type."
         },
         {
             "path": "assets/helpers/abTests/abtest.ts",
-            "message": "Could not find a declaration file for module 'seedrandom'. '/Users/tom_pretty/code/support-frontend/support-frontend/node_modules/seedrandom/index.js' implicitly has an 'any' type."
+            "message": "Could not find a declaration file for module 'seedrandom'. 'support-frontend/node_modules/seedrandom/index.js' implicitly has an 'any' type."
         },
         {
             "path": "assets/helpers/productPrice/promotions.tsx",
-            "message": "Could not find a declaration file for module 'dompurify'. '/Users/tom_pretty/code/support-frontend/support-frontend/node_modules/dompurify/dist/purify.cjs.js' implicitly has an 'any' type."
+            "message": "Could not find a declaration file for module 'dompurify'. 'support-frontend/node_modules/dompurify/dist/purify.cjs.js' implicitly has an 'any' type."
         },
         {
             "path": "assets/helpers/rendering/render.ts",
-            "message": "Could not find a declaration file for module 'react-dom'. '/Users/tom_pretty/code/support-frontend/support-frontend/node_modules/react-dom/index.js' implicitly has an 'any' type."
+            "message": "Could not find a declaration file for module 'react-dom'. 'support-frontend/node_modules/react-dom/index.js' implicitly has an 'any' type."
         },
         {
             "path": "assets/helpers/rendering/render.ts",
-            "message": "Could not find a declaration file for module 'preact/debug'. '/Users/tom_pretty/code/support-frontend/support-frontend/node_modules/preact/debug/dist/debug.js' implicitly has an 'any' type."
+            "message": "Could not find a declaration file for module 'preact/debug'. 'support-frontend/node_modules/preact/debug/dist/debug.js' implicitly has an 'any' type."
         },
         {
             "path": "assets/helpers/rendering/ssrPages.ts",
-            "message": "Could not find a declaration file for module 'react-dom/server'. '/Users/tom_pretty/code/support-frontend/support-frontend/node_modules/react-dom/server.js' implicitly has an 'any' type."
+            "message": "Could not find a declaration file for module 'react-dom/server'. 'support-frontend/node_modules/react-dom/server.js' implicitly has an 'any' type."
         },
         {
             "path": "assets/helpers/tracking/googleTagManager.ts",
-            "message": "Could not find a declaration file for module 'uuid'. '/Users/tom_pretty/code/support-frontend/support-frontend/node_modules/uuid/index.js' implicitly has an 'any' type."
+            "message": "Could not find a declaration file for module 'uuid'. 'support-frontend/node_modules/uuid/index.js' implicitly has an 'any' type."
         },
         {
             "path": "assets/pages/contributions-landing/components/ContributionFormContainer.tsx",
-            "message": "Could not find a declaration file for module 'react-router-dom'. '/Users/tom_pretty/code/support-frontend/support-frontend/node_modules/react-router-dom/index.js' implicitly has an 'any' type."
+            "message": "Could not find a declaration file for module 'react-router-dom'. 'support-frontend/node_modules/react-router-dom/index.js' implicitly has an 'any' type."
         },
         {
             "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
-            "message": "Could not find a declaration file for module 'react-router-dom'. '/Users/tom_pretty/code/support-frontend/support-frontend/node_modules/react-router-dom/index.js' implicitly has an 'any' type."
+            "message": "Could not find a declaration file for module 'react-router-dom'. 'support-frontend/node_modules/react-router-dom/index.js' implicitly has an 'any' type."
         }
     ],
     "TS2554": [


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Update the `ts-log-errors.js` script to strip full paths from the error messages and just log relative ones