### PR TITLE
suppress 6/6 on checkout form

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -36,7 +36,7 @@ export const pageUrlRegexes = {
 				/\/subscribe\/paper(\/checkout|\/checkout\/guest)?(\?.*)?$/,
 		},
 		subsShowcaseAndWeeklyPages:
-			'(/??/subscribe(\\?.*)?$|/??/subscribe/weekly(\\?.*)?$)',
+			'(/??/subscribe(\\?.*)?$|/??/subscribe/weekly(\\/checkout)?(\\?.*)?$)',
 	},
 };
 export const tests: Tests = {

--- a/support-frontend/assets/helpers/productPrice/billingPeriods.ts
+++ b/support-frontend/assets/helpers/productPrice/billingPeriods.ts
@@ -18,11 +18,14 @@ export type WeeklyBillingPeriod =
 	| typeof Quarterly
 	| typeof Annual;
 export type ContributionBillingPeriod = typeof Monthly | typeof Annual;
-const weeklyBillingPeriods: WeeklyBillingPeriod[] = [
-	SixWeekly,
-	postIntroductorySixForSixBillingPeriod,
-	Annual,
-];
+
+const weeklyBillingPeriods = (
+	enableSixForSix: boolean,
+): WeeklyBillingPeriod[] =>
+	enableSixForSix
+		? [SixWeekly, postIntroductorySixForSixBillingPeriod, Annual]
+		: [postIntroductorySixForSixBillingPeriod, Annual];
+
 const weeklyGiftBillingPeriods: WeeklyBillingPeriod[] = [Quarterly, Annual];
 
 function billingPeriodNoun(billingPeriod: BillingPeriod, fixedTerm = false) {

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -27,6 +27,7 @@ import type { ErrorReason } from 'helpers/forms/errorReasons';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { countries } from 'helpers/internationalisation/country';
 import { weeklyDeliverableCountries } from 'helpers/internationalisation/weeklyDeliverableCountries';
+import type { SetCountryAction } from 'helpers/page/commonActions';
 import { weeklyBillingPeriods } from 'helpers/productPrice/billingPeriods';
 import { getWeeklyFulfilmentOption } from 'helpers/productPrice/fulfilmentOptions';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
@@ -57,7 +58,6 @@ import {
 	formatUserDate,
 } from 'helpers/utilities/dateConversions';
 import { getWeeklyDays } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
-import type { SetCountryAction } from 'helpers/page/commonActions';
 import 'helpers/page/commonActions';
 import { DirectDebit, PayPal, Stripe } from 'helpers/forms/paymentMethods';
 import {
@@ -352,7 +352,9 @@ function WeeklyCheckoutForm(props: PropTypes) {
 					<BillingPeriodSelector
 						fulfilmentOption={fulfilmentOption}
 						onChange={(billingPeriod) => props.setBillingPeriod(billingPeriod)}
-						billingPeriods={weeklyBillingPeriods}
+						billingPeriods={weeklyBillingPeriods(
+							props.participations.sixForSixSuppression !== 'variant',
+						)}
 						pricingCountry={props.deliveryCountry}
 						productPrices={props.productPrices}
 						selected={props.billingPeriod}

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
@@ -122,7 +122,7 @@ const getProducts = ({
 }: WeeklyProductPricesProps): Product[] => {
 	const billingPeriodsToUse = orderIsAGift
 		? weeklyGiftBillingPeriods
-		: weeklyBillingPeriods;
+		: weeklyBillingPeriods(participations.sixForSixSuppression !== 'variant');
 
 	if (participations.sixForSixSuppression === 'variant') {
 		const index = billingPeriodsToUse.indexOf('SixWeekly');


### PR DESCRIPTION
original PR - https://github.com/guardian/support-frontend/pull/3316

https://support.thegulocal.com/subscribe/weekly/checkout?period=Monthly#ab-sixForSixSuppression=variant
![Screen Shot 2021-11-01 at 08 29 28](https://user-images.githubusercontent.com/1513454/139643727-ffc45e41-9a7f-4161-b4e7-e5812a01543e.png)

https://support.thegulocal.com/subscribe/weekly/checkout?period=Monthly#ab-sixForSixSuppression=control

![Screen Shot 2021-11-01 at 08 29 19](https://user-images.githubusercontent.com/1513454/139643755-837b725d-03c5-4d20-8f11-d21d05c4919f.png)
