### PR TITLE
Configure CORS for the support domain

### DIFF
--- a/support-frontend/app/wiring/AppComponents.scala
+++ b/support-frontend/app/wiring/AppComponents.scala
@@ -9,6 +9,7 @@ import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.filters.HttpFiltersComponents
+import play.filters.cors.{CORSComponents, CORSConfig}
 import play.filters.gzip.GzipFilter
 
 trait AppComponents extends PlayComponents
@@ -20,6 +21,7 @@ trait AppComponents extends PlayComponents
   with ActionBuilders
   with Assets
   with GoogleAuth
+  with CORSComponents
   with HttpFiltersComponents {
   self: BuiltInComponentsFromContext =>
 
@@ -35,7 +37,10 @@ trait AppComponents extends PlayComponents
   override lazy val httpErrorHandler = customHandler
   override lazy val errorController = new ErrorController(actionRefiners, customHandler)
 
+  final override lazy val corsConfig: CORSConfig = CORSConfig().withOriginsAllowed(_ == appConfig.supportUrl)
+
   override lazy val httpFilters: Seq[EssentialFilter] = Seq(
+    corsFilter,
     new SetCookiesCheck(),
     securityHeadersFilter,
     new CacheHeadersCheck(),


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We want to be able to run support-frontend inside an iframe so that it can be embedded in Salesforce and potentially in dotcom as well.

This causes an issue with ajax requests from the client side code to the back end because these are protected by a CSRF check which needs access to the `GU_support_csrf` cookie to succeed. As this cookie has the `sameSite` value of `Lax` [see docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) it is not sent for a cross-site request (Salesforce to support) and so the CSRF check fails and the request returns a 403 error.

Fortunately the Play Framework bypasses CSRF checks for domains which are [trusted using CORS](https://www.playframework.com/documentation/2.8.x/CorsFilter) so we just need to configure CORS to trust the support domain and ajax requests will succeed.

This PR does that using the already existing `support.url` config setting

[**Trello Card**](https://trello.com/c/sjtqnemU/143-fix-ajax-requests)

## Is this an AB test?
- [ ] Yes
- [x] No

