### PR TITLE
Fully disable 6/6

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -160,9 +160,6 @@ export const tests: Tests = {
 	sixForSixSuppression: {
 		variants: [
 			{
-				id: 'control',
-			},
-			{
 				id: 'variant',
 			},
 		],


### PR DESCRIPTION
The decision has been made to completely remove 6/6 for Guardian Weekly.
But we want the ability to bring it back at some point, but it might be a bit different, and we don't know if it'll be an AB test.
In the absence of requirements I'm just removing the control from the AB test. This means all users will _not_ see 6/6.
We can revisit this later and remove the AB test once we know how it's going to work.

![Screen Shot 2021-11-16 at 14 37 21](https://user-images.githubusercontent.com/1513454/142005391-c71e0096-aaff-4563-b1ea-8deaa9d76a85.png)
