### PR TITLE
Remove subheader copy from gifting product pages

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithImage.tsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithImage.tsx
@@ -22,11 +22,6 @@ type PropTypes = {
 
 const GiftCopy = () => (
 	<p>
-		<strong>
-			Share what matters most,
-			<br css={mobileLineBreak} /> even when apart
-		</strong>
-		<br />
 		Show that you care with the gift of a digital gift subscription. Your loved
 		ones will get the richest, ad-free experience of our independent journalism
 		and your gift will help fund our work.

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithImage.tsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithImage.tsx
@@ -13,7 +13,7 @@ import { AUDCountries } from 'helpers/internationalisation/countryGroup';
 import type { PromotionCopy } from 'helpers/productPrice/promotions';
 import { promotionHTML } from 'helpers/productPrice/promotions';
 import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
-import { heroCopy, mobileLineBreak, paragraphs } from './heroWithImageStyles';
+import { heroCopy, paragraphs } from './heroWithImageStyles';
 
 type PropTypes = {
 	promotionCopy: PromotionCopy;

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
@@ -80,9 +80,6 @@ const roundelCentreLine = css`
 		})}
 	}
 `;
-const giftHeroSubHeading = css`
-	font-weight: 700;
-`;
 const showOnMobile = css`
 	display: block;
 

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
@@ -115,9 +115,6 @@ const getFirstParagraph = (
 	if (orderIsAGift) {
 		return (
 			<>
-				<h3 css={giftHeroSubHeading}>
-					Stay on the same page, even when you’re apart
-				</h3>
 				<p>
 					Share the gift of clarity with the Guardian Weekly magazine. A
 					round-up of the world news, opinion and long reads that have shaped


### PR DESCRIPTION
## What are you doing in this PR?
This PR removes the subheader copy from the gifting pages for digital subscriptions and Guardian Weekly. 

[**Trello Card**](https://trello.com/c/JvASVIip/168-remove-hardcoded-gifting-subheaders)

## Why are you doing this?
A new gifting marketing campaign kicks off next week and the narrative is taking a different direction from the 'even while apart' concept. The old copy could clash so we're removing it.

## Is this an AB test?
- [ ] Yes
- [x] No

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/55701358/143249792-dc647fc6-0967-41c1-b594-9df46db5daef.png)

![image](https://user-images.githubusercontent.com/55701358/143249675-a56ac34d-893b-4ee0-ba77-1d9ee255bb62.png)

After:
![image](https://user-images.githubusercontent.com/55701358/143249895-b1f9d0a6-9430-4d75-8441-e50eda179b1f.png)

![image](https://user-images.githubusercontent.com/55701358/143249588-f1eba6f1-791a-4283-ac4f-524e32105e5a.png)
