### PR TITLE
Acquisitions backfill script

### DIFF
--- a/support-lambdas/acquisitions-firehose-transformer/scripts/backfill.md
+++ b/support-lambdas/acquisitions-firehose-transformer/scripts/backfill.md
@@ -1,0 +1,18 @@
+### backfill.sc
+On 2021-11-24 we failed to write most acquisitions to the acquisition_events_prod athena table.
+
+This was caused by a temporary fixer.io outage, which meant we didn't have currency rates in dynamodb.
+
+We backfilled the missing data by:
+
+1. dumping acquisitions from BigQuery with:
+```
+SELECT payment_frequency,country_code,amount,currency,event_timestamp,campaign_codes,component_id,product,payment_provider,referrer_url,annualised_value, annualised_value_in_gbp,labels FROM `datatech-platform-prod.datalake.acquisitions`
+WHERE received_date = date'2021-11-24'
+AND product IN('CONTRIBUTION', 'RECURRING_CONTRIBUTION')
+```
+2. running the backfill.sc script with ammonite: `amm backfill.sc /path/to/file.csv > backfill`
+3. deleting any successful data for that date from s3 at: acquisition-events/PROD/2021/11/24/
+4. uploading the output file (containing a json object per line) to S3 at: acquisition-events/PROD/2021/11/24/
+5. confirmed it worked in athena with: `SELECT * FROM acquisition_events_prod WHERE acquisition_date = date'2021-11-24'`
+

--- a/support-lambdas/acquisitions-firehose-transformer/scripts/backfill.sc
+++ b/support-lambdas/acquisitions-firehose-transformer/scripts/backfill.sc
@@ -1,0 +1,67 @@
+import scala.io.Source
+
+case class BigQueryItem(
+  paymentFrequency: String,
+  countryCode: String,
+  amount: String,
+  currency: String,
+  eventTimestamp: String,
+  campaignCodes: String,
+  componentId: String,
+  product: String,
+  paymentProvider: String,
+  referrerUrl: String,
+  annualisedValue: String,
+  annualisedValueInGBP: String,
+  labels: String
+)
+
+def toJson(item: BigQueryItem): String = {
+  s"""
+     |{
+     |  "paymentFrequency": "${item.paymentFrequency}",
+     |  "countryCode": "${item.countryCode}",
+     |  "amount": ${item.amount},
+     |  "annualisedValue": ${item.annualisedValue},
+     |  "annualisedValueGBP": ${item.annualisedValueInGBP},
+     |  "currency": "${item.currency}",
+     |  "timestamp": "${item.eventTimestamp}",
+     |  "campaignCode": "${item.campaignCodes}",
+     |  "componentId": "${item.componentId}",
+     |  "product": "${item.product}",
+     |  "paymentProvider": "${item.paymentProvider}",
+     |  "referrerUrl": "${item.referrerUrl}",
+     |  "labels": ${item.labels}
+     |}
+     |""".stripMargin.replaceAll("\n","")
+}
+
+def parseLine(line: String): Option[BigQueryItem] = {
+  line.split(",").toList match {
+    case pf :: cc :: amount :: ccy :: ts :: campaignCodes :: componentId :: product :: pp :: ref :: av :: avgbp :: labels :: Nil =>
+      val timestamp = ts.replaceAll("T"," ").take(19)
+      val campaignCode = campaignCodes.replaceAll("""[\[\]]""", "")
+      Some(BigQueryItem(
+        pf, cc, amount, ccy, timestamp, campaignCode, componentId, product, pp, ref, av, avgbp, labels
+      ))
+    case other =>
+      println(s"Ignoring $other")
+      None
+  }
+}
+
+def readLines(path: String): List[String] = {
+  val source = Source.fromFile(path)
+  val lines = source.getLines().toList
+  source.close()
+  lines
+}
+
+@main
+def main(path: String) = {
+  readLines(path)
+    .map(parseLine)
+    .flatten
+    .map(toJson)
+    .foreach(println)
+}


### PR DESCRIPTION
On 2021-11-24 we failed to write most acquisitions to the acquisition_events_prod athena table.

This was caused by a temporary fixer.io outage, which meant we didn't have currency rates in dynamodb.

We backfilled the missing data using this script.