### PR TITLE
Disable promo message in roundel

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithPriceCards.tsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithPriceCards.tsx
@@ -18,7 +18,6 @@ import {
 import DefaultRoundel from './defaultRoundel';
 import { HeroPriceCards } from './heroPriceCards';
 import {
-	circleTextGeneric,
 	embeddedRoundel,
 	heroCopy,
 	heroTitle,
@@ -72,9 +71,6 @@ function HeroWithPriceCards({
 	const promoCopy = promotionHTML(promotionCopy.description, {
 		tag: 'div',
 	});
-	const roundelText = promotionHTML(promotionCopy.roundel, {
-		css: circleTextGeneric,
-	}) || <DefaultRoundel />;
 	const nonAusCopy = getTimeboundCopy(
 		'digitalSubscription',
 		getTimeboundQuery() || new Date(),
@@ -99,14 +95,14 @@ function HeroWithPriceCards({
 							priceList={priceList}
 							roundel={
 								<HeroRoundel cssOverrides={embeddedRoundel} theme="digital">
-									{roundelText}
+									<DefaultRoundel />
 								</HeroRoundel>
 							}
 						/>
 					}
 					roundelElement={
 						<HeroRoundel cssOverrides={roundelOverrides} theme="digital">
-							{roundelText}
+							<DefaultRoundel />
 						</HeroRoundel>
 					}
 				>


### PR DESCRIPTION
The UX is quite bad if the roundel copy is set from the promo tool:
1. It's not clear which cta the roundel copy is referring to (it's actually the second here)
2. The size and formatting of the copy can break the UI

![Screen Shot 2021-11-29 at 11 02 15](https://user-images.githubusercontent.com/1513454/143858514-9b6ef905-979c-4ef3-8eca-8dc50f0a2af5.png)

For now the solution is to stop taking the copy from the promo tool.
The roundel will always say "14 day free trial", which is what the default page says.
![Screen Shot 2021-11-29 at 11 05 29](https://user-images.githubusercontent.com/1513454/143858878-1bf6745c-2add-4274-a32f-1481f8efab63.png)
