### PR TITLE
Migrate to switches v2

### DIFF
--- a/support-frontend/app/admin/settings/SettingsProvider.scala
+++ b/support-frontend/app/admin/settings/SettingsProvider.scala
@@ -2,7 +2,6 @@ package admin.settings
 
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicReference
-
 import admin.settings.SettingsProvider._
 import akka.actor.ActorSystem
 import cats.data.EitherT

--- a/support-frontend/app/admin/settings/Switches.scala
+++ b/support-frontend/app/admin/settings/Switches.scala
@@ -6,15 +6,9 @@ import io.circe.generic.extras.auto._
 import io.circe.{Decoder, Encoder, Json}
 import io.circe.optics.JsonPath._
 
-sealed trait SwitchState {
-  def isOn: Boolean
-}
-case object On extends SwitchState {
-  def isOn: Boolean = true
-}
-case object Off extends SwitchState {
-  def isOn: Boolean = false
-}
+sealed abstract class SwitchState(val isOn: Boolean)
+case object On extends SwitchState(true)
+case object Off extends SwitchState(false)
 
 object SwitchState {
   import io.circe.generic.extras.semiauto.{ deriveEnumerationDecoder, deriveEnumerationEncoder }

--- a/support-frontend/app/admin/settings/Switches.scala
+++ b/support-frontend/app/admin/settings/Switches.scala
@@ -17,44 +17,44 @@ object SwitchState {
 }
 
 case class FeatureSwitches(
-  enableQuantumMetric: SwitchState = Off,
-  usStripeAccountForSingle: SwitchState = On
+  enableQuantumMetric: SwitchState,
+  usStripeAccountForSingle: SwitchState
 )
 
 case class CampaignSwitches(
-  enableContributionsCampaign: SwitchState = Off,
-  forceContributionsCampaign: SwitchState = Off
+  enableContributionsCampaign: SwitchState,
+  forceContributionsCampaign: SwitchState
 )
 
 case class SubscriptionsSwitches(
-  enableDigitalSubGifting: SwitchState = On,
-  useDotcomContactPage: SwitchState = On,
-  checkoutPostcodeLookup: SwitchState = On
+  enableDigitalSubGifting: SwitchState,
+  useDotcomContactPage: SwitchState,
+  checkoutPostcodeLookup: SwitchState
 )
 
 case class RecaptchaSwitches(
-  enableRecaptchaBackend: SwitchState = On,
-  enableRecaptchaFrontend: SwitchState = On
+  enableRecaptchaBackend: SwitchState,
+  enableRecaptchaFrontend: SwitchState
 )
 
 case class OneOffPaymentMethodSwitches(
-  stripe: SwitchState = On,
-  stripeApplePay: SwitchState = On,
-  stripePaymentRequestButton: SwitchState = On,
-  payPal: SwitchState = On,
-  amazonPay: SwitchState = On
+  stripe: SwitchState,
+  stripeApplePay: SwitchState,
+  stripePaymentRequestButton: SwitchState,
+  payPal: SwitchState,
+  amazonPay: SwitchState
 )
 
 case class RecurringPaymentMethodSwitches(
-  stripe: SwitchState = On,
-  stripeApplePay: SwitchState = On,
-  stripePaymentRequestButton: SwitchState = On,
-  payPal: SwitchState = On,
-  directDebit: SwitchState = On,
-  existingCard: SwitchState = On,
-  existingDirectDebit: SwitchState = On,
-  amazonPay: SwitchState = Off,
-  sepa: SwitchState = Off
+  stripe: SwitchState,
+  stripeApplePay: SwitchState,
+  stripePaymentRequestButton: SwitchState,
+  payPal: SwitchState,
+  directDebit: SwitchState,
+  existingCard: SwitchState,
+  existingDirectDebit: SwitchState,
+  amazonPay: SwitchState,
+  sepa: SwitchState
 )
 
 case class Switches(
@@ -102,6 +102,7 @@ object Switches {
     }
 
   implicit private val customConfig: Configuration = Configuration.default.withDefaults
+
   private val switchesEncoder = Encoder[Switches]
   private val switchesDecoder = Decoder[Switches].prepare(_.withFocus(flattenAllSwitches))
 

--- a/support-frontend/app/admin/settings/Switches.scala
+++ b/support-frontend/app/admin/settings/Switches.scala
@@ -97,13 +97,7 @@ object Switches {
     root.each.obj.modify { switchGroup =>
       switchGroup("switches")
         .flatMap(_.asObject)
-        .map { switches =>
-          val flattenedSwitches = switches.mapValues(flattenSwitchState)
-          switchGroup
-            .deepMerge(flattenedSwitches)
-            .remove("switches")
-            .remove("description")
-        }
+        .map(switches => switches.mapValues(flattenSwitchState))
         .getOrElse(switchGroup)
     }
 

--- a/support-frontend/app/admin/settings/Switches.scala
+++ b/support-frontend/app/admin/settings/Switches.scala
@@ -1,21 +1,121 @@
 package admin.settings
 
 import com.gu.support.encoding.Codec
-import com.gu.support.encoding.Codec.deriveCodec
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.auto._
+import io.circe.{Decoder, Encoder, Json}
+import io.circe.optics.JsonPath._
+
+sealed trait SwitchState {
+  def isOn: Boolean
+}
+case object On extends SwitchState {
+  def isOn: Boolean = true
+}
+case object Off extends SwitchState {
+  def isOn: Boolean = false
+}
+
+object SwitchState {
+  import io.circe.generic.extras.semiauto.{ deriveEnumerationDecoder, deriveEnumerationEncoder }
+  implicit val stateDecoder: Decoder[SwitchState] = deriveEnumerationDecoder[SwitchState]
+  implicit val stateEncoder: Encoder[SwitchState] = deriveEnumerationEncoder[SwitchState]
+}
+
+case class FeatureSwitches(
+  enableQuantumMetric: SwitchState = Off,
+  usStripeAccountForSingle: SwitchState = On
+)
+
+case class CampaignSwitches(
+  enableContributionsCampaign: SwitchState = Off,
+  forceContributionsCampaign: SwitchState = Off
+)
+
+case class SubscriptionsSwitches(
+  enableDigitalSubGifting: SwitchState = On,
+  useDotcomContactPage: SwitchState = On,
+  checkoutPostcodeLookup: SwitchState = On
+)
+
+case class RecaptchaSwitches(
+  enableRecaptchaBackend: SwitchState = On,
+  enableRecaptchaFrontend: SwitchState = On
+)
+
+case class OneOffPaymentMethodSwitches(
+  stripe: SwitchState = On,
+  stripeApplePay: SwitchState = On,
+  stripePaymentRequestButton: SwitchState = On,
+  payPal: SwitchState = On,
+  amazonPay: SwitchState = On
+)
+
+case class RecurringPaymentMethodSwitches(
+  stripe: SwitchState = On,
+  stripeApplePay: SwitchState = On,
+  stripePaymentRequestButton: SwitchState = On,
+  payPal: SwitchState = On,
+  directDebit: SwitchState = On,
+  existingCard: SwitchState = On,
+  existingDirectDebit: SwitchState = On,
+  amazonPay: SwitchState = Off,
+  sepa: SwitchState = Off
+)
 
 case class Switches(
-  oneOffPaymentMethods: PaymentMethodsSwitch,
-  recurringPaymentMethods: PaymentMethodsSwitch,
-  enableDigitalSubGifting: SwitchState,
-  useDotcomContactPage: Option[SwitchState],
-  enableRecaptchaBackend: SwitchState,
-  enableRecaptchaFrontend: SwitchState,
-  experiments: Map[String, ExperimentSwitch],
-  enableContributionsCampaign: SwitchState,
-  forceContributionsCampaign: SwitchState,
-  enableQuantumMetric: SwitchState
+  oneOffPaymentMethods: OneOffPaymentMethodSwitches,
+  recurringPaymentMethods: RecurringPaymentMethodSwitches,
+  subscriptionsSwitches: SubscriptionsSwitches,
+  featureSwitches: FeatureSwitches,
+  campaignSwitches: CampaignSwitches,
+  recaptchaSwitches: RecaptchaSwitches
 )
 
 object Switches {
-  implicit val switchesCodec: Codec[Switches] = deriveCodec
+  /**
+   * Transforms from e.g:
+   *  {
+   *    "oneOffPaymentMethods" : {
+   *      "description" : "Payment methods - one-off contributions",
+   *      "switches" : {
+   *        "stripe" : {
+   *          "description" : "Stripe - Credit/Debit card",
+   *          "state" : "On"
+   *        }
+   *      }
+   *    }
+   *  }
+   *  To:
+   *  {
+   *    "oneOffPaymentMethods" : {
+   *      "stripe": "On"
+   *    }
+   *  }
+   */
+  private def flattenSwitchState(json: Json): Json =
+    root.state.string
+      .getOption(json)
+      .map(Json.fromString)
+      .getOrElse(json)
+
+  private def flattenAllSwitches: Json => Json =
+    root.each.obj.modify { switchGroup =>
+      switchGroup("switches")
+        .flatMap(_.asObject)
+        .map { switches =>
+          val flattenedSwitches = switches.mapValues(flattenSwitchState)
+          switchGroup
+            .deepMerge(flattenedSwitches)
+            .remove("switches")
+            .remove("description")
+        }
+        .getOrElse(switchGroup)
+    }
+
+  implicit private val customConfig: Configuration = Configuration.default.withDefaults
+  private val switchesEncoder = Encoder[Switches]
+  private val switchesDecoder = Decoder[Switches].prepare(_.withFocus(flattenAllSwitches))
+
+  implicit val switchesCodec = new Codec(switchesEncoder, switchesDecoder)
 }

--- a/support-frontend/app/controllers/DigitalSubscriptionController.scala
+++ b/support-frontend/app/controllers/DigitalSubscriptionController.scala
@@ -43,7 +43,7 @@ class DigitalSubscriptionController(
       implicit request =>
         implicit val settings: AllSettings = settingsProvider.getAllSettings()
 
-        if (!settings.switches.enableDigitalSubGifting.isOn && orderIsAGift) {
+        if (!settings.switches.subscriptionsSwitches.enableDigitalSubGifting.isOn && orderIsAGift) {
           Redirect(routes.DigitalSubscriptionController.digitalGeoRedirect(false)).withSettingsSurrogateKey
         } else {
           val canonicalLink = Some(buildCanonicalDigitalSubscriptionLink("uk", orderIsAGift))

--- a/support-frontend/app/controllers/StripeController.scala
+++ b/support-frontend/app/controllers/StripeController.scala
@@ -45,8 +45,8 @@ class StripeController(
   import services.SetupIntent.encoder
 
   def createSetupIntentRecaptcha: Action[SetupIntentRequestRecaptcha] = PrivateAction.async(circe.json[SetupIntentRequestRecaptcha]) { implicit request =>
-    val recaptchaBackendEnabled = settingsProvider.getAllSettings().switches.enableRecaptchaBackend.isOn
-    val recaptchaFrontendEnabled = settingsProvider.getAllSettings().switches.enableRecaptchaFrontend.isOn
+    val recaptchaBackendEnabled = settingsProvider.getAllSettings().switches.recaptchaSwitches.enableRecaptchaBackend.isOn
+    val recaptchaFrontendEnabled = settingsProvider.getAllSettings().switches.recaptchaSwitches.enableRecaptchaFrontend.isOn
 
     // We never validate on backend unless frontend validation is Enabled
     val recaptchaEnabled = recaptchaFrontendEnabled && recaptchaBackendEnabled

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -79,7 +79,7 @@
     }
   };
   window.guardian.stripeKeyUnitedStates = {
-    @if(settings.switches.experiments.get("usStripeAccountForSingle").exists(_.isOn)) {
+    @if(settings.switches.featureSwitches.usStripeAccountForSingle.isOn) {
         ONE_OFF: {
             default: "@paymentMethodConfigs.oneOffDefaultStripeConfig.forCountry(Some(Country.US)).publicKey",
             uat: "@paymentMethodConfigs.oneOffUatStripeConfig.forCountry(Some(Country.US)).publicKey"
@@ -110,10 +110,10 @@
     window.guardian.guestAccountCreationToken = "@guestAccountCreationToken";
   }
 
-  window.guardian.forceContributionsCampaign = @settings.switches.forceContributionsCampaign.isOn
-  window.guardian.enableContributionsCampaign = @settings.switches.enableContributionsCampaign.isOn
+  window.guardian.forceContributionsCampaign = @settings.switches.campaignSwitches.forceContributionsCampaign.isOn
+  window.guardian.enableContributionsCampaign = @settings.switches.campaignSwitches.enableContributionsCampaign.isOn
 
-  window.guardian.recaptchaEnabled = @settings.switches.enableRecaptchaFrontend.isOn
+  window.guardian.recaptchaEnabled = @settings.switches.recaptchaSwitches.enableRecaptchaFrontend.isOn
   window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey"
   </script>
 }

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -64,11 +64,11 @@
         uat: "@uatPayPalConfig.payPalEnvironment"
       };
 
-      window.guardian.checkoutPostcodeLookup = "@settings.switches.experiments.get("checkoutPostcodeLookup").exists(_.isOn)"
+      window.guardian.checkoutPostcodeLookup = "@settings.switches.subscriptionsSwitches.checkoutPostcodeLookup.isOn
 
       window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey"
 
-      window.guardian.recaptchaEnabled = @settings.switches.enableRecaptchaFrontend.isOn
+      window.guardian.recaptchaEnabled = @settings.switches.recaptchaSwitches.enableRecaptchaFrontend.isOn
 
       window.guardian.isTestUser = @uatMode
 

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -37,7 +37,7 @@ function init(): void {
 	 */
 	if (
 		getGlobal('ssr') ||
-		!isSwitchOn('enableQuantumMetric') ||
+		!isSwitchOn('featureSwitches.enableQuantumMetric') ||
 		!pathIsValid()
 	) {
 		return;

--- a/support-frontend/assets/helpers/utilities/dotcomContactPage.tsx
+++ b/support-frontend/assets/helpers/utilities/dotcomContactPage.tsx
@@ -5,6 +5,6 @@ const ContactPageLink = (props: { linkText: string }) => (
 	<a href="https://www.theguardian.com/help/contact-us">{props.linkText}</a>
 );
 
-const useDotcomContactPage = (): boolean => isSwitchOn('useDotcomContactPage');
+const useDotcomContactPage = (): boolean => isSwitchOn('subscriptionsSwitches.useDotcomContactPage');
 
 export { ContactPageLink, useDotcomContactPage };

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -25,6 +25,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
+  "io.circe" %% "circe-optics" % circeVersion,
   "joda-time" % "joda-time" % "2.9.9",
   "com.gu.identity" %% "identity-auth-play" % "3.248",
   "com.gu" %% "identity-test-users" % "0.8",

--- a/support-frontend/test/admin/settings/SwitchesSpec.scala
+++ b/support-frontend/test/admin/settings/SwitchesSpec.scala
@@ -137,12 +137,12 @@ class SwitchesSpec extends AnyWordSpec with Matchers {
 
       decode[Switches](json) mustBe (Right(
         Switches(
-          oneOffPaymentMethods = OneOffPaymentMethodSwitches(),
-          recurringPaymentMethods = RecurringPaymentMethodSwitches(),
-          subscriptionsSwitches = SubscriptionsSwitches(),
+          oneOffPaymentMethods = OneOffPaymentMethodSwitches(On,On,On,On,On),
+          recurringPaymentMethods = RecurringPaymentMethodSwitches(On,On,On,On,On,On,On,Off,Off),
+          subscriptionsSwitches = SubscriptionsSwitches(On,On,On),
           featureSwitches = FeatureSwitches(On, On),
-          campaignSwitches = CampaignSwitches(),
-          recaptchaSwitches = RecaptchaSwitches()
+          campaignSwitches = CampaignSwitches(Off, Off),
+          recaptchaSwitches = RecaptchaSwitches(On, On)
         )
       ))
     }

--- a/support-frontend/test/admin/settings/SwitchesSpec.scala
+++ b/support-frontend/test/admin/settings/SwitchesSpec.scala
@@ -1,0 +1,150 @@
+package admin.settings
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import io.circe.parser.decode
+
+class SwitchesSpec extends AnyWordSpec with Matchers {
+  "Switches" should {
+    "decode json" in {
+      val json =
+        """
+          |{
+          |  "oneOffPaymentMethods" : {
+          |    "description" : "Payment methods - one-off contributions",
+          |    "switches" : {
+          |      "stripe" : {
+          |        "description" : "Stripe - Credit/Debit card",
+          |        "state" : "On"
+          |      },
+          |      "stripeApplePay" : {
+          |        "description" : "Stripe - Apple Pay",
+          |        "state" : "On"
+          |      },
+          |      "stripePaymentRequestButton" : {
+          |        "description" : "Stripe - Payment Request Button",
+          |        "state" : "On"
+          |      },
+          |      "payPal" : {
+          |        "description" : "PayPal",
+          |        "state" : "On"
+          |      },
+          |      "amazonPay" : {
+          |        "description" : "Amazon Pay",
+          |        "state" : "On"
+          |      }
+          |    }
+          |  },
+          |  "recurringPaymentMethods" : {
+          |    "description" : "Payment methods - recurring contributions",
+          |    "switches" : {
+          |      "stripe" : {
+          |        "description" : "Stripe - Credit/Debit card",
+          |        "state" : "On"
+          |      },
+          |      "stripeApplePay" : {
+          |        "description" : "Stripe - Apple Pay",
+          |        "state" : "On"
+          |      },
+          |      "stripePaymentRequestButton" : {
+          |        "description" : "Stripe - Payment Request Button",
+          |        "state" : "On"
+          |      },
+          |      "payPal" : {
+          |        "description" : "PayPal",
+          |        "state" : "On"
+          |      },
+          |      "amazonPay" : {
+          |        "description" : "Amazon Pay",
+          |        "state" : "Off"
+          |      },
+          |      "directDebit" : {
+          |        "description" : "Direct Debit",
+          |        "state" : "On"
+          |      },
+          |      "existingCard" : {
+          |        "description" : "Existing card",
+          |        "state" : "On"
+          |      },
+          |      "existingDirectDebit" : {
+          |        "description" : "Existing Direct Debit",
+          |        "state" : "On"
+          |      },
+          |      "sepa" : {
+          |        "description" : "SEPA",
+          |        "state" : "Off"
+          |      }
+          |    }
+          |  },
+          |  "subscriptionsSwitches": {
+          |    "description": "Subscriptions",
+          |    "switches": {
+          |      "checkoutPostcodeLookup" : {
+          |        "description" : "Enable external service postcode lookup in checkout form",
+          |        "state" : "On"
+          |      },
+          |      "enableDigitalSubGifting" : {
+          |        "description" : "Enable Digital Sub gifting",
+          |        "state" : "On"
+          |      },
+          |      "useDotcomContactPage" : {
+          |        "description" : "Use Dotcom contact page",
+          |        "state" : "On"
+          |      }
+          |    }
+          |  },
+          |  "featureSwitches" : {
+          |    "description" : "Feature switches",
+          |    "switches" : {
+          |      "enableQuantumMetric" : {
+          |        "description" : "Enable quantum metric",
+          |        "state" : "On"
+          |      },
+          |      "usStripeAccountForSingle" : {
+          |        "description" : "US Stripe account for single contributions",
+          |        "state" : "On"
+          |      }
+          |    }
+          |  },
+          |  "campaignSwitches" : {
+          |    "description" : "Campaign switches",
+          |    "switches" : {
+          |      "enableContributionsCampaign" : {
+          |        "description" : "Enable contributions campaign",
+          |        "state" : "Off"
+          |      },
+          |      "forceContributionsCampaign" : {
+          |        "description" : "Force all users into the contributions campaign (ignore url path)",
+          |        "state" : "Off"
+          |      }
+          |    }
+          |  },
+          |  "recaptchaSwitches": {
+          |    "description" : "Recaptcha switches",
+          |    "switches" : {
+          |      "enableRecaptchaBackend" : {
+          |        "description" : "Enable Recaptcha on the backend",
+          |        "state" : "On"
+          |      },
+          |      "enableRecaptchaFrontend" : {
+          |        "description" : "Enable Recaptcha on the client",
+          |        "state" : "On"
+          |      }
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+
+      decode[Switches](json) mustBe (Right(
+        Switches(
+          oneOffPaymentMethods = OneOffPaymentMethodSwitches(),
+          recurringPaymentMethods = RecurringPaymentMethodSwitches(),
+          subscriptionsSwitches = SubscriptionsSwitches(),
+          featureSwitches = FeatureSwitches(On, On),
+          campaignSwitches = CampaignSwitches(),
+          recaptchaSwitches = RecaptchaSwitches()
+        )
+      ))
+    }
+  }
+}

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -103,12 +103,12 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
 
     val allSettings = AllSettings(
       Switches(
-        oneOffPaymentMethods = OneOffPaymentMethodSwitches(),
-        recurringPaymentMethods = RecurringPaymentMethodSwitches(),
-        subscriptionsSwitches = SubscriptionsSwitches(),
-        featureSwitches = FeatureSwitches(),
-        campaignSwitches = CampaignSwitches(),
-        recaptchaSwitches = RecaptchaSwitches()
+        oneOffPaymentMethods = OneOffPaymentMethodSwitches(On,On,On,On,On),
+        recurringPaymentMethods = RecurringPaymentMethodSwitches(On,On,On,On,Off,On,On,On,Off),
+        subscriptionsSwitches = SubscriptionsSwitches(On,On,On),
+        featureSwitches = FeatureSwitches(On, On),
+        campaignSwitches = CampaignSwitches(On, On),
+        recaptchaSwitches = RecaptchaSwitches(On, On)
       ),
       configuredAmounts,
       ContributionTypes(Nil, Nil, Nil, Nil, Nil, Nil, Nil),

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -1,7 +1,6 @@
 package controllers
 
 import actions.CustomActionBuilders
-import admin.settings.SwitchState.{Off, On}
 import admin.settings._
 import assets.RefPath
 import cats.data.EitherT
@@ -104,16 +103,12 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
 
     val allSettings = AllSettings(
       Switches(
-        oneOffPaymentMethods = PaymentMethodsSwitch(On, On, On, On, None, None, None, None, None),
-        recurringPaymentMethods = PaymentMethodsSwitch(On, On, On, On, Some(On), Some(On), Some(On), None, None),
-        experiments = Map.empty,
-        enableDigitalSubGifting = On,
-        useDotcomContactPage = Some(SwitchState.Off),
-        enableRecaptchaBackend = Off,
-        enableRecaptchaFrontend = Off,
-        enableContributionsCampaign = On,
-        forceContributionsCampaign = On,
-        enableQuantumMetric = Off
+        oneOffPaymentMethods = OneOffPaymentMethodSwitches(),
+        recurringPaymentMethods = RecurringPaymentMethodSwitches(),
+        subscriptionsSwitches = SubscriptionsSwitches(),
+        featureSwitches = FeatureSwitches(),
+        campaignSwitches = CampaignSwitches(),
+        recaptchaSwitches = RecaptchaSwitches()
       ),
       configuredAmounts,
       ContributionTypes(Nil, Nil, Nil, Nil, Nil, Nil, Nil),


### PR DESCRIPTION
We are migrating the switches json config to a new format. This is to make the S3 file the single source of truth. See switchboard PR: https://github.com/guardian/support-admin-console/pull/256

This PR migrates the scala model and uses the new file, switches_v2.json.
It does some transformation to the json to make the scala case classes more convenient for our app.
The app will fail to come up if the file is missing/invalid or any switches are missing (same behaviour as before)