### PR TITLE
Bump SBT to 1.5.6

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.5.6

--- a/support-frontend/project/build.properties
+++ b/support-frontend/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.2.8


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Bump SBT to 1.5.6 to get around the log4j vulnerability.