### PR TITLE
add dependency to deploy to avoid race condition

### DIFF
--- a/support-logs/retention-lambda/riff-raff.yaml
+++ b/support-logs/retention-lambda/riff-raff.yaml
@@ -14,3 +14,4 @@ deployments:
       fileName: support-logs-retention-lambda.zip
       functionNames: [support-logs-retention-lambda-]
       prefixStack: false
+    dependencies: [support-logs-retention-lambda-cfn]


### PR DESCRIPTION
Co-authored-by: TomPretty <TomPretty@users.noreply.github.com>

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR adds a dependency from the lambda to the cfn step in the support-logs-retention lambda.

## Why are you doing this?

There waas a race condition where it would sometimes (10% of the time) fail with a 
```
software.amazon.awssdk.services.lambda.model.ResourceConflictException The operation cannot be performed at this time. An update is in progress for resource: arn:aws:lambda:eu-west-1:865473395570:function:support-logs-retention-lambda-PROD (Service: Lambda, Status Code: 409, Request ID: 887dde9b-e592-44c6-9ae9-66faa7d6a1b5, Extended Request ID: null)
```

This was because the cfn and the lambda were deploying  the same time, which occasionally collided.
