### PR TITLE
Update nested dependency immer

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -211,7 +211,8 @@
     "postcss-load-config/cosmiconfig/js-yaml": "3.13.1",
     "lodash": "^4.17.21",
     "ssri": "^6.0.2",
-    "y18n": "^4.0.1"
+    "y18n": "^4.0.1",
+    "immer": "^9.0.6"
   },
   "lint-staged": {
     "./assets/**/**/*.{js,jsx,ts,tsx}": "eslint"

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -8048,10 +8048,10 @@ ignore@^5.0.5, ignore@^5.1.4, ignore@^5.1.8:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-immer@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
-  integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
+immer@1.10.0, immer@^9.0.6:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.7.tgz#b6156bd7db55db7abc73fd2fdadf4e579a701075"
+  integrity sha512-KGllzpbamZDvOIxnmJ0jI840g7Oikx58lBPWV0hUh7dtAyZpFqqrBZdKka5GlTwMTZ1Tjc/bKKW4VSFAt6BqMA==
 
 import-cwd@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
## What are you doing in this PR?

Upgrade `immer` to version `9.0.6` to address dependabot alert.

This is a nested dependency via `@storybook/react@5.3.21` which requires `immer@1.10.0` via a transitive dependency on `react-dev-utils@9.1.0`, none of the dependencies in this nested tree have updated `immer` to the version with the resolution (`9.0.6`), so I'm adding this to the `resolutions` section in our `package.json`.
