### PR TITLE
Update nested dependency serialize-javascript

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -212,7 +212,8 @@
     "lodash": "^4.17.21",
     "ssri": "^6.0.2",
     "y18n": "^4.0.1",
-    "immer": "^9.0.6"
+    "immer": "^9.0.6",
+    "serialize-javascript": "^4.0.0"
   },
   "lint-staged": {
     "./assets/**/**/*.{js,jsx,ts,tsx}": "eslint"

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -13184,12 +13184,7 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^1.7.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
-  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
-
-serialize-javascript@^4.0.0:
+serialize-javascript@^1.7.0, serialize-javascript@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
   integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==


### PR DESCRIPTION
## What are you doing in this PR?

Upgrade `serialize-javascript` to version `4.0.0` to address dependabot alert.

This is a nested dependency via `uglifyjs-webpack-plugin@^2.2.0`, there is no updated version of `uglifyjs-webpack-plugin`  with the resolution (`4.0.0`), so I'm adding this to the `resolutions` section in our `package.json`.

I've tested our build steps and it all looks OK.
