### PR TITLE
Update digital pack post-purchase survey

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/subscriptionsSurvey/SubscriptionsSurvey.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/subscriptionsSurvey/SubscriptionsSurvey.tsx
@@ -10,7 +10,7 @@ type PropTypes = {
 	product: SubscriptionProduct;
 };
 const surveyLinks: Record<SubscriptionProduct, string> = {
-	DigitalPack: 'https://www.surveymonkey.com/r/PQMWMHW',
+	DigitalPack: 'https://www.surveymonkey.co.uk/r/SLKWCHT',
 	GuardianWeekly: 'https://www.surveymonkey.co.uk/r/9DRKP78',
 	Paper: 'https://www.surveymonkey.co.uk/r/99PGHSX',
 };


### PR DESCRIPTION
## What are you doing in this PR?
Update the digital pack post-purchase survey link to point to the new survey.

[**Trello Card**](https://trello.com/c/52J7FJew)

## Why are you doing this?
We're running new motivation surveys, hence the new link here (replacing the old 2020 one). 

## Is this an AB test?
- [ ] Yes
- [x] No