### PR TITLE
add public flag to s3 assets

### DIFF
--- a/support-frontend/conf/riff-raff.yaml
+++ b/support-frontend/conf/riff-raff.yaml
@@ -30,3 +30,4 @@ deployments:
       prefixPackage: false
       prefixStack: false
       cacheControl: public, max-age=3600
+      publicReadAcl: true

--- a/support-frontend/conf/riff-raff.yaml
+++ b/support-frontend/conf/riff-raff.yaml
@@ -8,6 +8,7 @@ deployments:
       prefixPackage: false
       prefixStack: false
       cacheControl: public, max-age=31536000
+      publicReadAcl: true
   cfn:
     type: cloud-formation
     app: frontend

--- a/support-workers/riff-raff.yaml
+++ b/support-workers/riff-raff.yaml
@@ -26,3 +26,4 @@ deployments:
     parameters:
       bucket: support-workers-dist
       cacheControl: private
+      publicReadAcl: false


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR adds the publicReadAcl: true parameter to the s3 upload for the assets.

## Why are you doing this?

This is needed because these are served from the web s3 interface direct to fastly.
There is a coming change to riffraff to make the default "false" instead of "true" https://github.com/guardian/riff-raff/pull/664