### PR TITLE
use default param for default promo code on gift page

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -64,7 +64,7 @@ const WeeklyLandingPage = ({
 	const sanitisedPromoCopy = getPromotionCopy(promotionCopy);
 	const defaultPromo = orderIsAGift ? 'GW20GIFT1Y' : '10ANNUAL';
 	const promoTermsLink = promotionTermsUrl(
-		getQueryParameter(promoQueryParam) ?? defaultPromo,
+		getQueryParameter(promoQueryParam, defaultPromo),
 	);
 	// ID for Selenium tests
 	const pageQaId = `qa-guardian-weekly${orderIsAGift ? '-gift' : ''}`;


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes the link for the promos on the GW gift page

## Why are you doing this?

This page has a broken link https://support.theguardian.com/int/subscribe/weekly/gift

![image](https://user-images.githubusercontent.com/7304387/148777223-1db40829-1fe1-4166-aa4e-bfa0c697808e.png)

