### PR TITLE
Upgrade to play 2.8.13

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8") // when updating major version, also update play-circe version
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.13") // when updating major version, also update play-circe version
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "identity-test-users" % "0.8",
   "com.google.guava" % "guava" % "29.0-jre",
   "io.lemonlabs" %% "scala-uri" % scalaUriVersion,
-  "com.gu.play-googleauth" %% "play-v27" % "2.2.2",
+  "com.gu.play-googleauth" %% "play-v28" % "2.2.2",
   "io.github.bonigarcia" % "webdrivermanager" % "3.3.0" % "test",
   "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % "test",
   "org.scalatestplus" %% "scalatestplus-mockito" % "1.0.0-M2" % Test,

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "identity-test-users" % "0.8",
   "com.google.guava" % "guava" % "29.0-jre",
   "io.lemonlabs" %% "scala-uri" % scalaUriVersion,
-  "com.gu.play-googleauth" %% "play-v27" % "2.1.0",
+  "com.gu.play-googleauth" %% "play-v27" % "2.2.2",
   "io.github.bonigarcia" % "webdrivermanager" % "3.3.0" % "test",
   "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % "test",
   "org.scalatestplus" %% "scalatestplus-mockito" % "1.0.0-M2" % Test,

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
   "org.scalatestplus" %% "mockito-3-4" % "3.2.1.0" % "test",
   "org.mockito" % "mockito-core" % "3.4.0",
   "org.typelevel" %% "cats-core" % catsVersion,
-  "com.github.blemale" %% "scaffeine" % "5.1.2",
+  "com.github.blemale" %% "scaffeine" % "4.1.0",
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
   "org.scalatestplus" %% "mockito-3-4" % "3.2.1.0" % "test",
   "org.mockito" % "mockito-core" % "3.4.0",
   "org.typelevel" %% "cats-core" % catsVersion,
-  "com.github.blemale" %% "scaffeine" % "3.1.0",
+  "com.github.blemale" %% "scaffeine" % "5.1.2",
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,

--- a/support-payment-api/src/main/scala/actions/RateLimitingAction.scala
+++ b/support-payment-api/src/main/scala/actions/RateLimitingAction.scala
@@ -3,7 +3,7 @@ package actions
 import com.github.blemale.scaffeine.{Cache, Scaffeine}
 import com.typesafe.scalalogging.StrictLogging
 import controllers.JsonUtils
-import model.{PaymentProvider, RequestEnvironments, ResultBody}
+import model.{PaymentProvider, ResultBody}
 import play.api.mvc._
 import services.CloudWatchService
 

--- a/support-payment-api/src/main/scala/actions/RateLimitingAction.scala
+++ b/support-payment-api/src/main/scala/actions/RateLimitingAction.scala
@@ -8,7 +8,7 @@ import play.api.mvc._
 import services.CloudWatchService
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration._
+import scala.concurrent.duration.FiniteDuration
 import play.api.libs.circe.Circe
 
 /**
@@ -19,7 +19,7 @@ import play.api.libs.circe.Circe
   * from the backend, not the browser.
   */
 
-case class RateLimitingSettings(maxRequests: Int, interval: Duration)
+case class RateLimitingSettings(maxRequests: Int, interval: FiniteDuration)
 
 class RateLimitingAction(
   val parse: PlayBodyParsers,
@@ -43,8 +43,8 @@ class RateLimitingAction(
       .expireAfter(
         // Start timing from when the ip is first cached, and do not restart the timer after updates
         create = (_: IpAddress, _: Int) => settings.interval,
-        update = (_: IpAddress, _: Int, currentDuration: Duration) => currentDuration,
-        read = (_: IpAddress, _: Int, currentDuration: Duration) => currentDuration
+        update = (_: IpAddress, _: Int, currentDuration: FiniteDuration) => currentDuration,
+        read = (_: IpAddress, _: Int, currentDuration: FiniteDuration) => currentDuration
       )
       .maximumSize(1000)
       .build[IpAddress, Int]()

--- a/support-payment-api/src/test/scala/actions/RateLimitingActionSpec.scala
+++ b/support-payment-api/src/test/scala/actions/RateLimitingActionSpec.scala
@@ -10,6 +10,7 @@ import play.api.test.Helpers._
 import services.CloudWatchService
 
 import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -17,7 +18,7 @@ class RateLimitingActionSpec extends AnyWordSpec with Matchers with Results with
   val cc = stubControllerComponents()
   val mockCloudWatchService: CloudWatchService = mock[CloudWatchService]
 
-  private def newAction(maxRequests: Int, interval: Duration) =
+  private def newAction(maxRequests: Int, interval: FiniteDuration) =
     new RateLimitingAction(
       cc.parsers,
       cc.executionContext,

--- a/support-services/build.sbt
+++ b/support-services/build.sbt
@@ -6,7 +6,6 @@ description := "Scala library to provide shared services to Guardian Support pro
 
 libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "dynamodb" % awsClientVersion2,
-  "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1",
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion,
   "org.scala-stm" %% "scala-stm" % "0.11.0", // only for promotions
 )

--- a/support-services/src/main/scala/com/gu/support/redemption/corporate/DynamoTableAsync.scala
+++ b/support-services/src/main/scala/com/gu/support/redemption/corporate/DynamoTableAsync.scala
@@ -10,8 +10,8 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, GetItemRequest, UpdateItemRequest}
 
-import scala.collection.JavaConverters._
-import scala.compat.java8.FutureConverters._
+import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
 object DynamoTableAsync {
@@ -61,7 +61,7 @@ class DynamoTableAsync(
       .key(Map(primaryKeyName -> AttributeValue.builder.s(key).build).asJava)
       .build
 
-    val eventualGetItemResponse = dynamoDBAsyncClient.getItem(getItemRequest).toScala.recoverWith {
+    val eventualGetItemResponse = dynamoDBAsyncClient.getItem(getItemRequest).asScala.recoverWith {
       case cex: CompletionException => Future.failed(cex.getCause)
     }
 
@@ -90,7 +90,7 @@ class DynamoTableAsync(
       ).asJava)
       .build
 
-    val eventualUpdateItemResponse = dynamoDBAsyncClient.updateItem(updateItemRequest).toScala.recoverWith {
+    val eventualUpdateItemResponse = dynamoDBAsyncClient.updateItem(updateItemRequest).asScala.recoverWith {
       case cex: CompletionException => Future.failed(cex.getCause)
     }
 


### PR DESCRIPTION
The dependency `akka-http-core` has been marked by snyk as high severity.

Updates to scaffeine/play-googleauth necessary because of a `scala-java8-compat_2.13` version incompatibility