### PR TITLE
don't send PROD PaymentSuccess for test users

### DIFF
--- a/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
+++ b/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
@@ -25,15 +25,17 @@ object AwsCloudWatchMetricSetup {
       )
     )
 
-  def paymentSuccessRequest(stage: Stage, paymentProvider: PaymentProvider, productType: ProductType): MetricRequest =
+  def paymentSuccessRequest(stage: Stage, isTestUser: Boolean, paymentProvider: PaymentProvider, productType: ProductType): MetricRequest = {
+    val qualifiedStage = stage.toString + (if (isTestUser) "-UAT" else "")
     getMetricRequest(
       MetricName("PaymentSuccess"),
       Map(
         MetricDimensionName("PaymentProvider") -> MetricDimensionValue(paymentProvider.name),
         MetricDimensionName("ProductType") -> MetricDimensionValue(productType.toString),
-        MetricDimensionName("Stage") -> MetricDimensionValue(stage.toString)
+        MetricDimensionName("Stage") -> MetricDimensionValue(qualifiedStage)
       )
     )
+  }
 
   def createSetupIntentRequest(stage: Stage, mode: String): MetricRequest =
     getMetricRequest(


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This Pr prevents us sending PROD PaymentSuccess for test users.
We will send them as stage `PROD-UAT` instead

## Why are you doing this?

We have a bunch of alarms looking for PROD payment success events, however it turns out test users (e.g. post deploy tests) will trigger the same event, causing the alarms to not be fired if we have done deploys recently!
