### PR TITLE
use iso country instead of the text to fix braze issue

### DIFF
--- a/support-workers/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
@@ -23,7 +23,7 @@ class ContributionEmailFields(
         "EmailAddress" -> contributionProcessedInfo.user.primaryEmailAddress,
         "created" -> created.toString,
         "amount" -> contributionProcessedInfo.product.amount.toString,
-        "currency" -> contributionProcessedInfo.product.currency.identifier,
+        "currency" -> contributionProcessedInfo.product.currency.iso,
         "edition" -> contributionProcessedInfo.user.billingAddress.country.alpha2,
         "name" -> contributionProcessedInfo.user.firstName,
         "product" -> s"${contributionProcessedInfo.product.billingPeriod.toString.toLowerCase}-contribution"

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -76,7 +76,7 @@ class SendThankYouEmailSpec extends AsyncLambdaSpec {
         .validate("sort code", "20-20-20")
         .validate("first payment date", "Monday, 10 January 2000")
         .validate("payment method", "Direct Debit")
-        .validate("currency", "£")
+        .validate("currency", "GBP")
         .validate("IdentityUserId", "1234")
       succeed
     }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Change contributions thank you email to send the currency field as iso (e.g. AUD) instead of the text version (e.g. AU$)

https://trello.com/c/iuiXcPqV/258-make-thank-you-email-send-eg-gbp-instead-of-as-currency

## Why are you doing this?

We noticed the thank you emails were missing the currency symbol.  The code our end didn't seem to have changed in any way for several years, and was expecting the contents of the currency field to be used in the email.  It was previously the ISO code but was changed in 2018 to be the "glyph" as a request from someone https://github.com/guardian/support-workers/pull/114
Current logic in braze is to assume it's an iso currency code and do a look up, so we will match that.

No one on the team that looks after braze seems to know about it so the suggestion is to just fix our end to suit.
