### PR TITLE
Interactive table TS error fixes

### DIFF
--- a/support-frontend/assets/components/interactiveTable/interactiveTable.tsx
+++ b/support-frontend/assets/components/interactiveTable/interactiveTable.tsx
@@ -3,7 +3,7 @@ import { visuallyHidden as _visuallyHidden } from '@guardian/src-foundations/acc
 import { from, until } from '@guardian/src-foundations/mq';
 import { background } from '@guardian/src-foundations/palette';
 import { body } from '@guardian/src-foundations/typography';
-import type { Node } from 'react';
+import type { ReactNode } from 'react';
 import React from 'react';
 import type { CellData, RowData } from './interactiveTableRow';
 import {
@@ -35,10 +35,10 @@ const stickyHeader = css`
 	background-color: ${background.ctaPrimary};
 `;
 type InteractiveTablePropTypes = {
-	caption: Node;
+	caption: ReactNode;
 	headers: CellData[];
 	rows: RowData[];
-	footer: Node;
+	footer: ReactNode;
 };
 
 function InteractiveTable({
@@ -46,7 +46,7 @@ function InteractiveTable({
 	headers,
 	rows,
 	footer,
-}: InteractiveTablePropTypes) {
+}: InteractiveTablePropTypes): JSX.Element {
 	return (
 		<table css={table}>
 			<caption css={visuallyHidden}>{caption}</caption>

--- a/support-frontend/assets/components/interactiveTable/interactiveTableRow.tsx
+++ b/support-frontend/assets/components/interactiveTable/interactiveTableRow.tsx
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { css } from '@emotion/core';
 import { Button } from '@guardian/src-button';
 import { space, transitions } from '@guardian/src-foundations';
@@ -13,7 +12,7 @@ import {
 import { textSans } from '@guardian/src-foundations/typography';
 import { SvgChevronDownSingle } from '@guardian/src-icons';
 import React, { useState } from 'react';
-import type { Node } from 'react';
+import type { ReactNode } from 'react';
 
 const borderStyle = `${border.secondary} 1px solid`;
 const visuallyHidden = css`
@@ -77,6 +76,7 @@ const headingCell = css`
 `;
 const primaryTableCell = css`
 	-ms-grid-column: 1;
+	grid-column: 1;
 	justify-content: flex-start;
 	padding-left: ${space[3]}px;
 
@@ -86,10 +86,12 @@ const primaryTableCell = css`
 `;
 const iconCell = css`
 	-ms-grid-column: 3;
+	grid-column: 3;
 	max-width: 48px;
 `;
 const expandableButtonCell = css`
 	-ms-grid-column: 4;
+	grid-column: 4;
 	max-height: 72px;
 	display: flex;
 	align-items: center;
@@ -103,6 +105,7 @@ const detailsCell = css`
 	-ms-grid-column: 1;
 	-ms-grid-column-span: 4;
 	-ms-grid-row: 2;
+	grid-row: 2;
 	grid-column: 1 / span 4;
 	background-color: ${sport[800]};
 	border-top: ${borderStyle};
@@ -160,7 +163,7 @@ const yellowBackground = css`
 	background: ${brandAltBackground.primary};
 `;
 export type CellData = {
-	content: Node;
+	content: ReactNode;
 	isPrimary?: boolean;
 	isIcon?: boolean;
 	isHidden?: boolean;
@@ -169,14 +172,14 @@ export type CellData = {
 export type RowData = {
 	rowId: string;
 	columns: CellData[];
-	details: Node;
+	details: ReactNode;
 	onClick?: (showDetails: boolean) => void;
 };
 export function InteractiveTableHeaderRow({
 	columns,
 }: {
 	columns: CellData[];
-}) {
+}): JSX.Element {
 	return (
 		<tr role="row" css={[tableRow, tableHeaderRow]}>
 			{columns.map((col, index) => (
@@ -194,6 +197,7 @@ export function InteractiveTableHeaderRow({
 												iconCell,
 												css`
 													-ms-grid-column: ${index + 1};
+													grid-column: ${index + 1};
 												`,
 										  ]
 										: ['']),
@@ -206,13 +210,17 @@ export function InteractiveTableHeaderRow({
 		</tr>
 	);
 }
-export function InteractiveTableFooterRow({ children }: { children: Node }) {
+export function InteractiveTableFooterRow({
+	children,
+}: {
+	children: ReactNode;
+}): JSX.Element {
 	return (
 		<tr role="row" css={[finalRow, yellowBackground]}>
 			<td
 				role="cell"
-				colSpan="5"
-				aria-colspan="5"
+				colSpan={5}
+				aria-colspan={5}
 				css={[tableCell, primaryTableCell]}
 			>
 				{children}
@@ -225,7 +233,7 @@ export function InteractiveTableRow({
 	columns,
 	details,
 	onClick = () => undefined,
-}: RowData) {
+}: RowData): JSX.Element {
 	const [showDetails, setShowDetails] = useState<boolean>(false);
 
 	function onRowClick() {
@@ -259,6 +267,7 @@ export function InteractiveTableRow({
 							iconCell,
 							css`
 								-ms-grid-column: ${index + 1};
+								grid-column: ${index + 1};
 							`,
 						]}
 					>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/comparison/interactiveTableContents.tsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/comparison/interactiveTableContents.tsx
@@ -2,9 +2,9 @@ import { css } from '@emotion/core';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import React from 'react';
+import { SvgFreeTrial } from 'components/icons/freeTrial';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import 'helpers/internationalisation/countryGroup';
-import { SvgFreeTrial } from 'components/icons/freeTrial';
 import { getLocalisedRows } from './interactiveTableRowContents';
 
 const iconSizeMobile = 28;

--- a/support-frontend/assets/pages/digital-subscription-landing/components/comparison/interactiveTableRowContents.tsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/comparison/interactiveTableRowContents.tsx
@@ -9,7 +9,7 @@ import {
 import { headline } from '@guardian/src-foundations/typography';
 import { SvgCheckmark } from '@guardian/src-icons';
 import React from 'react';
-import type { Node } from 'react';
+import type { ReactNode } from 'react';
 import 'helpers/internationalisation/countryGroup';
 import GridImage from 'components/gridImage/gridImage';
 import GridPicture from 'components/gridPicture/gridPicture';
@@ -240,31 +240,34 @@ const appFeatureHeadline = css`
 	color: ${brand[400]};
 `;
 
-const Padlock = () => (
-	<div aria-label="Not included" css={[indicators, greyBackground]}>
-		<SvgPadlock />
-	</div>
-);
+function Padlock(): JSX.Element {
+	return (
+		<div aria-label="Not included" css={[indicators, greyBackground]}>
+			<SvgPadlock />
+		</div>
+	);
+}
 
-const Checkmark = () => (
-	<div aria-label="Included" css={[indicators, checkmark, yellowBackground]}>
-		<SvgCheckmark />
-	</div>
-);
+function Checkmark(): JSX.Element {
+	return (
+		<div aria-label="Included" css={[indicators, checkmark, yellowBackground]}>
+			<SvgCheckmark />
+		</div>
+	);
+}
 
 type AppName = 'Guardian' | 'Editions';
 type AppFeatureWithIconPropTypes = {
 	appName: AppName;
-	children: Node;
-	// eslint-disable-next-line react/require-default-props
+	children: ReactNode;
 	heading?: string;
 };
 
-const AppFeatureWithIcon = ({
+function AppFeatureWithIcon({
 	appName,
 	heading = `The ${appName} App`,
 	children,
-}: AppFeatureWithIconPropTypes) => {
+}: AppFeatureWithIconPropTypes): JSX.Element {
 	const icon =
 		appName === 'Editions' ? <SvgEditionsIcon /> : <SvgLiveAppIcon />;
 	return (
@@ -274,7 +277,7 @@ const AppFeatureWithIcon = ({
 			{children}
 		</section>
 	);
-};
+}
 
 function trackRowClick(rowId: string) {
 	const trackingId = `Comparison_table-${rowId}_row`;

--- a/support-frontend/typescript-errors.json
+++ b/support-frontend/typescript-errors.json
@@ -1,2327 +1,2309 @@
 {
-    "errorCounts": {
-        "byCode": {
-            "TS1208": 1,
-            "TS2305": 21,
-            "TS2322": 128,
-            "TS2578": 8,
-            "TS2339": 26,
-            "TS2345": 99,
-            "TS7006": 60,
-            "TS7053": 12,
-            "TS7034": 5,
-            "TS7005": 10,
-            "TS6133": 9,
-            "TS7031": 18,
-            "TS2564": 2,
-            "TS2769": 14,
-            "TS2314": 5,
-            "TS2304": 5,
-            "TS2741": 5,
-            "TS2739": 14,
-            "TS2532": 4,
-            "TS2556": 3,
-            "TS2554": 31,
-            "TS2569": 2,
-            "TS2411": 1,
-            "TS7017": 4,
-            "TS2367": 4,
-            "TS2740": 5,
-            "TS2531": 2,
-            "TS7016": 1,
-            "TS2707": 1,
-            "TS2525": 5,
-            "TS2745": 2,
-            "TS7022": 1,
-            "TS2571": 3,
-            "TS2698": 6
-        },
-        "byPath": {
-            "assets/__mocks__/imageMock.ts": 1,
-            "assets/components/asyncronously/asyncronously.ts": 2,
-            "assets/components/content/content.tsx": 2,
-            "assets/components/footerCompliant/Footer.tsx": 4,
-            "assets/components/forms/customFields/options.tsx": 1,
-            "assets/components/forms/label.tsx": 2,
-            "assets/components/headers/header/header.tsx": 6,
-            "assets/components/headers/header/mobileMenuToggler.tsx": 1,
-            "assets/components/headers/mobileMenu/mobileMenu.tsx": 2,
-            "assets/components/headers/veggieBurgerButton/veggieBurgerButton.tsx": 2,
-            "assets/components/interactiveTable/interactiveTable.tsx": 1,
-            "assets/components/interactiveTable/interactiveTableRow.tsx": 3,
-            "assets/components/menu/menu.tsx": 2,
-            "assets/components/product/productOption.tsx": 1,
-            "assets/components/product/productOptionSmall.tsx": 1,
-            "assets/components/subscriptionCheckouts/layout.tsx": 1,
-            "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx": 6,
-            "assets/pages/digital-subscription-checkout/components/thankYou/pageSection.tsx": 1,
-            "assets/pages/digital-subscription-landing/components/comparison/comparisonTable.tsx": 3,
-            "assets/pages/digital-subscription-landing/components/comparison/interactiveTableRowContents.tsx": 1,
-            "assets/pages/paper-subscription-landing/components/content/linkTo.tsx": 4,
-            "assets/pages/subscriptions-landing/components/subscriptionsProduct.tsx": 2,
-            "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx": 4,
-            "assets/components/datePicker/datePickerHelpers.test.ts": 2,
-            "assets/components/directDebit/directDebitForm/directDebitForm.tsx": 10,
-            "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx": 5,
-            "assets/components/headers/links/links.tsx": 1,
-            "assets/components/marketingConsent/marketingConsent.tsx": 1,
-            "assets/components/page/page.tsx": 1,
-            "assets/components/page/pageTitle.tsx": 4,
-            "assets/components/priceLabel/priceLabel.tsx": 1,
-            "assets/components/subscriptionCheckouts/address/addressFields.tsx": 14,
-            "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx": 12,
-            "assets/components/subscriptionCheckouts/billingPeriodSelector.tsx": 2,
-            "assets/components/subscriptionCheckouts/personalDetails.tsx": 7,
-            "assets/components/subscriptionCheckouts/summary.tsx": 6,
-            "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx": 4,
-            "assets/helpers/__tests__/formValidation.ts": 29,
-            "assets/helpers/checkoutForm/checkoutForm.ts": 3,
-            "assets/helpers/globalsAndSwitches/globals.ts": 2,
-            "assets/helpers/internationalisation/localCurrencyCountry.ts": 9,
-            "assets/helpers/productPrice/__tests__/promotionsTests.ts": 14,
-            "assets/helpers/utilities/utilities.ts": 1,
-            "assets/hocs/canShow.tsx": 1,
-            "assets/hocs/withError.tsx": 1,
-            "assets/hocs/withLabel.tsx": 1,
-            "assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.tsx": 2,
-            "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx": 9,
-            "assets/pages/contributions-landing/components/SepaForm.tsx": 7,
-            "assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.tsx": 1,
-            "assets/pages/contributions-landing/contributionsLandingReducer.ts": 5,
-            "assets/pages/contributions-landing/setUserStateActions.ts": 3,
-            "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx": 9,
-            "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx": 4,
-            "assets/pages/digital-subscription-checkout/components/endSummary/endSummaryMobile.tsx": 1,
-            "assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.ts": 1,
-            "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx": 7,
-            "assets/pages/digital-subscription-landing/components/events/eventsModule.tsx": 1,
-            "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx": 4,
-            "assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.tsx": 1,
-            "assets/pages/paper-subscription-checkout/components/addDigiSubCta.tsx": 3,
-            "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx": 16,
-            "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx": 8,
-            "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx": 12,
-            "assets/pages/paper-subscription-checkout/helpers/options.ts": 2,
-            "assets/pages/paper-subscription-landing/components/content/prices.tsx": 1,
-            "assets/pages/paper-subscription-landing/components/hero/hero.tsx": 1,
-            "assets/pages/showcase/components/ctaContribute.tsx": 1,
-            "assets/pages/showcase/components/ctaSubscribe.tsx": 1,
-            "assets/pages/showcase/components/hero.tsx": 3,
-            "assets/pages/showcase/components/otherProduct.tsx": 1,
-            "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx": 7,
-            "assets/pages/subscriptions-redemption/api.ts": 1,
-            "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx": 7,
-            "assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx": 2,
-            "assets/pages/weekly-subscription-landing/components/content/prices.tsx": 1,
-            "assets/pages/contributions-landing/components/ContributionArticleCount.tsx": 3,
-            "assets/pages/paper-subscription-landing/components/content/tabAccordionRow.tsx": 1,
-            "assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx": 2,
-            "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx": 22,
-            "assets/components/paypalExpressButton/PayPalExpressButton.tsx": 1,
-            "assets/helpers/__tests__/urlTest.ts": 1,
-            "assets/helpers/csrf/csrfReducer.ts": 2,
-            "assets/helpers/internationalisation/__tests__/countryGroupTest.ts": 1,
-            "assets/helpers/internationalisation/__tests__/countryTest.ts": 1,
-            "assets/helpers/rendering/render.ts": 8,
-            "assets/pages/contributions-landing/contributionsLanding.tsx": 5,
-            "assets/pages/digital-subscription-checkout/thankYouContainer.ts": 2,
-            "assets/components/datePicker/datePicker.tsx": 2,
-            "assets/components/directDebit/__tests__/directDebitReducerTest.ts": 1,
-            "assets/components/directDebit/helpers/ajax.ts": 2,
-            "assets/components/marketingConsent/helpers.ts": 1,
-            "assets/components/marketingConsent/marketingConsentPaper.tsx": 2,
-            "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx": 13,
-            "assets/components/subscriptionCheckouts/address/__tests__/addressFieldsStore.ts": 1,
-            "assets/components/subscriptionCheckouts/addressSearch/__tests__/addressFieldsStore.ts": 1,
-            "assets/components/subscriptionCheckouts/stripeForm/stripeForm.tsx": 1,
-            "assets/helpers/__tests__/checkoutsTest.ts": 7,
-            "assets/helpers/__tests__/promiseTest.ts": 3,
-            "assets/helpers/contributions.ts": 2,
-            "assets/helpers/identityApis.ts": 1,
-            "assets/helpers/internationalisation/__tests__/currencyTest.ts": 1,
-            "assets/helpers/page/__tests__/pageTest.ts": 4,
-            "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts": 4,
-            "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts": 8,
-            "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts": 5,
-            "assets/helpers/productPrice/__tests__/productPricesTests.ts": 6,
-            "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts": 4,
-            "assets/helpers/productPrice/paperProductPrices.ts": 2,
-            "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts": 9,
-            "assets/pages/contributions-landing/components/AmazonPay/AmazonPayWallet.tsx": 1,
-            "assets/pages/contributions-landing/components/ContributionSubmit.tsx": 1,
-            "assets/pages/contributions-landing/components/ContributionTypeTabs.tsx": 2,
-            "assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx": 2,
-            "assets/pages/contributions-landing/contributionsLandingActions.ts": 1,
-            "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx": 8,
-            "assets/pages/digital-subscription-checkout/thankYouGift.tsx": 1,
-            "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.tsx": 2,
-            "assets/pages/promotion-terms/promotionTerms.tsx": 1,
-            "assets/pages/weekly-subscription-checkout/components/thankYou.tsx": 6,
-            "assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx": 1,
-            "assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx": 1,
-            "assets/helpers/rendering/ssrPages.ts": 1,
-            "assets/pages/contributions-landing/components/ExistingRecurringContributorErrorMessage.tsx": 1,
-            "assets/pages/paper-subscription-checkout/components/thankYou.tsx": 5,
-            "assets/pages/subscriptions-landing/components/subscriptionsLandingContent.tsx": 1,
-            "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx": 7,
-            "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts": 6,
-            "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts": 5,
-            "assets/helpers/forms/checkouts.ts": 1,
-            "assets/helpers/urls/externalLinks.ts": 3,
-            "assets/pages/contributions-landing/contributionsLandingInit.ts": 2,
-            "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.tsx": 1,
-            "assets/components/subscriptionCheckouts/addressSearch/addressResultsHelpers.ts": 1,
-            "assets/helpers/polyfills/layout.ts": 1,
-            "assets/components/subscriptionCheckouts/address/postcodeFinderStore.ts": 1,
-            "assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryThankYou.tsx": 1,
-            "assets/pages/digital-subscription-checkout/components/endSummary/endSummarySelector.ts": 1,
-            "assets/pages/paper-subscription-checkout/helpers/orderSummaryText.ts": 1,
-            "assets/helpers/__tests__/contributionsTests.ts": 3,
-            "assets/pages/showcase/components/otherProducts.tsx": 1,
-            "assets/helpers/globalsAndSwitches/settings.ts": 1,
-            "assets/helpers/polyfills/details.ts": 1,
-            "assets/pages/promotion-terms/weeklyTerms.tsx": 1,
-            "assets/pages/weekly-subscription-checkout/helpers/__tests__/deliveryDays.ts": 1,
-            "assets/helpers/productPrice/productOptions.ts": 2,
-            "assets/helpers/productPrice/subscriptions.ts": 1,
-            "assets/pages/paper-subscription-landing/components/content/deliveryTab.tsx": 1,
-            "assets/pages/promotion-terms/promotionTermsReducer.ts": 4
-        }
+  "errorCounts": {
+    "byCode": {
+      "TS1208": 1,
+      "TS2305": 21,
+      "TS2322": 128,
+      "TS2578": 8,
+      "TS2339": 26,
+      "TS2345": 99,
+      "TS7006": 60,
+      "TS7053": 12,
+      "TS7034": 5,
+      "TS7005": 10,
+      "TS6133": 9,
+      "TS7031": 18,
+      "TS2564": 2,
+      "TS2769": 14,
+      "TS2314": 5,
+      "TS2304": 5,
+      "TS2741": 5,
+      "TS2739": 14,
+      "TS2532": 4,
+      "TS2556": 3,
+      "TS2554": 31,
+      "TS2569": 2,
+      "TS2411": 1,
+      "TS7017": 4,
+      "TS2367": 4,
+      "TS2740": 5,
+      "TS2531": 2,
+      "TS7016": 1,
+      "TS2707": 1,
+      "TS2525": 5,
+      "TS2745": 2,
+      "TS7022": 1,
+      "TS2571": 3,
+      "TS2698": 6
     },
-    "TS1208": [
-        {
-            "path": "assets/__mocks__/imageMock.ts",
-            "message": "'imageMock.ts' cannot be compiled under '--isolatedModules' because it is considered a global script file. Add an import, export, or an empty 'export {}' statement to make it a module."
-        }
-    ],
-    "TS2305": [
-        {
-            "path": "assets/components/asyncronously/asyncronously.ts",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/components/content/content.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/components/footerCompliant/Footer.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/components/forms/customFields/options.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/components/forms/label.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/components/headers/header/header.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/components/headers/header/mobileMenuToggler.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/components/headers/mobileMenu/mobileMenu.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/components/headers/veggieBurgerButton/veggieBurgerButton.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/components/interactiveTable/interactiveTable.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/components/interactiveTable/interactiveTableRow.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/components/menu/menu.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/components/product/productOption.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/components/product/productOptionSmall.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/layout.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/thankYou/pageSection.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/comparison/comparisonTable.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/comparison/interactiveTableRowContents.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-landing/components/content/linkTo.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        },
-        {
-            "path": "assets/pages/subscriptions-landing/components/subscriptionsProduct.tsx",
-            "message": "Module '\"react\"' has no exported member 'Node'."
-        }
-    ],
-    "TS2322": [
-        {
-            "path": "assets/components/asyncronously/asyncronously.ts",
-            "message": "Type 'ComponentType<any>' is not assignable to type 'null'."
-        },
-        {
-            "path": "assets/components/content/content.tsx",
-            "message": "Type 'Option<string> | undefined' is not assignable to type 'string | undefined'."
-        },
-        {
-            "path": "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx",
-            "message": "Type '{ children: (Element | Element[])[]; style: { top: number; left: number; position: string; }; }' is not assignable to type 'IntrinsicAttributes & { children: any; }'."
-        },
-        {
-            "path": "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx",
-            "message": "Type '{ children: string[]; href: string; onClick: () => void; isSelected: boolean; }' is not assignable to type 'IntrinsicAttributes & itemProps & { href: string; }'."
-        },
-        {
-            "path": "assets/components/datePicker/datePickerHelpers.test.ts",
-            "message": "Type 'typeof MockDate' is not assignable to type 'DateConstructor'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-            "message": "Type 'string' is not assignable to type 'number | undefined'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-            "message": "Type 'string' is not assignable to type 'number | undefined'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-            "message": "Type 'string' is not assignable to type 'number | undefined'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
-            "message": "Type 'string' is not assignable to type 'number | undefined'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
-            "message": "Type '{ id: string; label: string; autoComplete: string; type: \"text\"; inputmode: string; pattern: string; value: string; onChange: (e: ChangeEvent<HTMLInputElement>) => void; error: string; minLength: number; maxLength: number; width: 10; }' is not assignable to type 'IntrinsicAttributes & Pick<TextInputProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | ... 280 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
-            "message": "Type '{ id: string; value: string; autoComplete: string; onChange: (e: ChangeEvent<HTMLInputElement>) => void; minLength: number; maxLength: number; type: \"text\"; inputmode: string; pattern: string; label: string; error: string; }' is not assignable to type 'IntrinsicAttributes & Pick<TextInputProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | ... 280 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
-            "message": "Type 'string' is not assignable to type 'boolean | undefined'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
-            "message": "Type 'EventHandler' is not assignable to type 'MouseEventHandler<HTMLButtonElement>'."
-        },
-        {
-            "path": "assets/components/forms/label.tsx",
-            "message": "Type 'Option<string>' is not assignable to type 'string | undefined'."
-        },
-        {
-            "path": "assets/components/headers/links/links.tsx",
-            "message": "Type '\"_blank\" | null' is not assignable to type 'HTMLAttributeAnchorTarget | undefined'."
-        },
-        {
-            "path": "assets/components/headers/mobileMenu/mobileMenu.tsx",
-            "message": "Type '{ width: number; } | null | undefined' is not assignable to type 'CSSProperties | undefined'."
-        },
-        {
-            "path": "assets/components/headers/veggieBurgerButton/veggieBurgerButton.tsx",
-            "message": "Type '{ children: any[]; 'aria-haspopup': Option<string>; onClick: Option<(...args: any[]) => any>; style: Option<{}>; className: string; ref: Option<(...args: any[]) => any>; }' is not assignable to type 'DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>'."
-        },
-        {
-            "path": "assets/components/interactiveTable/interactiveTableRow.tsx",
-            "message": "Type 'string' is not assignable to type 'number | undefined'."
-        },
-        {
-            "path": "assets/components/marketingConsent/marketingConsent.tsx",
-            "message": "Type '{ children: string; appearance: \"green\"; iconSide: \"right\"; \"aria-label\": string; onClick: () => void; icon: Element; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\"> & Partial<Pick<PropTypes, \"type\" | \"disabled\" | ... 4 more ... | \"aria-label\">> & Partial<...>'."
-        },
-        {
-            "path": "assets/components/menu/menu.tsx",
-            "message": "Type '{ children: any[]; className: any; \"data-is-selected\": boolean; }' is not assignable to type 'IntrinsicAttributes'."
-        },
-        {
-            "path": "assets/components/page/page.tsx",
-            "message": "Type 'string | null | undefined' is not assignable to type 'string | undefined'."
-        },
-        {
-            "path": "assets/components/page/pageTitle.tsx",
-            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-        },
-        {
-            "path": "assets/components/page/pageTitle.tsx",
-            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-        },
-        {
-            "path": "assets/components/page/pageTitle.tsx",
-            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-        },
-        {
-            "path": "assets/components/page/pageTitle.tsx",
-            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-        },
-        {
-            "path": "assets/components/priceLabel/priceLabel.tsx",
-            "message": "Type 'false | Record<string, any> | undefined' is not assignable to type 'string | undefined'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-            "message": "Type 'ReactNode' is not assignable to type 'Element'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-            "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-            "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-            "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-            "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-            "message": "Type 'null' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>> | undefined'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-            "message": "Type '{ children: any[]; onChange: (e: ChangeEvent<HTMLSelectElement>) => void; forwardRef: (r: any) => void; id: string; label: string; }' is not assignable to type 'IntrinsicAttributes & Pick<SelectProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"children\" | \"color\" | \"hidden\" | \"id\" | \"onChange\" | ... 257 more ... | \"supporting\"> & Partial<...> & Partial<...>'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-            "message": "Type 'null' is not assignable to type 'string | number | readonly string[] | undefined'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/billingPeriodSelector.tsx",
-            "message": "Type '{ children: Element[]; legend: string; role: string; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/billingPeriodSelector.tsx",
-            "message": "Type '{ label: string; value: string; supporting: string; offer: string; name: string; checked: boolean; onChange: () => Action; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"type\" | ... 278 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
-            "message": "Type '{ children: Element[]; id: string; label: string; hideLabel: true; error: string | undefined; role: string; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
-            "message": "Type 'null' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>> | undefined'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
-            "message": "Type 'Option<string> | undefined' is not assignable to type 'string | number | readonly string[] | undefined'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
-            "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/summary.tsx",
-            "message": "Type '{ className: any; productPrice: ProductPrice; billingPeriod: BillingPeriod; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"billingPeriod\" | \"productPrice\"> & Partial<Pick<PropTypes, \"orderIsAGift\" | \"giftStyles\">> & Partial<...>'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/summary.tsx",
-            "message": "Type '{ className: any; productPrice: ProductPrice; billingPeriod: BillingPeriod; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"billingPeriod\" | \"productPrice\"> & Partial<Pick<PropTypes, \"orderIsAGift\" | \"giftStyles\">> & Partial<...>'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/summary.tsx",
-            "message": "Type '{ className: any; productPrice: ProductPrice; billingPeriod: BillingPeriod; giftStyles: any; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"billingPeriod\" | \"productPrice\"> & Partial<Pick<PropTypes, \"orderIsAGift\" | \"giftStyles\">> & Partial<...>'."
-        },
-        {
-            "path": "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx",
-            "message": "Type '{ children: string; href: string; onClick: (...args: any[]) => any; appearance: \"primary\" | \"secondary\" | \"tertiary\" | \"tertiaryFeature\"; modifierClasses: string[]; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\" | \"href\"> & Partial<Pick<PropTypes, \"appearance\" | \"icon\" | \"iconSide\" | \"modifierClasses\" | \"aria-label\">> & Partial<...>'."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Type '{ countryCode: string; stateCode?: string | undefined; } | {}' is not assignable to type '{ countryCode: string; stateCode?: string | undefined; } | undefined'."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Type 'null' is not assignable to type 'string'."
-        },
-        {
-            "path": "assets/helpers/checkoutForm/checkoutForm.ts",
-            "message": "Type 'unknown' is not assignable to type 'string'."
-        },
-        {
-            "path": "assets/helpers/globalsAndSwitches/globals.ts",
-            "message": "Type 'unknown' is not assignable to type 'Settings'."
-        },
-        {
-            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-            "message": "Type 'string | null | undefined' is not assignable to type 'string | number | symbol'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-            "message": "Type 'null' is not assignable to type 'number | undefined'."
-        },
-        {
-            "path": "assets/helpers/utilities/utilities.ts",
-            "message": "Type 'string | null | undefined' is not assignable to type 'string'."
-        },
-        {
-            "path": "assets/hocs/canShow.tsx",
-            "message": "Type 'Omit<AugmentedProps<Props>, \"isShown\">' is not assignable to type 'IntrinsicAttributes & Props & { children?: ReactNode; }'."
-        },
-        {
-            "path": "assets/hocs/withError.tsx",
-            "message": "Type 'Omit<AugmentedProps<Props>, \"error\">' is not assignable to type 'IntrinsicAttributes & Props & { children?: ReactNode; }'."
-        },
-        {
-            "path": "assets/hocs/withLabel.tsx",
-            "message": "Type 'Omit<AugmentedProps<Props>, \"footer\" | \"label\" | \"optional\">' is not assignable to type 'IntrinsicAttributes & Props & { children?: ReactNode; }'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.tsx",
-            "message": "Type '{ children: string; type: \"button\"; onClick: () => void; \"aria-label\": string; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\"> & Partial<Pick<PropTypes, \"type\" | \"disabled\" | ... 4 more ... | \"aria-label\">> & Partial<...>'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-            "message": "Type 'false | \"Please select a payment method\"' is not assignable to type 'string | undefined'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-            "message": "Type 'false | Element' is not assignable to type 'Element'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-            "message": "Type 'false | Element[]' is not assignable to type 'Element'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-            "message": "Type 'RecentlySignedInExistingPaymentMethod' is not assignable to type 'string'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-            "message": "Type '{ '& + div': { display: string; width: string; margin: number; justifyContent: string; }; '& + div svg': { width: string; height: string; }; '&:not(:checked) + div svg': { filter: string; }; }' is not assignable to type 'SerializedStyles | SerializedStyles[] | undefined'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-            "message": "Type '{ '& + div': { display: string; width: string; margin: number; justifyContent: string; }; '& + div svg': { width: string; height: string; }; '&:not(:checked) + div svg': { filter: string; }; }' is not assignable to type 'SerializedStyles | SerializedStyles[] | undefined'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-            "message": "Type 'false | Element | undefined' is not assignable to type 'Element'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
-            "message": "Type 'string' is not assignable to type 'number | undefined'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
-            "message": "Type 'string | null' is not assignable to type 'string | number | readonly string[] | undefined'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
-            "message": "Type 'string | null' is not assignable to type 'string | undefined'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
-            "message": "Type 'string' is not assignable to type 'number | undefined'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
-            "message": "Type 'string' is not assignable to type 'number | undefined'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
-            "message": "Type 'string | null' is not assignable to type 'string | number | readonly string[] | undefined'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
-            "message": "Type 'string | null' is not assignable to type 'string | undefined'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.tsx",
-            "message": "Type '{ stripeKey: string; isTestUser: boolean; }' is not assignable to type 'IntrinsicAttributes & Omit<{ contributionType: keyof RegularContributionTypeMap<null> | \"ONE_OFF\"; checkoutFormHasBeenSubmitted: boolean; ... 9 more ...; isTestUser: boolean; } & { ...; } & { ...; }, \"csrf\" | ... 19 more ... | \"setStripeRecurringRecaptchaVerified\">'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
-            "message": "Type '{ Stripe: null; AmazonPay: null; }' is not assignable to type '{ Stripe: StripeHandler | null; }'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
-            "message": "Type '{ hasBegunLoading: false; amazonPayLibrary: { amazonLoginObject: null; amazonPaymentsObject: null; }; loginButtonReady: false; walletIsStale: false; orderReferenceId: null; paymentSelected: false; hasAccessToken: false; fatalError: false; amazonBillingAgreementConsentStatus: false; }' is not assignable to type 'AmazonPayData'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
-            "message": "Type '{ contributionType: keyof RegularContributionTypeMap<null> | \"ONE_OFF\"; showOtherAmount: boolean; formData: { otherAmounts: OtherAmounts; ... 5 more ...; email: string | null; }; ... 17 more ...; oneOffRecaptchaToken: string | null; }' is not assignable to type 'FormState'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/setUserStateActions.ts",
-            "message": "Type '(isSignedIn: boolean) => (arg0: (...args: any[]) => any) => void' is not assignable to type '(isSignedIn: boolean) => Action'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/setUserStateActions.ts",
-            "message": "Type '() => (arg0: (...args: any[]) => any) => void' is not assignable to type '() => Action'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/setUserStateActions.ts",
-            "message": "Type '(unsafeState: string) => (arg0: (...args: any[]) => any) => void' is not assignable to type '(stateField: string) => Action'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-            "message": "Type 'Promise<{ json: () => Promise<{ client_secret: string; }>; }>' is not assignable to type 'Promise<Response>'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx",
-            "message": "Type '{ image: Element; title: string; description: string; productPrice: ProductPrice; billingPeriod: \"Annual\" | \"Monthly\"; changeSubscription: string; isPatron: boolean; }' is not assignable to type 'IntrinsicAttributes & Pick<OrderSummaryPropTypes, \"title\" | \"image\" | \"billingPeriod\" | \"productPrice\" | \"isPatron\"> & Partial<...> & Partial<...>'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx",
-            "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx",
-            "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/endSummary/endSummaryMobile.tsx",
-            "message": "Type '{ orderIsAGift: Option<boolean> | undefined; }' is not assignable to type 'IntrinsicAttributes & Omit<EndSummaryProps, \"orderIsAGift\" | \"promotion\" | \"price\" | \"priceDescription\" | \"digitalGiftBillingPeriod\" | \"isPatron\">'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.ts",
-            "message": "Type '\"normal\"' is not assignable to type 'FontWeight | undefined'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/comparison/comparisonTable.tsx",
-            "message": "Type 'SerializedStyles' is not assignable to type 'string | string[] | undefined'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/comparison/comparisonTable.tsx",
-            "message": "Type 'string' is not assignable to type 'number | undefined'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
-            "message": "Type '{ icon: JSX.Element; description: string; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
-            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
-            "message": "Type '{ icon: JSX.Element; description: string; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
-            "message": "Type '{ icon: JSX.Element; description: JSX.Element; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
-            "message": "Type '{ icon: JSX.Element; description: JSX.Element; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
-            "message": "Type '{ icon: JSX.Element; description: string; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
-            "message": "Type 'SerializedStyles' is not assignable to type 'string[] | Option<string> | undefined'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/events/eventsModule.tsx",
-            "message": "Type 'SerializedStyles' is not assignable to type 'string | string[] | undefined'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx",
-            "message": "Type 'SerializedStyles | null' is not assignable to type 'SerializedStyles'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx",
-            "message": "Type 'SerializedStyles | null' is not assignable to type 'SerializedStyles'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.tsx",
-            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/addDigiSubCta.tsx",
-            "message": "Type 'string | SerializedStyles' is not assignable to type 'SerializedStyles'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-            "message": "Type '{ image: Element; total: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; includesDigiSub: boolean; digiSubPrice: string; changeSubscription: string; }' is not assignable to type 'IntrinsicAttributes & (Omit<Matching<{ fulfilmentOption: FulfilmentOptions; productOption: ProductOptions; billingPeriod: BillingPeriod; productPrices: ProductPrices; } & DispatchProp<...>, PropTypes>, \"productPrices\" | ... 2 more ... | \"productOption\"> | Omit<...>)'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
-            "message": "Type 'Promise<{ json: () => Promise<{ client_secret: string; }>; }>' is not assignable to type 'Promise<Response>'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-            "message": "Type '{ image: Element; total: ProductPrice; digiSubPrice: string; includesDigiSub: boolean; changeSubscription: string; productType: \"Paper\"; paymentStartDate: string; }' is not assignable to type 'IntrinsicAttributes & (Omit<Matching<{ fulfilmentOption: FulfilmentOptions; productOption: ProductOptions; billingPeriod: BillingPeriod; productPrices: ProductPrices; } & DispatchProp<...>, PropTypes>, \"productPrices\" | ... 2 more ... | \"productOption\"> | Omit<...>)'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-            "message": "Type '{ children: Element; modifierClasses: string[]; }' is not assignable to type 'IntrinsicAttributes & { children: any; }'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-            "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-            "message": "Type 'Option<string>' is not assignable to type 'string | undefined'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-            "message": "Type '{ children: Element[]; label: string; hideLabel: true; id: string; name: string; orienntation: string; error: string | undefined; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-            "message": "Type '{ inputId: string; value: string; label: string; name: string; checked: boolean; onChange: () => Action; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"type\" | ... 278 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-            "message": "Type '{ children: Element[]; label: string; hideLabel: true; id: string; error: string | undefined; legend: string; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-            "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-            "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/helpers/options.ts",
-            "message": "Type 'string' is not assignable to type 'PaperProductOptions'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-landing/components/content/prices.tsx",
-            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-landing/components/hero/hero.tsx",
-            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-        },
-        {
-            "path": "assets/pages/showcase/components/ctaContribute.tsx",
-            "message": "Type '{ children: string; icon: Element; appearance: \"secondary\"; href: string; onClick: () => void; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\" | \"href\"> & Partial<Pick<PropTypes, \"appearance\" | \"icon\" | \"iconSide\" | \"modifierClasses\" | \"aria-label\">> & Partial<...>'."
-        },
-        {
-            "path": "assets/pages/showcase/components/ctaSubscribe.tsx",
-            "message": "Type '{ children: string; icon: Element; href: string; onClick: () => void; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\" | \"href\"> & Partial<Pick<PropTypes, \"appearance\" | \"icon\" | \"iconSide\" | \"modifierClasses\" | \"aria-label\">> & Partial<...>'."
-        },
-        {
-            "path": "assets/pages/showcase/components/hero.tsx",
-            "message": "Type 'Element' is not assignable to type 'string'."
-        },
-        {
-            "path": "assets/pages/showcase/components/hero.tsx",
-            "message": "Type 'Element' is not assignable to type 'string'."
-        },
-        {
-            "path": "assets/pages/showcase/components/otherProduct.tsx",
-            "message": "Type '{ children: string; icon: Element; appearance: \"greyHollow\"; href: string; onClick: () => void; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\" | \"href\"> & Partial<Pick<PropTypes, \"appearance\" | \"icon\" | \"iconSide\" | \"modifierClasses\" | \"aria-label\">> & Partial<...>'."
-        },
-        {
-            "path": "assets/pages/subscriptions-landing/components/subscriptionsProduct.tsx",
-            "message": "Type 'Option<boolean> | undefined' is not assignable to type 'Option<boolean>'."
-        },
-        {
-            "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
-            "message": "Type '{ ctaButtonText: string; link: string; analyticsTracking: () => void; modifierClasses: string; }' is not assignable to type 'ProductButton'."
-        },
-        {
-            "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
-            "message": "Type '{ ctaButtonText: string; link: string; analyticsTracking: () => void; modifierClasses: string; }' is not assignable to type 'ProductButton'."
-        },
-        {
-            "path": "assets/pages/subscriptions-redemption/api.ts",
-            "message": "Type 'null' is not assignable to type 'RegularPaymentRequestAddress | undefined'."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
-            "message": "Type '{ children: Element; modifierClasses: string[]; }' is not assignable to type 'IntrinsicAttributes & { children: any; }'."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
-            "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
-            "message": "Type '{ inputId: string; value: string; label: string; name: string; checked: boolean; onChange: () => void; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"type\" | ... 278 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
-            "message": "Type '{ children: Element[]; id: string; error: string | undefined; legend: string; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
-            "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
-            "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx",
-            "message": "Type 'boolean | undefined' is not assignable to type 'boolean'."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx",
-            "message": "Type 'boolean | undefined' is not assignable to type 'boolean'."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-landing/components/content/prices.tsx",
-            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-        }
-    ],
-    "TS2578": [
-        {
-            "path": "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx",
-            "message": "Unused '@ts-expect-error' directive."
-        },
-        {
-            "path": "assets/components/footerCompliant/Footer.tsx",
-            "message": "Unused '@ts-expect-error' directive."
-        },
-        {
-            "path": "assets/components/interactiveTable/interactiveTableRow.tsx",
-            "message": "Unused '@ts-expect-error' directive."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/ContributionArticleCount.tsx",
-            "message": "Unused '@ts-expect-error' directive."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx",
-            "message": "Unused '@ts-expect-error' directive."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/addDigiSubCta.tsx",
-            "message": "Unused '@ts-expect-error' directive."
-        },
-        {
-            "path": "assets/pages/paper-subscription-landing/components/content/tabAccordionRow.tsx",
-            "message": "Unused '@ts-expect-error' directive."
-        },
-        {
-            "path": "assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx",
-            "message": "Unused '@ts-expect-error' directive."
-        }
-    ],
-    "TS2339": [
-        {
-            "path": "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx",
-            "message": "Property 'getBoundingClientRect' does not exist on type 'never'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-            "message": "Property 'value' does not exist on type 'EventTarget'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-            "message": "Property 'value' does not exist on type 'EventTarget'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-            "message": "Property 'value' does not exist on type 'EventTarget'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-            "message": "Property 'checked' does not exist on type 'EventTarget'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Property 'value' does not exist on type 'EventTarget'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Property 'value' does not exist on type 'EventTarget'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Property 'value' does not exist on type 'EventTarget'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Property 'checked' does not exist on type 'EventTarget'."
-        },
-        {
-            "path": "assets/components/footerCompliant/Footer.tsx",
-            "message": "Property 'showPrivacyManager' does not exist on type 'never'."
-        },
-        {
-            "path": "assets/components/paypalExpressButton/PayPalExpressButton.tsx",
-            "message": "Property 'Button' does not exist on type '{ FUNDING: { CREDIT: unknown; }; }'."
-        },
-        {
-            "path": "assets/helpers/__tests__/urlTest.ts",
-            "message": "Property 'jsdom' does not exist on type 'typeof globalThis'."
-        },
-        {
-            "path": "assets/helpers/csrf/csrfReducer.ts",
-            "message": "Property 'csrf' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
-        },
-        {
-            "path": "assets/helpers/csrf/csrfReducer.ts",
-            "message": "Property 'csrf' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
-        },
-        {
-            "path": "assets/helpers/internationalisation/__tests__/countryGroupTest.ts",
-            "message": "Property 'jsdom' does not exist on type 'typeof globalThis'."
-        },
-        {
-            "path": "assets/helpers/internationalisation/__tests__/countryTest.ts",
-            "message": "Property 'jsdom' does not exist on type 'typeof globalThis'."
-        },
-        {
-            "path": "assets/helpers/rendering/render.ts",
-            "message": "Property 'settings' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
-        },
-        {
-            "path": "assets/helpers/rendering/render.ts",
-            "message": "Property 'settings' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/ContributionArticleCount.tsx",
-            "message": "Property 'showPrivacyManager' does not exist on type 'never'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
-            "message": "Property 'polyfillScriptLoaded' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
-            "message": "Property 'polyfillVersion' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
-            "message": "Property 'polyfillVersion' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/thankYouContainer.ts",
-            "message": "Property 'common' does not exist on type 'DefaultRootState'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-            "message": "Property 'checked' does not exist on type 'EventTarget'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-            "message": "Property 'checked' does not exist on type 'EventTarget'."
-        },
-        {
-            "path": "assets/pages/showcase/components/hero.tsx",
-            "message": "Property 'title' does not exist on type '{ title: string; caption: Element; images: { first: string; second: string; third: string; fourth: string; }; } | { title: string; caption: Element; images: { first: string; second: string; third: string; fourth: string; }; } | { ...; }'."
-        }
-    ],
-    "TS2345": [
-        {
-            "path": "assets/components/datePicker/datePicker.tsx",
-            "message": "Argument of type '{ [x: string]: string | false; dateError: string; dateValidated: false; }' is not assignable to parameter of type 'StateTypes | ((prevState: Readonly<StateTypes>, props: Readonly<PropTypes>) => StateTypes | Pick<StateTypes, keyof StateTypes> | null) | Pick<...> | null'."
-        },
-        {
-            "path": "assets/components/datePicker/datePicker.tsx",
-            "message": "Argument of type '{ [x: string]: string | false; dateError: string; dateValidated: false; }' is not assignable to parameter of type 'StateTypes | ((prevState: Readonly<StateTypes>, props: Readonly<PropTypes>) => StateTypes | Pick<StateTypes, keyof StateTypes> | null) | Pick<...> | null'."
-        },
-        {
-            "path": "assets/components/directDebit/__tests__/directDebitReducerTest.ts",
-            "message": "Argument of type '{}' is not assignable to parameter of type 'Action'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-            "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-            "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Argument of type '{ [x: number]: any; }' is not assignable to parameter of type 'StateTypes | Pick<StateTypes, keyof StateTypes> | ((prevState: Readonly<StateTypes>, props: Readonly<PropTypes>) => StateTypes | ... 1 more ... | null) | null'."
-        },
-        {
-            "path": "assets/components/directDebit/helpers/ajax.ts",
-            "message": "Argument of type '{ method: string; headers: { 'Content-Type': string; 'Csrf-Token': string; }; credentials: string; body: string; }' is not assignable to parameter of type 'RequestInit'."
-        },
-        {
-            "path": "assets/components/footerCompliant/Footer.tsx",
-            "message": "Argument of type 'CMP' is not assignable to parameter of type 'SetStateAction<null>'."
-        },
-        {
-            "path": "assets/components/marketingConsent/helpers.ts",
-            "message": "Argument of type '{ method: string; headers: { 'Content-Type': string; 'Csrf-Token': string; }; credentials: string; body: string; }' is not assignable to parameter of type 'RequestInit'."
-        },
-        {
-            "path": "assets/components/marketingConsent/marketingConsentPaper.tsx",
-            "message": "Argument of type 'typeof MarketingConsent' is not assignable to parameter of type 'ComponentType<Matching<{ confirmOptIn: any; email: string; csrf: any; } & { onClick: (email: string, csrf: Csrf) => void; }, ButtonPropTypes & { error: boolean; }>>'."
-        },
-        {
-            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-            "message": "Argument of type '(dispatch: Dispatch<SetCountryChangedAction | SetCountryAction>) => void' is not assignable to parameter of type 'Action'."
-        },
-        {
-            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-            "message": "Argument of type '(dispatch: Dispatch<Action>, getState: () => CheckoutState) => void' is not assignable to parameter of type 'Action'."
-        },
-        {
-            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-            "message": "Argument of type '(dispatch: Dispatch<Action>, getState: () => CheckoutState) => void' is not assignable to parameter of type 'Action'."
-        },
-        {
-            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-            "message": "Argument of type '(dispatch: Dispatch<Action>, getState: () => CheckoutState) => void' is not assignable to parameter of type 'Action'."
-        },
-        {
-            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-            "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
-        },
-        {
-            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-            "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
-        },
-        {
-            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-            "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
-        },
-        {
-            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-            "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
-        },
-        {
-            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-            "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ hasLoaded: boolean; csrf: Csrf; productPrices: ProductPrices; currencyId: IsoCurrency; isTestUser: boolean; amount: number; submissionError: Option<...>; wasClicked: boolean; } & { ...; }, PropTypes>>'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/__tests__/addressFieldsStore.ts",
-            "message": "Argument of type '{ fields: { country: string; city: null; lineOne: null; lineTwo: null; postCode: null; state: null; formErrors: never[]; }; }' is not assignable to parameter of type 'CombinedState<{ fields: AddressFieldsState; postcode: PostcodeFinderState; }>'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-            "message": "Argument of type 'typeof AddressFields' is not assignable to parameter of type 'ComponentType<Matching<{ formErrors: FormErrors; traverseState: (arg0: any) => State; scope: AddressType; country: string; state: string | null; lineOne: Option<string>; lineTwo: Option<...>; postCode: Option<...>; city: Option<...>; countries: Record<...>; } & { ...; }, ClassAttributes<...> & ... 2 more ... & { ......'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/addressSearch/__tests__/addressFieldsStore.ts",
-            "message": "Argument of type '{ fields: { country: string; city: null; lineOne: null; lineTwo: null; postCode: null; state: null; formErrors: never[]; }; }' is not assignable to parameter of type 'CombinedState<{ fields: AddressFieldsState; postcode: PostcodeFinderState; }>'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/stripeForm/stripeForm.tsx",
-            "message": "Argument of type 'unknown' is not assignable to parameter of type 'SetStateAction<Option<string>>'."
-        },
-        {
-            "path": "assets/helpers/__tests__/checkoutsTest.ts",
-            "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
-        },
-        {
-            "path": "assets/helpers/__tests__/checkoutsTest.ts",
-            "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
-        },
-        {
-            "path": "assets/helpers/__tests__/checkoutsTest.ts",
-            "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
-        },
-        {
-            "path": "assets/helpers/__tests__/checkoutsTest.ts",
-            "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
-        },
-        {
-            "path": "assets/helpers/__tests__/checkoutsTest.ts",
-            "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
-        },
-        {
-            "path": "assets/helpers/__tests__/checkoutsTest.ts",
-            "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Argument of type '{ ONE_OFF: string; MONTHLY: string; ANNUAL: string; }' is not assignable to parameter of type 'SelectedAmounts'."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Argument of type '{ ONE_OFF: string; MONTHLY: string; ANNUAL: string; }' is not assignable to parameter of type 'SelectedAmounts'."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Argument of type '{ ONE_OFF: string; MONTHLY: string; ANNUAL: string; }' is not assignable to parameter of type 'SelectedAmounts'."
-        },
-        {
-            "path": "assets/helpers/__tests__/promiseTest.ts",
-            "message": "Argument of type '(done: any, fail: any) => void' is not assignable to parameter of type 'ProvidesCallback | undefined'."
-        },
-        {
-            "path": "assets/helpers/contributions.ts",
-            "message": "Argument of type 'string | number | null' is not assignable to parameter of type 'string'."
-        },
-        {
-            "path": "assets/helpers/identityApis.ts",
-            "message": "Argument of type '(resp: {    userType: UserType;}) => UserType' is not assignable to parameter of type '(value: Record<string, unknown>) => \"current\" | \"new\" | \"guest\" | PromiseLike<\"current\" | \"new\" | \"guest\">'."
-        },
-        {
-            "path": "assets/helpers/internationalisation/__tests__/currencyTest.ts",
-            "message": "Argument of type '\"ZZ\"' is not assignable to parameter of type 'CountryGroupId'."
-        },
-        {
-            "path": "assets/helpers/page/__tests__/pageTest.ts",
-            "message": "Argument of type '{ campaign: string; referrerAcquisitionData: { referrerPageviewId: null; campaignCode: null; componentId: null; componentType: null; source: null; abTests: never[]; queryParameters: never[]; }; internationalisation: { ...; }; abParticipations: {}; otherQueryParams: never[]; settings: { ...; }; }' is not assignable to parameter of type 'CommonState'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts",
-            "message": "Argument of type '{ 'United Kingdom': { Collection: { SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ......' is not assignable to parameter of type 'ProductPrices'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts",
-            "message": "Argument of type '{ 'United Kingdom': { Collection: { SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ......' is not assignable to parameter of type 'ProductPrices'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts",
-            "message": "Argument of type '{ 'United Kingdom': { Collection: { SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ......' is not assignable to parameter of type 'ProductPrices'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts",
-            "message": "Argument of type '{ 'United Kingdom': { Collection: { SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ......' is not assignable to parameter of type 'ProductPrices'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
-            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { ...; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
-            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
-            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { ...; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
-            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
-            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { ...; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
-            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
-            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { ...; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
-            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
-            "message": "Argument of type '{ price: number; currency: string; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { amount: number; durationMonths: number; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
-            "message": "Argument of type '{ price: number; currency: string; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
-            "message": "Argument of type '{ price: number; currency: string; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
-            "message": "Argument of type '{ price: number; currency: string; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { amount: number; durationMonths: number; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
-            "message": "Argument of type '{ price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { price: number; periodLength: number; periodType: string; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
-            "message": "Argument of type '{ 'United Kingdom': { Collection: { Weekend: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; NoProductOptions: { Monthly: { GBP: { ...; }; }; }; }; NoFulfilmentOptions: { ...; }; }; }' is not assignable to parameter of type 'ProductPrices'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
-            "message": "Argument of type '{ 'United Kingdom': { Collection: { Weekend: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; NoProductOptions: { Monthly: { GBP: { ...; }; }; }; }; NoFulfilmentOptions: { ...; }; }; }' is not assignable to parameter of type 'ProductPrices'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
-            "message": "Argument of type '{ 'United Kingdom': { Collection: { Weekend: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; NoProductOptions: { Monthly: { GBP: { ...; }; }; }; }; NoFulfilmentOptions: { ...; }; }; }' is not assignable to parameter of type 'ProductPrices'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
-            "message": "Argument of type '{ 'United Kingdom': { Collection: { Sunday: { Monthly: { GBP: { price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: number; introductoryPrice: { ...; }; }[]; }; }; }; }; }; }' is not assignable to parameter of type 'ProductPrices'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
-            "message": "Argument of type '\"8.99\"' is not assignable to parameter of type 'number | null | undefined'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-            "message": "Argument of type 'null' is not assignable to parameter of type 'Promotion | undefined'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-            "message": "Argument of type '{}' is not assignable to parameter of type 'Promotion'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-            "message": "Argument of type '{ discountedPrice: number; }' is not assignable to parameter of type 'Promotion'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-            "message": "Argument of type '{ discountedPrice: number; }' is not assignable to parameter of type 'Promotion'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-            "message": "Argument of type '({ name: string; description: string; promoCode: number; discountedPrice: number; introductoryPrice?: undefined; } | { name: string; description: string; promoCode: number; introductoryPrice: { ...; }; discountedPrice?: undefined; })[]' is not assignable to parameter of type 'Promotion[]'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { price: number; periodLength: number; periodType: string; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-            "message": "Argument of type '{ name: string; description: string; promoCode: string; introductoryPrice: { price: number; periodLength: number; periodType: string; }; }' is not assignable to parameter of type 'Promotion'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts",
-            "message": "Argument of type '{ 'United Kingdom': { RestOfWorld: { NoProductOptions: { Quarterly: { GBP: { price: number; currency: string; promotions: never[]; }; }; SixWeekly: { GBP: { price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { ...; }; }[]; }; }; Annual: { ...; }; }...' is not assignable to parameter of type 'ProductPrices'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts",
-            "message": "Argument of type '{ 'United Kingdom': { RestOfWorld: { NoProductOptions: { Quarterly: { GBP: { price: number; currency: string; promotions: never[]; }; }; SixWeekly: { GBP: { price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { ...; }; }[]; }; }; Annual: { ...; }; }...' is not assignable to parameter of type 'ProductPrices'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts",
-            "message": "Argument of type '{ 'United Kingdom': { RestOfWorld: { NoProductOptions: { Quarterly: { GBP: { price: number; currency: string; promotions: never[]; }; }; SixWeekly: { GBP: { price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { ...; }; }[]; }; }; Annual: { ...; }; }...' is not assignable to parameter of type 'ProductPrices'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts",
-            "message": "Argument of type '{ 'United Kingdom': { RestOfWorld: { NoProductOptions: { Quarterly: { GBP: { price: number; currency: string; promotions: never[]; }; }; SixWeekly: { GBP: { price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { ...; }; }[]; }; }; Annual: { ...; }; }...' is not assignable to parameter of type 'ProductPrices'."
-        },
-        {
-            "path": "assets/helpers/productPrice/paperProductPrices.ts",
-            "message": "Argument of type 'FulfilmentOptions | null | undefined' is not assignable to parameter of type 'FulfilmentOptions | undefined'."
-        },
-        {
-            "path": "assets/helpers/productPrice/paperProductPrices.ts",
-            "message": "Argument of type 'FulfilmentOptions | null | undefined' is not assignable to parameter of type 'FulfilmentOptions | undefined'."
-        },
-        {
-            "path": "assets/helpers/rendering/render.ts",
-            "message": "Argument of type 'unknown' is not assignable to parameter of type 'Error'."
-        },
-        {
-            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-            "message": "Argument of type '{ field: string; message: string; }[]' is not assignable to parameter of type 'FormError<FormField>[]'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/AmazonPay/AmazonPayWallet.tsx",
-            "message": "Argument of type '(props: PropTypes) => Element | null' is not assignable to parameter of type 'ComponentType<Matching<{ amazonPayData: AmazonPayData; checkoutFormHasBeenSubmitted: boolean; } & { setAmazonPayWalletIsStale: (isReady: boolean) => Action; setAmazonPayOrderReferenceId: (orderReferenceId: string) => void; setAmazonPayPaymentSelected: (paymentSelected: boolean) => void; setAmazonPayBillingAgreementI...'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/ContributionArticleCount.tsx",
-            "message": "Argument of type 'CMP' is not assignable to parameter of type 'SetStateAction<null>'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/ContributionSubmit.tsx",
-            "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ currency: IsoCurrency; contributionType: keyof RegularContributionTypeMap<null> | \"ONE_OFF\"; isWaiting: boolean; paymentMethod: PaymentMethod; ... 9 more ...; amazonPayData: AmazonPayData; } & { ...; }, PropTypes>>'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/ContributionTypeTabs.tsx",
-            "message": "Argument of type 'string' is not assignable to parameter of type 'PaymentMethod'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-            "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ countryId: string; countryGroupId: CountryGroupId; currency: IsoCurrency; contributionType: keyof RegularContributionTypeMap<null> | \"ONE_OFF\"; ... 7 more ...; checkoutFormHasBeenSubmitted: boolean; } & { ...; }, PropTypes>>'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx",
-            "message": "Argument of type '(clientSecret: string) => Promise<Stripe3DSResult>' is not assignable to parameter of type '(clientSecret: string) => Promise<PaymentIntentResult>'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx",
-            "message": "Argument of type 'unknown' is not assignable to parameter of type 'string'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
-            "message": "Argument of type '(dispatch: Dispatch, getState: () => State) => void' is not assignable to parameter of type 'AnyAction'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/contributionsLandingActions.ts",
-            "message": "Argument of type '(clientSecret: string) => Promise<PaymentIntentResult>' is not assignable to parameter of type '(clientSecret: string) => Promise<Stripe3DSResult>'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-            "message": "Argument of type '\"\"' is not assignable to parameter of type 'BillingPeriod'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx",
-            "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ country: string; formErrors: FormError<FormField>[]; submissionError: Option<ErrorReason>; productPrices: ProductPrices; ... 31 more ...; salesforceCaseId?: string | undefined; } & { ...; }, FormFields & ... 1 more ... & { ...; }>>'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
-            "message": "Argument of type '\"\"' is not assignable to parameter of type 'BillingPeriod'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/thankYouContainer.ts",
-            "message": "Argument of type 'DefaultRootState' is not assignable to parameter of type 'AnyCheckoutState'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/thankYouGift.tsx",
-            "message": "Argument of type 'typeof ThankYouGift' is not assignable to parameter of type 'ComponentType<Matching<{ giftDeliveryDate: Option<string>; giftRecipient: Option<string>; } & DispatchProp<AnyAction>, PropTypes>>'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx",
-            "message": "Argument of type '{ positive: true; negative: false; }' is not assignable to parameter of type 'SetStateAction<{ positive: boolean; negative: boolean; open: boolean; }>'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.tsx",
-            "message": "Argument of type 'typeof PaperOrderSummary' is not assignable to parameter of type 'ComponentType<Matching<{ fulfilmentOption: FulfilmentOptions; productOption: ProductOptions; billingPeriod: BillingPeriod; productPrices: ProductPrices; } & DispatchProp<...>, PropTypes>>'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-            "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ formErrors: FormError<FormField>[]; submissionError: Option<ErrorReason>; productPrices: ProductPrices; billingAddressErrors: FormErrors; ... 33 more ...; salesforceCaseId?: string | undefined; } & { ...; }, FormFields & ... 1 more ... & { ...; }>>'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/helpers/options.ts",
-            "message": "Argument of type 'string' is not assignable to parameter of type '\"Saturday\" | \"Sunday\" | \"Weekend\" | \"Sixday\" | \"Everyday\"'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx",
-            "message": "Argument of type 'null' is not assignable to parameter of type 'string'."
-        },
-        {
-            "path": "assets/pages/promotion-terms/promotionTerms.tsx",
-            "message": "Argument of type 'ReduxState<{ productPrices: ProductPrices | null | undefined; promotionTerms: any; countryGroupId: CountryGroupId; }>' is not assignable to parameter of type 'State'."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
-            "message": "Argument of type 'DefaultRootState' is not assignable to parameter of type 'AnyCheckoutState'."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
-            "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ billingCountry: string; deliveryCountry: string; formErrors: FormError<FormField>[]; submissionError: Option<ErrorReason>; productPrices: ProductPrices; ... 31 more ...; salesforceCaseId?: string | undefined; } & { ...; }, FormFields & ... 1 more ... & { ...; }>>'."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx",
-            "message": "Argument of type 'Promotion | undefined' is not assignable to parameter of type 'Promotion | null'."
-        }
-    ],
-    "TS7006": [
-        {
-            "path": "assets/components/datePicker/datePickerHelpers.test.ts",
-            "message": "Parameter 'param' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-            "message": "Parameter 'state' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx",
-            "message": "Parameter 'state' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Parameter 'state' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Parameter 'field' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Parameter 'dispatchUpdate' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Parameter 'event' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Parameter 'event' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Parameter 'event' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/marketingConsent/marketingConsentPaper.tsx",
-            "message": "Parameter 'state' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-            "message": "Parameter 'ownProps' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-            "message": "Parameter 'billingPeriod' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-            "message": "Parameter 'trackingId' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-            "message": "Parameter 'product' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-            "message": "Parameter 'e' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-            "message": "Parameter 'r' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-            "message": "Parameter 'result' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-            "message": "Parameter 'key' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
-            "message": "Parameter 'e' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
-            "message": "Parameter 'e' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
-            "message": "Parameter 'e' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
-            "message": "Parameter 'e' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/summary.tsx",
-            "message": "Parameter 'props' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx",
-            "message": "Parameter 'isFeature' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx",
-            "message": "Parameter 'index' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx",
-            "message": "Parameter 'hierarchy' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/helpers/__tests__/checkoutsTest.ts",
-            "message": "Parameter 'key' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/helpers/__tests__/promiseTest.ts",
-            "message": "Parameter 'done' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/helpers/__tests__/promiseTest.ts",
-            "message": "Parameter 'fail' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/helpers/rendering/render.ts",
-            "message": "Parameter 'opts' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/helpers/rendering/ssrPages.ts",
-            "message": "Parameter 'content' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.tsx",
-            "message": "Parameter 'response' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/ExistingRecurringContributorErrorMessage.tsx",
-            "message": "Parameter 'event' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-            "message": "Parameter 'commonState' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-            "message": "Parameter 'initialState' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-            "message": "Parameter 'component' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
-            "message": "Parameter 'commonState' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
-            "message": "Parameter 'initialState' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
-            "message": "Parameter 'component' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-            "message": "Parameter 'searchText' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-            "message": "Parameter 'content' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-            "message": "Parameter 'node' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-            "message": "Parameter 'element' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-            "message": "Parameter 'originalState' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-            "message": "Parameter 'component' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
-            "message": "Parameter 'initialState' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
-            "message": "Parameter 'initialState' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
-            "message": "Parameter 'component' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
-            "message": "Parameter 'fulfilmentOption' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
-            "message": "Parameter 'item' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-landing/components/content/linkTo.tsx",
-            "message": "Parameter 'tab' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-landing/components/content/linkTo.tsx",
-            "message": "Parameter 'activeTab' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/subscriptions-landing/components/subscriptionsLandingContent.tsx",
-            "message": "Parameter 'index' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
-            "message": "Parameter 'billingPeriod' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
-            "message": "Parameter 'billingPeriod' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
-            "message": "Parameter 'isPending' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
-            "message": "Parameter 'orderIsGift' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
-            "message": "Parameter 'initialState' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
-            "message": "Parameter 'initialState' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
-            "message": "Parameter 'component' implicitly has an 'any' type."
-        }
-    ],
-    "TS7053": [
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Element implicitly has an 'any' type because expression of type 'any' can't be used to index type 'Readonly<StateTypes>'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<PropTypes> & Readonly<{ children?: ReactNode; }>'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
-        },
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
-        },
-        {
-            "path": "assets/helpers/contributions.ts",
-            "message": "Element implicitly has an 'any' type because expression of type 'number' can't be used to index type '{ '1': string; '2': string; '5': string; '6': string; '7': string; '10': string; '15': string; '20': string; '25': string; '30': string; '35': string; '40': string; '50': string; '75': string; '100': string; '125': string; '166': string; '200': string; ... 7 more ...; '16000': string; }'."
-        },
-        {
-            "path": "assets/helpers/globalsAndSwitches/globals.ts",
-            "message": "Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-            "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ... 7 more ...; EverydayPlus: { ...; ...'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
-            "message": "Element implicitly has an 'any' type because expression of type 'any' can't be used to index type 'Record<FulfilmentOptions, string[]>'."
-        }
-    ],
-    "TS7034": [
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Variable 'cardErrors' implicitly has type 'any[]' in some locations where its type cannot be determined."
-        },
-        {
-            "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
-            "message": "Variable 'testCopy' implicitly has type 'any' in some locations where its type cannot be determined."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
-            "message": "Variable 'productPrices' implicitly has type 'any' in some locations where its type cannot be determined."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
-            "message": "Variable 'productOptions' implicitly has type 'any' in some locations where its type cannot be determined."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-            "message": "Variable 'props' implicitly has type 'any' in some locations where its type cannot be determined."
-        }
-    ],
-    "TS7005": [
-        {
-            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-            "message": "Variable 'cardErrors' implicitly has an 'any[]' type."
-        },
-        {
-            "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
-            "message": "Variable 'testCopy' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
-            "message": "Variable 'testCopy' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
-            "message": "Variable 'testCopy' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
-            "message": "Variable 'testCopy' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
-            "message": "Variable 'testCopy' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
-            "message": "Variable 'productOptions' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
-            "message": "Variable 'productPrices' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
-            "message": "Variable 'productOptions' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-            "message": "Variable 'props' implicitly has an 'any' type."
-        }
-    ],
-    "TS6133": [
-        {
-            "path": "assets/components/directDebit/helpers/ajax.ts",
-            "message": "'isTestUser' is declared but its value is never read."
-        },
-        {
-            "path": "assets/helpers/forms/checkouts.ts",
-            "message": "'allSwitches' is declared but its value is never read."
-        },
-        {
-            "path": "assets/helpers/urls/externalLinks.ts",
-            "message": "'product' is declared but its value is never read."
-        },
-        {
-            "path": "assets/helpers/urls/externalLinks.ts",
-            "message": "'countryGroupId' is declared but its value is never read."
-        },
-        {
-            "path": "assets/helpers/urls/externalLinks.ts",
-            "message": "'countryGroupId' is declared but its value is never read."
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/ContributionTypeTabs.tsx",
-            "message": "'renderControl' is declared but its value is never read."
-        },
-        {
-            "path": "assets/pages/contributions-landing/contributionsLandingInit.ts",
-            "message": "'selectAmount' is declared but its value is never read."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.tsx",
-            "message": "'dispatch' is declared but its value is never read."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-            "message": "'content' is declared but its value is never read."
-        }
-    ],
-    "TS7031": [
-        {
-            "path": "assets/components/headers/header/header.tsx",
-            "message": "Binding element 'menuRef' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/headers/header/header.tsx",
-            "message": "Binding element 'logoRef' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/headers/header/header.tsx",
-            "message": "Binding element 'containerRef' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-            "message": "Binding element 'lineOne' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-            "message": "Binding element 'lineTwo' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-            "message": "Binding element 'city' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-            "message": "Binding element 'onClick' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-            "message": "Binding element 'isLoading' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-            "message": "Binding element 'initialState' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-            "message": "Binding element 'children' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
-            "message": "Binding element 'initialState' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
-            "message": "Binding element 'children' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-            "message": "Binding element 'initialState' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-            "message": "Binding element 'children' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
-            "message": "Binding element 'initialState' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
-            "message": "Binding element 'children' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
-            "message": "Binding element 'initialState' implicitly has an 'any' type."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
-            "message": "Binding element 'children' implicitly has an 'any' type."
-        }
-    ],
-    "TS2564": [
-        {
-            "path": "assets/components/headers/header/header.tsx",
-            "message": "Property 'observer' has no initializer and is not definitely assigned in the constructor."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-            "message": "Property 'selectRef' has no initializer and is not definitely assigned in the constructor."
-        }
-    ],
-    "TS2769": [
-        {
-            "path": "assets/components/headers/header/header.tsx",
-            "message": "No overload matches this call."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-            "message": "No overload matches this call."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-            "message": "No overload matches this call."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/addressSearch/addressResultsHelpers.ts",
-            "message": "No overload matches this call."
-        },
-        {
-            "path": "assets/helpers/polyfills/layout.ts",
-            "message": "No overload matches this call."
-        },
-        {
-            "path": "assets/helpers/rendering/render.ts",
-            "message": "No overload matches this call."
-        },
-        {
-            "path": "assets/helpers/rendering/render.ts",
-            "message": "No overload matches this call."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-            "message": "No overload matches this call."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
-            "message": "No overload matches this call."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-            "message": "No overload matches this call."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
-            "message": "No overload matches this call."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
-            "message": "No overload matches this call."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
-            "message": "No overload matches this call."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
-            "message": "No overload matches this call."
-        }
-    ],
-    "TS2314": [
-        {
-            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-            "message": "Generic type '$Call' requires 1 type argument(s)."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/postcodeFinderStore.ts",
-            "message": "Generic type '$Call' requires 1 type argument(s)."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/summary.tsx",
-            "message": "Generic type '$Call' requires 1 type argument(s)."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryThankYou.tsx",
-            "message": "Generic type '$Call' requires 1 type argument(s)."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.tsx",
-            "message": "Generic type '$Call' requires 1 type argument(s)."
-        }
-    ],
-    "TS2304": [
-        {
-            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-            "message": "Cannot find name 'GlobalState'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-            "message": "Cannot find name 'GlobalState'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-            "message": "Cannot find name 'GlobalState'."
-        },
-        {
-            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-            "message": "Cannot find name 'Stage'."
-        },
-        {
-            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-            "message": "Cannot find name 'Stage'."
-        }
-    ],
-    "TS2741": [
-        {
-            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-            "message": "Property 'label' is missing in type '{ onKeyPress: (e: KeyboardEvent<HTMLInputElement>) => void; css: SerializedStyles; name: string; width: 10; }' but required in type 'Pick<TextInputProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"id\" | \"onChange\" | \"value\" | \"dir\" | \"size\" | ... 275 more ... | \"enterKeyHint\">'."
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
-            "message": "Property 'value' is missing in type '{ id: string; image: any; label: string; name: string; checked: boolean; onChange: (...args: any[]) => any; }' but required in type 'Pick<RadioProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"type\" | \"id\" | \"onChange\" | \"value\" | \"dir\" | \"size\" | ... 273 more ... | \"enterKeyHint\">'."
-        },
-        {
-            "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
-            "message": "Property 'Widgets' is missing in type 'Record<string, any>' but required in type 'AmazonPaymentsObject'."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/endSummary/endSummarySelector.ts",
-            "message": "Property 'isPatron' is missing in type '{ priceDescription: string; promotion: string; orderIsAGift: boolean; digitalGiftBillingPeriod: \"Annual\" | \"Quarterly\"; price: string; }' but required in type 'EndSummaryProps'."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/helpers/orderSummaryText.ts",
-            "message": "Property 'NoProductOptions' is missing in type '{ Saturday: string; SaturdayPlus: string; Sunday: string; SundayPlus: string; Weekend: string; WeekendPlus: string; Sixday: string; SixdayPlus: string; Everyday: string; EverydayPlus: string; }' but required in type 'Record<ProductOptions, string>'."
-        }
-    ],
-    "TS2739": [
-        {
-            "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
-            "message": "Type '{ Stripe: Element; PayPal: Element; DirectDebit: Element; }' is missing the following properties from type 'Record<PaymentMethod, any>': Sepa, ExistingCard, ExistingDirectDebit, AmazonPay, None"
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
-            "message": "Type '{ Stripe: string; PayPal: string; DirectDebit: string; }' is missing the following properties from type 'Record<PaymentMethod, string>': Sepa, ExistingCard, ExistingDirectDebit, AmazonPay, None"
-        },
-        {
-            "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
-            "message": "Type '{ Stripe: string; PayPal: string; DirectDebit: string; }' is missing the following properties from type 'Record<PaymentMethod, string>': Sepa, ExistingCard, ExistingDirectDebit, AmazonPay, None"
-        },
-        {
-            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-            "message": "Type '{ ONE_OFF: { amounts: number[]; defaultAmount: number; }; }' is missing the following properties from type 'ContributionAmounts': MONTHLY, ANNUAL"
-        },
-        {
-            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-            "message": "Type '{ ONE_OFF: { min: number; minInWords: string; max: number; maxInWords: string; default: number; }; }' is missing the following properties from type 'Config': MONTHLY, ANNUAL"
-        },
-        {
-            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-            "message": "Type '{ ONE_OFF: { amounts: number[]; defaultAmount: number; }; }' is missing the following properties from type 'ContributionAmounts': MONTHLY, ANNUAL"
-        },
-        {
-            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-            "message": "Type '{ ONE_OFF: { min: number; minInWords: string; max: number; maxInWords: string; default: number; }; }' is missing the following properties from type 'Config': MONTHLY, ANNUAL"
-        },
-        {
-            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-            "message": "Type '{ ONE_OFF: { amounts: number[]; defaultAmount: number; }; }' is missing the following properties from type 'ContributionAmounts': MONTHLY, ANNUAL"
-        },
-        {
-            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-            "message": "Type '{ ONE_OFF: { min: number; minInWords: string; max: number; maxInWords: string; default: number; }; }' is missing the following properties from type 'Config': MONTHLY, ANNUAL"
-        },
-        {
-            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-            "message": "Type '{ ONE_OFF: { amounts: number[]; defaultAmount: number; }; }' is missing the following properties from type 'ContributionAmounts': MONTHLY, ANNUAL"
-        },
-        {
-            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-            "message": "Type '{ ONE_OFF: { min: number; minInWords: string; max: number; maxInWords: string; default: number; }; }' is missing the following properties from type 'Config': MONTHLY, ANNUAL"
-        },
-        {
-            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-            "message": "Type 'Element[]' is missing the following properties from type 'ReactElement<any, any>': type, props, key"
-        },
-        {
-            "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
-            "message": "Type '{}' is missing the following properties from type 'SelectedAmounts': MONTHLY, ANNUAL, ONE_OFF"
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
-            "message": "Type '{ HomeDelivery: string[]; Collection: string[]; }' is missing the following properties from type 'Record<FulfilmentOptions, string[]>': Domestic, RestOfWorld, NoFulfilmentOptions"
-        }
-    ],
-    "TS2532": [
-        {
-            "path": "assets/components/subscriptionCheckouts/summary.tsx",
-            "message": "Object is possibly 'undefined'."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Object is possibly 'undefined'."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Object is possibly 'undefined'."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Object is possibly 'undefined'."
-        }
-    ],
-    "TS2556": [
-        {
-            "path": "assets/helpers/__tests__/contributionsTests.ts",
-            "message": "A spread argument must either have a tuple type or be passed to a rest parameter."
-        },
-        {
-            "path": "assets/helpers/__tests__/contributionsTests.ts",
-            "message": "A spread argument must either have a tuple type or be passed to a rest parameter."
-        },
-        {
-            "path": "assets/helpers/__tests__/contributionsTests.ts",
-            "message": "A spread argument must either have a tuple type or be passed to a rest parameter."
-        }
-    ],
-    "TS2554": [
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/__tests__/formValidation.ts",
-            "message": "Expected 3 arguments, but got 2."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-            "message": "Expected 1 arguments, but got 0."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-            "message": "Expected 1 arguments, but got 0."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-            "message": "Expected 1 arguments, but got 0."
-        },
-        {
-            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-            "message": "Expected 3 arguments, but got 1."
-        },
-        {
-            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-            "message": "Expected 6 arguments, but got 1."
-        },
-        {
-            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-            "message": "Expected 3 arguments, but got 1."
-        },
-        {
-            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-            "message": "Expected 6 arguments, but got 1."
-        },
-        {
-            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-            "message": "Expected 6 arguments, but got 1."
-        },
-        {
-            "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
-            "message": "Expected 1 arguments, but got 0."
-        },
-        {
-            "path": "assets/pages/showcase/components/otherProducts.tsx",
-            "message": "Expected 1 arguments, but got 0."
-        }
-    ],
-    "TS2569": [
-        {
-            "path": "assets/helpers/checkoutForm/checkoutForm.ts",
-            "message": "Type 'HTMLCollectionOf<HTMLInputElement>' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators."
-        },
-        {
-            "path": "assets/helpers/checkoutForm/checkoutForm.ts",
-            "message": "Type 'HTMLFormControlsCollection' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators."
-        }
-    ],
-    "TS2411": [
-        {
-            "path": "assets/helpers/globalsAndSwitches/settings.ts",
-            "message": "Property 'experiments' of type 'Record<string, { name: string; description: string; state: Status; }>' is not assignable to 'string' index type 'SwitchObject'."
-        }
-    ],
-    "TS7017": [
-        {
-            "path": "assets/helpers/page/__tests__/pageTest.ts",
-            "message": "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature."
-        },
-        {
-            "path": "assets/helpers/page/__tests__/pageTest.ts",
-            "message": "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature."
-        },
-        {
-            "path": "assets/helpers/page/__tests__/pageTest.ts",
-            "message": "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature."
-        },
-        {
-            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-            "message": "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature."
-        }
-    ],
-    "TS2367": [
-        {
-            "path": "assets/helpers/polyfills/details.ts",
-            "message": "This condition will always return 'true' since the types 'Element' and 'Document' have no overlap."
-        },
-        {
-            "path": "assets/pages/paper-subscription-landing/components/content/linkTo.tsx",
-            "message": "This condition will always return 'false' since the types 'PaperFulfilmentOptions' and '\"delivery\"' have no overlap."
-        },
-        {
-            "path": "assets/pages/promotion-terms/weeklyTerms.tsx",
-            "message": "This condition will always return 'false' since the types '\"Monthly\"' and '\"Quarterly\"' have no overlap."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/helpers/__tests__/deliveryDays.ts",
-            "message": "This condition will always return 'false' since the types '() => number' and 'number' have no overlap."
-        }
-    ],
-    "TS2740": [
-        {
-            "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
-            "message": "Type '{ GBP: { price: number; savingVsRetail: number; currency: \"GBP\"; fixedTerm: false; promotions: never[]; }; }' is missing the following properties from type 'Record<IsoCurrency, ProductPrice>': NZD, AUD, CAD, USD, and 5 more."
-        },
-        {
-            "path": "assets/helpers/productPrice/productOptions.ts",
-            "message": "Type '{ Saturday: \"SaturdayPlus\"; Sunday: \"SundayPlus\"; Weekend: \"WeekendPlus\"; Sixday: \"SixdayPlus\"; Everyday: \"EverydayPlus\"; }' is missing the following properties from type 'Record<ProductOptions, ProductOptions>': NoProductOptions, SaturdayPlus, SundayPlus, WeekendPlus, and 2 more."
-        },
-        {
-            "path": "assets/helpers/productPrice/productOptions.ts",
-            "message": "Type '{ SaturdayPlus: \"Saturday\"; SundayPlus: \"Sunday\"; WeekendPlus: \"Weekend\"; SixdayPlus: \"Sixday\"; EverydayPlus: \"Everyday\"; }' is missing the following properties from type 'Record<ProductOptions, ProductOptions>': NoProductOptions, Saturday, Sunday, Weekend, and 2 more."
-        },
-        {
-            "path": "assets/helpers/productPrice/subscriptions.ts",
-            "message": "Type '{ GBPCountries: number; }' is missing the following properties from type 'Record<CountryGroupId, number>': UnitedStates, AUDCountries, EURCountries, International, and 2 more."
-        },
-        {
-            "path": "assets/helpers/rendering/render.ts",
-            "message": "Type 'Element' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, dir, and 109 more."
-        }
-    ],
-    "TS2531": [
-        {
-            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-            "message": "Object is possibly 'null'."
-        },
-        {
-            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-            "message": "Object is possibly 'null'."
-        }
-    ],
-    "TS7016": [
-        {
-            "path": "assets/helpers/rendering/render.ts",
-            "message": "Could not find a declaration file for module 'preact/debug'. 'support-frontend/node_modules/preact/debug/dist/debug.js' implicitly has an 'any' type."
-        }
-    ],
-    "TS2707": [
-        {
-            "path": "assets/pages/contributions-landing/contributionsLandingInit.ts",
-            "message": "Generic type 'Store<S, A>' requires between 0 and 2 type arguments."
-        }
-    ],
-    "TS2525": [
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-            "message": "Initializer provides no value for this binding element and the binding element has no default value."
-        },
-        {
-            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
-            "message": "Initializer provides no value for this binding element and the binding element has no default value."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-            "message": "Initializer provides no value for this binding element and the binding element has no default value."
-        },
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
-            "message": "Initializer provides no value for this binding element and the binding element has no default value."
-        },
-        {
-            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
-            "message": "Initializer provides no value for this binding element and the binding element has no default value."
-        }
-    ],
-    "TS2745": [
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/addDigiSubCta.tsx",
-            "message": "This JSX tag's 'children' prop expects type 'ReactElement<any, string | JSXElementConstructor<any>>[]' which requires multiple children, but only a single child was provided."
-        },
-        {
-            "path": "assets/pages/paper-subscription-landing/components/content/deliveryTab.tsx",
-            "message": "This JSX tag's 'children' prop expects type 'ReactElement<any, string | JSXElementConstructor<any>>[]' which requires multiple children, but only a single child was provided."
-        }
-    ],
-    "TS7022": [
-        {
-            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-            "message": "'initialState' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer."
-        }
-    ],
-    "TS2571": [
-        {
-            "path": "assets/pages/promotion-terms/promotionTermsReducer.ts",
-            "message": "Object is of type 'unknown'."
-        },
-        {
-            "path": "assets/pages/promotion-terms/promotionTermsReducer.ts",
-            "message": "Object is of type 'unknown'."
-        },
-        {
-            "path": "assets/pages/promotion-terms/promotionTermsReducer.ts",
-            "message": "Object is of type 'unknown'."
-        }
-    ],
-    "TS2698": [
-        {
-            "path": "assets/pages/promotion-terms/promotionTermsReducer.ts",
-            "message": "Spread types may only be created from object types."
-        },
-        {
-            "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
-            "message": "Spread types may only be created from object types."
-        },
-        {
-            "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
-            "message": "Spread types may only be created from object types."
-        },
-        {
-            "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
-            "message": "Spread types may only be created from object types."
-        },
-        {
-            "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
-            "message": "Spread types may only be created from object types."
-        },
-        {
-            "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
-            "message": "Spread types may only be created from object types."
-        }
-    ]
+    "byPath": {
+      "assets/__mocks__/imageMock.ts": 1,
+      "assets/components/asyncronously/asyncronously.ts": 2,
+      "assets/components/content/content.tsx": 2,
+      "assets/components/footerCompliant/Footer.tsx": 4,
+      "assets/components/forms/customFields/options.tsx": 1,
+      "assets/components/forms/label.tsx": 2,
+      "assets/components/headers/header/header.tsx": 6,
+      "assets/components/headers/header/mobileMenuToggler.tsx": 1,
+      "assets/components/headers/mobileMenu/mobileMenu.tsx": 2,
+      "assets/components/headers/veggieBurgerButton/veggieBurgerButton.tsx": 2,
+      "assets/components/menu/menu.tsx": 2,
+      "assets/components/product/productOption.tsx": 1,
+      "assets/components/product/productOptionSmall.tsx": 1,
+      "assets/components/subscriptionCheckouts/layout.tsx": 1,
+      "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx": 6,
+      "assets/pages/digital-subscription-checkout/components/thankYou/pageSection.tsx": 1,
+      "assets/pages/digital-subscription-landing/components/comparison/comparisonTable.tsx": 3,
+      "assets/pages/digital-subscription-landing/components/comparison/interactiveTableRowContents.tsx": 1,
+      "assets/pages/paper-subscription-landing/components/content/linkTo.tsx": 4,
+      "assets/pages/subscriptions-landing/components/subscriptionsProduct.tsx": 2,
+      "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx": 4,
+      "assets/components/datePicker/datePickerHelpers.test.ts": 2,
+      "assets/components/directDebit/directDebitForm/directDebitForm.tsx": 10,
+      "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx": 5,
+      "assets/components/headers/links/links.tsx": 1,
+      "assets/components/marketingConsent/marketingConsent.tsx": 1,
+      "assets/components/page/page.tsx": 1,
+      "assets/components/page/pageTitle.tsx": 4,
+      "assets/components/priceLabel/priceLabel.tsx": 1,
+      "assets/components/subscriptionCheckouts/address/addressFields.tsx": 14,
+      "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx": 12,
+      "assets/components/subscriptionCheckouts/billingPeriodSelector.tsx": 2,
+      "assets/components/subscriptionCheckouts/personalDetails.tsx": 7,
+      "assets/components/subscriptionCheckouts/summary.tsx": 6,
+      "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx": 4,
+      "assets/helpers/__tests__/formValidation.ts": 29,
+      "assets/helpers/checkoutForm/checkoutForm.ts": 3,
+      "assets/helpers/globalsAndSwitches/globals.ts": 2,
+      "assets/helpers/internationalisation/localCurrencyCountry.ts": 9,
+      "assets/helpers/productPrice/__tests__/promotionsTests.ts": 14,
+      "assets/helpers/utilities/utilities.ts": 1,
+      "assets/hocs/canShow.tsx": 1,
+      "assets/hocs/withError.tsx": 1,
+      "assets/hocs/withLabel.tsx": 1,
+      "assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.tsx": 2,
+      "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx": 9,
+      "assets/pages/contributions-landing/components/SepaForm.tsx": 7,
+      "assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.tsx": 1,
+      "assets/pages/contributions-landing/contributionsLandingReducer.ts": 5,
+      "assets/pages/contributions-landing/setUserStateActions.ts": 3,
+      "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx": 9,
+      "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx": 4,
+      "assets/pages/digital-subscription-checkout/components/endSummary/endSummaryMobile.tsx": 1,
+      "assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.ts": 1,
+      "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx": 7,
+      "assets/pages/digital-subscription-landing/components/events/eventsModule.tsx": 1,
+      "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx": 4,
+      "assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.tsx": 1,
+      "assets/pages/paper-subscription-checkout/components/addDigiSubCta.tsx": 3,
+      "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx": 16,
+      "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx": 8,
+      "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx": 12,
+      "assets/pages/paper-subscription-checkout/helpers/options.ts": 2,
+      "assets/pages/paper-subscription-landing/components/content/prices.tsx": 1,
+      "assets/pages/paper-subscription-landing/components/hero/hero.tsx": 1,
+      "assets/pages/showcase/components/ctaContribute.tsx": 1,
+      "assets/pages/showcase/components/ctaSubscribe.tsx": 1,
+      "assets/pages/showcase/components/hero.tsx": 3,
+      "assets/pages/showcase/components/otherProduct.tsx": 1,
+      "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx": 7,
+      "assets/pages/subscriptions-redemption/api.ts": 1,
+      "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx": 7,
+      "assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx": 2,
+      "assets/pages/weekly-subscription-landing/components/content/prices.tsx": 1,
+      "assets/pages/contributions-landing/components/ContributionArticleCount.tsx": 3,
+      "assets/pages/paper-subscription-landing/components/content/tabAccordionRow.tsx": 1,
+      "assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx": 2,
+      "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx": 22,
+      "assets/components/paypalExpressButton/PayPalExpressButton.tsx": 1,
+      "assets/helpers/__tests__/urlTest.ts": 1,
+      "assets/helpers/csrf/csrfReducer.ts": 2,
+      "assets/helpers/internationalisation/__tests__/countryGroupTest.ts": 1,
+      "assets/helpers/internationalisation/__tests__/countryTest.ts": 1,
+      "assets/helpers/rendering/render.ts": 8,
+      "assets/pages/contributions-landing/contributionsLanding.tsx": 5,
+      "assets/pages/digital-subscription-checkout/thankYouContainer.ts": 2,
+      "assets/components/datePicker/datePicker.tsx": 2,
+      "assets/components/directDebit/__tests__/directDebitReducerTest.ts": 1,
+      "assets/components/directDebit/helpers/ajax.ts": 2,
+      "assets/components/marketingConsent/helpers.ts": 1,
+      "assets/components/marketingConsent/marketingConsentPaper.tsx": 2,
+      "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx": 13,
+      "assets/components/subscriptionCheckouts/address/__tests__/addressFieldsStore.ts": 1,
+      "assets/components/subscriptionCheckouts/addressSearch/__tests__/addressFieldsStore.ts": 1,
+      "assets/components/subscriptionCheckouts/stripeForm/stripeForm.tsx": 1,
+      "assets/helpers/__tests__/checkoutsTest.ts": 7,
+      "assets/helpers/__tests__/promiseTest.ts": 3,
+      "assets/helpers/contributions.ts": 2,
+      "assets/helpers/identityApis.ts": 1,
+      "assets/helpers/internationalisation/__tests__/currencyTest.ts": 1,
+      "assets/helpers/page/__tests__/pageTest.ts": 4,
+      "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts": 4,
+      "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts": 8,
+      "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts": 5,
+      "assets/helpers/productPrice/__tests__/productPricesTests.ts": 6,
+      "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts": 4,
+      "assets/helpers/productPrice/paperProductPrices.ts": 2,
+      "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts": 9,
+      "assets/pages/contributions-landing/components/AmazonPay/AmazonPayWallet.tsx": 1,
+      "assets/pages/contributions-landing/components/ContributionSubmit.tsx": 1,
+      "assets/pages/contributions-landing/components/ContributionTypeTabs.tsx": 2,
+      "assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx": 2,
+      "assets/pages/contributions-landing/contributionsLandingActions.ts": 1,
+      "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx": 8,
+      "assets/pages/digital-subscription-checkout/thankYouGift.tsx": 1,
+      "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.tsx": 2,
+      "assets/pages/promotion-terms/promotionTerms.tsx": 1,
+      "assets/pages/weekly-subscription-checkout/components/thankYou.tsx": 6,
+      "assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx": 1,
+      "assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx": 1,
+      "assets/helpers/rendering/ssrPages.ts": 1,
+      "assets/pages/contributions-landing/components/ExistingRecurringContributorErrorMessage.tsx": 1,
+      "assets/pages/paper-subscription-checkout/components/thankYou.tsx": 5,
+      "assets/pages/subscriptions-landing/components/subscriptionsLandingContent.tsx": 1,
+      "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx": 7,
+      "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts": 6,
+      "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts": 5,
+      "assets/helpers/forms/checkouts.ts": 1,
+      "assets/helpers/urls/externalLinks.ts": 3,
+      "assets/pages/contributions-landing/contributionsLandingInit.ts": 2,
+      "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.tsx": 1,
+      "assets/components/subscriptionCheckouts/addressSearch/addressResultsHelpers.ts": 1,
+      "assets/helpers/polyfills/layout.ts": 1,
+      "assets/components/subscriptionCheckouts/address/postcodeFinderStore.ts": 1,
+      "assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryThankYou.tsx": 1,
+      "assets/pages/digital-subscription-checkout/components/endSummary/endSummarySelector.ts": 1,
+      "assets/pages/paper-subscription-checkout/helpers/orderSummaryText.ts": 1,
+      "assets/helpers/__tests__/contributionsTests.ts": 3,
+      "assets/pages/showcase/components/otherProducts.tsx": 1,
+      "assets/helpers/globalsAndSwitches/settings.ts": 1,
+      "assets/helpers/polyfills/details.ts": 1,
+      "assets/pages/promotion-terms/weeklyTerms.tsx": 1,
+      "assets/pages/weekly-subscription-checkout/helpers/__tests__/deliveryDays.ts": 1,
+      "assets/helpers/productPrice/productOptions.ts": 2,
+      "assets/helpers/productPrice/subscriptions.ts": 1,
+      "assets/pages/paper-subscription-landing/components/content/deliveryTab.tsx": 1,
+      "assets/pages/promotion-terms/promotionTermsReducer.ts": 4
+    }
+  },
+  "TS1208": [
+    {
+      "path": "assets/__mocks__/imageMock.ts",
+      "message": "'imageMock.ts' cannot be compiled under '--isolatedModules' because it is considered a global script file. Add an import, export, or an empty 'export {}' statement to make it a module."
+    }
+  ],
+  "TS2305": [
+    {
+      "path": "assets/components/asyncronously/asyncronously.ts",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/components/content/content.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/components/footerCompliant/Footer.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/components/forms/customFields/options.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/components/forms/label.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/components/headers/header/header.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/components/headers/header/mobileMenuToggler.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/components/headers/mobileMenu/mobileMenu.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/components/headers/veggieBurgerButton/veggieBurgerButton.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/components/menu/menu.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/components/product/productOption.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/components/product/productOptionSmall.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/layout.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/thankYou/pageSection.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/comparison/comparisonTable.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/comparison/interactiveTableRowContents.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-landing/components/content/linkTo.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    },
+    {
+      "path": "assets/pages/subscriptions-landing/components/subscriptionsProduct.tsx",
+      "message": "Module '\"react\"' has no exported member 'Node'."
+    }
+  ],
+  "TS2322": [
+    {
+      "path": "assets/components/asyncronously/asyncronously.ts",
+      "message": "Type 'ComponentType<any>' is not assignable to type 'null'."
+    },
+    {
+      "path": "assets/components/content/content.tsx",
+      "message": "Type 'Option<string> | undefined' is not assignable to type 'string | undefined'."
+    },
+    {
+      "path": "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx",
+      "message": "Type '{ children: (Element | Element[])[]; style: { top: number; left: number; position: string; }; }' is not assignable to type 'IntrinsicAttributes & { children: any; }'."
+    },
+    {
+      "path": "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx",
+      "message": "Type '{ children: string[]; href: string; onClick: () => void; isSelected: boolean; }' is not assignable to type 'IntrinsicAttributes & itemProps & { href: string; }'."
+    },
+    {
+      "path": "assets/components/datePicker/datePickerHelpers.test.ts",
+      "message": "Type 'typeof MockDate' is not assignable to type 'DateConstructor'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+      "message": "Type 'string' is not assignable to type 'number | undefined'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+      "message": "Type 'string' is not assignable to type 'number | undefined'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+      "message": "Type 'string' is not assignable to type 'number | undefined'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
+      "message": "Type 'string' is not assignable to type 'number | undefined'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
+      "message": "Type '{ id: string; label: string; autoComplete: string; type: \"text\"; inputmode: string; pattern: string; value: string; onChange: (e: ChangeEvent<HTMLInputElement>) => void; error: string; minLength: number; maxLength: number; width: 10; }' is not assignable to type 'IntrinsicAttributes & Pick<TextInputProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | ... 280 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
+      "message": "Type '{ id: string; value: string; autoComplete: string; onChange: (e: ChangeEvent<HTMLInputElement>) => void; minLength: number; maxLength: number; type: \"text\"; inputmode: string; pattern: string; label: string; error: string; }' is not assignable to type 'IntrinsicAttributes & Pick<TextInputProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | ... 280 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
+      "message": "Type 'string' is not assignable to type 'boolean | undefined'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
+      "message": "Type 'EventHandler' is not assignable to type 'MouseEventHandler<HTMLButtonElement>'."
+    },
+    {
+      "path": "assets/components/forms/label.tsx",
+      "message": "Type 'Option<string>' is not assignable to type 'string | undefined'."
+    },
+    {
+      "path": "assets/components/headers/links/links.tsx",
+      "message": "Type '\"_blank\" | null' is not assignable to type 'HTMLAttributeAnchorTarget | undefined'."
+    },
+    {
+      "path": "assets/components/headers/mobileMenu/mobileMenu.tsx",
+      "message": "Type '{ width: number; } | null | undefined' is not assignable to type 'CSSProperties | undefined'."
+    },
+    {
+      "path": "assets/components/headers/veggieBurgerButton/veggieBurgerButton.tsx",
+      "message": "Type '{ children: any[]; 'aria-haspopup': Option<string>; onClick: Option<(...args: any[]) => any>; style: Option<{}>; className: string; ref: Option<(...args: any[]) => any>; }' is not assignable to type 'DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>'."
+    },
+    {
+      "path": "assets/components/marketingConsent/marketingConsent.tsx",
+      "message": "Type '{ children: string; appearance: \"green\"; iconSide: \"right\"; \"aria-label\": string; onClick: () => void; icon: Element; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\"> & Partial<Pick<PropTypes, \"type\" | \"disabled\" | ... 4 more ... | \"aria-label\">> & Partial<...>'."
+    },
+    {
+      "path": "assets/components/menu/menu.tsx",
+      "message": "Type '{ children: any[]; className: any; \"data-is-selected\": boolean; }' is not assignable to type 'IntrinsicAttributes'."
+    },
+    {
+      "path": "assets/components/page/page.tsx",
+      "message": "Type 'string | null | undefined' is not assignable to type 'string | undefined'."
+    },
+    {
+      "path": "assets/components/page/pageTitle.tsx",
+      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+    },
+    {
+      "path": "assets/components/page/pageTitle.tsx",
+      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+    },
+    {
+      "path": "assets/components/page/pageTitle.tsx",
+      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+    },
+    {
+      "path": "assets/components/page/pageTitle.tsx",
+      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+    },
+    {
+      "path": "assets/components/priceLabel/priceLabel.tsx",
+      "message": "Type 'false | Record<string, any> | undefined' is not assignable to type 'string | undefined'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+      "message": "Type 'ReactNode' is not assignable to type 'Element'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+      "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+      "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+      "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+      "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+      "message": "Type 'null' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>> | undefined'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+      "message": "Type '{ children: any[]; onChange: (e: ChangeEvent<HTMLSelectElement>) => void; forwardRef: (r: any) => void; id: string; label: string; }' is not assignable to type 'IntrinsicAttributes & Pick<SelectProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"children\" | \"color\" | \"hidden\" | \"id\" | \"onChange\" | ... 257 more ... | \"supporting\"> & Partial<...> & Partial<...>'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+      "message": "Type 'null' is not assignable to type 'string | number | readonly string[] | undefined'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/billingPeriodSelector.tsx",
+      "message": "Type '{ children: Element[]; legend: string; role: string; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/billingPeriodSelector.tsx",
+      "message": "Type '{ label: string; value: string; supporting: string; offer: string; name: string; checked: boolean; onChange: () => Action; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"type\" | ... 278 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
+      "message": "Type '{ children: Element[]; id: string; label: string; hideLabel: true; error: string | undefined; role: string; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
+      "message": "Type 'null' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>> | undefined'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
+      "message": "Type 'Option<string> | undefined' is not assignable to type 'string | number | readonly string[] | undefined'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
+      "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/summary.tsx",
+      "message": "Type '{ className: any; productPrice: ProductPrice; billingPeriod: BillingPeriod; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"billingPeriod\" | \"productPrice\"> & Partial<Pick<PropTypes, \"orderIsAGift\" | \"giftStyles\">> & Partial<...>'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/summary.tsx",
+      "message": "Type '{ className: any; productPrice: ProductPrice; billingPeriod: BillingPeriod; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"billingPeriod\" | \"productPrice\"> & Partial<Pick<PropTypes, \"orderIsAGift\" | \"giftStyles\">> & Partial<...>'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/summary.tsx",
+      "message": "Type '{ className: any; productPrice: ProductPrice; billingPeriod: BillingPeriod; giftStyles: any; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"billingPeriod\" | \"productPrice\"> & Partial<Pick<PropTypes, \"orderIsAGift\" | \"giftStyles\">> & Partial<...>'."
+    },
+    {
+      "path": "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx",
+      "message": "Type '{ children: string; href: string; onClick: (...args: any[]) => any; appearance: \"primary\" | \"secondary\" | \"tertiary\" | \"tertiaryFeature\"; modifierClasses: string[]; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\" | \"href\"> & Partial<Pick<PropTypes, \"appearance\" | \"icon\" | \"iconSide\" | \"modifierClasses\" | \"aria-label\">> & Partial<...>'."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Type '{ countryCode: string; stateCode?: string | undefined; } | {}' is not assignable to type '{ countryCode: string; stateCode?: string | undefined; } | undefined'."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Type 'null' is not assignable to type 'string'."
+    },
+    {
+      "path": "assets/helpers/checkoutForm/checkoutForm.ts",
+      "message": "Type 'unknown' is not assignable to type 'string'."
+    },
+    {
+      "path": "assets/helpers/globalsAndSwitches/globals.ts",
+      "message": "Type 'unknown' is not assignable to type 'Settings'."
+    },
+    {
+      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+      "message": "Type 'string | null | undefined' is not assignable to type 'string | number | symbol'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+      "message": "Type 'null' is not assignable to type 'number | undefined'."
+    },
+    {
+      "path": "assets/helpers/utilities/utilities.ts",
+      "message": "Type 'string | null | undefined' is not assignable to type 'string'."
+    },
+    {
+      "path": "assets/hocs/canShow.tsx",
+      "message": "Type 'Omit<AugmentedProps<Props>, \"isShown\">' is not assignable to type 'IntrinsicAttributes & Props & { children?: ReactNode; }'."
+    },
+    {
+      "path": "assets/hocs/withError.tsx",
+      "message": "Type 'Omit<AugmentedProps<Props>, \"error\">' is not assignable to type 'IntrinsicAttributes & Props & { children?: ReactNode; }'."
+    },
+    {
+      "path": "assets/hocs/withLabel.tsx",
+      "message": "Type 'Omit<AugmentedProps<Props>, \"footer\" | \"label\" | \"optional\">' is not assignable to type 'IntrinsicAttributes & Props & { children?: ReactNode; }'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.tsx",
+      "message": "Type '{ children: string; type: \"button\"; onClick: () => void; \"aria-label\": string; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\"> & Partial<Pick<PropTypes, \"type\" | \"disabled\" | ... 4 more ... | \"aria-label\">> & Partial<...>'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+      "message": "Type 'false | \"Please select a payment method\"' is not assignable to type 'string | undefined'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+      "message": "Type 'false | Element' is not assignable to type 'Element'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+      "message": "Type 'false | Element[]' is not assignable to type 'Element'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+      "message": "Type 'RecentlySignedInExistingPaymentMethod' is not assignable to type 'string'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+      "message": "Type '{ '& + div': { display: string; width: string; margin: number; justifyContent: string; }; '& + div svg': { width: string; height: string; }; '&:not(:checked) + div svg': { filter: string; }; }' is not assignable to type 'SerializedStyles | SerializedStyles[] | undefined'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+      "message": "Type '{ '& + div': { display: string; width: string; margin: number; justifyContent: string; }; '& + div svg': { width: string; height: string; }; '&:not(:checked) + div svg': { filter: string; }; }' is not assignable to type 'SerializedStyles | SerializedStyles[] | undefined'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+      "message": "Type 'false | Element | undefined' is not assignable to type 'Element'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
+      "message": "Type 'string' is not assignable to type 'number | undefined'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
+      "message": "Type 'string | null' is not assignable to type 'string | number | readonly string[] | undefined'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
+      "message": "Type 'string | null' is not assignable to type 'string | undefined'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
+      "message": "Type 'string' is not assignable to type 'number | undefined'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
+      "message": "Type 'string' is not assignable to type 'number | undefined'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
+      "message": "Type 'string | null' is not assignable to type 'string | number | readonly string[] | undefined'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
+      "message": "Type 'string | null' is not assignable to type 'string | undefined'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.tsx",
+      "message": "Type '{ stripeKey: string; isTestUser: boolean; }' is not assignable to type 'IntrinsicAttributes & Omit<{ contributionType: keyof RegularContributionTypeMap<null> | \"ONE_OFF\"; checkoutFormHasBeenSubmitted: boolean; ... 9 more ...; isTestUser: boolean; } & { ...; } & { ...; }, \"csrf\" | ... 19 more ... | \"setStripeRecurringRecaptchaVerified\">'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
+      "message": "Type '{ Stripe: null; AmazonPay: null; }' is not assignable to type '{ Stripe: StripeHandler | null; }'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
+      "message": "Type '{ hasBegunLoading: false; amazonPayLibrary: { amazonLoginObject: null; amazonPaymentsObject: null; }; loginButtonReady: false; walletIsStale: false; orderReferenceId: null; paymentSelected: false; hasAccessToken: false; fatalError: false; amazonBillingAgreementConsentStatus: false; }' is not assignable to type 'AmazonPayData'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
+      "message": "Type '{ contributionType: keyof RegularContributionTypeMap<null> | \"ONE_OFF\"; showOtherAmount: boolean; formData: { otherAmounts: OtherAmounts; ... 5 more ...; email: string | null; }; ... 17 more ...; oneOffRecaptchaToken: string | null; }' is not assignable to type 'FormState'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/setUserStateActions.ts",
+      "message": "Type '(isSignedIn: boolean) => (arg0: (...args: any[]) => any) => void' is not assignable to type '(isSignedIn: boolean) => Action'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/setUserStateActions.ts",
+      "message": "Type '() => (arg0: (...args: any[]) => any) => void' is not assignable to type '() => Action'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/setUserStateActions.ts",
+      "message": "Type '(unsafeState: string) => (arg0: (...args: any[]) => any) => void' is not assignable to type '(stateField: string) => Action'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+      "message": "Type 'Promise<{ json: () => Promise<{ client_secret: string; }>; }>' is not assignable to type 'Promise<Response>'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx",
+      "message": "Type '{ image: Element; title: string; description: string; productPrice: ProductPrice; billingPeriod: \"Annual\" | \"Monthly\"; changeSubscription: string; isPatron: boolean; }' is not assignable to type 'IntrinsicAttributes & Pick<OrderSummaryPropTypes, \"title\" | \"image\" | \"billingPeriod\" | \"productPrice\" | \"isPatron\"> & Partial<...> & Partial<...>'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx",
+      "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx",
+      "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/endSummary/endSummaryMobile.tsx",
+      "message": "Type '{ orderIsAGift: Option<boolean> | undefined; }' is not assignable to type 'IntrinsicAttributes & Omit<EndSummaryProps, \"orderIsAGift\" | \"promotion\" | \"price\" | \"priceDescription\" | \"digitalGiftBillingPeriod\" | \"isPatron\">'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.ts",
+      "message": "Type '\"normal\"' is not assignable to type 'FontWeight | undefined'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/comparison/comparisonTable.tsx",
+      "message": "Type 'SerializedStyles' is not assignable to type 'string | string[] | undefined'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/comparison/comparisonTable.tsx",
+      "message": "Type 'string' is not assignable to type 'number | undefined'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
+      "message": "Type '{ icon: JSX.Element; description: string; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
+      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
+      "message": "Type '{ icon: JSX.Element; description: string; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
+      "message": "Type '{ icon: JSX.Element; description: JSX.Element; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
+      "message": "Type '{ icon: JSX.Element; description: JSX.Element; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
+      "message": "Type '{ icon: JSX.Element; description: string; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
+      "message": "Type 'SerializedStyles' is not assignable to type 'string[] | Option<string> | undefined'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/events/eventsModule.tsx",
+      "message": "Type 'SerializedStyles' is not assignable to type 'string | string[] | undefined'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx",
+      "message": "Type 'SerializedStyles | null' is not assignable to type 'SerializedStyles'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx",
+      "message": "Type 'SerializedStyles | null' is not assignable to type 'SerializedStyles'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.tsx",
+      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/addDigiSubCta.tsx",
+      "message": "Type 'string | SerializedStyles' is not assignable to type 'SerializedStyles'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+      "message": "Type '{ image: Element; total: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; includesDigiSub: boolean; digiSubPrice: string; changeSubscription: string; }' is not assignable to type 'IntrinsicAttributes & (Omit<Matching<{ fulfilmentOption: FulfilmentOptions; productOption: ProductOptions; billingPeriod: BillingPeriod; productPrices: ProductPrices; } & DispatchProp<...>, PropTypes>, \"productPrices\" | ... 2 more ... | \"productOption\"> | Omit<...>)'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
+      "message": "Type 'Promise<{ json: () => Promise<{ client_secret: string; }>; }>' is not assignable to type 'Promise<Response>'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+      "message": "Type '{ image: Element; total: ProductPrice; digiSubPrice: string; includesDigiSub: boolean; changeSubscription: string; productType: \"Paper\"; paymentStartDate: string; }' is not assignable to type 'IntrinsicAttributes & (Omit<Matching<{ fulfilmentOption: FulfilmentOptions; productOption: ProductOptions; billingPeriod: BillingPeriod; productPrices: ProductPrices; } & DispatchProp<...>, PropTypes>, \"productPrices\" | ... 2 more ... | \"productOption\"> | Omit<...>)'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+      "message": "Type '{ children: Element; modifierClasses: string[]; }' is not assignable to type 'IntrinsicAttributes & { children: any; }'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+      "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+      "message": "Type 'Option<string>' is not assignable to type 'string | undefined'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+      "message": "Type '{ children: Element[]; label: string; hideLabel: true; id: string; name: string; orienntation: string; error: string | undefined; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+      "message": "Type '{ inputId: string; value: string; label: string; name: string; checked: boolean; onChange: () => Action; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"type\" | ... 278 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+      "message": "Type '{ children: Element[]; label: string; hideLabel: true; id: string; error: string | undefined; legend: string; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+      "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+      "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/helpers/options.ts",
+      "message": "Type 'string' is not assignable to type 'PaperProductOptions'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-landing/components/content/prices.tsx",
+      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-landing/components/hero/hero.tsx",
+      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+    },
+    {
+      "path": "assets/pages/showcase/components/ctaContribute.tsx",
+      "message": "Type '{ children: string; icon: Element; appearance: \"secondary\"; href: string; onClick: () => void; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\" | \"href\"> & Partial<Pick<PropTypes, \"appearance\" | \"icon\" | \"iconSide\" | \"modifierClasses\" | \"aria-label\">> & Partial<...>'."
+    },
+    {
+      "path": "assets/pages/showcase/components/ctaSubscribe.tsx",
+      "message": "Type '{ children: string; icon: Element; href: string; onClick: () => void; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\" | \"href\"> & Partial<Pick<PropTypes, \"appearance\" | \"icon\" | \"iconSide\" | \"modifierClasses\" | \"aria-label\">> & Partial<...>'."
+    },
+    {
+      "path": "assets/pages/showcase/components/hero.tsx",
+      "message": "Type 'Element' is not assignable to type 'string'."
+    },
+    {
+      "path": "assets/pages/showcase/components/hero.tsx",
+      "message": "Type 'Element' is not assignable to type 'string'."
+    },
+    {
+      "path": "assets/pages/showcase/components/otherProduct.tsx",
+      "message": "Type '{ children: string; icon: Element; appearance: \"greyHollow\"; href: string; onClick: () => void; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\" | \"href\"> & Partial<Pick<PropTypes, \"appearance\" | \"icon\" | \"iconSide\" | \"modifierClasses\" | \"aria-label\">> & Partial<...>'."
+    },
+    {
+      "path": "assets/pages/subscriptions-landing/components/subscriptionsProduct.tsx",
+      "message": "Type 'Option<boolean> | undefined' is not assignable to type 'Option<boolean>'."
+    },
+    {
+      "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
+      "message": "Type '{ ctaButtonText: string; link: string; analyticsTracking: () => void; modifierClasses: string; }' is not assignable to type 'ProductButton'."
+    },
+    {
+      "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
+      "message": "Type '{ ctaButtonText: string; link: string; analyticsTracking: () => void; modifierClasses: string; }' is not assignable to type 'ProductButton'."
+    },
+    {
+      "path": "assets/pages/subscriptions-redemption/api.ts",
+      "message": "Type 'null' is not assignable to type 'RegularPaymentRequestAddress | undefined'."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
+      "message": "Type '{ children: Element; modifierClasses: string[]; }' is not assignable to type 'IntrinsicAttributes & { children: any; }'."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
+      "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
+      "message": "Type '{ inputId: string; value: string; label: string; name: string; checked: boolean; onChange: () => void; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"type\" | ... 278 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
+      "message": "Type '{ children: Element[]; id: string; error: string | undefined; legend: string; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
+      "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
+      "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx",
+      "message": "Type 'boolean | undefined' is not assignable to type 'boolean'."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx",
+      "message": "Type 'boolean | undefined' is not assignable to type 'boolean'."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-landing/components/content/prices.tsx",
+      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+    }
+  ],
+  "TS2578": [
+    {
+      "path": "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx",
+      "message": "Unused '@ts-expect-error' directive."
+    },
+    {
+      "path": "assets/components/footerCompliant/Footer.tsx",
+      "message": "Unused '@ts-expect-error' directive."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/ContributionArticleCount.tsx",
+      "message": "Unused '@ts-expect-error' directive."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx",
+      "message": "Unused '@ts-expect-error' directive."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/addDigiSubCta.tsx",
+      "message": "Unused '@ts-expect-error' directive."
+    },
+    {
+      "path": "assets/pages/paper-subscription-landing/components/content/tabAccordionRow.tsx",
+      "message": "Unused '@ts-expect-error' directive."
+    },
+    {
+      "path": "assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx",
+      "message": "Unused '@ts-expect-error' directive."
+    }
+  ],
+  "TS2339": [
+    {
+      "path": "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx",
+      "message": "Property 'getBoundingClientRect' does not exist on type 'never'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+      "message": "Property 'value' does not exist on type 'EventTarget'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+      "message": "Property 'value' does not exist on type 'EventTarget'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+      "message": "Property 'value' does not exist on type 'EventTarget'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+      "message": "Property 'checked' does not exist on type 'EventTarget'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Property 'value' does not exist on type 'EventTarget'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Property 'value' does not exist on type 'EventTarget'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Property 'value' does not exist on type 'EventTarget'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Property 'checked' does not exist on type 'EventTarget'."
+    },
+    {
+      "path": "assets/components/footerCompliant/Footer.tsx",
+      "message": "Property 'showPrivacyManager' does not exist on type 'never'."
+    },
+    {
+      "path": "assets/components/paypalExpressButton/PayPalExpressButton.tsx",
+      "message": "Property 'Button' does not exist on type '{ FUNDING: { CREDIT: unknown; }; }'."
+    },
+    {
+      "path": "assets/helpers/__tests__/urlTest.ts",
+      "message": "Property 'jsdom' does not exist on type 'typeof globalThis'."
+    },
+    {
+      "path": "assets/helpers/csrf/csrfReducer.ts",
+      "message": "Property 'csrf' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
+    },
+    {
+      "path": "assets/helpers/csrf/csrfReducer.ts",
+      "message": "Property 'csrf' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
+    },
+    {
+      "path": "assets/helpers/internationalisation/__tests__/countryGroupTest.ts",
+      "message": "Property 'jsdom' does not exist on type 'typeof globalThis'."
+    },
+    {
+      "path": "assets/helpers/internationalisation/__tests__/countryTest.ts",
+      "message": "Property 'jsdom' does not exist on type 'typeof globalThis'."
+    },
+    {
+      "path": "assets/helpers/rendering/render.ts",
+      "message": "Property 'settings' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
+    },
+    {
+      "path": "assets/helpers/rendering/render.ts",
+      "message": "Property 'settings' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/ContributionArticleCount.tsx",
+      "message": "Property 'showPrivacyManager' does not exist on type 'never'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
+      "message": "Property 'polyfillScriptLoaded' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
+      "message": "Property 'polyfillVersion' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
+      "message": "Property 'polyfillVersion' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/thankYouContainer.ts",
+      "message": "Property 'common' does not exist on type 'DefaultRootState'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+      "message": "Property 'checked' does not exist on type 'EventTarget'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+      "message": "Property 'checked' does not exist on type 'EventTarget'."
+    },
+    {
+      "path": "assets/pages/showcase/components/hero.tsx",
+      "message": "Property 'title' does not exist on type '{ title: string; caption: Element; images: { first: string; second: string; third: string; fourth: string; }; } | { title: string; caption: Element; images: { first: string; second: string; third: string; fourth: string; }; } | { ...; }'."
+    }
+  ],
+  "TS2345": [
+    {
+      "path": "assets/components/datePicker/datePicker.tsx",
+      "message": "Argument of type '{ [x: string]: string | false; dateError: string; dateValidated: false; }' is not assignable to parameter of type 'StateTypes | ((prevState: Readonly<StateTypes>, props: Readonly<PropTypes>) => StateTypes | Pick<StateTypes, keyof StateTypes> | null) | Pick<...> | null'."
+    },
+    {
+      "path": "assets/components/datePicker/datePicker.tsx",
+      "message": "Argument of type '{ [x: string]: string | false; dateError: string; dateValidated: false; }' is not assignable to parameter of type 'StateTypes | ((prevState: Readonly<StateTypes>, props: Readonly<PropTypes>) => StateTypes | Pick<StateTypes, keyof StateTypes> | null) | Pick<...> | null'."
+    },
+    {
+      "path": "assets/components/directDebit/__tests__/directDebitReducerTest.ts",
+      "message": "Argument of type '{}' is not assignable to parameter of type 'Action'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+      "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+      "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Argument of type '{ [x: number]: any; }' is not assignable to parameter of type 'StateTypes | Pick<StateTypes, keyof StateTypes> | ((prevState: Readonly<StateTypes>, props: Readonly<PropTypes>) => StateTypes | ... 1 more ... | null) | null'."
+    },
+    {
+      "path": "assets/components/directDebit/helpers/ajax.ts",
+      "message": "Argument of type '{ method: string; headers: { 'Content-Type': string; 'Csrf-Token': string; }; credentials: string; body: string; }' is not assignable to parameter of type 'RequestInit'."
+    },
+    {
+      "path": "assets/components/footerCompliant/Footer.tsx",
+      "message": "Argument of type 'CMP' is not assignable to parameter of type 'SetStateAction<null>'."
+    },
+    {
+      "path": "assets/components/marketingConsent/helpers.ts",
+      "message": "Argument of type '{ method: string; headers: { 'Content-Type': string; 'Csrf-Token': string; }; credentials: string; body: string; }' is not assignable to parameter of type 'RequestInit'."
+    },
+    {
+      "path": "assets/components/marketingConsent/marketingConsentPaper.tsx",
+      "message": "Argument of type 'typeof MarketingConsent' is not assignable to parameter of type 'ComponentType<Matching<{ confirmOptIn: any; email: string; csrf: any; } & { onClick: (email: string, csrf: Csrf) => void; }, ButtonPropTypes & { error: boolean; }>>'."
+    },
+    {
+      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+      "message": "Argument of type '(dispatch: Dispatch<SetCountryChangedAction | SetCountryAction>) => void' is not assignable to parameter of type 'Action'."
+    },
+    {
+      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+      "message": "Argument of type '(dispatch: Dispatch<Action>, getState: () => CheckoutState) => void' is not assignable to parameter of type 'Action'."
+    },
+    {
+      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+      "message": "Argument of type '(dispatch: Dispatch<Action>, getState: () => CheckoutState) => void' is not assignable to parameter of type 'Action'."
+    },
+    {
+      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+      "message": "Argument of type '(dispatch: Dispatch<Action>, getState: () => CheckoutState) => void' is not assignable to parameter of type 'Action'."
+    },
+    {
+      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+      "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
+    },
+    {
+      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+      "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
+    },
+    {
+      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+      "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
+    },
+    {
+      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+      "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
+    },
+    {
+      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+      "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ hasLoaded: boolean; csrf: Csrf; productPrices: ProductPrices; currencyId: IsoCurrency; isTestUser: boolean; amount: number; submissionError: Option<...>; wasClicked: boolean; } & { ...; }, PropTypes>>'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/__tests__/addressFieldsStore.ts",
+      "message": "Argument of type '{ fields: { country: string; city: null; lineOne: null; lineTwo: null; postCode: null; state: null; formErrors: never[]; }; }' is not assignable to parameter of type 'CombinedState<{ fields: AddressFieldsState; postcode: PostcodeFinderState; }>'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+      "message": "Argument of type 'typeof AddressFields' is not assignable to parameter of type 'ComponentType<Matching<{ formErrors: FormErrors; traverseState: (arg0: any) => State; scope: AddressType; country: string; state: string | null; lineOne: Option<string>; lineTwo: Option<...>; postCode: Option<...>; city: Option<...>; countries: Record<...>; } & { ...; }, ClassAttributes<...> & ... 2 more ... & { ......'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/addressSearch/__tests__/addressFieldsStore.ts",
+      "message": "Argument of type '{ fields: { country: string; city: null; lineOne: null; lineTwo: null; postCode: null; state: null; formErrors: never[]; }; }' is not assignable to parameter of type 'CombinedState<{ fields: AddressFieldsState; postcode: PostcodeFinderState; }>'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/stripeForm/stripeForm.tsx",
+      "message": "Argument of type 'unknown' is not assignable to parameter of type 'SetStateAction<Option<string>>'."
+    },
+    {
+      "path": "assets/helpers/__tests__/checkoutsTest.ts",
+      "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
+    },
+    {
+      "path": "assets/helpers/__tests__/checkoutsTest.ts",
+      "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
+    },
+    {
+      "path": "assets/helpers/__tests__/checkoutsTest.ts",
+      "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
+    },
+    {
+      "path": "assets/helpers/__tests__/checkoutsTest.ts",
+      "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
+    },
+    {
+      "path": "assets/helpers/__tests__/checkoutsTest.ts",
+      "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
+    },
+    {
+      "path": "assets/helpers/__tests__/checkoutsTest.ts",
+      "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Argument of type '{ ONE_OFF: string; MONTHLY: string; ANNUAL: string; }' is not assignable to parameter of type 'SelectedAmounts'."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Argument of type '{ ONE_OFF: string; MONTHLY: string; ANNUAL: string; }' is not assignable to parameter of type 'SelectedAmounts'."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Argument of type '{ ONE_OFF: string; MONTHLY: string; ANNUAL: string; }' is not assignable to parameter of type 'SelectedAmounts'."
+    },
+    {
+      "path": "assets/helpers/__tests__/promiseTest.ts",
+      "message": "Argument of type '(done: any, fail: any) => void' is not assignable to parameter of type 'ProvidesCallback | undefined'."
+    },
+    {
+      "path": "assets/helpers/contributions.ts",
+      "message": "Argument of type 'string | number | null' is not assignable to parameter of type 'string'."
+    },
+    {
+      "path": "assets/helpers/identityApis.ts",
+      "message": "Argument of type '(resp: {    userType: UserType;}) => UserType' is not assignable to parameter of type '(value: Record<string, unknown>) => \"current\" | \"new\" | \"guest\" | PromiseLike<\"current\" | \"new\" | \"guest\">'."
+    },
+    {
+      "path": "assets/helpers/internationalisation/__tests__/currencyTest.ts",
+      "message": "Argument of type '\"ZZ\"' is not assignable to parameter of type 'CountryGroupId'."
+    },
+    {
+      "path": "assets/helpers/page/__tests__/pageTest.ts",
+      "message": "Argument of type '{ campaign: string; referrerAcquisitionData: { referrerPageviewId: null; campaignCode: null; componentId: null; componentType: null; source: null; abTests: never[]; queryParameters: never[]; }; internationalisation: { ...; }; abParticipations: {}; otherQueryParams: never[]; settings: { ...; }; }' is not assignable to parameter of type 'CommonState'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts",
+      "message": "Argument of type '{ 'United Kingdom': { Collection: { SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ......' is not assignable to parameter of type 'ProductPrices'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts",
+      "message": "Argument of type '{ 'United Kingdom': { Collection: { SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ......' is not assignable to parameter of type 'ProductPrices'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts",
+      "message": "Argument of type '{ 'United Kingdom': { Collection: { SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ......' is not assignable to parameter of type 'ProductPrices'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts",
+      "message": "Argument of type '{ 'United Kingdom': { Collection: { SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ......' is not assignable to parameter of type 'ProductPrices'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
+      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { ...; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
+      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
+      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { ...; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
+      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
+      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { ...; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
+      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
+      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { ...; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
+      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
+      "message": "Argument of type '{ price: number; currency: string; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { amount: number; durationMonths: number; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
+      "message": "Argument of type '{ price: number; currency: string; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
+      "message": "Argument of type '{ price: number; currency: string; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
+      "message": "Argument of type '{ price: number; currency: string; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { amount: number; durationMonths: number; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
+      "message": "Argument of type '{ price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { price: number; periodLength: number; periodType: string; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
+      "message": "Argument of type '{ 'United Kingdom': { Collection: { Weekend: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; NoProductOptions: { Monthly: { GBP: { ...; }; }; }; }; NoFulfilmentOptions: { ...; }; }; }' is not assignable to parameter of type 'ProductPrices'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
+      "message": "Argument of type '{ 'United Kingdom': { Collection: { Weekend: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; NoProductOptions: { Monthly: { GBP: { ...; }; }; }; }; NoFulfilmentOptions: { ...; }; }; }' is not assignable to parameter of type 'ProductPrices'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
+      "message": "Argument of type '{ 'United Kingdom': { Collection: { Weekend: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; NoProductOptions: { Monthly: { GBP: { ...; }; }; }; }; NoFulfilmentOptions: { ...; }; }; }' is not assignable to parameter of type 'ProductPrices'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
+      "message": "Argument of type '{ 'United Kingdom': { Collection: { Sunday: { Monthly: { GBP: { price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: number; introductoryPrice: { ...; }; }[]; }; }; }; }; }; }' is not assignable to parameter of type 'ProductPrices'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
+      "message": "Argument of type '\"8.99\"' is not assignable to parameter of type 'number | null | undefined'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+      "message": "Argument of type 'null' is not assignable to parameter of type 'Promotion | undefined'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+      "message": "Argument of type '{}' is not assignable to parameter of type 'Promotion'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+      "message": "Argument of type '{ discountedPrice: number; }' is not assignable to parameter of type 'Promotion'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+      "message": "Argument of type '{ discountedPrice: number; }' is not assignable to parameter of type 'Promotion'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+      "message": "Argument of type '({ name: string; description: string; promoCode: number; discountedPrice: number; introductoryPrice?: undefined; } | { name: string; description: string; promoCode: number; introductoryPrice: { ...; }; discountedPrice?: undefined; })[]' is not assignable to parameter of type 'Promotion[]'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { price: number; periodLength: number; periodType: string; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+      "message": "Argument of type '{ name: string; description: string; promoCode: string; introductoryPrice: { price: number; periodLength: number; periodType: string; }; }' is not assignable to parameter of type 'Promotion'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts",
+      "message": "Argument of type '{ 'United Kingdom': { RestOfWorld: { NoProductOptions: { Quarterly: { GBP: { price: number; currency: string; promotions: never[]; }; }; SixWeekly: { GBP: { price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { ...; }; }[]; }; }; Annual: { ...; }; }...' is not assignable to parameter of type 'ProductPrices'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts",
+      "message": "Argument of type '{ 'United Kingdom': { RestOfWorld: { NoProductOptions: { Quarterly: { GBP: { price: number; currency: string; promotions: never[]; }; }; SixWeekly: { GBP: { price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { ...; }; }[]; }; }; Annual: { ...; }; }...' is not assignable to parameter of type 'ProductPrices'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts",
+      "message": "Argument of type '{ 'United Kingdom': { RestOfWorld: { NoProductOptions: { Quarterly: { GBP: { price: number; currency: string; promotions: never[]; }; }; SixWeekly: { GBP: { price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { ...; }; }[]; }; }; Annual: { ...; }; }...' is not assignable to parameter of type 'ProductPrices'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts",
+      "message": "Argument of type '{ 'United Kingdom': { RestOfWorld: { NoProductOptions: { Quarterly: { GBP: { price: number; currency: string; promotions: never[]; }; }; SixWeekly: { GBP: { price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { ...; }; }[]; }; }; Annual: { ...; }; }...' is not assignable to parameter of type 'ProductPrices'."
+    },
+    {
+      "path": "assets/helpers/productPrice/paperProductPrices.ts",
+      "message": "Argument of type 'FulfilmentOptions | null | undefined' is not assignable to parameter of type 'FulfilmentOptions | undefined'."
+    },
+    {
+      "path": "assets/helpers/productPrice/paperProductPrices.ts",
+      "message": "Argument of type 'FulfilmentOptions | null | undefined' is not assignable to parameter of type 'FulfilmentOptions | undefined'."
+    },
+    {
+      "path": "assets/helpers/rendering/render.ts",
+      "message": "Argument of type 'unknown' is not assignable to parameter of type 'Error'."
+    },
+    {
+      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+      "message": "Argument of type '{ field: string; message: string; }[]' is not assignable to parameter of type 'FormError<FormField>[]'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/AmazonPay/AmazonPayWallet.tsx",
+      "message": "Argument of type '(props: PropTypes) => Element | null' is not assignable to parameter of type 'ComponentType<Matching<{ amazonPayData: AmazonPayData; checkoutFormHasBeenSubmitted: boolean; } & { setAmazonPayWalletIsStale: (isReady: boolean) => Action; setAmazonPayOrderReferenceId: (orderReferenceId: string) => void; setAmazonPayPaymentSelected: (paymentSelected: boolean) => void; setAmazonPayBillingAgreementI...'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/ContributionArticleCount.tsx",
+      "message": "Argument of type 'CMP' is not assignable to parameter of type 'SetStateAction<null>'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/ContributionSubmit.tsx",
+      "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ currency: IsoCurrency; contributionType: keyof RegularContributionTypeMap<null> | \"ONE_OFF\"; isWaiting: boolean; paymentMethod: PaymentMethod; ... 9 more ...; amazonPayData: AmazonPayData; } & { ...; }, PropTypes>>'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/ContributionTypeTabs.tsx",
+      "message": "Argument of type 'string' is not assignable to parameter of type 'PaymentMethod'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+      "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ countryId: string; countryGroupId: CountryGroupId; currency: IsoCurrency; contributionType: keyof RegularContributionTypeMap<null> | \"ONE_OFF\"; ... 7 more ...; checkoutFormHasBeenSubmitted: boolean; } & { ...; }, PropTypes>>'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx",
+      "message": "Argument of type '(clientSecret: string) => Promise<Stripe3DSResult>' is not assignable to parameter of type '(clientSecret: string) => Promise<PaymentIntentResult>'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx",
+      "message": "Argument of type 'unknown' is not assignable to parameter of type 'string'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
+      "message": "Argument of type '(dispatch: Dispatch, getState: () => State) => void' is not assignable to parameter of type 'AnyAction'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/contributionsLandingActions.ts",
+      "message": "Argument of type '(clientSecret: string) => Promise<PaymentIntentResult>' is not assignable to parameter of type '(clientSecret: string) => Promise<Stripe3DSResult>'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+      "message": "Argument of type '\"\"' is not assignable to parameter of type 'BillingPeriod'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx",
+      "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ country: string; formErrors: FormError<FormField>[]; submissionError: Option<ErrorReason>; productPrices: ProductPrices; ... 31 more ...; salesforceCaseId?: string | undefined; } & { ...; }, FormFields & ... 1 more ... & { ...; }>>'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
+      "message": "Argument of type '\"\"' is not assignable to parameter of type 'BillingPeriod'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/thankYouContainer.ts",
+      "message": "Argument of type 'DefaultRootState' is not assignable to parameter of type 'AnyCheckoutState'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/thankYouGift.tsx",
+      "message": "Argument of type 'typeof ThankYouGift' is not assignable to parameter of type 'ComponentType<Matching<{ giftDeliveryDate: Option<string>; giftRecipient: Option<string>; } & DispatchProp<AnyAction>, PropTypes>>'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx",
+      "message": "Argument of type '{ positive: true; negative: false; }' is not assignable to parameter of type 'SetStateAction<{ positive: boolean; negative: boolean; open: boolean; }>'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.tsx",
+      "message": "Argument of type 'typeof PaperOrderSummary' is not assignable to parameter of type 'ComponentType<Matching<{ fulfilmentOption: FulfilmentOptions; productOption: ProductOptions; billingPeriod: BillingPeriod; productPrices: ProductPrices; } & DispatchProp<...>, PropTypes>>'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+      "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ formErrors: FormError<FormField>[]; submissionError: Option<ErrorReason>; productPrices: ProductPrices; billingAddressErrors: FormErrors; ... 33 more ...; salesforceCaseId?: string | undefined; } & { ...; }, FormFields & ... 1 more ... & { ...; }>>'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/helpers/options.ts",
+      "message": "Argument of type 'string' is not assignable to parameter of type '\"Saturday\" | \"Sunday\" | \"Weekend\" | \"Sixday\" | \"Everyday\"'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx",
+      "message": "Argument of type 'null' is not assignable to parameter of type 'string'."
+    },
+    {
+      "path": "assets/pages/promotion-terms/promotionTerms.tsx",
+      "message": "Argument of type 'ReduxState<{ productPrices: ProductPrices | null | undefined; promotionTerms: any; countryGroupId: CountryGroupId; }>' is not assignable to parameter of type 'State'."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
+      "message": "Argument of type 'DefaultRootState' is not assignable to parameter of type 'AnyCheckoutState'."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
+      "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ billingCountry: string; deliveryCountry: string; formErrors: FormError<FormField>[]; submissionError: Option<ErrorReason>; productPrices: ProductPrices; ... 31 more ...; salesforceCaseId?: string | undefined; } & { ...; }, FormFields & ... 1 more ... & { ...; }>>'."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx",
+      "message": "Argument of type 'Promotion | undefined' is not assignable to parameter of type 'Promotion | null'."
+    }
+  ],
+  "TS7006": [
+    {
+      "path": "assets/components/datePicker/datePickerHelpers.test.ts",
+      "message": "Parameter 'param' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+      "message": "Parameter 'state' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx",
+      "message": "Parameter 'state' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Parameter 'state' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Parameter 'field' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Parameter 'dispatchUpdate' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Parameter 'event' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Parameter 'event' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Parameter 'event' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/marketingConsent/marketingConsentPaper.tsx",
+      "message": "Parameter 'state' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+      "message": "Parameter 'ownProps' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+      "message": "Parameter 'billingPeriod' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+      "message": "Parameter 'trackingId' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+      "message": "Parameter 'product' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+      "message": "Parameter 'e' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+      "message": "Parameter 'r' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+      "message": "Parameter 'result' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+      "message": "Parameter 'key' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
+      "message": "Parameter 'e' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
+      "message": "Parameter 'e' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
+      "message": "Parameter 'e' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
+      "message": "Parameter 'e' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/summary.tsx",
+      "message": "Parameter 'props' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx",
+      "message": "Parameter 'isFeature' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx",
+      "message": "Parameter 'index' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx",
+      "message": "Parameter 'hierarchy' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/helpers/__tests__/checkoutsTest.ts",
+      "message": "Parameter 'key' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/helpers/__tests__/promiseTest.ts",
+      "message": "Parameter 'done' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/helpers/__tests__/promiseTest.ts",
+      "message": "Parameter 'fail' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/helpers/rendering/render.ts",
+      "message": "Parameter 'opts' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/helpers/rendering/ssrPages.ts",
+      "message": "Parameter 'content' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.tsx",
+      "message": "Parameter 'response' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/ExistingRecurringContributorErrorMessage.tsx",
+      "message": "Parameter 'event' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+      "message": "Parameter 'commonState' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+      "message": "Parameter 'initialState' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+      "message": "Parameter 'component' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
+      "message": "Parameter 'commonState' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
+      "message": "Parameter 'initialState' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
+      "message": "Parameter 'component' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+      "message": "Parameter 'searchText' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+      "message": "Parameter 'content' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+      "message": "Parameter 'node' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+      "message": "Parameter 'element' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+      "message": "Parameter 'originalState' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+      "message": "Parameter 'component' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
+      "message": "Parameter 'initialState' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
+      "message": "Parameter 'initialState' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
+      "message": "Parameter 'component' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
+      "message": "Parameter 'fulfilmentOption' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
+      "message": "Parameter 'item' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-landing/components/content/linkTo.tsx",
+      "message": "Parameter 'tab' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-landing/components/content/linkTo.tsx",
+      "message": "Parameter 'activeTab' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/subscriptions-landing/components/subscriptionsLandingContent.tsx",
+      "message": "Parameter 'index' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
+      "message": "Parameter 'billingPeriod' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
+      "message": "Parameter 'billingPeriod' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
+      "message": "Parameter 'isPending' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
+      "message": "Parameter 'orderIsGift' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
+      "message": "Parameter 'initialState' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
+      "message": "Parameter 'initialState' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
+      "message": "Parameter 'component' implicitly has an 'any' type."
+    }
+  ],
+  "TS7053": [
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Element implicitly has an 'any' type because expression of type 'any' can't be used to index type 'Readonly<StateTypes>'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<PropTypes> & Readonly<{ children?: ReactNode; }>'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
+    },
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
+    },
+    {
+      "path": "assets/helpers/contributions.ts",
+      "message": "Element implicitly has an 'any' type because expression of type 'number' can't be used to index type '{ '1': string; '2': string; '5': string; '6': string; '7': string; '10': string; '15': string; '20': string; '25': string; '30': string; '35': string; '40': string; '50': string; '75': string; '100': string; '125': string; '166': string; '200': string; ... 7 more ...; '16000': string; }'."
+    },
+    {
+      "path": "assets/helpers/globalsAndSwitches/globals.ts",
+      "message": "Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ... 7 more ...; EverydayPlus: { ...; ...'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
+      "message": "Element implicitly has an 'any' type because expression of type 'any' can't be used to index type 'Record<FulfilmentOptions, string[]>'."
+    }
+  ],
+  "TS7034": [
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Variable 'cardErrors' implicitly has type 'any[]' in some locations where its type cannot be determined."
+    },
+    {
+      "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
+      "message": "Variable 'testCopy' implicitly has type 'any' in some locations where its type cannot be determined."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
+      "message": "Variable 'productPrices' implicitly has type 'any' in some locations where its type cannot be determined."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
+      "message": "Variable 'productOptions' implicitly has type 'any' in some locations where its type cannot be determined."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+      "message": "Variable 'props' implicitly has type 'any' in some locations where its type cannot be determined."
+    }
+  ],
+  "TS7005": [
+    {
+      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+      "message": "Variable 'cardErrors' implicitly has an 'any[]' type."
+    },
+    {
+      "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
+      "message": "Variable 'testCopy' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
+      "message": "Variable 'testCopy' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
+      "message": "Variable 'testCopy' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
+      "message": "Variable 'testCopy' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
+      "message": "Variable 'testCopy' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
+      "message": "Variable 'productOptions' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
+      "message": "Variable 'productPrices' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
+      "message": "Variable 'productOptions' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+      "message": "Variable 'props' implicitly has an 'any' type."
+    }
+  ],
+  "TS6133": [
+    {
+      "path": "assets/components/directDebit/helpers/ajax.ts",
+      "message": "'isTestUser' is declared but its value is never read."
+    },
+    {
+      "path": "assets/helpers/forms/checkouts.ts",
+      "message": "'allSwitches' is declared but its value is never read."
+    },
+    {
+      "path": "assets/helpers/urls/externalLinks.ts",
+      "message": "'product' is declared but its value is never read."
+    },
+    {
+      "path": "assets/helpers/urls/externalLinks.ts",
+      "message": "'countryGroupId' is declared but its value is never read."
+    },
+    {
+      "path": "assets/helpers/urls/externalLinks.ts",
+      "message": "'countryGroupId' is declared but its value is never read."
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/ContributionTypeTabs.tsx",
+      "message": "'renderControl' is declared but its value is never read."
+    },
+    {
+      "path": "assets/pages/contributions-landing/contributionsLandingInit.ts",
+      "message": "'selectAmount' is declared but its value is never read."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.tsx",
+      "message": "'dispatch' is declared but its value is never read."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+      "message": "'content' is declared but its value is never read."
+    }
+  ],
+  "TS7031": [
+    {
+      "path": "assets/components/headers/header/header.tsx",
+      "message": "Binding element 'menuRef' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/headers/header/header.tsx",
+      "message": "Binding element 'logoRef' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/headers/header/header.tsx",
+      "message": "Binding element 'containerRef' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+      "message": "Binding element 'lineOne' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+      "message": "Binding element 'lineTwo' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+      "message": "Binding element 'city' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+      "message": "Binding element 'onClick' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+      "message": "Binding element 'isLoading' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+      "message": "Binding element 'initialState' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+      "message": "Binding element 'children' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
+      "message": "Binding element 'initialState' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
+      "message": "Binding element 'children' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+      "message": "Binding element 'initialState' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+      "message": "Binding element 'children' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
+      "message": "Binding element 'initialState' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
+      "message": "Binding element 'children' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
+      "message": "Binding element 'initialState' implicitly has an 'any' type."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
+      "message": "Binding element 'children' implicitly has an 'any' type."
+    }
+  ],
+  "TS2564": [
+    {
+      "path": "assets/components/headers/header/header.tsx",
+      "message": "Property 'observer' has no initializer and is not definitely assigned in the constructor."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+      "message": "Property 'selectRef' has no initializer and is not definitely assigned in the constructor."
+    }
+  ],
+  "TS2769": [
+    {
+      "path": "assets/components/headers/header/header.tsx",
+      "message": "No overload matches this call."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+      "message": "No overload matches this call."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+      "message": "No overload matches this call."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/addressSearch/addressResultsHelpers.ts",
+      "message": "No overload matches this call."
+    },
+    {
+      "path": "assets/helpers/polyfills/layout.ts",
+      "message": "No overload matches this call."
+    },
+    {
+      "path": "assets/helpers/rendering/render.ts",
+      "message": "No overload matches this call."
+    },
+    {
+      "path": "assets/helpers/rendering/render.ts",
+      "message": "No overload matches this call."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+      "message": "No overload matches this call."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
+      "message": "No overload matches this call."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+      "message": "No overload matches this call."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
+      "message": "No overload matches this call."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
+      "message": "No overload matches this call."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
+      "message": "No overload matches this call."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
+      "message": "No overload matches this call."
+    }
+  ],
+  "TS2314": [
+    {
+      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+      "message": "Generic type '$Call' requires 1 type argument(s)."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/postcodeFinderStore.ts",
+      "message": "Generic type '$Call' requires 1 type argument(s)."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/summary.tsx",
+      "message": "Generic type '$Call' requires 1 type argument(s)."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryThankYou.tsx",
+      "message": "Generic type '$Call' requires 1 type argument(s)."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.tsx",
+      "message": "Generic type '$Call' requires 1 type argument(s)."
+    }
+  ],
+  "TS2304": [
+    {
+      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+      "message": "Cannot find name 'GlobalState'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+      "message": "Cannot find name 'GlobalState'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+      "message": "Cannot find name 'GlobalState'."
+    },
+    {
+      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+      "message": "Cannot find name 'Stage'."
+    },
+    {
+      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+      "message": "Cannot find name 'Stage'."
+    }
+  ],
+  "TS2741": [
+    {
+      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+      "message": "Property 'label' is missing in type '{ onKeyPress: (e: KeyboardEvent<HTMLInputElement>) => void; css: SerializedStyles; name: string; width: 10; }' but required in type 'Pick<TextInputProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"id\" | \"onChange\" | \"value\" | \"dir\" | \"size\" | ... 275 more ... | \"enterKeyHint\">'."
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
+      "message": "Property 'value' is missing in type '{ id: string; image: any; label: string; name: string; checked: boolean; onChange: (...args: any[]) => any; }' but required in type 'Pick<RadioProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"type\" | \"id\" | \"onChange\" | \"value\" | \"dir\" | \"size\" | ... 273 more ... | \"enterKeyHint\">'."
+    },
+    {
+      "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
+      "message": "Property 'Widgets' is missing in type 'Record<string, any>' but required in type 'AmazonPaymentsObject'."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/endSummary/endSummarySelector.ts",
+      "message": "Property 'isPatron' is missing in type '{ priceDescription: string; promotion: string; orderIsAGift: boolean; digitalGiftBillingPeriod: \"Annual\" | \"Quarterly\"; price: string; }' but required in type 'EndSummaryProps'."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/helpers/orderSummaryText.ts",
+      "message": "Property 'NoProductOptions' is missing in type '{ Saturday: string; SaturdayPlus: string; Sunday: string; SundayPlus: string; Weekend: string; WeekendPlus: string; Sixday: string; SixdayPlus: string; Everyday: string; EverydayPlus: string; }' but required in type 'Record<ProductOptions, string>'."
+    }
+  ],
+  "TS2739": [
+    {
+      "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
+      "message": "Type '{ Stripe: Element; PayPal: Element; DirectDebit: Element; }' is missing the following properties from type 'Record<PaymentMethod, any>': Sepa, ExistingCard, ExistingDirectDebit, AmazonPay, None"
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
+      "message": "Type '{ Stripe: string; PayPal: string; DirectDebit: string; }' is missing the following properties from type 'Record<PaymentMethod, string>': Sepa, ExistingCard, ExistingDirectDebit, AmazonPay, None"
+    },
+    {
+      "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
+      "message": "Type '{ Stripe: string; PayPal: string; DirectDebit: string; }' is missing the following properties from type 'Record<PaymentMethod, string>': Sepa, ExistingCard, ExistingDirectDebit, AmazonPay, None"
+    },
+    {
+      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+      "message": "Type '{ ONE_OFF: { amounts: number[]; defaultAmount: number; }; }' is missing the following properties from type 'ContributionAmounts': MONTHLY, ANNUAL"
+    },
+    {
+      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+      "message": "Type '{ ONE_OFF: { min: number; minInWords: string; max: number; maxInWords: string; default: number; }; }' is missing the following properties from type 'Config': MONTHLY, ANNUAL"
+    },
+    {
+      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+      "message": "Type '{ ONE_OFF: { amounts: number[]; defaultAmount: number; }; }' is missing the following properties from type 'ContributionAmounts': MONTHLY, ANNUAL"
+    },
+    {
+      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+      "message": "Type '{ ONE_OFF: { min: number; minInWords: string; max: number; maxInWords: string; default: number; }; }' is missing the following properties from type 'Config': MONTHLY, ANNUAL"
+    },
+    {
+      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+      "message": "Type '{ ONE_OFF: { amounts: number[]; defaultAmount: number; }; }' is missing the following properties from type 'ContributionAmounts': MONTHLY, ANNUAL"
+    },
+    {
+      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+      "message": "Type '{ ONE_OFF: { min: number; minInWords: string; max: number; maxInWords: string; default: number; }; }' is missing the following properties from type 'Config': MONTHLY, ANNUAL"
+    },
+    {
+      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+      "message": "Type '{ ONE_OFF: { amounts: number[]; defaultAmount: number; }; }' is missing the following properties from type 'ContributionAmounts': MONTHLY, ANNUAL"
+    },
+    {
+      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+      "message": "Type '{ ONE_OFF: { min: number; minInWords: string; max: number; maxInWords: string; default: number; }; }' is missing the following properties from type 'Config': MONTHLY, ANNUAL"
+    },
+    {
+      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+      "message": "Type 'Element[]' is missing the following properties from type 'ReactElement<any, any>': type, props, key"
+    },
+    {
+      "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
+      "message": "Type '{}' is missing the following properties from type 'SelectedAmounts': MONTHLY, ANNUAL, ONE_OFF"
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
+      "message": "Type '{ HomeDelivery: string[]; Collection: string[]; }' is missing the following properties from type 'Record<FulfilmentOptions, string[]>': Domestic, RestOfWorld, NoFulfilmentOptions"
+    }
+  ],
+  "TS2532": [
+    {
+      "path": "assets/components/subscriptionCheckouts/summary.tsx",
+      "message": "Object is possibly 'undefined'."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Object is possibly 'undefined'."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Object is possibly 'undefined'."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Object is possibly 'undefined'."
+    }
+  ],
+  "TS2556": [
+    {
+      "path": "assets/helpers/__tests__/contributionsTests.ts",
+      "message": "A spread argument must either have a tuple type or be passed to a rest parameter."
+    },
+    {
+      "path": "assets/helpers/__tests__/contributionsTests.ts",
+      "message": "A spread argument must either have a tuple type or be passed to a rest parameter."
+    },
+    {
+      "path": "assets/helpers/__tests__/contributionsTests.ts",
+      "message": "A spread argument must either have a tuple type or be passed to a rest parameter."
+    }
+  ],
+  "TS2554": [
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/__tests__/formValidation.ts",
+      "message": "Expected 3 arguments, but got 2."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+      "message": "Expected 1 arguments, but got 0."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+      "message": "Expected 1 arguments, but got 0."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+      "message": "Expected 1 arguments, but got 0."
+    },
+    {
+      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+      "message": "Expected 3 arguments, but got 1."
+    },
+    {
+      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+      "message": "Expected 6 arguments, but got 1."
+    },
+    {
+      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+      "message": "Expected 3 arguments, but got 1."
+    },
+    {
+      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+      "message": "Expected 6 arguments, but got 1."
+    },
+    {
+      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+      "message": "Expected 6 arguments, but got 1."
+    },
+    {
+      "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
+      "message": "Expected 1 arguments, but got 0."
+    },
+    {
+      "path": "assets/pages/showcase/components/otherProducts.tsx",
+      "message": "Expected 1 arguments, but got 0."
+    }
+  ],
+  "TS2569": [
+    {
+      "path": "assets/helpers/checkoutForm/checkoutForm.ts",
+      "message": "Type 'HTMLCollectionOf<HTMLInputElement>' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators."
+    },
+    {
+      "path": "assets/helpers/checkoutForm/checkoutForm.ts",
+      "message": "Type 'HTMLFormControlsCollection' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators."
+    }
+  ],
+  "TS2411": [
+    {
+      "path": "assets/helpers/globalsAndSwitches/settings.ts",
+      "message": "Property 'experiments' of type 'Record<string, { name: string; description: string; state: Status; }>' is not assignable to 'string' index type 'SwitchObject'."
+    }
+  ],
+  "TS7017": [
+    {
+      "path": "assets/helpers/page/__tests__/pageTest.ts",
+      "message": "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature."
+    },
+    {
+      "path": "assets/helpers/page/__tests__/pageTest.ts",
+      "message": "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature."
+    },
+    {
+      "path": "assets/helpers/page/__tests__/pageTest.ts",
+      "message": "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature."
+    },
+    {
+      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+      "message": "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature."
+    }
+  ],
+  "TS2367": [
+    {
+      "path": "assets/helpers/polyfills/details.ts",
+      "message": "This condition will always return 'true' since the types 'Element' and 'Document' have no overlap."
+    },
+    {
+      "path": "assets/pages/paper-subscription-landing/components/content/linkTo.tsx",
+      "message": "This condition will always return 'false' since the types 'PaperFulfilmentOptions' and '\"delivery\"' have no overlap."
+    },
+    {
+      "path": "assets/pages/promotion-terms/weeklyTerms.tsx",
+      "message": "This condition will always return 'false' since the types '\"Monthly\"' and '\"Quarterly\"' have no overlap."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/helpers/__tests__/deliveryDays.ts",
+      "message": "This condition will always return 'false' since the types '() => number' and 'number' have no overlap."
+    }
+  ],
+  "TS2740": [
+    {
+      "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
+      "message": "Type '{ GBP: { price: number; savingVsRetail: number; currency: \"GBP\"; fixedTerm: false; promotions: never[]; }; }' is missing the following properties from type 'Record<IsoCurrency, ProductPrice>': NZD, AUD, CAD, USD, and 5 more."
+    },
+    {
+      "path": "assets/helpers/productPrice/productOptions.ts",
+      "message": "Type '{ Saturday: \"SaturdayPlus\"; Sunday: \"SundayPlus\"; Weekend: \"WeekendPlus\"; Sixday: \"SixdayPlus\"; Everyday: \"EverydayPlus\"; }' is missing the following properties from type 'Record<ProductOptions, ProductOptions>': NoProductOptions, SaturdayPlus, SundayPlus, WeekendPlus, and 2 more."
+    },
+    {
+      "path": "assets/helpers/productPrice/productOptions.ts",
+      "message": "Type '{ SaturdayPlus: \"Saturday\"; SundayPlus: \"Sunday\"; WeekendPlus: \"Weekend\"; SixdayPlus: \"Sixday\"; EverydayPlus: \"Everyday\"; }' is missing the following properties from type 'Record<ProductOptions, ProductOptions>': NoProductOptions, Saturday, Sunday, Weekend, and 2 more."
+    },
+    {
+      "path": "assets/helpers/productPrice/subscriptions.ts",
+      "message": "Type '{ GBPCountries: number; }' is missing the following properties from type 'Record<CountryGroupId, number>': UnitedStates, AUDCountries, EURCountries, International, and 2 more."
+    },
+    {
+      "path": "assets/helpers/rendering/render.ts",
+      "message": "Type 'Element' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, dir, and 109 more."
+    }
+  ],
+  "TS2531": [
+    {
+      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+      "message": "Object is possibly 'null'."
+    },
+    {
+      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+      "message": "Object is possibly 'null'."
+    }
+  ],
+  "TS7016": [
+    {
+      "path": "assets/helpers/rendering/render.ts",
+      "message": "Could not find a declaration file for module 'preact/debug'. 'support-frontend/node_modules/preact/debug/dist/debug.js' implicitly has an 'any' type."
+    }
+  ],
+  "TS2707": [
+    {
+      "path": "assets/pages/contributions-landing/contributionsLandingInit.ts",
+      "message": "Generic type 'Store<S, A>' requires between 0 and 2 type arguments."
+    }
+  ],
+  "TS2525": [
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+      "message": "Initializer provides no value for this binding element and the binding element has no default value."
+    },
+    {
+      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
+      "message": "Initializer provides no value for this binding element and the binding element has no default value."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+      "message": "Initializer provides no value for this binding element and the binding element has no default value."
+    },
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
+      "message": "Initializer provides no value for this binding element and the binding element has no default value."
+    },
+    {
+      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
+      "message": "Initializer provides no value for this binding element and the binding element has no default value."
+    }
+  ],
+  "TS2745": [
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/addDigiSubCta.tsx",
+      "message": "This JSX tag's 'children' prop expects type 'ReactElement<any, string | JSXElementConstructor<any>>[]' which requires multiple children, but only a single child was provided."
+    },
+    {
+      "path": "assets/pages/paper-subscription-landing/components/content/deliveryTab.tsx",
+      "message": "This JSX tag's 'children' prop expects type 'ReactElement<any, string | JSXElementConstructor<any>>[]' which requires multiple children, but only a single child was provided."
+    }
+  ],
+  "TS7022": [
+    {
+      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+      "message": "'initialState' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer."
+    }
+  ],
+  "TS2571": [
+    {
+      "path": "assets/pages/promotion-terms/promotionTermsReducer.ts",
+      "message": "Object is of type 'unknown'."
+    },
+    {
+      "path": "assets/pages/promotion-terms/promotionTermsReducer.ts",
+      "message": "Object is of type 'unknown'."
+    },
+    {
+      "path": "assets/pages/promotion-terms/promotionTermsReducer.ts",
+      "message": "Object is of type 'unknown'."
+    }
+  ],
+  "TS2698": [
+    {
+      "path": "assets/pages/promotion-terms/promotionTermsReducer.ts",
+      "message": "Spread types may only be created from object types."
+    },
+    {
+      "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
+      "message": "Spread types may only be created from object types."
+    },
+    {
+      "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
+      "message": "Spread types may only be created from object types."
+    },
+    {
+      "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
+      "message": "Spread types may only be created from object types."
+    },
+    {
+      "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
+      "message": "Spread types may only be created from object types."
+    },
+    {
+      "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
+      "message": "Spread types may only be created from object types."
+    }
+  ]
 }

--- a/support-frontend/typescript-errors.json
+++ b/support-frontend/typescript-errors.json
@@ -1,2309 +1,2304 @@
 {
-  "errorCounts": {
-    "byCode": {
-      "TS1208": 1,
-      "TS2305": 21,
-      "TS2322": 128,
-      "TS2578": 8,
-      "TS2339": 26,
-      "TS2345": 99,
-      "TS7006": 60,
-      "TS7053": 12,
-      "TS7034": 5,
-      "TS7005": 10,
-      "TS6133": 9,
-      "TS7031": 18,
-      "TS2564": 2,
-      "TS2769": 14,
-      "TS2314": 5,
-      "TS2304": 5,
-      "TS2741": 5,
-      "TS2739": 14,
-      "TS2532": 4,
-      "TS2556": 3,
-      "TS2554": 31,
-      "TS2569": 2,
-      "TS2411": 1,
-      "TS7017": 4,
-      "TS2367": 4,
-      "TS2740": 5,
-      "TS2531": 2,
-      "TS7016": 1,
-      "TS2707": 1,
-      "TS2525": 5,
-      "TS2745": 2,
-      "TS7022": 1,
-      "TS2571": 3,
-      "TS2698": 6
-    },
-    "byPath": {
-      "assets/__mocks__/imageMock.ts": 1,
-      "assets/components/asyncronously/asyncronously.ts": 2,
-      "assets/components/content/content.tsx": 2,
-      "assets/components/footerCompliant/Footer.tsx": 4,
-      "assets/components/forms/customFields/options.tsx": 1,
-      "assets/components/forms/label.tsx": 2,
-      "assets/components/headers/header/header.tsx": 6,
-      "assets/components/headers/header/mobileMenuToggler.tsx": 1,
-      "assets/components/headers/mobileMenu/mobileMenu.tsx": 2,
-      "assets/components/headers/veggieBurgerButton/veggieBurgerButton.tsx": 2,
-      "assets/components/menu/menu.tsx": 2,
-      "assets/components/product/productOption.tsx": 1,
-      "assets/components/product/productOptionSmall.tsx": 1,
-      "assets/components/subscriptionCheckouts/layout.tsx": 1,
-      "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx": 6,
-      "assets/pages/digital-subscription-checkout/components/thankYou/pageSection.tsx": 1,
-      "assets/pages/digital-subscription-landing/components/comparison/comparisonTable.tsx": 3,
-      "assets/pages/digital-subscription-landing/components/comparison/interactiveTableRowContents.tsx": 1,
-      "assets/pages/paper-subscription-landing/components/content/linkTo.tsx": 4,
-      "assets/pages/subscriptions-landing/components/subscriptionsProduct.tsx": 2,
-      "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx": 4,
-      "assets/components/datePicker/datePickerHelpers.test.ts": 2,
-      "assets/components/directDebit/directDebitForm/directDebitForm.tsx": 10,
-      "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx": 5,
-      "assets/components/headers/links/links.tsx": 1,
-      "assets/components/marketingConsent/marketingConsent.tsx": 1,
-      "assets/components/page/page.tsx": 1,
-      "assets/components/page/pageTitle.tsx": 4,
-      "assets/components/priceLabel/priceLabel.tsx": 1,
-      "assets/components/subscriptionCheckouts/address/addressFields.tsx": 14,
-      "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx": 12,
-      "assets/components/subscriptionCheckouts/billingPeriodSelector.tsx": 2,
-      "assets/components/subscriptionCheckouts/personalDetails.tsx": 7,
-      "assets/components/subscriptionCheckouts/summary.tsx": 6,
-      "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx": 4,
-      "assets/helpers/__tests__/formValidation.ts": 29,
-      "assets/helpers/checkoutForm/checkoutForm.ts": 3,
-      "assets/helpers/globalsAndSwitches/globals.ts": 2,
-      "assets/helpers/internationalisation/localCurrencyCountry.ts": 9,
-      "assets/helpers/productPrice/__tests__/promotionsTests.ts": 14,
-      "assets/helpers/utilities/utilities.ts": 1,
-      "assets/hocs/canShow.tsx": 1,
-      "assets/hocs/withError.tsx": 1,
-      "assets/hocs/withLabel.tsx": 1,
-      "assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.tsx": 2,
-      "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx": 9,
-      "assets/pages/contributions-landing/components/SepaForm.tsx": 7,
-      "assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.tsx": 1,
-      "assets/pages/contributions-landing/contributionsLandingReducer.ts": 5,
-      "assets/pages/contributions-landing/setUserStateActions.ts": 3,
-      "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx": 9,
-      "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx": 4,
-      "assets/pages/digital-subscription-checkout/components/endSummary/endSummaryMobile.tsx": 1,
-      "assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.ts": 1,
-      "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx": 7,
-      "assets/pages/digital-subscription-landing/components/events/eventsModule.tsx": 1,
-      "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx": 4,
-      "assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.tsx": 1,
-      "assets/pages/paper-subscription-checkout/components/addDigiSubCta.tsx": 3,
-      "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx": 16,
-      "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx": 8,
-      "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx": 12,
-      "assets/pages/paper-subscription-checkout/helpers/options.ts": 2,
-      "assets/pages/paper-subscription-landing/components/content/prices.tsx": 1,
-      "assets/pages/paper-subscription-landing/components/hero/hero.tsx": 1,
-      "assets/pages/showcase/components/ctaContribute.tsx": 1,
-      "assets/pages/showcase/components/ctaSubscribe.tsx": 1,
-      "assets/pages/showcase/components/hero.tsx": 3,
-      "assets/pages/showcase/components/otherProduct.tsx": 1,
-      "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx": 7,
-      "assets/pages/subscriptions-redemption/api.ts": 1,
-      "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx": 7,
-      "assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx": 2,
-      "assets/pages/weekly-subscription-landing/components/content/prices.tsx": 1,
-      "assets/pages/contributions-landing/components/ContributionArticleCount.tsx": 3,
-      "assets/pages/paper-subscription-landing/components/content/tabAccordionRow.tsx": 1,
-      "assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx": 2,
-      "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx": 22,
-      "assets/components/paypalExpressButton/PayPalExpressButton.tsx": 1,
-      "assets/helpers/__tests__/urlTest.ts": 1,
-      "assets/helpers/csrf/csrfReducer.ts": 2,
-      "assets/helpers/internationalisation/__tests__/countryGroupTest.ts": 1,
-      "assets/helpers/internationalisation/__tests__/countryTest.ts": 1,
-      "assets/helpers/rendering/render.ts": 8,
-      "assets/pages/contributions-landing/contributionsLanding.tsx": 5,
-      "assets/pages/digital-subscription-checkout/thankYouContainer.ts": 2,
-      "assets/components/datePicker/datePicker.tsx": 2,
-      "assets/components/directDebit/__tests__/directDebitReducerTest.ts": 1,
-      "assets/components/directDebit/helpers/ajax.ts": 2,
-      "assets/components/marketingConsent/helpers.ts": 1,
-      "assets/components/marketingConsent/marketingConsentPaper.tsx": 2,
-      "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx": 13,
-      "assets/components/subscriptionCheckouts/address/__tests__/addressFieldsStore.ts": 1,
-      "assets/components/subscriptionCheckouts/addressSearch/__tests__/addressFieldsStore.ts": 1,
-      "assets/components/subscriptionCheckouts/stripeForm/stripeForm.tsx": 1,
-      "assets/helpers/__tests__/checkoutsTest.ts": 7,
-      "assets/helpers/__tests__/promiseTest.ts": 3,
-      "assets/helpers/contributions.ts": 2,
-      "assets/helpers/identityApis.ts": 1,
-      "assets/helpers/internationalisation/__tests__/currencyTest.ts": 1,
-      "assets/helpers/page/__tests__/pageTest.ts": 4,
-      "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts": 4,
-      "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts": 8,
-      "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts": 5,
-      "assets/helpers/productPrice/__tests__/productPricesTests.ts": 6,
-      "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts": 4,
-      "assets/helpers/productPrice/paperProductPrices.ts": 2,
-      "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts": 9,
-      "assets/pages/contributions-landing/components/AmazonPay/AmazonPayWallet.tsx": 1,
-      "assets/pages/contributions-landing/components/ContributionSubmit.tsx": 1,
-      "assets/pages/contributions-landing/components/ContributionTypeTabs.tsx": 2,
-      "assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx": 2,
-      "assets/pages/contributions-landing/contributionsLandingActions.ts": 1,
-      "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx": 8,
-      "assets/pages/digital-subscription-checkout/thankYouGift.tsx": 1,
-      "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.tsx": 2,
-      "assets/pages/promotion-terms/promotionTerms.tsx": 1,
-      "assets/pages/weekly-subscription-checkout/components/thankYou.tsx": 6,
-      "assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx": 1,
-      "assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx": 1,
-      "assets/helpers/rendering/ssrPages.ts": 1,
-      "assets/pages/contributions-landing/components/ExistingRecurringContributorErrorMessage.tsx": 1,
-      "assets/pages/paper-subscription-checkout/components/thankYou.tsx": 5,
-      "assets/pages/subscriptions-landing/components/subscriptionsLandingContent.tsx": 1,
-      "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx": 7,
-      "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts": 6,
-      "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts": 5,
-      "assets/helpers/forms/checkouts.ts": 1,
-      "assets/helpers/urls/externalLinks.ts": 3,
-      "assets/pages/contributions-landing/contributionsLandingInit.ts": 2,
-      "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.tsx": 1,
-      "assets/components/subscriptionCheckouts/addressSearch/addressResultsHelpers.ts": 1,
-      "assets/helpers/polyfills/layout.ts": 1,
-      "assets/components/subscriptionCheckouts/address/postcodeFinderStore.ts": 1,
-      "assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryThankYou.tsx": 1,
-      "assets/pages/digital-subscription-checkout/components/endSummary/endSummarySelector.ts": 1,
-      "assets/pages/paper-subscription-checkout/helpers/orderSummaryText.ts": 1,
-      "assets/helpers/__tests__/contributionsTests.ts": 3,
-      "assets/pages/showcase/components/otherProducts.tsx": 1,
-      "assets/helpers/globalsAndSwitches/settings.ts": 1,
-      "assets/helpers/polyfills/details.ts": 1,
-      "assets/pages/promotion-terms/weeklyTerms.tsx": 1,
-      "assets/pages/weekly-subscription-checkout/helpers/__tests__/deliveryDays.ts": 1,
-      "assets/helpers/productPrice/productOptions.ts": 2,
-      "assets/helpers/productPrice/subscriptions.ts": 1,
-      "assets/pages/paper-subscription-landing/components/content/deliveryTab.tsx": 1,
-      "assets/pages/promotion-terms/promotionTermsReducer.ts": 4
-    }
-  },
-  "TS1208": [
-    {
-      "path": "assets/__mocks__/imageMock.ts",
-      "message": "'imageMock.ts' cannot be compiled under '--isolatedModules' because it is considered a global script file. Add an import, export, or an empty 'export {}' statement to make it a module."
-    }
-  ],
-  "TS2305": [
-    {
-      "path": "assets/components/asyncronously/asyncronously.ts",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/components/content/content.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/components/footerCompliant/Footer.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/components/forms/customFields/options.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/components/forms/label.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/components/headers/header/header.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/components/headers/header/mobileMenuToggler.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/components/headers/mobileMenu/mobileMenu.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/components/headers/veggieBurgerButton/veggieBurgerButton.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/components/menu/menu.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/components/product/productOption.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/components/product/productOptionSmall.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/layout.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/thankYou/pageSection.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/comparison/comparisonTable.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/comparison/interactiveTableRowContents.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-landing/components/content/linkTo.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    },
-    {
-      "path": "assets/pages/subscriptions-landing/components/subscriptionsProduct.tsx",
-      "message": "Module '\"react\"' has no exported member 'Node'."
-    }
-  ],
-  "TS2322": [
-    {
-      "path": "assets/components/asyncronously/asyncronously.ts",
-      "message": "Type 'ComponentType<any>' is not assignable to type 'null'."
-    },
-    {
-      "path": "assets/components/content/content.tsx",
-      "message": "Type 'Option<string> | undefined' is not assignable to type 'string | undefined'."
-    },
-    {
-      "path": "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx",
-      "message": "Type '{ children: (Element | Element[])[]; style: { top: number; left: number; position: string; }; }' is not assignable to type 'IntrinsicAttributes & { children: any; }'."
-    },
-    {
-      "path": "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx",
-      "message": "Type '{ children: string[]; href: string; onClick: () => void; isSelected: boolean; }' is not assignable to type 'IntrinsicAttributes & itemProps & { href: string; }'."
-    },
-    {
-      "path": "assets/components/datePicker/datePickerHelpers.test.ts",
-      "message": "Type 'typeof MockDate' is not assignable to type 'DateConstructor'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-      "message": "Type 'string' is not assignable to type 'number | undefined'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-      "message": "Type 'string' is not assignable to type 'number | undefined'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-      "message": "Type 'string' is not assignable to type 'number | undefined'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
-      "message": "Type 'string' is not assignable to type 'number | undefined'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
-      "message": "Type '{ id: string; label: string; autoComplete: string; type: \"text\"; inputmode: string; pattern: string; value: string; onChange: (e: ChangeEvent<HTMLInputElement>) => void; error: string; minLength: number; maxLength: number; width: 10; }' is not assignable to type 'IntrinsicAttributes & Pick<TextInputProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | ... 280 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
-      "message": "Type '{ id: string; value: string; autoComplete: string; onChange: (e: ChangeEvent<HTMLInputElement>) => void; minLength: number; maxLength: number; type: \"text\"; inputmode: string; pattern: string; label: string; error: string; }' is not assignable to type 'IntrinsicAttributes & Pick<TextInputProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | ... 280 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
-      "message": "Type 'string' is not assignable to type 'boolean | undefined'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
-      "message": "Type 'EventHandler' is not assignable to type 'MouseEventHandler<HTMLButtonElement>'."
-    },
-    {
-      "path": "assets/components/forms/label.tsx",
-      "message": "Type 'Option<string>' is not assignable to type 'string | undefined'."
-    },
-    {
-      "path": "assets/components/headers/links/links.tsx",
-      "message": "Type '\"_blank\" | null' is not assignable to type 'HTMLAttributeAnchorTarget | undefined'."
-    },
-    {
-      "path": "assets/components/headers/mobileMenu/mobileMenu.tsx",
-      "message": "Type '{ width: number; } | null | undefined' is not assignable to type 'CSSProperties | undefined'."
-    },
-    {
-      "path": "assets/components/headers/veggieBurgerButton/veggieBurgerButton.tsx",
-      "message": "Type '{ children: any[]; 'aria-haspopup': Option<string>; onClick: Option<(...args: any[]) => any>; style: Option<{}>; className: string; ref: Option<(...args: any[]) => any>; }' is not assignable to type 'DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>'."
-    },
-    {
-      "path": "assets/components/marketingConsent/marketingConsent.tsx",
-      "message": "Type '{ children: string; appearance: \"green\"; iconSide: \"right\"; \"aria-label\": string; onClick: () => void; icon: Element; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\"> & Partial<Pick<PropTypes, \"type\" | \"disabled\" | ... 4 more ... | \"aria-label\">> & Partial<...>'."
-    },
-    {
-      "path": "assets/components/menu/menu.tsx",
-      "message": "Type '{ children: any[]; className: any; \"data-is-selected\": boolean; }' is not assignable to type 'IntrinsicAttributes'."
-    },
-    {
-      "path": "assets/components/page/page.tsx",
-      "message": "Type 'string | null | undefined' is not assignable to type 'string | undefined'."
-    },
-    {
-      "path": "assets/components/page/pageTitle.tsx",
-      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-    },
-    {
-      "path": "assets/components/page/pageTitle.tsx",
-      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-    },
-    {
-      "path": "assets/components/page/pageTitle.tsx",
-      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-    },
-    {
-      "path": "assets/components/page/pageTitle.tsx",
-      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-    },
-    {
-      "path": "assets/components/priceLabel/priceLabel.tsx",
-      "message": "Type 'false | Record<string, any> | undefined' is not assignable to type 'string | undefined'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-      "message": "Type 'ReactNode' is not assignable to type 'Element'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-      "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-      "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-      "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-      "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-      "message": "Type 'null' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>> | undefined'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-      "message": "Type '{ children: any[]; onChange: (e: ChangeEvent<HTMLSelectElement>) => void; forwardRef: (r: any) => void; id: string; label: string; }' is not assignable to type 'IntrinsicAttributes & Pick<SelectProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"children\" | \"color\" | \"hidden\" | \"id\" | \"onChange\" | ... 257 more ... | \"supporting\"> & Partial<...> & Partial<...>'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-      "message": "Type 'null' is not assignable to type 'string | number | readonly string[] | undefined'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/billingPeriodSelector.tsx",
-      "message": "Type '{ children: Element[]; legend: string; role: string; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/billingPeriodSelector.tsx",
-      "message": "Type '{ label: string; value: string; supporting: string; offer: string; name: string; checked: boolean; onChange: () => Action; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"type\" | ... 278 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
-      "message": "Type '{ children: Element[]; id: string; label: string; hideLabel: true; error: string | undefined; role: string; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
-      "message": "Type 'null' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>> | undefined'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
-      "message": "Type 'Option<string> | undefined' is not assignable to type 'string | number | readonly string[] | undefined'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
-      "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/summary.tsx",
-      "message": "Type '{ className: any; productPrice: ProductPrice; billingPeriod: BillingPeriod; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"billingPeriod\" | \"productPrice\"> & Partial<Pick<PropTypes, \"orderIsAGift\" | \"giftStyles\">> & Partial<...>'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/summary.tsx",
-      "message": "Type '{ className: any; productPrice: ProductPrice; billingPeriod: BillingPeriod; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"billingPeriod\" | \"productPrice\"> & Partial<Pick<PropTypes, \"orderIsAGift\" | \"giftStyles\">> & Partial<...>'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/summary.tsx",
-      "message": "Type '{ className: any; productPrice: ProductPrice; billingPeriod: BillingPeriod; giftStyles: any; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"billingPeriod\" | \"productPrice\"> & Partial<Pick<PropTypes, \"orderIsAGift\" | \"giftStyles\">> & Partial<...>'."
-    },
-    {
-      "path": "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx",
-      "message": "Type '{ children: string; href: string; onClick: (...args: any[]) => any; appearance: \"primary\" | \"secondary\" | \"tertiary\" | \"tertiaryFeature\"; modifierClasses: string[]; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\" | \"href\"> & Partial<Pick<PropTypes, \"appearance\" | \"icon\" | \"iconSide\" | \"modifierClasses\" | \"aria-label\">> & Partial<...>'."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Type '{ countryCode: string; stateCode?: string | undefined; } | {}' is not assignable to type '{ countryCode: string; stateCode?: string | undefined; } | undefined'."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Type 'null' is not assignable to type 'string'."
-    },
-    {
-      "path": "assets/helpers/checkoutForm/checkoutForm.ts",
-      "message": "Type 'unknown' is not assignable to type 'string'."
-    },
-    {
-      "path": "assets/helpers/globalsAndSwitches/globals.ts",
-      "message": "Type 'unknown' is not assignable to type 'Settings'."
-    },
-    {
-      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-      "message": "Type 'string | null | undefined' is not assignable to type 'string | number | symbol'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-      "message": "Type 'null' is not assignable to type 'number | undefined'."
-    },
-    {
-      "path": "assets/helpers/utilities/utilities.ts",
-      "message": "Type 'string | null | undefined' is not assignable to type 'string'."
-    },
-    {
-      "path": "assets/hocs/canShow.tsx",
-      "message": "Type 'Omit<AugmentedProps<Props>, \"isShown\">' is not assignable to type 'IntrinsicAttributes & Props & { children?: ReactNode; }'."
-    },
-    {
-      "path": "assets/hocs/withError.tsx",
-      "message": "Type 'Omit<AugmentedProps<Props>, \"error\">' is not assignable to type 'IntrinsicAttributes & Props & { children?: ReactNode; }'."
-    },
-    {
-      "path": "assets/hocs/withLabel.tsx",
-      "message": "Type 'Omit<AugmentedProps<Props>, \"footer\" | \"label\" | \"optional\">' is not assignable to type 'IntrinsicAttributes & Props & { children?: ReactNode; }'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.tsx",
-      "message": "Type '{ children: string; type: \"button\"; onClick: () => void; \"aria-label\": string; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\"> & Partial<Pick<PropTypes, \"type\" | \"disabled\" | ... 4 more ... | \"aria-label\">> & Partial<...>'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-      "message": "Type 'false | \"Please select a payment method\"' is not assignable to type 'string | undefined'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-      "message": "Type 'false | Element' is not assignable to type 'Element'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-      "message": "Type 'false | Element[]' is not assignable to type 'Element'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-      "message": "Type 'RecentlySignedInExistingPaymentMethod' is not assignable to type 'string'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-      "message": "Type '{ '& + div': { display: string; width: string; margin: number; justifyContent: string; }; '& + div svg': { width: string; height: string; }; '&:not(:checked) + div svg': { filter: string; }; }' is not assignable to type 'SerializedStyles | SerializedStyles[] | undefined'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-      "message": "Type '{ '& + div': { display: string; width: string; margin: number; justifyContent: string; }; '& + div svg': { width: string; height: string; }; '&:not(:checked) + div svg': { filter: string; }; }' is not assignable to type 'SerializedStyles | SerializedStyles[] | undefined'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-      "message": "Type 'false | Element | undefined' is not assignable to type 'Element'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
-      "message": "Type 'string' is not assignable to type 'number | undefined'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
-      "message": "Type 'string | null' is not assignable to type 'string | number | readonly string[] | undefined'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
-      "message": "Type 'string | null' is not assignable to type 'string | undefined'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
-      "message": "Type 'string' is not assignable to type 'number | undefined'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
-      "message": "Type 'string' is not assignable to type 'number | undefined'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
-      "message": "Type 'string | null' is not assignable to type 'string | number | readonly string[] | undefined'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
-      "message": "Type 'string | null' is not assignable to type 'string | undefined'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.tsx",
-      "message": "Type '{ stripeKey: string; isTestUser: boolean; }' is not assignable to type 'IntrinsicAttributes & Omit<{ contributionType: keyof RegularContributionTypeMap<null> | \"ONE_OFF\"; checkoutFormHasBeenSubmitted: boolean; ... 9 more ...; isTestUser: boolean; } & { ...; } & { ...; }, \"csrf\" | ... 19 more ... | \"setStripeRecurringRecaptchaVerified\">'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
-      "message": "Type '{ Stripe: null; AmazonPay: null; }' is not assignable to type '{ Stripe: StripeHandler | null; }'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
-      "message": "Type '{ hasBegunLoading: false; amazonPayLibrary: { amazonLoginObject: null; amazonPaymentsObject: null; }; loginButtonReady: false; walletIsStale: false; orderReferenceId: null; paymentSelected: false; hasAccessToken: false; fatalError: false; amazonBillingAgreementConsentStatus: false; }' is not assignable to type 'AmazonPayData'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
-      "message": "Type '{ contributionType: keyof RegularContributionTypeMap<null> | \"ONE_OFF\"; showOtherAmount: boolean; formData: { otherAmounts: OtherAmounts; ... 5 more ...; email: string | null; }; ... 17 more ...; oneOffRecaptchaToken: string | null; }' is not assignable to type 'FormState'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/setUserStateActions.ts",
-      "message": "Type '(isSignedIn: boolean) => (arg0: (...args: any[]) => any) => void' is not assignable to type '(isSignedIn: boolean) => Action'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/setUserStateActions.ts",
-      "message": "Type '() => (arg0: (...args: any[]) => any) => void' is not assignable to type '() => Action'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/setUserStateActions.ts",
-      "message": "Type '(unsafeState: string) => (arg0: (...args: any[]) => any) => void' is not assignable to type '(stateField: string) => Action'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-      "message": "Type 'Promise<{ json: () => Promise<{ client_secret: string; }>; }>' is not assignable to type 'Promise<Response>'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx",
-      "message": "Type '{ image: Element; title: string; description: string; productPrice: ProductPrice; billingPeriod: \"Annual\" | \"Monthly\"; changeSubscription: string; isPatron: boolean; }' is not assignable to type 'IntrinsicAttributes & Pick<OrderSummaryPropTypes, \"title\" | \"image\" | \"billingPeriod\" | \"productPrice\" | \"isPatron\"> & Partial<...> & Partial<...>'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx",
-      "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx",
-      "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/endSummary/endSummaryMobile.tsx",
-      "message": "Type '{ orderIsAGift: Option<boolean> | undefined; }' is not assignable to type 'IntrinsicAttributes & Omit<EndSummaryProps, \"orderIsAGift\" | \"promotion\" | \"price\" | \"priceDescription\" | \"digitalGiftBillingPeriod\" | \"isPatron\">'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.ts",
-      "message": "Type '\"normal\"' is not assignable to type 'FontWeight | undefined'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/comparison/comparisonTable.tsx",
-      "message": "Type 'SerializedStyles' is not assignable to type 'string | string[] | undefined'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/comparison/comparisonTable.tsx",
-      "message": "Type 'string' is not assignable to type 'number | undefined'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
-      "message": "Type '{ icon: JSX.Element; description: string; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
-      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
-      "message": "Type '{ icon: JSX.Element; description: string; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
-      "message": "Type '{ icon: JSX.Element; description: JSX.Element; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
-      "message": "Type '{ icon: JSX.Element; description: JSX.Element; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
-      "message": "Type '{ icon: JSX.Element; description: string; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
-      "message": "Type 'SerializedStyles' is not assignable to type 'string[] | Option<string> | undefined'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/events/eventsModule.tsx",
-      "message": "Type 'SerializedStyles' is not assignable to type 'string | string[] | undefined'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx",
-      "message": "Type 'SerializedStyles | null' is not assignable to type 'SerializedStyles'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx",
-      "message": "Type 'SerializedStyles | null' is not assignable to type 'SerializedStyles'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.tsx",
-      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/addDigiSubCta.tsx",
-      "message": "Type 'string | SerializedStyles' is not assignable to type 'SerializedStyles'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-      "message": "Type '{ image: Element; total: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; includesDigiSub: boolean; digiSubPrice: string; changeSubscription: string; }' is not assignable to type 'IntrinsicAttributes & (Omit<Matching<{ fulfilmentOption: FulfilmentOptions; productOption: ProductOptions; billingPeriod: BillingPeriod; productPrices: ProductPrices; } & DispatchProp<...>, PropTypes>, \"productPrices\" | ... 2 more ... | \"productOption\"> | Omit<...>)'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
-      "message": "Type 'Promise<{ json: () => Promise<{ client_secret: string; }>; }>' is not assignable to type 'Promise<Response>'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-      "message": "Type '{ image: Element; total: ProductPrice; digiSubPrice: string; includesDigiSub: boolean; changeSubscription: string; productType: \"Paper\"; paymentStartDate: string; }' is not assignable to type 'IntrinsicAttributes & (Omit<Matching<{ fulfilmentOption: FulfilmentOptions; productOption: ProductOptions; billingPeriod: BillingPeriod; productPrices: ProductPrices; } & DispatchProp<...>, PropTypes>, \"productPrices\" | ... 2 more ... | \"productOption\"> | Omit<...>)'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-      "message": "Type '{ children: Element; modifierClasses: string[]; }' is not assignable to type 'IntrinsicAttributes & { children: any; }'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-      "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-      "message": "Type 'Option<string>' is not assignable to type 'string | undefined'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-      "message": "Type '{ children: Element[]; label: string; hideLabel: true; id: string; name: string; orienntation: string; error: string | undefined; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-      "message": "Type '{ inputId: string; value: string; label: string; name: string; checked: boolean; onChange: () => Action; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"type\" | ... 278 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-      "message": "Type '{ children: Element[]; label: string; hideLabel: true; id: string; error: string | undefined; legend: string; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-      "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-      "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/helpers/options.ts",
-      "message": "Type 'string' is not assignable to type 'PaperProductOptions'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-landing/components/content/prices.tsx",
-      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-landing/components/hero/hero.tsx",
-      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-    },
-    {
-      "path": "assets/pages/showcase/components/ctaContribute.tsx",
-      "message": "Type '{ children: string; icon: Element; appearance: \"secondary\"; href: string; onClick: () => void; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\" | \"href\"> & Partial<Pick<PropTypes, \"appearance\" | \"icon\" | \"iconSide\" | \"modifierClasses\" | \"aria-label\">> & Partial<...>'."
-    },
-    {
-      "path": "assets/pages/showcase/components/ctaSubscribe.tsx",
-      "message": "Type '{ children: string; icon: Element; href: string; onClick: () => void; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\" | \"href\"> & Partial<Pick<PropTypes, \"appearance\" | \"icon\" | \"iconSide\" | \"modifierClasses\" | \"aria-label\">> & Partial<...>'."
-    },
-    {
-      "path": "assets/pages/showcase/components/hero.tsx",
-      "message": "Type 'Element' is not assignable to type 'string'."
-    },
-    {
-      "path": "assets/pages/showcase/components/hero.tsx",
-      "message": "Type 'Element' is not assignable to type 'string'."
-    },
-    {
-      "path": "assets/pages/showcase/components/otherProduct.tsx",
-      "message": "Type '{ children: string; icon: Element; appearance: \"greyHollow\"; href: string; onClick: () => void; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\" | \"href\"> & Partial<Pick<PropTypes, \"appearance\" | \"icon\" | \"iconSide\" | \"modifierClasses\" | \"aria-label\">> & Partial<...>'."
-    },
-    {
-      "path": "assets/pages/subscriptions-landing/components/subscriptionsProduct.tsx",
-      "message": "Type 'Option<boolean> | undefined' is not assignable to type 'Option<boolean>'."
-    },
-    {
-      "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
-      "message": "Type '{ ctaButtonText: string; link: string; analyticsTracking: () => void; modifierClasses: string; }' is not assignable to type 'ProductButton'."
-    },
-    {
-      "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
-      "message": "Type '{ ctaButtonText: string; link: string; analyticsTracking: () => void; modifierClasses: string; }' is not assignable to type 'ProductButton'."
-    },
-    {
-      "path": "assets/pages/subscriptions-redemption/api.ts",
-      "message": "Type 'null' is not assignable to type 'RegularPaymentRequestAddress | undefined'."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
-      "message": "Type '{ children: Element; modifierClasses: string[]; }' is not assignable to type 'IntrinsicAttributes & { children: any; }'."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
-      "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
-      "message": "Type '{ inputId: string; value: string; label: string; name: string; checked: boolean; onChange: () => void; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"type\" | ... 278 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
-      "message": "Type '{ children: Element[]; id: string; error: string | undefined; legend: string; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
-      "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
-      "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx",
-      "message": "Type 'boolean | undefined' is not assignable to type 'boolean'."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx",
-      "message": "Type 'boolean | undefined' is not assignable to type 'boolean'."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-landing/components/content/prices.tsx",
-      "message": "Type 'SerializedStyles' is not assignable to type 'string'."
-    }
-  ],
-  "TS2578": [
-    {
-      "path": "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx",
-      "message": "Unused '@ts-expect-error' directive."
-    },
-    {
-      "path": "assets/components/footerCompliant/Footer.tsx",
-      "message": "Unused '@ts-expect-error' directive."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/ContributionArticleCount.tsx",
-      "message": "Unused '@ts-expect-error' directive."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx",
-      "message": "Unused '@ts-expect-error' directive."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/addDigiSubCta.tsx",
-      "message": "Unused '@ts-expect-error' directive."
-    },
-    {
-      "path": "assets/pages/paper-subscription-landing/components/content/tabAccordionRow.tsx",
-      "message": "Unused '@ts-expect-error' directive."
-    },
-    {
-      "path": "assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx",
-      "message": "Unused '@ts-expect-error' directive."
-    }
-  ],
-  "TS2339": [
-    {
-      "path": "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx",
-      "message": "Property 'getBoundingClientRect' does not exist on type 'never'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-      "message": "Property 'value' does not exist on type 'EventTarget'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-      "message": "Property 'value' does not exist on type 'EventTarget'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-      "message": "Property 'value' does not exist on type 'EventTarget'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-      "message": "Property 'checked' does not exist on type 'EventTarget'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Property 'value' does not exist on type 'EventTarget'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Property 'value' does not exist on type 'EventTarget'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Property 'value' does not exist on type 'EventTarget'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Property 'checked' does not exist on type 'EventTarget'."
-    },
-    {
-      "path": "assets/components/footerCompliant/Footer.tsx",
-      "message": "Property 'showPrivacyManager' does not exist on type 'never'."
-    },
-    {
-      "path": "assets/components/paypalExpressButton/PayPalExpressButton.tsx",
-      "message": "Property 'Button' does not exist on type '{ FUNDING: { CREDIT: unknown; }; }'."
-    },
-    {
-      "path": "assets/helpers/__tests__/urlTest.ts",
-      "message": "Property 'jsdom' does not exist on type 'typeof globalThis'."
-    },
-    {
-      "path": "assets/helpers/csrf/csrfReducer.ts",
-      "message": "Property 'csrf' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
-    },
-    {
-      "path": "assets/helpers/csrf/csrfReducer.ts",
-      "message": "Property 'csrf' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
-    },
-    {
-      "path": "assets/helpers/internationalisation/__tests__/countryGroupTest.ts",
-      "message": "Property 'jsdom' does not exist on type 'typeof globalThis'."
-    },
-    {
-      "path": "assets/helpers/internationalisation/__tests__/countryTest.ts",
-      "message": "Property 'jsdom' does not exist on type 'typeof globalThis'."
-    },
-    {
-      "path": "assets/helpers/rendering/render.ts",
-      "message": "Property 'settings' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
-    },
-    {
-      "path": "assets/helpers/rendering/render.ts",
-      "message": "Property 'settings' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/ContributionArticleCount.tsx",
-      "message": "Property 'showPrivacyManager' does not exist on type 'never'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
-      "message": "Property 'polyfillScriptLoaded' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
-      "message": "Property 'polyfillVersion' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
-      "message": "Property 'polyfillVersion' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/thankYouContainer.ts",
-      "message": "Property 'common' does not exist on type 'DefaultRootState'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-      "message": "Property 'checked' does not exist on type 'EventTarget'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-      "message": "Property 'checked' does not exist on type 'EventTarget'."
-    },
-    {
-      "path": "assets/pages/showcase/components/hero.tsx",
-      "message": "Property 'title' does not exist on type '{ title: string; caption: Element; images: { first: string; second: string; third: string; fourth: string; }; } | { title: string; caption: Element; images: { first: string; second: string; third: string; fourth: string; }; } | { ...; }'."
-    }
-  ],
-  "TS2345": [
-    {
-      "path": "assets/components/datePicker/datePicker.tsx",
-      "message": "Argument of type '{ [x: string]: string | false; dateError: string; dateValidated: false; }' is not assignable to parameter of type 'StateTypes | ((prevState: Readonly<StateTypes>, props: Readonly<PropTypes>) => StateTypes | Pick<StateTypes, keyof StateTypes> | null) | Pick<...> | null'."
-    },
-    {
-      "path": "assets/components/datePicker/datePicker.tsx",
-      "message": "Argument of type '{ [x: string]: string | false; dateError: string; dateValidated: false; }' is not assignable to parameter of type 'StateTypes | ((prevState: Readonly<StateTypes>, props: Readonly<PropTypes>) => StateTypes | Pick<StateTypes, keyof StateTypes> | null) | Pick<...> | null'."
-    },
-    {
-      "path": "assets/components/directDebit/__tests__/directDebitReducerTest.ts",
-      "message": "Argument of type '{}' is not assignable to parameter of type 'Action'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-      "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-      "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Argument of type '{ [x: number]: any; }' is not assignable to parameter of type 'StateTypes | Pick<StateTypes, keyof StateTypes> | ((prevState: Readonly<StateTypes>, props: Readonly<PropTypes>) => StateTypes | ... 1 more ... | null) | null'."
-    },
-    {
-      "path": "assets/components/directDebit/helpers/ajax.ts",
-      "message": "Argument of type '{ method: string; headers: { 'Content-Type': string; 'Csrf-Token': string; }; credentials: string; body: string; }' is not assignable to parameter of type 'RequestInit'."
-    },
-    {
-      "path": "assets/components/footerCompliant/Footer.tsx",
-      "message": "Argument of type 'CMP' is not assignable to parameter of type 'SetStateAction<null>'."
-    },
-    {
-      "path": "assets/components/marketingConsent/helpers.ts",
-      "message": "Argument of type '{ method: string; headers: { 'Content-Type': string; 'Csrf-Token': string; }; credentials: string; body: string; }' is not assignable to parameter of type 'RequestInit'."
-    },
-    {
-      "path": "assets/components/marketingConsent/marketingConsentPaper.tsx",
-      "message": "Argument of type 'typeof MarketingConsent' is not assignable to parameter of type 'ComponentType<Matching<{ confirmOptIn: any; email: string; csrf: any; } & { onClick: (email: string, csrf: Csrf) => void; }, ButtonPropTypes & { error: boolean; }>>'."
-    },
-    {
-      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-      "message": "Argument of type '(dispatch: Dispatch<SetCountryChangedAction | SetCountryAction>) => void' is not assignable to parameter of type 'Action'."
-    },
-    {
-      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-      "message": "Argument of type '(dispatch: Dispatch<Action>, getState: () => CheckoutState) => void' is not assignable to parameter of type 'Action'."
-    },
-    {
-      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-      "message": "Argument of type '(dispatch: Dispatch<Action>, getState: () => CheckoutState) => void' is not assignable to parameter of type 'Action'."
-    },
-    {
-      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-      "message": "Argument of type '(dispatch: Dispatch<Action>, getState: () => CheckoutState) => void' is not assignable to parameter of type 'Action'."
-    },
-    {
-      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-      "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
-    },
-    {
-      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-      "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
-    },
-    {
-      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-      "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
-    },
-    {
-      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-      "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
-    },
-    {
-      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-      "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ hasLoaded: boolean; csrf: Csrf; productPrices: ProductPrices; currencyId: IsoCurrency; isTestUser: boolean; amount: number; submissionError: Option<...>; wasClicked: boolean; } & { ...; }, PropTypes>>'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/__tests__/addressFieldsStore.ts",
-      "message": "Argument of type '{ fields: { country: string; city: null; lineOne: null; lineTwo: null; postCode: null; state: null; formErrors: never[]; }; }' is not assignable to parameter of type 'CombinedState<{ fields: AddressFieldsState; postcode: PostcodeFinderState; }>'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-      "message": "Argument of type 'typeof AddressFields' is not assignable to parameter of type 'ComponentType<Matching<{ formErrors: FormErrors; traverseState: (arg0: any) => State; scope: AddressType; country: string; state: string | null; lineOne: Option<string>; lineTwo: Option<...>; postCode: Option<...>; city: Option<...>; countries: Record<...>; } & { ...; }, ClassAttributes<...> & ... 2 more ... & { ......'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/addressSearch/__tests__/addressFieldsStore.ts",
-      "message": "Argument of type '{ fields: { country: string; city: null; lineOne: null; lineTwo: null; postCode: null; state: null; formErrors: never[]; }; }' is not assignable to parameter of type 'CombinedState<{ fields: AddressFieldsState; postcode: PostcodeFinderState; }>'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/stripeForm/stripeForm.tsx",
-      "message": "Argument of type 'unknown' is not assignable to parameter of type 'SetStateAction<Option<string>>'."
-    },
-    {
-      "path": "assets/helpers/__tests__/checkoutsTest.ts",
-      "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
-    },
-    {
-      "path": "assets/helpers/__tests__/checkoutsTest.ts",
-      "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
-    },
-    {
-      "path": "assets/helpers/__tests__/checkoutsTest.ts",
-      "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
-    },
-    {
-      "path": "assets/helpers/__tests__/checkoutsTest.ts",
-      "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
-    },
-    {
-      "path": "assets/helpers/__tests__/checkoutsTest.ts",
-      "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
-    },
-    {
-      "path": "assets/helpers/__tests__/checkoutsTest.ts",
-      "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Argument of type '{ ONE_OFF: string; MONTHLY: string; ANNUAL: string; }' is not assignable to parameter of type 'SelectedAmounts'."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Argument of type '{ ONE_OFF: string; MONTHLY: string; ANNUAL: string; }' is not assignable to parameter of type 'SelectedAmounts'."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Argument of type '{ ONE_OFF: string; MONTHLY: string; ANNUAL: string; }' is not assignable to parameter of type 'SelectedAmounts'."
-    },
-    {
-      "path": "assets/helpers/__tests__/promiseTest.ts",
-      "message": "Argument of type '(done: any, fail: any) => void' is not assignable to parameter of type 'ProvidesCallback | undefined'."
-    },
-    {
-      "path": "assets/helpers/contributions.ts",
-      "message": "Argument of type 'string | number | null' is not assignable to parameter of type 'string'."
-    },
-    {
-      "path": "assets/helpers/identityApis.ts",
-      "message": "Argument of type '(resp: {    userType: UserType;}) => UserType' is not assignable to parameter of type '(value: Record<string, unknown>) => \"current\" | \"new\" | \"guest\" | PromiseLike<\"current\" | \"new\" | \"guest\">'."
-    },
-    {
-      "path": "assets/helpers/internationalisation/__tests__/currencyTest.ts",
-      "message": "Argument of type '\"ZZ\"' is not assignable to parameter of type 'CountryGroupId'."
-    },
-    {
-      "path": "assets/helpers/page/__tests__/pageTest.ts",
-      "message": "Argument of type '{ campaign: string; referrerAcquisitionData: { referrerPageviewId: null; campaignCode: null; componentId: null; componentType: null; source: null; abTests: never[]; queryParameters: never[]; }; internationalisation: { ...; }; abParticipations: {}; otherQueryParams: never[]; settings: { ...; }; }' is not assignable to parameter of type 'CommonState'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts",
-      "message": "Argument of type '{ 'United Kingdom': { Collection: { SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ......' is not assignable to parameter of type 'ProductPrices'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts",
-      "message": "Argument of type '{ 'United Kingdom': { Collection: { SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ......' is not assignable to parameter of type 'ProductPrices'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts",
-      "message": "Argument of type '{ 'United Kingdom': { Collection: { SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ......' is not assignable to parameter of type 'ProductPrices'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts",
-      "message": "Argument of type '{ 'United Kingdom': { Collection: { SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ......' is not assignable to parameter of type 'ProductPrices'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
-      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { ...; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
-      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
-      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { ...; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
-      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
-      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { ...; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
-      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
-      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { ...; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
-      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
-      "message": "Argument of type '{ price: number; currency: string; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { amount: number; durationMonths: number; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
-      "message": "Argument of type '{ price: number; currency: string; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
-      "message": "Argument of type '{ price: number; currency: string; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
-      "message": "Argument of type '{ price: number; currency: string; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { amount: number; durationMonths: number; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
-      "message": "Argument of type '{ price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { price: number; periodLength: number; periodType: string; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
-      "message": "Argument of type '{ 'United Kingdom': { Collection: { Weekend: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; NoProductOptions: { Monthly: { GBP: { ...; }; }; }; }; NoFulfilmentOptions: { ...; }; }; }' is not assignable to parameter of type 'ProductPrices'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
-      "message": "Argument of type '{ 'United Kingdom': { Collection: { Weekend: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; NoProductOptions: { Monthly: { GBP: { ...; }; }; }; }; NoFulfilmentOptions: { ...; }; }; }' is not assignable to parameter of type 'ProductPrices'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
-      "message": "Argument of type '{ 'United Kingdom': { Collection: { Weekend: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; NoProductOptions: { Monthly: { GBP: { ...; }; }; }; }; NoFulfilmentOptions: { ...; }; }; }' is not assignable to parameter of type 'ProductPrices'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
-      "message": "Argument of type '{ 'United Kingdom': { Collection: { Sunday: { Monthly: { GBP: { price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: number; introductoryPrice: { ...; }; }[]; }; }; }; }; }; }' is not assignable to parameter of type 'ProductPrices'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
-      "message": "Argument of type '\"8.99\"' is not assignable to parameter of type 'number | null | undefined'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-      "message": "Argument of type 'null' is not assignable to parameter of type 'Promotion | undefined'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-      "message": "Argument of type '{}' is not assignable to parameter of type 'Promotion'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-      "message": "Argument of type '{ discountedPrice: number; }' is not assignable to parameter of type 'Promotion'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-      "message": "Argument of type '{ discountedPrice: number; }' is not assignable to parameter of type 'Promotion'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-      "message": "Argument of type '({ name: string; description: string; promoCode: number; discountedPrice: number; introductoryPrice?: undefined; } | { name: string; description: string; promoCode: number; introductoryPrice: { ...; }; discountedPrice?: undefined; })[]' is not assignable to parameter of type 'Promotion[]'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { price: number; periodLength: number; periodType: string; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-      "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; }[]; }' is not assignable to parameter of type 'ProductPrice'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-      "message": "Argument of type '{ name: string; description: string; promoCode: string; introductoryPrice: { price: number; periodLength: number; periodType: string; }; }' is not assignable to parameter of type 'Promotion'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts",
-      "message": "Argument of type '{ 'United Kingdom': { RestOfWorld: { NoProductOptions: { Quarterly: { GBP: { price: number; currency: string; promotions: never[]; }; }; SixWeekly: { GBP: { price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { ...; }; }[]; }; }; Annual: { ...; }; }...' is not assignable to parameter of type 'ProductPrices'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts",
-      "message": "Argument of type '{ 'United Kingdom': { RestOfWorld: { NoProductOptions: { Quarterly: { GBP: { price: number; currency: string; promotions: never[]; }; }; SixWeekly: { GBP: { price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { ...; }; }[]; }; }; Annual: { ...; }; }...' is not assignable to parameter of type 'ProductPrices'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts",
-      "message": "Argument of type '{ 'United Kingdom': { RestOfWorld: { NoProductOptions: { Quarterly: { GBP: { price: number; currency: string; promotions: never[]; }; }; SixWeekly: { GBP: { price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { ...; }; }[]; }; }; Annual: { ...; }; }...' is not assignable to parameter of type 'ProductPrices'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts",
-      "message": "Argument of type '{ 'United Kingdom': { RestOfWorld: { NoProductOptions: { Quarterly: { GBP: { price: number; currency: string; promotions: never[]; }; }; SixWeekly: { GBP: { price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { ...; }; }[]; }; }; Annual: { ...; }; }...' is not assignable to parameter of type 'ProductPrices'."
-    },
-    {
-      "path": "assets/helpers/productPrice/paperProductPrices.ts",
-      "message": "Argument of type 'FulfilmentOptions | null | undefined' is not assignable to parameter of type 'FulfilmentOptions | undefined'."
-    },
-    {
-      "path": "assets/helpers/productPrice/paperProductPrices.ts",
-      "message": "Argument of type 'FulfilmentOptions | null | undefined' is not assignable to parameter of type 'FulfilmentOptions | undefined'."
-    },
-    {
-      "path": "assets/helpers/rendering/render.ts",
-      "message": "Argument of type 'unknown' is not assignable to parameter of type 'Error'."
-    },
-    {
-      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-      "message": "Argument of type '{ field: string; message: string; }[]' is not assignable to parameter of type 'FormError<FormField>[]'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/AmazonPay/AmazonPayWallet.tsx",
-      "message": "Argument of type '(props: PropTypes) => Element | null' is not assignable to parameter of type 'ComponentType<Matching<{ amazonPayData: AmazonPayData; checkoutFormHasBeenSubmitted: boolean; } & { setAmazonPayWalletIsStale: (isReady: boolean) => Action; setAmazonPayOrderReferenceId: (orderReferenceId: string) => void; setAmazonPayPaymentSelected: (paymentSelected: boolean) => void; setAmazonPayBillingAgreementI...'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/ContributionArticleCount.tsx",
-      "message": "Argument of type 'CMP' is not assignable to parameter of type 'SetStateAction<null>'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/ContributionSubmit.tsx",
-      "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ currency: IsoCurrency; contributionType: keyof RegularContributionTypeMap<null> | \"ONE_OFF\"; isWaiting: boolean; paymentMethod: PaymentMethod; ... 9 more ...; amazonPayData: AmazonPayData; } & { ...; }, PropTypes>>'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/ContributionTypeTabs.tsx",
-      "message": "Argument of type 'string' is not assignable to parameter of type 'PaymentMethod'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-      "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ countryId: string; countryGroupId: CountryGroupId; currency: IsoCurrency; contributionType: keyof RegularContributionTypeMap<null> | \"ONE_OFF\"; ... 7 more ...; checkoutFormHasBeenSubmitted: boolean; } & { ...; }, PropTypes>>'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx",
-      "message": "Argument of type '(clientSecret: string) => Promise<Stripe3DSResult>' is not assignable to parameter of type '(clientSecret: string) => Promise<PaymentIntentResult>'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx",
-      "message": "Argument of type 'unknown' is not assignable to parameter of type 'string'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
-      "message": "Argument of type '(dispatch: Dispatch, getState: () => State) => void' is not assignable to parameter of type 'AnyAction'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/contributionsLandingActions.ts",
-      "message": "Argument of type '(clientSecret: string) => Promise<PaymentIntentResult>' is not assignable to parameter of type '(clientSecret: string) => Promise<Stripe3DSResult>'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-      "message": "Argument of type '\"\"' is not assignable to parameter of type 'BillingPeriod'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx",
-      "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ country: string; formErrors: FormError<FormField>[]; submissionError: Option<ErrorReason>; productPrices: ProductPrices; ... 31 more ...; salesforceCaseId?: string | undefined; } & { ...; }, FormFields & ... 1 more ... & { ...; }>>'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
-      "message": "Argument of type '\"\"' is not assignable to parameter of type 'BillingPeriod'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/thankYouContainer.ts",
-      "message": "Argument of type 'DefaultRootState' is not assignable to parameter of type 'AnyCheckoutState'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/thankYouGift.tsx",
-      "message": "Argument of type 'typeof ThankYouGift' is not assignable to parameter of type 'ComponentType<Matching<{ giftDeliveryDate: Option<string>; giftRecipient: Option<string>; } & DispatchProp<AnyAction>, PropTypes>>'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx",
-      "message": "Argument of type '{ positive: true; negative: false; }' is not assignable to parameter of type 'SetStateAction<{ positive: boolean; negative: boolean; open: boolean; }>'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.tsx",
-      "message": "Argument of type 'typeof PaperOrderSummary' is not assignable to parameter of type 'ComponentType<Matching<{ fulfilmentOption: FulfilmentOptions; productOption: ProductOptions; billingPeriod: BillingPeriod; productPrices: ProductPrices; } & DispatchProp<...>, PropTypes>>'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
-      "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ formErrors: FormError<FormField>[]; submissionError: Option<ErrorReason>; productPrices: ProductPrices; billingAddressErrors: FormErrors; ... 33 more ...; salesforceCaseId?: string | undefined; } & { ...; }, FormFields & ... 1 more ... & { ...; }>>'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/helpers/options.ts",
-      "message": "Argument of type 'string' is not assignable to parameter of type '\"Saturday\" | \"Sunday\" | \"Weekend\" | \"Sixday\" | \"Everyday\"'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx",
-      "message": "Argument of type 'null' is not assignable to parameter of type 'string'."
-    },
-    {
-      "path": "assets/pages/promotion-terms/promotionTerms.tsx",
-      "message": "Argument of type 'ReduxState<{ productPrices: ProductPrices | null | undefined; promotionTerms: any; countryGroupId: CountryGroupId; }>' is not assignable to parameter of type 'State'."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
-      "message": "Argument of type 'DefaultRootState' is not assignable to parameter of type 'AnyCheckoutState'."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
-      "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ billingCountry: string; deliveryCountry: string; formErrors: FormError<FormField>[]; submissionError: Option<ErrorReason>; productPrices: ProductPrices; ... 31 more ...; salesforceCaseId?: string | undefined; } & { ...; }, FormFields & ... 1 more ... & { ...; }>>'."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx",
-      "message": "Argument of type 'Promotion | undefined' is not assignable to parameter of type 'Promotion | null'."
-    }
-  ],
-  "TS7006": [
-    {
-      "path": "assets/components/datePicker/datePickerHelpers.test.ts",
-      "message": "Parameter 'param' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
-      "message": "Parameter 'state' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx",
-      "message": "Parameter 'state' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Parameter 'state' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Parameter 'field' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Parameter 'dispatchUpdate' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Parameter 'event' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Parameter 'event' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Parameter 'event' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/marketingConsent/marketingConsentPaper.tsx",
-      "message": "Parameter 'state' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-      "message": "Parameter 'ownProps' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-      "message": "Parameter 'billingPeriod' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-      "message": "Parameter 'trackingId' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
-      "message": "Parameter 'product' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-      "message": "Parameter 'e' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-      "message": "Parameter 'r' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-      "message": "Parameter 'result' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-      "message": "Parameter 'key' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
-      "message": "Parameter 'e' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
-      "message": "Parameter 'e' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
-      "message": "Parameter 'e' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
-      "message": "Parameter 'e' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/summary.tsx",
-      "message": "Parameter 'props' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx",
-      "message": "Parameter 'isFeature' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx",
-      "message": "Parameter 'index' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx",
-      "message": "Parameter 'hierarchy' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/helpers/__tests__/checkoutsTest.ts",
-      "message": "Parameter 'key' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/helpers/__tests__/promiseTest.ts",
-      "message": "Parameter 'done' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/helpers/__tests__/promiseTest.ts",
-      "message": "Parameter 'fail' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/helpers/rendering/render.ts",
-      "message": "Parameter 'opts' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/helpers/rendering/ssrPages.ts",
-      "message": "Parameter 'content' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.tsx",
-      "message": "Parameter 'response' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/ExistingRecurringContributorErrorMessage.tsx",
-      "message": "Parameter 'event' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-      "message": "Parameter 'commonState' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-      "message": "Parameter 'initialState' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-      "message": "Parameter 'component' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
-      "message": "Parameter 'commonState' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
-      "message": "Parameter 'initialState' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
-      "message": "Parameter 'component' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-      "message": "Parameter 'searchText' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-      "message": "Parameter 'content' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-      "message": "Parameter 'node' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-      "message": "Parameter 'element' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-      "message": "Parameter 'originalState' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-      "message": "Parameter 'component' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
-      "message": "Parameter 'initialState' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
-      "message": "Parameter 'initialState' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
-      "message": "Parameter 'component' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
-      "message": "Parameter 'fulfilmentOption' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
-      "message": "Parameter 'item' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-landing/components/content/linkTo.tsx",
-      "message": "Parameter 'tab' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-landing/components/content/linkTo.tsx",
-      "message": "Parameter 'activeTab' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/subscriptions-landing/components/subscriptionsLandingContent.tsx",
-      "message": "Parameter 'index' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
-      "message": "Parameter 'billingPeriod' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
-      "message": "Parameter 'billingPeriod' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
-      "message": "Parameter 'isPending' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
-      "message": "Parameter 'orderIsGift' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
-      "message": "Parameter 'initialState' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
-      "message": "Parameter 'initialState' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
-      "message": "Parameter 'component' implicitly has an 'any' type."
-    }
-  ],
-  "TS7053": [
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Element implicitly has an 'any' type because expression of type 'any' can't be used to index type 'Readonly<StateTypes>'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<PropTypes> & Readonly<{ children?: ReactNode; }>'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
-    },
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
-    },
-    {
-      "path": "assets/helpers/contributions.ts",
-      "message": "Element implicitly has an 'any' type because expression of type 'number' can't be used to index type '{ '1': string; '2': string; '5': string; '6': string; '7': string; '10': string; '15': string; '20': string; '25': string; '30': string; '35': string; '40': string; '50': string; '75': string; '100': string; '125': string; '166': string; '200': string; ... 7 more ...; '16000': string; }'."
-    },
-    {
-      "path": "assets/helpers/globalsAndSwitches/globals.ts",
-      "message": "Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ... 7 more ...; EverydayPlus: { ...; ...'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
-      "message": "Element implicitly has an 'any' type because expression of type 'any' can't be used to index type 'Record<FulfilmentOptions, string[]>'."
-    }
-  ],
-  "TS7034": [
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Variable 'cardErrors' implicitly has type 'any[]' in some locations where its type cannot be determined."
-    },
-    {
-      "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
-      "message": "Variable 'testCopy' implicitly has type 'any' in some locations where its type cannot be determined."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
-      "message": "Variable 'productPrices' implicitly has type 'any' in some locations where its type cannot be determined."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
-      "message": "Variable 'productOptions' implicitly has type 'any' in some locations where its type cannot be determined."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-      "message": "Variable 'props' implicitly has type 'any' in some locations where its type cannot be determined."
-    }
-  ],
-  "TS7005": [
-    {
-      "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
-      "message": "Variable 'cardErrors' implicitly has an 'any[]' type."
-    },
-    {
-      "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
-      "message": "Variable 'testCopy' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
-      "message": "Variable 'testCopy' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
-      "message": "Variable 'testCopy' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
-      "message": "Variable 'testCopy' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
-      "message": "Variable 'testCopy' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
-      "message": "Variable 'productOptions' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
-      "message": "Variable 'productPrices' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
-      "message": "Variable 'productOptions' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-      "message": "Variable 'props' implicitly has an 'any' type."
-    }
-  ],
-  "TS6133": [
-    {
-      "path": "assets/components/directDebit/helpers/ajax.ts",
-      "message": "'isTestUser' is declared but its value is never read."
-    },
-    {
-      "path": "assets/helpers/forms/checkouts.ts",
-      "message": "'allSwitches' is declared but its value is never read."
-    },
-    {
-      "path": "assets/helpers/urls/externalLinks.ts",
-      "message": "'product' is declared but its value is never read."
-    },
-    {
-      "path": "assets/helpers/urls/externalLinks.ts",
-      "message": "'countryGroupId' is declared but its value is never read."
-    },
-    {
-      "path": "assets/helpers/urls/externalLinks.ts",
-      "message": "'countryGroupId' is declared but its value is never read."
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/ContributionTypeTabs.tsx",
-      "message": "'renderControl' is declared but its value is never read."
-    },
-    {
-      "path": "assets/pages/contributions-landing/contributionsLandingInit.ts",
-      "message": "'selectAmount' is declared but its value is never read."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.tsx",
-      "message": "'dispatch' is declared but its value is never read."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-      "message": "'content' is declared but its value is never read."
-    }
-  ],
-  "TS7031": [
-    {
-      "path": "assets/components/headers/header/header.tsx",
-      "message": "Binding element 'menuRef' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/headers/header/header.tsx",
-      "message": "Binding element 'logoRef' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/headers/header/header.tsx",
-      "message": "Binding element 'containerRef' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-      "message": "Binding element 'lineOne' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-      "message": "Binding element 'lineTwo' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-      "message": "Binding element 'city' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-      "message": "Binding element 'onClick' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-      "message": "Binding element 'isLoading' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-      "message": "Binding element 'initialState' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-      "message": "Binding element 'children' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
-      "message": "Binding element 'initialState' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
-      "message": "Binding element 'children' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-      "message": "Binding element 'initialState' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-      "message": "Binding element 'children' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
-      "message": "Binding element 'initialState' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
-      "message": "Binding element 'children' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
-      "message": "Binding element 'initialState' implicitly has an 'any' type."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
-      "message": "Binding element 'children' implicitly has an 'any' type."
-    }
-  ],
-  "TS2564": [
-    {
-      "path": "assets/components/headers/header/header.tsx",
-      "message": "Property 'observer' has no initializer and is not definitely assigned in the constructor."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-      "message": "Property 'selectRef' has no initializer and is not definitely assigned in the constructor."
-    }
-  ],
-  "TS2769": [
-    {
-      "path": "assets/components/headers/header/header.tsx",
-      "message": "No overload matches this call."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-      "message": "No overload matches this call."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-      "message": "No overload matches this call."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/addressSearch/addressResultsHelpers.ts",
-      "message": "No overload matches this call."
-    },
-    {
-      "path": "assets/helpers/polyfills/layout.ts",
-      "message": "No overload matches this call."
-    },
-    {
-      "path": "assets/helpers/rendering/render.ts",
-      "message": "No overload matches this call."
-    },
-    {
-      "path": "assets/helpers/rendering/render.ts",
-      "message": "No overload matches this call."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-      "message": "No overload matches this call."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
-      "message": "No overload matches this call."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-      "message": "No overload matches this call."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
-      "message": "No overload matches this call."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
-      "message": "No overload matches this call."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
-      "message": "No overload matches this call."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
-      "message": "No overload matches this call."
-    }
-  ],
-  "TS2314": [
-    {
-      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-      "message": "Generic type '$Call' requires 1 type argument(s)."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/postcodeFinderStore.ts",
-      "message": "Generic type '$Call' requires 1 type argument(s)."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/summary.tsx",
-      "message": "Generic type '$Call' requires 1 type argument(s)."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryThankYou.tsx",
-      "message": "Generic type '$Call' requires 1 type argument(s)."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.tsx",
-      "message": "Generic type '$Call' requires 1 type argument(s)."
-    }
-  ],
-  "TS2304": [
-    {
-      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-      "message": "Cannot find name 'GlobalState'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
-      "message": "Cannot find name 'GlobalState'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-      "message": "Cannot find name 'GlobalState'."
-    },
-    {
-      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-      "message": "Cannot find name 'Stage'."
-    },
-    {
-      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-      "message": "Cannot find name 'Stage'."
-    }
-  ],
-  "TS2741": [
-    {
-      "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
-      "message": "Property 'label' is missing in type '{ onKeyPress: (e: KeyboardEvent<HTMLInputElement>) => void; css: SerializedStyles; name: string; width: 10; }' but required in type 'Pick<TextInputProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"id\" | \"onChange\" | \"value\" | \"dir\" | \"size\" | ... 275 more ... | \"enterKeyHint\">'."
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
-      "message": "Property 'value' is missing in type '{ id: string; image: any; label: string; name: string; checked: boolean; onChange: (...args: any[]) => any; }' but required in type 'Pick<RadioProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"type\" | \"id\" | \"onChange\" | \"value\" | \"dir\" | \"size\" | ... 273 more ... | \"enterKeyHint\">'."
-    },
-    {
-      "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
-      "message": "Property 'Widgets' is missing in type 'Record<string, any>' but required in type 'AmazonPaymentsObject'."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/endSummary/endSummarySelector.ts",
-      "message": "Property 'isPatron' is missing in type '{ priceDescription: string; promotion: string; orderIsAGift: boolean; digitalGiftBillingPeriod: \"Annual\" | \"Quarterly\"; price: string; }' but required in type 'EndSummaryProps'."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/helpers/orderSummaryText.ts",
-      "message": "Property 'NoProductOptions' is missing in type '{ Saturday: string; SaturdayPlus: string; Sunday: string; SundayPlus: string; Weekend: string; WeekendPlus: string; Sixday: string; SixdayPlus: string; Everyday: string; EverydayPlus: string; }' but required in type 'Record<ProductOptions, string>'."
-    }
-  ],
-  "TS2739": [
-    {
-      "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
-      "message": "Type '{ Stripe: Element; PayPal: Element; DirectDebit: Element; }' is missing the following properties from type 'Record<PaymentMethod, any>': Sepa, ExistingCard, ExistingDirectDebit, AmazonPay, None"
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
-      "message": "Type '{ Stripe: string; PayPal: string; DirectDebit: string; }' is missing the following properties from type 'Record<PaymentMethod, string>': Sepa, ExistingCard, ExistingDirectDebit, AmazonPay, None"
-    },
-    {
-      "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
-      "message": "Type '{ Stripe: string; PayPal: string; DirectDebit: string; }' is missing the following properties from type 'Record<PaymentMethod, string>': Sepa, ExistingCard, ExistingDirectDebit, AmazonPay, None"
-    },
-    {
-      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-      "message": "Type '{ ONE_OFF: { amounts: number[]; defaultAmount: number; }; }' is missing the following properties from type 'ContributionAmounts': MONTHLY, ANNUAL"
-    },
-    {
-      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-      "message": "Type '{ ONE_OFF: { min: number; minInWords: string; max: number; maxInWords: string; default: number; }; }' is missing the following properties from type 'Config': MONTHLY, ANNUAL"
-    },
-    {
-      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-      "message": "Type '{ ONE_OFF: { amounts: number[]; defaultAmount: number; }; }' is missing the following properties from type 'ContributionAmounts': MONTHLY, ANNUAL"
-    },
-    {
-      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-      "message": "Type '{ ONE_OFF: { min: number; minInWords: string; max: number; maxInWords: string; default: number; }; }' is missing the following properties from type 'Config': MONTHLY, ANNUAL"
-    },
-    {
-      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-      "message": "Type '{ ONE_OFF: { amounts: number[]; defaultAmount: number; }; }' is missing the following properties from type 'ContributionAmounts': MONTHLY, ANNUAL"
-    },
-    {
-      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-      "message": "Type '{ ONE_OFF: { min: number; minInWords: string; max: number; maxInWords: string; default: number; }; }' is missing the following properties from type 'Config': MONTHLY, ANNUAL"
-    },
-    {
-      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-      "message": "Type '{ ONE_OFF: { amounts: number[]; defaultAmount: number; }; }' is missing the following properties from type 'ContributionAmounts': MONTHLY, ANNUAL"
-    },
-    {
-      "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
-      "message": "Type '{ ONE_OFF: { min: number; minInWords: string; max: number; maxInWords: string; default: number; }; }' is missing the following properties from type 'Config': MONTHLY, ANNUAL"
-    },
-    {
-      "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
-      "message": "Type 'Element[]' is missing the following properties from type 'ReactElement<any, any>': type, props, key"
-    },
-    {
-      "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
-      "message": "Type '{}' is missing the following properties from type 'SelectedAmounts': MONTHLY, ANNUAL, ONE_OFF"
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
-      "message": "Type '{ HomeDelivery: string[]; Collection: string[]; }' is missing the following properties from type 'Record<FulfilmentOptions, string[]>': Domestic, RestOfWorld, NoFulfilmentOptions"
-    }
-  ],
-  "TS2532": [
-    {
-      "path": "assets/components/subscriptionCheckouts/summary.tsx",
-      "message": "Object is possibly 'undefined'."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Object is possibly 'undefined'."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Object is possibly 'undefined'."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Object is possibly 'undefined'."
-    }
-  ],
-  "TS2556": [
-    {
-      "path": "assets/helpers/__tests__/contributionsTests.ts",
-      "message": "A spread argument must either have a tuple type or be passed to a rest parameter."
-    },
-    {
-      "path": "assets/helpers/__tests__/contributionsTests.ts",
-      "message": "A spread argument must either have a tuple type or be passed to a rest parameter."
-    },
-    {
-      "path": "assets/helpers/__tests__/contributionsTests.ts",
-      "message": "A spread argument must either have a tuple type or be passed to a rest parameter."
-    }
-  ],
-  "TS2554": [
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/__tests__/formValidation.ts",
-      "message": "Expected 3 arguments, but got 2."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-      "message": "Expected 1 arguments, but got 0."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-      "message": "Expected 1 arguments, but got 0."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-      "message": "Expected 1 arguments, but got 0."
-    },
-    {
-      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-      "message": "Expected 3 arguments, but got 1."
-    },
-    {
-      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-      "message": "Expected 6 arguments, but got 1."
-    },
-    {
-      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-      "message": "Expected 3 arguments, but got 1."
-    },
-    {
-      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-      "message": "Expected 6 arguments, but got 1."
-    },
-    {
-      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-      "message": "Expected 6 arguments, but got 1."
-    },
-    {
-      "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
-      "message": "Expected 1 arguments, but got 0."
-    },
-    {
-      "path": "assets/pages/showcase/components/otherProducts.tsx",
-      "message": "Expected 1 arguments, but got 0."
-    }
-  ],
-  "TS2569": [
-    {
-      "path": "assets/helpers/checkoutForm/checkoutForm.ts",
-      "message": "Type 'HTMLCollectionOf<HTMLInputElement>' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators."
-    },
-    {
-      "path": "assets/helpers/checkoutForm/checkoutForm.ts",
-      "message": "Type 'HTMLFormControlsCollection' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators."
-    }
-  ],
-  "TS2411": [
-    {
-      "path": "assets/helpers/globalsAndSwitches/settings.ts",
-      "message": "Property 'experiments' of type 'Record<string, { name: string; description: string; state: Status; }>' is not assignable to 'string' index type 'SwitchObject'."
-    }
-  ],
-  "TS7017": [
-    {
-      "path": "assets/helpers/page/__tests__/pageTest.ts",
-      "message": "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature."
-    },
-    {
-      "path": "assets/helpers/page/__tests__/pageTest.ts",
-      "message": "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature."
-    },
-    {
-      "path": "assets/helpers/page/__tests__/pageTest.ts",
-      "message": "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature."
-    },
-    {
-      "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
-      "message": "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature."
-    }
-  ],
-  "TS2367": [
-    {
-      "path": "assets/helpers/polyfills/details.ts",
-      "message": "This condition will always return 'true' since the types 'Element' and 'Document' have no overlap."
-    },
-    {
-      "path": "assets/pages/paper-subscription-landing/components/content/linkTo.tsx",
-      "message": "This condition will always return 'false' since the types 'PaperFulfilmentOptions' and '\"delivery\"' have no overlap."
-    },
-    {
-      "path": "assets/pages/promotion-terms/weeklyTerms.tsx",
-      "message": "This condition will always return 'false' since the types '\"Monthly\"' and '\"Quarterly\"' have no overlap."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/helpers/__tests__/deliveryDays.ts",
-      "message": "This condition will always return 'false' since the types '() => number' and 'number' have no overlap."
-    }
-  ],
-  "TS2740": [
-    {
-      "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
-      "message": "Type '{ GBP: { price: number; savingVsRetail: number; currency: \"GBP\"; fixedTerm: false; promotions: never[]; }; }' is missing the following properties from type 'Record<IsoCurrency, ProductPrice>': NZD, AUD, CAD, USD, and 5 more."
-    },
-    {
-      "path": "assets/helpers/productPrice/productOptions.ts",
-      "message": "Type '{ Saturday: \"SaturdayPlus\"; Sunday: \"SundayPlus\"; Weekend: \"WeekendPlus\"; Sixday: \"SixdayPlus\"; Everyday: \"EverydayPlus\"; }' is missing the following properties from type 'Record<ProductOptions, ProductOptions>': NoProductOptions, SaturdayPlus, SundayPlus, WeekendPlus, and 2 more."
-    },
-    {
-      "path": "assets/helpers/productPrice/productOptions.ts",
-      "message": "Type '{ SaturdayPlus: \"Saturday\"; SundayPlus: \"Sunday\"; WeekendPlus: \"Weekend\"; SixdayPlus: \"Sixday\"; EverydayPlus: \"Everyday\"; }' is missing the following properties from type 'Record<ProductOptions, ProductOptions>': NoProductOptions, Saturday, Sunday, Weekend, and 2 more."
-    },
-    {
-      "path": "assets/helpers/productPrice/subscriptions.ts",
-      "message": "Type '{ GBPCountries: number; }' is missing the following properties from type 'Record<CountryGroupId, number>': UnitedStates, AUDCountries, EURCountries, International, and 2 more."
-    },
-    {
-      "path": "assets/helpers/rendering/render.ts",
-      "message": "Type 'Element' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, dir, and 109 more."
-    }
-  ],
-  "TS2531": [
-    {
-      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-      "message": "Object is possibly 'null'."
-    },
-    {
-      "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
-      "message": "Object is possibly 'null'."
-    }
-  ],
-  "TS7016": [
-    {
-      "path": "assets/helpers/rendering/render.ts",
-      "message": "Could not find a declaration file for module 'preact/debug'. 'support-frontend/node_modules/preact/debug/dist/debug.js' implicitly has an 'any' type."
-    }
-  ],
-  "TS2707": [
-    {
-      "path": "assets/pages/contributions-landing/contributionsLandingInit.ts",
-      "message": "Generic type 'Store<S, A>' requires between 0 and 2 type arguments."
-    }
-  ],
-  "TS2525": [
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
-      "message": "Initializer provides no value for this binding element and the binding element has no default value."
-    },
-    {
-      "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
-      "message": "Initializer provides no value for this binding element and the binding element has no default value."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-      "message": "Initializer provides no value for this binding element and the binding element has no default value."
-    },
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
-      "message": "Initializer provides no value for this binding element and the binding element has no default value."
-    },
-    {
-      "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
-      "message": "Initializer provides no value for this binding element and the binding element has no default value."
-    }
-  ],
-  "TS2745": [
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/addDigiSubCta.tsx",
-      "message": "This JSX tag's 'children' prop expects type 'ReactElement<any, string | JSXElementConstructor<any>>[]' which requires multiple children, but only a single child was provided."
-    },
-    {
-      "path": "assets/pages/paper-subscription-landing/components/content/deliveryTab.tsx",
-      "message": "This JSX tag's 'children' prop expects type 'ReactElement<any, string | JSXElementConstructor<any>>[]' which requires multiple children, but only a single child was provided."
-    }
-  ],
-  "TS7022": [
-    {
-      "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
-      "message": "'initialState' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer."
-    }
-  ],
-  "TS2571": [
-    {
-      "path": "assets/pages/promotion-terms/promotionTermsReducer.ts",
-      "message": "Object is of type 'unknown'."
-    },
-    {
-      "path": "assets/pages/promotion-terms/promotionTermsReducer.ts",
-      "message": "Object is of type 'unknown'."
-    },
-    {
-      "path": "assets/pages/promotion-terms/promotionTermsReducer.ts",
-      "message": "Object is of type 'unknown'."
-    }
-  ],
-  "TS2698": [
-    {
-      "path": "assets/pages/promotion-terms/promotionTermsReducer.ts",
-      "message": "Spread types may only be created from object types."
-    },
-    {
-      "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
-      "message": "Spread types may only be created from object types."
-    },
-    {
-      "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
-      "message": "Spread types may only be created from object types."
-    },
-    {
-      "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
-      "message": "Spread types may only be created from object types."
-    },
-    {
-      "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
-      "message": "Spread types may only be created from object types."
-    },
-    {
-      "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
-      "message": "Spread types may only be created from object types."
-    }
-  ]
+    "errorCounts": {
+        "byCode": {
+            "TS1208": 1,
+            "TS2305": 18,
+            "TS2322": 127,
+            "TS2578": 7,
+            "TS2339": 26,
+            "TS2345": 99,
+            "TS7006": 60,
+            "TS7053": 12,
+            "TS7034": 5,
+            "TS7005": 10,
+            "TS6133": 9,
+            "TS7031": 18,
+            "TS2564": 2,
+            "TS2769": 14,
+            "TS2314": 5,
+            "TS2304": 5,
+            "TS2741": 5,
+            "TS2739": 14,
+            "TS2532": 4,
+            "TS2556": 3,
+            "TS2554": 31,
+            "TS2569": 2,
+            "TS2411": 1,
+            "TS7017": 4,
+            "TS2367": 4,
+            "TS2740": 5,
+            "TS2531": 2,
+            "TS7016": 1,
+            "TS2707": 1,
+            "TS2525": 5,
+            "TS2745": 2,
+            "TS7022": 1,
+            "TS2571": 3,
+            "TS2698": 6
+        },
+        "byPath": {
+            "assets/__mocks__/imageMock.ts": 1,
+            "assets/components/asyncronously/asyncronously.ts": 2,
+            "assets/components/content/content.tsx": 2,
+            "assets/components/footerCompliant/Footer.tsx": 4,
+            "assets/components/forms/customFields/options.tsx": 1,
+            "assets/components/forms/label.tsx": 2,
+            "assets/components/headers/header/header.tsx": 6,
+            "assets/components/headers/header/mobileMenuToggler.tsx": 1,
+            "assets/components/headers/mobileMenu/mobileMenu.tsx": 2,
+            "assets/components/headers/veggieBurgerButton/veggieBurgerButton.tsx": 2,
+            "assets/components/menu/menu.tsx": 2,
+            "assets/components/product/productOption.tsx": 1,
+            "assets/components/product/productOptionSmall.tsx": 1,
+            "assets/components/subscriptionCheckouts/layout.tsx": 1,
+            "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx": 6,
+            "assets/pages/digital-subscription-checkout/components/thankYou/pageSection.tsx": 1,
+            "assets/pages/digital-subscription-landing/components/comparison/comparisonTable.tsx": 3,
+            "assets/pages/paper-subscription-landing/components/content/linkTo.tsx": 4,
+            "assets/pages/subscriptions-landing/components/subscriptionsProduct.tsx": 2,
+            "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx": 4,
+            "assets/components/datePicker/datePickerHelpers.test.ts": 2,
+            "assets/components/directDebit/directDebitForm/directDebitForm.tsx": 10,
+            "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx": 5,
+            "assets/components/headers/links/links.tsx": 1,
+            "assets/components/marketingConsent/marketingConsent.tsx": 1,
+            "assets/components/page/page.tsx": 1,
+            "assets/components/page/pageTitle.tsx": 4,
+            "assets/components/priceLabel/priceLabel.tsx": 1,
+            "assets/components/subscriptionCheckouts/address/addressFields.tsx": 14,
+            "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx": 12,
+            "assets/components/subscriptionCheckouts/billingPeriodSelector.tsx": 2,
+            "assets/components/subscriptionCheckouts/personalDetails.tsx": 7,
+            "assets/components/subscriptionCheckouts/summary.tsx": 6,
+            "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx": 4,
+            "assets/helpers/__tests__/formValidation.ts": 29,
+            "assets/helpers/checkoutForm/checkoutForm.ts": 3,
+            "assets/helpers/globalsAndSwitches/globals.ts": 2,
+            "assets/helpers/internationalisation/localCurrencyCountry.ts": 9,
+            "assets/helpers/productPrice/__tests__/promotionsTests.ts": 14,
+            "assets/helpers/utilities/utilities.ts": 1,
+            "assets/hocs/canShow.tsx": 1,
+            "assets/hocs/withError.tsx": 1,
+            "assets/hocs/withLabel.tsx": 1,
+            "assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.tsx": 2,
+            "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx": 9,
+            "assets/pages/contributions-landing/components/SepaForm.tsx": 7,
+            "assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.tsx": 1,
+            "assets/pages/contributions-landing/contributionsLandingReducer.ts": 5,
+            "assets/pages/contributions-landing/setUserStateActions.ts": 3,
+            "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx": 9,
+            "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx": 4,
+            "assets/pages/digital-subscription-checkout/components/endSummary/endSummaryMobile.tsx": 1,
+            "assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.ts": 1,
+            "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx": 7,
+            "assets/pages/digital-subscription-landing/components/events/eventsModule.tsx": 1,
+            "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx": 4,
+            "assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.tsx": 1,
+            "assets/pages/paper-subscription-checkout/components/addDigiSubCta.tsx": 3,
+            "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx": 16,
+            "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx": 8,
+            "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx": 12,
+            "assets/pages/paper-subscription-checkout/helpers/options.ts": 2,
+            "assets/pages/paper-subscription-landing/components/content/prices.tsx": 1,
+            "assets/pages/paper-subscription-landing/components/hero/hero.tsx": 1,
+            "assets/pages/showcase/components/ctaContribute.tsx": 1,
+            "assets/pages/showcase/components/ctaSubscribe.tsx": 1,
+            "assets/pages/showcase/components/hero.tsx": 3,
+            "assets/pages/showcase/components/otherProduct.tsx": 1,
+            "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx": 7,
+            "assets/pages/subscriptions-redemption/api.ts": 1,
+            "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx": 7,
+            "assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx": 2,
+            "assets/pages/weekly-subscription-landing/components/content/prices.tsx": 1,
+            "assets/pages/contributions-landing/components/ContributionArticleCount.tsx": 3,
+            "assets/pages/paper-subscription-landing/components/content/tabAccordionRow.tsx": 1,
+            "assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx": 2,
+            "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx": 22,
+            "assets/components/paypalExpressButton/PayPalExpressButton.tsx": 1,
+            "assets/helpers/__tests__/urlTest.ts": 1,
+            "assets/helpers/csrf/csrfReducer.ts": 2,
+            "assets/helpers/internationalisation/__tests__/countryGroupTest.ts": 1,
+            "assets/helpers/internationalisation/__tests__/countryTest.ts": 1,
+            "assets/helpers/rendering/render.ts": 8,
+            "assets/pages/contributions-landing/contributionsLanding.tsx": 5,
+            "assets/pages/digital-subscription-checkout/thankYouContainer.ts": 2,
+            "assets/components/datePicker/datePicker.tsx": 2,
+            "assets/components/directDebit/__tests__/directDebitReducerTest.ts": 1,
+            "assets/components/directDebit/helpers/ajax.ts": 2,
+            "assets/components/marketingConsent/helpers.ts": 1,
+            "assets/components/marketingConsent/marketingConsentPaper.tsx": 2,
+            "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx": 13,
+            "assets/components/subscriptionCheckouts/address/__tests__/addressFieldsStore.ts": 1,
+            "assets/components/subscriptionCheckouts/addressSearch/__tests__/addressFieldsStore.ts": 1,
+            "assets/components/subscriptionCheckouts/stripeForm/stripeForm.tsx": 1,
+            "assets/helpers/__tests__/checkoutsTest.ts": 7,
+            "assets/helpers/__tests__/promiseTest.ts": 3,
+            "assets/helpers/contributions.ts": 2,
+            "assets/helpers/identityApis.ts": 1,
+            "assets/helpers/internationalisation/__tests__/currencyTest.ts": 1,
+            "assets/helpers/page/__tests__/pageTest.ts": 4,
+            "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts": 4,
+            "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts": 8,
+            "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts": 5,
+            "assets/helpers/productPrice/__tests__/productPricesTests.ts": 6,
+            "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts": 4,
+            "assets/helpers/productPrice/paperProductPrices.ts": 2,
+            "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts": 9,
+            "assets/pages/contributions-landing/components/AmazonPay/AmazonPayWallet.tsx": 1,
+            "assets/pages/contributions-landing/components/ContributionSubmit.tsx": 1,
+            "assets/pages/contributions-landing/components/ContributionTypeTabs.tsx": 2,
+            "assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx": 2,
+            "assets/pages/contributions-landing/contributionsLandingActions.ts": 1,
+            "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx": 8,
+            "assets/pages/digital-subscription-checkout/thankYouGift.tsx": 1,
+            "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.tsx": 2,
+            "assets/pages/promotion-terms/promotionTerms.tsx": 1,
+            "assets/pages/weekly-subscription-checkout/components/thankYou.tsx": 6,
+            "assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx": 1,
+            "assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx": 1,
+            "assets/helpers/rendering/ssrPages.ts": 1,
+            "assets/pages/contributions-landing/components/ExistingRecurringContributorErrorMessage.tsx": 1,
+            "assets/pages/paper-subscription-checkout/components/thankYou.tsx": 5,
+            "assets/pages/subscriptions-landing/components/subscriptionsLandingContent.tsx": 1,
+            "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx": 7,
+            "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts": 6,
+            "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts": 5,
+            "assets/helpers/forms/checkouts.ts": 1,
+            "assets/helpers/urls/externalLinks.ts": 3,
+            "assets/pages/contributions-landing/contributionsLandingInit.ts": 2,
+            "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.tsx": 1,
+            "assets/components/subscriptionCheckouts/addressSearch/addressResultsHelpers.ts": 1,
+            "assets/helpers/polyfills/layout.ts": 1,
+            "assets/components/subscriptionCheckouts/address/postcodeFinderStore.ts": 1,
+            "assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryThankYou.tsx": 1,
+            "assets/pages/digital-subscription-checkout/components/endSummary/endSummarySelector.ts": 1,
+            "assets/pages/paper-subscription-checkout/helpers/orderSummaryText.ts": 1,
+            "assets/helpers/__tests__/contributionsTests.ts": 3,
+            "assets/pages/showcase/components/otherProducts.tsx": 1,
+            "assets/helpers/globalsAndSwitches/settings.ts": 1,
+            "assets/helpers/polyfills/details.ts": 1,
+            "assets/pages/promotion-terms/weeklyTerms.tsx": 1,
+            "assets/pages/weekly-subscription-checkout/helpers/__tests__/deliveryDays.ts": 1,
+            "assets/helpers/productPrice/productOptions.ts": 2,
+            "assets/helpers/productPrice/subscriptions.ts": 1,
+            "assets/pages/paper-subscription-landing/components/content/deliveryTab.tsx": 1,
+            "assets/pages/promotion-terms/promotionTermsReducer.ts": 4
+        }
+    },
+    "TS1208": [
+        {
+            "path": "assets/__mocks__/imageMock.ts",
+            "message": "'imageMock.ts' cannot be compiled under '--isolatedModules' because it is considered a global script file. Add an import, export, or an empty 'export {}' statement to make it a module."
+        }
+    ],
+    "TS2305": [
+        {
+            "path": "assets/components/asyncronously/asyncronously.ts",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/components/content/content.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/components/footerCompliant/Footer.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/components/forms/customFields/options.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/components/forms/label.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/components/headers/header/header.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/components/headers/header/mobileMenuToggler.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/components/headers/mobileMenu/mobileMenu.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/components/headers/veggieBurgerButton/veggieBurgerButton.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/components/menu/menu.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/components/product/productOption.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/components/product/productOptionSmall.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/layout.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/thankYou/pageSection.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/comparison/comparisonTable.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-landing/components/content/linkTo.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        },
+        {
+            "path": "assets/pages/subscriptions-landing/components/subscriptionsProduct.tsx",
+            "message": "Module '\"react\"' has no exported member 'Node'."
+        }
+    ],
+    "TS2322": [
+        {
+            "path": "assets/components/asyncronously/asyncronously.ts",
+            "message": "Type 'ComponentType<any>' is not assignable to type 'null'."
+        },
+        {
+            "path": "assets/components/content/content.tsx",
+            "message": "Type 'Option<string> | undefined' is not assignable to type 'string | undefined'."
+        },
+        {
+            "path": "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx",
+            "message": "Type '{ children: (Element | Element[])[]; style: { top: number; left: number; position: string; }; }' is not assignable to type 'IntrinsicAttributes & { children: any; }'."
+        },
+        {
+            "path": "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx",
+            "message": "Type '{ children: string[]; href: string; onClick: () => void; isSelected: boolean; }' is not assignable to type 'IntrinsicAttributes & itemProps & { href: string; }'."
+        },
+        {
+            "path": "assets/components/datePicker/datePickerHelpers.test.ts",
+            "message": "Type 'typeof MockDate' is not assignable to type 'DateConstructor'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+            "message": "Type 'string' is not assignable to type 'number | undefined'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+            "message": "Type 'string' is not assignable to type 'number | undefined'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+            "message": "Type 'string' is not assignable to type 'number | undefined'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
+            "message": "Type 'string' is not assignable to type 'number | undefined'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
+            "message": "Type '{ id: string; label: string; autoComplete: string; type: \"text\"; inputmode: string; pattern: string; value: string; onChange: (e: ChangeEvent<HTMLInputElement>) => void; error: string; minLength: number; maxLength: number; width: 10; }' is not assignable to type 'IntrinsicAttributes & Pick<TextInputProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | ... 280 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
+            "message": "Type '{ id: string; value: string; autoComplete: string; onChange: (e: ChangeEvent<HTMLInputElement>) => void; minLength: number; maxLength: number; type: \"text\"; inputmode: string; pattern: string; label: string; error: string; }' is not assignable to type 'IntrinsicAttributes & Pick<TextInputProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | ... 280 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
+            "message": "Type 'string' is not assignable to type 'boolean | undefined'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx",
+            "message": "Type 'EventHandler' is not assignable to type 'MouseEventHandler<HTMLButtonElement>'."
+        },
+        {
+            "path": "assets/components/forms/label.tsx",
+            "message": "Type 'Option<string>' is not assignable to type 'string | undefined'."
+        },
+        {
+            "path": "assets/components/headers/links/links.tsx",
+            "message": "Type '\"_blank\" | null' is not assignable to type 'HTMLAttributeAnchorTarget | undefined'."
+        },
+        {
+            "path": "assets/components/headers/mobileMenu/mobileMenu.tsx",
+            "message": "Type '{ width: number; } | null | undefined' is not assignable to type 'CSSProperties | undefined'."
+        },
+        {
+            "path": "assets/components/headers/veggieBurgerButton/veggieBurgerButton.tsx",
+            "message": "Type '{ children: any[]; 'aria-haspopup': Option<string>; onClick: Option<(...args: any[]) => any>; style: Option<{}>; className: string; ref: Option<(...args: any[]) => any>; }' is not assignable to type 'DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>'."
+        },
+        {
+            "path": "assets/components/marketingConsent/marketingConsent.tsx",
+            "message": "Type '{ children: string; appearance: \"green\"; iconSide: \"right\"; \"aria-label\": string; onClick: () => void; icon: Element; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\"> & Partial<Pick<PropTypes, \"type\" | \"disabled\" | ... 4 more ... | \"aria-label\">> & Partial<...>'."
+        },
+        {
+            "path": "assets/components/menu/menu.tsx",
+            "message": "Type '{ children: any[]; className: any; \"data-is-selected\": boolean; }' is not assignable to type 'IntrinsicAttributes'."
+        },
+        {
+            "path": "assets/components/page/page.tsx",
+            "message": "Type 'string | null | undefined' is not assignable to type 'string | undefined'."
+        },
+        {
+            "path": "assets/components/page/pageTitle.tsx",
+            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+        },
+        {
+            "path": "assets/components/page/pageTitle.tsx",
+            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+        },
+        {
+            "path": "assets/components/page/pageTitle.tsx",
+            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+        },
+        {
+            "path": "assets/components/page/pageTitle.tsx",
+            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+        },
+        {
+            "path": "assets/components/priceLabel/priceLabel.tsx",
+            "message": "Type 'false | Record<string, any> | undefined' is not assignable to type 'string | undefined'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+            "message": "Type 'ReactNode' is not assignable to type 'Element'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+            "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+            "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+            "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+            "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+            "message": "Type 'null' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>> | undefined'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+            "message": "Type '{ children: any[]; onChange: (e: ChangeEvent<HTMLSelectElement>) => void; forwardRef: (r: any) => void; id: string; label: string; }' is not assignable to type 'IntrinsicAttributes & Pick<SelectProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"children\" | \"color\" | \"hidden\" | \"id\" | \"onChange\" | ... 257 more ... | \"supporting\"> & Partial<...> & Partial<...>'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+            "message": "Type 'null' is not assignable to type 'string | number | readonly string[] | undefined'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/billingPeriodSelector.tsx",
+            "message": "Type '{ children: Element[]; legend: string; role: string; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/billingPeriodSelector.tsx",
+            "message": "Type '{ label: string; value: string; supporting: string; offer: string; name: string; checked: boolean; onChange: () => Action; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"type\" | ... 278 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
+            "message": "Type '{ children: Element[]; id: string; label: string; hideLabel: true; error: string | undefined; role: string; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
+            "message": "Type 'null' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>> | undefined'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
+            "message": "Type 'Option<string> | undefined' is not assignable to type 'string | number | readonly string[] | undefined'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
+            "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/summary.tsx",
+            "message": "Type '{ className: any; productPrice: ProductPrice; billingPeriod: BillingPeriod; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"billingPeriod\" | \"productPrice\"> & Partial<Pick<PropTypes, \"orderIsAGift\" | \"giftStyles\">> & Partial<...>'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/summary.tsx",
+            "message": "Type '{ className: any; productPrice: ProductPrice; billingPeriod: BillingPeriod; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"billingPeriod\" | \"productPrice\"> & Partial<Pick<PropTypes, \"orderIsAGift\" | \"giftStyles\">> & Partial<...>'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/summary.tsx",
+            "message": "Type '{ className: any; productPrice: ProductPrice; billingPeriod: BillingPeriod; giftStyles: any; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"billingPeriod\" | \"productPrice\"> & Partial<Pick<PropTypes, \"orderIsAGift\" | \"giftStyles\">> & Partial<...>'."
+        },
+        {
+            "path": "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx",
+            "message": "Type '{ children: string; href: string; onClick: (...args: any[]) => any; appearance: \"primary\" | \"secondary\" | \"tertiary\" | \"tertiaryFeature\"; modifierClasses: string[]; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\" | \"href\"> & Partial<Pick<PropTypes, \"appearance\" | \"icon\" | \"iconSide\" | \"modifierClasses\" | \"aria-label\">> & Partial<...>'."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Type '{ countryCode: string; stateCode?: string | undefined; } | {}' is not assignable to type '{ countryCode: string; stateCode?: string | undefined; } | undefined'."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Type 'null' is not assignable to type 'string'."
+        },
+        {
+            "path": "assets/helpers/checkoutForm/checkoutForm.ts",
+            "message": "Type 'unknown' is not assignable to type 'string'."
+        },
+        {
+            "path": "assets/helpers/globalsAndSwitches/globals.ts",
+            "message": "Type 'unknown' is not assignable to type 'Settings'."
+        },
+        {
+            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+            "message": "Type 'string | null | undefined' is not assignable to type 'string | number | symbol'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+            "message": "Type 'null' is not assignable to type 'number | undefined'."
+        },
+        {
+            "path": "assets/helpers/utilities/utilities.ts",
+            "message": "Type 'string | null | undefined' is not assignable to type 'string'."
+        },
+        {
+            "path": "assets/hocs/canShow.tsx",
+            "message": "Type 'Omit<AugmentedProps<Props>, \"isShown\">' is not assignable to type 'IntrinsicAttributes & Props & { children?: ReactNode; }'."
+        },
+        {
+            "path": "assets/hocs/withError.tsx",
+            "message": "Type 'Omit<AugmentedProps<Props>, \"error\">' is not assignable to type 'IntrinsicAttributes & Props & { children?: ReactNode; }'."
+        },
+        {
+            "path": "assets/hocs/withLabel.tsx",
+            "message": "Type 'Omit<AugmentedProps<Props>, \"footer\" | \"label\" | \"optional\">' is not assignable to type 'IntrinsicAttributes & Props & { children?: ReactNode; }'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.tsx",
+            "message": "Type '{ children: string; type: \"button\"; onClick: () => void; \"aria-label\": string; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\"> & Partial<Pick<PropTypes, \"type\" | \"disabled\" | ... 4 more ... | \"aria-label\">> & Partial<...>'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+            "message": "Type 'false | \"Please select a payment method\"' is not assignable to type 'string | undefined'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+            "message": "Type 'false | Element' is not assignable to type 'Element'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+            "message": "Type 'false | Element[]' is not assignable to type 'Element'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+            "message": "Type 'RecentlySignedInExistingPaymentMethod' is not assignable to type 'string'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+            "message": "Type '{ '& + div': { display: string; width: string; margin: number; justifyContent: string; }; '& + div svg': { width: string; height: string; }; '&:not(:checked) + div svg': { filter: string; }; }' is not assignable to type 'SerializedStyles | SerializedStyles[] | undefined'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+            "message": "Type '{ '& + div': { display: string; width: string; margin: number; justifyContent: string; }; '& + div svg': { width: string; height: string; }; '&:not(:checked) + div svg': { filter: string; }; }' is not assignable to type 'SerializedStyles | SerializedStyles[] | undefined'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+            "message": "Type 'false | Element | undefined' is not assignable to type 'Element'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
+            "message": "Type 'string' is not assignable to type 'number | undefined'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
+            "message": "Type 'string | null' is not assignable to type 'string | number | readonly string[] | undefined'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
+            "message": "Type 'string | null' is not assignable to type 'string | undefined'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
+            "message": "Type 'string' is not assignable to type 'number | undefined'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
+            "message": "Type 'string' is not assignable to type 'number | undefined'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
+            "message": "Type 'string | null' is not assignable to type 'string | number | readonly string[] | undefined'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/SepaForm.tsx",
+            "message": "Type 'string | null' is not assignable to type 'string | undefined'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.tsx",
+            "message": "Type '{ stripeKey: string; isTestUser: boolean; }' is not assignable to type 'IntrinsicAttributes & Omit<{ contributionType: keyof RegularContributionTypeMap<null> | \"ONE_OFF\"; checkoutFormHasBeenSubmitted: boolean; ... 9 more ...; isTestUser: boolean; } & { ...; } & { ...; }, \"csrf\" | ... 19 more ... | \"setStripeRecurringRecaptchaVerified\">'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
+            "message": "Type '{ Stripe: null; AmazonPay: null; }' is not assignable to type '{ Stripe: StripeHandler | null; }'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
+            "message": "Type '{ hasBegunLoading: false; amazonPayLibrary: { amazonLoginObject: null; amazonPaymentsObject: null; }; loginButtonReady: false; walletIsStale: false; orderReferenceId: null; paymentSelected: false; hasAccessToken: false; fatalError: false; amazonBillingAgreementConsentStatus: false; }' is not assignable to type 'AmazonPayData'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
+            "message": "Type '{ contributionType: keyof RegularContributionTypeMap<null> | \"ONE_OFF\"; showOtherAmount: boolean; formData: { otherAmounts: OtherAmounts; ... 5 more ...; email: string | null; }; ... 17 more ...; oneOffRecaptchaToken: string | null; }' is not assignable to type 'FormState'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/setUserStateActions.ts",
+            "message": "Type '(isSignedIn: boolean) => (arg0: (...args: any[]) => any) => void' is not assignable to type '(isSignedIn: boolean) => Action'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/setUserStateActions.ts",
+            "message": "Type '() => (arg0: (...args: any[]) => any) => void' is not assignable to type '() => Action'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/setUserStateActions.ts",
+            "message": "Type '(unsafeState: string) => (arg0: (...args: any[]) => any) => void' is not assignable to type '(stateField: string) => Action'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+            "message": "Type 'Promise<{ json: () => Promise<{ client_secret: string; }>; }>' is not assignable to type 'Promise<Response>'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx",
+            "message": "Type '{ image: Element; title: string; description: string; productPrice: ProductPrice; billingPeriod: \"Annual\" | \"Monthly\"; changeSubscription: string; isPatron: boolean; }' is not assignable to type 'IntrinsicAttributes & Pick<OrderSummaryPropTypes, \"title\" | \"image\" | \"billingPeriod\" | \"productPrice\" | \"isPatron\"> & Partial<...> & Partial<...>'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx",
+            "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx",
+            "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/endSummary/endSummaryMobile.tsx",
+            "message": "Type '{ orderIsAGift: Option<boolean> | undefined; }' is not assignable to type 'IntrinsicAttributes & Omit<EndSummaryProps, \"orderIsAGift\" | \"promotion\" | \"price\" | \"priceDescription\" | \"digitalGiftBillingPeriod\" | \"isPatron\">'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.ts",
+            "message": "Type '\"normal\"' is not assignable to type 'FontWeight | undefined'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/comparison/comparisonTable.tsx",
+            "message": "Type 'SerializedStyles' is not assignable to type 'string | string[] | undefined'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/comparison/comparisonTable.tsx",
+            "message": "Type 'string' is not assignable to type 'number | undefined'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
+            "message": "Type '{ icon: JSX.Element; description: string; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
+            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
+            "message": "Type '{ icon: JSX.Element; description: string; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
+            "message": "Type '{ icon: JSX.Element; description: JSX.Element; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
+            "message": "Type '{ icon: JSX.Element; description: JSX.Element; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
+            "message": "Type '{ icon: JSX.Element; description: string; ariaLabel: string; free: JSX.Element; paid: JSX.Element; }' is not assignable to type 'TableRow'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/comparison/tableContents.tsx",
+            "message": "Type 'SerializedStyles' is not assignable to type 'string[] | Option<string> | undefined'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/events/eventsModule.tsx",
+            "message": "Type 'SerializedStyles' is not assignable to type 'string | string[] | undefined'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx",
+            "message": "Type 'SerializedStyles | null' is not assignable to type 'SerializedStyles'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx",
+            "message": "Type 'SerializedStyles | null' is not assignable to type 'SerializedStyles'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.tsx",
+            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/addDigiSubCta.tsx",
+            "message": "Type 'string | SerializedStyles' is not assignable to type 'SerializedStyles'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+            "message": "Type '{ image: Element; total: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; includesDigiSub: boolean; digiSubPrice: string; changeSubscription: string; }' is not assignable to type 'IntrinsicAttributes & (Omit<Matching<{ fulfilmentOption: FulfilmentOptions; productOption: ProductOptions; billingPeriod: BillingPeriod; productPrices: ProductPrices; } & DispatchProp<...>, PropTypes>, \"productPrices\" | ... 2 more ... | \"productOption\"> | Omit<...>)'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
+            "message": "Type 'Promise<{ json: () => Promise<{ client_secret: string; }>; }>' is not assignable to type 'Promise<Response>'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+            "message": "Type '{ image: Element; total: ProductPrice; digiSubPrice: string; includesDigiSub: boolean; changeSubscription: string; productType: \"Paper\"; paymentStartDate: string; }' is not assignable to type 'IntrinsicAttributes & (Omit<Matching<{ fulfilmentOption: FulfilmentOptions; productOption: ProductOptions; billingPeriod: BillingPeriod; productPrices: ProductPrices; } & DispatchProp<...>, PropTypes>, \"productPrices\" | ... 2 more ... | \"productOption\"> | Omit<...>)'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+            "message": "Type '{ children: Element; modifierClasses: string[]; }' is not assignable to type 'IntrinsicAttributes & { children: any; }'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+            "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+            "message": "Type 'Option<string>' is not assignable to type 'string | undefined'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+            "message": "Type '{ children: Element[]; label: string; hideLabel: true; id: string; name: string; orienntation: string; error: string | undefined; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+            "message": "Type '{ inputId: string; value: string; label: string; name: string; checked: boolean; onChange: () => Action; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"type\" | ... 278 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+            "message": "Type '{ children: Element[]; label: string; hideLabel: true; id: string; error: string | undefined; legend: string; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+            "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+            "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/helpers/options.ts",
+            "message": "Type 'string' is not assignable to type 'PaperProductOptions'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-landing/components/content/prices.tsx",
+            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-landing/components/hero/hero.tsx",
+            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+        },
+        {
+            "path": "assets/pages/showcase/components/ctaContribute.tsx",
+            "message": "Type '{ children: string; icon: Element; appearance: \"secondary\"; href: string; onClick: () => void; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\" | \"href\"> & Partial<Pick<PropTypes, \"appearance\" | \"icon\" | \"iconSide\" | \"modifierClasses\" | \"aria-label\">> & Partial<...>'."
+        },
+        {
+            "path": "assets/pages/showcase/components/ctaSubscribe.tsx",
+            "message": "Type '{ children: string; icon: Element; href: string; onClick: () => void; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\" | \"href\"> & Partial<Pick<PropTypes, \"appearance\" | \"icon\" | \"iconSide\" | \"modifierClasses\" | \"aria-label\">> & Partial<...>'."
+        },
+        {
+            "path": "assets/pages/showcase/components/hero.tsx",
+            "message": "Type 'Element' is not assignable to type 'string'."
+        },
+        {
+            "path": "assets/pages/showcase/components/hero.tsx",
+            "message": "Type 'Element' is not assignable to type 'string'."
+        },
+        {
+            "path": "assets/pages/showcase/components/otherProduct.tsx",
+            "message": "Type '{ children: string; icon: Element; appearance: \"greyHollow\"; href: string; onClick: () => void; }' is not assignable to type 'IntrinsicAttributes & Pick<PropTypes, \"children\" | \"getRef\" | \"postDeploymentTestID\" | \"href\"> & Partial<Pick<PropTypes, \"appearance\" | \"icon\" | \"iconSide\" | \"modifierClasses\" | \"aria-label\">> & Partial<...>'."
+        },
+        {
+            "path": "assets/pages/subscriptions-landing/components/subscriptionsProduct.tsx",
+            "message": "Type 'Option<boolean> | undefined' is not assignable to type 'Option<boolean>'."
+        },
+        {
+            "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
+            "message": "Type '{ ctaButtonText: string; link: string; analyticsTracking: () => void; modifierClasses: string; }' is not assignable to type 'ProductButton'."
+        },
+        {
+            "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
+            "message": "Type '{ ctaButtonText: string; link: string; analyticsTracking: () => void; modifierClasses: string; }' is not assignable to type 'ProductButton'."
+        },
+        {
+            "path": "assets/pages/subscriptions-redemption/api.ts",
+            "message": "Type 'null' is not assignable to type 'RegularPaymentRequestAddress | undefined'."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
+            "message": "Type '{ children: Element; modifierClasses: string[]; }' is not assignable to type 'IntrinsicAttributes & { children: any; }'."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
+            "message": "Type 'Option<string>' is not assignable to type 'string | number | readonly string[] | undefined'."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
+            "message": "Type '{ inputId: string; value: string; label: string; name: string; checked: boolean; onChange: () => void; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"type\" | ... 278 more ... | \"enterKeyHint\"> & Partial<...> & Partial<...>'."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
+            "message": "Type '{ children: Element[]; id: string; error: string | undefined; legend: string; }' is not assignable to type 'IntrinsicAttributes & Pick<RadioGroupProps, \"label\" | \"children\" | \"id\" | \"className\" | \"name\" | \"error\" | \"cssOverrides\" | \"supporting\"> & Partial<...> & Partial<...>'."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
+            "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
+            "message": "Type 'Record<string, any>[]' is not assignable to type 'FormError<FormField>[]'."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx",
+            "message": "Type 'boolean | undefined' is not assignable to type 'boolean'."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx",
+            "message": "Type 'boolean | undefined' is not assignable to type 'boolean'."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-landing/components/content/prices.tsx",
+            "message": "Type 'SerializedStyles' is not assignable to type 'string'."
+        }
+    ],
+    "TS2578": [
+        {
+            "path": "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx",
+            "message": "Unused '@ts-expect-error' directive."
+        },
+        {
+            "path": "assets/components/footerCompliant/Footer.tsx",
+            "message": "Unused '@ts-expect-error' directive."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/ContributionArticleCount.tsx",
+            "message": "Unused '@ts-expect-error' directive."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx",
+            "message": "Unused '@ts-expect-error' directive."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/addDigiSubCta.tsx",
+            "message": "Unused '@ts-expect-error' directive."
+        },
+        {
+            "path": "assets/pages/paper-subscription-landing/components/content/tabAccordionRow.tsx",
+            "message": "Unused '@ts-expect-error' directive."
+        },
+        {
+            "path": "assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx",
+            "message": "Unused '@ts-expect-error' directive."
+        }
+    ],
+    "TS2339": [
+        {
+            "path": "assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx",
+            "message": "Property 'getBoundingClientRect' does not exist on type 'never'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+            "message": "Property 'value' does not exist on type 'EventTarget'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+            "message": "Property 'value' does not exist on type 'EventTarget'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+            "message": "Property 'value' does not exist on type 'EventTarget'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+            "message": "Property 'checked' does not exist on type 'EventTarget'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Property 'value' does not exist on type 'EventTarget'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Property 'value' does not exist on type 'EventTarget'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Property 'value' does not exist on type 'EventTarget'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Property 'checked' does not exist on type 'EventTarget'."
+        },
+        {
+            "path": "assets/components/footerCompliant/Footer.tsx",
+            "message": "Property 'showPrivacyManager' does not exist on type 'never'."
+        },
+        {
+            "path": "assets/components/paypalExpressButton/PayPalExpressButton.tsx",
+            "message": "Property 'Button' does not exist on type '{ FUNDING: { CREDIT: unknown; }; }'."
+        },
+        {
+            "path": "assets/helpers/__tests__/urlTest.ts",
+            "message": "Property 'jsdom' does not exist on type 'typeof globalThis'."
+        },
+        {
+            "path": "assets/helpers/csrf/csrfReducer.ts",
+            "message": "Property 'csrf' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
+        },
+        {
+            "path": "assets/helpers/csrf/csrfReducer.ts",
+            "message": "Property 'csrf' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
+        },
+        {
+            "path": "assets/helpers/internationalisation/__tests__/countryGroupTest.ts",
+            "message": "Property 'jsdom' does not exist on type 'typeof globalThis'."
+        },
+        {
+            "path": "assets/helpers/internationalisation/__tests__/countryTest.ts",
+            "message": "Property 'jsdom' does not exist on type 'typeof globalThis'."
+        },
+        {
+            "path": "assets/helpers/rendering/render.ts",
+            "message": "Property 'settings' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
+        },
+        {
+            "path": "assets/helpers/rendering/render.ts",
+            "message": "Property 'settings' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/ContributionArticleCount.tsx",
+            "message": "Property 'showPrivacyManager' does not exist on type 'never'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
+            "message": "Property 'polyfillScriptLoaded' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
+            "message": "Property 'polyfillVersion' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
+            "message": "Property 'polyfillVersion' does not exist on type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/thankYouContainer.ts",
+            "message": "Property 'common' does not exist on type 'DefaultRootState'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+            "message": "Property 'checked' does not exist on type 'EventTarget'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+            "message": "Property 'checked' does not exist on type 'EventTarget'."
+        },
+        {
+            "path": "assets/pages/showcase/components/hero.tsx",
+            "message": "Property 'title' does not exist on type '{ title: string; caption: Element; images: { first: string; second: string; third: string; fourth: string; }; } | { title: string; caption: Element; images: { first: string; second: string; third: string; fourth: string; }; } | { ...; }'."
+        }
+    ],
+    "TS2345": [
+        {
+            "path": "assets/components/datePicker/datePicker.tsx",
+            "message": "Argument of type '{ [x: string]: string | false; dateError: string; dateValidated: false; }' is not assignable to parameter of type 'StateTypes | ((prevState: Readonly<StateTypes>, props: Readonly<PropTypes>) => StateTypes | Pick<StateTypes, keyof StateTypes> | null) | Pick<...> | null'."
+        },
+        {
+            "path": "assets/components/datePicker/datePicker.tsx",
+            "message": "Argument of type '{ [x: string]: string | false; dateError: string; dateValidated: false; }' is not assignable to parameter of type 'StateTypes | ((prevState: Readonly<StateTypes>, props: Readonly<PropTypes>) => StateTypes | Pick<StateTypes, keyof StateTypes> | null) | Pick<...> | null'."
+        },
+        {
+            "path": "assets/components/directDebit/__tests__/directDebitReducerTest.ts",
+            "message": "Argument of type '{}' is not assignable to parameter of type 'Action'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+            "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+            "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Argument of type '{ [x: number]: any; }' is not assignable to parameter of type 'StateTypes | Pick<StateTypes, keyof StateTypes> | ((prevState: Readonly<StateTypes>, props: Readonly<PropTypes>) => StateTypes | ... 1 more ... | null) | null'."
+        },
+        {
+            "path": "assets/components/directDebit/helpers/ajax.ts",
+            "message": "Argument of type '{ method: string; headers: { 'Content-Type': string; 'Csrf-Token': string; }; credentials: string; body: string; }' is not assignable to parameter of type 'RequestInit'."
+        },
+        {
+            "path": "assets/components/footerCompliant/Footer.tsx",
+            "message": "Argument of type 'CMP' is not assignable to parameter of type 'SetStateAction<null>'."
+        },
+        {
+            "path": "assets/components/marketingConsent/helpers.ts",
+            "message": "Argument of type '{ method: string; headers: { 'Content-Type': string; 'Csrf-Token': string; }; credentials: string; body: string; }' is not assignable to parameter of type 'RequestInit'."
+        },
+        {
+            "path": "assets/components/marketingConsent/marketingConsentPaper.tsx",
+            "message": "Argument of type 'typeof MarketingConsent' is not assignable to parameter of type 'ComponentType<Matching<{ confirmOptIn: any; email: string; csrf: any; } & { onClick: (email: string, csrf: Csrf) => void; }, ButtonPropTypes & { error: boolean; }>>'."
+        },
+        {
+            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+            "message": "Argument of type '(dispatch: Dispatch<SetCountryChangedAction | SetCountryAction>) => void' is not assignable to parameter of type 'Action'."
+        },
+        {
+            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+            "message": "Argument of type '(dispatch: Dispatch<Action>, getState: () => CheckoutState) => void' is not assignable to parameter of type 'Action'."
+        },
+        {
+            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+            "message": "Argument of type '(dispatch: Dispatch<Action>, getState: () => CheckoutState) => void' is not assignable to parameter of type 'Action'."
+        },
+        {
+            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+            "message": "Argument of type '(dispatch: Dispatch<Action>, getState: () => CheckoutState) => void' is not assignable to parameter of type 'Action'."
+        },
+        {
+            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+            "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
+        },
+        {
+            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+            "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
+        },
+        {
+            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+            "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
+        },
+        {
+            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+            "message": "Argument of type '(...args: any[]) => any' is not assignable to parameter of type 'Action'."
+        },
+        {
+            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+            "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ hasLoaded: boolean; csrf: Csrf; productPrices: ProductPrices; currencyId: IsoCurrency; isTestUser: boolean; amount: number; submissionError: Option<...>; wasClicked: boolean; } & { ...; }, PropTypes>>'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/__tests__/addressFieldsStore.ts",
+            "message": "Argument of type '{ fields: { country: string; city: null; lineOne: null; lineTwo: null; postCode: null; state: null; formErrors: never[]; }; }' is not assignable to parameter of type 'CombinedState<{ fields: AddressFieldsState; postcode: PostcodeFinderState; }>'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+            "message": "Argument of type 'typeof AddressFields' is not assignable to parameter of type 'ComponentType<Matching<{ formErrors: FormErrors; traverseState: (arg0: any) => State; scope: AddressType; country: string; state: string | null; lineOne: Option<string>; lineTwo: Option<...>; postCode: Option<...>; city: Option<...>; countries: Record<...>; } & { ...; }, ClassAttributes<...> & ... 2 more ... & { ......'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/addressSearch/__tests__/addressFieldsStore.ts",
+            "message": "Argument of type '{ fields: { country: string; city: null; lineOne: null; lineTwo: null; postCode: null; state: null; formErrors: never[]; }; }' is not assignable to parameter of type 'CombinedState<{ fields: AddressFieldsState; postcode: PostcodeFinderState; }>'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/stripeForm/stripeForm.tsx",
+            "message": "Argument of type 'unknown' is not assignable to parameter of type 'SetStateAction<Option<string>>'."
+        },
+        {
+            "path": "assets/helpers/__tests__/checkoutsTest.ts",
+            "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
+        },
+        {
+            "path": "assets/helpers/__tests__/checkoutsTest.ts",
+            "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
+        },
+        {
+            "path": "assets/helpers/__tests__/checkoutsTest.ts",
+            "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
+        },
+        {
+            "path": "assets/helpers/__tests__/checkoutsTest.ts",
+            "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
+        },
+        {
+            "path": "assets/helpers/__tests__/checkoutsTest.ts",
+            "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
+        },
+        {
+            "path": "assets/helpers/__tests__/checkoutsTest.ts",
+            "message": "Argument of type 'true' is not assignable to parameter of type 'CountryGroupId'."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Argument of type '{ ONE_OFF: string; MONTHLY: string; ANNUAL: string; }' is not assignable to parameter of type 'SelectedAmounts'."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Argument of type '{ ONE_OFF: string; MONTHLY: string; ANNUAL: string; }' is not assignable to parameter of type 'SelectedAmounts'."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Argument of type '{ ONE_OFF: string; MONTHLY: string; ANNUAL: string; }' is not assignable to parameter of type 'SelectedAmounts'."
+        },
+        {
+            "path": "assets/helpers/__tests__/promiseTest.ts",
+            "message": "Argument of type '(done: any, fail: any) => void' is not assignable to parameter of type 'ProvidesCallback | undefined'."
+        },
+        {
+            "path": "assets/helpers/contributions.ts",
+            "message": "Argument of type 'string | number | null' is not assignable to parameter of type 'string'."
+        },
+        {
+            "path": "assets/helpers/identityApis.ts",
+            "message": "Argument of type '(resp: {    userType: UserType;}) => UserType' is not assignable to parameter of type '(value: Record<string, unknown>) => \"current\" | \"new\" | \"guest\" | PromiseLike<\"current\" | \"new\" | \"guest\">'."
+        },
+        {
+            "path": "assets/helpers/internationalisation/__tests__/currencyTest.ts",
+            "message": "Argument of type '\"ZZ\"' is not assignable to parameter of type 'CountryGroupId'."
+        },
+        {
+            "path": "assets/helpers/page/__tests__/pageTest.ts",
+            "message": "Argument of type '{ campaign: string; referrerAcquisitionData: { referrerPageviewId: null; campaignCode: null; componentId: null; componentType: null; source: null; abTests: never[]; queryParameters: never[]; }; internationalisation: { ...; }; abParticipations: {}; otherQueryParams: never[]; settings: { ...; }; }' is not assignable to parameter of type 'CommonState'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts",
+            "message": "Argument of type '{ 'United Kingdom': { Collection: { SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ......' is not assignable to parameter of type 'ProductPrices'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts",
+            "message": "Argument of type '{ 'United Kingdom': { Collection: { SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ......' is not assignable to parameter of type 'ProductPrices'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts",
+            "message": "Argument of type '{ 'United Kingdom': { Collection: { SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ......' is not assignable to parameter of type 'ProductPrices'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/paperProductPricesTests.ts",
+            "message": "Argument of type '{ 'United Kingdom': { Collection: { SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ......' is not assignable to parameter of type 'ProductPrices'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
+            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { ...; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
+            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
+            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { ...; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
+            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
+            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { ...; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
+            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
+            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { ...; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts",
+            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
+            "message": "Argument of type '{ price: number; currency: string; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { amount: number; durationMonths: number; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
+            "message": "Argument of type '{ price: number; currency: string; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
+            "message": "Argument of type '{ price: number; currency: string; promotions: never[]; }' is not assignable to parameter of type 'ProductPrice'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
+            "message": "Argument of type '{ price: number; currency: string; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; numberOfDiscountedPeriods: number; discount: { amount: number; durationMonths: number; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts",
+            "message": "Argument of type '{ price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { price: number; periodLength: number; periodType: string; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
+            "message": "Argument of type '{ 'United Kingdom': { Collection: { Weekend: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; NoProductOptions: { Monthly: { GBP: { ...; }; }; }; }; NoFulfilmentOptions: { ...; }; }; }' is not assignable to parameter of type 'ProductPrices'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
+            "message": "Argument of type '{ 'United Kingdom': { Collection: { Weekend: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; NoProductOptions: { Monthly: { GBP: { ...; }; }; }; }; NoFulfilmentOptions: { ...; }; }; }' is not assignable to parameter of type 'ProductPrices'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
+            "message": "Argument of type '{ 'United Kingdom': { Collection: { Weekend: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; NoProductOptions: { Monthly: { GBP: { ...; }; }; }; }; NoFulfilmentOptions: { ...; }; }; }' is not assignable to parameter of type 'ProductPrices'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
+            "message": "Argument of type '{ 'United Kingdom': { Collection: { Sunday: { Monthly: { GBP: { price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: number; introductoryPrice: { ...; }; }[]; }; }; }; }; }; }' is not assignable to parameter of type 'ProductPrices'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
+            "message": "Argument of type '\"8.99\"' is not assignable to parameter of type 'number | null | undefined'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+            "message": "Argument of type 'null' is not assignable to parameter of type 'Promotion | undefined'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+            "message": "Argument of type '{}' is not assignable to parameter of type 'Promotion'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+            "message": "Argument of type '{ discountedPrice: number; }' is not assignable to parameter of type 'Promotion'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+            "message": "Argument of type '{ discountedPrice: number; }' is not assignable to parameter of type 'Promotion'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+            "message": "Argument of type '({ name: string; description: string; promoCode: number; discountedPrice: number; introductoryPrice?: undefined; } | { name: string; description: string; promoCode: number; introductoryPrice: { ...; }; discountedPrice?: undefined; })[]' is not assignable to parameter of type 'Promotion[]'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { price: number; periodLength: number; periodType: string; }; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+            "message": "Argument of type '{ price: number; currency: string; fixedTerm: boolean; promotions: { name: string; description: string; promoCode: string; discountedPrice: number; }[]; }' is not assignable to parameter of type 'ProductPrice'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+            "message": "Argument of type '{ name: string; description: string; promoCode: string; introductoryPrice: { price: number; periodLength: number; periodType: string; }; }' is not assignable to parameter of type 'Promotion'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts",
+            "message": "Argument of type '{ 'United Kingdom': { RestOfWorld: { NoProductOptions: { Quarterly: { GBP: { price: number; currency: string; promotions: never[]; }; }; SixWeekly: { GBP: { price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { ...; }; }[]; }; }; Annual: { ...; }; }...' is not assignable to parameter of type 'ProductPrices'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts",
+            "message": "Argument of type '{ 'United Kingdom': { RestOfWorld: { NoProductOptions: { Quarterly: { GBP: { price: number; currency: string; promotions: never[]; }; }; SixWeekly: { GBP: { price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { ...; }; }[]; }; }; Annual: { ...; }; }...' is not assignable to parameter of type 'ProductPrices'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts",
+            "message": "Argument of type '{ 'United Kingdom': { RestOfWorld: { NoProductOptions: { Quarterly: { GBP: { price: number; currency: string; promotions: never[]; }; }; SixWeekly: { GBP: { price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { ...; }; }[]; }; }; Annual: { ...; }; }...' is not assignable to parameter of type 'ProductPrices'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/weeklyProductPrice.ts",
+            "message": "Argument of type '{ 'United Kingdom': { RestOfWorld: { NoProductOptions: { Quarterly: { GBP: { price: number; currency: string; promotions: never[]; }; }; SixWeekly: { GBP: { price: number; currency: string; promotions: { name: string; description: string; promoCode: string; introductoryPrice: { ...; }; }[]; }; }; Annual: { ...; }; }...' is not assignable to parameter of type 'ProductPrices'."
+        },
+        {
+            "path": "assets/helpers/productPrice/paperProductPrices.ts",
+            "message": "Argument of type 'FulfilmentOptions | null | undefined' is not assignable to parameter of type 'FulfilmentOptions | undefined'."
+        },
+        {
+            "path": "assets/helpers/productPrice/paperProductPrices.ts",
+            "message": "Argument of type 'FulfilmentOptions | null | undefined' is not assignable to parameter of type 'FulfilmentOptions | undefined'."
+        },
+        {
+            "path": "assets/helpers/rendering/render.ts",
+            "message": "Argument of type 'unknown' is not assignable to parameter of type 'Error'."
+        },
+        {
+            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+            "message": "Argument of type '{ field: string; message: string; }[]' is not assignable to parameter of type 'FormError<FormField>[]'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/AmazonPay/AmazonPayWallet.tsx",
+            "message": "Argument of type '(props: PropTypes) => Element | null' is not assignable to parameter of type 'ComponentType<Matching<{ amazonPayData: AmazonPayData; checkoutFormHasBeenSubmitted: boolean; } & { setAmazonPayWalletIsStale: (isReady: boolean) => Action; setAmazonPayOrderReferenceId: (orderReferenceId: string) => void; setAmazonPayPaymentSelected: (paymentSelected: boolean) => void; setAmazonPayBillingAgreementI...'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/ContributionArticleCount.tsx",
+            "message": "Argument of type 'CMP' is not assignable to parameter of type 'SetStateAction<null>'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/ContributionSubmit.tsx",
+            "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ currency: IsoCurrency; contributionType: keyof RegularContributionTypeMap<null> | \"ONE_OFF\"; isWaiting: boolean; paymentMethod: PaymentMethod; ... 9 more ...; amazonPayData: AmazonPayData; } & { ...; }, PropTypes>>'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/ContributionTypeTabs.tsx",
+            "message": "Argument of type 'string' is not assignable to parameter of type 'PaymentMethod'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+            "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ countryId: string; countryGroupId: CountryGroupId; currency: IsoCurrency; contributionType: keyof RegularContributionTypeMap<null> | \"ONE_OFF\"; ... 7 more ...; checkoutFormHasBeenSubmitted: boolean; } & { ...; }, PropTypes>>'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx",
+            "message": "Argument of type '(clientSecret: string) => Promise<Stripe3DSResult>' is not assignable to parameter of type '(clientSecret: string) => Promise<PaymentIntentResult>'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx",
+            "message": "Argument of type 'unknown' is not assignable to parameter of type 'string'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
+            "message": "Argument of type '(dispatch: Dispatch, getState: () => State) => void' is not assignable to parameter of type 'AnyAction'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/contributionsLandingActions.ts",
+            "message": "Argument of type '(clientSecret: string) => Promise<PaymentIntentResult>' is not assignable to parameter of type '(clientSecret: string) => Promise<Stripe3DSResult>'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+            "message": "Argument of type '\"\"' is not assignable to parameter of type 'BillingPeriod'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx",
+            "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ country: string; formErrors: FormError<FormField>[]; submissionError: Option<ErrorReason>; productPrices: ProductPrices; ... 31 more ...; salesforceCaseId?: string | undefined; } & { ...; }, FormFields & ... 1 more ... & { ...; }>>'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
+            "message": "Argument of type '\"\"' is not assignable to parameter of type 'BillingPeriod'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/thankYouContainer.ts",
+            "message": "Argument of type 'DefaultRootState' is not assignable to parameter of type 'AnyCheckoutState'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/thankYouGift.tsx",
+            "message": "Argument of type 'typeof ThankYouGift' is not assignable to parameter of type 'ComponentType<Matching<{ giftDeliveryDate: Option<string>; giftRecipient: Option<string>; } & DispatchProp<AnyAction>, PropTypes>>'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx",
+            "message": "Argument of type '{ positive: true; negative: false; }' is not assignable to parameter of type 'SetStateAction<{ positive: boolean; negative: boolean; open: boolean; }>'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.tsx",
+            "message": "Argument of type 'typeof PaperOrderSummary' is not assignable to parameter of type 'ComponentType<Matching<{ fulfilmentOption: FulfilmentOptions; productOption: ProductOptions; billingPeriod: BillingPeriod; productPrices: ProductPrices; } & DispatchProp<...>, PropTypes>>'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx",
+            "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ formErrors: FormError<FormField>[]; submissionError: Option<ErrorReason>; productPrices: ProductPrices; billingAddressErrors: FormErrors; ... 33 more ...; salesforceCaseId?: string | undefined; } & { ...; }, FormFields & ... 1 more ... & { ...; }>>'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/helpers/options.ts",
+            "message": "Argument of type 'string' is not assignable to parameter of type '\"Saturday\" | \"Sunday\" | \"Weekend\" | \"Sixday\" | \"Everyday\"'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx",
+            "message": "Argument of type 'null' is not assignable to parameter of type 'string'."
+        },
+        {
+            "path": "assets/pages/promotion-terms/promotionTerms.tsx",
+            "message": "Argument of type 'ReduxState<{ productPrices: ProductPrices | null | undefined; promotionTerms: any; countryGroupId: CountryGroupId; }>' is not assignable to parameter of type 'State'."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
+            "message": "Argument of type 'DefaultRootState' is not assignable to parameter of type 'AnyCheckoutState'."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx",
+            "message": "Argument of type '(props: PropTypes) => Element' is not assignable to parameter of type 'ComponentType<Matching<{ billingCountry: string; deliveryCountry: string; formErrors: FormError<FormField>[]; submissionError: Option<ErrorReason>; productPrices: ProductPrices; ... 31 more ...; salesforceCaseId?: string | undefined; } & { ...; }, FormFields & ... 1 more ... & { ...; }>>'."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx",
+            "message": "Argument of type 'Promotion | undefined' is not assignable to parameter of type 'Promotion | null'."
+        }
+    ],
+    "TS7006": [
+        {
+            "path": "assets/components/datePicker/datePickerHelpers.test.ts",
+            "message": "Parameter 'param' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitForm/directDebitForm.tsx",
+            "message": "Parameter 'state' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx",
+            "message": "Parameter 'state' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Parameter 'state' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Parameter 'field' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Parameter 'dispatchUpdate' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Parameter 'event' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Parameter 'event' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Parameter 'event' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/marketingConsent/marketingConsentPaper.tsx",
+            "message": "Parameter 'state' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+            "message": "Parameter 'ownProps' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+            "message": "Parameter 'billingPeriod' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+            "message": "Parameter 'trackingId' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/paypalExpressButton/PayPalOneClickCheckoutButton.tsx",
+            "message": "Parameter 'product' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+            "message": "Parameter 'e' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+            "message": "Parameter 'r' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+            "message": "Parameter 'result' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+            "message": "Parameter 'key' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
+            "message": "Parameter 'e' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
+            "message": "Parameter 'e' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
+            "message": "Parameter 'e' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/personalDetails.tsx",
+            "message": "Parameter 'e' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/summary.tsx",
+            "message": "Parameter 'props' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx",
+            "message": "Parameter 'isFeature' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx",
+            "message": "Parameter 'index' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionsProductDescription/subscriptionsProductDescription.tsx",
+            "message": "Parameter 'hierarchy' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/helpers/__tests__/checkoutsTest.ts",
+            "message": "Parameter 'key' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/helpers/__tests__/promiseTest.ts",
+            "message": "Parameter 'done' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/helpers/__tests__/promiseTest.ts",
+            "message": "Parameter 'fail' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/helpers/rendering/render.ts",
+            "message": "Parameter 'opts' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/helpers/rendering/ssrPages.ts",
+            "message": "Parameter 'content' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.tsx",
+            "message": "Parameter 'response' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/ExistingRecurringContributorErrorMessage.tsx",
+            "message": "Parameter 'event' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+            "message": "Parameter 'commonState' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+            "message": "Parameter 'initialState' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+            "message": "Parameter 'component' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
+            "message": "Parameter 'commonState' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
+            "message": "Parameter 'initialState' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
+            "message": "Parameter 'component' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+            "message": "Parameter 'searchText' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+            "message": "Parameter 'content' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+            "message": "Parameter 'node' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+            "message": "Parameter 'element' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+            "message": "Parameter 'originalState' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+            "message": "Parameter 'component' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
+            "message": "Parameter 'initialState' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
+            "message": "Parameter 'initialState' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
+            "message": "Parameter 'component' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
+            "message": "Parameter 'fulfilmentOption' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
+            "message": "Parameter 'item' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-landing/components/content/linkTo.tsx",
+            "message": "Parameter 'tab' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-landing/components/content/linkTo.tsx",
+            "message": "Parameter 'activeTab' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/subscriptions-landing/components/subscriptionsLandingContent.tsx",
+            "message": "Parameter 'index' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
+            "message": "Parameter 'billingPeriod' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
+            "message": "Parameter 'billingPeriod' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
+            "message": "Parameter 'isPending' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
+            "message": "Parameter 'orderIsGift' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
+            "message": "Parameter 'initialState' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
+            "message": "Parameter 'initialState' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
+            "message": "Parameter 'component' implicitly has an 'any' type."
+        }
+    ],
+    "TS7053": [
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Element implicitly has an 'any' type because expression of type 'any' can't be used to index type 'Readonly<StateTypes>'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<PropTypes> & Readonly<{ children?: ReactNode; }>'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
+        },
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Readonly<StateTypes>'."
+        },
+        {
+            "path": "assets/helpers/contributions.ts",
+            "message": "Element implicitly has an 'any' type because expression of type 'number' can't be used to index type '{ '1': string; '2': string; '5': string; '6': string; '7': string; '10': string; '15': string; '20': string; '25': string; '30': string; '35': string; '40': string; '50': string; '75': string; '100': string; '125': string; '166': string; '200': string; ... 7 more ...; '16000': string; }'."
+        },
+        {
+            "path": "assets/helpers/globalsAndSwitches/globals.ts",
+            "message": "Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{ amazonPayClientId: { default: string; uat: string; }; amazonPaySellerId: { default: string; uat: string; }; email?: string | undefined; enableContributionsCampaign: boolean; forceContributionsCampaign: boolean; ... 15 more ...; v2recaptchaPublicKey: string; }'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+            "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ SixdayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; SundayPlus: { Monthly: { GBP: { price: number; savingVsRetail: number; currency: string; fixedTerm: boolean; promotions: never[]; }; }; }; ... 7 more ...; EverydayPlus: { ...; ...'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
+            "message": "Element implicitly has an 'any' type because expression of type 'any' can't be used to index type 'Record<FulfilmentOptions, string[]>'."
+        }
+    ],
+    "TS7034": [
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Variable 'cardErrors' implicitly has type 'any[]' in some locations where its type cannot be determined."
+        },
+        {
+            "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
+            "message": "Variable 'testCopy' implicitly has type 'any' in some locations where its type cannot be determined."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
+            "message": "Variable 'productPrices' implicitly has type 'any' in some locations where its type cannot be determined."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
+            "message": "Variable 'productOptions' implicitly has type 'any' in some locations where its type cannot be determined."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+            "message": "Variable 'props' implicitly has type 'any' in some locations where its type cannot be determined."
+        }
+    ],
+    "TS7005": [
+        {
+            "path": "assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx",
+            "message": "Variable 'cardErrors' implicitly has an 'any[]' type."
+        },
+        {
+            "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
+            "message": "Variable 'testCopy' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
+            "message": "Variable 'testCopy' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
+            "message": "Variable 'testCopy' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
+            "message": "Variable 'testCopy' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/helpers/timeBoundedCopy/timeBoundedCopy.test.ts",
+            "message": "Variable 'testCopy' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
+            "message": "Variable 'productOptions' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
+            "message": "Variable 'productPrices' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.ts",
+            "message": "Variable 'productOptions' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+            "message": "Variable 'props' implicitly has an 'any' type."
+        }
+    ],
+    "TS6133": [
+        {
+            "path": "assets/components/directDebit/helpers/ajax.ts",
+            "message": "'isTestUser' is declared but its value is never read."
+        },
+        {
+            "path": "assets/helpers/forms/checkouts.ts",
+            "message": "'allSwitches' is declared but its value is never read."
+        },
+        {
+            "path": "assets/helpers/urls/externalLinks.ts",
+            "message": "'product' is declared but its value is never read."
+        },
+        {
+            "path": "assets/helpers/urls/externalLinks.ts",
+            "message": "'countryGroupId' is declared but its value is never read."
+        },
+        {
+            "path": "assets/helpers/urls/externalLinks.ts",
+            "message": "'countryGroupId' is declared but its value is never read."
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/ContributionTypeTabs.tsx",
+            "message": "'renderControl' is declared but its value is never read."
+        },
+        {
+            "path": "assets/pages/contributions-landing/contributionsLandingInit.ts",
+            "message": "'selectAmount' is declared but its value is never read."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.tsx",
+            "message": "'dispatch' is declared but its value is never read."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+            "message": "'content' is declared but its value is never read."
+        }
+    ],
+    "TS7031": [
+        {
+            "path": "assets/components/headers/header/header.tsx",
+            "message": "Binding element 'menuRef' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/headers/header/header.tsx",
+            "message": "Binding element 'logoRef' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/headers/header/header.tsx",
+            "message": "Binding element 'containerRef' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+            "message": "Binding element 'lineOne' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+            "message": "Binding element 'lineTwo' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+            "message": "Binding element 'city' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+            "message": "Binding element 'onClick' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+            "message": "Binding element 'isLoading' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+            "message": "Binding element 'initialState' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+            "message": "Binding element 'children' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
+            "message": "Binding element 'initialState' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
+            "message": "Binding element 'children' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+            "message": "Binding element 'initialState' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+            "message": "Binding element 'children' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
+            "message": "Binding element 'initialState' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
+            "message": "Binding element 'children' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
+            "message": "Binding element 'initialState' implicitly has an 'any' type."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
+            "message": "Binding element 'children' implicitly has an 'any' type."
+        }
+    ],
+    "TS2564": [
+        {
+            "path": "assets/components/headers/header/header.tsx",
+            "message": "Property 'observer' has no initializer and is not definitely assigned in the constructor."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+            "message": "Property 'selectRef' has no initializer and is not definitely assigned in the constructor."
+        }
+    ],
+    "TS2769": [
+        {
+            "path": "assets/components/headers/header/header.tsx",
+            "message": "No overload matches this call."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+            "message": "No overload matches this call."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+            "message": "No overload matches this call."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/addressSearch/addressResultsHelpers.ts",
+            "message": "No overload matches this call."
+        },
+        {
+            "path": "assets/helpers/polyfills/layout.ts",
+            "message": "No overload matches this call."
+        },
+        {
+            "path": "assets/helpers/rendering/render.ts",
+            "message": "No overload matches this call."
+        },
+        {
+            "path": "assets/helpers/rendering/render.ts",
+            "message": "No overload matches this call."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+            "message": "No overload matches this call."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
+            "message": "No overload matches this call."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+            "message": "No overload matches this call."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
+            "message": "No overload matches this call."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
+            "message": "No overload matches this call."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/thankYou.tsx",
+            "message": "No overload matches this call."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
+            "message": "No overload matches this call."
+        }
+    ],
+    "TS2314": [
+        {
+            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+            "message": "Generic type '$Call' requires 1 type argument(s)."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/postcodeFinderStore.ts",
+            "message": "Generic type '$Call' requires 1 type argument(s)."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/summary.tsx",
+            "message": "Generic type '$Call' requires 1 type argument(s)."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryThankYou.tsx",
+            "message": "Generic type '$Call' requires 1 type argument(s)."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.tsx",
+            "message": "Generic type '$Call' requires 1 type argument(s)."
+        }
+    ],
+    "TS2304": [
+        {
+            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+            "message": "Cannot find name 'GlobalState'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/addressFields.tsx",
+            "message": "Cannot find name 'GlobalState'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+            "message": "Cannot find name 'GlobalState'."
+        },
+        {
+            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+            "message": "Cannot find name 'Stage'."
+        },
+        {
+            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+            "message": "Cannot find name 'Stage'."
+        }
+    ],
+    "TS2741": [
+        {
+            "path": "assets/components/subscriptionCheckouts/address/postcodeFinder.tsx",
+            "message": "Property 'label' is missing in type '{ onKeyPress: (e: KeyboardEvent<HTMLInputElement>) => void; css: SerializedStyles; name: string; width: 10; }' but required in type 'Pick<TextInputProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"id\" | \"onChange\" | \"value\" | \"dir\" | \"size\" | ... 275 more ... | \"enterKeyHint\">'."
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
+            "message": "Property 'value' is missing in type '{ id: string; image: any; label: string; name: string; checked: boolean; onChange: (...args: any[]) => any; }' but required in type 'Pick<RadioProps, \"form\" | \"label\" | \"slot\" | \"style\" | \"title\" | \"pattern\" | \"children\" | \"color\" | \"hidden\" | \"type\" | \"id\" | \"onChange\" | \"value\" | \"dir\" | \"size\" | ... 273 more ... | \"enterKeyHint\">'."
+        },
+        {
+            "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
+            "message": "Property 'Widgets' is missing in type 'Record<string, any>' but required in type 'AmazonPaymentsObject'."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/endSummary/endSummarySelector.ts",
+            "message": "Property 'isPatron' is missing in type '{ priceDescription: string; promotion: string; orderIsAGift: boolean; digitalGiftBillingPeriod: \"Annual\" | \"Quarterly\"; price: string; }' but required in type 'EndSummaryProps'."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/helpers/orderSummaryText.ts",
+            "message": "Property 'NoProductOptions' is missing in type '{ Saturday: string; SaturdayPlus: string; Sunday: string; SundayPlus: string; Weekend: string; WeekendPlus: string; Sixday: string; SixdayPlus: string; Everyday: string; EverydayPlus: string; }' but required in type 'Record<ProductOptions, string>'."
+        }
+    ],
+    "TS2739": [
+        {
+            "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
+            "message": "Type '{ Stripe: Element; PayPal: Element; DirectDebit: Element; }' is missing the following properties from type 'Record<PaymentMethod, any>': Sepa, ExistingCard, ExistingDirectDebit, AmazonPay, None"
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
+            "message": "Type '{ Stripe: string; PayPal: string; DirectDebit: string; }' is missing the following properties from type 'Record<PaymentMethod, string>': Sepa, ExistingCard, ExistingDirectDebit, AmazonPay, None"
+        },
+        {
+            "path": "assets/components/subscriptionCheckouts/paymentMethodSelector.tsx",
+            "message": "Type '{ Stripe: string; PayPal: string; DirectDebit: string; }' is missing the following properties from type 'Record<PaymentMethod, string>': Sepa, ExistingCard, ExistingDirectDebit, AmazonPay, None"
+        },
+        {
+            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+            "message": "Type '{ ONE_OFF: { amounts: number[]; defaultAmount: number; }; }' is missing the following properties from type 'ContributionAmounts': MONTHLY, ANNUAL"
+        },
+        {
+            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+            "message": "Type '{ ONE_OFF: { min: number; minInWords: string; max: number; maxInWords: string; default: number; }; }' is missing the following properties from type 'Config': MONTHLY, ANNUAL"
+        },
+        {
+            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+            "message": "Type '{ ONE_OFF: { amounts: number[]; defaultAmount: number; }; }' is missing the following properties from type 'ContributionAmounts': MONTHLY, ANNUAL"
+        },
+        {
+            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+            "message": "Type '{ ONE_OFF: { min: number; minInWords: string; max: number; maxInWords: string; default: number; }; }' is missing the following properties from type 'Config': MONTHLY, ANNUAL"
+        },
+        {
+            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+            "message": "Type '{ ONE_OFF: { amounts: number[]; defaultAmount: number; }; }' is missing the following properties from type 'ContributionAmounts': MONTHLY, ANNUAL"
+        },
+        {
+            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+            "message": "Type '{ ONE_OFF: { min: number; minInWords: string; max: number; maxInWords: string; default: number; }; }' is missing the following properties from type 'Config': MONTHLY, ANNUAL"
+        },
+        {
+            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+            "message": "Type '{ ONE_OFF: { amounts: number[]; defaultAmount: number; }; }' is missing the following properties from type 'ContributionAmounts': MONTHLY, ANNUAL"
+        },
+        {
+            "path": "assets/helpers/internationalisation/localCurrencyCountry.ts",
+            "message": "Type '{ ONE_OFF: { min: number; minInWords: string; max: number; maxInWords: string; default: number; }; }' is missing the following properties from type 'Config': MONTHLY, ANNUAL"
+        },
+        {
+            "path": "assets/pages/contributions-landing/components/PaymentMethodSelector.tsx",
+            "message": "Type 'Element[]' is missing the following properties from type 'ReactElement<any, any>': type, props, key"
+        },
+        {
+            "path": "assets/pages/contributions-landing/contributionsLandingReducer.ts",
+            "message": "Type '{}' is missing the following properties from type 'SelectedAmounts': MONTHLY, ANNUAL, ONE_OFF"
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/thankYou.tsx",
+            "message": "Type '{ HomeDelivery: string[]; Collection: string[]; }' is missing the following properties from type 'Record<FulfilmentOptions, string[]>': Domestic, RestOfWorld, NoFulfilmentOptions"
+        }
+    ],
+    "TS2532": [
+        {
+            "path": "assets/components/subscriptionCheckouts/summary.tsx",
+            "message": "Object is possibly 'undefined'."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Object is possibly 'undefined'."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Object is possibly 'undefined'."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Object is possibly 'undefined'."
+        }
+    ],
+    "TS2556": [
+        {
+            "path": "assets/helpers/__tests__/contributionsTests.ts",
+            "message": "A spread argument must either have a tuple type or be passed to a rest parameter."
+        },
+        {
+            "path": "assets/helpers/__tests__/contributionsTests.ts",
+            "message": "A spread argument must either have a tuple type or be passed to a rest parameter."
+        },
+        {
+            "path": "assets/helpers/__tests__/contributionsTests.ts",
+            "message": "A spread argument must either have a tuple type or be passed to a rest parameter."
+        }
+    ],
+    "TS2554": [
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/__tests__/formValidation.ts",
+            "message": "Expected 3 arguments, but got 2."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+            "message": "Expected 1 arguments, but got 0."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+            "message": "Expected 1 arguments, but got 0."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+            "message": "Expected 1 arguments, but got 0."
+        },
+        {
+            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+            "message": "Expected 3 arguments, but got 1."
+        },
+        {
+            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+            "message": "Expected 6 arguments, but got 1."
+        },
+        {
+            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+            "message": "Expected 3 arguments, but got 1."
+        },
+        {
+            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+            "message": "Expected 6 arguments, but got 1."
+        },
+        {
+            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+            "message": "Expected 6 arguments, but got 1."
+        },
+        {
+            "path": "assets/pages/contributions-landing/contributionsLanding.tsx",
+            "message": "Expected 1 arguments, but got 0."
+        },
+        {
+            "path": "assets/pages/showcase/components/otherProducts.tsx",
+            "message": "Expected 1 arguments, but got 0."
+        }
+    ],
+    "TS2569": [
+        {
+            "path": "assets/helpers/checkoutForm/checkoutForm.ts",
+            "message": "Type 'HTMLCollectionOf<HTMLInputElement>' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators."
+        },
+        {
+            "path": "assets/helpers/checkoutForm/checkoutForm.ts",
+            "message": "Type 'HTMLFormControlsCollection' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators."
+        }
+    ],
+    "TS2411": [
+        {
+            "path": "assets/helpers/globalsAndSwitches/settings.ts",
+            "message": "Property 'experiments' of type 'Record<string, { name: string; description: string; state: Status; }>' is not assignable to 'string' index type 'SwitchObject'."
+        }
+    ],
+    "TS7017": [
+        {
+            "path": "assets/helpers/page/__tests__/pageTest.ts",
+            "message": "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature."
+        },
+        {
+            "path": "assets/helpers/page/__tests__/pageTest.ts",
+            "message": "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature."
+        },
+        {
+            "path": "assets/helpers/page/__tests__/pageTest.ts",
+            "message": "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature."
+        },
+        {
+            "path": "assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts",
+            "message": "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature."
+        }
+    ],
+    "TS2367": [
+        {
+            "path": "assets/helpers/polyfills/details.ts",
+            "message": "This condition will always return 'true' since the types 'Element' and 'Document' have no overlap."
+        },
+        {
+            "path": "assets/pages/paper-subscription-landing/components/content/linkTo.tsx",
+            "message": "This condition will always return 'false' since the types 'PaperFulfilmentOptions' and '\"delivery\"' have no overlap."
+        },
+        {
+            "path": "assets/pages/promotion-terms/weeklyTerms.tsx",
+            "message": "This condition will always return 'false' since the types '\"Monthly\"' and '\"Quarterly\"' have no overlap."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/helpers/__tests__/deliveryDays.ts",
+            "message": "This condition will always return 'false' since the types '() => number' and 'number' have no overlap."
+        }
+    ],
+    "TS2740": [
+        {
+            "path": "assets/helpers/productPrice/__tests__/productPricesTests.ts",
+            "message": "Type '{ GBP: { price: number; savingVsRetail: number; currency: \"GBP\"; fixedTerm: false; promotions: never[]; }; }' is missing the following properties from type 'Record<IsoCurrency, ProductPrice>': NZD, AUD, CAD, USD, and 5 more."
+        },
+        {
+            "path": "assets/helpers/productPrice/productOptions.ts",
+            "message": "Type '{ Saturday: \"SaturdayPlus\"; Sunday: \"SundayPlus\"; Weekend: \"WeekendPlus\"; Sixday: \"SixdayPlus\"; Everyday: \"EverydayPlus\"; }' is missing the following properties from type 'Record<ProductOptions, ProductOptions>': NoProductOptions, SaturdayPlus, SundayPlus, WeekendPlus, and 2 more."
+        },
+        {
+            "path": "assets/helpers/productPrice/productOptions.ts",
+            "message": "Type '{ SaturdayPlus: \"Saturday\"; SundayPlus: \"Sunday\"; WeekendPlus: \"Weekend\"; SixdayPlus: \"Sixday\"; EverydayPlus: \"Everyday\"; }' is missing the following properties from type 'Record<ProductOptions, ProductOptions>': NoProductOptions, Saturday, Sunday, Weekend, and 2 more."
+        },
+        {
+            "path": "assets/helpers/productPrice/subscriptions.ts",
+            "message": "Type '{ GBPCountries: number; }' is missing the following properties from type 'Record<CountryGroupId, number>': UnitedStates, AUDCountries, EURCountries, International, and 2 more."
+        },
+        {
+            "path": "assets/helpers/rendering/render.ts",
+            "message": "Type 'Element' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, dir, and 109 more."
+        }
+    ],
+    "TS2531": [
+        {
+            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+            "message": "Object is possibly 'null'."
+        },
+        {
+            "path": "assets/helpers/productPrice/__tests__/promotionsTests.ts",
+            "message": "Object is possibly 'null'."
+        }
+    ],
+    "TS7016": [
+        {
+            "path": "assets/helpers/rendering/render.ts",
+            "message": "Could not find a declaration file for module 'preact/debug'. 'support-frontend/node_modules/preact/debug/dist/debug.js' implicitly has an 'any' type."
+        }
+    ],
+    "TS2707": [
+        {
+            "path": "assets/pages/contributions-landing/contributionsLandingInit.ts",
+            "message": "Generic type 'Store<S, A>' requires between 0 and 2 type arguments."
+        }
+    ],
+    "TS2525": [
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.test.tsx",
+            "message": "Initializer provides no value for this binding element and the binding element has no default value."
+        },
+        {
+            "path": "assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.test.tsx",
+            "message": "Initializer provides no value for this binding element and the binding element has no default value."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+            "message": "Initializer provides no value for this binding element and the binding element has no default value."
+        },
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx",
+            "message": "Initializer provides no value for this binding element and the binding element has no default value."
+        },
+        {
+            "path": "assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx",
+            "message": "Initializer provides no value for this binding element and the binding element has no default value."
+        }
+    ],
+    "TS2745": [
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/addDigiSubCta.tsx",
+            "message": "This JSX tag's 'children' prop expects type 'ReactElement<any, string | JSXElementConstructor<any>>[]' which requires multiple children, but only a single child was provided."
+        },
+        {
+            "path": "assets/pages/paper-subscription-landing/components/content/deliveryTab.tsx",
+            "message": "This JSX tag's 'children' prop expects type 'ReactElement<any, string | JSXElementConstructor<any>>[]' which requires multiple children, but only a single child was provided."
+        }
+    ],
+    "TS7022": [
+        {
+            "path": "assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx",
+            "message": "'initialState' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer."
+        }
+    ],
+    "TS2571": [
+        {
+            "path": "assets/pages/promotion-terms/promotionTermsReducer.ts",
+            "message": "Object is of type 'unknown'."
+        },
+        {
+            "path": "assets/pages/promotion-terms/promotionTermsReducer.ts",
+            "message": "Object is of type 'unknown'."
+        },
+        {
+            "path": "assets/pages/promotion-terms/promotionTermsReducer.ts",
+            "message": "Object is of type 'unknown'."
+        }
+    ],
+    "TS2698": [
+        {
+            "path": "assets/pages/promotion-terms/promotionTermsReducer.ts",
+            "message": "Spread types may only be created from object types."
+        },
+        {
+            "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
+            "message": "Spread types may only be created from object types."
+        },
+        {
+            "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
+            "message": "Spread types may only be created from object types."
+        },
+        {
+            "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
+            "message": "Spread types may only be created from object types."
+        },
+        {
+            "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
+            "message": "Spread types may only be created from object types."
+        },
+        {
+            "path": "assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx",
+            "message": "Spread types may only be created from object types."
+        }
+    ]
 }


### PR DESCRIPTION
This PR tries to address errors in `interactiveTables.tsx` and its child components. There are a few more changes than in previous error busting efforts, though each quite small.

- Add several `grid-column` and `grid-row` properties to `interactiveTableRow.tsx` as the styling plugin says it improves browser compatability
- The values for `colSpan` and `aria-colspan` have been changed from strings to numbers 

As in previous PRs I have also added return types where possible, though there were a couple of places (`getRows()` and `getLocalisedRows()`) where what's being returned doesn't fit the nice neat `JSX.Element` or similar. Rather than get bogged down I've left them without return types for now.