### PR TITLE
upgrade google-cloud-bigquery to 2.8.0

### DIFF
--- a/support-modules/acquisition-events/build.sbt
+++ b/support-modules/acquisition-events/build.sbt
@@ -5,7 +5,7 @@ name := "module-acquisition-events"
 description := "Module for sending acquisition events"
 
 libraryDependencies ++= Seq(
-  "com.google.cloud" % "google-cloud-bigquery" % "1.137.2",
+  "com.google.cloud" % "google-cloud-bigquery" % "2.8.0",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "com.amazonaws" % "aws-java-sdk-kinesis" % "1.12.10",


### PR DESCRIPTION
because it depends on a version of protobuf with a vulnerability.
we [previously](https://github.com/guardian/support-frontend/pull/3431) attempted just a minor version upgrade but this wasn't enough.

Testing:

- [x] recurring contribution goes to BigQuery
- [x] single contribution goes to BigQuery