### PR TITLE
Show a more specific error message for users with disallowed email

### DIFF
--- a/support-frontend/app/models/identity/responses/IdentityErrorResponse.scala
+++ b/support-frontend/app/models/identity/responses/IdentityErrorResponse.scala
@@ -1,0 +1,47 @@
+package models.identity.responses
+
+import models.identity.responses.IdentityErrorResponse.IdentityError
+import play.api.libs.json.{Json, Reads}
+
+// Models and error returned by Identity
+//
+// Example response:
+// =================
+//
+// {
+//    "status": "error",
+//    "errors": [
+//        {
+//            "message": "Registration Error",
+//            "description": "Please sign up using an email address from a different provider"
+//        }
+//    ]
+//}
+
+case class IdentityErrorResponse(
+  status: String,
+  errors: List[IdentityError]
+)
+
+object IdentityErrorResponse {
+  implicit val reads: Reads[IdentityErrorResponse] = Json.reads[IdentityErrorResponse]
+
+  case class IdentityError(
+    message: String,
+    description: String,
+  )
+
+  object IdentityError {
+    object InvalidEmailAddress {
+      val message = "Registration Error"
+      val description = "Please sign up using an email address from a different provider"
+      val errorReasonCode = "invalid_email_address"
+    }
+
+    def isDisallowedEmailError(identityError: IdentityError) =
+      identityError.message == InvalidEmailAddress.message &&
+      identityError.description == InvalidEmailAddress.description
+
+    implicit val reads: Reads[IdentityError] = Json.reads[IdentityError]
+  }
+}

--- a/support-frontend/app/models/identity/responses/IdentityErrorResponse.scala
+++ b/support-frontend/app/models/identity/responses/IdentityErrorResponse.scala
@@ -28,7 +28,7 @@ object IdentityErrorResponse {
 
   case class IdentityError(
     message: String,
-    description: String,
+    description: String
   )
 
   object IdentityError {
@@ -38,7 +38,7 @@ object IdentityErrorResponse {
       val errorReasonCode = "invalid_email_address"
     }
 
-    def isDisallowedEmailError(identityError: IdentityError) =
+    def isDisallowedEmailError(identityError: IdentityError): Boolean =
       identityError.message == InvalidEmailAddress.message &&
       identityError.description == InvalidEmailAddress.description
 

--- a/support-frontend/app/services/HttpIdentityService.scala
+++ b/support-frontend/app/services/HttpIdentityService.scala
@@ -150,7 +150,7 @@ class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient:
         .asEither
         .leftMap(err =>
           IdentityError(
-            message = "Error deserialising json to UserResponse",
+            message = "Error deserialising json to GuestRegistrationResponse",
             description = err.mkString(",")
           ))
         .map(response => response.guestRegistrationRequest.userId)

--- a/support-frontend/app/services/HttpIdentityService.scala
+++ b/support-frontend/app/services/HttpIdentityService.scala
@@ -1,7 +1,6 @@
 package services
 
 import java.net.URI
-
 import cats.data.EitherT
 import cats.implicits._
 import com.google.common.net.InetAddresses
@@ -12,7 +11,8 @@ import config.Identity
 import io.circe.Encoder
 import io.circe.generic.semiauto.deriveEncoder
 import models.identity.requests.CreateGuestAccountRequestBody
-import models.identity.responses.{GuestRegistrationResponse, SetGuestPasswordResponseCookies, UserResponse}
+import models.identity.responses.IdentityErrorResponse.IdentityError
+import models.identity.responses.{GuestRegistrationResponse, IdentityErrorResponse, SetGuestPasswordResponseCookies, UserResponse}
 import play.api.libs.json.{Json, Reads}
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 import play.api.mvc.RequestHeader
@@ -105,7 +105,7 @@ class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient:
       .subflatMap(resp => resp.json.validate[CreateSignInTokenResponse].asEither.leftMap(_.mkString(",")))
   }
 
-  def getUserIdFromEmail(email: String)(implicit ec: ExecutionContext): EitherT[Future, String, String] =
+  def getUserIdFromEmail(email: String)(implicit ec: ExecutionContext): EitherT[Future, IdentityError, String] =
     execute(
       wsClient.url(s"$apiUrl/user")
         .withHttpHeaders(List("X-GU-ID-Client-Access-Token" -> s"Bearer $apiClientToken"): _*)
@@ -115,7 +115,11 @@ class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient:
     ) { resp =>
       resp.json.validate[UserResponse]
         .asEither
-        .leftMap(_.mkString(","))
+        .leftMap(err =>
+          IdentityError(
+            message = "Error deserialising json to UserResponse",
+            description = err.mkString(",")
+        ))
         .map(userResponse => userResponse.user.id)
     }
 
@@ -123,7 +127,7 @@ class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient:
     email: String,
     firstName: String,
     lastName: String
-  )(implicit ec: ExecutionContext): EitherT[Future, String, String] = {
+  )(implicit ec: ExecutionContext): EitherT[Future, IdentityError, String] = {
     val body = CreateGuestAccountRequestBody(
       email,
       PrivateFields(
@@ -144,19 +148,31 @@ class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient:
     ) { resp =>
       resp.json.validate[GuestRegistrationResponse]
         .asEither
-        .leftMap(_.mkString(","))
+        .leftMap(err =>
+          IdentityError(
+            message = "Error deserialising json to UserResponse",
+            description = err.mkString(",")
+          ))
         .map(response => response.guestRegistrationRequest.userId)
     }
   }
 
   private def uriWithoutQuery(uri: URI) = uri.toString.takeWhile(_ != '?')
 
-  private def execute[A](requestHolder: WSRequest)(func: (WSResponse) => Either[String, A])(implicit ec: ExecutionContext) = {
+  private def execute[A](requestHolder: WSRequest)(func: (WSResponse) => Either[IdentityError, A])(implicit ec: ExecutionContext) = {
     EitherT.right(requestHolder.execute()).subflatMap {
       case r if r.success =>
         func(r)
       case r =>
-        Left(s"Identity API error: ${requestHolder.method} ${uriWithoutQuery(requestHolder.uri)} STATUS ${r.status}, BODY: ${r.body}")
+        r.json.validate[IdentityErrorResponse]
+          .asEither
+          .leftMap( _ =>
+              IdentityError(
+                message = s"${r.body}",
+                description = s"Identity API error: ${requestHolder.method} ${uriWithoutQuery(requestHolder.uri)} STATUS ${r.status}, BODY: ${r.body}"
+              )
+          )
+          .flatMap(error => Left(error.errors.head))
     }
   }
 }

--- a/support-frontend/assets/helpers/forms/errorReasons.ts
+++ b/support-frontend/assets/helpers/forms/errorReasons.ts
@@ -18,6 +18,7 @@ export type ErrorReason =
 	| 'amazon_pay_try_other_card'
 	| 'amazon_pay_try_again'
 	| 'amazon_pay_fatal'
+	| 'invalid_email_address'
 	| 'unknown';
 
 // ----- Functions ----- //
@@ -65,6 +66,9 @@ function appropriateErrorMessage(errorReason: ErrorReason | string): string {
 
 		case 'incomplete_payment_request_details':
 			return 'Please complete all relevant fields for your saved cards and billing addresses within your browser settings and try your payment again. Alternatively, you can use the form below.';
+
+		case 'invalid_email_address':
+			return 'Please use an email address from a different provider';
 
 		default:
 			return 'The transaction was temporarily declined. Please try entering your payment details again. Alternatively, try another payment method.';

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -368,11 +368,15 @@ function postRegularPaymentRequest(
 					error: 'internal_error',
 				} as PaymentResult;
 			} else if (response.status === 400) {
-				logException(`Bad request error while trying to post to ${uri}`);
-				return {
-					paymentStatus: 'failure',
-					error: 'personal_details_incorrect',
-				} as PaymentResult;
+				return response.text().then((text: string) => {
+					logException(
+						`Bad request error while trying to post to ${uri} - ${text}`,
+					);
+					return {
+						paymentStatus: 'failure',
+						error: text,
+					} as PaymentResult;
+				});
 			}
 
 			return response.json().then(checkRegularStatus(participations, csrf));


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
There are some email providers which are disallowed by Identity eg. `@0815.ru` addressses. Currently when a user tries to sign up for a contribution or subscription with one of these addresses we return a generic 500 error and trigger an alarm which then needs to be investigated.

This PR takes advantage of some [work done by Identity]( https://github.com/guardian/identity/pull/2023) to return a better error message to users and to avoid triggering an alarm for these cases. 

Unfortunately there are still a lot of email addresses which will trigger the alarm, for example `test@gmail.com123`. This is because Identity's email validation regex doesn't pick up the error in this email address, so it is trying to create the user but failing when it tries to create it in Okta as their email validation is better than what's in identity and these errors are still returned to support-frontend as a generic 500. 

Identity have an outstanding card to return this type of error to us in the same way as they do disallowed email errors, at which point we can test whether this PR works for the new errors as well.


[**Trello Card**](https://trello.com/c/IJC7qudC/147-handle-identity-blocked-email-domain-errors-on-create-endpoint)

## Is this an AB test?
- [ ] Yes
- [x] No

## Screenshots
**The new error message:**
<img width="614" alt="Screen Shot 2022-02-07 at 17 52 47" src="https://user-images.githubusercontent.com/181371/152844336-16106878-e42c-48b0-bbbb-ea7347f2fe7a.png">

