### PR TITLE
Add post-deployment test for contributing with direct debit

### DIFF
--- a/support-frontend/project/build.properties
+++ b/support-frontend/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.2

--- a/support-frontend/project/build.properties
+++ b/support-frontend/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.6.2

--- a/support-frontend/test/selenium/contributions/RecurringContributionsSpec.scala
+++ b/support-frontend/test/selenium/contributions/RecurringContributionsSpec.scala
@@ -66,6 +66,41 @@ class RecurringContributionsSpec extends AnyFeatureSpec with GivenWhenThen with 
 
     }
 
+    Scenario("Monthly contribution sign-up with direct debit - GBP") {
+
+      val testUser = new PostDeployTestUser(driverConfig)
+      val landingPage = ContributionsLanding("uk", testUser)
+
+      val contributionThankYou = new ContributionThankYou("uk")
+
+      Given("that a test user goes to the contributions landing page")
+      goTo(landingPage)
+      assert(landingPage.pageHasLoaded)
+
+      When("the user selects the monthly option")
+      landingPage.clickMonthly
+
+      Given("The user fills in their details correctly")
+      landingPage.clearForm(hasNameFields = true)
+      landingPage.fillInPersonalDetails(hasNameFields = true)
+
+      Given("that the user selects to pay with direct debit")
+      When("they press the direct debit payment button")
+      landingPage.selectDirectDebit()
+
+      And("enter direct debit details")
+      landingPage.fillInDirectDebitDetails()
+
+      When("they click to pay")
+      landingPage.payDirectDebit()
+
+      Then("the thankyou page should display")
+      eventually {
+        assert(contributionThankYou.pageHasLoaded)
+      }
+
+    }
+
     Scenario("Annual contribution sign-up with Stripe - USD") {
 
       val testUser = new PostDeployTestUser(driverConfig)

--- a/support-frontend/test/selenium/contributions/RecurringContributionsSpec.scala
+++ b/support-frontend/test/selenium/contributions/RecurringContributionsSpec.scala
@@ -87,6 +87,7 @@ class RecurringContributionsSpec extends AnyFeatureSpec with GivenWhenThen with 
       Given("that the user selects to pay with direct debit")
       When("they press the direct debit payment button")
       landingPage.selectDirectDebit()
+			landingPage.clickContribute
 
       And("enter direct debit details")
       landingPage.fillInDirectDebitDetails()

--- a/support-frontend/test/selenium/contributions/RecurringContributionsSpec.scala
+++ b/support-frontend/test/selenium/contributions/RecurringContributionsSpec.scala
@@ -87,7 +87,7 @@ class RecurringContributionsSpec extends AnyFeatureSpec with GivenWhenThen with 
       Given("that the user selects to pay with direct debit")
       When("they press the direct debit payment button")
       landingPage.selectDirectDebit()
-			landingPage.clickContribute
+      landingPage.clickContribute
 
       And("enter direct debit details")
       landingPage.fillInDirectDebitDetails()

--- a/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
+++ b/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
@@ -21,6 +21,7 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
   private val otherAmount = id("contributionOther")
 
   private val stripeSelector = id("paymentMethodSelector-Stripe")
+  private val directDebitSelector = id("paymentMethodSelector-DirectDebit")
   private val payPalSelector = id("paymentMethodSelector-PayPal")
   private val stateSelector = id("contributionState")
 
@@ -80,6 +81,29 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
       }
     }
   }
+	
+	private object DirectDebitFields {
+		val accountHolderName = cssSelector("#account-holder-name-input")
+    val accountNumber = cssSelector("#account-number-input")
+    val sortCode1 = cssSelector("#qa-sort-code-1")
+    val sortCode2 = cssSelector("#qa-sort-code-2")
+    val sortCode3 = cssSelector("#qa-sort-code-3")
+		val confirmation = cssSelector("#qa-confirmation-input")
+		val submitButton = cssSelector("#qa-submit-button-1")
+		val payButton =  cssSelector("#qa-submit-button-2")
+
+    def fillIn(): Unit = {
+      setValue(accountHolderName, "CP Scott")
+      setValue(accountNumber, "55779911")
+      setValue(sortCode1, "20")
+      setValue(sortCode2, "00")
+      setValue(sortCode3, "00")
+			clickOn(confirmation)
+			clickOn(submitButton)
+    }
+		
+		def pay(): Unit = clickOn(payButton)
+	}
 
   def fillInPersonalDetails(hasNameFields: Boolean) { RegisterFields.fillIn(hasNameFields) }
 
@@ -88,8 +112,14 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
   def selectState: Unit = setSingleSelectionValue(stateSelector, "NY")
 
   def selectStripePayment(): Unit = clickOn(stripeSelector)
+  
+	def selectDirectDebit(): Unit = clickOn(directDebitSelector)
 
   def fillInCardDetails(hasZipCodeField: Boolean): Unit = CardDetailsFields.fillIn(hasZipCodeField)
+	
+	def fillInDirectDebitDetails(): Unit = DirectDebitFields.fillIn()
+	
+	def payDirectDebit(): Unit = DirectDebitFields.pay()
 
   def selectPayPalPayment(): Unit = clickOn(payPalSelector)
 

--- a/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
+++ b/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
@@ -81,16 +81,16 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
       }
     }
   }
-	
-	private object DirectDebitFields {
-		val accountHolderName = cssSelector("#account-holder-name-input")
+  
+  private object DirectDebitFields {
+    val accountHolderName = cssSelector("#account-holder-name-input")
     val accountNumber = cssSelector("#account-number-input")
     val sortCode1 = cssSelector("#qa-sort-code-1")
     val sortCode2 = cssSelector("#qa-sort-code-2")
     val sortCode3 = cssSelector("#qa-sort-code-3")
-		val confirmation = cssSelector("#qa-confirmation-input")
-		val submitButton = cssSelector("#qa-submit-button-1")
-		val payButton =  cssSelector("#qa-submit-button-2")
+    val confirmation = cssSelector("#qa-confirmation-input")
+    val submitButton = cssSelector("#qa-submit-button-1")
+    val payButton =  cssSelector("#qa-submit-button-2")
 
     def fillIn(): Unit = {
       setValue(accountHolderName, "CP Scott")
@@ -98,12 +98,12 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
       setValue(sortCode1, "20")
       setValue(sortCode2, "00")
       setValue(sortCode3, "00")
-			clickOn(confirmation)
-			clickOn(submitButton)
+      clickOn(confirmation)
+      clickOn(submitButton)
     }
-		
-		def pay(): Unit = clickOn(payButton)
-	}
+    
+    def pay(): Unit = clickOn(payButton)
+  }
 
   def fillInPersonalDetails(hasNameFields: Boolean) { RegisterFields.fillIn(hasNameFields) }
 
@@ -113,13 +113,13 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
 
   def selectStripePayment(): Unit = clickOn(stripeSelector)
   
-	def selectDirectDebit(): Unit = clickOn(directDebitSelector)
+  def selectDirectDebit(): Unit = clickOn(directDebitSelector)
 
   def fillInCardDetails(hasZipCodeField: Boolean): Unit = CardDetailsFields.fillIn(hasZipCodeField)
-	
-	def fillInDirectDebitDetails(): Unit = DirectDebitFields.fillIn()
-	
-	def payDirectDebit(): Unit = DirectDebitFields.pay()
+  
+  def fillInDirectDebitDetails(): Unit = DirectDebitFields.fillIn()
+  
+  def payDirectDebit(): Unit = DirectDebitFields.pay()
 
   def selectPayPalPayment(): Unit = clickOn(payPalSelector)
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds a post-deployment test for setting up a recurring contribution with direct debit.

## Why are you doing this?

There was an issue introduced in #3428 (fixed in #3434 ) which prevented users from contributing via direct debit, and was only noticed the following day due to an alarm. This is the kind of issue that should get caught immediately by post-deployment tests, but we didn't have any covering that payment method.
