### PR TITLE
Fix for running selenium tests against code

### DIFF
--- a/support-frontend/conf/DEV.public.conf
+++ b/support-frontend/conf/DEV.public.conf
@@ -11,7 +11,11 @@ identity.api.url="https://idapi.code.dev-theguardian.com"
 identity.production.keys=false
 identity.useStub=false
 guardianDomain=".thegulocal.com"
+
+# To run selenium post-deployment tests against code use the config below
+# support.url="https://support.code.dev-theguardian.com"
 support.url="https://support.thegulocal.com"
+
 googleAuth.redirectUrl = "https://support.thegulocal.com/oauth2callback"
 paymentApi.url="https://payment.code.dev-guardianapis.com"
 membersDataService.api.url="https://members-data-api.thegulocal.com"

--- a/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
+++ b/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
@@ -85,7 +85,7 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
       }
     }
   }
-  
+
   private object DirectDebitFields {
     val accountHolderName = cssSelector("#account-holder-name-input")
     val accountNumber = cssSelector("#account-number-input")
@@ -94,7 +94,7 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
     val sortCode3 = cssSelector("#qa-sort-code-3")
     val confirmation = cssSelector("#qa-confirmation-input")
     val submitButton = cssSelector("#qa-submit-button-1")
-    val payButton =  cssSelector("#qa-submit-button-2")
+    val payButton = cssSelector("#qa-submit-button-2")
 
     def fillIn(): Unit = {
       setValue(accountHolderName, "CP Scott")
@@ -105,7 +105,7 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
       clickOn(confirmation)
       clickOn(submitButton)
     }
-    
+
     def pay(): Unit = clickOn(payButton)
   }
 
@@ -116,13 +116,13 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
   def selectState: Unit = setSingleSelectionValue(stateSelector, "NY")
 
   def selectStripePayment(): Unit = clickOn(stripeSelector)
-  
+
   def selectDirectDebit(): Unit = clickOn(directDebitSelector)
 
   def fillInCardDetails(hasZipCodeField: Boolean): Unit = CardDetailsFields.fillIn(hasZipCodeField)
-  
+
   def fillInDirectDebitDetails(): Unit = DirectDebitFields.fillIn()
-  
+
   def payDirectDebit(): Unit = DirectDebitFields.pay()
 
   def selectPayPalPayment(): Unit = clickOn(payPalSelector)

--- a/support-frontend/test/selenium/util/Config.scala
+++ b/support-frontend/test/selenium/util/Config.scala
@@ -11,8 +11,6 @@ object Config {
 
   private val conf = ConfigFactory.load()
 
-  val guardianDomain = conf.getString("guardianDomain")
-
   val supportFrontendUrl = conf.getString("support.url")
 
   val waitTimeout = 45

--- a/support-frontend/test/selenium/util/PostDeployTestUser.scala
+++ b/support-frontend/test/selenium/util/PostDeployTestUser.scala
@@ -18,7 +18,7 @@ class PostDeployTestUser(driverConfig: DriverConfig, bypassRecaptchaCookies: Opt
 
   private def addTestUserCookies(testUsername: String) = {
     driverConfig.addCookie(name = "pre-signin-test-user", value = testUsername)
-    driverConfig.addCookie(name = "_test_username", value = testUsername, domain = Some(Config.guardianDomain))
+    driverConfig.addCookie(name = "_test_username", value = testUsername)
     driverConfig.addCookie(
       name = "_post_deploy_user",
       value = "true",


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
When I tried to run the selenium tests against CODE to test some changes they failed due to an error writing cookies. This PR fixes that and puts a comment in the `DEV.public.conf` file to make it clear how to run the tests against CODE.
