### PR TITLE
Retry failed Identity calls

### DIFF
--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -94,11 +94,8 @@ class CreateSubscriptionController(
       body: CreateSupportWorkersRequest,
   ): EitherT[Future, IdentityError, IdentityIdAndEmail] = {
     implicit val scheduler: Scheduler = system.scheduler
-    val existingIdentityId = identityService.getUserIdFromEmail(body.email)
-    val identityId =
-      existingIdentityId.leftFlatMap(_ =>
-        identityService.createUserIdFromEmailUser(body.email, body.firstName, body.lastName),
-      )
+    val identityId = identityService.getOrCreateUserFromEmail(body.email, body.firstName, body.lastName)
+
     identityId.map(identityId => IdentityIdAndEmail(identityId, body.email))
   }
 

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -2,6 +2,7 @@ package controllers
 
 import actions.AsyncAuthenticatedBuilder.OptionalAuthRequest
 import actions.CustomActionBuilders
+import akka.actor.{ActorSystem, Scheduler}
 import cats.data.EitherT
 import cats.implicits._
 import com.gu.monitoring.SafeLogger
@@ -42,7 +43,7 @@ class CreateSubscriptionController(
     testUsers: TestUserService,
     components: ControllerComponents,
     guardianDomain: GuardianDomain,
-)(implicit val ec: ExecutionContext)
+)(implicit val ec: ExecutionContext, system: ActorSystem)
     extends AbstractController(components)
     with Circe {
 
@@ -92,6 +93,7 @@ class CreateSubscriptionController(
   private def getOrCreateIdentityUser(
       body: CreateSupportWorkersRequest,
   ): EitherT[Future, IdentityError, IdentityIdAndEmail] = {
+    implicit val scheduler: Scheduler = system.scheduler
     val existingIdentityId = identityService.getUserIdFromEmail(body.email)
     val identityId =
       existingIdentityId.leftFlatMap(_ =>

--- a/support-frontend/app/models/identity/requests/CreateGuestAccountRequestBody.scala
+++ b/support-frontend/app/models/identity/requests/CreateGuestAccountRequestBody.scala
@@ -10,7 +10,7 @@ import play.api.libs.ws.{BodyWritable, InMemoryBody}
 // Example request:
 // =================
 // {
-//   "email": "a@b.com",
+//   "primaryEmailAddress": "a@b.com",
 //   "privateFields": {
 //     "firstName": "a",
 //     "secondName": "b"

--- a/support-frontend/app/utils/EitherTRetry.scala
+++ b/support-frontend/app/utils/EitherTRetry.scala
@@ -5,25 +5,24 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import akka.pattern.after
 import akka.actor.Scheduler
+import cats.data.EitherT
 import com.gu.monitoring.SafeLogger
 
 /** retry implementation from Scala Future contributor https://gist.github.com/viktorklang/9414163
   */
-object FutureRetry {
+object EitherTRetry {
 
-  /** Given an operation that produces a T, returns a Future containing the result of T, unless an exception is thrown,
-    * in which case the operation will be retried after _delay_ time, if there are more possible retries, which is
+  /** Given an operation that produces a EitherT[Future, A, B], returns that value, unless an exception is thrown, in
+    * which case the operation will be retried after _delay_ time, if there are more possible retries, which is
     * configured through the _retries_ parameter. If the operation does not succeed and there is no retries left, the
     * resulting Future will contain the last failure.
     */
-  def retry[T](op: => Future[T], delay: FiniteDuration, retries: Int)(implicit
+  def retry[A, B](op: => EitherT[Future, A, B], delay: FiniteDuration, retries: Int)(implicit
       ec: ExecutionContext,
       s: Scheduler,
-  ): Future[T] = {
+  ): EitherT[Future, A, B] = {
     SafeLogger.info(s"Future.retry trying with $retries left")
-    op recoverWith { case _ if retries > 0 => after(delay, s)(retry(op, delay, retries - 1)) }
+    op.recoverWith { case _ if retries > 0 => EitherT(after(delay, s)(retry(op, delay, retries - 1).value)) }
   }
 
-  def retry[T](op: => Future[T])(implicit ec: ExecutionContext, s: Scheduler): Future[T] =
-    retry(op, delay = 200.milliseconds, retries = 2)
 }

--- a/support-frontend/app/utils/EitherTRetry.scala
+++ b/support-frontend/app/utils/EitherTRetry.scala
@@ -1,27 +1,25 @@
 package utils
 
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import akka.pattern.after
 import akka.actor.Scheduler
+import akka.pattern.after
 import cats.data.EitherT
-import com.gu.monitoring.SafeLogger
 
-/** retry implementation from Scala Future contributor https://gist.github.com/viktorklang/9414163
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+
+/** retry implementation based on this gist from Scala Future contributor https://gist.github.com/viktorklang/9414163
   */
 object EitherTRetry {
 
   /** Given an operation that produces a EitherT[Future, A, B], returns that value, unless an exception is thrown, in
-    * which case the operation will be retried after _delay_ time, if there are more possible retries, which is
-    * configured through the _retries_ parameter. If the operation does not succeed and there is no retries left, the
-    * resulting Future will contain the last failure.
+    * which case the operation will be retried after _delay_ time if retries, which is configured through the _retries_
+    * parameter, is greater than 0. If the operation does not succeed and there are no retries left, the resulting
+    * EitherT will contain the last failure.
     */
   def retry[A, B](op: => EitherT[Future, A, B], delay: FiniteDuration, retries: Int)(implicit
       ec: ExecutionContext,
       s: Scheduler,
   ): EitherT[Future, A, B] = {
-    SafeLogger.info(s"Future.retry trying with $retries left")
     op.recoverWith { case _ if retries > 0 => EitherT(after(delay, s)(retry(op, delay, retries - 1).value)) }
   }
 

--- a/support-frontend/app/utils/FutureRetry.scala
+++ b/support-frontend/app/utils/FutureRetry.scala
@@ -1,0 +1,29 @@
+package utils
+
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import akka.pattern.after
+import akka.actor.Scheduler
+import com.gu.monitoring.SafeLogger
+
+/** retry implementation from Scala Future contributor https://gist.github.com/viktorklang/9414163
+  */
+object FutureRetry {
+
+  /** Given an operation that produces a T, returns a Future containing the result of T, unless an exception is thrown,
+    * in which case the operation will be retried after _delay_ time, if there are more possible retries, which is
+    * configured through the _retries_ parameter. If the operation does not succeed and there is no retries left, the
+    * resulting Future will contain the last failure.
+    */
+  def retry[T](op: => Future[T], delay: FiniteDuration, retries: Int)(implicit
+      ec: ExecutionContext,
+      s: Scheduler,
+  ): Future[T] = {
+    SafeLogger.info(s"Future.retry trying with $retries left")
+    op recoverWith { case _ if retries > 0 => after(delay, s)(retry(op, delay, retries - 1)) }
+  }
+
+  def retry[T](op: => Future[T])(implicit ec: ExecutionContext, s: Scheduler): Future[T] =
+    retry(op, delay = 200.milliseconds, retries = 2)
+}

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -14,6 +14,7 @@ trait Controllers {
     with ApplicationConfiguration
     with ActionBuilders
     with wiring.Assets
+    with PlayComponents
     with GoogleAuth =>
 
   lazy val assetController = new controllers.Assets(httpErrorHandler, assetsMetadata)


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We have been seeing frequent timeouts from Identity when creating guest users which has been causing checkouts to fail. This PR introduces some retry functionality so that when a create attempt times out we try again before giving up.

We had considered moving the create guest account step into the support-workers step function but a potential issue would be if we get a user who gives us a bad email address when Identity is down for some reason we will keep retrying until we eventually find out that it's bad, but by that point the user will have gone away, probably thinking that their purchase has succeeded. It's not clear what we can actually do at that point, we won't be able to email them as we normally would on failure because their email is invalid. While this is a bit of an edge case but would almost certainly happen at some point. 

The changes required to move the logic into support-workers are also quite extensive so as a first step we are just introducing some simple retry logic into support-frontend to see if that solves the problem.


[**Trello Card**](https://trello.com/c/xvGTbXUa/295-move-identity-call-at-create-into-support-workers-step-functions)
