### PR TITLE
Move support-frontend build to Github actions

### DIFF
--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
     build_check:
+      if: github.event.pull_request.head.repo.owner.login == 'guardian'
       name: Bundle Analyser
       defaults:
         run:

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 jobs:
     compressed_size:
+        if: github.event.pull_request.head.repo.owner.login == 'guardian'
         name: Compressed Size
         defaults:
           run:

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,0 +1,26 @@
+name: Test Scala-steward PRs
+
+on:
+  pull_request:
+    branches: [ main ]
+
+env:
+  GU_SUPPORT_WORKERS_LOAD_S3_CONFIG: false
+
+jobs:
+  support_frontend_build:
+    if: github.actor == 'scala-steward'
+
+    name: support-frontend build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Set up Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Build and run tests
+        run: sbt test

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -1,0 +1,83 @@
+name: Build support-frontend
+
+on:
+  pull_request:
+    branches: [ main ]
+
+env:
+  GU_SUPPORT_WORKERS_LOAD_S3_CONFIG: false
+
+jobs:
+  support_frontend_build:
+    if: github.event.pull_request.head.repo.owner.login == 'guardian'
+
+    # Required by actions-assume-aws-role
+    permissions:
+      id-token: write
+      contents: read
+
+    name: support-frontend build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Env
+        run: env
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      # (Respects .nvmrc)
+      - name: Setup Node
+        uses: guardian/actions-setup-node@v2.4.1
+        with:
+          cache: 'yarn'
+          cache-dependency-path: support-frontend/yarn.lock
+
+      - name: Install
+        run: yarn
+        working-directory: support-frontend
+
+      - name: Build the html used for SSR pages
+        run: yarn run build-ssr
+        working-directory: support-frontend
+
+      - name: Build assets
+        run: yarn run build-prod
+        working-directory: support-frontend
+
+      # The CDK build requires node 16 and currently the rest of the build is on v12
+      - name: Setup Node for CDK
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'yarn'
+          cache-dependency-path: cdk/yarn.lock
+
+      - name: Build CFN from CDK
+        run: ./script/ci
+        working-directory: cdk
+
+      # Required by sbt riffRaffUpload
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+
+      - name: Setup Java 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+            ~/.coursier
+          key: sbt
+
+      - name: Build and upload to RiffRaff
+        run: |
+          export LAST_TEAMCITY_BUILD=10000
+          export BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+          sbt "project support-frontend" riffRaffUpload

--- a/.github/workflows/ts-monitor.yml
+++ b/.github/workflows/ts-monitor.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 jobs:
     typescript_monitor:
+        if: github.event.pull_request.head.repo.owner.login == 'guardian'
         name: Typescript Monitor
         defaults:
           run:

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -61,7 +61,12 @@ maintainer := "Membership <membership.dev@theguardian.com>"
 
 riffRaffPackageType := (Debian / packageBin).value
 riffRaffManifestProjectName := "support:frontend-mono"
+riffRaffBuildIdentifier := Option(System.getenv("BUILD_NUMBER")).getOrElse("DEV")
+riffRaffManifestBranch := Option(System.getenv("GITHUB_HEAD_REF"))
+  .orElse(Option(System.getenv("BRANCH_NAME")))
+  .getOrElse("unknown_branch")
 riffRaffPackageName := "frontend"
+riffRaffAwsCredentialsProfile := Some("membership") // needed when running locally
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffArtifactResources += (file("cdk/cdk.out/Frontend.template.json"), "cfn/cfn.json")

--- a/support-frontend/webpack.ssr.js
+++ b/support-frontend/webpack.ssr.js
@@ -3,11 +3,10 @@ const common = require('./webpack.common.js');
 const entryPoints = require('./webpack.entryPoints');
 
 module.exports = merge(common('[name].css', '[name].js', false), {
-  mode: 'production',
-  devtool: 'source-map',
-  entry: entryPoints.ssr,
-  output: {
-    library: ['Support', '[name]'],
-    libraryTarget: 'commonjs',
-  },
+	mode: 'development',
+	entry: entryPoints.ssr,
+	output: {
+		library: ['Support', '[name]'],
+		libraryTarget: 'commonjs',
+	},
 });


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR adds a github action to run the full support-frontend build. This will replace the Teamcity build which we currently have and has the benefit of moving all of our CI logic into source control rather than having it only accessible through the UI of Teamcity.

It also adds a new action which will test PRs from the [Scala steward fork](https://github.com/scala-steward/support-frontend) which is the method Scala steward uses to open PRs against our codebase. Currently these are not tested by CI which makes dealing with them a pain.

[**Trello Card**](https://trello.com/c/s6l5ywJu/330-move-support-fronted-build-to-github-actions)
