### PR TITLE
Increase payment-api rate limit

### DIFF
--- a/support-payment-api/src/main/scala/controllers/StripeController.scala
+++ b/support-payment-api/src/main/scala/controllers/StripeController.scala
@@ -34,7 +34,7 @@ class StripeController(
     cc.parsers,
     cc.executionContext,
     cloudWatchService,
-    RateLimitingSettings(5, 5.hours),
+    RateLimitingSettings(10, 5.hours),
     paymentProvider = PaymentProvider.Stripe,
     stage = RequestEnvironments.stage,
   )


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->

We get quite a few Alarms triggered by requests to the payment-api hitting the rate-limit, this PR increases it from 5 requests over 5 hours to 10 requests.
