### PR TITLE
Prepare cfn template for cdk migration - phase 1

### DIFF
--- a/support-frontend/cloud-formation/cfn.yaml
+++ b/support-frontend/cloud-formation/cfn.yaml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: support-frontend
 Parameters:
-  VpcId:
+  CfnVpcId:
     Type: String
     Description: VpcId of your existing Virtual Private Cloud (VPC)
     Default: vpc-e6e00183
@@ -96,7 +96,7 @@ Resources:
       ImageId: !Ref AMI
       SecurityGroups:
         - !Ref InstanceSecurityGroup
-        - !Ref WazuhSecurityGroup
+        - !Ref NewWazuhSecurityGroup
       InstanceType: !FindInMap [ StageVariables, !Ref Stage, InstanceType ]
       IamInstanceProfile: !Ref InstanceProfile
       AssociatePublicIpAddress: false
@@ -279,7 +279,7 @@ Resources:
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
       UnhealthyThresholdCount: 2
-      VpcId: !Ref VpcId
+      VpcId: !Ref CfnVpcId
       TargetGroupAttributes:
       - Key: deregistration_delay.timeout_seconds
         Value: '20'
@@ -290,7 +290,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Permit incoming HTTPS access on port 443, egress to port 9000
-      VpcId: !Ref VpcId
+      VpcId: !Ref CfnVpcId
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 443
@@ -306,7 +306,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Open up SSH access and enable HTTP access on the configured port
-      VpcId: !Ref VpcId
+      VpcId: !Ref CfnVpcId
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 22
@@ -322,12 +322,24 @@ Resources:
           ToPort: 443
           CidrIp: 0.0.0.0/0
 
+  NewWazuhSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow outbound traffic from wazuh agent to manager
+      VpcId:
+        Ref: CfnVpcId
+      SecurityGroupEgress:
+      - IpProtocol: tcp
+        FromPort: 1514
+        ToPort: 1515
+        CidrIp: 0.0.0.0/0
+
   WazuhSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Allow outbound traffic from wazuh agent to manager
       VpcId:
-        Ref: VpcId
+        Ref: CfnVpcId
       SecurityGroupEgress:
       - IpProtocol: tcp
         FromPort: 1514


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Prepare `cfn.yaml` for the cdk migration. The `GuEc2App` pattern adds some of its own parameters & resources, which conflict with our existing template.

The simple change is to rename our `VpcId` to remove the conflict.

The slightly trickier change is around the security group. We can't just rename our `WazuhSecurityGroup` resource. Changing this logical ID will cause AWS to delete the old resource and create a new one. However, AWS won't let us delete a security group that is being used by ec2 instances (it would probably be bad if it did!). This means we need to do this rename in two steps:

1. Add a new security group with a new name and update all references to the old security group to this new one (this PR)
2. Remove the old security group (#3594)

By adding a new security group and updating the references, after deploying this change nothing will reference the old one. It will then be fine to delete it in the follow up PR.

## TODO

- [x] deploy to CODE
