### PR TITLE
Run build on merge to main

### DIFF
--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -3,7 +3,8 @@ name: Build support-frontend
 on:
   pull_request:
     branches: [ main ]
-
+  push:
+    branches: [ main ]
 env:
   GU_SUPPORT_WORKERS_LOAD_S3_CONFIG: false
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
#3531 introduced a mechanism to run support-frontend builds with Github actions. Unfortunately the build was only running on pull requests, not on merges to `main`. This fixes that.