### PR TITLE
Fix issues with proxying Webpack hot reloading via websocket

### DIFF
--- a/support-frontend/nginx/support.conf
+++ b/support-frontend/nginx/support.conf
@@ -8,7 +8,7 @@ server {
     ssl_prefer_server_ciphers on;
 
     # Proxy the Websocket connection to the Webpack server - see https://stackoverflow.com/a/40549432/438886
-    location /sockjs-node/ {
+    location /ws {
         proxy_set_header X-Real-IP  $remote_addr;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header Host $host;

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -15,7 +15,7 @@
     "build-github-action": "npm-run-all clean 'webpack --config webpack.prod.js --env ci=github'",
     "webpack": "webpack",
     "webpack-dev-server": "webpack serve --config webpack.dev.js --port 9211",
-    "devrun": "npm-run-all clean webpack-dev-server",
+    "devrun": "NODE_ENV=DEV npm-run-all clean webpack-dev-server",
     "test": "NODE_ENV=test echo 'Running JS tests' && jest",
     "test-watch": "NODE_ENV=test echo 'Running JS tests in watch mode' && jest --watch",
     "paparazzi": "paparazzi && open ./paparazzi",

--- a/support-frontend/webpack.dev.js
+++ b/support-frontend/webpack.dev.js
@@ -13,5 +13,11 @@ module.exports = merge(common('[name].css', '[name].js', false), {
 				secure: false,
 			},
 		},
+		client: {
+			webSocketURL: 'https://support.thegulocal.com/ws'
+		},
+	},
+	resolve: {
+		fallback: { "crypto": false }
 	},
 });


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes an issue where, following the recent upgrade to Webpack 5, the hot reloading feature of Webpack dev server was no longer correctly being proxied via Nginx. It also fixes an issue where Preact devtools were not working when running the site locally.

**NB. After this is merged, everyone will need to run the setup.sh script to update their local Nginx config**

## Why are you doing this?

With Webpack 4, we were using the old `public` configuration option to make sure that dev server websocket requests were proxied via our local HTTPS setup:
[Docs on 'public'](https://v4.webpack.js.org/configuration/dev-server/#devserverpublic)
[Dev server script prior to the Webpack 5 upgrade](https://github.com/guardian/support-frontend/blob/773ad1cdc1472a0e1977d87d5c1d3664d06550b1/support-frontend/package.json#L17)

This option has changed in Webpack 5 to require you to specify a `client.webSocketURL` option instead:
[Docs on client options](https://webpack.js.org/configuration/dev-server/#websocketurl)

In addition, the dev server used to use [SockJS](https://github.com/sockjs/sockjs-client) as a websocket emulator, but now by default will use native websockets. This means that the path for the websocket connection- which need to be forwarded via our Nginx config- has changed.

I've also added an explicit `NODE_ENV=DEV` to the `devrun` Yarn script to make sure that Preact devtools (and probably other stuff that's looking for `process.env.NODE_ENV`) works correctly again- previously we were [setting this in a weird way via a Webpack plugin](https://github.com/guardian/support-frontend/blob/d737cee7a851023e772778980b4794a8632c0af7/support-frontend/webpack.dev.js#L17), which was removed when upgrading to Webpack 5.