### PR TITLE
Prices endpoint

### DIFF
--- a/support-frontend/app/controllers/PricesController.scala
+++ b/support-frontend/app/controllers/PricesController.scala
@@ -47,20 +47,7 @@ object PricesController {
       Canada: CountryGroupPriceData,
   )
 
-  import io.circe.generic.auto._
-  implicit val pricesEncoder = Encoder[Prices]
-}
-
-class PricesController(
-    priceSummaryServiceProvider: PriceSummaryServiceProvider,
-    actionRefiners: CustomActionBuilders,
-    components: ControllerComponents,
-) extends AbstractController(components)
-    with Circe {
-
-  import actionRefiners._
-
-  private def buildRatePlanPriceData(priceSummary: PriceSummary): RatePlanPriceData = {
+  def buildRatePlanPriceData(priceSummary: PriceSummary): RatePlanPriceData = {
     val price = priceSummary.promotions.headOption
       .flatMap(_.discountedPrice)
       .getOrElse(priceSummary.price)
@@ -68,7 +55,7 @@ class PricesController(
     RatePlanPriceData(price.toString)
   }
 
-  private def buildProductPriceData(
+  def buildProductPriceData(
       productPrices: ProductPrices,
       countryGroup: CountryGroup,
       currency: Currency,
@@ -84,6 +71,19 @@ class PricesController(
       Monthly = buildRatePlanPriceData(monthlyPriceSummary),
       Annual = buildRatePlanPriceData(annualPriceSummary),
     )
+
+  import io.circe.generic.auto._
+  implicit val pricesEncoder = Encoder[Prices]
+}
+
+class PricesController(
+    priceSummaryServiceProvider: PriceSummaryServiceProvider,
+    actionRefiners: CustomActionBuilders,
+    components: ControllerComponents,
+) extends AbstractController(components)
+    with Circe {
+
+  import actionRefiners._
 
   private def buildCountryGroupPriceData(
       countryGroup: CountryGroup,

--- a/support-frontend/app/controllers/PricesController.scala
+++ b/support-frontend/app/controllers/PricesController.scala
@@ -1,0 +1,117 @@
+package controllers
+
+import actions.CustomActionBuilders
+import com.gu.i18n.{CountryGroup, Currency}
+import com.gu.support.pricing.{PriceSummary, PriceSummaryServiceProvider, ProductPrices}
+import io.circe.Encoder
+import io.circe.syntax._
+import play.api.libs.circe.Circe
+import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
+import PricesController._
+import com.gu.i18n.Currency.{AUD, CAD, EUR, GBP, NZD, USD}
+import com.gu.support.catalog.{
+  DigitalPack,
+  Domestic,
+  FulfilmentOptions,
+  GuardianWeekly,
+  NoFulfilmentOptions,
+  NoProductOptions,
+}
+import com.gu.support.promotions.DefaultPromotions
+import com.gu.support.workers.{Annual, Monthly}
+import com.gu.support.zuora.api.ReaderType.Direct
+
+object PricesController {
+  case class RatePlanPriceData(price: String)
+
+  case class ProductPriceData(
+      Monthly: RatePlanPriceData,
+      Annual: RatePlanPriceData,
+  )
+
+  case class CountryGroupPriceData(
+      GuardianWeekly: Option[ProductPriceData],
+      Digisub: Option[ProductPriceData],
+  )
+
+  /** This is the model that we return from the prices endpoint. It gives us what we need for displaying prices in
+    * Dotcom messages. It is simpler than the internal com.gu.support.ProductPrices model.
+    */
+  case class Prices(
+      GBPCountries: CountryGroupPriceData,
+      UnitedStates: CountryGroupPriceData,
+      EURCountries: CountryGroupPriceData,
+      AUDCountries: CountryGroupPriceData,
+      International: CountryGroupPriceData,
+      NZDCountries: CountryGroupPriceData,
+      Canada: CountryGroupPriceData,
+  )
+
+  import io.circe.generic.auto._
+  implicit val pricesEncoder = Encoder[Prices]
+}
+
+class PricesController(
+    priceSummaryServiceProvider: PriceSummaryServiceProvider,
+    actionRefiners: CustomActionBuilders,
+    components: ControllerComponents,
+) extends AbstractController(components)
+    with Circe {
+
+  import actionRefiners._
+
+  private def buildRatePlanPriceData(priceSummary: PriceSummary): RatePlanPriceData = {
+    val price = priceSummary.promotions.headOption
+      .flatMap(_.discountedPrice)
+      .getOrElse(priceSummary.price)
+
+    RatePlanPriceData(price.toString)
+  }
+
+  private def buildProductPriceData(
+      productPrices: ProductPrices,
+      countryGroup: CountryGroup,
+      currency: Currency,
+      fulfilmentOptions: FulfilmentOptions,
+  ): Option[ProductPriceData] =
+    for {
+      countryGroupPrices <- productPrices.get(countryGroup)
+      fulfilmentPrices <- countryGroupPrices.get(fulfilmentOptions)
+      productOptionPrices <- fulfilmentPrices.get(NoProductOptions)
+      monthlyPriceSummary <- productOptionPrices.get(Monthly).flatMap(_.get(currency))
+      annualPriceSummary <- productOptionPrices.get(Annual).flatMap(_.get(currency))
+    } yield ProductPriceData(
+      Monthly = buildRatePlanPriceData(monthlyPriceSummary),
+      Annual = buildRatePlanPriceData(annualPriceSummary),
+    )
+
+  private def buildCountryGroupPriceData(
+      countryGroup: CountryGroup,
+      currency: Currency,
+  ): CountryGroupPriceData = {
+    val guardianWeeklyProductPrices = priceSummaryServiceProvider
+      .forUser(false)
+      .getPrices(GuardianWeekly, DefaultPromotions.GuardianWeekly.NonGift.all, Direct)
+    val digisubProductPrices = priceSummaryServiceProvider
+      .forUser(false)
+      .getPrices(DigitalPack, DefaultPromotions.DigitalSubscription.all, Direct)
+
+    CountryGroupPriceData(
+      GuardianWeekly = buildProductPriceData(guardianWeeklyProductPrices, countryGroup, currency, Domestic),
+      Digisub = buildProductPriceData(digisubProductPrices, countryGroup, currency, NoFulfilmentOptions),
+    )
+  }
+
+  def getPrices: Action[AnyContent] = CachedAction() {
+    val prices = Prices(
+      GBPCountries = buildCountryGroupPriceData(CountryGroup.UK, GBP),
+      UnitedStates = buildCountryGroupPriceData(CountryGroup.US, USD),
+      EURCountries = buildCountryGroupPriceData(CountryGroup.Europe, EUR),
+      AUDCountries = buildCountryGroupPriceData(CountryGroup.Australia, AUD),
+      International = buildCountryGroupPriceData(CountryGroup.RestOfTheWorld, USD),
+      NZDCountries = buildCountryGroupPriceData(CountryGroup.NewZealand, NZD),
+      Canada = buildCountryGroupPriceData(CountryGroup.Canada, CAD),
+    )
+    Ok(prices.asJson)
+  }
+}

--- a/support-frontend/app/wiring/AppComponents.scala
+++ b/support-frontend/app/wiring/AppComponents.scala
@@ -78,6 +78,7 @@ trait AppComponents
     payPalOneOffController,
     directDebitController,
     promotionsController,
+    pricesController,
     assetController,
     faviconController,
   )

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -234,4 +234,10 @@ trait Controllers {
     appConfig.stage,
   )
 
+  lazy val pricesController = new PricesController(
+    priceSummaryServiceProvider,
+    actionRefiners,
+    controllerComponents,
+  )
+
 }

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -168,6 +168,9 @@ POST /direct-debit/check-account                                   controllers.D
 GET /p/:promoCode/terms                                           controllers.Promotions.terms(promoCode)
 GET /p/:promoCode                                                 controllers.Promotions.promo(promoCode)
 
+# ----- Prices API ----- #
+GET /prices                                                       controllers.PricesController.getPrices()
+
 # ----- Verification ----- #
 
 GET  /.well-known/*file                                            controllers.Assets.at(path="/public", file)

--- a/support-frontend/test/controllers/PricesControllerTest.scala
+++ b/support-frontend/test/controllers/PricesControllerTest.scala
@@ -1,0 +1,101 @@
+package controllers
+
+import com.gu.i18n.CountryGroup
+import com.gu.i18n.Currency.GBP
+import com.gu.support.catalog.{Domestic, NoProductOptions}
+import com.gu.support.pricing.{PriceSummary, ProductPrices, PromotionSummary}
+import com.gu.support.promotions.{DiscountBenefit, PromotionCopy}
+import com.gu.support.workers.{Annual, Monthly}
+import controllers.PricesController.{ProductPriceData, RatePlanPriceData}
+import org.joda.time.Months
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class PricesControllerTest extends AnyWordSpec with Matchers {
+
+  val guardianWeeklyProductPrices: ProductPrices = Map(
+    CountryGroup.UK ->
+      Map(
+        Domestic ->
+          Map(
+            NoProductOptions ->
+              Map(
+                Monthly ->
+                  Map(
+                    GBP -> PriceSummary(
+                      price = 12.5,
+                      savingVsRetail = None,
+                      currency = GBP,
+                      fixedTerm = false,
+                      promotions = List(
+                        PromotionSummary(
+                          "Jan 22 - GW Discount Campaign",
+                          "Save 50% for 3 months",
+                          "GWJAN22SALE",
+                          Some(6.25),
+                          Some(3),
+                          Some(DiscountBenefit(50.0, Some(Months.THREE))),
+                          None,
+                          None,
+                          None,
+                          Some(
+                            PromotionCopy(
+                              Some("Find clarity with the Guardian's global magazine"),
+                              None,
+                              Some("50% off for 3 months"),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                Annual ->
+                  Map(
+                    GBP -> PriceSummary(
+                      price = 150,
+                      savingVsRetail = None,
+                      currency = GBP,
+                      fixedTerm = false,
+                      promotions = List(
+                        PromotionSummary(
+                          "10% Off Annual Guardian Weekly Subs",
+                          "Subscribe for 12 months and save 10%",
+                          "10ANNUAL",
+                          Some(135.00),
+                          Some(1),
+                          Some(DiscountBenefit(10.0, Some(Months.TWELVE))),
+                          None,
+                          None,
+                          None,
+                          Some(PromotionCopy(None, None, Some("Subscribe for 12 months and save 10%"))),
+                        ),
+                      ),
+                    ),
+                  ),
+              ),
+          ),
+      ),
+  )
+
+  "PricesControllerTest" should {
+    "transform ProductPrices" in {
+      val expected = ProductPriceData(
+        Monthly = RatePlanPriceData(
+          price = "6.25",
+        ),
+        Annual = RatePlanPriceData(
+          price = "135.0",
+        ),
+      )
+
+      val result = PricesController.buildProductPriceData(
+        guardianWeeklyProductPrices,
+        CountryGroup.UK,
+        GBP,
+        Domestic,
+      )
+
+      result mustEqual (Some(expected))
+    }
+  }
+}


### PR DESCRIPTION
This adds a `/prices` endpoint.
It takes the internal `ProductPrices` model used by support-frontend and returns a simplified model for use by support-dotcom-components. This enables us to reference regional product prices in dotcom messages.

For now I've just included Digisub and Weekly, and Monthly/Annual rate plans.

If there are promos for a given region/product/rate-plan, then it goes with the `discountedPrice` of the first promo. Otherwise it falls back on the standard `price`.

E.g. response:
![Screen Shot 2022-04-11 at 10 52 16](https://user-images.githubusercontent.com/1513454/162713674-8097acf3-1a37-4799-9b1c-18331660e07d.png)
