### PR TITLE
Don't alarm for disallowed email addresses

### DIFF
--- a/support-frontend/app/actions/CustomActionBuilders.scala
+++ b/support-frontend/app/actions/CustomActionBuilders.scala
@@ -33,7 +33,7 @@ class CustomActionBuilders(
       cc.parsers.defaultBodyParser,
     )
 
-  case class LoggingAndAlarmOnFailure[A](chainedAction: Action[A]) extends EssentialAction {
+  case class LoggingAndAlarmOnException[A](chainedAction: Action[A]) extends EssentialAction {
 
     def apply(requestHeader: RequestHeader): Accumulator[ByteString, Result] = {
       val accumulator = chainedAction.apply(requestHeader)

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -5,10 +5,8 @@ import actions.CustomActionBuilders
 import akka.actor.{ActorSystem, Scheduler}
 import cats.data.EitherT
 import cats.implicits._
-import com.gu.aws.{AwsCloudWatchMetricPut, AwsCloudWatchMetricSetup}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
-import com.gu.support.config.Stage
 import com.gu.support.workers._
 import config.Configuration.GuardianDomain
 import controllers.CreateSubscriptionController._
@@ -46,7 +44,6 @@ class CreateSubscriptionController(
     testUsers: TestUserService,
     components: ControllerComponents,
     guardianDomain: GuardianDomain,
-    stage: Stage,
 )(implicit val ec: ExecutionContext, system: ActorSystem)
     extends AbstractController(components)
     with Circe {

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -53,7 +53,7 @@ class CreateSubscriptionController(
   import actionRefiners._
 
   def create: EssentialAction =
-    LoggingAndAlarmOnFailure {
+    LoggingAndAlarmOnException {
       MaybeAuthenticatedAction.async(circe.json[CreateSupportWorkersRequest]) { implicit request =>
         val maybeLoggedInIdentityIdAndEmail =
           request.user.map(authIdUser => IdentityIdAndEmail(authIdUser.id, authIdUser.primaryEmailAddress))

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -152,7 +152,6 @@ trait Controllers {
     testUsers,
     controllerComponents,
     appConfig.guardianDomain,
-    appConfig.stage,
   )
 
   lazy val supportWorkersStatusController = new SupportWorkersStatus(

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -152,6 +152,7 @@ trait Controllers {
     testUsers,
     controllerComponents,
     appConfig.guardianDomain,
+    appConfig.stage,
   )
 
   lazy val supportWorkersStatusController = new SupportWorkersStatus(


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

#3436 introduced better handling of disallowed email addresses, however we are still triggering an alarm every time one is used which is unnecessary now that we inform the end user and allow them to input a different email.

This PR removes the alarm for this type of email error.


[**Trello Card**](https://trello.com/c/cipTaMhA/333-prevent-alarm-when-user-signs-up-with-a-blocked-email-domain)
