### PR TITLE
Fix continuous deployment for GitHub action build

### DIFF
--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - rb-dummy-main
 env:
   GU_SUPPORT_WORKERS_LOAD_S3_CONFIG: false
 

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - rb-dummy-main
 env:
   GU_SUPPORT_WORKERS_LOAD_S3_CONFIG: false
 
@@ -84,5 +85,5 @@ jobs:
       - name: Build and upload to RiffRaff
         run: |
           export LAST_TEAMCITY_BUILD=10000
-          export BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
           sbt "project support-frontend" riffRaffUpload

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,9 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.13") // when updating major version, also update play-circe version
+addSbtPlugin(
+  "com.typesafe.play" % "sbt-plugin" % "2.8.13",
+) // when updating major version, also update play-circe version
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
@@ -18,7 +20,7 @@ libraryDependencies += "org.vafer" % "jdeb" % "1.5" artifacts (Artifact("jdeb", 
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.3")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.4.1")
 

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -61,10 +61,6 @@ maintainer := "Membership <membership.dev@theguardian.com>"
 
 riffRaffPackageType := (Debian / packageBin).value
 riffRaffManifestProjectName := "support:frontend-mono"
-riffRaffBuildIdentifier := Option(System.getenv("BUILD_NUMBER")).getOrElse("DEV")
-riffRaffManifestBranch := Option(System.getenv("GITHUB_HEAD_REF"))
-  .orElse(Option(System.getenv("BRANCH_NAME")))
-  .getOrElse("unknown_branch")
 riffRaffPackageName := "frontend"
 riffRaffAwsCredentialsProfile := Some("membership") // needed when running locally
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/support-lambdas/acquisition-events-api/build.sbt
+++ b/support-lambdas/acquisition-events-api/build.sbt
@@ -2,7 +2,7 @@ import LibraryVersions.circeVersion
 import LibraryVersions._
 
 name := "acquisition-events-api"
-description:= "A lambda for acquisitions events api"
+description := "A lambda for acquisitions events api"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
 assembly / assemblyMergeStrategy := {
   case x if x.endsWith("module-info.class") => MergeStrategy.discard
   case str if str.contains("simulacrum") => MergeStrategy.first
-  case PathList("javax", "annotation", _ @ _*) => MergeStrategy.first
+  case PathList("javax", "annotation", _ @_*) => MergeStrategy.first
   case y =>
     val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(y)
@@ -28,5 +28,3 @@ riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := s"support:lambdas:${name.value}"
 riffRaffArtifactResources += (file(s"support-lambdas/${name.value}/cfn.yaml"), "cfn/cfn.yaml")
-riffRaffManifestBranch := Option(System.getenv("BRANCH_NAME")).getOrElse("unknown_branch")
-riffRaffBuildIdentifier := Option(System.getenv("BUILD_NUMBER")).getOrElse("DEV")

--- a/support-lambdas/acquisitions-firehose-transformer/build.sbt
+++ b/support-lambdas/acquisitions-firehose-transformer/build.sbt
@@ -1,8 +1,7 @@
 import LibraryVersions.circeVersion
 
-
 name := "acquisitions-firehose-transformer"
-description:= "A Firehose transformation lambda for serialising the acquisitions event stream to csv"
+description := "A Firehose transformation lambda for serialising the acquisitions event stream to csv"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.4",
@@ -11,13 +10,13 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "com.gu" %% "acquisitions-value-calculator-client" % "2.0.6",
-  "org.scanamo" %% "scanamo" % "1.0.0-M17"
+  "org.scanamo" %% "scanamo" % "1.0.0-M17",
 )
 assembly / assemblyMergeStrategy := {
   case x if x.endsWith("module-info.class") => MergeStrategy.discard
   case str if str.contains("simulacrum") => MergeStrategy.first
   case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
-  case PathList("javax", "annotation", _ @ _*) => MergeStrategy.first
+  case PathList("javax", "annotation", _ @_*) => MergeStrategy.first
   case y =>
     val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(y)
@@ -29,5 +28,3 @@ riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := s"support:lambdas:${name.value}"
 riffRaffArtifactResources += (file(s"support-lambdas/${name.value}/cfn.yaml"), "cfn/cfn.yaml")
-riffRaffManifestBranch := Option(System.getenv("BRANCH_NAME")).getOrElse("unknown_branch")
-riffRaffBuildIdentifier := Option(System.getenv("BUILD_NUMBER")).getOrElse("DEV")

--- a/support-lambdas/it-test-runner/build.sbt
+++ b/support-lambdas/it-test-runner/build.sbt
@@ -14,14 +14,11 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "io.symphonia" % "lambda-logging" % "1.0.3",
-  "org.scalatest" %% "scalatest" % "3.2.2" // not a "Test" dependency, it's an actual one
+  "org.scalatest" %% "scalatest" % "3.2.2", // not a "Test" dependency, it's an actual one
 )
 
 riffRaffPackageType := assembly.value
 riffRaffManifestProjectName := s"support:it-test-runner"
-riffRaffManifestBranch := Option(System.getenv("BRANCH_NAME")).getOrElse("unknown_branch")
-riffRaffBuildIdentifier := Option(System.getenv("BUILD_NUMBER")).getOrElse("DEV")
-riffRaffManifestVcsUrl := "git@github.com/guardian/support-frontend.git"
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffArtifactResources += (file("support-lambdas/it-test-runner/cfn.yaml"), "cfn/cfn.yaml")

--- a/support-lambdas/stripe-intent/build.sbt
+++ b/support-lambdas/stripe-intent/build.sbt
@@ -1,7 +1,7 @@
 import LibraryVersions.{awsClientVersion, circeVersion, jacksonDatabindVersion, jacksonVersion, okhttpVersion}
 
 name := "stripe-intent"
-description:= "Returns a stripe setup intent token so we can get authorisation of a recurring payment on the client side"
+description := "Returns a stripe setup intent token so we can get authorisation of a recurring payment on the client side"
 
 assemblyJarName := "stripe-intent.jar"
 riffRaffPackageType := assembly.value
@@ -9,12 +9,10 @@ riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "support:lambdas:Stripe Intent"
 riffRaffArtifactResources += (file("support-lambdas/stripe-intent/cfn.yaml"), "cfn/cfn.yaml")
-riffRaffManifestBranch := Option(System.getenv("BRANCH_NAME")).getOrElse("unknown_branch")
-riffRaffBuildIdentifier := Option(System.getenv("BUILD_NUMBER")).getOrElse("DEV")
 assembly / assemblyMergeStrategy := {
   case x if x.endsWith("module-info.class") => MergeStrategy.discard
   case str if str.contains("simulacrum") => MergeStrategy.first
-  case PathList("javax", "annotation", _ @ _*) => MergeStrategy.first
+  case PathList("javax", "annotation", _ @_*) => MergeStrategy.first
   case y =>
     val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(y)
@@ -23,7 +21,7 @@ assembly / assemblyMergeStrategy := {
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core",
   "io.circe" %% "circe-generic",
-  "io.circe" %% "circe-parser"
+  "io.circe" %% "circe-parser",
 ).map(_ % circeVersion)
 
 libraryDependencies ++= Seq(

--- a/support-redemptiondb/build.sbt
+++ b/support-redemptiondb/build.sbt
@@ -1,6 +1,5 @@
-
 name := "support-redemptiondb"
-description:= "packages the database cfn for the redemption code db"
+description := "packages the database cfn for the redemption code db"
 
 assemblyJarName := "dummy.jar"
 riffRaffPackageType := new File("dummy.jar")
@@ -8,5 +7,3 @@ riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "support:db:redemptiondb"
 riffRaffArtifactResources += (file("support-redemptiondb/cfn.yaml"), "cfn/cfn.yaml")
-riffRaffManifestBranch := Option(System.getenv("BRANCH_NAME")).getOrElse("unknown_branch")
-riffRaffBuildIdentifier := Option(System.getenv("BUILD_NUMBER")).getOrElse("DEV")

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -31,27 +31,26 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser" % circeVersion,
   "io.sentry" % "sentry-logback" % "1.7.4",
   "com.google.code.findbugs" % "jsr305" % "3.0.2",
-  "com.gocardless" % "gocardless-pro" % "2.8.0"
+  "com.gocardless" % "gocardless-pro" % "2.8.0",
 )
 
 riffRaffPackageType := assembly.value
 riffRaffManifestProjectName := s"support:support-workers-mono"
-riffRaffManifestBranch := Option(System.getenv("BRANCH_NAME")).getOrElse("unknown_branch")
-riffRaffBuildIdentifier := Option(System.getenv("BUILD_NUMBER")).getOrElse("DEV")
-riffRaffManifestVcsUrl := "git@github.com/guardian/support-frontend.git"
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffArtifactResources += (file("support-workers/cloud-formation/target/cfn.yaml"), "cfn/cfn.yaml")
-riffRaffArtifactResources += (file("support-workers/target/scala-2.13/support-workers-it.jar"), "it-tests/support-workers-it.jar")
+riffRaffArtifactResources += (file(
+  "support-workers/target/scala-2.13/support-workers-it.jar",
+), "it-tests/support-workers-it.jar")
 assemblyJarName := s"${name.value}.jar"
 assembly / assemblyMergeStrategy := {
-  case PathList("models", xs@_*) => MergeStrategy.discard
+  case PathList("models", xs @ _*) => MergeStrategy.discard
   case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
   case x if x.endsWith("module-info.class") => MergeStrategy.discard
   case "mime.types" => MergeStrategy.first
   case str if str.contains("simulacrum") => MergeStrategy.first
   case name if name.endsWith("execution.interceptors") => MergeStrategy.filterDistinctLines
-  case PathList("javax", "annotation", _ @ _*) => MergeStrategy.first
+  case PathList("javax", "annotation", _ @_*) => MergeStrategy.first
   case y =>
     val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(y)
@@ -60,13 +59,13 @@ assembly / assemblyMergeStrategy := {
 Project.inConfig(IntegrationTest)(baseAssemblySettings)
 IntegrationTest / assembly / assemblyJarName := s"${name.value}-it.jar"
 IntegrationTest / assembly / assemblyMergeStrategy := {
-  case PathList("models", xs@_*) => MergeStrategy.discard
+  case PathList("models", xs @ _*) => MergeStrategy.discard
   case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
   case x if x.endsWith("logback.xml") => MergeStrategy.first
   case x if x.endsWith("module-info.class") => MergeStrategy.discard
   case "mime.types" => MergeStrategy.first
   case name if name.endsWith("execution.interceptors") => MergeStrategy.filterDistinctLines
-  case PathList("javax", "annotation", _ @ _*) => MergeStrategy.first
+  case PathList("javax", "annotation", _ @_*) => MergeStrategy.first
   case y =>
     val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(y)
@@ -74,7 +73,8 @@ IntegrationTest / assembly / assemblyMergeStrategy := {
 IntegrationTest / assembly / test := {}
 assembly / aggregate := false
 
-lazy val deployToCode = inputKey[Unit]("Directly update AWS lambda code from DEV instead of via RiffRaff for faster feedback loop")
+lazy val deployToCode =
+  inputKey[Unit]("Directly update AWS lambda code from DEV instead of via RiffRaff for faster feedback loop")
 
 deployToCode := {
   import scala.sys.process._
@@ -89,9 +89,9 @@ deployToCode := {
     "-UpdateSupporterProductDataLambda-",
     "-FailureHandlerLambda-",
     "-SendAcquisitionEventLambda-",
-    "-PreparePaymentMethodForReuseLambda-"
+    "-PreparePaymentMethodForReuseLambda-",
   ).foreach(functionPartial =>
-    s"aws lambda update-function-code --function-name support${functionPartial}CODE --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
+    s"aws lambda update-function-code --function-name support${functionPartial}CODE --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!,
   )
 
 }

--- a/supporter-product-data/build.sbt
+++ b/supporter-product-data/build.sbt
@@ -4,7 +4,6 @@ import sbt.Keys.libraryDependencies
 
 version := "0.1-SNAPSHOT"
 
-
 libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "software.amazon.awssdk" % "dynamodb" % awsClientVersion2,
@@ -18,20 +17,17 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser" % circeVersion,
   "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1",
   "com.nrinaudo" %% "kantan.csv-generic" % "0.6.1",
-  "com.nrinaudo" %% "kantan.csv-java8" % "0.6.1"
+  "com.nrinaudo" %% "kantan.csv-java8" % "0.6.1",
 )
 
 riffRaffPackageType := assembly.value
 riffRaffManifestProjectName := s"support:supporter-product-data"
-riffRaffManifestBranch := Option(System.getenv("BRANCH_NAME")).getOrElse("unknown_branch")
-riffRaffBuildIdentifier := Option(System.getenv("BUILD_NUMBER")).getOrElse("DEV")
-riffRaffManifestVcsUrl := "git@github.com/guardian/support-frontend.git"
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffArtifactResources += (file("supporter-product-data/cloudformation/cfn.yaml"), "cfn/cfn.yaml")
 assemblyJarName := s"${name.value}.jar"
 assembly / assemblyMergeStrategy := {
-  case PathList("models", xs@_*) => MergeStrategy.discard
+  case PathList("models", xs @ _*) => MergeStrategy.discard
   case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
   case x if x.endsWith("module-info.class") => MergeStrategy.discard
   case "mime.types" => MergeStrategy.first
@@ -41,7 +37,8 @@ assembly / assemblyMergeStrategy := {
     oldStrategy(y)
 }
 
-lazy val deployToCode = inputKey[Unit]("Directly update AWS lambda code from DEV instead of via RiffRaff for faster feedback loop")
+lazy val deployToCode =
+  inputKey[Unit]("Directly update AWS lambda code from DEV instead of via RiffRaff for faster feedback loop")
 
 deployToCode := {
   import scala.sys.process._
@@ -51,14 +48,15 @@ deployToCode := {
   List(
     "-SupporterProductDataQueryZuora-",
     "-SupporterProductDataFetchResults-",
-    "-SupporterProductDataUpdateDynamo-"
+    "-SupporterProductDataUpdateDynamo-",
   ).foreach(functionPartial =>
-    s"aws lambda update-function-code --function-name support${functionPartial}DEV --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
+    s"aws lambda update-function-code --function-name support${functionPartial}DEV --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!,
   )
 
 }
 
-lazy val deployToProd = inputKey[Unit]("Directly update AWS lambda code to PROD instead of via RiffRaff for faster feedback loop")
+lazy val deployToProd =
+  inputKey[Unit]("Directly update AWS lambda code to PROD instead of via RiffRaff for faster feedback loop")
 
 deployToProd := {
   import scala.sys.process._
@@ -68,9 +66,9 @@ deployToProd := {
   List(
     "-SupporterProductDataQueryZuora-",
     "-SupporterProductDataFetchResults-",
-    "-SupporterProductDataUpdateDynamo-"
+    "-SupporterProductDataUpdateDynamo-",
   ).foreach(functionPartial =>
-    s"aws lambda update-function-code --function-name support${functionPartial}PROD --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
+    s"aws lambda update-function-code --function-name support${functionPartial}PROD --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!,
   )
 
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
#3661 updated our Github build action so that it ran on merge to the main branch, however builds were not being picked up by RiffRaff's continuous deployment. This was because we were using a very old version of the `sbt-riffraff-artifact` library which didn't fully support the GHA environment. This has now been upgraded to the latest version and CD is working correctly.

[**Trello Card**](https://trello.com/c/s6l5ywJu/330-move-support-fronted-build-to-github-actions)
