### PR TITLE
Remove duplicated VpcId property from `AWS::ElasticLoadBalancingV2:TargetGroup`

### DIFF
--- a/support-payment-api/src/main/resources/cloud-formation.yaml
+++ b/support-payment-api/src/main/resources/cloud-formation.yaml
@@ -340,8 +340,6 @@ Resources:
       Name: !Sub ${Stack}-${Stage}-${App}
       Port: 9000
       Protocol: HTTP
-      VpcId:
-        Ref: VpcId
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: /healthcheck
       HealthCheckPort: 9000


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Remove duplicated VpcId property from `AWS::ElasticLoadBalancingV2:TargetGroup`.
