### PR TITLE
Add some new acquisition data values to support apps

### DIFF
--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
@@ -70,6 +70,8 @@ object PaymentFrequency {
 
   case object Quarterly extends PaymentFrequency("QUARTERLY")
 
+  case object SixMonthly extends PaymentFrequency("SIX_MONTHLY")
+
   case object Annually extends PaymentFrequency("ANNUALLY")
 }
 
@@ -86,6 +88,8 @@ object AcquisitionProduct {
   case object Paper extends AcquisitionProduct("PRINT_SUBSCRIPTION")
 
   case object GuardianWeekly extends AcquisitionProduct("PRINT_SUBSCRIPTION")
+
+  case object AppPremiumTier extends AcquisitionProduct("APP_PREMIUM_TIER")
 
 }
 
@@ -152,4 +156,6 @@ object PaymentProvider {
   case object DirectDebit extends PaymentProvider("GOCARDLESS")
 
   case object AmazonPay extends PaymentProvider("AMAZON_PAY")
+
+  case object InAppPurchase extends PaymentProvider("IN_APP_PURCHASE")
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
The apps teams are going to start using the acquisitions api we built rather than sending events via Ophan. To enable this we need to add some missing data values into the acquisition model.


[**Trello Card**](https://trello.com/c/OkahHCdA/412-add-new-values-to-acquisition-data-model-to-support-apps)
