### PR TITLE
Github action build for support-workers

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -2,13 +2,12 @@ name: Test Scala-steward PRs
 
 on:
   pull_request:
-    branches: [ main ]
 
 env:
   GU_SUPPORT_WORKERS_LOAD_S3_CONFIG: false
 
 jobs:
-  support_frontend_build:
+  run_sbt_tests:
     if: github.actor == 'scala-steward'
 
     name: support-frontend build

--- a/.github/workflows/support-workers-build.yml
+++ b/.github/workflows/support-workers-build.yml
@@ -1,0 +1,79 @@
+name: Build support-workers
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+env:
+  GU_SUPPORT_WORKERS_LOAD_S3_CONFIG: false
+
+jobs:
+  support_workers_build:
+    if: >-
+      github.event.pull_request.head.repo.owner.login == 'guardian' ||
+      github.event_name == 'push'
+
+    # Required by actions-assume-aws-role
+    permissions:
+      id-token: write
+      contents: read
+
+    name: support-workers build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Env
+        run: env
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      # (Respects .nvmrc)
+      - name: Setup Node
+        uses: guardian/actions-setup-node@v2.4.1
+        with:
+          cache: 'yarn'
+          cache-dependency-path: support-workers/cloud-formation/src/yarn.lock
+
+      - name: Install
+        run: yarn
+        working-directory: support-workers/cloud-formation/src
+
+      - name: Build the cloudformation
+        run: yarn run build-cfn
+        working-directory: support-workers/cloud-formation/src
+
+      # Required by sbt riffRaffUpload
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+
+      - name: Setup Java 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+            ~/.coursier
+          key: sbt
+
+      # This runs three separate builds
+      # - the integration tests build which is uploaded so it can be run in a lambda
+      # - the support-workers build
+      # = the support-redemptiondb build which supports corporate digisub functionality
+      - name: Build and upload to RiffRaff
+
+        run: |
+          export LAST_TEAMCITY_BUILD=10000
+          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+          sbt "project support-workers" it:assembly \
+          "project support-workers" test riffRaffUpload \
+          "project support-redemptiondb" riffRaffUpload

--- a/.github/workflows/support-workers-build.yml
+++ b/.github/workflows/support-workers-build.yml
@@ -71,12 +71,18 @@ jobs:
       # = the support-redemptiondb build which deploys the dynamo db cfn for corporate digisub functionality
       - name: Build integration test assembly
         run: |
-          export LAST_TEAMCITY_BUILD=10000
+          export LAST_TEAMCITY_BUILD=12000
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
           sbt "project support-workers" it:assembly
 
       - name: Build and upload support-workers and it tests to RiffRaff
-        run: sbt "project support-workers" riffRaffUpload
+        run: |
+          export LAST_TEAMCITY_BUILD=12000
+          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+          sbt "project support-workers" riffRaffUpload
 
       - name: Build and upload support-redemptiondb to RiffRaff
-        run: sbt "project support-redemptiondb" riffRaffUpload
+        run: |
+          export LAST_TEAMCITY_BUILD=12000
+          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+          sbt "project support-redemptiondb" riffRaffUpload

--- a/.github/workflows/support-workers-build.yml
+++ b/.github/workflows/support-workers-build.yml
@@ -65,15 +65,18 @@ jobs:
             ~/.coursier
           key: sbt
 
-      # This runs three separate builds
+      # There are three separate build in the support-workers project
       # - the integration tests build which is uploaded so it can be run in a lambda
       # - the support-workers build
-      # = the support-redemptiondb build which supports corporate digisub functionality
-      - name: Build and upload to RiffRaff
-
+      # = the support-redemptiondb build which deploys the dynamo db cfn for corporate digisub functionality
+      - name: Build integration test assembly
         run: |
           export LAST_TEAMCITY_BUILD=10000
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt "project support-workers" it:assembly \
-          "project support-workers" test riffRaffUpload \
-          "project support-redemptiondb" riffRaffUpload
+          sbt "project support-workers" it:assembly
+
+      - name: Build and upload support-workers and it tests to RiffRaff
+        run: sbt "project support-workers" riffRaffUpload
+
+      - name: Build and upload support-redemptiondb to RiffRaff
+        run: sbt "project support-redemptiondb" riffRaffUpload


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Following on from #3531 this moves the support-workers build from Teamcity to Github actions. The benefits are the same - having CI/CD configuration in source control.

Once this is merged I'll switch off the old build and change the required check to this build rather than the TC one.
