### PR TITLE
Fix a critical vulnerability in http4s

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -27,7 +27,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser" % circeVersion,
   "io.circe" %% "circe-optics" % circeVersion,
   "joda-time" % "joda-time" % "2.9.9",
-  "com.gu.identity" %% "identity-auth-play" % "3.248",
+  "com.gu.identity" %% "identity-auth-play" % "3.254",
   "com.gu" %% "identity-test-users" % "0.8",
   "com.google.guava" % "guava" % "29.0-jre",
   "io.lemonlabs" %% "scala-uri" % scalaUriVersion,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Upgrade identity-auth-play to 3.248 to mitigate a critical vulnerability in http4s see https://github.com/guardian/identity/pull/2106 for more info.