### PR TITLE
Change reader type on Patron benefit subs

### DIFF
--- a/support-models/src/main/scala/com/gu/support/zuora/api/SubscriptionData.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/SubscriptionData.scala
@@ -121,6 +121,9 @@ object ReaderType {
   case object Agent extends ReaderType {
     val value = "Agent"
   }
+  case object Patron extends ReaderType {
+    val value = "Patron"
+  }
   case object Unknown extends ReaderType {
     val value = "Unknown"
   }
@@ -131,6 +134,7 @@ object ReaderType {
       case Agent.value => Agent
       case Corporate.value => Corporate
       case Direct.value => Direct
+      case Patron.value => Patron
       case _ => Unknown
     }
 

--- a/support-workers/.history
+++ b/support-workers/.history
@@ -1,0 +1,4 @@
+project support-workers
+project
+support-workers
+exit

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/GuardianWeeklySubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/GuardianWeeklySubscriptionBuilder.scala
@@ -6,6 +6,7 @@ import com.gu.support.promotions.{DefaultPromotions, PromoCode, PromoError, Prom
 import com.gu.support.workers.ProductTypeRatePlans._
 import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.GuardianWeeklyState
 import com.gu.support.workers.{BillingPeriod, SixWeekly}
+import com.gu.support.zuora.api.ReaderType.{Direct, Patron}
 import com.gu.support.zuora.api._
 import com.gu.zuora.subscriptionBuilders.GuardianWeeklySubscriptionBuilder.initialTermInDays
 import com.gu.zuora.subscriptionBuilders.ProductSubscriptionBuilders.{applyPromoCodeIfPresent, validateRatePlan}
@@ -26,7 +27,7 @@ class GuardianWeeklySubscriptionBuilder(
 
     val contractEffectiveDate = dateGenerator.today
 
-    val readerType = if (state.giftRecipient.isDefined) ReaderType.Gift else ReaderType.Direct
+    val readerType = overrideReaderTypeIfRequired(state)
 
     val recurringProductRatePlanId =
       validateRatePlan(weeklyRatePlan(state.product, environment, readerType), state.product.describe)
@@ -88,6 +89,16 @@ class GuardianWeeklySubscriptionBuilder(
         Some(state.paymentMethod),
         Some(soldToContact),
       )
+    }
+  }
+
+  private[this] def overrideReaderTypeIfRequired(state: GuardianWeeklyState): ReaderType = {
+    if (state.giftRecipient.isDefined) {
+      ReaderType.Gift
+    } else if (state.promoCode.exists(_.endsWith("PATRON"))) {
+      Patron
+    } else {
+      Direct
     }
   }
 

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
@@ -7,7 +7,7 @@ import com.gu.salesforce.Salesforce.SalesforceContactRecords
 import com.gu.support.acquisitions.{AbTest, AcquisitionData, OphanIds}
 import com.gu.support.config.TouchPointEnvironments.SANDBOX
 import com.gu.support.config.{TouchPointEnvironments, ZuoraDigitalPackConfig}
-import com.gu.support.promotions.PromotionService
+import com.gu.support.promotions.{Promotion, PromotionService, PromotionWithCode}
 import com.gu.support.redemption.corporate.{CorporateCodeValidator, DynamoLookup}
 import com.gu.support.redemption.gifting.GiftCodeValidator
 import com.gu.support.redemption.gifting.generator.GiftCodeGeneratorService
@@ -24,6 +24,9 @@ import com.gu.support.zuora.api.ReaderType.{Corporate, Gift}
 import com.gu.support.zuora.api._
 import com.gu.zuora.Fixtures.blankReferrerAcquisitionData
 import org.joda.time.LocalDate
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar._
@@ -125,6 +128,48 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
         RatePlan("2c92c0f84bbfec8b014bc655f4852d9d"),
         Nil,
         Nil,
+      ),
+    )
+  }
+
+  "SubscriptionData for a Monthly subscription with a Patron PromoCode" should "be correct" in {
+    val aPromotion = mock[Promotion]
+    val pwc = PromotionWithCode("FOOPATRON", aPromotion)
+
+    when(promotionService.findPromotion(ArgumentMatchers.eq("FOOPATRON"))).thenReturn(Right(pwc))
+
+    when(
+      promotionService.applyPromotion(
+        ArgumentMatchers.eq(pwc),
+        ArgumentMatchers.eq(Country.UK),
+        ArgumentMatchers.eq("2c92c0f84bbfec8b014bc655f4852d9d"),
+        any(),
+        ArgumentMatchers.eq(false),
+      ),
+    ).thenAnswer { i =>
+      {
+        val sd = i.getArgument[SubscriptionData](3)
+        val patchedSubscription = sd.subscription.copy(promoCode = Some(pwc.promoCode))
+        Right(sd.copy(subscription = patchedSubscription))
+      }
+    }
+
+    monthlyPatron.subscriptionData shouldBe SubscriptionData(
+      List(RatePlanData(RatePlan("2c92c0f84bbfec8b014bc655f4852d9d"), List(), List())),
+      Subscription(
+        contractAcceptanceDate = saleDate.plusDays(16),
+        contractEffectiveDate = saleDate,
+        termStartDate = saleDate,
+        createdRequestId = "f7651338-5d94-4f57-85fd-262030de9ad5",
+        autoRenew = true,
+        initialTermPeriodType = Month,
+        initialTerm = 12,
+        renewalTerm = 12,
+        termType = "TERMED",
+        readerType = ReaderType.Patron,
+        promoCode = Some("FOOPATRON"),
+        redemptionCode = None,
+        corporateAccountId = None,
       ),
     )
   }
@@ -296,5 +341,22 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
     .toOption
     .get
     .subscriptionData
+
+  lazy val monthlyPatron =
+    subscriptionDirectPurchaseBuilder
+      .build(
+        DigitalSubscriptionDirectPurchaseState(
+          Country.UK,
+          DigitalPack(GBP, Monthly),
+          PayPalReferenceTransaction("baid", "hi@gu.com"),
+          Some("FOOPATRON"),
+          SalesforceContactRecord("", ""),
+        ),
+        None,
+        None,
+        None,
+      )
+      .toOption
+      .get
 
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->
Making a change for the platform to save a Guardian Weekly or Digital Subscription with a reader type of Patron if the patron promo code is used to buy it. 

[**Trello Card**](https://trello.com) - TBC incident resolution

## Why are you doing this?
This will let me make a data change to update historical subs, and also have the reader type act as the flag for manage-frontend to display the subscription in an appropriate context (e.g. free with Patron, no next billing date etc)

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [ ] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

