### PR TITLE
Added the ability for the /prices endpoint to include details about the promotions which determine the returned prices

### DIFF
--- a/support-frontend/app/controllers/PricesController.scala
+++ b/support-frontend/app/controllers/PricesController.scala
@@ -127,11 +127,8 @@ class PricesController(
     )
   }
 
-  def getPrices: Action[AnyContent] = CachedAction() {
-    Ok(getPrices(false).asJson)
-  }
-
-  def getPricesWithSummary: Action[AnyContent] = CachedAction() {
-    Ok(getPrices(true).asJson)
+  def getPrices: Action[AnyContent] = NoCacheAction() { implicit request =>
+    val includeSummary = request.getQueryString("include-summary").nonEmpty
+    Ok(getPrices(includeSummary).asJson)
   }
 }

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -170,6 +170,7 @@ GET /p/:promoCode                                                 controllers.Pr
 
 # ----- Prices API ----- #
 GET /prices                                                       controllers.PricesController.getPrices()
+GET /pricesWithSummary                                            controllers.PricesController.getPricesWithSummary()
 
 # ----- Verification ----- #
 

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -170,7 +170,6 @@ GET /p/:promoCode                                                 controllers.Pr
 
 # ----- Prices API ----- #
 GET /prices                                                       controllers.PricesController.getPrices()
-GET /pricesWithSummary                                            controllers.PricesController.getPricesWithSummary()
 
 # ----- Verification ----- #
 

--- a/support-frontend/test/controllers/PricesControllerTest.scala
+++ b/support-frontend/test/controllers/PricesControllerTest.scala
@@ -82,9 +82,13 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
       val expected = ProductPriceData(
         Monthly = RatePlanPriceData(
           price = "6.25",
+          currency = "£",
+          priceSummary = None,
         ),
         Annual = RatePlanPriceData(
           price = "135.0",
+          currency = "£",
+          priceSummary = None,
         ),
       )
 
@@ -93,6 +97,74 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
         CountryGroup.UK,
         GBP,
         Domestic,
+        false,
+      )
+
+      result mustEqual (Some(expected))
+    }
+
+    "transform ProductPrices including PriceSummary" in {
+      val expected = ProductPriceData(
+        Monthly = RatePlanPriceData(
+          price = "6.25",
+          currency = "£",
+          priceSummary = Some(
+            PriceSummary(
+              price = 12.5,
+              savingVsRetail = None,
+              currency = GBP,
+              fixedTerm = false,
+              promotions = List(
+                PromotionSummary(
+                  "Jan 22 - GW Discount Campaign",
+                  "Save 50% for 3 months",
+                  "GWJAN22SALE",
+                  Some(6.25),
+                  Some(3),
+                  Some(DiscountBenefit(50.0, Some(Months.THREE))),
+                  None,
+                  None,
+                  None,
+                  None, // no landing page text
+                ),
+              ),
+            ),
+          ),
+        ),
+        Annual = RatePlanPriceData(
+          price = "135.0",
+          currency = "£",
+          priceSummary = Some(
+            PriceSummary(
+              price = 150,
+              savingVsRetail = None,
+              currency = GBP,
+              fixedTerm = false,
+              promotions = List(
+                PromotionSummary(
+                  "10% Off Annual Guardian Weekly Subs",
+                  "Subscribe for 12 months and save 10%",
+                  "10ANNUAL",
+                  Some(135.00),
+                  Some(1),
+                  Some(DiscountBenefit(10.0, Some(Months.TWELVE))),
+                  None,
+                  None,
+                  None,
+                  None, // no landing page text
+                ),
+              ),
+            ),
+          ),
+        ),
+      )
+
+      val result = PricesController.buildProductPriceData(
+        guardianWeeklyProductPrices,
+        CountryGroup.UK,
+        GBP,
+        Domestic,
+        true,
       )
 
       result mustEqual (Some(expected))

--- a/support-frontend/test/controllers/PricesControllerTest.scala
+++ b/support-frontend/test/controllers/PricesControllerTest.scala
@@ -100,7 +100,7 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
         false,
       )
 
-      result mustEqual (Some(expected))
+      result mustBe Some(expected)
     }
 
     "transform ProductPrices including PriceSummary" in {
@@ -167,7 +167,7 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
         true,
       )
 
-      result mustEqual (Some(expected))
+      result mustBe Some(expected)
     }
   }
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Added the ability for the `/prices` endpoint endpoint to include, when the query parameter `?include-summary` is provided, details about the promotions which determine the returned prices.

Also added currency as a price should never be referenced without its currency being alongside.

## Why are you doing this?
This is to enable the currently displayed offers on the Digital Subscription and Guardian Weekly checkouts to be shown elsewhere, for example a cancellation-save journey.

## Is this an AB test?
- [ ] Yes
- [x] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots
N/A
