### PR TITLE
Increase 5xx alarm threshold

### DIFF
--- a/cdk/lib/__snapshots__/frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/frontend.test.ts.snap
@@ -636,7 +636,7 @@ Object {
             "ReturnData": false,
           },
         ],
-        "Threshold": 1,
+        "Threshold": 5,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -140,7 +140,7 @@ export class Frontend extends GuStack {
             "Some or all actions on support website are failing"
           ),
           actionsEnabled: shouldEnableAlarms,
-          tolerated5xxPercentage: 1,
+          tolerated5xxPercentage: 5,
         },
         unhealthyInstancesAlarm: false,
       },


### PR DESCRIPTION
Currently a single 500 response is often enough to trigger this alarm. This means our `create recurring product failed` alarm is almost always followed by the 5xx alarm. In the spirit of trying to reduce the number of alarms that we receive to reduce noise and increase the proportion of meaningful alarms, we decided to up the threshold.

We can see the last few times that we received the create recurring product alarm the traffic percentage was up to about 3.6%. By upping to 5% the aim is only get alerted by this alarm when an issue is affecting multiple users at the same time.

![Screenshot 2022-05-26 at 15 27 43](https://user-images.githubusercontent.com/17720442/170965394-8ff95dfe-4e36-44fe-8c94-95bf676ea685.png)

