### PR TITLE
Remove the revenue distribution step from support-workers

### DIFF
--- a/support-models/src/main/scala/com/gu/support/zuora/api/response/SubscriptionsResponse.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/response/SubscriptionsResponse.scala
@@ -40,18 +40,3 @@ object RatePlanCharge {
 }
 
 case class RatePlanCharge(id: String, name: String)
-
-object RevenueSchedulesResponse {
-  implicit val codec: Codec[RevenueSchedulesResponse] = deriveCodec
-}
-
-case class RevenueSchedulesResponse(revenueSchedules: List[RevenueSchedule])
-
-object RevenueSchedule {
-  implicit val codec: Codec[RevenueSchedule] = deriveCodec
-}
-case class RevenueSchedule(
-    number: String,
-    amount: BigDecimal,
-    undistributedUnrecognizedRevenue: BigDecimal,
-)

--- a/support-services/src/main/scala/com/gu/zuora/ZuoraGiftService.scala
+++ b/support-services/src/main/scala/com/gu/zuora/ZuoraGiftService.scala
@@ -1,25 +1,18 @@
 package com.gu.zuora
 
-import cats.data.OptionT
-import cats.implicits.catsStdInstancesForFuture
-import com.gu.aws.{AwsCloudWatchMetricPut, AwsCloudWatchMetricSetup}
 import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger.Sanitizer
 import com.gu.okhttp.RequestRunners.FutureHttpClient
 import com.gu.rest.WebServiceHelper
 import com.gu.support.config.{Stage, ZuoraConfig}
 import com.gu.support.redemptions.RedemptionCode
 import com.gu.support.touchpoint.TouchpointService
-import com.gu.support.workers.states.SendThankYouEmailState.TermDates
-import com.gu.support.zuora.api.{Day, DistributeRevenueRequest, QueryData, UpdateRedemptionDataRequest}
 import com.gu.support.zuora.api.response.{
-  RevenueSchedulesResponse,
   Subscription,
   SubscriptionRedemptionQueryResponse,
   ZuoraErrorResponse,
-  ZuoraResponse,
   ZuoraSuccessOrFailureResponse,
 }
+import com.gu.support.zuora.api.{Day, QueryData, UpdateRedemptionDataRequest}
 import io.circe.syntax.EncoderOps
 import org.joda.time.LocalDate
 
@@ -81,71 +74,5 @@ class ZuoraGiftService(val config: ZuoraConfig, stage: Stage, client: FutureHttp
         val errorMessage = s"Failed to update gifteeIdentityId on Digital Subscription gift for user $gifteeIdentityId."
         Failure(new RuntimeException(errorMessage, originalError))
     }
-  }
-
-  def setupRevenueRecognition(
-      subscription: Subscription,
-      termDates: TermDates,
-  ) = {
-    // This doc describes what this method is doing: https://docs.google.com/document/d/1yNeaR2l1Ss_unXygntuntmRX-GicDelryuK25vmqToc/edit
-    val response = (for {
-      ratePlan <- OptionT.fromOption(subscription.ratePlans.headOption)
-      ratePlanChargeId <- OptionT.fromOption(ratePlan.ratePlanCharges.headOption.map(_.id))
-      revenueSchedule <- OptionT.liftF(getRevenueSchedule(ratePlanChargeId))
-      successOrFailureResponse <- maybeDistributeRevenue(revenueSchedule, termDates)
-    } yield successOrFailureResponse).value
-
-    val subscriptionNumber = subscription.subscriptionNumber
-    response.transform {
-      case Success(Some(response)) if response.success =>
-        SafeLogger.info(s"Successfully set up revenue recognition for Digital Subscription gift $subscriptionNumber")
-        Success(())
-      case failed =>
-        val errorMessage =
-          scrub"Failed to set up revenue recognition for Digital Subscription gift $subscriptionNumber. Error was $failed"
-        SafeLogger.error(errorMessage)
-        AwsCloudWatchMetricPut(AwsCloudWatchMetricPut.client)(
-          AwsCloudWatchMetricSetup.revenueDistributionFailureRequest(stage),
-        )
-        // For the revenue recognition we want to continue even if there is a failure because by this point
-        // the redemption will have succeeded so we need to let the user know about that and then sort out the
-        // revenue recognition separately
-        Success(())
-    }
-  }
-
-  private def getRevenueSchedule(ratePlanChargeId: String): Future[RevenueSchedulesResponse] =
-    get[RevenueSchedulesResponse](s"revenue-schedules/subscription-charges/${ratePlanChargeId}", authHeaders)
-
-  private def maybeDistributeRevenue(
-      revenueSchedule: RevenueSchedulesResponse,
-      termDates: TermDates,
-  ) =
-    if (revenueScheduleIsAlreadyDistributed(revenueSchedule))
-      OptionT.fromOption(Some(ZuoraSuccessOrFailureResponse(success = true, None)))
-    else
-      for {
-        revenueScheduleNumber <- OptionT.fromOption(revenueSchedule.revenueSchedules.headOption.map(_.number))
-        successOrFailureResponse <- OptionT.liftF(distributeRevenueByStartAndEndDates(revenueScheduleNumber, termDates))
-      } yield successOrFailureResponse
-
-  private def revenueScheduleIsAlreadyDistributed(revenueSchedule: RevenueSchedulesResponse) =
-    revenueSchedule.revenueSchedules.exists(revenueSchedule =>
-      // revenueSchedule.amount and revenueSchedule.undistributedUnrecognizedRevenue will be
-      // the same until the distribute revenue call has been made
-      revenueSchedule.amount > revenueSchedule.undistributedUnrecognizedRevenue,
-    )
-
-  // https://www.zuora.com/developer/api-reference/#operation/PUT_RevenueByRecognitionStartandEndDates
-  private def distributeRevenueByStartAndEndDates(
-      revenueScheduleNumber: String,
-      termDates: TermDates,
-  ) = {
-    val data = DistributeRevenueRequest(termDates.giftStartDate, termDates.giftEndDate)
-    putJson[ZuoraSuccessOrFailureResponse](
-      s"revenue-schedules/${revenueScheduleNumber}/distribute-revenue-with-date-range",
-      data.asJson,
-      authHeaders,
-    )
   }
 }

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -222,28 +222,6 @@ Resources:
       Statistic: Sum
     DependsOn: SupportWorkersPROD
 
-  RevenueRecognitionSetupFailureAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: CreateProdResources
-    Properties:
-      AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-      AlarmName: !Sub Data Corruption - Revenue distribution for Digital Subscription gift failed in ${Stage}
-      AlarmDescription: >
-        There was a failure whilst calling Zuora to distribute revenue during a Digital Subscription gift redemption.
-        Follow the steps in https://docs.google.com/document/d/1yNeaR2l1Ss_unXygntuntmRX-GicDelryuK25vmqToc/edit#bookmark=id.hz2dy29e5qip to debug.
-      MetricName: RevenueDistributionFailure
-      Namespace: support-frontend
-      Dimensions:
-        - Name: Stage
-          Value: !Ref Stage
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 1
-      Period: 60
-      EvaluationPeriods: 1
-      Statistic: Sum
-    DependsOn: SupportWorkersPROD
-
   NoPaypalContributionsInTwoHoursAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources

--- a/support-workers/src/main/scala/com/gu/zuora/productHandlers/ZuoraDigitalSubscriptionGiftRedemptionHandler.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/productHandlers/ZuoraDigitalSubscriptionGiftRedemptionHandler.scala
@@ -83,7 +83,6 @@ class ZuoraUpdater(
     )
     (dates, newTermLength) = calculatedDates
     _ <- updateGiftIdentityIdCall(newTermLength)
-    _ <- zuoraService.setupRevenueRecognition(fullGiftSubscription, dates)
   } yield (ZuoraSubscriptionNumber(fullGiftSubscription.subscriptionNumber), dates, productRatePlan.billingPeriod)
 
   private def calculateNewTermLength(productRatePlan: ProductRatePlan[Product], customerAcceptanceDate: LocalDate) = {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Now that we have the [revenue recogniser lambda](https://github.com/guardian/support-service-lambdas/tree/main/handlers/revenue-recogniser-job) we no longer need to distribute revenue in support-workers. This also means that we no longer need the alarm which is triggered when this fails, which it does regularly due to data consistency issues with Zuora.


[**Trello Card**](https://trello.com/c/AFJ8Jojz/437-spike-can-we-remove-data-corruption-alarm)
