### PR TITLE
Turn off ts monitor action on dependabot prs

### DIFF
--- a/.github/workflows/ts-monitor.yml
+++ b/.github/workflows/ts-monitor.yml
@@ -4,7 +4,9 @@ on: [pull_request]
 
 jobs:
   typescript_monitor:
-    if: github.event.pull_request.head.repo.owner.login == 'guardian'
+    if: >-
+      (github.actor != 'dependabot[bot]') &&
+        (github.event.pull_request.head.repo.owner.login == 'guardian')
     name: Typescript Monitor
     defaults:
       run:


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This is the last broken action on dependabot PRs! I don't think we need to run it given it's just for small dependency updates (also give that we'll probably be dropping it very soon!)
