### PR TITLE
Fix easy eslint errors

### DIFF
--- a/support-frontend/.eslintrc.js
+++ b/support-frontend/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
 					},
 				],
 				'@emotion/pkg-renaming': 'error',
+        '@typescript-eslint/no-unused-vars': ["error", { "ignoreRestSiblings": true }],
 			},
 		},
 	],

--- a/support-frontend/assets/components/headers/header/headerWithCountrySwitcher.tsx
+++ b/support-frontend/assets/components/headers/header/headerWithCountrySwitcher.tsx
@@ -1,12 +1,12 @@
 // ----- Imports ----- //
+
 import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
-import type { Option } from 'helpers/types/option';
-import 'helpers/types/option';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import 'helpers/internationalisation/countryGroup';
 import type { SubscriptionProduct } from 'helpers/productPrice/subscriptions';
-import 'helpers/productPrice/subscriptions';
-import Header from './header'; // ------ Component ----- //
+import type { Option } from 'helpers/types/option';
+import Header from './header';
+
+// ------ Component ----- //
 
 export default function ({
 	path,
@@ -19,7 +19,7 @@ export default function ({
 	listOfCountryGroups: CountryGroupId[];
 	trackProduct?: Option<SubscriptionProduct>;
 }) {
-	return function () {
+	return function (): JSX.Element {
 		return (
 			<Header
 				countryGroupId={countryGroupId}

--- a/support-frontend/assets/components/subscriptionCheckouts/directDebit/directDebitPaymentTerms.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/directDebit/directDebitPaymentTerms.tsx
@@ -1,9 +1,8 @@
 import { css } from '@emotion/react';
 import { border, from, space } from '@guardian/source-foundations';
-import type { Option } from 'helpers/types/option';
-import 'helpers/types/option';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import { DirectDebit } from 'helpers/forms/paymentMethods';
+import type { Option } from 'helpers/types/option';
 import DirectDebitTerms from './directDebitTerms';
 
 const directDebitSection = css`
@@ -27,7 +26,7 @@ const borderTop = css`
 `;
 export default function DirectDebitPaymentTerms(props: {
 	paymentMethod: Option<PaymentMethod>;
-}) {
+}): JSX.Element | null {
 	return props.paymentMethod === DirectDebit ? (
 		<span css={directDebitSection}>
 			<span css={borderTop}>

--- a/support-frontend/assets/components/subscriptionCheckouts/headerWrapper.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/headerWrapper.tsx
@@ -1,17 +1,20 @@
 // ----- Imports ----- //
+
 import { connect } from 'react-redux';
-import type { WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
-import type { Stage } from 'helpers/subscriptionsForms/formFields';
-import 'helpers/subscriptionsForms/formFields';
 import Header from 'components/headers/header/header';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import type { Stage } from 'helpers/subscriptionsForms/formFields';
+import type { WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
+
 // ----- Types ----- //
+
 type PropTypes = {
 	stage: Stage;
 	countryGroupId: CountryGroupId;
 };
 
 // ----- State/Props Maps ----- //
+
 function mapStateToProps(state: WithDeliveryCheckoutState) {
 	return {
 		stage: state.page.checkout.stage,
@@ -20,6 +23,7 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
 }
 
 // ----- Component ----- //
+
 function HeaderWrapper(props: PropTypes) {
 	return (
 		<Header
@@ -27,6 +31,8 @@ function HeaderWrapper(props: PropTypes) {
 			countryGroupId={props.countryGroupId}
 		/>
 	);
-} // ----- Export ----- //
+}
+
+// ----- Export ----- //
 
 export default connect(mapStateToProps)(HeaderWrapper);

--- a/support-frontend/assets/components/subscriptionCheckouts/payPalSubmitButton.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/payPalSubmitButton.tsx
@@ -1,4 +1,5 @@
 // ----- Imports ----- //
+
 import { css } from '@emotion/react';
 import { space } from '@guardian/source-foundations';
 import PayPalExpressButton from 'components/paypalExpressButton/PayPalExpressButton';
@@ -10,17 +11,12 @@ import type {
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import { PayPal } from 'helpers/forms/paymentMethods';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
-import 'helpers/internationalisation/currency';
-import 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
-import type { FormError } from 'helpers/subscriptionsForms/validation';
-import 'helpers/subscriptionsForms/validation';
 import type { FormField } from 'helpers/subscriptionsForms/formFields';
-import 'helpers/subscriptionsForms/formFields';
+import type { FormError } from 'helpers/subscriptionsForms/validation';
 import type { Option } from 'helpers/types/option';
-import { ErrorSummary } from './submitFormErrorSummary';
-import 'helpers/types/option';
 import { hiddenIf } from 'helpers/utilities/utilities';
+import { ErrorSummary } from './submitFormErrorSummary';
 
 const payPalButton = css`
 	box-sizing: border-box;
@@ -32,7 +28,9 @@ const showButton = css`
 const hideButton = css`
 	display: none;
 `;
+
 // ----- Types ----- //
+
 type PropTypes = {
 	paymentMethod: Option<PaymentMethod>;
 	currencyId: IsoCurrency;
@@ -49,7 +47,7 @@ type PropTypes = {
 };
 
 // ----- Render ----- //
-function PayPalSubmitButton(props: PropTypes) {
+function PayPalSubmitButton(props: PropTypes): JSX.Element {
 	// We have to show/hide PayPalExpressButton rather than conditionally rendering it
 	// because we don't want to destroy and replace the iframe each time.
 	// See PayPalExpressButton for more info.

--- a/support-frontend/assets/components/subscriptionCheckouts/paymentTerms.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/paymentTerms.tsx
@@ -1,15 +1,14 @@
 import { FormSection } from 'components/checkoutForm/checkoutForm';
-import type { Option } from 'helpers/types/option';
-import 'helpers/types/option';
+import CancellationPolicy from 'components/subscriptionCheckouts/cancellationPolicy';
+import DirectDebitTerms from 'components/subscriptionCheckouts/directDebit/directDebitTerms';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import { DirectDebit } from 'helpers/forms/paymentMethods';
-import DirectDebitTerms from 'components/subscriptionCheckouts/directDebit/directDebitTerms';
-import CancellationPolicy from 'components/subscriptionCheckouts/cancellationPolicy';
+import type { Option } from 'helpers/types/option';
 
 export default function PaymentTerms(props: {
 	paymentMethod: Option<PaymentMethod>;
 	orderIsAGift?: boolean;
-}) {
+}): JSX.Element {
 	return (
 		<FormSection>
 			{!props.orderIsAGift && <CancellationPolicy />}

--- a/support-frontend/assets/components/ticker/contributionTicker.tsx
+++ b/support-frontend/assets/components/ticker/contributionTicker.tsx
@@ -1,8 +1,11 @@
 // ----- Imports ----- //
+
 import { Component } from 'react';
 import { classNameWithModifiers } from 'helpers/utilities/utilities';
 import './contributionTicker.scss';
+
 // ---- Types ----- //
+
 type DataFromServer = {
 	total: number;
 	goal: number;
@@ -31,6 +34,7 @@ type PropTypes = TickerSettings & {
 };
 
 // ---- Helpers ----- //
+
 const getInitialTickerValues = (
 	tickerCountType: TickerCountType,
 ): Promise<DataFromServer> =>
@@ -60,7 +64,9 @@ grows nearer to 0 which represents 100% fulfilled.
 const percentageToTranslate = (total: number, end: number) => {
 	const percentage = (total / end) * 100 - 100;
 	return percentage > 0 ? 0 : percentage;
-}; // ----- Component ----- //
+};
+
+// ----- Component ----- //
 
 export default class ContributionTicker extends Component<
 	PropTypes,
@@ -78,7 +84,7 @@ export default class ContributionTicker extends Component<
 	}
 
 	componentDidMount(): void {
-		getInitialTickerValues(this.props.tickerCountType).then(
+		void getInitialTickerValues(this.props.tickerCountType).then(
 			({ total, goal }) => {
 				/* ***************************************************************
       Starting the initial count at 80% of its total instead of 0
@@ -117,7 +123,7 @@ export default class ContributionTicker extends Component<
 		);
 	}
 
-	increaseTextCounter = (dataFromServer: DataFromServer) => () => {
+	increaseTextCounter = (dataFromServer: DataFromServer) => (): void => {
 		const nextCount = this.state.count + Math.floor(this.state.count / 100);
 		const finishedCounting =
 			nextCount <= this.state.count || // count isn't going up because total is too small
@@ -134,7 +140,8 @@ export default class ContributionTicker extends Component<
 			window.requestAnimationFrame(this.increaseTextCounter(dataFromServer));
 		}
 	};
-	renderContributedSoFar = () => {
+
+	renderContributedSoFar = (): JSX.Element => {
 		if (!this.state.goalReached) {
 			return (
 				<div className="contributions-landing-ticker__so-far">
@@ -177,7 +184,7 @@ export default class ContributionTicker extends Component<
 		return <div className="contributions-landing-ticker__so-far" />;
 	};
 
-	render() {
+	render(): JSX.Element {
 		const goal = this.state.dataFromServer ? this.state.dataFromServer.goal : 0;
 		const total = this.state.dataFromServer
 			? this.state.dataFromServer.total

--- a/support-frontend/assets/helpers/async/promise.ts
+++ b/support-frontend/assets/helpers/async/promise.ts
@@ -8,7 +8,9 @@ function repeatPromise<A>(n: number, p: () => Promise<A>): Promise<A> {
 // Runs a promise `i` milliseconds in the future
 function sleepPromise<A>(i: number, p: () => Promise<A>): Promise<A> {
 	return new Promise((resolve, reject) => {
-		setTimeout(() => p().then(resolve, reject), i);
+		setTimeout(() => {
+			p().then(resolve, reject);
+		}, i);
 	});
 }
 

--- a/support-frontend/assets/helpers/campaigns/campaignReferralCodes.ts
+++ b/support-frontend/assets/helpers/campaigns/campaignReferralCodes.ts
@@ -34,6 +34,6 @@ export const generateReferralCode = (
 	campaignCode: string,
 ): string => {
 	const code = newReferralCode();
-	postReferralCode(referralCodeEndpoint, code, email, campaignCode);
+	void postReferralCode(referralCodeEndpoint, code, email, campaignCode);
 	return code;
 };

--- a/support-frontend/assets/helpers/internationalisation/country.ts
+++ b/support-frontend/assets/helpers/internationalisation/country.ts
@@ -1,9 +1,9 @@
-import type { $Keys } from 'utility-types';
 // ----- Imports ----- //
+
+import type { $Keys } from 'utility-types';
 import * as cookie from 'helpers/storage/cookie';
 import type { Option } from 'helpers/types/option';
 import { getQueryParameter } from 'helpers/urls/url';
-import 'helpers/types/option';
 import {
 	AUDCountries,
 	Canada,
@@ -15,7 +15,9 @@ import {
 	UnitedStates,
 } from './countryGroup';
 import type { CountryGroupId } from './countryGroup';
+
 // ----- Setup ----- //
+
 const usStates: Record<string, string> = {
 	AK: 'Alaska',
 	AL: 'Alabama',
@@ -398,10 +400,12 @@ const stripePaymentRequestAllowedCountries = [
 	'SK',
 	'US',
 ];
-export const isInStripePaymentRequestAllowedCountries = (country: IsoCountry) =>
-	stripePaymentRequestAllowedCountries.includes(country);
+export const isInStripePaymentRequestAllowedCountries = (
+	country: IsoCountry,
+): boolean => stripePaymentRequestAllowedCountries.includes(country);
 
 // ----- Functions ----- /
+
 function stateProvinceFromMap(
 	l: string,
 	states: Record<string, string>,
@@ -559,7 +563,7 @@ function fromGeolocation(): IsoCountry | null | undefined {
 	return null;
 }
 
-function setCountry(country: IsoCountry) {
+function setCountry(country: IsoCountry): void {
 	cookie.set('GU_country', country, 7);
 }
 

--- a/support-frontend/assets/helpers/internationalisation/currency.ts
+++ b/support-frontend/assets/helpers/internationalisation/currency.ts
@@ -1,9 +1,12 @@
 // ----- Imports ----- //
+
 import { getQueryParameter } from 'helpers/urls/url';
 import type { IsoCountry } from './country';
 import type { CountryGroup, CountryGroupId } from './countryGroup';
 import { countryGroups, fromCountry } from './countryGroup';
+
 // ----- Types ----- //
+
 export type IsoCurrency =
 	| 'GBP'
 	| 'USD'
@@ -25,7 +28,9 @@ export type SpokenCurrency = {
 	singular: string;
 	plural: string;
 };
+
 // ----- Config ----- //
+
 const currencies: Record<IsoCurrency, Currency> = {
 	GBP: {
 		glyph: '£',
@@ -200,7 +205,7 @@ function fromQueryParameter(): IsoCurrency | null | undefined {
 }
 
 function detect(countryGroup: CountryGroupId): IsoCurrency {
-	return fromQueryParameter() || fromCountryGroupId(countryGroup) || 'GBP';
+	return fromQueryParameter() ?? fromCountryGroupId(countryGroup) ?? 'GBP';
 }
 
 const glyph = (c: IsoCurrency): string => currencies[c].glyph;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmountChoices.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmountChoices.tsx
@@ -1,8 +1,8 @@
 // ----- Imports ----- //
+
 import { css } from '@emotion/react';
 import { until } from '@guardian/source-foundations';
 import { ChoiceCard, ChoiceCardGroup } from '@guardian/source-react-components';
-import * as React from 'react';
 import type { ContributionType, SelectedAmounts } from 'helpers/contributions';
 import { formatAmount } from 'helpers/forms/checkouts';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -67,7 +67,7 @@ const isSelected = (
 	return amount === defaultAmount;
 };
 
-const ContributionAmountChoices: React.FC<ContributionAmountChoicesProps> = ({
+function ContributionAmountChoices({
 	validAmounts,
 	defaultAmount,
 	countryGroupId,
@@ -77,7 +77,7 @@ const ContributionAmountChoices: React.FC<ContributionAmountChoicesProps> = ({
 	selectedAmounts,
 	currency,
 	shouldShowFrequencyButtons,
-}: ContributionAmountChoicesProps) => {
+}: ContributionAmountChoicesProps): JSX.Element {
 	const isOtherAmountFullWidth = validAmounts.length % 2 === 0;
 	return (
 		<ChoiceCardGroup
@@ -129,6 +129,6 @@ const ContributionAmountChoices: React.FC<ContributionAmountChoicesProps> = ({
 			/>
 		</ChoiceCardGroup>
 	);
-};
+}
 
 export default ContributionAmountChoices;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmountChoicesChoiceLabel.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmountChoicesChoiceLabel.tsx
@@ -1,6 +1,5 @@
-import type { ContributionType } from 'helpers/contributions';
-import 'helpers/contributions';
 import { css } from '@emotion/react';
+import type { ContributionType } from 'helpers/contributions';
 
 type ContributionAmountLabelProps = {
 	formattedAmount: string;
@@ -12,7 +11,7 @@ function ContributionAmountChoicesChoiceLabel({
 	formattedAmount,
 	shouldShowFrequencyButtons,
 	contributionType,
-}: ContributionAmountLabelProps) {
+}: ContributionAmountLabelProps): JSX.Element {
 	let frequencyLabel = '';
 
 	if (shouldShowFrequencyButtons) {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionErrorMessage.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionErrorMessage.tsx
@@ -1,16 +1,14 @@
 // ----- Imports ----- //
+
 import { connect } from 'react-redux';
-import type { ContributionType } from 'helpers/contributions';
-import 'helpers/contributions';
-import type { ErrorReason } from 'helpers/forms/errorReasons';
-import 'helpers/forms/errorReasons';
 import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';
+import type { ContributionType } from 'helpers/contributions';
+import type { ErrorReason } from 'helpers/forms/errorReasons';
 import type { State } from '../contributionsLandingReducer';
-import '../contributionsLandingReducer';
 import { ExistingRecurringContributorErrorMessage } from './ExistingRecurringContributorErrorMessage';
+
 // ----- Types ----- //
 
-/* eslint-disable react/no-unused-prop-types */
 type PropTypes = {
 	contributionType: ContributionType;
 	paymentError: ErrorReason | null;
@@ -20,7 +18,6 @@ type PropTypes = {
 	checkoutFormHasBeenSubmitted: boolean;
 };
 
-/* eslint-enable react/no-unused-prop-types */
 const mapStateToProps = (state: State) => ({
 	paymentMethod: state.page.form.paymentMethod,
 	contributionType: state.page.form.contributionType,
@@ -33,7 +30,9 @@ const mapStateToProps = (state: State) => ({
 });
 
 // ----- Functions ----- //
+
 // ----- Render ----- //
+
 function ContributionErrorMessage(props: PropTypes) {
 	const shouldsShowExistingContributorErrorMessage =
 		props.contributionType !== 'ONE_OFF' &&

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouAusMap.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouAusMap.tsx
@@ -5,7 +5,6 @@ import {
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
 import { useEffect } from 'react';
-import * as React from 'react';
 import {
 	trackComponentClick,
 	trackComponentLoad,
@@ -23,7 +22,7 @@ const buttonContainer = css`
 const AUS_MAP_URL =
 	'https://support.theguardian.com/aus-map?INTCMP=thankyou-page-aus-map-cta';
 
-const ContributionThankYouAusMap: React.FC = () => {
+function ContributionThankYouAusMap(): JSX.Element {
 	useEffect(() => {
 		trackComponentLoad(OPHAN_COMPONENT_ID_AUS_MAP);
 	}, []);
@@ -64,6 +63,6 @@ const ContributionThankYouAusMap: React.FC = () => {
 			body={actionBody}
 		/>
 	);
-};
+}
 
 export default ContributionThankYouAusMap;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSignIn.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSignIn.tsx
@@ -6,7 +6,6 @@ import {
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
-import * as React from 'react';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import {
 	trackComponentClick,
@@ -51,10 +50,10 @@ type CreateSignInUrlResponse = {
 	signInLink: string;
 };
 
-const ContributionThankYouSignIn: React.FC<ContributionThankYouSignInProps> = ({
+function ContributionThankYouSignIn({
 	email,
 	csrf,
-}: ContributionThankYouSignInProps) => {
+}: ContributionThankYouSignInProps): JSX.Element {
 	const [isExpanded, setIsExpanded] = useState(false);
 	const [signInUrl, setSignInUrl] = useState('https://theguardian.com');
 
@@ -167,6 +166,6 @@ const ContributionThankYouSignIn: React.FC<ContributionThankYouSignInProps> = ({
 			body={actionBody}
 		/>
 	);
-};
+}
 
 export default ContributionThankYouSignIn;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSignUp.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSignUp.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source-foundations';
 import { useEffect } from 'react';
-import * as React from 'react';
 import { trackComponentLoad } from 'helpers/tracking/behaviour';
 import ActionBody from './components/ActionBody';
 import ActionContainer from './components/ActionContainer';
@@ -14,7 +13,7 @@ const listContainer = css`
 	margin-top: ${space[4]}px;
 `;
 
-const ContributionThankYouSignUp: React.FC = () => {
+function ContributionThankYouSignUp(): JSX.Element {
 	useEffect(() => {
 		trackComponentLoad(OPHAN_COMPONENT_ID_SIGN_UP);
 	}, []);
@@ -47,6 +46,6 @@ const ContributionThankYouSignUp: React.FC = () => {
 			body={actionBody}
 		/>
 	);
-};
+}
 
 export default ContributionThankYouSignUp;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSocialShare.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSocialShare.tsx
@@ -7,7 +7,6 @@ import {
 	SvgTwitter,
 } from '@guardian/source-react-components';
 import { useEffect } from 'react';
-import * as React from 'react';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import {
 	trackComponentClick,
@@ -48,14 +47,12 @@ type ContributionThankYouSocialShareProps = {
 	countryId: IsoCountry;
 };
 
-const ContributionThankYouSocialShare: React.FC<
-	ContributionThankYouSocialShareProps
-> = ({
+function ContributionThankYouSocialShare({
 	email,
 	createReferralCodes,
 	campaignCode,
 	countryId,
-}: ContributionThankYouSocialShareProps) => {
+}: ContributionThankYouSocialShareProps): JSX.Element {
 	useEffect(() => {
 		trackComponentLoad(OPHAN_COMPONENT_ID_SOCIAL);
 	}, []);
@@ -142,6 +139,6 @@ const ContributionThankYouSocialShare: React.FC<
 			body={actionBody}
 		/>
 	);
-};
+}
 
 export default ContributionThankYouSocialShare;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/components/ActionBody.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/components/ActionBody.tsx
@@ -16,8 +16,8 @@ type ActionBodyProps = {
 	children: React.ReactNode;
 };
 
-const ActionBody: React.FC<ActionBodyProps> = ({
-	children,
-}: ActionBodyProps) => <div css={bodyContainer}>{children}</div>;
+function ActionBody({ children }: ActionBodyProps): JSX.Element {
+	return <div css={bodyContainer}>{children}</div>;
+}
 
 export default ActionBody;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/components/ActionContainer.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/components/ActionContainer.tsx
@@ -48,16 +48,18 @@ type ActionContainerProps = {
 	body: React.ReactNode;
 };
 
-const ActionContainer: React.FC<ActionContainerProps> = ({
+function ActionContainer({
 	icon,
 	header,
 	body,
-}: ActionContainerProps) => (
-	<section css={container}>
-		<div css={iconContainer}>{icon}</div>
-		<div css={headerContainer}>{header}</div>
-		<div css={bodyContainer}>{body}</div>
-	</section>
-);
+}: ActionContainerProps): JSX.Element {
+	return (
+		<section css={container}>
+			<div css={iconContainer}>{icon}</div>
+			<div css={headerContainer}>{header}</div>
+			<div css={bodyContainer}>{body}</div>
+		</section>
+	);
+}
 
 export default ActionContainer;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/components/ActionHeader.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/components/ActionHeader.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { body, from } from '@guardian/source-foundations';
-import * as React from 'react';
 
 const text = css`
 	${body.medium({
@@ -15,12 +14,12 @@ type ActionHeaderProps = {
 	title: string;
 };
 
-const ActionHeader: React.FC<ActionHeaderProps> = ({
-	title,
-}: ActionHeaderProps) => (
-	<header>
-		<h1 css={text}>{title}</h1>
-	</header>
-);
+function ActionHeader({ title }: ActionHeaderProps): JSX.Element {
+	return (
+		<header>
+			<h1 css={text}>{title}</h1>
+		</header>
+	);
+}
 
 export default ActionHeader;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/utils/ophan.ts
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/utils/ophan.ts
@@ -1,8 +1,6 @@
+import type { ContributionType } from 'helpers/contributions';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import { trackComponentEvents } from 'helpers/tracking/ophan';
-import 'helpers/forms/paymentMethods';
-import type { ContributionType } from 'helpers/contributions';
-import 'helpers/contributions';
 
 export const OPHAN_COMPONENT_ID_SIGN_IN = 'sign-into-the-guardian-link';
 export const OPHAN_COMPONENT_ID_SIGN_UP = 'set-password';
@@ -93,7 +91,7 @@ export const trackUserData = (
 	isSignedIn: boolean,
 	isKnownEmail: boolean,
 	isLargeDonation: boolean,
-) => {
+): void => {
 	trackPaymentMethod(paymentMethod);
 	trackContributionType(contributionType);
 	trackSignedIn(isSignedIn);

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/thankYou/hero.tsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/thankYou/hero.tsx
@@ -1,16 +1,17 @@
 // ----- Imports ----- //
+
 import type {
 	GridImage,
 	GridSlot,
 	Source as GridSource,
 } from 'components/gridPicture/gridPicture';
 import GridPicture from 'components/gridPicture/gridPicture';
-import type { ImageId as GridId } from 'helpers/images/theGrid';
-import 'helpers/images/theGrid';
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
+import type { ImageId as GridId } from 'helpers/images/theGrid';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import 'helpers/internationalisation/countryGroup';
+
 // ----- Setup ----- //
+
 type GridImages = {
 	breakpoints: {
 		mobile: GridImage;
@@ -89,7 +90,11 @@ const gridSlots: GridSlots = {
 	},
 };
 
-function ThankYouHero({ countryGroupId }: { countryGroupId: CountryGroupId }) {
+function ThankYouHero({
+	countryGroupId,
+}: {
+	countryGroupId: CountryGroupId;
+}): JSX.Element {
 	const gridImages: GridImages = heroesByCountry[countryGroupId];
 	const sources: GridSource[] = [
 		{ ...gridSlots.mobile, ...gridImages.breakpoints.mobile },
@@ -109,6 +114,8 @@ function ThankYouHero({ countryGroupId }: { countryGroupId: CountryGroupId }) {
 			</LeftMarginSection>
 		</div>
 	);
-} // ----- Export ----- //
+}
+
+// ----- Export ----- //
 
 export default ThankYouHero;

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouPendingContent.tsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouPendingContent.tsx
@@ -1,18 +1,20 @@
 // ----- Imports ----- //
+
 import * as React from 'react';
 import Content from 'components/content/content';
 import HeadingBlock from 'components/headingBlock/headingBlock';
 import { HeroWrapper } from 'components/productPage/productPageHero/productPageHero';
+import { SubscriptionsSurvey } from 'components/subscriptionCheckouts/subscriptionsSurvey/SubscriptionsSurvey';
+import Text, { LargeParagraph } from 'components/text/text';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
 	DigitalPack,
 	sendTrackingEventsOnClick,
 } from 'helpers/productPrice/subscriptions';
-import 'helpers/internationalisation/countryGroup';
-import { SubscriptionsSurvey } from 'components/subscriptionCheckouts/subscriptionsSurvey/SubscriptionsSurvey';
-import Text, { LargeParagraph } from 'components/text/text';
 import ThankYouHero from './components/thankYou/hero';
+
 // ----- Types ----- //
+
 type PropTypes = {
 	countryGroupId: CountryGroupId;
 	marketingConsent: React.ReactNode;
@@ -20,7 +22,8 @@ type PropTypes = {
 };
 
 // ----- Component ----- //
-function ThankYouPendingContent(props: PropTypes) {
+
+function ThankYouPendingContent(props: PropTypes): JSX.Element {
 	return (
 		<div className="thank-you-stage">
 			<ThankYouHero countryGroupId={props.countryGroupId} />
@@ -60,6 +63,8 @@ function ThankYouPendingContent(props: PropTypes) {
 			<Content>{props.marketingConsent}</Content>
 		</div>
 	);
-} // ----- Export ----- //
+}
+
+// ----- Export ----- //
 
 export default ThankYouPendingContent;

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithImage.tsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroWithImage.tsx
@@ -1,4 +1,5 @@
 // ----- Imports ----- //
+
 import { ThemeProvider } from '@emotion/react';
 import {
 	buttonThemeBrand,
@@ -32,11 +33,14 @@ function GiftCopy() {
 	);
 }
 
-function HeroWithImage({ promotionCopy, countryGroupId }: PropTypes) {
+function HeroWithImage({
+	promotionCopy,
+	countryGroupId,
+}: PropTypes): JSX.Element {
 	const promoCopy = promotionHTML(promotionCopy.description, {
 		tag: 'div',
 	});
-	const copy = promoCopy || <GiftCopy />;
+	const copy = promoCopy ?? <GiftCopy />;
 	return (
 		<PageTitle title="Give the digital subscription" theme="digital">
 			<CentredContainer>

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLandingProps.ts
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLandingProps.ts
@@ -33,5 +33,5 @@ export const digitalLandingProps = (): DigitalLandingPropTypes => ({
 	participations: initAbTests(countryId, countryGroupId, getSettings()),
 	productPrices: getProductPrices(),
 	promotionCopy: getPromotionCopy(),
-	orderIsAGift: getGlobal('orderIsAGift') || false,
+	orderIsAGift: getGlobal('orderIsAGift') ?? false,
 });

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/subscriptionSurvey.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/subscriptionSurvey.tsx
@@ -1,4 +1,5 @@
 // ----- Imports ----- //
+
 import { css, ThemeProvider } from '@emotion/react';
 import { from, headline, space, textSans } from '@guardian/source-foundations';
 import {
@@ -38,7 +39,7 @@ const marginForButton = css`
 	margin: ${space[5]}px 0 0;
 `;
 
-function SubscriptionsSurvey() {
+function SubscriptionsSurvey(): JSX.Element | null {
 	const surveyLink = 'https://www.surveymonkey.co.uk/r/Q37XNTV';
 	const title = 'Tell us about your subscription';
 	const message =

--- a/support-frontend/assets/pages/paper-subscription-checkout/helpers/__tests__/deliveryDays.test.ts
+++ b/support-frontend/assets/pages/paper-subscription-checkout/helpers/__tests__/deliveryDays.test.ts
@@ -1,4 +1,5 @@
 // ----- Imports ----- //
+
 import {
 	Everyday,
 	Sixday,
@@ -18,7 +19,9 @@ import {
 import { getFormattedStartDate, getPaymentStartDate } from '../subsCardDays';
 import { getVoucherDays } from '../voucherDeliveryDays';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function -- Test file so fine to disable lint rule
 jest.mock('ophan', () => {});
+
 // ----- Tests ----- //
 const monday = 1551075752198;
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/helpers/subsCardDays.ts
+++ b/support-frontend/assets/pages/paper-subscription-checkout/helpers/subsCardDays.ts
@@ -1,6 +1,5 @@
 import type { ActivePaperProducts } from 'helpers/productPrice/productOptions';
 import { formatMachineDate } from 'helpers/utilities/dateConversions';
-import 'helpers/productPrice/productOptions';
 
 const additionalDays = [
 	{
@@ -104,7 +103,7 @@ const monthText = [
 ];
 const milsInADay = 1000 * 60 * 60 * 24;
 
-const getFormattedStartDate = (startDate: Date) => {
+const getFormattedStartDate = (startDate: Date): string => {
 	if (startDate) {
 		const machineDateArray = formatMachineDate(startDate).split('-');
 		return `${machineDateArray[2]} ${monthText[startDate.getMonth()]} ${
@@ -118,7 +117,7 @@ const getFormattedStartDate = (startDate: Date) => {
 const getPaymentStartDate = (
 	date: number,
 	productOption: ActivePaperProducts,
-) => {
+): Date => {
 	const day = new Date(date).getDay();
 	const delay = additionalDays[day][productOption];
 	const delayInMils = delay * milsInADay;

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -1,9 +1,8 @@
-import * as React from 'react';
 import { List } from 'components/list/list';
 import BenefitsContainer from './benefitsContainer';
 import BenefitsHeading from './benefitsHeading';
 
-const Benefits: React.FC = () => {
+function Benefits(): JSX.Element {
 	return (
 		<BenefitsContainer
 			sections={[
@@ -35,6 +34,6 @@ const Benefits: React.FC = () => {
 			]}
 		/>
 	);
-};
+}
 
 export default Benefits;

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
@@ -1,4 +1,5 @@
 // ----- Imports ----- //
+
 import { css, ThemeProvider } from '@emotion/react';
 import { body, from, headline, space } from '@guardian/source-foundations';
 import {
@@ -6,7 +7,6 @@ import {
 	LinkButton,
 	SvgArrowDownStraight,
 } from '@guardian/source-react-components';
-import * as React from 'react';
 import GiftHeadingAnimation from 'components/animations/giftHeadingAnimation';
 import CentredContainer from 'components/containers/centredContainer';
 import GridImage from 'components/gridImage/gridImage';
@@ -131,12 +131,12 @@ const getFirstParagraph = (
 	);
 };
 
-const WeeklyHero: React.FC<PropTypes> = ({
+function WeeklyHero({
 	orderIsAGift,
 	countryGroupId,
 	promotionCopy,
 	participations,
-}) => {
+}: PropTypes): JSX.Element {
 	const currencyId = fromCountryGroupId(countryGroupId) ?? 'GBP';
 
 	const defaultRoundelText =
@@ -215,6 +215,6 @@ const WeeklyHero: React.FC<PropTypes> = ({
 			</CentredContainer>
 		</PageTitle>
 	);
-};
+}
 
 export { WeeklyHero };


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

I've gone through and fixed up all the easy eslint errors. We're now left with the following breakdown:

**errors**

- @typescript-eslint/no-unsafe-assignment: 4
- @typescript-eslint/no-unsafe-return: 1
- @typescript-eslint/no-unsafe-member-access: 5
- @typescript-eslint/no-unnecessary-condition: 6

**warnings**

- @typescript-eslint/no-explicit-any: 28
- @typescript-eslint/explicit-module-boundary-types: 117

I think it'd be worth a mini push to get all of the errors out of the way so that we can turn on linting checks in our ci. We can then pick up the warnings as and when we touch the specific files (they're mostly pretty easy as typescript infers the type that we want anyway).
