### PR TITLE
Strip new line characters from response body logging

### DIFF
--- a/support-modules/rest/src/main/scala/com/gu/rest/WebServiceHelper.scala
+++ b/support-modules/rest/src/main/scala/com/gu/rest/WebServiceHelper.scala
@@ -97,7 +97,7 @@ trait WebServiceHelper[Error <: Throwable] {
         .toTry
       responseBody <- Try(body.string())
       codeBody = CodeBody(code, responseBody)
-      _ = SafeLogger.info(s"response $code body: ${responseBody}")
+      _ = SafeLogger.info(s"response $code body: ${responseBody.replace("\n", "")}")
       _ <-
         if ((contentType.`type`(), contentType.subtype()) == ("application", "json")) Success(())
         else Failure(WebServiceHelperError(codeBody, s"wrong content type"))


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Http responses from the Stripe billing API have lots of newlines in them which when logged break out the message into multiple lines, this gets very confusing for large responses.

This PR strips the newline characters before logging