### PR TITLE
Remove set up of extra node version in workflow

### DIFF
--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -36,7 +36,9 @@ jobs:
         uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: 'yarn'
-          cache-dependency-path: support-frontend/yarn.lock
+          cache-dependency-path: |
+            support-frontend/yarn.lock
+            cdk/yarn.lock
 
       - name: Install
         run: yarn
@@ -49,14 +51,6 @@ jobs:
       - name: Build assets
         run: yarn run build-prod
         working-directory: support-frontend
-
-      # The CDK build requires node 16 and currently the rest of the build is on v12
-      - name: Setup Node for CDK
-        uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-          cache: 'yarn'
-          cache-dependency-path: cdk/yarn.lock
 
       - name: Build CFN from CDK
         run: ./script/ci


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Now that we're using the same version of node for cdk and support-frontend there is no need to have two separate node setup steps
