### PR TITLE
Add typescript & eslint workflows

### DIFF
--- a/.github/workflows/support-frontend-eslint.yml
+++ b/.github/workflows/support-frontend-eslint.yml
@@ -1,0 +1,28 @@
+name: support-frontend - eslint
+
+on:
+  push:
+    paths:
+      - support-frontend/**
+
+jobs:
+  support_frontend_build:
+    name: support-frontend - eslint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: guardian/actions-setup-node@v2.4.1
+        with:
+          cache: 'yarn'
+          cache-dependency-path: support-frontend/yarn.lock
+
+      - name: Install
+        run: yarn
+        working-directory: support-frontend
+
+      - name: Lint check
+        run: yarn lint:check
+        working-directory: support-frontend

--- a/.github/workflows/support-frontend-typescript.yml
+++ b/.github/workflows/support-frontend-typescript.yml
@@ -1,0 +1,28 @@
+name: support-frontend - typescript
+
+on:
+  push:
+    paths:
+      - support-frontend/**
+
+jobs:
+  support_frontend_build:
+    name: support-frontend - typescript
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: guardian/actions-setup-node@v2.4.1
+        with:
+          cache: 'yarn'
+          cache-dependency-path: support-frontend/yarn.lock
+
+      - name: Install
+        run: yarn
+        working-directory: support-frontend
+
+      - name: Type check
+        run: yarn tsc
+        working-directory: support-frontend


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Adds two new workflows: `support-frontend-typescript` and `support-frontend-eslint`. Now that we've got both typescript and lint errors down to 0, we can turn on these checks in CI to ensure they stay that way.

I've followed the style of dotcom-rendering which is to have them as separate workflows so that they can run in parallel.

**NB:** The new actions won't show on this PR as it's not touching any files in the `support-frontend` directory. I tested they were working by making a small change to a `ts` file, but have now dropped that change.
