### PR TITLE
Notify Quantum Metric of user AB test participations 

### DIFF
--- a/support-frontend/assets/helpers/page/analyticsAndConsent.ts
+++ b/support-frontend/assets/helpers/page/analyticsAndConsent.ts
@@ -25,7 +25,7 @@ function analyticsInitialisation(
 	setReferrerDataInLocalStorage(acquisitionData);
 	void googleTagManager.init(participations);
 	ophan.init();
-	initQuantumMetric();
+	initQuantumMetric(participations);
 	trackAbTests(participations);
 	// Sentry logging.
 	initLogger().catch((err) => {

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -101,4 +101,4 @@ function init(participations: Participations): void {
 	});
 }
 
-export { init, sendEventABTestParticipations };
+export { init };

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -25,7 +25,7 @@ function sendEventABTestParticipations(participations: Participations): void {
 	Object.keys(participations).forEach((testId) => {
 		const value = `${testId}-${participations[testId]}`;
 		/**
-		 * Quantum Metric's sets up QuantumMetricAPI
+		 * Quantum Metric's script sets up QuantumMetricAPI
 		 * We need to check it is defined and ready before we can
 		 * send events to it. If it is not ready we add the events to
 		 * a valueQueue to be processed later.

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -55,23 +55,17 @@ function sendEventABTestParticipations(participations: Participations): void {
 	}
 }
 
-function addQM(): Promise<void> {
-	return new Promise((resolve) => {
-		loadScript(
-			'https://cdn.quantummetric.com/instrumentation/1.31.3/quantum-gnm.js',
-			{
-				async: true,
-				integrity:
-					'sha384-jL1rlM/U30WWRsDEQDalNiDV8FOjayD5RCgzkywrohMqg6oME3zbszWB31/40MAD',
-				crossOrigin: 'anonymous',
-			},
-		)
-			.then(() => {
-				resolve();
-			})
-			.catch(() => {
-				logException('Failed to load Quantum Metric');
-			});
+function addQM() {
+	return loadScript(
+		'https://cdn.quantummetric.com/instrumentation/1.31.3/quantum-gnm.js',
+		{
+			async: true,
+			integrity:
+				'sha384-jL1rlM/U30WWRsDEQDalNiDV8FOjayD5RCgzkywrohMqg6oME3zbszWB31/40MAD',
+			crossOrigin: 'anonymous',
+		},
+	).catch(() => {
+		logException('Failed to load Quantum Metric');
 	});
 }
 

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -96,6 +96,7 @@
     "@emotion/serialize": "^0.11.16",
     "@emotion/utils": "^1.1.0",
     "@guardian/consent-management-platform": "^10.5.0",
+    "@guardian/libs": "^5.1.0",
     "@guardian/pasteup": "1.0.0-alpha.7",
     "@guardian/source-foundations": "^4.1.0",
     "@guardian/source-react-components": "^4.0.3",
@@ -207,6 +208,7 @@
     "webpack-manifest-plugin": "^5.0.0",
     "webpack-merge": "^5.8.0",
     "webpack-stats-plugin": "^0.3.2",
+    "web-vitals": "^2.0.0",
     "yargs": "^17.4.0"
   },
   "resolutions": {

--- a/support-frontend/window.d.ts
+++ b/support-frontend/window.d.ts
@@ -7,6 +7,7 @@ import type {
 } from 'helpers/forms/paymentIntegrations/amazonPay/types';
 import type { StripeKey } from 'helpers/forms/stripe';
 import type { Settings } from 'helpers/globalsAndSwitches/settings';
+import type { SendEventId } from 'helpers/tracking/quantumMetric';
 import type { User } from 'helpers/user/userReducer';
 import type { ProductPrices } from './assets/helpers/productPrice/productPrices';
 
@@ -77,7 +78,10 @@ declare global {
 				) => ComponentType;
 			};
 		};
-		QuantumMetricAPI: unknown;
+		QuantumMetricAPI?: {
+			isOn: () => boolean;
+			sendEvent: (id: SendEventId, isConversion: 0 | 1, value: string) => void;
+		};
 		v2OnloadCallback: () => void;
 		__REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: <R>(a: R) => R;
 		__REDUX_DEVTOOLS_EXTENSION__?: () => undefined;

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1300,6 +1300,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.3.0.tgz#fa98c7b8216ab35b8cf3087cd9ba336958fac99a"
   integrity sha512-XB9o8qtDOg+KlPh1sjEr4u+Ai3RFTRr2riZ/HJpdlh8Cu4ZpYjCSGUZXSGkxp1CwFWT9sduANnsWSqZ97iBloQ==
 
+"@guardian/libs@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-5.1.0.tgz#5f7a228d8382e07809e09aeffed6d472558ed41d"
+  integrity sha512-AKVh+CraVAR49y60IX7UYrIMlfhS/zhN1f31FqJ/nHtGv92XFzCoijknkl+pFQUtuZvD2zYCygpqLGCWPVDk/Q==
+
 "@guardian/paparazzi@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@guardian/paparazzi/-/paparazzi-0.3.1.tgz#2eea9b928de29557ac4fd86e2cef364464ad9cc1"
@@ -14669,6 +14674,11 @@ wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+web-vitals@^2.0.0:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-2.1.4.tgz#76563175a475a5e835264d373704f9dde718290c"
+  integrity sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
## What are you doing in this PR?

We need to notify Quantum Metric of a user's AB test participations, using the `window.QuantumMetricAPI.sendEvent` function. This PR sends this relevant data to Quantum Metric.

Whilst doing this I've also updated the logic to load Quantum Metric's script by replacing some custom logic to add the script with `import { loadScript } from '@guardian/libs'`. 

[**Trello Card**](https://trello.com/c/BfI7Ru7b/462-quantum-metric-implement-sendevent-call-for-ab-test-participations)