### PR TITLE
Remove `createStripePaymentMethod` from redux state

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx
@@ -22,7 +22,6 @@ import type { Action } from 'pages/contributions-landing/contributionsLandingAct
 import {
 	onThirdPartyPaymentAuthorised,
 	paymentFailure,
-	setCreateStripePaymentMethod,
 	setHandleStripe3DS,
 	paymentWaiting as setPaymentWaiting,
 	setStripeCardFormComplete,
@@ -80,9 +79,6 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<State, void, Action>) => ({
 		),
 	paymentFailure: (paymentError: ErrorReason) =>
 		dispatch(paymentFailure(paymentError)),
-	setCreateStripePaymentMethod: (
-		createStripePaymentMethod: (clientSecret: string | null) => void,
-	) => dispatch(setCreateStripePaymentMethod(createStripePaymentMethod)),
 	setHandleStripe3DS: (
 		handleStripe3DS: (clientSecret: string) => Promise<PaymentIntentResult>,
 	) => dispatch(setHandleStripe3DS(handleStripe3DS)),
@@ -104,6 +100,9 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 
 interface PropsFromParent {
 	stripeKey: string;
+	setCreateStripePaymentMethod: (
+		create: (clientSecret: string | null) => void,
+	) => void;
 }
 
 type PropsFromRedux = ConnectedProps<typeof connector>;

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.tsx
@@ -23,6 +23,9 @@ type PropTypes = {
 	isTestUser: boolean;
 	contributionType: ContributionType;
 	paymentMethod: PaymentMethod;
+	setCreateStripePaymentMethod: (
+		create: (clientSecret: string | null) => void,
+	) => void;
 };
 
 function StripeCardFormContainer(props: PropTypes): JSX.Element | null {
@@ -51,7 +54,10 @@ function StripeCardFormContainer(props: PropTypes): JSX.Element | null {
 						stripe={stripeObjects[stripeAccount]}
 						options={elementsOptions}
 					>
-						<StripeCardForm stripeKey={stripeKey} />
+						<StripeCardForm
+							stripeKey={stripeKey}
+							setCreateStripePaymentMethod={props.setCreateStripePaymentMethod}
+						/>
 					</Elements>
 				</div>
 			);

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.ts
@@ -224,10 +224,6 @@ export type Action =
 			type: 'SET_STRIPE_V3_HAS_LOADED';
 	  }
 	| {
-			type: 'SET_CREATE_STRIPE_PAYMENT_METHOD';
-			createStripePaymentMethod: (clientSecret: string | null) => void;
-	  }
-	| {
 			type: 'SET_HANDLE_STRIPE_3DS';
 			handleStripe3DS: (clientSecret: string) => Promise<PaymentIntentResult>;
 	  }
@@ -540,13 +536,6 @@ const getUserType =
 const setTickerGoalReached = (): Action => ({
 	type: 'SET_TICKER_GOAL_REACHED',
 	tickerGoalReached: true,
-});
-
-const setCreateStripePaymentMethod = (
-	createStripePaymentMethod: (clientSecret: string | null) => void,
-): Action => ({
-	type: 'SET_CREATE_STRIPE_PAYMENT_METHOD',
-	createStripePaymentMethod,
 });
 
 const setHandleStripe3DS = (
@@ -1154,7 +1143,6 @@ export {
 	setStripePaymentRequestButtonClicked,
 	setStripePaymentRequestButtonError,
 	setTickerGoalReached,
-	setCreateStripePaymentMethod,
 	setHandleStripe3DS,
 	setStripeCardFormComplete,
 	setStripeSetupIntentClientSecret,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.ts
@@ -58,7 +58,6 @@ export interface StripeCardFormData {
 	recurringRecaptchaVerified: boolean;
 	// TODO: No non-serialisable values should be in Redux state!! This needs to be refactored
 	// These callbacks must be initialised after the StripeCardForm component has been created
-	createPaymentMethod: ((clientSecret: string | null) => void) | null;
 	handle3DS: ((clientSecret: string) => Promise<PaymentIntentResult>) | null; // For single only
 }
 
@@ -185,7 +184,6 @@ function createFormReducer() {
 			formComplete: false,
 			setupIntentClientSecret: null,
 			recurringRecaptchaVerified: false,
-			createPaymentMethod: null,
 			handle3DS: null,
 		},
 		sepaData: {
@@ -334,15 +332,6 @@ function createFormReducer() {
 						...state.amazonPayData,
 						amazonBillingAgreementConsentStatus:
 							action.amazonBillingAgreementConsentStatus,
-					},
-				};
-
-			case 'SET_CREATE_STRIPE_PAYMENT_METHOD':
-				return {
-					...state,
-					stripeCardFormData: {
-						...state.stripeCardFormData,
-						createPaymentMethod: action.createStripePaymentMethod,
 					},
 				};
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

We're aiming to remove all non-serialisable state from the contributions redux store. This PR removes the `createStripePaymentMethod` by moving it into state in the `ContributionsForm` component.

