### PR TITLE
Small tweak to the patrons data pipeline

### DIFF
--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/services/StripeSubscriptionsProcessor.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/services/StripeSubscriptionsProcessor.scala
@@ -34,9 +34,7 @@ class StripeSubscriptionsProcessor(
   def processSubs(list: List[StripeSubscription]) = {
     Future.sequence(
       list
-        .filterNot(sub =>
-          sub.customer.email.contains("@guardian.co.uk") || sub.customer.email.contains("@theguardian.com"),
-        )
+        .filterNot(sub => sub.customer.email == "patrons@theguardian.com")
         .distinctBy(
           _.customer.email, // I think this is probably only an issue in dev, but there can be multiple subs with the same email
         )

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/services/StripeSubscriptionsProcessor.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/services/StripeSubscriptionsProcessor.scala
@@ -32,9 +32,10 @@ class StripeSubscriptionsProcessor(
   }
 
   def processSubs(list: List[StripeSubscription]) = {
+    val unknownEmailViaCSR = "patrons@theguardian.com"
     Future.sequence(
       list
-        .filterNot(sub => sub.customer.email == "patrons@theguardian.com")
+        .filterNot(sub => sub.customer.email == unknownEmailViaCSR)
         .distinctBy(
           _.customer.email, // I think this is probably only an issue in dev, but there can be multiple subs with the same email
         )


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We want to filter out the patrons@theguardian.com email address from the Stripe to SupporterProductData pipeline as this is an address used by CSRs when a patron does not provide an email, however we shouldn't filter out all guardian email addresses - mostly because this makes testing difficult!