### PR TITLE
Factor out some hooks from `StripeCardForm.tsx`

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/fields.ts
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/fields.ts
@@ -1,0 +1,3 @@
+// ---- Types ---- //
+
+export type CardFieldName = 'CardNumber' | 'Expiry' | 'CVC';

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/useCardFormFieldStates.ts
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/useCardFormFieldStates.ts
@@ -1,0 +1,107 @@
+import type { StripeElementChangeEvent } from '@stripe/stripe-js';
+import { useState } from 'react';
+import type { CardFieldName } from './fields';
+
+// ---- Types ---- //
+
+type CardFieldState =
+	| {
+			name: 'Error';
+			errorMessage: string;
+	  }
+	| {
+			name: 'Incomplete';
+	  }
+	| {
+			name: 'Complete';
+	  };
+
+type FieldStates = Record<CardFieldName, CardFieldState>;
+
+interface CardFormFieldStates {
+	fieldStates: FieldStates;
+	onFieldChange: (
+		fieldName: CardFieldName,
+	) => (update: StripeElementChangeEvent) => void;
+	errorMessage?: string;
+}
+
+// ---- Hook ---- //
+
+export function useCardFormFieldStates(): CardFormFieldStates {
+	const [fieldStates, setFieldStates] =
+		useState<FieldStates>(INITAL_FIELD_STATES);
+
+	const onFieldChange =
+		(fieldName: CardFieldName) => (update: StripeElementChangeEvent) => {
+			setFieldStates((prevData) => ({
+				...prevData,
+				[fieldName]: updatedFieldState(update),
+			}));
+		};
+
+	return {
+		fieldStates,
+		onFieldChange,
+		errorMessage: errorMessage(fieldStates),
+	};
+}
+
+// ---- Helpers ---- //
+
+const INITAL_FIELD_STATES: FieldStates = {
+	CardNumber: {
+		name: 'Incomplete',
+	},
+	Expiry: {
+		name: 'Incomplete',
+	},
+	CVC: {
+		name: 'Incomplete',
+	},
+};
+
+// --- Field state update helper --- //
+
+function updatedFieldState(update: StripeElementChangeEvent): CardFieldState {
+	if (update.error) {
+		return fieldStateError(update.error.message);
+	}
+	if (update.complete) {
+		return FIELD_STATE_COMPLETE;
+	}
+
+	return FIELD_STATE_INCOMPLETE;
+}
+
+// --- Field state constructors --- //
+
+function fieldStateError(errorMessage: string): CardFieldState {
+	return { name: 'Error', errorMessage };
+}
+const FIELD_STATE_COMPLETE: CardFieldState = { name: 'Complete' };
+
+const FIELD_STATE_INCOMPLETE: CardFieldState = { name: 'Incomplete' };
+
+// --- Field error helpers --- //
+
+function errorMessage(fieldStates: FieldStates): string | undefined {
+	return (
+		errorMessageFromState(fieldStates.CardNumber) ??
+		errorMessageFromState(fieldStates.Expiry) ??
+		errorMessageFromState(fieldStates.CVC) ??
+		incompleteErrorFromState(fieldStates.CardNumber) ??
+		incompleteErrorFromState(fieldStates.Expiry) ??
+		incompleteErrorFromState(fieldStates.CVC)
+	);
+}
+
+function errorMessageFromState(state: CardFieldState): string | undefined {
+	return state.name === 'Error' ? state.errorMessage : undefined;
+}
+
+function incompleteErrorFromState(state: CardFieldState): string | undefined {
+	return state.name === 'Incomplete'
+		? 'Please complete your card details'
+		: undefined;
+}

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/useSelectedField.ts
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/useSelectedField.ts
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import type { CardFieldName } from './fields';
+
+// ---- Types ---- //
+
+interface SelectedField {
+	selectedField?: CardFieldName;
+	selectField: (fieldName: CardFieldName) => () => void;
+	clearSelectedField: () => void;
+}
+
+// ---- Hook ---- //
+
+export function useSelectedField(): SelectedField {
+	const [selectedField, setSelectedField] = useState<CardFieldName | undefined>(
+		undefined,
+	);
+
+	const selectField = (fieldName: CardFieldName) => () => {
+		setSelectedField(fieldName);
+	};
+
+	const clearSelectedField = () => {
+		setSelectedField(undefined);
+	};
+
+	return {
+		selectedField,
+		selectField,
+		clearSelectedField,
+	};
+}


### PR DESCRIPTION
## What are you doing in this PR?

A separate piece of work requires some changes to `StripeCardForm.tsx`. The file is pretty big and has a mix of stripe/redux/rendering logic going on which makes it quite difficult to work on. I'm planning to do a few refactors to chunk the file up a bit and make it easier to work with. This first change factors out a couple of hooks:

- useSelectedField
- useCardFormFieldStates

The `useSelectedField` hook isn't really needed at all. I just quite like the aesthetic of having functions that create callbacks to be passed to click handlers. That is, using:

```ts
onFocus={selectField("CVC")}
```

over:

```ts
onFocus={() => selectField("CVC")}
```

The `useCardFormFieldStates` moves the logic associated with keeping track of the state of each of the form fields out of main component and into this hook.

I don't anticipate either of these will be reused anywhere else, but really just using the hooks as a way to move logic out of the component itself.

