### PR TITLE
More `StripeCardForm.tsx` refactors

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/CreditCardIcons.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/CreditCardIcons.tsx
@@ -1,0 +1,17 @@
+import type { IsoCountry } from 'helpers/internationalisation/country';
+import CreditCardsROW from './creditCardsROW.svg';
+import CreditCardsUS from './creditCardsUS.svg';
+
+interface CreditCardIconsProps {
+	country: IsoCountry;
+}
+
+export function CreditCardIcons({
+	country,
+}: CreditCardIconsProps): JSX.Element {
+	if (country === 'US') {
+		return <CreditCardsUS className="form__credit-card-icons" />;
+	}
+
+	return <CreditCardsROW className="form__credit-card-icons" />;
+}

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx
@@ -141,7 +141,9 @@ function CardForm(props: PropTypes) {
 		}
 	};
 
-	// Creates a new setupIntent upon recaptcha verification
+	// Sets up a callback for when the recaptcha has been verified.
+	// This callback will make a request to the backend to create a
+	// new setupIntent.
 	const setupRecurringRecaptchaCallback = () => {
 		setCalledRecaptchaRender(true);
 
@@ -325,20 +327,19 @@ function CardForm(props: PropTypes) {
 		}
 	}, [props.setupIntentClientSecret]);
 
-	const isZipCodeFieldValid = () =>
-		showZipCodeField ? isValidZipCode(zipCode) : true;
+	const isZipCodeFieldValid = showZipCodeField ? isValidZipCode(zipCode) : true;
+
+	const showZipCodeError =
+		props.checkoutFormHasBeenSubmitted && !isZipCodeFieldValid;
 
 	useEffect(() => {
 		const formIsComplete =
 			fieldStates.CardNumber.name === 'Complete' &&
 			fieldStates.Expiry.name === 'Complete' &&
 			fieldStates.CVC.name === 'Complete' &&
-			isZipCodeFieldValid();
+			isZipCodeFieldValid;
 		props.setStripeCardFormComplete(formIsComplete);
 	}, [fieldStates, zipCode]);
-
-	const showZipCodeError =
-		props.checkoutFormHasBeenSubmitted && !isZipCodeFieldValid();
 
 	const recaptchaVerified =
 		props.contributionType === 'ONE_OFF'

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx
@@ -340,14 +340,6 @@ function CardForm(props: PropTypes) {
 	const showZipCodeError =
 		props.checkoutFormHasBeenSubmitted && !isZipCodeFieldValid();
 
-	const showCards = (country: IsoCountry) => {
-		if (country === 'US') {
-			return <CreditCardsUS className="form__credit-card-icons" />;
-		}
-
-		return <CreditCardsROW className="form__credit-card-icons" />;
-	};
-
 	const recaptchaVerified =
 		props.contributionType === 'ONE_OFF'
 			? props.oneOffRecaptchaToken
@@ -367,7 +359,7 @@ function CardForm(props: PropTypes) {
 				label={
 					<>
 						<label htmlFor="stripeCardNumberElement">Card number</label>
-						{showCards(props.country)}
+						<CreditCardIcons country={props.country} />
 					</>
 				}
 				input={
@@ -496,6 +488,17 @@ function VerificationCopy({
 			{"Please tick to verify you're a human"}{' '}
 		</div>
 	);
+}
+
+interface CreditCardIconsProps {
+	country: IsoCountry;
+}
+function CreditCardIcons({ country }: CreditCardIconsProps) {
+	if (country === 'US') {
+		return <CreditCardsUS className="form__credit-card-icons" />;
+	}
+
+	return <CreditCardsROW className="form__credit-card-icons" />;
 }
 
 // ---- Helper functions ---- //

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/VerificationCopy.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/VerificationCopy.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import type { ContributionType } from 'helpers/contributions';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { trackRecaptchaVerificationWarning } from './helpers/tracking';
+
+interface VerificationCopyProps {
+	countryGroupId: CountryGroupId;
+	contributionType: ContributionType;
+}
+
+export function VerificationCopy({
+	countryGroupId,
+	contributionType,
+}: VerificationCopyProps): JSX.Element {
+	useEffect(() => {
+		trackRecaptchaVerificationWarning(countryGroupId, contributionType);
+	}, []);
+
+	return (
+		<div className="form__error">
+			{' '}
+			{"Please tick to verify you're a human"}{' '}
+		</div>
+	);
+}

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/helpers/dom.ts
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/helpers/dom.ts
@@ -1,0 +1,9 @@
+export function recaptchaElementNotEmpty(): boolean {
+	const el = document.getElementById('robot_checkbox');
+
+	if (el) {
+		return el.children.length > 0;
+	}
+
+	return true;
+}

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/helpers/errors.ts
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/helpers/errors.ts
@@ -1,0 +1,5 @@
+export function noClientSecretError(json: unknown): Error {
+	return new Error(
+		`Missing client_secret field in server response: ${JSON.stringify(json)}`,
+	);
+}

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/helpers/logging.ts
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/helpers/logging.ts
@@ -1,0 +1,13 @@
+import type { StripeError } from '@stripe/stripe-js';
+import { routes } from 'helpers/urls/routes';
+import { logException } from 'helpers/utilities/logger';
+
+export function logCreateSetupIntentError(err: Error): void {
+	logException(
+		`Error getting Setup Intent client_secret from ${routes.stripeSetupIntentRecaptcha}: ${err.message}`,
+	);
+}
+
+export function logCreatePaymentMethodError(errorData: StripeError): void {
+	logException(`Error creating Payment Method: ${JSON.stringify(errorData)}`);
+}

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/helpers/stripe.ts
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/helpers/stripe.ts
@@ -1,0 +1,33 @@
+import { fetchJson, requestOptions } from 'helpers/async/fetch';
+import type { Csrf } from 'helpers/csrf/csrfReducer';
+import { routes } from 'helpers/urls/routes';
+import { noClientSecretError } from './errors';
+import { trackRecaptchaVerified } from './tracking';
+
+export function createStripeSetupIntent(
+	token: string,
+	stripeKey: string,
+	isTestUser: boolean,
+	csrf: Csrf,
+): Promise<string> {
+	return fetchJson(
+		routes.stripeSetupIntentRecaptcha,
+		requestOptions(
+			{
+				token,
+				stripePublicKey: stripeKey,
+				isTestUser: isTestUser,
+			},
+			'same-origin',
+			'POST',
+			csrf,
+		),
+	).then((json) => {
+		if (json.client_secret && typeof json.client_secret === 'string') {
+			trackRecaptchaVerified();
+			return json.client_secret;
+		} else {
+			throw noClientSecretError(json);
+		}
+	});
+}

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/helpers/styles.ts
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/helpers/styles.ts
@@ -1,0 +1,18 @@
+import { css } from '@emotion/react';
+
+export const styles = {
+	stripeField: {
+		base: {
+			fontFamily:
+				"'GuardianTextSans', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif",
+			'::placeholder': {
+				color: '#999999',
+			},
+			fontSize: '17px',
+			lineHeight: '1.5',
+		},
+	},
+	zipCodeContainer: css`
+		margin-top: 0.65rem;
+	`,
+};

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/helpers/tracking.ts
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/helpers/tracking.ts
@@ -1,0 +1,24 @@
+import type { ContributionType } from 'helpers/contributions';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { trackComponentLoad } from 'helpers/tracking/behaviour';
+
+export function trackRecaptchaClientTokenReceived(): void {
+	trackComponentLoad('contributions-recaptcha-client-token-received');
+}
+
+export function trackRecaptchaVerified(): void {
+	trackComponentLoad('contributions-recaptcha-verified');
+}
+
+export function trackStripe3ds(): void {
+	trackComponentLoad('stripe-3ds');
+}
+
+export function trackRecaptchaVerificationWarning(
+	countryGroupId: CountryGroupId,
+	contributionType: ContributionType,
+): void {
+	trackComponentLoad(
+		`recaptchaV2-verification-warning-${countryGroupId}-${contributionType}-loaded`,
+	);
+}


### PR DESCRIPTION
## What are you doing in this PR?

A handful of refactors to the `StripeCardForm.tsx` file consisting of:

- adding comment headers
- deleting/updating old comments
- small formatting tweaks (e.g adding some extra spaces)
- moving things around
- factoring out some helper components
- factoring out some helper functions


I'll dig into the reasoning behind these individually.

### Adding comment headers

This just helps to break the file up at a glance into distinct sections

### Deleting/updating old comments

Some of the old comments were a little misleading so I've updated/deleted them where appropriate to make them more helpful

### Small formatting tweaks 

Mainly just adding some spaces that were lost in the typescript migration

### Moving things around

I've tried to reorgansise the file to have more important things (e.g the component itself) nearer the top and less important things (e.g the styles) nearer the bottom. I've also moved some functions around to collocate them with other related functions (e.g all of the recurring setup functions are together and all of the oneoff setup functions are together).

### Factoring out helper components

We had `renderVerificationCopy` and `showCards` functions that returned `jsx`. I've refactored both of these into proper react components and then moved them to the bottom of the file in the `Helper components` section.

### Factoring out helper functions 

I've tried to factor more of the code out of the component. The biggest one is the `createStripeSetupIntent` function which makes the recurring recaptcha callback setup function inside of the component more manageable.

The other functions I've factored out or a number of tracking, logging, and error helpers.  These aren't super neccessary, but I think they provide just a slightly higher level interface that makes the places in which they're used a little more readable, e.g

```ts
logCreateSetupIntentError(err);
props.paymentFailure('internal_error');
props.setPaymentWaiting(false);
```

vs

```ts
logException(
	`Error getting Setup Intent client_secret from ${routes.stripeSetupIntentRecaptcha}: ${err.message}`,
);
props.paymentFailure('internal_error');
props.setPaymentWaiting(false);
```
