### PR TITLE
Quamtum Metric: sendEvent on subscription conversion

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -19,7 +19,6 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { Quarterly } from 'helpers/productPrice/billingPeriods';
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
-import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import {
 	finalPrice,
 	getCurrency,
@@ -150,8 +149,8 @@ function getGiftRecipient(giftingState: GiftingState) {
 function buildRegularPaymentRequest(
 	state: AnyCheckoutState,
 	paymentAuthorisation: PaymentAuthorisation,
-	price: ProductPrice,
 	addresses: Addresses,
+	promotions?: Promotion[],
 	currencyId?: Option<IsoCurrency>,
 ): RegularPaymentRequest {
 	const { title, firstName, lastName, email, telephone } =
@@ -161,7 +160,7 @@ function buildRegularPaymentRequest(
 	const product = getProduct(state, currencyId);
 	const paymentFields =
 		regularPaymentFieldsFromAuthorisation(paymentAuthorisation);
-	const promoCode = getPromoCode(price.promotions);
+	const promoCode = getPromoCode(promotions);
 	const giftRecipient = getGiftRecipient(state.page.checkoutForm.gifting);
 	return {
 		title,
@@ -207,8 +206,8 @@ function onPaymentAuthorised(
 	const data = buildRegularPaymentRequest(
 		state,
 		paymentAuthorisation,
-		productPrice,
 		addresses,
+		productPrice.promotions,
 		currencyId,
 	);
 

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -156,24 +156,8 @@ function buildRegularPaymentRequest(
 ): RegularPaymentRequest {
 	const { title, firstName, lastName, email, telephone } =
 		state.page.checkoutForm.personalDetails;
-	const {
-		// billingPeriod,
-		// fulfilmentOption,
-		// productOption,
-		// productPrices,
-		deliveryInstructions,
-		csrUsername,
-		salesforceCaseId,
-		debugInfo,
-	} = state.page.checkout;
-	// const addresses = getAddresses(state);
-	// const price = getProductPrice(
-	// 	productPrices,
-	// 	addresses.billingAddress.country,
-	// 	billingPeriod,
-	// 	fulfilmentOption,
-	// 	productOption,
-	// );
+	const { deliveryInstructions, csrUsername, salesforceCaseId, debugInfo } =
+		state.page.checkout;
 	const product = getProduct(state, currencyId);
 	const paymentFields =
 		regularPaymentFieldsFromAuthorisation(paymentAuthorisation);

--- a/support-frontend/assets/helpers/tracking/__tests__/quantumMetricHelpersTest.ts
+++ b/support-frontend/assets/helpers/tracking/__tests__/quantumMetricHelpersTest.ts
@@ -1,5 +1,5 @@
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
-import { getAnnualValue } from '../quantumMetricHelpers';
+import { getSubscriptionAnnualValue } from '../quantumMetricHelpers';
 
 describe('Quantum Metric Helpers', () => {
 	it('should get a monthly subscriptions annual value with a promotion', () => {
@@ -20,7 +20,7 @@ describe('Quantum Metric Helpers', () => {
 		};
 		const billingPeriod = 'Monthly';
 
-		expect(getAnnualValue(productPrice, billingPeriod)).toBe(12588);
+		expect(getSubscriptionAnnualValue(productPrice, billingPeriod)).toBe(12588);
 	});
 	it('should get a monthly subscriptions annual value without a promotion', () => {
 		const productPrice: ProductPrice = {
@@ -30,7 +30,7 @@ describe('Quantum Metric Helpers', () => {
 		};
 		const billingPeriod = 'Monthly';
 
-		expect(getAnnualValue(productPrice, billingPeriod)).toBe(14388);
+		expect(getSubscriptionAnnualValue(productPrice, billingPeriod)).toBe(14388);
 	});
 	it('should get an annual subscriptions annual value with a promotion', () => {
 		const productPrice: ProductPrice = {
@@ -49,7 +49,7 @@ describe('Quantum Metric Helpers', () => {
 			],
 		};
 		const billingPeriod = 'Annual';
-		expect(getAnnualValue(productPrice, billingPeriod)).toBe(9900);
+		expect(getSubscriptionAnnualValue(productPrice, billingPeriod)).toBe(9900);
 	});
 	it('should get an annual subscriptions annual value without a promotion', () => {
 		const productPrice: ProductPrice = {
@@ -58,7 +58,7 @@ describe('Quantum Metric Helpers', () => {
 			fixedTerm: false,
 		};
 		const billingPeriod = 'Annual';
-		expect(getAnnualValue(productPrice, billingPeriod)).toBe(11900);
+		expect(getSubscriptionAnnualValue(productPrice, billingPeriod)).toBe(11900);
 	});
 	it('should get a fixed term subscriptions value', () => {
 		const productPrice: ProductPrice = {
@@ -68,6 +68,6 @@ describe('Quantum Metric Helpers', () => {
 		};
 		const billingPeriod = 'Monthly';
 
-		expect(getAnnualValue(productPrice, billingPeriod)).toBe(3600);
+		expect(getSubscriptionAnnualValue(productPrice, billingPeriod)).toBe(3600);
 	});
 });

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -62,11 +62,8 @@ function sendEventSubscriptionCheckoutEvent(
 	billingPeriod: BillingPeriod,
 	isConversion: boolean,
 ): void {
-	/**
-	 * Check user has granted consent to Quantum Metric
-	 */
-	void getConsent().then((hasConsent) => {
-		if (hasConsent) {
+	void canRunQuantumMetric().then((canRun) => {
+		if (canRun) {
 			const sourceCurrency = productPrice.currency;
 			const value = getAnnualValue(productPrice, billingPeriod);
 
@@ -227,7 +224,12 @@ function addQM() {
 	});
 }
 
-function getConsent(): Promise<boolean> {
+function canRunQuantumMetric(): Promise<boolean> {
+	// resolve immediately with false if the feature switch is OFF
+	if (!isSwitchOn('featureSwitches.enableQuantumMetric')) {
+		return Promise.resolve(false);
+	}
+	// checks users consent status
 	return new Promise((resolve) => {
 		onConsentChange((state) => {
 			if (
@@ -247,12 +249,8 @@ function getConsent(): Promise<boolean> {
 }
 
 export function init(participations: Participations): void {
-	// return immediately if the feature switch is OFF
-	if (!isSwitchOn('featureSwitches.enableQuantumMetric')) {
-		return;
-	}
-	void getConsent().then((hasConsent) => {
-		if (hasConsent) {
+	void canRunQuantumMetric().then((canRun) => {
+		if (canRun) {
 			void addQM().then(() => {
 				/**
 				 * Quantum Metric's script has loaded so we can attempt to

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -7,7 +7,7 @@ import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import type { SubscriptionProduct } from 'helpers/productPrice/subscriptions';
 import { logException } from 'helpers/utilities/logger';
-import { getAnnualValue } from './quantumMetricHelpers';
+import { getSubscriptionAnnualValue } from './quantumMetricHelpers';
 
 type SendEventTestParticipationId = 30;
 
@@ -64,16 +64,14 @@ function sendEventSubscriptionCheckoutEvent(
 ): void {
 	void canRunQuantumMetric().then((canRun) => {
 		if (canRun) {
-			const sourceCurrency = productPrice.currency;
-			const value = getAnnualValue(productPrice, billingPeriod);
-
-			if (!value) {
-				return;
-			}
-
-			const targetCurrency: IsoCurrency = 'GBP';
 			const sendEventWhenReady = () => {
-				if (window.QuantumMetricAPI?.isOn()) {
+				const sourceCurrency = productPrice.currency;
+				const targetCurrency: IsoCurrency = 'GBP';
+				const value = getSubscriptionAnnualValue(productPrice, billingPeriod);
+
+				if (!value) {
+					return;
+				} else if (window.QuantumMetricAPI?.isOn()) {
 					const convertedValue: number =
 						window.QuantumMetricAPI.currencyConvertFromToValue(
 							value,

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -216,7 +216,7 @@ function sendEventABTestParticipations(participations: Participations): void {
 	}
 }
 
-// ---- Initialisation ---- //
+// ---- initialisation logic ---- //
 
 function addQM() {
 	return loadScript(

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -21,7 +21,7 @@ enum SendEventCheckoutStart {
 	GuardianWeeklySubGift = 79,
 }
 
-enum SendEventCheckoutConverion {
+enum SendEventCheckoutConversion {
 	DigiSub = 31,
 	PaperSub = 67,
 	GuardianWeeklySub = 68,
@@ -32,7 +32,7 @@ enum SendEventCheckoutConverion {
 type SendEventId =
 	| SendEventTestParticipationId
 	| SendEventCheckoutStart
-	| SendEventCheckoutConverion;
+	| SendEventCheckoutConversion;
 
 // ---- sendEvent logic ---- //
 
@@ -61,7 +61,7 @@ function waitForQuantumMetricAPi(onReady: () => void) {
 }
 
 function sendEventSubscriptionCheckoutEvent(
-	id: SendEventCheckoutStart | SendEventCheckoutConverion,
+	id: SendEventCheckoutStart | SendEventCheckoutConversion,
 	productPrice: ProductPrice,
 	billingPeriod: BillingPeriod,
 	isConversion: boolean,
@@ -114,34 +114,34 @@ function productToCheckoutEvents(
 			return orderIsAGift
 				? checkoutEvents(
 						SendEventCheckoutStart.DigiSubGift,
-						SendEventCheckoutConverion.DigiSubGift,
+						SendEventCheckoutConversion.DigiSubGift,
 				  )
 				: checkoutEvents(
 						SendEventCheckoutStart.DigiSub,
-						SendEventCheckoutConverion.DigiSub,
+						SendEventCheckoutConversion.DigiSub,
 				  );
 		case 'GuardianWeekly':
 			return orderIsAGift
 				? checkoutEvents(
 						SendEventCheckoutStart.GuardianWeeklySubGift,
-						SendEventCheckoutConverion.GuardianWeeklySubGift,
+						SendEventCheckoutConversion.GuardianWeeklySubGift,
 				  )
 				: checkoutEvents(
 						SendEventCheckoutStart.GuardianWeeklySub,
-						SendEventCheckoutConverion.GuardianWeeklySub,
+						SendEventCheckoutConversion.GuardianWeeklySub,
 				  );
 		case 'Paper':
 		case 'PaperAndDigital':
 			return checkoutEvents(
 				SendEventCheckoutStart.PaperSub,
-				SendEventCheckoutConverion.PaperSub,
+				SendEventCheckoutConversion.PaperSub,
 			);
 	}
 }
 
 function checkoutEvents(
 	start: SendEventCheckoutStart,
-	conversion: SendEventCheckoutConverion,
+	conversion: SendEventCheckoutConversion,
 ) {
 	return { start, conversion };
 }

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -11,7 +11,7 @@ import { getAnnualValue } from './quantumMetricHelpers';
 
 type SendEventTestParticipationId = 30;
 
-export enum SendEventCheckoutStart {
+enum SendEventCheckoutStart {
 	DigiSub = 75,
 	PaperSub = 76,
 	GuardianWeeklySub = 77,
@@ -19,7 +19,7 @@ export enum SendEventCheckoutStart {
 	GuardianWeeklySubGift = 79,
 }
 
-export enum SendEventCheckoutConverion {
+enum SendEventCheckoutConverion {
 	DigiSub = 31,
 	PaperSub = 67,
 	GuardianWeeklySub = 68,

--- a/support-frontend/assets/helpers/tracking/quantumMetricHelpers.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetricHelpers.ts
@@ -1,11 +1,13 @@
+import { onConsentChange } from '@guardian/consent-management-platform';
+import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import { getAppliedPromo } from 'helpers/productPrice/promotions';
 
-export const getSubscriptionAnnualValue = (
+export function getSubscriptionAnnualValue(
 	productPrice: ProductPrice,
 	billingPeriod: BillingPeriod,
-): number | undefined => {
+): number | undefined {
 	const fullPrice = productPrice.price;
 	const promotion = getAppliedPromo(productPrice.promotions);
 
@@ -44,4 +46,42 @@ export const getSubscriptionAnnualValue = (
 		discountInPenceCents * promotion.numberOfDiscountedPeriods;
 
 	return discountedAnnualPrice;
-};
+}
+
+export function waitForQuantumMetricAPi(onReady: () => void): void {
+	let pollCount = 0;
+	const checkForQuantumMetricAPi = setInterval(() => {
+		pollCount = pollCount + 1;
+		if (window.QuantumMetricAPI?.isOn()) {
+			onReady();
+			clearInterval(checkForQuantumMetricAPi);
+		} else if (pollCount === 10) {
+			// give up waiting if QuantumMetricAPI is not ready after 10 attempts
+			clearInterval(checkForQuantumMetricAPi);
+		}
+	}, 500);
+}
+
+export function canRunQuantumMetric(): Promise<boolean> {
+	// resolve immediately with false if the feature switch is OFF
+	if (!isSwitchOn('featureSwitches.enableQuantumMetric')) {
+		return Promise.resolve(false);
+	}
+	// checks users consent status
+	return new Promise((resolve) => {
+		onConsentChange((state) => {
+			if (
+				state.ccpa?.doNotSell === false || // check whether US users have NOT withdrawn consent
+				state.aus?.personalisedAdvertising || // check whether AUS users have consented to personalisedAdvertising
+				(state.tcfv2?.consents && // check TCFv2 purposes for non-US/AUS users
+					state.tcfv2.consents['1'] && // Store and/or access information on a device
+					state.tcfv2.consents['8'] && // Measure content performance
+					state.tcfv2.consents['10']) // Develop and improve products
+			) {
+				resolve(true);
+			} else {
+				resolve(false);
+			}
+		});
+	});
+}

--- a/support-frontend/assets/helpers/tracking/quantumMetricHelpers.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetricHelpers.ts
@@ -2,7 +2,7 @@ import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import { getAppliedPromo } from 'helpers/productPrice/promotions';
 
-export const getAnnualValue = (
+export const getSubscriptionAnnualValue = (
 	productPrice: ProductPrice,
 	billingPeriod: BillingPeriod,
 ): number | undefined => {

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.tsx
@@ -51,10 +51,7 @@ import {
 	trackSubmitAttempt,
 } from 'helpers/subscriptionsForms/submit';
 import { firstError } from 'helpers/subscriptionsForms/validation';
-import {
-	SendEventCheckoutStart,
-	sendEventSubscriptionCheckoutStart,
-} from 'helpers/tracking/quantumMetric';
+import { sendEventSubscriptionCheckoutStart } from 'helpers/tracking/quantumMetric';
 import { routes } from 'helpers/urls/routes';
 import { signOut } from 'helpers/user/user';
 import EndSummaryMobile from 'pages/digital-subscription-checkout/components/endSummary/endSummaryMobile';
@@ -81,6 +78,7 @@ function mapStateToProps(state: SubscriptionsState) {
 		billingPeriod: state.page.checkout.billingPeriod as DigitalBillingPeriod,
 		addressErrors: state.page.billingAddress.fields.formErrors,
 		participations: state.common.abParticipations,
+		product: state.page.checkout.product,
 	};
 }
 
@@ -137,7 +135,8 @@ function DigitalCheckoutForm(props: PropTypes) {
 
 	useEffect(() => {
 		sendEventSubscriptionCheckoutStart(
-			SendEventCheckoutStart.DigiSub,
+			props.product,
+			false,
 			productPrice,
 			props.billingPeriod,
 		);

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.tsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.tsx
@@ -49,10 +49,7 @@ import {
 } from 'helpers/subscriptionsForms/submit';
 import type { CheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import { firstError } from 'helpers/subscriptionsForms/validation';
-import {
-	SendEventCheckoutStart,
-	sendEventSubscriptionCheckoutStart,
-} from 'helpers/tracking/quantumMetric';
+import { sendEventSubscriptionCheckoutStart } from 'helpers/tracking/quantumMetric';
 import { routes } from 'helpers/urls/routes';
 import { signOut } from 'helpers/user/user';
 import { withError } from 'hocs/withError';
@@ -131,7 +128,8 @@ function DigitalCheckoutFormGift(props: PropTypes): JSX.Element {
 
 	useEffect(() => {
 		sendEventSubscriptionCheckoutStart(
-			SendEventCheckoutStart.DigiSubGift,
+			props.product,
+			true,
 			productPrice,
 			props.billingPeriod,
 		);

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -76,10 +76,7 @@ import type {
 } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import { firstError } from 'helpers/subscriptionsForms/validation';
 import type { FormError } from 'helpers/subscriptionsForms/validation';
-import {
-	SendEventCheckoutStart,
-	sendEventSubscriptionCheckoutStart,
-} from 'helpers/tracking/quantumMetric';
+import { sendEventSubscriptionCheckoutStart } from 'helpers/tracking/quantumMetric';
 import { paperSubsUrl } from 'helpers/urls/routes';
 import { getQueryParameter } from 'helpers/urls/url';
 import { titles } from 'helpers/user/details';
@@ -280,7 +277,8 @@ function PaperCheckoutForm(props: PropTypes) {
 		);
 
 		sendEventSubscriptionCheckoutStart(
-			SendEventCheckoutStart.PaperSub,
+			props.product,
+			false,
 			props.amount,
 			props.billingPeriod,
 		);

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -63,10 +63,7 @@ import {
 } from 'helpers/subscriptionsForms/submit';
 import type { WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import { firstError } from 'helpers/subscriptionsForms/validation';
-import {
-	SendEventCheckoutStart,
-	sendEventSubscriptionCheckoutStart,
-} from 'helpers/tracking/quantumMetric';
+import { sendEventSubscriptionCheckoutStart } from 'helpers/tracking/quantumMetric';
 import { routes } from 'helpers/urls/routes';
 import { titles } from 'helpers/user/details';
 import { signOut } from 'helpers/user/user';
@@ -177,7 +174,8 @@ function WeeklyCheckoutForm(props: PropTypes) {
 
 	useEffect(() => {
 		sendEventSubscriptionCheckoutStart(
-			SendEventCheckoutStart.GuardianWeeklySub,
+			props.product,
+			false,
 			price,
 			props.billingPeriod,
 		);

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
@@ -60,10 +60,7 @@ import {
 } from 'helpers/subscriptionsForms/submit';
 import type { WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import { firstError } from 'helpers/subscriptionsForms/validation';
-import {
-	SendEventCheckoutStart,
-	sendEventSubscriptionCheckoutStart,
-} from 'helpers/tracking/quantumMetric';
+import { sendEventSubscriptionCheckoutStart } from 'helpers/tracking/quantumMetric';
 import { routes } from 'helpers/urls/routes';
 import { titles } from 'helpers/user/details';
 import { signOut } from 'helpers/user/user';
@@ -174,7 +171,8 @@ function WeeklyCheckoutFormGifting(props: PropTypes): JSX.Element {
 
 	useEffect(() => {
 		sendEventSubscriptionCheckoutStart(
-			SendEventCheckoutStart.GuardianWeeklySubGift,
+			props.product,
+			true,
 			price,
 			props.billingPeriod,
 		);


### PR DESCRIPTION
## What are you doing in this PR?

This PR implements a `sendEvent` call for Subscription checkout Conversions. To do this I've created a new export `sendEventSubscriptionCheckoutConversion` from `quantumMetric.ts`, there was a lot of repeated logic between this and `sendEventSubscriptionCheckoutStart` so I pulled out the common code between these two functions into a new  function`sendEventSubscriptionCheckoutEvent` that is internal to `quantumMetric.ts`.

[**Trello Card**](https://trello.com/c/juhvvBXC/491-quantum-metric-implement-sendevent-call-for-subscription-conversion)