### PR TITLE
Fail CreatePaymentMethod for bad runs

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
@@ -28,6 +28,7 @@ object ErrorHandler {
 
   def toRetryException(throwable: Throwable): RetryException =
     throwable match {
+      case e: RetryException => e
       case e: StripeError => fromStripeError(e)
       case e: PayPalError => e.asRetryException
       case e: ZuoraErrorResponse => e.asRetryException

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -60,7 +60,11 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
         case state: ContributionState =>
           zuoraContributionHandler.subscribe(state)
         case state: PaperState =>
-          zuoraPaperHandler.subscribe(state, zuoraSubscriptionState.csrUsername, zuoraSubscriptionState.salesforceCaseId)
+          zuoraPaperHandler.subscribe(
+            state,
+            zuoraSubscriptionState.csrUsername,
+            zuoraSubscriptionState.salesforceCaseId,
+          )
         case state: GuardianWeeklyState =>
           zuoraGuardianWeeklyHandler.subscribe(
             state,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -7,16 +7,21 @@ import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.config.TouchPointEnvironments
 import com.gu.support.redemption.corporate._
 import com.gu.support.workers._
+import com.gu.support.workers.exceptions.RetryNone
 import com.gu.support.workers.states.CreateZuoraSubscriptionProductState._
 import com.gu.support.workers.states.{CreateZuoraSubscriptionState, SendAcquisitionEventState}
 import com.gu.zuora.ZuoraSubscriptionCreator
 import com.gu.zuora.productHandlers._
 import com.gu.zuora.subscriptionBuilders._
 
+import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvider)
     extends ServicesHandler[CreateZuoraSubscriptionState, SendAcquisitionEventState](servicesProvider) {
+
+  val badName: Option[String] = System.getenv.asScala.get("BAD_NAME")
 
   def this() = this(ServiceProvider)
 
@@ -27,49 +32,54 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
       services: Services,
   ): FutureHandlerResult = {
 
-    val zuoraProductHandlers = new ZuoraProductHandlers(services, zuoraSubscriptionState)
-    import zuoraProductHandlers._
+    if (badName.contains(zuoraSubscriptionState.user.lastName)) {
+      Future.failed(new RetryNone("Failing because it's a bad request"))
+    } else {
 
-    val eventualSendThankYouEmailState = zuoraSubscriptionState.productSpecificState match {
-      case state: DigitalSubscriptionGiftRedemptionState =>
-        zuoraDigitalSubscriptionGiftRedemptionHandler.redeemGift(state)
-      case state: DigitalSubscriptionDirectPurchaseState =>
-        zuoraDigitalSubscriptionDirectHandler.subscribe(
-          state,
-          zuoraSubscriptionState.csrUsername,
-          zuoraSubscriptionState.salesforceCaseId,
-          zuoraSubscriptionState.acquisitionData,
-        )
-      case state: DigitalSubscriptionGiftPurchaseState =>
-        zuoraDigitalSubscriptionGiftPurchaseHandler.subscribe(
-          state,
-          zuoraSubscriptionState.csrUsername,
-          zuoraSubscriptionState.salesforceCaseId,
-        )
-      case state: DigitalSubscriptionCorporateRedemptionState =>
-        zuoraDigitalSubscriptionCorporateRedemptionHandler.subscribe(state)
-      case state: ContributionState =>
-        zuoraContributionHandler.subscribe(state)
-      case state: PaperState =>
-        zuoraPaperHandler.subscribe(state, zuoraSubscriptionState.csrUsername, zuoraSubscriptionState.salesforceCaseId)
-      case state: GuardianWeeklyState =>
-        zuoraGuardianWeeklyHandler.subscribe(
-          state,
-          zuoraSubscriptionState.csrUsername,
-          zuoraSubscriptionState.salesforceCaseId,
-        )
-    }
+      val zuoraProductHandlers = new ZuoraProductHandlers(services, zuoraSubscriptionState)
+      import zuoraProductHandlers._
 
-    eventualSendThankYouEmailState.map { nextState =>
-      HandlerResult(
-        SendAcquisitionEventState(
-          requestId = zuoraSubscriptionState.requestId,
-          analyticsInfo = zuoraSubscriptionState.analyticsInfo,
-          sendThankYouEmailState = nextState,
-          acquisitionData = zuoraSubscriptionState.acquisitionData,
-        ),
-        requestInfo,
-      )
+      val eventualSendThankYouEmailState = zuoraSubscriptionState.productSpecificState match {
+        case state: DigitalSubscriptionGiftRedemptionState =>
+          zuoraDigitalSubscriptionGiftRedemptionHandler.redeemGift(state)
+        case state: DigitalSubscriptionDirectPurchaseState =>
+          zuoraDigitalSubscriptionDirectHandler.subscribe(
+            state,
+            zuoraSubscriptionState.csrUsername,
+            zuoraSubscriptionState.salesforceCaseId,
+            zuoraSubscriptionState.acquisitionData,
+          )
+        case state: DigitalSubscriptionGiftPurchaseState =>
+          zuoraDigitalSubscriptionGiftPurchaseHandler.subscribe(
+            state,
+            zuoraSubscriptionState.csrUsername,
+            zuoraSubscriptionState.salesforceCaseId,
+          )
+        case state: DigitalSubscriptionCorporateRedemptionState =>
+          zuoraDigitalSubscriptionCorporateRedemptionHandler.subscribe(state)
+        case state: ContributionState =>
+          zuoraContributionHandler.subscribe(state)
+        case state: PaperState =>
+          zuoraPaperHandler.subscribe(state, zuoraSubscriptionState.csrUsername, zuoraSubscriptionState.salesforceCaseId)
+        case state: GuardianWeeklyState =>
+          zuoraGuardianWeeklyHandler.subscribe(
+            state,
+            zuoraSubscriptionState.csrUsername,
+            zuoraSubscriptionState.salesforceCaseId,
+          )
+      }
+
+      eventualSendThankYouEmailState.map { nextState =>
+        HandlerResult(
+          SendAcquisitionEventState(
+            requestId = zuoraSubscriptionState.requestId,
+            analyticsInfo = zuoraSubscriptionState.analyticsInfo,
+            sendThankYouEmailState = nextState,
+            acquisitionData = zuoraSubscriptionState.acquisitionData,
+          ),
+          requestInfo,
+        )
+      }
     }
 
   }


### PR DESCRIPTION
We have some bad support-workers runs which we need to fail immediately, as they're currently retrying and hitting zuora.
This PR changes it to look for an environment variable, and if it exists and the `lastName` in the request matches then it fails.