### PR TITLE
Remove AmazonPay objects from redux store

### DIFF
--- a/support-frontend/assets/helpers/forms/paymentIntegrations/amazonPay/types.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/amazonPay/types.ts
@@ -70,14 +70,9 @@ export interface AmazonPaymentsObject {
 		Consent: ConsentConstructor;
 	};
 }
-export interface AmazonPayLibrary {
-	amazonLoginObject: AmazonLoginObject | null;
-	amazonPaymentsObject: AmazonPaymentsObject | null;
-}
 
 export interface AmazonPayData {
 	hasBegunLoading: boolean; // to avoid loading the sdk more than once
-	amazonPayLibrary: AmazonPayLibrary; // sdk objects
 	walletIsStale: boolean; // for re-rendering the wallet widget when an error needs to be displayed
 	hasAccessToken: boolean; // set when user logs in
 	paymentSelected: boolean; // indicates if user has selected a payment method from their wallet

--- a/support-frontend/assets/pages/contributions-landing/components/AmazonPay/AmazonPayCheckout.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/AmazonPay/AmazonPayCheckout.tsx
@@ -1,0 +1,38 @@
+import type { ContributionType } from 'helpers/contributions';
+import type {
+	AmazonLoginObject,
+	AmazonPayData,
+	AmazonPaymentsObject,
+} from 'helpers/forms/paymentIntegrations/amazonPay/types';
+import AmazonPayLoginButton from './AmazonPayLoginButton';
+import AmazonPayWallet from './AmazonPayWallet';
+
+interface AmazonPayProps {
+	loginObject?: AmazonLoginObject;
+	paymentsObject?: AmazonPaymentsObject;
+	amazonPayData: AmazonPayData;
+	isTestUser: boolean;
+	contributionType: ContributionType;
+}
+
+export function AmazonPayCheckout({
+	loginObject,
+	paymentsObject,
+	amazonPayData,
+	isTestUser,
+	contributionType,
+}: AmazonPayProps): JSX.Element {
+	return amazonPayData.hasAccessToken ? (
+		<AmazonPayWallet
+			amazonLoginObject={loginObject}
+			amazonPaymentsObject={paymentsObject}
+			isTestUser={isTestUser}
+			contributionType={contributionType}
+		/>
+	) : (
+		<AmazonPayLoginButton
+			amazonLoginObject={loginObject}
+			amazonPaymentsObject={paymentsObject}
+		/>
+	);
+}

--- a/support-frontend/assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.tsx
@@ -5,7 +5,7 @@ import Button from 'components/button/button';
 import AnimatedDots from 'components/spinners/animatedDots';
 import type {
 	AmazonLoginObject,
-	AmazonPayData,
+	AmazonPaymentsObject,
 } from 'helpers/forms/paymentIntegrations/amazonPay/types';
 import {
 	trackComponentClick,
@@ -14,16 +14,14 @@ import {
 import { logException } from 'helpers/utilities/logger';
 import { setAmazonPayHasAccessToken } from 'pages/contributions-landing/contributionsLandingActions';
 import type { Action } from 'pages/contributions-landing/contributionsLandingActions';
-import type { State } from 'pages/contributions-landing/contributionsLandingReducer';
 
 type PropTypes = {
-	amazonPayData: AmazonPayData;
+	amazonLoginObject?: AmazonLoginObject;
+	amazonPaymentsObject?: AmazonPaymentsObject;
 	setAmazonPayHasAccessToken: () => Action;
 };
 
-const mapStateToProps = (state: State) => ({
-	amazonPayData: state.page.form.amazonPayData,
-});
+const mapStateToProps = () => ({});
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
 	setAmazonPayHasAccessToken: () => dispatch(setAmazonPayHasAccessToken),
@@ -46,17 +44,14 @@ class AmazonPayLoginButtonComponent extends Component<PropTypes> {
 	};
 
 	render() {
-		const { amazonLoginObject, amazonPaymentsObject } =
-			this.props.amazonPayData.amazonPayLibrary;
-
-		if (amazonLoginObject && amazonPaymentsObject) {
+		if (this.props.amazonLoginObject && this.props.amazonPaymentsObject) {
 			trackComponentLoad('amazon-pay-login-loaded');
 			return (
 				<div>
 					<div id="AmazonLoginButton" />
 					<Button
 						type="button"
-						onClick={this.loginPopup(amazonLoginObject)}
+						onClick={this.loginPopup(this.props.amazonLoginObject)}
 						aria-label="Submit contribution"
 					>
 						Proceed with Amazon Pay

--- a/support-frontend/assets/pages/contributions-landing/components/AmazonPay/AmazonPayWallet.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/AmazonPay/AmazonPayWallet.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import type { ThunkDispatch } from 'redux-thunk';
 import type { ContributionType } from 'helpers/contributions';
 import type {
+	AmazonLoginObject,
 	AmazonPayData,
 	AmazonPaymentsObject,
 	BaseWalletConfig,
@@ -24,6 +25,8 @@ import './AmazonPay.scss';
 
 type PropTypes = {
 	amazonPayData: AmazonPayData;
+	amazonLoginObject?: AmazonLoginObject;
+	amazonPaymentsObject?: AmazonPaymentsObject;
 	setAmazonPayWalletIsStale: (isStale: boolean) => void;
 	setAmazonPayOrderReferenceId: (referenceId: string) => void;
 	setAmazonPayPaymentSelected: (paymentSelected: boolean) => void;
@@ -145,37 +148,29 @@ function AmazonPayWalletComponent(props: PropTypes) {
 	};
 
 	useEffect(() => {
-		const { amazonPaymentsObject } = props.amazonPayData.amazonPayLibrary;
-
-		if (amazonPaymentsObject) {
-			createWalletWidget(amazonPaymentsObject);
+		if (props.amazonPaymentsObject) {
+			createWalletWidget(props.amazonPaymentsObject);
 		}
-	}, [
-		props.amazonPayData.amazonPayLibrary.amazonPaymentsObject,
-		props.amazonPayData.walletIsStale,
-	]);
-	useEffect(() => {
-		const { amazonPaymentsObject } = props.amazonPayData.amazonPayLibrary;
+	}, [props.amazonPaymentsObject, props.amazonPayData.walletIsStale]);
 
+	useEffect(() => {
 		if (
-			amazonPaymentsObject &&
+			props.amazonPaymentsObject &&
 			props.amazonPayData.amazonBillingAgreementId &&
 			props.contributionType !== 'ONE_OFF'
 		) {
 			createConsentWidget(
-				amazonPaymentsObject,
+				props.amazonPaymentsObject,
 				props.amazonPayData.amazonBillingAgreementId,
 			);
 		}
 	}, [
-		props.amazonPayData.amazonPayLibrary.amazonPaymentsObject,
+		props.amazonPaymentsObject,
 		props.amazonPayData.amazonBillingAgreementId,
 		props.contributionType,
 	]);
-	const { amazonLoginObject, amazonPaymentsObject } =
-		props.amazonPayData.amazonPayLibrary;
 
-	if (amazonLoginObject && amazonPaymentsObject) {
+	if (props.amazonLoginObject && props.amazonPaymentsObject) {
 		trackComponentLoad('amazon-pay-wallet-loaded');
 		return (
 			<div>

--- a/support-frontend/assets/pages/contributions-landing/components/AmazonPay/useAmazonPayObjects.ts
+++ b/support-frontend/assets/pages/contributions-landing/components/AmazonPay/useAmazonPayObjects.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'preact/hooks';
+import { useState } from 'react';
+import { setupAmazonPay } from 'helpers/forms/paymentIntegrations/amazonPay/setup';
+import type {
+	AmazonLoginObject,
+	AmazonPaymentsObject,
+} from 'helpers/forms/paymentIntegrations/amazonPay/types';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+
+interface AmazonPayObjects {
+	loginObject?: AmazonLoginObject;
+	paymentsObject?: AmazonPaymentsObject;
+}
+
+export function useAmazonPayObjects(
+	hasSelectedAmazonPay: boolean,
+	countryGroupId: CountryGroupId,
+	isTestUser: boolean,
+): AmazonPayObjects {
+	const [loginObject, setLoginObject] = useState<
+		AmazonLoginObject | undefined
+	>();
+
+	const [paymentsObject, setPaymentsObject] = useState<
+		AmazonPaymentsObject | undefined
+	>();
+
+	useEffect(() => {
+		const hasLoaded = loginObject !== undefined || paymentsObject !== undefined;
+
+		if (hasSelectedAmazonPay && !hasLoaded)
+			setupAmazonPay(
+				countryGroupId,
+				setLoginObject,
+				setPaymentsObject,
+				isTestUser,
+			);
+	}, [hasSelectedAmazonPay]);
+
+	return { loginObject, paymentsObject };
+}

--- a/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.tsx
@@ -45,7 +45,6 @@ import { getReauthenticateUrl } from 'helpers/urls/externalLinks';
 import { classNameWithModifiers } from 'helpers/utilities/utilities';
 import type { Action } from '../contributionsLandingActions';
 import {
-	loadAmazonPaySdk,
 	loadPayPalExpressSdk,
 	updatePaymentMethod,
 	updateSelectedExistingPaymentMethod,
@@ -72,10 +71,6 @@ interface PaymentMethodSelectorProps {
 	payPalHasBegunLoading: boolean;
 	amazonPayHasBegunLoading: boolean;
 	loadPayPalExpressSdk: (contributionType: ContributionType) => void;
-	loadAmazonPaySdk: (
-		countryGroupId: CountryGroupId,
-		isTestUser: boolean,
-	) => void;
 	checkoutFormHasBeenSubmitted: boolean;
 }
 
@@ -99,7 +94,6 @@ const mapDispatchToProps = {
 	updatePaymentMethod,
 	updateSelectedExistingPaymentMethod,
 	loadPayPalExpressSdk,
-	loadAmazonPaySdk,
 };
 
 function PaymentMethodSelector(props: PaymentMethodSelectorProps) {
@@ -119,13 +113,6 @@ function PaymentMethodSelector(props: PaymentMethodSelectorProps) {
 			case PayPal:
 				if (!props.payPalHasBegunLoading) {
 					props.loadPayPalExpressSdk(props.contributionType);
-				}
-
-				break;
-
-			case AmazonPay:
-				if (!props.amazonPayHasBegunLoading) {
-					props.loadAmazonPaySdk(props.countryGroupId, props.isTestUser);
 				}
 
 				break;

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.ts
@@ -14,11 +14,6 @@ import { getAmount, logInvalidCombination } from 'helpers/contributions';
 import type { ThirdPartyPaymentLibrary } from 'helpers/forms/checkouts';
 import type { ErrorReason } from 'helpers/forms/errorReasons';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
-import { setupAmazonPay } from 'helpers/forms/paymentIntegrations/amazonPay/setup';
-import type {
-	AmazonLoginObject,
-	AmazonPaymentsObject,
-} from 'helpers/forms/paymentIntegrations/amazonPay/types';
 import type {
 	AmazonPayData,
 	CreatePaypalPaymentData,
@@ -70,7 +65,6 @@ import {
 	findIsoCountry,
 	stateProvinceFromString,
 } from 'helpers/internationalisation/country';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { Annual, Monthly } from 'helpers/productPrice/billingPeriods';
 import {
 	setEmail,
@@ -139,14 +133,6 @@ export type Action =
 	  }
 	| {
 			type: 'SET_AMAZON_PAY_HAS_BEGUN_LOADING';
-	  }
-	| {
-			type: 'SET_AMAZON_PAY_LOGIN_OBJECT';
-			amazonLoginObject: AmazonLoginObject;
-	  }
-	| {
-			type: 'SET_AMAZON_PAY_PAYMENTS_OBJECT';
-			amazonPaymentsObject: AmazonPaymentsObject;
 	  }
 	| {
 			type: 'SET_AMAZON_PAY_WALLET_IS_STALE';
@@ -423,20 +409,6 @@ const setAmazonPayHasBegunLoading = (): Action => ({
 	type: 'SET_AMAZON_PAY_HAS_BEGUN_LOADING',
 });
 
-const setAmazonPayLoginObject = (
-	amazonLoginObject: AmazonLoginObject,
-): Action => ({
-	type: 'SET_AMAZON_PAY_LOGIN_OBJECT',
-	amazonLoginObject,
-});
-
-const setAmazonPayPaymentsObject = (
-	amazonPaymentsObject: AmazonPaymentsObject,
-): Action => ({
-	type: 'SET_AMAZON_PAY_PAYMENTS_OBJECT',
-	amazonPaymentsObject,
-});
-
 const setAmazonPayWalletIsStale = (isStale: boolean): Action => ({
 	type: 'SET_AMAZON_PAY_WALLET_IS_STALE',
 	isStale,
@@ -493,13 +465,6 @@ const loadPayPalExpressSdk =
 			dispatch(setPayPalHasBegunLoading());
 			void loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));
 		}
-	};
-
-const loadAmazonPaySdk =
-	(countryGroupId: CountryGroupId, isTestUser: boolean) =>
-	(dispatch: Dispatch): void => {
-		dispatch(setAmazonPayHasBegunLoading());
-		setupAmazonPay(countryGroupId, dispatch, isTestUser);
 	};
 
 const updateContributionTypeAndPaymentMethod =
@@ -1111,8 +1076,6 @@ export {
 	updateBillingCountry,
 	updateUserFormData,
 	setAmazonPayHasBegunLoading,
-	setAmazonPayLoginObject,
-	setAmazonPayPaymentsObject,
 	setAmazonPayWalletIsStale,
 	setAmazonPayHasAccessToken,
 	setAmazonPayFatalError,
@@ -1143,7 +1106,6 @@ export {
 	updatePayPalButtonReady,
 	updateRecaptchaToken,
 	loadPayPalExpressSdk,
-	loadAmazonPaySdk,
 	setSepaIban,
 	setSepaAccountHolderName,
 	setSepaAddressStreetName,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.ts
@@ -19,7 +19,7 @@ import {
 } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import type { ExistingPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
-import { AmazonPay, PayPal } from 'helpers/forms/paymentMethods';
+import { PayPal } from 'helpers/forms/paymentMethods';
 import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import type { Switches } from 'helpers/globalsAndSwitches/settings';
 import type { IsoCountry } from 'helpers/internationalisation/country';
@@ -40,7 +40,6 @@ import { doesUserAppearToBeSignedIn } from 'helpers/user/user';
 import { loadRecaptchaV2 } from '../../helpers/forms/recaptcha';
 import {
 	getUserType,
-	loadAmazonPaySdk,
 	loadPayPalExpressSdk,
 	selectAmounts,
 	setUserTypeFromIdentityResponse,
@@ -248,12 +247,6 @@ function selectInitialContributionTypeAndPaymentMethod(
 	switch (paymentMethod) {
 		case PayPal:
 			dispatch(loadPayPalExpressSdk(contributionType));
-			break;
-
-		case AmazonPay:
-			dispatch(
-				loadAmazonPaySdk(countryGroupId, state.page.user.isTestUser ?? false),
-			);
 			break;
 
 		default:

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.ts
@@ -137,10 +137,6 @@ function createFormReducer() {
 		},
 		amazonPayData: {
 			hasBegunLoading: false,
-			amazonPayLibrary: {
-				amazonLoginObject: null,
-				amazonPaymentsObject: null,
-			},
 			walletIsStale: false,
 			orderReferenceId: null,
 			paymentSelected: false,
@@ -249,30 +245,6 @@ function createFormReducer() {
 				return {
 					...state,
 					amazonPayData: { ...state.amazonPayData, hasBegunLoading: true },
-				};
-
-			case 'SET_AMAZON_PAY_LOGIN_OBJECT':
-				return {
-					...state,
-					amazonPayData: {
-						...state.amazonPayData,
-						amazonPayLibrary: {
-							...state.amazonPayData.amazonPayLibrary,
-							amazonLoginObject: action.amazonLoginObject,
-						},
-					},
-				};
-
-			case 'SET_AMAZON_PAY_PAYMENTS_OBJECT':
-				return {
-					...state,
-					amazonPayData: {
-						...state.amazonPayData,
-						amazonPayLibrary: {
-							...state.amazonPayData.amazonPayLibrary,
-							amazonPaymentsObject: action.amazonPaymentsObject,
-						},
-					},
 				};
 
 			case 'SET_AMAZON_PAY_WALLET_IS_STALE':


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This change removes the `AmazonLoginObject` and `AmazonPaymentsObject` from the redux store, and moves them to component state. We're removing them as they contain non-serialisable state.

To do this, I've created a `useAmazonPayObjects` hook that is responsible for initialising the AmazonPay sdk and storing the objects in state. I initially used this inside of the new `AmazonPayCheckout` component that I factored out of the `ContributionsSubmit` component. However, that gets mounted/unmounted as the user changes payment method which makes it a little awkward as we only want to initialise the sdk once. Instead, I lifted the `useAmazonPayObjects` hook into the parent `ContributionsSubmit` component as that is always rendered. This makes the `AmazonPayCheckout` component less useful, but I think it's still nice to have as it removes some logic from the `ContributionsSubmit` component.


[**Trello Card**](https://trello.com/c/YMpJALyM/507-%F0%9F%9B%A0-redux-toolkit-migration-remove-amazonpay-objects-from-contributions-state-%F0%9F%9B%A0)