### PR TITLE
Updated GW images

### DIFF
--- a/support-frontend/assets/helpers/images/imageCatalogue.json
+++ b/support-frontend/assets/helpers/images/imageCatalogue.json
@@ -5,8 +5,8 @@
   "benefitsPackshotBulletsMobUKUS": "8ad46bcc6d2558dab35c7e1388290ccf251a21de/0_0_333_493",
   "benefitsPackshotParaMobAndDesktopUK": "6faea782717c5a1058fcfc3afff5cde3fa36cf25/0_0_603_363",
   "benefitsPackshotParaMobAndDesktopUS": "48c291a960dc4ac7060ba65e3e43d722661e7dd4/0_0_604_363",
-  "checkoutPackshotWeekly": "4e5a4983a03a87a1efcbe6fd0d97e51a4d12f2ee/0_0_1358_954",
-  "checkoutPackshotWeeklyGifting": "8fee537ee7e4a6862a50a7d8767222d645ae82e6/0_0_696_400",
+  "checkoutPackshotWeekly": "c8dd569a0d811e1a9d222c7fd92b22853aac3dc4/0_0_1358_954",
+  "checkoutPackshotWeeklyGifting": "71b26671bfc98a3165c4bbb28b705821d231a046/0_0_696_400",
   "comparisonTableAdFree": "be60312ad456d5fd2ddbb775ba9fe85d7d0d0bbe/0_0_1480_488",
   "comparisonTableCrosswordsDesktop": "6a0c815c0409c9dce804d2e40882aa67df4644f7/0_0_1106_694",
   "comparisonTableCrosswordsMob": "169f65026305d2e89b4eb61be429387d7b883dd6/0_0_244_250",
@@ -57,7 +57,7 @@
   "showcaseUSTrump": "30512603929dd3bd4d493738dc8338e36e710619/1103_0_3010_3009",
   "subscriptionDailyMobile": "9b650a7dcc33e30d228ddec7bd27a0594b4ece41/0_0_568_1174",
   "subscriptionDailyPackshot": "773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084",
-  "subscriptionGuardianWeeklyPackShot": "4e5a4983a03a87a1efcbe6fd0d97e51a4d12f2ee/0_0_1358_954",
+  "subscriptionGuardianWeeklyPackShot": "c8dd569a0d811e1a9d222c7fd92b22853aac3dc4/0_0_1358_954",
   "subscriptionIpad": "c2843d4ec6bc7644c62c8691b6c7e83e76c93e0e/0_0_1302_998",
   "subscriptionIphone": "8850945f0003d2a7204050644db446d827dead95/0_0_578_1096",
   "subscriptionPrint": "/81d6bda5f74a84b952e7162d553ae71499c0c7ed/0_9_540_324",
@@ -65,7 +65,7 @@
   "weekendPackshotDesktop": "dc1bb7218877d954a5841b24765e89f7c3aa6f95/0_0_1800_1080",
   "weekendPackshotMobile": "622d1b94173e9c711ff421d89cf9abddf3319197/0_0_1100_1100",
   "weeklyCampaignBenefitsImg": "340db3a4561cbd502dc59b764ab8d93433511103/0_255_1972_1183",
-  "weeklyCampaignHeroImg": "689fd4bc86cfc3816bd8c107fbed791d0385284f/0_0_1552_1176",
+  "weeklyCampaignHeroImg": "6d6779094c71ddba2dcfdfeb1b44aa46bce76a8b/0_0_1552_1176",
   "weeklyLandingHero": "87e6e2d907b9de594c73239bae0b49f2f811173c/738_0_6362_3008",
   "woleSoyinka": "7a24fd9a5293314cf0ed51445443220c30d88d4d/0_0_2667_1600"
 }


### PR DESCRIPTION
## What are you doing in this PR?

This PR update the packshot images for Guardian Weekly.

## Screenshots
There are 3 image sizes, used in 5 pages.

**1358x954**
| /subscribe | /subscribe/weekly/checkout |
| -- | -- |
| ![Screenshot 2022-06-17 at 11 24 22](https://user-images.githubusercontent.com/99180049/174294059-515743ac-b9b5-4098-ac1e-bee5b42967c3.png) | ![Screenshot 2022-06-17 at 11 25 08](https://user-images.githubusercontent.com/99180049/174294128-72634b9d-08d6-4d94-93a6-7bbf2daa3fa8.png) |

**1552x1176**
| /subscribe/weekly | /subscribe/weekly/gift |
| -- | -- |
| ![Screenshot 2022-06-17 at 11 23 24](https://user-images.githubusercontent.com/99180049/174294448-c19fa982-1b37-4a1c-8e25-390b002a2729.png) | ![Screenshot 2022-06-17 at 11 23 53](https://user-images.githubusercontent.com/99180049/174294480-f4db703d-f25d-4dbb-a157-14360ed34c65.png) |

**696x400**
| /subscribe/weekly/checkout/gift |
| -- |
| ![Screenshot 2022-06-17 at 11 25 42](https://user-images.githubusercontent.com/99180049/174294520-01bc998d-1c99-4384-8d76-896e69d071d3.png) |
