### PR TITLE
Remove third party payment lib from contribs state

### DIFF
--- a/support-frontend/assets/helpers/contributions.ts
+++ b/support-frontend/assets/helpers/contributions.ts
@@ -1,5 +1,4 @@
 // ----- Imports ----- //
-import type { ThirdPartyPaymentLibrary } from 'helpers/forms/checkouts';
 import type {
 	PaymentMethod,
 	PaymentMethodMap,
@@ -41,19 +40,6 @@ export const logInvalidCombination = (
 	logException(
 		`Invalid combination of contribution type ${contributionType} and payment method ${paymentMethod}`,
 	);
-};
-
-// Legacy type, only used by stripe checkout. Can be cleaned up after stripe checkout fully removed
-export type ThirdPartyPaymentLibraries = {
-	ONE_OFF: {
-		Stripe: ThirdPartyPaymentLibrary | null;
-	};
-	MONTHLY: {
-		Stripe: ThirdPartyPaymentLibrary | null;
-	};
-	ANNUAL: {
-		Stripe: ThirdPartyPaymentLibrary | null;
-	};
 };
 
 export type AmountSelection = {

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -48,11 +48,6 @@ export type PaymentMethodSwitch =
 	| 'existingCard'
 	| 'existingDirectDebit'
 	| 'amazonPay';
-type StripeHandler = {
-	open: (...args: unknown[]) => unknown;
-	close: (...args: unknown[]) => unknown;
-};
-export type ThirdPartyPaymentLibrary = StripeHandler;
 
 // ----- Functions ----- //
 function toPaymentMethodSwitchNaming(

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.tsx
@@ -17,7 +17,6 @@ import type {
 	OtherAmounts,
 	PaymentMatrix,
 	SelectedAmounts,
-	ThirdPartyPaymentLibraries,
 } from 'helpers/contributions';
 import type { ErrorReason } from 'helpers/forms/errorReasons';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
@@ -80,7 +79,6 @@ type PropTypes = {
 	otherAmounts: OtherAmounts;
 	paymentMethod: PaymentMethod;
 	existingPaymentMethod?: RecentlySignedInExistingPaymentMethod;
-	thirdPartyPaymentLibraries: ThirdPartyPaymentLibraries;
 	contributionType: ContributionType;
 	currency: IsoCurrency;
 	paymentError: ErrorReason | null;
@@ -143,7 +141,6 @@ const mapStateToProps = (state: State) => ({
 	otherAmounts: state.page.form.formData.otherAmounts,
 	paymentMethod: state.page.form.paymentMethod,
 	existingPaymentMethod: state.page.form.existingPaymentMethod,
-	thirdPartyPaymentLibraries: state.page.form.thirdPartyPaymentLibraries,
 	stripeClientSecret:
 		state.page.form.stripeCardFormData.setupIntentClientSecret,
 	contributionType: state.page.form.contributionType,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.ts
@@ -11,7 +11,6 @@ import type {
 	SelectedAmounts,
 } from 'helpers/contributions';
 import { getAmount, logInvalidCombination } from 'helpers/contributions';
-import type { ThirdPartyPaymentLibrary } from 'helpers/forms/checkouts';
 import type { ErrorReason } from 'helpers/forms/errorReasons';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import type {
@@ -123,13 +122,6 @@ export type Action =
 	| {
 			type: 'UPDATE_USER_FORM_DATA';
 			userFormData: UserFormData;
-	  }
-	| {
-			type: 'UPDATE_PAYMENT_READY';
-			thirdPartyPaymentLibraryByContrib: Record<
-				ContributionType,
-				Record<PaymentMethod, ThirdPartyPaymentLibrary>
-			>;
 	  }
 	| {
 			type: 'SET_AMAZON_PAY_HAS_BEGUN_LOADING';

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.ts
@@ -8,7 +8,6 @@ import type {
 	ContributionType,
 	OtherAmounts,
 	SelectedAmounts,
-	ThirdPartyPaymentLibraries,
 } from 'helpers/contributions';
 import { getContributionTypeFromSession } from 'helpers/forms/checkouts';
 import type { ErrorReason } from 'helpers/forms/errorReasons';
@@ -76,8 +75,6 @@ interface FormState {
 	contributionType: ContributionType;
 	paymentMethod: PaymentMethod;
 	existingPaymentMethod?: RecentlySignedInExistingPaymentMethod;
-	thirdPartyPaymentLibraries: ThirdPartyPaymentLibraries;
-	// TODO clean up when rest of Stripe Checkout is removed
 	amazonPayData: AmazonPayData;
 	payPalData: PayPalData;
 	selectedAmounts: SelectedAmounts;
@@ -124,17 +121,6 @@ function createFormReducer() {
 	const initialState: FormState = {
 		contributionType: getContributionTypeFromSession() ?? 'MONTHLY',
 		paymentMethod: 'None',
-		thirdPartyPaymentLibraries: {
-			ONE_OFF: {
-				Stripe: null,
-			},
-			MONTHLY: {
-				Stripe: null,
-			},
-			ANNUAL: {
-				Stripe: null,
-			},
-		},
 		amazonPayData: {
 			hasBegunLoading: false,
 			walletIsStale: false,
@@ -220,25 +206,6 @@ function createFormReducer() {
 				return {
 					...state,
 					existingPaymentMethod: action.existingPaymentMethod,
-				};
-
-			case 'UPDATE_PAYMENT_READY':
-				return {
-					...state,
-					thirdPartyPaymentLibraries: {
-						ONE_OFF: {
-							...state.thirdPartyPaymentLibraries.ONE_OFF,
-							...action.thirdPartyPaymentLibraryByContrib.ONE_OFF,
-						},
-						MONTHLY: {
-							...state.thirdPartyPaymentLibraries.MONTHLY,
-							...action.thirdPartyPaymentLibraryByContrib.MONTHLY,
-						},
-						ANNUAL: {
-							...state.thirdPartyPaymentLibraries.ANNUAL,
-							...action.thirdPartyPaymentLibraryByContrib.ANNUAL,
-						},
-					},
 				};
 
 			case 'SET_AMAZON_PAY_HAS_BEGUN_LOADING':


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This is the last bit of state that is non-serialisable. It's legacy state that isn't used anywhere (this means it was always just `null`).

[**Trello Card**](https://trello.com/c/YMpJALyM/507-%F0%9F%9B%A0-redux-toolkit-migration-remove-amazonpay-objects-from-contributions-state-%F0%9F%9B%A0)
