### PR TITLE
add temp hackday redirect for getting bwid cookie into CODE env

### DIFF
--- a/support-frontend/app/controllers/DiagnosticsController.scala
+++ b/support-frontend/app/controllers/DiagnosticsController.scala
@@ -6,7 +6,7 @@ import Results.Ok
 
 class DiagnosticsController(
     actionRefiners: CustomActionBuilders,
-) {
+) extends Results {
 
   val relevantCookies = List(
     "gu_user_features_expiry",
@@ -40,6 +40,19 @@ class DiagnosticsController(
             " = " + cookie.value
         }.toList
     Ok(humanReadableCookies.mkString("\n\n"))
+  }
+
+  // temp redirect so that we can use the PROD bwid in the CODE env - remove after hackdays June 2022
+  def hackday(): Action[AnyContent] = NoCacheAction() { implicit request =>
+    request.cookies.get("bwid").map(_.value) match {
+      case Some(bwid) =>
+        Redirect(
+          url = "https://support.code.dev-theguardian.com/propensity",
+          queryStringParams = Map("bwid" -> Seq(bwid)),
+        )
+      case None => Ok("You don't have a bwid cookie, so we can't check your history")
+    }
+
   }
 
 }

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -3,6 +3,7 @@
 GET /healthcheck                                                   controllers.Application.healthcheck()
 GET /error500                                                      lib.ErrorController.error500()
 GET /cookies                                                       controllers.DiagnosticsController.cookies()
+GET /hackday                                                       controllers.DiagnosticsController.hackday()
 
 # ----- Unsupported Browsers ----- #
 


### PR DESCRIPTION
## What does it do?

This PR adds a temporary hack to get the bwid into CODE env for the hack days.
This is because we want to let people see what product we would recommend to them based on their actual browsing history and the propensity model.  However the main code is hacky so won't go to PROD.  See https://github.com/guardian/support-frontend/pull/3943

This PR needs to be reverted after the hack day as it won't be useful.

## Some notes on PII for review!

The browser id is PII so we need to make sure it is taken care of.  The CODE env is entirely behind https so encrypted in transit, same as PROD.
The cookie value is sent as a URL param instead of a cookie, which is slightly more likely to be copy pasted somewhere by mistake and shared.
The bwid -> product mappings will be stored in dynamodb, which is encrypted at rest and in transit.  The data will be stored behind AWS auth and only accessible via the one endpoint (which will only be deployed to CODE for the demo.
No other data relating to the browser id will be available at any point.