### PR TITLE
DO not merge: add propensity based page for recommending a product

### DIFF
--- a/support-frontend/app/controllers/SubscriptionsController.scala
+++ b/support-frontend/app/controllers/SubscriptionsController.scala
@@ -24,16 +24,16 @@ import views.ViewHelpers.outputJson
 import scala.concurrent.{ExecutionContext, Future}
 
 class SubscriptionsController(
-  val actionRefiners: CustomActionBuilders,
-  priceSummaryServiceProvider: PriceSummaryServiceProvider,
-  val assets: AssetsResolver,
-  components: ControllerComponents,
-  stringsConfig: StringsConfig,
-  settingsProvider: AllSettingsProvider,
-  val supportUrl: String,
-  propensityDynamoTable: DynamoTableAsync,
+    val actionRefiners: CustomActionBuilders,
+    priceSummaryServiceProvider: PriceSummaryServiceProvider,
+    val assets: AssetsResolver,
+    components: ControllerComponents,
+    stringsConfig: StringsConfig,
+    settingsProvider: AllSettingsProvider,
+    val supportUrl: String,
+    propensityDynamoTable: DynamoTableAsync,
 )(implicit val ec: ExecutionContext)
-  extends AbstractController(components)
+    extends AbstractController(components)
     with GeoRedirect
     with CanonicalLinks
     with SettingsSurrogateKeySyntax {
@@ -126,12 +126,13 @@ class SubscriptionsController(
       recommendedProduct <- OptionT.fromOption[Future](productDyamoValue match {
         case DynamoLookup.DynamoString(string) => Some(string)
         case _ => None
-      }
-      )
+      })
     } yield recommendedProduct
-    val jsLine = maybeProductToSuggest.map { product =>
-      s"""window.guardian.propensityProduct = "$product""""
-    }.getOrElse("// no propensityProduct")
+    val jsLine = maybeProductToSuggest
+      .map { product =>
+        s"""window.guardian.propensityProduct = "$product""""
+      }
+      .getOrElse("// no propensityProduct")
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = "Support the Guardian | Get a Subscription"
     val mainElement = EmptyDiv("subscriptions-landing-page")
@@ -150,7 +151,7 @@ class SubscriptionsController(
             s"""<script type="text/javascript">
               window.guardian.pricingCopy = ${outputJson(pricingCopy)}
               $jsLine
-            </script>"""
+            </script>""",
           )
         },
       ).withSettingsSurrogateKey

--- a/support-frontend/app/services/PropensityTable.scala
+++ b/support-frontend/app/services/PropensityTable.scala
@@ -1,0 +1,17 @@
+package services
+
+import com.gu.support.redemption.corporate.DynamoTableAsync
+
+import scala.concurrent.ExecutionContext
+
+object PropensityTable {
+  val primaryKey = "bwid"
+
+  object ProductField {
+    val name = "product"
+  }
+
+  def async()(implicit e: ExecutionContext): DynamoTableAsync =
+    DynamoTableAsync(s"hack-jun2022-propensity-products", primaryKey)
+
+}

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -58,6 +58,7 @@ trait Controllers {
     stringsConfig,
     allSettingsProvider,
     appConfig.supportUrl,
+    propensityDynamoTable,
   )
 
   lazy val redemptionController = new RedemptionController(

--- a/support-frontend/app/wiring/Services.scala
+++ b/support-frontend/app/wiring/Services.scala
@@ -8,7 +8,7 @@ import com.gu.support.config.TouchPointEnvironments
 import com.gu.support.getaddressio.GetAddressIOService
 import services.pricing.{DefaultPromotionServiceS3, PriceSummaryServiceProvider}
 import com.gu.support.promotions.PromotionServiceProvider
-import com.gu.support.redemption.corporate.{DynamoTableAsyncProvider, RedemptionTable}
+import com.gu.support.redemption.corporate.{DynamoTableAsync, DynamoTableAsyncProvider, RedemptionTable}
 import com.gu.zuora.ZuoraGiftLookupServiceProvider
 import play.api.BuiltInComponentsFromContext
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -65,6 +65,8 @@ trait Services {
   val dynamoTableAsyncProvider: DynamoTableAsyncProvider = { isTestUser =>
     RedemptionTable.forEnvAsync(TouchPointEnvironments.fromStage(appConfig.stage, isTestUser))
   }
+
+  val propensityDynamoTable: DynamoTableAsync = PropensityTable.async()
 
   lazy val zuoraGiftLookupServiceProvider: ZuoraGiftLookupServiceProvider =
     new ZuoraGiftLookupServiceProvider(appConfig.zuoraConfigProvider, appConfig.stage)

--- a/support-frontend/assets/pages/subscriptions-landing/components/propensityHeader.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/propensityHeader.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { classNameWithModifiers } from '../../../helpers/utilities/utilities';
+
+function PropensityHeader(): JSX.Element {
+	const [open, setOpen] = useState<boolean>(false);
+	return (
+		<div className="subscriptions__feature">
+			<div className="subscriptions__feature-container">
+				<h2 className="subscriptions__feature-text">
+					Based on your browsing history we recommend this product for you
+				</h2>
+				<button onClick={() => setOpen(!open)}>
+					{open ? 'Close' : 'Learn More'}
+				</button>
+				<div
+					className={classNameWithModifiers('learn-more', [
+						open ? 'open' : null,
+					])}
+				>
+					To improve your buying experience, we recommend the product we think
+					you are most likely to enjoy. We do this by comparing your reading
+					behaviour with the expected behaviour of existing subscribers. To see
+					a full list of products, please visit our main{' '}
+					<a href={'/uk/subscribe'}>Subscriptions Page</a>
+					To understand and control how we use your data, see our
+					<a href={'https://www.theguardian.com/help/privacy-policy'}>
+						Privacy Policy
+					</a>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export default PropensityHeader;

--- a/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsLandingContent.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsLandingContent.tsx
@@ -2,6 +2,7 @@
 import { getSubscriptionCopy } from '../copy/subscriptionCopy';
 import type { SubscriptionsLandingPropTypes } from '../subscriptionsLandingProps';
 import FeatureHeader from './featureHeader';
+import PropensityHeader from './propensityHeader';
 import SubscriptionsProduct from './subscriptionsProduct';
 
 const isFeature = (index: number) => index === 0; // make the first card a feature
@@ -10,6 +11,7 @@ function SubscriptionsLandingContent({
 	countryGroupId,
 	pricingCopy,
 	participations,
+	propensityProduct,
 }: SubscriptionsLandingPropTypes): JSX.Element | null {
 	if (!pricingCopy) {
 		return null;
@@ -19,13 +21,14 @@ function SubscriptionsLandingContent({
 		countryGroupId,
 		pricingCopy,
 		participations,
+		propensityProduct,
 	);
 	return (
 		<div
 			className="subscriptions-landing-page"
 			id="qa-subscriptions-landing-page"
 		>
-			<FeatureHeader />
+			{propensityProduct ? <PropensityHeader /> : <FeatureHeader />}
 			<div className="subscriptions__product-container">
 				{subscriptionCopy.map((product, index) => (
 					<SubscriptionsProduct

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
@@ -98,6 +98,37 @@ const getDigitalImage = (isTop: boolean, countryGroupId: CountryGroupId) => {
 	return <DigitalPackshot countryGroupId={countryGroupId} />;
 };
 
+const recurring = (): ProductCopy => ({
+	title: 'Recurring Contribution',
+	subtitle: 'From £2 per month',
+	description:
+		'Make a regular contribution from just £2 per month, or choose annual if you prefer.',
+	productImage: '',
+	offer: undefined,
+	buttons: [
+		{
+			ctaButtonText: 'Make a recurring contribution',
+			link: '/uk/contribute?selected-contribution-type=MONTHLY', //ONE_OFF
+			analyticsTracking: () => undefined,
+		},
+	],
+});
+
+const single = (): ProductCopy => ({
+	title: 'Single Contribution',
+	subtitle: 'From £1',
+	description: 'Make a contribution today.',
+	productImage: '',
+	offer: undefined,
+	buttons: [
+		{
+			ctaButtonText: 'Make a contribution',
+			link: '/uk/contribute?selected-contribution-type=ONE_OFF',
+			analyticsTracking: () => undefined,
+		},
+	],
+});
+
 const digital = (
 	countryGroupId: CountryGroupId,
 	priceCopy: PriceCopy,
@@ -249,20 +280,64 @@ const getSubscriptionCopy = (
 	countryGroupId: CountryGroupId,
 	pricingCopy: PricingCopy,
 	participations: Participations,
+	propensityProduct: string | null | undefined,
 ): ProductCopy[] => {
 	if (countryGroupId === GBPCountries) {
-		return [
-			guardianWeekly(
-				countryGroupId,
-				pricingCopy[GuardianWeekly],
-				true,
-				participations,
-			),
-			digital(countryGroupId, pricingCopy[DigitalPack], false),
-			paper(countryGroupId, pricingCopy[Paper], false), // Removing the link to the old paper+digital page during the June 21 Sale
-			// paperAndDigital(countryGroupId, state.common.referrerAcquisitionData, state.common.abParticipations),
-			premiumApp(countryGroupId),
-		];
+		if (propensityProduct) {
+			let firstProduct;
+			switch (propensityProduct) {
+				case 'Digital Subscription':
+					firstProduct = digital(
+						countryGroupId,
+						pricingCopy[DigitalPack],
+						false,
+					);
+					break;
+				case 'Premium App':
+					firstProduct = premiumApp(countryGroupId);
+					break;
+				case 'Single Contribution':
+					firstProduct = single();
+					break;
+				case 'Recurring Contribution':
+					firstProduct = recurring();
+					break;
+				case 'Guardian Weekly - Subscription':
+					firstProduct = guardianWeekly(
+						countryGroupId,
+						pricingCopy[GuardianWeekly],
+						true,
+						participations,
+					);
+					break;
+				case 'Newspaper - Subscription':
+					firstProduct = paper(countryGroupId, pricingCopy[Paper], false);
+					break;
+				// Patron and DS Gift ignored?
+				default:
+					firstProduct = guardianWeekly(
+						countryGroupId,
+						pricingCopy[GuardianWeekly],
+						true,
+						participations,
+					);
+			}
+
+			return [firstProduct];
+		} else {
+			return [
+				guardianWeekly(
+					countryGroupId,
+					pricingCopy[GuardianWeekly],
+					true,
+					participations,
+				),
+				digital(countryGroupId, pricingCopy[DigitalPack], false),
+				paper(countryGroupId, pricingCopy[Paper], false), // Removing the link to the old paper+digital page during the June 21 Sale
+				// paperAndDigital(countryGroupId, state.common.referrerAcquisitionData, state.common.abParticipations),
+				premiumApp(countryGroupId),
+			];
+		}
 	} else if (
 		[EURCountries, AUDCountries, NZDCountries].includes(countryGroupId)
 	) {

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
@@ -91,6 +91,17 @@
 	}
 }
 
+.learn-more {
+	display: none;
+	border: darkgray solid thin;
+	background-color: lightgray;
+	margin: 1em;
+}
+
+.learn-more--open {
+	display: block;
+}
+
 /****************** subscriptions product-container ********************/
 
 .subscriptions__product-container {

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
@@ -23,6 +23,7 @@ function SubscriptionsLandingPage({
 	countryGroupId,
 	participations,
 	pricingCopy,
+	propensityProduct,
 	referrerAcquisitions,
 }: SubscriptionsLandingPropTypes) {
 	const Header = headerWithCountrySwitcherContainer({
@@ -44,6 +45,7 @@ function SubscriptionsLandingPage({
 				countryGroupId={countryGroupId}
 				participations={participations}
 				pricingCopy={pricingCopy}
+				propensityProduct={propensityProduct}
 				referrerAcquisitions={referrerAcquisitions}
 			/>
 		</Page>

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLandingProps.ts
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLandingProps.ts
@@ -18,6 +18,7 @@ export type SubscriptionsLandingPropTypes = {
 	countryGroupId: CountryGroupId;
 	participations: Participations;
 	pricingCopy: PricingCopy | null | undefined;
+	propensityProduct: string | null | undefined;
 	referrerAcquisitions: ReferrerAcquisitionData;
 };
 const countryGroupId = detectCountryGroup();
@@ -25,5 +26,6 @@ export const subscriptionsLandingProps = (): SubscriptionsLandingPropTypes => ({
 	countryGroupId,
 	participations: initAbTests(detectCountry(), countryGroupId, getSettings()),
 	pricingCopy: getGlobal('pricingCopy'),
+	propensityProduct: getGlobal('propensityProduct'),
 	referrerAcquisitions: getReferrerAcquisitionData(),
 });

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -88,6 +88,7 @@ POST /identity/signin-url                                          controllers.I
 
 GET  /subscribe                                                    controllers.SubscriptionsController.geoRedirect()
 GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe                  controllers.SubscriptionsController.landing(country: String)
+GET  /propensity                 controllers.SubscriptionsController.propensity(bwid: Option[String])
 
 # This is just a fallback in case someone accidentally uses an unsupported country-specific
 # subscribe route. We just redirect to the subscriptions site and let its geolocation handle it.

--- a/support-frontend/scripts/loadPropensityToDynamo.sc
+++ b/support-frontend/scripts/loadPropensityToDynamo.sc
@@ -1,0 +1,105 @@
+#!/usr/bin/env amm
+
+/**
+ * This script is to load a file exported from data science containing browserid -> product mappings
+ * into DynamoDB.  This is a costly operation (order of 3 dollars) for 2 million rows, so ideally we would not
+ * do that too frequently.
+ */
+
+import $ivy.`software.amazon.awssdk:dynamodb:2.17.214`
+import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, BatchWriteItemRequest, PutRequest, WriteRequest}
+
+import java.io.{BufferedWriter, File, FileWriter}
+import scala.jdk.CollectionConverters._
+import scala.io.Source
+import scala.util.{Failure, Success, Try}
+
+val filename = "/Users/john_duffell/Downloads/bwidToProduct.csv"
+val suffix = "_FAILED"
+val batchSize = 1 // max 25
+
+private def getRawLinesForFile(name: String) = {
+  val source = Source.fromFile(name)
+  val lines = Try(source.getLines().toList)
+  source.close()
+  lines.get
+}
+
+private def writeLinesToFile(name: String, lines: List[String]) = {
+  val file = new File(name)
+  val bw = new BufferedWriter(new FileWriter(file))
+  bw.write(lines.mkString("\n"))
+  bw.close()
+}
+
+@main
+def loadFileToDynamo(): Unit = {
+  val header :: data = getRawLinesForFile(filename)
+  if (header != "bwid,product") {
+    println("CSV file must have headings bwid,product")
+  } else {
+    val bwidProductList = data.map { rowString =>
+      val bwid :: product :: _ = rowString.split(",").toList
+      (bwid, product)
+    }
+
+    val batches = bwidProductList.grouped(batchSize).toList
+    val unwritten = batches.flatMap(writeBatch)
+    if (unwritten.isEmpty) {
+      println("all batches written successfully")
+    } else {
+      println(unwritten.size + " batches not written, writing to a file")
+      val fileLines = "bwid,product" :: unwritten.map { case (bwid, product) => bwid + "," + product }
+      writeLinesToFile(filename + suffix, fileLines)
+    }
+
+  }
+}
+
+lazy val client = {
+  import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider
+  import software.amazon.awssdk.regions.Region
+  import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+  val credentialsProvider = ProfileCredentialsProvider.create("membership")
+  val region = Region.EU_WEST_1
+  val ddb = DynamoDbClient.builder.region(region).credentialsProvider(credentialsProvider).build
+
+  ddb
+}
+
+private def writeBatch(batch: List[(String, String)]) = {
+  println("writing batch "+ batch.size + " items")
+  val itemsToWrite = batch.map { case (bwid, product) =>
+    WriteRequest.builder()
+    .putRequest(
+      PutRequest.builder()
+        .item(
+          Map(
+            "bwid" -> AttributeValue.builder().s(bwid).build(),
+            "product" -> AttributeValue.builder().s(product).build(),
+          ).asJava
+        )
+        .build()
+    ).build()
+  }
+  val request = BatchWriteItemRequest.builder()
+    .requestItems(Map("hack-jun2022-propensity-products" -> itemsToWrite.asJava).asJava)
+    .build()
+
+  Try(client.batchWriteItem(request)) match {
+    case Success(response) =>
+      if (!response.unprocessedItems().isEmpty) {
+        println("whoops - unprocessed items were present!")
+      }
+      println(response)
+      val unprocessedItems = response.unprocessedItems().asScala.toMap.values.headOption.map(_.asScala.toList).getOrElse(List.empty)
+      unprocessedItems.map { writeRequest =>
+        val items = writeRequest.putRequest().item().asScala.toMap
+        (items("bwid").s(), items("product").s())
+      }
+    case Failure(t) =>
+      println("failed with error: " + t.toString)
+      t.printStackTrace()
+      batch
+  }
+}


### PR DESCRIPTION
This is the hack day project.  It adds an endpoint to show the product we would recommend based on your browser id and the propensity model generated by data science.

It will be deployed to CODE for the presentations and shortly afterwards, and then removed afterwards.