### PR TITLE
Use global default promo for Digisub

### DIFF
--- a/support-frontend/assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts
+++ b/support-frontend/assets/helpers/productPrice/__tests__/priceDescriptionsDigitalTests.ts
@@ -40,9 +40,9 @@ const productPriceAnnualWithDiscount: ProductPrice = {
 	fixedTerm: false,
 	promotions: [
 		{
-			name: 'Introductory Promotion UK',
+			name: 'Introductory Promotion Global',
 			description: '16% off for the first year',
-			promoCode: 'ANNUAL-INTRO-UK',
+			promoCode: 'ANNUAL-INTRO-GLOBAL',
 			discountedPrice: 99,
 			numberOfDiscountedPeriods: 1,
 			discount: {

--- a/support-frontend/assets/helpers/tracking/__tests__/quantumMetricHelpersTest.ts
+++ b/support-frontend/assets/helpers/tracking/__tests__/quantumMetricHelpersTest.ts
@@ -39,9 +39,9 @@ describe('Quantum Metric Helpers', () => {
 			fixedTerm: false,
 			promotions: [
 				{
-					name: 'Introductory Promotion UK',
+					name: 'Introductory Promotion Global',
 					description: '16% off for the first year',
-					promoCode: 'ANNUAL-INTRO-UK',
+					promoCode: 'ANNUAL-INTRO-GLOBAL',
 					discountedPrice: 99,
 					numberOfDiscountedPeriods: 1,
 					discount: { amount: 16.81, durationMonths: 12 },

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/__fixtures__/productPrices.ts
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/__fixtures__/productPrices.ts
@@ -11,9 +11,9 @@ export const productPrices: ProductPrices = {
 						fixedTerm: false,
 						promotions: [
 							{
-								name: 'Introductory Promotion UK',
+								name: 'Introductory Promotion Global',
 								description: 'Save over 20% against monthly in the first year',
-								promoCode: 'ANNUAL-INTRO-UK',
+								promoCode: 'ANNUAL-INTRO-GLOBAL',
 								discountedPrice: 99,
 								numberOfDiscountedPeriods: 1,
 								discount: {

--- a/support-models/src/main/scala/com/gu/support/promotions/DefaultPromotions.scala
+++ b/support-models/src/main/scala/com/gu/support/promotions/DefaultPromotions.scala
@@ -10,12 +10,7 @@ object DefaultPromotions {
 
     object Annual {
       def all = List(
-        "ANNUAL-INTRO-EU",
-        "ANNUAL-INTRO-UK",
-        "ANNUAL-INTRO-US",
-        "ANNUAL-INTRO-NZ",
-        "ANNUAL-INTRO-CA",
-        "ANNUAL-INTRO-AU",
+        "ANNUAL-INTRO-GLOBAL",
       )
     }
     def all: List[PromoCode] = Monthly.all ++ Annual.all


### PR DESCRIPTION
the offers are all the same, so a single promo works.
Currently on the checkout page if a user changes their country then it loses the offer

### Before - offer is lost when switching to US:
![Screen Shot 2022-06-22 at 09 36 25](https://user-images.githubusercontent.com/1513454/174983810-d7a2f99c-f071-402e-a20b-f39bf63c8261.png)

### After - offer is retained when switching to US:
![Screen Shot 2022-06-22 at 09 36 52](https://user-images.githubusercontent.com/1513454/174983820-f4642494-605b-4552-8580-de81d1226312.png)
