### PR TITLE
Quantum Metric: sendEvent on contribution amount updates

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -19,6 +19,7 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { Quarterly } from 'helpers/productPrice/billingPeriods';
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
+import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import {
 	finalPrice,
 	getCurrency,

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -19,7 +19,6 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { Quarterly } from 'helpers/productPrice/billingPeriods';
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
-import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import {
 	finalPrice,
 	getCurrency,

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -56,17 +56,6 @@ function sendEventSubscriptionCheckoutEvent(
 ): void {
 	void canRunQuantumMetric().then((canRun) => {
 		if (canRun) {
-<<<<<<< HEAD
-=======
-			const sourceCurrency = productPrice.currency;
-			const value = getAnnualValue(productPrice, billingPeriod);
-
-			if (!value) {
-				return;
-			}
-
-			const targetCurrency: IsoCurrency = 'GBP';
->>>>>>> b396f876d (check feature switch on sendEvent)
 			const sendEventWhenReady = () => {
 				const sourceCurrency = productPrice.currency;
 				const targetCurrency: IsoCurrency = 'GBP';
@@ -231,33 +220,6 @@ function addQM() {
 	});
 }
 
-<<<<<<< HEAD
-=======
-function canRunQuantumMetric(): Promise<boolean> {
-	// resolve immediately with false if the feature switch is OFF
-	if (!isSwitchOn('featureSwitches.enableQuantumMetric')) {
-		return Promise.resolve(false);
-	}
-	// checks users consent status
-	return new Promise((resolve) => {
-		onConsentChange((state) => {
-			if (
-				state.ccpa?.doNotSell === false || // check whether US users have NOT withdrawn consent
-				state.aus?.personalisedAdvertising || // check whether AUS users have consented to personalisedAdvertising
-				(state.tcfv2?.consents && // check TCFv2 purposes for non-US/AUS users
-					state.tcfv2.consents['1'] && // Store and/or access information on a device
-					state.tcfv2.consents['8'] && // Measure content performance
-					state.tcfv2.consents['10']) // Develop and improve products
-			) {
-				resolve(true);
-			} else {
-				resolve(false);
-			}
-		});
-	});
-}
-
->>>>>>> b396f876d (check feature switch on sendEvent)
 export function init(participations: Participations): void {
 	void canRunQuantumMetric().then((canRun) => {
 		if (canRun) {

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -32,7 +32,7 @@ enum SendEventCheckoutConversion {
 	GuardianWeeklySubGift = 70,
 }
 
-enum SendEventContributionAmountToggle {
+enum SendEventContributionAmountUpdate {
 	SingleContribution = 71,
 	RecurringContribution = 72,
 }
@@ -41,7 +41,7 @@ type SendEventId =
 	| SendEventTestParticipationId
 	| SendEventCheckoutStart
 	| SendEventCheckoutConversion
-	| SendEventContributionAmountToggle;
+	| SendEventContributionAmountUpdate;
 
 // ---- sendEvent logic ---- //
 
@@ -193,8 +193,8 @@ export function sendEventContributionAmountUpdated(
 				if (window.QuantumMetricAPI?.isOn()) {
 					const sendEventId =
 						contributionType === 'ONE_OFF'
-							? SendEventContributionAmountToggle.SingleContribution
-							: SendEventContributionAmountToggle.RecurringContribution;
+							? SendEventContributionAmountUpdate.SingleContribution
+							: SendEventContributionAmountUpdate.RecurringContribution;
 					const valueInPence =
 						contributionType === 'ONE_OFF' || contributionType === 'ANNUAL'
 							? amount * 100

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -43,6 +43,8 @@ type SendEventId =
 	| SendEventCheckoutConversion
 	| SendEventContributionAmountToggle;
 
+// ---- sendEvent logic ---- //
+
 function sendEvent(
 	id: SendEventId,
 	isConversion: boolean,

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -56,6 +56,17 @@ function sendEventSubscriptionCheckoutEvent(
 ): void {
 	void canRunQuantumMetric().then((canRun) => {
 		if (canRun) {
+<<<<<<< HEAD
+=======
+			const sourceCurrency = productPrice.currency;
+			const value = getAnnualValue(productPrice, billingPeriod);
+
+			if (!value) {
+				return;
+			}
+
+			const targetCurrency: IsoCurrency = 'GBP';
+>>>>>>> b396f876d (check feature switch on sendEvent)
 			const sendEventWhenReady = () => {
 				const sourceCurrency = productPrice.currency;
 				const targetCurrency: IsoCurrency = 'GBP';
@@ -220,6 +231,33 @@ function addQM() {
 	});
 }
 
+<<<<<<< HEAD
+=======
+function canRunQuantumMetric(): Promise<boolean> {
+	// resolve immediately with false if the feature switch is OFF
+	if (!isSwitchOn('featureSwitches.enableQuantumMetric')) {
+		return Promise.resolve(false);
+	}
+	// checks users consent status
+	return new Promise((resolve) => {
+		onConsentChange((state) => {
+			if (
+				state.ccpa?.doNotSell === false || // check whether US users have NOT withdrawn consent
+				state.aus?.personalisedAdvertising || // check whether AUS users have consented to personalisedAdvertising
+				(state.tcfv2?.consents && // check TCFv2 purposes for non-US/AUS users
+					state.tcfv2.consents['1'] && // Store and/or access information on a device
+					state.tcfv2.consents['8'] && // Measure content performance
+					state.tcfv2.consents['10']) // Develop and improve products
+			) {
+				resolve(true);
+			} else {
+				resolve(false);
+			}
+		});
+	});
+}
+
+>>>>>>> b396f876d (check feature switch on sendEvent)
 export function init(participations: Participations): void {
 	void canRunQuantumMetric().then((canRun) => {
 		if (canRun) {

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -15,7 +15,7 @@ import {
 
 type SendEventTestParticipationId = 30;
 
-export enum SendEventCheckoutStart {
+enum SendEventCheckoutStart {
 	DigiSub = 75,
 	PaperSub = 76,
 	GuardianWeeklySub = 77,

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -50,7 +50,6 @@ function sendEvent(
 	isConversion: boolean,
 	value: string,
 ): void {
-	console.log('sendEvent --->', id, isConversion, value);
 	if (window.QuantumMetricAPI?.isOn()) {
 		window.QuantumMetricAPI.sendEvent(id, isConversion ? 1 : 0, value);
 	}

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -15,7 +15,7 @@ import {
 
 type SendEventTestParticipationId = 30;
 
-enum SendEventCheckoutStart {
+export enum SendEventCheckoutStart {
 	DigiSub = 75,
 	PaperSub = 76,
 	GuardianWeeklySub = 77,

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -178,7 +178,7 @@ export function sendEventSubscriptionCheckoutConversion(
 	}
 }
 
-export function sendEventContributionAmountToggled(
+export function sendEventContributionAmountUpdated(
 	amount: number | 'other',
 	contributionType: ContributionType,
 	sourceCurrency: IsoCurrency,

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -48,6 +48,7 @@ function sendEvent(
 	isConversion: boolean,
 	value: string,
 ): void {
+	console.log('sendEvent --->', id, isConversion, value);
 	if (window.QuantumMetricAPI?.isOn()) {
 		window.QuantumMetricAPI.sendEvent(id, isConversion ? 1 : 0, value);
 	}

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -191,13 +191,18 @@ export function sendEventContributionAmountToggled(
 		if (canRun) {
 			const sendEventWhenReady = () => {
 				if (window.QuantumMetricAPI?.isOn()) {
-					const annualValueInPence =
-						contributionType === 'ANNUAL' ? amount * 100 : amount * 100 * 12;
-					const sendEventId = contributionType === 'ONE_OFF' ? 71 : 72;
+					const sendEventId =
+						contributionType === 'ONE_OFF'
+							? SendEventContributionAmountToggle.SingleContribution
+							: SendEventContributionAmountToggle.RecurringContribution;
+					const valueInPence =
+						contributionType === 'ONE_OFF' || contributionType === 'ANNUAL'
+							? amount * 100
+							: amount * 100 * 12;
 					const targetCurrency: IsoCurrency = 'GBP';
 					const convertedValue: number =
 						window.QuantumMetricAPI.currencyConvertFromToValue(
-							annualValueInPence,
+							valueInPence,
 							sourceCurrency,
 							targetCurrency,
 						);

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.tsx
@@ -199,13 +199,15 @@ function ContributionAmount(props: PropTypes) {
 
 								const otherAmountNumber = parseInt(otherAmount, 10);
 
-								if (typeof otherAmountNumber === 'number') {
-									sendEventContributionAmountUpdated(
-										otherAmountNumber,
-										props.contributionType,
-										props.currency,
-									);
+								if (Number.isNaN(otherAmountNumber)) {
+									return;
 								}
+
+								sendEventContributionAmountUpdated(
+									otherAmountNumber,
+									props.contributionType,
+									props.currency,
+								);
 							}
 						}}
 						error={otherAmountErrorMessage}

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.tsx
@@ -29,6 +29,7 @@ import {
 import type { State } from '../contributionsLandingReducer';
 import '../contributionsLandingReducer';
 import ContributionAmountChoices from './ContributionAmountChoices';
+import { sendEventContributionAmountToggled } from 'helpers/tracking/quantumMetric';
 
 const otherAmoutInputCss = css`
 	padding-left: ${space[5]}px;
@@ -53,6 +54,7 @@ type PropTypes = {
 		amount: number | 'other',
 		countryGroupId: CountryGroupId,
 		contributionType: ContributionType,
+		currency: IsoCurrency,
 	) => () => void;
 	otherAmounts: OtherAmounts;
 	updateOtherAmount: (
@@ -90,12 +92,14 @@ const mapDispatchToProps = (dispatch: (...args: any[]) => any) => ({
 			amount: number | 'other',
 			countryGroupId: CountryGroupId,
 			contributionType: ContributionType,
+			currency: IsoCurrency,
 		) =>
 		() => {
+			dispatch(selectAmount(amount, contributionType));
+			sendEventContributionAmountToggled(amount, contributionType, currency);
 			trackComponentClick(
 				`npf-contribution-amount-toggle-${countryGroupId}-${contributionType}-${amount}`,
 			);
-			dispatch(selectAmount(amount, contributionType));
 		},
 	updateOtherAmount: (amount: string, contributionType: ContributionType) => {
 		dispatch(updateOtherAmount(amount, contributionType));

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.tsx
@@ -21,7 +21,7 @@ import {
 } from 'helpers/internationalisation/currency';
 import type { LocalCurrencyCountry } from 'helpers/internationalisation/localCurrencyCountry';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
-import { sendEventContributionAmountToggled } from 'helpers/tracking/quantumMetric';
+import { sendEventContributionAmountUpdated } from 'helpers/tracking/quantumMetric';
 import { classNameWithModifiers } from 'helpers/utilities/utilities';
 import {
 	selectAmount,
@@ -96,7 +96,7 @@ const mapDispatchToProps = (dispatch: (...args: any[]) => any) => ({
 		) =>
 		() => {
 			dispatch(selectAmount(amount, contributionType));
-			sendEventContributionAmountToggled(amount, contributionType, currency);
+			sendEventContributionAmountUpdated(amount, contributionType, currency);
 			trackComponentClick(
 				`npf-contribution-amount-toggle-${countryGroupId}-${contributionType}-${amount}`,
 			);
@@ -191,12 +191,23 @@ function ContributionAmount(props: PropTypes) {
 								props.contributionType,
 							)
 						}
-						onBlur={() =>
-							!!otherAmount &&
-							trackComponentClick(
-								`npf-contribution-amount-toggle-${props.countryGroupId}-${props.contributionType}-${otherAmount}`,
-							)
-						}
+						onBlur={() => {
+							if (otherAmount) {
+								trackComponentClick(
+									`npf-contribution-amount-toggle-${props.countryGroupId}-${props.contributionType}-${otherAmount}`,
+								);
+
+								const otherAmountNumber = parseInt(otherAmount, 10);
+
+								if (typeof otherAmountNumber === 'number') {
+									sendEventContributionAmountUpdated(
+										otherAmountNumber,
+										props.contributionType,
+										props.currency,
+									);
+								}
+							}
+						}}
 						error={otherAmountErrorMessage}
 						autoComplete="off"
 						autoFocus

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.tsx
@@ -21,6 +21,7 @@ import {
 } from 'helpers/internationalisation/currency';
 import type { LocalCurrencyCountry } from 'helpers/internationalisation/localCurrencyCountry';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
+import { sendEventContributionAmountToggled } from 'helpers/tracking/quantumMetric';
 import { classNameWithModifiers } from 'helpers/utilities/utilities';
 import {
 	selectAmount,
@@ -29,7 +30,6 @@ import {
 import type { State } from '../contributionsLandingReducer';
 import '../contributionsLandingReducer';
 import ContributionAmountChoices from './ContributionAmountChoices';
-import { sendEventContributionAmountToggled } from 'helpers/tracking/quantumMetric';
 
 const otherAmoutInputCss = css`
 	padding-left: ${space[5]}px;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmountChoices.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmountChoices.tsx
@@ -47,6 +47,7 @@ type ContributionAmountChoicesProps = {
 		arg0: number | 'other',
 		arg1: CountryGroupId,
 		arg2: ContributionType,
+		arg3: IsoCurrency,
 	) => () => void;
 	shouldShowFrequencyButtons: boolean;
 };
@@ -102,7 +103,12 @@ function ContributionAmountChoices({
 							contributionType,
 							defaultAmount,
 						)}
-						onChange={selectAmount(amount, countryGroupId, contributionType)}
+						onChange={selectAmount(
+							amount,
+							countryGroupId,
+							contributionType,
+							currency,
+						)}
 						label={
 							<ContributionAmountChoicesChoiceLabel
 								formattedAmount={formatAmount(
@@ -124,7 +130,12 @@ function ContributionAmountChoices({
 				name="contributionAmount"
 				value="other"
 				checked={showOther}
-				onChange={selectAmount('other', countryGroupId, contributionType)}
+				onChange={selectAmount(
+					'other',
+					countryGroupId,
+					contributionType,
+					currency,
+				)}
 				label="Other"
 			/>
 		</ChoiceCardGroup>


### PR DESCRIPTION
## What are you doing in this PR?

This PR introduces a new `sendEvent` call on Quantum Metric when users toggle the contribution amount on the contributions checkout or specify an "other amount" to contribute.