### PR TITLE
Limit acquisition-events-api 4XX alarm

### DIFF
--- a/support-lambdas/acquisition-events-api/cfn.yaml
+++ b/support-lambdas/acquisition-events-api/cfn.yaml
@@ -123,6 +123,8 @@ Resources:
       Dimensions:
         - Name: ApiName
           Value: !Sub acquisition-events-api-${Stage}
+        - Name: Method
+          Value: POST
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
       Period: 300


### PR DESCRIPTION
bots are hitting `GET /`, which triggers this alarm. We're only interested in POST requests