### PR TITLE
Restore post-deployment tests for direct debit checkouts

### DIFF
--- a/support-frontend/test/selenium/contributions/RecurringContributionsSpec.scala
+++ b/support-frontend/test/selenium/contributions/RecurringContributionsSpec.scala
@@ -71,41 +71,41 @@ class RecurringContributionsSpec
 
     }
 
-//    Scenario("Monthly contribution sign-up with direct debit - GBP") {
-//
-//      val testUser = new PostDeployTestUser(driverConfig)
-//      val landingPage = ContributionsLanding("uk", testUser)
-//
-//      val contributionThankYou = new ContributionThankYou("uk")
-//
-//      Given("that a test user goes to the contributions landing page")
-//      goTo(landingPage)
-//      assert(landingPage.pageHasLoaded)
-//
-//      When("the user selects the monthly option")
-//      landingPage.clickMonthly
-//
-//      Given("The user fills in their details correctly")
-//      landingPage.clearForm(hasNameFields = true)
-//      landingPage.fillInPersonalDetails(hasNameFields = true)
-//
-//      Given("that the user selects to pay with direct debit")
-//      When("they press the direct debit payment button")
-//      landingPage.selectDirectDebit()
-//      landingPage.clickContribute
-//
-//      And("enter direct debit details")
-//      landingPage.fillInDirectDebitDetails()
-//
-//      When("they click to pay")
-//      landingPage.payDirectDebit()
-//
-//      Then("the thankyou page should display")
-//      eventually {
-//        assert(contributionThankYou.pageHasLoaded)
-//      }
-//
-//    }
+    Scenario("Monthly contribution sign-up with direct debit - GBP") {
+
+      val testUser = new PostDeployTestUser(driverConfig)
+      val landingPage = ContributionsLanding("uk", testUser)
+
+      val contributionThankYou = new ContributionThankYou("uk")
+
+      Given("that a test user goes to the contributions landing page")
+      goTo(landingPage)
+      assert(landingPage.pageHasLoaded)
+
+      When("the user selects the monthly option")
+      landingPage.clickMonthly
+
+      Given("The user fills in their details correctly")
+      landingPage.clearForm(hasNameFields = true)
+      landingPage.fillInPersonalDetails(hasNameFields = true)
+
+      Given("that the user selects to pay with direct debit")
+      When("they press the direct debit payment button")
+      landingPage.selectDirectDebit()
+      landingPage.clickContribute
+
+      And("enter direct debit details")
+      landingPage.fillInDirectDebitDetails()
+
+      When("they click to pay")
+      landingPage.payDirectDebit()
+
+      Then("the thankyou page should display")
+      eventually {
+        assert(contributionThankYou.pageHasLoaded)
+      }
+
+    }
 
     Scenario("Annual contribution sign-up with Stripe - USD") {
 

--- a/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
+++ b/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
@@ -102,7 +102,7 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
       setValue(sortCode1, "20")
       setValue(sortCode2, "00")
       setValue(sortCode3, "00")
-			clickRecaptcha
+      clickRecaptcha
       clickOn(confirmation)
       clickOn(submitButton)
     }

--- a/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
+++ b/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
@@ -31,7 +31,7 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
 
   private val stripeOverlayIframe = cssSelector(".stripe_checkout_app")
 
-  private val stripeRecaptchaButton = id("robot_checkbox")
+  private val recaptchaButton = id("robot_checkbox")
 
   private object RegisterFields {
     private val firstName = id("contributionFirstName")
@@ -102,6 +102,7 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
       setValue(sortCode1, "20")
       setValue(sortCode2, "00")
       setValue(sortCode3, "00")
+			clickRecaptcha
       clickOn(confirmation)
       clickOn(submitButton)
     }
@@ -133,7 +134,7 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
   }
 
   def clickRecaptcha: Unit = {
-    clickOn(stripeRecaptchaButton)
+    clickOn(recaptchaButton)
     waitForTestRecaptchaToComplete
   }
 

--- a/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
@@ -46,11 +46,11 @@ class CheckoutsSpec
     }
   }
 
-//  Feature("Paper checkout") {
-//    Scenario("User already logged in - Direct Debit checkout") {
-//      testCheckout("Paper", new PaperCheckout, new PaperProductPage, payWithDirectDebit)
-//    }
-//  }
+  Feature("Paper checkout") {
+    Scenario("User already logged in - Direct Debit checkout") {
+      testCheckout("Paper", new PaperCheckout, new PaperProductPage, payWithDirectDebit)
+    }
+  }
 
   Feature("Guardian Weekly checkout") {
     Scenario("User already logged in - Stripe checkout") {
@@ -58,16 +58,16 @@ class CheckoutsSpec
     }
   }
 
-//  Feature("Guardian Weekly gift checkout") {
-//    Scenario("User already logged in - Direct Debit checkout") {
-//      testCheckout(
-//        "Guardian Weekly gift",
-//        new GuardianWeeklyGiftCheckout,
-//        new WeeklyGiftProductPage,
-//        payWithDirectDebit,
-//      )
-//    }
-//  }
+  Feature("Guardian Weekly gift checkout") {
+    Scenario("User already logged in - Direct Debit checkout") {
+      testCheckout(
+        "Guardian Weekly gift",
+        new GuardianWeeklyGiftCheckout,
+        new WeeklyGiftProductPage,
+        payWithDirectDebit,
+      )
+    }
+  }
 
   def testCheckout(
       checkoutName: String,

--- a/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
@@ -13,7 +13,7 @@ trait CheckoutPage extends Page with Browser {
   private val cardNumber = name("cardnumber")
   private val expiry = name("exp-date")
   private val cvc = name("cvc")
-  private val stripeRecaptchaButton = id("robot_checkbox")
+  private val recaptchaButton = id("robot_checkbox")
 
   // Direct debit
   private val directDebitButton = id("qa-direct-debit")
@@ -27,6 +27,11 @@ trait CheckoutPage extends Page with Browser {
   def selectStripePaymentMethod(): Unit = clickOn(stripeRadioButton)
 
   def selectDirectDebitPaymentMethod(): Unit = clickOn(directDebitButton)
+
+  def clickRecaptcha: Unit = {
+    clickOn(recaptchaButton)
+    waitForTestRecaptchaToComplete
+  }
 
   def pageHasLoaded: Boolean = {
     pageHasElement(personalDetails)
@@ -55,8 +60,7 @@ trait CheckoutPage extends Page with Browser {
     switchToFrame(2)
     setValue(cvc, "123")
     switchToParentFrame
-    clickOn(stripeRecaptchaButton)
-    waitForTestRecaptchaToComplete
+    clickRecaptcha
   }
 
   def waitForTestRecaptchaToComplete: Unit = Thread.sleep(1000)
@@ -66,6 +70,7 @@ trait CheckoutPage extends Page with Browser {
     setValue(sortCode, "200000")
     setValue(accountNumber, "55779911")
     clickOn(accountConfirmation)
+    clickRecaptcha
   }
 
   def thankYouPageHasLoaded: Boolean = {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This reinstates the Selenium tests for paying with direct debit for various products, adding a 'complete recaptcha' step to them.

## Why are you doing this?

Now we've reinstated direct debit payment in #3941 we can bring these tests back.