### PR TITLE
Quantum Metric: sendEvent contribution conversion

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -19,6 +19,7 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { Quarterly } from 'helpers/productPrice/billingPeriods';
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
+import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import {
 	finalPrice,
 	getCurrency,

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -19,7 +19,6 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { Quarterly } from 'helpers/productPrice/billingPeriods';
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
-import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import {
 	finalPrice,
 	getCurrency,

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -16,7 +16,7 @@ import {
 
 type SendEventTestParticipationId = 30;
 
-enum SendEventCheckoutStart {
+export enum SendEventCheckoutStart {
 	DigiSub = 75,
 	PaperSub = 76,
 	GuardianWeeklySub = 77,

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -40,7 +40,7 @@ enum SendEventContributionAmountUpdate {
 
 enum SendEventContributionCheckoutConversion {
 	SingleContribution = 73,
-	RecurringContribution = 4,
+	RecurringContribution = 74,
 }
 
 type SendEventId =

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -50,6 +50,7 @@ function sendEvent(
 	isConversion: boolean,
 	value: string,
 ): void {
+	console.log('sendEvent --->', id, isConversion, value);
 	if (window.QuantumMetricAPI?.isOn()) {
 		window.QuantumMetricAPI.sendEvent(id, isConversion ? 1 : 0, value);
 	}

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -63,17 +63,6 @@ function sendEventSubscriptionCheckoutEvent(
 ): void {
 	void canRunQuantumMetric().then((canRun) => {
 		if (canRun) {
-<<<<<<< HEAD
-=======
-			const sourceCurrency = productPrice.currency;
-			const value = getAnnualValue(productPrice, billingPeriod);
-
-			if (!value) {
-				return;
-			}
-
-			const targetCurrency: IsoCurrency = 'GBP';
->>>>>>> b396f876d (check feature switch on sendEvent)
 			const sendEventWhenReady = () => {
 				const sourceCurrency = productPrice.currency;
 				const targetCurrency: IsoCurrency = 'GBP';
@@ -289,33 +278,6 @@ function addQM() {
 	});
 }
 
-<<<<<<< HEAD
-=======
-function canRunQuantumMetric(): Promise<boolean> {
-	// resolve immediately with false if the feature switch is OFF
-	if (!isSwitchOn('featureSwitches.enableQuantumMetric')) {
-		return Promise.resolve(false);
-	}
-	// checks users consent status
-	return new Promise((resolve) => {
-		onConsentChange((state) => {
-			if (
-				state.ccpa?.doNotSell === false || // check whether US users have NOT withdrawn consent
-				state.aus?.personalisedAdvertising || // check whether AUS users have consented to personalisedAdvertising
-				(state.tcfv2?.consents && // check TCFv2 purposes for non-US/AUS users
-					state.tcfv2.consents['1'] && // Store and/or access information on a device
-					state.tcfv2.consents['8'] && // Measure content performance
-					state.tcfv2.consents['10']) // Develop and improve products
-			) {
-				resolve(true);
-			} else {
-				resolve(false);
-			}
-		});
-	});
-}
-
->>>>>>> b396f876d (check feature switch on sendEvent)
 export function init(participations: Participations): void {
 	void canRunQuantumMetric().then((canRun) => {
 		if (canRun) {

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -63,6 +63,17 @@ function sendEventSubscriptionCheckoutEvent(
 ): void {
 	void canRunQuantumMetric().then((canRun) => {
 		if (canRun) {
+<<<<<<< HEAD
+=======
+			const sourceCurrency = productPrice.currency;
+			const value = getAnnualValue(productPrice, billingPeriod);
+
+			if (!value) {
+				return;
+			}
+
+			const targetCurrency: IsoCurrency = 'GBP';
+>>>>>>> b396f876d (check feature switch on sendEvent)
 			const sendEventWhenReady = () => {
 				const sourceCurrency = productPrice.currency;
 				const targetCurrency: IsoCurrency = 'GBP';
@@ -278,6 +289,33 @@ function addQM() {
 	});
 }
 
+<<<<<<< HEAD
+=======
+function canRunQuantumMetric(): Promise<boolean> {
+	// resolve immediately with false if the feature switch is OFF
+	if (!isSwitchOn('featureSwitches.enableQuantumMetric')) {
+		return Promise.resolve(false);
+	}
+	// checks users consent status
+	return new Promise((resolve) => {
+		onConsentChange((state) => {
+			if (
+				state.ccpa?.doNotSell === false || // check whether US users have NOT withdrawn consent
+				state.aus?.personalisedAdvertising || // check whether AUS users have consented to personalisedAdvertising
+				(state.tcfv2?.consents && // check TCFv2 purposes for non-US/AUS users
+					state.tcfv2.consents['1'] && // Store and/or access information on a device
+					state.tcfv2.consents['8'] && // Measure content performance
+					state.tcfv2.consents['10']) // Develop and improve products
+			) {
+				resolve(true);
+			} else {
+				resolve(false);
+			}
+		});
+	});
+}
+
+>>>>>>> b396f876d (check feature switch on sendEvent)
 export function init(participations: Participations): void {
 	void canRunQuantumMetric().then((canRun) => {
 		if (canRun) {

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -45,14 +45,11 @@ type SendEventId =
 
 // ---- sendEvent logic ---- //
 
-// ---- sendEvent logic ---- //
-
 function sendEvent(
 	id: SendEventId,
 	isConversion: boolean,
 	value: string,
 ): void {
-	console.log('sendEvent --->', id, isConversion, value);
 	if (window.QuantumMetricAPI?.isOn()) {
 		window.QuantumMetricAPI.sendEvent(id, isConversion ? 1 : 0, value);
 	}

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -45,6 +45,8 @@ type SendEventId =
 
 // ---- sendEvent logic ---- //
 
+// ---- sendEvent logic ---- //
+
 function sendEvent(
 	id: SendEventId,
 	isConversion: boolean,

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -16,7 +16,7 @@ import {
 
 type SendEventTestParticipationId = 30;
 
-export enum SendEventCheckoutStart {
+enum SendEventCheckoutStart {
 	DigiSub = 75,
 	PaperSub = 76,
 	GuardianWeeklySub = 77,

--- a/support-frontend/assets/helpers/tracking/quantumMetricHelpers.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetricHelpers.ts
@@ -2,7 +2,9 @@ import {
 	getConsentFor,
 	onConsent,
 } from '@guardian/consent-management-platform';
+import type { ContributionType } from 'helpers/contributions';
 import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import { getAppliedPromo } from 'helpers/productPrice/promotions';
@@ -49,6 +51,28 @@ export function getSubscriptionAnnualValue(
 		discountInPenceCents * promotion.numberOfDiscountedPeriods;
 
 	return discountedAnnualPrice;
+}
+
+export function getContributionAnnualValue(
+	contributionType: ContributionType,
+	amount: number,
+	sourceCurrency: IsoCurrency,
+): number | undefined {
+	const valueInPence =
+		contributionType === 'ONE_OFF' || contributionType === 'ANNUAL'
+			? amount * 100
+			: amount * 100 * 12;
+	const targetCurrency: IsoCurrency = 'GBP';
+
+	if (window.QuantumMetricAPI?.isOn()) {
+		const convertedValue: number =
+			window.QuantumMetricAPI.currencyConvertFromToValue(
+				valueInPence,
+				sourceCurrency,
+				targetCurrency,
+			);
+		return convertedValue;
+	}
 }
 
 export function waitForQuantumMetricAPi(onReady: () => void): void {


### PR DESCRIPTION
## What are you doing in this PR?

Note: This PR merges into [gh-sendEvent-contribution-toggle](https://github.com/guardian/support-frontend/tree/gh-sendEvent-contribution-toggle), I'd like to merge that branch's associated PR (https://github.com/guardian/support-frontend/pull/3945) before updating this PR to target `main`.

Trigger sendEvent call to Quauntum Metric's API on Contribution Checkout conversion. The PR splits out some common logic into 2 new functions: `sendEventWhenReadyTrigger` and `getContributionAnnualValue`.