### PR TITLE
Quantum Metric: Check Quantum Metric's consent state before

### DIFF
--- a/support-frontend/assets/helpers/tracking/quantumMetricHelpers.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetricHelpers.ts
@@ -1,4 +1,7 @@
-import { onConsentChange } from '@guardian/consent-management-platform';
+import {
+	getConsentFor,
+	onConsent,
+} from '@guardian/consent-management-platform';
 import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
@@ -67,21 +70,8 @@ export function canRunQuantumMetric(): Promise<boolean> {
 	if (!isSwitchOn('featureSwitches.enableQuantumMetric')) {
 		return Promise.resolve(false);
 	}
-	// checks users consent status
-	return new Promise((resolve) => {
-		onConsentChange((state) => {
-			if (
-				state.ccpa?.doNotSell === false || // check whether US users have NOT withdrawn consent
-				state.aus?.personalisedAdvertising || // check whether AUS users have consented to personalisedAdvertising
-				(state.tcfv2?.consents && // check TCFv2 purposes for non-US/AUS users
-					state.tcfv2.consents['1'] && // Store and/or access information on a device
-					state.tcfv2.consents['8'] && // Measure content performance
-					state.tcfv2.consents['10']) // Develop and improve products
-			) {
-				resolve(true);
-			} else {
-				resolve(false);
-			}
-		});
+	// check users consent state
+	return onConsent().then((state) => {
+		return getConsentFor('qm', state);
 	});
 }

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -85,7 +85,7 @@
     "@emotion/react": "^11.1.5",
     "@emotion/serialize": "^0.11.16",
     "@emotion/utils": "^1.1.0",
-    "@guardian/consent-management-platform": "^10.5.0",
+    "@guardian/consent-management-platform": "^10.7.1",
     "@guardian/libs": "^5.1.0",
     "@guardian/pasteup": "1.0.0-alpha.7",
     "@guardian/source-foundations": "^4.1.0",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1252,15 +1252,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/browserslist-config@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-1.0.1.tgz#694ab24f6a028646ae752f5e035ea13a0746c30a"
-  integrity sha512-xjQSUXmln96Qr/G8yRCaDWe5HbablzGU9lax1zDUZkfArV/rBj8P34x/RH0ksf3J8BaykVTma97W+g/WRz7Isw==
-
-"@guardian/consent-management-platform@^10.5.0":
-  version "10.5.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.5.0.tgz#5195abd5cf6d940dbdfb7c27b05165913999ed0e"
-  integrity sha512-oxCcHLalyMMIMneolgX7d/n5NM+e7cVYhPwITmYdw2dyM6zpmsZsUENEVnno49HpU0MamD7YzNrhE4HT2w2YIA==
+"@guardian/consent-management-platform@^10.7.1":
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.7.1.tgz#ed672e1a7cc0e177d820dc7b2ebbfd26531a2d86"
+  integrity sha512-9wN4Bu0VMfpDg0p1/PjO/hAuPN7pJrBm24YXLWmAnfvHci0Wr+WMSF5ZOwhbMA01jl5IP3Hr1TKpFbkg3NhGdg==
   dependencies:
     "@guardian/libs" "1.6.1 - 3.3.0"
 

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1252,6 +1252,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@guardian/browserslist-config@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-1.0.1.tgz#694ab24f6a028646ae752f5e035ea13a0746c30a"
+  integrity sha512-xjQSUXmln96Qr/G8yRCaDWe5HbablzGU9lax1zDUZkfArV/rBj8P34x/RH0ksf3J8BaykVTma97W+g/WRz7Isw==
+
 "@guardian/consent-management-platform@^10.7.1":
   version "10.7.1"
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.7.1.tgz#ed672e1a7cc0e177d820dc7b2ebbfd26531a2d86"


### PR DESCRIPTION
## What are you doing in this PR?

This PR updates `@guardian/consent-management-platform` to the latest version so we can query a user's consent state related to Quantum Metric directly. As part of this change I've also switch from using the `onConsentChange` (runs a callback after every change to consent) function exposed by the library to `onConsent` (resolves a Promise on initialisation with a user's consent state) as I don't believe we need to re-run any code on consent status changing.