### PR TITLE
Use shared Guardian browserslist config

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -30,16 +30,7 @@
     "check-images": "echo 'Purging unused images' && node scripts/gridImages.js"
   },
   "browserslist": [
-    "Chrome >= 49",
-    "ChromeAndroid >= 49",
-    "Safari >= 8",
-    "ios_saf >= 8",
-    "IE >= 11",
-    "Edge >= 14",
-    "Firefox >= 48",
-    "FirefoxAndroid > 48",
-    "Samsung >= 4",
-    "Opera >= 54"
+		"extends @guardian/browserslist-config"
   ],
   "jest": {
     "testMatch": [
@@ -139,6 +130,7 @@
     "@babel/preset-typescript": "^7.14.5",
     "@emotion/babel-plugin": "^11.7.2",
     "@emotion/eslint-plugin": "^11.7.0",
+		"@guardian/browserslist-config": "^1.0.1",
     "@guardian/eslint-config-typescript": "^0.6.0",
     "@guardian/eslint-plugin-source-foundations": "^4.0.2",
     "@guardian/eslint-plugin-source-react-components": "^4.0.2",
@@ -200,14 +192,14 @@
     "ts-loader": "9.2.8",
     "tsc-files": "^1.1.3",
     "typescript": "^4.3.2",
+		"web-vitals": "^2.0.0",
     "webpack": "^5.71.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.7.4",
     "webpack-manifest-plugin": "^5.0.0",
     "webpack-merge": "^5.8.0",
-    "webpack-stats-plugin": "^0.3.2",
-    "web-vitals": "^2.0.0",
+		"webpack-stats-plugin": "^0.3.2",
     "yargs": "^17.4.0"
   },
   "resolutions": {

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1252,6 +1252,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@guardian/browserslist-config@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-1.0.1.tgz#694ab24f6a028646ae752f5e035ea13a0746c30a"
+  integrity sha512-xjQSUXmln96Qr/G8yRCaDWe5HbablzGU9lax1zDUZkfArV/rBj8P34x/RH0ksf3J8BaykVTma97W+g/WRz7Isw==
+
 "@guardian/consent-management-platform@^10.5.0":
   version "10.5.0"
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.5.0.tgz#5195abd5cf6d940dbdfb7c27b05165913999ed0e"


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This updates our Browserslist config to use the shared [@guardian/configs](https://github.com/guardian/configs) package, which draws on our actual usage stats.