### PR TITLE
Update other amount field UX

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.tsx
@@ -142,7 +142,7 @@ function ContributionAmount(props: PropTypes) {
 						value={`${otherAmount ?? ''}`}
 						onChange={(e) =>
 							props.setOtherAmount({
-								amount: e.target.value.replace(/[^0-9]/g, ''),
+								amount: e.target.value,
 								contributionType: props.contributionType,
 							})
 						}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

We've had a number of issue raised by users accidently creating contributions of 100x what they expected. Our theory is that they typed `.00` into the other amount field. The current behaviour of the field is to remove the `.` and thus just leave `00`. That means typing e.g `1.00` will actually fill `100` into the other amount field. 

I first explored what other similar forms do, and found the [oxfam donate form](https://www.oxfam.org.uk/donate/) to have quite nice UX. Initially it only allows you to type a number or a `.`. After typing a `.`, you can then only type at most two more digits.

I started trying to recreate that UX but the behaviour of our form fields is a little tricky. If you make an update to a field, but the state doesn't change as a result (ie. because you filtered out the newly typed character), the field will still display the newly typed character. This is because the react component isn't rerendered and we're left with the form state (ie the state maintained by the browser) out of sync with our react state. To demonstrate, I captured this interaction with the prod site:

![Jul-05-2022 16-22-10](https://user-images.githubusercontent.com/17720442/177362610-2262b408-09a5-4572-85f5-22af9e0778c6.gif)

Whilst typing the `g`s, the react state isn't getting updated. This is because the `g`s are being filtered out by the call to `replace(/[^0-9]/g, '')`. Then when I type another `0`, `50ggggggg0.replace(/[^0-9]/g, '')` is `500`, so the state is then updated and we resync the form field with the react state.

Ideally this wouldn't be the behaviour and we could rely on the two states being insync. 

To get a quick fix in, I decided then that the best thing to do would be to let users type whatever they want into the form, and then validate it after. I checked what validation we've already got in place which is [here](https://github.com/guardian/support-frontend/blob/main/support-frontend/assets/helpers/forms/formValidation.ts#L99). Which looks to be everything we need! Hence the final change is only tiny!
