### PR TITLE
Quantum Metric: Check correct consent state in US/AUS

### DIFF
--- a/support-frontend/assets/helpers/tracking/quantumMetricHelpers.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetricHelpers.ts
@@ -96,6 +96,10 @@ export function canRunQuantumMetric(): Promise<boolean> {
 	}
 	// check users consent state
 	return onConsent().then((state) => {
-		return getConsentFor('qm', state);
+		return (
+			state.ccpa?.doNotSell ??
+			state.aus?.personalisedAdvertising ??
+			getConsentFor('qm', state)
+		);
 	});
 }

--- a/support-frontend/assets/helpers/tracking/quantumMetricHelpers.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetricHelpers.ts
@@ -97,8 +97,7 @@ export function canRunQuantumMetric(): Promise<boolean> {
 	// check users consent state
 	return onConsent().then((state) => {
 		return (
-			state.ccpa?.doNotSell ??
-			state.aus?.personalisedAdvertising ??
+			(state.ccpa?.doNotSell === false || state.aus?.personalisedAdvertising) ??
 			getConsentFor('qm', state)
 		);
 	});


### PR DESCRIPTION
## What are you doing in this PR?

I noted that the Quantum Metric script isn't running in the US/AUS, this is because the `getConsentFor` check only returns the consent state for IAB compliant regions, the US/AUS have their own consent state that needs to be interrogated.