### PR TITLE
Maintain order of promos

### DIFF
--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
@@ -30,7 +30,7 @@ class PromotionService(config: PromotionsConfig, maybeCollection: Option[Promoti
     val promosByCode: Map[PromoCode, List[Promotion]] =
       allWith6For6
         .flatMap(promo => promo.promoCodes.map(code => code -> promo))
-        .groupMap(_._1) { case (promoCode, promo) => promo }
+        .groupMap(_._1)(_._2)
 
     promoCodes.foldLeft(List.empty[PromotionWithCode]) { (acc, promoCode) =>
       acc ++ promosByCode.getOrElse(promoCode, Nil).map(promotion => PromotionWithCode(promoCode, promotion))

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
@@ -25,14 +25,17 @@ class PromotionService(config: PromotionsConfig, maybeCollection: Option[Promoti
       case tooMany => Left(DuplicateCode(tooMany.mkString(", ")))
     }
 
-  def findPromotions(promoCodes: List[PromoCode]): List[PromotionWithCode] =
-    promoCodes
-      .foldLeft(List.empty[PromotionWithCode]) { (acc, promoCode) =>
-        allWith6For6.find(promo => promo.promoCodes.exists(_ == promoCode)) match {
-          case Some(promotion) => acc :+ PromotionWithCode(promoCode, promotion)
-          case None => acc
-        }
-      }
+  // promoCodes here is expected to be a small list of default promos plus one from the querystring
+  def findPromotions(promoCodes: List[PromoCode]): List[PromotionWithCode] = {
+    val promosByCode: Map[PromoCode, List[Promotion]] =
+      allWith6For6
+        .flatMap(promo => promo.promoCodes.map(code => code -> promo))
+        .groupMap(_._1) { case (promoCode, promo) => promo }
+
+    promoCodes.foldLeft(List.empty[PromotionWithCode]) { (acc, promoCode) =>
+      acc ++ promosByCode.getOrElse(promoCode, Nil).map(promotion => PromotionWithCode(promoCode, promotion))
+    }
+  }
 
   def validatePromotion(
       promotion: PromotionWithCode,

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
@@ -26,10 +26,12 @@ class PromotionService(config: PromotionsConfig, maybeCollection: Option[Promoti
     }
 
   def findPromotions(promoCodes: List[PromoCode]): List[PromotionWithCode] =
-    allWith6For6
-      .foldLeft(List.empty[PromotionWithCode]) { (acc, promotion) =>
-        val maybeCode = promoCodes.intersect(promotion.promoCodes.toList).headOption
-        maybeCode.map(code => acc :+ PromotionWithCode(code, promotion)).getOrElse(acc)
+    promoCodes
+      .foldLeft(List.empty[PromotionWithCode]) { (acc, promoCode) =>
+        allWith6For6.find(promo => promo.promoCodes.exists(_ == promoCode)) match {
+          case Some(promotion) => acc :+ PromotionWithCode(promoCode, promotion)
+          case None => acc
+        }
       }
 
   def validatePromotion(

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceSpec.scala
@@ -27,13 +27,12 @@ class PromotionServiceSpec extends AsyncFlatSpec with Matchers {
     )
   }
 
-  it should "find multiple promo codes" in {
+  it should "find multiple promo codes, in correct order" in {
     val promotions =
       serviceWithFixtures.findPromotions(
         List(freeTrialPromoCode, tenAnnual),
       )
-    promotions should contain(freeTrialWithCode)
-    promotions should contain(guardianWeeklyWithCode)
+    promotions should equal(List(freeTrialWithCode, guardianWeeklyWithCode))
   }
 
   it should "handle Nil in findPromotions" in {
@@ -138,12 +137,12 @@ object PromotionServiceSpec {
     Some(
       new SimplePromotionCollection(
         List(
-          freeTrial,
           discount,
           double,
           tracking.promotion,
           renewal.promotion,
           guardianWeeklyAnnual,
+          freeTrial,
           duplicate1,
           duplicate2,
         ),


### PR DESCRIPTION
`PromotionsService.findPromotions` receives a list of possible `promoCodes`, and returns the full data for each (originating from dynamodb).
We define an array of 'default' promos (in S3), and the ordering of this array is important. But currently the ordering gets lost in `findPromotions`, because it iterates (with `foldLeft`) through the full list of promotions from dynamodb.
This PR changes the logic to iterate through the list of `promoCodes`, mapping each to a promotion object from dynamodb.