### PR TITLE
Update GW landing page images in line with Boris Johnson promo

### DIFF
--- a/support-frontend/assets/helpers/images/imageCatalogue.json
+++ b/support-frontend/assets/helpers/images/imageCatalogue.json
@@ -5,8 +5,8 @@
   "benefitsPackshotBulletsMobUKUS": "8ad46bcc6d2558dab35c7e1388290ccf251a21de/0_0_333_493",
   "benefitsPackshotParaMobAndDesktopUK": "6faea782717c5a1058fcfc3afff5cde3fa36cf25/0_0_603_363",
   "benefitsPackshotParaMobAndDesktopUS": "48c291a960dc4ac7060ba65e3e43d722661e7dd4/0_0_604_363",
-  "checkoutPackshotWeekly": "c8dd569a0d811e1a9d222c7fd92b22853aac3dc4/0_0_1358_954",
-  "checkoutPackshotWeeklyGifting": "71b26671bfc98a3165c4bbb28b705821d231a046/0_0_696_400",
+  "checkoutPackshotWeekly": "fd6894bdc9d291e8cbafcb6e588b10de56fd0317/0_0_1358_954",
+  "checkoutPackshotWeeklyGifting": "5a02d13aa911b5bac7f979325bfbc649a1be1786/0_0_696_400",
   "comparisonTableAdFree": "be60312ad456d5fd2ddbb775ba9fe85d7d0d0bbe/0_0_1480_488",
   "comparisonTableCrosswordsDesktop": "6a0c815c0409c9dce804d2e40882aa67df4644f7/0_0_1106_694",
   "comparisonTableCrosswordsMob": "169f65026305d2e89b4eb61be429387d7b883dd6/0_0_244_250",
@@ -57,7 +57,7 @@
   "showcaseUSTrump": "30512603929dd3bd4d493738dc8338e36e710619/1103_0_3010_3009",
   "subscriptionDailyMobile": "9b650a7dcc33e30d228ddec7bd27a0594b4ece41/0_0_568_1174",
   "subscriptionDailyPackshot": "773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084",
-  "subscriptionGuardianWeeklyPackShot": "c8dd569a0d811e1a9d222c7fd92b22853aac3dc4/0_0_1358_954",
+  "subscriptionGuardianWeeklyPackShot": "fd6894bdc9d291e8cbafcb6e588b10de56fd0317/0_0_1358_954",
   "subscriptionIpad": "c2843d4ec6bc7644c62c8691b6c7e83e76c93e0e/0_0_1302_998",
   "subscriptionIphone": "8850945f0003d2a7204050644db446d827dead95/0_0_578_1096",
   "subscriptionPrint": "/81d6bda5f74a84b952e7162d553ae71499c0c7ed/0_9_540_324",
@@ -65,7 +65,7 @@
   "weekendPackshotDesktop": "dc1bb7218877d954a5841b24765e89f7c3aa6f95/0_0_1800_1080",
   "weekendPackshotMobile": "622d1b94173e9c711ff421d89cf9abddf3319197/0_0_1100_1100",
   "weeklyCampaignBenefitsImg": "340db3a4561cbd502dc59b764ab8d93433511103/0_255_1972_1183",
-  "weeklyCampaignHeroImg": "6d6779094c71ddba2dcfdfeb1b44aa46bce76a8b/0_0_1552_1176",
+  "weeklyCampaignHeroImg": "91f4218fdcdc603fbcb3cc1bc2aa7878af160245/0_0_1552_1176",
   "weeklyLandingHero": "87e6e2d907b9de594c73239bae0b49f2f811173c/738_0_6362_3008",
   "woleSoyinka": "7a24fd9a5293314cf0ed51445443220c30d88d4d/0_0_2667_1600"
 }


### PR DESCRIPTION
## What are you doing in this PR?
This PR update the packshot images for Guardian Weekly.

## Screenshots
There are 3 image sizes, used in 5 pages.

**1358x954**
| /subscribe | /subscribe/weekly/checkout |
| --- | --- |
| ![Screenshot 2022-07-08 at 16 39 42](https://user-images.githubusercontent.com/99180049/178026417-4584a37c-37a7-48c1-9165-4be32543fb11.png) | ![Screenshot 2022-07-08 at 16 39 13](https://user-images.githubusercontent.com/99180049/178026375-a91ebc59-1e9b-4741-82ac-45adf56305b6.png) |

**1552x1176**
| /subscribe/weekly | /subscribe/weekly/gift |
| --- | --- |
| ![Screenshot 2022-07-08 at 16 38 36](https://user-images.githubusercontent.com/99180049/178026332-4161c70d-d2d7-459b-877f-462a307e3634.png) | ![Screenshot 2022-07-08 at 16 38 16](https://user-images.githubusercontent.com/99180049/178026273-304e4ab2-1907-4db5-aac7-bb7696a5d9d6.png) |

**696x400**
| /subscribe/weekly/checkout/gift |
| --- |
| ![Screenshot 2022-07-08 at 16 37 52](https://user-images.githubusercontent.com/99180049/178026215-7a6cec4f-bb15-4eda-b3c8-a0d287fc07fe.png) |