### PR TITLE
Quantum Metric: Round product value before sending to Quantum Metric

### DIFF
--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -104,7 +104,7 @@ function sendEventSubscriptionCheckoutEvent(
 							sourceCurrency,
 							targetCurrency,
 						);
-					sendEvent(id, isConversion, convertedValue.toString());
+					sendEvent(id, isConversion, Math.round(convertedValue).toString());
 				}
 			};
 
@@ -208,7 +208,7 @@ export function sendEventContributionCheckoutConversion(
 					sourceCurrency,
 				);
 				if (convertedValue) {
-					sendEvent(sendEventId, true, convertedValue.toString());
+					sendEvent(sendEventId, true, Math.round(convertedValue).toString());
 				}
 			};
 


### PR DESCRIPTION
## What are you doing in this PR?

We've been seeing unusually high product values in Quantum Metric (QM), the issue lies in the way we convert the product value when sending it onto QM.

We pass the monetary value of a subscription or contribution to QM, before we send this figure we pass the value through `window.QuantumMetricAPI.currencyConvertFromToValue` to get the value in `GBP`

For example if a user chooses a one off contribution of $30. This value is multiplied by 100 to get it's value in cents: 3000. When this is converted to GBP, the number that is returned from `currencyConvertFromToValue` is 2533.77.  We've been passing 2533.77 to Quantum Metric. The problem is QM interprets this as 253377 (or $2533.77) because it ignores the decimal point. 

The solution is to apply `Math.round()` to the value before we send it on to QM,  the figure provided will then be in line with the accepted format, in this case 2534, or £25.34. 
