### PR TITLE
Add direct debit feature switch for subs

### DIFF
--- a/support-frontend/app/admin/settings/Switches.scala
+++ b/support-frontend/app/admin/settings/Switches.scala
@@ -57,9 +57,14 @@ case class RecurringPaymentMethodSwitches(
     sepa: SwitchState,
 )
 
+case class SubscriptionsPaymentMethodSwitches(
+    directDebit: SwitchState,
+)
+
 case class Switches(
     oneOffPaymentMethods: OneOffPaymentMethodSwitches,
     recurringPaymentMethods: RecurringPaymentMethodSwitches,
+    subscriptionsPaymentMethods: SubscriptionsPaymentMethodSwitches,
     subscriptionsSwitches: SubscriptionsSwitches,
     featureSwitches: FeatureSwitches,
     campaignSwitches: CampaignSwitches,

--- a/support-frontend/test/admin/settings/SwitchesSpec.scala
+++ b/support-frontend/test/admin/settings/SwitchesSpec.scala
@@ -76,6 +76,15 @@ class SwitchesSpec extends AnyWordSpec with Matchers {
           |      }
           |    }
           |  },
+          |  "subscriptionsPaymentMethods": {
+          |    "description": "Payment methods - subscriptions",
+          |    "switches": {
+          |      "directDebit": {
+          |        "description": "Direct Debit",
+          |        "state": "On"
+          |      }
+          |    }
+          |  },
           |  "subscriptionsSwitches": {
           |    "description": "Subscriptions",
           |    "switches": {
@@ -139,6 +148,7 @@ class SwitchesSpec extends AnyWordSpec with Matchers {
         Switches(
           oneOffPaymentMethods = OneOffPaymentMethodSwitches(On, On, On, On, On),
           recurringPaymentMethods = RecurringPaymentMethodSwitches(On, On, On, On, On, On, On, Off, Off),
+          subscriptionsPaymentMethods = SubscriptionsPaymentMethodSwitches(On),
           subscriptionsSwitches = SubscriptionsSwitches(On, On, On),
           featureSwitches = FeatureSwitches(On, On),
           campaignSwitches = CampaignSwitches(Off, Off),

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -75,6 +75,7 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
       Switches(
         oneOffPaymentMethods = OneOffPaymentMethodSwitches(On, On, On, On, On),
         recurringPaymentMethods = RecurringPaymentMethodSwitches(On, On, On, On, Off, On, On, On, Off),
+        subscriptionsPaymentMethods = SubscriptionsPaymentMethodSwitches(On),
         subscriptionsSwitches = SubscriptionsSwitches(On, On, On),
         featureSwitches = FeatureSwitches(On, On),
         campaignSwitches = CampaignSwitches(On, On),


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This adds a direct debit feature switch for subscriptions which will allow us to switch off direct debit as a payment method in future if need be.

The corresponding JSON files have been updated in S3 and the new switch is present in the RRCP for all environments.

[**Trello Card**](https://trello.com/c/6JPATMMG/495-put-feature-switches-around-subscription-payment-methods-client-side)