### PR TITLE
Bump jackson-databind to version 2.13.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,6 +88,7 @@ lazy val commonDependencies = Seq(
   "com.typesafe" % "config" % "1.4.2",
   scalatest % "test",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.2",
 )
 
 lazy val root = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,6 @@ lazy val commonDependencies = Seq(
   "com.typesafe" % "config" % "1.4.2",
   scalatest % "test",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.2",
 )
 
 lazy val root = (project in file("."))

--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -6,7 +6,7 @@ object LibraryVersions {
 
   val catsVersion = "2.1.1"
   val jacksonVersion = "2.13.3"
-  val jacksonDatabindVersion = "2.11.4"
+  val jacksonDatabindVersion = "2.13.3"
   val okhttpVersion = "3.10.0"
   val scalaUriVersion = "4.0.2"
   val playCirceVersion = "2814.2"

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -42,6 +42,7 @@ libraryDependencies ++= Seq(
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
   filters,
   ws,
 )

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -41,6 +41,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
   "com.google.guava" % "guava" % "25.0-jre", // -- added explicitly - snyk report avoid logback vulnerability
   "com.paypal.sdk" % "rest-api-sdk" % "1.14.0" exclude ("org.apache.logging.log4j", "log4j-slf4j-impl"),
   akkaHttpServer, // or use nettyServer for Netty


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR updates `jackson-databind` to version 2.13.3. In order to do this we also needed to update the `jackson-module-scala` transitive dependency which requires an older version of jackson-databind.

[**Trello Card**](https://trello.com/c/QWsbCtTn/506-update-jackson-databind-dependency-high-vulnerability)

## Why are you doing this?
To mitigate potential security vulnerabilities.
