### PR TITLE
Fix issue caused by setting a different country for delivery and billing on the GW checkout

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/address/sideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/sideEffects.ts
@@ -33,8 +33,14 @@ export function addAddressSideEffects(
 		matcher: shouldUpdateInternationalisation,
 		effect(action, listener) {
 			const country = fromString(action.payload);
+			const { productType } = listener.getState().page.checkoutForm.product;
+			const isSettingDeliveryAddress = setDeliveryCountry.match(action);
 
-			if (country) {
+			// The billing address is only relevant to the displayed price for the digital subscription
+			const countryShouldBeUpdated =
+				isSettingDeliveryAddress || productType === 'DigitalPack';
+
+			if (country && countryShouldBeUpdated) {
 				listener.dispatch(setCountryInternationalisation(country));
 			}
 		},


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Co-authored with @GHaberis @marialani @michaelbjacobson 

This fixes an issue where a user attempting to buy Guardian Weekly for delivery to a country different to the billing address country would see incorrect price information displayed, and might cause a step function failure due to incorrect promo codes being applied.