### PR TITLE
Refactor subs form validation

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/formValidation.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formValidation.ts
@@ -21,11 +21,46 @@ import { getFulfilmentOption } from 'helpers/subscriptionsForms/subscriptionChec
 import type { FormError } from 'helpers/subscriptionsForms/validation';
 import { applyCheckoutRules, applyDeliveryRules } from './rules';
 
+// ---- Types ---- //
+
 type Error<T> = {
 	errors: Array<FormError<T>>;
 	dispatchErrors: (dispatch: Dispatch) => void;
 };
 type AnyErrorType = Error<AddressFormField> | Error<FormField>;
+
+// ---- Validation ---- //
+
+export function validateCheckoutForm(
+	dispatch: Dispatch,
+	state: SubscriptionsState,
+): boolean {
+	const allErrors = checkoutValidation(state);
+	dispatchAllErrors(dispatch, allErrors);
+	return allErrors.length === 0;
+}
+
+export function validateWithDeliveryForm(
+	dispatch: Dispatch<Action>,
+	state: SubscriptionsState,
+): boolean {
+	const allErrors = withDeliveryValidation(state);
+	dispatchAllErrors(dispatch, allErrors);
+	return allErrors.length === 0;
+}
+
+export function checkoutFormIsValid(state: SubscriptionsState): boolean {
+	if (state.page.checkoutForm.product.productType === DigitalPack) {
+		return checkoutValidation(state).length === 0;
+	}
+	return withDeliveryValidation(state).length === 0;
+}
+
+export function withDeliveryFormIsValid(state: SubscriptionsState): boolean {
+	return withDeliveryValidation(state).length === 0;
+}
+
+// ---- Helpers ---- //
 
 function checkoutValidation(state: SubscriptionsState): AnyErrorType[] {
 	const errors: AnyErrorType[] = [];
@@ -51,9 +86,6 @@ function checkoutValidation(state: SubscriptionsState): AnyErrorType[] {
 
 	return errors;
 }
-
-const shouldValidateBillingAddress = (fields: FormFields) =>
-	!fields.billingAddressIsSame;
 
 function withDeliveryValidation(state: SubscriptionsState): AnyErrorType[] {
 	const errors: AnyErrorType[] = [];
@@ -96,37 +128,10 @@ function withDeliveryValidation(state: SubscriptionsState): AnyErrorType[] {
 	return errors;
 }
 
-function validateCheckoutForm(
-	dispatch: Dispatch,
-	state: SubscriptionsState,
-): boolean {
-	const allErrors = checkoutValidation(state);
-	allErrors.forEach((e) => e.dispatchErrors(dispatch));
-	return allErrors.length === 0;
+function shouldValidateBillingAddress(fields: FormFields) {
+	return !fields.billingAddressIsSame;
 }
 
-function validateWithDeliveryForm(
-	dispatch: Dispatch<Action>,
-	state: SubscriptionsState,
-): boolean {
-	const allErrors = withDeliveryValidation(state);
+function dispatchAllErrors(dispatch: Dispatch, allErrors: AnyErrorType[]) {
 	allErrors.forEach((e) => e.dispatchErrors(dispatch));
-	return allErrors.length === 0;
 }
-
-const checkoutFormIsValid = (state: SubscriptionsState): boolean => {
-	if (state.page.checkoutForm.product.productType === DigitalPack) {
-		return checkoutValidation(state).length === 0;
-	}
-	return withDeliveryValidation(state).length === 0;
-};
-
-const withDeliveryFormIsValid = (state: SubscriptionsState): boolean =>
-	withDeliveryValidation(state).length === 0;
-
-export {
-	validateWithDeliveryForm,
-	validateCheckoutForm,
-	checkoutFormIsValid,
-	withDeliveryFormIsValid,
-};

--- a/support-frontend/assets/helpers/subscriptionsForms/formValidation.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formValidation.ts
@@ -63,11 +63,8 @@ export function withDeliveryFormIsValid(state: SubscriptionsState): boolean {
 // ---- Helpers ---- //
 
 function checkoutValidation(state: SubscriptionsState): AnyErrorType[] {
-	const errors: AnyErrorType[] = [];
-	const pushIfErrors = getPushIfErrors(errors);
-
 	const checkoutErrors = applyCheckoutRules(getFormFields(state));
-	pushIfErrors({
+	const checkoutErrorsList = getErrorList({
 		errors: checkoutErrors,
 		dispatchErrors: (dispatch) => dispatch(setFormErrors(checkoutErrors)),
 	});
@@ -75,32 +72,29 @@ function checkoutValidation(state: SubscriptionsState): AnyErrorType[] {
 	const billingAddressErrors = applyBillingAddressRules(
 		state.page.checkoutForm.billingAddress.fields,
 	);
-	pushIfErrors({
+	const billingAddressErrorsList = getErrorList({
 		errors: billingAddressErrors,
 		dispatchErrors: (dispatch) =>
 			dispatch(setBillingAddressFormErrors(billingAddressErrors)),
 	});
 
-	return errors;
+	return [...checkoutErrorsList, ...billingAddressErrorsList];
 }
 
 function withDeliveryValidation(state: SubscriptionsState): AnyErrorType[] {
-	const errors: AnyErrorType[] = [];
-	const pushIfErrors = getPushIfErrors(errors);
-
 	const formFields = getFormFields(state);
 
-	const deliveryErrrors = applyDeliveryRules(formFields);
-	pushIfErrors({
-		errors: deliveryErrrors,
-		dispatchErrors: (dispatch) => dispatch(setFormErrors(deliveryErrrors)),
+	const deliveryErrors = applyDeliveryRules(formFields);
+	const deliveryErrorsList = getErrorList({
+		errors: deliveryErrors,
+		dispatchErrors: (dispatch) => dispatch(setFormErrors(deliveryErrors)),
 	});
 
 	const deliveryAddressErrors = applyDeliveryAddressRules(
 		getFulfilmentOption(state),
 		state.page.checkoutForm.deliveryAddress.fields,
 	);
-	pushIfErrors({
+	const deliveryAddressErrorsList = getErrorList({
 		errors: deliveryAddressErrors,
 		dispatchErrors: (dispatch) =>
 			dispatch(setDeliveryAddressFormErrors(deliveryAddressErrors)),
@@ -110,14 +104,20 @@ function withDeliveryValidation(state: SubscriptionsState): AnyErrorType[] {
 		const billingAddressErrors = applyBillingAddressRules(
 			state.page.checkoutForm.billingAddress.fields,
 		);
-		pushIfErrors({
+		const billingAddressErrorsList = getErrorList({
 			errors: billingAddressErrors,
 			dispatchErrors: (dispatch) =>
 				dispatch(setBillingAddressFormErrors(billingAddressErrors)),
 		});
+
+		return [
+			...deliveryErrorsList,
+			...deliveryAddressErrorsList,
+			...billingAddressErrorsList,
+		];
 	}
 
-	return errors;
+	return [...deliveryErrorsList, ...deliveryAddressErrorsList];
 }
 
 function shouldValidateBillingAddress(fields: FormFields) {
@@ -128,11 +128,6 @@ function dispatchAllErrors(dispatch: Dispatch, allErrors: AnyErrorType[]) {
 	allErrors.forEach((e) => e.dispatchErrors(dispatch));
 }
 
-function getPushIfErrors(errors: AnyErrorType[]) {
-	function pushIfErrors(error: AnyErrorType) {
-		if (error.errors.length > 0) {
-			errors.push(error);
-		}
-	}
-	return pushIfErrors;
+function getErrorList(error: AnyErrorType) {
+	return error.errors.length > 0 ? [error] : [];
 }

--- a/support-frontend/assets/helpers/subscriptionsForms/formValidation.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formValidation.ts
@@ -64,65 +64,57 @@ export function withDeliveryFormIsValid(state: SubscriptionsState): boolean {
 
 function checkoutValidation(state: SubscriptionsState): AnyErrorType[] {
 	const errors: AnyErrorType[] = [];
+	const pushIfErrors = getPushIfErrors(errors);
 
 	const checkoutErrors = applyCheckoutRules(getFormFields(state));
-	if (checkoutErrors.length > 0) {
-		errors.push({
-			errors: checkoutErrors,
-			dispatchErrors: (dispatch) => dispatch(setFormErrors(checkoutErrors)),
-		});
-	}
+	pushIfErrors({
+		errors: checkoutErrors,
+		dispatchErrors: (dispatch) => dispatch(setFormErrors(checkoutErrors)),
+	});
 
 	const billingAddressErrors = applyBillingAddressRules(
 		state.page.checkoutForm.billingAddress.fields,
 	);
-	if (checkoutErrors.length > 0) {
-		errors.push({
-			errors: billingAddressErrors,
-			dispatchErrors: (dispatch) =>
-				dispatch(setBillingAddressFormErrors(billingAddressErrors)),
-		});
-	}
+	pushIfErrors({
+		errors: billingAddressErrors,
+		dispatchErrors: (dispatch) =>
+			dispatch(setBillingAddressFormErrors(billingAddressErrors)),
+	});
 
 	return errors;
 }
 
 function withDeliveryValidation(state: SubscriptionsState): AnyErrorType[] {
 	const errors: AnyErrorType[] = [];
+	const pushIfErrors = getPushIfErrors(errors);
 
 	const formFields = getFormFields(state);
 
 	const deliveryErrrors = applyDeliveryRules(formFields);
-	if (deliveryErrrors.length > 0) {
-		errors.push({
-			errors: deliveryErrrors,
-			dispatchErrors: (dispatch) => dispatch(setFormErrors(deliveryErrrors)),
-		});
-	}
+	pushIfErrors({
+		errors: deliveryErrrors,
+		dispatchErrors: (dispatch) => dispatch(setFormErrors(deliveryErrrors)),
+	});
 
 	const deliveryAddressErrors = applyDeliveryAddressRules(
 		getFulfilmentOption(state),
 		state.page.checkoutForm.deliveryAddress.fields,
 	);
-	if (deliveryAddressErrors.length > 0) {
-		errors.push({
-			errors: deliveryAddressErrors,
-			dispatchErrors: (dispatch) =>
-				dispatch(setDeliveryAddressFormErrors(deliveryAddressErrors)),
-		});
-	}
+	pushIfErrors({
+		errors: deliveryAddressErrors,
+		dispatchErrors: (dispatch) =>
+			dispatch(setDeliveryAddressFormErrors(deliveryAddressErrors)),
+	});
 
 	if (shouldValidateBillingAddress(formFields)) {
 		const billingAddressErrors = applyBillingAddressRules(
 			state.page.checkoutForm.billingAddress.fields,
 		);
-		if (billingAddressErrors.length > 0) {
-			errors.push({
-				errors: billingAddressErrors,
-				dispatchErrors: (dispatch) =>
-					dispatch(setBillingAddressFormErrors(billingAddressErrors)),
-			});
-		}
+		pushIfErrors({
+			errors: billingAddressErrors,
+			dispatchErrors: (dispatch) =>
+				dispatch(setBillingAddressFormErrors(billingAddressErrors)),
+		});
 	}
 
 	return errors;
@@ -134,4 +126,13 @@ function shouldValidateBillingAddress(fields: FormFields) {
 
 function dispatchAllErrors(dispatch: Dispatch, allErrors: AnyErrorType[]) {
 	allErrors.forEach((e) => e.dispatchErrors(dispatch));
+}
+
+function getPushIfErrors(errors: AnyErrorType[]) {
+	function pushIfErrors(error: AnyErrorType) {
+		if (error.errors.length > 0) {
+			errors.push(error);
+		}
+	}
+	return pushIfErrors;
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Make a few refactors to the subs form validation logic. This was due to a seemingly unrelated piece of work to migrate the PayPal state to an RTK slice causing some errors in this file. 

I noticed that our types were slightly weaker than they needed to be. We have

```ts
type Error<T> = {
	errors: Array<FormError<T>>;
	errorAction: (arg0: any) => Action;
};
```

But the `errorAction` function takes the `errors` array if it gets called, so we should be able to use

```ts
type Error<T> = {
	errors: Array<FormError<T>>;
	errorAction: (errors: Array<FormError<T>>) => Action;
};
```

However, that introduced a new error. What we currently have is an array of 

```ts
type AnyErrorType = Error<AddressFormField> | Error<FormField>;
```

Which we then loop through to dispatch the errors

```ts
allErrors.forEach(({ errors, errorAction }) => {
  dispatch(errorAction(errors));
});
```

I haven't quite figured out why, but at this point typescript no longer knows that the `errors` and `errorAction` have the same generic type. I've created a [typescript playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAYg9nAPAFQHxQLxQN4CgpTAAWAlgHYDmAXFMgNz5QBmArmQMY0AUx51tASkzoAbnBIATBgF8GuUJCgAhAIYAnTLASIAzsDV90AHy1IyLALYAjCGtRz2cMnqgWQqtTQ+a8BXpRoAIiIIABtQuECAGkZWDm5-fj0DSiEMdGxpGNlcXAB6PNpSHSgSErgAaxUQADo63DcPGrj2Lkb1GsSBBycXdrUdL3UAbQBdTWHGXwJCUgCoYLCI6MYCFoS5pP0+NIysxn2Cab9NmgBGAAYYmeY2TigeU6hza1tdnEOofdG5AuUWYCzMqlHRkADkwAa7nUOmacDUAFEVOwiFwuFZ1O9phi1M07uiOl0ZN1cEA) that illustrates this. I'd be interested to hear if anybody has any ideas about this one!

I decided that it was then probably easiest to replace the `errorAction` function with something that was more generic and got access to the `errors` array through its closure. I changed it for a `dispatchErrors` function that just takes a `dispatch` and returns `void`. This also meant I had to replace the declarative building up of the `AnyErrorType[]` array with some imperative code instead. 

That was the main bulk of the structural changes, outside of that, I also added some comment headers to chunk up the file and reorganised it to put the most important functions at the top (i.e the ones that get exported) and moved the helper functions to the bottom. 
