### PR TITLE
Create reusable white box container component for checkout MVP

### DIFF
--- a/support-frontend/assets/components/checkoutBox/checkoutBox.tsx
+++ b/support-frontend/assets/components/checkoutBox/checkoutBox.tsx
@@ -6,6 +6,7 @@ const mainStyles = css`
 	display: block;
 	overflow: hidden;
 	background-color: ${neutral[100]};
+	color: ${neutral[7]};
 	border: 1px solid ${neutral[86]};
 	border-radius: ${space[3]}px;
 

--- a/support-frontend/assets/components/checkoutBox/checkoutBox.tsx
+++ b/support-frontend/assets/components/checkoutBox/checkoutBox.tsx
@@ -1,0 +1,53 @@
+import { css } from '@emotion/react';
+import { from, neutral, space } from '@guardian/source-foundations';
+import type { CSSOverridable } from 'helpers/types/cssOverrideable';
+
+const mainStyles = css`
+	display: block;
+	overflow: hidden;
+	background-color: ${neutral[100]};
+	border: 1px solid ${neutral[86]};
+	border-radius: ${space[3]}px;
+	margin-bottom: ${space[3]}px;
+
+	${from.mobileLandscape} {
+		margin-bottom: ${space[4]}px;
+	}
+`;
+
+export interface BoxProps extends CSSOverridable {
+	children: React.ReactNode;
+	tag?: keyof JSX.IntrinsicElements;
+}
+
+export function Box(props: BoxProps): JSX.Element {
+	const TagName = props.tag ?? 'section';
+	return (
+		<TagName css={[mainStyles, props.cssOverrides ? props.cssOverrides : '']}>
+			{props.children}
+		</TagName>
+	);
+}
+
+const innerContainerStyles = css`
+	padding: ${space[3]}px;
+
+	${from.tablet} {
+		padding: ${space[5]}px;
+	}
+
+	${from.desktop} {
+		padding: ${space[6]}px;
+	}
+`;
+
+export function BoxContents(props: BoxProps): JSX.Element {
+	const TagName = props.tag ?? 'div';
+	return (
+		<TagName
+			css={[innerContainerStyles, props.cssOverrides ? props.cssOverrides : '']}
+		>
+			{props.children}
+		</TagName>
+	);
+}

--- a/support-frontend/assets/components/checkoutBox/checkoutBox.tsx
+++ b/support-frontend/assets/components/checkoutBox/checkoutBox.tsx
@@ -27,7 +27,7 @@ export interface BoxProps extends CSSOverridable {
 export function Box(props: BoxProps): JSX.Element {
 	const TagName = props.tag ?? 'section';
 	return (
-		<TagName css={[mainStyles, props.cssOverrides ? props.cssOverrides : '']}>
+		<TagName css={[mainStyles, props.cssOverrides ?? '']}>
 			{props.children}
 		</TagName>
 	);
@@ -48,9 +48,7 @@ const innerContainerStyles = css`
 export function BoxContents(props: BoxProps): JSX.Element {
 	const TagName = props.tag ?? 'div';
 	return (
-		<TagName
-			css={[innerContainerStyles, props.cssOverrides ? props.cssOverrides : '']}
-		>
+		<TagName css={[innerContainerStyles, props.cssOverrides ?? '']}>
 			{props.children}
 		</TagName>
 	);

--- a/support-frontend/assets/components/checkoutBox/checkoutBox.tsx
+++ b/support-frontend/assets/components/checkoutBox/checkoutBox.tsx
@@ -8,10 +8,13 @@ const mainStyles = css`
 	background-color: ${neutral[100]};
 	border: 1px solid ${neutral[86]};
 	border-radius: ${space[3]}px;
-	margin-bottom: ${space[3]}px;
 
-	${from.mobileLandscape} {
-		margin-bottom: ${space[4]}px;
+	:not(:last-child) {
+		margin-bottom: ${space[3]}px;
+
+		${from.mobileLandscape} {
+			margin-bottom: ${space[4]}px;
+		}
 	}
 `;
 

--- a/support-frontend/stories/checkoutLayout/CheckoutBox.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutBox.stories.tsx
@@ -1,0 +1,82 @@
+import { css } from '@emotion/react';
+import { brand, neutral } from '@guardian/source-foundations';
+import { Column, Columns } from '@guardian/source-react-components';
+import type { BoxProps } from 'components/checkoutBox/checkoutBox';
+import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
+import { Container } from 'components/layout/container';
+
+export default {
+	title: 'Checkout Layout/Box',
+	component: Box,
+	subcomponents: { BoxContents },
+	argTypes: {
+		tag: {
+			control: { type: 'select', options: ['div', 'section', 'fieldset'] },
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'A container box for sections of the checkout form. The BoxContents component can be used to provide uniform padding to content inside a Box.',
+			},
+		},
+	},
+	decorators: [
+		(Story: React.FC): JSX.Element => (
+			<Container backgroundColor="#D9D9D9">
+				<Columns
+					collapseUntil="tablet"
+					cssOverrides={css`
+						justify-content: center;
+						padding: 1rem 0;
+					`}
+				>
+					<Column width={[1, 3 / 4, 1 / 2]}>
+						<Story />
+					</Column>
+				</Columns>
+			</Container>
+		),
+	],
+};
+
+function Template(args: BoxProps): JSX.Element {
+	return <Box {...args} />;
+}
+
+Template.args = {} as Record<string, unknown>;
+
+export const WithBoxContents = Template.bind({});
+
+WithBoxContents.args = {
+	children: (
+		<BoxContents>
+			This is simple container for content on the checkout page.
+		</BoxContents>
+	),
+	tag: 'section',
+};
+
+export const WithoutBoxContents = Template.bind({});
+
+WithoutBoxContents.args = {
+	children: (
+		<div>
+			<h2
+				style={{
+					backgroundColor: brand[600],
+					color: neutral[100],
+					height: '42px',
+					padding: '8px',
+				}}
+			>
+				Heading
+			</h2>
+			<BoxContents>
+				Elements not wrapped in a BoxContents will take up the full width of the
+				Box, but not overflow it.
+			</BoxContents>
+		</div>
+	),
+};

--- a/support-frontend/stories/checkoutLayout/CheckoutBox.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutBox.stories.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { brand, neutral } from '@guardian/source-foundations';
-import { Column, Columns } from '@guardian/source-react-components';
+import { Column, Columns, TextInput } from '@guardian/source-react-components';
 import type { BoxProps } from 'components/checkoutBox/checkoutBox';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { Container } from 'components/layout/container';
@@ -45,14 +45,15 @@ function Template(args: BoxProps): JSX.Element {
 	return <Box {...args} />;
 }
 
-Template.args = {} as Record<string, unknown>;
+Template.args = {} as BoxProps;
 
 export const WithBoxContents = Template.bind({});
 
 WithBoxContents.args = {
 	children: (
 		<BoxContents>
-			This is simple container for content on the checkout page.
+			This is simple container for content on the checkout page. Children may be
+			wrapped in a BoxContents component to provide consistent padding.
 		</BoxContents>
 	),
 	tag: 'section',
@@ -80,3 +81,38 @@ WithoutBoxContents.args = {
 		</div>
 	),
 };
+
+export const WithFormElements = Template.bind({});
+
+WithFormElements.args = {
+	children: (
+		<BoxContents>
+			<TextInput
+				id="email"
+				type="email"
+				label="Email address"
+				cssOverrides={css`
+					margin-bottom: 16px;
+				`}
+			/>
+			<TextInput
+				id="firstName"
+				label="First name"
+				cssOverrides={css`
+					margin-bottom: 16px;
+				`}
+			/>
+			<TextInput id="lastName" label="Last name" />
+		</BoxContents>
+	),
+};
+
+export function Stacked(): JSX.Element {
+	return (
+		<>
+			<WithBoxContents {...WithBoxContents.args} />
+			<WithFormElements {...WithFormElements.args} />
+			<WithoutBoxContents {...WithoutBoxContents.args} />
+		</>
+	);
+}

--- a/support-frontend/stories/checkoutLayout/CheckoutBox.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutBox.stories.tsx
@@ -24,7 +24,7 @@ export default {
 	},
 	decorators: [
 		(Story: React.FC): JSX.Element => (
-			<Container backgroundColor="#D9D9D9">
+			<Container backgroundColor={neutral[97]}>
 				<Columns
 					collapseUntil="tablet"
 					cssOverrides={css`

--- a/support-frontend/stories/checkoutLayout/CheckoutHeading.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutHeading.stories.tsx
@@ -1,5 +1,7 @@
+import { css } from '@emotion/react';
 import { brand } from '@guardian/source-foundations';
 import { Column, Columns } from '@guardian/source-react-components';
+import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import type { CheckoutHeadingProps } from 'components/checkoutHeading/checkoutHeading';
 import { CheckoutHeading } from 'components/checkoutHeading/checkoutHeading';
 import { Container } from 'components/layout/container';
@@ -96,28 +98,24 @@ WithSiblingOverlaid.decorators = [
 					}}
 				>
 					<Container>
-						<Columns>
-							<Column width={[0, 0, 1 / 3]}></Column>
-							<Column>
-								<div
-									style={{
-										background: '#ffffff',
-										width: '100%',
-										maxWidth: '540px',
-										height: '600px',
-										marginTop: '120px',
-										padding: '12px',
-										border: '1px solid black',
-									}}
-								>
-									<p>
-										Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut
-										faucibus nibh erat, eget rutrum ligula vehicula sit amet.
-										Etiam scelerisque dapibus pulvinar. Integer non accumsan
-										justo. Duis et vehicula risus. Nulla ligula eros, consequat
-										sodales lectus eget, eleifend venenatis neque.
-									</p>
-								</div>
+						<Columns
+							cssOverrides={css`
+								padding-top: 120px;
+							`}
+						>
+							<Column width={[0, 1 / 8, 1 / 3]}></Column>
+							<Column width={[1, 3 / 4, 1 / 2]}>
+								<Box>
+									<BoxContents>
+										<p>
+											Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+											Ut faucibus nibh erat, eget rutrum ligula vehicula sit
+											amet. Etiam scelerisque dapibus pulvinar. Integer non
+											accumsan justo. Duis et vehicula risus. Nulla ligula eros,
+											consequat sodales lectus eget, eleifend venenatis neque.
+										</p>
+									</BoxContents>
+								</Box>
 							</Column>
 						</Columns>
 					</Container>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds a simple white box component that is used throughout the new checkout MVP to contain elements of the form and other content. The box applies a consistent background colour, font colour, border, border radius, and bottom margin, but has no pre-determined width or height. Additionally there is an accompanying `BoxContents` component that can be used to apply consistent padding at different breakpoints to items inside the box.

[**Trello Card**](https://trello.com/c/N9HYZrrC)

## Why are you doing this?

This is another core component of the new checkout MVP.

## Accessibility test checklist
 - [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

### Mobile
![Screenshot 2022-07-25 at 17 11 36](https://user-images.githubusercontent.com/29146931/180825225-58d7aa3c-0051-432a-af92-f40c8b15c4e1.png)

### Desktop
![Screenshot 2022-07-25 at 17-11-21 checkout-layout-box--stacked](https://user-images.githubusercontent.com/29146931/180825266-f55a20cd-3af8-4311-aba4-4117eca34465.png)

