### PR TITLE
Change the Customer Acceptance Date to tomorrow for Recurring Contributions

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -128,6 +128,7 @@ class ZuoraProductHandlers(services: Services, state: CreateZuoraSubscriptionSta
     new ContributionSubscriptionBuilder(
       services.config.zuoraConfigProvider.get(isTestUser).contributionConfig,
       subscribeItemBuilder,
+      dateGenerator,
     ),
     state.user,
   )

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/ContributionSubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/ContributionSubscriptionBuilder.scala
@@ -5,18 +5,33 @@ import com.gu.support.workers.BillingPeriod
 import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.ContributionState
 import com.gu.support.zuora.api.ReaderType.Direct
 import com.gu.support.zuora.api._
-import org.joda.time.{DateTimeZone, LocalDate}
+import com.gu.helpers.DateGenerator
 
 class ContributionSubscriptionBuilder(
     config: BillingPeriod => ZuoraContributionConfig,
     subscribeItemBuilder: SubscribeItemBuilder,
+    dateGenerator: DateGenerator,
 ) {
 
   def build(state: ContributionState): SubscribeItem = {
     val contributionConfig = config(state.product.billingPeriod)
+
+    val contractEffectiveDate = dateGenerator.today
+
+    // Before 26 July 2022 the Customer Acceptance Date for Recurring Contributions was always  the same as the
+    // Contract Effective Date (i.e. today). A change was made to push the CAS one day forward so as not to trigger
+    // an invoice and payment immediately when making a Recurring Contribution. This will affect the customer experience
+    // for users who have no money in their account when purchasing, as tbey will no longer be notified on the checkout,
+    // instead they will be notified by email the day after purchasing.
+    //
+    // The reason for making this change relates to a project being undertaken by the Finance team on August 1st 2022
+    // to re-publish revenue schedules from 4-4-5 over to calendar monthly. This change is going live a few days ahead
+    // of that date to enable the change to be monitored for any issues downstream.
+    val contractAcceptanceDate = contractEffectiveDate.plusDays(1)
+
     val subscriptionData = subscribeItemBuilder.buildProductSubscription(
-      contributionConfig.productRatePlanId,
-      List(
+      productRatePlanId = contributionConfig.productRatePlanId,
+      ratePlanCharges = List(
         RatePlanChargeData(
           RatePlanChargeOverride(
             contributionConfig.productRatePlanChargeId,
@@ -24,6 +39,8 @@ class ContributionSubscriptionBuilder(
           ), // Pass the amount the user selected into Zuora
         ),
       ),
+      contractEffectiveDate = contractEffectiveDate,
+      contractAcceptanceDate = contractAcceptanceDate,
       readerType = Direct,
     )
     subscribeItemBuilder.build(subscriptionData, state.salesForceContact, Some(state.paymentMethod), None)

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/ContributionSubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/ContributionSubscriptionBuilder.scala
@@ -21,7 +21,7 @@ class ContributionSubscriptionBuilder(
     // Before 26 July 2022 the Customer Acceptance Date for Recurring Contributions was always  the same as the
     // Contract Effective Date (i.e. today). A change was made to push the CAS one day forward so as not to trigger
     // an invoice and payment immediately when making a Recurring Contribution. This will affect the customer experience
-    // for users who have no money in their account when purchasing, as tbey will no longer be notified on the checkout,
+    // for users who have no money in their account when purchasing, as they will no longer be notified on the checkout,
     // instead they will be notified by email the day after purchasing.
     //
     // The reason for making this change relates to a project being undertaken by the Finance team on August 1st 2022

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/ContributionSubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/ContributionSubscriptionBuilder.scala
@@ -25,8 +25,9 @@ class ContributionSubscriptionBuilder(
     // instead they will be notified by email the day after purchasing.
     //
     // The reason for making this change relates to a project being undertaken by the Finance team on August 1st 2022
-    // to re-publish revenue schedules from 4-4-5 over to calendar monthly. This change is going live a few days ahead
-    // of that date to enable the change to be monitored for any issues downstream.
+    // to re-publish revenue schedules from 4-4-5 over to calendar monthly, and it requires no invoices be posted or
+    // payments be made during the change window. This change is going live a few days ahead of that date to enable
+    // the change to be monitored for any issues downstream.
     val contractAcceptanceDate = contractEffectiveDate.plusDays(1)
 
     val subscriptionData = subscribeItemBuilder.buildProductSubscription(


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Changeing the Customer Acceptance Date for Recurring Contributions to tomorrow instead of today.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?
Before 26 July 2022 the Customer Acceptance Date for Recurring Contributions was always  the same as the Contract Effective Date (i.e. today). A change was made to push the CAS one day forward so as not to trigger an invoice and payment immediately when making a Recurring Contribution. This will affect the customer experience for users who have no money in their account when purchasing, as they will no longer be notified on the checkout, instead they will be notified by email the day after purchasing.

The reason for making this change relates to a project being undertaken by the Finance team on August 1st 2022 to re-publish revenue schedules from 4-4-5 over to calendar monthly and it requires no invoices be posted or payments or refunds be made during the change window. This change is going live a few days ahead of that date to enable the change to be monitored for any issues downstream.

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [X] No



