### PR TITLE
Quantum Metric: Round contribution value on contributions checkout amount update event

### DIFF
--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -239,7 +239,7 @@ export function sendEventContributionAmountUpdated(
 					sourceCurrency,
 				);
 				if (convertedValue) {
-					sendEvent(sendEventId, false, convertedValue.toString());
+					sendEvent(sendEventId, false, Math.round(convertedValue).toString());
 				}
 			};
 


### PR DESCRIPTION
## What are you doing in this PR?

This PR is an addition to https://github.com/guardian/support-frontend/pull/4024. We need to round `convertedValue` before passing it to Quantum Metric, for the reason explained in https://github.com/guardian/support-frontend/pull/4024.