### PR TITLE
Factor out other amount field component and add tests

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmountOtherAmountField.test.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmountOtherAmountField.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ContributionAmountOtherAmountFieldProps } from './ContributionAmountOtherAmountField';
+import { ContributionAmountOtherAmountField } from './ContributionAmountOtherAmountField';
+
+describe('ContributionAmountOtherAmountField', () => {
+	it('calls the onChange callback when a user types in the field', async () => {
+		const onChange = jest.fn();
+
+		renderComponent({ onChange });
+
+		await userEvent.type(screen.getByTestId('other-amount-input'), '10.00');
+
+		expect(onChange).toHaveBeenCalledTimes(5);
+	});
+
+	it('calls the onBlur callback when a user blurs the field', () => {
+		const onBlur = jest.fn();
+
+		renderComponent({ onBlur });
+
+		screen.getByTestId('other-amount-input').focus();
+		screen.getByTestId('other-amount-input').blur();
+
+		expect(onBlur).toHaveBeenCalledTimes(1);
+	});
+
+	it("doesn't display an error message when the amount is valid", () => {
+		renderComponent({ amount: '10.00', canShowErrorMessage: true });
+
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+	});
+
+	it('displays an error message when the amount is empty', () => {
+		renderComponent({ amount: '', canShowErrorMessage: true });
+
+		expect(screen.getByRole('alert')).toBeInTheDocument();
+	});
+
+	it('displays an error message when the amount is not a number', () => {
+		renderComponent({ amount: 'foo', canShowErrorMessage: true });
+
+		expect(screen.getByRole('alert')).toBeInTheDocument();
+	});
+
+	it('displays an error message when the amount has too many decimal places', () => {
+		renderComponent({ amount: '10.000', canShowErrorMessage: true });
+
+		expect(screen.getByRole('alert')).toBeInTheDocument();
+	});
+});
+
+// ---- Helpers ---- //
+
+function renderComponent({
+	amount = '',
+	currency = 'GBP',
+	countryGroupId = 'GBPCountries',
+	contributionType = 'ONE_OFF',
+	canShowErrorMessage = false,
+	min: minAmount = 5,
+	max: maxAmount = 20,
+	onChange = jest.fn(),
+	onBlur = jest.fn(),
+	localCurrencyCountry = undefined,
+	useLocalCurrency = false,
+}: Partial<ContributionAmountOtherAmountFieldProps>) {
+	render(
+		<ContributionAmountOtherAmountField
+			amount={amount}
+			countryGroupId={countryGroupId}
+			contributionType={contributionType}
+			currency={currency}
+			min={minAmount}
+			max={maxAmount}
+			onChange={onChange}
+			onBlur={onBlur}
+			canShowErrorMessage={canShowErrorMessage}
+			localCurrencyCountry={localCurrencyCountry}
+			useLocalCurrency={useLocalCurrency}
+		/>,
+	);
+}

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmountOtherAmountField.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmountOtherAmountField.tsx
@@ -1,0 +1,111 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/source-foundations';
+import { TextInput } from '@guardian/source-react-components';
+import type { ContributionType } from 'helpers/contributions';
+import { formatAmount } from 'helpers/forms/checkouts';
+import { amountIsValid } from 'helpers/forms/formValidation';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import {
+	currencies,
+	spokenCurrencies,
+} from 'helpers/internationalisation/currency';
+import type { LocalCurrencyCountry } from 'helpers/internationalisation/localCurrencyCountry';
+import { classNameWithModifiers } from 'helpers/utilities/utilities';
+
+// ----- Component ----- //
+
+export interface ContributionAmountOtherAmountFieldProps {
+	amount: string;
+	countryGroupId: CountryGroupId;
+	contributionType: ContributionType;
+	min: number;
+	max: number;
+	currency: IsoCurrency;
+	canShowErrorMessage: boolean;
+	onChange: (amount: string) => void;
+	onBlur: () => void;
+	localCurrencyCountry?: LocalCurrencyCountry;
+	useLocalCurrency: boolean;
+}
+
+export function ContributionAmountOtherAmountField({
+	amount,
+	countryGroupId,
+	contributionType,
+	min,
+	max,
+	currency,
+	canShowErrorMessage,
+	onChange,
+	onBlur,
+	localCurrencyCountry,
+	useLocalCurrency,
+}: ContributionAmountOtherAmountFieldProps): JSX.Element {
+	const minAmount = formatAmount(
+		currencies[currency],
+		spokenCurrencies[currency],
+		min,
+		false,
+	);
+
+	const maxAmount = formatAmount(
+		currencies[currency],
+		spokenCurrencies[currency],
+		max,
+		false,
+	);
+
+	const glyph: string = currencies[currency].glyph;
+
+	const errorMessage =
+		canShowErrorMessage &&
+		!amountIsValid(
+			amount,
+			countryGroupId,
+			contributionType,
+			localCurrencyCountry,
+			useLocalCurrency,
+		)
+			? `Please provide an amount between ${minAmount} and ${maxAmount}`
+			: '';
+
+	return (
+		<div
+			className={classNameWithModifiers('form__field', [
+				'contribution-other-amount',
+			])}
+		>
+			<p css={glyphStyles}>{glyph}</p>
+
+			<TextInput
+				id="contributionOther"
+				data-testid="other-amount-input"
+				cssOverrides={inputStyles}
+				label={`Other amount`}
+				value={amount}
+				onChange={(e) => onChange(e.target.value)}
+				onBlur={onBlur}
+				error={errorMessage}
+				autoComplete="off"
+				autoFocus
+				inputMode="numeric"
+				pattern="[0-9]*"
+			/>
+		</div>
+	);
+}
+
+// ---- Styles ---- //
+
+const inputStyles = css`
+	padding-left: ${space[5]}px;
+`;
+
+const glyphStyles = css`
+	position: absolute;
+	font-weight: bold;
+	bottom: 22px; // half of the fixed height of the input element we get from source
+	transform: translateY(50%);
+	padding-left: ${space[2]}px;
+`;

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -151,6 +151,7 @@
     "@storybook/testing-library": "^0.0.13",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.3",
+    "@testing-library/user-event": "^14.3.0",
     "@types/jsdom": "^16.2.14",
     "@types/lodash.debounce": "^4.0.6",
     "@types/react-dom": "^17.0.11",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -3264,6 +3264,11 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+"@testing-library/user-event@^14.3.0":
+  version "14.3.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.3.0.tgz#0a6750b94b40e4739706d41e8efc2ccf64d2aad9"
+  integrity sha512-P02xtBBa8yMaLhK8CzJCIns8rqwnF6FxhR9zs810flHOBXUYCFjLd8Io1rQrAkQRWEmW2PGdZIEdMxf/KLsqFA==
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Factors out a new `ContributionAmountOtherAmountField` component and adds some unit tests. I went back and forth a little bit on the best way to add tests to this component. I was weighing up:

1. Factoring out a simple, presentational component that can be tested very easily (what I did in the end)
2. Just adding tests to the more complex, `ContributionAmount` component. 

Adding the tests to `ContributionAmount` component would have more closely replicated a proper user interaction, but would have required getting things to play nice with redux. 

In the end I decided to factor out a component which would be easy to test - we can just pass in different props and assert it renders in different ways. 

I think we'd also get benefits of some higher level tests too, e.g testing the `ContributionAmount` component or testing the checkout directly. This would definitely be a separate piece of work so can be done as a follow up!