### PR TITLE
disable DatePicker snapshot tests

### DIFF
--- a/support-frontend/stories/checkouts/DatePicker.stories.tsx
+++ b/support-frontend/stories/checkouts/DatePicker.stories.tsx
@@ -31,3 +31,9 @@ export function DatePicker(args: {
 DatePicker.args = {
 	value: formatMachineDate(new Date()),
 };
+DatePicker.parameters = {
+	// TODO: We can factor out a purely presentational component and then re-enable
+	// the snapshot tests. For now the component has hardcoded references to Date.now()
+	// so will cause a snapshot diff every day!
+	chromatic: { disableSnapshot: true },
+};


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Disable `DatePicker` snapshot tests. We should be able to add the tests back if we factor out a presentational component that doesn't have any hardcoded references to `Date.now`.