### PR TITLE
Payment API CDK migration - Phase 1

### DIFF
--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -31,6 +31,17 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
+      - name: Setup Node for CDK
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'yarn'
+          cache-dependency-path: cdk/yarn.lock
+
+      - name: Build CFN from CDK
+        run: ./script/ci
+        working-directory: cdk
+
       # Required by sbt riffRaffUpload
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,6 +1,7 @@
 import "source-map-support/register";
 import { App } from "@aws-cdk/core";
 import { Frontend } from "../lib/frontend";
+import { PaymentApi } from "../lib/payment-api";
 import { StripePatronsData } from "../lib/stripe-patrons-data";
 
 const app = new App();
@@ -46,4 +47,14 @@ new StripePatronsData(app, "StripePatronsData-PROD", {
   stack: "support",
   stage: "PROD",
   cloudFormationStackName,
+});
+
+new PaymentApi(app, "Payment-API-CODE", {
+  stack: "support",
+  stage: "CODE",
+});
+
+new PaymentApi(app, "Payment-API-PROD", {
+  stack: "support",
+  stage: "PROD",
 });

--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -1,0 +1,1190 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The Payment API stack matches the snapshot 1`] = `
+Object {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": Object {
+    "CreateCodeResources": Object {
+      "Fn::Equals": Array [
+        "PROD",
+        "CODE",
+      ],
+    },
+    "CreateProdResources": Object {
+      "Fn::Equals": Array [
+        "PROD",
+        "PROD",
+      ],
+    },
+  },
+  "Description": "payment-api",
+  "Mappings": Object {
+    "StageVariables": Object {
+      "CODE": Object {
+        "InstanceType": "t4g.small",
+        "MaxInstances": 2,
+        "MinInstances": 1,
+      },
+      "PROD": Object {
+        "InstanceType": "t4g.small",
+        "MaxInstances": 6,
+        "MinInstances": 3,
+      },
+    },
+  },
+  "Metadata": Object {
+    "AWS::CloudFormation::Interface": Object {
+      "ParameterGroups": Array [
+        Object {
+          "Label": Object {
+            "default": "Tags",
+          },
+          "Parameters": Array [
+            "Stack",
+            "App",
+            "Stage",
+          ],
+        },
+        Object {
+          "Label": Object {
+            "default": "AMI",
+          },
+          "Parameters": Array [
+            "AMI",
+          ],
+        },
+        Object {
+          "Label": Object {
+            "default": "Used to fetch RiffRaff artifact",
+          },
+          "Parameters": Array [
+            "ProjectName",
+            "ProjectVersion",
+          ],
+        },
+        Object {
+          "Label": Object {
+            "default": "Networking",
+          },
+          "Parameters": Array [
+            "SiteDomain",
+            "VpcId",
+            "Subnets",
+            "BastionSecurityGroup",
+          ],
+        },
+        Object {
+          "Label": Object {
+            "default": "AWS Resources",
+          },
+          "Parameters": Array [
+            "EmailSqsQueueCodeArn",
+            "EmailSqsQueueProdArn",
+            "ContributionsStoreSqsQueueCodeArn",
+            "ContributionsStoreSqsQueueProdArn",
+            "CertificateArn",
+          ],
+        },
+      ],
+    },
+  },
+  "Parameters": Object {
+    "AMI": Object {
+      "Description": "AMI ID. Set by RiffRaff on each deploy",
+      "Type": "String",
+    },
+    "App": Object {
+      "Default": "payment-api",
+      "Description": "Should never change",
+      "Type": "String",
+    },
+    "BastionSecurityGroup": Object {
+      "Description": "The SG for the bastion to enable ssh tunnelling",
+      "Type": "String",
+    },
+    "CertificateArn": Object {
+      "Description": "The ARN of the HTTPS certificate",
+      "Type": "String",
+    },
+    "CfnVpcId": Object {
+      "Description": "VpcId of your Virtual Private Cloud (VPC)",
+      "Type": "String",
+    },
+    "ContributionsStoreSqsQueueCodeArn": Object {
+      "Description": "For the PROD stack you still need to supply this, because PROD instances need access to both PROD and CODE contribution store queues.
+",
+      "Type": "String",
+    },
+    "ContributionsStoreSqsQueueProdArn": Object {
+      "Description": "For the CODE stack you can leave this empty since it won't be used. For the PROD stack you need to set it.
+",
+      "Type": "String",
+    },
+    "EmailSqsQueueCodeArn": Object {
+      "Description": "For the PROD stack you still need to supply this, because PROD instances need access to both PROD and CODE email queues.
+",
+      "Type": "String",
+    },
+    "EmailSqsQueueProdArn": Object {
+      "Description": "For the CODE stack you can leave this empty since it won't be used. For the PROD stack you need to set it.
+",
+      "Type": "String",
+    },
+    "KinesisStreamArn": Object {
+      "Description": "ARN of the kinesis stream to write events to",
+      "Type": "String",
+    },
+    "OphanRole": Object {
+      "Description": "ARN of the Ophan cross-account role",
+      "Type": "String",
+    },
+    "PrivateVpcSubnets": Object {
+      "Description": "Private subnets to use for EC2 instances",
+      "Type": "List<AWS::EC2::Subnet::Id>",
+    },
+    "ProjectName": Object {
+      "Default": "payment-api",
+      "Description": "This must match the name key in your build.sbt. It will probably be the same as App, but doesn't have to be.
+",
+      "Type": "String",
+    },
+    "ProjectVersion": Object {
+      "Default": 0.1,
+      "Description": "This must match the version key in your build.sbt",
+      "Type": "String",
+    },
+    "PublicVpcSubnets": Object {
+      "Description": "Public subnets to use for the ELB",
+      "Type": "List<AWS::EC2::Subnet::Id>",
+    },
+    "SiteDomain": Object {
+      "Description": "Route53 CNAME for load balancer (pointed to by NS1 domain name)",
+      "Type": "String",
+    },
+    "SqsKmsArn": Object {
+      "Description": "ARN of the KMS key for encrypting SQS data",
+      "Type": "String",
+    },
+    "Stack": Object {
+      "Default": "support",
+      "Description": "Should never change",
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "AmazonPayPaymentError": Object {
+      "Condition": "CreateProdResources",
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:contributions-dev",
+          },
+        ],
+        "AlarmName": Object {
+          "Fn::Sub": "\${App} PROD Amazon Pay payment error for one-off contribution via the payment-api",
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "payment-provider",
+            "Value": "AmazonPay",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "payment-error",
+        "Namespace": "support-payment-api-PROD",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "AppRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "ec2.amazonaws.com",
+                ],
+              },
+            },
+          ],
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Sub": "arn:aws:iam::\${AWS::AccountId}:policy/guardian-ec2-role-for-ssm",
+          },
+        ],
+        "Path": "/",
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::GetAtt": "PaymentAPILogGroup.Arn",
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "CloudwatchLogs",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "ssm:GetParametersByPath",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Sub": "arn:aws:ssm:\${AWS::Region}:\${AWS::AccountId}:parameter/\${App}/*",
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "SSMConfigParams",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "sqs:GetQueueUrl",
+                    "sqs:SendMessage",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::If": Array [
+                      "CreateProdResources",
+                      Array [
+                        Object {
+                          "Ref": "EmailSqsQueueCodeArn",
+                        },
+                        Object {
+                          "Ref": "EmailSqsQueueProdArn",
+                        },
+                      ],
+                      Array [
+                        Object {
+                          "Ref": "EmailSqsQueueCodeArn",
+                        },
+                      ],
+                    ],
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "SqsMessages",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "cloudwatch:PutMetricData",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "CloudWatchMetrics",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": "sts:AssumeRole",
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Ref": "OphanRole",
+                  },
+                },
+              ],
+            },
+            "PolicyName": "AssumeOphanRole",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": "kinesis:*",
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Ref": "KinesisStreamArn",
+                  },
+                },
+              ],
+            },
+            "PolicyName": "KinesisPut",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": "sqs:SendMessage",
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::If": Array [
+                      "CreateProdResources",
+                      Array [
+                        Object {
+                          "Ref": "ContributionsStoreSqsQueueCodeArn",
+                        },
+                        Object {
+                          "Ref": "ContributionsStoreSqsQueueProdArn",
+                        },
+                      ],
+                      Array [
+                        Object {
+                          "Ref": "ContributionsStoreSqsQueueCodeArn",
+                        },
+                      ],
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": "SQSPut",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": "kms:Encrypt",
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Ref": "SqsKmsArn",
+                  },
+                },
+              ],
+            },
+            "PolicyName": "SqsKmsEncryption",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": "s3:GetObject",
+                  "Effect": "Allow",
+                  "Resource": Array [
+                    Object {
+                      "Fn::If": Array [
+                        "CreateProdResources",
+                        Object {
+                          "Fn::Sub": "arn:aws:s3:::support-admin-console/*/*",
+                        },
+                        Object {
+                          "Fn::Sub": "arn:aws:s3:::support-admin-console/CODE/*",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            "PolicyName": "SettingsBucket",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Object {
+                "Action": "s3:GetObject",
+                "Effect": "Allow",
+                "Resource": Array [
+                  "arn:aws:s3::*:membership-dist/*",
+                ],
+              },
+            },
+            "PolicyName": "s3Deploy",
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "AutoScalingGroup": Object {
+      "Properties": Object {
+        "HealthCheckGracePeriod": 300,
+        "HealthCheckType": "ELB",
+        "LaunchConfigurationName": Object {
+          "Ref": "LaunchConfig",
+        },
+        "MaxSize": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            "PROD",
+            "MaxInstances",
+          ],
+        },
+        "MinSize": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            "PROD",
+            "MinInstances",
+          ],
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": Object {
+              "Ref": "App",
+            },
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "PropagateAtLaunch": true,
+            "Value": "guardian/support-frontend",
+          },
+          Object {
+            "Key": "Name",
+            "PropagateAtLaunch": true,
+            "Value": Object {
+              "Fn::Join": Array [
+                "-",
+                Array [
+                  Object {
+                    "Ref": "Stack",
+                  },
+                  "PROD",
+                  Object {
+                    "Ref": "App",
+                  },
+                ],
+              ],
+            },
+          },
+          Object {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": "PROD",
+          },
+        ],
+        "TargetGroupARNs": Array [
+          Object {
+            "Ref": "TargetGroup",
+          },
+        ],
+        "VPCZoneIdentifier": Object {
+          "Ref": "PrivateVpcSubnets",
+        },
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "DescribeEC2Policy": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeAutoScalingInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "AppRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ElasticLoadBalancer": Object {
+      "Properties": Object {
+        "Name": Object {
+          "Fn::Sub": "\${Stack}-PROD-\${App}",
+        },
+        "SecurityGroups": Array [
+          Object {
+            "Ref": "LoadBalancerSecurityGroup",
+          },
+        ],
+        "Subnets": Object {
+          "Ref": "PublicVpcSubnets",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": Object {
+              "Ref": "App",
+            },
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "FrontendELBDNSrecord": Object {
+      "Properties": Object {
+        "Comment": "CNAME for AWS ELB",
+        "HostedZoneId": "/hostedzone/Z1E4V12LQGXFEC",
+        "Name": Object {
+          "Ref": "SiteDomain",
+        },
+        "ResourceRecords": Array [
+          Object {
+            "Fn::GetAtt": "ElasticLoadBalancer.DNSName",
+          },
+        ],
+        "TTL": "120",
+        "Type": "CNAME",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
+    "High5XXRateAlarm": Object {
+      "Condition": "CreateProdResources",
+      "DependsOn": Array [
+        "ElasticLoadBalancer",
+        "TargetGroup",
+      ],
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:contributions-dev",
+          },
+        ],
+        "AlarmName": Object {
+          "Fn::Sub": "High 5XX rate for \${App} in PROD",
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "LoadBalancer",
+            "Value": Object {
+              "Fn::GetAtt": "ElasticLoadBalancer.LoadBalancerFullName",
+            },
+          },
+          Object {
+            "Name": "TargetGroup",
+            "Value": Object {
+              "Fn::GetAtt": "TargetGroup.TargetGroupFullName",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "HTTPCode_Target_5XX_Count",
+        "Namespace": "AWS/ApplicationELB",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 3,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "InstanceProfile": Object {
+      "Properties": Object {
+        "Path": "/",
+        "Roles": Array [
+          Object {
+            "Ref": "AppRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+    "InstanceSecurityGroup": Object {
+      "Properties": Object {
+        "GroupDescription": "Open up SSH access and enable HTTP access on the configured port",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 5432,
+            "IpProtocol": "tcp",
+            "ToPort": 5432,
+          },
+        ],
+        "SecurityGroupIngress": Array [
+          Object {
+            "FromPort": 22,
+            "IpProtocol": "tcp",
+            "SourceSecurityGroupId": Object {
+              "Ref": "BastionSecurityGroup",
+            },
+            "ToPort": 22,
+          },
+          Object {
+            "FromPort": 9000,
+            "IpProtocol": "tcp",
+            "SourceSecurityGroupId": Object {
+              "Ref": "LoadBalancerSecurityGroup",
+            },
+            "ToPort": 9000,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "CfnVpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LaunchConfig": Object {
+      "Properties": Object {
+        "AssociatePublicIpAddress": false,
+        "IamInstanceProfile": Object {
+          "Ref": "InstanceProfile",
+        },
+        "ImageId": Object {
+          "Ref": "AMI",
+        },
+        "InstanceType": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            "PROD",
+            "InstanceType",
+          ],
+        },
+        "SecurityGroups": Array [
+          Object {
+            "Ref": "InstanceSecurityGroup",
+          },
+          Object {
+            "Ref": "NewWazuhSecurityGroup",
+          },
+        ],
+        "UserData": Object {
+          "Fn::Base64": Object {
+            "Fn::Sub": "#!/bin/bash -ev
+mkdir /etc/gu
+
+cat > /etc/gu/stage <<'EOF'
+PROD
+EOF
+
+aws --region \${AWS::Region} s3 cp s3://membership-dist/\${Stack}/PROD/\${App}/\${ProjectName}_\${ProjectVersion}_all.deb /tmp
+dpkg -i /tmp/\${ProjectName}_\${ProjectVersion}_all.deb
+/opt/cloudwatch-logs/configure-logs application \${Stack} PROD \${App} /var/log/\${App}/application.log
+",
+          },
+        },
+      },
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+    },
+    "LoadBalancerListener": Object {
+      "Properties": Object {
+        "Certificates": Array [
+          Object {
+            "CertificateArn": Object {
+              "Ref": "CertificateArn",
+            },
+          },
+        ],
+        "DefaultActions": Array [
+          Object {
+            "TargetGroupArn": Object {
+              "Ref": "TargetGroup",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": Object {
+          "Ref": "ElasticLoadBalancer",
+        },
+        "Port": 443,
+        "Protocol": "HTTPS",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "LoadBalancerSecurityGroup": Object {
+      "Properties": Object {
+        "GroupDescription": "Permit incoming HTTPS access on port 443, egress to port 9000",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 9000,
+            "IpProtocol": "tcp",
+            "ToPort": 9000,
+          },
+        ],
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "CfnVpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "NewWazuhSecurityGroup": Object {
+      "Properties": Object {
+        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 1514,
+            "IpProtocol": "tcp",
+            "ToPort": 1515,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "CfnVpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "NoHealthyInstancesAlarm": Object {
+      "Condition": "CreateProdResources",
+      "DependsOn": Array [
+        "ElasticLoadBalancer",
+        "TargetGroup",
+      ],
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:contributions-dev",
+          },
+        ],
+        "AlarmName": Object {
+          "Fn::Sub": "No healthy instances for \${App} in PROD",
+        },
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "LoadBalancer",
+            "Value": Object {
+              "Fn::GetAtt": "ElasticLoadBalancer.LoadBalancerFullName",
+            },
+          },
+          Object {
+            "Name": "TargetGroup",
+            "Value": Object {
+              "Fn::GetAtt": "TargetGroup.TargetGroupFullName",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "HealthyHostCount",
+        "Namespace": "AWS/ApplicationELB",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.5,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "NoPaypalPaymentsInOneHourAlarm": Object {
+      "Condition": "CreateProdResources",
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:contributions-dev",
+          },
+        ],
+        "AlarmName": Object {
+          "Fn::Sub": "\${App} PROD No successful paypal payments via payment-api for an hour",
+        },
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "payment-provider",
+            "Value": "Paypal",
+          },
+        ],
+        "EvaluationPeriods": 12,
+        "MetricName": "payment-success",
+        "Namespace": "support-payment-api-PROD",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "NoPaypalPaymentsInTwoHours247Alarm": Object {
+      "Condition": "CreateProdResources",
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:reader-revenue-24-7",
+          },
+        ],
+        "AlarmDescription": "There have been no one-off contributions using paypal in the last 2 hours",
+        "AlarmName": Object {
+          "Fn::Sub": "\${App} PROD CP One-off contributions with PayPal might be down",
+        },
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "payment-provider",
+            "Value": "Paypal",
+          },
+        ],
+        "EvaluationPeriods": 12,
+        "MetricName": "payment-success",
+        "Namespace": "support-payment-api-PROD",
+        "Period": 600,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "NoStripePaymentsInOneHourAlarm": Object {
+      "Condition": "CreateProdResources",
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:contributions-dev",
+          },
+        ],
+        "AlarmName": Object {
+          "Fn::Sub": "\${App} PROD No successful stripe payments via payment-api for an hour",
+        },
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "payment-provider",
+            "Value": "Stripe",
+          },
+        ],
+        "EvaluationPeriods": 12,
+        "MetricName": "payment-success",
+        "Namespace": "support-payment-api-PROD",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "NoStripePaymentsInThreeHours247Alarm": Object {
+      "Condition": "CreateProdResources",
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:reader-revenue-24-7",
+          },
+        ],
+        "AlarmDescription": "There have been no one-off contributions using card payment in the last 3 hours",
+        "AlarmName": Object {
+          "Fn::Sub": "\${App} PROD CP One-off contributions with Card might be down",
+        },
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "payment-provider",
+            "Value": "Stripe",
+          },
+        ],
+        "EvaluationPeriods": 12,
+        "MetricName": "payment-success",
+        "Namespace": "support-payment-api-PROD",
+        "Period": 900,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "PaymentAPILogGroup": Object {
+      "Properties": Object {
+        "LogGroupName": Object {
+          "Fn::Sub": "\${Stack}-\${App}-PROD",
+        },
+        "RetentionInDays": 14,
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+    },
+    "PaypalPaymentError": Object {
+      "Condition": "CreateProdResources",
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:contributions-dev",
+          },
+        ],
+        "AlarmName": Object {
+          "Fn::Sub": "\${App} PROD Paypal payment error for one-off contribution via the payment-api",
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "payment-provider",
+            "Value": "Paypal",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "payment-error",
+        "Namespace": "support-payment-api-PROD",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "PostPaymentError": Object {
+      "Condition": "CreateProdResources",
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:contributions-dev",
+          },
+        ],
+        "AlarmName": Object {
+          "Fn::Sub": "\${App} PROD Failed post-payment task for one-off contributions via the payment-api",
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "post-payment-tasks-error",
+        "Namespace": "support-payment-api-PROD",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "StripePaymentError": Object {
+      "Condition": "CreateProdResources",
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:contributions-dev",
+          },
+        ],
+        "AlarmName": Object {
+          "Fn::Sub": "\${App} PROD Stripe payment error for one-off contribution via the payment-api",
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "payment-provider",
+            "Value": "Stripe",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "payment-error",
+        "Namespace": "support-payment-api-PROD",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "StripeRateLimitingAlarm": Object {
+      "Condition": "CreateProdResources",
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:contributions-dev",
+          },
+        ],
+        "AlarmName": Object {
+          "Fn::Sub": "\${App} PROD One or more requests have exceeded the rate limit for Stripe one-off contributions via payment-api in the last 15 mins",
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "payment-provider",
+            "Value": "Stripe",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "stripe-rate-limit-exceeded",
+        "Namespace": "support-payment-api-PROD",
+        "Period": 900,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "TargetGroup": Object {
+      "DependsOn": Array [
+        "ElasticLoadBalancer",
+      ],
+      "Properties": Object {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/healthcheck",
+        "HealthCheckPort": "9000",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 2,
+        "Name": Object {
+          "Fn::Sub": "\${Stack}-PROD-\${App}",
+        },
+        "Port": 9000,
+        "Protocol": "HTTP",
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "TargetGroupAttributes": Array [
+          Object {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "20",
+          },
+        ],
+        "UnhealthyThresholdCount": 2,
+        "VpcId": Object {
+          "Ref": "CfnVpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+  },
+}
+`;

--- a/cdk/lib/payment-api.test.ts
+++ b/cdk/lib/payment-api.test.ts
@@ -1,0 +1,16 @@
+import "@aws-cdk/assert/jest";
+import { SynthUtils } from "@aws-cdk/assert";
+import { App } from "@aws-cdk/core";
+import { PaymentApi } from "./payment-api";
+
+describe("The Payment API stack", () => {
+  it("matches the snapshot", () => {
+    const app = new App();
+    const stack = new PaymentApi(app, "Frontend-PROD", {
+      stack: "support",
+      stage: "PROD",
+    });
+
+    expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+  });
+});

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -1,0 +1,22 @@
+import { join } from "path";
+import { CfnInclude } from "@aws-cdk/cloudformation-include";
+import type { App } from "@aws-cdk/core";
+import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
+import { GuStack } from "@guardian/cdk/lib/constructs/core";
+
+export class PaymentApi extends GuStack {
+  constructor(scope: App, id: string, props: GuStackProps) {
+    super(scope, id, props);
+    const yamlTemplateFilePath = join(
+      __dirname,
+      "../..",
+      "support-payment-api/src/main/resources/cloud-formation.yaml"
+    );
+    new CfnInclude(this, "YamlTemplate", {
+      templateFile: yamlTemplateFilePath,
+      parameters: {
+        Stage: props.stage,
+      },
+    });
+  }
+}

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -35,6 +35,7 @@
     "@aws-cdk/aws-cloudwatch": "1.152.0",
     "@aws-cdk/aws-logs": "1.152.0",
     "@aws-cdk/core": "1.152.0",
+    "@aws-cdk/cloudformation-include": "1.152.0",
     "@guardian/cdk": "40.0.1",
     "source-map-support": "^0.5.20"
   }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -10,6 +10,14 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@aws-cdk/alexa-ask@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/alexa-ask/-/alexa-ask-1.152.0.tgz#bb933d5ebf3d1354689c72cbed2c57ea6c63092c"
+  integrity sha512-Yd+DZKBkxYIigvItXFv4LcQojmQ0OzKbIzAI+MT1jMbFW8l8zP816qWQlKbUQuJEYRopjqv3PB1sdmlEbTkyXg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
 "@aws-cdk/assert@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-1.152.0.tgz#4fb1cc6933560aa245ded9efb9153fcc8a0da4df"
@@ -29,6 +37,14 @@
     "@aws-cdk/cx-api" "1.152.0"
     constructs "^3.3.69"
 
+"@aws-cdk/aws-accessanalyzer@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-accessanalyzer/-/aws-accessanalyzer-1.152.0.tgz#f8f6466aa87b71d79faddb21f2db7d3e95c4df26"
+  integrity sha512-mWC0p7j57eNaNH5ndBK1hy94+ClNbW0uk5Si+Ssv9P38pJDBwhHzvCAFSXdIwV2eXq2AK1wgjIusA2sLg7rfIA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
 "@aws-cdk/aws-acmpca@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-acmpca/-/aws-acmpca-1.152.0.tgz#7d84a6f6fe883bcadc58a85669770814555000a3"
@@ -36,6 +52,39 @@
   dependencies:
     "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
+
+"@aws-cdk/aws-amazonmq@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-amazonmq/-/aws-amazonmq-1.152.0.tgz#874c8aab55b7f35e9ceed1e57bb465234b86cea2"
+  integrity sha512-DF92azvKPBaeK5oGuyfXg7w4gf5RiF3ZjLwW318ipiX5tUgFG5f/u2ZhxUKOqZWo7odGox4FXUAf0bKQLem7mw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-amplify@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-amplify/-/aws-amplify-1.152.0.tgz#615d4fac9c0a88ca1e1c3720e39eaa603fa8d86d"
+  integrity sha512-FCuidpOdDqbeXtJYRbBgK4DwAww5Pjj8J/69dBrR0KGy37mPS29OwT9Kb0jxCGhi1BPt9mJ6pUAduu3GqTScXA==
+  dependencies:
+    "@aws-cdk/aws-codebuild" "1.152.0"
+    "@aws-cdk/aws-codecommit" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-kms" "1.152.0"
+    "@aws-cdk/aws-lambda" "1.152.0"
+    "@aws-cdk/aws-lambda-nodejs" "1.152.0"
+    "@aws-cdk/aws-s3-assets" "1.152.0"
+    "@aws-cdk/aws-secretsmanager" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    "@aws-cdk/custom-resources" "1.152.0"
+    constructs "^3.3.69"
+    yaml "1.10.2"
+
+"@aws-cdk/aws-amplifyuibuilder@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-amplifyuibuilder/-/aws-amplifyuibuilder-1.152.0.tgz#68ba6835917ae426d872fbc28eab8932f05ba5f7"
+  integrity sha512-p7yq9yaM1EjTLiAjePaaRJ4V1r5rSFPzfRYFm2VniKdeRElD8GdddMdlX0C/f4Ef+AgUQ2eyQV0Ul/4jpGBKgA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
 
 "@aws-cdk/aws-apigateway@1.152.0":
   version "1.152.0"
@@ -57,6 +106,41 @@
     "@aws-cdk/cx-api" "1.152.0"
     constructs "^3.3.69"
 
+"@aws-cdk/aws-apigatewayv2@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigatewayv2/-/aws-apigatewayv2-1.152.0.tgz#0f6dd240925ed2a2d75473f966a26670d1f7521e"
+  integrity sha512-gK0gWv4GZrttjmjdzsICMVglLhJA4sVf2vVred6BJx5RRn40A8lAvIpVgsmtJ0fcvTQsMge1FBWAxhaF7lyCLQ==
+  dependencies:
+    "@aws-cdk/aws-certificatemanager" "1.152.0"
+    "@aws-cdk/aws-cloudwatch" "1.152.0"
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-s3" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-appconfig@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-appconfig/-/aws-appconfig-1.152.0.tgz#844d36f144177d4bd189207396c9207eeed5152e"
+  integrity sha512-OdLd81sR1MAoE40HrTrx0M9YUzlKIa90P43Q82MbMZuqybbrOXLfLVw9JC1C5vKAtfLIwawtMj+7v8oWa1hdZA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-appflow@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-appflow/-/aws-appflow-1.152.0.tgz#eeec4229f1aade9249aeb0a142b21cf923328f56"
+  integrity sha512-FK0mFhkdECj4U2Lrg4Vatpius3uvufVP7BYQduJ4popnqb8mOc8fySOfYZWzOSyVJj34ozi/dLr/TUJRFm3GFQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-appintegrations@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-appintegrations/-/aws-appintegrations-1.152.0.tgz#bc9d404454a9bdff5dea80c88857d9a56fc8d545"
+  integrity sha512-nISalEnNMs005CeejMr5KWYg8maqNDEJtGJo5XtdtTIzBfvytYrgknIDA4Rmeh9jrRlMhv4GEhg6f21jwyW4Gg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
 "@aws-cdk/aws-applicationautoscaling@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.152.0.tgz#4e055ba9594f09dff98ed139be0094b9b3067c31"
@@ -67,6 +151,86 @@
     "@aws-cdk/aws-iam" "1.152.0"
     "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
+
+"@aws-cdk/aws-applicationinsights@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationinsights/-/aws-applicationinsights-1.152.0.tgz#9dbbdd831e994fb10a9342f62481f0e60008d3c8"
+  integrity sha512-I3l0alKKg819ZAf0m5CSAIEi1y2ZAPJ6EQMfODHYWpt8QYJUbOoj+5KUyFX8NV02TGs4irK7JgPW45qFiaG8EA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-appmesh@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-appmesh/-/aws-appmesh-1.152.0.tgz#70797410e54a3bec57f5ff14e2bb5b953f9ef51c"
+  integrity sha512-dYncDpI8w5ZoLClPxd1qeW38XLn570jiz5MSbowEM7JlEMQT/2qIrlTWNhLHjGwj0pjDR015wr0NLDR0V9GMOQ==
+  dependencies:
+    "@aws-cdk/aws-acmpca" "1.152.0"
+    "@aws-cdk/aws-certificatemanager" "1.152.0"
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-servicediscovery" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-apprunner@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apprunner/-/aws-apprunner-1.152.0.tgz#b8fc80ddc95448ee2612a3ea630b35df4937df39"
+  integrity sha512-/770qRXFutNP0Ez4yjYi/v5UBwaILBod8kyi4AAM/ik+1TgFZ6aHU600lZ50FffmIUW/WsX0LUSBi/cTH5qf5A==
+  dependencies:
+    "@aws-cdk/aws-ecr" "1.152.0"
+    "@aws-cdk/aws-ecr-assets" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-appstream@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-appstream/-/aws-appstream-1.152.0.tgz#24fe8ce23f8c9e98af695bd7f5c5e153c6801dd4"
+  integrity sha512-lz7//1MfDwJ7orm16bCoRXpBui6yQv0tXAf1IyLIDdfiENHetL+IDoJCcoZqRMaUv05l7rZ0ktRiDC3rnJmr8g==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-appsync@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-appsync/-/aws-appsync-1.152.0.tgz#b3735498d8cc52f52495deef9aeff955e4eda028"
+  integrity sha512-qsocN/QJmQtgu0WVk0Qa3HmNCmX6lwgZD3ALwIuHoQqUDIQgOmVaWP3FFy8z1AgizLovaoqJFTAD1svTCJSoSg==
+  dependencies:
+    "@aws-cdk/aws-certificatemanager" "1.152.0"
+    "@aws-cdk/aws-cognito" "1.152.0"
+    "@aws-cdk/aws-dynamodb" "1.152.0"
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-elasticsearch" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-lambda" "1.152.0"
+    "@aws-cdk/aws-opensearchservice" "1.152.0"
+    "@aws-cdk/aws-rds" "1.152.0"
+    "@aws-cdk/aws-s3-assets" "1.152.0"
+    "@aws-cdk/aws-secretsmanager" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-aps@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-aps/-/aws-aps-1.152.0.tgz#d345ae01a74002613a256c0254b9b1aa4f598d23"
+  integrity sha512-Bfp+QKDzTQ0Y6xWFrBPeMIx9+TnV7XOeNAvrQCMjIwF2kH3JpayGubY71Bbu7Nf84aS6UJrFlDYEiI3ufaHvPg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-athena@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-athena/-/aws-athena-1.152.0.tgz#24b8050fd3dec31f855237f306d6783d71b8048f"
+  integrity sha512-dygOokV02FVZVVJjopXLSfkqqozjseL5XF4McEOC8LmEP3ZXTk8wculKrpvoKwq9cEQQ0t+YNumtSgUpDBegFw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-auditmanager@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-auditmanager/-/aws-auditmanager-1.152.0.tgz#d63975d2515149fd5fc8e1a1bcd71b8283c14a02"
+  integrity sha512-tT9MmYVNZdni7RuYc/+Z24wUKksfKCVjMIh2DoIJqpj9pIkHkGauxrDkTA62TPC4KhYQX0CoLS893fHNVcQxUw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
 
 "@aws-cdk/aws-autoscaling-common@1.152.0":
   version "1.152.0"
@@ -107,6 +271,73 @@
     "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
 
+"@aws-cdk/aws-autoscalingplans@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscalingplans/-/aws-autoscalingplans-1.152.0.tgz#b4fc4fe18e6ca3a59e0fcfacaf3c785da9901810"
+  integrity sha512-cmhGdVrUUiEkZ4XCJtXodtFwHvazZeXeFeUlSSAX1ys8Q6auLJwCo5MIaYVnCgAXEjGZ/sMoODPYOry1g8d1wA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-backup@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-backup/-/aws-backup-1.152.0.tgz#36f2bba262c5ced73fb00b2e2eaddec55cc4df65"
+  integrity sha512-HY//Biwf/zmLmY40YzOb1911b5zZNOYQ4qltybZFP99ECfhV23e4lQVWuX7NZqQjEdi+JDAZweDGEAnVqOrHFQ==
+  dependencies:
+    "@aws-cdk/aws-dynamodb" "1.152.0"
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-efs" "1.152.0"
+    "@aws-cdk/aws-events" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-kms" "1.152.0"
+    "@aws-cdk/aws-rds" "1.152.0"
+    "@aws-cdk/aws-sns" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-batch@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-batch/-/aws-batch-1.152.0.tgz#785f8f772aad4793a3fa4a4409d29faa6e513b0c"
+  integrity sha512-GzRta6OAJtISDR1lYh/ly0XKTM3mUKDZRxvwBRI6qppJMdzzTebkzbaL7mCw7IxS7edqEWuB9YEvU//2QcR8yQ==
+  dependencies:
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-ecr" "1.152.0"
+    "@aws-cdk/aws-ecs" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-secretsmanager" "1.152.0"
+    "@aws-cdk/aws-ssm" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-billingconductor@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-billingconductor/-/aws-billingconductor-1.152.0.tgz#2d8f58697d271f14603d16a4aedea9198a7abc73"
+  integrity sha512-i439r1NyjXFyG7VrZ5BjQZmXthKY3Te7YayZoIcFGqfs3KKkRVxIujZQLA7vZHvUnml493Y7Ed5gVAS9dkByNA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-budgets@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-budgets/-/aws-budgets-1.152.0.tgz#d74b466ac6851ac0b76d87bc7545b1640968c84a"
+  integrity sha512-zD2dJpR00tZe5MbzjPBM8OuLtJzrP5v+oxfWIhsYYOBCANQm3hc2iJ635RZmtEv16UdttxUYjLoLngT9WKVMHw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-cassandra@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cassandra/-/aws-cassandra-1.152.0.tgz#053269c7817ef7a723ba62cec5d3f1cd761429d0"
+  integrity sha512-x0W4ZnehEdl5VCWqk4Y6LvtaqUinWYuiNV6zuT2NZdcwahoJIjwe+IGPWBzjXEgvS6Lb+S4qDcAH05IKJM8jng==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-ce@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ce/-/aws-ce-1.152.0.tgz#e7b30653f98d4e5258565bdb301bad7110de6085"
+  integrity sha512-1Y2KF44jQ5jVSx64G2shUnCPlU9DULgHZ6jGcKYSRpz6s+k27SZKLDHxuTRtOpH25X98sJYYHZX/pcLg1eKWpQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
 "@aws-cdk/aws-certificatemanager@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.152.0.tgz#f62de1c41426d447fccfc57f97cba4ad491e16ec"
@@ -117,6 +348,29 @@
     "@aws-cdk/aws-iam" "1.152.0"
     "@aws-cdk/aws-lambda" "1.152.0"
     "@aws-cdk/aws-route53" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-chatbot@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-chatbot/-/aws-chatbot-1.152.0.tgz#124f2fe7cb514ea9f681abbf54767cdd536c782c"
+  integrity sha512-s3hSNYaiV5ZgAxEg0z62WzzrvWlQR1KYFOXRHyHHgl5osB8bBLug1OzvWYbbLqKEaOm1w0T4m3bQ80mp7TxEFg==
+  dependencies:
+    "@aws-cdk/aws-cloudwatch" "1.152.0"
+    "@aws-cdk/aws-codestarnotifications" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-logs" "1.152.0"
+    "@aws-cdk/aws-sns" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-cloud9@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloud9/-/aws-cloud9-1.152.0.tgz#9e31381842f26d3df3b921e6371112830bb16286"
+  integrity sha512-+V6dWjK2cP5q3JUxXMiGWTdRC/PRczyNdxDwvIdQkfipp/igWDJNjgBtwXBFHRVqfBfBuuvQLPlJIepjuScwew==
+  dependencies:
+    "@aws-cdk/aws-codecommit" "1.152.0"
+    "@aws-cdk/aws-ec2" "1.152.0"
     "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
 
@@ -150,6 +404,21 @@
     "@aws-cdk/cx-api" "1.152.0"
     constructs "^3.3.69"
 
+"@aws-cdk/aws-cloudtrail@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudtrail/-/aws-cloudtrail-1.152.0.tgz#cb569f7b8c0a7c0ad8bec672e30810db10170182"
+  integrity sha512-QNRYR99trOd1fDKMWxBKFyetyGxI2ZvhgJQaYIbrKqjuFmN15wUKH8rvA8AbgFJTkpN7teDbY1Bn6vFfDa5/zA==
+  dependencies:
+    "@aws-cdk/aws-events" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-kms" "1.152.0"
+    "@aws-cdk/aws-lambda" "1.152.0"
+    "@aws-cdk/aws-logs" "1.152.0"
+    "@aws-cdk/aws-s3" "1.152.0"
+    "@aws-cdk/aws-sns" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
 "@aws-cdk/aws-cloudwatch-actions@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch-actions/-/aws-cloudwatch-actions-1.152.0.tgz#c9695fced5737bb0c3119c8ca38bc9a858ee90be"
@@ -171,6 +440,13 @@
     "@aws-cdk/aws-iam" "1.152.0"
     "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
+
+"@aws-cdk/aws-codeartifact@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codeartifact/-/aws-codeartifact-1.152.0.tgz#64b7a1f53f9b8298cd3119cf2d5924771501cb42"
+  integrity sha512-oM4SeS2QUByBREsMIBWtI0y8QTkT/aYJE8/S1QZLSS2cs5EQkebmQmyh9sQuWjtEL/cFl7aDrStcMCHjKjwGLw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
 
 "@aws-cdk/aws-codebuild@1.152.0":
   version "1.152.0"
@@ -208,6 +484,23 @@
     "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
 
+"@aws-cdk/aws-codedeploy@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codedeploy/-/aws-codedeploy-1.152.0.tgz#92ba29ec69746d16d78bdf084e309c81b754c5d0"
+  integrity sha512-lFI1GkE3JMpcqpTzDWABLdRIQK9WlxXT7g1ZDcTFFtShfRpdfGz3ExiiG7TWtME/vEUGoVXgHJAyXSmPZqtsMg==
+  dependencies:
+    "@aws-cdk/aws-autoscaling" "1.152.0"
+    "@aws-cdk/aws-cloudwatch" "1.152.0"
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-elasticloadbalancing" "1.152.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-lambda" "1.152.0"
+    "@aws-cdk/aws-s3" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    "@aws-cdk/custom-resources" "1.152.0"
+    constructs "^3.3.69"
+
 "@aws-cdk/aws-codeguruprofiler@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.152.0.tgz#080c038fd796e8ef2bc95d80d3b0c3520a1b8a10"
@@ -216,6 +509,13 @@
     "@aws-cdk/aws-iam" "1.152.0"
     "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
+
+"@aws-cdk/aws-codegurureviewer@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codegurureviewer/-/aws-codegurureviewer-1.152.0.tgz#a4558d17036da9fca4ac33f9e96bdd2cd1d8f27d"
+  integrity sha512-ogA1Dj2P+o6DQv/dXjDJVEjXUVfyFJCEFOyhU4sk0sOzEbJ+MjSYVcrLG3TcBNR2RGmfEXItCqq08a5eJmaYyQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
 
 "@aws-cdk/aws-codepipeline@1.152.0":
   version "1.152.0"
@@ -229,6 +529,22 @@
     "@aws-cdk/aws-s3" "1.152.0"
     "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
+
+"@aws-cdk/aws-codestar@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codestar/-/aws-codestar-1.152.0.tgz#547c8a504ad1473e4c1dc398c6d8ca55e58cf586"
+  integrity sha512-K2NOsmbH+qoQ274RSqgCOf6FBPDxQkDnmbE+PX7rcbnfmwUn+hsIFKlnMkxp3P7OJ8z9ljUOynmOMq7jBVsrZw==
+  dependencies:
+    "@aws-cdk/aws-s3" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-codestarconnections@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codestarconnections/-/aws-codestarconnections-1.152.0.tgz#7515ebe048539eb8ad36cd911a903f006badb14d"
+  integrity sha512-ZFS9lPtLZ8F+9DOsygp8myE22cBLQQ30gAf1rSR55siZmiZK5uq4ZHw15TKvoVC18vNPVAN3kGbdSFdvmC0fOw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
 
 "@aws-cdk/aws-codestarnotifications@1.152.0":
   version "1.152.0"
@@ -251,6 +567,121 @@
     "@aws-cdk/custom-resources" "1.152.0"
     constructs "^3.3.69"
     punycode "^2.1.1"
+
+"@aws-cdk/aws-config@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-config/-/aws-config-1.152.0.tgz#497b722190f8b72514f2c3de49bad92e95c12d7d"
+  integrity sha512-unIKN5mLULKfeKoQJPlukEihc+CVG+YXdC1AaLctcGi3wBlDs7USNCM1MVRCTuQJ+V1liNXfBWZRmi9JYjNhmg==
+  dependencies:
+    "@aws-cdk/aws-events" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-lambda" "1.152.0"
+    "@aws-cdk/aws-sns" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-connect@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-connect/-/aws-connect-1.152.0.tgz#1cd5e6fdc5ee79e1bda7dc2897ff3134aeee52be"
+  integrity sha512-et/tSQaj8DXw5WOphy7uErL4ZoXbZR64rbGhssLlp+fm3F3uFYtEvIxQ6wKE11ng4sw6QB+/VokwimLmqag6RA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-cur@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cur/-/aws-cur-1.152.0.tgz#fe62d34ec86b902306b9853719812f529cdbe185"
+  integrity sha512-DYbrXSXMFfZ2TSiZ14ISfB8Icw8IBGrTCP1KIJkNgl3YuszLuTpnWgq2OjLaGRgEABN2Jlv1ErWOy/iy8KfmAg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-customerprofiles@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-customerprofiles/-/aws-customerprofiles-1.152.0.tgz#64a9db5d289e818377be57bb808d276103466da6"
+  integrity sha512-44tgxHYTID848zDBXe/n65EKN4SapacsY95aevB22qxlatPvGay8ZttM54Fe7VnDCiY3/N3ICnQY6HYXfo5apg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-databrew@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-databrew/-/aws-databrew-1.152.0.tgz#27c19efbc77dd7574c62ad42e1757675ed5f4485"
+  integrity sha512-PMgNMAMbSU0d1EF6a+6wMSzrBB6EcZS8adhuotUET10pgUAlKQMtCGMdvc9fwsG53/qjvSUphlhUEBFwnThpJw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-datapipeline@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-datapipeline/-/aws-datapipeline-1.152.0.tgz#5fe3eab03d71551528c71d9972ca12e13988782c"
+  integrity sha512-a3kuezcQQ1rXRElnr3zQ6qjnrFmNIFSQQEYcU2/O3sVk1PpqS3d0qJ7IyQiBGd5k9H0uPr9FcRyJ4Ct2yK8MHw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-datasync@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-datasync/-/aws-datasync-1.152.0.tgz#ad656130fc3103bac0548aa8cc76ce5f5f9e1265"
+  integrity sha512-jHdeGciVP7gc6go2QVe0SpdLKEQNmdN6ZQK9pw98jifd/sKf9rcjaAuoXemakUm0VcPlonTaWbLp8kfhvjFTFA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-dax@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-dax/-/aws-dax-1.152.0.tgz#f046a61f774e430fc6be942f5d0db64742afc96b"
+  integrity sha512-e8pJX3dgws5Dn0gWtiOXiC1N94fq5NVD3P9nzTsgt8l+nPWURwTFmpCrWNjD1jxwpYpeXTa1GzK+aKSBo9DkgQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-detective@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-detective/-/aws-detective-1.152.0.tgz#720efbf265ff280ead479b7f3bb211273744f317"
+  integrity sha512-8MHJcFyiHaBOuJbHYhBCeRWOxIoCYyVztUNcsdTigzjr6qT9B4iSIwE/CymZDahk6s26/7XErk12o1sq0Y6MHQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-devopsguru@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-devopsguru/-/aws-devopsguru-1.152.0.tgz#701fec26afc82b9ae5e8103faaa8519284457f9e"
+  integrity sha512-NJixbYFzsEd0H+cMHhtrCAlglVHgkhyysEiq0bmFv6S3m54uvm+tDOtADa0KRPpzkEpxuyqh85iRASBPboY92g==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-directoryservice@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-directoryservice/-/aws-directoryservice-1.152.0.tgz#7f3a29d0703939cae591c8112a10fc826b95d76e"
+  integrity sha512-KYVfnWWN7ujSTCSbudrG9e33KTzm4YqP5v5od2LdnUmFNLEaDYfCw96/HdHFVmqUOW2LJ59w65qLQ2edzwawpA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-dlm@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-dlm/-/aws-dlm-1.152.0.tgz#92ad5caf3dd97ecaeb458f45770db1681bf29a2b"
+  integrity sha512-zicjGBJjnqJ0dxtcZDAjLRZq/+jUO36HGyHUK328NqXNAN3rtxBmcQ9M8lEv6MbI5XeoEdBK/M3hOMr/eNdOtw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-dms@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-dms/-/aws-dms-1.152.0.tgz#f368a89e99c4a0f3f6eab561e52e954a62f713f6"
+  integrity sha512-Dgx5HGyT99KFBucHXzpCWObHkVNZP5af/LXvxsO/aoGVgZbVnu4iNFKnsu9pgWXNRaGEUNMgpnh5l3x+ve2Z1w==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-docdb@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-docdb/-/aws-docdb-1.152.0.tgz#b672c7c07ef2cde70a0439bede0556dae04d8029"
+  integrity sha512-WXENFiYsi74mDnAi+MlPwLEBpXAHletKplA4rpdQ/fUkAV026r6p3QRgL2lAO8RBqmEVr4wXCfNiHMFUaUc2HA==
+  dependencies:
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-efs" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-kms" "1.152.0"
+    "@aws-cdk/aws-logs" "1.152.0"
+    "@aws-cdk/aws-secretsmanager" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
 
 "@aws-cdk/aws-dynamodb@1.152.0":
   version "1.152.0"
@@ -374,6 +805,22 @@
     constructs "^3.3.69"
     yaml "1.10.2"
 
+"@aws-cdk/aws-elasticache@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticache/-/aws-elasticache-1.152.0.tgz#d7bdcd2ff528fd352576f8f887515295fce06049"
+  integrity sha512-LYx5j+m5rath+F0LrCd0bpUP+BEfir/8cUwn9pumEmAItIKIBpQQaCcK3XfsBlwjLqcjMBS3mnaecIEJzwJqMw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-elasticbeanstalk@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticbeanstalk/-/aws-elasticbeanstalk-1.152.0.tgz#d5d0bdb8a14c3806d74036aa452f576fbad1c95c"
+  integrity sha512-Tt2JS2Zn5P/qCL5BTz2NU53/wT1mLCE8X2vyFGz5PU2hWHovHheDpu+zKsgD45zYhTv0c5pJLYg8IqfchLDEFA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
 "@aws-cdk/aws-elasticloadbalancing@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.152.0.tgz#c942c33c88eec770a5b20023f6572e8670bdeb97"
@@ -399,6 +846,38 @@
     "@aws-cdk/cx-api" "1.152.0"
     "@aws-cdk/region-info" "1.152.0"
     constructs "^3.3.69"
+
+"@aws-cdk/aws-elasticsearch@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticsearch/-/aws-elasticsearch-1.152.0.tgz#32687ebbdae4ef38cc16fdfabc41fffe727b1f3a"
+  integrity sha512-tJMQ9+HODLQ2HuuqqMhz7wanl2xpTiIdP7qdoyNuCyi8VYKL4V2m9slzvXg/HvBA1Xjx53Itlm/KI1l6W8JWLQ==
+  dependencies:
+    "@aws-cdk/aws-certificatemanager" "1.152.0"
+    "@aws-cdk/aws-cloudwatch" "1.152.0"
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-kms" "1.152.0"
+    "@aws-cdk/aws-logs" "1.152.0"
+    "@aws-cdk/aws-route53" "1.152.0"
+    "@aws-cdk/aws-secretsmanager" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    "@aws-cdk/custom-resources" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-emr@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-emr/-/aws-emr-1.152.0.tgz#372bb069b2e7cfabc851161da97a2c8fea8dbb73"
+  integrity sha512-dN1nrupA6e1DwIdeFxRx9KhAWPpWBuVLldRZ5Uih3Yy6VADEeFMyKiZjOANrkbBlsYt85ttAYcK/O847ZTnR5g==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-emrcontainers@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-emrcontainers/-/aws-emrcontainers-1.152.0.tgz#c2d8c48bea6e12e9eb3d61343984805f28abae31"
+  integrity sha512-jEQ7F0W9jWPZZyJFFY36IQYl/TDLfzblCn7x5ty+HPvvUq+wlkxtwMsD8pPIscv4bkFVUsWI+2XWVfmKbIKPiw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
 
 "@aws-cdk/aws-events-targets@1.152.0":
   version "1.152.0"
@@ -435,6 +914,76 @@
     "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
 
+"@aws-cdk/aws-eventschemas@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-eventschemas/-/aws-eventschemas-1.152.0.tgz#cb34b0dfc0d44169034030c8a37f8ee75027a64c"
+  integrity sha512-OQNKA1obU+qLQl7OWh8gH2x5+o6NJJbikSmq11VUA+BqOJDrP+SGjE8E+1Wr/QvtOVWLWuNoODgU0NXqZZhZgw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-evidently@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-evidently/-/aws-evidently-1.152.0.tgz#42c491a913bfbba158f7186d8022aacbe2ddb1a3"
+  integrity sha512-RMbPt5eWWA/yjH39Llt5O+WmzZswSBzeDVTI8hWbgJM17RiO4ACj5/lpNR2UX/HmJedoTkbwczUgZ6CX7eVgRQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-finspace@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-finspace/-/aws-finspace-1.152.0.tgz#bf33c13fdb0408bb04daba824ec6db4dcfb2ce7e"
+  integrity sha512-LtgplqzkzsNnsFHMby87jsmVqxq1Xxt1e7mKyhtHWP2dNcc0gZ9SInIH4wJ51jUbiHjLZJvStmZjESAD+/cp1g==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-fis@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-fis/-/aws-fis-1.152.0.tgz#c3b852c70d517bb8ce60949c3ceedc4e41ff52b7"
+  integrity sha512-BRJbWZTzkOa2H4qfw8J+ZIDrs5J8+C910zEhXr1kYSlz3NZcdTsFxvQjuZ0NCbirfTNzbSKeQlB1AN2tJg5h1g==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-fms@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-fms/-/aws-fms-1.152.0.tgz#951e89e8a85a4342743c3179979d3449b67821d6"
+  integrity sha512-Z4KAwAC0KBiXGuSrVhhti/QGp93Odt7c1oZC528slPP6JoDwoE8pL5Flfgok+RYy7mOUJu8rVENc6zc76Q4jsA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-forecast@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-forecast/-/aws-forecast-1.152.0.tgz#7b748d0dd1f8c23ba4bbda4f2374a3f4685d8596"
+  integrity sha512-NvSjkds3gyWE+JCPxorJsW7m8MVvoD5mS+Ebn+zi5yPvH0BpCoj6+X9ISKPdHx0zcoRDATxGCl6NJe95SWlJtw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-frauddetector@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-frauddetector/-/aws-frauddetector-1.152.0.tgz#169cd59c76a47efb833da2068ad0cd5177ee587a"
+  integrity sha512-vHo5k0gSKHDqL7h2Y9OhELb4foaqKaeTV9DE3v23ILUHqnf+wyT+cmWmbYhq8w497olBejQZ3t2/Yxq+o0Gydg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-fsx@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-fsx/-/aws-fsx-1.152.0.tgz#4ca959362ac6055e67df60f6e759851f856f5cf2"
+  integrity sha512-xFulMg6/978xX6PTusqClYmsQIYXvvKa1LLxZ+sr8Lc8ySoiMCEcAWPdrkrfAbyDKTp1ouWWSWKhSCM95ltpOw==
+  dependencies:
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-kms" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-gamelift@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-gamelift/-/aws-gamelift-1.152.0.tgz#4d6edacca67c505992d26e7177a89b2c13c0382c"
+  integrity sha512-U0zkpRkeLjApfIqUrHF8PHoJStsnSW8NSuhalBKnfB1FJXn8oW2GsGfPTBIroSckWXPu5IOdF7NmvYTrJXeaJg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
 "@aws-cdk/aws-globalaccelerator@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.152.0.tgz#b3d99e90e76829bcebe534c29e30edf395f0b091"
@@ -445,6 +994,62 @@
     "@aws-cdk/custom-resources" "1.152.0"
     constructs "^3.3.69"
 
+"@aws-cdk/aws-glue@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-glue/-/aws-glue-1.152.0.tgz#bd2b112fe481e2baa3d26b136c9eb045dc93a803"
+  integrity sha512-2mNE0H6jBVG1qNhMQ2vHrJjR0fxHPbcDWj+w4zsexP5dKkix4El4IbFXIaad9M+58y8/nQIKvkzJXYyu+7UFpQ==
+  dependencies:
+    "@aws-cdk/assets" "1.152.0"
+    "@aws-cdk/aws-cloudwatch" "1.152.0"
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-events" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-kms" "1.152.0"
+    "@aws-cdk/aws-logs" "1.152.0"
+    "@aws-cdk/aws-s3" "1.152.0"
+    "@aws-cdk/aws-s3-assets" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    "@aws-cdk/custom-resources" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-greengrass@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-greengrass/-/aws-greengrass-1.152.0.tgz#119e1fc24c92ce8cebe9e356134600627acbae51"
+  integrity sha512-4OpfOgv4q7Z3E2aarg50R/wWXqsr8KXYY1Czi3jC+IZRtdwMstaxloFlAj144vGn3xAR86oV92BR/26lcOXn/g==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-greengrassv2@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-greengrassv2/-/aws-greengrassv2-1.152.0.tgz#bf54033953d6ce5ac4fcf828ccedf3077de187f7"
+  integrity sha512-uvyXHoGnnPirTV6aSYW9Xv2DZTqWkmASfBf2BxAzusrpeVT3h0L0+q1dzZUQysRgXtH9Tyk6qnSwxXdhFIeZfw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-groundstation@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-groundstation/-/aws-groundstation-1.152.0.tgz#15596966a6a51cb45759c1eea693c0e783305bfb"
+  integrity sha512-8UPr6Tp5snaAjC+FAZ7LoGjk5Q8sB7X2r38EKxQ+8oriYQ7x8RmBLtYFfD2EdD2YClX2aefzIOjDDlIIzR0eSw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-guardduty@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-guardduty/-/aws-guardduty-1.152.0.tgz#3b67e0834b6eb6d34a4236c555c54ae96ce2cf7d"
+  integrity sha512-jndgdjIXJ/sBVEqglp4jyl+tjwKNJdUDvcVwFhasqR9SqE2ctNTu3SGO30aY4aD+oJxwy8vyGe7eDEn8Zd1LNA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-healthlake@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-healthlake/-/aws-healthlake-1.152.0.tgz#0bcb49cee3cc7b0c18e11ea4d7ddc89e42996d9e"
+  integrity sha512-ccH3w6txxx0K8yfG53S5e9ytP26917upyozMGVzSa2Ii4uPWFJGTd51zNwZAgLiTY3jdmBkDu2MHNEtbFWtp9w==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
 "@aws-cdk/aws-iam@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.152.0.tgz#a82461794148ce36f630f391fa89dfea8a208744"
@@ -454,6 +1059,119 @@
     "@aws-cdk/cx-api" "1.152.0"
     "@aws-cdk/region-info" "1.152.0"
     constructs "^3.3.69"
+
+"@aws-cdk/aws-imagebuilder@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-imagebuilder/-/aws-imagebuilder-1.152.0.tgz#844a52d88df9c12fb7c24f0053dba5dd0f27e8b8"
+  integrity sha512-5/IT0fnZNeUZdiKOh2Y+HGRPp/8hiLmf6U3YiBp967bmI5TeeNa2aL/NNveu+BIfYYmgVosr0cKX2Drm/BjNng==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-inspector@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-inspector/-/aws-inspector-1.152.0.tgz#ff4935f871a78f8e8b1082bf78444b2cb63a3532"
+  integrity sha512-/+QuAFCDAQHyhHGcXOOHjHc/HUptB6nR0jQL0PB+9XL93rg7VNjMkE/dKD21IJZ+70Ntt0CphJx7+RfzPp/KCQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-inspectorv2@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-inspectorv2/-/aws-inspectorv2-1.152.0.tgz#1ac8b252cc2b2958a0edd37cc0f7bdbd4d8c0dc5"
+  integrity sha512-3g3gShH1lKmegR2tZCxjU4f2EBbJ+Qlmgy2nMYpc+SpgF3CFuq2reE81iEhN+mZn1UsYPfMKuwLOgAMIBb1BAQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-iot1click@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iot1click/-/aws-iot1click-1.152.0.tgz#716de1e84511e88eb4e134ec0ec11b39d7842ef1"
+  integrity sha512-m9mvNk2xWnjjJEIBn3237J/TC8DmVJ7i/CVPeHa+S0Tty9XHYKPCedlvkFA6YYo4g0aSZkXPaiD3b7t9kJ205w==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-iot@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iot/-/aws-iot-1.152.0.tgz#02061b9939942890306005571576f00a769b480c"
+  integrity sha512-b8uUlJHrYboaBsIaluPEn8cZCf6foVW8TOIfyi+Dm/+4r9qF3cZQcJFaBcZv/ENFwussQfIVp3UcMTJyRMGy5g==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-iotanalytics@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iotanalytics/-/aws-iotanalytics-1.152.0.tgz#3ec18d6d15f1eb34c6248147a1b74ee6f588eb65"
+  integrity sha512-VZCDcehLjK8InrFLRXe/jD+7jKGUf8qftm8Ux4DVOxyJT5n7zWPYWdoeQF1VqEDHIrJGp89n395Y9kAM/7F62A==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-iotcoredeviceadvisor@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iotcoredeviceadvisor/-/aws-iotcoredeviceadvisor-1.152.0.tgz#8eaf5f0465d4b613a62a29d3a274f894e0ed4286"
+  integrity sha512-fdi4+VYjLaOfN+58NHy6nJZB4vY5Ullx4+acSgQUJnsku6XyAsoMEnG/YPIikPR6TIu8EChi7xsULyX+lbG+LQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-iotevents@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iotevents/-/aws-iotevents-1.152.0.tgz#877ac6861d4f1ffb0e60a97f7f94d84ad5efae5f"
+  integrity sha512-GmEIXj1zxVrBc8V9b44NKDT7KsJkPh+Toz+BxY4ALKVP6+VjKTjK4LwOSOSA88qHOD++MPXOB7vWGEa3D05bCg==
+  dependencies:
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-iotfleethub@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iotfleethub/-/aws-iotfleethub-1.152.0.tgz#72b4650c821b131c3b384868bbedc0f8d9fdc53c"
+  integrity sha512-wrWG+TIoxtjKNJ22Dm66B/kRH8Ialq7duoF8L7/r7wsuZw64wMvRyKEaITHLs2xJUh/yy+QalxbiFJat5ilQyQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-iotsitewise@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iotsitewise/-/aws-iotsitewise-1.152.0.tgz#8f57802f4b921ef09858359aee8649f5d44ae92d"
+  integrity sha512-nCqqZop228tKHl3+7Iv8GTugnGFcIigE615zi7GUWOqvXE72lL0QfoOGYVX6uA1LyenFSd1XtJ3UeQrO8VlRfQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-iotthingsgraph@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iotthingsgraph/-/aws-iotthingsgraph-1.152.0.tgz#bbc7abd9f8baf7106ddde0cda5c746e9cb350fdf"
+  integrity sha512-SGt8jp/i7Y2n4A2qBHpvf183xqCntd6WY/gBkSaDcOyG4RtmsWQPVXttBkanXVSzU26WKhUhPspwoFwEZogYtg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-iotwireless@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iotwireless/-/aws-iotwireless-1.152.0.tgz#1a63fb68f366852c78f3456af3145273d28df453"
+  integrity sha512-od7YHcbbpgg/eh2Ig3DzJZ9K9DEBIHKE4bigpRkyoZ7BFb/ixgzrXPXCuq2sjekzObLyLRfpJtDDLoIqRJnh5A==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-ivs@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ivs/-/aws-ivs-1.152.0.tgz#54402aeaab1e66e6532112e95ede9a65a1d51509"
+  integrity sha512-A8POD0xDPiE2Tp/g64avza2d1BdmWkYHYWyVzHxcZUz3HR3p99yuR8dNlCW8bpd0DXe7Y7XBJi2jjC9MFJ+j6Q==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-kafkaconnect@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kafkaconnect/-/aws-kafkaconnect-1.152.0.tgz#543c416ee958279314e43d34f7fa66e828ffddd6"
+  integrity sha512-tTiIxVVgr0cHFJ2JXGLU+vnUQkhJqbJeMKJRRWv1+yA55a4NtWVjZlgbQpgViVZhGbYYk64ee0YFp+kPRfX6Nw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-kendra@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kendra/-/aws-kendra-1.152.0.tgz#d51cc4f19bfc1e3b52b6ec28d2f4a9fb7e37b7b8"
+  integrity sha512-xIivZPA9EzG3tJ8Z5pT4nd4Chk+jjmpwKgh6vcr6c7OaheHmtQc/sY53KdIvlLYXBVOdVMoYEiqLtD7dxiPZYw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
 
 "@aws-cdk/aws-kinesis@1.152.0":
   version "1.152.0"
@@ -466,6 +1184,21 @@
     "@aws-cdk/aws-logs" "1.152.0"
     "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
+
+"@aws-cdk/aws-kinesisanalytics@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisanalytics/-/aws-kinesisanalytics-1.152.0.tgz#9ae8bfa8132a4278ed1ea941c7de414f85a4ce9c"
+  integrity sha512-O5O+VrdTPp6ehYA4phrAwyx1yxvvYKUsHWjLbBP80VhNCoP6FBbK4+UOXOXFB3eTE7WtTR34ULDMKu6/JEbbQA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-kinesisanalyticsv2@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisanalyticsv2/-/aws-kinesisanalyticsv2-1.152.0.tgz#c1576f2b20aa4263921410c712cd457106f8a924"
+  integrity sha512-LZ1h+M8qmF8wwZDQeya5ru82bnC6Q8O0fqDoOWeqDtxp8bJ0Abas0qpUTuH1JbtVpJ6ObqSYOuQwLZOmY7Ac9A==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
 
 "@aws-cdk/aws-kinesisfirehose@1.152.0":
   version "1.152.0"
@@ -484,6 +1217,13 @@
     "@aws-cdk/region-info" "1.152.0"
     constructs "^3.3.69"
 
+"@aws-cdk/aws-kinesisvideo@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisvideo/-/aws-kinesisvideo-1.152.0.tgz#04d4aeb6d0d77b9fca689fc30329e69536a18fb9"
+  integrity sha512-1pgDBIKOeUZr/IkdMHPk+fBblLF2uWwSKw5WHzMGAaP9DH+GGl76Azy51/k57Ni/YZh1u7lVW5qtr/GFa+29OQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
 "@aws-cdk/aws-kms@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.152.0.tgz#28be3f98cee36cd1a3550b68831b2eeec171b8c6"
@@ -493,6 +1233,14 @@
     "@aws-cdk/cloud-assembly-schema" "1.152.0"
     "@aws-cdk/core" "1.152.0"
     "@aws-cdk/cx-api" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-lakeformation@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lakeformation/-/aws-lakeformation-1.152.0.tgz#0fcaa9460aa122677e052166d24790a76369e9db"
+  integrity sha512-su4Z/t+fdfz50yPX83zcq3AHirWOVvuRa5vkUwJY8Fe1uMZFBx5ekqJ24dW/ArWKkrl1jv2ejQU4fmhBg07WUQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
 
 "@aws-cdk/aws-lambda-event-sources@1.152.0":
@@ -513,6 +1261,15 @@
     "@aws-cdk/aws-sns" "1.152.0"
     "@aws-cdk/aws-sns-subscriptions" "1.152.0"
     "@aws-cdk/aws-sqs" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-lambda-nodejs@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-nodejs/-/aws-lambda-nodejs-1.152.0.tgz#f7e4067929a5d85259964909d53fb86e35c309ba"
+  integrity sha512-N5S3S9QI/1qMZXctGuNcHhT5OAkp2yGS2K3xK3qQS1L7bzwWbQGf8e98maxm71ZSA2yxQcTaPudwwju7kPPhEg==
+  dependencies:
+    "@aws-cdk/aws-lambda" "1.152.0"
     "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
 
@@ -542,6 +1299,34 @@
     "@aws-cdk/region-info" "1.152.0"
     constructs "^3.3.69"
 
+"@aws-cdk/aws-lex@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lex/-/aws-lex-1.152.0.tgz#fbf9356975a76f38a0a90d99962b41f1d9bcf0a4"
+  integrity sha512-zYo7SY3myvFq+OiaMwEJRvV1H679+wUX1qwnaG390Z/JrtOVV8Tq/M40FPOzlTLcfMfQ20IS1FPSk+dxFQ48vA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-licensemanager@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-licensemanager/-/aws-licensemanager-1.152.0.tgz#5658252f208b18c339a90d01f14aedd94a0bddda"
+  integrity sha512-K2k5UdcLnL39gDfkJ41nErB1ihyq538EfG90ErMuiLtAZPXPvGKvyXWzPWxmNGwwTi2wTRLlJYBuVi2hsEK9WQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-lightsail@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lightsail/-/aws-lightsail-1.152.0.tgz#853d03a99fa5e571ff93e393ab2bb8109bad738e"
+  integrity sha512-EhoXzzpo3gRrKJu/2xMRXm1f8RQfLnYbyHosqf4DMcX8XYsqOlfbfS7j6xXHyVXkCum6+hF1zTSpepTpuvpp5w==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-location@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-location/-/aws-location-1.152.0.tgz#b551019d8cf2b41f79104bb7eb4f63c0958d677f"
+  integrity sha512-ItbLLjKRQcoOC5uqmBAH2WCZgGgZNKjpcglESvZsglviaIwQXAbNXRdG/NYOivTZ7fB1xGefSCcmWvFGA9PyjA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
 "@aws-cdk/aws-logs@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.152.0.tgz#31c280b5b67ebfe91b016628587260ba13489bce"
@@ -553,6 +1338,229 @@
     "@aws-cdk/aws-s3-assets" "1.152.0"
     "@aws-cdk/core" "1.152.0"
     "@aws-cdk/cx-api" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-lookoutequipment@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lookoutequipment/-/aws-lookoutequipment-1.152.0.tgz#17be7dfc1f8f6394e4e508175e442c2711516f25"
+  integrity sha512-bqlRZrSrzfI+R/WGFYP0CeVG0mXOTvrelZYPT7AL4A9FeS5e/QuD7Npged6kt3/Qq9H85yjT39Wy6NKz2RZUCA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-lookoutmetrics@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lookoutmetrics/-/aws-lookoutmetrics-1.152.0.tgz#b36beb8b43eda4be142a87d04e00cd9e3f350265"
+  integrity sha512-AYEUlPYcVwUVctzfq7mbZw5md3UQCgqllA/SCyXpBFS22ph+ukRoca4Q/V3F8ZhCCOkoJzKikuH5G3BhrNcRkg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-lookoutvision@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lookoutvision/-/aws-lookoutvision-1.152.0.tgz#1a1f3661c2fc5e3eaf18de7b21b93c24d58e035e"
+  integrity sha512-0zUrd3wAzm+pC5uafmLfM+rgNjVfUSHw84CgC1v774pzgC18Ceznwhx3OwVSjFVA7/qo4zMnlA8ijh+vtmBhsA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-macie@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-macie/-/aws-macie-1.152.0.tgz#00a5bb6499ab54dc2fb7566b8d3bee28ef254e53"
+  integrity sha512-ighF5SzqrZVd0h8P+l8vHwEZd1k1sDrpZrxwxjdPvSy2PvF4exuCQum9oQLhcawhPfsrs5vaCszVQjxHUgFJHw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-managedblockchain@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-managedblockchain/-/aws-managedblockchain-1.152.0.tgz#dbbdc5b26a9d74d5a7c5403909f8f478b4b91f8d"
+  integrity sha512-6zebNwZumRMpfHVvzIRlx/fz0dbV8xaadugiFHnpJPoQk/7VDN0shFlfkIj2kt29a7vEabVHpoBHLANLtWj7ag==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-mediaconnect@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-mediaconnect/-/aws-mediaconnect-1.152.0.tgz#460dc0945bf5b542836d10fafa1955c11fc26213"
+  integrity sha512-ALGqpKl7+2XdlpsaH90X9X8obggH9vghFCu9VmvYxSQvQMLXkYn2yOM0nlYjEKGoROUQUHfBKAPLks0foObmNg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-mediaconvert@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-mediaconvert/-/aws-mediaconvert-1.152.0.tgz#96b8a4fbba2c48a17dc8a27dab3ad0bd4de31e1b"
+  integrity sha512-lJFYd/b5wA+oNHuQJNDHaYAMXVrxcFUqPpMm3ZLgH5JTOMM42S212GOJE7/fpNsC0Q0p9vxVtvcs8Zlst9pUCQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-medialive@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-medialive/-/aws-medialive-1.152.0.tgz#74e2b9c115818df11e46547bf361b0ab9108f6d9"
+  integrity sha512-b8CVV3aDjKVPRt+AyBQUveebTGXdK712KZwtMlN7B7wfQkvPKvzI9cA6Ih6AjBUKfWFtpI2IEdWGHXqsV2gbqA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-mediapackage@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-mediapackage/-/aws-mediapackage-1.152.0.tgz#d0b72965b782523e605398c47e95c012ae6ca2e9"
+  integrity sha512-RYHQXQy8ELJPNH47npT03pLbXdJ9fPP5sy8NDC85nwzvysImrArEVRHWNTiDlQqCPpXZgI+rYg6wfHr0UqOKtg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-mediastore@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-mediastore/-/aws-mediastore-1.152.0.tgz#23cc7acf1cdc359344263087446f3938620bf9c1"
+  integrity sha512-R5tkZJtuMoe5rVqolllxBCVSmxuYSIqgMzqmBmidOCzktg5IWJ/eLpG4sE7MxRSanLcZ2pa9l5OjmVKBjhNJ0w==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-memorydb@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-memorydb/-/aws-memorydb-1.152.0.tgz#20f7e8e2f791c948153dda026c5e44f25a65ef27"
+  integrity sha512-yjE5zrfPWMKTXKttt/YCbtdzUH4mADezmAAM522fx9a1zJOte74WUnC3ko7Z8599mim00/cHUCYKzfAn9bE9ZQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-msk@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-msk/-/aws-msk-1.152.0.tgz#d3a324ad4ddc5677f5a96fd7f5b3fa8110a0d1a9"
+  integrity sha512-AGTr3tBn9AVTXyKPhIpyZ61mdre/41A3eXotUxmI04/Uudz3qINow0y41M/0yPWROHPMDsbNMb4+QzSmPbK5Sg==
+  dependencies:
+    "@aws-cdk/aws-acmpca" "1.152.0"
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-kms" "1.152.0"
+    "@aws-cdk/aws-logs" "1.152.0"
+    "@aws-cdk/aws-s3" "1.152.0"
+    "@aws-cdk/aws-secretsmanager" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    "@aws-cdk/custom-resources" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-mwaa@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-mwaa/-/aws-mwaa-1.152.0.tgz#15b7e65c7befc1ac07152a512ccf09403134709d"
+  integrity sha512-VACGATZUAvgQBuhN1UJJ5e2JbRAWrrMLjPmTYTT4/jXHK/jmD4iWviqO8DiNm9cA32pEfioqjtePjxMnKaqf9Q==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-neptune@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-neptune/-/aws-neptune-1.152.0.tgz#6d0ca03f77913567e8d9e5c9fb7fa5747f0403da"
+  integrity sha512-4KhQJRzmsijqWEkm6sAdu6f2gsrc2K0imMF6sYPEF9F+AKLrz/nKAWy3myJNOE9Jst1wfNfGV0DXYodNKM1gqA==
+  dependencies:
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-kms" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-networkfirewall@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-networkfirewall/-/aws-networkfirewall-1.152.0.tgz#79849a16ec6b7bad71dfd1c3c84b7c5ad50aa47c"
+  integrity sha512-6alPAlX+hSACkRQWVee1JG/V1q1THtZZiTyX5A3YtOvx4u/zZ9cb611Hu/GTknIiU6zygxyYkzuHI+b0IYSg3w==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-networkmanager@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-networkmanager/-/aws-networkmanager-1.152.0.tgz#cb32da3b894acc518e1fb103e4941fc1a8814927"
+  integrity sha512-aErBZP62mhWU9tkDnAvwl8/6LpbqJLSaC/XiQH3j7UMjvG7/IT81KPAhR1M71f6BLOqbJ7e7CPFGtGRxD+sbNA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-nimblestudio@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-nimblestudio/-/aws-nimblestudio-1.152.0.tgz#a1538fb07b7e1ed9793b452a7f1eedadfecf1167"
+  integrity sha512-FoBIxT4PKByQ8o47NnylitPskzq3c8eBbNEs66/E+ZrMMbGXk7ZT1sRWMK3Zj6Rlf3PM1fZ2hg4BQcj0PtVBbg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-opensearchservice@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-opensearchservice/-/aws-opensearchservice-1.152.0.tgz#b9550222c1f3623d165c1e10f7ca8de50fabfa8c"
+  integrity sha512-LiIxO8hPTElUkytou4ExUX8Es4U18f7xKKpUVZXm4dEZdrpLcIl5bdLmIUJL9W5aWJwpu8G/oz1WkqxIbq/deg==
+  dependencies:
+    "@aws-cdk/aws-certificatemanager" "1.152.0"
+    "@aws-cdk/aws-cloudwatch" "1.152.0"
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-kms" "1.152.0"
+    "@aws-cdk/aws-logs" "1.152.0"
+    "@aws-cdk/aws-route53" "1.152.0"
+    "@aws-cdk/aws-secretsmanager" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    "@aws-cdk/custom-resources" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-opsworks@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-opsworks/-/aws-opsworks-1.152.0.tgz#0535284e1482b5d2270745536ce0fca3aa93c5b6"
+  integrity sha512-Eas1xisAtIk4OGwr8d5IhL0lBcNNyS83EDaaH+F/35s+a0bRbBhFwOiIRGeV1wWVR5p2VwwJYb9RfPZgfcwIag==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-opsworkscm@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-opsworkscm/-/aws-opsworkscm-1.152.0.tgz#f494b14de1b2a6efff53cacf5623b085fd943d1e"
+  integrity sha512-nVBrx2yLDnJeLT18V2ZTjL56PYBy5ShO3zXrgGFqaMhwVPNORgseZQWWe2NMBIUu+lbFB3ODZgrWGX+br9R+2Q==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-panorama@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-panorama/-/aws-panorama-1.152.0.tgz#576a801c48b519d202393208b6a00085fbcfde61"
+  integrity sha512-EvOppMUKe+F1jjFqNN+sWMQnwUpyq6mO1HF6EHt/t5krfedwDU9aI6iptYVJ2U5mfDS30Ggfbf3wXkeabIm6/g==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-personalize@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-personalize/-/aws-personalize-1.152.0.tgz#0290389a14df78e98123a3a9799628fd77286d44"
+  integrity sha512-rMimnmLDSsedIMZV/LVtktKPEh30inW/uGaFenmlAUPKWUYGoxHXfWTYKp5pA3p1vbhyWvvrQPa+Nkr5Hzlxtw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-pinpoint@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-pinpoint/-/aws-pinpoint-1.152.0.tgz#46564c48f7fcb0e95f5133a39fb7438b4db4d96c"
+  integrity sha512-eVN2K7subJUgsBnCLPxTj5oMFd2wJTfIJ25yOUGWWGxNh5wgLXFB1jfsPLBbW93KbiFuBtecO2+AounlUdPhDQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-pinpointemail@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-pinpointemail/-/aws-pinpointemail-1.152.0.tgz#8f1497943681fc1b36cba4b2b32703705c38d6f7"
+  integrity sha512-ve2amVo6XGS0Sx2kUZR4GubHH0hwjmJ9hDoBqlAFjNfcqO6AkZ7Mvx3BcvZ/nB8SaxdWG0/LVKhoHcxrhWt20w==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-qldb@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-qldb/-/aws-qldb-1.152.0.tgz#179de8513be623ffac65d38fd03437502d1777ba"
+  integrity sha512-ab9KuZ/1mjFsI8TmA7rwpw4Fgkivoe6bUvooD+RmOJUe7kx3vc34DN9PkITto8On8hnfzv9X60Q95BQEJZMR2g==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-quicksight@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-quicksight/-/aws-quicksight-1.152.0.tgz#992a2718ede4fdd3a1cb7d9e8dd4770df81bc1d5"
+  integrity sha512-bRiOpsV2/SGfjsexSE0Vg0J+E1gvdbarn7MoG4+R6J9rIvIxU+3KsvB42JqE/hPR1v3JRI7Nf8ocs5AzAzFJxg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-ram@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ram/-/aws-ram-1.152.0.tgz#3818604178d3c4ed0892ec66069a830d67b1867b"
+  integrity sha512-juOaBx17BKeI8tULsTNXDSLdHu/y1OkzFIfGQlM1u1NbpYIqHBW9eb07jDOLO3f4RwE8O2wTyJuo2DHNTkDn+w==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
 
 "@aws-cdk/aws-rds@1.152.0":
@@ -570,6 +1578,58 @@
     "@aws-cdk/aws-secretsmanager" "1.152.0"
     "@aws-cdk/core" "1.152.0"
     "@aws-cdk/cx-api" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-redshift@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-redshift/-/aws-redshift-1.152.0.tgz#9c318f7b24736e8e19d2e48fd7cc22dedaa344f9"
+  integrity sha512-pi8sP8XtjaVwByfnYgp5uQsR14p5wjF2BTtOnpcJYytb8FMQNBSyeAbPnnMHV8oxQXr9zVfWbpoZK4fOmR2B4w==
+  dependencies:
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-kms" "1.152.0"
+    "@aws-cdk/aws-lambda" "1.152.0"
+    "@aws-cdk/aws-s3" "1.152.0"
+    "@aws-cdk/aws-secretsmanager" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    "@aws-cdk/custom-resources" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-refactorspaces@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-refactorspaces/-/aws-refactorspaces-1.152.0.tgz#0951a75ae34db158ca02550132e5d60b27239499"
+  integrity sha512-M6aK+9UYNQOYoMFfjvUNQ8FBVy8O+T9bh8rtoHQqnkIvKJUFEEljLBRRnTF67laEUjnLaQhHcZ53WQoZBz4H8Q==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-rekognition@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-rekognition/-/aws-rekognition-1.152.0.tgz#f2acf5fcf7df5ef520689e26e513eb27ff950348"
+  integrity sha512-Z204xTCpmFHLMChxM2xmvI+OmwS79t+8Li8Hp08Gmv8h0mWSJJ14CsuV+tP2wc4KxPvHAVN7oyTQoakbY+H0HA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-resiliencehub@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-resiliencehub/-/aws-resiliencehub-1.152.0.tgz#6caa4703e4b1cc6c68df12c4aaaab874dad8b590"
+  integrity sha512-2wyED8kpRqDkcycATP121KMUnztJ1UD5yCa1ytwT11i3/PcDk+W5POEkRkXRlYRV7hk/k0xYwStjmeyr0LgwmA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-resourcegroups@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-resourcegroups/-/aws-resourcegroups-1.152.0.tgz#b306ec5676f333c73601b2e1c62ac263c03f47c9"
+  integrity sha512-aO9D5QeM/dVmIGj4emgwNG6RNjPGAdt22Vpnssmqqd7Zbca84c4YGqhHBu70FMwqE/Yp4KvVzx32JkDbWM9AIw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-robomaker@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-robomaker/-/aws-robomaker-1.152.0.tgz#58454698de42e8f2a8fcef276c3493d86e071b57"
+  integrity sha512-sXIHE7V/zKOriI5GoS0a+4NVRt/0kHCRnh0LF6cd5ZybiMUxNkaoMH2oa7ZbPLqjRxQLTRDgbsb+/VwUAonnyw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
 
 "@aws-cdk/aws-route53-targets@1.152.0":
@@ -603,6 +1663,38 @@
     "@aws-cdk/core" "1.152.0"
     "@aws-cdk/custom-resources" "1.152.0"
     constructs "^3.3.69"
+
+"@aws-cdk/aws-route53recoverycontrol@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53recoverycontrol/-/aws-route53recoverycontrol-1.152.0.tgz#d9c6255b2b409c51324dfbf2264c3e658d251a6f"
+  integrity sha512-GQH0IKf8BCh/wo9NDrKeBj6Mt81O7hhqpZJYV0DMLpy/EEBT4YXP/aa+5HCGj1VyYPZQQIRTycLu/mID9gv6HA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-route53recoveryreadiness@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53recoveryreadiness/-/aws-route53recoveryreadiness-1.152.0.tgz#683c97791bf6d0114fbf4232a83547de9b485702"
+  integrity sha512-5MKYuQfqqfmI428Fx0s7NHLo5noFqzvLWj7pWdKzprXHk6h1DR5Bja31l2kRB/Lslev+qedupe/rzGLPSDW8WA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-route53resolver@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53resolver/-/aws-route53resolver-1.152.0.tgz#c5dd42c937daafdb29b1247e6c9d323fbd086104"
+  integrity sha512-5JWFMCHPHLr7/6kcgd48YxRkl647tNSpT5WV1N6dQJsZ/U+ND9H6X9zVWadqBqNmk+SaDsimrVDrvQDNh7eIKw==
+  dependencies:
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-s3" "1.152.0"
+    "@aws-cdk/aws-s3-assets" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-rum@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-rum/-/aws-rum-1.152.0.tgz#a06bdae49a9d3bce46d55affdb6ac5bc4f1cb46e"
+  integrity sha512-O3jFhb4T7ER5bLN3RQVrXETlsobCsecVQ6Rxr7q3otTr3GpHkDHZl2Lfmlqjip3a7oVPIJ/ZjodKZYhpsZ/KNQ==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
 
 "@aws-cdk/aws-s3-assets@1.152.0":
   version "1.152.0"
@@ -643,10 +1735,44 @@
     "@aws-cdk/cx-api" "1.152.0"
     constructs "^3.3.69"
 
+"@aws-cdk/aws-s3objectlambda@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3objectlambda/-/aws-s3objectlambda-1.152.0.tgz#de14b55b04a3faf6a6419002da92899c2340e6d3"
+  integrity sha512-8OTGf6OFLiNfyT71eLlHaaMPfMAD69NXadKmBoDjgUMvkuTp1nky+lEr6jQmEfoUbSkhSBHML4uUAfKbTYGLXw==
+  dependencies:
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-lambda" "1.152.0"
+    "@aws-cdk/aws-s3" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-s3outposts@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3outposts/-/aws-s3outposts-1.152.0.tgz#09f25a78702023162b453d3421b3fbdfd8cee29d"
+  integrity sha512-0EIEKOGIpVxtZJ0wDTzzgvCTG7mxnjmpPu7lru/5SCd3r9TDQJwEkO5JGjJZyiC6rgwWDN5PVVsshm9M+XWdcA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-sagemaker@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sagemaker/-/aws-sagemaker-1.152.0.tgz#374268d57086ee7920ece7514c03f958488be2d7"
+  integrity sha512-5JFfhuGVopVMROjbupSUc4mGieW+FNAxfkO+mU9CDOImk5JEdiokg22tl4DsfPc0fFEbdYbWry+0MxtM4HwR6g==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
 "@aws-cdk/aws-sam@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sam/-/aws-sam-1.152.0.tgz#af3f9c50dbea65ac0a9f2bfd5c3149e8b82faa6d"
   integrity sha512-4dSNoNHQO+HmcEn9SCxKJRqzXeNWnlIraPtqMsT4r/qE9VxlXzxz2q+5cyEEnSiPNTEvaR8GhfLae4ySvIbjNg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-sdb@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sdb/-/aws-sdb-1.152.0.tgz#d1051148b1f1980282040cf102579de8178375f7"
+  integrity sha512-tVNnN0jdmBFH3qWem7FKT7zo9SbE3/Ki6dUGaSGxyU3vmmxf6G+1OHPqZH67H/H8+esang0RPgwF5sv68yr64A==
   dependencies:
     "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
@@ -665,6 +1791,33 @@
     "@aws-cdk/cx-api" "1.152.0"
     constructs "^3.3.69"
 
+"@aws-cdk/aws-securityhub@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-securityhub/-/aws-securityhub-1.152.0.tgz#c97b88307c76d9b76b1f65e3d0d6976b2ee4fa1c"
+  integrity sha512-Qvj/SuwznQ5fe0wt0vukzFXkUbDocGYSNgaMJZWeicG9jyaoZFh3PKWZ6RcvUaRLYrp4vUTmdv1VZ/Q0NIC88A==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-servicecatalog@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicecatalog/-/aws-servicecatalog-1.152.0.tgz#b6963d412ce2883044340aa44c1a02c47ef5af12"
+  integrity sha512-WPrwzi13YBzAUJg/ue4ea4ttfXmcq5q7kD2kziyYJ58WKHc8uMm2ncz1rwfrgYyapVmmf/mn6HrXPp3D1p0Jtg==
+  dependencies:
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-s3-assets" "1.152.0"
+    "@aws-cdk/aws-sns" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-servicecatalogappregistry@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicecatalogappregistry/-/aws-servicecatalogappregistry-1.152.0.tgz#c4c53b1eb2ebcb18a42be50a72f14e7c1d089ad3"
+  integrity sha512-IH6+SEmstJPTcoP6IWAvuCmuvGzKmh1l88TQp8a87SIdtl9k3cIA3WLepo7/IDS5pqStvBPwfcRgsGj4LXkNrw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
 "@aws-cdk/aws-servicediscovery@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.152.0.tgz#dd35930ab7fbba61cd41016cf07f3934d5af33c8"
@@ -673,6 +1826,16 @@
     "@aws-cdk/aws-ec2" "1.152.0"
     "@aws-cdk/aws-elasticloadbalancingv2" "1.152.0"
     "@aws-cdk/aws-route53" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-ses@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ses/-/aws-ses-1.152.0.tgz#27576cf93bf8fc5eaed2fe59628daea8547f0b4c"
+  integrity sha512-/CFPBaiVXnh4IevJcRGozK7vTRg3DSbEPJbrfTMBwamYcpD4ivQwZeIw6oo9RFqwjonP5MkG4ONlACyY6cwotQ==
+  dependencies:
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-lambda" "1.152.0"
     "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
 
@@ -733,6 +1896,27 @@
     "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
 
+"@aws-cdk/aws-ssmcontacts@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssmcontacts/-/aws-ssmcontacts-1.152.0.tgz#566e7f1c0cc6412f421b0bb232488cc7d3de07c7"
+  integrity sha512-I9UYvMXTauQy6B//1kYdrP2o3qtngUtgP4z2mi1wXiwb2OFK74/AdlFxPu0SgcK0hVjHXH4CI2s22Itu6S2tDg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-ssmincidents@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssmincidents/-/aws-ssmincidents-1.152.0.tgz#d4744bb515dc8a8abff97ccdc636c4f610427c46"
+  integrity sha512-O2xxrLy7f62i6e9kwTd6z41IQoEB8JDo4/nC+oGtnvS8/Nu5shSkBlHR4iQuLwme5SsNVmBcG/u3eJ8tuvVGow==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-sso@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sso/-/aws-sso-1.152.0.tgz#511452ba359abc2e201c7f017e292138b91f6142"
+  integrity sha512-w2IBwgeM9G9kGrNYMvD0fyhyT+U63tA/FWjXQ8lz9QW2vLPthyU/jHpOvqnArTPcN/V8T0OJkwBwdRNMyUsysw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
 "@aws-cdk/aws-stepfunctions-tasks@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions-tasks/-/aws-stepfunctions-tasks-1.152.0.tgz#d12abc76d953a4e04307a28e5ee727a2f2fdb3b5"
@@ -774,6 +1958,81 @@
     "@aws-cdk/core" "1.152.0"
     constructs "^3.3.69"
 
+"@aws-cdk/aws-synthetics@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-synthetics/-/aws-synthetics-1.152.0.tgz#c9df38cc6c8afb2b090c46fc6b7df03bc273f378"
+  integrity sha512-jPqbP7v3w2B3+fiZVM56kAMF0Rg5wI0uIw+JppwteTL0hdoYfLZU1LjJgRK9ApmxXX4JypUehkBGuGOhvQMTuQ==
+  dependencies:
+    "@aws-cdk/aws-cloudwatch" "1.152.0"
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-s3" "1.152.0"
+    "@aws-cdk/aws-s3-assets" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-timestream@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-timestream/-/aws-timestream-1.152.0.tgz#96fc4aa89758d385cfa2c7e317e9915443eeac39"
+  integrity sha512-cfvRHJY9bRxVPdkj1Q1b6DpzJyHJ2E0U+DdnO7NSoxlGkDpLqW+8jBszzUu2ay0byoFxcJu7z8OFFm/7vRI8Mg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
+"@aws-cdk/aws-transfer@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-transfer/-/aws-transfer-1.152.0.tgz#af667ba8425b56294b343d1b469410a56c49bb11"
+  integrity sha512-ADNYTngxUwJSnb5/mLu46JpljfXAFNlPzrYBidw6DrPXD1z1ccPZAd8xaQT+PbZND0IuKl0wjdAPGJAUFuMT+Q==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-waf@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-waf/-/aws-waf-1.152.0.tgz#92ba47f21913a742c35f8753d6f920be11cd3e16"
+  integrity sha512-zgJTzck1R4WSGNGWwLOJwI96kG7OHNUL/tsvqIepdkH+hu+NsK6RgbqN2+vKsLdyQRFRWGWDV1K0DWLKDcHjiw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-wafregional@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-wafregional/-/aws-wafregional-1.152.0.tgz#6f7082ef0a45706ea08267b7f087886f1a465425"
+  integrity sha512-3QybY4g0M5JWE0UQ+QiQQhjep5GgOBHmqwUbcOQv5JHDvsKTHxEfMg6CAxr9NyvRbc6R5TL6fohUYqO9/1Icfw==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-wafv2@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-wafv2/-/aws-wafv2-1.152.0.tgz#21ad9bcc0db6788ffb8ed303e4ae36d44adc037e"
+  integrity sha512-yt20yeXHpXpX6PRtqnVE/oo/wmstcNwZBMwE85mFRsTMoO8SjUmMp3ewyknx1yJQGRyLwhOcX78rZxxXvPWnlg==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-wisdom@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-wisdom/-/aws-wisdom-1.152.0.tgz#e27689d281cbb7ceea857434e99105c1216b5746"
+  integrity sha512-93Y1vF7ddzCyCcAPys3dSxFYoxR6v28HKnGt9rrYps4SisaburNjNsb9YFukMNLtSkTYR1v/czMzD8GaOBNK4A==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-workspaces@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-workspaces/-/aws-workspaces-1.152.0.tgz#ea9edc99a0990d87e7ec8d726dcb82798d56aca1"
+  integrity sha512-7ZjUED1WfGchd3OMxMrHvu6PE3NHMVQYuamdxS3XQ2IAoG2VPdF0fcH8QMl7iQAzR3h0YY8sd8hsen78r98YHA==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-xray@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-xray/-/aws-xray-1.152.0.tgz#9e76f471d2062141721789169e090a8a6bc3c796"
+  integrity sha512-Md8keFDvVjbcLb0I/ZxFU001V23Yx8eiRQ35yuiD/s8DE906TNFKZ6ZhVXWtAYXvoNXUf1tmlwZskL4zKrbHow==
+  dependencies:
+    "@aws-cdk/core" "1.152.0"
+
 "@aws-cdk/cfnspec@1.152.0":
   version "1.152.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.152.0.tgz#c2939df10c6675aed332eacca5020392b0ad6e7a"
@@ -802,6 +2061,201 @@
     fast-deep-equal "^3.1.3"
     string-width "^4.2.3"
     table "^6.8.0"
+
+"@aws-cdk/cloudformation-include@1.152.0":
+  version "1.152.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-include/-/cloudformation-include-1.152.0.tgz#47985242a8f9ec06190a199d991608ddb29eeb80"
+  integrity sha512-DXZo0wPsyivSTMCipxYlxCUrYLc18ycfWtAIEYEhkgjQX168Q79BnUvLnIV2b9tNC1CMSLdStTnUefNhG2KybQ==
+  dependencies:
+    "@aws-cdk/alexa-ask" "1.152.0"
+    "@aws-cdk/aws-accessanalyzer" "1.152.0"
+    "@aws-cdk/aws-acmpca" "1.152.0"
+    "@aws-cdk/aws-amazonmq" "1.152.0"
+    "@aws-cdk/aws-amplify" "1.152.0"
+    "@aws-cdk/aws-amplifyuibuilder" "1.152.0"
+    "@aws-cdk/aws-apigateway" "1.152.0"
+    "@aws-cdk/aws-apigatewayv2" "1.152.0"
+    "@aws-cdk/aws-appconfig" "1.152.0"
+    "@aws-cdk/aws-appflow" "1.152.0"
+    "@aws-cdk/aws-appintegrations" "1.152.0"
+    "@aws-cdk/aws-applicationautoscaling" "1.152.0"
+    "@aws-cdk/aws-applicationinsights" "1.152.0"
+    "@aws-cdk/aws-appmesh" "1.152.0"
+    "@aws-cdk/aws-apprunner" "1.152.0"
+    "@aws-cdk/aws-appstream" "1.152.0"
+    "@aws-cdk/aws-appsync" "1.152.0"
+    "@aws-cdk/aws-aps" "1.152.0"
+    "@aws-cdk/aws-athena" "1.152.0"
+    "@aws-cdk/aws-auditmanager" "1.152.0"
+    "@aws-cdk/aws-autoscaling" "1.152.0"
+    "@aws-cdk/aws-autoscalingplans" "1.152.0"
+    "@aws-cdk/aws-backup" "1.152.0"
+    "@aws-cdk/aws-batch" "1.152.0"
+    "@aws-cdk/aws-billingconductor" "1.152.0"
+    "@aws-cdk/aws-budgets" "1.152.0"
+    "@aws-cdk/aws-cassandra" "1.152.0"
+    "@aws-cdk/aws-ce" "1.152.0"
+    "@aws-cdk/aws-certificatemanager" "1.152.0"
+    "@aws-cdk/aws-chatbot" "1.152.0"
+    "@aws-cdk/aws-cloud9" "1.152.0"
+    "@aws-cdk/aws-cloudfront" "1.152.0"
+    "@aws-cdk/aws-cloudtrail" "1.152.0"
+    "@aws-cdk/aws-cloudwatch" "1.152.0"
+    "@aws-cdk/aws-codeartifact" "1.152.0"
+    "@aws-cdk/aws-codebuild" "1.152.0"
+    "@aws-cdk/aws-codecommit" "1.152.0"
+    "@aws-cdk/aws-codedeploy" "1.152.0"
+    "@aws-cdk/aws-codeguruprofiler" "1.152.0"
+    "@aws-cdk/aws-codegurureviewer" "1.152.0"
+    "@aws-cdk/aws-codepipeline" "1.152.0"
+    "@aws-cdk/aws-codestar" "1.152.0"
+    "@aws-cdk/aws-codestarconnections" "1.152.0"
+    "@aws-cdk/aws-codestarnotifications" "1.152.0"
+    "@aws-cdk/aws-cognito" "1.152.0"
+    "@aws-cdk/aws-config" "1.152.0"
+    "@aws-cdk/aws-connect" "1.152.0"
+    "@aws-cdk/aws-cur" "1.152.0"
+    "@aws-cdk/aws-customerprofiles" "1.152.0"
+    "@aws-cdk/aws-databrew" "1.152.0"
+    "@aws-cdk/aws-datapipeline" "1.152.0"
+    "@aws-cdk/aws-datasync" "1.152.0"
+    "@aws-cdk/aws-dax" "1.152.0"
+    "@aws-cdk/aws-detective" "1.152.0"
+    "@aws-cdk/aws-devopsguru" "1.152.0"
+    "@aws-cdk/aws-directoryservice" "1.152.0"
+    "@aws-cdk/aws-dlm" "1.152.0"
+    "@aws-cdk/aws-dms" "1.152.0"
+    "@aws-cdk/aws-docdb" "1.152.0"
+    "@aws-cdk/aws-dynamodb" "1.152.0"
+    "@aws-cdk/aws-ec2" "1.152.0"
+    "@aws-cdk/aws-ecr" "1.152.0"
+    "@aws-cdk/aws-ecs" "1.152.0"
+    "@aws-cdk/aws-efs" "1.152.0"
+    "@aws-cdk/aws-eks" "1.152.0"
+    "@aws-cdk/aws-elasticache" "1.152.0"
+    "@aws-cdk/aws-elasticbeanstalk" "1.152.0"
+    "@aws-cdk/aws-elasticloadbalancing" "1.152.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.152.0"
+    "@aws-cdk/aws-elasticsearch" "1.152.0"
+    "@aws-cdk/aws-emr" "1.152.0"
+    "@aws-cdk/aws-emrcontainers" "1.152.0"
+    "@aws-cdk/aws-events" "1.152.0"
+    "@aws-cdk/aws-eventschemas" "1.152.0"
+    "@aws-cdk/aws-evidently" "1.152.0"
+    "@aws-cdk/aws-finspace" "1.152.0"
+    "@aws-cdk/aws-fis" "1.152.0"
+    "@aws-cdk/aws-fms" "1.152.0"
+    "@aws-cdk/aws-forecast" "1.152.0"
+    "@aws-cdk/aws-frauddetector" "1.152.0"
+    "@aws-cdk/aws-fsx" "1.152.0"
+    "@aws-cdk/aws-gamelift" "1.152.0"
+    "@aws-cdk/aws-globalaccelerator" "1.152.0"
+    "@aws-cdk/aws-glue" "1.152.0"
+    "@aws-cdk/aws-greengrass" "1.152.0"
+    "@aws-cdk/aws-greengrassv2" "1.152.0"
+    "@aws-cdk/aws-groundstation" "1.152.0"
+    "@aws-cdk/aws-guardduty" "1.152.0"
+    "@aws-cdk/aws-healthlake" "1.152.0"
+    "@aws-cdk/aws-iam" "1.152.0"
+    "@aws-cdk/aws-imagebuilder" "1.152.0"
+    "@aws-cdk/aws-inspector" "1.152.0"
+    "@aws-cdk/aws-inspectorv2" "1.152.0"
+    "@aws-cdk/aws-iot" "1.152.0"
+    "@aws-cdk/aws-iot1click" "1.152.0"
+    "@aws-cdk/aws-iotanalytics" "1.152.0"
+    "@aws-cdk/aws-iotcoredeviceadvisor" "1.152.0"
+    "@aws-cdk/aws-iotevents" "1.152.0"
+    "@aws-cdk/aws-iotfleethub" "1.152.0"
+    "@aws-cdk/aws-iotsitewise" "1.152.0"
+    "@aws-cdk/aws-iotthingsgraph" "1.152.0"
+    "@aws-cdk/aws-iotwireless" "1.152.0"
+    "@aws-cdk/aws-ivs" "1.152.0"
+    "@aws-cdk/aws-kafkaconnect" "1.152.0"
+    "@aws-cdk/aws-kendra" "1.152.0"
+    "@aws-cdk/aws-kinesis" "1.152.0"
+    "@aws-cdk/aws-kinesisanalytics" "1.152.0"
+    "@aws-cdk/aws-kinesisanalyticsv2" "1.152.0"
+    "@aws-cdk/aws-kinesisfirehose" "1.152.0"
+    "@aws-cdk/aws-kinesisvideo" "1.152.0"
+    "@aws-cdk/aws-kms" "1.152.0"
+    "@aws-cdk/aws-lakeformation" "1.152.0"
+    "@aws-cdk/aws-lambda" "1.152.0"
+    "@aws-cdk/aws-lex" "1.152.0"
+    "@aws-cdk/aws-licensemanager" "1.152.0"
+    "@aws-cdk/aws-lightsail" "1.152.0"
+    "@aws-cdk/aws-location" "1.152.0"
+    "@aws-cdk/aws-logs" "1.152.0"
+    "@aws-cdk/aws-lookoutequipment" "1.152.0"
+    "@aws-cdk/aws-lookoutmetrics" "1.152.0"
+    "@aws-cdk/aws-lookoutvision" "1.152.0"
+    "@aws-cdk/aws-macie" "1.152.0"
+    "@aws-cdk/aws-managedblockchain" "1.152.0"
+    "@aws-cdk/aws-mediaconnect" "1.152.0"
+    "@aws-cdk/aws-mediaconvert" "1.152.0"
+    "@aws-cdk/aws-medialive" "1.152.0"
+    "@aws-cdk/aws-mediapackage" "1.152.0"
+    "@aws-cdk/aws-mediastore" "1.152.0"
+    "@aws-cdk/aws-memorydb" "1.152.0"
+    "@aws-cdk/aws-msk" "1.152.0"
+    "@aws-cdk/aws-mwaa" "1.152.0"
+    "@aws-cdk/aws-neptune" "1.152.0"
+    "@aws-cdk/aws-networkfirewall" "1.152.0"
+    "@aws-cdk/aws-networkmanager" "1.152.0"
+    "@aws-cdk/aws-nimblestudio" "1.152.0"
+    "@aws-cdk/aws-opensearchservice" "1.152.0"
+    "@aws-cdk/aws-opsworks" "1.152.0"
+    "@aws-cdk/aws-opsworkscm" "1.152.0"
+    "@aws-cdk/aws-panorama" "1.152.0"
+    "@aws-cdk/aws-personalize" "1.152.0"
+    "@aws-cdk/aws-pinpoint" "1.152.0"
+    "@aws-cdk/aws-pinpointemail" "1.152.0"
+    "@aws-cdk/aws-qldb" "1.152.0"
+    "@aws-cdk/aws-quicksight" "1.152.0"
+    "@aws-cdk/aws-ram" "1.152.0"
+    "@aws-cdk/aws-rds" "1.152.0"
+    "@aws-cdk/aws-redshift" "1.152.0"
+    "@aws-cdk/aws-refactorspaces" "1.152.0"
+    "@aws-cdk/aws-rekognition" "1.152.0"
+    "@aws-cdk/aws-resiliencehub" "1.152.0"
+    "@aws-cdk/aws-resourcegroups" "1.152.0"
+    "@aws-cdk/aws-robomaker" "1.152.0"
+    "@aws-cdk/aws-route53" "1.152.0"
+    "@aws-cdk/aws-route53recoverycontrol" "1.152.0"
+    "@aws-cdk/aws-route53recoveryreadiness" "1.152.0"
+    "@aws-cdk/aws-route53resolver" "1.152.0"
+    "@aws-cdk/aws-rum" "1.152.0"
+    "@aws-cdk/aws-s3" "1.152.0"
+    "@aws-cdk/aws-s3objectlambda" "1.152.0"
+    "@aws-cdk/aws-s3outposts" "1.152.0"
+    "@aws-cdk/aws-sagemaker" "1.152.0"
+    "@aws-cdk/aws-sam" "1.152.0"
+    "@aws-cdk/aws-sdb" "1.152.0"
+    "@aws-cdk/aws-secretsmanager" "1.152.0"
+    "@aws-cdk/aws-securityhub" "1.152.0"
+    "@aws-cdk/aws-servicecatalog" "1.152.0"
+    "@aws-cdk/aws-servicecatalogappregistry" "1.152.0"
+    "@aws-cdk/aws-servicediscovery" "1.152.0"
+    "@aws-cdk/aws-ses" "1.152.0"
+    "@aws-cdk/aws-signer" "1.152.0"
+    "@aws-cdk/aws-sns" "1.152.0"
+    "@aws-cdk/aws-sqs" "1.152.0"
+    "@aws-cdk/aws-ssm" "1.152.0"
+    "@aws-cdk/aws-ssmcontacts" "1.152.0"
+    "@aws-cdk/aws-ssmincidents" "1.152.0"
+    "@aws-cdk/aws-sso" "1.152.0"
+    "@aws-cdk/aws-stepfunctions" "1.152.0"
+    "@aws-cdk/aws-synthetics" "1.152.0"
+    "@aws-cdk/aws-timestream" "1.152.0"
+    "@aws-cdk/aws-transfer" "1.152.0"
+    "@aws-cdk/aws-waf" "1.152.0"
+    "@aws-cdk/aws-wafregional" "1.152.0"
+    "@aws-cdk/aws-wafv2" "1.152.0"
+    "@aws-cdk/aws-wisdom" "1.152.0"
+    "@aws-cdk/aws-workspaces" "1.152.0"
+    "@aws-cdk/aws-xray" "1.152.0"
+    "@aws-cdk/core" "1.152.0"
+    constructs "^3.3.69"
+    yaml "1.10.2"
 
 "@aws-cdk/core@1.152.0":
   version "1.152.0"

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -67,4 +67,5 @@ riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "support:payment-api-mono"
 riffRaffPackageType := (Debian / packageBin).value
-riffRaffArtifactResources += (file("support-payment-api/src/main/resources/cloud-formation.yaml"), "cfn/cfn.yaml")
+riffRaffArtifactResources += (file("cdk/cdk.out/Payment-API-PROD.template.json"), "cfn/Payment-API-PROD.template.json")
+riffRaffArtifactResources += (file("cdk/cdk.out/Payment-API-CODE.template.json"), "cfn/Payment-API-CODE.template.json")

--- a/support-payment-api/src/main/resources/riff-raff.yaml
+++ b/support-payment-api/src/main/resources/riff-raff.yaml
@@ -9,7 +9,9 @@ deployments:
         Recipe: bionic-membership-ARM
         AmigoStage: PROD
       amiEncrypted: true
-      templatePath: cfn.yaml
+      templateStagePaths:
+        CODE: Payment-API-CODE.template.json
+        PROD: Payment-API-PROD.template.json
   payment-api:
     type: autoscaling
     parameters:


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

In this phase, we introduce CDK to the payment-api project. At this stage we're just using the `CfnInclude` construct to load the existing cloudformation template. This allows us to get all the plumbing in place (eg generating the template during CI and pointing riffraff at the new location) without also generating new versions of all of the resources. In phase 2, we will spin up a duplicate set of all resources using proper cdk/gu-cdk constructs/patterns. When we are happy this new set of resources is running as expected, we can redirect traffic to the new resources. In phase 3, after the old resources are no longer receiving traffic, we can tear them down.