### PR TITLE
Allow payment api build to run on dispatch

### DIFF
--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -1,6 +1,7 @@
 name: Build payment-api
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

For the CDK migration work, it would be convenient to run this workflow manually. In order to do that we need allow it to trigger on the `workflow_dispatch` event: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow.

Annoyingly we can't actually test this is working as we need the updated workflow in the `main` branch to trigger it manually! 

