### PR TITLE
Update contribs LP payment method test ids

### DIFF
--- a/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
+++ b/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
@@ -24,9 +24,9 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
 
   private val otherAmount = id("contributionOther")
 
-  private val stripeSelector = id("paymentMethodSelector-Stripe")
-  private val directDebitSelector = id("paymentMethodSelector-DirectDebit")
-  private val payPalSelector = id("paymentMethodSelector-PayPal")
+  private val stripeSelector = id("qa-credit-card")
+  private val directDebitSelector = id("qa-direct-debit")
+  private val payPalSelector = id("qa-paypal")
   private val stateSelector = id("contributionState")
 
   private val stripeOverlayIframe = cssSelector(".stripe_checkout_app")


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This fixes the post deployment contribs LP payment method tests by updating the relevant test ids following https://github.com/guardian/support-frontend/pull/4056.

