### PR TITLE
Fix layout bug for DigiSubs packshot

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
@@ -837,13 +837,11 @@
 
 	img {
 		position: absolute;
-		bottom: -50px;
 		width: 100%;
 	}
 
 	@include mq($from: tablet) {
 		position: absolute;
-		bottom: 0;
 		padding: 0px;
 
 		img {


### PR DESCRIPTION
Co-authored-by: Maria Olanipekun <marialani@users.noreply.github.com>
Co-authored-by: Paul Dempsey <paul-daniel-dempsey@users.noreply.github.com>

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR fixes a visual layout bug for the Digital Subscriptions pack shot on the subscriptions-landing-page



[**Trello Card**](https://trello.com/c/bj8rocra/433-subscriptions-lp-digisub-packshot-mobile-layout-bug)


## Screenshots
<img width="504" alt="Screenshot 2022-08-11 at 13 25 11" src="https://user-images.githubusercontent.com/73653255/184133097-db1e8abe-9376-43d2-a172-6af5e077ea86.png">



