### PR TITLE
fix issue with newspaper link highlighting in header

### DIFF
--- a/support-frontend/assets/components/headers/links/links.tsx
+++ b/support-frontend/assets/components/headers/links/links.tsx
@@ -85,6 +85,19 @@ function internationalisationID(
 	return null;
 }
 
+function getActiveLinkClassModifiers(
+	urlWithoutParams: string,
+	href: string,
+): string | null {
+	if (
+		urlWithoutParams.endsWith(href) ||
+		urlWithoutParams.endsWith(`${href}/delivery`)
+	) {
+		return 'active';
+	}
+	return null;
+}
+
 // Export
 function Links({ location, getRef, countryGroupId }: PropTypes): JSX.Element {
 	const { protocol, host, pathname } = window.location;
@@ -127,7 +140,7 @@ function Links({ location, getRef, countryGroupId }: PropTypes): JSX.Element {
 							<li
 								className={cx(
 									classNameWithModifiers('component-header-links__li', [
-										urlWithoutParams.endsWith(href) ? 'active' : null,
+										getActiveLinkClassModifiers(urlWithoutParams, href),
 									]),
 									additionalClasses,
 								)}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR fixes a missing yellow highlight selection bug for Newspaper  /  home delivery 

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com/c/KcjWDEQ3/518-fix-issue-with-header-link-highlight-on-newspaper-landing-page)

## Why are you doing this?
![image](https://user-images.githubusercontent.com/76729591/184132957-e22371ce-c035-4fd2-a8e5-a3f6063814a6.png)

<!--
Remember, PRs are documentation for future contributors.
-->
