### PR TITLE
update support-i18n to release with scala 2.13 and 3.1

### DIFF
--- a/support-internationalisation/build.sbt
+++ b/support-internationalisation/build.sbt
@@ -2,7 +2,7 @@ import sbtrelease.ReleaseStateTransformations._
 
 name := "support-internationalisation"
 
-crossScalaVersions := Seq("2.11.12", "2.12.16")
+crossScalaVersions := Seq("2.13.8", "3.1.3")
 
 description := "Scala library to provide internationalisation classes to Guardian Membership/Subscriptions/support projects."
 

--- a/support-internationalisation/src/test/scala/com/gu/i18n/CountryGroupTest.scala
+++ b/support-internationalisation/src/test/scala/com/gu/i18n/CountryGroupTest.scala
@@ -1,11 +1,11 @@
 package com.gu.i18n
 
 import com.gu.i18n.Currency._
-import org.scalatest.Inspectors
-import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class CountryGroupTest extends AsyncFlatSpec with Matchers with Inspectors {
+class CountryGroupTest extends AnyFlatSpec with Matchers with Inspectors {
 
   "A CountryGroup" should "be found by id" in {
     CountryGroup.byId("ie") shouldBe None

--- a/support-internationalisation/version.sbt
+++ b/support-internationalisation/version.sbt
@@ -1,1 +1,1 @@
-version := "0.14-SNAPSHOT"
+version := "0.14"

--- a/support-internationalisation/version.sbt
+++ b/support-internationalisation/version.sbt
@@ -1,1 +1,1 @@
-version := "0.14"
+version := "0.15-SNAPSHOT"


### PR DESCRIPTION
This PR updates support-i18n to release for scala 2.13 and 3.1., and releases v0.14

It didn't even build with scala 2.11, and it had previously been released for scala 2.13 (for support-service-lambdas)

We now use scala 3 for new product-move-api, and even though scala 3 can use scala 2.13 libraries, it does make sense to release scala 3 libs where possible.

I have done a release to confirm my changes work, so this PR is to review what's already been done!  Release is visisble here https://mvnrepository.com/artifact/com.gu/support-internationalisation_3/0.14

---

I did have a go at making it a scala 3 only module (see https://github.com/guardian/support-frontend/compare/jd-support-i18n-scala-3...jd-support-i18n-scala-3-only ), but there seems to be an issue with scalatest versions that stops the tests from compiling as follows:
```
[IJ]support-workers/Test/compile
[info] compiling 43 Scala sources and 1 Java source to /Users/john_duffell/code/support-frontend/support-workers/target/scala-2.13/test-classes ...
[error] Unsupported Scala 3 generic tuple type scala.Tuple in bounds of type MirroredElemTypes; found in  scala.deriving.Mirror.<refinement>.
[error] one error found
[error] (Test / compileIncremental) Compilation failed
[error] Total time: 18 s, completed 16-Aug-2022 10:26:45
```