### PR TITLE
re-add previous changes

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.test.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.test.tsx
@@ -21,7 +21,9 @@ import type { SubscriptionsStore } from '../../../helpers/redux/subscriptionsSto
 import { formatMachineDate } from '../../../helpers/utilities/dateConversions';
 import WeeklyCheckoutForm from './weeklyCheckoutForm';
 
-function setUpStore(initialState: WithDeliveryCheckoutState) {
+function setUpStore(
+	initialState: WithDeliveryCheckoutState,
+): SubscriptionsStore {
 	const store = createTestStoreForSubscriptions(
 		GuardianWeekly,
 		'Monthly',
@@ -50,8 +52,8 @@ describe('Guardian Weekly checkout form', () => {
 	// Suppress warnings related to our version of Redux and improper JSX
 	console.warn = jest.fn();
 	console.error = jest.fn();
+
 	let initialState: unknown;
-	let store: SubscriptionsStore;
 	const billingPeriod: BillingPeriod = 'Monthly';
 	const productOption: ProductOptions = 'NoProductOptions';
 	const fulfilmentOption: FulfilmentOptions = 'Domestic';
@@ -98,41 +100,39 @@ describe('Guardian Weekly checkout form', () => {
 		mockFetch({
 			client_secret: 'super secret',
 		});
-
-		// @ts-expect-error -- Type mismatch is unimportant for tests
-		store = setUpStore(initialState);
-
-		renderWithStore(<WeeklyCheckoutForm />, {
-			initialState,
-			store,
-		});
 	});
 
 	describe('Payment methods', () => {
 		describe('with all switches on', () => {
 			beforeEach(() => {
 				mock(isSwitchOn).mockImplementation(() => true);
+
+				renderWithStore(<WeeklyCheckoutForm />, {
+					initialState,
+					// @ts-expect-error -- Type mismatch is unimportant for tests
+					store: setUpStore(initialState),
+				});
 			});
 
-      it('shows all payment options', () => {
-        expect(screen.queryByText('PayPal')).toBeInTheDocument();
-        expect(screen.queryByText('Direct debit')).toBeInTheDocument();
-        expect(screen.queryByText('Credit/Debit card')).toBeInTheDocument();
-      });
+			it('shows all payment options', () => {
+				expect(screen.queryByText('PayPal')).toBeInTheDocument();
+				expect(screen.queryByText('Direct debit')).toBeInTheDocument();
+				expect(screen.queryByText('Credit/Debit card')).toBeInTheDocument();
+			});
 
-      it('does not show the direct debit option when the delivery address is outside the UK', async () => {
-        const countrySelect = await screen.findByLabelText('Country');
-        fireEvent.change(countrySelect, {
-          target: {
-            value: 'DE',
-          },
-        });
-        expect(screen.queryByText('Direct debit')).not.toBeInTheDocument();
-      });
+			it('does not show the direct debit option when the delivery address is outside the UK', async () => {
+				const countrySelect = await screen.findByLabelText('Country');
+				fireEvent.change(countrySelect, {
+					target: {
+						value: 'DE',
+					},
+				});
+				expect(screen.queryByText('Direct debit')).not.toBeInTheDocument();
+			});
 
-      it('shows the direct debit option when the currency is GBP and the delivery address is in the UK', () => {
-        expect(screen.queryByText('Direct debit')).toBeInTheDocument();
-      });
+			it('shows the direct debit option when the currency is GBP and the delivery address is in the UK', () => {
+				expect(screen.queryByText('Direct debit')).toBeInTheDocument();
+			});
 		});
 
 		describe('with only PayPal switch on', () => {
@@ -140,6 +140,12 @@ describe('Guardian Weekly checkout form', () => {
 				mock(isSwitchOn).mockImplementation(
 					(key) => key === 'subscriptionsPaymentMethods.paypal',
 				);
+
+				renderWithStore(<WeeklyCheckoutForm />, {
+					initialState,
+					// @ts-expect-error -- Type mismatch is unimportant for tests
+					store: setUpStore(initialState),
+				});
 			});
 
 			it('does not show the direct debit option', () => {
@@ -155,6 +161,12 @@ describe('Guardian Weekly checkout form', () => {
 				mock(isSwitchOn).mockImplementation(
 					(key) => key === 'subscriptionsPaymentMethods.directDebit',
 				);
+
+				renderWithStore(<WeeklyCheckoutForm />, {
+					initialState,
+					// @ts-expect-error -- Type mismatch is unimportant for tests
+					store: setUpStore(initialState),
+				});
 			});
 
 			it('does not show the PayPal option', () => {
@@ -170,6 +182,12 @@ describe('Guardian Weekly checkout form', () => {
 				mock(isSwitchOn).mockImplementation(
 					(key) => key === 'subscriptionsPaymentMethods.creditCard',
 				);
+
+				renderWithStore(<WeeklyCheckoutForm />, {
+					initialState,
+					// @ts-expect-error -- Type mismatch is unimportant for tests
+					store: setUpStore(initialState),
+				});
 			});
 
 			it('does not show the PayPal option', () => {
@@ -184,6 +202,12 @@ describe('Guardian Weekly checkout form', () => {
 	describe('Validation', () => {
 		beforeEach(() => {
 			mock(isSwitchOn).mockImplementation(() => true);
+
+			renderWithStore(<WeeklyCheckoutForm />, {
+				initialState,
+				// @ts-expect-error -- Type mismatch is unimportant for tests
+				store: setUpStore(initialState),
+			});
 		});
 
 		it('should display an error if a silly character is entered into an input field', async () => {
@@ -241,6 +265,16 @@ describe('Guardian Weekly checkout form', () => {
 	});
 
 	describe('Pricing internationalisation', () => {
+		beforeEach(() => {
+			mock(isSwitchOn).mockImplementation(() => true);
+
+			renderWithStore(<WeeklyCheckoutForm />, {
+				initialState,
+				// @ts-expect-error -- Type mismatch is unimportant for tests
+				store: setUpStore(initialState),
+			});
+		});
+
 		it('should display correct prices based on delivery address country (regardless of billing address country)', async () => {
 			const addressIsNotSame = await screen.findByRole('radio', {
 				name: 'No',

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.test.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.test.tsx
@@ -16,6 +16,7 @@ import { setProductPrices } from 'helpers/redux/checkout/product/actions';
 import { setInitialCommonState } from 'helpers/redux/commonState/actions';
 import type { WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import { setFirstName } from 'pages/contributions-landing/contributionsLandingActions';
+import { createTestStoreForSubscriptions } from '../../../__test-utils__/testStore';
 import { isSwitchOn } from '../../../helpers/globalsAndSwitches/globals';
 import type { BillingPeriod } from '../../../helpers/productPrice/billingPeriods';
 import type { FulfilmentOptions } from '../../../helpers/productPrice/fulfilmentOptions';
@@ -25,7 +26,6 @@ import { NoProductOptions } from '../../../helpers/productPrice/productOptions';
 import type { SubscriptionsStore } from '../../../helpers/redux/subscriptionsStore';
 import { formatMachineDate } from '../../../helpers/utilities/dateConversions';
 import WeeklyCheckoutForm from './weeklyCheckoutForm';
-import {createTestStoreForSubscriptions} from "../../../__test-utils__/testStore";
 
 function setUpStore(initialState: WithDeliveryCheckoutState) {
 	const store = createTestStoreForSubscriptions(

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.test.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.test.tsx
@@ -1,36 +1,55 @@
+/* eslint-disable eslint-comments/require-description -- This is a mocks file, it is not intended to be good code! */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
 import '__mocks__/stripeMock';
-import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { fireEvent, screen } from '@testing-library/react';
 import { mockFetch } from '__mocks__/fetchMock';
 import { weeklyProducts } from '__mocks__/productInfoMocks';
 import { renderWithStore } from '__test-utils__/render';
-import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import { GuardianWeekly } from 'helpers/productPrice/subscriptions';
+import {
+	setBillingCountry,
+	setDeliveryCountry,
+} from 'helpers/redux/checkout/address/actions';
+import { setProductPrices } from 'helpers/redux/checkout/product/actions';
 import { setInitialCommonState } from 'helpers/redux/commonState/actions';
-import { commonReducer } from 'helpers/redux/commonState/reducer';
 import type { WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
-import { createReducer } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
+import { setFirstName } from 'pages/contributions-landing/contributionsLandingActions';
+import { isSwitchOn } from '../../../helpers/globalsAndSwitches/globals';
+import type { BillingPeriod } from '../../../helpers/productPrice/billingPeriods';
+import type { FulfilmentOptions } from '../../../helpers/productPrice/fulfilmentOptions';
+import { getWeeklyFulfilmentOption } from '../../../helpers/productPrice/fulfilmentOptions';
+import type { ProductOptions } from '../../../helpers/productPrice/productOptions';
+import { NoProductOptions } from '../../../helpers/productPrice/productOptions';
+import type { SubscriptionsStore } from '../../../helpers/redux/subscriptionsStore';
+import { initReduxForSubscriptions } from '../../../helpers/redux/subscriptionsStore';
+import { formatMachineDate } from '../../../helpers/utilities/dateConversions';
 import WeeklyCheckoutForm from './weeklyCheckoutForm';
 
 function setUpStore(initialState: WithDeliveryCheckoutState) {
-	const store = configureStore({
-		reducer: combineReducers({
-			page: createReducer(),
-			common: commonReducer,
-		}),
-		preloadedState: initialState,
-	});
+	const store = initReduxForSubscriptions(
+		GuardianWeekly,
+		'Monthly',
+		formatMachineDate(new Date()),
+		NoProductOptions,
+		getWeeklyFulfilmentOption,
+	);
+	store.dispatch(setProductPrices(weeklyProducts));
 	store.dispatch(setInitialCommonState(initialState.common));
 	return store;
 }
 
-jest.mock('helpers/globalsAndSwitches/globals', () => ({
-	__esModule: true,
-	isSwitchOn: jest.fn(),
-	getSettings: jest.fn(),
-	getGlobal: jest.fn(),
-}));
+jest.mock('helpers/globalsAndSwitches/globals', () => {
+	const actualGlobalsAndSwitches = jest.requireActual(
+		'helpers/globalsAndSwitches/globals',
+	);
 
+	return {
+		...actualGlobalsAndSwitches,
+		isSwitchOn: jest.fn(),
+	};
+});
 const mock = (mockFn: unknown) => mockFn as jest.Mock;
 
 describe('Guardian Weekly checkout form', () => {
@@ -38,7 +57,14 @@ describe('Guardian Weekly checkout form', () => {
 	console.warn = jest.fn();
 	console.error = jest.fn();
 	let initialState: unknown;
+	let store: SubscriptionsStore;
+	const billingPeriod: BillingPeriod = 'Monthly';
+	const productOption: ProductOptions = 'NoProductOptions';
+	const fulfilmentOption: FulfilmentOptions = 'Domestic';
+
 	beforeEach(() => {
+		mock(isSwitchOn).mockImplementation(() => true);
+
 		initialState = {
 			page: {
 				checkout: {
@@ -48,9 +74,9 @@ describe('Guardian Weekly checkout form', () => {
 				checkoutForm: {
 					product: {
 						productType: GuardianWeekly,
-						billingPeriod: 'Monthly',
-						productOption: 'NoProductOptions',
-						fulfilmentOption: 'Domestic',
+						billingPeriod,
+						productOption,
+						fulfilmentOption,
 						productPrices: weeklyProducts,
 					},
 					billingAddress: {
@@ -80,116 +106,54 @@ describe('Guardian Weekly checkout form', () => {
 		mockFetch({
 			client_secret: 'super secret',
 		});
+
+		// @ts-expect-error -- Type mismatch is unimportant for tests
+		store = setUpStore(initialState);
+
+		renderWithStore(<WeeklyCheckoutForm />, {
+			initialState,
+			store,
+		});
+	});
+
+	afterEach(() => {
+		// TODO: Set up a non-global store for tests
+		store.dispatch(setFirstName(''));
+		store.dispatch(setDeliveryCountry('GB'));
+		store.dispatch(setBillingCountry('GB'));
 	});
 
 	describe('Payment methods', () => {
-		describe('with all switches on', () => {
-			beforeEach(() => {
-				mock(isSwitchOn).mockImplementation(() => true);
-
-				renderWithStore(<WeeklyCheckoutForm />, {
-					initialState,
-					// @ts-expect-error -- Type mismatch is unimportant for tests
-					store: setUpStore(initialState),
-				});
-			});
-
-			it('shows all payment options', () => {
-				expect(screen.queryByText('PayPal')).toBeInTheDocument();
-				expect(screen.queryByText('Direct debit')).toBeInTheDocument();
-				expect(screen.queryByText('Credit/Debit card')).toBeInTheDocument();
-			});
-
-			it('shows the direct debit option when the currency is GBP and the delivery address is in the UK', () => {
-				expect(screen.queryByText('Direct debit')).toBeInTheDocument();
-			});
-
-			it('does not show the direct debit option when the delivery address is outside the UK', async () => {
-				const countrySelect = await screen.findByLabelText('Country');
-				fireEvent.change(countrySelect, {
-					target: {
-						value: 'DE',
-					},
-				});
-				expect(screen.queryByText('Direct debit')).not.toBeInTheDocument();
-			});
+		it('shows the direct debit option when the currency is GBP and the delivery address is in the UK', () => {
+			expect(screen.queryByText('Direct debit')).toBeInTheDocument();
 		});
 
-		describe('with only paypal switch on', () => {
-			beforeEach(() => {
-				mock(isSwitchOn).mockImplementation(
-					(key) => key === 'subscriptionsPaymentMethods.paypal',
-				);
-
-				renderWithStore(<WeeklyCheckoutForm />, {
-					initialState,
-					// @ts-expect-error -- Type mismatch is unimportant for tests
-					store: setUpStore(initialState),
-				});
+		it('does not show the direct debit option when the delivery address is outside the UK', async () => {
+			const countrySelect = await screen.findByLabelText('Country');
+			fireEvent.change(countrySelect, {
+				target: {
+					value: 'DE',
+				},
 			});
-
-			it('does not show the direct debit option', () => {
-				expect(screen.queryByText('Direct debit')).not.toBeInTheDocument();
-			});
-			it('does not show the credit/debit card option', () => {
-				expect(screen.queryByText('Credit/Debit card')).not.toBeInTheDocument();
-			});
+			expect(screen.queryByText('Direct debit')).not.toBeInTheDocument();
 		});
 
-		describe('with only direct debit switch on', () => {
-			beforeEach(() => {
-				mock(isSwitchOn).mockImplementation(
-					(key) => key === 'subscriptionsPaymentMethods.directDebit',
-				);
-
-				renderWithStore(<WeeklyCheckoutForm />, {
-					initialState,
-					// @ts-expect-error -- Type mismatch is unimportant for tests
-					store: setUpStore(initialState),
-				});
+		it('does not show the direct debit option when the billing address is outside the UK', async () => {
+			const addressIsNotSame = await screen.findByRole('radio', {
+				name: 'No',
 			});
-
-			it('does not show the direct debit option', () => {
-				expect(screen.queryByText('PayPal')).not.toBeInTheDocument();
+			fireEvent.click(addressIsNotSame);
+			const allCountrySelects = await screen.findAllByLabelText('Country');
+			fireEvent.change(allCountrySelects[1], {
+				target: {
+					value: 'IE',
+				},
 			});
-			it('does not show the credit/debit card option', () => {
-				expect(screen.queryByText('Credit/Debit card')).not.toBeInTheDocument();
-			});
-		});
-
-		describe('with only credit/debit card switch on', () => {
-			beforeEach(() => {
-				mock(isSwitchOn).mockImplementation(
-					(key) => key === 'subscriptionsPaymentMethods.creditCard',
-				);
-
-				renderWithStore(<WeeklyCheckoutForm />, {
-					initialState,
-					// @ts-expect-error -- Type mismatch is unimportant for tests
-					store: setUpStore(initialState),
-				});
-			});
-
-			it('does not show the direct debit option', () => {
-				expect(screen.queryByText('PayPal')).not.toBeInTheDocument();
-			});
-			it('does not show the credit/debit card option', () => {
-				expect(screen.queryByText('Direct debit')).not.toBeInTheDocument();
-			});
+			expect(screen.queryByText('Direct debit')).not.toBeInTheDocument();
 		});
 	});
 
 	describe('Validation', () => {
-		beforeEach(() => {
-			mock(isSwitchOn).mockImplementation(() => true);
-
-			renderWithStore(<WeeklyCheckoutForm />, {
-				initialState,
-				// @ts-expect-error -- Type mismatch is unimportant for tests
-				store: setUpStore(initialState),
-			});
-		});
-
 		it('should display an error if a silly character is entered into an input field', async () => {
 			const firstNameInput = await screen.findByLabelText('First name');
 			fireEvent.change(firstNameInput, {
@@ -241,6 +205,40 @@ describe('Guardian Weekly checkout form', () => {
 					'Please use only letters, numbers and punctuation.',
 				),
 			).toHaveLength(0);
+		});
+	});
+
+	describe('Pricing internationalisation', () => {
+		it('should display correct prices based on delivery address country (regardless of billing address country)', async () => {
+			const addressIsNotSame = await screen.findByRole('radio', {
+				name: 'No',
+			});
+			fireEvent.click(addressIsNotSame);
+
+			const [Germany, UnitedKingdom] = ['DE', 'GB'];
+			const [deliveryAddressCountry, billingAddressCountry] =
+				await screen.findAllByLabelText('Country');
+			fireEvent.change(deliveryAddressCountry, {
+				target: {
+					value: Germany,
+				},
+			});
+			fireEvent.change(billingAddressCountry, {
+				target: {
+					value: UnitedKingdom,
+				},
+			});
+
+			const expectedPrice: number =
+				// @ts-expect-error -- `weeklyProducts` is a hard-coded mock, no risk of null values
+				weeklyProducts['Europe'][fulfilmentOption][productOption][
+					billingPeriod
+				]['EUR']['price'];
+
+			expect(
+				screen.queryAllByText(new RegExp(`€${expectedPrice}.+per month`))
+					.length,
+			).toBeGreaterThan(0);
 		});
 	});
 });

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.test.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.test.tsx
@@ -23,12 +23,12 @@ import { getWeeklyFulfilmentOption } from '../../../helpers/productPrice/fulfilm
 import type { ProductOptions } from '../../../helpers/productPrice/productOptions';
 import { NoProductOptions } from '../../../helpers/productPrice/productOptions';
 import type { SubscriptionsStore } from '../../../helpers/redux/subscriptionsStore';
-import { initReduxForSubscriptions } from '../../../helpers/redux/subscriptionsStore';
 import { formatMachineDate } from '../../../helpers/utilities/dateConversions';
 import WeeklyCheckoutForm from './weeklyCheckoutForm';
+import {createTestStoreForSubscriptions} from "../../../__test-utils__/testStore";
 
 function setUpStore(initialState: WithDeliveryCheckoutState) {
-	const store = initReduxForSubscriptions(
+	const store = createTestStoreForSubscriptions(
 		GuardianWeekly,
 		'Monthly',
 		formatMachineDate(new Date()),

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.test.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.test.tsx
@@ -193,7 +193,7 @@ describe('Guardian Weekly checkout form', () => {
 			it('does not show the PayPal option', () => {
 				expect(screen.queryByText('PayPal')).not.toBeInTheDocument();
 			});
-			it('does not show the direct debit card option', () => {
+			it('does not show the direct debit option', () => {
 				expect(screen.queryByText('Direct debit')).not.toBeInTheDocument();
 			});
 		});

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -15,8 +15,8 @@ import Form, {
 	FormSection,
 	FormSectionHiddenUntilSelected,
 } from 'components/checkoutForm/checkoutForm';
-import type { CsrCustomerData } from 'components/csr/csrMode';
 import { useCsrCustomerData } from 'components/csr/csrMode';
+import type { CsrCustomerData } from 'components/csr/csrMode';
 import DirectDebitForm from 'components/directDebit/directDebitProgressiveDisclosure/directDebitForm';
 import { options } from 'components/forms/customFields/options';
 import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';


### PR DESCRIPTION
This PR adds a new test to validate that, in the Guardian Weekly checkout, the prices displayed are those for the delivery country, not the billing country.