### PR TITLE
upgrade support-internationalisation to scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -308,6 +308,7 @@ lazy val `acquisitions-firehose-transformer` = (project in file("support-lambdas
   .disablePlugins(ReleasePlugin, SbtPgp, Sonatype)
   .settings(
     scalafmtSettings,
+    scalacOptions += "-Ytasty-reader",
     libraryDependencies ++= commonDependencies,
     mergeStrategySettings,
   )
@@ -319,6 +320,7 @@ lazy val `acquisition-events-api` = (project in file("support-lambdas/acquisitio
   .disablePlugins(ReleasePlugin, SbtPgp, Sonatype)
   .settings(
     scalafmtSettings,
+    scalacOptions += "-Ytasty-reader",
     libraryDependencies ++= commonDependencies,
     mergeStrategySettings,
   )

--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ lazy val releaseSettings = Seq(
 lazy val commonDependencies = Seq(
   "com.typesafe" % "config" % "1.4.2",
   scalatest % "test",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
+  "com.typesafe.scala-logging" % "scala-logging_2.13" % "3.9.5",
 )
 
 lazy val root = (project in file("."))
@@ -128,6 +128,7 @@ lazy val `support-frontend` = (project in file("support-frontend"))
     buildInfoKeys := BuildInfoSettings.buildInfoKeys,
     buildInfoPackage := "app",
     buildInfoOptions += BuildInfoOption.ToMap,
+    scalacOptions += "-Ytasty-reader",
     scalafmtSettings,
   )
   .dependsOn(
@@ -147,6 +148,7 @@ lazy val `support-workers` = (project in file("support-workers"))
     integrationTestSettings,
     scalafmtSettings,
     libraryDependencies ++= commonDependencies,
+    scalacOptions += "-Ytasty-reader",
     mergeStrategySettings,
   )
   .dependsOn(
@@ -206,6 +208,7 @@ lazy val `support-payment-api` = (project in file("support-payment-api"))
     buildInfoPackage := "app",
     buildInfoOptions += BuildInfoOption.ToMap,
     libraryDependencies ++= commonDependencies,
+    scalacOptions += "-Ytasty-reader",
     scalafmtSettings,
   )
   .dependsOn(`support-models`, `support-internationalisation`, `module-acquisition-events`)
@@ -217,6 +220,7 @@ lazy val `support-models` = (project in file("support-models"))
     releaseSettings,
     integrationTestSettings,
     scalafmtSettings,
+    scalacOptions += "-Ytasty-reader",
     libraryDependencies ++= commonDependencies,
   )
   .dependsOn(`support-internationalisation`)
@@ -228,6 +232,7 @@ lazy val `support-config` = (project in file("support-config"))
     releaseSettings,
     integrationTestSettings,
     scalafmtSettings,
+    scalacOptions += "-Ytasty-reader",
     libraryDependencies ++= commonDependencies,
   )
   .dependsOn(`support-models`, `support-internationalisation`)
@@ -239,6 +244,7 @@ lazy val `support-services` = (project in file("support-services"))
     releaseSettings,
     integrationTestSettings,
     scalafmtSettings,
+    scalacOptions += "-Ytasty-reader",
     libraryDependencies ++= commonDependencies,
   )
   .dependsOn(`support-internationalisation`, `support-models`, `support-config`, `module-rest`, `module-aws`)
@@ -262,6 +268,7 @@ lazy val `module-acquisition-events` = (project in file("support-modules/acquisi
   .disablePlugins(ReleasePlugin, SbtPgp, Sonatype, AssemblyPlugin)
   .settings(
     scalafmtSettings,
+    scalacOptions += "-Ytasty-reader",
     libraryDependencies ++= commonDependencies,
   )
   .dependsOn(`support-config`)

--- a/support-internationalisation/build.sbt
+++ b/support-internationalisation/build.sbt
@@ -2,8 +2,8 @@ import sbtrelease.ReleaseStateTransformations._
 
 name := "support-internationalisation"
 
-scalaVersion := "3.1.3"
-crossScalaVersions := Seq("2.13.8", "3.1.3")
+scalaVersion := "3.1.2" // beware >= 3.1.3 has an incompatibility with <= 2.13.8 which causes compile issue `Unsupported Scala 3 generic tuple type scala.Tuple in bounds of type MirroredElemTypes; found in  scala.deriving.Mirror.<refinement>.`
+crossScalaVersions := Seq("2.13.8", "3.1.2")
 
 description := "Scala library to provide internationalisation classes to Guardian Membership/Subscriptions/support projects."
 

--- a/support-internationalisation/build.sbt
+++ b/support-internationalisation/build.sbt
@@ -2,6 +2,7 @@ import sbtrelease.ReleaseStateTransformations._
 
 name := "support-internationalisation"
 
+scalaVersion := "3.1.3"
 crossScalaVersions := Seq("2.13.8", "3.1.3")
 
 description := "Scala library to provide internationalisation classes to Guardian Membership/Subscriptions/support projects."

--- a/support-internationalisation/build.sbt
+++ b/support-internationalisation/build.sbt
@@ -2,7 +2,7 @@ import sbtrelease.ReleaseStateTransformations._
 
 name := "support-internationalisation"
 
-crossScalaVersions := Seq("2.11.12", "2.12.17")
+crossScalaVersions := Seq("2.13.8", "3.1.3")
 
 description := "Scala library to provide internationalisation classes to Guardian Membership/Subscriptions/support projects."
 

--- a/support-internationalisation/src/test/scala/com/gu/i18n/CountryGroupTest.scala
+++ b/support-internationalisation/src/test/scala/com/gu/i18n/CountryGroupTest.scala
@@ -1,11 +1,11 @@
 package com.gu.i18n
 
 import com.gu.i18n.Currency._
-import org.scalatest.Inspectors
-import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class CountryGroupTest extends AsyncFlatSpec with Matchers with Inspectors {
+class CountryGroupTest extends AnyFlatSpec with Matchers with Inspectors {
 
   "A CountryGroup" should "be found by id" in {
     CountryGroup.byId("ie") shouldBe None

--- a/support-internationalisation/version.sbt
+++ b/support-internationalisation/version.sbt
@@ -1,1 +1,1 @@
-version := "0.14-SNAPSHOT"
+version := "0.14"

--- a/support-internationalisation/version.sbt
+++ b/support-internationalisation/version.sbt
@@ -1,1 +1,1 @@
-version := "0.15"
+version := "0.16-SNAPSHOT"

--- a/support-internationalisation/version.sbt
+++ b/support-internationalisation/version.sbt
@@ -1,1 +1,1 @@
-version := "0.15-SNAPSHOT"
+version := "0.15"

--- a/support-internationalisation/version.sbt
+++ b/support-internationalisation/version.sbt
@@ -1,1 +1,1 @@
-version := "0.14"
+version := "0.15-SNAPSHOT"


### PR DESCRIPTION
This PR updates support-i18n to release for scala 2.13 and 3.1., and releases v0.14+0.15

It didn't even build with scala 2.11, and it had previously been released for scala 2.13 (for support-service-lambdas)

We now use scala 3 for new product-move-api, and even though scala 3 can use scala 2.13 libraries, it does make sense to release scala 3 libs where possible if we're ever going to use scala 3.

I have done a release to confirm my changes work, so this PR is to review what's already been done! Release is visisble here https://mvnrepository.com/artifact/com.gu/support-internationalisation_3/0.15

(Supersedes https://github.com/guardian/support-frontend/pull/4125 )

This PR does mean that it's the first thing in this mono repo to really use scala 3, but there's no reason why more things couldn't use it.  The only issue would be in the play modules, because play framework doesn't support scala 3 yet.

Of course I haven't really made any code changes to take advantage of scala 3 syntax or features, but that's an opportunity for future.  It is still cross compiled but I don't know whether we need to maintain the 2.13 version?  Membership-common is already on 2.13 so could use the 3 version via tasty-reader.

There's a chance that this might trigger this bug in intellij's scala version determiner.  I'm not sure if/when it's going to be fixed. It means intellij built in compiler tries to compile some scala 2 as scala 3 (although SBT has no issue). https://youtrack.jetbrains.com/issue/SCL-18866/sbt-module-can-wrongly-depend-on-scala-sdk-instead-of-normal-scala-library-in-multi-module-projects