### PR TITLE
disabled digitalsubscription bolt-on to paper checkout in abtest newP…

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -441,10 +441,12 @@ function PaperCheckoutForm(props: PropTypes) {
 							</Rows>
 						</FormSection>
 					) : null}
-					<AddDigiSubCta
-						digiSubPrice={expandedPricingText}
-						addDigitalSubscription={addDigitalSubscription}
-					/>
+					{props.participations.newProduct !== 'variant' ? (
+						<AddDigiSubCta
+							digiSubPrice={expandedPricingText}
+							addDigitalSubscription={addDigitalSubscription}
+						/>
+					) : null}
 					{paymentMethods.length > 0 ? (
 						<FormSection
 							cssOverrides={removeTopBorder}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR hides the digital subscription bolt-on within the newspaper checkout behind the ab-newProduct 0% AB test
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com/c/xbot0Ipb/569-support-site-remove-digital-subscription-bolt-on-from-paper-checkout)

## Why are you doing this?
![Screenshot 2022-08-22 at 12 05 24](https://user-images.githubusercontent.com/76729591/185906695-e59e71a8-badc-4d52-869e-dcee678fb797.png)
![Screenshot 2022-08-22 at 12 06 06](https://user-images.githubusercontent.com/76729591/185906765-d4233073-293f-40e9-9c6a-29eb905c7079.png)


<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [x] Yes
- [ ] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)


