### PR TITLE
Add Nav component - checkout MVP

### DIFF
--- a/support-frontend/assets/components/nav/nav.tsx
+++ b/support-frontend/assets/components/nav/nav.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { between, brand, from } from '@guardian/source-foundations';
+import { brand, from, space } from '@guardian/source-foundations';
 import { Column, Columns } from '@guardian/source-react-components';
 import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import { Container } from 'components/layout/container';
@@ -13,21 +13,16 @@ const container = css`
 	}
 `;
 
-const divider = css`
-	width: 420px;
+const col1CssOverrides = css`
 	height: 28px;
 	border-right: 1px solid ${brand[600]};
-	margin-right: 11px;
-
-	${between.leftCol.and.wide} {
-		margin-right: 7px;
-	}
+	margin-right: 0;
 `;
 
-const columnCssOverrides = css`
+const col2CssOverrides = css`
 	min-height: 42px;
 	display: flex;
-	align-items: center;
+	padding: ${space[2]}px;
 `;
 
 interface NavProps {
@@ -51,8 +46,8 @@ function Nav({
 				backgroundColor={brand[400]}
 			>
 				<Columns>
-					<div css={divider} />
-					<Column cssOverrides={columnCssOverrides}>
+					<Column span={5} cssOverrides={col1CssOverrides} />
+					<Column cssOverrides={col2CssOverrides}>
 						<CountryGroupSwitcher
 							countryGroupIds={countryGroupIds}
 							selectedCountryGroup={selectedCountryGroup}

--- a/support-frontend/assets/components/nav/nav.tsx
+++ b/support-frontend/assets/components/nav/nav.tsx
@@ -1,0 +1,77 @@
+import { css } from '@emotion/react';
+import { between, brand, from, neutral } from '@guardian/source-foundations';
+import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+
+const container = css`
+	display: none;
+
+	${from.desktop} {
+		display: flex;
+		min-width: 100%;
+		min-height: 41px;
+		background-color: ${brand[400]};
+		color: ${neutral[97]};
+	}
+`;
+
+const gutter = (direction: string) => css`
+  border-${direction}: 1px solid ${brand[600]};
+
+  ${from.desktop} {
+    width: 60px;
+  }
+
+  ${from.leftCol} {
+    width: 30px;
+  }
+
+  ${from.wide} {
+    width: 70px;
+  }
+`;
+
+const divider = css`
+	width: 420px;
+	height: 28px;
+	border-right: 1px solid ${brand[600]};
+	margin-right: 11px;
+
+	${between.leftCol.and.wide} {
+		margin-right: 7px;
+	}
+`;
+
+const countrySwitcher = css`
+	flex-grow: 1;
+	margin: auto 0;
+`;
+
+interface NavProps {
+	countryGroupIds: CountryGroupId[];
+	selectedCountryGroup: CountryGroupId;
+	subPath: string;
+}
+
+function Nav({
+	countryGroupIds,
+	selectedCountryGroup,
+	subPath,
+}: NavProps): JSX.Element {
+	return (
+		<nav css={container}>
+			<span css={gutter('right')} />
+			<span css={divider} />
+			<div css={countrySwitcher}>
+				<CountryGroupSwitcher
+					countryGroupIds={countryGroupIds}
+					selectedCountryGroup={selectedCountryGroup}
+					subPath={subPath}
+				/>
+			</div>
+			<span css={gutter('left')} />
+		</nav>
+	);
+}
+
+export default Nav;

--- a/support-frontend/assets/components/nav/nav.tsx
+++ b/support-frontend/assets/components/nav/nav.tsx
@@ -1,34 +1,16 @@
 import { css } from '@emotion/react';
-import { between, brand, from, neutral } from '@guardian/source-foundations';
+import { between, brand, from } from '@guardian/source-foundations';
+import { Column, Columns } from '@guardian/source-react-components';
 import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import { Container } from 'components/layout/container';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 const container = css`
 	display: none;
 
 	${from.desktop} {
-		display: flex;
-		min-width: 100%;
-		min-height: 41px;
-		background-color: ${brand[400]};
-		color: ${neutral[97]};
+		display: block;
 	}
-`;
-
-const gutter = (direction: string) => css`
-  border-${direction}: 1px solid ${brand[600]};
-
-  ${from.desktop} {
-    width: 60px;
-  }
-
-  ${from.leftCol} {
-    width: 30px;
-  }
-
-  ${from.wide} {
-    width: 70px;
-  }
 `;
 
 const divider = css`
@@ -42,9 +24,10 @@ const divider = css`
 	}
 `;
 
-const countrySwitcher = css`
-	flex-grow: 1;
-	margin: auto 0;
+const columnCssOverrides = css`
+	min-height: 42px;
+	display: flex;
+	align-items: center;
 `;
 
 interface NavProps {
@@ -60,16 +43,24 @@ function Nav({
 }: NavProps): JSX.Element {
 	return (
 		<nav css={container}>
-			<span css={gutter('right')} />
-			<span css={divider} />
-			<div css={countrySwitcher}>
-				<CountryGroupSwitcher
-					countryGroupIds={countryGroupIds}
-					selectedCountryGroup={selectedCountryGroup}
-					subPath={subPath}
-				/>
-			</div>
-			<span css={gutter('left')} />
+			<Container
+				sideBorders={true}
+				sidePadding={false}
+				topBorder={true}
+				borderColor={brand[600]}
+				backgroundColor={brand[400]}
+			>
+				<Columns>
+					<div css={divider} />
+					<Column cssOverrides={columnCssOverrides}>
+						<CountryGroupSwitcher
+							countryGroupIds={countryGroupIds}
+							selectedCountryGroup={selectedCountryGroup}
+							subPath={subPath}
+						/>
+					</Column>
+				</Columns>
+			</Container>
 		</nav>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -1,9 +1,32 @@
 import { CheckoutHeading } from 'components/checkoutHeading/checkoutHeading';
+import Nav from 'components/nav/nav';
 import { PageScaffold } from 'components/page/pageScaffold';
+import {
+	AUDCountries,
+	Canada,
+	EURCountries,
+	GBPCountries,
+	International,
+	NZDCountries,
+	UnitedStates,
+} from 'helpers/internationalisation/countryGroup';
 
 export function SupporterPlusLandingPage(): JSX.Element {
 	return (
 		<PageScaffold id="supporter-plus-landing">
+			<Nav
+				countryGroupIds={[
+					GBPCountries,
+					UnitedStates,
+					AUDCountries,
+					EURCountries,
+					NZDCountries,
+					Canada,
+					International,
+				]}
+				selectedCountryGroup={GBPCountries}
+				subPath={window.location.search}
+			/>
 			<CheckoutHeading heading="Thank you for your support">
 				<p>
 					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque

--- a/support-frontend/stories/nav/Nav.stories.tsx
+++ b/support-frontend/stories/nav/Nav.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from 'helpers/internationalisation/countryGroup';
 
 export default {
-	title: 'SFD/Nav',
+	title: 'Checkout Layout/Nav',
 	component: NavComponent,
 	argTypes: {
 		countryGroup: {

--- a/support-frontend/stories/nav/Nav.stories.tsx
+++ b/support-frontend/stories/nav/Nav.stories.tsx
@@ -1,0 +1,73 @@
+import { expect } from '@storybook/jest';
+import { userEvent, waitFor, within } from '@storybook/testing-library';
+import NavComponent from 'components/nav/nav';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import {
+	AUDCountries,
+	Canada,
+	EURCountries,
+	GBPCountries,
+	International,
+	NZDCountries,
+	UnitedStates,
+} from 'helpers/internationalisation/countryGroup';
+
+export default {
+	title: 'SFD/Nav',
+	component: NavComponent,
+	argTypes: {
+		countryGroup: {
+			type: 'select',
+			options: [
+				AUDCountries,
+				Canada,
+				EURCountries,
+				GBPCountries,
+				International,
+				NZDCountries,
+				UnitedStates,
+			],
+		},
+	},
+	decorators: [(Story: React.FC): JSX.Element => <Story />],
+};
+
+export function Nav(args: { countryGroup: CountryGroupId }): JSX.Element {
+	return (
+		<NavComponent
+			countryGroupIds={[
+				GBPCountries,
+				UnitedStates,
+				AUDCountries,
+				EURCountries,
+				NZDCountries,
+				Canada,
+				International,
+			]}
+			selectedCountryGroup={args.countryGroup}
+			subPath={window.location.search}
+		/>
+	);
+}
+
+Nav.args = {
+	countryGroup: GBPCountries,
+};
+
+Nav.play = async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
+	const canvas = within(canvasElement);
+
+	userEvent.click(canvas.getByRole('button'));
+
+	await waitFor(() => {
+		expect(canvas.getByRole('dialog')).toHaveAttribute('aria-hidden', 'false');
+	});
+
+	await waitFor(() => {
+		userEvent.click(canvas.getByTestId('dialog-backdrop'));
+	});
+
+	await waitFor(() => {
+		expect(canvas.getByTestId('dialog')).not.toBeVisible();
+	});
+};


### PR DESCRIPTION
## What are you doing in this PR?

This PR adds a `Nav` component for use on the new Guardian supporter checkout. This component will only be displayed on screen sizes desktop and above.

[**Trello Card**](https://trello.com/c/tKBalS2s/638-checkout-mvp-build-new-nav-component)

## Screenshots
Desktop
<img width="979" alt="United Kingdom £" src="https://user-images.githubusercontent.com/44685872/186123927-096eb021-1487-4605-bb03-514c06c77085.png">

LeftCol
<img width="1025" alt="United Kingdom £" src="https://user-images.githubusercontent.com/44685872/186123958-f61e2bb1-3aa9-4b80-8ae4-3c1f12d067c5.png">

Wide
<img width="1063" alt="United v Kingdom £" src="https://user-images.githubusercontent.com/44685872/186124220-ea14c9bb-8775-4f9a-9cd6-1c2be5d732fe.png">

