### PR TITLE
Remove email max-length validation message

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/rules.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/rules.ts
@@ -67,6 +67,10 @@ function applyPersonalDetailsRules(
 			error: formError('email', 'Please enter a valid email address.'),
 		},
 		{
+			rule: notLongerThan(fields.email, 80),
+			error: formError('email', 'Email address is too long.'),
+		},
+		{
 			rule: emailAddressesMatch(
 				fields.isSignedIn,
 				fields.email,

--- a/support-frontend/assets/helpers/subscriptionsForms/rules.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/rules.ts
@@ -67,10 +67,6 @@ function applyPersonalDetailsRules(
 			error: formError('email', 'Please enter a valid email address.'),
 		},
 		{
-			rule: notLongerThan(fields.email, 40),
-			error: formError('email', 'Email address is too long.'),
-		},
-		{
 			rule: emailAddressesMatch(
 				fields.isSignedIn,
 				fields.email,


### PR DESCRIPTION
## What are you doing in this PR?

Email should not have a max-length validation on it, this rule was incorrectly added when adding max-length validation to first and last name.