### PR TITLE
Work out promo code from delivery address not billing address

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -198,9 +198,11 @@ function onPaymentAuthorised(
 	const { csrf } = state.page.checkoutForm;
 	const { abParticipations } = state.common;
 	const addresses = getAddresses(state);
+	const pricingCountry =
+		addresses.deliveryAddress?.country ?? addresses.billingAddress.country;
 	const productPrice = getProductPrice(
 		productPrices,
-		addresses.billingAddress.country,
+		pricingCountry,
 		billingPeriod,
 		fulfilmentOption,
 		productOption,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
When we work out which promo code applies in the Guardian Weekly checkout we need to use the country from the user's delivery address as this is what pricing is worked out from. Previously we weren't doing this so this PR changes the logic.