### PR TITLE
Get paper default promos from S3

### DIFF
--- a/support-frontend/app/controllers/PaperSubscriptionController.scala
+++ b/support-frontend/app/controllers/PaperSubscriptionController.scala
@@ -41,8 +41,8 @@ class PaperSubscriptionController(
   def paper(): Action[AnyContent] = CachedAction() { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val canonicalLink = Some(buildCanonicalPaperSubscriptionLink())
-    val queryPromos =
-      DefaultPromotions.Paper.june21Promotion :: request.queryString.get("promoCode").map(_.toList).getOrElse(Nil)
+    val defaultPromos = priceSummaryServiceProvider.forUser(isTestUser = false).getDefaultPromoCodes(Paper)
+    val queryPromos = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil)
 
     Ok(
       views.html.main(
@@ -59,7 +59,8 @@ class PaperSubscriptionController(
         ),
         shareUrl = canonicalLink,
       ) {
-        val maybePromotionCopy = landingCopyProvider.promotionCopyForPrimaryCountry(queryPromos, Paper, UK)
+        val maybePromotionCopy =
+          landingCopyProvider.promotionCopyForPrimaryCountry(queryPromos ++ defaultPromos, Paper, UK)
         Html(
           s"""<script type="text/javascript">
       window.guardian.productPrices = ${outputJson(

--- a/support-frontend/app/controllers/SubscriptionsController.scala
+++ b/support-frontend/app/controllers/SubscriptionsController.scala
@@ -61,7 +61,7 @@ class SubscriptionsController(
     val service = priceSummaryServiceProvider.forUser(false)
 
     val paperMap = if (countryGroup == CountryGroup.UK) {
-      val paper = service.getPrices(Paper, List(DefaultPromotions.Paper.june21Promotion))(CountryGroup.UK)(Collection)(
+      val paper = service.getPrices(Paper, Nil)(CountryGroup.UK)(Collection)(
         Sunday,
       )(Monthly)(GBP)
       Map(Paper.toString -> pricingCopy(paper))

--- a/support-frontend/app/services/pricing/DefaultPromotionService.scala
+++ b/support-frontend/app/services/pricing/DefaultPromotionService.scala
@@ -9,7 +9,7 @@ import io.circe.generic.auto._
 import akka.actor.ActorSystem
 import com.gu.aws.AwsCloudWatchMetricPut.{client => cloudwatchClient}
 import com.gu.aws.AwsCloudWatchMetricSetup.defaultPromotionsLoadingFailure
-import com.gu.support.catalog.{GuardianWeekly, Product}
+import com.gu.support.catalog.{GuardianWeekly, Paper, Product}
 import com.typesafe.scalalogging.LazyLogging
 import services.pricing.DefaultPromotionService.DefaultPromotions
 
@@ -23,7 +23,7 @@ trait DefaultPromotionService {
 }
 
 object DefaultPromotionService {
-  case class DefaultPromotions(guardianWeekly: List[String])
+  case class DefaultPromotions(guardianWeekly: List[String], paper: List[String])
 
   implicit val decoder = Decoder[DefaultPromotions]
 }
@@ -41,7 +41,7 @@ class DefaultPromotionServiceS3(
     new AmazonS3URI(s"s3://gu-promotions-tool-private/${env.envValue}/defaultPromos.json")
   }
   private val defaultPromoCodes = new AtomicReference[DefaultPromotions](
-    DefaultPromotions(guardianWeekly = Nil),
+    DefaultPromotions(guardianWeekly = Nil, paper = Nil),
   )
 
   private def fetch(): Try[DefaultPromotions] =
@@ -65,6 +65,7 @@ class DefaultPromotionServiceS3(
   def getPromoCodes(product: Product): List[String] =
     product match {
       case GuardianWeekly => defaultPromoCodes.get().guardianWeekly
+      case Paper => defaultPromoCodes.get().paper
       case _ => Nil
     }
 

--- a/support-models/src/main/scala/com/gu/support/promotions/DefaultPromotions.scala
+++ b/support-models/src/main/scala/com/gu/support/promotions/DefaultPromotions.scala
@@ -16,10 +16,6 @@ object DefaultPromotions {
     def all: List[PromoCode] = Monthly.all ++ Annual.all
   }
 
-  object Paper {
-    val june21Promotion = "JUNE21SALE"
-  }
-
   object GuardianWeekly {
     object Gift {
       val twentyPercentOff = "GW20GIFT1Y"


### PR DESCRIPTION
We already do this for Guardian Weekly, this PR replaces hardcoded default promos for the `Paper` product.

I tested locally by:
1. setting `stage="PROD"`
2. adding `"paper": ["AUTUMN14"]` to the config file in S3
3. checking the `AUTUMN14` promo comes through on the default `/subscribe/paper` page

### Price card on product page:
![Screen Shot 2022-08-31 at 08 38 29](https://user-images.githubusercontent.com/1513454/187620845-9788c7bb-6d0d-4981-9a10-7bc3d696c319.png)

### Payment page:
![Screen Shot 2022-08-31 at 08 38 13](https://user-images.githubusercontent.com/1513454/187620840-3f2c1c58-d8da-4960-8c5c-e8d9d5f165ff.png)
