### PR TITLE
Block contributions form submission on first name, last name and email validation errors

### DIFF
--- a/support-frontend/assets/helpers/__tests__/formValidation.ts
+++ b/support-frontend/assets/helpers/__tests__/formValidation.ts
@@ -3,6 +3,7 @@ import {
 	amountOrOtherAmountIsValid,
 	checkStateIfApplicable,
 	maxTwoDecimals,
+	notLongerThan,
 } from '../forms/formValidation';
 import {
 	AUDCountries,
@@ -222,6 +223,14 @@ describe('formValidation', () => {
 					UnitedStates,
 				),
 			).toEqual(false);
+		});
+	});
+	describe('notLongerThan', () => {
+		it('should return false if string is too long', () => {
+			expect(notLongerThan('hello world', 10)).toBeFalsy();
+		});
+		it('should return true if string is under max length', () => {
+			expect(notLongerThan('hello world', 20)).toBeTruthy();
 		});
 	});
 });

--- a/support-frontend/assets/helpers/forms/formValidation.ts
+++ b/support-frontend/assets/helpers/forms/formValidation.ts
@@ -64,18 +64,31 @@ export const maxTwoDecimals: (arg0: string) => boolean = (input) =>
 export const containsEmoji: (input: string | null) => boolean = (input) =>
 	/\p{Emoji_Presentation}/u.test(input ?? '');
 
+export const notLongerThan = (
+	value: string | null | undefined,
+	maxLength: number,
+): boolean => {
+	if (!value) return true;
+	return value.length < maxLength;
+};
+
 export const checkFirstName: (firstName: string | null) => boolean = (
 	firstName,
-) => isNotEmpty(firstName) && !containsEmoji(firstName);
+) =>
+	isNotEmpty(firstName) &&
+	!containsEmoji(firstName) &&
+	notLongerThan(firstName, 40);
 
 export const checkLastName: (lastName: string | null) => boolean = (lastName) =>
-	isNotEmpty(lastName) && !containsEmoji(lastName);
+	isNotEmpty(lastName) &&
+	!containsEmoji(lastName) &&
+	notLongerThan(lastName, 40);
 
 export const checkBillingState: (arg0: string | null) => boolean = (s) =>
 	typeof s === 'string' && isNotEmpty(s);
 
 export const checkEmail: (arg0: string | null) => boolean = (input) =>
-	isNotEmpty(input) && isValidEmail(input);
+	isNotEmpty(input) && isValidEmail(input) && notLongerThan(input, 80);
 
 export const emailAddressesMatch: (
 	isSignedIn: boolean,

--- a/support-frontend/assets/helpers/forms/formValidation.ts
+++ b/support-frontend/assets/helpers/forms/formValidation.ts
@@ -65,7 +65,7 @@ export const containsEmoji: (input: string | null) => boolean = (input) =>
 	/\p{Emoji_Presentation}/u.test(input ?? '');
 
 export const notLongerThan = (
-	value: string | null | undefined,
+	value: string | null,
 	maxLength: number,
 ): boolean => {
 	if (!value) return true;

--- a/support-frontend/assets/helpers/subscriptionsForms/rules.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/rules.ts
@@ -1,8 +1,8 @@
 import {
-	checkEmail,
 	checkGiftStartDate,
 	checkOptionalEmail,
 	emailAddressesMatch,
+	isValidEmail,
 } from 'helpers/forms/formValidation';
 import type { PersonalDetailsState } from 'helpers/redux/checkout/personalDetails/state';
 import type { FormField, FormFields } from './formFields';
@@ -63,7 +63,11 @@ function applyPersonalDetailsRules(
 			),
 		},
 		{
-			rule: checkEmail(fields.email),
+			rule: nonEmptyString(fields.email),
+			error: formError('email', 'Please enter an email address.'),
+		},
+		{
+			rule: isValidEmail(fields.email),
 			error: formError('email', 'Please enter a valid email address.'),
 		},
 		{
@@ -115,7 +119,11 @@ function applyCheckoutRules(fields: FormFields): Array<FormError<FormField>> {
 			),
 		},
 		{
-			rule: checkEmail(fields.email),
+			rule: nonEmptyString(fields.email),
+			error: formError('email', 'Please enter an email address.'),
+		},
+		{
+			rule: isValidEmail(fields.email),
 			error: formError('email', 'Please enter a valid email address.'),
 		},
 		{
@@ -163,12 +171,24 @@ function applyCheckoutRules(fields: FormFields): Array<FormError<FormField>> {
 						),
 					},
 					{
-						rule:
-							checkEmail(fields.emailGiftRecipient) &&
-							nonSillyCharacters(fields.emailGiftRecipient),
+						rule: nonEmptyString(fields.emailGiftRecipient),
 						error: formError(
 							'emailGiftRecipient',
-							'Please use a valid email address for the recipient.',
+							'Please enter an email address for the recipient.',
+						),
+					},
+					{
+						rule: isValidEmail(fields.emailGiftRecipient),
+						error: formError(
+							'emailGiftRecipient',
+							'Please enter a valid email address for the recipient.',
+						),
+					},
+					{
+						rule: notLongerThan(fields.emailGiftRecipient, 80),
+						error: formError(
+							'emailGiftRecipient',
+							'Email address is too long.',
 						),
 					},
 					{

--- a/support-frontend/assets/helpers/subscriptionsForms/rules.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/rules.ts
@@ -119,6 +119,10 @@ function applyCheckoutRules(fields: FormFields): Array<FormError<FormField>> {
 			error: formError('email', 'Please enter a valid email address.'),
 		},
 		{
+			rule: notLongerThan(fields.email, 80),
+			error: formError('email', 'Email address is too long.'),
+		},
+		{
 			rule: emailAddressesMatch(isSignedIn, fields.email, fields.confirmEmail),
 			error: formError('confirmEmail', 'The email addresses do not match.'),
 		},


### PR DESCRIPTION
## What are you doing in this PR?

We've seen invalid (too long) first name (max length 40), last name (max length 40) and email addresses (max length 80) submitted from the Contributions checkout which have caused errors on the server. 

This happens because the Contributions form does not currently block the form's submission on max-length validation errors, although it does show the validation error message on the form's submission.

After looking at this I found we're using different logic to show validation error messages and prevent form submission on the Contributions checkout. The rules defined in `assets/helpers/subscriptionsForms/rules.ts` determine when validation error messages show. However the rules defined in `support-frontend/assets/helpers/forms/formValidation.ts` are used when determining whether the form is submittable.

In `formValidation.ts` (is form submittable) we didn't have any checks on the length of first name, last name and email addresses, so we were allowing the form to be submitted. My short-term solution to the issue is to include a max-length check  in `formValidation.ts`, however I really don't think this ideal, the validation logic for showing error messages and preventing form submission should be shared - and this should be something we look at on the new product checkout.

I've also updated the validation checks on the email address in `rules.ts` (what errors messages to show), replacing a catch-all `checkEmail` rule with separate `nonEmptyString`, `isValidEmail` and `notLongerThan` rules as this means the error message shown will be more relevant to the actual error. 

[**Trello Card**](https://trello.com/c/sjvO6tFc/664-client-side-validation-bugs)

## Why are you doing this?

We've seen invalid (too long) first name, last name and email addresses submitted which have caused errors further downstream.

## Screenshots

### Before 
We see the processing screen which indicates the form has posted to the `/create` end point despite validation errors, as a result we get a server side error that'll alarm

![before_validation](https://user-images.githubusercontent.com/1590704/187646227-5dc709bd-b09e-4eea-b6d7-9cb3c42f2336.gif)

### After 
We block form submission and display validation errors.

![after_validation](https://user-images.githubusercontent.com/1590704/187657829-79adbdb2-268b-430e-88f6-05a1676988d6.gif)
