### PR TITLE
Pd support link remove

### DIFF
--- a/support-frontend/assets/components/headers/header/header.scss
+++ b/support-frontend/assets/components/headers/header/header.scss
@@ -154,7 +154,7 @@ $header-links-min-width: gu-span(12);
 	border-top: 1px solid gu-colour(brand-pastel);
 	z-index: 9;
 	white-space: nowrap;
-	margin: 0 ($gu-h-spacing * -2) 0 ($gu-h-spacing * -1);
+	margin: 0 ($gu-h-spacing * -2) 0 0;
 	box-sizing: border-box;
 
 	@media (min-width: $header-links-min-width + 40) {

--- a/support-frontend/assets/components/headers/header/header.tsx
+++ b/support-frontend/assets/components/headers/header/header.tsx
@@ -13,7 +13,7 @@ export type PropTypes = {
 	utility?: JSX.Element;
 	countryGroupId: CountryGroupId;
 	display?: 'navigation' | 'checkout' | 'guardianLogo' | void;
-	hideDigitalSupport?: boolean;
+	hideDigiSupptContrib?: boolean;
 };
 export type State = {
 	fitsLinksInOneRow: boolean;
@@ -135,7 +135,7 @@ export default class Header extends Component<PropTypes, State> {
 			utility,
 			display,
 			countryGroupId,
-			hideDigitalSupport: hideDigitalSupport,
+			hideDigiSupptContrib: hideDigiSupptContrib,
 		} = this.props;
 		const { fitsLinksInOneRow, fitsLinksAtAll, isTestUser } = this.state;
 		return (
@@ -174,7 +174,7 @@ export default class Header extends Component<PropTypes, State> {
 									<Links
 										countryGroupId={countryGroupId}
 										location="mobile"
-										hideDigitalSupport={hideDigitalSupport}
+										hideDigiSupptContrib={hideDigiSupptContrib}
 									/>
 								}
 								utility={utility}
@@ -189,7 +189,7 @@ export default class Header extends Component<PropTypes, State> {
 								getRef={(el) => {
 									this.menuRef = el;
 								}}
-								hideDigitalSupport={hideDigitalSupport}
+								hideDigiSupptContrib={hideDigiSupptContrib}
 							/>
 						</div>
 					)}

--- a/support-frontend/assets/components/headers/header/header.tsx
+++ b/support-frontend/assets/components/headers/header/header.tsx
@@ -13,7 +13,7 @@ export type PropTypes = {
 	utility?: JSX.Element;
 	countryGroupId: CountryGroupId;
 	display?: 'navigation' | 'checkout' | 'guardianLogo' | void;
-	hideDigiSupptContrib?: boolean;
+	isNewProduct?: boolean;
 };
 export type State = {
 	fitsLinksInOneRow: boolean;
@@ -131,12 +131,7 @@ export default class Header extends Component<PropTypes, State> {
 	observer: ResizeObserver | null | undefined;
 
 	render(): JSX.Element {
-		const {
-			utility,
-			display,
-			countryGroupId,
-			hideDigiSupptContrib: hideDigiSupptContrib,
-		} = this.props;
+		const { utility, display, countryGroupId, isNewProduct } = this.props;
 		const { fitsLinksInOneRow, fitsLinksAtAll, isTestUser } = this.state;
 		return (
 			<header
@@ -174,7 +169,7 @@ export default class Header extends Component<PropTypes, State> {
 									<Links
 										countryGroupId={countryGroupId}
 										location="mobile"
-										hideDigiSupptContrib={hideDigiSupptContrib}
+										isNewProduct={isNewProduct}
 									/>
 								}
 								utility={utility}
@@ -189,7 +184,7 @@ export default class Header extends Component<PropTypes, State> {
 								getRef={(el) => {
 									this.menuRef = el;
 								}}
-								hideDigiSupptContrib={hideDigiSupptContrib}
+								isNewProduct={isNewProduct}
 							/>
 						</div>
 					)}

--- a/support-frontend/assets/components/headers/header/header.tsx
+++ b/support-frontend/assets/components/headers/header/header.tsx
@@ -13,7 +13,7 @@ export type PropTypes = {
 	utility?: JSX.Element;
 	countryGroupId: CountryGroupId;
 	display?: 'navigation' | 'checkout' | 'guardianLogo' | void;
-	hideDigital?: boolean;
+	hideDigitalSupport?: boolean;
 };
 export type State = {
 	fitsLinksInOneRow: boolean;
@@ -131,7 +131,12 @@ export default class Header extends Component<PropTypes, State> {
 	observer: ResizeObserver | null | undefined;
 
 	render(): JSX.Element {
-		const { utility, display, countryGroupId, hideDigital } = this.props;
+		const {
+			utility,
+			display,
+			countryGroupId,
+			hideDigitalSupport: hideDigitalSupport,
+		} = this.props;
 		const { fitsLinksInOneRow, fitsLinksAtAll, isTestUser } = this.state;
 		return (
 			<header
@@ -169,7 +174,7 @@ export default class Header extends Component<PropTypes, State> {
 									<Links
 										countryGroupId={countryGroupId}
 										location="mobile"
-										hideDigital={hideDigital}
+										hideDigitalSupport={hideDigitalSupport}
 									/>
 								}
 								utility={utility}
@@ -184,7 +189,7 @@ export default class Header extends Component<PropTypes, State> {
 								getRef={(el) => {
 									this.menuRef = el;
 								}}
-								hideDigital={hideDigital}
+								hideDigitalSupport={hideDigitalSupport}
 							/>
 						</div>
 					)}

--- a/support-frontend/assets/components/headers/header/headerWithCountrySwitcher.tsx
+++ b/support-frontend/assets/components/headers/header/headerWithCountrySwitcher.tsx
@@ -13,13 +13,13 @@ export default function ({
 	countryGroupId,
 	listOfCountryGroups,
 	trackProduct,
-	hideDigiSupptContrib: hideDigiSupptContrib,
+	isNewProduct,
 }: {
 	path: string;
 	countryGroupId: CountryGroupId;
 	listOfCountryGroups: CountryGroupId[];
 	trackProduct?: Option<SubscriptionProduct>;
-	hideDigiSupptContrib?: boolean;
+	isNewProduct?: boolean;
 }) {
 	return function (): JSX.Element {
 		return (
@@ -33,7 +33,7 @@ export default function ({
 						trackProduct={trackProduct}
 					/>
 				}
-				hideDigiSupptContrib={hideDigiSupptContrib}
+				isNewProduct={isNewProduct}
 			/>
 		);
 	};

--- a/support-frontend/assets/components/headers/header/headerWithCountrySwitcher.tsx
+++ b/support-frontend/assets/components/headers/header/headerWithCountrySwitcher.tsx
@@ -13,13 +13,13 @@ export default function ({
 	countryGroupId,
 	listOfCountryGroups,
 	trackProduct,
-	hideDigitalSupport: hideDigitalSupport,
+	hideDigiSupptContrib: hideDigiSupptContrib,
 }: {
 	path: string;
 	countryGroupId: CountryGroupId;
 	listOfCountryGroups: CountryGroupId[];
 	trackProduct?: Option<SubscriptionProduct>;
-	hideDigitalSupport?: boolean;
+	hideDigiSupptContrib?: boolean;
 }) {
 	return function (): JSX.Element {
 		return (
@@ -33,7 +33,7 @@ export default function ({
 						trackProduct={trackProduct}
 					/>
 				}
-				hideDigitalSupport={hideDigitalSupport}
+				hideDigiSupptContrib={hideDigiSupptContrib}
 			/>
 		);
 	};

--- a/support-frontend/assets/components/headers/header/headerWithCountrySwitcher.tsx
+++ b/support-frontend/assets/components/headers/header/headerWithCountrySwitcher.tsx
@@ -13,13 +13,13 @@ export default function ({
 	countryGroupId,
 	listOfCountryGroups,
 	trackProduct,
-	hideDigital,
+	hideDigitalSupport: hideDigitalSupport,
 }: {
 	path: string;
 	countryGroupId: CountryGroupId;
 	listOfCountryGroups: CountryGroupId[];
 	trackProduct?: Option<SubscriptionProduct>;
-	hideDigital?: boolean;
+	hideDigitalSupport?: boolean;
 }) {
 	return function (): JSX.Element {
 		return (
@@ -33,7 +33,7 @@ export default function ({
 						trackProduct={trackProduct}
 					/>
 				}
-				hideDigital={hideDigital}
+				hideDigitalSupport={hideDigitalSupport}
 			/>
 		);
 	};

--- a/support-frontend/assets/components/headers/links/links.tsx
+++ b/support-frontend/assets/components/headers/links/links.tsx
@@ -24,7 +24,7 @@ type PropTypes = {
 	location: 'desktop' | 'mobile';
 	countryGroupId?: CountryGroupId;
 	getRef?: (element: Element | null) => void;
-	hideDigiSupptContrib?: boolean;
+	isNewProduct?: boolean;
 };
 
 const links: HeaderNavLink[] = [
@@ -104,7 +104,7 @@ function Links({
 	location,
 	getRef,
 	countryGroupId,
-	hideDigiSupptContrib: hideDigiSupptContrib,
+	isNewProduct,
 }: PropTypes): JSX.Element {
 	const { protocol, host, pathname } = window.location;
 	const urlWithoutParams = `${protocol}//${host}${pathname}`;
@@ -120,7 +120,7 @@ function Links({
 							text === 'Support' ||
 							text === 'Contributions'
 						) {
-							if (hideDigiSupptContrib) {
+							if (isNewProduct) {
 								return false;
 							}
 						}

--- a/support-frontend/assets/components/headers/links/links.tsx
+++ b/support-frontend/assets/components/headers/links/links.tsx
@@ -24,7 +24,7 @@ type PropTypes = {
 	location: 'desktop' | 'mobile';
 	countryGroupId?: CountryGroupId;
 	getRef?: (element: Element | null) => void;
-	hideDigital?: boolean;
+	hideDigitalSupport?: boolean;
 };
 
 const links: HeaderNavLink[] = [
@@ -104,7 +104,7 @@ function Links({
 	location,
 	getRef,
 	countryGroupId,
-	hideDigital,
+	hideDigitalSupport: hideDigitalSupport,
 }: PropTypes): JSX.Element {
 	const { protocol, host, pathname } = window.location;
 	const urlWithoutParams = `${protocol}//${host}${pathname}`;
@@ -115,8 +115,10 @@ function Links({
 			<ul className="component-header-links__ul" ref={getRef}>
 				{links
 					.filter(({ text }) => {
-						if (text === 'Digital' && hideDigital) {
-							return false;
+						if (text === 'Digital' || text === 'Support') {
+							if (hideDigitalSupport) {
+								return false;
+							}
 						}
 						return true;
 					})

--- a/support-frontend/assets/components/headers/links/links.tsx
+++ b/support-frontend/assets/components/headers/links/links.tsx
@@ -24,7 +24,7 @@ type PropTypes = {
 	location: 'desktop' | 'mobile';
 	countryGroupId?: CountryGroupId;
 	getRef?: (element: Element | null) => void;
-	hideDigitalSupport?: boolean;
+	hideDigiSupptContrib?: boolean;
 };
 
 const links: HeaderNavLink[] = [
@@ -104,7 +104,7 @@ function Links({
 	location,
 	getRef,
 	countryGroupId,
-	hideDigitalSupport: hideDigitalSupport,
+	hideDigiSupptContrib: hideDigiSupptContrib,
 }: PropTypes): JSX.Element {
 	const { protocol, host, pathname } = window.location;
 	const urlWithoutParams = `${protocol}//${host}${pathname}`;
@@ -115,8 +115,12 @@ function Links({
 			<ul className="component-header-links__ul" ref={getRef}>
 				{links
 					.filter(({ text }) => {
-						if (text === 'Digital' || text === 'Support') {
-							if (hideDigitalSupport) {
+						if (
+							text === 'Digital' ||
+							text === 'Support' ||
+							text === 'Contributions'
+						) {
+							if (hideDigiSupptContrib) {
 								return false;
 							}
 						}

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
@@ -47,7 +47,7 @@ function PaperLandingPage({
 	promotionCopy,
 	participations,
 }: PaperLandingPropTypes) {
-	const hideDigitalSupport = participations.newProduct === 'variant';
+	const hideDigiSupptContrib = participations.newProduct === 'variant';
 	const sanitisedPromoCopy = getPromotionCopy(promotionCopy);
 	const fulfilment: PaperFulfilmentOptions = window.location.pathname.includes(
 		'delivery',
@@ -78,7 +78,7 @@ function PaperLandingPage({
 			header={
 				<Header
 					countryGroupId={GBPCountries}
-					hideDigitalSupport={hideDigitalSupport}
+					hideDigiSupptContrib={hideDigiSupptContrib}
 				/>
 			}
 			footer={paperSubsFooter}

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
@@ -47,7 +47,7 @@ function PaperLandingPage({
 	promotionCopy,
 	participations,
 }: PaperLandingPropTypes) {
-	const hideDigital = participations.newProduct === 'variant';
+	const hideDigitalSupport = participations.newProduct === 'variant';
 	const sanitisedPromoCopy = getPromotionCopy(promotionCopy);
 	const fulfilment: PaperFulfilmentOptions = window.location.pathname.includes(
 		'delivery',
@@ -76,7 +76,10 @@ function PaperLandingPage({
 		<Page
 			id={pageQaId}
 			header={
-				<Header countryGroupId={GBPCountries} hideDigital={hideDigital} />
+				<Header
+					countryGroupId={GBPCountries}
+					hideDigitalSupport={hideDigitalSupport}
+				/>
 			}
 			footer={paperSubsFooter}
 		>

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
@@ -47,7 +47,7 @@ function PaperLandingPage({
 	promotionCopy,
 	participations,
 }: PaperLandingPropTypes) {
-	const hideDigiSupptContrib = participations.newProduct === 'variant';
+	const isNewProduct = participations.newProduct === 'variant';
 	const sanitisedPromoCopy = getPromotionCopy(promotionCopy);
 	const fulfilment: PaperFulfilmentOptions = window.location.pathname.includes(
 		'delivery',
@@ -76,10 +76,7 @@ function PaperLandingPage({
 		<Page
 			id={pageQaId}
 			header={
-				<Header
-					countryGroupId={GBPCountries}
-					hideDigiSupptContrib={hideDigiSupptContrib}
-				/>
+				<Header countryGroupId={GBPCountries} isNewProduct={isNewProduct} />
 			}
 			footer={paperSubsFooter}
 		>

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
@@ -25,7 +25,7 @@ function SubscriptionsLandingPage({
 	pricingCopy,
 	referrerAcquisitions,
 }: SubscriptionsLandingPropTypes) {
-	const hideDigitalSupport = participations.newProduct === 'variant';
+	const hideDigiSupptContrib = participations.newProduct === 'variant';
 	const Header = headerWithCountrySwitcherContainer({
 		path: '/subscribe',
 		countryGroupId,
@@ -38,7 +38,7 @@ function SubscriptionsLandingPage({
 			NZDCountries,
 			International,
 		],
-		hideDigitalSupport: hideDigitalSupport,
+		hideDigiSupptContrib: hideDigiSupptContrib,
 	});
 	return (
 		<Page header={<Header />} footer={<Footer centred />}>

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
@@ -25,7 +25,7 @@ function SubscriptionsLandingPage({
 	pricingCopy,
 	referrerAcquisitions,
 }: SubscriptionsLandingPropTypes) {
-	const hideDigital = participations.newProduct === 'variant';
+	const hideDigitalSupport = participations.newProduct === 'variant';
 	const Header = headerWithCountrySwitcherContainer({
 		path: '/subscribe',
 		countryGroupId,
@@ -38,7 +38,7 @@ function SubscriptionsLandingPage({
 			NZDCountries,
 			International,
 		],
-		hideDigital: hideDigital,
+		hideDigitalSupport: hideDigitalSupport,
 	});
 	return (
 		<Page header={<Header />} footer={<Footer centred />}>

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
@@ -25,7 +25,7 @@ function SubscriptionsLandingPage({
 	pricingCopy,
 	referrerAcquisitions,
 }: SubscriptionsLandingPropTypes) {
-	const hideDigiSupptContrib = participations.newProduct === 'variant';
+	const isNewProduct = participations.newProduct === 'variant';
 	const Header = headerWithCountrySwitcherContainer({
 		path: '/subscribe',
 		countryGroupId,
@@ -38,7 +38,7 @@ function SubscriptionsLandingPage({
 			NZDCountries,
 			International,
 		],
-		hideDigiSupptContrib: hideDigiSupptContrib,
+		isNewProduct,
 	});
 	return (
 		<Page header={<Header />} footer={<Footer centred />}>

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -67,7 +67,7 @@ function WeeklyLandingPage({
 	const sanitisedPromoCopy = getPromotionCopy(promotionCopy);
 	// ID for Selenium tests
 	const pageQaId = `qa-guardian-weekly${orderIsAGift ? '-gift' : ''}`;
-	const hideDigital = participations.newProduct === 'variant';
+	const hideDigitalSupport = participations.newProduct === 'variant';
 	const Header = headerWithCountrySwitcherContainer({
 		path,
 		countryGroupId,
@@ -81,7 +81,7 @@ function WeeklyLandingPage({
 			International,
 		],
 		trackProduct: 'GuardianWeekly',
-		hideDigital: hideDigital,
+		hideDigitalSupport: hideDigitalSupport,
 	});
 	return (
 		<Page

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -67,7 +67,7 @@ function WeeklyLandingPage({
 	const sanitisedPromoCopy = getPromotionCopy(promotionCopy);
 	// ID for Selenium tests
 	const pageQaId = `qa-guardian-weekly${orderIsAGift ? '-gift' : ''}`;
-	const hideDigiSupptContrib = participations.newProduct === 'variant';
+	const isNewProduct = participations.newProduct === 'variant';
 	const Header = headerWithCountrySwitcherContainer({
 		path,
 		countryGroupId,
@@ -81,7 +81,7 @@ function WeeklyLandingPage({
 			International,
 		],
 		trackProduct: 'GuardianWeekly',
-		hideDigiSupptContrib: hideDigiSupptContrib,
+		isNewProduct,
 	});
 	return (
 		<Page

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -67,7 +67,7 @@ function WeeklyLandingPage({
 	const sanitisedPromoCopy = getPromotionCopy(promotionCopy);
 	// ID for Selenium tests
 	const pageQaId = `qa-guardian-weekly${orderIsAGift ? '-gift' : ''}`;
-	const hideDigitalSupport = participations.newProduct === 'variant';
+	const hideDigiSupptContrib = participations.newProduct === 'variant';
 	const Header = headerWithCountrySwitcherContainer({
 		path,
 		countryGroupId,
@@ -81,7 +81,7 @@ function WeeklyLandingPage({
 			International,
 		],
 		trackProduct: 'GuardianWeekly',
-		hideDigitalSupport: hideDigitalSupport,
+		hideDigiSupptContrib: hideDigiSupptContrib,
 	});
 	return (
 		<Page


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We need to remove the 'Support' page on the Support site, remove it from the nav.

This should be released behind the ab-newProduct 0% AB test so they're visible to the variant only. This AB test has already been set-up and is in use for showing changes to the checkout, you can force the AB test to be visible as so: https://support.theguardian.com/uk/subscribe#ab-newProduct=variant

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com/c/3UI1xLUM/576-support-site-remove-the-support-landing-page)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->
![image-3](https://user-images.githubusercontent.com/76729591/187895398-4fa16896-c8d7-4fdd-999a-3b5e16034049.png)

![Screenshot 2022-08-31 at 10 33 43](https://user-images.githubusercontent.com/76729591/187893853-79e2d0c9-8f5a-4d79-9365-bf73a0b7dbf7.png)

![Screenshot 2022-08-31 at 10 34 16](https://user-images.githubusercontent.com/76729591/187893967-d49bafcf-bf08-4baf-a7ff-5c657ad737ee.png)

![Screenshot 2022-08-31 at 10 34 30](https://user-images.githubusercontent.com/76729591/187894010-3e41f400-d401-4dbd-b74c-ea1f150991f0.png)

<img width="504" alt="Screenshot 2022-09-01 at 11 39 40" src="https://user-images.githubusercontent.com/76729591/187895222-69d4f6c5-51b5-4dc9-98c5-861f95d3d356.png">


## Is this an AB test?
- [x] Yes
- [ ] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)