### PR TITLE
Add sentry logging when recaptcha fails to load

### DIFF
--- a/support-frontend/assets/helpers/forms/recaptcha.ts
+++ b/support-frontend/assets/helpers/forms/recaptcha.ts
@@ -1,9 +1,14 @@
+import { logException } from 'helpers/utilities/logger';
+
 const loadRecaptchaV2 = (): Promise<void> =>
 	new Promise<void>((resolve, reject) => {
 		const recaptchaScript = document.createElement('script');
 		recaptchaScript.src =
 			'https://www.google.com/recaptcha/api.js?onload=v2OnloadCallback&render=explicit';
-		recaptchaScript.onerror = reject;
+		recaptchaScript.onerror = (error) => {
+			logException(`Recaptcha failed to load:  ${JSON.stringify(error)}`);
+			reject(error);
+		};
 		recaptchaScript.onload = () => resolve();
 
 		document.head.appendChild(recaptchaScript);


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds Sentry logging when the Recaptcha script fails to load.

## Why are you doing this?

This increases visibility on problems with Recaptcha loading in certain environments.

