### PR TITLE
Pd links remove newspaper subscriptions nonuk

### DIFF
--- a/support-frontend/assets/components/headers/links/links.tsx
+++ b/support-frontend/assets/components/headers/links/links.tsx
@@ -108,6 +108,8 @@ function Links({
 }: PropTypes): JSX.Element {
 	const { protocol, host, pathname } = window.location;
 	const urlWithoutParams = `${protocol}//${host}${pathname}`;
+	const internationalisationIDValue = internationalisationID(countryGroupId);
+	const isNotUk = internationalisationIDValue !== 'uk';
 	return (
 		<nav
 			className={classNameWithModifiers('component-header-links', [location])}
@@ -115,14 +117,12 @@ function Links({
 			<ul className="component-header-links__ul" ref={getRef}>
 				{links
 					.filter(({ text }) => {
-						const internationalisationIDValue =
-							internationalisationID(countryGroupId);
 						if (
 							text === 'Digital' ||
 							text === 'Support' ||
 							text === 'Contributions' ||
-							(text === 'Newspaper' && internationalisationIDValue !== 'uk') ||
-							(text === 'Subscriptions' && internationalisationIDValue !== 'uk')
+							(text === 'Newspaper' && isNotUk) ||
+							(text === 'Subscriptions' && isNotUk)
 						) {
 							if (isNewProduct) {
 								return false;
@@ -145,9 +145,6 @@ function Links({
 						return true;
 					})
 					.map((link) => {
-						const internationalisationIDValue =
-							internationalisationID(countryGroupId);
-
 						if (internationalisationIDValue == null || !link.internal) {
 							return link;
 						}

--- a/support-frontend/assets/components/headers/links/links.tsx
+++ b/support-frontend/assets/components/headers/links/links.tsx
@@ -122,8 +122,7 @@ function Links({
 							text === 'Support' ||
 							text === 'Contributions' ||
 							(text === 'Newspaper' && internationalisationIDValue !== 'uk') ||
-							(text === 'Guardian Weekly' &&
-								internationalisationIDValue !== 'uk')
+							(text === 'Subscriptions' && internationalisationIDValue !== 'uk')
 						) {
 							if (isNewProduct) {
 								return false;

--- a/support-frontend/assets/components/headers/links/links.tsx
+++ b/support-frontend/assets/components/headers/links/links.tsx
@@ -115,10 +115,15 @@ function Links({
 			<ul className="component-header-links__ul" ref={getRef}>
 				{links
 					.filter(({ text }) => {
+						const internationalisationIDValue =
+							internationalisationID(countryGroupId);
 						if (
 							text === 'Digital' ||
 							text === 'Support' ||
-							text === 'Contributions'
+							text === 'Contributions' ||
+							(text === 'Newspaper' && internationalisationIDValue !== 'uk') ||
+							(text === 'Guardian Weekly' &&
+								internationalisationIDValue !== 'uk')
 						) {
 							if (isNewProduct) {
 								return false;


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
The "Subscriptions" and "Newspaper" links in the navigation should only be visible to users within the UK.

This should be released behind the ab-newProduct 0% AB test so they're visible to the variant only. This AB test has already been set-up and is in use for showing changes to the checkout, you can force the AB test to be visible as so: https://support.theguardian.com/uk/subscribe#ab-newProduct=variant
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->
![image](https://user-images.githubusercontent.com/76729591/188194226-4dd43d95-1cd9-4436-9f0f-3357e36f9520.png)

![image](https://user-images.githubusercontent.com/76729591/188194482-b3c8eefe-891f-498c-adb5-627f8e9afc73.png)

![image](https://user-images.githubusercontent.com/76729591/188194588-4bb3687d-f908-4037-8b4b-5d6a3a7b3127.png)

![image](https://user-images.githubusercontent.com/76729591/188194771-8856b61b-5bb8-4323-bb50-94e012b46c1b.png)

NOTE : 2 menu items small enough to not require side-bar (additional code change reqd?)
![image](https://user-images.githubusercontent.com/76729591/188194876-abb233b0-7059-4e6e-8cec-809dc74a3e99.png)


[**Trello Card**](https://trello.com/c/d3CVEEHj/652-support-site-only-show-subscriptions-and-newspaper-links-in-the-nav-for-the-uk)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [x] Yes
- [ ] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)