### PR TITLE
Log error message on Quantum Metric script load error

### DIFF
--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -293,8 +293,8 @@ function addQM() {
 				'sha384-QqJrp8s9Nl3x7Z6sc9kQG5eYJLVWYwlEsvhjCukLSwFsWtK17WdC5whHVwSXQh1F',
 			crossOrigin: 'anonymous',
 		},
-	).catch(() => {
-		logException('Failed to load Quantum Metric');
+	).catch((e: Error) => {
+		logException(`Failed to load Quantum Metric: ${e.message}`);
 	});
 }
 


### PR DESCRIPTION
## What are you doing in this PR?

Logs the error message when the Quantum Metric script fails to load. We see this error in Sentry often and this extra information might help understand why.