### PR TITLE
Make recaptcha script loading the responsibility of the Recaptcha component

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
@@ -10,7 +10,6 @@ import SvgArrowRightStraight from 'components/svgs/arrowRightStraight';
 import SvgDirectDebitSymbol from 'components/svgs/directDebitSymbol';
 import SvgDirectDebitSymbolAndText from 'components/svgs/directDebitSymbolAndText';
 import SvgExclamationAlternate from 'components/svgs/exclamationAlternate';
-import { useRecaptchaV2 } from 'helpers/customHooks/useRecaptcha';
 import type { PaymentAuthorisation } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { contributionsEmail } from 'helpers/legal';
@@ -234,11 +233,6 @@ function RecaptchaInput(props: {
 	setRecaptchaToken: (token: string) => void;
 	expireRecaptchaToken?: () => void;
 }) {
-	useRecaptchaV2(
-		recaptchaId,
-		props.setRecaptchaToken,
-		props.expireRecaptchaToken,
-	);
 	return (
 		<div className="component-direct-debit-form__recaptcha">
 			<label
@@ -247,7 +241,11 @@ function RecaptchaInput(props: {
 			>
 				Security check
 			</label>
-			<Recaptcha id={recaptchaId} />
+			<Recaptcha
+				id={recaptchaId}
+				onRecaptchaCompleted={props.setRecaptchaToken}
+				onRecaptchaExpired={props.expireRecaptchaToken}
+			/>
 		</div>
 	);
 }

--- a/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/components/playback.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/components/playback.tsx
@@ -11,7 +11,6 @@ import { useEffect, useRef } from 'react';
 import * as React from 'react';
 import { RecaptchaField } from 'components/recaptcha/recaptchaField';
 import { ErrorSummary } from 'components/subscriptionCheckouts/submitFormErrorSummary';
-import { useRecaptchaV2 } from 'helpers/customHooks/useRecaptcha';
 
 const directDebitForm = css`
 	clear: left;
@@ -64,12 +63,6 @@ function Playback(props: {
 	expireRecaptchaToken?: () => void;
 	recaptchaError: string;
 }): JSX.Element {
-	useRecaptchaV2(
-		recaptchaId,
-		props.setRecaptchaToken,
-		props.expireRecaptchaToken,
-	);
-
 	const subscribeButtonRef = useRef<HTMLDivElement>(null);
 
 	// Actively moving focus to the buttons prevents a screenreader 'losing its place' in the document
@@ -114,6 +107,8 @@ function Playback(props: {
 					label="Security check"
 					id={recaptchaId}
 					error={props.recaptchaError}
+					onRecaptchaCompleted={props.setRecaptchaToken}
+					onRecaptchaExpired={props.expireRecaptchaToken}
 				/>
 			</div>
 

--- a/support-frontend/assets/components/recaptcha/recaptcha.tsx
+++ b/support-frontend/assets/components/recaptcha/recaptcha.tsx
@@ -1,12 +1,19 @@
+import { useRecaptchaV2 } from 'helpers/customHooks/useRecaptcha';
 import './recaptcha.scss';
 
 export type RecaptchaProps = {
 	id?: string;
+	onRecaptchaCompleted: (token: string) => void;
+	onRecaptchaExpired?: () => void;
 };
 
 export function Recaptcha({
 	id = 'robot_checkbox',
+	onRecaptchaCompleted,
+	onRecaptchaExpired,
 }: RecaptchaProps): JSX.Element {
+	useRecaptchaV2(id, onRecaptchaCompleted, onRecaptchaExpired);
+
 	return (
 		<>
 			<div id={id} className="robot_checkbox" />

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/composedStripeElements.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/composedStripeElements.tsx
@@ -8,6 +8,7 @@ import type React from 'react';
 import { compose } from 'redux';
 import type { PropsForHoc as WithErrorProps } from 'components/forms/customFields/error';
 import type { PropsForHoc as WithLabelProps } from 'components/forms/label';
+import type { RecaptchaProps } from 'components/recaptcha/recaptcha';
 import { Recaptcha } from 'components/recaptcha/recaptcha';
 import { withError } from 'hocs/withError';
 import { withLabel } from 'hocs/withLabel';
@@ -36,7 +37,7 @@ export const CardCvcWithError = compose<
 )(CardCvcElement);
 
 export const RecaptchaWithError = compose<
-	React.FC<stripeJs.CardNumberElementProps & WithErrorAndLabelProps>
+	React.FC<RecaptchaProps & WithErrorAndLabelProps>
 >(
 	withLabel,
 	withError,

--- a/support-frontend/assets/helpers/customHooks/useRecaptcha.ts
+++ b/support-frontend/assets/helpers/customHooks/useRecaptcha.ts
@@ -1,22 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { loadRecaptchaV2 } from 'helpers/forms/recaptcha';
-
-type RecaptchaHookData = {
-	isEnabled: boolean;
-	hasLoaded: boolean;
-};
 
 export function useRecaptchaV2(
 	placeholderId: string,
 	onCompletionCallback: (token: string) => void,
 	onExpireCallback?: () => void,
-): RecaptchaHookData {
-	const [hasLoaded, setHasLoaded] = useState(false);
-
+): void {
 	useEffect(() => {
 		if (window.guardian.recaptchaEnabled) {
 			window.v2OnloadCallback = () => {
-				setHasLoaded(true);
 				window.grecaptcha?.render(placeholderId, {
 					sitekey: window.guardian.v2recaptchaPublicKey,
 					callback: onCompletionCallback,
@@ -26,9 +18,4 @@ export function useRecaptchaV2(
 			void loadRecaptchaV2();
 		}
 	}, []);
-
-	return {
-		isEnabled: window.guardian.recaptchaEnabled ?? false,
-		hasLoaded,
-	};
 }

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx
@@ -14,7 +14,6 @@ import { connect } from 'react-redux';
 import { Recaptcha } from 'components/recaptcha/recaptcha';
 import QuestionMarkHintIcon from 'components/svgs/questionMarkHintIcon';
 import { usePrevious } from 'helpers/customHooks/usePrevious';
-import { useRecaptchaV2 } from 'helpers/customHooks/useRecaptcha';
 import { isValidZipCode } from 'helpers/forms/formValidation';
 import type { StripePaymentIntentAuthorisation } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
 import { Stripe } from 'helpers/forms/paymentMethods';
@@ -111,28 +110,24 @@ function CardForm(props: PropTypes) {
 
 	const [zipCode, setZipCode] = useState('');
 
-	useRecaptchaV2(
-		'robot_checkbox',
-		(token: string) => {
-			trackRecaptchaClientTokenReceived();
-			props.setRecaptchaToken(token);
+	const onRecaptchaCompleted = (token: string) => {
+		trackRecaptchaClientTokenReceived();
+		props.setRecaptchaToken(token);
 
-			if (props.contributionType !== 'ONE_OFF') {
-				props
-					.getStripeSetupIntent({
-						token,
-						stripePublicKey: props.stripeKey,
-						isTestUser: props.isTestUser,
-					})
-					.catch((err: Error) => {
-						logCreateSetupIntentError(err);
-						props.paymentFailure('internal_error');
-						props.setPaymentWaiting(false);
-					});
-			}
-		},
-		props.expireRecaptchaToken,
-	);
+		if (props.contributionType !== 'ONE_OFF') {
+			props
+				.getStripeSetupIntent({
+					token,
+					stripePublicKey: props.stripeKey,
+					isTestUser: props.isTestUser,
+				})
+				.catch((err: Error) => {
+					logCreateSetupIntentError(err);
+					props.paymentFailure('internal_error');
+					props.setPaymentWaiting(false);
+				});
+		}
+	};
 
 	const showZipCodeField = props.country === 'US';
 
@@ -400,7 +395,10 @@ function CardForm(props: PropTypes) {
 							contributionType={props.contributionType}
 						/>
 					)}
-					<Recaptcha />
+					<Recaptcha
+						onRecaptchaCompleted={onRecaptchaCompleted}
+						onRecaptchaExpired={props.expireRecaptchaToken}
+					/>
 				</div>
 			) : null}
 		</div>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This moves responsibility for loading the recaptcha script and rendering the checkbox into the `Recaptcha` component.

## Why are you doing this?

When loading recaptcha in a parent component via the hook, we were depending on the placeholder element `<div id="robot_checkbox"></div>`, which the recaptcha checkbox attaches to, being available by the time the script itself loaded. Normally this would be fine, as a `useEffect` hook is guaranteed to be called _after_ the first component render.

However in the case of the Stripe payment form components, on the first render the component will be empty- we wait for the Stripe SDK to load before rendering the contents of the form, _including the recaptcha placeholder_. This was inadvertently causing a race condition between the recaptcha script and the Stripe SDK- if Stripe loaded first then the component would render, including the placeholder element, and everything would be fine, but if the recaptcha script loaded first the placeholder would not yet have rendered and it would have no element to hook onto, throwing an error.

This fixes the race condition by calling the hook from within the `Recaptcha` component that renders the placeholder element plus terms & conditions. Given that `useEffect` always runs after the first render, this guarantees that we will not be attempting to load the recaptcha script until the placeholder element has been added to the DOM, no matter where we use the component.
