### PR TITLE
Add a debug slice for Redux action history - with serialisation error protection

### DIFF
--- a/support-frontend/assets/__test-utils__/testStore.ts
+++ b/support-frontend/assets/__test-utils__/testStore.ts
@@ -10,6 +10,7 @@ import type {
 	ContributionsStore,
 } from 'helpers/redux/contributionsStore';
 import { initReduxForContributions } from 'helpers/redux/contributionsStore';
+import { debugReducer } from 'helpers/redux/debug/reducer';
 import type {
 	SubscriptionsStartListening,
 	SubscriptionsState,
@@ -33,6 +34,7 @@ export function createTestStoreForSubscriptions(
 	const baseReducer = {
 		common: commonReducer,
 		page: subscriptionsPageReducer,
+		debug: debugReducer,
 	};
 
 	const listenerMiddleware = createListenerMiddleware();
@@ -68,6 +70,7 @@ export function createTestStoreForContributions(
 	const baseReducer = {
 		common: commonReducer,
 		page: initReducer(),
+		debug: debugReducer,
 	};
 
 	const listenerMiddleware = createListenerMiddleware();

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/payPalRecurringCheckout.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/payPalRecurringCheckout.ts
@@ -5,11 +5,11 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { CsrfState } from 'helpers/redux/checkout/csrf/state';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import * as storage from 'helpers/storage/storage';
 import type { Option } from 'helpers/types/option';
 import { routes } from 'helpers/urls/routes';
 import { logException } from 'helpers/utilities/logger';
-import type { State } from 'pages/contributions-landing/contributionsLandingReducer';
 import { billingPeriodFromContrib, getAmount } from '../../contributions';
 
 export type SetupPayPalRequestType = (
@@ -75,7 +75,7 @@ const setupRecurringPayPalPayment =
 		currency: IsoCurrency,
 		csrf: CsrfState,
 	) =>
-	(_dispatch: Dispatch, getState: () => State): void => {
+	(_dispatch: Dispatch, getState: () => ContributionsState): void => {
 		const state = getState();
 		const csrfToken = csrf.token;
 		const contributionType = getContributionType(state);

--- a/support-frontend/assets/helpers/redux/contributionsStore.ts
+++ b/support-frontend/assets/helpers/redux/contributionsStore.ts
@@ -9,6 +9,7 @@ import { addProductSideEffects } from './checkout/product/contributionsSideEffec
 import { addRecaptchaSideEffects } from './checkout/recaptcha/contributionsSideEffects';
 import { setInitialCommonState } from './commonState/actions';
 import { commonReducer } from './commonState/reducer';
+import { debugReducer } from './debug/reducer';
 import { getInitialState } from './utils/setup';
 
 // Listener middleware allows us to specify side-effects for certain actions
@@ -27,6 +28,7 @@ export const contributionsStore = configureStore({
 	reducer: {
 		common: commonReducer,
 		page: initReducer(),
+		debug: debugReducer,
 	},
 	middleware: (getDefaultMiddleware) =>
 		getDefaultMiddleware().prepend(listenerMiddleware.middleware),

--- a/support-frontend/assets/helpers/redux/debug/reducer.ts
+++ b/support-frontend/assets/helpers/redux/debug/reducer.ts
@@ -1,0 +1,23 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const isAnyAction = () => true;
+
+export const debugSlice = createSlice({
+	name: 'debug',
+	initialState: {
+		actionHistory: '',
+	},
+	reducers: {},
+	extraReducers: (builder) => {
+		builder.addMatcher(isAnyAction, (state, action) => {
+			try {
+				const { type, payload } = action as { type: string; payload: unknown };
+				state.actionHistory += ` ${JSON.stringify({ type, payload })}\n`;
+			} catch (error) {
+				return;
+			}
+		});
+	},
+});
+
+export const debugReducer = debugSlice.reducer;

--- a/support-frontend/assets/helpers/redux/redemptionsStore.ts
+++ b/support-frontend/assets/helpers/redux/redemptionsStore.ts
@@ -3,11 +3,13 @@ import { renderError } from 'helpers/rendering/render';
 import { redemptionPageReducer } from 'pages/subscriptions-redemption/subscriptionsRedemptionReducer';
 import { setInitialCommonState } from './commonState/actions';
 import { commonReducer } from './commonState/reducer';
+import { debugReducer } from './debug/reducer';
 import { getInitialState } from './utils/setup';
 
 const baseReducer = {
 	common: commonReducer,
 	page: redemptionPageReducer,
+	debug: debugReducer,
 };
 
 export const redemptionStore = configureStore({

--- a/support-frontend/assets/helpers/redux/subscriptionsStore.ts
+++ b/support-frontend/assets/helpers/redux/subscriptionsStore.ts
@@ -19,6 +19,7 @@ import {
 } from './checkout/product/actions';
 import { setInitialCommonState } from './commonState/actions';
 import { commonReducer } from './commonState/reducer';
+import { debugReducer } from './debug/reducer';
 import { getInitialState } from './utils/setup';
 
 const subscriptionsPageReducer = createReducer();
@@ -28,6 +29,7 @@ export type SubscriptionsReducer = typeof subscriptionsPageReducer;
 const baseReducer = {
 	common: commonReducer,
 	page: subscriptionsPageReducer,
+	debug: debugReducer,
 };
 
 // Listener middleware allows us to specify side-effects for certain actions

--- a/support-frontend/assets/helpers/subscriptionsForms/formFields.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formFields.ts
@@ -55,7 +55,6 @@ export type FormState = Omit<
 	submissionError: Option<ErrorReason>;
 	formSubmitted: boolean;
 	isTestUser: boolean;
-	debugInfo: string;
 };
 
 function getFormFields(state: SubscriptionsState): FormFields {

--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.ts
@@ -13,18 +13,9 @@ function createFormReducer() {
 		formSubmitted: false,
 		isTestUser: isTestUser(),
 		deliveryInstructions: null,
-		debugInfo: '',
 	};
 
-	return function (
-		originalState: FormState = initialState,
-		action: Action,
-	): FormState {
-		const state = {
-			...originalState,
-			debugInfo: `${originalState.debugInfo} ${JSON.stringify(action)}\n`,
-		};
-
+	return function (state: FormState = initialState, action: Action): FormState {
 		switch (action.type) {
 			case 'SET_STAGE':
 				return { ...state, stage: action.stage };

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -145,9 +145,10 @@ function buildRegularPaymentRequest(
 	promotions?: Promotion[],
 	currencyId?: Option<IsoCurrency>,
 ): RegularPaymentRequest {
+	const { actionHistory } = state.debug;
 	const { title, firstName, lastName, email, telephone } =
 		state.page.checkoutForm.personalDetails;
-	const { deliveryInstructions, csrUsername, salesforceCaseId, debugInfo } =
+	const { deliveryInstructions, csrUsername, salesforceCaseId } =
 		state.page.checkout;
 	const product = getProduct(state, currencyId);
 	const paymentFields =
@@ -176,7 +177,7 @@ function buildRegularPaymentRequest(
 		deliveryInstructions,
 		csrUsername,
 		salesforceCaseId,
-		debugInfo,
+		debugInfo: actionHistory,
 	};
 }
 

--- a/support-frontend/assets/pages/contributions-checkout-in-epic/ContributionsCheckout.tsx
+++ b/support-frontend/assets/pages/contributions-checkout-in-epic/ContributionsCheckout.tsx
@@ -14,7 +14,7 @@ import {
 	setSelectedAmount,
 } from 'helpers/redux/checkout/product/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
-import type { State } from 'pages/contributions-landing/contributionsLandingReducer';
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import { ContributionsCheckoutForm } from './ContributionsCheckoutForm';
 import { ContributionsCheckoutSubmitting } from './ContributionsCheckoutSubmitting';
 import { ContributionsCheckoutThankYou } from './ContributionsCheckoutThankYou';
@@ -24,7 +24,7 @@ import { useSecondaryCta } from './useSecondaryCta';
 
 type Status = 'INPUT' | 'SUBMITTING' | 'SUCCESS';
 
-const getStatus = (state: State): Status => {
+const getStatus = (state: ContributionsState): Status => {
 	if (state.page.form.paymentComplete) {
 		return 'SUCCESS';
 	} else if (state.page.form.isWaiting) {
@@ -33,7 +33,7 @@ const getStatus = (state: State): Status => {
 	return 'INPUT';
 };
 
-const getAmounts = (state: State): ContributionAmounts => {
+const getAmounts = (state: ContributionsState): ContributionAmounts => {
 	const amounts = state.common.amounts;
 
 	return {
@@ -52,7 +52,7 @@ const getAmounts = (state: State): ContributionAmounts => {
 	};
 };
 
-const mapStateToProps = (state: State) => ({
+const mapStateToProps = (state: ContributionsState) => ({
 	status: getStatus(state),
 	country: state.common.internationalisation.countryId,
 	countryGroupId: state.common.internationalisation.countryGroupId,

--- a/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.ts
+++ b/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.ts
@@ -19,11 +19,12 @@ import { stripeCardFormIsIncomplete } from 'helpers/forms/stripe';
 import type { StateProvince } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import type { Action as UserAction } from 'helpers/user/userActions';
 import type { LocalCurrencyCountry } from '../../helpers/internationalisation/localCurrencyCountry';
 import { setFormIsValid } from './contributionsLandingActions';
 import type { Action as ContributionsLandingAction } from './contributionsLandingActions';
-import type { State } from './contributionsLandingReducer';
+
 // ----- Types ----- //
 type Action = ContributionsLandingAction | UserAction;
 
@@ -105,7 +106,7 @@ const getFormIsValid = (formIsValidParameters: FormIsValidParameters) => {
 	);
 };
 
-const amazonPayFormOk = (state: State): boolean => {
+const amazonPayFormOk = (state: ContributionsState): boolean => {
 	if (state.page.checkoutForm.payment.paymentMethod === AmazonPay) {
 		const {
 			orderReferenceId,
@@ -128,7 +129,7 @@ const amazonPayFormOk = (state: State): boolean => {
 	return true;
 };
 
-const sepaFormOk = (state: State): boolean => {
+const sepaFormOk = (state: ContributionsState): boolean => {
 	if (state.page.checkoutForm.payment.paymentMethod === Sepa) {
 		const { accountHolderName, iban } = state.page.checkoutForm.payment.sepa;
 		return !!accountHolderName && isValidIban(iban);
@@ -137,7 +138,7 @@ const sepaFormOk = (state: State): boolean => {
 	return true;
 };
 
-const formIsValidParameters = (state: State) => ({
+const formIsValidParameters = (state: ContributionsState) => ({
 	selectedAmounts: state.page.checkoutForm.product.selectedAmounts,
 	otherAmounts: state.page.checkoutForm.product.otherAmounts,
 	countryGroupId: state.common.internationalisation.countryGroupId,
@@ -157,7 +158,7 @@ const formIsValidParameters = (state: State) => ({
 });
 
 function enableOrDisableForm() {
-	return (dispatch: Dispatch, getState: () => State): void => {
+	return (dispatch: Dispatch, getState: () => ContributionsState): void => {
 		const state = getState();
 		const { isRecurringContributor } = state.page.user;
 		const contributionType = getContributionType(state);
@@ -186,7 +187,7 @@ function enableOrDisableForm() {
 }
 
 function setFormSubmissionDependentValue(setStateValue: () => Action) {
-	return (dispatch: Dispatch, getState: () => State): void => {
+	return (dispatch: Dispatch, getState: () => ContributionsState): void => {
 		dispatch(setStateValue());
 		enableOrDisableForm()(dispatch, getState);
 	};

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.tsx
@@ -8,14 +8,14 @@ import {
 	setSelectedAmount,
 } from 'helpers/redux/checkout/product/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { sendEventContributionAmountUpdated } from 'helpers/tracking/quantumMetric';
 import { classNameWithModifiers } from 'helpers/utilities/utilities';
-import type { State } from '../contributionsLandingReducer';
 import ContributionAmountChoices from './ContributionAmountChoices';
 import { ContributionAmountOtherAmountField } from './ContributionAmountOtherAmountField';
 
-const mapStateToProps = (state: State) => ({
+const mapStateToProps = (state: ContributionsState) => ({
 	countryGroupId: state.common.internationalisation.countryGroupId,
 	currency: state.common.internationalisation.currencyId,
 	contributionType: getContributionType(state),

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionErrorMessage.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionErrorMessage.tsx
@@ -5,7 +5,7 @@ import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMess
 import type { ContributionType } from 'helpers/contributions';
 import type { ErrorReason } from 'helpers/forms/errorReasons';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
-import type { State } from '../contributionsLandingReducer';
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import { ExistingRecurringContributorErrorMessage } from './ExistingRecurringContributorErrorMessage';
 
 // ----- Types ----- //
@@ -19,7 +19,7 @@ type PropTypes = {
 	checkoutFormHasBeenSubmitted: boolean;
 };
 
-const mapStateToProps = (state: State) => ({
+const mapStateToProps = (state: ContributionsState) => ({
 	paymentMethod: state.page.checkoutForm.payment.paymentMethod,
 	contributionType: getContributionType(state),
 	paymentError: state.page.form.paymentError,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.tsx
@@ -50,6 +50,7 @@ import {
 	setUseLocalAmounts,
 	setUseLocalCurrencyFlag,
 } from 'helpers/redux/commonState/actions';
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import { payPalCancelUrl, payPalReturnUrl } from 'helpers/urls/routes';
 import { logException } from 'helpers/utilities/logger';
 import { classNameWithModifiers } from 'helpers/utilities/utilities';
@@ -60,7 +61,6 @@ import {
 	setCheckoutFormHasBeenSubmitted,
 	updateSelectedExistingPaymentMethod,
 } from 'pages/contributions-landing/contributionsLandingActions';
-import type { State } from 'pages/contributions-landing/contributionsLandingReducer';
 import ContributionAmount from './ContributionAmount';
 import ContributionChoicesHeader from './ContributionChoicesHeader';
 import ContributionErrorMessage from './ContributionErrorMessage';
@@ -81,7 +81,7 @@ const getCheckoutFormValue = (
 	userValue: string | null,
 ): string | null => (formValue === null ? userValue : formValue);
 
-const mapStateToProps = (state: State) => {
+const mapStateToProps = (state: ContributionsState) => {
 	const contributionType = getContributionType(state);
 	return {
 		isWaiting: state.page.form.isWaiting,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.tsx
@@ -23,6 +23,7 @@ import { countryGroups } from 'helpers/internationalisation/countryGroup';
 import 'helpers/forms/paymentIntegrations/readerRevenueApis';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import { sendEventContributionCheckoutConversion } from 'helpers/tracking/quantumMetric';
 import {
@@ -30,7 +31,6 @@ import {
 	paymentWaiting,
 	setTickerGoalReached,
 } from '../contributionsLandingActions';
-import type { State } from '../contributionsLandingReducer';
 import ContributionForm from './ContributionForm';
 import { ContributionFormBlurb } from './ContributionFormBlurb';
 import {
@@ -64,7 +64,7 @@ type PropTypes = {
 	selectedAmounts: SelectedAmounts;
 };
 
-const mapStateToProps = (state: State) => ({
+const mapStateToProps = (state: ContributionsState) => ({
 	paymentComplete: state.page.form.paymentComplete,
 	countryGroupId: state.common.internationalisation.countryGroupId,
 	tickerGoalReached: state.page.form.tickerGoalReached,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.tsx
@@ -8,6 +8,7 @@ import {
 	emailRegexPattern,
 } from 'helpers/forms/formValidation';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import { applyPersonalDetailsRules } from 'helpers/subscriptionsForms/rules';
 import { firstError } from 'helpers/subscriptionsForms/validation';
 import { classNameWithModifiers } from 'helpers/utilities/utilities';
@@ -17,7 +18,6 @@ import {
 	setLastName,
 	updateBillingState,
 } from '../contributionsLandingActions';
-import type { State } from '../contributionsLandingReducer';
 import ContributionState from './ContributionState';
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -28,7 +28,7 @@ const getCheckoutFormValue = (
 ): string | null =>
 	formValue === null || formValue === '' ? userValue : formValue;
 
-const mapStateToProps = (state: State) => ({
+const mapStateToProps = (state: ContributionsState) => ({
 	firstName:
 		getCheckoutFormValue(
 			state.page.checkoutForm.personalDetails.firstName,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionState.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionState.tsx
@@ -21,7 +21,7 @@ import {
 	UnitedStates,
 } from 'helpers/internationalisation/countryGroup';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
-import type { State } from '../contributionsLandingReducer';
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
 
 // ----- Types ----- //
 
@@ -34,7 +34,7 @@ interface ContributionStateProps {
 	contributionType: string;
 }
 
-const mapStateToProps = (state: State) => ({
+const mapStateToProps = (state: ContributionsState) => ({
 	countryGroupId: state.common.internationalisation.countryGroupId,
 	contributionType: getContributionType(state),
 });

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.tsx
@@ -11,15 +11,15 @@ import type { PayPalCheckoutDetails } from 'helpers/forms/paymentIntegrations/pa
 import type { PaymentAuthorisation } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
 import { AmazonPay, PayPal } from 'helpers/forms/paymentMethods';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import { hiddenIf } from 'helpers/utilities/utilities';
 import { sendFormSubmitEventForPayPalRecurring } from '../contributionsLandingActions';
-import type { State } from '../contributionsLandingReducer';
 import { AmazonPayCheckout } from './AmazonPay/AmazonPayCheckout';
 import { useAmazonPayObjects } from './AmazonPay/useAmazonPayObjects';
 
 // ----- Types ----- //
 
-function mapStateToProps(state: State) {
+function mapStateToProps(state: ContributionsState) {
 	const contributionType = getContributionType(state);
 	return {
 		currency: state.common.internationalisation.currencyId,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.tsx
@@ -21,9 +21,9 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { CsrfState } from 'helpers/redux/checkout/csrf/state';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import type { User } from 'helpers/user/userReducer';
-import type { State } from 'pages/contributions-landing/contributionsLandingReducer';
 import { showBenefitsThankYouText as shouldShowBenefitsThankYouText } from '../DigiSubBenefits/helpers';
 import ContributionThankYouAusMap from './ContributionThankYouAusMap';
 import ContributionThankYouHeader from './ContributionThankYouHeader';
@@ -151,7 +151,7 @@ type ContributionThankYouProps = {
 	isInNewProductTest: boolean;
 };
 
-const mapStateToProps = (state: State) => {
+const mapStateToProps = (state: ContributionsState) => {
 	const contributionType = getContributionType(state);
 	return {
 		email: state.page.checkoutForm.personalDetails.email,

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.tsx
@@ -24,12 +24,12 @@ import {
 	expireRecaptchaToken,
 	setRecaptchaToken,
 } from 'helpers/redux/checkout/recaptcha/actions';
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import {
 	onThirdPartyPaymentAuthorised,
 	paymentFailure,
 	paymentWaiting as setPaymentWaiting,
 } from 'pages/contributions-landing/contributionsLandingActions';
-import type { State } from 'pages/contributions-landing/contributionsLandingReducer';
 import { CreditCardIcons } from './CreditCardIcons';
 import {
 	logCreatePaymentMethodError,
@@ -48,7 +48,7 @@ import './stripeCardForm.scss';
 
 // ----- Redux -----//
 
-const mapStateToProps = (state: State) => ({
+const mapStateToProps = (state: ContributionsState) => ({
 	contributionType: getContributionType(state),
 	checkoutFormHasBeenSubmitted:
 		state.page.form.formData.checkoutFormHasBeenSubmitted,

--- a/support-frontend/assets/pages/subscriptions-redemption/api.ts
+++ b/support-frontend/assets/pages/subscriptions-redemption/api.ts
@@ -172,6 +172,7 @@ function buildRegularPaymentRequest(
 	currencyId: IsoCurrency,
 	countryId: IsoCountry,
 	participations: Participations,
+	debugInfo: string,
 ): RegularPaymentRequest {
 	const product: SubscriptionProductFields = {
 		productType: DigitalPack,
@@ -201,7 +202,7 @@ function buildRegularPaymentRequest(
 		ophanIds: getOphanIds(),
 		referrerAcquisitionData: getReferrerAcquisitionData(),
 		supportAbTests: getSupportAbTests(participations),
-		debugInfo: 'no form/redux for redemption page',
+		debugInfo,
 	};
 }
 
@@ -228,6 +229,7 @@ function createSubscription(
 		state.common.internationalisation.currencyId,
 		state.common.internationalisation.countryId,
 		state.common.abParticipations,
+		state.debug.actionHistory,
 	);
 
 	const handleSubscribeResult = (result: PaymentResult) => {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This is a re-do of #4188 - please see that PR description for details on the change.

## Why are you doing this?

The previous PR caused a problem on the contributions checkout with the async thunk action that checks the validity of direct debit details, which contains a `meta` property with an unserializable, circular reference. This issue has been corrected by only serialising the `type` and `payload` values from actions, and additionally adding a try/catch to the debug reducer to guard against future edge cases.
