### PR TITLE
Remove duplicated code between ContributionsLanding and ContributionsLandingPage

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.tsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.tsx
@@ -63,7 +63,7 @@ const router = () => {
 	const landingPage = showNewProductPage ? (
 		<SupporterPlusLandingPage />
 	) : (
-		<ContributionsLandingPage />
+		<ContributionsLandingPage countryGroupId={countryGroupId} />
 	);
 
 	return (

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingPage.tsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingPage.tsx
@@ -6,46 +6,10 @@ import { RoundelHeader } from 'components/headers/roundelHeader/header';
 import Page from 'components/page/page';
 import { getCampaignSettings } from 'helpers/campaigns/campaigns';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import {
-	countryGroups,
-	detect,
-} from 'helpers/internationalisation/countryGroup';
-import { setUpTrackingAndConsents } from 'helpers/page/page';
-import { isDetailsSupported, polyfillDetails } from 'helpers/polyfills/details';
-import { gaEvent } from 'helpers/tracking/googleTagManager';
+import { countryGroups } from 'helpers/internationalisation/countryGroup';
 import { ContributionFormContainer } from './components/ContributionFormContainer';
 import './contributionsLanding.scss';
 import './newContributionsLandingTemplate.scss';
-
-if (!isDetailsSupported) {
-	polyfillDetails();
-}
-
-setUpTrackingAndConsents();
-
-// ----- Redux Store ----- //
-
-const countryGroupId: CountryGroupId = detect();
-
-if (!window.guardian.polyfillScriptLoaded) {
-	gaEvent({
-		category: 'polyfill',
-		action: 'not loaded',
-		label: window.guardian.polyfillVersion ?? '',
-	});
-}
-
-if (typeof Object.values !== 'function') {
-	gaEvent({
-		category: 'polyfill',
-		action: 'Object.values not available after polyfill',
-		label: window.guardian.polyfillVersion ?? '',
-	});
-}
-
-// ----- Internationalisation ----- //
-
-const selectedCountryGroup = countryGroups[countryGroupId];
 
 // ----- Render ----- //
 
@@ -54,8 +18,13 @@ const cssModifiers = campaignSettings?.cssModifiers ?? [];
 const backgroundImageSrc = campaignSettings?.backgroundImage;
 FocusStyleManager.onlyShowFocusOnTabs(); // https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility
 
-export function ContributionsLandingPage(): JSX.Element {
+export function ContributionsLandingPage({
+	countryGroupId,
+}: {
+	countryGroupId: CountryGroupId;
+}): JSX.Element {
 	const { campaignCode } = useParams();
+	const selectedCountryGroup = countryGroups[countryGroupId];
 
 	return (
 		<Page


### PR DESCRIPTION
## What are you doing in this PR?

This PR removes function calls that are duplicated in the `contributionsLanding` and `contributionsLandingPage` modules.

Earlier today I noticed the function `setUpTrackingAndConsents` was unexpectedly being called twice on the Contributions Landing Page. 

Having investigated this I found that we are calling it twice in the hierarchy of components used to render this page:

```jsx
<ContributionsLanding>
    <ContributionsLandingPage />
</ContributionsLanding>
```

Originally `setUpTrackingAndConsents` was called once from `ContributionsLanding` , however in https://github.com/guardian/support-frontend/pull/4156 we split out the main body of the component into two new child components (`SupporterPlusLanding` / `ContributionsLandingPage`), these are rendered conditionally depending on whether a user is in the `supporterPlus` AB test, so we either render `SupporterPlusLanding` OR `ContributionsLandingPage`.

In that PR we created a new module/component `contributionsLandingPage`/`ContributionsLandingPage`, however when we set this up we duplicated some code that's already in it's parent component,`ContributionsLanding`. This means this code is executed twice, such as function calls: `polyfillDetails()`, `setUpTrackingAndConsents()` and some `gaEvent` calls related to the Polyfill script being loaded.

To prevent these functions being called twice I've removed the calls from the child `ContributionsLandingPage` as they're already called in the parent `ContributionsLanding`.  

I've also made an update to pass `countryGroupId` down as a prop from the parent to the child, to save us calling `detect()` twice.