### PR TITLE
Quantum Metric: sendEventContributionCartValue

### DIFF
--- a/support-frontend/assets/helpers/page/analyticsAndConsent.ts
+++ b/support-frontend/assets/helpers/page/analyticsAndConsent.ts
@@ -25,6 +25,7 @@ function analyticsInitialisation(
 	setReferrerDataInLocalStorage(acquisitionData);
 	void googleTagManager.init(participations);
 	ophan.init();
+	console.log('*** initQuantumMetric ***');
 	initQuantumMetric(participations);
 	trackAbTests(participations);
 	// Sentry logging.

--- a/support-frontend/assets/helpers/page/analyticsAndConsent.ts
+++ b/support-frontend/assets/helpers/page/analyticsAndConsent.ts
@@ -25,7 +25,6 @@ function analyticsInitialisation(
 	setReferrerDataInLocalStorage(acquisitionData);
 	void googleTagManager.init(participations);
 	ophan.init();
-	console.log('*** initQuantumMetric ***');
 	initQuantumMetric(participations);
 	trackAbTests(participations);
 	// Sentry logging.

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -1,11 +1,5 @@
 import { isAnyOf } from '@reduxjs/toolkit';
-import type { ContributionType } from 'helpers/contributions';
-import type { IsoCurrency } from 'helpers/internationalisation/currency';
-import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
-import type {
-	ContributionsStartListening,
-	ContributionsState,
-} from 'helpers/redux/contributionsStore';
+import type { ContributionsStartListening } from 'helpers/redux/contributionsStore';
 import * as storage from 'helpers/storage/storage';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
@@ -16,6 +10,7 @@ import {
 	setProductType,
 	setSelectedAmount,
 } from './actions';
+import { getContributionCartValueData } from './selectors/cartValue';
 
 const shouldCheckFormEnabled = isAnyOf(
 	setAllAmounts,
@@ -28,28 +23,6 @@ const shouldSendEventContributionCartValue = isAnyOf(
 	setProductType,
 	setSelectedAmount,
 );
-
-function getContributionCartValueData(contributionsState: ContributionsState): {
-	contributionAmount: string | number | null;
-	contributionType: ContributionType;
-	contributionCurrency: IsoCurrency;
-} {
-	const pageState = contributionsState.page;
-	const selectedAmounts = pageState.checkoutForm.product.selectedAmounts;
-	const contributionType = getContributionType(contributionsState);
-	const selectedAmount = selectedAmounts[contributionType];
-	const contributionAmount =
-		selectedAmount === 'other'
-			? pageState.checkoutForm.product.otherAmounts[contributionType].amount
-			: selectedAmount;
-	const contributionCurrency = pageState.checkoutForm.product.currency;
-
-	return {
-		contributionAmount,
-		contributionType,
-		contributionCurrency,
-	};
-}
 
 export function addProductSideEffects(
 	startListening: ContributionsStartListening,

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -31,8 +31,6 @@ function getContributionCartValueData(pageState: PageState): {
 	contributionType: ContributionType;
 	contributionCurrency: IsoCurrency;
 } {
-	console.log('pageState --->', pageState);
-
 	const selectedAmounts = pageState.checkoutForm.product.selectedAmounts;
 	/**
 	 * selectedAmounts (type SelectedAmounts) can only be indexed with ContributionType,

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/cartValue.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/cartValue.ts
@@ -1,0 +1,29 @@
+import type { ContributionType } from 'helpers/contributions';
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
+
+// Used when sending data to Quantum Metric from Contributions Checkout
+function getContributionCartValueData(contributionsState: ContributionsState): {
+	contributionAmount: string | number | null;
+	contributionType: ContributionType;
+	contributionCurrency: IsoCurrency;
+} {
+	const pageState = contributionsState.page;
+	const selectedAmounts = pageState.checkoutForm.product.selectedAmounts;
+	const contributionType = getContributionType(contributionsState);
+	const selectedAmount = selectedAmounts[contributionType];
+	const contributionAmount =
+		selectedAmount === 'other'
+			? pageState.checkoutForm.product.otherAmounts[contributionType].amount
+			: selectedAmount;
+	const contributionCurrency = pageState.checkoutForm.product.currency;
+
+	return {
+		contributionAmount,
+		contributionType,
+		contributionCurrency,
+	};
+}
+
+export { getContributionCartValueData };

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -57,6 +57,7 @@ function sendEvent(
 	isConversion: boolean,
 	value: string,
 ): void {
+	console.log('sendEvent ---->', id, isConversion, value);
 	if (window.QuantumMetricAPI?.isOn()) {
 		window.QuantumMetricAPI.sendEvent(id, isConversion ? 1 : 0, value);
 	}
@@ -217,7 +218,7 @@ export function sendEventContributionCheckoutConversion(
 	});
 }
 
-export function sendEventContributionAmountUpdated(
+export function sendEventContributionCartValue(
 	amount: string,
 	contributionType: ContributionType,
 	sourceCurrency: IsoCurrency,

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -57,7 +57,6 @@ function sendEvent(
 	isConversion: boolean,
 	value: string,
 ): void {
-	console.log('sendEvent ---->', id, isConversion, value);
 	if (window.QuantumMetricAPI?.isOn()) {
 		window.QuantumMetricAPI.sendEvent(id, isConversion ? 1 : 0, value);
 	}
@@ -300,7 +299,6 @@ function addQM() {
 }
 
 export function init(participations: Participations): void {
-	console.log('*** init ***');
 	void canRunQuantumMetric().then((canRun) => {
 		if (canRun) {
 			void addQM().then(() => {
@@ -309,7 +307,6 @@ export function init(participations: Participations): void {
 				 * send user AB test participations via the sendEvent function.
 				 */
 				sendEventABTestParticipations(participations);
-				console.log('*** sendEventABTestParticipations ***');
 			});
 		}
 	});

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -286,7 +286,7 @@ function sendEventABTestParticipations(participations: Participations): void {
 
 function addQM() {
 	return loadScript(
-		'https://cdn.quantummetric.com/instrumentation/1.31.5/quantum-gnmx.js',
+		'https://cdn.quantummetric.com/instrumentation/1.31.5/quantum-gnm.js',
 		{
 			async: true,
 			integrity:

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -57,6 +57,7 @@ function sendEvent(
 	isConversion: boolean,
 	value: string,
 ): void {
+	console.log('sendEvent ---->', id, isConversion, value);
 	if (window.QuantumMetricAPI?.isOn()) {
 		window.QuantumMetricAPI.sendEvent(id, isConversion ? 1 : 0, value);
 	}
@@ -286,15 +287,15 @@ function sendEventABTestParticipations(participations: Participations): void {
 
 function addQM() {
 	return loadScript(
-		'https://cdn.quantummetric.com/instrumentation/1.31.5/quantum-gnm.js',
+		'https://cdn.quantummetric.com/instrumentation/1.31.5/quantum-gnmx.js',
 		{
 			async: true,
 			integrity:
 				'sha384-QqJrp8s9Nl3x7Z6sc9kQG5eYJLVWYwlEsvhjCukLSwFsWtK17WdC5whHVwSXQh1F',
 			crossOrigin: 'anonymous',
 		},
-	).catch((e: Error) => {
-		logException(`Failed to load Quantum Metric: ${e.message}`);
+	).catch(() => {
+		logException('Failed to load Quantum Metric');
 	});
 }
 

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -57,7 +57,6 @@ function sendEvent(
 	isConversion: boolean,
 	value: string,
 ): void {
-	console.log('sendEvent ---->', id, isConversion, value);
 	if (window.QuantumMetricAPI?.isOn()) {
 		window.QuantumMetricAPI.sendEvent(id, isConversion ? 1 : 0, value);
 	}

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -57,6 +57,7 @@ function sendEvent(
 	isConversion: boolean,
 	value: string,
 ): void {
+	console.log('sendEvent ---->', id, isConversion, value);
 	if (window.QuantumMetricAPI?.isOn()) {
 		window.QuantumMetricAPI.sendEvent(id, isConversion ? 1 : 0, value);
 	}
@@ -299,6 +300,7 @@ function addQM() {
 }
 
 export function init(participations: Participations): void {
+	console.log('*** init ***');
 	void canRunQuantumMetric().then((canRun) => {
 		if (canRun) {
 			void addQM().then(() => {
@@ -307,6 +309,7 @@ export function init(participations: Participations): void {
 				 * send user AB test participations via the sendEvent function.
 				 */
 				sendEventABTestParticipations(participations);
+				console.log('*** sendEventABTestParticipations ***');
 			});
 		}
 	});

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.tsx
@@ -10,7 +10,7 @@ import {
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
-import { sendEventContributionAmountUpdated } from 'helpers/tracking/quantumMetric';
+import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
 import { classNameWithModifiers } from 'helpers/utilities/utilities';
 import ContributionAmountChoices from './ContributionAmountChoices';
 import { ContributionAmountOtherAmountField } from './ContributionAmountOtherAmountField';
@@ -104,7 +104,7 @@ function ContributionAmount(props: PropTypes) {
 								`npf-contribution-amount-toggle-${props.countryGroupId}-${props.contributionType}-${otherAmount}`,
 							);
 
-							sendEventContributionAmountUpdated(
+							sendEventContributionCartValue(
 								otherAmount,
 								props.contributionType,
 								props.currency,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.ts
@@ -69,7 +69,7 @@ interface FormState {
 	oneOffRecaptchaToken: string | null;
 }
 
-interface PageState {
+export interface PageState {
 	form: FormState;
 	checkoutForm: {
 		personalDetails: PersonalDetailsState;


### PR DESCRIPTION
## What are you doing in this PR?

The aim here is to keep QM informed of the "cart value" during a contributions checkout session.

We currently have a function `sendEventContributionAmountUpdated` that's called when user clicks on a contribution amount button on the contributions checkout, this function informs Quantum Metric of the "cart value" of the checkout  session. However we only send this event on these button click, whilst a users cart value can be set on other page events, specifically...

- **Page load:** When a user lands on the page there is a default payment frequency and a default payment amount already selected - so the cart essentially has a default value on page load, should we track this as a user could feasibly checkout without clicking a payment amount button.

- **Changing payment frequency:** When a user switches between single/monthly/annual the selected payment amount changes they are effectively altering their cart value as the default selected amount changes too. 

We're not informing Quantum Metric of the cart value on these events. This PR addresses that by 1) Renaming `sendEventContributionAmountUpdated` to `sendEventContributionCartValue` to more accurately reflect this functions actual purpose and 2) Calling `sendEventContributionCartValue` on:

- Page load by hooking into the side effects for the `setAllAmounts` action.

-  A user clicking a payment frequency button by hooking into the side effects for the `setProductType` action.
 
- A user clicking on a payment amount button by hooking into the side effects for the `setSelectedAmount` action.

When these actions are executed we now call `sendEventContributionCartValue`.

