### PR TITLE
Newspaper autumn offers changes

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/components/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/paperPrices.tsx
@@ -40,7 +40,30 @@ const getPriceCopyString = (
 	return <>per month{productCopy}</>;
 };
 
+const autumnPromoCodes = [
+	'AUTUMNEVERYDAY10HD',
+	'AUTUMNSAT10',
+	'AUTUMNSAT10HD',
+	'AUTUMNSIXDAY10',
+	'AUTUMNSIXDAY10HD',
+	'AUTUMNSUN10',
+	'AUTUMNSUN10HD',
+	'AUTUMNWEEKEND10',
+	'AUTUMNWEEKEND10HD',
+	'AUTUMN14',
+	'FESTIVAL20',
+	'AUTUMN20',
+	'AUTUMN30',
+];
+
 const getOfferText = (price: ProductPrice) => {
+	if (
+		price.promotions?.some((promo) =>
+			autumnPromoCodes.includes(promo.promoCode),
+		)
+	) {
+		return '';
+	}
 	if (price.savingVsRetail && price.savingVsRetail > 0) {
 		return `Save ${price.savingVsRetail}% on retail price`;
 	}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR is to support Marketing's autumn campaign of newspaper offers.

They are creating a number of offers for this campaign and (initially) want the offer text in the product price cards to be empty as it otherwise displays the saving from regular price vs retail price without taking the promotion into account.

In conjunction we are making some of the promotions default.

## Screenshots
![Screenshot 2022-09-08 at 14 10 14](https://user-images.githubusercontent.com/99180049/189313980-9aadaf74-3497-4987-b36b-1a8a0f7d63e5.png)
