### PR TITLE
Add header for new checkout

### DIFF
--- a/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx
+++ b/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx
@@ -16,7 +16,7 @@ import moduleStyles from './countryGroupSwitcher.module.scss';
 const styles = moduleStyles as { button: string };
 
 // ----- Props ----- //
-export type PropTypes = {
+export type CountryGroupSwitcherProps = {
 	countryGroupIds: CountryGroupId[];
 	selectedCountryGroup: CountryGroupId;
 	trackProduct?: Option<SubscriptionProduct>;
@@ -29,7 +29,7 @@ function CountryGroupSwitcher({
 	selectedCountryGroup,
 	countryGroupIds,
 	trackProduct,
-}: PropTypes): JSX.Element {
+}: CountryGroupSwitcherProps): JSX.Element {
 	const buttonRef = useRef<HTMLButtonElement>(null);
 	const [menuOpen, setMenuOpen] = useState(false);
 	const [bounds, setBounds] = useState({

--- a/support-frontend/assets/components/headers/simpleHeader/countrySwitcherContainer.tsx
+++ b/support-frontend/assets/components/headers/simpleHeader/countrySwitcherContainer.tsx
@@ -1,0 +1,15 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/source-foundations';
+import type { ReactNode } from 'react';
+
+const topSpacing = css`
+	margin-top: ${space[2]}px;
+`;
+
+export function CountrySwitcherContainer({
+	children,
+}: {
+	children: ReactNode;
+}): JSX.Element {
+	return <div css={topSpacing}>{children}</div>;
+}

--- a/support-frontend/assets/components/headers/simpleHeader/simpleHeader.tsx
+++ b/support-frontend/assets/components/headers/simpleHeader/simpleHeader.tsx
@@ -1,0 +1,49 @@
+import { css } from '@emotion/react';
+import { brand, from, neutral, space } from '@guardian/source-foundations';
+import {
+	Column,
+	Columns,
+	SvgGuardianLogo,
+} from '@guardian/source-react-components';
+import type { ReactNode } from 'react';
+import { Container } from 'components/layout/container';
+
+const logoContainer = css`
+	display: flex;
+	justify-content: flex-end;
+	margin-top: 6px;
+	margin-bottom: 15px;
+	height: 44px;
+
+	${from.desktop} {
+		margin-top: ${space[2]}px;
+		height: 100px;
+	}
+
+	svg {
+		height: 100%;
+	}
+`;
+
+type HeaderProps = {
+	children?: ReactNode;
+};
+
+export function Header({ children }: HeaderProps): JSX.Element {
+	return (
+		<header>
+			<Container backgroundColor={brand[400]}>
+				<Columns>
+					<Column>{children}</Column>
+					<Column span={[2, 3, 4]}>
+						<div css={logoContainer}>
+							<SvgGuardianLogo textColor={neutral[100]} />
+						</div>
+					</Column>
+					{/* Only show at wide breakpoint */}
+					<Column span={[0, 0, 0, 0, 1]}></Column>
+				</Columns>
+			</Container>
+		</header>
+	);
+}

--- a/support-frontend/assets/components/layout/container.tsx
+++ b/support-frontend/assets/components/layout/container.tsx
@@ -3,8 +3,18 @@ import { from, neutral } from '@guardian/source-foundations';
 import { Container as SourceContainer } from '@guardian/source-react-components';
 import React from 'react';
 
+type ContainerElement =
+	| 'div'
+	| 'article'
+	| 'aside'
+	| 'footer'
+	| 'header'
+	| 'nav'
+	| 'section';
+
 type Props = {
 	children: React.ReactNode;
+	element?: ContainerElement;
 	sidePadding?: boolean;
 	topBorder?: boolean;
 	sideBorders?: boolean;
@@ -48,6 +58,7 @@ const topBorderStyles = (color: string = neutral[86]) => css`
 
 export function Container({
 	children,
+	element,
 	sidePadding = true,
 	topBorder,
 	sideBorders,
@@ -56,6 +67,7 @@ export function Container({
 }: Props): JSX.Element {
 	return (
 		<SourceContainer
+			element={element}
 			topBorder={topBorder}
 			borderColor={borderColor}
 			backgroundColor={backgroundColor}

--- a/support-frontend/assets/components/nav/nav.tsx
+++ b/support-frontend/assets/components/nav/nav.tsx
@@ -5,18 +5,12 @@ import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSw
 import { Container } from 'components/layout/container';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
-const col1CssOverrides = css`
+const switcherContainer = css`
 	height: 28px;
-	border-right: 1px solid ${brand[600]};
-	margin-right: 0;
+	border-left: 1px solid ${brand[600]};
+	padding: ${space[2]}px 0 0 ${space[3]}px;
+	margin-bottom: ${space[3]}px;
 `;
-
-const col2CssOverrides = css`
-	min-height: 42px;
-	display: flex;
-	padding: ${space[2]}px;
-`;
-
 interface NavProps {
 	countryGroupIds: CountryGroupId[];
 	selectedCountryGroup: CountryGroupId;
@@ -32,20 +26,21 @@ function Nav({
 		<Container
 			element="nav"
 			sideBorders={true}
-			sidePadding={false}
 			topBorder={true}
 			borderColor={brand[600]}
 			backgroundColor={brand[400]}
 		>
 			<Hide until="desktop">
 				<Columns>
-					<Column span={5} cssOverrides={col1CssOverrides} />
-					<Column cssOverrides={col2CssOverrides}>
-						<CountryGroupSwitcher
-							countryGroupIds={countryGroupIds}
-							selectedCountryGroup={selectedCountryGroup}
-							subPath={subPath}
-						/>
+					<Column span={5} />
+					<Column>
+						<div css={switcherContainer}>
+							<CountryGroupSwitcher
+								countryGroupIds={countryGroupIds}
+								selectedCountryGroup={selectedCountryGroup}
+								subPath={subPath}
+							/>
+						</div>
 					</Column>
 				</Columns>
 			</Hide>

--- a/support-frontend/assets/components/nav/nav.tsx
+++ b/support-frontend/assets/components/nav/nav.tsx
@@ -1,17 +1,9 @@
 import { css } from '@emotion/react';
-import { brand, from, space } from '@guardian/source-foundations';
-import { Column, Columns } from '@guardian/source-react-components';
+import { brand, space } from '@guardian/source-foundations';
+import { Column, Columns, Hide } from '@guardian/source-react-components';
 import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import { Container } from 'components/layout/container';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-
-const container = css`
-	display: none;
-
-	${from.desktop} {
-		display: block;
-	}
-`;
 
 const col1CssOverrides = css`
 	height: 28px;
@@ -37,14 +29,15 @@ function Nav({
 	subPath,
 }: NavProps): JSX.Element {
 	return (
-		<nav css={container}>
-			<Container
-				sideBorders={true}
-				sidePadding={false}
-				topBorder={true}
-				borderColor={brand[600]}
-				backgroundColor={brand[400]}
-			>
+		<Container
+			element="nav"
+			sideBorders={true}
+			sidePadding={false}
+			topBorder={true}
+			borderColor={brand[600]}
+			backgroundColor={brand[400]}
+		>
+			<Hide until="desktop">
 				<Columns>
 					<Column span={5} cssOverrides={col1CssOverrides} />
 					<Column cssOverrides={col2CssOverrides}>
@@ -55,8 +48,8 @@ function Nav({
 						/>
 					</Column>
 				</Columns>
-			</Container>
-		</nav>
+			</Hide>
+		</Container>
 	);
 }
 

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -7,6 +7,7 @@ import {
 } from '@guardian/source-react-components-development-kitchen';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { CheckoutHeading } from 'components/checkoutHeading/checkoutHeading';
+import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { Container } from 'components/layout/container';
 import Nav from 'components/nav/nav';
 import { PageScaffold } from 'components/page/pageScaffold';
@@ -57,6 +58,7 @@ export function SupporterPlusLandingPage(): JSX.Element {
 	return (
 		<PageScaffold
 			id="supporter-plus-landing"
+			header={<Header></Header>}
 			footer={
 				<FooterWithContents>
 					<FooterLinks></FooterLinks>

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -9,6 +9,7 @@ import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { CheckoutHeading } from 'components/checkoutHeading/checkoutHeading';
 import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countrySwitcherContainer';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { Container } from 'components/layout/container';
 import Nav from 'components/nav/nav';
@@ -77,7 +78,9 @@ export function SupporterPlusLandingPage(): JSX.Element {
 			header={
 				<Header>
 					<Hide from="desktop">
-						<CountryGroupSwitcher {...countrySwitcherProps} />
+						<CountrySwitcherContainer>
+							<CountryGroupSwitcher {...countrySwitcherProps} />
+						</CountrySwitcherContainer>
 					</Hide>
 				</Header>
 			}

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -7,6 +7,8 @@ import {
 } from '@guardian/source-react-components-development-kitchen';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { CheckoutHeading } from 'components/checkoutHeading/checkoutHeading';
+import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { Container } from 'components/layout/container';
 import Nav from 'components/nav/nav';
@@ -52,32 +54,40 @@ const largeDemoBox = css`
 	min-height: 400px;
 `;
 
+const countrySwitcherProps: CountryGroupSwitcherProps = {
+	countryGroupIds: [
+		GBPCountries,
+		UnitedStates,
+		AUDCountries,
+		EURCountries,
+		NZDCountries,
+		Canada,
+		International,
+	],
+	selectedCountryGroup: GBPCountries,
+	subPath: '/contribute',
+};
+
 export function SupporterPlusLandingPage(): JSX.Element {
 	const heading = <LandingPageHeading />;
 
 	return (
 		<PageScaffold
 			id="supporter-plus-landing"
-			header={<Header></Header>}
+			header={
+				<Header>
+					<Hide from="desktop">
+						<CountryGroupSwitcher {...countrySwitcherProps} />
+					</Hide>
+				</Header>
+			}
 			footer={
 				<FooterWithContents>
 					<FooterLinks></FooterLinks>
 				</FooterWithContents>
 			}
 		>
-			<Nav
-				countryGroupIds={[
-					GBPCountries,
-					UnitedStates,
-					AUDCountries,
-					EURCountries,
-					NZDCountries,
-					Canada,
-					International,
-				]}
-				selectedCountryGroup={GBPCountries}
-				subPath={window.location.search}
-			/>
+			<Nav {...countrySwitcherProps} />
 			<CheckoutHeading heading={heading}>
 				<p>
 					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque

--- a/support-frontend/stories/core/SimpleHeader.stories.tsx
+++ b/support-frontend/stories/core/SimpleHeader.stories.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+import { Header } from 'components/headers/simpleHeader/simpleHeader';
+
+export default {
+	title: 'Core/Simple Header',
+	component: Header,
+	// argTypes: {
+	// 	display: {
+	// 		control: {
+	// 			type: 'radio',
+	// 			options: ['navigation', 'checkout', 'guardianLogo'],
+	// 		},
+	// 	},
+	// 	countryGroupId: {
+	// 		control: {
+	// 			type: 'select',
+	// 			options: [
+	// 				GBPCountries,
+	// 				UnitedStates,
+	// 				AUDCountries,
+	// 				EURCountries,
+	// 				NZDCountries,
+	// 				Canada,
+	// 				International,
+	// 			],
+	// 		},
+	// 	},
+	// },
+};
+
+function Template(args: { children?: ReactNode }) {
+	return <Header>{args.children}</Header>;
+}
+
+export const Default = Template.bind({});

--- a/support-frontend/stories/core/SimpleHeader.stories.tsx
+++ b/support-frontend/stories/core/SimpleHeader.stories.tsx
@@ -1,35 +1,48 @@
 import type { ReactNode } from 'react';
+import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countrySwitcherContainer';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
+import {
+	AUDCountries,
+	Canada,
+	EURCountries,
+	GBPCountries,
+	International,
+	NZDCountries,
+	UnitedStates,
+} from 'helpers/internationalisation/countryGroup';
 
 export default {
 	title: 'Core/Simple Header',
 	component: Header,
-	// argTypes: {
-	// 	display: {
-	// 		control: {
-	// 			type: 'radio',
-	// 			options: ['navigation', 'checkout', 'guardianLogo'],
-	// 		},
-	// 	},
-	// 	countryGroupId: {
-	// 		control: {
-	// 			type: 'select',
-	// 			options: [
-	// 				GBPCountries,
-	// 				UnitedStates,
-	// 				AUDCountries,
-	// 				EURCountries,
-	// 				NZDCountries,
-	// 				Canada,
-	// 				International,
-	// 			],
-	// 		},
-	// 	},
-	// },
 };
 
 function Template(args: { children?: ReactNode }) {
 	return <Header>{args.children}</Header>;
 }
 
+Template.args = {} as Record<string, unknown>;
+
 export const Default = Template.bind({});
+
+export const WithCountrySwitcher = Template.bind({});
+
+WithCountrySwitcher.args = {
+	children: (
+		<CountrySwitcherContainer>
+			<CountryGroupSwitcher
+				countryGroupIds={[
+					GBPCountries,
+					UnitedStates,
+					AUDCountries,
+					EURCountries,
+					NZDCountries,
+					Canada,
+					International,
+				]}
+				selectedCountryGroup={GBPCountries}
+				subPath="/"
+			/>
+		</CountrySwitcherContainer>
+	),
+};


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds a simplified header component for the new checkout, and adds it to the new page showing the country group switcher below the desktop breakpoint.

I've also made some tweaks to the `Nav` component to make sure we retain the top border below the desktop breakpoint, and make sure the switcher sits in line with the body columns when visible.

[**Trello Card**](https://trello.com/c/Ho5AyV02)

## Why are you doing this?

This is part of the ongoing work for the new product checkout.

## Accessibility test checklist
 - [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

### Component

#### Mobile
![Screenshot 2022-09-12 at 14 56 45](https://user-images.githubusercontent.com/29146931/189676077-9eea9144-81dd-45ff-9155-ebd298c6d5fb.png)

#### Tablet
![Screenshot 2022-09-12 at 14 56 34](https://user-images.githubusercontent.com/29146931/189676089-3c1b84d5-24fd-4407-b3e0-357533c8b9ca.png)

#### Desktop
![Screenshot 2022-09-12 at 14-56-14 core-simple-header--default](https://user-images.githubusercontent.com/29146931/189676138-725dae4a-34f2-4ee5-bf58-d33d1a0ebbc6.png)

### Page

#### Mobile (iOS, Safari, iPhone 12)
![Screenshot 2022-09-12 at 15 05 18](https://user-images.githubusercontent.com/29146931/189676237-1d150088-f15c-4c66-a4ea-5cc54fd78b2e.png)

#### Tablet (Android, Chome, Galaxy S8)
![Screenshot 2022-09-12 at 15 06 44](https://user-images.githubusercontent.com/29146931/189676323-eb8f9808-df9d-40aa-833d-b7156ab6702c.png)

#### Desktop (macOS, Firefox)
![Screenshot 2022-09-12 at 14-57-52 Support the Guardian Make a Contribution](https://user-images.githubusercontent.com/29146931/189676389-0ebeeedd-15b8-4e0b-86d6-c97f89ae1916.png)
