### PR TITLE
Fix test

### DIFF
--- a/supporter-product-data/src/test/scala/com/gu/lambdas/QueryZuoraLambdaSpec.scala
+++ b/supporter-product-data/src/test/scala/com/gu/lambdas/QueryZuoraLambdaSpec.scala
@@ -11,7 +11,7 @@ import java.time.LocalDate
 @IntegrationTest
 class QueryZuoraLambdaSpec extends AsyncFlatSpec with Matchers {
 
-  QueryZuoraLambda.getClass.getSimpleName should "be able to run a query" in {
+  "QueryZuoraLambda" should "be able to run a query" in {
     QueryZuoraLambda
       .queryZuora(DEV, Incremental)
       .map(resultState => resultState.attemptedQueryTime.toLocalDate shouldBe LocalDate.now)


### PR DESCRIPTION
This test shouldn't run in CI because it is an integration test and needs janus creds to work, however using the `QueryZuoraLambda.getClass.getSimpleName` construct to get the classname for the test name was causing the class to be initialised, which in turn was running code which required creds, and so was failing.
