### PR TITLE
Allow supporterProductData to put metric data in CloudWatch

### DIFF
--- a/supporter-product-data/cloudformation/cfn.yaml
+++ b/supporter-product-data/cloudformation/cfn.yaml
@@ -73,6 +73,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                   - lambda:InvokeFunction
+                  - cloudwatch:PutMetricData
                 Resource: "*"
         - PolicyName: WorkBucket
           PolicyDocument:


### PR DESCRIPTION
I've noticed an error in the supporter product data logs because it is unable to write metric to CloudWatch due to a permissions issue. This PR fixes that