### PR TITLE
Migrate payment request button state to Redux Toolkit

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentRequestButton/actions.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentRequestButton/actions.ts
@@ -1,0 +1,4 @@
+import { paymentRequestButtonSlice } from './reducer';
+
+export const { clickPaymentRequestButton, setPaymentRequestError } =
+	paymentRequestButtonSlice.actions;

--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentRequestButton/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentRequestButton/reducer.ts
@@ -1,0 +1,21 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
+import type { StripeAccount } from 'helpers/forms/stripe';
+import type { PaymentRequestError } from './state';
+import { initialPaymentRequestButtonState } from './state';
+
+export const paymentRequestButtonSlice = createSlice({
+	name: 'paymentRequestButton',
+	initialState: initialPaymentRequestButtonState,
+	reducers: {
+		clickPaymentRequestButton(state, action: PayloadAction<StripeAccount>) {
+			state[action.payload].buttonClicked = true;
+		},
+		setPaymentRequestError(state, action: PayloadAction<PaymentRequestError>) {
+			const { account, error } = action.payload;
+			state[account].paymentError = error;
+		},
+	},
+});
+
+export const paymentRequestButtonReducer = paymentRequestButtonSlice.reducer;

--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentRequestButton/selectors.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentRequestButton/selectors.ts
@@ -1,0 +1,11 @@
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
+
+export function hasPaymentRequestButtonBeenClicked(
+	state: ContributionsState,
+): boolean {
+	const { paymentRequestButton } = state.page.checkoutForm.payment;
+	return (
+		paymentRequestButton.ONE_OFF.buttonClicked ||
+		paymentRequestButton.REGULAR.buttonClicked
+	);
+}

--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentRequestButton/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentRequestButton/state.ts
@@ -1,0 +1,26 @@
+import type { ErrorReason } from 'helpers/forms/errorReasons';
+import type { StripeAccount } from 'helpers/forms/stripe';
+
+type StripePaymentRequestButtonData = {
+	buttonClicked: boolean;
+	paymentError?: ErrorReason;
+};
+
+export type PaymentRequestError = {
+	account: StripeAccount;
+	error: ErrorReason;
+};
+
+export type PaymentRequestButtonState = Record<
+	StripeAccount,
+	StripePaymentRequestButtonData
+>;
+
+export const initialPaymentRequestButtonState: PaymentRequestButtonState = {
+	ONE_OFF: {
+		buttonClicked: false,
+	},
+	REGULAR: {
+		buttonClicked: false,
+	},
+};

--- a/support-frontend/assets/helpers/redux/checkout/payment/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/reducer.ts
@@ -5,6 +5,8 @@ import type { AmazonPayState } from './amazonPay/state';
 import { directDebitReducer } from './directDebit/reducer';
 import type { DirectDebitState } from './directDebit/state';
 import { paymentMethodReducer } from './paymentMethod/reducer';
+import { paymentRequestButtonReducer } from './paymentRequestButton/reducer';
+import type { PaymentRequestButtonState } from './paymentRequestButton/state';
 import { payPalReducer } from './payPal/reducer';
 import type { PayPalState } from './payPal/state';
 import { sepaReducer } from './sepa/reducer';
@@ -19,6 +21,7 @@ export type PaymentState = {
 	sepa: SepaState;
 	payPal: PayPalState;
 	stripe: StripeCardState;
+	paymentRequestButton: PaymentRequestButtonState;
 };
 
 export const paymentReducer = combineReducers({
@@ -28,4 +31,5 @@ export const paymentReducer = combineReducers({
 	sepa: sepaReducer,
 	payPal: payPalReducer,
 	stripe: stripeCardReducer,
+	paymentRequestButton: paymentRequestButtonReducer,
 });

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.tsx
@@ -3,6 +3,7 @@ import type { ConnectedProps } from 'react-redux';
 import { connect } from 'react-redux';
 import { config } from 'helpers/contributions';
 import 'helpers/internationalisation/countryGroup';
+import { hasPaymentRequestButtonBeenClicked } from 'helpers/redux/checkout/payment/paymentRequestButton/selectors';
 import {
 	setOtherAmount,
 	setSelectedAmount,
@@ -24,11 +25,7 @@ const mapStateToProps = (state: ContributionsState) => ({
 	otherAmounts: state.page.checkoutForm.product.otherAmounts,
 	checkoutFormHasBeenSubmitted:
 		state.page.form.formData.checkoutFormHasBeenSubmitted,
-	stripePaymentRequestButtonClicked:
-		state.page.form.stripePaymentRequestButtonData.ONE_OFF
-			.stripePaymentRequestButtonClicked ||
-		state.page.form.stripePaymentRequestButtonData.REGULAR
-			.stripePaymentRequestButtonClicked,
+	stripePaymentRequestButtonClicked: hasPaymentRequestButtonBeenClicked(state),
 	localCurrencyCountry: state.common.internationalisation.localCurrencyCountry,
 	useLocalCurrency: state.common.internationalisation.useLocalCurrency,
 });

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.tsx
@@ -100,7 +100,8 @@ const mapStateToProps = (state: ContributionsState) => {
 		contributionType,
 		paymentError: state.page.form.paymentError,
 		selectedAmounts: state.page.checkoutForm.product.selectedAmounts,
-		userTypeFromIdentityResponse: state.page.form.userTypeFromIdentityResponse,
+		userTypeFromIdentityResponse:
+			state.page.checkoutForm.personalDetails.userTypeFromIdentityResponse,
 		isSignedIn: state.page.user.isSignedIn,
 		formIsValid: state.page.form.formIsValid,
 		isPostDeploymentTestUser: state.page.user.isPostDeploymentTestUser,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.tsx
@@ -165,7 +165,8 @@ const mapStateToProps = (state: ContributionsState) => {
 		currency: state.common.internationalisation.currencyId,
 		csrf: state.page.checkoutForm.csrf,
 		user: state.page.user,
-		userTypeFromIdentityResponse: state.page.form.userTypeFromIdentityResponse,
+		userTypeFromIdentityResponse:
+			state.page.checkoutForm.personalDetails.userTypeFromIdentityResponse,
 		paymentMethod: state.page.checkoutForm.payment.paymentMethod,
 		countryId: state.common.internationalisation.countryId,
 		campaignCode: state.common.referrerAcquisitionData.campaignCode,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.ts
@@ -32,7 +32,6 @@ import {
 	postRegularPaymentRequest,
 	regularPaymentFieldsFromAuthorisation,
 } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
-import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import {
 	AmazonPay,
 	DirectDebit,
@@ -85,10 +84,6 @@ import type { UserFormData } from './contributionsLandingReducer';
 
 export type Action =
 	| {
-			type: 'UPDATE_PAYMENT_METHOD';
-			paymentMethod: PaymentMethod;
-	  }
-	| {
 			type: 'UPDATE_SELECTED_EXISTING_PAYMENT_METHOD';
 			existingPaymentMethod?: RecentlySignedInExistingPaymentMethod;
 	  }
@@ -103,10 +98,6 @@ export type Action =
 	| {
 			type: 'UPDATE_USER_FORM_DATA';
 			userFormData: UserFormData;
-	  }
-	| {
-			type: 'PAYMENT_RESULT';
-			paymentResult: Promise<PaymentResult>;
 	  }
 	| {
 			type: 'PAYMENT_FAILURE';
@@ -124,14 +115,7 @@ export type Action =
 			formIsSubmittable: boolean;
 	  }
 	| {
-			type: 'SET_HAS_SEEN_DIRECT_DEBIT_THANK_YOU_COPY';
-	  }
-	| {
 			type: 'PAYMENT_SUCCESS';
-	  }
-	| {
-			type: 'SET_USER_TYPE_FROM_IDENTITY_RESPONSE';
-			userTypeFromIdentityResponse: UserTypeFromIdentityResponse;
 	  }
 	| {
 			type: 'SET_FORM_IS_VALID';
@@ -221,6 +205,9 @@ const sendFormSubmitEventForPayPalRecurring =
 		const state = getState();
 		const formSubmitParameters: FormSubmitParameters = {
 			...state.page.form,
+			paymentMethod: state.page.checkoutForm.payment.paymentMethod,
+			userTypeFromIdentityResponse:
+				state.page.checkoutForm.personalDetails.userTypeFromIdentityResponse,
 			contributionType: getContributionType(state),
 			flowPrefix: 'npf',
 			form: getForm('form--contribution'),

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.ts
@@ -41,7 +41,6 @@ import {
 	Sepa,
 	Stripe,
 } from 'helpers/forms/paymentMethods';
-import type { StripeAccount } from 'helpers/forms/stripe';
 import {
 	getStripeKey,
 	stripeAccountForContributionType,
@@ -61,6 +60,7 @@ import {
 	setAmazonPayFatalError,
 	setAmazonPayWalletIsStale,
 } from 'helpers/redux/checkout/payment/amazonPay/actions';
+import { setPaymentRequestError } from 'helpers/redux/checkout/payment/paymentRequestButton/actions';
 import {
 	setEmail,
 	setFirstName,
@@ -124,26 +124,6 @@ export type Action =
 			formIsSubmittable: boolean;
 	  }
 	| {
-			type: 'SET_STRIPE_PAYMENT_REQUEST_BUTTON_CLICKED';
-			stripeAccount: StripeAccount;
-	  }
-	| {
-			type: 'SET_STRIPE_PAYMENT_REQUEST_ERROR';
-			paymentError: ErrorReason;
-			stripeAccount: StripeAccount;
-	  }
-	| {
-			type: 'SET_STRIPE_V3_HAS_LOADED';
-	  }
-	| {
-			type: 'SET_STRIPE_CARD_FORM_COMPLETE';
-			isComplete: boolean;
-	  }
-	| {
-			type: 'SET_STRIPE_SETUP_INTENT_CLIENT_SECRET';
-			setupIntentClientSecret: string;
-	  }
-	| {
 			type: 'SET_HAS_SEEN_DIRECT_DEBIT_THANK_YOU_COPY';
 	  }
 	| {
@@ -172,22 +152,6 @@ const updateSelectedExistingPaymentMethod = (
 ): Action => ({
 	type: 'UPDATE_SELECTED_EXISTING_PAYMENT_METHOD',
 	existingPaymentMethod,
-});
-
-const setStripePaymentRequestButtonClicked = (
-	stripeAccount: StripeAccount,
-): Action => ({
-	type: 'SET_STRIPE_PAYMENT_REQUEST_BUTTON_CLICKED',
-	stripeAccount,
-});
-
-const setStripePaymentRequestButtonError = (
-	paymentError: ErrorReason,
-	stripeAccount: StripeAccount,
-): Action => ({
-	type: 'SET_STRIPE_PAYMENT_REQUEST_ERROR',
-	paymentError,
-	stripeAccount,
 });
 
 const updateUserFormData =
@@ -250,24 +214,6 @@ const setTickerGoalReached = (): Action => ({
 	type: 'SET_TICKER_GOAL_REACHED',
 	tickerGoalReached: true,
 });
-
-const setStripeCardFormComplete =
-	(isComplete: boolean) =>
-	(dispatch: Dispatch, getState: () => ContributionsState): void => {
-		setFormSubmissionDependentValue(() => ({
-			type: 'SET_STRIPE_CARD_FORM_COMPLETE',
-			isComplete,
-		}))(dispatch, getState);
-	};
-
-const setStripeSetupIntentClientSecret =
-	(setupIntentClientSecret: string) =>
-	(dispatch: Dispatch, getState: () => ContributionsState): void => {
-		setFormSubmissionDependentValue(() => ({
-			type: 'SET_STRIPE_SETUP_INTENT_CLIENT_SECRET',
-			setupIntentClientSecret,
-		}))(dispatch, getState);
-	};
 
 const sendFormSubmitEventForPayPalRecurring =
 	() =>
@@ -513,10 +459,11 @@ const onPaymentResult =
 
 					if (isPaymentRequestButton && result.error) {
 						dispatch(
-							setStripePaymentRequestButtonError(
-								result.error,
-								stripeAccountForContributionType[getContributionType(state)],
-							),
+							setPaymentRequestError({
+								error: result.error,
+								account:
+									stripeAccountForContributionType[getContributionType(state)],
+							}),
 						);
 					} else {
 						if (paymentAuthorisation.paymentMethod === 'AmazonPay') {
@@ -798,9 +745,5 @@ export {
 	getUserType,
 	setFormIsValid,
 	sendFormSubmitEventForPayPalRecurring,
-	setStripePaymentRequestButtonClicked,
-	setStripePaymentRequestButtonError,
 	setTickerGoalReached,
-	setStripeCardFormComplete,
-	setStripeSetupIntentClientSecret,
 };

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.ts
@@ -2,8 +2,6 @@
 import type { Reducer } from 'redux';
 import { combineReducers } from 'redux';
 import type { ErrorReason } from 'helpers/forms/errorReasons';
-import type { PaymentMethod } from 'helpers/forms/paymentMethods';
-import type { UserTypeFromIdentityResponse } from 'helpers/identityApis';
 import type {
 	IsoCountry,
 	StateProvince,
@@ -50,14 +48,11 @@ export interface StripeCardFormData {
 }
 
 interface FormState {
-	paymentMethod: PaymentMethod;
 	existingPaymentMethod?: RecentlySignedInExistingPaymentMethod;
 	isWaiting: boolean;
 	formData: FormData;
 	paymentComplete: boolean;
 	paymentError: ErrorReason | null;
-	hasSeenDirectDebitThankYouCopy: boolean;
-	userTypeFromIdentityResponse: UserTypeFromIdentityResponse;
 	formIsValid: boolean;
 	formIsSubmittable: boolean;
 	tickerGoalReached: boolean;
@@ -87,7 +82,6 @@ export interface State {
 function createFormReducer() {
 	// ----- Initial state ----- //
 	const initialState: FormState = {
-		paymentMethod: 'None',
 		formData: {
 			billingState: null,
 			billingCountry: null,
@@ -96,8 +90,6 @@ function createFormReducer() {
 		isWaiting: false,
 		paymentComplete: false,
 		paymentError: null,
-		hasSeenDirectDebitThankYouCopy: false,
-		userTypeFromIdentityResponse: 'noRequestSent',
 		formIsValid: true,
 		formIsSubmittable: true,
 		tickerGoalReached: false,
@@ -108,19 +100,10 @@ function createFormReducer() {
 		action: Action,
 	): FormState {
 		switch (action.type) {
-			case 'UPDATE_PAYMENT_METHOD':
-				return { ...state, paymentMethod: action.paymentMethod };
-
 			case 'UPDATE_SELECTED_EXISTING_PAYMENT_METHOD':
 				return {
 					...state,
 					existingPaymentMethod: action.existingPaymentMethod,
-				};
-
-			case 'SET_USER_TYPE_FROM_IDENTITY_RESPONSE':
-				return {
-					...state,
-					userTypeFromIdentityResponse: action.userTypeFromIdentityResponse,
 				};
 
 			case 'UPDATE_BILLING_STATE':
@@ -175,9 +158,6 @@ function createFormReducer() {
 					...state,
 					formData: { ...state.formData, checkoutFormHasBeenSubmitted: true },
 				};
-
-			case 'SET_HAS_SEEN_DIRECT_DEBIT_THANK_YOU_COPY':
-				return { ...state, hasSeenDirectDebitThankYouCopy: true };
 
 			default:
 				return state;

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.ts
@@ -54,11 +54,6 @@ interface FormState {
 	existingPaymentMethod?: RecentlySignedInExistingPaymentMethod;
 	isWaiting: boolean;
 	formData: FormData;
-	stripePaymentRequestButtonData: {
-		ONE_OFF: StripePaymentRequestButtonData;
-		REGULAR: StripePaymentRequestButtonData;
-	};
-	stripeCardFormData: StripeCardFormData;
 	paymentComplete: boolean;
 	paymentError: ErrorReason | null;
 	hasSeenDirectDebitThankYouCopy: boolean;
@@ -98,21 +93,6 @@ function createFormReducer() {
 			billingCountry: null,
 			checkoutFormHasBeenSubmitted: false,
 		},
-		stripePaymentRequestButtonData: {
-			ONE_OFF: {
-				stripePaymentRequestButtonClicked: false,
-				paymentError: null,
-			},
-			REGULAR: {
-				stripePaymentRequestButtonClicked: false,
-				paymentError: null,
-			},
-		},
-		stripeCardFormData: {
-			formComplete: false,
-			setupIntentClientSecret: null,
-			recurringRecaptchaVerified: false,
-		},
 		isWaiting: false,
 		paymentComplete: false,
 		paymentError: null,
@@ -137,24 +117,6 @@ function createFormReducer() {
 					existingPaymentMethod: action.existingPaymentMethod,
 				};
 
-			case 'SET_STRIPE_CARD_FORM_COMPLETE':
-				return {
-					...state,
-					stripeCardFormData: {
-						...state.stripeCardFormData,
-						formComplete: action.isComplete,
-					},
-				};
-
-			case 'SET_STRIPE_SETUP_INTENT_CLIENT_SECRET':
-				return {
-					...state,
-					stripeCardFormData: {
-						...state.stripeCardFormData,
-						setupIntentClientSecret: action.setupIntentClientSecret,
-					},
-				};
-
 			case 'SET_USER_TYPE_FROM_IDENTITY_RESPONSE':
 				return {
 					...state,
@@ -173,30 +135,6 @@ function createFormReducer() {
 					formData: {
 						...state.formData,
 						billingCountry: action.billingCountry,
-					},
-				};
-
-			case 'SET_STRIPE_PAYMENT_REQUEST_BUTTON_CLICKED':
-				return {
-					...state,
-					stripePaymentRequestButtonData: {
-						...state.stripePaymentRequestButtonData,
-						[action.stripeAccount]: {
-							...state.stripePaymentRequestButtonData[action.stripeAccount],
-							stripePaymentRequestButtonClicked: true,
-						},
-					},
-				};
-
-			case 'SET_STRIPE_PAYMENT_REQUEST_ERROR':
-				return {
-					...state,
-					stripePaymentRequestButtonData: {
-						...state.stripePaymentRequestButtonData,
-						[action.stripeAccount]: {
-							...state.stripePaymentRequestButtonData[action.stripeAccount],
-							paymentError: action.paymentError,
-						},
 					},
 				};
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This refactors the Redux state relating to the Payment Request Button- which allows users to pay with Apple/Google pay or other saved payment methods- into an RTK slice, and removes the old code. It also removes some other action and reducer code that is no longer being used.

[**Trello Card**](https://trello.com/c/E0iqjJ1R)

## Why are you doing this?

This is the last bit of payment-related state that needed migrating to RTK 🥳 
