### PR TITLE
Remove the print + digital component from newspaper checkout

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -441,7 +441,8 @@ function PaperCheckoutForm(props: PropTypes) {
 							</Rows>
 						</FormSection>
 					) : null}
-					{props.participations.newProduct !== 'variant' ? (
+					{props.participations.newProduct ===
+					'Hide this for the time being because it is not working correctly. We can delete it when the new prop is launched and tested' ? (
 						<AddDigiSubCta
 							digiSubPrice={expandedPricingText}
 							addDigitalSubscription={addDigitalSubscription}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
The amounts being shown for print + digital on the newspaper checkout are incorrect so we are going to switch it off. Assuming that the new proposition launches and  is successful we can delete it at a later date as it will no longer be needed.