### PR TITLE
IPv6 address issue for Sepa fix

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
@@ -93,7 +93,7 @@ case class SepaPaymentMethod(
     BankTransferAccountName: String,
     BankTransferAccountNumber: String,
     Email: String,
-    // IPAddress: String,
+    IPAddress: String,
     GatewayOptionData: GatewayOptionData,
     BankTransferType: String = "SEPA",
     `Type`: String = "BankTransfer",

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
@@ -93,7 +93,6 @@ case class SepaPaymentMethod(
     BankTransferAccountName: String,
     BankTransferAccountNumber: String,
     Email: String,
-    IPAddress: String,
     GatewayOptionData: GatewayOptionData,
     BankTransferType: String = "SEPA",
     `Type`: String = "BankTransfer",

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
@@ -93,7 +93,7 @@ case class SepaPaymentMethod(
     BankTransferAccountName: String,
     BankTransferAccountNumber: String,
     Email: String,
-    IPAddress: String,
+    // IPAddress: String,
     GatewayOptionData: GatewayOptionData,
     BankTransferType: String = "SEPA",
     `Type`: String = "BankTransfer",

--- a/support-models/src/test/scala/com/gu/support/encoding/PaymentMethodEncoderSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/encoding/PaymentMethodEncoderSpec.scala
@@ -74,8 +74,9 @@ class PaymentMethodEncoderSpec extends AsyncFlatSpec with Matchers with LazyLogg
       BankTransferAccountName = "Mr Test",
       BankTransferAccountNumber = "DE89370400440532013000",
       Email = "mr.test@guardian.co.uk",
-      IPAddress = "127.0.0.1",
-      GatewayOptionData = GatewayOptionData(List(GatewayOption(name = "UserAgent", value = "IE11"))),
+      GatewayOptionData = GatewayOptionData(
+        List(GatewayOption(name = "UserAgent", value = "IE11"), GatewayOption("IPAddress", "127.0.0.1")),
+      ),
     )
 
     val expected =
@@ -89,6 +90,10 @@ class PaymentMethodEncoderSpec extends AsyncFlatSpec with Matchers with LazyLogg
          |        {
          |            "name": "UserAgent",
          |            "value": "IE11"
+         |        },
+         |        {
+         |            "name" : "IPAddress",
+         |            "value" : "127.0.0.1"
          |        }
          |    ]
          |},

--- a/support-models/src/test/scala/com/gu/support/encoding/PaymentMethodEncoderSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/encoding/PaymentMethodEncoderSpec.scala
@@ -84,7 +84,6 @@ class PaymentMethodEncoderSpec extends AsyncFlatSpec with Matchers with LazyLogg
          |"BankTransferAccountName": "Mr Test",
          |"BankTransferAccountNumber": "DE89370400440532013000",
          |"Email": "mr.test@guardian.co.uk",
-         |"IPAddress": "127.0.0.1",
          |"GatewayOptionData": {
          |    "GatewayOption": [
          |        {

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -179,16 +179,8 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       ipAddress: String,
       userAgent: String,
   ): Future[SepaPaymentMethod] = {
-    val isIpv6Address: Boolean = ipAddress.length() > 15
-    var gatewayOptionData = List(
-      GatewayOption(
-        "UserAgent",
-        userAgent.take(255),
-      ),
-    )
-    if (isIpv6Address) {
+    if (ipAddress.length() > 15) {
       SafeLogger.warn(s"IPv6 Address: ${ipAddress} is longer than 15 characters")
-      gatewayOptionData = gatewayOptionData :+ GatewayOption("IPAddress", ipAddress)
     }
     if (userAgent.length() > 255) {
       SafeLogger.warn(s"User Agent: ${userAgent} will be truncated to 255 characters")
@@ -200,8 +192,18 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
         Country = sepa.country,
         StreetName = sepa.streetName,
         Email = user.primaryEmailAddress,
-        IPAddress = if (isIpv6Address) "0.0.0.0" else ipAddress,
-        GatewayOptionData = GatewayOptionData(gatewayOptionData),
+        GatewayOptionData = GatewayOptionData(
+          List(
+            GatewayOption(
+              "UserAgent",
+              userAgent.take(255),
+            ),
+            GatewayOption(
+              "IPAddress",
+              ipAddress,
+            ),
+          ),
+        ),
       ),
     )
   }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -76,7 +76,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       case dd: DirectDebitPaymentFields =>
         createDirectDebitPaymentMethod(dd, user)
       case sepa: SepaPaymentFields =>
-        createSepaPaymentMethod(sepa, user, ipAddress, userAgent)
+        createSepaPaymentMethod(sepa, user, "2a01:4b00:86af:3700:3c91:f0c5:1188:53c6", userAgent)
       case _: ExistingPaymentFields =>
         Future.failed(new RuntimeException("Existing payment methods should never make their way to this lambda"))
       case amazonPay: AmazonPayPaymentFields =>

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -76,7 +76,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       case dd: DirectDebitPaymentFields =>
         createDirectDebitPaymentMethod(dd, user)
       case sepa: SepaPaymentFields =>
-        createSepaPaymentMethod(sepa, user, "2a01:4b00:86af:3700:3c91:f0c5:1188:53c6", userAgent)
+        createSepaPaymentMethod(sepa, user, ipAddress, userAgent)
       case _: ExistingPaymentFields =>
         Future.failed(new RuntimeException("Existing payment methods should never make their way to this lambda"))
       case amazonPay: AmazonPayPaymentFields =>

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -200,7 +200,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
         Country = sepa.country,
         StreetName = sepa.streetName,
         Email = user.primaryEmailAddress,
-        // IPAddress = if (isIpv6Address) "0.0.0.0" else ipAddress,
+        IPAddress = if (isIpv6Address) "0.0.0.0" else ipAddress,
         GatewayOptionData = GatewayOptionData(gatewayOptionData),
       ),
     )

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -179,8 +179,15 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       ipAddress: String,
       userAgent: String,
   ): Future[SepaPaymentMethod] = {
+    var gatewayOptionData = List(
+      GatewayOption(
+        "UserAgent",
+        userAgent.take(255),
+      ),
+    )
     if (ipAddress.length() > 15) {
       SafeLogger.warn(s"IPv6 Address: ${ipAddress} is longer than 15 characters")
+      gatewayOptionData = gatewayOptionData :+ GatewayOption("IPAddress", ipAddress)
     }
     if (userAgent.length() > 255) {
       SafeLogger.warn(s"User Agent: ${userAgent} will be truncated to 255 characters")
@@ -193,14 +200,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
         StreetName = sepa.streetName,
         Email = user.primaryEmailAddress,
         IPAddress = ipAddress,
-        GatewayOptionData = GatewayOptionData(
-          List(
-            GatewayOption(
-              "UserAgent",
-              userAgent.take(255), // zuora's max length for GatewayOption values
-            ),
-          ),
-        ),
+        GatewayOptionData = GatewayOptionData(gatewayOptionData),
       ),
     )
   }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -179,13 +179,14 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       ipAddress: String,
       userAgent: String,
   ): Future[SepaPaymentMethod] = {
+    val isIpv6Address: Boolean = ipAddress.length() > 15
     var gatewayOptionData = List(
       GatewayOption(
         "UserAgent",
         userAgent.take(255),
       ),
     )
-    if (ipAddress.length() > 15) {
+    if (isIpv6Address) {
       SafeLogger.warn(s"IPv6 Address: ${ipAddress} is longer than 15 characters")
       gatewayOptionData = gatewayOptionData :+ GatewayOption("IPAddress", ipAddress)
     }
@@ -199,7 +200,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
         Country = sepa.country,
         StreetName = sepa.streetName,
         Email = user.primaryEmailAddress,
-        IPAddress = if (ipAddress.length() > 15) "" else ipAddress,
+        IPAddress = if (isIpv6Address) "0.0.0.0" else ipAddress,
         GatewayOptionData = GatewayOptionData(gatewayOptionData),
       ),
     )

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -200,7 +200,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
         Country = sepa.country,
         StreetName = sepa.streetName,
         Email = user.primaryEmailAddress,
-        IPAddress = if (isIpv6Address) "0.0.0.0" else ipAddress,
+        // IPAddress = if (isIpv6Address) "0.0.0.0" else ipAddress,
         GatewayOptionData = GatewayOptionData(gatewayOptionData),
       ),
     )

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -199,7 +199,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
         Country = sepa.country,
         StreetName = sepa.streetName,
         Email = user.primaryEmailAddress,
-        IPAddress = ipAddress,
+        IPAddress = if (ipAddress.length() > 15) "" else ipAddress,
         GatewayOptionData = GatewayOptionData(gatewayOptionData),
       ),
     )

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -76,7 +76,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       case dd: DirectDebitPaymentFields =>
         createDirectDebitPaymentMethod(dd, user)
       case sepa: SepaPaymentFields =>
-        createSepaPaymentMethod(sepa, user, ipAddress, userAgent)
+        createSepaPaymentMethod(sepa, user, "2001:db8:3333:4444:5555:6666:7777:8888", userAgent)
       case _: ExistingPaymentFields =>
         Future.failed(new RuntimeException("Existing payment methods should never make their way to this lambda"))
       case amazonPay: AmazonPayPaymentFields =>


### PR DESCRIPTION
Co-authored by: Michael Jacobson
## What are you doing in this PR?
This ia a PR for sending IPv6 address in Gateway Options to Zuora for SEPA contributions

[**Trello Card**](https://trello.com/c/32fPPSd0/414-sending-ipv6-address-in-gateway-options-to-zuora-for-sepa-contributions)

## Why are you doing this?

We had  failed support workers caused by an IPv6 address being sent to zuora for a recurring SEPA contribution. Zuora rejects IP addresses longer than 15 chars (essentially enforcing that we must use IPv4 addresses)
When taking SEPA payments for recurring Contributions we have to supply Zuora with the client's IP address when creating the subscription (the IPAddress field in the request to v1/action/subscribe).
For shorter ipv4 addresses this works fine, but for ipv6 addresses it returns an error: "The length of IP Address can not be longer than 15 characters. Zuora suggested the work around is to  add the longer IP Address into the GatewayOption field, as it should override the IPAddress field.