### PR TITLE
PR to remove the country dropdown on the Subscriptions Landing Page

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
@@ -1,5 +1,6 @@
 // ----- Imports ----- //
 import Footer from 'components/footerCompliant/Footer';
+import Header from 'components/headers/header/header';
 import headerWithCountrySwitcherContainer from 'components/headers/header/headerWithCountrySwitcher';
 import Page from 'components/page/page';
 import {
@@ -26,7 +27,7 @@ function SubscriptionsLandingPage({
 	referrerAcquisitions,
 }: SubscriptionsLandingPropTypes) {
 	const isNewProduct = participations.newProduct === 'variant';
-	const Header = headerWithCountrySwitcherContainer({
+	const HeaderWithCountrySwitcher = headerWithCountrySwitcherContainer({
 		path: '/subscribe',
 		countryGroupId,
 		listOfCountryGroups: [
@@ -41,7 +42,16 @@ function SubscriptionsLandingPage({
 		isNewProduct,
 	});
 	return (
-		<Page header={<Header />} footer={<Footer centred />}>
+		<Page
+			header={
+				isNewProduct ? (
+					<Header countryGroupId={countryGroupId} isNewProduct={isNewProduct} />
+				) : (
+					<HeaderWithCountrySwitcher />
+				)
+			}
+			footer={<Footer centred />}
+		>
 			<SubscriptionLandingContent
 				countryGroupId={countryGroupId}
 				participations={participations}


### PR DESCRIPTION

## What are you doing in this PR?
This is  a PR to remove the country dropdown on the Subscriptions Landing Page

This should be released behind the ab-newProduct 0% AB test so they're visible to the variant only. 

[**Trello Card**](https://trello.com/c/whARz87c/706-remove-the-country-dropdown-on-the-subscriptions-landing-page)

## Why are you doing this?
After removing Digital Subscriptions from sale the Subscriptions Landing Page ([Support the Guardian | Get a Subscription](https://support.theguardian.com/uk/subscribe)) will only become relevant to the UK only, as Guardian Weekly will be the only sub on offer to non-UK regions.So we have to remove the country dropdown on the Subscriptions Landing Page


## Is this an AB test?
- [ ] Yes
[**Optimize Link**](https://optimize.google.com/optimize/home)

Before Change
<img width="1717" alt="Screenshot 2022-09-22 at 14 12 54" src="https://user-images.githubusercontent.com/73653255/191756758-53620bf8-afeb-4a23-b8b5-86327b49d5cc.png">

After change
<img width="1717" alt="Screenshot 2022-09-22 at 14 13 27" src="https://user-images.githubusercontent.com/73653255/191756798-013e9c64-eeaf-4bba-b2c1-dceacaeaaaf2.png">
