### PR TITLE
Fix for Contributions checkout layout bug: SEPA on Mobile

### DIFF
--- a/support-frontend/assets/components/svgs/sepa.tsx
+++ b/support-frontend/assets/components/svgs/sepa.tsx
@@ -1,9 +1,9 @@
 export default function SvgSepa(): JSX.Element {
 	return (
 		<svg
-			width="97"
-			height="28"
-			viewBox="0 0 97 28"
+			width="40"
+			height="30"
+			viewBox="0 0 97 30"
 			xmlns="http://www.w3.org/2000/svg"
 			className="svg-sepa"
 			aria-hidden="true"


### PR DESCRIPTION

## What are you doing in this PR?
PR to fix  the Contributions checkout layout bug for SEPA on Mobile

[**Trello Card**](https://trello.com/c/ixBu5HSs/697-contributions-checkout-layout-bug-sepa-on-mobile)

## Why are you doing this?
The SEPA logo goes off screen to the right-hand side causing a horizontal scroll due to  the contributions checkout layout bug


## Is this an AB test?
- [ ] No

## Screenshots

Before Change (Bug)
 
<img width="401" alt="Screenshot 2022-09-27 at 16 42 16" src="https://user-images.githubusercontent.com/73653255/192572777-bc8dafb6-4f41-4afe-a45f-2c62f95ca076.png">

After Change 
<img width="401" alt="Screenshot 2022-09-27 at 16 44 40" src="https://user-images.githubusercontent.com/73653255/192573059-2a05ae52-08da-421e-baac-faf2e8b4cd4c.png">


