### PR TITLE
Add PriceCards component and connect to benefits checklist via Redux

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
@@ -67,15 +67,15 @@ const para = css`
 	font-weight: bold;
 `;
 
-type PropTypes = {
+export type CheckoutBenefitsListProps = {
 	title: string;
 	checkListData: CheckListData[];
 };
 
-function CheckoutBenefitsList({
+export function CheckoutBenefitsList({
 	title,
 	checkListData,
-}: PropTypes): JSX.Element {
+}: CheckoutBenefitsListProps): JSX.Element {
 	return (
 		<div css={container}>
 			<h3 css={heading}>{title}</h3>
@@ -95,5 +95,3 @@ function CheckoutBenefitsList({
 		</div>
 	);
 }
-
-export default CheckoutBenefitsList;

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -124,7 +124,7 @@ export function CheckoutBenefitsListContainer({
 
 	const thresholdPrice =
 		getThresholdPrice(countryGroupId, contributionType) ?? 1;
-	const thresholdPriceWithCurrency = simpleFormatAmount(
+	const userSelectedAmountWithCurrency = simpleFormatAmount(
 		currencies[currencyId],
 		selectedAmount,
 	);
@@ -133,7 +133,7 @@ export function CheckoutBenefitsListContainer({
 
 	return renderBenefitsList({
 		title: getBenefitsListTitle(
-			thresholdPriceWithCurrency,
+			userSelectedAmountWithCurrency,
 			contributionType,
 			selectedAmount,
 			simpleFormatAmount(currencies[currencyId], minimumContributionAmount),

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -96,8 +96,12 @@ function getBenefitsListTitle(
 
 export function CheckoutBenefitsListContainer({
 	renderBenefitsList,
-}: CheckoutBenefitsListContainerProps): JSX.Element {
+}: CheckoutBenefitsListContainerProps): JSX.Element | null {
 	const contributionType = useContributionsSelector(getContributionType);
+	if (contributionType === 'ONE_OFF') {
+		return null;
+	}
+
 	const { countryGroupId, currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
@@ -107,7 +111,7 @@ export function CheckoutBenefitsListContainer({
 		getThresholdPrice(countryGroupId, contributionType) ?? 1;
 	const thresholdPriceWithCurrency = simpleFormatAmount(
 		currencies[currencyId],
-		thresholdPrice,
+		selectedAmount,
 	);
 	const showBenefitsMessaging = thresholdPrice <= selectedAmount;
 

--- a/support-frontend/assets/components/priceCards/priceCard.tsx
+++ b/support-frontend/assets/components/priceCards/priceCard.tsx
@@ -1,0 +1,33 @@
+import { ChoiceCard } from '@guardian/source-react-components';
+
+export type PriceCardProps = {
+	amount: string;
+	amountWithCurrency: string;
+	isSelected: boolean;
+	onClick: (amount: string) => void;
+	paymentInterval?: 'month' | 'year';
+};
+
+export function PriceCard({
+	amount,
+	amountWithCurrency,
+	isSelected,
+	onClick,
+	paymentInterval,
+}: PriceCardProps): JSX.Element {
+	const labelText = paymentInterval
+		? `${amountWithCurrency} per ${paymentInterval}`
+		: amountWithCurrency;
+
+	return (
+		<ChoiceCard
+			id={`amount-${amount}`}
+			key={`amount-${amount}`}
+			name="amount"
+			onChange={() => onClick(amount)}
+			checked={isSelected}
+			value={amount}
+			label={labelText}
+		/>
+	);
+}

--- a/support-frontend/assets/components/priceCards/priceCard.tsx
+++ b/support-frontend/assets/components/priceCards/priceCard.tsx
@@ -8,7 +8,23 @@ export type PriceCardProps = {
 	isSelected: boolean;
 	onClick: (amount: string) => void;
 	paymentInterval?: PriceCardPaymentInterval;
+	alternateLabel?: string;
 };
+
+function getPriceCardLabel(
+	amountWithCurrency: string,
+	paymentInterval?: PriceCardPaymentInterval,
+	alternateLabel?: string,
+) {
+	if (alternateLabel) {
+		return alternateLabel;
+	}
+	if (paymentInterval) {
+		return `${amountWithCurrency} per ${paymentInterval}`;
+	}
+
+	return amountWithCurrency;
+}
 
 export function PriceCard({
 	amount,
@@ -16,10 +32,13 @@ export function PriceCard({
 	isSelected,
 	onClick,
 	paymentInterval,
+	alternateLabel,
 }: PriceCardProps): JSX.Element {
-	const labelText = paymentInterval
-		? `${amountWithCurrency} per ${paymentInterval}`
-		: amountWithCurrency;
+	const labelText = getPriceCardLabel(
+		amountWithCurrency,
+		paymentInterval,
+		alternateLabel,
+	);
 
 	return (
 		<ChoiceCard

--- a/support-frontend/assets/components/priceCards/priceCard.tsx
+++ b/support-frontend/assets/components/priceCards/priceCard.tsx
@@ -1,11 +1,13 @@
 import { ChoiceCard } from '@guardian/source-react-components';
 
+export type PriceCardPaymentInterval = 'month' | 'year';
+
 export type PriceCardProps = {
 	amount: string;
 	amountWithCurrency: string;
 	isSelected: boolean;
 	onClick: (amount: string) => void;
-	paymentInterval?: 'month' | 'year';
+	paymentInterval?: PriceCardPaymentInterval;
 };
 
 export function PriceCard({

--- a/support-frontend/assets/components/priceCards/priceCards.tsx
+++ b/support-frontend/assets/components/priceCards/priceCards.tsx
@@ -31,21 +31,30 @@ const mobileGrid = css`
 `;
 
 const cardsContainer = css`
-	padding-top: ${space[2]}px;
-	padding-bottom: ${space[6]}px;
+	padding: ${space[2]}px 0;
 
 	${from.mobileLandscape} {
-		padding-top: ${space[3]}px;
-		padding-bottom: 28px;
+		padding: ${space[3]}px 0;
 	}
 
 	${from.tablet} {
-		padding-top: ${space[2]}px;
-		padding-bottom: 32px;
+		padding: ${space[2]}px 0;
 	}
 
-	${from.desktop} {
-		padding-bottom: ${space[9]}px;
+	:not(:last-child) {
+		padding-bottom: ${space[6]}px;
+
+		${from.mobileLandscape} {
+			padding-bottom: 28px;
+		}
+
+		${from.tablet} {
+			padding-bottom: 32px;
+		}
+
+		${from.desktop} {
+			padding-bottom: ${space[9]}px;
+		}
 	}
 `;
 

--- a/support-frontend/assets/components/priceCards/priceCards.tsx
+++ b/support-frontend/assets/components/priceCards/priceCards.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { from, space, until } from '@guardian/source-foundations';
-import { ChoiceCard, ChoiceCardGroup } from '@guardian/source-react-components';
+import { ChoiceCardGroup } from '@guardian/source-react-components';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { currencies } from 'helpers/internationalisation/currency';
@@ -101,13 +101,12 @@ export function PriceCards({
 						paymentInterval={paymentInterval}
 					/>
 				))}
-				<ChoiceCard
-					id="amount-other"
-					key="amount-other"
-					name="amount"
-					onChange={() => onAmountChange('other')}
-					value="other"
-					label={otherAmountLabel}
+				<PriceCard
+					amount="other"
+					amountWithCurrency="other"
+					isSelected={selectedAmount === 'other'}
+					onClick={onAmountChange}
+					alternateLabel={otherAmountLabel}
 				/>
 			</>
 		</ChoiceCardGroup>

--- a/support-frontend/assets/components/priceCards/priceCards.tsx
+++ b/support-frontend/assets/components/priceCards/priceCards.tsx
@@ -71,6 +71,8 @@ export function PriceCards({
 	onAmountChange,
 	paymentInterval,
 }: PriceCardsProps): JSX.Element {
+	const otherAmountLabel = amounts.length % 2 ? 'Other' : 'Choose your amount';
+
 	return (
 		<ChoiceCardGroup
 			cssOverrides={getChoiceCardGroupStyles(amounts.length)}
@@ -96,7 +98,7 @@ export function PriceCards({
 					name="amount"
 					onChange={() => onAmountChange('other')}
 					value="other"
-					label="Choose your amount"
+					label={otherAmountLabel}
 				/>
 			</>
 		</ChoiceCardGroup>

--- a/support-frontend/assets/components/priceCards/priceCards.tsx
+++ b/support-frontend/assets/components/priceCards/priceCards.tsx
@@ -4,6 +4,7 @@ import { ChoiceCard, ChoiceCardGroup } from '@guardian/source-react-components';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { currencies } from 'helpers/internationalisation/currency';
+import type { PriceCardPaymentInterval } from './priceCard';
 import { PriceCard } from './priceCard';
 
 const cardStyles = css`
@@ -48,12 +49,19 @@ const cardsContainer = css`
 	}
 `;
 
+function getChoiceCardGroupStyles(amountOfAmounts: number) {
+	if (amountOfAmounts % 2) {
+		return [cardStyles, mobileGrid, cardsContainer];
+	}
+	return [cardStyles, otherAmountFullWidthStyles, mobileGrid, cardsContainer];
+}
+
 export type PriceCardsProps = {
 	amounts: string[];
 	selectedAmount: string;
 	currency: IsoCurrency;
 	onAmountChange: (newAmount: string) => void;
-	paymentInterval?: 'month' | 'year';
+	paymentInterval?: PriceCardPaymentInterval;
 };
 
 export function PriceCards({
@@ -65,12 +73,7 @@ export function PriceCards({
 }: PriceCardsProps): JSX.Element {
 	return (
 		<ChoiceCardGroup
-			cssOverrides={[
-				cardStyles,
-				otherAmountFullWidthStyles,
-				mobileGrid,
-				cardsContainer,
-			]}
+			cssOverrides={getChoiceCardGroupStyles(amounts.length)}
 			name="amounts"
 			columns={2}
 		>

--- a/support-frontend/assets/components/priceCards/priceCards.tsx
+++ b/support-frontend/assets/components/priceCards/priceCards.tsx
@@ -1,0 +1,42 @@
+import { css } from '@emotion/react';
+import { ChoiceCardGroup } from '@guardian/source-react-components';
+import { simpleFormatAmount } from 'helpers/forms/checkouts';
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import { currencies } from 'helpers/internationalisation/currency';
+import { PriceCard } from './priceCard';
+
+const cardStyles = css`
+	label {
+		border-radius: 10px;
+	}
+`;
+
+export type PriceCardsProps = {
+	amounts: string[];
+	selectedAmount: string;
+	currency: IsoCurrency;
+	onAmountChange: (newAmount: string) => void;
+	paymentInterval?: 'month' | 'year';
+};
+
+export function PriceCards({
+	amounts,
+	selectedAmount,
+	currency,
+	onAmountChange,
+	paymentInterval,
+}: PriceCardsProps): JSX.Element {
+	return (
+		<ChoiceCardGroup cssOverrides={cardStyles} name="amounts" columns={2}>
+			{amounts.map((amount) => (
+				<PriceCard
+					amount={amount}
+					amountWithCurrency={simpleFormatAmount(currencies[currency], amount)}
+					isSelected={amount === selectedAmount}
+					onClick={onAmountChange}
+					paymentInterval={paymentInterval}
+				/>
+			))}
+		</ChoiceCardGroup>
+	);
+}

--- a/support-frontend/assets/components/priceCards/priceCards.tsx
+++ b/support-frontend/assets/components/priceCards/priceCards.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
-import { ChoiceCardGroup } from '@guardian/source-react-components';
+import { from, space, until } from '@guardian/source-foundations';
+import { ChoiceCard, ChoiceCardGroup } from '@guardian/source-react-components';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { currencies } from 'helpers/internationalisation/currency';
@@ -8,6 +9,42 @@ import { PriceCard } from './priceCard';
 const cardStyles = css`
 	label {
 		border-radius: 10px;
+	}
+`;
+
+const otherAmountFullWidthStyles = css`
+	> div > label:last-of-type {
+		grid-column-start: 1;
+		grid-column-end: 3;
+	}
+`;
+
+const mobileGrid = css`
+	> div {
+		${until.mobileLandscape} {
+			display: grid;
+			column-gap: ${space[2]}px;
+			grid-template-columns: repeat(2, 1fr);
+		}
+	}
+`;
+
+const cardsContainer = css`
+	padding-top: ${space[2]}px;
+	padding-bottom: ${space[6]}px;
+
+	${from.mobileLandscape} {
+		padding-top: ${space[3]}px;
+		padding-bottom: 28px;
+	}
+
+	${from.tablet} {
+		padding-top: ${space[2]}px;
+		padding-bottom: 32px;
+	}
+
+	${from.desktop} {
+		padding-bottom: ${space[9]}px;
 	}
 `;
 
@@ -27,16 +64,38 @@ export function PriceCards({
 	paymentInterval,
 }: PriceCardsProps): JSX.Element {
 	return (
-		<ChoiceCardGroup cssOverrides={cardStyles} name="amounts" columns={2}>
-			{amounts.map((amount) => (
-				<PriceCard
-					amount={amount}
-					amountWithCurrency={simpleFormatAmount(currencies[currency], amount)}
-					isSelected={amount === selectedAmount}
-					onClick={onAmountChange}
-					paymentInterval={paymentInterval}
+		<ChoiceCardGroup
+			cssOverrides={[
+				cardStyles,
+				otherAmountFullWidthStyles,
+				mobileGrid,
+				cardsContainer,
+			]}
+			name="amounts"
+			columns={2}
+		>
+			<>
+				{amounts.map((amount) => (
+					<PriceCard
+						amount={amount}
+						amountWithCurrency={simpleFormatAmount(
+							currencies[currency],
+							amount,
+						)}
+						isSelected={amount === selectedAmount}
+						onClick={onAmountChange}
+						paymentInterval={paymentInterval}
+					/>
+				))}
+				<ChoiceCard
+					id="amount-other"
+					key="amount-other"
+					name="amount"
+					onChange={() => onAmountChange('other')}
+					value="other"
+					label="Choose your amount"
 				/>
-			))}
+			</>
 		</ChoiceCardGroup>
 	);
 }

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -1,0 +1,66 @@
+import type { ContributionType, SelectedAmounts } from 'helpers/contributions';
+import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
+import type { PriceCardPaymentInterval } from './priceCard';
+import type { PriceCardsProps } from './priceCards';
+
+type PriceCardsContainerProps = {
+	frequency: ContributionType;
+	renderPriceCards: (props: PriceCardsProps) => JSX.Element;
+};
+
+const contributionTypeToPaymentInterval: Partial<
+	Record<ContributionType, PriceCardPaymentInterval>
+> = {
+	MONTHLY: 'month',
+	ANNUAL: 'year',
+};
+
+function getSelectedAmount(
+	selectedAmounts: SelectedAmounts,
+	contributionType: ContributionType,
+	defaultAmount: number,
+) {
+	return selectedAmounts[contributionType] || defaultAmount;
+}
+
+export function PriceCardsContainer({
+	frequency,
+	renderPriceCards,
+}: PriceCardsContainerProps): JSX.Element {
+	const dispatch = useContributionsDispatch();
+	const currency = useContributionsSelector(
+		(state) => state.common.internationalisation.currencyId,
+	);
+	const { amounts } = useContributionsSelector((state) => state.common);
+	const { selectedAmounts } = useContributionsSelector(
+		(state) => state.page.checkoutForm.product,
+	);
+
+	const { amounts: frequencyAmounts, defaultAmount } = amounts[frequency];
+	const selectedAmount = getSelectedAmount(
+		selectedAmounts,
+		frequency,
+		defaultAmount,
+	).toString();
+
+	function onAmountChange(newAmount: string) {
+		dispatch(
+			setSelectedAmount({
+				contributionType: frequency,
+				amount: newAmount,
+			}),
+		);
+	}
+
+	return renderPriceCards({
+		currency,
+		amounts: frequencyAmounts.map((amount) => amount.toString()),
+		selectedAmount,
+		onAmountChange,
+		paymentInterval: contributionTypeToPaymentInterval[frequency],
+	});
+}

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -246,26 +246,32 @@ function getPaymentDescription(
 	return '';
 }
 
-const formatAmount = (
+const simpleFormatAmount = (
 	currency: Currency,
-	spokenCurrency: SpokenCurrency,
-	amount: number,
-	verbose: boolean,
+	amount: number | string,
 ): string => {
 	const glyph = currency.isPaddedGlyph ? ` ${currency.glyph} ` : currency.glyph;
-
-	if (verbose) {
-		return `${amount} ${
-			amount === 1 ? spokenCurrency.singular : spokenCurrency.plural
-		}`;
-	}
-
 	const amountText = /^(\d+\.\d)$/.test(`${amount}`) ? `${amount}0` : amount;
 
 	const valueWithGlyph = currency.isSuffixGlyph
 		? `${amountText}${glyph}`
 		: `${glyph}${amountText}`;
 	return valueWithGlyph.trim();
+};
+
+const formatAmount = (
+	currency: Currency,
+	spokenCurrency: SpokenCurrency,
+	amount: number,
+	verbose: boolean,
+): string => {
+	if (verbose) {
+		return `${amount} ${
+			amount === 1 ? spokenCurrency.singular : spokenCurrency.plural
+		}`;
+	}
+
+	return simpleFormatAmount(currency, amount);
 };
 
 const getContributeButtonCopy = (
@@ -369,6 +375,7 @@ function getAvailablePaymentRequestButtonPaymentMethod(
 export {
 	getContributeButtonCopy,
 	getContributeButtonCopyWithPaymentType,
+	simpleFormatAmount,
 	formatAmount,
 	getValidContributionTypesFromUrlOrElse,
 	getContributionTypeFromSession,

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/selectedAmount.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/selectedAmount.ts
@@ -8,6 +8,7 @@ export function getUserSelectedAmount(state: ContributionsState): number {
 
 	if (priceCardAmountSelected === 'other') {
 		const customAmount = otherAmounts[contributionType];
+		// TODO: what do we do when this is NaN? Do we handle elsewhere?
 		return Number.parseFloat(customAmount.amount ?? '');
 	}
 

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/selectedAmount.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/selectedAmount.ts
@@ -1,0 +1,15 @@
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
+import { getContributionType } from './productType';
+
+export function getUserSelectedAmount(state: ContributionsState): number {
+	const contributionType = getContributionType(state);
+	const { selectedAmounts, otherAmounts } = state.page.checkoutForm.product;
+	const priceCardAmountSelected = selectedAmounts[contributionType];
+
+	if (priceCardAmountSelected === 'other') {
+		const customAmount = otherAmounts[contributionType];
+		return Number.parseFloat(customAmount.amount ?? '');
+	}
+
+	return priceCardAmountSelected;
+}

--- a/support-frontend/assets/helpers/redux/commonState/selectors.ts
+++ b/support-frontend/assets/helpers/redux/commonState/selectors.ts
@@ -1,5 +1,7 @@
 import type { ContributionType } from 'helpers/contributions';
+import { config } from 'helpers/contributions';
 import { getValidContributionTypesFromUrlOrElse } from 'helpers/forms/checkouts';
+import { getContributionType } from '../checkout/product/selectors/productType';
 import type { ContributionsState } from '../contributionsStore';
 
 export function getDefaultContributionType(
@@ -15,4 +17,19 @@ export function getDefaultContributionType(
 		contribTypesForLocale[0];
 
 	return defaultContributionType.contributionType;
+}
+
+export function getMinimumContributionAmount(
+	state: ContributionsState,
+): number {
+	const { countryGroupId, useLocalCurrency, localCurrencyCountry } =
+		state.common.internationalisation;
+	const contributionType = getContributionType(state);
+
+	const { min } =
+		useLocalCurrency && localCurrencyCountry && contributionType === 'ONE_OFF'
+			? localCurrencyCountry.config[contributionType]
+			: config[countryGroupId][contributionType];
+
+	return min;
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -1,0 +1,34 @@
+import { CheckoutBenefitsList } from 'components/checkoutBenefits/checkoutBenefitsList';
+import { CheckoutBenefitsListContainer } from 'components/checkoutBenefits/checkoutBenefitsListContainer';
+import { BoxContents } from 'components/checkoutBox/checkoutBox';
+import { PaymentFrequencyTabsContainer } from 'components/paymentFrequencyTabs/paymentFrequencyTabsContainer';
+import { PaymentFrequencyTabs } from 'components/paymentFrequencyTabs/paymentFrequenncyTabs';
+import { PriceCards } from 'components/priceCards/priceCards';
+import { PriceCardsContainer } from 'components/priceCards/priceCardsContainer';
+
+export function AmountAndBenefits(): JSX.Element {
+	return (
+		<PaymentFrequencyTabsContainer
+			render={(tabProps) => (
+				<PaymentFrequencyTabs
+					{...tabProps}
+					renderTabContent={(tabId) => (
+						<BoxContents>
+							<PriceCardsContainer
+								frequency={tabId}
+								renderPriceCards={(priceCardProps) => (
+									<PriceCards {...priceCardProps} />
+								)}
+							/>
+							<CheckoutBenefitsListContainer
+								renderBenefitsList={(benefitsListProps) => (
+									<CheckoutBenefitsList {...benefitsListProps} />
+								)}
+							/>
+						</BoxContents>
+					)}
+				/>
+			)}
+		/>
+	);
+}

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -5,8 +5,7 @@ import {
 	FooterLinks,
 	FooterWithContents,
 } from '@guardian/source-react-components-development-kitchen';
-import CheckoutBenefitsList from 'components/checkoutBenefits/checkoutBenefitsList';
-import { checkListData } from 'components/checkoutBenefits/checkoutBenefitsListContainer';
+import { CheckoutBenefitsListContainer } from 'components/checkoutBenefits/checkoutBenefitsListContainer';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { CheckoutHeading } from 'components/checkoutHeading/checkoutHeading';
 import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
@@ -29,6 +28,7 @@ import {
 	NZDCountries,
 	UnitedStates,
 } from 'helpers/internationalisation/countryGroup';
+import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { LandingPageHeading } from './components/landingPageHeading';
 import { PatronsMessage } from './components/patronsMessage';
 
@@ -55,21 +55,24 @@ const largeDemoBox = css`
 	min-height: 400px;
 `;
 
-const countrySwitcherProps: CountryGroupSwitcherProps = {
-	countryGroupIds: [
-		GBPCountries,
-		UnitedStates,
-		AUDCountries,
-		EURCountries,
-		NZDCountries,
-		Canada,
-		International,
-	],
-	selectedCountryGroup: GBPCountries,
-	subPath: '/contribute',
-};
-
 export function SupporterPlusLandingPage(): JSX.Element {
+	const selectedCountryGroup = useContributionsSelector(
+		(state) => state.common.internationalisation.countryGroupId,
+	);
+
+	const countrySwitcherProps: CountryGroupSwitcherProps = {
+		countryGroupIds: [
+			GBPCountries,
+			UnitedStates,
+			AUDCountries,
+			EURCountries,
+			NZDCountries,
+			Canada,
+			International,
+		],
+		selectedCountryGroup,
+		subPath: '/contribute',
+	};
 	const heading = <LandingPageHeading />;
 
 	return (
@@ -115,9 +118,8 @@ export function SupporterPlusLandingPage(): JSX.Element {
 														<PriceCards {...props} />
 													)}
 												/>
-												<CheckoutBenefitsList
-													title="For £12 per month, you'll unlock"
-													checkListData={checkListData(true)}
+												<CheckoutBenefitsListContainer
+													showBenefitsMessaging={true}
 												/>
 											</BoxContents>
 										)}

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -5,7 +5,6 @@ import {
 	FooterLinks,
 	FooterWithContents,
 } from '@guardian/source-react-components-development-kitchen';
-import { CheckoutBenefitsListContainer } from 'components/checkoutBenefits/checkoutBenefitsListContainer';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { CheckoutHeading } from 'components/checkoutHeading/checkoutHeading';
 import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
@@ -15,10 +14,6 @@ import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { Container } from 'components/layout/container';
 import Nav from 'components/nav/nav';
 import { PageScaffold } from 'components/page/pageScaffold';
-import { PaymentFrequencyTabsContainer } from 'components/paymentFrequencyTabs/paymentFrequencyTabsContainer';
-import { PaymentFrequencyTabs } from 'components/paymentFrequencyTabs/paymentFrequenncyTabs';
-import { PriceCards } from 'components/priceCards/priceCards';
-import { PriceCardsContainer } from 'components/priceCards/priceCardsContainer';
 import {
 	AUDCountries,
 	Canada,
@@ -31,6 +26,7 @@ import {
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { LandingPageHeading } from './components/landingPageHeading';
 import { PatronsMessage } from './components/patronsMessage';
+import { AmountAndBenefits } from './formSections/amountAndBenefits';
 
 const checkoutContainer = css`
 	position: relative;
@@ -106,26 +102,7 @@ export function SupporterPlusLandingPage(): JSX.Element {
 					<Column span={[1, 8, 7]}>
 						<Hide from="desktop">{heading}</Hide>
 						<Box>
-							<PaymentFrequencyTabsContainer
-								render={(tabProps) => (
-									<PaymentFrequencyTabs
-										{...tabProps}
-										renderTabContent={(tabId) => (
-											<BoxContents>
-												<PriceCardsContainer
-													frequency={tabId}
-													renderPriceCards={(props) => (
-														<PriceCards {...props} />
-													)}
-												/>
-												<CheckoutBenefitsListContainer
-													showBenefitsMessaging={true}
-												/>
-											</BoxContents>
-										)}
-									/>
-								)}
-							/>
+							<AmountAndBenefits />
 						</Box>
 						<Box>
 							<BoxContents>

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -18,6 +18,8 @@ import Nav from 'components/nav/nav';
 import { PageScaffold } from 'components/page/pageScaffold';
 import { PaymentFrequencyTabsContainer } from 'components/paymentFrequencyTabs/paymentFrequencyTabsContainer';
 import { PaymentFrequencyTabs } from 'components/paymentFrequencyTabs/paymentFrequenncyTabs';
+import { PriceCards } from 'components/priceCards/priceCards';
+import { PriceCardsContainer } from 'components/priceCards/priceCardsContainer';
 import {
 	AUDCountries,
 	Canada,
@@ -49,10 +51,6 @@ const checkoutContainer = css`
 `;
 
 // TODO: these are purely for demo purposes, delete once the boxes have real content in
-const smallDemoBox = css`
-	min-height: 200px;
-`;
-
 const largeDemoBox = css`
 	min-height: 400px;
 `;
@@ -111,7 +109,12 @@ export function SupporterPlusLandingPage(): JSX.Element {
 										{...tabProps}
 										renderTabContent={(tabId) => (
 											<BoxContents>
-												<p css={smallDemoBox}>Amount selection for {tabId}</p>
+												<PriceCardsContainer
+													frequency={tabId}
+													renderPriceCards={(props) => (
+														<PriceCards {...props} />
+													)}
+												/>
 												<CheckoutBenefitsList
 													title="For £12 per month, you'll unlock"
 													checkListData={checkListData(true)}

--- a/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
@@ -36,10 +36,10 @@ function Template(args: {
 	higherTier: boolean;
 	lowerTier: boolean;
 }): JSX.Element {
-	const { higherTier, lowerTier } = args;
+	const { title, higherTier, lowerTier } = args;
 	return (
 		<CheckoutBenefitsList
-			title={args.title}
+			title={title}
 			checkListData={checkListData({ lowerTier, higherTier })}
 		/>
 	);

--- a/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
@@ -31,19 +31,34 @@ export default {
 	],
 };
 
-export function BenefitsList(args: {
+function Template(args: {
 	title: string;
-	showBenefitsMessaging: boolean;
+	higherTier: boolean;
+	lowerTier: boolean;
 }): JSX.Element {
+	const { higherTier, lowerTier } = args;
 	return (
 		<CheckoutBenefitsList
 			title={args.title}
-			checkListData={checkListData(args.showBenefitsMessaging)}
+			checkListData={checkListData({ lowerTier, higherTier })}
 		/>
 	);
 }
 
-BenefitsList.args = {
+Template.args = {} as Record<string, unknown>;
+
+export const AllBenefitsUnlocked = Template.bind({});
+
+AllBenefitsUnlocked.args = {
 	title: "For £12 per month, you'll unlock",
-	showBenefitsMessaging: true,
+	higherTier: true,
+	lowerTier: true,
+};
+
+export const LowerTierUnlocked = Template.bind({});
+
+LowerTierUnlocked.args = {
+	title: "For £5 per month, you'll unlock",
+	higherTier: false,
+	lowerTier: true,
 };

--- a/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
@@ -1,13 +1,13 @@
 import { css } from '@emotion/react';
 import { neutral } from '@guardian/source-foundations';
 import { Column, Columns, Container } from '@guardian/source-react-components';
-import CheckoutBenefitsListComponent from 'components/checkoutBenefits/checkoutBenefitsList';
+import { CheckoutBenefitsList } from 'components/checkoutBenefits/checkoutBenefitsList';
 import { checkListData } from 'components/checkoutBenefits/checkoutBenefitsListContainer';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 
 export default {
 	title: 'Checkout Layout/Benefits List',
-	component: CheckoutBenefitsListComponent,
+	component: CheckoutBenefitsList,
 	decorators: [
 		(Story: React.FC): JSX.Element => (
 			<Container backgroundColor={neutral[97]}>
@@ -36,7 +36,7 @@ export function BenefitsList(args: {
 	showBenefitsMessaging: boolean;
 }): JSX.Element {
 	return (
-		<CheckoutBenefitsListComponent
+		<CheckoutBenefitsList
 			title={args.title}
 			checkListData={checkListData(args.showBenefitsMessaging)}
 		/>

--- a/support-frontend/stories/checkouts/PriceCard.stories.tsx
+++ b/support-frontend/stories/checkouts/PriceCard.stories.tsx
@@ -1,0 +1,37 @@
+import type { PriceCardProps } from 'components/priceCards/priceCard';
+import { PriceCard } from 'components/priceCards/priceCard';
+import { withCenterAlignment } from '../../.storybook/decorators/withCenterAlignment';
+import { withSourceReset } from '../../.storybook/decorators/withSourceReset';
+
+export default {
+	title: 'Checkouts/Price Card',
+	component: PriceCard,
+	argTypes: {
+		onClick: { action: 'card clicked' },
+		paymentInterval: { control: { type: 'radio', options: ['month', 'year'] } },
+	},
+	decorators: [withCenterAlignment, withSourceReset],
+};
+
+function Template(args: PriceCardProps) {
+	return <PriceCard {...args} />;
+}
+
+Template.args = {} as Omit<PriceCardProps, 'onClick'>;
+
+export const WithFrequency = Template.bind({});
+
+WithFrequency.args = {
+	amount: '10',
+	amountWithCurrency: '£10',
+	isSelected: true,
+	paymentInterval: 'month',
+};
+
+export const WithoutFrequency = Template.bind({});
+
+WithoutFrequency.args = {
+	amount: '30',
+	amountWithCurrency: '$30',
+	isSelected: false,
+};

--- a/support-frontend/stories/checkouts/PriceCards.stories.tsx
+++ b/support-frontend/stories/checkouts/PriceCards.stories.tsx
@@ -74,3 +74,12 @@ RecurringContribution.args = {
 	currency: 'GBP',
 	paymentInterval: 'month',
 };
+
+export const OddAmountOfOptions = Template.bind({});
+
+OddAmountOfOptions.args = {
+	amounts: ['5', '12', '15', '20', '30'],
+	selectedAmount: '12',
+	currency: 'GBP',
+	paymentInterval: 'year',
+};

--- a/support-frontend/stories/checkouts/PriceCards.stories.tsx
+++ b/support-frontend/stories/checkouts/PriceCards.stories.tsx
@@ -1,0 +1,76 @@
+import { css } from '@emotion/react';
+import { Column, Columns } from '@guardian/source-react-components';
+import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
+import type { PriceCardsProps } from 'components/priceCards/priceCards';
+import { PriceCards } from 'components/priceCards/priceCards';
+import { withCenterAlignment } from '../../.storybook/decorators/withCenterAlignment';
+import { withSourceReset } from '../../.storybook/decorators/withSourceReset';
+
+export default {
+	title: 'Checkouts/Price Cards',
+	component: PriceCards,
+	argTypes: {
+		onAmountChange: { action: 'amount changed' },
+		currency: {
+			control: {
+				type: 'select',
+				options: [
+					'GBP',
+					'USD',
+					'AUD',
+					'EUR',
+					'NZD',
+					'CAD',
+					'SEK',
+					'CHF',
+					'NOK',
+					'DKK',
+				],
+			},
+		},
+		paymentInterval: { control: { type: 'radio', options: ['month', 'year'] } },
+	},
+	decorators: [
+		(Story: React.FC): JSX.Element => (
+			<Columns
+				collapseUntil="tablet"
+				cssOverrides={css`
+					width: 100%;
+				`}
+			>
+				<Column span={[1, 8, 7]}>
+					<Box>
+						<BoxContents>
+							<Story />
+						</BoxContents>
+					</Box>
+				</Column>
+			</Columns>
+		),
+		withCenterAlignment,
+		withSourceReset,
+	],
+};
+
+function Template(args: PriceCardsProps) {
+	return <PriceCards {...args} />;
+}
+
+Template.args = {} as Omit<PriceCardsProps, 'onAmountChange'>;
+
+export const SingleContribution = Template.bind({});
+
+SingleContribution.args = {
+	amounts: ['5', '12', '15', '20'],
+	selectedAmount: '12',
+	currency: 'GBP',
+};
+
+export const RecurringContribution = Template.bind({});
+
+RecurringContribution.args = {
+	amounts: ['5', '12', '15', '20'],
+	selectedAmount: '12',
+	currency: 'GBP',
+	paymentInterval: 'month',
+};


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds the component for selecting the user's contribution amount, along with the logic to manage updating Redux and thus feeding back into the state of the benefits checklist component.

There are two outstanding aspects of this work that still need to be resolved:

- The 'greyed out' text in the benefits checklist [has insufficient colour contrast against a white background](https://www.whocanuse.com/?bg=ffffff&fg=999999)
- We don't have precise wording for the benefits list title when the user chooses to contribute a custom amount and the amount of their contribution is initially nothing.

[**Trello Card**](https://trello.com/c/NYI2pZTN)

## Why are you doing this?

This is a core component for the new product checkout.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

### Mobile - Galaxy S20, Chrome

![Screenshot 2022-10-03 at 14 26 35](https://user-images.githubusercontent.com/29146931/193590184-2ebba18f-7d1e-4752-bd9b-274a9eec4c63.png)

### Tablet - iPad 8th gen, Safari

![Screenshot 2022-10-03 at 14 27 58](https://user-images.githubusercontent.com/29146931/193590249-306c32ce-fa71-4387-99b8-f652118d37a3.png)

### Desktop - macOS, Firefox

![Screenshot 2022-10-03 at 14-18-50 Support the Guardian Make a Contribution](https://user-images.githubusercontent.com/29146931/193590316-9b571429-5ba4-4ad7-9fea-157e261ce8f1.png)

![Screenshot 2022-10-03 at 14-19-09 Support the Guardian Make a Contribution](https://user-images.githubusercontent.com/29146931/193590324-ff3782d2-4a93-4e10-ae2e-508e6bbe410e.png)

![Screenshot 2022-10-03 at 14-19-22 Support the Guardian Make a Contribution](https://user-images.githubusercontent.com/29146931/193590373-01cfa821-45a0-4604-9a82-1d02e3d71ac8.png)
