### PR TITLE
Set the correct invoice template ID when creating a subscription in Zuora

### DIFF
--- a/support-config/src/main/resources/touchpoint.PROD.conf
+++ b/support-config/src/main/resources/touchpoint.PROD.conf
@@ -35,8 +35,8 @@ touchpoint.backend.environments {
         password = ""
       }
       invoiceTemplateIds {
-        default = "2c92a0fb49377eae014951ca848e074b"
-        au = "2c92a0fd5ecce80c015ee71028643020"
+        defaultTemplateId = "2c92a0fb49377eae014951ca848e074b"
+        auTemplateId = "2c92a0fd5ecce80c015ee71028643020"
       }
       contribution {
         monthly {

--- a/support-config/src/main/resources/touchpoint.PROD.conf
+++ b/support-config/src/main/resources/touchpoint.PROD.conf
@@ -34,6 +34,10 @@ touchpoint.backend.environments {
         username = ""
         password = ""
       }
+      invoiceTemplateIds {
+        default = "2c92a0fb49377eae014951ca848e074b"
+        au = "2c92a0fd5ecce80c015ee71028643020"
+      }
       contribution {
         monthly {
           productRatePlanId = "2c92a0fc5aacfadd015ad24db4ff5e97"

--- a/support-config/src/main/resources/touchpoint.SANDBOX.conf
+++ b/support-config/src/main/resources/touchpoint.SANDBOX.conf
@@ -35,8 +35,8 @@ touchpoint.backend.environments {
         password = ""
       }
       invoiceTemplateIds {
-        default = "2c92c0f849369b8801493bf7db7e450e"
-        au = "2c92c0f85ecc47e5015ee7360d602757"
+        defaultTemplateId = "2c92c0f849369b8801493bf7db7e450e"
+        auTemplateId = "2c92c0f85ecc47e5015ee7360d602757"
       }
       contribution {
         monthly {

--- a/support-config/src/main/resources/touchpoint.SANDBOX.conf
+++ b/support-config/src/main/resources/touchpoint.SANDBOX.conf
@@ -34,6 +34,10 @@ touchpoint.backend.environments {
         username = ""
         password = ""
       }
+      invoiceTemplateIds {
+        default = "2c92c0f849369b8801493bf7db7e450e"
+        au = "2c92c0f85ecc47e5015ee7360d602757"
+      }
       contribution {
         monthly {
           productRatePlanId = "2c92c0f85a6b134e015a7fcd9f0c7855"

--- a/support-config/src/main/resources/touchpoint.UAT.conf
+++ b/support-config/src/main/resources/touchpoint.UAT.conf
@@ -35,8 +35,8 @@ touchpoint.backend.environments {
         password = ""
       }
       invoiceTemplateIds {
-        default = "2c92c0f948bfe18b0148e642981d3969"
-        au = "2c92c0f95ecc52d7015ee7348b9d4f61"
+        defaultTemplateId = "2c92c0f948bfe18b0148e642981d3969"
+        auTemplateId = "2c92c0f95ecc52d7015ee7348b9d4f61"
       }
       contribution {
         monthly {

--- a/support-config/src/main/resources/touchpoint.UAT.conf
+++ b/support-config/src/main/resources/touchpoint.UAT.conf
@@ -34,6 +34,10 @@ touchpoint.backend.environments {
         username = ""
         password = ""
       }
+      invoiceTemplateIds {
+        default = "2c92c0f948bfe18b0148e642981d3969"
+        au = "2c92c0f95ecc52d7015ee7348b9d4f61"
+      }
       contribution {
         monthly {
           productRatePlanId = "2c92c0f85ab269be015acd9d014549b7"

--- a/support-config/src/main/scala/com/gu/support/config/ZuoraConfigProvider.scala
+++ b/support-config/src/main/scala/com/gu/support/config/ZuoraConfigProvider.scala
@@ -76,7 +76,7 @@ class ZuoraConfigProvider(config: Config, defaultStage: Stage)
   )
 
   private def invoiceTemplatesFromConfig(config: Config) = ZuoraInvoiceTemplatesConfig(
-    defaultTemplateId = config.getString("default"),
-    auTemplateId = config.getString("au"),
+    defaultTemplateId = config.getString("defaultTemplateId"),
+    auTemplateId = config.getString("auTemplateId"),
   )
 }

--- a/support-config/src/main/scala/com/gu/support/config/ZuoraConfigProvider.scala
+++ b/support-config/src/main/scala/com/gu/support/config/ZuoraConfigProvider.scala
@@ -21,10 +21,16 @@ case class ZuoraSupporterPlusConfig(
     annualChargeId: String,
 )
 
+case class ZuoraInvoiceTemplatesConfig(
+    auTemplateId: String,
+    defaultTemplateId: String,
+)
+
 case class ZuoraConfig(
     url: String,
     username: String,
     password: String,
+    invoiceTemplateIds: ZuoraInvoiceTemplatesConfig,
     monthlyContribution: ZuoraContributionConfig,
     annualContribution: ZuoraContributionConfig,
     digitalPack: ZuoraDigitalPackConfig,
@@ -45,6 +51,7 @@ class ZuoraConfigProvider(config: Config, defaultStage: Stage)
     url = config.getString(s"zuora.api.url"),
     username = config.getString(s"zuora.api.username"),
     password = config.getString(s"zuora.api.password"),
+    invoiceTemplateIds = invoiceTemplatesFromConfig(config.getConfig("zuora.invoiceTemplateIds")),
     monthlyContribution = contributionFromConfig(config.getConfig("zuora.contribution.monthly")),
     annualContribution = contributionFromConfig(config.getConfig("zuora.contribution.annual")),
     digitalPack = digitalPackFromConfig(config.getConfig("zuora.digitalpack")),
@@ -66,5 +73,10 @@ class ZuoraConfigProvider(config: Config, defaultStage: Stage)
   private def supporterPlusFromConfig(config: Config) = ZuoraSupporterPlusConfig(
     monthlyChargeId = config.getString("monthly.productRatePlanChargeId"),
     annualChargeId = config.getString("annual.productRatePlanChargeId"),
+  )
+
+  private def invoiceTemplatesFromConfig(config: Config) = ZuoraInvoiceTemplatesConfig(
+    defaultTemplateId = config.getString("default"),
+    auTemplateId = config.getString("au"),
   )
 }

--- a/support-models/src/main/scala/com/gu/support/zuora/api/Account.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/Account.scala
@@ -26,4 +26,5 @@ case class Account(
     paymentTerm: String = "Due Upon Receipt",
     bcdSettingOption: String = "AutoSet",
     batch: String = "Batch1",
+    invoiceTemplateId: String,
 )

--- a/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
@@ -1,6 +1,6 @@
 package com.gu.support.zuora.api
 
-import com.gu.i18n.Currency.GBP
+import com.gu.i18n.Currency.{AUD, GBP}
 import com.gu.i18n.{Country, Currency}
 import com.gu.support.workers.{
   CreditCardReferenceTransaction,
@@ -113,13 +113,28 @@ object Fixtures {
       currency: Currency = GBP,
       paymentGateway: PaymentGateway = StripeGatewayDefault,
   ): Account = Account(
-    salesforceAccountId,
-    currency,
-    salesforceAccountId,
-    salesforceId,
-    identityId,
-    Some(paymentGateway),
-    "createdreqid_hi",
+    name = salesforceAccountId,
+    currency = currency,
+    crmId = salesforceAccountId,
+    sfContactId__c = salesforceId,
+    identityId__c = identityId,
+    paymentGateway = Some(paymentGateway),
+    createdRequestId__c = "createdreqid_hi",
+    invoiceTemplateId = "defaultInvoiceTemplateId",
+  )
+
+  def auAccount(
+      currency: Currency = AUD,
+      paymentGateway: PaymentGateway = StripeGatewayAUD,
+  ): Account = Account(
+    name = salesforceAccountId,
+    currency = currency,
+    crmId = salesforceAccountId,
+    sfContactId__c = salesforceId,
+    identityId__c = identityId,
+    paymentGateway = Some(paymentGateway),
+    createdRequestId__c = "createdreqid_hi",
+    invoiceTemplateId = "auInvoiceTemplateId",
   )
 
   val deliveryInstructions = "Leave behind the dustbin"
@@ -220,10 +235,10 @@ object Fixtures {
         "AutoPay" : true,
         "PaymentTerm" : "Due Upon Receipt",
         "BcdSettingOption" : "AutoSet",
-        "Batch" : "Batch1"
+        "Batch" : "Batch1",
+        "InvoiceTemplateId" : "anInvoiceTemplateId"
       }
     """
-
   val subscriptionJson =
     s"""
       {

--- a/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
@@ -18,12 +18,20 @@ import org.scalatest.flatspec.AsyncFlatSpec
 class SerialisationSpec extends AsyncFlatSpec with SerialisationTestHelpers with LazyLogging with Inspectors {
 
   "Account" should "serialise to correct json" in {
-    val json = account(GBP).asJson
+    val json = account().asJson
     (json \\ "Currency").head.asString should be(Some("GBP"))
     (json \\ "PaymentGateway").head.asString should be(Some("Stripe Gateway 1"))
+    (json \\ "InvoiceTemplateId").head.asString should be(Some("defaultInvoiceTemplateId"))
   }
 
-  it should "deserialise correctly" in {
+  "AUAccount" should "serialise to correct json" in {
+    val json = auAccount().asJson
+    (json \\ "Currency").head.asString should be(Some("AUD"))
+    (json \\ "PaymentGateway").head.asString should be(Some("Stripe Gateway GNM Membership AUS"))
+    (json \\ "InvoiceTemplateId").head.asString should be(Some("auInvoiceTemplateId"))
+  }
+
+  "InternationalAccount" should "deserialise correctly" in {
     testDecoding[Account](s"$accountJson")
   }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -94,6 +94,7 @@ class ZuoraProductHandlers(services: Services, state: CreateZuoraSubscriptionSta
     state.requestId,
     state.user,
     state.product.currency,
+    services.config.zuoraConfigProvider.get(isTestUser).invoiceTemplateIds,
   )
   lazy val zuoraDigitalSubscriptionGiftPurchaseHandler = new ZuoraDigitalSubscriptionGiftPurchaseHandler(
     zuoraSubscriptionCreator,

--- a/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
@@ -2,9 +2,10 @@ package com.gu.support.workers
 
 import com.gu.helpers
 import com.gu.helpers.DateGenerator
+import com.gu.i18n.Country.Australia
 import com.gu.i18n.Currency.GBP
 import com.gu.i18n.{Country, Currency}
-import com.gu.support.config.{TouchPointEnvironments, ZuoraDigitalPackConfig}
+import com.gu.support.config.{TouchPointEnvironments, ZuoraDigitalPackConfig, ZuoraInvoiceTemplatesConfig}
 import com.gu.support.redemption.corporate.DynamoLookup.{DynamoBoolean, DynamoString}
 import com.gu.support.redemption.corporate.DynamoUpdate.DynamoFieldUpdate
 import com.gu.support.redemption.corporate.{
@@ -45,6 +46,11 @@ import java.util.UUID
 import scala.concurrent.Future
 
 class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
+
+  val invoiceTemplateIds = ZuoraInvoiceTemplatesConfig(
+    auTemplateId = "auInvoiceTemplateId",
+    defaultTemplateId = "defaultInvoiceTemplateId",
+  )
 
   it should "create a Digital Pack corporate subscription" in {
 
@@ -117,6 +123,7 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
             Address(None, None, None, None, None, Country.UK),
           ),
           GBP,
+          invoiceTemplateIds,
         ),
       ),
       user =
@@ -202,6 +209,7 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
             Address(None, None, None, None, None, Country.UK),
           ),
           Currency.GBP,
+          invoiceTemplateIds,
         ),
       ),
       user =

--- a/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -30,13 +30,14 @@ object Fixtures {
       currency: Currency = GBP,
       paymentGateway: PaymentGateway = StripeGatewayDefault,
   ): Account = Account(
-    salesforceAccountId,
-    currency,
-    salesforceAccountId,
-    salesforceId,
-    identityId,
-    Some(paymentGateway),
-    "createdreqid_hi",
+    name = salesforceAccountId,
+    currency = currency,
+    crmId = salesforceAccountId,
+    sfContactId__c = salesforceId,
+    identityId__c = identityId,
+    paymentGateway = Some(paymentGateway),
+    createdRequestId__c = "createdreqid_hi",
+    invoiceTemplateId = "defaultInvoiceTemplateId",
   )
 
   val contactDetails = ContactDetails("Test-FirstName", "Test-LastName", Some("test@thegulocal.com"), Country.UK)

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
@@ -2,11 +2,12 @@ package com.gu.zuora.subscriptionBuilders
 
 import com.gu.helpers.DateGenerator
 import com.gu.i18n.Country
+import com.gu.i18n.Country.Australia
 import com.gu.i18n.Currency.GBP
 import com.gu.salesforce.Salesforce.SalesforceContactRecords
 import com.gu.support.acquisitions.{AbTest, AcquisitionData, OphanIds}
 import com.gu.support.config.TouchPointEnvironments.SANDBOX
-import com.gu.support.config.{TouchPointEnvironments, ZuoraDigitalPackConfig}
+import com.gu.support.config.{TouchPointEnvironments, ZuoraDigitalPackConfig, ZuoraInvoiceTemplatesConfig}
 import com.gu.support.promotions.{Promotion, PromotionService, PromotionWithCode}
 import com.gu.support.redemption.corporate.{CorporateCodeValidator, DynamoLookup}
 import com.gu.support.redemption.gifting.GiftCodeValidator
@@ -219,6 +220,10 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
   lazy val promotionService = mock[PromotionService]
   lazy val saleDate = new LocalDate(2020, 6, 5)
   lazy val giftCodeGeneratorService = new GiftCodeGeneratorService
+  lazy val invoiceTemplateIds = ZuoraInvoiceTemplatesConfig(
+    auTemplateId = "auInvoiceTemplateId",
+    defaultTemplateId = "defaultInvoiceTemplateId",
+  )
 
   val testCode = "test-code-123"
 
@@ -239,6 +244,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
       UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
       User("1234", "hi@thegulocal.com", None, "bob", "smith", Address(None, None, None, None, None, Country.UK)),
       GBP,
+      invoiceTemplateIds,
     ),
   )
 
@@ -263,6 +269,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
       UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
       User("1234", "hi@thegulocal.com", None, "bob", "smith", Address(None, None, None, None, None, Country.UK)),
       GBP,
+      invoiceTemplateIds,
     ),
   )
 
@@ -275,6 +282,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
       UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
       User("1234", "hi@thegulocal.com", None, "bob", "smith", Address(None, None, None, None, None, Country.UK)),
       GBP,
+      invoiceTemplateIds,
     ),
   )
 

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/GuardianWeeklySubscriptionBuildersSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/GuardianWeeklySubscriptionBuildersSpec.scala
@@ -2,10 +2,12 @@ package com.gu.zuora.subscriptionBuilders
 
 import com.gu.helpers.DateGenerator
 import com.gu.i18n.Country
+import com.gu.i18n.Country.Australia
 import com.gu.i18n.Currency.GBP
 import com.gu.salesforce.Salesforce.SalesforceContactRecords
 import com.gu.support.catalog.Domestic
 import com.gu.support.config.TouchPointEnvironments.SANDBOX
+import com.gu.support.config.ZuoraInvoiceTemplatesConfig
 import com.gu.support.promotions.{Promotion, PromotionService, PromotionWithCode}
 import com.gu.support.workers.GiftRecipient.WeeklyGiftRecipient
 import com.gu.support.workers._
@@ -136,6 +138,10 @@ class GuardianWeeklySubscriptionBuildersSpec extends AnyFlatSpec with Matchers {
   lazy val promotionService = mock[PromotionService]
   lazy val saleDate = new LocalDate(2019, 10, 24)
   lazy val firstDeliveryDate = saleDate.plusDays(3)
+  lazy val invoiceTemplateIds = ZuoraInvoiceTemplatesConfig(
+    auTemplateId = "auInvoiceTemplateId",
+    defaultTemplateId = "defaultInvoiceTemplateId",
+  )
 
   lazy val subscribeItemBuilder = new SubscribeItemBuilder(
     UUID.randomUUID(),
@@ -149,6 +155,7 @@ class GuardianWeeklySubscriptionBuildersSpec extends AnyFlatSpec with Matchers {
       Some(Address(None, None, None, None, None, Country.UK)),
     ),
     GBP,
+    invoiceTemplateIds,
   )
 
   lazy val gift: SubscriptionData = new GuardianWeeklySubscriptionBuilder(


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Inserting the correct invoice template ID, based on the sold-to country and currency, into every account creation API call to Zuora.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com/c/LFp15ME6)

## Why are you doing this?
This change replicates, and improves upon, what used to happen in Membership Common (https://github.com/guardian/membership-common/pull/539). It ensures any new customer having their product supplied to Australia, paying AUD, who wants to download (within Manage which calls https://github.com/guardian/invoicing-api/tree/main/src/main/scala/com/gu/invoicing/pdf) their invoice from Zuora, has the correct company name, and correct layout for GST (Goods and Sales Tax), rather than showing the UK company name and VAT.

There will also be some follow-up changes to:

1. Backfill
2. Create a Zuora Workflow to ensure this happens for subscriptions created outside of this process.
3. Create a Zuora Workflow to set the invoice correctly if someone moves, either to, or away from, Australia

Invoice templates are Word documents entered into Zuora's Billing admin portal:

<img width="575" alt="Screenshot 2022-10-05 at 17 14 06" src="https://user-images.githubusercontent.com/1515970/194110069-159bf620-3f84-4dd3-ab11-918b95f63dd8.png">

<!--
Remember, PRs are documentation for future contributors.
-->

## Screenshots

Screenshots of the two templates are here:

Default:

<img width="555" alt="Screenshot 2022-10-05 at 17 16 56" src="https://user-images.githubusercontent.com/1515970/194110492-99c46ada-bc2c-4908-88c0-7d9c2a68580c.png">

Australia:

<img width="570" alt="Screenshot 2022-10-05 at 17 17 09" src="https://user-images.githubusercontent.com/1515970/194110520-981d641d-d7b1-4f25-a59f-4f67bcf79b01.png">


