### PR TITLE
Update broken accessibility testing links in our PR template to point at useful resources

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,9 +26,9 @@ If this is an AB test, PR reviewers should open and check the Optimize test.
 [**Optimize Link**](https://optimize.google.com/optimize/home)
 
 ## Accessibility test checklist
- - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
+ - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
+ - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
+ - [ ] [Colour contrast passed](https://www.whocanuse.com/)
 
 ## Screenshots
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This updates our PR template so the links for the accessibility checks go to useful resources rather than the broken accessibility.gutools.co.uk site.