### PR TITLE
Update TY page copy

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.tsx
@@ -131,8 +131,8 @@ function ContributionThankYouHeader({
 
 	function AdditionalCopy() {
 		const mainText = shouldShowLargeDonationMessage
-			? 'It’s not every day we receive such a generous contribution. We would love to stay in touch. So that we can, please select the add-ons that suit you best. '
-			: 'We would love to stay in touch. So that we can, please select the add-ons that suit you best. ';
+			? 'It’s not every day we receive such a generous contribution – thank you. We’ll be in touch to bring you closer to our journalism. Please select the extra add-ons that suit you best. '
+			: 'To support us further, and enhance your experience with the Guardian, select the add-ons that suit you best. As you’re now a valued supporter, we’ll be in touch to bring you closer to our journalism. ';
 
 		const benefitsThresholdIsMetText =
 			'You have unlocked access to the Guardian’s digital subscription, offering you the best possible experience of our independent journalism. Look out for emails from us shortly, so you can activate your exclusive extras. In the meantime, please select the add-ons that suit you best.';
@@ -140,7 +140,7 @@ function ContributionThankYouHeader({
 		function MarketingCopy() {
 			return (
 				<span>
-					You can amend your preferences at any time via{' '}
+					You can amend your email preferences at any time via{' '}
 					<a href="https://manage.theguardian.com">your account</a>.
 				</span>
 			);


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This updates the contributions thank you pages copy to include reference to soft-opt in.

[**Trello Card**](https://trello.com/c/bHWcgbI8/752-ensure-that-appropriate-soft-opt-in-copy-is-on-all-post-purchase-confirmation-pages)

## Why are you doing this?
This copy was to be included when soft opt in was first implemented. It may have since be overwritten, this is to reinstate the correct copy whilst we continue to investigate.
