### PR TITLE
Changed sentry logback to 6.5.0

### DIFF
--- a/support-frontend/app/monitoring/SentryLogging.scala
+++ b/support-frontend/app/monitoring/SentryLogging.scala
@@ -23,7 +23,7 @@ object SentryLogging {
       case Some(sentryDSN) =>
         SafeLogger.info(s"Initialising Sentry logging")
         Try {
-          val sentryClient = Sentry.init(sentryDSN)
+          Sentry.init(sentryDSN)
           val sentryAppender = new SentryAppender {
             addFilter(errorLevelFilter)
             addFilter(piiFilter)
@@ -33,7 +33,7 @@ object SentryLogging {
 
           val buildInfo: Map[String, String] = app.BuildInfo.toMap.view.mapValues(_.toString).toMap
           val tags = Map("stage" -> config.stage.toString) ++ buildInfo
-          sentryClient.setTags(tags.asJava)
+          tags.foreach { case (key, value) => Sentry.setTag(key, value) }
 
           LoggerFactory.getLogger(ROOT_LOGGER_NAME).asInstanceOf[Logger].addAppender(sentryAppender)
         } match {

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -14,7 +14,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "simple-configuration-ssm" % "1.5.7",
   "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
   "org.mockito" % "mockito-core" % "2.28.2" % Test,
-  "io.sentry" % "sentry-logback" % "1.7.30",
+  "io.sentry" % "sentry-logback" % "6.5.0",
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sts" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,


### PR DESCRIPTION

## What are you doing in this PR?
 Update Scala dependency sentry-logback from 1.7.30 to 6.5.0 for support-frontend.

[**Trello Card**](https://trello.com/c/z0bNp5nJ/603-support-frontend-update-scala-dependency-sentry-logback)

## Why are you doing this?
We are five major versions behind, and automated Scala Steward PRs are failing for this dependency, so we need to manually update.
Cf. https://github.com/guardian/support-frontend/pull/4164
Latest-https://github.com/guardian/support-frontend/pull/4274

## Is this an AB test?
- [ ] No
