### PR TITLE
Add skip links and test user banner to new checkout

### DIFF
--- a/support-frontend/assets/components/layout/container.tsx
+++ b/support-frontend/assets/components/layout/container.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { from, neutral } from '@guardian/source-foundations';
 import { Container as SourceContainer } from '@guardian/source-react-components';
+import type { HTMLAttributes } from 'react';
 import React from 'react';
 
 type ContainerElement =
@@ -12,7 +13,7 @@ type ContainerElement =
 	| 'nav'
 	| 'section';
 
-type Props = {
+interface ContainerProps extends HTMLAttributes<HTMLElement> {
 	children: React.ReactNode;
 	element?: ContainerElement;
 	sidePadding?: boolean;
@@ -20,7 +21,7 @@ type Props = {
 	sideBorders?: boolean;
 	borderColor?: string;
 	backgroundColor?: string;
-};
+}
 
 const sidePaddingStyles = css`
 	> div {
@@ -64,7 +65,8 @@ export function Container({
 	sideBorders,
 	borderColor = neutral[86],
 	backgroundColor,
-}: Props): JSX.Element {
+	...props
+}: ContainerProps): JSX.Element {
 	return (
 		<SourceContainer
 			element={element}
@@ -76,6 +78,7 @@ export function Container({
 				sideBorders ? sideBorderStyles(borderColor) : css``,
 				topBorder ? topBorderStyles(borderColor) : css``,
 			]}
+			{...props}
 		>
 			{children}
 		</SourceContainer>

--- a/support-frontend/assets/components/nav/nav.tsx
+++ b/support-frontend/assets/components/nav/nav.tsx
@@ -24,6 +24,7 @@ function Nav({
 }: NavProps): JSX.Element {
 	return (
 		<Container
+			id="navigation"
 			element="nav"
 			sideBorders={true}
 			topBorder={true}

--- a/support-frontend/assets/components/page/page.tsx
+++ b/support-frontend/assets/components/page/page.tsx
@@ -2,6 +2,7 @@
 import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 import CsrBanner from 'components/csr/csrBanner';
+import { SkipLink } from 'components/skipLink/skipLink';
 import { classNameWithModifiers } from 'helpers/utilities/utilities';
 
 // ----- Types ----- //
@@ -42,9 +43,10 @@ export default function Page(props: PropTypes): JSX.Element {
 			id={props.id}
 			className={classNameWithModifiers('gu-content', props.classModifiers)}
 		>
+			<SkipLink id="maincontent" label="Skip to main content" />
 			<CsrBanner />
 			{props.header}
-			<main role="main" className="gu-content__main">
+			<main role="main" id="maincontent" className="gu-content__main">
 				{backgroundImage}
 				{props.children}
 			</main>

--- a/support-frontend/assets/components/page/pageScaffold.tsx
+++ b/support-frontend/assets/components/page/pageScaffold.tsx
@@ -2,6 +2,7 @@ import { css, Global } from '@emotion/react';
 import { FocusStyleManager, resets } from '@guardian/source-foundations';
 import type { ReactNode } from 'react';
 import CsrBanner from 'components/csr/csrBanner';
+import { SkipLink } from 'components/skipLink/skipLink';
 import { useScrollToAnchor } from 'helpers/customHooks/useScrollToAnchor';
 
 export type PageScaffoldProps = {
@@ -23,9 +24,13 @@ export function PageScaffold(props: PageScaffoldProps): JSX.Element {
 					${resets.resetCSS}
 				`}
 			/>
+			<SkipLink id="maincontent" label="Skip to main content" />
+			<SkipLink id="navigation" label="Skip to navigation" />
 			<CsrBanner />
 			{props.header}
-			<main role="main">{props.children}</main>
+			<main role="main" id="maincontent">
+				{props.children}
+			</main>
 			{props.footer}
 		</div>
 	);

--- a/support-frontend/assets/components/page/pageScaffold.tsx
+++ b/support-frontend/assets/components/page/pageScaffold.tsx
@@ -3,6 +3,7 @@ import { FocusStyleManager, resets } from '@guardian/source-foundations';
 import type { ReactNode } from 'react';
 import CsrBanner from 'components/csr/csrBanner';
 import { SkipLink } from 'components/skipLink/skipLink';
+import { TestUserBanner } from 'components/test-user-banner/testUserBanner';
 import { useScrollToAnchor } from 'helpers/customHooks/useScrollToAnchor';
 
 export type PageScaffoldProps = {
@@ -27,6 +28,7 @@ export function PageScaffold(props: PageScaffoldProps): JSX.Element {
 			<SkipLink id="maincontent" label="Skip to main content" />
 			<SkipLink id="navigation" label="Skip to navigation" />
 			<CsrBanner />
+			<TestUserBanner />
 			{props.header}
 			<main role="main" id="maincontent">
 				{props.children}

--- a/support-frontend/assets/components/skipLink/skipLink.tsx
+++ b/support-frontend/assets/components/skipLink/skipLink.tsx
@@ -3,22 +3,23 @@ import { focus, neutral, textSans } from '@guardian/source-foundations';
 
 const skipLinkStyles = css`
 	${textSans.medium()}
+	display: block;
+	position: absolute;
 	height: 40px;
 	top: -40px;
+	padding: 0;
+	margin: 0;
 	line-height: 30px;
 	overflow: hidden;
-	padding: 0;
-	position: absolute;
 	background: ${neutral[100]};
-	display: block;
-	text-align: center;
-	margin: 0;
-	text-decoration: none;
 	color: ${neutral[0]};
+	text-align: center;
+	text-decoration: none;
+
 	&:focus,
 	&:active {
-		border: 5px solid ${focus[400]};
 		position: static;
+		border: 5px solid ${focus[400]};
 	}
 	&:visited,
 	&:active {

--- a/support-frontend/assets/components/skipLink/skipLink.tsx
+++ b/support-frontend/assets/components/skipLink/skipLink.tsx
@@ -1,0 +1,42 @@
+import { css } from '@emotion/react';
+import { focus, neutral, textSans } from '@guardian/source-foundations';
+
+const skipLinkStyles = css`
+	${textSans.medium()}
+	height: 40px;
+	top: -40px;
+	line-height: 30px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	background: ${neutral[100]};
+	display: block;
+	text-align: center;
+	margin: 0;
+	text-decoration: none;
+	color: ${neutral[0]};
+	&:focus,
+	&:active {
+		border: 5px solid ${focus[400]};
+		position: static;
+	}
+	&:visited,
+	&:active {
+		color: ${neutral[0]};
+	}
+`;
+
+type Identifier = 'maincontent' | 'navigation';
+
+type SkipLinkProps = {
+	id: Identifier;
+	label: string;
+};
+
+export function SkipLink({ id, label }: SkipLinkProps): JSX.Element {
+	return (
+		<a href={`#${id}`} css={skipLinkStyles}>
+			{label}
+		</a>
+	);
+}

--- a/support-frontend/assets/components/test-user-banner/testUserBanner.tsx
+++ b/support-frontend/assets/components/test-user-banner/testUserBanner.tsx
@@ -1,0 +1,26 @@
+import { css } from '@emotion/react';
+import { error, neutral, space, textSans } from '@guardian/source-foundations';
+import { useContributionsSelector } from 'helpers/redux/storeHooks';
+
+const testUserBannerStyles = css`
+	${textSans.large()};
+	background-color: ${error[400]};
+	color: ${neutral[100]};
+	text-align: center;
+	padding: ${space[2]}px 0;
+`;
+
+export function TestUserBanner(): JSX.Element | null {
+	const isTestUser = useContributionsSelector(
+		(state) => state.page.user.isTestUser,
+	);
+
+	if (isTestUser) {
+		return (
+			<div css={testUserBannerStyles}>
+				<p>You are a test user</p>
+			</div>
+		);
+	}
+	return null;
+}

--- a/support-frontend/assets/components/test-user-banner/testUserBanner.tsx
+++ b/support-frontend/assets/components/test-user-banner/testUserBanner.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { error, neutral, space, textSans } from '@guardian/source-foundations';
-import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import { isTestUser } from 'helpers/user/user';
 
 const testUserBannerStyles = css`
 	${textSans.large()};
@@ -11,11 +11,9 @@ const testUserBannerStyles = css`
 `;
 
 export function TestUserBanner(): JSX.Element | null {
-	const isTestUser = useContributionsSelector(
-		(state) => state.page.user.isTestUser,
-	);
+	const testUser = isTestUser();
 
-	if (isTestUser) {
+	if (testUser) {
 		return (
 			<div css={testUserBannerStyles}>
 				<p>You are a test user</p>

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -79,13 +79,16 @@ export function SupporterPlusLandingPage(): JSX.Element {
 		<PageScaffold
 			id="supporter-plus-landing"
 			header={
-				<Header>
-					<Hide from="desktop">
-						<CountrySwitcherContainer>
-							<CountryGroupSwitcher {...countrySwitcherProps} />
-						</CountrySwitcherContainer>
-					</Hide>
-				</Header>
+				<>
+					<Header>
+						<Hide from="desktop">
+							<CountrySwitcherContainer>
+								<CountryGroupSwitcher {...countrySwitcherProps} />
+							</CountrySwitcherContainer>
+						</Hide>
+					</Header>
+					<Nav {...countrySwitcherProps} />
+				</>
 			}
 			footer={
 				<FooterWithContents>
@@ -93,7 +96,6 @@ export function SupporterPlusLandingPage(): JSX.Element {
 				</FooterWithContents>
 			}
 		>
-			<Nav {...countrySwitcherProps} />
 			<CheckoutHeading heading={heading}>
 				<p>
 					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR adds two [skip links](https://webaim.org/techniques/skipnav/) to the new checkout, and a single 'skip to main content' link to all other pages on the site using the `Page` template component. The component is based on [a similar component in dotcom-rendering](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/components/SkipTo.tsx). The links are invisible unless they currently have keyboard focus.

It also adds a test user banner to the new checkout.

[**Trello Card**](https://trello.com)

## Why are you doing this?

Skip links are a useful aid for users who navigate with a keyboard or switch, and for screen reader users- they make it quicker to get to key content on a page. We currently don't have them anywhere on the site, so adding them to existing pages as well is a significant accessibility improvement that has no effect on existing designs and visuals.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

### New checkout
![Screenshot 2022-10-13 at 15 33 11](https://user-images.githubusercontent.com/29146931/195636290-c402e773-566d-4746-90fc-069b2ca05e96.png)

### Newspaper landing page
![Screenshot 2022-10-13 at 15 33 38](https://user-images.githubusercontent.com/29146931/195636345-8e47626e-a4bc-4fec-bbe5-92f522b1d56f.png)

### Test user banner
![Screenshot 2022-10-13 at 16-15-12 Support the Guardian Make a Contribution](https://user-images.githubusercontent.com/29146931/195637317-42207e3a-7f92-4b17-bb24-5e2bb88a47db.png)
