### PR TITLE
Reinstate Upsell CTA - v2 Checkout

### DIFF
--- a/support-frontend/assets/components/button/upsellButton.tsx
+++ b/support-frontend/assets/components/button/upsellButton.tsx
@@ -1,0 +1,53 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css, ThemeProvider } from '@emotion/react';
+import { from, neutral, space } from '@guardian/source-foundations';
+import {
+	Button,
+	buttonThemeReaderRevenueBrand,
+} from '@guardian/source-react-components';
+
+const button = css`
+	width: 100%;
+	justify-content: space-around;
+	color: ${neutral[7]};
+	margin: ${space[5]}px 0 ${space[3]}px;
+
+	${from.mobileMedium} {
+		margin-bottom: ${space[4]}px;
+	}
+
+	${from.desktop} {
+		margin: ${space[6]}px 0 ${space[5]}px;
+	}
+`;
+
+interface UpsellButtonProps {
+	buttonCopy: string | null;
+	handleButtonClick: () => void;
+	cssOverrides?: SerializedStyles;
+}
+
+function UpsellButton({
+	buttonCopy,
+	handleButtonClick,
+}: UpsellButtonProps): JSX.Element {
+	return (
+		<>
+			{buttonCopy && (
+				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
+					<Button
+						iconSide="left"
+						priority="primary"
+						size="default"
+						cssOverrides={button}
+						onClick={handleButtonClick}
+					>
+						{buttonCopy}
+					</Button>
+				</ThemeProvider>
+			)}
+		</>
+	);
+}
+
+export default UpsellButton;

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
@@ -6,7 +6,6 @@ import {
 	space,
 	textSans,
 } from '@guardian/source-foundations';
-import UpsellButton from 'components/button/upsellButton';
 import type { CheckListData } from './checkoutBenefitsListData';
 
 const container = css`
@@ -75,8 +74,6 @@ export type CheckoutBenefitsListProps = {
 export function CheckoutBenefitsList({
 	title,
 	checkListData,
-	buttonCopy,
-	handleButtonClick,
 }: CheckoutBenefitsListProps): JSX.Element {
 	return (
 		<div css={container}>
@@ -92,10 +89,6 @@ export function CheckoutBenefitsList({
 					</tr>
 				))}
 			</table>
-			<UpsellButton
-				buttonCopy={buttonCopy}
-				handleButtonClick={handleButtonClick}
-			/>
 			<hr css={hr(`${space[5]}px 0 ${space[4]}px`)} />
 			<p css={para}>Cancel anytime</p>
 		</div>

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
@@ -6,7 +6,8 @@ import {
 	space,
 	textSans,
 } from '@guardian/source-foundations';
-import type { CheckListData } from './checkoutBenefitsListContainer';
+import UpsellButton from 'components/button/upsellButton';
+import type { CheckListData } from './checkoutBenefitsListData';
 
 const container = css`
 	${textSans.small({ lineHeight: 'tight' })};
@@ -41,7 +42,6 @@ const checkListText = css`
 
 const table = css`
 	padding-top: ${space[4]}px;
-	margin-bottom: 28px;
 
 	& tr:not(:last-child) {
 		border-bottom: 10px solid transparent;
@@ -59,8 +59,6 @@ const hr = (margin: string) => css`
 	height: 1px;
 	background-color: #dcdcdc;
 	margin: ${margin};
-
-	margin-bottom: ${space[4]}px 0;
 `;
 
 const para = css`
@@ -70,11 +68,15 @@ const para = css`
 export type CheckoutBenefitsListProps = {
 	title: string;
 	checkListData: CheckListData[];
+	buttonCopy: string | null;
+	handleButtonClick: () => void;
 };
 
 export function CheckoutBenefitsList({
 	title,
 	checkListData,
+	buttonCopy,
+	handleButtonClick,
 }: CheckoutBenefitsListProps): JSX.Element {
 	return (
 		<div css={container}>
@@ -90,6 +92,10 @@ export function CheckoutBenefitsList({
 					</tr>
 				))}
 			</table>
+			<UpsellButton
+				buttonCopy={buttonCopy}
+				handleButtonClick={handleButtonClick}
+			/>
 			<hr css={hr(`${space[5]}px 0 ${space[4]}px`)} />
 			<p css={para}>Cancel anytime</p>
 		</div>

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
@@ -89,6 +89,10 @@ export function CheckoutBenefitsList({
 					</tr>
 				))}
 			</table>
+			{/* <UpsellButton
+				buttonCopy={buttonCopy}
+				handleButtonClick={handleButtonClick}
+			/> */}
 			<hr css={hr(`${space[5]}px 0 ${space[4]}px`)} />
 			<p css={para}>Cancel anytime</p>
 		</div>

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -1,96 +1,20 @@
-import type { SerializedStyles } from '@emotion/react';
-import { css } from '@emotion/react';
-import { neutral } from '@guardian/source-foundations';
-import { SvgCrossRound, SvgTickRound } from '@guardian/source-react-components';
 import type { ContributionType } from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import { currencies } from 'helpers/internationalisation/currency';
+import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import { getMinimumContributionAmount } from 'helpers/redux/commonState/selectors';
-import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
 import { getThresholdPrice } from 'pages/contributions-landing/components/DigiSubBenefits/helpers';
 import type { CheckoutBenefitsListProps } from './checkoutBenefitsList';
-
-const greyedOut = css`
-	color: ${neutral[60]};
-
-	svg {
-		fill: ${neutral[60]};
-	}
-`;
-
-const boldText = css`
-	font-weight: bold;
-`;
-
-export type CheckListData = {
-	icon: JSX.Element;
-	text?: JSX.Element;
-	maybeGreyedOut: null | SerializedStyles;
-};
-
-type TierUnlocks = {
-	lowerTier: boolean;
-	higherTier: boolean;
-};
+import { checkListData } from './checkoutBenefitsListData';
 
 type CheckoutBenefitsListContainerProps = {
 	renderBenefitsList: (props: CheckoutBenefitsListProps) => JSX.Element;
-};
-
-const getSvgIcon = (isUnlocked: boolean) =>
-	isUnlocked ? (
-		<SvgTickRound isAnnouncedByScreenReader size="small" />
-	) : (
-		<SvgCrossRound isAnnouncedByScreenReader size="small" />
-	);
-
-export const checkListData = ({
-	lowerTier,
-	higherTier,
-}: TierUnlocks): CheckListData[] => {
-	return [
-		{
-			icon: getSvgIcon(lowerTier),
-			text: (
-				<p>
-					<span css={boldText}>Uninterrupted reading. </span> No more yellow
-					banners
-				</p>
-			),
-			maybeGreyedOut: lowerTier ? null : greyedOut,
-		},
-		{
-			icon: getSvgIcon(lowerTier),
-			text: (
-				<p>
-					<span css={boldText}>Supporter newsletter. </span>Giving you editorial
-					insight on the week’s top stories
-				</p>
-			),
-			maybeGreyedOut: lowerTier ? null : greyedOut,
-		},
-		{
-			icon: getSvgIcon(higherTier),
-			text: (
-				<p>
-					<span css={boldText}>Ad-free. </span>On any device when signed in
-				</p>
-			),
-			maybeGreyedOut: higherTier ? null : greyedOut,
-		},
-		{
-			icon: getSvgIcon(higherTier),
-			text: (
-				<p>
-					<span css={boldText}>Unlimited app access. </span>For the best mobile
-					experience
-				</p>
-			),
-			maybeGreyedOut: higherTier ? null : greyedOut,
-		},
-	];
 };
 
 function getBenefitsListTitle(
@@ -106,9 +30,20 @@ function getBenefitsListTitle(
 	return `For ${priceString} per ${billingPeriod}, you’ll unlock`;
 }
 
+const getbuttonCopy = (
+	higherTier: boolean,
+	thresholdPriceWithCurrency: string,
+	selectedAmount: number,
+) =>
+	higherTier || Number.isNaN(selectedAmount)
+		? null
+		: `Switch to ${thresholdPriceWithCurrency} to unlock all extras`;
+
 export function CheckoutBenefitsListContainer({
 	renderBenefitsList,
 }: CheckoutBenefitsListContainerProps): JSX.Element | null {
+	const dispatch = useContributionsDispatch();
+
 	const contributionType = useContributionsSelector(getContributionType);
 	if (contributionType === 'ONE_OFF') {
 		return null;
@@ -122,14 +57,29 @@ export function CheckoutBenefitsListContainer({
 		getMinimumContributionAmount,
 	);
 
+	const currency = currencies[currencyId];
+
 	const thresholdPrice =
 		getThresholdPrice(countryGroupId, contributionType) ?? 1;
+	const thresholdPriceWithCurrency = simpleFormatAmount(
+		currency,
+		thresholdPrice,
+	);
 	const userSelectedAmountWithCurrency = simpleFormatAmount(
-		currencies[currencyId],
+		currency,
 		selectedAmount,
 	);
-	const higherTier = thresholdPrice <= selectedAmount;
+	const higherTier = selectedAmount >= thresholdPrice;
 	const lowerTier = selectedAmount > minimumContributionAmount;
+
+	function handleButtonClick() {
+		dispatch(
+			setSelectedAmount({
+				contributionType,
+				amount: thresholdPrice.toString(),
+			}),
+		);
+	}
 
 	return renderBenefitsList({
 		title: getBenefitsListTitle(
@@ -142,5 +92,11 @@ export function CheckoutBenefitsListContainer({
 			lowerTier,
 			higherTier,
 		}),
+		buttonCopy: getbuttonCopy(
+			higherTier,
+			thresholdPriceWithCurrency,
+			selectedAmount,
+		),
+		handleButtonClick,
 	});
 }

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
@@ -1,0 +1,84 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import { neutral } from '@guardian/source-foundations';
+import { SvgCrossRound, SvgTickRound } from '@guardian/source-react-components';
+
+const greyedOut = css`
+	color: ${neutral[60]};
+
+	svg {
+		fill: ${neutral[60]};
+	}
+`;
+
+const boldText = css`
+	font-weight: bold;
+`;
+
+type TierUnlocks = {
+	lowerTier: boolean;
+	higherTier: boolean;
+};
+
+export type CheckListData = {
+	icon: JSX.Element;
+	text?: JSX.Element;
+	maybeGreyedOut: null | SerializedStyles;
+};
+
+export const getSvgIcon = (isUnlocked: boolean): JSX.Element =>
+	isUnlocked ? (
+		<SvgTickRound isAnnouncedByScreenReader size="small" />
+	) : (
+		<SvgCrossRound isAnnouncedByScreenReader size="small" />
+	);
+
+export const checkListData = ({
+	lowerTier,
+	higherTier,
+}: TierUnlocks): CheckListData[] => {
+	const maybeGreyedOutLowerTier = lowerTier ? null : greyedOut;
+	const maybeGreyedOutHigherTier = higherTier ? null : greyedOut;
+
+	return [
+		{
+			icon: getSvgIcon(lowerTier),
+			text: (
+				<p>
+					<span css={boldText}>Uninterrupted reading. </span> No more yellow
+					banners
+				</p>
+			),
+			maybeGreyedOut: maybeGreyedOutLowerTier,
+		},
+		{
+			icon: getSvgIcon(lowerTier),
+			text: (
+				<p>
+					<span css={boldText}>Supporter newsletter. </span>Giving you editorial
+					insight on the week’s top stories
+				</p>
+			),
+			maybeGreyedOut: maybeGreyedOutLowerTier,
+		},
+		{
+			icon: getSvgIcon(higherTier),
+			text: (
+				<p>
+					<span css={boldText}>Ad-free. </span>On any device when signed in
+				</p>
+			),
+			maybeGreyedOut: maybeGreyedOutHigherTier,
+		},
+		{
+			icon: getSvgIcon(higherTier),
+			text: (
+				<p>
+					<span css={boldText}>Unlimited app access. </span>For the best mobile
+					experience
+				</p>
+			),
+			maybeGreyedOut: maybeGreyedOutHigherTier,
+		},
+	];
+};

--- a/support-frontend/assets/helpers/globalsAndSwitches/globals.test.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/globals.test.ts
@@ -37,6 +37,12 @@ describe('getGlobal', () => {
 		);
 	});
 
+	it('uses the passed path to traverse the window.guardian settings object even if given a fully qualified path', () => {
+		expect(getGlobal('window.guardian.settings.amounts.GBPCountries')).toEqual(
+			emptyConfiguredRegionAmounts,
+		);
+	});
+
 	it('returns any item reached in traversal that is not an object', () => {
 		expect(getGlobal('settings.contributionTypes.Canada.something')).toEqual(
 			[],

--- a/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
@@ -11,6 +11,7 @@ function isRecord(
 
 function getGlobal<T>(path = ''): T | null {
 	const value = path
+		.replace(/^window.guardian./, '')
 		.replace(/\[(.+?)\]/g, '.$1')
 		.split('.')
 		.reduce<unknown>((config: unknown, key: string) => {

--- a/support-frontend/assets/helpers/redux/checkout/product/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/state.ts
@@ -3,6 +3,7 @@ import type {
 	OtherAmounts,
 	SelectedAmounts,
 } from 'helpers/contributions';
+import { getGlobal } from 'helpers/globalsAndSwitches/globals';
 import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
@@ -46,7 +47,7 @@ export const initialProductState: ProductState = {
 	productOption: 'NoProductOptions',
 	fulfilmentOption: 'NoFulfilmentOptions',
 	billingPeriod: 'Monthly',
-	productPrices: window.guardian.productPrices,
+	productPrices: getGlobal('window.guardian.productPrices') ?? {},
 	selectedAmounts: {
 		ONE_OFF: 0,
 		MONTHLY: 0,
@@ -64,6 +65,6 @@ export const initialProductState: ProductState = {
 		},
 	},
 	currency,
-	orderIsAGift: window.guardian.orderIsAGift,
+	orderIsAGift: getGlobal('window.guardian.orderIsAGift') ?? false,
 	startDate: formatMachineDate(new Date()),
 };

--- a/support-frontend/assets/helpers/redux/checkout/product/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/state.ts
@@ -47,7 +47,7 @@ export const initialProductState: ProductState = {
 	productOption: 'NoProductOptions',
 	fulfilmentOption: 'NoFulfilmentOptions',
 	billingPeriod: 'Monthly',
-	productPrices: getGlobal('window.guardian.productPrices') ?? {},
+	productPrices: getGlobal('productPrices') ?? {},
 	selectedAmounts: {
 		ONE_OFF: 0,
 		MONTHLY: 0,
@@ -65,6 +65,6 @@ export const initialProductState: ProductState = {
 		},
 	},
 	currency,
-	orderIsAGift: getGlobal('window.guardian.orderIsAGift') ?? false,
+	orderIsAGift: getGlobal('orderIsAGift') ?? false,
 	startDate: formatMachineDate(new Date()),
 };

--- a/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
@@ -7,7 +7,7 @@ import { checkListData } from 'components/checkoutBenefits/checkoutBenefitsListD
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 
 export default {
-	title: 'Checkout Layout/Benefits List',
+	title: 'Checkouts/Benefits List',
 	component: CheckoutBenefitsList,
 	argTypes: {
 		handleButtonClick: { action: 'button clicked' },

--- a/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
@@ -1,13 +1,17 @@
 import { css } from '@emotion/react';
 import { neutral } from '@guardian/source-foundations';
 import { Column, Columns, Container } from '@guardian/source-react-components';
+import type { CheckoutBenefitsListProps } from 'components/checkoutBenefits/checkoutBenefitsList';
 import { CheckoutBenefitsList } from 'components/checkoutBenefits/checkoutBenefitsList';
-import { checkListData } from 'components/checkoutBenefits/checkoutBenefitsListContainer';
+import { checkListData } from 'components/checkoutBenefits/checkoutBenefitsListData';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 
 export default {
 	title: 'Checkout Layout/Benefits List',
 	component: CheckoutBenefitsList,
+	argTypes: {
+		handleButtonClick: { action: 'button clicked' },
+	},
 	decorators: [
 		(Story: React.FC): JSX.Element => (
 			<Container backgroundColor={neutral[97]}>
@@ -31,34 +35,24 @@ export default {
 	],
 };
 
-function Template(args: {
-	title: string;
-	higherTier: boolean;
-	lowerTier: boolean;
-}): JSX.Element {
-	const { title, higherTier, lowerTier } = args;
-	return (
-		<CheckoutBenefitsList
-			title={title}
-			checkListData={checkListData({ lowerTier, higherTier })}
-		/>
-	);
+function Template(args: CheckoutBenefitsListProps) {
+	return <CheckoutBenefitsList {...args} />;
 }
 
-Template.args = {} as Record<string, unknown>;
+Template.args = {} as Omit<CheckoutBenefitsListProps, 'handleButtonClick'>;
 
 export const AllBenefitsUnlocked = Template.bind({});
 
 AllBenefitsUnlocked.args = {
 	title: "For £12 per month, you'll unlock",
-	higherTier: true,
-	lowerTier: true,
+	checkListData: checkListData({ lowerTier: true, higherTier: true }),
+	buttonCopy: null,
 };
 
 export const LowerTierUnlocked = Template.bind({});
 
 LowerTierUnlocked.args = {
 	title: "For £5 per month, you'll unlock",
-	higherTier: false,
-	lowerTier: true,
+	checkListData: checkListData({ lowerTier: true, higherTier: false }),
+	buttonCopy: 'Switch to £12 per month to unlock all extras',
 };


### PR DESCRIPTION

## What are you doing in this PR?
This PR adds the up-sell CTA to the v2 checkout. A previous [PR](https://github.com/guardian/support-frontend/pull/4256) doing this was merged and [reverted](https://github.com/guardian/support-frontend/pull/4284) yesterday due to a bug caused by changes to the default product state in redux (see below). 

Most all of the changes in this PR are the same as the original, apart from the changes necessary to fix this bug, which are as follows:
- globals.ts - where the `getGlobal` function now has the ability to take a full path i.e. one prefixed with the string `window.guardian`
- globals.test.ts - where we include a test to ensure the `getGlobal` function can handle a string prefixed with `window.guardian` 

Whilst working on the original PR we'd encountered a bug in storybook whereby the accompanying stories for the Upsell CTA and the Supporter Plus page checkout would fail to render. This was down to the fact it was looking for a property on the redux product state that was not accessible at that point of execution for the Upsell CTA component. Though interestingly other storybook components accessing the same redux state did not seem to be afffected, leading us to conclude the root cause may be down to how webpack bundles the code.

The original changes to the product state fixed the bug in storybook and left the contributions pages unaffected. Although, the Subscriptions checkouts were unintentionally affected by this change, causing a bug in production down to the fact that we were trying to read a property on the product state which was no longer being accessed correctly. 

[**Trello Card**](https://trello.com/c/lXuc01lP/690-v2-checkout-build-upsell-cta-component)

