### PR TITLE
Add the 'other amount' field to the new product checkout

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -101,7 +101,7 @@ function getBenefitsListTitle(
 ) {
 	const billingPeriod = contributionType === 'MONTHLY' ? 'month' : 'year';
 	if (Number.isNaN(selectedAmount)) {
-		return `Contribute more than ${minimumAmountPriceString} per ${billingPeriod} to unlock benefits`;
+		return `Contribute at least ${minimumAmountPriceString} per ${billingPeriod} to unlock benefits`;
 	}
 	return `For ${priceString} per ${billingPeriod}, you’ll unlock`;
 }
@@ -129,7 +129,7 @@ export function CheckoutBenefitsListContainer({
 		selectedAmount,
 	);
 	const higherTier = thresholdPrice <= selectedAmount;
-	const lowerTier = selectedAmount > minimumContributionAmount;
+	const lowerTier = selectedAmount >= minimumContributionAmount;
 
 	return renderBenefitsList({
 		title: getBenefitsListTitle(

--- a/support-frontend/assets/components/otherAmount/otherAmount.tsx
+++ b/support-frontend/assets/components/otherAmount/otherAmount.tsx
@@ -30,7 +30,7 @@ export function OtherAmount({
 	const prefix = currencyDetails.isSuffixGlyph ? '' : glyph;
 	const suffix = currencyDetails.isSuffixGlyph ? glyph : '';
 
-	const supportingText = `Choose an amount above ${simpleFormatAmount(
+	const supportingText = `Must be at least ${simpleFormatAmount(
 		currencyDetails,
 		minAmount,
 	)}`;

--- a/support-frontend/assets/components/otherAmount/otherAmount.tsx
+++ b/support-frontend/assets/components/otherAmount/otherAmount.tsx
@@ -1,0 +1,42 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/source-foundations';
+import { NumericInput } from '@guardian/source-react-components-development-kitchen';
+import { currencies } from 'helpers/internationalisation/currency';
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
+
+const topSpacing = css`
+	margin-top: ${space[2]}px;
+`;
+
+export type OtherAmountProps = {
+	selectedAmount: string;
+	currency: IsoCurrency;
+	onAmountChange?: (newAmount: string) => void;
+};
+
+export function OtherAmount({
+	selectedAmount,
+	currency,
+}: OtherAmountProps): JSX.Element | null {
+	const currencyDetails = currencies[currency];
+	const glyph = currencyDetails.isPaddedGlyph
+		? ` ${currencyDetails.glyph} `
+		: currencyDetails.glyph;
+
+	const prefix = currencyDetails.isSuffixGlyph ? '' : glyph;
+	const suffix = currencyDetails.isSuffixGlyph ? glyph : '';
+
+	if (selectedAmount === 'other') {
+		return (
+			<div css={topSpacing}>
+				<NumericInput
+					id="otherAmount"
+					label="Choose your amount"
+					prefixText={prefix}
+					suffixText={suffix}
+				/>
+			</div>
+		);
+	}
+	return null;
+}

--- a/support-frontend/assets/components/otherAmount/otherAmount.tsx
+++ b/support-frontend/assets/components/otherAmount/otherAmount.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source-foundations';
 import { NumericInput } from '@guardian/source-react-components-development-kitchen';
+import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import { currencies } from 'helpers/internationalisation/currency';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 
@@ -11,12 +12,15 @@ const topSpacing = css`
 export type OtherAmountProps = {
 	selectedAmount: string;
 	currency: IsoCurrency;
-	onAmountChange?: (newAmount: string) => void;
+	minAmount: number;
+	onOtherAmountChange: (newAmount: string) => void;
 };
 
 export function OtherAmount({
 	selectedAmount,
 	currency,
+	minAmount,
+	onOtherAmountChange,
 }: OtherAmountProps): JSX.Element | null {
 	const currencyDetails = currencies[currency];
 	const glyph = currencyDetails.isPaddedGlyph
@@ -26,14 +30,23 @@ export function OtherAmount({
 	const prefix = currencyDetails.isSuffixGlyph ? '' : glyph;
 	const suffix = currencyDetails.isSuffixGlyph ? glyph : '';
 
+	const supportingText = `Choose an amount above ${simpleFormatAmount(
+		currencyDetails,
+		minAmount,
+	)}`;
+
 	if (selectedAmount === 'other') {
 		return (
 			<div css={topSpacing}>
 				<NumericInput
 					id="otherAmount"
 					label="Choose your amount"
+					supporting={supportingText}
 					prefixText={prefix}
 					suffixText={suffix}
+					onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+						onOtherAmountChange(e.target.value)
+					}
 				/>
 			</div>
 		);

--- a/support-frontend/assets/components/priceCards/priceCards.tsx
+++ b/support-frontend/assets/components/priceCards/priceCards.tsx
@@ -61,9 +61,9 @@ const cardsContainer = css`
 
 function getChoiceCardGroupStyles(amountOfAmounts: number) {
 	if (amountOfAmounts % 2) {
-		return [cardStyles, mobileGrid, cardsContainer];
+		return [cardStyles, mobileGrid];
 	}
-	return [cardStyles, otherAmountFullWidthStyles, mobileGrid, cardsContainer];
+	return [cardStyles, otherAmountFullWidthStyles, mobileGrid];
 }
 
 export type PriceCardsProps = {
@@ -72,6 +72,7 @@ export type PriceCardsProps = {
 	currency: IsoCurrency;
 	onAmountChange: (newAmount: string) => void;
 	paymentInterval?: PriceCardPaymentInterval;
+	otherAmountField?: React.ReactNode;
 };
 
 export function PriceCards({
@@ -80,36 +81,40 @@ export function PriceCards({
 	currency,
 	onAmountChange,
 	paymentInterval,
+	otherAmountField,
 }: PriceCardsProps): JSX.Element {
 	const otherAmountLabel = amounts.length % 2 ? 'Other' : 'Choose your amount';
 
 	return (
-		<ChoiceCardGroup
-			cssOverrides={getChoiceCardGroupStyles(amounts.length)}
-			name="amounts"
-			columns={2}
-		>
-			<>
-				{amounts.map((amount) => (
+		<div css={cardsContainer}>
+			<ChoiceCardGroup
+				cssOverrides={getChoiceCardGroupStyles(amounts.length)}
+				name="amounts"
+				columns={2}
+			>
+				<>
+					{amounts.map((amount) => (
+						<PriceCard
+							amount={amount}
+							amountWithCurrency={simpleFormatAmount(
+								currencies[currency],
+								amount,
+							)}
+							isSelected={amount === selectedAmount}
+							onClick={onAmountChange}
+							paymentInterval={paymentInterval}
+						/>
+					))}
 					<PriceCard
-						amount={amount}
-						amountWithCurrency={simpleFormatAmount(
-							currencies[currency],
-							amount,
-						)}
-						isSelected={amount === selectedAmount}
+						amount="other"
+						amountWithCurrency="other"
+						isSelected={selectedAmount === 'other'}
 						onClick={onAmountChange}
-						paymentInterval={paymentInterval}
+						alternateLabel={otherAmountLabel}
 					/>
-				))}
-				<PriceCard
-					amount="other"
-					amountWithCurrency="other"
-					isSelected={selectedAmount === 'other'}
-					onClick={onAmountChange}
-					alternateLabel={otherAmountLabel}
-				/>
-			</>
-		</ChoiceCardGroup>
+				</>
+			</ChoiceCardGroup>
+			{otherAmountField}
+		</div>
 	);
 }

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -1,5 +1,10 @@
+import type { OtherAmountProps } from 'components/otherAmount/otherAmount';
 import type { ContributionType, SelectedAmounts } from 'helpers/contributions';
-import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
+import {
+	setOtherAmount,
+	setSelectedAmount,
+} from 'helpers/redux/checkout/product/actions';
+import { getMinimumContributionAmount } from 'helpers/redux/commonState/selectors';
 import {
 	useContributionsDispatch,
 	useContributionsSelector,
@@ -7,9 +12,11 @@ import {
 import type { PriceCardPaymentInterval } from './priceCard';
 import type { PriceCardsProps } from './priceCards';
 
+type PriceCardsRenderProps = PriceCardsProps & OtherAmountProps;
+
 type PriceCardsContainerProps = {
 	frequency: ContributionType;
-	renderPriceCards: (props: PriceCardsProps) => JSX.Element;
+	renderPriceCards: (props: PriceCardsRenderProps) => JSX.Element;
 };
 
 const contributionTypeToPaymentInterval: Partial<
@@ -39,6 +46,7 @@ export function PriceCardsContainer({
 	const { selectedAmounts } = useContributionsSelector(
 		(state) => state.page.checkoutForm.product,
 	);
+	const minAmount = useContributionsSelector(getMinimumContributionAmount);
 
 	const { amounts: frequencyAmounts, defaultAmount } = amounts[frequency];
 	const selectedAmount = getSelectedAmount(
@@ -56,11 +64,22 @@ export function PriceCardsContainer({
 		);
 	}
 
+	function onOtherAmountChange(newAmount: string) {
+		dispatch(
+			setOtherAmount({
+				contributionType: frequency,
+				amount: newAmount,
+			}),
+		);
+	}
+
 	return renderPriceCards({
 		currency,
 		amounts: frequencyAmounts.map((amount) => amount.toString()),
 		selectedAmount,
-		onAmountChange,
 		paymentInterval: contributionTypeToPaymentInterval[frequency],
+		minAmount,
+		onAmountChange,
+		onOtherAmountChange,
 	});
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -17,14 +17,28 @@ export function AmountAndBenefits(): JSX.Element {
 						<BoxContents>
 							<PriceCardsContainer
 								frequency={tabId}
-								renderPriceCards={(priceCardProps) => (
+								renderPriceCards={({
+									amounts,
+									selectedAmount,
+									currency,
+									paymentInterval,
+									onAmountChange,
+									minAmount,
+									onOtherAmountChange,
+								}) => (
 									<>
 										<PriceCards
-											{...priceCardProps}
+											amounts={amounts}
+											selectedAmount={selectedAmount}
+											currency={currency}
+											paymentInterval={paymentInterval}
+											onAmountChange={onAmountChange}
 											otherAmountField={
 												<OtherAmount
-													currency={priceCardProps.currency}
-													selectedAmount={priceCardProps.selectedAmount}
+													currency={currency}
+													minAmount={minAmount}
+													selectedAmount={selectedAmount}
+													onOtherAmountChange={onOtherAmountChange}
 												/>
 											}
 										/>

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -1,6 +1,7 @@
 import { CheckoutBenefitsList } from 'components/checkoutBenefits/checkoutBenefitsList';
 import { CheckoutBenefitsListContainer } from 'components/checkoutBenefits/checkoutBenefitsListContainer';
 import { BoxContents } from 'components/checkoutBox/checkoutBox';
+import { OtherAmount } from 'components/otherAmount/otherAmount';
 import { PaymentFrequencyTabsContainer } from 'components/paymentFrequencyTabs/paymentFrequencyTabsContainer';
 import { PaymentFrequencyTabs } from 'components/paymentFrequencyTabs/paymentFrequenncyTabs';
 import { PriceCards } from 'components/priceCards/priceCards';
@@ -17,7 +18,17 @@ export function AmountAndBenefits(): JSX.Element {
 							<PriceCardsContainer
 								frequency={tabId}
 								renderPriceCards={(priceCardProps) => (
-									<PriceCards {...priceCardProps} />
+									<>
+										<PriceCards
+											{...priceCardProps}
+											otherAmountField={
+												<OtherAmount
+													currency={priceCardProps.currency}
+													selectedAmount={priceCardProps.selectedAmount}
+												/>
+											}
+										/>
+									</>
 								)}
 							/>
 							<CheckoutBenefitsListContainer

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -90,7 +90,7 @@
     "@guardian/pasteup": "1.0.0-alpha.7",
     "@guardian/source-foundations": "^5.2.1",
     "@guardian/source-react-components": "^7.1.0",
-    "@guardian/source-react-components-development-kitchen": "^3.1.10",
+    "@guardian/source-react-components-development-kitchen": "^5.0.0",
     "@juggle/resize-observer": "^3.3.1",
     "@reduxjs/toolkit": "^1.8.1",
     "@sentry/browser": "^5.4.0",

--- a/support-frontend/stories/checkouts/OtherAmount.stories.tsx
+++ b/support-frontend/stories/checkouts/OtherAmount.stories.tsx
@@ -1,0 +1,43 @@
+import type { OtherAmountProps } from 'components/otherAmount/otherAmount';
+import { OtherAmount } from 'components/otherAmount/otherAmount';
+import { withCenterAlignment } from '../../.storybook/decorators/withCenterAlignment';
+import { withSourceReset } from '../../.storybook/decorators/withSourceReset';
+
+export default {
+	title: 'Checkouts/Other Amount',
+	component: OtherAmount,
+	argTypes: {
+		onOtherAmountChange: { action: 'value changed' },
+	},
+	decorators: [withCenterAlignment, withSourceReset],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The currency glyph will be displayed in either the prefix or suffix of the input depending on the currency localisation',
+			},
+		},
+	},
+};
+
+function Template(args: OtherAmountProps) {
+	return <OtherAmount {...args} />;
+}
+
+Template.args = {} as Omit<OtherAmountProps, 'onOtherAmountChange'>;
+
+export const Default = Template.bind({});
+
+Default.args = {
+	selectedAmount: 'other',
+	currency: 'GBP',
+	minAmount: 2,
+};
+
+export const WithSuffix = Template.bind({});
+
+WithSuffix.args = {
+	selectedAmount: 'other',
+	currency: 'SEK',
+	minAmount: 10,
+};

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1753,10 +1753,10 @@
   dependencies:
     mini-svg-data-uri "^1.3.3"
 
-"@guardian/source-react-components-development-kitchen@^3.1.10":
-  version "3.1.10"
-  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-3.1.10.tgz#1f38d98b900be4859c9ed35981737226e4769889"
-  integrity sha512-RV1QiugUDoTivxrafTRFBnk6nEgDlXx2gzqcW6IvzzKf20nlNgtOpfKWZ2JuvU/2mQSyXnqN9IAQtTKvjRcLwg==
+"@guardian/source-react-components-development-kitchen@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-5.0.0.tgz#17fbe059bf70cd6dc3e09726373f8499f0cce80c"
+  integrity sha512-X/LD6mjPy41CvGiEGbicAm7h+MZq50aTyAnESlHQATmNxLHUlLpXy4jZ+M2iePAKlaoCWUY7GnMCi/dP37Wk7w==
 
 "@guardian/source-react-components@^7.1.0":
   version "7.1.0"


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds the 'other amount' field to the new checkout, to allow users to select a custom amount. It uses the [NumericInput](https://guardian.github.io/source/?path=/docs/packages-source-react-components-development-kitchen-numericinput--playground) component from Source dev kitchen to display the currency glyph either before or after the field, depending on localisation, and force a numeric keypad on mobile devices.

[**Trello Card**](https://trello.com/c/3TeO6cLv)

## Why are you doing this?

This allows users to select a custom amount to contribute. I've also added a supplementary hint to the input indicating our (configurable) minimum contribution amount, as we don't currently surface this to users.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

### Mobile - Pixel 5, Chrome
<img width="445" alt="Screenshot 2022-10-18 at 12 24 47" src="https://user-images.githubusercontent.com/29146931/196423585-09104499-bd7d-4991-927b-fa59146dd572.png">

### Tablet - iPad 8th gen, Safari
<img width="623" alt="Screenshot 2022-10-18 at 12 26 20" src="https://user-images.githubusercontent.com/29146931/196423710-34d5bb10-ca5b-462e-ac05-b060dbc6bb39.png">

### Desktop - macOS, Firefox
![Screenshot 2022-10-18 at 12-21-54 Support the Guardian Make a Contribution](https://user-images.githubusercontent.com/29146931/196423957-8d292dbe-0020-46db-b8ab-cd9d3e6db293.png)
