### PR TITLE
Fix integration tests

### DIFF
--- a/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -37,7 +37,7 @@ object Fixtures {
     identityId__c = identityId,
     paymentGateway = Some(paymentGateway),
     createdRequestId__c = "createdreqid_hi",
-    invoiceTemplateId = "defaultInvoiceTemplateId",
+    invoiceTemplateId = "2c92c0f849369b8801493bf7db7e450e",
   )
 
   val contactDetails = ContactDetails("Test-FirstName", "Test-LastName", Some("test@thegulocal.com"), Country.UK)


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
#4261 introduced a mechanism to set the correct invoice template on a subscription, however it broke some integration tests because it used dummy data in the fixtures used by those tests to make calls made to Zuora whereas Zuora expects the invoice id which is passed in to actually exist.

[**Trello Card**](https://trello.com/c/PjWsKxcH/773-fix-it-test-regression)
