### PR TITLE
Patron cancellations

### DIFF
--- a/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
+++ b/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
@@ -47,7 +47,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
-    "ApiGatewayHigh5xxPercentageAlarmExampleapigatewayinstance0B776A32": {
+    "ApiGatewayHigh5xxPercentageAlarmStripepatronsdata8C2DB30B": {
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [
@@ -68,15 +68,15 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "example-api-gateway-instance exceeded 1% error rate",
-        "AlarmName": "High 5XX error % from example-api-gateway-instance (ApiGateway) in PROD",
+        "AlarmDescription": "stripe-patrons-data exceeded 1% error rate",
+        "AlarmName": "High 5XX error % from stripe-patrons-data (ApiGateway) in PROD",
         "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": [
           {
             "Expression": "100*m1/m2",
             "Id": "expr_1",
-            "Label": "% of 5XX responses served for example-api-gateway-instance",
+            "Label": "% of 5XX responses served for stripe-patrons-data",
           },
           {
             "Id": "m1",
@@ -85,7 +85,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
                 "Dimensions": [
                   {
                     "Name": "ApiName",
-                    "Value": "support-PROD-example-api-gateway-instance",
+                    "Value": "support-PROD-stripe-patrons-data",
                   },
                 ],
                 "MetricName": "5XXError",
@@ -103,7 +103,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
                 "Dimensions": [
                   {
                     "Name": "ApiName",
-                    "Value": "support-PROD-example-api-gateway-instance",
+                    "Value": "support-PROD-stripe-patrons-data",
                   },
                 ],
                 "MetricName": "Count",
@@ -122,7 +122,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
     },
     "RestApi0C43BF4B": {
       "Properties": {
-        "Name": "support-PROD-example-api-gateway-instance",
+        "Name": "support-PROD-stripe-patrons-data",
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -211,7 +211,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC5035777c64ff4f14d74070508947cff7b40": {
+    "RestApiDeployment180EC5031415bce23b484655df855d90ebafb1d3": {
       "DependsOn": [
         "RestApipatron1DDE9314",
         "RestApipatronsubscriptioncancelcountryIdPOSTFA2082F3",
@@ -233,7 +233,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC5035777c64ff4f14d74070508947cff7b40",
+          "Ref": "RestApiDeployment180EC5031415bce23b484655df855d90ebafb1d3",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -988,6 +988,38 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
                   ],
                 ],
               },
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/stripe-patrons-data/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:Scan",
+                "dynamodb:UpdateItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:Query",
+                "dynamodb:DescribeTable",
+              ],
+              "Effect": "Allow",
+              "Resource": "arn:aws:dynamodb:*:*:table/SupporterProductData-PROD",
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
+++ b/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
@@ -6,8 +6,39 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
       "GuLambdaErrorPercentageAlarm",
+      "GuLambdaFunction",
+      "GuApiGatewayWithLambdaByPath",
+      "GuApiGateway5xxPercentageAlarm",
     ],
     "gu:cdk:version": "TEST",
+  },
+  "Outputs": {
+    "RestApiEndpoint0551178A": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "RestApi0C43BF4B",
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            {
+              "Ref": "RestApiDeploymentStageprod3855DE66",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
   },
   "Parameters": {
     "DistributionBucketName": {
@@ -17,6 +48,349 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "ApiGatewayHigh5xxPercentageAlarmExampleapigatewayinstance0B776A32": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":my-topic-for-cloudwatch-alerts",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "example-api-gateway-instance exceeded 1% error rate",
+        "AlarmName": "High 5XX error % from example-api-gateway-instance (ApiGateway) in PROD",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "% of 5XX responses served for example-api-gateway-instance",
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "support-PROD-example-api-gateway-instance",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "support-PROD-example-api-gateway-instance",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApi0C43BF4B": {
+      "Properties": {
+        "Name": "support-PROD-example-api-gateway-instance",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApiAccount7C83CF5A": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "RestApi0C43BF4B",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiCloudWatchRoleE3ED6605": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiDeployment180EC50306e942dca44ef0235ca1a23115d2ec23": {
+      "DependsOn": [
+        "RestApilambdaoneGET6E862584",
+        "RestApilambdaoneA9252B2D",
+      ],
+      "Properties": {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApiDeploymentStageprod3855DE66": {
+      "DependsOn": [
+        "RestApiAccount7C83CF5A",
+      ],
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "RestApiDeployment180EC50306e942dca44ef0235ca1a23115d2ec23",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "StageName": "prod",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApilambdaoneA9252B2D": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "lambda-one",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApilambdaoneGET6E862584": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "supporterproductdataapiaccountcreated9B7951CA",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "RestApilambdaoneA9252B2D",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApilambdaoneGETApiPermissionStripePatronsDataPRODRestApi790D3BDCGETlambdaoneCAEDFFD1": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "supporterproductdataapiaccountcreated9B7951CA",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/GET/lambda-one",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApilambdaoneGETApiPermissionTestStripePatronsDataPRODRestApi790D3BDCGETlambdaone328D69C9": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "supporterproductdataapiaccountcreated9B7951CA",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/GET/lambda-one",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
     "StripePatronsDataPROD61F45521": {
       "DependsOn": [
         "StripePatronsDataPRODServiceRoleDefaultPolicy91A6C2F5",
@@ -380,6 +754,213 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::Lambda::Permission",
+    },
+    "supporterproductdataapiaccountcreated9B7951CA": {
+      "DependsOn": [
+        "supporterproductdataapiaccountcreatedServiceRoleDefaultPolicyCC75CDA2",
+        "supporterproductdataapiaccountcreatedServiceRole0BC34CD8",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "support/PROD/supporter-product-data-api/lambda-one.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "supporter-product-data-api",
+            "STACK": "support",
+            "STAGE": "PROD",
+          },
+        },
+        "Handler": "lambda-one.handler",
+        "MemorySize": 1024,
+        "Role": {
+          "Fn::GetAtt": [
+            "supporterproductdataapiaccountcreatedServiceRole0BC34CD8",
+            "Arn",
+          ],
+        },
+        "Runtime": "java11",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "supporter-product-data-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "supporterproductdataapiaccountcreatedServiceRole0BC34CD8": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "supporter-product-data-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "supporterproductdataapiaccountcreatedServiceRoleDefaultPolicyCC75CDA2": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/support/PROD/supporter-product-data-api/lambda-one.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/supporter-product-data-api",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/supporter-product-data-api/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "supporterproductdataapiaccountcreatedServiceRoleDefaultPolicyCC75CDA2",
+        "Roles": [
+          {
+            "Ref": "supporterproductdataapiaccountcreatedServiceRole0BC34CD8",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
   },
 }

--- a/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
+++ b/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
@@ -6,7 +6,6 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
       "GuLambdaErrorPercentageAlarm",
-      "GuLambdaFunction",
       "GuApiGatewayWithLambdaByPath",
       "GuApiGateway5xxPercentageAlarm",
     ],
@@ -212,10 +211,13 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC50306e942dca44ef0235ca1a23115d2ec23": {
+    "RestApiDeployment180EC5035777c64ff4f14d74070508947cff7b40": {
       "DependsOn": [
-        "RestApilambdaoneGET6E862584",
-        "RestApilambdaoneA9252B2D",
+        "RestApipatron1DDE9314",
+        "RestApipatronsubscriptioncancelcountryIdPOSTFA2082F3",
+        "RestApipatronsubscriptioncancelcountryId57A3F9F4",
+        "RestApipatronsubscriptioncancel0F56DD38",
+        "RestApipatronsubscriptionAE58DC90",
       ],
       "Properties": {
         "Description": "Automatically created by the RestApi construct",
@@ -231,7 +233,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC50306e942dca44ef0235ca1a23115d2ec23",
+          "Ref": "RestApiDeployment180EC5035777c64ff4f14d74070508947cff7b40",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -258,7 +260,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Stage",
     },
-    "RestApilambdaoneA9252B2D": {
+    "RestApipatron1DDE9314": {
       "Properties": {
         "ParentId": {
           "Fn::GetAtt": [
@@ -266,59 +268,55 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
             "RootResourceId",
           ],
         },
-        "PathPart": "lambda-one",
+        "PathPart": "patron",
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
         },
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "RestApilambdaoneGET6E862584": {
+    "RestApipatronsubscriptionAE58DC90": {
       "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "GET",
-        "Integration": {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                {
-                  "Fn::GetAtt": [
-                    "supporterproductdataapiaccountcreated9B7951CA",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
+        "ParentId": {
+          "Ref": "RestApipatron1DDE9314",
         },
-        "ResourceId": {
-          "Ref": "RestApilambdaoneA9252B2D",
-        },
+        "PathPart": "subscription",
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
         },
       },
-      "Type": "AWS::ApiGateway::Method",
+      "Type": "AWS::ApiGateway::Resource",
     },
-    "RestApilambdaoneGETApiPermissionStripePatronsDataPRODRestApi790D3BDCGETlambdaoneCAEDFFD1": {
+    "RestApipatronsubscriptioncancel0F56DD38": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApipatronsubscriptionAE58DC90",
+        },
+        "PathPart": "cancel",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApipatronsubscriptioncancelcountryId57A3F9F4": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApipatronsubscriptioncancel0F56DD38",
+        },
+        "PathPart": "{countryId}",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApipatronsubscriptioncancelcountryIdPOSTApiPermissionStripePatronsDataPRODRestApi790D3BDCPOSTpatronsubscriptioncancelcountryId69A52814": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "supporterproductdataapiaccountcreated9B7951CA",
+            "stripepatronsdatacancelled2E3CED96",
             "Arn",
           ],
         },
@@ -347,19 +345,19 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
               {
                 "Ref": "RestApiDeploymentStageprod3855DE66",
               },
-              "/GET/lambda-one",
+              "/POST/patron/subscription/cancel/*",
             ],
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "RestApilambdaoneGETApiPermissionTestStripePatronsDataPRODRestApi790D3BDCGETlambdaone328D69C9": {
+    "RestApipatronsubscriptioncancelcountryIdPOSTApiPermissionTestStripePatronsDataPRODRestApi790D3BDCPOSTpatronsubscriptioncancelcountryId414EED6A": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "supporterproductdataapiaccountcreated9B7951CA",
+            "stripepatronsdatacancelled2E3CED96",
             "Arn",
           ],
         },
@@ -384,12 +382,52 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
               {
                 "Ref": "RestApi0C43BF4B",
               },
-              "/test-invoke-stage/GET/lambda-one",
+              "/test-invoke-stage/POST/patron/subscription/cancel/*",
             ],
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
+    },
+    "RestApipatronsubscriptioncancelcountryIdPOSTFA2082F3": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "POST",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "stripepatronsdatacancelled2E3CED96",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "RestApipatronsubscriptioncancelcountryId57A3F9F4",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
     },
     "StripePatronsDataPROD61F45521": {
       "DependsOn": [
@@ -755,30 +793,31 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "supporterproductdataapiaccountcreated9B7951CA": {
+    "stripepatronsdatacancelled2E3CED96": {
       "DependsOn": [
-        "supporterproductdataapiaccountcreatedServiceRoleDefaultPolicyCC75CDA2",
-        "supporterproductdataapiaccountcreatedServiceRole0BC34CD8",
+        "stripepatronsdatacancelledServiceRoleDefaultPolicy46825C35",
+        "stripepatronsdatacancelledServiceRole157E3052",
       ],
       "Properties": {
         "Code": {
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "support/PROD/supporter-product-data-api/lambda-one.zip",
+          "S3Key": "support/PROD/stripe-patrons-data/stripe-patrons-data.jar",
         },
         "Environment": {
           "Variables": {
-            "APP": "supporter-product-data-api",
+            "APP": "stripe-patrons-data",
             "STACK": "support",
             "STAGE": "PROD",
           },
         },
-        "Handler": "lambda-one.handler",
+        "FunctionName": "stripe-patrons-data-cancelled-PROD",
+        "Handler": "com.gu.patrons.lambdas.PatronCancelledEventLambda::handleRequest",
         "MemorySize": 1024,
         "Role": {
           "Fn::GetAtt": [
-            "supporterproductdataapiaccountcreatedServiceRole0BC34CD8",
+            "stripepatronsdatacancelledServiceRole157E3052",
             "Arn",
           ],
         },
@@ -786,7 +825,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
         "Tags": [
           {
             "Key": "App",
-            "Value": "supporter-product-data-api",
+            "Value": "stripe-patrons-data",
           },
           {
             "Key": "gu:cdk:version",
@@ -805,11 +844,11 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
             "Value": "PROD",
           },
         ],
-        "Timeout": 30,
+        "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
     },
-    "supporterproductdataapiaccountcreatedServiceRole0BC34CD8": {
+    "stripepatronsdatacancelledServiceRole157E3052": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -840,7 +879,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
         "Tags": [
           {
             "Key": "App",
-            "Value": "supporter-product-data-api",
+            "Value": "stripe-patrons-data",
           },
           {
             "Key": "gu:cdk:version",
@@ -862,7 +901,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "supporterproductdataapiaccountcreatedServiceRoleDefaultPolicyCC75CDA2": {
+    "stripepatronsdatacancelledServiceRoleDefaultPolicy46825C35": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -901,7 +940,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/support/PROD/supporter-product-data-api/lambda-one.zip",
+                      "/support/PROD/stripe-patrons-data/stripe-patrons-data.jar",
                     ],
                   ],
                 },
@@ -922,7 +961,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/PROD/support/supporter-product-data-api",
+                    ":parameter/PROD/support/stripe-patrons-data",
                   ],
                 ],
               },
@@ -945,7 +984,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/PROD/support/supporter-product-data-api/*",
+                    ":parameter/PROD/support/stripe-patrons-data/*",
                   ],
                 ],
               },
@@ -953,10 +992,10 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "supporterproductdataapiaccountcreatedServiceRoleDefaultPolicyCC75CDA2",
+        "PolicyName": "stripepatronsdatacancelledServiceRoleDefaultPolicy46825C35",
         "Roles": [
           {
-            "Ref": "supporterproductdataapiaccountcreatedServiceRole0BC34CD8",
+            "Ref": "stripepatronsdatacancelledServiceRole157E3052",
           },
         ],
       },

--- a/cdk/lib/stripe-patrons-data.test.ts
+++ b/cdk/lib/stripe-patrons-data.test.ts
@@ -12,7 +12,5 @@ describe("The Stripe patrons data stack", () => {
 
     const template = Template.fromStack(stack);
     expect(template.toJSON()).toMatchSnapshot();
-
-    //expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
   });
 });

--- a/cdk/lib/stripe-patrons-data.test.ts
+++ b/cdk/lib/stripe-patrons-data.test.ts
@@ -12,5 +12,7 @@ describe("The Stripe patrons data stack", () => {
 
     const template = Template.fromStack(stack);
     expect(template.toJSON()).toMatchSnapshot();
+
+    //expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
   });
 });

--- a/cdk/lib/stripe-patrons-data.ts
+++ b/cdk/lib/stripe-patrons-data.ts
@@ -92,6 +92,9 @@ class PatronCancelledLambda extends GuLambdaFunction {
       runtime: Runtime.JAVA_11,
       timeout: Duration.minutes(15),
     });
+
+    this.addToRolePolicy(parameterStorePolicy(scope, appName));
+    this.addToRolePolicy(dynamoPolicy(scope.stage));
   }
 }
 
@@ -107,7 +110,7 @@ export class StripePatronsData extends GuStack {
 
     // Wire up the API
     new GuApiGatewayWithLambdaByPath(this, {
-      app: "example-api-gateway-instance",
+      app: appName,
       targets: [
         {
           path: "patron/subscription/cancel/{countryId}",

--- a/cdk/lib/stripe-patrons-data.ts
+++ b/cdk/lib/stripe-patrons-data.ts
@@ -1,10 +1,11 @@
-import { GuScheduledLambda } from "@guardian/cdk";
+import { GuApiGatewayWithLambdaByPath, GuScheduledLambda } from "@guardian/cdk";
 import type {
   GuLambdaErrorPercentageMonitoringProps,
   NoMonitoring,
 } from "@guardian/cdk/lib/constructs/cloudwatch";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack } from "@guardian/cdk/lib/constructs/core";
+import { GuLambdaFunction } from "@guardian/cdk/lib/constructs/lambda";
 import type { App } from "aws-cdk-lib";
 import { Duration } from "aws-cdk-lib";
 import { Schedule } from "aws-cdk-lib/aws-events";
@@ -82,5 +83,36 @@ export class StripePatronsData extends GuStack {
     super(scope, id, props);
 
     new StripePatronsDataLambda(this, id);
+
+    // Configure lambdas
+    const accountCreatedLambda = new GuLambdaFunction(
+      this,
+      "supporter-product-data-api-account-created",
+      {
+        app: "supporter-product-data-api",
+        runtime: Runtime.JAVA_11,
+        handler: "lambda-one.handler",
+        fileName: "lambda-one.zip",
+      }
+    );
+
+    // Wire up the API
+    new GuApiGatewayWithLambdaByPath(this, {
+      app: "example-api-gateway-instance",
+      targets: [
+        {
+          path: "lambda-one",
+          httpMethod: "GET",
+          lambda: accountCreatedLambda,
+        },
+      ],
+      // Create an alarm
+      monitoringConfiguration: {
+        snsTopicName: "my-topic-for-cloudwatch-alerts",
+        http5xxAlarm: {
+          tolerated5xxPercentage: 1,
+        },
+      },
+    });
   }
 }

--- a/cdk/lib/stripe-patrons-data.ts
+++ b/cdk/lib/stripe-patrons-data.ts
@@ -12,9 +12,39 @@ import { Schedule } from "aws-cdk-lib/aws-events";
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
 
+function environmentFromStage(stage: string) {
+  return stage == "CODE" ? "DEV" : stage;
+}
+
+function dynamoPolicy(stage: string) {
+  return new PolicyStatement({
+    actions: [
+      "dynamodb:GetItem",
+      "dynamodb:Scan",
+      "dynamodb:UpdateItem",
+      "dynamodb:DeleteItem",
+      "dynamodb:Query",
+      "dynamodb:DescribeTable",
+    ],
+    resources: [
+      `arn:aws:dynamodb:*:*:table/SupporterProductData-${environmentFromStage(
+        stage
+      )}`,
+    ],
+  });
+}
+
+function parameterStorePolicy(scope: GuStack, appName: string) {
+  return new PolicyStatement({
+    actions: ["ssm:GetParametersByPath"],
+    resources: [
+      `arn:aws:ssm:${scope.region}:${scope.account}:parameter/${scope.stage}/support/${appName}/*`,
+    ],
+  });
+}
+
 class StripePatronsDataLambda extends GuScheduledLambda {
-  constructor(scope: GuStack, id: string) {
-    const appName = "stripe-patrons-data";
+  constructor(scope: GuStack, id: string, appName: string) {
     super(scope, id, {
       app: appName,
       fileName: `${appName}.jar`,
@@ -32,8 +62,8 @@ class StripePatronsDataLambda extends GuScheduledLambda {
     ): NoMonitoring | GuLambdaErrorPercentageMonitoringProps {
       if (stage == "PROD") {
         return {
-          alarmName: `${appName}-${scope.stage}-ErrorAlarm`,
-          alarmDescription: `Triggers if there are errors from ${appName} on ${scope.stage}`,
+          alarmName: `${appName}-${stage}-ErrorAlarm`,
+          alarmDescription: `Triggers if there are errors from ${appName} on ${stage}`,
           snsTopicName: "reader-revenue-dev",
           toleratedErrorPercentage: 1,
           numberOfMinutesAboveThresholdBeforeAlarm: 46, // The lambda runs every 15 mins so alarm if it fails 3 times in a row
@@ -42,39 +72,26 @@ class StripePatronsDataLambda extends GuScheduledLambda {
       return { noMonitoring: true };
     }
 
-    function environmentFromStage(stage: string) {
-      return stage == "CODE" ? "DEV" : stage;
-    }
-
     function scheduleRateForEnvironment(stage: string) {
       return Schedule.rate(Duration.minutes(stage == "PROD" ? 15 : 60));
     }
 
-    this.addToRolePolicy(
-      new PolicyStatement({
-        actions: ["ssm:GetParametersByPath"],
-        resources: [
-          `arn:aws:ssm:${scope.region}:${scope.account}:parameter/${scope.stage}/support/${appName}/*`,
-        ],
-      })
-    );
-    this.addToRolePolicy(
-      new PolicyStatement({
-        actions: [
-          "dynamodb:GetItem",
-          "dynamodb:Scan",
-          "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem",
-          "dynamodb:Query",
-          "dynamodb:DescribeTable",
-        ],
-        resources: [
-          `arn:aws:dynamodb:*:*:table/SupporterProductData-${environmentFromStage(
-            scope.stage
-          )}`,
-        ],
-      })
-    );
+    this.addToRolePolicy(parameterStorePolicy(scope, appName));
+    this.addToRolePolicy(dynamoPolicy(scope.stage));
+  }
+}
+
+class PatronCancelledLambda extends GuLambdaFunction {
+  constructor(scope: GuStack, id: string, appName: string) {
+    super(scope, `${appName}-cancelled`, {
+      app: appName,
+      fileName: `${appName}.jar`,
+      functionName: `${appName}-cancelled-${scope.stage}`,
+      handler:
+        "com.gu.patrons.lambdas.PatronCancelledEventLambda::handleRequest",
+      runtime: Runtime.JAVA_11,
+      timeout: Duration.minutes(15),
+    });
   }
 }
 
@@ -82,28 +99,20 @@ export class StripePatronsData extends GuStack {
   constructor(scope: App, id: string, props: GuStackProps) {
     super(scope, id, props);
 
-    new StripePatronsDataLambda(this, id);
+    const appName = "stripe-patrons-data";
 
-    // Configure lambdas
-    const accountCreatedLambda = new GuLambdaFunction(
-      this,
-      "supporter-product-data-api-account-created",
-      {
-        app: "supporter-product-data-api",
-        runtime: Runtime.JAVA_11,
-        handler: "lambda-one.handler",
-        fileName: "lambda-one.zip",
-      }
-    );
+    new StripePatronsDataLambda(this, id, appName);
+
+    const patronCancelledLambda = new PatronCancelledLambda(this, id, appName);
 
     // Wire up the API
     new GuApiGatewayWithLambdaByPath(this, {
       app: "example-api-gateway-instance",
       targets: [
         {
-          path: "lambda-one",
-          httpMethod: "GET",
-          lambda: accountCreatedLambda,
+          path: "patron/subscription/cancel/{countryId}",
+          httpMethod: "POST",
+          lambda: patronCancelledLambda,
         },
       ],
       // Create an alarm

--- a/stripe-patrons-data/build.sbt
+++ b/stripe-patrons-data/build.sbt
@@ -52,9 +52,9 @@ deployToCode := {
   (s"aws s3 cp ${assembly.value} s3://" + s3Bucket + "/" + s3Path + " --profile membership --region eu-west-1").!!
   List(
     "stripe-patrons-data-CODE",
-    "stripe-patrons-data-cancelled-CODE"
+    "stripe-patrons-data-cancelled-CODE",
   ).foreach(functionPartial => {
     System.out.println(s"Updating function $functionPartial")
-    s"aws lambda update-function-code --function-name ${functionPartial} --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
+    s"aws lambda update-function-code --function-name $functionPartial --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
   })
 }

--- a/stripe-patrons-data/build.sbt
+++ b/stripe-patrons-data/build.sbt
@@ -13,6 +13,8 @@ libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "dynamodb" % awsClientVersion2,
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
+  "com.amazonaws" % "aws-lambda-java-events" % "3.11.0",
+  "com.stripe" % "stripe-java" % "20.128.0",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
@@ -50,8 +52,9 @@ deployToCode := {
   (s"aws s3 cp ${assembly.value} s3://" + s3Bucket + "/" + s3Path + " --profile membership --region eu-west-1").!!
   List(
     "stripe-patrons-data-CODE",
-  ).foreach(functionPartial =>
-    s"aws lambda update-function-code --function-name ${functionPartial} --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!,
-  )
-
+    "stripe-patrons-data-cancelled-CODE"
+  ).foreach(functionPartial => {
+    System.out.println(s"Updating function $functionPartial")
+    s"aws lambda update-function-code --function-name ${functionPartial} --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
+  })
 }

--- a/stripe-patrons-data/riff-raff.yaml
+++ b/stripe-patrons-data/riff-raff.yaml
@@ -1,5 +1,5 @@
-stacks: [support]
-regions: [eu-west-1]
+stacks: [ support ]
+regions: [ eu-west-1 ]
 allowedStages:
   - CODE
   - PROD
@@ -15,7 +15,10 @@ deployments:
     type: aws-lambda
     parameters:
       bucket: membership-dist
-      functionNames: [stripe-patrons-data-]
+      functionNames:
+        - stripe-patrons-data-
+        - stripe-patrons-data-cancelled-
       fileName: stripe-patrons-data.jar
       prefixStack: false
-    dependencies: [cfn]
+    dependencies: [ cfn ]
+

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/conf/PatronsStripeConfig.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/conf/PatronsStripeConfig.scala
@@ -7,6 +7,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 case class PatronsStripeConfig(
     apiKey: String,
+    signingSecret: String,
 )
 
 object PatronsStripeConfig extends ConfigService {
@@ -17,6 +18,7 @@ object PatronsStripeConfig extends ConfigService {
     ParameterStoreService(stage).getParametersByPath(stripeConfigPath).map { params =>
       PatronsStripeConfig(
         findParameterOrThrow("api-key", params),
+        findParameterOrThrow("signing-secret", params),
       )
     }
   }

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/lambdas/PatronCancelledEventLambda.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/lambdas/PatronCancelledEventLambda.scala
@@ -1,13 +1,57 @@
 package com.gu.patrons.lambdas
 
-import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
+import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
 import com.gu.monitoring.SafeLogger
+import com.gu.patrons.conf.PatronsStripeConfig
+import com.gu.patrons.model.{Error, InvalidRequestError, StageConstructors}
+import com.stripe.net.Webhook
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
 
-class PatronCancelledEventLambda extends RequestHandler[PatronCancelledInputEvent, Unit] {
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.{Duration, MILLISECONDS, MINUTES}
+import scala.jdk.CollectionConverters.MapHasAsScala
+import scala.util.Try
 
-  override def handleRequest(input: PatronCancelledInputEvent, context: Context) = {
-    SafeLogger.info(s"CountryId is ${input.countryId}")
+object PatronCancelledEventLambda {
+
+  def handleRequest(event: APIGatewayProxyRequestEvent): APIGatewayProxyResponseEvent = {
+    val response = new APIGatewayProxyResponseEvent()
+    val stage = StageConstructors.fromEnvironment
+    SafeLogger.info(s"Stage is $stage")
+    SafeLogger.info(s"Path is ${event.getPathParameters.get("countryId")}")
+
+    Await.result(
+      PatronsStripeConfig.fromParameterStore(stage).map { config =>
+        SafeLogger.info(s"signing secret is ${config.signingSecret}")
+        val payload = getPayload(event, config.signingSecret)
+      },
+      Duration(15, MINUTES),
+    )
+
+    response.setStatusCode(200)
+    response
   }
+
+  def getPayload(event: APIGatewayProxyRequestEvent, signingSecret: String): Either[Error, String] =
+    for {
+      payload <- Option(event.getBody()).toRight(InvalidRequestError("Missing body"))
+      _ = SafeLogger.info(s"payload is $payload")
+      sigHeader <- event.getHeaders.asScala.get("Stripe-Signature").toRight(InvalidRequestError("Missing sig header"))
+      _ <- Try(Webhook.Signature.verifyHeader(payload, sigHeader, signingSecret, 300)).toEither.left.map(e =>
+        InvalidRequestError(e.getMessage()),
+      )
+      _ = SafeLogger.info(s"payload successfully verified")
+    } yield payload
+
 }
 
-case class PatronCancelledInputEvent(countryId: String)
+case class PatronCancelledEvent(data: PatronCancelledData, `type`: String)
+object PatronCancelledEvent {
+  implicit val decoder: Decoder[PatronCancelledEvent] = deriveDecoder
+  implicit val dataDecoder: Decoder[PatronCancelledData] = deriveDecoder
+  implicit val objectDecoder: Decoder[PatronCancelledObject] = deriveDecoder
+}
+case class PatronCancelledData(`object`: PatronCancelledObject)
+case class PatronCancelledObject(customer: String)

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/lambdas/PatronCancelledEventLambda.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/lambdas/PatronCancelledEventLambda.scala
@@ -1,53 +1,143 @@
 package com.gu.patrons.lambdas
 
+import cats.data.EitherT
 import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
 import com.gu.monitoring.SafeLogger
-import com.gu.patrons.conf.PatronsStripeConfig
-import com.gu.patrons.model.{Error, InvalidRequestError, StageConstructors}
+import com.gu.okhttp.RequestRunners.configurableFutureRunner
+import com.gu.patrons.conf.{PatronsIdentityConfig, PatronsStripeConfig}
+import com.gu.patrons.model.{ConfigLoadingError, DynamoDbError, Error, InvalidJsonError, InvalidRequestError, StageConstructors, UserNotFoundIdentityError, UserNotFoundStripeError}
+import com.gu.patrons.services.PatronsIdentityService
+import com.gu.supporterdata.model.Stage
+import com.gu.supporterdata.services.SupporterDataDynamoService
+import com.stripe.model.Customer
 import com.stripe.net.Webhook
+import com.typesafe.scalalogging.StrictLogging
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
+import io.circe.parser.decode
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemResponse
 
-import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.{Duration, MILLISECONDS, MINUTES}
+import scala.concurrent.duration.{Duration, DurationInt, MINUTES}
+import scala.concurrent.{Await, Future}
 import scala.jdk.CollectionConverters.MapHasAsScala
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
-object PatronCancelledEventLambda {
+object PatronCancelledEventLambda extends StrictLogging {
 
   def handleRequest(event: APIGatewayProxyRequestEvent): APIGatewayProxyResponseEvent = {
-    val response = new APIGatewayProxyResponseEvent()
-    val stage = StageConstructors.fromEnvironment
-    SafeLogger.info(s"Stage is $stage")
-    SafeLogger.info(s"Path is ${event.getPathParameters.get("countryId")}")
-
     Await.result(
-      PatronsStripeConfig.fromParameterStore(stage).map { config =>
-        SafeLogger.info(s"signing secret is ${config.signingSecret}")
-        val payload = getPayload(event, config.signingSecret)
-      },
+      deleteCustomerFromDynamoDb(event),
       Duration(15, MINUTES),
     )
+  }
 
-    response.setStatusCode(200)
+  def deleteCustomerFromDynamoDb(event: APIGatewayProxyRequestEvent): Future[APIGatewayProxyResponseEvent] = {
+    val stage = StageConstructors.fromEnvironment
+    SafeLogger.info(s"Path is ${event.getPathParameters.get("countryId")}")
+    val runner = configurableFutureRunner(60.seconds)
+
+    (for {
+      stripeConfig <- getStripeConfig(stage)
+      identityConfig <- getIdentityConfig(stage)
+      identityService = new PatronsIdentityService(identityConfig, runner)
+      payload <- getPayload(event, stripeConfig.signingSecret)
+      event <- getEvent(payload)
+      customer <- getCustomer(event.customerId)
+      identityId <- getIdentityId(customer.getEmail, identityService)
+      _ <- deleteCustomer(stage, identityId)
+    } yield ()).value.map(getAPIGatewayResult)
+  }
+
+  def getAPIGatewayResult(result: Either[Error, Unit]) = {
+    val response = new APIGatewayProxyResponseEvent()
+    result match {
+      case Left(error @ (ConfigLoadingError(_) | DynamoDbError(_))) =>
+        logger.error(error.message)
+        response.setStatusCode(500)
+      case Left(error @ (InvalidRequestError(_) | InvalidJsonError(_))) =>
+        logger.error(error.message)
+        response.setStatusCode(400)
+      case Left(error @ (UserNotFoundIdentityError(_) | UserNotFoundStripeError(_))) =>
+        logger.error(error.message)
+        response.setStatusCode(200)
+      case Right(_) =>
+        logger.info("Successfully removed user from data store")
+        response.setStatusCode(200)
+    }
     response
   }
 
-  def getPayload(event: APIGatewayProxyRequestEvent, signingSecret: String): Either[Error, String] =
-    for {
-      payload <- Option(event.getBody()).toRight(InvalidRequestError("Missing body"))
+  def getStripeConfig(stage: Stage): EitherT[Future, Error, PatronsStripeConfig] = {
+    logger.info("Attempting to fetch Stripe config information from parameter store")
+    val futureConfig: Future[Either[Error, PatronsStripeConfig]] = PatronsStripeConfig
+      .fromParameterStore(stage)
+      .transform {
+        case Success(config) => Try(Right(config))
+        case Failure(err) => Try(Left(ConfigLoadingError(err.getMessage)))
+      }
+    EitherT(futureConfig)
+  }
+
+  def getIdentityConfig(stage: Stage): EitherT[Future, Error, PatronsIdentityConfig] = {
+    logger.info("Attempting to fetch Identity config information from parameter store")
+    val futureConfig: Future[Either[Error, PatronsIdentityConfig]] = PatronsIdentityConfig
+      .fromParameterStore(stage)
+      .transform {
+        case Success(config) => Try(Right(config))
+        case Failure(err) => Try(Left(ConfigLoadingError(err.getMessage)))
+      }
+    EitherT(futureConfig)
+  }
+
+  def getPayload(
+      event: APIGatewayProxyRequestEvent,
+      signingSecret: String,
+  ): EitherT[Future, Error, String] = {
+    logger.info("Attempting to verify event payload")
+    EitherT.fromEither(for {
+      payload <- Option(event.getBody).toRight(InvalidRequestError("Missing body"))
       _ = SafeLogger.info(s"payload is $payload")
       sigHeader <- event.getHeaders.asScala.get("Stripe-Signature").toRight(InvalidRequestError("Missing sig header"))
-      _ <- Try(Webhook.Signature.verifyHeader(payload, sigHeader, signingSecret, 300)).toEither.left.map(e =>
-        InvalidRequestError(e.getMessage()),
-      )
-      _ = SafeLogger.info(s"payload successfully verified")
-    } yield payload
+      _ <- Try(
+        Webhook.Signature.verifyHeader(payload, sigHeader, signingSecret, 300),
+      ).toEither.left.map(e => InvalidRequestError(e.getMessage))
+      _ = logger.info(s"payload successfully verified")
+    } yield payload)
+  }
 
+  def getEvent(payload: String): EitherT[Future, Error, PatronCancelledEvent] = {
+    logger.info(s"Attempting to decode event from payload: $payload")
+    EitherT.fromEither(decode[PatronCancelledEvent](payload).left.map(e => InvalidJsonError(e.getMessage)))
+  }
+
+  def getCustomer(customerId: String): EitherT[Future, Error, Customer] = {
+    logger.info(s"Attempting to retrieve customer with id $customerId from Stripe")
+    EitherT.fromEither(Try(Customer.retrieve(customerId)).toEither.left.map(e => UserNotFoundStripeError(e.getMessage)))
+  }
+
+  def getIdentityId(
+      email: String,
+      identityService: PatronsIdentityService,
+  ): EitherT[Future, UserNotFoundIdentityError, String] = {
+    logger.info(s"Attempting to find identity id for user with email $email")
+    EitherT(
+      identityService
+        .getUserIdFromEmail(email)
+        .map(_.toRight(UserNotFoundIdentityError(s"No identity id found for email $email"))),
+    )
+  }
+
+  def deleteCustomer(stage: Stage, identityId: String): EitherT[Future, Error, DeleteItemResponse] = {
+    logger.info(s"Attempting to delete Patron record for user with identity id $identityId")
+    val dynamoService = SupporterDataDynamoService(stage)
+    EitherT(dynamoService.deleteItem(identityId).map(_.left.map(DynamoDbError)))
+  }
 }
 
-case class PatronCancelledEvent(data: PatronCancelledData, `type`: String)
+case class PatronCancelledEvent(data: PatronCancelledData, `type`: String) {
+  def customerId = data.`object`.customer
+}
 object PatronCancelledEvent {
   implicit val decoder: Decoder[PatronCancelledEvent] = deriveDecoder
   implicit val dataDecoder: Decoder[PatronCancelledData] = deriveDecoder

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/lambdas/PatronCancelledEventLambda.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/lambdas/PatronCancelledEventLambda.scala
@@ -1,0 +1,13 @@
+package com.gu.patrons.lambdas
+
+import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
+import com.gu.monitoring.SafeLogger
+
+class PatronCancelledEventLambda extends RequestHandler[PatronCancelledInputEvent, Unit] {
+
+  override def handleRequest(input: PatronCancelledInputEvent, context: Context) = {
+    SafeLogger.info(s"CountryId is ${input.countryId}")
+  }
+}
+
+case class PatronCancelledInputEvent(countryId: String)

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/model/Errors.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/model/Errors.scala
@@ -10,6 +10,8 @@ case class InvalidRequestError(message: String) extends Error
 
 case class InvalidJsonError(message: String) extends Error
 
-case class MissingPaymentNumberError(message: String) extends Error
+case class UserNotFoundIdentityError(message: String) extends Error
 
-case class ZuoraApiError(message: String) extends Error
+case class UserNotFoundStripeError(message: String) extends Error
+
+case class DynamoDbError(message: String) extends Error

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/model/Errors.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/model/Errors.scala
@@ -1,0 +1,15 @@
+package com.gu.patrons.model
+
+sealed trait Error {
+  val message: String
+}
+
+case class ConfigLoadingError(message: String) extends Error
+
+case class InvalidRequestError(message: String) extends Error
+
+case class InvalidJsonError(message: String) extends Error
+
+case class MissingPaymentNumberError(message: String) extends Error
+
+case class ZuoraApiError(message: String) extends Error

--- a/stripe-patrons-data/src/test/scala/com/gu/patrons/services/Fixtures.scala
+++ b/stripe-patrons-data/src/test/scala/com/gu/patrons/services/Fixtures.scala
@@ -363,4 +363,133 @@ object Fixtures {
     }
     """
 
+  val patronCancelledEventJson =
+    """
+      {
+        "id": "evt_1LudpBJETvkRwpwqmTN4BiHf",
+        "object": "event",
+        "api_version": "2018-07-27",
+        "created": 1666191893,
+        "data": {
+            "object": {
+                "id": "sub_sched_1Ludp9JETvkRwpwqjpaRy7xf",
+                "object": "subscription_schedule",
+                "application": null,
+                "billing": "charge_automatically",
+                "billing_thresholds": null,
+                "canceled_at": 1666191892,
+                "collection_method": "charge_automatically",
+                "completed_at": null,
+                "created": 1666191891,
+                "current_phase": null,
+                "customer": "cus_Mdvgw8EXalnWPN",
+                "default_payment_method": null,
+                "default_settings": {
+                    "application_fee_percent": null,
+                    "automatic_tax": {
+                        "enabled": false
+                    },
+                    "billing_cycle_anchor": "automatic",
+                    "billing_thresholds": null,
+                    "collection_method": "charge_automatically",
+                    "default_payment_method": null,
+                    "default_source": null,
+                    "description": null,
+                    "invoice_settings": null,
+                    "transfer_data": null
+                },
+                "default_source": null,
+                "end_behavior": "release",
+                "invoice_settings": null,
+                "livemode": false,
+                "metadata": {},
+                "phases": [
+                    {
+                        "add_invoice_items": [],
+                        "application_fee_percent": null,
+                        "billing_cycle_anchor": null,
+                        "billing_thresholds": null,
+                        "collection_method": null,
+                        "coupon": null,
+                        "currency": "usd",
+                        "default_payment_method": null,
+                        "default_tax_rates": [],
+                        "description": null,
+                        "end_date": 1668870291,
+                        "invoice_settings": null,
+                        "metadata": {},
+                        "plans": [
+                            {
+                                "billing_thresholds": null,
+                                "plan": "price_1Ludp3JETvkRwpwqqzio1ZAa",
+                                "price": "price_1Ludp3JETvkRwpwqqzio1ZAa",
+                                "quantity": 1,
+                                "tax_rates": []
+                            }
+                        ],
+                        "prorate": true,
+                        "proration_behavior": "create_prorations",
+                        "start_date": 1666191891,
+                        "tax_percent": null,
+                        "transfer_data": null,
+                        "trial_end": null
+                    },
+                    {
+                        "add_invoice_items": [],
+                        "application_fee_percent": null,
+                        "billing_cycle_anchor": null,
+                        "billing_thresholds": null,
+                        "collection_method": null,
+                        "coupon": null,
+                        "currency": "usd",
+                        "default_payment_method": null,
+                        "default_tax_rates": [],
+                        "description": null,
+                        "end_date": 1671462291,
+                        "invoice_settings": null,
+                        "metadata": {},
+                        "plans": [
+                            {
+                                "billing_thresholds": null,
+                                "plan": "price_1Ludp3JETvkRwpwqqzio1ZAa",
+                                "price": "price_1Ludp3JETvkRwpwqqzio1ZAa",
+                                "quantity": 2,
+                                "tax_rates": []
+                            }
+                        ],
+                        "prorate": true,
+                        "proration_behavior": "create_prorations",
+                        "start_date": 1668870291,
+                        "tax_percent": null,
+                        "transfer_data": null,
+                        "trial_end": null
+                    }
+                ],
+                "released_at": null,
+                "released_subscription": null,
+                "renewal_behavior": "release",
+                "renewal_interval": null,
+                "status": "canceled",
+                "subscription": "sub_1Ludp9JETvkRwpwqycRMOqKB",
+                "test_clock": null
+            },
+            "previous_attributes": {
+                "canceled_at": null,
+                "current_phase": {
+                    "end_date": 1668870291,
+                    "start_date": 1666191891
+                },
+                "status": "active"
+            }
+        },
+        "livemode": false,
+        "pending_webhooks": 1,
+        "request": {
+            "id": "req_72L2bFQ27rqY96",
+            "idempotency_key": "74a42f32-b262-40ec-b94b-a220744b4fcb"
+        },
+        "type": "subscription_schedule.canceled"
+    }
+    """
+
 }

--- a/stripe-patrons-data/src/test/scala/com/gu/patrons/services/SerialisationSpec.scala
+++ b/stripe-patrons-data/src/test/scala/com/gu/patrons/services/SerialisationSpec.scala
@@ -1,5 +1,6 @@
 package com.gu.patrons.services
 
+import com.gu.patrons.lambdas.PatronCancelledEvent
 import com.gu.patrons.model.StripeSubscription
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.parser._
@@ -18,4 +19,15 @@ class SerialisationSpec extends AnyFlatSpec with Matchers with LazyLogging {
     }
 
   }
+
+  "PatronCancelledEvent" should "deserialise successfully" in {
+    decode[PatronCancelledEvent](Fixtures.patronCancelledEventJson) match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right(sub) =>
+        logger.info(sub.data.`object`.customer)
+        sub.data.`object`.customer should be("cus_Mdvgw8EXalnWPN")
+    }
+  }
+
 }

--- a/support-modules/supporter-product-data-dynamo/src/main/scala/com/gu/supporterdata/model/FieldNames.scala
+++ b/support-modules/supporter-product-data-dynamo/src/main/scala/com/gu/supporterdata/model/FieldNames.scala
@@ -1,18 +1,24 @@
 package com.gu.supporterdata.model
 
 object FieldNames {
-  val subscriptionName = "subscriptionName"
+  val subscriptionNameField = "subscriptionName"
 
-  val identityId = "identityId"
+  val identityIdField = "identityId"
 
-  val productRatePlanName = "productRatePlanName"
+  val productRatePlanNameField = "productRatePlanName"
 
-  val productRatePlanId = "productRatePlanId"
+  val productRatePlanIdField = "productRatePlanId"
 
-  val termEndDate = "termEndDate"
+  val termEndDateField = "termEndDate"
 
-  val contractEffectiveDate = "contractEffectiveDate"
+  val contractEffectiveDateField = "contractEffectiveDate"
 
-  val subscriptionStatus = "subscriptionStatus"
+  val cancellationDateField = "cancellationDate"
+
+  val expiryDateNameField = "expiryDate"
+
+  val contributionAmountField = "contributionAmount"
+
+  val contributionCurrencyField = "contributionCurrency"
 
 }

--- a/support-modules/supporter-product-data-dynamo/src/main/scala/com/gu/supporterdata/services/SupporterDataDynamoService.scala
+++ b/support-modules/supporter-product-data-dynamo/src/main/scala/com/gu/supporterdata/services/SupporterDataDynamoService.scala
@@ -27,9 +27,11 @@ class SupporterDataDynamoService(client: DynamoDbAsyncClient, tableName: String)
 
   def deleteItem(
       identityIdToDelete: String,
+      subscriptionId: String,
   )(implicit executionContext: ExecutionContext): Future[Either[String, DeleteItemResponse]] = {
     val key = Map(
       identityId -> AttributeValue.builder.s(identityIdToDelete).build,
+      subscriptionName -> AttributeValue.builder.s(subscriptionId).build,
     ).asJava
     val request = DeleteItemRequest.builder.tableName(tableName).key(key).build
     client


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Currently we have a system to add Patrons customers into the SupporterProductData data store when they take out a subscription, but no way to remove them when they cancel. This PR provides that mechanism.

## Technical details
This PR consists of a lambda `PatronCancelledLambda` which is triggered by an API Gateway endpoint which in turn is called by a Stripe webhook whenever a subscription is cancelled (the webhook type is `customer.subscription.deleted`). 

This then finds the appropriate record in the Dynamo table and sets a cancellation date attribute to today.

[Details of how to test this are here](https://docs.google.com/document/d/1IbU_r-h71cIHbtSpWkm43E_TRTxoKNQtjb4-PekXRkI/edit#heading=h.z5ca9etiqjqp)
