### PR TITLE
Update survey links (and remove feedback widget)

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/subscriptionsSurvey/SubscriptionsSurvey.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/subscriptionsSurvey/SubscriptionsSurvey.tsx
@@ -10,10 +10,8 @@ type PropTypes = {
 };
 
 const surveyLinks: Partial<Record<SubscriptionProduct, string>> = {
-	DigitalPack: 'https://www.surveymonkey.co.uk/r/SLKWCHT',
 	GuardianWeekly:
 		'https://guardiannewsampampmedia.formstack.com/forms/guardian_weekly_2022',
-	Paper: 'https://www.surveymonkey.co.uk/r/99PGHSX',
 };
 
 export function SubscriptionsSurvey({

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSurvey.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSurvey.tsx
@@ -20,7 +20,7 @@ const buttonContainer = css`
 	margin-top: ${space[6]}px;
 `;
 
-const SURVEY_LINK = 'https://www.surveymonkey.co.uk/r/VDQ32ND';
+const SURVEY_LINK = 'https://guardiannewsampampmedia.formstack.com/forms/guardian_contributions';
 const AUS_SURVEY_LINK =
 	'https://guardiannewsampampmedia.formstack.com/forms/australia_2022';
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSurvey.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSurvey.tsx
@@ -20,7 +20,8 @@ const buttonContainer = css`
 	margin-top: ${space[6]}px;
 `;
 
-const SURVEY_LINK = 'https://guardiannewsampampmedia.formstack.com/forms/guardian_contributions';
+const SURVEY_LINK =
+	'https://guardiannewsampampmedia.formstack.com/forms/guardian_contributions';
 const AUS_SURVEY_LINK =
 	'https://guardiannewsampampmedia.formstack.com/forms/australia_2022';
 

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouContent.tsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouContent.tsx
@@ -12,7 +12,6 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { getPromotions, userIsPatron } from 'helpers/patrons';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
-import { DigitalPack } from 'helpers/productPrice/subscriptions';
 import type { Option } from 'helpers/types/option';
 import AppsSection from './components/thankYou/appsSection';
 import EventsModule from './components/thankYou/eventsModule';

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouContent.tsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouContent.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import Content from 'components/content/content';
 import HeadingBlock from 'components/headingBlock/headingBlock';
 import { HeroWrapper } from 'components/productPage/productPageHero/productPageHero';
-import { SubscriptionsSurvey } from 'components/subscriptionCheckouts/subscriptionsSurvey/SubscriptionsSurvey';
 import Text, { LargeParagraph } from 'components/text/text';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
@@ -93,9 +92,6 @@ function ThankYouContent(props: PropTypes): JSX.Element {
 				<AppsSection countryGroupId={props.countryGroupId} />
 				{showEventsContent && <EventsModule />}
 			</Content>
-			{props.includePaymentCopy ? (
-				<SubscriptionsSurvey product={DigitalPack} />
-			) : null}
 			<Content>{props.marketingConsent}</Content>
 		</div>
 	);

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouGift.tsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouGift.tsx
@@ -296,16 +296,6 @@ function ThankYouGift(props: PropTypes) {
 						</ul>
 					</PageSection>
 					<PageSection>
-						<h3 css={minorHeading}>Tell us about your experience</h3>
-						<LinkButton
-							href="https://www.surveymonkey.co.uk/r/QF9ZGQR"
-							priority="secondary"
-							aria-label="Link to subscription survey"
-						>
-							Share your thoughts
-						</LinkButton>
-					</PageSection>
-					<PageSection>
 						{props.marketingConsent}
 						<div css={sansText}>
 							This is the option to choose if you want to hear about how to make

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouGift.tsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouGift.tsx
@@ -9,7 +9,7 @@ import {
 	text,
 	textSans,
 } from '@guardian/source-foundations';
-import { LinkButton, SvgCheckmark } from '@guardian/source-react-components';
+import { SvgCheckmark } from '@guardian/source-react-components';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import GridImage from 'components/gridImage/gridImage';
@@ -79,12 +79,6 @@ const blueSans = css`
 `;
 const subHeading = css`
 	${headline.xsmall({
-		fontWeight: 'bold',
-	})};
-	margin-bottom: ${space[3]}px;
-`;
-const minorHeading = css`
-	${headline.xxsmall({
 		fontWeight: 'bold',
 	})};
 	margin-bottom: ${space[3]}px;

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouPendingContent.tsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouPendingContent.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import Content from 'components/content/content';
 import HeadingBlock from 'components/headingBlock/headingBlock';
 import { HeroWrapper } from 'components/productPage/productPageHero/productPageHero';
-import { SubscriptionsSurvey } from 'components/subscriptionCheckouts/subscriptionsSurvey/SubscriptionsSurvey';
 import Text, { LargeParagraph } from 'components/text/text';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
@@ -57,9 +56,6 @@ function ThankYouPendingContent(props: PropTypes): JSX.Element {
 					</p>
 				</Text>
 			</Content>
-			{props.includePaymentCopy ? (
-				<SubscriptionsSurvey product={DigitalPack} />
-			) : null}
 			<Content>{props.marketingConsent}</Content>
 		</div>
 	);

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouPendingContent.tsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouPendingContent.tsx
@@ -6,10 +6,7 @@ import HeadingBlock from 'components/headingBlock/headingBlock';
 import { HeroWrapper } from 'components/productPage/productPageHero/productPageHero';
 import Text, { LargeParagraph } from 'components/text/text';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import {
-	DigitalPack,
-	sendTrackingEventsOnClick,
-} from 'helpers/productPrice/subscriptions';
+import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
 import ThankYouHero from './components/thankYou/hero';
 
 // ----- Types ----- //

--- a/support-frontend/assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.tsx
@@ -104,7 +104,7 @@ function FeedbackWidget({ display }: { display: boolean }): JSX.Element {
 							size="small"
 							id="feedbackLink"
 							aria-label="Click here to fill in a short survey about the information on this page"
-							href="https://www.surveymonkey.co.uk/r/63XM7CX"
+							href=""
 							target="_blank"
 							rel="noopener noreferrer"
 							onClick={() => setShowWidget(false)}

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.tsx
@@ -36,7 +36,6 @@ import { routes } from 'helpers/urls/routes';
 import ThankYouContent from 'pages/digital-subscription-checkout/thankYouContainer';
 import ThankYouPendingContent from 'pages/digital-subscription-checkout/thankYouPendingContent';
 import EventsModule from 'pages/digital-subscription-landing/components/events/eventsModule';
-import FeedbackWidget from 'pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget';
 import { DigitalFooter } from '../../components/footerCompliant/FooterWithPromoTerms';
 import {
 	footer,
@@ -258,7 +257,6 @@ function DigitalLandingComponent({
 					/>
 				</CentredContainer>
 			</FullWidthContainer>
-			<FeedbackWidget display={widgetShouldDisplay} />
 		</span>
 	);
 }

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.tsx
@@ -14,7 +14,6 @@ import GiftNonGiftCta from 'components/product/giftNonGiftCta';
 import CheckoutStage from 'components/subscriptionCheckouts/stage';
 import MarketingConsent from 'components/subscriptionCheckouts/thankYou/marketingConsentContainer';
 import MarketingConsentGift from 'components/subscriptionCheckouts/thankYou/marketingConsentContainerGift';
-import { useHasBeenSeen } from 'helpers/customHooks/useHasBeenSeen';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
 	AUDCountries,
@@ -196,11 +195,6 @@ function DigitalLandingComponent({
 		currencyId,
 		countryGroupId,
 	);
-
-	const [widgetShouldDisplay, setElementToObserve] = useHasBeenSeen({
-		threshold: 0.3,
-		debounce: true,
-	});
 
 	return (
 		<span>

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.tsx
@@ -14,7 +14,6 @@ import GiftNonGiftCta from 'components/product/giftNonGiftCta';
 import CheckoutStage from 'components/subscriptionCheckouts/stage';
 import MarketingConsent from 'components/subscriptionCheckouts/thankYou/marketingConsentContainer';
 import MarketingConsentGift from 'components/subscriptionCheckouts/thankYou/marketingConsentContainerGift';
-import { useHasBeenSeen } from 'helpers/customHooks/useHasBeenSeen';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
 	AUDCountries,
@@ -197,11 +196,6 @@ function DigitalLandingComponent({
 		countryGroupId,
 	);
 
-	const [setElementToObserve] = useHasBeenSeen({
-		threshold: 0.3,
-		debounce: true,
-	});
-
 	return (
 		<span>
 			{orderIsAGift ? (
@@ -218,7 +212,7 @@ function DigitalLandingComponent({
 			)}
 			<FullWidthContainer>
 				<CentredContainer>
-					<div css={interactiveTableContainer} ref={setElementToObserve}>
+					<div css={interactiveTableContainer}>
 						<InteractiveTable
 							caption={<>What&apos;s included in a paid digital subscription</>}
 							headers={headers}

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.tsx
@@ -196,7 +196,7 @@ function DigitalLandingComponent({
 		currencyId,
 		countryGroupId,
 	);
-  
+
 	const [setElementToObserve] = useHasBeenSeen({
 		threshold: 0.3,
 		debounce: true,

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.tsx
@@ -14,6 +14,7 @@ import GiftNonGiftCta from 'components/product/giftNonGiftCta';
 import CheckoutStage from 'components/subscriptionCheckouts/stage';
 import MarketingConsent from 'components/subscriptionCheckouts/thankYou/marketingConsentContainer';
 import MarketingConsentGift from 'components/subscriptionCheckouts/thankYou/marketingConsentContainerGift';
+import { useHasBeenSeen } from 'helpers/customHooks/useHasBeenSeen';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
 	AUDCountries,
@@ -195,6 +196,11 @@ function DigitalLandingComponent({
 		currencyId,
 		countryGroupId,
 	);
+  
+	const [setElementToObserve] = useHasBeenSeen({
+		threshold: 0.3,
+		debounce: true,
+	});
 
 	return (
 		<span>


### PR DESCRIPTION
## What are you doing in this PR?

This PR removes a) removes / updates post-purchase motivation survey links from our 'thank you' pages and b) removes the 'Is this page helpful/' feedback widget from the digisub product landing page.

[**Trello Card**](https://trello.com/c/M2oMTLLM/778-motivations-survey-on-support-site-update-links-and-remove-where-no-longer-required)

## Why are you doing this?

Some old surveys are not longer required and we shouldn't keep gathering responses for them. We've also moved away from SurveyMonkey to Formstack, and we have a fresh survey ready to go for Contributions.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

![image](https://user-images.githubusercontent.com/55701358/197521193-bcea068b-fff9-4486-a120-7a8eac4d5750.png)

(The widget has been removed.)

The Contributions 'thank you' page survey link has been updated and the survey has been switched off for the digi sub / digi sub gift thank you pages. Surveys are unchanged for print subscriptions (including Guardian Weekly).