### PR TITLE
Update the interaction of the other amount field with the benefits list

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
@@ -77,7 +77,7 @@ export function CheckoutBenefitsList({
 }: CheckoutBenefitsListProps): JSX.Element {
 	return (
 		<div css={container}>
-			<h3 css={heading}>{title}</h3>
+			<h2 css={heading}>{title}</h2>
 			<hr css={hr(`${space[4]}px 0`)} />
 			<table css={table}>
 				{checkListData.map((item) => (

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -20,13 +20,8 @@ type CheckoutBenefitsListContainerProps = {
 function getBenefitsListTitle(
 	priceString: string,
 	contributionType: ContributionType,
-	selectedAmount: number,
-	minimumAmountPriceString: string,
 ) {
 	const billingPeriod = contributionType === 'MONTHLY' ? 'month' : 'year';
-	if (Number.isNaN(selectedAmount)) {
-		return `Contribute at least ${minimumAmountPriceString} per ${billingPeriod} to unlock benefits`;
-	}
 	return `For ${priceString} per ${billingPeriod}, you’ll unlock`;
 }
 
@@ -82,12 +77,14 @@ export function CheckoutBenefitsListContainer({
 		);
 	}
 
+	if (!lowerTier || Number.isNaN(selectedAmount)) {
+		return null;
+	}
+
 	return renderBenefitsList({
 		title: getBenefitsListTitle(
 			userSelectedAmountWithCurrency,
 			contributionType,
-			selectedAmount,
-			simpleFormatAmount(currencies[currencyId], minimumContributionAmount),
 		),
 		checkListData: checkListData({
 			lowerTier,

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -66,7 +66,9 @@ export function CheckoutBenefitsListContainer({
 	);
 
 	const higherTier = thresholdPrice <= selectedAmount;
-	const lowerTier = selectedAmount >= minimumContributionAmount;
+	const displayBenefits =
+		!Number.isNaN(selectedAmount) &&
+		selectedAmount >= minimumContributionAmount;
 
 	function handleButtonClick() {
 		dispatch(
@@ -77,7 +79,7 @@ export function CheckoutBenefitsListContainer({
 		);
 	}
 
-	if (!lowerTier || Number.isNaN(selectedAmount)) {
+	if (!displayBenefits) {
 		return null;
 	}
 
@@ -87,7 +89,6 @@ export function CheckoutBenefitsListContainer({
 			contributionType,
 		),
 		checkListData: checkListData({
-			lowerTier,
 			higherTier,
 		}),
 		buttonCopy: getbuttonCopy(

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
@@ -23,7 +23,7 @@ type TierUnlocks = {
 export type CheckListData = {
 	icon: JSX.Element;
 	text?: JSX.Element;
-	maybeGreyedOut: null | SerializedStyles;
+	maybeGreyedOut?: SerializedStyles;
 };
 
 export const getSvgIcon = (isUnlocked: boolean): JSX.Element =>
@@ -33,33 +33,27 @@ export const getSvgIcon = (isUnlocked: boolean): JSX.Element =>
 		<SvgCrossRound isAnnouncedByScreenReader size="small" />
 	);
 
-export const checkListData = ({
-	lowerTier,
-	higherTier,
-}: TierUnlocks): CheckListData[] => {
-	const maybeGreyedOutLowerTier = lowerTier ? null : greyedOut;
-	const maybeGreyedOutHigherTier = higherTier ? null : greyedOut;
+export const checkListData = ({ higherTier }: TierUnlocks): CheckListData[] => {
+	const maybeGreyedOutHigherTier = higherTier ? undefined : greyedOut;
 
 	return [
 		{
-			icon: getSvgIcon(lowerTier),
+			icon: getSvgIcon(true),
 			text: (
 				<p>
 					<span css={boldText}>Uninterrupted reading. </span> No more yellow
 					banners
 				</p>
 			),
-			maybeGreyedOut: maybeGreyedOutLowerTier,
 		},
 		{
-			icon: getSvgIcon(lowerTier),
+			icon: getSvgIcon(true),
 			text: (
 				<p>
 					<span css={boldText}>Supporter newsletter. </span>Giving you editorial
 					insight on the week’s top stories
 				</p>
 			),
-			maybeGreyedOut: maybeGreyedOutLowerTier,
 		},
 		{
 			icon: getSvgIcon(higherTier),

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
@@ -16,7 +16,6 @@ const boldText = css`
 `;
 
 type TierUnlocks = {
-	lowerTier: boolean;
 	higherTier: boolean;
 };
 

--- a/support-frontend/assets/components/otherAmount/otherAmount.tsx
+++ b/support-frontend/assets/components/otherAmount/otherAmount.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source-foundations';
 import { NumericInput } from '@guardian/source-react-components-development-kitchen';
-import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import { currencies } from 'helpers/internationalisation/currency';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 
@@ -11,6 +10,7 @@ const topSpacing = css`
 
 export type OtherAmountProps = {
 	selectedAmount: string;
+	otherAmount: string;
 	currency: IsoCurrency;
 	minAmount: number;
 	onOtherAmountChange: (newAmount: string) => void;
@@ -18,8 +18,8 @@ export type OtherAmountProps = {
 
 export function OtherAmount({
 	selectedAmount,
+	otherAmount,
 	currency,
-	minAmount,
 	onOtherAmountChange,
 }: OtherAmountProps): JSX.Element | null {
 	const currencyDetails = currencies[currency];
@@ -30,20 +30,15 @@ export function OtherAmount({
 	const prefix = currencyDetails.isSuffixGlyph ? '' : glyph;
 	const suffix = currencyDetails.isSuffixGlyph ? glyph : '';
 
-	const supportingText = `Must be at least ${simpleFormatAmount(
-		currencyDetails,
-		minAmount,
-	)}`;
-
 	if (selectedAmount === 'other') {
 		return (
 			<div css={topSpacing}>
 				<NumericInput
 					id="otherAmount"
-					label="Choose your amount"
-					supporting={supportingText}
+					label="Enter your amount"
 					prefixText={prefix}
 					suffixText={suffix}
+					value={otherAmount}
 					onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
 						onOtherAmountChange(e.target.value)
 					}

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -43,17 +43,19 @@ export function PriceCardsContainer({
 		(state) => state.common.internationalisation.currencyId,
 	);
 	const { amounts } = useContributionsSelector((state) => state.common);
-	const { selectedAmounts } = useContributionsSelector(
+	const { selectedAmounts, otherAmounts } = useContributionsSelector(
 		(state) => state.page.checkoutForm.product,
 	);
 	const minAmount = useContributionsSelector(getMinimumContributionAmount);
 
 	const { amounts: frequencyAmounts, defaultAmount } = amounts[frequency];
+
 	const selectedAmount = getSelectedAmount(
 		selectedAmounts,
 		frequency,
 		defaultAmount,
 	).toString();
+	const otherAmount = otherAmounts[frequency].amount ?? '';
 
 	function onAmountChange(newAmount: string) {
 		dispatch(
@@ -77,6 +79,7 @@ export function PriceCardsContainer({
 		currency,
 		amounts: frequencyAmounts.map((amount) => amount.toString()),
 		selectedAmount,
+		otherAmount,
 		paymentInterval: contributionTypeToPaymentInterval[frequency],
 		minAmount,
 		onAmountChange,

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -20,6 +20,7 @@ export function AmountAndBenefits(): JSX.Element {
 								renderPriceCards={({
 									amounts,
 									selectedAmount,
+									otherAmount,
 									currency,
 									paymentInterval,
 									onAmountChange,
@@ -38,6 +39,7 @@ export function AmountAndBenefits(): JSX.Element {
 													currency={currency}
 													minAmount={minAmount}
 													selectedAmount={selectedAmount}
+													otherAmount={otherAmount}
 													onOtherAmountChange={onOtherAmountChange}
 												/>
 											}

--- a/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
@@ -45,7 +45,7 @@ export const AllBenefitsUnlocked = Template.bind({});
 
 AllBenefitsUnlocked.args = {
 	title: "For £12 per month, you'll unlock",
-	checkListData: checkListData({ lowerTier: true, higherTier: true }),
+	checkListData: checkListData({ higherTier: true }),
 	buttonCopy: null,
 };
 
@@ -53,6 +53,6 @@ export const LowerTierUnlocked = Template.bind({});
 
 LowerTierUnlocked.args = {
 	title: "For £5 per month, you'll unlock",
-	checkListData: checkListData({ lowerTier: true, higherTier: false }),
+	checkListData: checkListData({ higherTier: false }),
 	buttonCopy: 'Switch to £12 per month to unlock all extras',
 };

--- a/support-frontend/stories/checkouts/OtherAmount.stories.tsx
+++ b/support-frontend/stories/checkouts/OtherAmount.stories.tsx
@@ -30,6 +30,7 @@ export const Default = Template.bind({});
 
 Default.args = {
 	selectedAmount: 'other',
+	otherAmount: '',
 	currency: 'GBP',
 	minAmount: 2,
 };
@@ -38,6 +39,7 @@ export const WithSuffix = Template.bind({});
 
 WithSuffix.args = {
 	selectedAmount: 'other',
+	otherAmount: '',
 	currency: 'SEK',
 	minAmount: 10,
 };

--- a/support-frontend/stories/screens/SupporterPlusLanding.stories.tsx
+++ b/support-frontend/stories/screens/SupporterPlusLanding.stories.tsx
@@ -1,6 +1,7 @@
 import '__mocks__/settingsMock';
 import { Provider } from 'react-redux';
 import { createTestStoreForContributions } from '__test-utils__/testStore';
+import { init as formInit } from 'pages/contributions-landing/contributionsLandingInit';
 import { SupporterPlusLandingPage } from 'pages/supporter-plus-landing/supporterPlusLanding';
 
 global.window.guardian = {
@@ -12,6 +13,8 @@ global.window.guardian = {
 };
 
 const store = createTestStoreForContributions();
+
+formInit(store);
 
 export default {
 	component: SupporterPlusLandingPage,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This updates the behaviour of the 'choose your amount' field and the benefits checklist in the following ways:

- When the field is empty or the user has entered an amount lower than the minimum contribution amount, the benefits list is not rendered, rather than being rendered with all items greyed out/crossed out
- When the user enters an amount at or above the minimum amount, the list will appear
- We no longer show supporting text informing the user of the minimum contribution amount as this is too much of a divergence from the existing checkout

[**Trello Card**](https://trello.com/c/tu7pD3uM)

## Why are you doing this?

These are some amendments following design review of the initial implementation

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

### Empty field
![Screenshot 2022-10-25 at 14-35-14 screens-supporter-plus-landing-page--default](https://user-images.githubusercontent.com/29146931/197787939-f81d01b6-9872-4bf2-bd7e-c8fc8a0af7e1.png)

### Minimum amount entered
![Screenshot 2022-10-25 at 14-35-31 screens-supporter-plus-landing-page--default](https://user-images.githubusercontent.com/29146931/197788002-3eaea7c9-2063-41be-a5bc-91b414082fbf.png)
