### PR TITLE
Rb gw promo copy fix

### DIFF
--- a/support-frontend/app/controllers/LandingCopyProvider.scala
+++ b/support-frontend/app/controllers/LandingCopyProvider.scala
@@ -1,10 +1,9 @@
 package controllers
 
-import com.gu.i18n.Country.UK
 import com.gu.i18n.{Country, CountryGroup}
-import com.gu.support.catalog.Product
-import com.gu.support.config.Stage
-import com.gu.support.promotions.{ProductPromotionCopy, PromoCode, PromotionCopy, PromotionServiceProvider}
+import com.gu.support.catalog._
+import com.gu.support.config.{Stage, TouchPointEnvironments}
+import com.gu.support.promotions.{ProductPromotionCopy, PromotionCopy, PromotionServiceProvider}
 
 class LandingCopyProvider(
     promotionServiceProvider: PromotionServiceProvider,
@@ -15,22 +14,39 @@ class LandingCopyProvider(
   // To see if there is any promotional copy in place for this page we need to get a country in the current region (country group)
   // this is because promotions apply to countries not regions. We can use any country however because the promo tool UI only deals
   // with regions and then adds all the countries for that region to the promotion
-  def promotionCopy(queryPromos: List[String], product1: Product, countryCode: String): Option[PromotionCopy] = {
-    val country = (for {
+  def promotionCopy(queryPromos: List[String], product1: Product, countryCode: String): Option[PromotionCopy] =
+    for {
       countryGroup <- CountryGroup.byId(countryCode)
+      productRatePlanIds = getProductRatePlanIdsForCountryGroup(product1, countryGroup)
       country <- countryGroup.countries.headOption
-    } yield country).getOrElse(UK)
-    promotionCopyForPrimaryCountry(queryPromos, product1, country)
+      promoCopy <- promotionCopyForPrimaryCountry(queryPromos, productRatePlanIds, country)
+    } yield promoCopy
+
+  def getProductRatePlanIdsForCountryGroup(product: Product, countryGroup: CountryGroup) = {
+    val environment = TouchPointEnvironments.fromStage(stage)
+    (product, countryGroup) match {
+      case (GuardianWeekly, CountryGroup.RestOfTheWorld) =>
+        GuardianWeekly
+          .ratePlans(environment)
+          .filter(productRatePlan => productRatePlan.fulfilmentOptions == RestOfWorld)
+          .map(_.id)
+      case (GuardianWeekly, _) =>
+        GuardianWeekly
+          .ratePlans(environment)
+          .filter(productRatePlan => productRatePlan.fulfilmentOptions == Domestic)
+          .map(_.id)
+      case _ => product.getProductRatePlanIds(environment)
+    }
   }
 
   def promotionCopyForPrimaryCountry(
       queryPromos: List[String],
-      product1: Product,
+      productRatePlanIds: List[ProductRatePlanId],
       country: Country,
   ): Option[PromotionCopy] = {
     queryPromos
       .to(LazyList) // For efficiency - only call getCopyForPromoCode until we find a valid promo
-      .map(promoCode => promoCopyService.getCopyForPromoCode(promoCode, product1, country))
+      .map(promoCode => promoCopyService.getCopyForPromoCode(promoCode, productRatePlanIds, country))
       .collectFirst { case Some(promoCopy) => promoCopy }
   }
 }

--- a/support-frontend/app/controllers/LandingCopyProvider.scala
+++ b/support-frontend/app/controllers/LandingCopyProvider.scala
@@ -23,12 +23,12 @@ class LandingCopyProvider(
   ): Option[PromotionCopy] =
     for {
       countryGroup <- CountryGroup.byId(countryCode)
-      productRatePlanIds = getProductRatePlanIdsForCountryGroup(product1, countryGroup)
+      productRatePlanIds = getProductRatePlanIdsForCountryGroup(product1, countryGroup, isGift)
       country <- countryGroup.countries.headOption
       promoCopy <- promotionCopyForPrimaryCountry(queryPromos, productRatePlanIds, country)
     } yield promoCopy
 
-  def getProductRatePlanIdsForCountryGroup(product: Product, countryGroup: CountryGroup, isGift: Boolean = false) = {
+  def getProductRatePlanIdsForCountryGroup(product: Product, countryGroup: CountryGroup, isGift: Boolean) = {
     val environment = TouchPointEnvironments.fromStage(stage)
     val readerType = if (isGift) Gift else Direct
     (product, countryGroup) match {

--- a/support-frontend/app/controllers/LandingCopyProvider.scala
+++ b/support-frontend/app/controllers/LandingCopyProvider.scala
@@ -4,6 +4,7 @@ import com.gu.i18n.{Country, CountryGroup}
 import com.gu.support.catalog._
 import com.gu.support.config.{Stage, TouchPointEnvironments}
 import com.gu.support.promotions.{ProductPromotionCopy, PromotionCopy, PromotionServiceProvider}
+import com.gu.support.zuora.api.ReaderType.{Direct, Gift}
 
 class LandingCopyProvider(
     promotionServiceProvider: PromotionServiceProvider,
@@ -14,7 +15,12 @@ class LandingCopyProvider(
   // To see if there is any promotional copy in place for this page we need to get a country in the current region (country group)
   // this is because promotions apply to countries not regions. We can use any country however because the promo tool UI only deals
   // with regions and then adds all the countries for that region to the promotion
-  def promotionCopy(queryPromos: List[String], product1: Product, countryCode: String): Option[PromotionCopy] =
+  def promotionCopy(
+      queryPromos: List[String],
+      product1: Product,
+      countryCode: String,
+      isGift: Boolean = false,
+  ): Option[PromotionCopy] =
     for {
       countryGroup <- CountryGroup.byId(countryCode)
       productRatePlanIds = getProductRatePlanIdsForCountryGroup(product1, countryGroup)
@@ -22,18 +28,23 @@ class LandingCopyProvider(
       promoCopy <- promotionCopyForPrimaryCountry(queryPromos, productRatePlanIds, country)
     } yield promoCopy
 
-  def getProductRatePlanIdsForCountryGroup(product: Product, countryGroup: CountryGroup) = {
+  def getProductRatePlanIdsForCountryGroup(product: Product, countryGroup: CountryGroup, isGift: Boolean = false) = {
     val environment = TouchPointEnvironments.fromStage(stage)
+    val readerType = if (isGift) Gift else Direct
     (product, countryGroup) match {
       case (GuardianWeekly, CountryGroup.RestOfTheWorld) =>
         GuardianWeekly
           .ratePlans(environment)
-          .filter(productRatePlan => productRatePlan.fulfilmentOptions == RestOfWorld)
+          .filter(productRatePlan =>
+            productRatePlan.fulfilmentOptions == RestOfWorld && productRatePlan.readerType == readerType,
+          )
           .map(_.id)
       case (GuardianWeekly, _) =>
         GuardianWeekly
           .ratePlans(environment)
-          .filter(productRatePlan => productRatePlan.fulfilmentOptions == Domestic)
+          .filter(productRatePlan =>
+            productRatePlan.fulfilmentOptions == Domestic && productRatePlan.readerType == readerType,
+          )
           .map(_.id)
       case _ => product.getProductRatePlanIds(environment)
     }

--- a/support-frontend/app/controllers/PaperSubscriptionController.scala
+++ b/support-frontend/app/controllers/PaperSubscriptionController.scala
@@ -60,7 +60,7 @@ class PaperSubscriptionController(
         shareUrl = canonicalLink,
       ) {
         val maybePromotionCopy =
-          landingCopyProvider.promotionCopyForPrimaryCountry(queryPromos ++ defaultPromos, Paper, UK)
+          landingCopyProvider.promotionCopy(queryPromos ++ defaultPromos, Paper, "uk")
         Html(
           s"""<script type="text/javascript">
       window.guardian.productPrices = ${outputJson(

--- a/support-frontend/app/controllers/WeeklySubscriptionController.scala
+++ b/support-frontend/app/controllers/WeeklySubscriptionController.scala
@@ -48,7 +48,7 @@ class WeeklySubscriptionController(
         .toList
     val defaultPromos = priceSummaryServiceProvider.forUser(isTestUser = false).getDefaultPromoCodes(GuardianWeekly)
     val maybePromotionCopy =
-      landingCopyProvider.promotionCopy(queryPromos ++ defaultPromos, GuardianWeekly, countryCode)
+      landingCopyProvider.promotionCopy(queryPromos ++ defaultPromos, GuardianWeekly, countryCode, orderIsAGift)
 
     Ok(
       views.html.main(

--- a/support-services/src/main/scala/com/gu/support/promotions/ProductPromotionCopy.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/ProductPromotionCopy.scala
@@ -1,13 +1,12 @@
 package com.gu.support.promotions
 
 import com.gu.i18n.Country
+import com.gu.support.catalog.ProductRatePlanId
 import com.gu.support.config.{Stage, TouchPointEnvironment, TouchPointEnvironments}
-import PromotionValidator._
-import com.gu.support.catalog.Product
+import com.gu.support.promotions.PromotionValidator._
 
 class ProductPromotionCopy(promotionService: PromotionService, touchPointEnvironment: TouchPointEnvironment) {
-  def getCopyForPromoCode(promoCode: PromoCode, product: Product, country: Country): Option[PromotionCopy] = {
-    val productRatePlanIds = product.getProductRatePlanIds(touchPointEnvironment)
+  def getCopyForPromoCode(promoCode: PromoCode, productRatePlanIds: List[ProductRatePlanId], country: Country): Option[PromotionCopy] = {
     val promotion = promotionService.findPromotion(promoCode)
     promotion.toOption // if promo code not valid, just ignore
       .find(_.promotion.validForAnyProductRatePlan(productRatePlanIds, country, isRenewal = false).nonEmpty)


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

PR to  correct the  promotion code in offer strap line on the Guardian Weekly International Landing Page.


[**Trello Card**](https://trello.com/c/h252Ele8/725-gw-int-lp-offer-strap-line-bug)

## Why are you doing this?

The offer strap line on the Guardian Weekly International Landing Page is displaying a promotion in the strap line even if the promotion is only set-up for "Domestic" fulfilment in the promo code tool.
This is a bug, the only promos supported on the international landing page are those set-up for "ROW" fulfilment in the promo code tool.

## Is this an AB test?
- [ ] Yes
- [x] No


## Screenshots
Before Change
<img width="1145" alt="image" src="https://user-images.githubusercontent.com/73653255/197987785-3ed18642-9639-4dd5-8ca4-de7a2dac65a5.png">

After Change
"Save up to 35% a year" is the default PromoCode.

<img width="1145" alt="image" src="https://user-images.githubusercontent.com/73653255/197987266-a85bb0ef-6f23-4ebc-97f9-803773f69cad.png">

