### PR TITLE
Update contributions checkout copy

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.tsx
@@ -161,15 +161,14 @@ export type CountryMetaData = {
 	formMessage?: JSX.Element;
 };
 const defaultHeaderCopy =
-	'Support\xa0our\njournalism\xa0with\na\xa0contribution\nof\xa0any\xa0size';
+	'Support\xa0fearless\nindependent\xa0journalism';
 const defaultContributeCopy = (
 	<span>
-		Your support helps protect the Guardian’s independence and it means we can
-		keep delivering quality journalism that’s open for everyone around the
-		world.
+		As a reader-funded news organisation, we rely on your generosity.
 		<span className="gu-content__blurb-blurb-last-sentence">
 			{' '}
-			Every contribution, however big or small, is so valuable for our future.
+			Please give what you can, so millions more can benefit from quality
+			reporting on the events shaping our world.
 		</span>
 	</span>
 );

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.tsx
@@ -161,14 +161,12 @@ export type CountryMetaData = {
 	formMessage?: JSX.Element;
 };
 const defaultHeaderCopy =
-	'Support\xa0fearless\nindependent\xa0journalism';
+	'Support\xa0fearless\nindependent\njournalism';
 const defaultContributeCopy = (
 	<span>
-		As a reader-funded news organisation, we rely on your generosity.
-		<span className="gu-content__blurb-blurb-last-sentence">
-			{' '}
-			Please give what you can, so millions more can benefit from quality
-			reporting on the events shaping our world.
+		As a reader-funded news organisation, we rely on your generosity. 
+		Please give what you can, so millions more can benefit from quality
+		reporting on the events shaping our world.
 		</span>
 	</span>
 );

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.tsx
@@ -160,13 +160,12 @@ export type CountryMetaData = {
 	// Optional message to display at the top of the form
 	formMessage?: JSX.Element;
 };
-const defaultHeaderCopy =
-	'Support\xa0fearless\nindependent\njournalism';
+const defaultHeaderCopy = 'Support\xa0fearless\nindependent\njournalism';
 const defaultContributeCopy = (
 	<span>
-		As a reader-funded news organisation, we rely on your generosity. 
-		Please give what you can, so millions more can benefit from quality
-		reporting on the events shaping our world.
+		As a reader-funded news organisation, we rely on your generosity. Please
+		give what you can, so millions more can benefit from quality reporting on
+		the events shaping our world.
 	</span>
 );
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.tsx
@@ -160,7 +160,7 @@ export type CountryMetaData = {
 	// Optional message to display at the top of the form
 	formMessage?: JSX.Element;
 };
-const defaultHeaderCopy = 'Support\xa0fearless\nindependent\njournalism';
+const defaultHeaderCopy = 'Support\xa0fearless,\nindependent\njournalism';
 const defaultContributeCopy = (
 	<span>
 		As a reader-funded news organisation, we rely on your generosity. Please

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.tsx
@@ -167,7 +167,6 @@ const defaultContributeCopy = (
 		As a reader-funded news organisation, we rely on your generosity. 
 		Please give what you can, so millions more can benefit from quality
 		reporting on the events shaping our world.
-		</span>
 	</span>
 );
 


### PR DESCRIPTION
Update the headline and body copy for consistency ahead of the v2 checkout AB test.

## What are you doing in this PR?

Update the Contributions checkout headline and body copy for consistency with the new v2 checkout design, ahead of the upcoming AB test.

[**Trello Card**](https://trello.com/c/Cm0SKxUh/726-update-headline-and-body-copy-on-current-checkout-for-mvp-release)

## Why are you doing this?

We want to have consistency for this copy between variants in the upcoming test. There's no harm in releasing this change early.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

![image](https://user-images.githubusercontent.com/55701358/197996248-7381d1af-5f9c-448e-bbf6-d6b1ac882743.png)

![image](https://user-images.githubusercontent.com/55701358/198270307-4b4fd86a-b3ee-43e1-9e83-bdc3ac23a0fd.png)

