### PR TITLE
Remove the gu_supporter_plus cookie for now

### DIFF
--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -281,8 +281,8 @@ class CreateSubscriptionController(
         )
       case _: SupporterPlus =>
         List(
-          "gu_digital_subscriber" -> true.toString, // TODO: confirm these
-          "gu_supporter_plus" -> true.toString,
+          "gu_digital_subscriber" -> true.toString,
+          // "gu_supporter_plus" -> true.toString, // TODO: add this and remove the digisub one when the CMP cookie list has been updated
           "GU_AF1" -> DateTime.now().plusDays(1).getMillis.toString,
         )
       case _: DigitalPack =>


### PR DESCRIPTION
We want to add a cookie (gu_supporter_plus) which enables the website to identify and treat a signed-out browser as hosting a recently subscribed "Supporter plus" product holder, however the new cookie has not yet been cleared by the data protection team and added to the consent manangement platform so we are commenting it out until that work is complete.



[**Trello Card**](https://trello.com/c/MgspqDBS/802-dont-set-gusupporterplus-cookie-until-it-is-added-to-the-consent-management-platform)
