### PR TITLE
Add error summary component and form validation on submit for new checkout

### DIFF
--- a/support-frontend/assets/components/errorSummary/errorSummary.tsx
+++ b/support-frontend/assets/components/errorSummary/errorSummary.tsx
@@ -20,6 +20,11 @@ const errorContainerStyles = css`
 	}
 `;
 
+const errorListStyles = css`
+	list-style: disc;
+	margin-bottom: ${space[1]}px;
+`;
+
 type CheckoutErrorLink = {
 	href: string;
 	message: string;
@@ -47,7 +52,7 @@ export function CheckoutErrorSummary({
 				css={errorContainerStyles}
 				message="Some information is missing"
 				context={
-					<ul>
+					<ul css={errorListStyles}>
 						{errorList.map(({ href, message }) => (
 							<li>
 								<Link priority="secondary" href={href} subdued={true}>

--- a/support-frontend/assets/components/errorSummary/errorSummary.tsx
+++ b/support-frontend/assets/components/errorSummary/errorSummary.tsx
@@ -1,10 +1,20 @@
 import { css } from '@emotion/react';
-import { focusHalo } from '@guardian/source-foundations';
+import { focusHalo, from, space } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
 import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
 import { useAutoFocus } from 'helpers/customHooks/useAutoFocus';
 
 const errorContainerStyles = css`
+	margin-bottom: ${space[3]}px;
+
+	${from.tablet} {
+		margin-bottom: ${space[5]}px;
+	}
+
+	${from.desktop} {
+		margin-bottom: ${space[6]}px;
+	}
+
 	:focus {
 		${focusHalo};
 	}

--- a/support-frontend/assets/components/errorSummary/errorSummary.tsx
+++ b/support-frontend/assets/components/errorSummary/errorSummary.tsx
@@ -1,0 +1,38 @@
+import { Link } from '@guardian/source-react-components';
+import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
+import { useAutoFocus } from 'helpers/customHooks/useAutoFocus';
+
+type CheckoutErrorLink = {
+	href: string;
+	message: string;
+};
+
+export type CheckoutErrorSummaryProps = {
+	errorList: CheckoutErrorLink[];
+};
+
+export function CheckoutErrorSummary({
+	errorList,
+}: CheckoutErrorSummaryProps): JSX.Element | null {
+	const containerRef = useAutoFocus<HTMLDivElement>();
+
+	if (!errorList.length) return null;
+	return (
+		<div aria-live="polite" tabIndex={-1} ref={containerRef}>
+			<ErrorSummary
+				message="Some information is missing"
+				context={
+					<ul>
+						{errorList.map(({ href, message }) => (
+							<li>
+								<Link priority="secondary" href={href}>
+									{message}
+								</Link>
+							</li>
+						))}
+					</ul>
+				}
+			/>
+		</div>
+	);
+}

--- a/support-frontend/assets/components/errorSummary/errorSummary.tsx
+++ b/support-frontend/assets/components/errorSummary/errorSummary.tsx
@@ -1,6 +1,14 @@
+import { css } from '@emotion/react';
+import { focusHalo } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
 import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
 import { useAutoFocus } from 'helpers/customHooks/useAutoFocus';
+
+const errorContainerStyles = css`
+	:focus {
+		${focusHalo};
+	}
+`;
 
 type CheckoutErrorLink = {
 	href: string;
@@ -18,14 +26,21 @@ export function CheckoutErrorSummary({
 
 	if (!errorList.length) return null;
 	return (
-		<div aria-live="polite" tabIndex={-1} ref={containerRef}>
+		<div
+			css={errorContainerStyles}
+			role="alert"
+			tabIndex={-1}
+			ref={containerRef}
+			aria-live="polite"
+		>
 			<ErrorSummary
+				css={errorContainerStyles}
 				message="Some information is missing"
 				context={
 					<ul>
 						{errorList.map(({ href, message }) => (
 							<li>
-								<Link priority="secondary" href={href}>
+								<Link priority="secondary" href={href} subdued={true}>
 									{message}
 								</Link>
 							</li>

--- a/support-frontend/assets/components/errorSummary/errorSummaryContainer.tsx
+++ b/support-frontend/assets/components/errorSummary/errorSummaryContainer.tsx
@@ -1,0 +1,24 @@
+import { getAllErrorsForContributions } from 'helpers/redux/checkout/checkoutSelectors';
+import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import type { CheckoutErrorSummaryProps } from './errorSummary';
+
+function createErrorList(errors: Partial<Record<string, string[]>>) {
+	return Object.entries(errors).flatMap(([fieldName, errorList]) => {
+		if (!errorList) return [];
+		return errorList.map((message) => ({ href: `#${fieldName}`, message }));
+	});
+}
+
+type CheckoutErrorSummaryContainerProps = {
+	renderSummary: (renderProps: CheckoutErrorSummaryProps) => JSX.Element | null;
+};
+
+export function CheckoutErrorSummaryContainer({
+	renderSummary,
+}: CheckoutErrorSummaryContainerProps): JSX.Element | null {
+	const errors = useContributionsSelector(getAllErrorsForContributions);
+
+	return renderSummary({
+		errorList: createErrorList(errors),
+	});
+}

--- a/support-frontend/assets/components/otherAmount/selectors.ts
+++ b/support-frontend/assets/components/otherAmount/selectors.ts
@@ -11,7 +11,9 @@ function amountIsNotInRange(amount: string, min: number, max: number) {
 	return amountAsFloat > max || amountAsFloat < min;
 }
 
-export function getOtherAmountErrors(state: ContributionsState): string[] {
+export function getOtherAmountErrors(
+	state: ContributionsState,
+): string[] | undefined {
 	const constributionType = getContributionType(state);
 	const { errors, otherAmounts, selectedAmounts } =
 		state.page.checkoutForm.product;
@@ -33,6 +35,4 @@ export function getOtherAmountErrors(state: ContributionsState): string[] {
 	if (amountIsNotInRange(customAmount, minAmount, maxAmount)) {
 		return [`Please provide an amount between ${minAmount} and ${maxAmount}`];
 	}
-
-	return [];
 }

--- a/support-frontend/assets/components/paymentButton/noPaymentMethodButton.tsx
+++ b/support-frontend/assets/components/paymentButton/noPaymentMethodButton.tsx
@@ -1,11 +1,8 @@
-import { validateForm } from 'helpers/redux/checkout/checkoutActions';
-import { useContributionsDispatch } from 'helpers/redux/storeHooks';
+import { useFormValidation } from 'helpers/customHooks/useFormValidation';
 import { DefaultPaymentButtonContainer } from './defaultPaymentButtonContainer';
 
 export function NoPaymentMethodButton(): JSX.Element {
-	const dispatch = useContributionsDispatch();
+	const onClick = useFormValidation(() => undefined);
 
-	return (
-		<DefaultPaymentButtonContainer onClick={() => dispatch(validateForm())} />
-	);
+	return <DefaultPaymentButtonContainer onClick={onClick} />;
 }

--- a/support-frontend/assets/components/stripeCardForm/selectors.ts
+++ b/support-frontend/assets/components/stripeCardForm/selectors.ts
@@ -2,6 +2,7 @@ import type { StripeFormErrors } from 'helpers/redux/checkout/payment/stripe/sta
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
 
 export type StripeCardFormDisplayErrors = StripeFormErrors & {
+	recaptcha?: string[];
 	zipCode?: string[];
 };
 
@@ -10,6 +11,7 @@ export function getStripeCardFormErrors(state: ContributionsState): {
 	showErrors: boolean;
 } {
 	const { errors, showErrors } = state.page.checkoutForm.payment.stripe;
+	const recaptchaErrors = state.page.checkoutForm.recaptcha.errors;
 
 	const shouldShowZipCode =
 		state.common.internationalisation.countryId === 'US';
@@ -19,5 +21,11 @@ export function getStripeCardFormErrors(state: ContributionsState): {
 		return { errors, showErrors };
 	}
 
-	return { errors, showErrors };
+	return {
+		errors: {
+			...errors,
+			recaptcha: recaptchaErrors,
+		},
+		showErrors,
+	};
 }

--- a/support-frontend/assets/components/stripeCardForm/stripeCardForm.tsx
+++ b/support-frontend/assets/components/stripeCardForm/stripeCardForm.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
-import { Inline, Stack, TextInput } from '@guardian/source-react-components';
+import { space } from '@guardian/source-foundations';
+import { Stack, TextInput } from '@guardian/source-react-components';
 import {
 	CardCvcElement,
 	CardExpiryElement,
@@ -17,15 +18,11 @@ const zipCodeContainer = css`
 	display: block;
 `;
 
-const inlineOverrides = css`
-	margin-left: 0;
+const inlineContainer = css`
+	display: flex;
 
-	& * {
-		margin-bottom: 0;
-	}
-
-	& *:first-of-type {
-		margin-left: 0;
+	& *:not(:last-of-type) {
+		margin-right: ${space[4]}px;
 	}
 `;
 
@@ -64,7 +61,7 @@ export function StripeCardForm({
 						/>
 					)}
 				/>
-				<Inline space={3} cssOverrides={inlineOverrides}>
+				<div css={inlineContainer}>
 					<ElementDecorator
 						id="expiry"
 						text="Expiry date"
@@ -87,7 +84,7 @@ export function StripeCardForm({
 							/>
 						)}
 					/>
-				</Inline>
+				</div>
 				{showZipCode && (
 					<div css={zipCodeContainer}>
 						<TextInput
@@ -104,6 +101,7 @@ export function StripeCardForm({
 					<ElementDecorator
 						id="robot-checkbox"
 						text="Security check"
+						error={errors.recaptcha?.[0]}
 						renderElement={() => recaptcha}
 					/>
 				)}

--- a/support-frontend/assets/components/stripeCardForm/stripePaymentButton.tsx
+++ b/support-frontend/assets/components/stripeCardForm/stripePaymentButton.tsx
@@ -6,6 +6,7 @@ import {
 import type { StripeError } from '@stripe/stripe-js';
 import { useEffect, useState } from 'preact/hooks';
 import { DefaultPaymentButtonContainer } from 'components/paymentButton/defaultPaymentButtonContainer';
+import { useFormValidation } from 'helpers/customHooks/useFormValidation';
 import { Stripe } from 'helpers/forms/paymentMethods';
 import {
 	useContributionsDispatch,
@@ -36,6 +37,21 @@ export function StripePaymentButton(): JSX.Element {
 	const { setupIntentClientSecret } = useContributionsSelector(
 		(state) => state.page.checkoutForm.payment.stripe,
 	);
+
+	const payWithStripe = useFormValidation(function pay() {
+		if (stripeAccount === 'ONE_OFF') {
+			oneOffPayment();
+		} else if (setupIntentClientSecret) {
+			recurringPayment(setupIntentClientSecret);
+		} else {
+			// The setupIntentClientSecret is requested asynchronously when the user completes the recaptcha and is
+			// required to establish our intent to take future card payments.
+			// Thus it's possible that the user clicks the payment button *before* we have this secret available.
+			// In this case we record that they *intend* to pay, and then attempt to make the payment via the useEffect hook below
+			// which will run when the client secret has become available
+			setPaymentAwaitingSetupIntent(true);
+		}
+	});
 
 	function handleStripeError(errorData: StripeError): void {
 		dispatch(paymentWaiting(false));
@@ -118,26 +134,11 @@ export function StripePaymentButton(): JSX.Element {
 		}
 	}
 
-	function pay() {
-		if (stripeAccount === 'ONE_OFF') {
-			oneOffPayment();
-		} else if (setupIntentClientSecret) {
-			recurringPayment(setupIntentClientSecret);
-		} else {
-			// The setupIntentClientSecret is requested asynchronously when the user completes the recaptcha and is
-			// required to establish our intent to take future card payments.
-			// Thus it's possible that the user clicks the payment button *before* we have this secret available.
-			// In this case we record that they *intend* to pay, and then attempt to make the payment via the useEffect hook below
-			// which will run when the client secret has become available
-			setPaymentAwaitingSetupIntent(true);
-		}
-	}
-
 	useEffect(() => {
 		if (setupIntentClientSecret && paymentAwaitingSetupIntent) {
 			recurringPayment(setupIntentClientSecret);
 		}
 	}, [setupIntentClientSecret, paymentAwaitingSetupIntent]);
 
-	return <DefaultPaymentButtonContainer onClick={pay} />;
+	return <DefaultPaymentButtonContainer onClick={payWithStripe} />;
 }

--- a/support-frontend/assets/helpers/customHooks/useAutoFocus.ts
+++ b/support-frontend/assets/helpers/customHooks/useAutoFocus.ts
@@ -1,15 +1,12 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
+// This provides a 'callback ref' to consistently auto-focus on any node once it's mounted
+// cf https://tkdodo.eu/blog/avoiding-use-effect-with-callback-refs
 export function useAutoFocus<T extends HTMLElement | null>(): (
 	node: T | null,
 ) => void {
-	const [ref, setRef] = useState<T | null>(null);
 	const refCallback = useCallback((node: T | null) => {
-		if (ref) return;
-		if (node) {
-			node.focus();
-		}
-		setRef(node);
+		node?.focus();
 	}, []);
 
 	return refCallback;

--- a/support-frontend/assets/helpers/customHooks/useAutoFocus.ts
+++ b/support-frontend/assets/helpers/customHooks/useAutoFocus.ts
@@ -1,10 +1,13 @@
 import { useCallback } from 'react';
 
-// This provides a 'callback ref' to consistently auto-focus on any node once it's mounted
-// cf https://tkdodo.eu/blog/avoiding-use-effect-with-callback-refs
+/**
+ * A hook that returns a ref which will move focus to its node on first render
+ */
 export function useAutoFocus<T extends HTMLElement | null>(): (
 	node: T | null,
 ) => void {
+	// This provides a 'callback ref'
+	// cf https://tkdodo.eu/blog/avoiding-use-effect-with-callback-refs
 	const refCallback = useCallback((node: T | null) => {
 		node?.focus();
 	}, []);

--- a/support-frontend/assets/helpers/customHooks/useAutoFocus.ts
+++ b/support-frontend/assets/helpers/customHooks/useAutoFocus.ts
@@ -1,0 +1,16 @@
+import { useCallback, useState } from 'react';
+
+export function useAutoFocus<T extends HTMLElement | null>(): (
+	node: T | null,
+) => void {
+	const [ref, setRef] = useState<T | null>(null);
+	const refCallback = useCallback((node: T | null) => {
+		if (ref) return;
+		if (node) {
+			node.focus();
+		}
+		setRef(node);
+	}, []);
+
+	return refCallback;
+}

--- a/support-frontend/assets/helpers/customHooks/useFormValidation.ts
+++ b/support-frontend/assets/helpers/customHooks/useFormValidation.ts
@@ -1,22 +1,45 @@
+import { useCallback } from 'preact/hooks';
+import { useEffect, useState } from 'react';
 import { validateForm } from 'helpers/redux/checkout/checkoutActions';
 import { contributionsFormHasErrors } from 'helpers/redux/checkout/checkoutSelectors';
 import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
+import { paymentWaiting } from 'pages/contributions-landing/contributionsLandingActions';
 
+/**
+ * A hook to wrap any payment handler function.
+ * Validates the form, and will only run the handler if the form is valid.
+ */
 export function useFormValidation(
 	paymentHandler: (event: React.MouseEvent<HTMLButtonElement>) => void,
 ): (event: React.MouseEvent<HTMLButtonElement>) => void {
+	const [clickEvent, setClickEvent] =
+		useState<React.MouseEvent<HTMLButtonElement> | null>(null);
 	const dispatch = useContributionsDispatch();
-
 	const errorsPreventSubmission = useContributionsSelector(
 		contributionsFormHasErrors,
 	);
 
-	return function validateAndPay(event: React.MouseEvent<HTMLButtonElement>) {
-		dispatch(validateForm());
-		if (errorsPreventSubmission) return;
-		paymentHandler(event);
-	};
+	const validateAndPay = useCallback(
+		function validateAndPay(event: React.MouseEvent<HTMLButtonElement>) {
+			dispatch(validateForm());
+			setClickEvent(event);
+		},
+		[dispatch],
+	);
+
+	useEffect(() => {
+		if (errorsPreventSubmission) {
+			setClickEvent(null);
+			return;
+		}
+		if (clickEvent) {
+			dispatch(paymentWaiting(true));
+			paymentHandler(clickEvent);
+		}
+	}, [clickEvent, errorsPreventSubmission]);
+
+	return validateAndPay;
 }

--- a/support-frontend/assets/helpers/customHooks/useFormValidation.ts
+++ b/support-frontend/assets/helpers/customHooks/useFormValidation.ts
@@ -1,0 +1,22 @@
+import { validateForm } from 'helpers/redux/checkout/checkoutActions';
+import { contributionsFormHasErrors } from 'helpers/redux/checkout/checkoutSelectors';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
+
+export function useFormValidation(
+	paymentHandler: (event: React.MouseEvent<HTMLButtonElement>) => void,
+): (event: React.MouseEvent<HTMLButtonElement>) => void {
+	const dispatch = useContributionsDispatch();
+
+	const errorsPreventSubmission = useContributionsSelector(
+		contributionsFormHasErrors,
+	);
+
+	return function validateAndPay(event: React.MouseEvent<HTMLButtonElement>) {
+		dispatch(validateForm());
+		if (errorsPreventSubmission) return;
+		paymentHandler(event);
+	};
+}

--- a/support-frontend/assets/helpers/redux/checkout/checkoutSelectors.ts
+++ b/support-frontend/assets/helpers/redux/checkout/checkoutSelectors.ts
@@ -11,8 +11,9 @@ function getPaymentMethodErrors(
 		case 'Stripe':
 			return payment.stripe.showErrors ? payment.stripe.errors : {};
 
-		case 'DirectDebit':
-			return payment.directDebit.errors ?? {};
+		// TODO: implement this once we have a new DD form
+		// case 'DirectDebit':
+		// 	return payment.directDebit.errors ?? {};
 
 		case 'Sepa':
 			return payment.sepa.errors;
@@ -32,21 +33,26 @@ export function getAllErrorsForContributions(
 
 	const otherAmount = getOtherAmountErrors(state);
 	const paymentMethod = state.page.checkoutForm.payment.paymentMethod.errors;
+	const robot_checkbox = state.page.checkoutForm.recaptcha.errors;
+
+	const nonPersonalDetailsErrors = {
+		otherAmount,
+		paymentMethod,
+		...getPaymentMethodErrors(state),
+		robot_checkbox,
+	};
 
 	if (contributionType === 'ONE_OFF') {
 		return {
-			otherAmount,
 			email,
-			...getPaymentMethodErrors(state),
+			...nonPersonalDetailsErrors,
 		};
 	}
 	return {
-		otherAmount,
 		firstName,
 		lastName,
 		email,
-		paymentMethod,
-		...getPaymentMethodErrors(state),
+		...nonPersonalDetailsErrors,
 	};
 }
 

--- a/support-frontend/assets/helpers/redux/checkout/checkoutSelectors.ts
+++ b/support-frontend/assets/helpers/redux/checkout/checkoutSelectors.ts
@@ -1,3 +1,4 @@
+import { getOtherAmountErrors } from 'components/otherAmount/selectors';
 import type { ContributionsState } from '../contributionsStore';
 import { getContributionType } from './product/selectors/productType';
 
@@ -42,13 +43,17 @@ export function getAllErrorsForContributions(
 	const { firstName, lastName, email } =
 		state.page.checkoutForm.personalDetails.errors ?? {};
 
+	const otherAmount = getOtherAmountErrors(state);
+
 	if (contributionType === 'ONE_OFF') {
 		return {
+			otherAmount,
 			email,
 			...getPaymentMethodErrors(state),
 		};
 	}
 	return {
+		otherAmount,
 		firstName,
 		lastName,
 		email,

--- a/support-frontend/assets/helpers/redux/checkout/recaptcha/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/recaptcha/reducer.ts
@@ -1,6 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import { setPaymentMethod } from 'helpers/redux/checkout/payment/paymentMethod/actions';
+import { validateForm } from '../checkoutActions';
 import { initialState } from './state';
 
 export const recaptchaSlice = createSlice({
@@ -10,6 +11,7 @@ export const recaptchaSlice = createSlice({
 		setRecaptchaToken(state, action: PayloadAction<string>) {
 			state.token = action.payload;
 			state.completed = true;
+			state.errors = [];
 		},
 		expireRecaptchaToken(state) {
 			state.token = '';
@@ -20,6 +22,12 @@ export const recaptchaSlice = createSlice({
 		builder.addCase(setPaymentMethod, (state) => {
 			state.token = '';
 			state.completed = false;
+		});
+
+		builder.addCase(validateForm, (state) => {
+			if (!state.completed) {
+				state.errors = ["Please check the 'I'm not a robot' checkbox"];
+			}
 		});
 	},
 });

--- a/support-frontend/assets/helpers/redux/checkout/recaptcha/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/recaptcha/state.ts
@@ -1,9 +1,11 @@
 export type RecaptchaState = {
 	token: string;
 	completed: boolean;
+	errors: string[];
 };
 
-export const initialState = {
+export const initialState: RecaptchaState = {
 	token: '',
 	completed: false,
+	errors: [],
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -1,6 +1,8 @@
 import { CheckoutBenefitsList } from 'components/checkoutBenefits/checkoutBenefitsList';
 import { CheckoutBenefitsListContainer } from 'components/checkoutBenefits/checkoutBenefitsListContainer';
 import { BoxContents } from 'components/checkoutBox/checkoutBox';
+import { CheckoutErrorSummary } from 'components/errorSummary/errorSummary';
+import { CheckoutErrorSummaryContainer } from 'components/errorSummary/errorSummaryContainer';
 import { OtherAmount } from 'components/otherAmount/otherAmount';
 import { PaymentFrequencyTabsContainer } from 'components/paymentFrequencyTabs/paymentFrequencyTabsContainer';
 import { PaymentFrequencyTabs } from 'components/paymentFrequencyTabs/paymentFrequenncyTabs';
@@ -15,6 +17,11 @@ export function AmountAndBenefits(): JSX.Element {
 					{...tabProps}
 					renderTabContent={(tabId) => (
 						<BoxContents>
+							<CheckoutErrorSummaryContainer
+								renderSummary={({ errorList }) => (
+									<CheckoutErrorSummary errorList={errorList} />
+								)}
+							/>
 							<PriceCardsContainer
 								frequency={tabId}
 								renderPriceCards={({

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -9,8 +9,6 @@ import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { CheckoutHeading } from 'components/checkoutHeading/checkoutHeading';
 import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
-import { CheckoutErrorSummary } from 'components/errorSummary/errorSummary';
-import { CheckoutErrorSummaryContainer } from 'components/errorSummary/errorSummaryContainer';
 import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countrySwitcherContainer';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { Container } from 'components/layout/container';
@@ -124,11 +122,6 @@ export function SupporterPlusLandingPage(): JSX.Element {
 							<BoxContents>
 								{/* The same Stripe provider *must* enclose the Stripe card form and payment button(s). Also enclosing the PRB reduces re-renders. */}
 								<ContributionsStripe>
-									<CheckoutErrorSummaryContainer
-										renderSummary={({ errorList }) => (
-											<CheckoutErrorSummary errorList={errorList} />
-										)}
-									/>
 									<SecureTransactionIndicator position="center" />
 									<PaymentRequestButtonContainer
 										CustomButton={SavedCardButton}

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -9,6 +9,8 @@ import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { CheckoutHeading } from 'components/checkoutHeading/checkoutHeading';
 import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import { CheckoutErrorSummary } from 'components/errorSummary/errorSummary';
+import { CheckoutErrorSummaryContainer } from 'components/errorSummary/errorSummaryContainer';
 import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countrySwitcherContainer';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { Container } from 'components/layout/container';
@@ -122,6 +124,11 @@ export function SupporterPlusLandingPage(): JSX.Element {
 							<BoxContents>
 								{/* The same Stripe provider *must* enclose the Stripe card form and payment button(s). Also enclosing the PRB reduces re-renders. */}
 								<ContributionsStripe>
+									<CheckoutErrorSummaryContainer
+										renderSummary={({ errorList }) => (
+											<CheckoutErrorSummary errorList={errorList} />
+										)}
+									/>
 									<SecureTransactionIndicator position="center" />
 									<PaymentRequestButtonContainer
 										CustomButton={SavedCardButton}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds

- An error summary component which will appear at the top of the form on validation and automatically receive keyboard focus, listing all errors as anchor links to the relevant input
- A `useFormValidation` hook to wrap any payment function that will submit the form, which will run form validation and only continue with form submission if the form state is valid.
- Some tweaks to error display based on validating the Stripe form (work in progress)

[**Trello Card**](https://trello.com/c/n6T98HFX)

## Why are you doing this?

This is a key part of building the new form validation system. Having an error summary with anchor links makes it much, much, much easier for all users to tackle problems that prevent them from submitting the form. The summary is announced to screen readers and auto-focused to make it easy to immediately navigate to fields with errors.

The `useFormValidation` hook provides a simpler and more generic way to make payment dependent on form validation without having to include validation logic in every single payment button component.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

### Error summary
![Screenshot 2022-10-27 at 11-26-23 Support the Guardian Make a Contribution](https://user-images.githubusercontent.com/29146931/198263860-02ca9d81-085e-4b3f-95a6-9b6a850ec571.png)

### Validation on the Stripe form
![Screenshot 2022-10-27 at 11 27 16](https://user-images.githubusercontent.com/29146931/198263911-a70ccdcb-6fd9-432e-892b-b8467c6b6c75.png)
