### PR TITLE
Update 2nd Argument in Quantum Metric sendEvent call

### DIFF
--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -318,11 +318,11 @@ function sendEventABTestParticipations(participations: Participations): void {
 
 function addQM() {
 	return loadScript(
-		'https://cdn.quantummetric.com/instrumentation/1.31.5/quantum-gnm.js',
+		'https://cdn.quantummetric.com/instrumentation/1.32.16/quantum-gnm.js',
 		{
 			async: true,
 			integrity:
-				'sha384-QqJrp8s9Nl3x7Z6sc9kQG5eYJLVWYwlEsvhjCukLSwFsWtK17WdC5whHVwSXQh1F',
+				'sha384-DuqUDRG4K0l7XMcHiXiWN2mwr8GdfMbKUpH40hCvJ2dpBeo4pWAxOvbaWpQ8LGZW',
 			crossOrigin: 'anonymous',
 		},
 	).catch(() => {

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -52,13 +52,45 @@ type SendEventId =
 
 // ---- sendEvent logic ---- //
 
+const {
+	DigiSub,
+	PaperSub,
+	GuardianWeeklySub,
+	DigiSubGift,
+	GuardianWeeklySubGift,
+} = SendEventSubscriptionCheckoutStart;
+
+const { SingleContribution, RecurringContribution } =
+	SendEventContributionAmountUpdate;
+
+const cartValueEventIds: SendEventId[] = [
+	DigiSub,
+	PaperSub,
+	GuardianWeeklySub,
+	DigiSubGift,
+	GuardianWeeklySubGift,
+	SingleContribution,
+	RecurringContribution,
+];
+
 function sendEvent(
 	id: SendEventId,
 	isConversion: boolean,
 	value: string,
 ): void {
+	/**
+	 * A cart value event is indicated by 64 in QM.
+	 * A non cart value event is indicated by 0 in QM.
+	 * And a conversion event is indicated by 1 in QM.
+	 */
+	const qmCartValueEventId = isConversion
+		? 1
+		: cartValueEventIds.includes(id)
+		? 64
+		: 0;
+
 	if (window.QuantumMetricAPI?.isOn()) {
-		window.QuantumMetricAPI.sendEvent(id, isConversion ? 1 : 0, value);
+		window.QuantumMetricAPI.sendEvent(id, qmCartValueEventId, value);
 	}
 }
 

--- a/support-frontend/window.d.ts
+++ b/support-frontend/window.d.ts
@@ -81,7 +81,11 @@ declare global {
 		};
 		QuantumMetricAPI?: {
 			isOn: () => boolean;
-			sendEvent: (id: SendEventId, isConversion: 0 | 1, value: string) => void;
+			sendEvent: (
+				id: SendEventId,
+				isConversion: 0 | 1 | 64,
+				value: string,
+			) => void;
 			currencyConvertFromToValue: (
 				value: number,
 				sourceCurrency: IsoCurrency,


### PR DESCRIPTION
## What are you doing in this PR?

QM contacted us to request we update the 2nd argument in the `window.QuantumMetricAPI.sendEvent` call. Previously this had been `0` or `1`. `0` would indicate the event was not a conversion event, and 1 would indicate it was a conversion event. They've requested we change this, so now we still pass `1` for a conversion event, and non-conversion events will now be either `0` or `64`. `0` will indicate a non cart value event, and `64` will indicate a cart value event. "cart value" is the term QM use to indicate the value of the subscription/contribution a user is going to make.

I've also updated the QM script source.

[**Trello Card**](hhttps://trello.com/c/25ul9iPp/803-quantum-metric-cart-value-changes)