### PR TITLE
Set up supporterPlus AB test control

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.tsx
@@ -123,8 +123,8 @@ const mapStateToProps = (state: ContributionsState) => {
 		sepa: state.page.checkoutForm.payment.sepa,
 		productSetAbTestVariant:
 			state.common.abParticipations.productSetTest === 'variant',
-		isInNewProductTest:
-			state.common.abParticipations.newProduct === 'variant' &&
+		isInSupporterPlusTestControl:
+			state.common.abParticipations.supporterPlus === 'control' &&
 			contributionType !== 'ONE_OFF',
 		switches: state.common.settings.switches,
 	};
@@ -388,7 +388,7 @@ function ContributionForm(props: PropTypes): JSX.Element {
 				)}
 			</div>
 
-			{props.isInNewProductTest && (
+			{props.isInSupporterPlusTestControl && (
 				<BenefitsBulletPoints
 					showBenefitsMessaging={showBenefitsMessaging}
 					countryGroupId={props.countryGroupId}
@@ -484,7 +484,7 @@ function ContributionForm(props: PropTypes): JSX.Element {
 				<ContributionSubmit
 					onPaymentAuthorisation={props.onPaymentAuthorisation}
 					showBenefitsMessaging={showBenefitsMessaging}
-					userInNewProductTest={props.isInNewProductTest}
+					userInNewProductTest={props.isInSupporterPlusTestControl}
 				/>
 			</div>
 
@@ -498,7 +498,7 @@ function ContributionForm(props: PropTypes): JSX.Element {
 					props.otherAmounts,
 					props.contributionType,
 				)}
-				userInNewProductTest={props.isInNewProductTest}
+				userInNewProductTest={props.isInSupporterPlusTestControl}
 			/>
 			{props.isWaiting ? (
 				<ProgressMessage message={['Processing transaction', 'Please wait']} />

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.tsx
@@ -148,7 +148,7 @@ type ContributionThankYouProps = {
 	paymentMethod: PaymentMethod;
 	countryId: IsoCountry;
 	campaignCode?: string;
-	isInNewProductTest: boolean;
+	isInSupporterPlusTestControl: boolean;
 };
 
 const mapStateToProps = (state: ContributionsState) => {
@@ -170,7 +170,8 @@ const mapStateToProps = (state: ContributionsState) => {
 		paymentMethod: state.page.checkoutForm.payment.paymentMethod.name,
 		countryId: state.common.internationalisation.countryId,
 		campaignCode: state.common.referrerAcquisitionData.campaignCode,
-		isInNewProductTest: state.common.abParticipations.newProduct === 'variant',
+		isInSupporterPlusTestControl:
+			state.common.abParticipations.supporterPlus === 'control',
 	};
 };
 
@@ -186,7 +187,7 @@ function ContributionThankYou({
 	paymentMethod,
 	countryId,
 	campaignCode,
-	isInNewProductTest,
+	isInSupporterPlusTestControl,
 }: ContributionThankYouProps) {
 	const isNewAccount = userTypeFromIdentityResponse === 'new';
 
@@ -279,7 +280,7 @@ function ContributionThankYou({
 	const secondColumn = shownComponents.slice(numberOfComponentsInFirstColumn);
 
 	const showNewProductThankYouText =
-		isInNewProductTest &&
+		isInSupporterPlusTestControl &&
 		shouldShowBenefitsThankYouText(countryId, amount, contributionType);
 
 	return (

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.ts
@@ -82,7 +82,7 @@ import trackConversion from 'helpers/tracking/conversions';
 import type { Option } from 'helpers/types/option';
 import { routes } from 'helpers/urls/routes';
 import { logException } from 'helpers/utilities/logger';
-import { getThresholdPrice } from 'pages/contributions-landing/components/DigiSubBenefits/helpers';
+import { isSupporterPlusPurchase } from './newProductTestHelper';
 
 export type Action =
 	| {
@@ -275,23 +275,8 @@ function getBillingCountryAndState(
 	};
 }
 
-function getProductOptionsForBenefitsTest(
-	amount: number,
-	state: ContributionsState,
-) {
-	const isInNewProductTest =
-		state.common.abParticipations.newProduct === 'variant';
-	const contributionType = getContributionType(state);
-	const isRecurring = contributionType !== 'ONE_OFF';
-
-	const thresholdPrice = getThresholdPrice(
-		state.common.internationalisation.countryGroupId,
-		contributionType,
-	);
-	const amountIsHighEnough = !!(thresholdPrice && amount >= thresholdPrice);
-	const shouldGetSupporterPlus =
-		isInNewProductTest && isRecurring && amountIsHighEnough;
-	return shouldGetSupporterPlus
+function getProductOptionsForSupporterPlusTest(state: ContributionsState) {
+	return isSupporterPlusPurchase(state)
 		? { productType: 'SupporterPlus' as const }
 		: { productType: 'Contribution' as const };
 }
@@ -314,7 +299,7 @@ function regularPaymentRequestFromAuthorisation(
 		contributionType,
 	);
 
-	const productOptions = getProductOptionsForBenefitsTest(amount, state);
+	const productOptions = getProductOptionsForSupporterPlusTest(state);
 
 	return {
 		firstName: state.page.checkoutForm.personalDetails.firstName.trim(),

--- a/support-frontend/assets/pages/contributions-landing/newProductTestHelper.ts
+++ b/support-frontend/assets/pages/contributions-landing/newProductTestHelper.ts
@@ -4,19 +4,26 @@ import type { ContributionsState } from '../../helpers/redux/contributionsStore'
 import { getThresholdPrice } from './components/DigiSubBenefits/helpers';
 
 export function isSupporterPlusPurchase(state: ContributionsState): boolean {
+	const userInSupporterPlusTest = !!state.common.abParticipations.supporterPlus;
+
+	if (!userInSupporterPlusTest) {
+		return false;
+	}
+
 	const contributionType = getContributionType(state);
 
 	const thresholdPrice = getThresholdPrice(
 		state.common.internationalisation.countryGroupId,
 		contributionType,
 	);
+
 	const amount = getAmount(
 		state.page.checkoutForm.product.selectedAmounts,
 		state.page.checkoutForm.product.otherAmounts,
 		contributionType,
 	);
+
 	const amountIsHighEnough = !!(thresholdPrice && amount >= thresholdPrice);
-	return (
-		state.common.abParticipations.newProduct == 'variant' && amountIsHighEnough
-	);
+
+	return amountIsHighEnough;
 }


### PR DESCRIPTION
## What are you doing in this PR?

For the upcoming AB test we'll be using the `supporterPlus` AB test that already exists in the [abtestDefinitions](https://github.com/guardian/support-frontend/blob/main/support-frontend/assets/helpers/abTests/abtestDefinitions.ts#L155).

The control will see the the current checkout with supporter plus enabled, and the VARIANT will see the V2 checkout.

Currently the proposed control is not behind the `supporterPlus` AB test, but it is behind  the `newProduct` AB test's `variant` (see: `https://support.theguardian.com/uk/contribute#ab-newProduct=variant`).

This PR changes this, so it now sits behind the `supporterPlus` AB test's `control`,  which means it'll therefore be available to preview at `https://support.theguardian.com/uk/contribute#ab-supporterPlus=control`

[**Trello Card**](https://trello.com/c/g76f6Iuv/805-configure-supporterplus-ab-test-in-support-frontend)