### PR TITLE
Add validation to the personal details section on the new checkout

### DIFF
--- a/support-frontend/assets/components/paymentRequestButton/hooks/usePaymentRequestCompletion.ts
+++ b/support-frontend/assets/components/paymentRequestButton/hooks/usePaymentRequestCompletion.ts
@@ -85,10 +85,5 @@ export function usePaymentRequestCompletion(
 				);
 			}
 		}
-	}, [
-		stripe,
-		paymentMethod,
-		internalPaymentMethodName,
-		errorsPreventSubmission,
-	]);
+	}, [paymentMethod]);
 }

--- a/support-frontend/assets/components/personalDetails/personalDetails.tsx
+++ b/support-frontend/assets/components/personalDetails/personalDetails.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 import { css } from '@emotion/react';
 import { from, space, visuallyHidden } from '@guardian/source-foundations';
-import { Stack, TextInput } from '@guardian/source-react-components';
+import { TextInput } from '@guardian/source-react-components';
 import { Divider } from '@guardian/source-react-components-development-kitchen';
 import type { ContributionType } from 'helpers/contributions';
 import { emailRegexPattern } from 'helpers/forms/formValidation';
@@ -21,10 +21,14 @@ const dividerStyles = css`
 	}
 `;
 
-const stackStyles = css`
+const fieldGroupStyles = css`
 	position: relative;
+	& > *:not(:first-of-type) {
+		margin-top: ${space[3]}px;
+	}
+
 	${from.tablet} {
-		& > * + * {
+		& > *:not(:first-of-type) {
 			margin-top: ${space[4]}px;
 		}
 	}
@@ -58,7 +62,7 @@ export function PersonalDetails({
 	contributionState,
 }: PersonalDetailsProps): JSX.Element {
 	return (
-		<Stack space={3} cssOverrides={stackStyles}>
+		<div css={fieldGroupStyles}>
 			<h3 css={hiddenHeading}>Your details</h3>
 			<div>
 				<TextInput
@@ -112,7 +116,7 @@ export function PersonalDetails({
 			{contributionState}
 
 			<Divider size="full" cssOverrides={dividerStyles} />
-		</Stack>
+		</div>
 	);
 }
 

--- a/support-frontend/assets/components/personalDetails/personalDetails.tsx
+++ b/support-frontend/assets/components/personalDetails/personalDetails.tsx
@@ -1,8 +1,34 @@
 // ----- Imports ----- //
-import { TextInput } from '@guardian/source-react-components';
+import { css } from '@emotion/react';
+import { from, space, visuallyHidden } from '@guardian/source-foundations';
+import { Stack, TextInput } from '@guardian/source-react-components';
+import { Divider } from '@guardian/source-react-components-development-kitchen';
 import type { ContributionType } from 'helpers/contributions';
 import { emailRegexPattern } from 'helpers/forms/formValidation';
-import { classNameWithModifiers } from 'helpers/utilities/utilities';
+import type { PersonalDetailsState } from 'helpers/redux/checkout/personalDetails/state';
+
+const hiddenHeading = css`
+	${visuallyHidden};
+`;
+
+const dividerStyles = css`
+	margin-left: 0;
+	width: 100%;
+	margin-top: 40px;
+
+	${from.tablet} {
+		margin-top: 44px;
+	}
+`;
+
+const stackStyles = css`
+	position: relative;
+	${from.tablet} {
+		& > * + * {
+			margin-top: ${space[4]}px;
+		}
+	}
+`;
 
 export type PersonalDetailsProps = {
 	email: string;
@@ -15,6 +41,7 @@ export type PersonalDetailsProps = {
 	onLastNameChange: (lastName: string) => void;
 	signOutLink: React.ReactNode;
 	contributionState: React.ReactNode;
+	errors?: PersonalDetailsState['errors'];
 };
 
 export function PersonalDetails({
@@ -26,20 +53,16 @@ export function PersonalDetails({
 	onEmailChange,
 	onFirstNameChange,
 	onLastNameChange,
+	errors,
 	signOutLink,
 	contributionState,
 }: PersonalDetailsProps): JSX.Element {
 	return (
-		<div className="form-fields">
-			<h3 className="hidden-heading">Your details</h3>
-
-			<div
-				className={classNameWithModifiers('form__field', [
-					'contribution-email',
-				])}
-			>
+		<Stack space={3} cssOverrides={stackStyles}>
+			<h3 css={hiddenHeading}>Your details</h3>
+			<div>
 				<TextInput
-					id="contributionEmail"
+					id="email"
 					data-qm-masking="blocklist"
 					label="Email address"
 					value={email}
@@ -48,7 +71,7 @@ export function PersonalDetails({
 					supporting="example@domain.com"
 					onChange={(e) => onEmailChange(e.target.value)}
 					pattern={emailRegexPattern}
-					error={''}
+					error={errors?.email?.[0]}
 					disabled={isSignedInPersonalDetails}
 				/>
 			</div>
@@ -56,46 +79,40 @@ export function PersonalDetails({
 			{signOutLink}
 
 			{contributionType !== 'ONE_OFF' ? (
-				<div>
-					<div
-						className={classNameWithModifiers('form__field', [
-							'contribution-fname',
-						])}
-					>
+				<>
+					<div>
 						<TextInput
-							id="contributionFirstName"
+							id="firstName"
 							data-qm-masking="blocklist"
 							label="First name"
 							value={firstName}
 							autoComplete="given-name"
 							autoCapitalize="words"
 							onChange={(e) => onFirstNameChange(e.target.value)}
-							error={''}
+							error={errors?.firstName?.[0]}
 							required
 						/>
 					</div>
-					<div
-						className={classNameWithModifiers('form__field', [
-							'contribution-lname',
-						])}
-					>
+					<div>
 						<TextInput
-							id="contributionLastName"
+							id="lastName"
 							data-qm-masking="blocklist"
 							label="Last name"
 							value={lastName}
 							autoComplete="family-name"
 							autoCapitalize="words"
 							onChange={(e) => onLastNameChange(e.target.value)}
-							error={''}
+							error={errors?.lastName?.[0]}
 							required
 						/>
 					</div>
-				</div>
+				</>
 			) : null}
 
 			{contributionState}
-		</div>
+
+			<Divider size="full" cssOverrides={dividerStyles} />
+		</Stack>
 	);
 }
 

--- a/support-frontend/assets/components/personalDetails/personalDetailsContainer.tsx
+++ b/support-frontend/assets/components/personalDetails/personalDetailsContainer.tsx
@@ -69,6 +69,7 @@ export function PersonalDetailsContainer({
 		contributionState: (
 			<StateSelect
 				countryGroupId={countryGroupId}
+				contributionType={contributionType}
 				state={state}
 				onStateChange={onBillingStateChange}
 				error={errorObject?.state?.[0]}

--- a/support-frontend/assets/components/personalDetails/personalDetailsContainer.tsx
+++ b/support-frontend/assets/components/personalDetails/personalDetailsContainer.tsx
@@ -11,7 +11,7 @@ import {
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
 import type { PersonalDetailsProps } from './personalDetails';
-import StateSelect from './stateSelect';
+import { StateSelect } from './stateSelect';
 
 type PersonalDetailsContainerProps = {
 	renderPersonalDetails: (props: PersonalDetailsProps) => JSX.Element;

--- a/support-frontend/assets/components/personalDetails/personalDetailsContainer.tsx
+++ b/support-frontend/assets/components/personalDetails/personalDetailsContainer.tsx
@@ -1,5 +1,4 @@
 import Signout from 'components/signout/signout';
-import { checkBillingState } from 'helpers/forms/formValidation';
 import { setBillingState } from 'helpers/redux/checkout/address/actions';
 import {
 	setEmail,
@@ -11,8 +10,8 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
-import ContributionState from 'pages/contributions-landing/components/ContributionState';
 import type { PersonalDetailsProps } from './personalDetails';
+import StateSelect from './stateSelect';
 
 type PersonalDetailsContainerProps = {
 	renderPersonalDetails: (props: PersonalDetailsProps) => JSX.Element;
@@ -23,19 +22,13 @@ export function PersonalDetailsContainer({
 }: PersonalDetailsContainerProps): JSX.Element {
 	const dispatch = useContributionsDispatch();
 
-	const { email, firstName, lastName } = useContributionsSelector(
+	const { email, firstName, lastName, errors } = useContributionsSelector(
 		(state) => state.page.checkoutForm.personalDetails,
 	);
 	const contributionType = useContributionsSelector(getContributionType);
-	const billingState = useContributionsSelector(
-		(state) => state.page.checkoutForm.billingAddress.fields.state,
+	const { state, errorObject } = useContributionsSelector(
+		(state) => state.page.checkoutForm.billingAddress.fields,
 	);
-	const checkoutFormHasBeenSubmitted = useContributionsSelector(
-		(state) => state.page.form.formData.checkoutFormHasBeenSubmitted,
-	);
-	function onEmailChange(email: string) {
-		dispatch(setEmail(email));
-	}
 	const isSignedInPersonalDetails = useContributionsSelector(
 		(state) => state.page.checkoutForm.personalDetails.isSignedIn,
 	);
@@ -45,12 +38,19 @@ export function PersonalDetailsContainer({
 	const countryGroupId = useContributionsSelector(
 		(state) => state.common.internationalisation.countryGroupId,
 	);
+
+	function onEmailChange(email: string) {
+		dispatch(setEmail(email));
+	}
+
 	function onFirstNameChange(firstName: string) {
 		dispatch(setFirstName(firstName));
 	}
+
 	function onLastNameChange(lastName: string) {
 		dispatch(setLastName(lastName));
 	}
+
 	function onBillingStateChange(billingState: string) {
 		dispatch(setBillingState(billingState));
 	}
@@ -64,15 +64,14 @@ export function PersonalDetailsContainer({
 		onEmailChange,
 		onFirstNameChange,
 		onLastNameChange,
+		errors,
 		signOutLink: <Signout isSignedIn={isSignedInUser} />,
 		contributionState: (
-			<ContributionState
-				onChange={(newBillingState) => onBillingStateChange(newBillingState)}
-				selectedState={billingState}
-				isValid={checkBillingState(billingState)}
-				formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-				contributionType={contributionType}
+			<StateSelect
 				countryGroupId={countryGroupId}
+				state={state}
+				onStateChange={onBillingStateChange}
+				error={errorObject?.state?.[0]}
 			/>
 		),
 	});

--- a/support-frontend/assets/components/personalDetails/stateSelect.tsx
+++ b/support-frontend/assets/components/personalDetails/stateSelect.tsx
@@ -15,9 +15,9 @@ type StateSelectProps = {
 };
 
 const stateDescriptors: Partial<Record<CountryGroupId, string>> = {
-	UnitedStates: 'state',
-	Canada: 'province',
-	AUDCountries: 'state / territory',
+	UnitedStates: 'State',
+	Canada: 'Province',
+	AUDCountries: 'State / Territory',
 };
 
 const stateLists: Partial<Record<CountryGroupId, Record<string, string>>> = {
@@ -26,13 +26,7 @@ const stateLists: Partial<Record<CountryGroupId, Record<string, string>>> = {
 	AUDCountries: auStates,
 };
 
-function getLabel(countryGroupId: CountryGroupId) {
-	const descriptor = stateDescriptors[countryGroupId] ?? 'state';
-
-	return `Please select your ${descriptor}`;
-}
-
-export default function StateSelect({
+export function StateSelect({
 	countryGroupId,
 	state,
 	onStateChange,
@@ -45,7 +39,7 @@ export default function StateSelect({
 			<div>
 				<Select
 					id="state"
-					label={getLabel(countryGroupId)}
+					label={stateDescriptors[countryGroupId] ?? 'State'}
 					value={state}
 					onChange={(e) => onStateChange(e.target.value)}
 					error={error}
@@ -53,7 +47,11 @@ export default function StateSelect({
 					<>
 						<Option value="">&nbsp;</Option>
 						{Object.entries(statesList).map(([abbreviation, name]) => {
-							return <Option value={abbreviation}>{name}</Option>;
+							return (
+								<Option value={abbreviation} selected={abbreviation === state}>
+									{name}
+								</Option>
+							);
 						})}
 					</>
 				</Select>

--- a/support-frontend/assets/components/personalDetails/stateSelect.tsx
+++ b/support-frontend/assets/components/personalDetails/stateSelect.tsx
@@ -1,0 +1,64 @@
+import { Option, Select } from '@guardian/source-react-components';
+import {
+	auStates,
+	caStates,
+	usStates,
+} from 'helpers/internationalisation/country';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { shouldCollectStateForContributions } from 'helpers/internationalisation/shouldCollectStateForContribs';
+
+type StateSelectProps = {
+	countryGroupId: CountryGroupId;
+	state: string;
+	onStateChange: (newState: string) => void;
+	error?: string;
+};
+
+const stateDescriptors: Partial<Record<CountryGroupId, string>> = {
+	UnitedStates: 'state',
+	Canada: 'province',
+	AUDCountries: 'state / territory',
+};
+
+const stateLists: Partial<Record<CountryGroupId, Record<string, string>>> = {
+	UnitedStates: usStates,
+	Canada: caStates,
+	AUDCountries: auStates,
+};
+
+function getLabel(countryGroupId: CountryGroupId) {
+	const descriptor = stateDescriptors[countryGroupId] ?? 'state';
+
+	return `Please select your ${descriptor}`;
+}
+
+export default function StateSelect({
+	countryGroupId,
+	state,
+	onStateChange,
+	error,
+}: StateSelectProps): JSX.Element | null {
+	const statesList = stateLists[countryGroupId] ?? {};
+
+	if (shouldCollectStateForContributions(countryGroupId)) {
+		return (
+			<div>
+				<Select
+					id="state"
+					label={getLabel(countryGroupId)}
+					value={state}
+					onChange={(e) => onStateChange(e.target.value)}
+					error={error}
+				>
+					<>
+						<Option value="">&nbsp;</Option>
+						{Object.entries(statesList).map(([abbreviation, name]) => {
+							return <Option value={abbreviation}>{name}</Option>;
+						})}
+					</>
+				</Select>
+			</div>
+		);
+	}
+	return null;
+}

--- a/support-frontend/assets/components/personalDetails/stateSelect.tsx
+++ b/support-frontend/assets/components/personalDetails/stateSelect.tsx
@@ -1,4 +1,5 @@
 import { Option, Select } from '@guardian/source-react-components';
+import type { ContributionType } from 'helpers/contributions';
 import {
 	auStates,
 	caStates,
@@ -9,6 +10,7 @@ import { shouldCollectStateForContributions } from 'helpers/internationalisation
 
 type StateSelectProps = {
 	countryGroupId: CountryGroupId;
+	contributionType: ContributionType;
 	state: string;
 	onStateChange: (newState: string) => void;
 	error?: string;
@@ -28,13 +30,14 @@ const stateLists: Partial<Record<CountryGroupId, Record<string, string>>> = {
 
 export function StateSelect({
 	countryGroupId,
+	contributionType,
 	state,
 	onStateChange,
 	error,
 }: StateSelectProps): JSX.Element | null {
 	const statesList = stateLists[countryGroupId] ?? {};
 
-	if (shouldCollectStateForContributions(countryGroupId)) {
+	if (shouldCollectStateForContributions(countryGroupId, contributionType)) {
 		return (
 			<div>
 				<Select

--- a/support-frontend/assets/helpers/internationalisation/shouldCollectStateForContribs.ts
+++ b/support-frontend/assets/helpers/internationalisation/shouldCollectStateForContribs.ts
@@ -1,3 +1,4 @@
+import type { ContributionType } from 'helpers/contributions';
 import type { CountryGroup, CountryGroupId } from './countryGroup';
 import {
 	AUDCountries,
@@ -8,7 +9,10 @@ import {
 
 export function shouldCollectStateForContributions(
 	countryGroupId: CountryGroupId,
+	contributionType: ContributionType,
 ): boolean {
+	if (contributionType === 'ONE_OFF') return false;
+
 	if (countryGroupId === UnitedStates || countryGroupId === Canada) {
 		return true;
 	}

--- a/support-frontend/assets/helpers/redux/checkout/personalDetails/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/personalDetails/reducer.ts
@@ -14,18 +14,23 @@ export const personalDetailsSlice = createSlice({
 			const newTitle =
 				action.payload !== 'Select a title' ? action.payload : state.title;
 			state.title = newTitle;
+			delete state.errors?.title;
 		},
 		setFirstName(state, action: PayloadAction<string>) {
 			state.firstName = action.payload;
+			delete state.errors?.firstName;
 		},
 		setLastName(state, action: PayloadAction<string>) {
 			state.lastName = action.payload;
+			delete state.errors?.lastName;
 		},
 		setEmail(state, action: PayloadAction<string>) {
 			state.email = action.payload;
+			delete state.errors?.email;
 		},
 		setConfirmEmail(state, action: PayloadAction<string>) {
 			state.confirmEmail = action.payload;
+			delete state.errors?.confirmEmail;
 		},
 		setIsSignedIn(state, action: PayloadAction<boolean>) {
 			state.isSignedIn = action.payload;
@@ -38,6 +43,7 @@ export const personalDetailsSlice = createSlice({
 		},
 		setTelephone(state, action: PayloadAction<string>) {
 			state.telephone = action.payload;
+			delete state.errors?.telephone;
 		},
 	},
 	extraReducers: (builder) => {

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -7,8 +7,9 @@ export function getStateOrProvinceError(
 	state: ContributionsState,
 ): ErrorCollection {
 	const { countryGroupId } = state.common.internationalisation;
+	const contributionType = getContributionType(state);
 
-	if (shouldCollectStateForContributions(countryGroupId)) {
+	if (shouldCollectStateForContributions(countryGroupId, contributionType)) {
 		return {
 			state: state.page.checkoutForm.billingAddress.fields.errorObject?.state,
 		};

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -33,9 +33,9 @@ export function getPersonalDetailsErrors(
 		};
 	}
 	return {
+		email,
 		firstName,
 		lastName,
-		email,
 		...stateOrProvinceErrors,
 	};
 }

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -10,8 +10,7 @@ export function getStateOrProvinceError(
 
 	if (shouldCollectStateForContributions(countryGroupId)) {
 		return {
-			contributionsState:
-				state.page.checkoutForm.billingAddress.fields.errorObject?.state,
+			state: state.page.checkoutForm.billingAddress.fields.errorObject?.state,
 		};
 	}
 	return {};

--- a/support-frontend/stories/checkoutLayout/PersonalDetails.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/PersonalDetails.stories.tsx
@@ -65,6 +65,7 @@ SingleContribSignedIn.args = {
 		<StateSelect
 			state=""
 			onStateChange={() => null}
+			contributionType={'ONE_OFF'}
 			countryGroupId={GBPCountries}
 		/>
 	),
@@ -83,6 +84,7 @@ SingleContribSignedOut.args = {
 		<StateSelect
 			state=""
 			onStateChange={() => null}
+			contributionType={'ONE_OFF'}
 			countryGroupId={GBPCountries}
 		/>
 	),
@@ -101,6 +103,7 @@ MultiContribSignedIn.args = {
 		<StateSelect
 			state=""
 			onStateChange={() => null}
+			contributionType={'MONTHLY'}
 			countryGroupId={GBPCountries}
 		/>
 	),
@@ -119,6 +122,7 @@ MultiContribSignedOut.args = {
 		<StateSelect
 			state=""
 			onStateChange={() => null}
+			contributionType={'MONTHLY'}
 			countryGroupId={GBPCountries}
 		/>
 	),
@@ -137,6 +141,7 @@ MultiContribUSSignedIn.args = {
 		<StateSelect
 			state=""
 			onStateChange={() => null}
+			contributionType={'MONTHLY'}
 			countryGroupId={UnitedStates}
 		/>
 	),
@@ -155,6 +160,7 @@ MultiContribUSSignedOut.args = {
 		<StateSelect
 			state=""
 			onStateChange={() => null}
+			contributionType={'MONTHLY'}
 			countryGroupId={UnitedStates}
 		/>
 	),
@@ -179,6 +185,7 @@ WithErrors.args = {
 			state=""
 			error="Please select your state, province or territory"
 			onStateChange={() => null}
+			contributionType={'MONTHLY'}
 			countryGroupId={UnitedStates}
 		/>
 	),

--- a/support-frontend/stories/checkoutLayout/PersonalDetails.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/PersonalDetails.stories.tsx
@@ -4,12 +4,12 @@ import { Column, Columns, Container } from '@guardian/source-react-components';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import type { PersonalDetailsProps } from 'components/personalDetails/personalDetails';
 import { PersonalDetails } from 'components/personalDetails/personalDetails';
+import { StateSelect } from 'components/personalDetails/stateSelect';
 import Signout from 'components/signout/signout';
 import {
 	GBPCountries,
 	UnitedStates,
 } from 'helpers/internationalisation/countryGroup';
-import ContributionState from 'pages/contributions-landing/components/ContributionState';
 
 export default {
 	title: 'Checkouts/Personal Details',
@@ -62,12 +62,9 @@ SingleContribSignedIn.args = {
 	isSignedInPersonalDetails: false,
 	signOutLink: <Signout isSignedIn={true} />,
 	contributionState: (
-		<ContributionState
-			selectedState={null}
-			onChange={() => null}
-			isValid={false}
-			formHasBeenSubmitted={false}
-			contributionType={'ONE_OFF'}
+		<StateSelect
+			state=""
+			onStateChange={() => null}
 			countryGroupId={GBPCountries}
 		/>
 	),
@@ -83,12 +80,9 @@ SingleContribSignedOut.args = {
 	isSignedInPersonalDetails: false,
 	signOutLink: <Signout isSignedIn={false} />,
 	contributionState: (
-		<ContributionState
-			selectedState={null}
-			onChange={() => null}
-			isValid={false}
-			formHasBeenSubmitted={false}
-			contributionType={'ONE_OFF'}
+		<StateSelect
+			state=""
+			onStateChange={() => null}
 			countryGroupId={GBPCountries}
 		/>
 	),
@@ -104,12 +98,9 @@ MultiContribSignedIn.args = {
 	isSignedInPersonalDetails: false,
 	signOutLink: <Signout isSignedIn={true} />,
 	contributionState: (
-		<ContributionState
-			selectedState={null}
-			onChange={() => null}
-			isValid={false}
-			formHasBeenSubmitted={false}
-			contributionType={'MONTHLY'}
+		<StateSelect
+			state=""
+			onStateChange={() => null}
 			countryGroupId={GBPCountries}
 		/>
 	),
@@ -125,12 +116,9 @@ MultiContribSignedOut.args = {
 	isSignedInPersonalDetails: false,
 	signOutLink: <Signout isSignedIn={false} />,
 	contributionState: (
-		<ContributionState
-			selectedState={null}
-			onChange={() => null}
-			isValid={false}
-			formHasBeenSubmitted={false}
-			contributionType={'MONTHLY'}
+		<StateSelect
+			state=""
+			onStateChange={() => null}
 			countryGroupId={GBPCountries}
 		/>
 	),
@@ -146,12 +134,9 @@ MultiContribUSSignedIn.args = {
 	isSignedInPersonalDetails: false,
 	signOutLink: <Signout isSignedIn={true} />,
 	contributionState: (
-		<ContributionState
-			selectedState={null}
-			onChange={() => null}
-			isValid={false}
-			formHasBeenSubmitted={false}
-			contributionType={'MONTHLY'}
+		<StateSelect
+			state=""
+			onStateChange={() => null}
 			countryGroupId={UnitedStates}
 		/>
 	),
@@ -167,12 +152,33 @@ MultiContribUSSignedOut.args = {
 	isSignedInPersonalDetails: false,
 	signOutLink: <Signout isSignedIn={false} />,
 	contributionState: (
-		<ContributionState
-			selectedState={null}
-			onChange={() => null}
-			isValid={false}
-			formHasBeenSubmitted={false}
-			contributionType={'MONTHLY'}
+		<StateSelect
+			state=""
+			onStateChange={() => null}
+			countryGroupId={UnitedStates}
+		/>
+	),
+};
+
+export const WithErrors = Template.bind({});
+
+WithErrors.args = {
+	email: '',
+	firstName: '',
+	lastName: '',
+	contributionType: 'MONTHLY',
+	isSignedInPersonalDetails: false,
+	errors: {
+		firstName: ['Please enter your first name'],
+		lastName: ['Please enter your last name'],
+		email: ['Please enter your email address'],
+	},
+	signOutLink: <Signout isSignedIn={false} />,
+	contributionState: (
+		<StateSelect
+			state=""
+			error="Please select your state, province or territory"
+			onStateChange={() => null}
 			countryGroupId={UnitedStates}
 		/>
 	),


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds validation to the personal details section on the new checkout form, displaying inline errors beside the relevant form fields as well as in the error summary at the top of the form.

It also adds a new `StateSelect` component to work with the new validation system and that makes use of the Source `Select` component, and makes some overall updates to styling.

[**Trello Card**](https://trello.com/c/n6T98HFX)

## Why are you doing this?

This is part of the ongoing validation system work for the new form.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

![Screenshot 2022-10-31 at 17-08-11 Support the Guardian Make a Contribution](https://user-images.githubusercontent.com/29146931/199067915-8aae996c-2e1a-4ab5-943b-7ca4955287e6.png)
