### PR TITLE
Integrate the old direct debit form with the new checkout

### DIFF
--- a/support-frontend/assets/components/paymentButton/directDebitPaymentButton.tsx
+++ b/support-frontend/assets/components/paymentButton/directDebitPaymentButton.tsx
@@ -1,0 +1,14 @@
+import { useFormValidation } from 'helpers/customHooks/useFormValidation';
+import { setPopupOpen } from 'helpers/redux/checkout/payment/directDebit/actions';
+import { useContributionsDispatch } from 'helpers/redux/storeHooks';
+import { DefaultPaymentButtonContainer } from './defaultPaymentButtonContainer';
+
+export function DirectDebitPaymentButton(): JSX.Element {
+	const dispatch = useContributionsDispatch();
+
+	const payWithDirectDebit = useFormValidation(function openDDForm() {
+		dispatch(setPopupOpen());
+	});
+
+	return <DefaultPaymentButtonContainer onClick={payWithDirectDebit} />;
+}

--- a/support-frontend/assets/helpers/customHooks/useRecaptcha.ts
+++ b/support-frontend/assets/helpers/customHooks/useRecaptcha.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { loadRecaptchaV2 } from 'helpers/forms/recaptcha';
 
 export function useRecaptchaV2(
@@ -6,14 +6,22 @@ export function useRecaptchaV2(
 	onCompletionCallback: (token: string) => void,
 	onExpireCallback?: () => void,
 ): void {
+	const [recaptchaId, setRecaptchaId] = useState<number | undefined>();
+
 	useEffect(() => {
 		if (window.guardian.recaptchaEnabled) {
 			window.v2OnloadCallback = () => {
-				window.grecaptcha?.render(placeholderId, {
-					sitekey: window.guardian.v2recaptchaPublicKey,
-					callback: onCompletionCallback,
-					'expired-callback': onExpireCallback,
-				});
+				try {
+					const id = window.grecaptcha?.render(placeholderId, {
+						sitekey: window.guardian.v2recaptchaPublicKey,
+						callback: onCompletionCallback,
+						'expired-callback': onExpireCallback,
+					});
+
+					setRecaptchaId(id);
+				} catch (error) {
+					window.grecaptcha?.reset(recaptchaId);
+				}
 			};
 			void loadRecaptchaV2();
 		}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/directDebitWrapper.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/directDebitWrapper.tsx
@@ -8,6 +8,7 @@ import {
 
 export function DirectDebitContainer(): JSX.Element {
 	const dispatch = useContributionsDispatch();
+
 	function onPaymentAuthorisation(paymentAuthorisation: PaymentAuthorisation) {
 		dispatch(paymentWaiting(true));
 		void dispatch(onThirdPartyPaymentAuthorised(paymentAuthorisation));

--- a/support-frontend/assets/pages/supporter-plus-landing/components/directDebitWrapper.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/directDebitWrapper.tsx
@@ -1,0 +1,22 @@
+import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
+import type { PaymentAuthorisation } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
+import { useContributionsDispatch } from 'helpers/redux/storeHooks';
+import {
+	onThirdPartyPaymentAuthorised,
+	paymentWaiting,
+} from 'pages/contributions-landing/contributionsLandingActions';
+
+export function DirectDebitContainer(): JSX.Element {
+	const dispatch = useContributionsDispatch();
+	function onPaymentAuthorisation(paymentAuthorisation: PaymentAuthorisation) {
+		dispatch(paymentWaiting(true));
+		void dispatch(onThirdPartyPaymentAuthorised(paymentAuthorisation));
+	}
+
+	return (
+		<DirectDebitPopUpForm
+			buttonText="Pay with Direct Debit"
+			onPaymentAuthorisation={onPaymentAuthorisation}
+		/>
+	);
+}

--- a/support-frontend/assets/pages/supporter-plus-landing/paymentButtons.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/paymentButtons.ts
@@ -1,4 +1,5 @@
 import { AmazonPaymentButton } from 'components/amazonPaymentButton/amazonPaymentButton';
+import { DirectDebitPaymentButton } from 'components/paymentButton/directDebitPaymentButton';
 import { SepaPaymentButton } from 'components/sepaForm/sepaPaymentButton';
 import { StripePaymentButton } from 'components/stripeCardForm/stripePaymentButton';
 import type { ContributionType } from 'helpers/contributions';
@@ -14,6 +15,7 @@ const allPaymentMethodButtons: PaymentMethodButtons = {
 	Stripe: StripePaymentButton,
 	AmazonPay: AmazonPaymentButton,
 	Sepa: SepaPaymentButton,
+	DirectDebit: DirectDebitPaymentButton,
 };
 
 export function getPaymentMethodButtons(

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -39,6 +39,7 @@ import {
 } from 'helpers/internationalisation/countryGroup';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import { DirectDebitContainer } from './components/directDebitWrapper';
 import { LandingPageHeading } from './components/landingPageHeading';
 import { PatronsMessage } from './components/patronsMessage';
 import { PaymentFailureMessage } from './components/paymentFailure';
@@ -152,6 +153,7 @@ export function SupporterPlusLandingPage({
 										)}
 									/>
 									<PaymentFailureMessage />
+									<DirectDebitContainer />
 								</ContributionsStripe>
 								<br />
 								<Button

--- a/support-frontend/window.d.ts
+++ b/support-frontend/window.d.ts
@@ -62,7 +62,8 @@ declare global {
 		enablePayPalButton?: () => void;
 		googleTagManagerDataLayer?: Array<Record<string, unknown>>;
 		grecaptcha?: {
-			render: (arg0: string, arg1: Record<string, unknown>) => void;
+			render: (arg0: string, arg1: Record<string, unknown>) => number;
+			reset: (id: number | undefined) => void;
 		};
 		gtag_enable_tcf_support?: boolean;
 		OffAmazonPayments?: AmazonPaymentsObject;


### PR DESCRIPTION
## What are you doing in this PR?

This adds a `DirectDebitPaymentButton` that opens the old direct debit popup form after validating the rest of the form, and a simple wrapper component for the form itself that manages the payment completion state.

It also tackles a small issue with the `Recaptcha` component and re-renders.

[**Trello Card**](https://trello.com/c/dZXBz1Q4)

## Why are you doing this?

We need to retain the old form for now until we can get a new design validated by GoCardless. This integrates it into the new form and allows payment via direct debit to be taken.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist

**NB. The old direct debit form is _not_ keyboard or screen reader navigable, which is why it needs to be replaced ASAP**

 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots
![Screenshot 2022-11-02 at 12-01-26 Support the Guardian Make a Contribution](https://user-images.githubusercontent.com/29146931/199485314-ff9fbcaf-547f-4f51-bd0a-5ef716587add.png)

