### PR TITLE
Fix v2 page layout, add link to header logo

### DIFF
--- a/support-frontend/assets/components/headers/simpleHeader/simpleHeader.tsx
+++ b/support-frontend/assets/components/headers/simpleHeader/simpleHeader.tsx
@@ -1,5 +1,11 @@
 import { css } from '@emotion/react';
-import { brand, from, neutral, space } from '@guardian/source-foundations';
+import {
+	brand,
+	from,
+	neutral,
+	space,
+	visuallyHidden,
+} from '@guardian/source-foundations';
 import {
 	Column,
 	Columns,
@@ -37,7 +43,16 @@ export function Header({ children }: HeaderProps): JSX.Element {
 					<Column>{children}</Column>
 					<Column span={[2, 3, 4]}>
 						<div css={logoContainer}>
-							<SvgGuardianLogo textColor={neutral[100]} />
+							<a href="https://www.theguardian.com">
+								<div
+									css={css`
+										${visuallyHidden};
+									`}
+								>
+									Return to the Guardian
+								</div>
+								<SvgGuardianLogo textColor={neutral[100]} />
+							</a>
 						</div>
 					</Column>
 					{/* Only show at wide breakpoint */}

--- a/support-frontend/assets/components/headers/simpleHeader/simpleHeader.tsx
+++ b/support-frontend/assets/components/headers/simpleHeader/simpleHeader.tsx
@@ -42,18 +42,16 @@ export function Header({ children }: HeaderProps): JSX.Element {
 				<Columns>
 					<Column>{children}</Column>
 					<Column span={[2, 3, 4]}>
-						<div css={logoContainer}>
-							<a href="https://www.theguardian.com">
-								<div
-									css={css`
-										${visuallyHidden};
-									`}
-								>
-									Return to the Guardian
-								</div>
-								<SvgGuardianLogo textColor={neutral[100]} />
-							</a>
-						</div>
+						<a href="https://www.theguardian.com" css={logoContainer}>
+							<div
+								css={css`
+									${visuallyHidden};
+								`}
+							>
+								Return to the Guardian
+							</div>
+							<SvgGuardianLogo textColor={neutral[100]} />
+						</a>
 					</Column>
 					{/* Only show at wide breakpoint */}
 					<Column span={[0, 0, 0, 0, 1]}></Column>

--- a/support-frontend/assets/components/legal/contribLegal/contribLegal.tsx
+++ b/support-frontend/assets/components/legal/contribLegal/contribLegal.tsx
@@ -10,7 +10,7 @@ type PropTypes = {
 	countryGroupId: CountryGroupId;
 }; // ----- Component ----- //
 
-export default function ContribLegal(props: PropTypes) {
+export default function ContribLegal(props: PropTypes): JSX.Element {
 	const contactUs = useDotcomContactPage() ? (
 		<ContactPageLink linkText="contact us here" />
 	) : (

--- a/support-frontend/assets/components/page/pageScaffold.tsx
+++ b/support-frontend/assets/components/page/pageScaffold.tsx
@@ -6,6 +6,21 @@ import { SkipLink } from 'components/skipLink/skipLink';
 import { TestUserBanner } from 'components/test-user-banner/testUserBanner';
 import { useScrollToAnchor } from 'helpers/customHooks/useScrollToAnchor';
 
+const container = css`
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
+
+	& main {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		& > :last-child {
+			flex: 1;
+		}
+	}
+`;
+
 export type PageScaffoldProps = {
 	id: string;
 	header?: ReactNode;
@@ -19,7 +34,7 @@ export function PageScaffold(props: PageScaffoldProps): JSX.Element {
 	useScrollToAnchor();
 
 	return (
-		<div id={props.id}>
+		<div id={props.id} css={container}>
 			<Global
 				styles={css`
 					${resets.resetCSS}

--- a/support-frontend/assets/components/page/pageScaffold.tsx
+++ b/support-frontend/assets/components/page/pageScaffold.tsx
@@ -10,6 +10,8 @@ const container = css`
 	display: flex;
 	flex-direction: column;
 	min-height: 100vh;
+	max-width: 100%;
+	overflow-x: hidden;
 
 	& main {
 		flex: 1;


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This ensures that the v2 checkout and thank you pages stretches to fit the entire height of their container on larger screen sizes and turns the logo in the header into a link

[**Trello Card**](https://trello.com/c/bxeDOc3Y/817-ensure-the-page-scaffold-stretches-to-fit-the-entire-height-of-the-screen-on-larger-screen-sizes)
[**Trello Card**](https://trello.com/c/3NlwL7tj/804-make-the-guardian-logo-a-link-on-the-v2-checkout)
