### PR TITLE
Filter 2022-12-30 option from GW checkout

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -288,9 +288,8 @@ function WeeklyCheckoutForm(props: PropTypes) {
 								hideLabel={true}
 							>
 								{days
-									// Don't render input if Christmas day or Christmas eve
-									.filter((day) => !formatMachineDate(day).endsWith('-12-25'))
-									.filter((day) => !formatMachineDate(day).endsWith('-12-24'))
+									// Don't show 2022-12-30 as this is not a valid publication date in 2022
+									.filter((day) => !formatMachineDate(day).endsWith('-12-30'))
 									.map((day) => {
 										const [userDate, machineDate] = [
 											formatUserDate(day),

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -289,9 +289,15 @@ function WeeklyCheckoutForm(props: PropTypes) {
 							>
 								{days
 									.filter((day) => {
-									    const invalidPublicationDates = ['-12-24', '-12-25', '-12-30'];
-									    const date = formatMachineDate(day);
-									    return !invalidPublicationDates.some(dateSuffix => date.endsWith(dateSuffix))
+										const invalidPublicationDates = [
+											'-12-24',
+											'-12-25',
+											'-12-30',
+										];
+										const date = formatMachineDate(day);
+										return !invalidPublicationDates.some((dateSuffix) =>
+											date.endsWith(dateSuffix),
+										);
 									})
 									.map((day) => {
 										const [userDate, machineDate] = [

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -288,8 +288,11 @@ function WeeklyCheckoutForm(props: PropTypes) {
 								hideLabel={true}
 							>
 								{days
-									// Don't show 2022-12-30 as this is not a valid publication date in 2022
-									.filter((day) => !formatMachineDate(day).endsWith('-12-30'))
+									.filter((day) => {
+									    const invalidPublicationDates = ['-12-24', '-12-25', '-12-30'];
+									    const date = formatMachineDate(day);
+									    return !invalidPublicationDates.some(dateSuffix => date.endsWith(dateSuffix))
+									})
 									.map((day) => {
 										const [userDate, machineDate] = [
 											formatUserDate(day),

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
@@ -246,8 +246,17 @@ function WeeklyCheckoutFormGifting(props: PropTypes): JSX.Element {
 								label="Gift delivery date"
 							>
 								{days
-									// Don't show 2022-12-30 as this is not a valid delivery date in 2022
-									.filter((day) => !formatMachineDate(day).endsWith('-12-30'))
+									.filter((day) => {
+										const invalidPublicationDates = [
+											'-12-24',
+											'-12-25',
+											'-12-30',
+										];
+										const date = formatMachineDate(day);
+										return !invalidPublicationDates.some((dateSuffix) =>
+											date.endsWith(dateSuffix),
+										);
+									})
 									.map((day) => {
 										const [userDate, machineDate] = [
 											formatUserDate(day),

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
@@ -246,9 +246,8 @@ function WeeklyCheckoutFormGifting(props: PropTypes): JSX.Element {
 								label="Gift delivery date"
 							>
 								{days
-									// Don't render input if Christmas day or Christmas eve
-									.filter((day) => !formatMachineDate(day).endsWith('-12-25'))
-									.filter((day) => !formatMachineDate(day).endsWith('-12-24'))
+									// Don't show 2022-12-30 as this is not a valid delivery date in 2022
+									.filter((day) => !formatMachineDate(day).endsWith('-12-30'))
 									.map((day) => {
 										const [userDate, machineDate] = [
 											formatUserDate(day),


### PR DESCRIPTION
## What are you doing in this PR?

We offer users the opportunity to choose their first publication date on the Guardian Weekly non-gifting checkout, or delivery date on the gifting checkout. The logic to determine which dates to show them is pretty simple, we calculate the next 5 Friday's and list them out.The issue we've had in the past is we've sometimes offered a publication/delivery date over the Christmas week when an issue isn't published. Users have selected this, and we've been unable to fulfil it

In 2022 we won't be publishing an issue on Friday 30th December 2022, so need to make sure that's not included as an option on these checkouts.

[**Trello Card**](https://trello.com/c/XzBzUL2V/369-dont-show-30-12-2022-as-an-available-publication-option-on-the-gw-checkout)