### PR TITLE
Update V2 Thank You Page header copy

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/subheading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/subheading.tsx
@@ -1,41 +1,127 @@
+import { css } from '@emotion/react';
 import type { ContributionType } from 'helpers/contributions';
+import type { UserTypeFromIdentityResponse } from 'helpers/identityApis';
 
 interface SubheadingProps {
 	shouldShowLargeDonationMessage: boolean;
 	contributionType: ContributionType;
 	amountIsAboveThreshold: boolean;
+	isSignedIn: boolean;
+	userTypeFromIdentityResponse: UserTypeFromIdentityResponse;
 }
 
-function MarketingCopy() {
-	return (
+function MarketingCopy({
+	contributionType,
+}: {
+	contributionType: ContributionType;
+}) {
+	return contributionType === 'ONE_OFF' ? (
 		<span>
 			You can amend your email preferences at any time via{' '}
+			<a href="https://manage.theguardian.com">your account</a>.
+		</span>
+	) : (
+		<span>
+			Adjust your email preferences at any time via{' '}
 			<a href="https://manage.theguardian.com">your account</a>.
 		</span>
 	);
 }
 
+const getSubHeadingCopy = (
+	shouldShowLargeDonationMessage: boolean,
+	amountIsAboveThreshold: boolean,
+	contributionType: ContributionType,
+	isSignedIn: boolean,
+	userTypeFromIdentityResponse: UserTypeFromIdentityResponse,
+) => {
+	const recurringCopy = (amountIsAboveThreshold: boolean) => {
+		return {
+			isSignedIn: amountIsAboveThreshold ? (
+				<>
+					<span
+						css={css`
+							font-weight: bold;
+						`}
+					>
+						You have unlocked your exclusive supporter extras – we hope you
+						enjoy them.
+					</span>{' '}
+					<span>
+						Look out for your exclusive newsletter from our supporter editor.
+						We’ll also be in touch with other great ways to get closer to
+						Guardian journalism.{' '}
+					</span>
+				</>
+			) : (
+				<span>
+					Look out for your exclusive newsletter from our supporter editor.
+					We’ll also be in touch with other great ways to get closer to Guardian
+					journalism.{' '}
+				</span>
+			),
+			notSignedIn: amountIsAboveThreshold ? (
+				<span>
+					Look out for your exclusive newsletter from our supporter editor.
+					We’ll also be in touch with other great ways to get closer to Guardian
+					journalism.{' '}
+				</span>
+			) : (
+				<span>
+					Look out for your exclusive newsletter from our supporter editor.
+					We’ll also be in touch with other great ways to get closer to Guardian
+					journalism.{' '}
+				</span>
+			),
+		};
+	};
+
+	const oneOffCopy = shouldShowLargeDonationMessage
+		? 'It’s not every day we receive such a generous amount. We would love to stay in touch. So that we can, please select the add-ons that suit you best. '
+		: 'We would love to stay in touch. So that we can, please select the add-ons that suit you best. ';
+
+	return contributionType === 'ONE_OFF'
+		? oneOffCopy
+		: recurringCopy(amountIsAboveThreshold)[
+				userTypeFromIdentityResponse === 'current' || isSignedIn
+					? 'isSignedIn'
+					: 'notSignedIn'
+		  ];
+};
+
 function Subheading({
 	shouldShowLargeDonationMessage,
 	contributionType,
 	amountIsAboveThreshold,
+	isSignedIn,
+	userTypeFromIdentityResponse,
 }: SubheadingProps): JSX.Element {
-	const subheadingCopy: Record<ContributionType, string> = {
-		ONE_OFF: shouldShowLargeDonationMessage
-			? 'It’s not every day we receive such a generous contribution – thank you. We’ll be in touch to bring you closer to our journalism. Please select the extra add-ons that suit you best. '
-			: 'To support us further, and enhance your experience with the Guardian, select the add-ons that suit you best. As you’re now a valued supporter, we’ll be in touch to bring you closer to our journalism. ',
-		MONTHLY: amountIsAboveThreshold
-			? 'You have unlocked access to the Guardian’s digital subscription, offering you the best possible experience of our independent journalism. Look out for emails from us shortly, so you can activate your exclusive extras. In the meantime, please select the add-ons that suit you best. '
-			: 'Look out for your exclusive newsletter from our supporter editor, and other ways to get the most out of your supporter experience. ',
-		ANNUAL: amountIsAboveThreshold
-			? 'Look out for your exclusive newsletter from our supporter editor, and other ways to get the most out of your supporter experience. '
-			: 'You have unlocked access to the Guardian’s digital subscription, offering you the best possible experience of our independent journalism. Look out for emails from us shortly, so you can activate your exclusive extras. In the meantime, please select the add-ons that suit you best.',
-	};
+	const subheadingCopy = getSubHeadingCopy(
+		shouldShowLargeDonationMessage,
+		amountIsAboveThreshold,
+		contributionType,
+		isSignedIn,
+		userTypeFromIdentityResponse,
+	);
 
 	return (
 		<>
-			{subheadingCopy[contributionType]}
-			{contributionType !== 'ONE_OFF' && <MarketingCopy />}
+			{subheadingCopy}
+			{contributionType !== 'ONE_OFF' && (
+				<MarketingCopy contributionType={contributionType} />
+			)}
+			{userTypeFromIdentityResponse !== 'current' &&
+				contributionType !== 'ONE_OFF' && (
+					<span
+						css={css`
+							font-weight: bold;
+						`}
+					>
+						{' '}
+						In the meantime, please sign in to get the best supporter
+						experience.
+					</span>
+				)}
 		</>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { body, from, space, titlepiece } from '@guardian/source-foundations';
 import type { ContributionType } from 'helpers/contributions';
+import type { UserTypeFromIdentityResponse } from 'helpers/identityApis';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import DirectDebitMessage from './directDebitMessage';
 import Heading from './heading';
@@ -43,6 +44,8 @@ type ThankYouHeaderProps = {
 	currency: IsoCurrency;
 	shouldShowLargeDonationMessage: boolean;
 	amountIsAboveThreshold: boolean;
+	isSignedIn: boolean;
+	userTypeFromIdentityResponse: UserTypeFromIdentityResponse;
 };
 
 function ThankYouHeader({
@@ -54,6 +57,8 @@ function ThankYouHeader({
 	currency,
 	shouldShowLargeDonationMessage,
 	amountIsAboveThreshold,
+	isSignedIn,
+	userTypeFromIdentityResponse,
 }: ThankYouHeaderProps): JSX.Element {
 	return (
 		<header css={header}>
@@ -72,6 +77,8 @@ function ThankYouHeader({
 					shouldShowLargeDonationMessage={shouldShowLargeDonationMessage}
 					contributionType={contributionType}
 					amountIsAboveThreshold={amountIsAboveThreshold}
+					isSignedIn={isSignedIn}
+					userTypeFromIdentityResponse={userTypeFromIdentityResponse}
 				/>
 			</p>
 		</header>

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -196,6 +196,8 @@ export function SupporterPlusThankYou(): JSX.Element {
 								paymentMethod,
 							)}
 							amountIsAboveThreshold={amountIsAboveThreshold}
+							isSignedIn={isSignedIn}
+							userTypeFromIdentityResponse={userTypeFromIdentityResponse}
 						/>
 					</div>
 

--- a/support-frontend/stories/screens/supporterPlusThankYou/AusSupporterPlusThankYou.stories.tsx
+++ b/support-frontend/stories/screens/supporterPlusThankYou/AusSupporterPlusThankYou.stories.tsx
@@ -259,6 +259,7 @@ RecurringNotSignedIn.decorators = [
 
 		store.dispatch(setCountryInternationalisation('AU'));
 		store.dispatch(setProductType(contributionType));
+		store.dispatch(setUserTypeFromIdentityResponse('guest'));
 		store.dispatch(
 			setFirstName(nameIsOverTenCharacters ? 'NameIsOverTenCharacters' : 'Joe'),
 		);
@@ -318,6 +319,7 @@ RecurringSignedIn.decorators = [
 
 		store.dispatch(setCountryInternationalisation('AU'));
 		store.dispatch(defaultUserActionFunctions.setIsSignedIn(true));
+		store.dispatch(setUserTypeFromIdentityResponse('current'));
 		store.dispatch(setProductType(contributionType));
 		store.dispatch(
 			setFirstName(nameIsOverTenCharacters ? 'NameIsOverTenCharacters' : 'Joe'),

--- a/support-frontend/stories/screens/supporterPlusThankYou/ROWSupporterPlusThankYou.stories.tsx
+++ b/support-frontend/stories/screens/supporterPlusThankYou/ROWSupporterPlusThankYou.stories.tsx
@@ -266,6 +266,7 @@ RecurringNotSignedIn.decorators = [
 		const store = createTestStoreForContributions();
 
 		store.dispatch(setProductType(contributionType));
+		store.dispatch(setUserTypeFromIdentityResponse('guest'));
 		store.dispatch(
 			setFirstName(nameIsOverTenCharacters ? 'NameIsOverTenCharacters' : 'Joe'),
 		);
@@ -329,6 +330,7 @@ RecurringSignedIn.decorators = [
 		const store = createTestStoreForContributions();
 
 		store.dispatch(defaultUserActionFunctions.setIsSignedIn(true));
+		store.dispatch(setUserTypeFromIdentityResponse('current'));
 		store.dispatch(setProductType(contributionType));
 		store.dispatch(
 			setFirstName(nameIsOverTenCharacters ? 'NameIsOverTenCharacters' : 'Joe'),


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This updates the Header copy for the Supporter Plus thank you pages. 

Please see [this section](https://docs.google.com/document/d/1YBqE24iC2LZpdY_wfwLepgdN3zObpYe793DmAgdp_Pg/edit?hl=en-GB&forcehl=1#heading=h.6qt1hvesks1q) of the copy update dock for the required copy combinations. Until we test the live checkout you can view these copy updates / the expected thank you page header text combinations [here](https://62e115310aef0868687b2322-koviusoskb.chromatic.com/?path=/story/screens-supporter-plus-thank-you-page-rest-of-world--one-off-not-signed-in) in storybook. 

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/wIJdGCxX/730-show-appropriate-copy-on-thank-you-page-for-v2-checkout)

## Screenshots
Please see the one-off/recurring supporter plus [storybook](https://62e115310aef0868687b2322-koviusoskb.chromatic.com/?path=/story/screens-supporter-plus-thank-you-page-rest-of-world--one-off-not-signed-in) thank you page screens. These should have either a `shouldShowLargeDonation` or `amountIsAboveThreshold` configurable control which will alter the display message