### PR TITLE
Add PayPal payment method for new checkout

### DIFF
--- a/support-frontend/assets/components/payPalPaymentButton/payPalButton.tsx
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalButton.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { fetchJson } from 'helpers/async/fetch';
+import type {
+	PayPalCheckoutDetails,
+	SetupPayPalRequestType,
+} from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
+import { PayPal } from 'helpers/forms/paymentMethods';
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
+import type { CsrfState } from 'helpers/redux/checkout/csrf/state';
+import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
+import { routes } from 'helpers/urls/routes';
+import { logException } from 'helpers/utilities/logger';
+import { onThirdPartyPaymentAuthorised } from 'pages/contributions-landing/contributionsLandingActions';
+
+function getPayPalOptions(
+	currencyId: IsoCurrency,
+	csrf: CsrfState,
+	onPayPalCheckoutCompleted: (arg0: PayPalCheckoutDetails) => void,
+	onClick: () => void,
+	isTestUser: boolean,
+	amount: number,
+	billingPeriod: BillingPeriod,
+	setupPayPalPayment: SetupPayPalRequestType,
+): PayPalButtonProps {
+	return {
+		env: isTestUser
+			? window.guardian.payPalEnvironment.uat
+			: window.guardian.payPalEnvironment.default,
+		style: {
+			color: 'blue',
+			size: 'responsive',
+			label: 'pay',
+			tagline: false,
+			layout: 'horizontal',
+			fundingicons: false,
+		},
+		// Defines whether user sees 'Agree and Continue' or 'Agree and Pay now' in overlay.
+		commit: true,
+		validate: console.log,
+		funding: {
+			disallowed: [window.paypal.FUNDING.CREDIT],
+		},
+		onClick,
+		// This function is called when user clicks the PayPal button.
+		payment: (
+			resolve: (arg0: string) => void,
+			reject: (error: Error) => void,
+		) =>
+			setupPayPalPayment(
+				resolve,
+				reject,
+				currencyId,
+				csrf,
+				amount,
+				billingPeriod,
+			),
+		// This function is called when the user finishes with PayPal interface (approves payment).
+		onAuthorize: async (payPalData: Record<string, unknown>) => {
+			try {
+				const body = {
+					token: payPalData.paymentToken,
+				};
+				const csrfToken = csrf.token;
+				const payPalCheckoutDetails = await fetchJson(
+					routes.payPalOneClickCheckout,
+					{
+						credentials: 'include',
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							'Csrf-Token': csrfToken ?? '',
+						},
+						body: JSON.stringify(body),
+					},
+				);
+				onPayPalCheckoutCompleted(
+					payPalCheckoutDetails as PayPalCheckoutDetails,
+				);
+			} catch (error) {
+				logException((error as Error).message);
+			}
+		},
+	};
+}
+
+export function PayPalButton(): JSX.Element {
+	const dispatch = useContributionsDispatch();
+	const { currencyId } = useContributionsSelector(
+		(state) => state.common.internationalisation,
+	);
+	const { csrf } = useContributionsSelector((state) => state.page.checkoutForm);
+	const { isTestUser } = useContributionsSelector((state) => state.page.user);
+	const amount = useContributionsSelector(getUserSelectedAmount);
+	const contributionType = useContributionsSelector(getContributionType);
+
+	function onCheckoutCompleted(payPalCheckoutDetails: PayPalCheckoutDetails) {
+		void dispatch(
+			onThirdPartyPaymentAuthorised({
+				paymentMethod: PayPal,
+				token: payPalCheckoutDetails.baid,
+			}),
+		);
+	}
+
+	const buttonProps = getPayPalOptions(
+		currencyId,
+		csrf,
+		onCheckoutCompleted,
+		console.log,
+		isTestUser ?? false,
+		amount,
+		contributionType.toLowerCase(),
+		console.log,
+	);
+
+	const Button = window.paypal.Button.driver('react', {
+		React,
+		ReactDOM,
+	});
+	return <Button {...buttonProps} />;
+}

--- a/support-frontend/assets/components/payPalPaymentButton/payPalButton.tsx
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalButton.tsx
@@ -1,108 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { fetchJson } from 'helpers/async/fetch';
-import type { PayPalCheckoutDetails } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
-import { PayPal } from 'helpers/forms/paymentMethods';
-import type { CsrfState } from 'helpers/redux/checkout/csrf/state';
-import type {
-	PayPalTokenReject,
-	PayPalTokenResolve,
-} from 'helpers/redux/checkout/payment/payPal/thunks';
-import { setUpPayPalPayment } from 'helpers/redux/checkout/payment/payPal/thunks';
-import {
-	useContributionsDispatch,
-	useContributionsSelector,
-} from 'helpers/redux/storeHooks';
-import { routes } from 'helpers/urls/routes';
-import { logException } from 'helpers/utilities/logger';
-import { onThirdPartyPaymentAuthorised } from 'pages/contributions-landing/contributionsLandingActions';
 
-function getPayPalOptions(
-	csrf: CsrfState,
-	onPayPalCheckoutCompleted: (arg0: PayPalCheckoutDetails) => void,
-	onClick: () => void,
-	isTestUser: boolean,
-	setUpForPayment: (
-		resolve: PayPalTokenResolve,
-		reject: PayPalTokenReject,
-	) => void,
-): PayPalButtonProps {
-	return {
-		env: isTestUser
-			? window.guardian.payPalEnvironment.uat
-			: window.guardian.payPalEnvironment.default,
-		style: {
-			color: 'blue',
-			size: 'responsive',
-			label: 'pay',
-			tagline: false,
-			layout: 'horizontal',
-			fundingicons: false,
-		},
-		// Defines whether user sees 'Agree and Continue' or 'Agree and Pay now' in overlay.
-		commit: true,
-		validate: console.log,
-		funding: {
-			disallowed: [window.paypal.FUNDING.CREDIT],
-		},
-		onClick,
-		// This function is called when user clicks the PayPal button.
-		payment: setUpForPayment,
-		// This function is called when the user finishes with PayPal interface (approves payment).
-		onAuthorize: async (payPalData: Record<string, unknown>) => {
-			try {
-				const body = {
-					token: payPalData.paymentToken,
-				};
-				const csrfToken = csrf.token;
-				const payPalCheckoutDetails = await fetchJson(
-					routes.payPalOneClickCheckout,
-					{
-						credentials: 'include',
-						method: 'POST',
-						headers: {
-							'Content-Type': 'application/json',
-							'Csrf-Token': csrfToken ?? '',
-						},
-						body: JSON.stringify(body),
-					},
-				);
-				onPayPalCheckoutCompleted(
-					payPalCheckoutDetails as PayPalCheckoutDetails,
-				);
-			} catch (error) {
-				logException((error as Error).message);
-			}
-		},
-	};
-}
-
-export function PayPalButton(): JSX.Element {
-	const dispatch = useContributionsDispatch();
-	const { csrf } = useContributionsSelector((state) => state.page.checkoutForm);
-	const { isTestUser } = useContributionsSelector((state) => state.page.user);
-
-	function onCheckoutCompleted(payPalCheckoutDetails: PayPalCheckoutDetails) {
-		void dispatch(
-			onThirdPartyPaymentAuthorised({
-				paymentMethod: PayPal,
-				token: payPalCheckoutDetails.baid,
-			}),
-		);
-	}
-
-	const buttonProps = getPayPalOptions(
-		csrf,
-		onCheckoutCompleted,
-		console.log,
-		isTestUser ?? false,
-		(resolve, reject) => void dispatch(setUpPayPalPayment({ resolve, reject })),
-	);
-
+export function PayPalButton(props: PayPalButtonProps): JSX.Element {
 	const Button = window.paypal.Button.driver('react', {
 		React,
 		ReactDOM,
 	});
 
-	return <Button {...buttonProps} />;
+	return <Button {...props} />;
 }

--- a/support-frontend/assets/components/payPalPaymentButton/payPalButtonProps.ts
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalButtonProps.ts
@@ -27,7 +27,7 @@ type PayPalPropsRequirements = {
 	onCompletion: (arg0: PayPalCheckoutDetails) => void;
 };
 
-export function getPayPalOptions({
+export function getPayPalButtonProps({
 	csrf,
 	isTestUser,
 	setValidationControls,

--- a/support-frontend/assets/components/payPalPaymentButton/payPalOneOffContainer.tsx
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalOneOffContainer.tsx
@@ -34,5 +34,10 @@ export function PayPalButtonOneOffContainer(): JSX.Element {
 		);
 	});
 
-	return <DefaultPaymentButtonContainer onClick={payOneOffWithPayPal} />;
+	return (
+		<DefaultPaymentButtonContainer
+			onClick={payOneOffWithPayPal}
+			createButtonText={(amount) => `Pay ${amount} with PayPal`}
+		/>
+	);
 }

--- a/support-frontend/assets/components/payPalPaymentButton/payPalOneOffContainer.tsx
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalOneOffContainer.tsx
@@ -1,0 +1,38 @@
+import { DefaultPaymentButtonContainer } from 'components/paymentButton/defaultPaymentButtonContainer';
+import { useFormValidation } from 'helpers/customHooks/useFormValidation';
+import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
+import { payPalCancelUrl, payPalReturnUrl } from 'helpers/urls/routes';
+import {
+	createOneOffPayPalPayment,
+	paymentWaiting,
+} from 'pages/contributions-landing/contributionsLandingActions';
+
+export function PayPalButtonOneOffContainer(): JSX.Element {
+	const dispatch = useContributionsDispatch();
+	const { currencyId, countryGroupId } = useContributionsSelector(
+		(state) => state.common.internationalisation,
+	);
+	const amount = useContributionsSelector(getUserSelectedAmount);
+	const { email } = useContributionsSelector(
+		(state) => state.page.checkoutForm.personalDetails,
+	);
+
+	const payOneOffWithPayPal = useFormValidation(function oneOffPaypalPayment() {
+		dispatch(paymentWaiting(true));
+
+		dispatch(
+			createOneOffPayPalPayment({
+				currency: currencyId,
+				amount,
+				returnURL: payPalReturnUrl(countryGroupId, email),
+				cancelURL: payPalCancelUrl(countryGroupId),
+			}),
+		);
+	});
+
+	return <DefaultPaymentButtonContainer onClick={payOneOffWithPayPal} />;
+}

--- a/support-frontend/assets/components/payPalPaymentButton/payPalPaymentButton.tsx
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalPaymentButton.tsx
@@ -1,0 +1,12 @@
+import AnimatedDots from 'components/spinners/animatedDots';
+import { usePayPal } from 'helpers/customHooks/usePayPal';
+import { PayPalButton } from './payPalButton';
+
+export function PayPalPaymentButton(): JSX.Element {
+	const payPalHasLoaded = usePayPal();
+
+	if (payPalHasLoaded) {
+		return <PayPalButton />;
+	}
+	return <AnimatedDots appearance="dark" />;
+}

--- a/support-frontend/assets/components/payPalPaymentButton/payPalPaymentButton.tsx
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalPaymentButton.tsx
@@ -1,18 +1,28 @@
+import { useEffect } from 'preact/hooks';
 import AnimatedDots from 'components/spinners/animatedDots';
 import { usePayPal } from 'helpers/customHooks/usePayPal';
+import { validateForm } from 'helpers/redux/checkout/checkoutActions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { contributionsFormHasErrors } from 'helpers/redux/selectors/formValidation';
-import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
 import { PayPalButtonOneOffContainer } from './payPalOneOffContainer';
 import { PayPalButtonRecurringContainer } from './payPalRecurringContainer';
 
 export function PayPalPaymentButton(): JSX.Element {
 	const payPalHasLoaded = usePayPal();
 
+	const dispatch = useContributionsDispatch();
 	const contributionType = useContributionsSelector(getContributionType);
 	const errorsPreventSubmission = useContributionsSelector(
 		contributionsFormHasErrors,
 	);
+
+	useEffect(() => {
+		dispatch(validateForm('PayPal'));
+	}, []);
 
 	if (!payPalHasLoaded) {
 		return <AnimatedDots appearance="dark" />;

--- a/support-frontend/assets/components/payPalPaymentButton/payPalPaymentButton.tsx
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalPaymentButton.tsx
@@ -3,6 +3,7 @@ import { usePayPal } from 'helpers/customHooks/usePayPal';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { contributionsFormHasErrors } from 'helpers/redux/selectors/formValidation';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import { PayPalButtonOneOffContainer } from './payPalOneOffContainer';
 import { PayPalButtonRecurringContainer } from './payPalRecurringContainer';
 
 export function PayPalPaymentButton(): JSX.Element {
@@ -13,10 +14,14 @@ export function PayPalPaymentButton(): JSX.Element {
 		contributionsFormHasErrors,
 	);
 
-	if (payPalHasLoaded && contributionType !== 'ONE_OFF') {
+	if (!payPalHasLoaded) {
+		return <AnimatedDots appearance="dark" />;
+	}
+
+	if (contributionType !== 'ONE_OFF') {
 		return (
 			<PayPalButtonRecurringContainer disabled={errorsPreventSubmission} />
 		);
 	}
-	return <AnimatedDots appearance="dark" />;
+	return <PayPalButtonOneOffContainer />;
 }

--- a/support-frontend/assets/components/payPalPaymentButton/payPalPaymentButton.tsx
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalPaymentButton.tsx
@@ -1,12 +1,22 @@
 import AnimatedDots from 'components/spinners/animatedDots';
 import { usePayPal } from 'helpers/customHooks/usePayPal';
-import { PayPalButton } from './payPalButton';
+import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import { contributionsFormHasErrors } from 'helpers/redux/selectors/formValidation';
+import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import { PayPalButtonRecurringContainer } from './payPalRecurringContainer';
 
 export function PayPalPaymentButton(): JSX.Element {
 	const payPalHasLoaded = usePayPal();
 
-	if (payPalHasLoaded) {
-		return <PayPalButton />;
+	const contributionType = useContributionsSelector(getContributionType);
+	const errorsPreventSubmission = useContributionsSelector(
+		contributionsFormHasErrors,
+	);
+
+	if (payPalHasLoaded && contributionType !== 'ONE_OFF') {
+		return (
+			<PayPalButtonRecurringContainer disabled={errorsPreventSubmission} />
+		);
 	}
 	return <AnimatedDots appearance="dark" />;
 }

--- a/support-frontend/assets/components/payPalPaymentButton/payPalRecurringContainer.tsx
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalRecurringContainer.tsx
@@ -9,8 +9,8 @@ import {
 } from 'helpers/redux/storeHooks';
 import { onThirdPartyPaymentAuthorised } from 'pages/contributions-landing/contributionsLandingActions';
 import { PayPalButton } from './payPalButton';
-import type { OnPaypalWindowOpen } from './utils';
-import { getPayPalOptions } from './utils';
+import type { OnPaypalWindowOpen } from './payPalButtonProps';
+import { getPayPalButtonProps } from './payPalButtonProps';
 
 type PayPalButtonControls = {
 	enable?: () => void;
@@ -43,7 +43,7 @@ export function PayPalButtonRecurringContainer({
 	const onWindowOpen: OnPaypalWindowOpen = (resolve, reject) =>
 		void dispatch(setUpPayPalPayment({ resolve, reject }));
 
-	const buttonProps = getPayPalOptions({
+	const buttonProps = getPayPalButtonProps({
 		csrf,
 		isTestUser: isTestUser ?? false,
 		setValidationControls,

--- a/support-frontend/assets/components/payPalPaymentButton/payPalRecurringContainer.tsx
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalRecurringContainer.tsx
@@ -1,0 +1,64 @@
+import { useEffect } from 'preact/hooks';
+import { useState } from 'react';
+import type { PayPalCheckoutDetails } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
+import { PayPal } from 'helpers/forms/paymentMethods';
+import { setUpPayPalPayment } from 'helpers/redux/checkout/payment/payPal/thunks';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
+import { onThirdPartyPaymentAuthorised } from 'pages/contributions-landing/contributionsLandingActions';
+import { PayPalButton } from './payPalButton';
+import type { OnPaypalWindowOpen } from './utils';
+import { getPayPalOptions } from './utils';
+
+type PayPalButtonControls = {
+	enable?: () => void;
+	disable?: () => void;
+};
+
+type PayPalButtonRecuringContainerProps = {
+	disabled: boolean;
+};
+
+export function PayPalButtonRecurringContainer({
+	disabled,
+}: PayPalButtonRecuringContainerProps): JSX.Element {
+	const [validationControls, setValidationControls] =
+		useState<PayPalButtonControls>({});
+
+	const dispatch = useContributionsDispatch();
+	const { csrf } = useContributionsSelector((state) => state.page.checkoutForm);
+	const { isTestUser } = useContributionsSelector((state) => state.page.user);
+
+	function onCompletion(payPalCheckoutDetails: PayPalCheckoutDetails) {
+		void dispatch(
+			onThirdPartyPaymentAuthorised({
+				paymentMethod: PayPal,
+				token: payPalCheckoutDetails.baid,
+			}),
+		);
+	}
+
+	const onWindowOpen: OnPaypalWindowOpen = (resolve, reject) =>
+		void dispatch(setUpPayPalPayment({ resolve, reject }));
+
+	const buttonProps = getPayPalOptions({
+		csrf,
+		isTestUser: isTestUser ?? false,
+		setValidationControls,
+		onClick: console.log,
+		onWindowOpen,
+		onCompletion,
+	});
+
+	useEffect(() => {
+		if (disabled) {
+			validationControls.disable?.();
+		} else {
+			validationControls.enable?.();
+		}
+	}, [disabled]);
+
+	return <PayPalButton {...buttonProps} />;
+}

--- a/support-frontend/assets/components/payPalPaymentButton/payPalRecurringContainer.tsx
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalRecurringContainer.tsx
@@ -7,7 +7,10 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
-import { onThirdPartyPaymentAuthorised } from 'pages/contributions-landing/contributionsLandingActions';
+import {
+	onThirdPartyPaymentAuthorised,
+	sendFormSubmitEventForPayPalRecurring,
+} from 'pages/contributions-landing/contributionsLandingActions';
 import { PayPalButton } from './payPalButton';
 import type { OnPaypalWindowOpen } from './payPalButtonProps';
 import { getPayPalButtonProps } from './payPalButtonProps';
@@ -47,7 +50,7 @@ export function PayPalButtonRecurringContainer({
 		csrf,
 		isTestUser: isTestUser ?? false,
 		setValidationControls,
-		onClick: console.log,
+		onClick: () => dispatch(sendFormSubmitEventForPayPalRecurring()),
 		onWindowOpen,
 		onCompletion,
 	});
@@ -58,7 +61,7 @@ export function PayPalButtonRecurringContainer({
 		} else {
 			validationControls.enable?.();
 		}
-	}, [disabled]);
+	}, [disabled, validationControls]);
 
 	return <PayPalButton {...buttonProps} />;
 }

--- a/support-frontend/assets/components/payPalPaymentButton/utils.ts
+++ b/support-frontend/assets/components/payPalPaymentButton/utils.ts
@@ -1,0 +1,84 @@
+import { fetchJson } from 'helpers/async/fetch';
+import type { PayPalCheckoutDetails } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
+import type { CsrfState } from 'helpers/redux/checkout/csrf/state';
+import type {
+	PayPalTokenReject,
+	PayPalTokenResolve,
+} from 'helpers/redux/checkout/payment/payPal/thunks';
+import { routes } from 'helpers/urls/routes';
+import { logException } from 'helpers/utilities/logger';
+
+export type PayPalButtonControls = {
+	enable?: () => void;
+	disable?: () => void;
+};
+
+export type OnPaypalWindowOpen = (
+	resolve: PayPalTokenResolve,
+	reject: PayPalTokenReject,
+) => void;
+
+type PayPalPropsRequirements = {
+	csrf: CsrfState;
+	isTestUser: boolean;
+	setValidationControls: (controls: PayPalButtonControls) => void;
+	onClick: () => void;
+	onWindowOpen: OnPaypalWindowOpen;
+	onCompletion: (arg0: PayPalCheckoutDetails) => void;
+};
+
+export function getPayPalOptions({
+	csrf,
+	isTestUser,
+	setValidationControls,
+	onClick,
+	onWindowOpen,
+	onCompletion,
+}: PayPalPropsRequirements): PayPalButtonProps {
+	return {
+		env: isTestUser
+			? window.guardian.payPalEnvironment.uat
+			: window.guardian.payPalEnvironment.default,
+		style: {
+			color: 'blue',
+			size: 'responsive',
+			label: 'pay',
+			tagline: false,
+			layout: 'horizontal',
+			fundingicons: false,
+		},
+		// Defines whether user sees 'Agree and Continue' or 'Agree and Pay now' in overlay.
+		commit: true,
+		validate: setValidationControls,
+		funding: {
+			disallowed: [window.paypal.FUNDING.CREDIT],
+		},
+		onClick,
+		// This function is called when user clicks the PayPal button.
+		payment: onWindowOpen,
+		// This function is called when the user finishes with PayPal interface (approves payment).
+		onAuthorize: async (payPalData: Record<string, unknown>) => {
+			try {
+				const body = {
+					token: payPalData.paymentToken,
+				};
+				const csrfToken = csrf.token;
+				const payPalCheckoutDetails = await fetchJson(
+					routes.payPalOneClickCheckout,
+					{
+						credentials: 'include',
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							'Csrf-Token': csrfToken ?? '',
+						},
+						body: JSON.stringify(body),
+					},
+				);
+				onCompletion(payPalCheckoutDetails as PayPalCheckoutDetails);
+			} catch (error) {
+				logException((error as Error).message);
+			}
+		},
+	};
+}

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -13,8 +13,14 @@ const contributionTypeToPaymentInterval: Partial<
 	ANNUAL: 'year',
 };
 
+type ButtonTextCreator = (
+	amountWithCurrency: string,
+	paymentInterval?: 'month' | 'year',
+) => string;
+
 export type DefaultPaymentContainerProps = {
 	onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+	createButtonText?: ButtonTextCreator;
 };
 
 function getButtonText(
@@ -22,14 +28,15 @@ function getButtonText(
 	paymentInterval?: 'month' | 'year',
 ) {
 	if (paymentInterval) {
-		return `${amountWithCurrency} per ${paymentInterval}`;
+		return `Pay ${amountWithCurrency} per ${paymentInterval}`;
 	}
 
-	return amountWithCurrency;
+	return `Pay ${amountWithCurrency}`;
 }
 
 export function DefaultPaymentButtonContainer({
 	onClick,
+	createButtonText = getButtonText,
 }: DefaultPaymentContainerProps): JSX.Element {
 	const { currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
@@ -45,7 +52,7 @@ export function DefaultPaymentButtonContainer({
 
 	const buttonText = Number.isNaN(selectedAmount)
 		? 'Pay now'
-		: getButtonText(
+		: createButtonText(
 				amountWithCurrency,
 				contributionTypeToPaymentInterval[contributionType],
 		  );

--- a/support-frontend/assets/helpers/customHooks/usePayPal.ts
+++ b/support-frontend/assets/helpers/customHooks/usePayPal.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'preact/hooks';
+import { loadPayPalExpressSdk } from 'helpers/redux/checkout/payment/payPal/reducer';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
+
+export function usePayPal(): boolean {
+	const dispatch = useContributionsDispatch();
+	const { hasLoaded, hasBegunLoading } = useContributionsSelector(
+		(state) => state.page.checkoutForm.payment.payPal,
+	);
+
+	useEffect(() => {
+		if (!hasBegunLoading) {
+			void dispatch(loadPayPalExpressSdk());
+		}
+	}, []);
+
+	return hasLoaded;
+}

--- a/support-frontend/assets/helpers/customHooks/usePayPal.ts
+++ b/support-frontend/assets/helpers/customHooks/usePayPal.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'preact/hooks';
-import { loadPayPalExpressSdk } from 'helpers/redux/checkout/payment/payPal/reducer';
+import { loadPayPalExpressSdk } from 'helpers/redux/checkout/payment/payPal/thunks';
 import {
 	useContributionsDispatch,
 	useContributionsSelector,

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/payPalRecurringCheckout.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/payPalRecurringCheckout.ts
@@ -249,7 +249,7 @@ const getPayPalOptions = (
 	billingPeriod: BillingPeriod,
 	setupPayPalPayment: SetupPayPalRequestType,
 	updatePayPalButtonReady: (ready: boolean) => void,
-): Record<string, unknown> => {
+): PayPalButtonProps => {
 	function toggleButton(actions: {
 		enable: () => void;
 		disable: () => void;

--- a/support-frontend/assets/helpers/redux/checkout/payment/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/contributionsSideEffects.ts
@@ -16,8 +16,8 @@ import {
 	setAmazonPayPaymentSelected,
 } from './amazonPay/actions';
 import { setPaymentMethod } from './paymentMethod/actions';
-import { loadPayPalExpressSdk } from './payPal/reducer';
 import type { PayPalState } from './payPal/state';
+import { loadPayPalExpressSdk } from './payPal/thunks';
 import {
 	setSepaAccountHolderName,
 	setSepaAddressCountry,

--- a/support-frontend/assets/helpers/redux/checkout/payment/payPal/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/payPal/reducer.ts
@@ -1,13 +1,8 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
-import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-import { loadPayPalRecurring } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
+import { createSlice } from '@reduxjs/toolkit';
 import { setPaymentMethod } from 'helpers/redux/checkout/payment/paymentMethod/actions';
 import { initialPayPalState } from './state';
-
-export const loadPayPalExpressSdk = createAsyncThunk(
-	'paypal/loadPayPalExpressSdk',
-	loadPayPalRecurring,
-);
+import { loadPayPalExpressSdk } from './thunks';
 
 export const payPalSlice = createSlice({
 	name: 'paypal',

--- a/support-frontend/assets/helpers/redux/checkout/payment/payPal/thunks.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/payPal/thunks.ts
@@ -1,0 +1,65 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { fetchJson } from 'helpers/async/fetch';
+import { billingPeriodFromContrib } from 'helpers/contributions';
+import { loadPayPalRecurring } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
+import { routes } from 'helpers/urls/routes';
+import { logException } from 'helpers/utilities/logger';
+import { getContributionType } from '../../product/selectors/productType';
+import { getUserSelectedAmount } from '../../product/selectors/selectedAmount';
+
+export type PayPalTokenResolve = (token: string) => void;
+export type PayPalTokenReject = (err: unknown) => void;
+
+type PayPalLoadFns = {
+	resolve: PayPalTokenResolve;
+	reject: PayPalTokenReject;
+};
+
+export const setUpPayPalPayment = createAsyncThunk<
+	unknown,
+	PayPalLoadFns,
+	{
+		state: ContributionsState;
+	}
+>('paypal/setUpPayment', async function setUp({ resolve, reject }, thunkApi) {
+	try {
+		const state = thunkApi.getState();
+		const { currencyId } = state.common.internationalisation;
+		const csrfToken = state.page.checkoutForm.csrf.token ?? '';
+		const contributionType = getContributionType(state);
+		const amount = getUserSelectedAmount(state);
+		const billingPeriod = billingPeriodFromContrib(contributionType);
+
+		const requestBody = {
+			amount,
+			billingPeriod,
+			currency: currencyId,
+			requireShippingAddress: false,
+		};
+
+		const payPalResponse = (await fetchJson(routes.payPalSetupPayment, {
+			credentials: 'include',
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Csrf-Token': csrfToken,
+			},
+			body: JSON.stringify(requestBody),
+		})) as { token?: string };
+
+		if (payPalResponse.token) {
+			resolve(payPalResponse.token);
+		} else {
+			throw new Error('PayPal token came back blank');
+		}
+	} catch (error) {
+		logException((error as Error).message);
+		reject(error);
+	}
+});
+
+export const loadPayPalExpressSdk = createAsyncThunk(
+	'paypal/loadPayPalExpressSdk',
+	loadPayPalRecurring,
+);

--- a/support-frontend/assets/helpers/redux/checkout/payment/payPal/thunks.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/payPal/thunks.ts
@@ -9,7 +9,7 @@ import { getContributionType } from '../../product/selectors/productType';
 import { getUserSelectedAmount } from '../../product/selectors/selectedAmount';
 
 export type PayPalTokenResolve = (token: string) => void;
-export type PayPalTokenReject = (err: unknown) => void;
+export type PayPalTokenReject = (err: Error) => void;
 
 type PayPalLoadFns = {
 	resolve: PayPalTokenResolve;
@@ -55,7 +55,7 @@ export const setUpPayPalPayment = createAsyncThunk<
 		}
 	} catch (error) {
 		logException((error as Error).message);
-		reject(error);
+		reject(error as Error);
 	}
 });
 

--- a/support-frontend/assets/helpers/redux/checkout/payment/subscriptionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/subscriptionsSideEffects.ts
@@ -3,7 +3,7 @@ import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
 import type { SubscriptionsStartListening } from 'helpers/redux/subscriptionsStore';
 import * as storage from 'helpers/storage/storage';
 import { setPaymentMethod } from './paymentMethod/actions';
-import { loadPayPalExpressSdk } from './payPal/reducer';
+import { loadPayPalExpressSdk } from './payPal/thunks';
 
 export function addPaymentsSideEffects(
 	startListening: SubscriptionsStartListening,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.tsx
@@ -36,7 +36,7 @@ import {
 import type { LocalCurrencyCountry } from 'helpers/internationalisation/localCurrencyCountry';
 import { setPopupOpen } from 'helpers/redux/checkout/payment/directDebit/actions';
 import { setPaymentMethod } from 'helpers/redux/checkout/payment/paymentMethod/actions';
-import { loadPayPalExpressSdk } from 'helpers/redux/checkout/payment/payPal/reducer';
+import { loadPayPalExpressSdk } from 'helpers/redux/checkout/payment/payPal/thunks';
 import {
 	setSepaAccountHolderName,
 	setSepaAddressCountry,

--- a/support-frontend/assets/pages/supporter-plus-landing/paymentButtons.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/paymentButtons.ts
@@ -1,5 +1,6 @@
 import { AmazonPaymentButton } from 'components/amazonPaymentButton/amazonPaymentButton';
 import { DirectDebitPaymentButton } from 'components/paymentButton/directDebitPaymentButton';
+import { PayPalPaymentButton } from 'components/payPalPaymentButton/payPalPaymentButton';
 import { SepaPaymentButton } from 'components/sepaForm/sepaPaymentButton';
 import { StripePaymentButton } from 'components/stripeCardForm/stripePaymentButton';
 import type { ContributionType } from 'helpers/contributions';
@@ -12,10 +13,11 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 type PaymentMethodButtons = Partial<Record<PaymentMethod, React.FC>>;
 
 const allPaymentMethodButtons: PaymentMethodButtons = {
-	Stripe: StripePaymentButton,
 	AmazonPay: AmazonPaymentButton,
-	Sepa: SepaPaymentButton,
 	DirectDebit: DirectDebitPaymentButton,
+	PayPal: PayPalPaymentButton,
+	Sepa: SepaPaymentButton,
+	Stripe: StripePaymentButton,
 };
 
 export function getPaymentMethodButtons(

--- a/support-frontend/window.d.ts
+++ b/support-frontend/window.d.ts
@@ -1,4 +1,4 @@
-import type { ComponentType } from 'react';
+import type { ComponentType, React } from 'react';
 import type { Participations } from 'helpers/abTests/abtest';
 import type {
 	AmazonObject,
@@ -16,6 +16,25 @@ declare global {
 	/* ~ Here, declare things that go in the global namespace, or augment
 	 *~ existing declarations in the global namespace
 	 */
+
+	type PayPalButtonProps = {
+		env: string;
+		style: Record<string, string | boolean>;
+		commit: boolean;
+		validate: (actions: { enable: () => void; disable: () => void }) => void;
+		funding: {
+			disallowed: unknown[];
+		};
+		onClick: () => void;
+		// This function is called when user clicks the PayPal button.
+		payment: (
+			resolve: (arg0: string) => void,
+			reject: (error: Error) => void,
+		) => void;
+		// This function is called when the user finishes with PayPal interface (approves payment).
+		onAuthorize: (data: Record<string, unknown>) => void;
+	};
+
 	interface Window {
 		guardian: {
 			amazonPayClientId: {
@@ -76,8 +95,8 @@ declare global {
 			Button: {
 				driver: (
 					name: 'react',
-					{ React, ReactDOM }: { React: unknown; ReactDOM: unknown },
-				) => ComponentType;
+					{ React, ReactDOM }: { React: React; ReactDOM: typeof ReactDOM },
+				) => ComponentType<PayPalButtonProps>;
 			};
 		};
 		QuantumMetricAPI?: {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds PayPal as a payment method to the new checkout for both one-off and recurring contributions, using the button from the PayPal SDK for the latter.

[**Trello Card**](https://trello.com)

## Why are you doing this?

I've taken some time to improve the types and refactor our handling of recurring PayPal payments specifically, as the existing implementation of this has quite a lot of dead code and is pretty confusing to try and follow.

In the future we should probably look at migrating to use [@paypal/paypal-js](https://github.com/paypal/paypal-js/) as this comes with built-in types.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

### Mobile - iPhone 13, Safari (one-off)
![Screenshot 2022-11-03 at 12 08 11](https://user-images.githubusercontent.com/29146931/199717230-ac0eedbe-dc15-46fe-afca-9820f35f0a20.png)

### Mobile - iPhone 13, Safari (recurring)
![Screenshot 2022-11-03 at 12 07 14](https://user-images.githubusercontent.com/29146931/199717303-5a6fe666-29e9-4962-9779-94a93bd80a1c.png)

### Tablet - Galaxy Tab S8, Chrome (recurring)
![Screenshot 2022-11-03 at 12 13 20](https://user-images.githubusercontent.com/29146931/199717564-623618ff-11cf-4ad4-83b9-72df59bb64f4.png)

### Desktop - macOS, Firefox (recurring)
![Screenshot 2022-11-03 at 12-04-22 Support the Guardian Make a Contribution](https://user-images.githubusercontent.com/29146931/199717617-a53511a5-3a7c-4300-ac3b-425cc47136df.png)
