### PR TITLE
Fix payment method selector bug

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.tsx
@@ -6,10 +6,9 @@ import {
 	SvgDirectDebit,
 	SvgPayPal,
 } from '@guardian/source-react-components';
+import type { ReactNode } from 'react';
 import React from 'react';
 import Rows from 'components/base/rows';
-import { PaymentMethodLabel } from 'components/paymentMethodSelector/paymentMethodLabel';
-import { RadioWithImage } from 'components/paymentMethodSelector/radioWithImage';
 import AnimatedDots from 'components/spinners/animatedDots';
 import SvgAmazonPayLogoDs from 'components/svgs/amazonPayLogoDs';
 import SvgSepa from 'components/svgs/sepa';
@@ -24,11 +23,12 @@ import {
 	subscriptionToExplainerPart,
 } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
+import type { Option } from 'helpers/types/option';
 import { getReauthenticateUrl } from 'helpers/urls/externalLinks';
 
 type PropTypes = {
 	availablePaymentMethods: PaymentMethod[];
-	paymentMethod: PaymentMethod | null;
+	paymentMethod: Option<PaymentMethod>;
 	setPaymentMethod: (method: PaymentMethod) => void;
 	validationError: string | undefined;
 	fullExistingPaymentMethods?: RecentlySignedInExistingPaymentMethod[];
@@ -40,6 +40,74 @@ type PropTypes = {
 	) => void;
 };
 
+type RadioWithImagePropTypes = {
+	id: string;
+	image: ReactNode;
+	label: string;
+	name: string;
+	checked: boolean;
+	onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+const radioWithImageStyles = css`
+	display: inline-flex;
+	justify-content: space-between;
+	align-items: center;
+`;
+
+const paymentIcon = css`
+	min-width: 30px;
+	max-width: 40px;
+`;
+
+function RadioWithImage({
+	id,
+	image,
+	label,
+	checked,
+	name,
+	onChange,
+}: RadioWithImagePropTypes) {
+	return (
+		<div css={radioWithImageStyles}>
+			<Radio
+				id={id}
+				label={label}
+				checked={checked}
+				name={name}
+				onChange={onChange}
+			/>
+			<div css={paymentIcon}>{image}</div>
+		</div>
+	);
+}
+
+interface PaymentMethodLabelProps {
+	label: string;
+	logo: JSX.Element;
+	isChecked: boolean;
+}
+
+const labelContainer = css`
+	display: flex;
+	width: 100%;
+	margin: 0;
+	justify-content: space-between;
+	align-items: center;
+
+	svg {
+		width: 36px;
+		height: 24px;
+		display: block;
+	}
+
+	&[data-checked='false'] {
+		svg {
+			filter: grayscale(100%);
+		}
+	}
+`;
+
 const explainerListContainer = css`
 	font-size: small;
 	font-style: italic;
@@ -48,6 +116,19 @@ const explainerListContainer = css`
 	color: #767676;
 	padding-right: 40px;
 `;
+
+function PaymentMethodLabel({
+	label,
+	logo,
+	isChecked,
+}: PaymentMethodLabelProps) {
+	return (
+		<div css={labelContainer} data-checked={isChecked.toString()}>
+			<div>{label}</div>
+			{logo}
+		</div>
+	);
+}
 
 const paymentMethodData = {
 	Stripe: {
@@ -125,8 +206,7 @@ function PaymentMethodSelector({
 					)}
 
 					{contributionTypeIsRecurring &&
-						fullExistingPaymentMethods?.length &&
-						fullExistingPaymentMethods.map(
+						fullExistingPaymentMethods?.map(
 							(
 								preExistingPaymentMethod: RecentlySignedInExistingPaymentMethod,
 							) => (


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
[This PR](https://github.com/guardian/support-frontend/pull/4353/files#diff-7b8647d698721301523125caa4577622c2098c3a91ab14090f6e2d237787b92a) added the payment method selector for the v2 checkout and did some refactoring of the existing component. This PR reverts the existing payment method selector back to it's original state and removes a visual bug that had been introduced.

