### PR TITLE
Add a processing overlay and actually proceed to the thank you page on payment completion

### DIFF
--- a/support-frontend/assets/components/loadingOverlay/loadingOverlay.tsx
+++ b/support-frontend/assets/components/loadingOverlay/loadingOverlay.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { neutral, textSans } from '@guardian/source-foundations';
-import { useEffect } from 'preact/hooks';
+import { useEffect } from 'react';
 import AnimatedDots from 'components/spinners/animatedDots';
 
 const loadingBackground = css`

--- a/support-frontend/assets/components/loadingOverlay/loadingOverlay.tsx
+++ b/support-frontend/assets/components/loadingOverlay/loadingOverlay.tsx
@@ -34,9 +34,14 @@ export function LoadingOverlay({ children }: LoadingOverlayProps): JSX.Element {
 			event.preventDefault();
 		}
 
-		window.addEventListener('keydown', preventKeydown, { capture: true });
+		document.body.addEventListener('keydown', preventKeydown, {
+			capture: true,
+		});
 
-		return () => window.removeEventListener('keydown', preventKeydown);
+		return () =>
+			document.body.removeEventListener('keydown', preventKeydown, {
+				capture: true,
+			});
 	}, []);
 
 	return (

--- a/support-frontend/assets/components/loadingOverlay/loadingOverlay.tsx
+++ b/support-frontend/assets/components/loadingOverlay/loadingOverlay.tsx
@@ -1,0 +1,55 @@
+import { css } from '@emotion/react';
+import { neutral, textSans } from '@guardian/source-foundations';
+import { useEffect } from 'preact/hooks';
+import AnimatedDots from 'components/spinners/animatedDots';
+
+const loadingBackground = css`
+	z-index: 10000;
+	background-color: rgba(0, 0, 0, 0.6);
+	position: fixed;
+	left: 0;
+	top: 0;
+	width: 100%;
+	height: 100%;
+	overflow-x: hidden;
+	overflow-y: auto;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+`;
+
+const loadingMessage = css`
+	${textSans.large()}
+	color: ${neutral[100]};
+	text-align: center;
+`;
+
+export type LoadingOverlayProps = {
+	children: React.ReactNode;
+};
+
+export function LoadingOverlay({ children }: LoadingOverlayProps): JSX.Element {
+	useEffect(() => {
+		function preventKeydown(event: KeyboardEvent) {
+			event.preventDefault();
+		}
+
+		window.addEventListener('keydown', preventKeydown, { capture: true });
+
+		return () => window.removeEventListener('keydown', preventKeydown);
+	}, []);
+
+	return (
+		<div css={loadingBackground}>
+			<div
+				css={loadingMessage}
+				role="alertdialog"
+				aria-modal="true"
+				aria-labelledby="loadingLabel"
+			>
+				<div id="loadingLabel">{children}</div>
+				<AnimatedDots appearance="light" />
+			</div>
+		</div>
+	);
+}

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButton.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButton.tsx
@@ -12,21 +12,15 @@ const buttonOverrides = css`
 export type DefaultPaymentButtonProps = {
 	buttonText: string;
 	onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
-	loading?: boolean;
 };
 
 export function DefaultPaymentButton({
 	buttonText,
 	onClick,
-	loading,
 }: DefaultPaymentButtonProps): JSX.Element {
 	return (
 		<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-			<Button
-				cssOverrides={buttonOverrides}
-				onClick={onClick}
-				isLoading={loading}
-			>
+			<Button cssOverrides={buttonOverrides} onClick={onClick}>
 				{buttonText}
 			</Button>
 		</ThemeProvider>

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -22,10 +22,10 @@ function getButtonText(
 	paymentInterval?: 'month' | 'year',
 ) {
 	if (paymentInterval) {
-		return `Pay ${amountWithCurrency} per ${paymentInterval}`;
+		return `${amountWithCurrency} per ${paymentInterval}`;
 	}
 
-	return `Pay ${amountWithCurrency}`;
+	return amountWithCurrency;
 }
 
 export function DefaultPaymentButtonContainer({

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -22,10 +22,10 @@ function getButtonText(
 	paymentInterval?: 'month' | 'year',
 ) {
 	if (paymentInterval) {
-		return `${amountWithCurrency} per ${paymentInterval}`;
+		return `Pay ${amountWithCurrency} per ${paymentInterval}`;
 	}
 
-	return amountWithCurrency;
+	return `Pay ${amountWithCurrency}`;
 }
 
 export function DefaultPaymentButtonContainer({
@@ -33,9 +33,6 @@ export function DefaultPaymentButtonContainer({
 }: DefaultPaymentContainerProps): JSX.Element {
 	const { currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
-	);
-	const paymentWaiting = useContributionsSelector(
-		(state) => state.page.form.isWaiting,
 	);
 	const selectedAmount = useContributionsSelector(getUserSelectedAmount);
 	const contributionType = useContributionsSelector(getContributionType);
@@ -50,11 +47,5 @@ export function DefaultPaymentButtonContainer({
 				contributionTypeToPaymentInterval[contributionType],
 		  );
 
-	return (
-		<DefaultPaymentButton
-			buttonText={buttonText}
-			onClick={onClick}
-			loading={paymentWaiting}
-		/>
-	);
+	return <DefaultPaymentButton buttonText={buttonText} onClick={onClick} />;
 }

--- a/support-frontend/assets/components/progressMessage/progressMessage.tsx
+++ b/support-frontend/assets/components/progressMessage/progressMessage.tsx
@@ -12,8 +12,9 @@ export default function ProgressMessage(props: PropTypes): JSX.Element {
 			<div className="component-progress-message__dialog">
 				{props.message.map((message) => (
 					<div
+						role="alert"
 						className="component-progress-message__message"
-						aria-live="polite"
+						// aria-live="polite"
 					>
 						{message}
 					</div>

--- a/support-frontend/assets/components/progressMessage/progressMessage.tsx
+++ b/support-frontend/assets/components/progressMessage/progressMessage.tsx
@@ -12,9 +12,8 @@ export default function ProgressMessage(props: PropTypes): JSX.Element {
 			<div className="component-progress-message__dialog">
 				{props.message.map((message) => (
 					<div
-						role="alert"
 						className="component-progress-message__message"
-						// aria-live="polite"
+						aria-live="polite"
 					>
 						{message}
 					</div>

--- a/support-frontend/assets/helpers/redux/checkout/payment/stripe/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/stripe/reducer.ts
@@ -21,6 +21,8 @@ export const stripeCardSlice = createSlice({
 		setStripeFormError(state, action: PayloadAction<StripeErrorPayload>) {
 			if (action.payload.error) {
 				state.errors[action.payload.field] = [action.payload.error];
+			} else {
+				delete state.errors[action.payload.field];
 			}
 		},
 	},

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -6,7 +6,7 @@ import {
 	FooterLinks,
 	FooterWithContents,
 } from '@guardian/source-react-components-development-kitchen';
-import { useEffect } from 'preact/hooks';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { CheckoutHeading } from 'components/checkoutHeading/checkoutHeading';

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -1,11 +1,6 @@
 import { css } from '@emotion/react';
 import { from, neutral, space, textSans } from '@guardian/source-foundations';
-import {
-	Button,
-	Column,
-	Columns,
-	Hide,
-} from '@guardian/source-react-components';
+import { Column, Columns, Hide } from '@guardian/source-react-components';
 import {
 	Divider,
 	FooterLinks,
@@ -178,15 +173,6 @@ export function SupporterPlusLandingPage({
 									<PaymentFailureMessage />
 									<DirectDebitContainer />
 								</ContributionsStripe>
-								<br />
-								<Button
-									onClick={(e) => {
-										e.preventDefault();
-										navigate(thankYouRoute);
-									}}
-								>
-									Go to thank you page
-								</Button>
 							</BoxContents>
 						</Box>
 						<Box>

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -20,6 +20,7 @@ import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSw
 import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countrySwitcherContainer';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { Container } from 'components/layout/container';
+import { LoadingOverlay } from 'components/loadingOverlay/loadingOverlay';
 import Nav from 'components/nav/nav';
 import { PageScaffold } from 'components/page/pageScaffold';
 import { PaymentButtonController } from 'components/paymentButton/paymentButtonController';
@@ -28,7 +29,6 @@ import PaymentMethodSelectorContainer from 'components/paymentMethodSelector/Pay
 import { PaymentRequestButtonContainer } from 'components/paymentRequestButton/paymentRequestButtonContainer';
 import { PersonalDetails } from 'components/personalDetails/personalDetails';
 import { PersonalDetailsContainer } from 'components/personalDetails/personalDetailsContainer';
-import ProgressMessage from 'components/progressMessage/progressMessage';
 import { SavedCardButton } from 'components/savedCardButton/savedCardButton';
 import { SecureTransactionIndicator } from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import { ContributionsStripe } from 'components/stripe/contributionsStripe';
@@ -198,7 +198,10 @@ export function SupporterPlusLandingPage({
 				</Columns>
 			</Container>
 			{isWaiting && (
-				<ProgressMessage message={['Processing transaction', 'Please wait']} />
+				<LoadingOverlay>
+					<p>Processing transaction</p>
+					<p>Please wait</p>
+				</LoadingOverlay>
 			)}
 		</PageScaffold>
 	);

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -11,6 +11,7 @@ import {
 	FooterLinks,
 	FooterWithContents,
 } from '@guardian/source-react-components-development-kitchen';
+import { useEffect } from 'preact/hooks';
 import { useNavigate } from 'react-router-dom';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { CheckoutHeading } from 'components/checkoutHeading/checkoutHeading';
@@ -27,6 +28,7 @@ import PaymentMethodSelectorContainer from 'components/paymentMethodSelector/Pay
 import { PaymentRequestButtonContainer } from 'components/paymentRequestButton/paymentRequestButtonContainer';
 import { PersonalDetails } from 'components/personalDetails/personalDetails';
 import { PersonalDetailsContainer } from 'components/personalDetails/personalDetailsContainer';
+import ProgressMessage from 'components/progressMessage/progressMessage';
 import { SavedCardButton } from 'components/savedCardButton/savedCardButton';
 import { SecureTransactionIndicator } from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import { ContributionsStripe } from 'components/stripe/contributionsStripe';
@@ -83,6 +85,9 @@ export function SupporterPlusLandingPage({
 		(state) => state.common.settings,
 	);
 	const contributionType = useContributionsSelector(getContributionType);
+	const { paymentComplete, isWaiting } = useContributionsSelector(
+		(state) => state.page.form,
+	);
 
 	const navigate = useNavigate();
 
@@ -100,6 +105,12 @@ export function SupporterPlusLandingPage({
 		subPath: '/contribute',
 	};
 	const heading = <LandingPageHeading />;
+
+	useEffect(() => {
+		if (paymentComplete) {
+			navigate(thankYouRoute, { replace: true });
+		}
+	}, [paymentComplete]);
 
 	return (
 		<PageScaffold
@@ -186,6 +197,9 @@ export function SupporterPlusLandingPage({
 					</Column>
 				</Columns>
 			</Container>
+			{isWaiting && (
+				<ProgressMessage message={['Processing transaction', 'Please wait']} />
+			)}
 		</PageScaffold>
 	);
 }

--- a/support-frontend/stories/checkoutLayout/LoadingOverlay.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/LoadingOverlay.stories.tsx
@@ -1,0 +1,36 @@
+import type { LoadingOverlayProps } from 'components/loadingOverlay/loadingOverlay';
+import { LoadingOverlay } from 'components/loadingOverlay/loadingOverlay';
+import { withCenterAlignment } from '../../.storybook/decorators/withCenterAlignment';
+import { withSourceReset } from '../../.storybook/decorators/withSourceReset';
+
+export default {
+	title: 'Checkout Layout/Loading Overlay',
+	component: LoadingOverlay,
+	argTypes: {},
+	decorators: [withCenterAlignment, withSourceReset],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'An accessible alert dialog to overlay the page and prevent interaction while payment is processing',
+			},
+		},
+	},
+};
+
+function Template(args: LoadingOverlayProps) {
+	return <LoadingOverlay>{args.children}</LoadingOverlay>;
+}
+
+Template.args = {} as LoadingOverlayProps;
+
+export const Default = Template.bind({});
+
+Default.args = {
+	children: (
+		<>
+			<p>Processing transaction</p>
+			<p>Please wait</p>
+		</>
+	),
+};


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds a new, accessible 'Processing transaction' overlay for payment processing, and navigates the user to the thank-you page on successful checkout completion.

It also fixes a small bug with validation on the Stripe card form.

[**Trello Card**](https://trello.com)

## Why are you doing this?

When people give us money it's nice to say thank you 😄

The old progress component is not properly announced to screen readers, and allows background keyboard events while it's visible.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

### Mobile - iPhone 13, Safari
![Screenshot 2022-11-03 at 17 38 36](https://user-images.githubusercontent.com/29146931/199797322-07bb9cac-5c3c-4f35-942f-87c1034f9113.png)

### Tablet - Galaxy Tab S8, Chrome
![Screenshot 2022-11-03 at 17 39 38](https://user-images.githubusercontent.com/29146931/199797395-bc053f18-62e2-4691-90d5-499352922945.png)

### Desktop - macOS, Firefox
![Screenshot 2022-11-03 at 17-40-04 Support the Guardian Make a Contribution](https://user-images.githubusercontent.com/29146931/199797466-a53ec4fb-f808-4782-bf6b-4edbdf2bae67.png)
