### PR TITLE
Add validation message to payment method selector

### DIFF
--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -21,8 +21,8 @@ function PaymentMethodSelectorContainer({
 		(state) => state.common.internationalisation,
 	);
 
-	const paymentMethod = useContributionsSelector(
-		(state) => state.page.checkoutForm.payment.paymentMethod.name,
+	const { name, errors } = useContributionsSelector(
+		(state) => state.page.checkoutForm.payment.paymentMethod,
 	);
 
 	const { existingPaymentMethod } = useContributionsSelector(
@@ -48,10 +48,10 @@ function PaymentMethodSelectorContainer({
 
 	return render({
 		availablePaymentMethods: availablePaymentMethods || [],
-		paymentMethod,
+		paymentMethod: name,
 		existingPaymentMethod,
 		existingPaymentMethods: existingPaymentMethods ?? [],
-		validationError: undefined,
+		validationError: errors?.[0],
 		fullExistingPaymentMethods: getFullExistingPaymentMethods(
 			existingPaymentMethods,
 		),

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -1,8 +1,7 @@
 import { contributionTypeIsRecurring } from 'helpers/contributions';
 import { getValidPaymentMethods } from 'helpers/forms/checkouts';
 import { getFullExistingPaymentMethods } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
-import type { PaymentMethod } from 'helpers/forms/paymentMethods';
-import { isContribution } from 'helpers/redux/checkout/product/selectors/productType';
+import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import type { PaymentMethodSelectorProps } from './paymentMethodSelector';
 
@@ -13,9 +12,7 @@ function PaymentMethodSelectorContainer({
 		paymentMethodSelectorProps: PaymentMethodSelectorProps,
 	) => JSX.Element;
 }): JSX.Element {
-	const contributionType = useContributionsSelector(
-		(state) => state.page.checkoutForm.product.productType,
-	);
+	const contributionType = useContributionsSelector(getContributionType);
 
 	const { countryId, countryGroupId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
@@ -37,17 +34,15 @@ function PaymentMethodSelectorContainer({
 		(state) => state.common.settings,
 	);
 
-	const availablePaymentMethods: PaymentMethod[] | false =
-		isContribution(contributionType) &&
-		getValidPaymentMethods(
-			contributionType,
-			switches,
-			countryId,
-			countryGroupId,
-		);
+	const availablePaymentMethods = getValidPaymentMethods(
+		contributionType,
+		switches,
+		countryId,
+		countryGroupId,
+	);
 
 	return render({
-		availablePaymentMethods: availablePaymentMethods || [],
+		availablePaymentMethods: availablePaymentMethods,
 		paymentMethod: name,
 		existingPaymentMethod,
 		existingPaymentMethods: existingPaymentMethods ?? [],
@@ -55,9 +50,7 @@ function PaymentMethodSelectorContainer({
 		fullExistingPaymentMethods: getFullExistingPaymentMethods(
 			existingPaymentMethods,
 		),
-		contributionTypeIsRecurring:
-			isContribution(contributionType) &&
-			contributionTypeIsRecurring(contributionType),
+		contributionTypeIsRecurring: contributionTypeIsRecurring(contributionType),
 	});
 }
 

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -97,6 +97,7 @@ export function PaymentMethodSelector({
 		<div css={container}>
 			<PaymentMethodSelectorLegend />
 			<RadioGroup
+				id="paymentMethod"
 				label="Select payment method"
 				hideLabel
 				error={validationError}

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/index.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/index.ts
@@ -3,7 +3,6 @@ import type { ContributionsState } from '../../contributionsStore';
 import {
 	getPaymentMethodErrors,
 	getPaymentRequestButtonErrors,
-	getRecaptchaError,
 } from './paymentValidation';
 import { getPersonalDetailsErrors } from './personalDetailsValidation';
 import type { ErrorCollection } from './utils';
@@ -25,12 +24,10 @@ export function getAllErrorsForContributions(
 
 	const otherAmount = getOtherAmountErrors(state);
 	const paymentMethod = state.page.checkoutForm.payment.paymentMethod.errors;
-	const robot_checkbox = getRecaptchaError(state);
 
 	const paymentErrors = {
 		paymentMethod,
 		...getPaymentMethodErrors(state),
-		robot_checkbox,
 	};
 
 	return {

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
@@ -16,6 +16,7 @@ export function getStripeFormErrors(
 	const { errors, showErrors } = state.page.checkoutForm.payment.stripe;
 	const shouldShowZipCode =
 		state.common.internationalisation.countryId === 'US';
+	const recaptchaErrors = getRecaptchaError(state);
 
 	if (!showErrors) return {};
 
@@ -25,9 +26,10 @@ export function getStripeFormErrors(
 		return {
 			...errors,
 			zipCode,
+			robot_checkbox: recaptchaErrors,
 		};
 	}
-	return errors;
+	return { ...errors, robot_checkbox: recaptchaErrors };
 }
 
 export function getPaymentMethodErrors(

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -90,7 +90,7 @@
     "@guardian/pasteup": "1.0.0-alpha.7",
     "@guardian/source-foundations": "^5.2.1",
     "@guardian/source-react-components": "^7.1.0",
-    "@guardian/source-react-components-development-kitchen": "^5.0.0",
+    "@guardian/source-react-components-development-kitchen": "^6.0.3",
     "@juggle/resize-observer": "^3.3.1",
     "@reduxjs/toolkit": "^1.8.1",
     "@sentry/browser": "^5.4.0",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1753,10 +1753,10 @@
   dependencies:
     mini-svg-data-uri "^1.3.3"
 
-"@guardian/source-react-components-development-kitchen@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-5.0.0.tgz#17fbe059bf70cd6dc3e09726373f8499f0cce80c"
-  integrity sha512-X/LD6mjPy41CvGiEGbicAm7h+MZq50aTyAnESlHQATmNxLHUlLpXy4jZ+M2iePAKlaoCWUY7GnMCi/dP37Wk7w==
+"@guardian/source-react-components-development-kitchen@^6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-6.0.3.tgz#b3aaa56b3ef557d31f5cf518ccea0dac006db9fc"
+  integrity sha512-pIB9jyxbN5J4fV4SUOTA8BuMiBWbpkqNXYAXwFwBaMIqzw4y3SCBYniO3YHejSbScUvYDXBh10LbPRA82bLfqA==
 
 "@guardian/source-react-components@^7.1.0":
   version "7.1.0"


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR

- Adds validation to the payment method selector when the user has not chosen a payment method
- Updates Source dev kitchen to fix a small visual bug with the error state of the other amount field
- Only checks recaptcha validation for Stripe, as we are still using the old direct debit form

[**Trello Card**](https://trello.com/c/n6T98HFX)

## Why are you doing this?

This is (hopefully) the last piece of form validation work for the new checkout (at least until we can add a better direct debit form).

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

### Validating the payment method field
![Screenshot 2022-11-04 at 11-24-32 Support the Guardian Make a Contribution](https://user-images.githubusercontent.com/29146931/199962450-1259b5ad-e329-4f1e-9634-a0b7d04df270.png)
