### PR TITLE
Fix issues around existing payment methods in the new checkout

### DIFF
--- a/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
+++ b/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
@@ -1,0 +1,25 @@
+import { DefaultPaymentButtonContainer } from 'components/paymentButton/defaultPaymentButtonContainer';
+import { useFormValidation } from 'helpers/customHooks/useFormValidation';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
+import { onThirdPartyPaymentAuthorised } from 'pages/contributions-landing/contributionsLandingActions';
+
+export function ExistingCardPaymentButton(): JSX.Element {
+	const dispatch = useContributionsDispatch();
+	const { existingPaymentMethod } = useContributionsSelector(
+		(state) => state.page.form,
+	);
+
+	const payWithExistingCard = useFormValidation(function pay() {
+		void dispatch(
+			onThirdPartyPaymentAuthorised({
+				paymentMethod: 'ExistingCard',
+				billingAccountId: existingPaymentMethod?.billingAccountId ?? '',
+			}),
+		);
+	});
+
+	return <DefaultPaymentButtonContainer onClick={payWithExistingCard} />;
+}

--- a/support-frontend/assets/components/existingMethodPaymentButton/existingDirectDebitPaymentButton.tsx
+++ b/support-frontend/assets/components/existingMethodPaymentButton/existingDirectDebitPaymentButton.tsx
@@ -1,0 +1,25 @@
+import { DefaultPaymentButtonContainer } from 'components/paymentButton/defaultPaymentButtonContainer';
+import { useFormValidation } from 'helpers/customHooks/useFormValidation';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
+import { onThirdPartyPaymentAuthorised } from 'pages/contributions-landing/contributionsLandingActions';
+
+export function ExistingDirectDebitPaymentButton(): JSX.Element {
+	const dispatch = useContributionsDispatch();
+	const { existingPaymentMethod } = useContributionsSelector(
+		(state) => state.page.form,
+	);
+
+	const payWithExistingDD = useFormValidation(function pay() {
+		void dispatch(
+			onThirdPartyPaymentAuthorised({
+				paymentMethod: 'ExistingDirectDebit',
+				billingAccountId: existingPaymentMethod?.billingAccountId ?? '',
+			}),
+		);
+	});
+
+	return <DefaultPaymentButtonContainer onClick={payWithExistingDD} />;
+}

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -1,9 +1,48 @@
+import type { ContributionType } from 'helpers/contributions';
 import { contributionTypeIsRecurring } from 'helpers/contributions';
 import { getValidPaymentMethods } from 'helpers/forms/checkouts';
-import { getFullExistingPaymentMethods } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
+import type {
+	ExistingPaymentMethod,
+	RecentlySignedInExistingPaymentMethod,
+} from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
+import {
+	getFullExistingPaymentMethods,
+	isUsableExistingPaymentMethod,
+} from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import type { PaymentMethodSelectorProps } from './paymentMethodSelector';
+
+function existingPaymentMethodsToDisplay(
+	contributionType: ContributionType,
+	existingPaymentMethods?: ExistingPaymentMethod[],
+): RecentlySignedInExistingPaymentMethod[] {
+	const shouldShowExistingPaymentMethods =
+		contributionTypeIsRecurring(contributionType);
+
+	const existingPaymentMethodList = getFullExistingPaymentMethods(
+		existingPaymentMethods,
+	);
+
+	return shouldShowExistingPaymentMethods ? existingPaymentMethodList : [];
+}
+
+function showReauthenticationLink(
+	contributionType: ContributionType,
+	existingPaymentMethods?: ExistingPaymentMethod[],
+): boolean {
+	const shouldShowExistingPaymentMethods =
+		contributionTypeIsRecurring(contributionType);
+	const hasExistingPaymentMethods = existingPaymentMethods?.length;
+
+	if (!shouldShowExistingPaymentMethods || !hasExistingPaymentMethods) {
+		return false;
+	}
+
+	return existingPaymentMethods.every(
+		(method) => !isUsableExistingPaymentMethod(method),
+	);
+}
 
 function PaymentMethodSelectorContainer({
 	render,
@@ -25,11 +64,9 @@ function PaymentMethodSelectorContainer({
 	const { existingPaymentMethod } = useContributionsSelector(
 		(state) => state.page.form,
 	);
-
 	const { existingPaymentMethods } = useContributionsSelector(
 		(state) => state.common,
 	);
-
 	const { switches } = useContributionsSelector(
 		(state) => state.common.settings,
 	);
@@ -41,16 +78,25 @@ function PaymentMethodSelectorContainer({
 		countryGroupId,
 	);
 
+	// We check on page init if we should try to retrieve existing payment methods from MDAPI
+	// If we are retrieving them, the value will be undefined, otherwise we set it to an empty array
+	// TODO: Do this in a less weird way with a proper thunk and pending state!
+	const pendingExistingPaymentMethods = existingPaymentMethods === undefined;
+
 	return render({
 		availablePaymentMethods: availablePaymentMethods,
 		paymentMethod: name,
 		existingPaymentMethod,
-		existingPaymentMethods: existingPaymentMethods ?? [],
-		validationError: errors?.[0],
-		fullExistingPaymentMethods: getFullExistingPaymentMethods(
+		existingPaymentMethodList: existingPaymentMethodsToDisplay(
+			contributionType,
 			existingPaymentMethods,
 		),
-		contributionTypeIsRecurring: contributionTypeIsRecurring(contributionType),
+		validationError: errors?.[0],
+		pendingExistingPaymentMethods,
+		showReauthenticateLink: showReauthenticationLink(
+			contributionType,
+			existingPaymentMethods,
+		),
 	});
 }
 

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -79,7 +79,8 @@ function PaymentMethodSelectorContainer({
 	);
 
 	// We check on page init if we should try to retrieve existing payment methods from MDAPI
-	// If we are retrieving them, the value will be undefined, otherwise we set it to an empty array
+	// If we are in the process of retrieving them but the request is still pending, the value will be undefined.
+	// If we know we're not retrieving them the value is immediately set to an empty array
 	// TODO: Do this in a less weird way with a proper thunk and pending state!
 	const pendingExistingPaymentMethods = existingPaymentMethods === undefined;
 

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -119,10 +119,10 @@ export function PaymentMethodSelector({
 									const existingPaymentMethodType =
 										preExistingPaymentMethod.paymentType;
 
-									const paymentType =
+									const paymentType: PaymentMethod =
 										existingPaymentMethodType === 'Card'
 											? 'ExistingCard'
-											: 'DirectDebit';
+											: 'ExistingDirectDebit';
 
 									return (
 										<ExistingPaymentMethodAccordionRow

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -6,22 +6,19 @@ import { useEffect } from 'react';
 import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';
 import { SecureTransactionIndicator } from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import AnimatedDots from 'components/spinners/animatedDots';
-import type {
-	ExistingPaymentMethod,
-	RecentlySignedInExistingPaymentMethod,
-} from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
+import type { RecentlySignedInExistingPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import { mapExistingPaymentMethodToPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import { setPaymentMethod } from 'helpers/redux/checkout/payment/paymentMethod/actions';
 import { useContributionsDispatch } from 'helpers/redux/storeHooks';
-import { getReauthenticateUrl } from 'helpers/urls/externalLinks';
-import { isCodeOrProd } from 'helpers/urls/url';
 import ContributionChoicesHeader from 'pages/contributions-landing/components/ContributionChoicesHeader';
+import { updateSelectedExistingPaymentMethod } from 'pages/contributions-landing/contributionsLandingActions';
 import { paymentMethodData } from './paymentMethodData';
 import {
 	AvailablePaymentMethodAccordionRow,
 	ExistingPaymentMethodAccordionRow,
 } from './paymentMethodSelectorAccordionRow';
+import { ReauthenticateLink } from './reauthenticateLink';
 
 const container = css`
 	margin-top: ${space[6]}px;
@@ -58,20 +55,20 @@ export interface PaymentMethodSelectorProps {
 	availablePaymentMethods: PaymentMethod[];
 	paymentMethod: PaymentMethod | null;
 	validationError: string | undefined;
-	fullExistingPaymentMethods: RecentlySignedInExistingPaymentMethod[];
-	contributionTypeIsRecurring?: boolean;
 	existingPaymentMethod?: RecentlySignedInExistingPaymentMethod;
-	existingPaymentMethods: ExistingPaymentMethod[];
+	existingPaymentMethodList: RecentlySignedInExistingPaymentMethod[];
+	pendingExistingPaymentMethods?: boolean;
+	showReauthenticateLink?: boolean;
 }
 
 export function PaymentMethodSelector({
 	availablePaymentMethods,
 	paymentMethod,
 	validationError,
-	fullExistingPaymentMethods,
-	contributionTypeIsRecurring,
 	existingPaymentMethod,
-	existingPaymentMethods,
+	existingPaymentMethodList,
+	pendingExistingPaymentMethods,
+	showReauthenticateLink,
 }: PaymentMethodSelectorProps): JSX.Element {
 	const dispatch = useContributionsDispatch();
 
@@ -81,7 +78,7 @@ export function PaymentMethodSelector({
 	}, []);
 
 	if (
-		fullExistingPaymentMethods.length < 1 &&
+		existingPaymentMethodList.length < 1 &&
 		availablePaymentMethods.length < 1
 	) {
 		return (
@@ -102,13 +99,11 @@ export function PaymentMethodSelector({
 				hideLabel
 				error={validationError}
 			>
-				{contributionTypeIsRecurring &&
-					!existingPaymentMethods.length &&
-					isCodeOrProd() && (
-						<div className="awaiting-existing-payment-options">
-							<AnimatedDots appearance="medium" />
-						</div>
-					)}
+				{pendingExistingPaymentMethods && (
+					<div className="awaiting-existing-payment-options">
+						<AnimatedDots appearance="medium" />
+					</div>
+				)}
 
 				<Accordion
 					cssOverrides={css`
@@ -117,45 +112,52 @@ export function PaymentMethodSelector({
 				>
 					{[
 						<>
-							{contributionTypeIsRecurring &&
-								fullExistingPaymentMethods.map(
-									(
-										preExistingPaymentMethod: RecentlySignedInExistingPaymentMethod,
-									) => {
-										const existingPaymentMethodType =
-											preExistingPaymentMethod.paymentType;
+							{existingPaymentMethodList.map(
+								(
+									preExistingPaymentMethod: RecentlySignedInExistingPaymentMethod,
+								) => {
+									const existingPaymentMethodType =
+										preExistingPaymentMethod.paymentType;
 
-										const paymentType =
-											existingPaymentMethodType === 'Card'
-												? 'ExistingCard'
-												: 'DirectDebit';
+									const paymentType =
+										existingPaymentMethodType === 'Card'
+											? 'ExistingCard'
+											: 'DirectDebit';
 
-										return (
-											<ExistingPaymentMethodAccordionRow
-												expanded={
-													paymentMethod ===
-														mapExistingPaymentMethodToPaymentMethod(
-															preExistingPaymentMethod,
-														) &&
-													existingPaymentMethod === preExistingPaymentMethod
-												}
-												paymentMethod={paymentMethod}
-												preExistingPaymentMethod={preExistingPaymentMethod}
-												existingPaymentMethod={existingPaymentMethod}
-												checked={
-													paymentMethod ===
-														mapExistingPaymentMethodToPaymentMethod(
-															preExistingPaymentMethod,
-														) &&
-													existingPaymentMethod === preExistingPaymentMethod
-												}
-												accordionBody={
-													paymentMethodData[paymentType].accordionBody
-												}
-											/>
-										);
-									},
-								)}
+									return (
+										<ExistingPaymentMethodAccordionRow
+											expanded={
+												paymentMethod ===
+													mapExistingPaymentMethodToPaymentMethod(
+														preExistingPaymentMethod,
+													) &&
+												existingPaymentMethod === preExistingPaymentMethod
+											}
+											paymentMethod={paymentMethod}
+											preExistingPaymentMethod={preExistingPaymentMethod}
+											existingPaymentMethod={existingPaymentMethod}
+											checked={
+												paymentMethod ===
+													mapExistingPaymentMethodToPaymentMethod(
+														preExistingPaymentMethod,
+													) &&
+												existingPaymentMethod === preExistingPaymentMethod
+											}
+											onChange={() => {
+												dispatch(setPaymentMethod(paymentType));
+												dispatch(
+													updateSelectedExistingPaymentMethod(
+														preExistingPaymentMethod,
+													),
+												);
+											}}
+											accordionBody={
+												paymentMethodData[paymentType].accordionBody
+											}
+										/>
+									);
+								},
+							)}
 
 							{availablePaymentMethods.map((method) => (
 								<AvailablePaymentMethodAccordionRow
@@ -172,17 +174,7 @@ export function PaymentMethodSelector({
 					]}
 				</Accordion>
 
-				{contributionTypeIsRecurring &&
-					existingPaymentMethods.length > 0 &&
-					fullExistingPaymentMethods.length === 0 && (
-						<li className="form__radio-group-item">
-							...or{' '}
-							<a className="reauthenticate-link" href={getReauthenticateUrl()}>
-								re-enter your password
-							</a>{' '}
-							to use one of your existing payment methods.
-						</li>
-					)}
+				{showReauthenticateLink && <ReauthenticateLink />}
 			</RadioGroup>
 		</div>
 	);

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -95,6 +95,7 @@ export function PaymentMethodSelector({
 			<PaymentMethodSelectorLegend />
 			<RadioGroup
 				id="paymentMethod"
+				role="radiogroup"
 				label="Select payment method"
 				hideLabel
 				error={validationError}

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelectorAccordionRow.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelectorAccordionRow.tsx
@@ -83,9 +83,7 @@ const collapsedBody = css`
 interface ExistingPaymentMethodAccordionRowProps {
 	expanded: boolean;
 	preExistingPaymentMethod: RecentlySignedInExistingPaymentMethod;
-	updateExistingPaymentMethod?: (
-		existingPaymentMethod: RecentlySignedInExistingPaymentMethod,
-	) => void;
+	onChange: () => void;
 	paymentMethod: PaymentMethod | null;
 	existingPaymentMethod: RecentlySignedInExistingPaymentMethod | undefined;
 	accordionBody?: JSX.Element;
@@ -96,7 +94,7 @@ export function ExistingPaymentMethodAccordionRow({
 	paymentMethod,
 	preExistingPaymentMethod,
 	existingPaymentMethod,
-	updateExistingPaymentMethod,
+	onChange,
 	expanded,
 	accordionBody,
 	checked,
@@ -114,9 +112,7 @@ export function ExistingPaymentMethodAccordionRow({
 				<RadioWithImage
 					id={`paymentMethod-existing${preExistingPaymentMethod.billingAccountId}`}
 					name="paymentMethod"
-					onChange={() => {
-						updateExistingPaymentMethod?.(preExistingPaymentMethod);
-					}}
+					onChange={onChange}
 					checked={
 						paymentMethod ===
 							mapExistingPaymentMethodToPaymentMethod(

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelectorAccordionRow.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelectorAccordionRow.tsx
@@ -8,7 +8,10 @@ import {
 	space,
 	transitions,
 } from '@guardian/source-foundations';
-import { Radio } from '@guardian/source-react-components';
+import {
+	SvgCreditCard,
+	SvgDirectDebit,
+} from '@guardian/source-react-components';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import {
 	getExistingPaymentMethodLabel,
@@ -17,21 +20,18 @@ import {
 	subscriptionToExplainerPart,
 } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
-import { paymentMethodData } from './paymentMethodData';
-import { PaymentMethodLabel } from './paymentMethodLabel';
 import { RadioWithImage } from './radioWithImage';
-
-const explainerListContainer = css`
-	font-size: small;
-	font-style: italic;
-	margin-left: 40px;
-	padding-bottom: 6px;
-	color: #767676;
-	padding-right: 40px;
-`;
 
 const radio = css`
 	padding: ${space[2]}px ${space[4]}px;
+`;
+
+const existingPaymentMethodOverrides = css`
+	/* Normalise the positioning of the radio button when we have supporting text */
+	& > div {
+		align-items: center;
+		margin-bottom: 0;
+	}
 `;
 
 const focused = css`
@@ -101,14 +101,19 @@ export function ExistingPaymentMethodAccordionRow({
 	accordionBody,
 	checked,
 }: ExistingPaymentMethodAccordionRowProps): EmotionJSX.Element {
+	const image =
+		preExistingPaymentMethod.paymentType === 'Card' ? (
+			<SvgCreditCard />
+		) : (
+			<SvgDirectDebit />
+		);
+
 	return (
 		<div css={checked ? focused : notFocused}>
-			<div>
-				<Radio
+			<div css={[...(checked && accordionBody ? [borderBottom] : [])]}>
+				<RadioWithImage
 					id={`paymentMethod-existing${preExistingPaymentMethod.billingAccountId}`}
 					name="paymentMethod"
-					type="radio"
-					value={preExistingPaymentMethod.paymentType}
 					onChange={() => {
 						updateExistingPaymentMethod?.(preExistingPaymentMethod);
 					}}
@@ -118,31 +123,20 @@ export function ExistingPaymentMethodAccordionRow({
 								preExistingPaymentMethod,
 							) && existingPaymentMethod === preExistingPaymentMethod
 					}
-					aria-labelledby="payment_method"
-					aria-expanded={expanded}
-					label={
-						<PaymentMethodLabel
-							label={getExistingPaymentMethodLabel(preExistingPaymentMethod)}
-							logo={
-								paymentMethodData[
-									mapExistingPaymentMethodToPaymentMethod(
-										preExistingPaymentMethod,
-									)
-								].icon
-							}
-							isChecked={existingPaymentMethod === preExistingPaymentMethod}
-						/>
-					}
-				/>
-
-				<div css={explainerListContainer}>
-					Used for your{' '}
-					{subscriptionsToExplainerList(
+					cssOverrides={[
+						radio,
+						...(checked && accordionBody ? [borderBottom] : []),
+						existingPaymentMethodOverrides,
+					]}
+					isSupporterPlus={true}
+					image={image}
+					label={getExistingPaymentMethodLabel(preExistingPaymentMethod)}
+					supportingText={`Used for your ${subscriptionsToExplainerList(
 						preExistingPaymentMethod.subscriptions.map(
 							subscriptionToExplainerPart,
 						),
-					)}
-				</div>
+					)}`}
+				/>
 			</div>
 
 			{/* Accordion Body */}

--- a/support-frontend/assets/components/paymentMethodSelector/radioWithImage.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/radioWithImage.tsx
@@ -47,6 +47,7 @@ type RadioWithImagePropTypes = {
 	onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 	cssOverrides?: SerializedStyles | SerializedStyles[];
 	isSupporterPlus?: boolean;
+	supportingText?: string;
 };
 
 export function RadioWithImage({
@@ -58,6 +59,7 @@ export function RadioWithImage({
 	onChange,
 	cssOverrides,
 	isSupporterPlus,
+	supportingText,
 }: RadioWithImagePropTypes): JSX.Element {
 	return (
 		<label
@@ -72,6 +74,10 @@ export function RadioWithImage({
 					label={getLabelText(label, checked, isSupporterPlus)}
 					checked={checked}
 					name={name}
+					supporting={supportingText}
+					cssOverrides={css`
+						margin-bottom: 0;
+					`}
 				/>
 				<div css={paymentIcon}>{image}</div>
 			</div>

--- a/support-frontend/assets/components/paymentMethodSelector/radioWithImage.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/radioWithImage.tsx
@@ -75,9 +75,6 @@ export function RadioWithImage({
 					checked={checked}
 					name={name}
 					supporting={supportingText}
-					cssOverrides={css`
-						margin-bottom: 0;
-					`}
 				/>
 				<div css={paymentIcon}>{image}</div>
 			</div>

--- a/support-frontend/assets/components/paymentMethodSelector/reauthenticateLink.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/reauthenticateLink.tsx
@@ -1,0 +1,20 @@
+import { css } from '@emotion/react';
+import { space, textSans } from '@guardian/source-foundations';
+import { getReauthenticateUrl } from 'helpers/urls/externalLinks';
+
+const reauthenticateLinkStyles = css`
+	${textSans.small()};
+	padding: ${space[3]}px;
+`;
+
+export function ReauthenticateLink(): JSX.Element {
+	return (
+		<p css={reauthenticateLinkStyles}>
+			...or{' '}
+			<a className="reauthenticate-link" href={getReauthenticateUrl()}>
+				re-enter your password
+			</a>{' '}
+			to use one of your existing payment methods.
+		</p>
+	);
+}

--- a/support-frontend/assets/helpers/forms/existingPaymentMethods/existingPaymentMethods.ts
+++ b/support-frontend/assets/helpers/forms/existingPaymentMethods/existingPaymentMethods.ts
@@ -18,6 +18,7 @@ export type ExistingPaymentMethodSubscription = {
 	isActive: boolean;
 	isCancelled: boolean;
 	name: string;
+	billingAccountId?: string;
 };
 
 type ExistingPaymentType = 'Card' | 'DirectDebit';

--- a/support-frontend/assets/helpers/redux/commonState/state.ts
+++ b/support-frontend/assets/helpers/redux/commonState/state.ts
@@ -65,5 +65,4 @@ export const initialCommonState: CommonState = {
 		useLocalCurrency: false,
 		defaultCurrency: 'USD',
 	},
-	existingPaymentMethods: [],
 };

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.ts
@@ -154,7 +154,23 @@ function initialisePaymentMethods(
 			},
 		);
 	} else {
-		dispatch(setExistingPaymentMethods([]));
+		dispatch(
+			setExistingPaymentMethods([
+				{
+					paymentType: 'Card',
+					billingAccountId: '2c92a00e718678220171978d334c65cf',
+					subscriptions: [
+						{
+							billingAccountId: '2c92a00e718678220171978d334c65cf',
+							isCancelled: false,
+							isActive: true,
+							name: 'Digital Pack',
+						},
+					],
+					card: '0123',
+				},
+			]),
+		);
 	}
 }
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.ts
@@ -154,23 +154,7 @@ function initialisePaymentMethods(
 			},
 		);
 	} else {
-		dispatch(
-			setExistingPaymentMethods([
-				{
-					paymentType: 'Card',
-					billingAccountId: '2c92a00e718678220171978d334c65cf',
-					subscriptions: [
-						{
-							billingAccountId: '2c92a00e718678220171978d334c65cf',
-							isCancelled: false,
-							isActive: true,
-							name: 'Digital Pack',
-						},
-					],
-					card: '0123',
-				},
-			]),
-		);
+		dispatch(setExistingPaymentMethods([]));
 	}
 }
 

--- a/support-frontend/assets/pages/supporter-plus-landing/paymentButtons.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/paymentButtons.ts
@@ -1,4 +1,6 @@
 import { AmazonPaymentButton } from 'components/amazonPaymentButton/amazonPaymentButton';
+import { ExistingCardPaymentButton } from 'components/existingMethodPaymentButton/existingCardPaymentButton';
+import { ExistingDirectDebitPaymentButton } from 'components/existingMethodPaymentButton/existingDirectDebitPaymentButton';
 import { DirectDebitPaymentButton } from 'components/paymentButton/directDebitPaymentButton';
 import { PayPalPaymentButton } from 'components/payPalPaymentButton/payPalPaymentButton';
 import { SepaPaymentButton } from 'components/sepaForm/sepaPaymentButton';
@@ -15,6 +17,8 @@ type PaymentMethodButtons = Partial<Record<PaymentMethod, React.FC>>;
 const allPaymentMethodButtons: PaymentMethodButtons = {
 	AmazonPay: AmazonPaymentButton,
 	DirectDebit: DirectDebitPaymentButton,
+	ExistingCard: ExistingCardPaymentButton,
+	ExistingDirectDebit: ExistingDirectDebitPaymentButton,
 	PayPal: PayPalPaymentButton,
 	Sepa: SepaPaymentButton,
 	Stripe: StripePaymentButton,

--- a/support-frontend/stories/checkouts/paymentMethodSelector.stories.tsx
+++ b/support-frontend/stories/checkouts/paymentMethodSelector.stories.tsx
@@ -61,8 +61,7 @@ function Template(args: { paymentMethod: PaymentMethod }): JSX.Element {
 				availablePaymentMethods={availablePaymentMethods}
 				paymentMethod={args.paymentMethod}
 				validationError={undefined}
-				existingPaymentMethods={[]}
-				fullExistingPaymentMethods={[]}
+				existingPaymentMethodList={[]}
 			/>
 		</div>
 	);


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR:
- Fixes an issue where we were showing a permanent loading state for existing payment methods even when not retrieving them
- Simplfies the logic around whether we should show a user's existing payment methods or a sign-in link to reauthenticate if their payment methods are stale
- Fixes visual problems with the display of those payment method options and the reauthenticate link
- Adds payment buttons for the `ExistingCard` and `ExistingDirectDebit` payment methods so users can actually check out with these payment types

## Why are you doing this?

This is a virtually undocumented and very poorly understood aspect of the contributions checkout which we had largely neglected in building the new checkout so far. This PR should fix things ready for launch, but a lot of the code this behaviour relies on needs refactoring post-launch and we desperately need to thoroughly document what this feature is, how it works, and how to test it.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

### Existing card payment methods displayed in the payment selector
![Screenshot 2022-11-04 at 13 30 27](https://user-images.githubusercontent.com/29146931/199986574-f28278bf-3037-4811-9c35-f49f24e605de.png)

### Sign-in link for users with a 'stale' existing payment method
![Screenshot 2022-11-04 at 13 09 00](https://user-images.githubusercontent.com/29146931/199986662-86f52cd4-1994-429a-822f-802137e8d691.png)
