### PR TITLE
AmazonPay disabled during construction

### DIFF
--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -157,7 +157,7 @@ function getPaymentMethods(
 			contributionType === 'ONE_OFF' ||
 			getQueryParameter('amazon-pay-recurring') === 'true'
 		) {
-			return [Stripe, PayPal, AmazonPay];
+			return [Stripe, PayPal];
 		}
 
 		return [Stripe, PayPal];


### PR DESCRIPTION
AmazonPay on (One-Off/USD) hidden on V2 checkout whilst being built.

[**Trello Card**](https://trello.com/c/uMSzlgxN/828-v2-disable-amazonpay-on-supporter-plus-one-off-usd-whilst-being-built)

![Screenshot 2022-11-04 at 14 35 45](https://user-images.githubusercontent.com/76729591/200001392-4cccea95-3754-4c5e-a9a8-7511ec0acc1b.png)

## Is this an AB test?
- [x ] Yes
- [ ] No

