### PR TITLE
Fix issue with validation on the other amount field

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/product/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/state.ts
@@ -21,10 +21,7 @@ const maxOneDecimalPlaceRegex = /^\d+\.?\d{0,2}$/;
 export const otherAmountSchema = z.object({
 	amount: z
 		.string({ invalid_type_error: 'Please enter an amount' })
-		.regex(maxOneDecimalPlaceRegex, { message: 'Please enter a valid amount' })
-		.refine((amount) => !Number.isNaN(Number.parseFloat(amount)), {
-			message: 'Please enter a valid amount',
-		}),
+		.regex(maxOneDecimalPlaceRegex, { message: 'Please enter a valid amount' }),
 });
 
 export type GuardianProduct =


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes an issue where validating the other amount field could produce duplicate error messages in the summary, when the amount failed both the regex condition and the 'is not `NaN` when parsed as a float' condition.

I've removed the NaN check altogether as it's not actually necessary- the regex will permit _only_ a numeric string with a maximum of one decimal place, which will always successfully parse to a number.

## Screenshots

![Screenshot 2022-11-04 at 14 41 38](https://user-images.githubusercontent.com/29146931/200003877-5a989908-b3a5-4094-8feb-2e41f49da0f5.png)
