### PR TITLE
Fix Supporter Plus Single Contrib T&Cs styling

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
@@ -122,7 +122,11 @@ export function PaymentTsAndCs({
 	};
 
 	if (contributionType === 'ONE_OFF') {
-		return <TsAndCsFooterLinks countryGroupId={countryGroupId} />;
+		return (
+			<div css={container}>
+				<TsAndCsFooterLinks countryGroupId={countryGroupId} />
+			</div>
+		);
 	}
 
 	if (contributionType === 'MONTHLY') {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This fixes the styling for the terms and conditions for a single contribution on the Supporter Plus checkout.

## Screenshots
<img width="653" alt="Screenshot 2022-11-04 at 15 09 54" src="https://user-images.githubusercontent.com/44685872/200009161-dc3a71df-fac8-46c5-b032-03df95596114.png">
