### PR TITLE
Disable pre-render of the contribution landing page

### DIFF
--- a/support-frontend/assets/helpers/rendering/ssrPages.ts
+++ b/support-frontend/assets/helpers/rendering/ssrPages.ts
@@ -1,14 +1,9 @@
 import { renderToString } from 'react-dom/server';
-import { EmptyContributionsLandingPage } from 'pages/contributions-landing/EmptyContributionsLandingPage';
 import { content as showcase } from 'pages/showcase/showcase';
 
 export const pages = [
 	{
 		filename: 'showcase.html',
 		html: renderToString(showcase),
-	},
-	{
-		filename: 'contributions-landing.html',
-		html: renderToString(EmptyContributionsLandingPage()),
 	},
 ];


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This disables pre-rendering (aka SSR, although it's not really) of the contributions landing page with the `EmptyContributionsLandingPage` component, ahead of A/B testing the new checkout.

[**Trello Card**](https://trello.com/c/dNBJJElZ)

## Why are you doing this?

Showing the pre-rendered version of the old checkout at first and then flashing to the very different new design creates a weird user experience that might unduly influence the A/B test.

After the conclusion of the test we'll need to think about what a pre-rendered version of the new checkout would need to look like before restoring this feature.
