### PR TITLE
use supporterPlus ab test in isSupporterPlusPurchase

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/newProductTestHelper.ts
+++ b/support-frontend/assets/pages/contributions-landing/newProductTestHelper.ts
@@ -17,6 +17,7 @@ export function isSupporterPlusPurchase(state: ContributionsState): boolean {
 	);
 	const amountIsHighEnough = !!(thresholdPrice && amount >= thresholdPrice);
 	return (
-		state.common.abParticipations.newProduct == 'variant' && amountIsHighEnough
+		state.common.abParticipations.supporterPlus == 'variant' &&
+		amountIsHighEnough
 	);
 }


### PR DESCRIPTION
## What are you doing in this PR?

`isSupporterPlusPurchase` returns a boolean to indicate when we should set the product type to "supporterPlus", it was previously set-up to only return true when the user was in the old `newProduct` AB test, however now it needs to return `true` if the users in the `variant` of the new `supporterPlus` AB test.

Note: It's been useful to have `newProduct` AB test as it's allowed us to complete supporter plus checkout whilst the new "V2" checkout has been in development, however now we can checkout using the V2 checkout we should be able get rid of the `newProduct` AB test and associated logic. This can be done in a follow-up PR.