### PR TITLE
Use isSupporterPlusPurchase in new checkout

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.ts
@@ -82,7 +82,7 @@ import trackConversion from 'helpers/tracking/conversions';
 import type { Option } from 'helpers/types/option';
 import { routes } from 'helpers/urls/routes';
 import { logException } from 'helpers/utilities/logger';
-import { getThresholdPrice } from 'pages/contributions-landing/components/DigiSubBenefits/helpers';
+import { isSupporterPlusPurchase } from './newProductTestHelper';
 
 export type Action =
 	| {
@@ -275,23 +275,8 @@ function getBillingCountryAndState(
 	};
 }
 
-function getProductOptionsForBenefitsTest(
-	amount: number,
-	state: ContributionsState,
-) {
-	const isInNewProductTest =
-		state.common.abParticipations.newProduct === 'variant';
-	const contributionType = getContributionType(state);
-	const isRecurring = contributionType !== 'ONE_OFF';
-
-	const thresholdPrice = getThresholdPrice(
-		state.common.internationalisation.countryGroupId,
-		contributionType,
-	);
-	const amountIsHighEnough = !!(thresholdPrice && amount >= thresholdPrice);
-	const shouldGetSupporterPlus =
-		isInNewProductTest && isRecurring && amountIsHighEnough;
-	return shouldGetSupporterPlus
+function getProductOptionsForSupporterPlusTest(state: ContributionsState) {
+	return isSupporterPlusPurchase(state)
 		? { productType: 'SupporterPlus' as const }
 		: { productType: 'Contribution' as const };
 }
@@ -314,7 +299,7 @@ function regularPaymentRequestFromAuthorisation(
 		contributionType,
 	);
 
-	const productOptions = getProductOptionsForBenefitsTest(amount, state);
+	const productOptions = getProductOptionsForSupporterPlusTest(state);
 
 	return {
 		firstName: state.page.checkoutForm.personalDetails.firstName.trim(),

--- a/support-frontend/assets/pages/contributions-landing/newProductTestHelper.ts
+++ b/support-frontend/assets/pages/contributions-landing/newProductTestHelper.ts
@@ -4,6 +4,10 @@ import type { ContributionsState } from '../../helpers/redux/contributionsStore'
 import { getThresholdPrice } from './components/DigiSubBenefits/helpers';
 
 export function isSupporterPlusPurchase(state: ContributionsState): boolean {
+	if (state.common.abParticipations.supporterPlus != 'variant') {
+		return false;
+	}
+
 	const contributionType = getContributionType(state);
 
 	const thresholdPrice = getThresholdPrice(
@@ -15,9 +19,8 @@ export function isSupporterPlusPurchase(state: ContributionsState): boolean {
 		state.page.checkoutForm.product.otherAmounts,
 		contributionType,
 	);
+
 	const amountIsHighEnough = !!(thresholdPrice && amount >= thresholdPrice);
-	return (
-		state.common.abParticipations.supporterPlus == 'variant' &&
-		amountIsHighEnough
-	);
+
+	return amountIsHighEnough;
 }


### PR DESCRIPTION
## What are you doing in this PR?

Users checking out above the threshold whilst in the `supporterPlus` AB test's `variant` will still be allocated as a Recurring Contributor. I thought this change to `isSupporterPlusPurchase` would fix that: https://github.com/guardian/support-frontend/pull/4382, however it didn't. That's because `isSupporterPlusPurchase` is not used at the point we submit the new checkout form and assign the `productOptions` in the `getProductOptionsForSupporterPlusTest` function.

In this PR i've renamed `getProductOptionsForBenefitsTest` to `getProductOptionsForSupporterPlusTest`, and updated it to use `isSupporterPlusPurchase` as they do exactly the same checks.

i've also updated `isSupporterPlusPurchase` to return `false` immediately if the user is not in the `supporterPlus` AB test's `variant` cohort, this just saves is doing all the amount calculations to just return `false` if the test/variant.