### PR TITLE
Fix Direct Debit overlay bug

### DIFF
--- a/support-frontend/assets/components/paymentButton/directDebitPaymentButton.tsx
+++ b/support-frontend/assets/components/paymentButton/directDebitPaymentButton.tsx
@@ -1,14 +1,20 @@
 import { useFormValidation } from 'helpers/customHooks/useFormValidation';
 import { setPopupOpen } from 'helpers/redux/checkout/payment/directDebit/actions';
-import { useContributionsDispatch } from 'helpers/redux/storeHooks';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
 import { DefaultPaymentButtonContainer } from './defaultPaymentButtonContainer';
 
 export function DirectDebitPaymentButton(): JSX.Element {
 	const dispatch = useContributionsDispatch();
+	const { paymentMethod } = useContributionsSelector(
+		(state) => state.page.checkoutForm.payment,
+	);
 
 	const payWithDirectDebit = useFormValidation(function openDDForm() {
 		dispatch(setPopupOpen());
-	});
+	}, paymentMethod.name !== 'DirectDebit');
 
 	return <DefaultPaymentButtonContainer onClick={payWithDirectDebit} />;
 }

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodData.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodData.tsx
@@ -15,7 +15,7 @@ interface PaymentMethodData {
 	id: string;
 	label: string;
 	icon: JSX.Element;
-	accordionBody?: JSX.Element;
+	accordionBody?: () => JSX.Element;
 }
 
 export const paymentMethodData: Record<PaymentMethod, PaymentMethodData> = {
@@ -23,7 +23,7 @@ export const paymentMethodData: Record<PaymentMethod, PaymentMethodData> = {
 		id: 'qa-credit-card',
 		label: 'Credit/Debit card',
 		icon: <SvgCreditCard />,
-		accordionBody: <StripeCardFormContainer />,
+		accordionBody: () => <StripeCardFormContainer />,
 	},
 	PayPal: {
 		id: 'qa-paypal',
@@ -39,7 +39,7 @@ export const paymentMethodData: Record<PaymentMethod, PaymentMethodData> = {
 		id: 'qa-direct-debit-sepa',
 		label: 'Direct debit (SEPA)',
 		icon: <SvgSepa />,
-		accordionBody: (
+		accordionBody: () => (
 			<SepaFormContainer
 				render={(sepaFormProps: SepaFormProps) => (
 					<SepaForm {...sepaFormProps} />

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelectorAccordionRow.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelectorAccordionRow.tsx
@@ -88,7 +88,7 @@ interface ExistingPaymentMethodAccordionRowProps {
 	) => void;
 	paymentMethod: PaymentMethod | null;
 	existingPaymentMethod: RecentlySignedInExistingPaymentMethod | undefined;
-	accordionBody?: JSX.Element;
+	accordionBody?: () => JSX.Element;
 	checked: boolean;
 }
 
@@ -152,7 +152,7 @@ export function ExistingPaymentMethodAccordionRow({
 					...(expanded && accordionBody ? [accordionBodyPadding] : []),
 				]}
 			>
-				<div hidden={!expanded}>{accordionBody}</div>
+				<div hidden={!expanded}>{accordionBody?.()}</div>
 			</div>
 		</div>
 	);
@@ -165,7 +165,7 @@ interface AvailablePaymentMethodAccordionRowProps {
 	name: string;
 	checked: boolean;
 	onChange: () => void;
-	accordionBody?: JSX.Element;
+	accordionBody?: () => JSX.Element;
 }
 
 export function AvailablePaymentMethodAccordionRow({
@@ -201,7 +201,7 @@ export function AvailablePaymentMethodAccordionRow({
 					...(checked && accordionBody ? [accordionBodyPadding] : []),
 				]}
 			>
-				<div hidden={!checked}>{accordionBody}</div>
+				<div hidden={!checked}>{checked && accordionBody?.()}</div>
 			</div>
 		</div>
 	);

--- a/support-frontend/assets/helpers/customHooks/useFormValidation.ts
+++ b/support-frontend/assets/helpers/customHooks/useFormValidation.ts
@@ -17,7 +17,10 @@ type PreventableEvent = {
  */
 export function useFormValidation<
 	EventType extends PreventableEvent = React.MouseEvent<HTMLButtonElement>,
->(paymentHandler: (event: EventType) => void): (event: EventType) => void {
+>(
+	paymentHandler: (event: EventType) => void,
+	dispatchPaymentWaiting = true,
+): (event: EventType) => void {
 	const [clickEvent, setClickEvent] = useState<EventType | null>(null);
 	const dispatch = useContributionsDispatch();
 	const { paymentMethod } = useContributionsSelector(
@@ -42,7 +45,8 @@ export function useFormValidation<
 			return;
 		}
 		if (clickEvent) {
-			dispatch(paymentWaiting(true));
+			dispatchPaymentWaiting && dispatch(paymentWaiting(true));
+
 			paymentHandler(clickEvent);
 		}
 	}, [clickEvent, errorsPreventSubmission]);


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This fixes an issue with the payment processing overlay, which would appear immediately when attempting to pay via direct debit. The overlay would sit above the modal and therefore block the user from completing the form. 

The form validation hook now takes an optional `dispatchPaymentWaiting` argument and to prevent recaptcha being called on component load the `accordionBody` of the payment method selector is now a function.

Co-authored by: @GHaberis @i-hardy 

