### PR TITLE
Fix issue with PayPal checkout not triggering the correct pending state

### DIFF
--- a/support-frontend/assets/components/payPalPaymentButton/payPalRecurringContainer.tsx
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalRecurringContainer.tsx
@@ -9,6 +9,7 @@ import {
 } from 'helpers/redux/storeHooks';
 import {
 	onThirdPartyPaymentAuthorised,
+	paymentWaiting,
 	sendFormSubmitEventForPayPalRecurring,
 } from 'pages/contributions-landing/contributionsLandingActions';
 import { PayPalButton } from './payPalButton';
@@ -35,6 +36,7 @@ export function PayPalButtonRecurringContainer({
 	const { isTestUser } = useContributionsSelector((state) => state.page.user);
 
 	function onCompletion(payPalCheckoutDetails: PayPalCheckoutDetails) {
+		dispatch(paymentWaiting(true));
 		void dispatch(
 			onThirdPartyPaymentAuthorised({
 				paymentMethod: PayPal,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes a bug where completing the recurring checkout with PayPal on the new checkout did not trigger the 'payment processing' state before navigating to the thank you page on payment completion.