### PR TITLE
Treat supporter plus as a contribution when considering payment method switches

### DIFF
--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -82,7 +82,7 @@ object CheckoutValidationRules {
       switches: Switches,
   ) =
     product match {
-      case _: Contribution =>
+      case _: Contribution | _: SupporterPlus =>
         checkContributionPaymentMethodEnabled(
           switches.recurringPaymentMethods,
           paymentFields,

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -141,7 +141,7 @@ class PaymentSwitchValidationTest extends AnyFlatSpec with Matchers {
   }
   it should "return Invalid if a user tries to pay with Pay Pal but the Pay Pal switch in RRCP is off for Subscription Payment " in {
     CheckoutValidationRules.checkPaymentMethodEnabled(
-      product = SupporterPlus(0, GBP, Monthly),
+      product = DigitalPack(GBP, Monthly),
       paymentFields = Left(PayPalPaymentFields("")),
       switches = TestData.buildSwitches(
         RecurringPaymentMethodSwitches(On, On, On, On, On, On, On, On, On),


### PR DESCRIPTION
Supporter plus has the same available payment methods as a contribution so it should be treated as one when evaluating payment method switches. 

Prior to this PR it wasn't - it was being treated as a subscription. However subscriptions do not have a switch for Sepa or Apple pay payment methods so supporter plus purchases were failing with an 'Invalid Payment Method' error.
