### PR TITLE
Add aria labels to app store logo links on the thank you page

### DIFF
--- a/support-frontend/assets/components/thankYou/appDownload/AppDownloadBadges.tsx
+++ b/support-frontend/assets/components/thankYou/appDownload/AppDownloadBadges.tsx
@@ -52,6 +52,7 @@ function AppDownloadBadges({
 				target="blank"
 				onClick={() => trackComponentClick(OPHAN_COMPONENT_ID_APP_STORE_BADGE)}
 				css={appStoreLink}
+				aria-label="Download on the Apple App Store"
 			>
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
@@ -191,6 +192,7 @@ function AppDownloadBadges({
 					trackComponentClick(OPHAN_COMPONENT_ID_GOOGLE_PLAY_BADGE)
 				}
 				css={googlePlayLink}
+				aria-label="Get it on Google Play"
 			>
 				<svg
 					xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This is a small fix to address an accessibility issue on the thank you pages that was being flagged up in Storybook. The app store logo links now have screen reader accessible text.