### PR TITLE
Add legal copy for Sepa payment method

### DIFF
--- a/support-frontend/assets/components/sepaForm/SepaForm.tsx
+++ b/support-frontend/assets/components/sepaForm/SepaForm.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import type { Country } from '@guardian/consent-management-platform/dist/types/countries';
-import { headline, space } from '@guardian/source-foundations';
+import { space } from '@guardian/source-foundations';
+import { textSans } from '@guardian/source-foundations/dist/cjs/typography/api';
 import {
 	Option as OptionForSelect,
 	Select,
@@ -12,14 +13,14 @@ import type { SepaState } from 'helpers/redux/checkout/payment/sepa/state';
 import { sortedOptions } from '../forms/customFields/sortedOptions';
 
 // -- Styles -- //
-
-const headerStyles = css`
-	${headline.xxxsmall({
-		fontWeight: 'bold',
-	})}
-`;
-const fieldsContainerStyles = css`
+const legalCopy = css`
+	${textSans.xxsmall({})};
+	font-size: 11px;
 	margin-top: ${space[4]}px;
+`;
+
+const legalCopyBold = css`
+	font-weight: bold;
 `;
 
 // -- Component -- //
@@ -48,8 +49,7 @@ export function SepaForm({
 }: SepaFormProps): JSX.Element {
 	return (
 		<div>
-			<h3 css={headerStyles}>Your account details</h3>
-			<Stack cssOverrides={fieldsContainerStyles} space={3}>
+			<Stack space={3}>
 				<div>
 					<TextInput
 						id="accountHolderName"
@@ -110,6 +110,14 @@ export function SepaForm({
 					</Select>
 				</div>
 			</Stack>
+			<p css={legalCopy}>
+				By proceeding, you authorise Guardian News & Media Ltd and Stripe, our
+				payment provider, to instruct your bank to debit your account.{' '}
+				<span css={legalCopyBold}>
+					You’re entitled to a refund from your bank under their T&Cs, which
+					must be claimed within 8 weeks of the first payment.
+				</span>
+			</p>
 		</div>
 	);
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This adds legal copy required for the sepa payment method on the supporter plus checkout page.

[**Trello Card**](https://trello.com/c/IINMXe6Y/834-2-sepa-tab)

## Screenshots
<img width="467" alt="Screenshot 2022-11-08 at 10 40 03" src="https://user-images.githubusercontent.com/44685872/200543806-01214528-4111-433e-9f6c-01eb749a941e.png">
