### PR TITLE
Fix issue with tab panel focus and issue with loading state after exiting a PRB interface

### DIFF
--- a/support-frontend/assets/components/paymentFrequencyTabs/paymentFrequenncyTabs.tsx
+++ b/support-frontend/assets/components/paymentFrequencyTabs/paymentFrequenncyTabs.tsx
@@ -93,7 +93,7 @@ export function PaymentFrequencyTabs({
 				role="tabpanel"
 				id={getTabPanelId(selectedTab)}
 				aria-labelledby={selectedTab}
-				tabIndex={0}
+				tabIndex={-1}
 			>
 				{renderTabContent(selectedTab)}
 			</div>

--- a/support-frontend/assets/components/paymentRequestButton/hooks/usePaymentRequestCompletion.ts
+++ b/support-frontend/assets/components/paymentRequestButton/hooks/usePaymentRequestCompletion.ts
@@ -43,7 +43,6 @@ export function usePaymentRequestCompletion(
 	useEffect(() => {
 		if (errorsPreventSubmission) {
 			dispatch(setPaymentMethod('None'));
-			dispatch(paymentWaiting(false));
 			resetPayerDetails(dispatch);
 			errorHandler('incomplete_payment_request_details');
 			return;

--- a/support-frontend/assets/components/paymentRequestButton/paymentRequestButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentRequestButton/paymentRequestButtonContainer.tsx
@@ -51,6 +51,7 @@ export function PaymentRequestButtonContainer({
 				trackComponentClick('apple-pay-clicked');
 				dispatch(setPaymentMethod(Stripe));
 			},
+			false,
 		);
 
 	function onClick(event: StripePaymentRequestButtonElementClickEvent) {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes:
- An issue where the `PaymentFrequencyTabs` tab panel was receiving manual keyboard focus, when it should only be able to receive focus programmatically
- An issue where opening a payment request interface (ie. Apple or Google Pay) and then closing it without paying left the checkout stuck in the 'processing' state
