### PR TITLE
Prevent users who already have a recurring contribution from taking out another on the new checkout

### DIFF
--- a/support-frontend/assets/helpers/redux/selectors/formValidation/index.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/index.ts
@@ -4,7 +4,10 @@ import {
 	getPaymentMethodErrors,
 	getPaymentRequestButtonErrors,
 } from './paymentValidation';
-import { getPersonalDetailsErrors } from './personalDetailsValidation';
+import {
+	getPersonalDetailsErrors,
+	getUserCanTakeOutContribution,
+} from './personalDetailsValidation';
 import type { ErrorCollection } from './utils';
 import { errorCollectionHasErrors } from './utils';
 
@@ -39,6 +42,7 @@ export function getAllErrorsForContributions(
 
 export function contributionsFormHasErrors(state: ContributionsState): boolean {
 	const errorObject = getAllErrorsForContributions(state);
+	const userCanTakeOutContribution = getUserCanTakeOutContribution(state);
 
-	return errorCollectionHasErrors(errorObject);
+	return errorCollectionHasErrors(errorObject) || !userCanTakeOutContribution;
 }

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -40,3 +40,16 @@ export function getPersonalDetailsErrors(
 		...stateOrProvinceErrors,
 	};
 }
+
+export function getUserCanTakeOutContribution(
+	state: ContributionsState,
+): boolean {
+	const contributionType = getContributionType(state);
+	if (contributionType === 'ONE_OFF') {
+		return true;
+	}
+	const userIsAlreadyARecurringContributor =
+		state.page.user.isRecurringContributorError;
+
+	return !userIsAlreadyARecurringContributor;
+}

--- a/support-frontend/assets/helpers/user/userActions.ts
+++ b/support-frontend/assets/helpers/user/userActions.ts
@@ -1,4 +1,5 @@
 import type { Dispatch } from 'redux';
+import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 
 // ----- Types ----- //
 export type Action =
@@ -56,6 +57,10 @@ export type Action =
 	| {
 			type: 'SET_IS_RETURNING_CONTRIBUTOR';
 			isReturningContributor: boolean;
+	  }
+	| {
+			type: 'global/validateForm';
+			paymentMethod?: PaymentMethod;
 	  };
 
 export type UserSetStateActions = {

--- a/support-frontend/assets/helpers/user/userReducer.ts
+++ b/support-frontend/assets/helpers/user/userReducer.ts
@@ -18,6 +18,7 @@ export type User = {
 	emailValidated: boolean;
 	isReturningContributor: boolean;
 	address4?: string | null;
+	isRecurringContributorError?: boolean;
 };
 
 // ----- Reducer ----- //
@@ -96,6 +97,15 @@ function createUserReducer(): (
 					...state,
 					isReturningContributor: action.isReturningContributor,
 				};
+
+			case 'global/validateForm':
+				if (state.isRecurringContributor) {
+					return {
+						...state,
+						isRecurringContributorError: true,
+					};
+				}
+				return state;
 
 			default:
 				return state;

--- a/support-frontend/assets/pages/supporter-plus-landing/components/existingRecurringContributorMessage.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/existingRecurringContributorMessage.tsx
@@ -1,0 +1,34 @@
+import { Link } from '@guardian/source-react-components';
+import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import { trackComponentClick } from 'helpers/tracking/behaviour';
+import { NonValidationFailureMessage } from './nonValidationFailureMessage';
+
+const manageUrl =
+	'https://manage.theguardian.com/contributions?INTCMP=existing-contributor-from-support';
+
+export function ExistingRecurringContributorMessage(): JSX.Element | null {
+	const isAlreadyRecurringContributor = useContributionsSelector(
+		(state) => state.page.user.isRecurringContributorError,
+	);
+
+	function onClick() {
+		trackComponentClick('send-to-mma-already-contributor');
+	}
+
+	if (isAlreadyRecurringContributor) {
+		return (
+			<NonValidationFailureMessage message="We've checked, and you are already a recurring contributor">
+				<p>
+					Thank you so much for your ongoing support. If you'd like to give
+					more, either select a single contribution or increase the amount of
+					your existing contribution by going to your{' '}
+					<Link href={manageUrl} onClick={onClick}>
+						account settings.
+					</Link>
+				</p>
+			</NonValidationFailureMessage>
+		);
+	}
+
+	return null;
+}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/existingRecurringContributorMessage.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/existingRecurringContributorMessage.tsx
@@ -1,4 +1,5 @@
 import { Link } from '@guardian/source-react-components';
+import { getUserCanTakeOutContribution } from 'helpers/redux/selectors/formValidation/personalDetailsValidation';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { NonValidationFailureMessage } from './nonValidationFailureMessage';
@@ -7,22 +8,22 @@ const manageUrl =
 	'https://manage.theguardian.com/contributions?INTCMP=existing-contributor-from-support';
 
 export function ExistingRecurringContributorMessage(): JSX.Element | null {
-	const isAlreadyRecurringContributor = useContributionsSelector(
-		(state) => state.page.user.isRecurringContributorError,
+	const isNotAlreadyARecurringContributor = useContributionsSelector(
+		getUserCanTakeOutContribution,
 	);
 
 	function onClick() {
 		trackComponentClick('send-to-mma-already-contributor');
 	}
 
-	if (isAlreadyRecurringContributor) {
+	if (!isNotAlreadyARecurringContributor) {
 		return (
 			<NonValidationFailureMessage message="We've checked, and you are already a recurring contributor">
 				<p>
 					Thank you so much for your ongoing support. If you'd like to give
 					more, either select a single contribution or increase the amount of
 					your existing contribution by going to your{' '}
-					<Link href={manageUrl} onClick={onClick}>
+					<Link priority="secondary" href={manageUrl} onClick={onClick}>
 						account settings.
 					</Link>
 				</p>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/existingRecurringContributorMessage.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/existingRecurringContributorMessage.tsx
@@ -8,7 +8,7 @@ const manageUrl =
 	'https://manage.theguardian.com/contributions?INTCMP=existing-contributor-from-support';
 
 export function ExistingRecurringContributorMessage(): JSX.Element | null {
-	const isNotAlreadyARecurringContributor = useContributionsSelector(
+	const isAlreadyARecurringContributor = !useContributionsSelector(
 		getUserCanTakeOutContribution,
 	);
 
@@ -16,7 +16,7 @@ export function ExistingRecurringContributorMessage(): JSX.Element | null {
 		trackComponentClick('send-to-mma-already-contributor');
 	}
 
-	if (!isNotAlreadyARecurringContributor) {
+	if (isAlreadyARecurringContributor) {
 		return (
 			<NonValidationFailureMessage message="We've checked, and you are already a recurring contributor">
 				<p>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/existingRecurringContributorMessage.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/existingRecurringContributorMessage.tsx
@@ -30,6 +30,5 @@ export function ExistingRecurringContributorMessage(): JSX.Element | null {
 			</NonValidationFailureMessage>
 		);
 	}
-
 	return null;
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/components/nonValidationFailureMessage.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/nonValidationFailureMessage.tsx
@@ -1,0 +1,27 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/source-foundations';
+import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
+
+const bottomSpacing = css`
+	margin-bottom: ${space[6]}px;
+`;
+
+type NonValidationFailureMessageProps = {
+	message: string;
+	children: React.ReactNode;
+};
+
+export function NonValidationFailureMessage({
+	message,
+	children,
+}: NonValidationFailureMessageProps): JSX.Element {
+	return (
+		<div role="alert">
+			<ErrorSummary
+				cssOverrides={bottomSpacing}
+				message={message}
+				context={children}
+			/>
+		</div>
+	);
+}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/paymentFailure.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/paymentFailure.tsx
@@ -1,6 +1,6 @@
-import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
 import { appropriateErrorMessage } from 'helpers/forms/errorReasons';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import { NonValidationFailureMessage } from './nonValidationFailureMessage';
 
 export function PaymentFailureMessage(): JSX.Element | null {
 	const paymentError = useContributionsSelector(
@@ -9,12 +9,9 @@ export function PaymentFailureMessage(): JSX.Element | null {
 
 	if (paymentError) {
 		return (
-			<div role="alert">
-				<ErrorSummary
-					message="Sorry, something went wrong"
-					context={appropriateErrorMessage(paymentError)}
-				/>
-			</div>
+			<NonValidationFailureMessage message="Sorry, something went wrong">
+				{appropriateErrorMessage(paymentError)}
+			</NonValidationFailureMessage>
 		);
 	}
 

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -41,6 +41,7 @@ import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { shouldShowBenefitsMessaging } from 'pages/contributions-landing/components/DigiSubBenefits/helpers';
 import { DirectDebitContainer } from './components/directDebitWrapper';
+import { ExistingRecurringContributorMessage } from './components/existingRecurringContributorMessage';
 import { GuardianTsAndCs } from './components/guardianTsAndCs';
 import { LandingPageHeading } from './components/landingPageHeading';
 import { PatronsMessage } from './components/patronsMessage';
@@ -186,6 +187,7 @@ export function SupporterPlusLandingPage({
 											countryGroupId,
 										)}
 									/>
+									<ExistingRecurringContributorMessage />
 									<PaymentFailureMessage />
 									<DirectDebitContainer />
 								</ContributionsStripe>


### PR DESCRIPTION
## What are you doing in this PR?

This fixes an issue where we were not preventing users who already have a recurring contribution from checking out with a new one. This is very much a quick-n-dirty patch as this information is stored in the user reducer which has not yet been migrated to Redux Toolkit and requires a significant refactor.

## Screenshots
![Screenshot 2022-11-08 at 14 41 23](https://user-images.githubusercontent.com/29146931/200595037-d8c421cf-f89d-434e-be60-2b33219ee12b.png)

