### PR TITLE
Soft-launch new checkout to 1% of audience

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -164,10 +164,13 @@ export const tests: Tests = {
 		audiences: {
 			ALL: {
 				offset: 0,
-				size: 1,
+				// This will allocate 2% of the whole audience into the test *at all*,
+				// with half of that ie. 1% seeing the variant
+				size: 0.02,
 			},
 		},
-		isActive: false,
+		isActive: true,
+		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		referrerControlled: false,
 		seed: 15,
 	},


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This turns on the `supporterPlus` A/B test to a limited amount of the audience. This will allocate 2% of users into the test, with half each being assigned to the control and variant.

[**Trello Card**](https://trello.com/c/od9m55Bw)