### PR TITLE
Clear other amount errors when switching product type

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/product/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/reducer.ts
@@ -25,6 +25,7 @@ export const productSlice = createSlice({
 	reducers: {
 		setProductType(state, action: PayloadAction<GuardianProduct>) {
 			state.productType = action.payload;
+			state.errors.otherAmount = [];
 		},
 		setProductOption(state, action: PayloadAction<ProductOptions>) {
 			state.productOption = action.payload;


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes a bug where error messages associated with the other amount field were not cleared when switching contribution frequency.
