### PR TITLE
Remove Aus specific logic from TY page feedback components

### DIFF
--- a/support-frontend/assets/components/thankYou/feedback/FeedbackItems.tsx
+++ b/support-frontend/assets/components/thankYou/feedback/FeedbackItems.tsx
@@ -2,83 +2,52 @@ import {
 	LinkButton,
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
-import type { IsoCountry } from 'helpers/internationalisation/country';
 import { setThankYouFeedbackSurveyHasBeenCompleted } from 'helpers/redux/checkout/thankYouState/actions';
 import { useContributionsDispatch } from 'helpers/redux/storeHooks';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import styles from 'pages/contributions-landing/components/ContributionThankYou/styles';
 import { OPHAN_COMPONENT_ID_SURVEY } from 'pages/contributions-landing/components/ContributionThankYou/utils/ophan';
 
-const getFeedbackHeader = (
-	countryId: IsoCountry,
-	feedbackSurveyHasBeenCompleted: boolean,
-): string => {
-	const isAus = countryId === 'AU';
-
-	const heading = isAus
-		? 'Tell us why you value Guardian Australia'
-		: 'Send your thoughts';
-
+const getFeedbackHeader = (feedbackSurveyHasBeenCompleted: boolean): string => {
 	return feedbackSurveyHasBeenCompleted
 		? 'Thank you for sharing your thoughts'
-		: heading;
+		: 'Send your thoughts';
 };
 
 function FeedbackBodyCopy({
-	countryId,
 	feedbackSurveyHasBeenCompleted,
 }: {
-	countryId: IsoCountry;
 	feedbackSurveyHasBeenCompleted: boolean;
 }): JSX.Element {
-	const isAus = countryId === 'AU';
-
 	return (
 		<>
 			{feedbackSurveyHasBeenCompleted ? (
 				'You’re helping us deepen our understanding of Guardian supporters.'
 			) : (
 				<>
-					{isAus && (
-						<span>
-							We would love to know more about your decision to support our
-							journalism today. We’ll publish a selection of our favourite
-							messages, so other readers can enjoy them too.
+					<>
+						<span css={styles.hideAfterTablet}>
+							Fill out this short form to tell us more about your experience of
+							supporting us today – it only takes a minute.
 						</span>
-					)}
 
-					{!isAus && (
-						<>
-							<span css={styles.hideAfterTablet}>
-								Fill out this short form to tell us more about your experience
-								of supporting us today – it only takes a minute.
-							</span>
-
-							<span css={styles.hideBeforeTablet}>
-								We would love to hear more about your experience of supporting
-								the Guardian today. Please fill out this short form – it only
-								takes a minute.
-							</span>
-						</>
-					)}
+						<span css={styles.hideBeforeTablet}>
+							We would love to hear more about your experience of supporting the
+							Guardian today. Please fill out this short form – it only takes a
+							minute.
+						</span>
+					</>
 				</>
 			)}
 		</>
 	);
 }
 
-function FeedbackCTA({ countryId }: { countryId: IsoCountry }): JSX.Element {
+function FeedbackCTA(): JSX.Element {
 	const dispatch = useContributionsDispatch();
 
-	const isAus = countryId === 'AU';
-
-	// PLACEHOLDER LINK - to be updated before v2 launch
 	const SURVEY_LINK =
-		'https://guardiannewsandmedia.formstack.com/forms/guardian_contributions';
-	const AUS_SURVEY_LINK =
-		'https://guardiannewsandmedia.formstack.com/forms/australia_2022';
-
-	const surveyLink = isAus ? AUS_SURVEY_LINK : SURVEY_LINK;
+		'https://guardiannewsandmedia.formstack.com/forms/guardian_supporter';
 
 	const onClick = () => {
 		trackComponentClick(OPHAN_COMPONENT_ID_SURVEY);
@@ -88,7 +57,7 @@ function FeedbackCTA({ countryId }: { countryId: IsoCountry }): JSX.Element {
 	return (
 		<LinkButton
 			onClick={onClick}
-			href={surveyLink}
+			href={SURVEY_LINK}
 			target="_blank"
 			rel="noopener noreferrer"
 			priority="primary"

--- a/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
@@ -73,16 +73,13 @@ export const getThankYouModuleData = (
 		},
 		feedback: {
 			icon: getThankYouModuleIcon('feedback'),
-			header: getFeedbackHeader(countryId, feedbackSurveyHasBeenCompleted),
+			header: getFeedbackHeader(feedbackSurveyHasBeenCompleted),
 			bodyCopy: (
 				<FeedbackBodyCopy
-					countryId={countryId}
 					feedbackSurveyHasBeenCompleted={feedbackSurveyHasBeenCompleted}
 				/>
 			),
-			ctas: feedbackSurveyHasBeenCompleted ? null : (
-				<FeedbackCTA countryId={countryId} />
-			),
+			ctas: feedbackSurveyHasBeenCompleted ? null : <FeedbackCTA />,
 			trackComponentLoadId: OPHAN_COMPONENT_ID_SURVEY,
 		},
 		marketingConsent: {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.tsx
@@ -225,7 +225,7 @@ function ContributionThankYou({
 	};
 
 	const surveyAction = {
-		component: <ContributionThankYouSurvey countryId={countryId} />,
+		component: <ContributionThankYouSurvey />,
 		shouldShow: true,
 	};
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSurvey.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSurvey.tsx
@@ -27,16 +27,8 @@ const buttonContainer = css`
 
 const SURVEY_LINK =
 	'https://guardiannewsandmedia.formstack.com/forms/guardian_contributions';
-const AUS_SURVEY_LINK =
-	'https://guardiannewsandmedia.formstack.com/forms/australia_2022';
 
-interface ContributionThankyouSurveyProps {
-	countryId: string;
-}
-
-function ContributionThankYouSurvey({
-	countryId,
-}: ContributionThankyouSurveyProps): JSX.Element {
+function ContributionThankYouSurvey(): JSX.Element {
 	const { feedbackSurveyHasBeenCompleted } = useContributionsSelector(
 		(state) => state.page.checkoutForm.thankYou,
 	);
@@ -47,19 +39,13 @@ function ContributionThankYouSurvey({
 		trackComponentLoad(OPHAN_COMPONENT_ID_SURVEY);
 	}, []);
 
-	const isAus = countryId === 'AU';
-
-	const heading = isAus
-		? 'Tell us why you value Guardian Australia'
-		: 'Send us your thoughts';
-
 	const actionIcon = <SvgSpeechBubbleWithPlus />;
 	const actionHeader = (
 		<ActionHeader
 			title={
 				feedbackSurveyHasBeenCompleted
 					? 'Thank you for sharing your thoughts'
-					: heading
+					: 'Send us your thoughts'
 			}
 		/>
 	);
@@ -68,8 +54,6 @@ function ContributionThankYouSurvey({
 		trackComponentClick(OPHAN_COMPONENT_ID_SURVEY);
 		dispatch(setThankYouFeedbackSurveyHasBeenCompleted(true));
 	};
-
-	const surveyLink = isAus ? AUS_SURVEY_LINK : SURVEY_LINK;
 
 	const actionBody = (
 		<ActionBody>
@@ -80,33 +64,21 @@ function ContributionThankYouSurvey({
 			) : (
 				<>
 					<p>
-						{isAus && (
-							<span>
-								We would love to know more about your decision to support our
-								journalism today. We’ll publish a selection of our favourite
-								messages, so other readers can enjoy them too.
-							</span>
-						)}
+						<span css={styles.hideAfterTablet}>
+							Fill out this short form to tell us more about your experience of
+							supporting us today – it only takes a minute.
+						</span>
 
-						{!isAus && (
-							<>
-								<span css={styles.hideAfterTablet}>
-									Fill out this short form to tell us more about your experience
-									of supporting us today – it only takes a minute.
-								</span>
-
-								<span css={styles.hideBeforeTablet}>
-									We would love to hear more about your experience of supporting
-									the Guardian today. Please fill out this short form – it only
-									takes a minute.
-								</span>
-							</>
-						)}
+						<span css={styles.hideBeforeTablet}>
+							We would love to hear more about your experience of supporting the
+							Guardian today. Please fill out this short form – it only takes a
+							minute.
+						</span>
 					</p>
 					<div css={buttonContainer}>
 						<LinkButton
 							onClick={onClick}
-							href={surveyLink}
+							href={SURVEY_LINK}
 							target="_blank"
 							rel="noopener noreferrer"
 							priority="primary"

--- a/support-frontend/stories/checkouts/thankYouModule.stories.tsx
+++ b/support-frontend/stories/checkouts/thankYouModule.stories.tsx
@@ -165,11 +165,9 @@ Feedback.args = {
 	moduleType: 'feedback',
 	isSignedIn: true,
 	icon: getThankYouModuleIcon('feedback'),
-	header: getFeedbackHeader('GB', false),
-	bodyCopy: (
-		<FeedbackBodyCopy countryId={'GB'} feedbackSurveyHasBeenCompleted={false} />
-	),
-	ctas: <FeedbackCTA countryId={'GB'} />,
+	header: getFeedbackHeader(false),
+	bodyCopy: <FeedbackBodyCopy feedbackSurveyHasBeenCompleted={false} />,
+	ctas: <FeedbackCTA />,
 };
 
 Feedback.decorators = [


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This removes Aus specific logic from the contributions and supporter plus thank you page feedback components. After this PR we will no longer be showing different copy and a different survey link to users in Australia.

[**Trello Card**](https://trello.com/c/DCMhYK5l/850-update-post-purchase-survey-link-for-supporter-plus-thank-you-page-and-remove-aus-specific-logic)

## Screenshots
| Before  | After  |
| -- | -- |
| ![localhost_9001_iframe html_args= id=screens-supporter-plus-thank-you-page-australia--recurring-not-signed-in viewMode=story (1)](https://user-images.githubusercontent.com/44685872/200826077-a193b0fc-8643-40fc-a84a-4aa38317f648.png) | ![localhost_9001_iframe html_args= id=screens-supporter-plus-thank-you-page-australia--recurring-not-signed-in viewMode=story](https://user-images.githubusercontent.com/44685872/200826114-7fd3a0ad-2a65-49b1-b73a-790e75235471.png) |


