### PR TITLE
supporterPlus-variant: send contribution conversion event to QM

### DIFF
--- a/support-frontend/assets/components/payPalPaymentButton/payPalOneOffContainer.tsx
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalOneOffContainer.tsx
@@ -9,6 +9,7 @@ import { payPalCancelUrl, payPalReturnUrl } from 'helpers/urls/routes';
 import {
 	createOneOffPayPalPayment,
 	paymentWaiting,
+	setCheckoutFormHasBeenSubmitted,
 } from 'pages/contributions-landing/contributionsLandingActions';
 
 export function PayPalButtonOneOffContainer(): JSX.Element {
@@ -32,6 +33,8 @@ export function PayPalButtonOneOffContainer(): JSX.Element {
 				cancelURL: payPalCancelUrl(countryGroupId),
 			}),
 		);
+
+		dispatch(setCheckoutFormHasBeenSubmitted());
 	});
 
 	return (

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -18,6 +18,7 @@ import { DirectDebit, PayPal } from 'helpers/forms/paymentMethods';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
+import { sendEventContributionCheckoutConversion } from 'helpers/tracking/quantumMetric';
 import {
 	OPHAN_COMPONENT_ID_RETURN_TO_GUARDIAN,
 	trackUserData,
@@ -121,6 +122,14 @@ export function SupporterPlusThankYou(): JSX.Element {
 	const isNewAccount = userTypeFromIdentityResponse === 'new';
 
 	const amount = getAmount(selectedAmounts, otherAmounts, contributionType);
+
+	useEffect(() => {
+		sendEventContributionCheckoutConversion(
+			amount,
+			contributionType,
+			currencyId,
+		);
+	}, []);
 
 	const amountIsAboveThreshold = shouldShowBenefitsMessaging(
 		contributionType,


### PR DESCRIPTION
## What are you doing in this PR?

This PR makes an update so we now call `sendEventContributionCheckoutConversion` when the new `supporterPlus-variant` TY page loads. This `sendEventContributionCheckoutConversion` function sends a conversion event to QuantumMetric (QM) with the `amount`, `contributionType` and `currencyId`.

I've also had to dispatch an additional `setCheckoutFormHasBeenSubmitted` action when a user clicks the Paypal payment button for one off contributions. This action has a side affect of setting the `contributionAmount` value in Session Storage, which is retrieved from Session Storage on the TY page, before being sent to QM.