### PR TITLE
V2 Checkout - Regionalise Patrons Message

### DIFF
--- a/support-frontend/assets/helpers/urls/externalLinks.ts
+++ b/support-frontend/assets/helpers/urls/externalLinks.ts
@@ -24,6 +24,8 @@ export type SubsUrls = {
 // ----- Setup ----- //
 
 const patronsUrl = 'https://patrons.theguardian.com';
+const patronsUrlUS =
+	'https://manage.theguardian.com/help-centre/article/contribute-another-way';
 const profileUrl = `https://profile.${getBaseDomain()}`;
 const manageUrl = `https://manage.${getBaseDomain()}`;
 const homeDeliveryUrl = `https://www.${getBaseDomain()}/help/2017/dec/11/help-with-delivery#nav1`;
@@ -49,10 +51,15 @@ function getMemLink(product: MemProduct, intCmp?: string | null): string {
 	return `${memUrls[product]}?${params.toString()}`;
 }
 
-function getPatronsLink(intCmp?: string): string {
+function getPatronsLink(
+	intCmp?: string,
+	countryGroupId?: CountryGroupId,
+): string {
 	const params = new URLSearchParams();
 	params.append('INTCMP', intCmp ?? defaultIntCmp);
-	return `${patronsUrl}?${params.toString()}`;
+
+	const url = countryGroupId === 'UnitedStates' ? patronsUrlUS : patronsUrl;
+	return `${url}?${params.toString()}`;
 }
 
 // Builds a link to the digital pack checkout.

--- a/support-frontend/assets/pages/supporter-plus-landing/components/patronsMessage.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/patronsMessage.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { headline, space, textSans } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { getPatronsLink } from 'helpers/urls/externalLinks';
 
 const headingStyles = css`
@@ -22,21 +23,50 @@ const linkStyles = css`
 
 const intCMPParameter = 'gdnwb_copts_support_contributions_referral';
 
-export function PatronsMessage(): JSX.Element {
+export function PatronsMessage({
+	countryGroupId,
+}: {
+	countryGroupId: CountryGroupId;
+}): JSX.Element {
+	const patronageAmountsWithGlyph = {
+		GBPCountries: '£100',
+		AUDCountries: '$185',
+		EURCountries: '€117',
+		International: '$135',
+		NZDCountries: '$200',
+		Canada: '$167',
+	};
+
 	return (
 		<>
 			<h2 css={headingStyles}>Guardian Patrons programme</h2>
-			<p css={copyStyles}>
-				If you would like to support us at a higher level, from £100 a month,
-				you can join us as a Guardian Patron.{' '}
-				<Link
-					css={linkStyles}
-					priority="secondary"
-					href={getPatronsLink(intCMPParameter)}
-				>
-					Find out more today.
-				</Link>
-			</p>
+			{countryGroupId === 'UnitedStates' ? (
+				<p css={copyStyles}>
+					To learn more about other ways to support the Guardian, including
+					checks and tax-exempt options, please visit our{' '}
+					<Link
+						css={linkStyles}
+						priority="secondary"
+						href={getPatronsLink(intCMPParameter, countryGroupId)}
+					>
+						help page
+					</Link>{' '}
+					on this topic.
+				</p>
+			) : (
+				<p css={copyStyles}>
+					If you would like to support us at a higher level, from{' '}
+					{patronageAmountsWithGlyph[countryGroupId]} a month, you can join us
+					as a Guardian Patron.{' '}
+					<Link
+						css={linkStyles}
+						priority="secondary"
+						href={getPatronsLink(intCMPParameter, countryGroupId)}
+					>
+						Find out more today.
+					</Link>
+				</p>
+			)}
 		</>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -205,7 +205,7 @@ export function SupporterPlusLandingPage({
 							</BoxContents>
 						</Box>
 						<Divider size="full" cssOverrides={divider} />
-						<PatronsMessage />
+						<PatronsMessage countryGroupId={countryGroupId} />
 						<Divider
 							size="full"
 							cssOverrides={css`

--- a/support-frontend/stories/checkouts/Patrons.stories.tsx
+++ b/support-frontend/stories/checkouts/Patrons.stories.tsx
@@ -1,0 +1,47 @@
+import { css } from '@emotion/react';
+import { Column, Columns } from '@guardian/source-react-components';
+import React from 'react';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { countryGroups } from 'helpers/internationalisation/countryGroup';
+import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsMessage';
+import { withCenterAlignment } from '../../.storybook/decorators/withCenterAlignment';
+import { withSourceReset } from '../../.storybook/decorators/withSourceReset';
+
+export default {
+	title: 'Checkouts/Patrons Message',
+	component: PatronsMessage,
+	argTypes: {
+		countryGroup: {
+			options: Object.keys(countryGroups) as CountryGroupId[],
+			control: { type: 'radio' },
+		},
+	},
+	decorators: [
+		(Story: React.FC): JSX.Element => (
+			<Columns
+				collapseUntil="tablet"
+				cssOverrides={css`
+					width: 100%;
+				`}
+			>
+				<Column span={[1, 8, 7]}>
+					<Story />
+				</Column>
+			</Columns>
+		),
+		withCenterAlignment,
+		withSourceReset,
+	],
+};
+
+function Template(args: { countryGroup: CountryGroupId }) {
+	return <PatronsMessage countryGroupId={args.countryGroup} />;
+}
+
+Template.args = {} as Record<string, unknown>;
+
+export const Default = Template.bind({});
+
+Default.args = {
+	countryGroup: 'GBPCountries',
+};

--- a/support-frontend/stories/screens/SupporterPlusLanding.stories.tsx
+++ b/support-frontend/stories/screens/SupporterPlusLanding.stories.tsx
@@ -2,8 +2,6 @@ import '__mocks__/settingsMock';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { createTestStoreForContributions } from '__test-utils__/testStore';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { countryGroups } from 'helpers/internationalisation/countryGroup';
 import { setCountryInternationalisation } from 'helpers/redux/commonState/actions';
 import { init as formInit } from 'pages/contributions-landing/contributionsLandingInit';
 import { SupporterPlusLandingPage } from 'pages/supporter-plus-landing/supporterPlusLanding';
@@ -24,44 +22,8 @@ formInit(store);
 export default {
 	component: SupporterPlusLandingPage,
 	title: 'Screens/Supporter Plus Landing Page',
-	argTypes: {
-		countryGroup: {
-			options: (Object.keys(countryGroups) as CountryGroupId[]).filter(
-				(countryGroup) => countryGroup !== 'AUDCountries',
-			),
-			control: { type: 'radio' },
-			if: { arg: 'countryGroup', exists: true },
-		},
-	},
-};
-
-function Template() {
-	return <SupporterPlusLandingPage thankYouRoute={'/uk/thankyou'} />;
-}
-
-Template.args = {} as Record<string, unknown>;
-Template.decorators = [] as unknown[];
-
-export const Default = Template.bind({});
-
-Default.args = {
-	countryGroup: 'GBPCountries',
-};
-
-Default.decorators = [
-	(
-		Story: React.FC,
-		{ args }: Record<string, { countryGroup: CountryGroupId }>,
-	): JSX.Element => {
-		const { countryGroup } = args;
-
-		const store = createTestStoreForContributions();
-
-		store.dispatch(
-			setCountryInternationalisation(countryGroups[countryGroup].countries[0]),
-		);
-
-		return (
+	decorators: [
+		(Story: React.FC): JSX.Element => (
 			<Provider store={store}>
 				<MemoryRouter>
 					<Routes>
@@ -69,6 +31,12 @@ Default.decorators = [
 					</Routes>
 				</MemoryRouter>
 			</Provider>
-		);
-	},
-];
+		),
+	],
+};
+
+function Template() {
+	return <SupporterPlusLandingPage thankYouRoute={'/uk/thankyou'} />;
+}
+
+export const Default = Template.bind({});

--- a/support-frontend/stories/screens/SupporterPlusLanding.stories.tsx
+++ b/support-frontend/stories/screens/SupporterPlusLanding.stories.tsx
@@ -2,6 +2,8 @@ import '__mocks__/settingsMock';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { createTestStoreForContributions } from '__test-utils__/testStore';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { countryGroups } from 'helpers/internationalisation/countryGroup';
 import { setCountryInternationalisation } from 'helpers/redux/commonState/actions';
 import { init as formInit } from 'pages/contributions-landing/contributionsLandingInit';
 import { SupporterPlusLandingPage } from 'pages/supporter-plus-landing/supporterPlusLanding';
@@ -22,8 +24,44 @@ formInit(store);
 export default {
 	component: SupporterPlusLandingPage,
 	title: 'Screens/Supporter Plus Landing Page',
-	decorators: [
-		(Story: React.FC): JSX.Element => (
+	argTypes: {
+		countryGroup: {
+			options: (Object.keys(countryGroups) as CountryGroupId[]).filter(
+				(countryGroup) => countryGroup !== 'AUDCountries',
+			),
+			control: { type: 'radio' },
+			if: { arg: 'countryGroup', exists: true },
+		},
+	},
+};
+
+function Template() {
+	return <SupporterPlusLandingPage thankYouRoute={'/uk/thankyou'} />;
+}
+
+Template.args = {} as Record<string, unknown>;
+Template.decorators = [] as unknown[];
+
+export const Default = Template.bind({});
+
+Default.args = {
+	countryGroup: 'GBPCountries',
+};
+
+Default.decorators = [
+	(
+		Story: React.FC,
+		{ args }: Record<string, { countryGroup: CountryGroupId }>,
+	): JSX.Element => {
+		const { countryGroup } = args;
+
+		const store = createTestStoreForContributions();
+
+		store.dispatch(
+			setCountryInternationalisation(countryGroups[countryGroup].countries[0]),
+		);
+
+		return (
 			<Provider store={store}>
 				<MemoryRouter>
 					<Routes>
@@ -31,12 +69,6 @@ export default {
 					</Routes>
 				</MemoryRouter>
 			</Provider>
-		),
-	],
-};
-
-function Template() {
-	return <SupporterPlusLandingPage thankYouRoute={'/uk/thankyou'} />;
-}
-
-export const Default = Template.bind({});
+		);
+	},
+];


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This regionalises the patrons messaging on the v2 supporter plus checkout page.

[**Trello Card**](https://trello.com/c/63QqPWSi/849-regionalise-patrons-copy-on-the-s-checkout)

## Screenshots
You can view the [patrons messaging story for this build here](https://62e115310aef0868687b2322-cqppmenzxh.chromatic.com/?path=/story/checkouts-patrons-message--default) to see the copy for each region. Please use the controls tab at the bottom of the page on storybook to change the country group. 