### PR TITLE
Use a US specific header above US patrons message

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/patronsMessage.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/patronsMessage.tsx
@@ -37,10 +37,14 @@ export function PatronsMessage({
 		Canada: '$167',
 	};
 
+	const isUSA = countryGroupId === 'UnitedStates';
+
 	return (
 		<>
-			<h2 css={headingStyles}>Guardian Patrons programme</h2>
-			{countryGroupId === 'UnitedStates' ? (
+			<h2 css={headingStyles}>
+				{isUSA ? 'Support another way' : 'Guardian Patrons programme'}
+			</h2>
+			{isUSA ? (
 				<p css={copyStyles}>
 					To learn more about other ways to support the Guardian, including
 					checks and tax-exempt options, please visit our{' '}


### PR DESCRIPTION
## What are you doing in this PR?

Use a US specific header "Support another way" above US patrons message.