### PR TITLE
Fix some issues with form validation and the payment request button

### DIFF
--- a/support-frontend/assets/components/paymentRequestButton/paymentRequestButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentRequestButton/paymentRequestButtonContainer.tsx
@@ -3,7 +3,7 @@ import {
 	useStripe,
 } from '@stripe/react-stripe-js';
 import type { StripePaymentRequestButtonElementClickEvent } from '@stripe/stripe-js';
-import { useFormValidation } from 'helpers/customHooks/useFormValidation';
+import { useOtherAmountValidation } from 'helpers/customHooks/useFormValidation';
 import { Stripe } from 'helpers/forms/paymentMethods';
 import { setPaymentMethod } from 'helpers/redux/checkout/payment/paymentMethod/actions';
 import { clickPaymentRequestButton } from 'helpers/redux/checkout/payment/paymentRequestButton/actions';
@@ -45,7 +45,7 @@ export function PaymentRequestButtonContainer({
 	);
 
 	const handleButtonClick =
-		useFormValidation<StripePaymentRequestButtonElementClickEvent>(
+		useOtherAmountValidation<StripePaymentRequestButtonElementClickEvent>(
 			function handleButtonClick() {
 				paymentRequest?.show();
 				trackComponentClick('apple-pay-clicked');

--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentRequestButton/actions.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentRequestButton/actions.ts
@@ -2,6 +2,7 @@ import { paymentRequestButtonSlice } from './reducer';
 
 export const {
 	clickPaymentRequestButton,
+	unClickPaymentRequestButton,
 	completePaymentRequest,
 	setPaymentRequestError,
 } = paymentRequestButtonSlice.actions;

--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentRequestButton/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentRequestButton/reducer.ts
@@ -15,6 +15,9 @@ export const paymentRequestButtonSlice = createSlice({
 				state[action.payload].completed = false;
 			}
 		},
+		unClickPaymentRequestButton(state, action: PayloadAction<StripeAccount>) {
+			state[action.payload].buttonClicked = false;
+		},
 		completePaymentRequest(state, action: PayloadAction<StripeAccount>) {
 			state[action.payload].completed = true;
 		},

--- a/support-frontend/assets/helpers/redux/checkout/product/actions.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/actions.ts
@@ -14,4 +14,5 @@ export const {
 	setOrderIsAGift,
 	setStartDate,
 	setOtherAmountError,
+	validateOtherAmount,
 } = productSlice.actions;

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -17,6 +17,7 @@ import {
 	setOtherAmountError,
 	setProductType,
 	setSelectedAmount,
+	validateOtherAmount,
 } from './actions';
 import { getContributionCartValueData } from './selectors/cartValue';
 import { isContribution } from './selectors/productType';
@@ -32,6 +33,8 @@ const shouldSendEventContributionCartValue = isAnyOf(
 	setProductType,
 	setSelectedAmount,
 );
+
+const validatesOtherAmountField = isAnyOf(validateForm, validateOtherAmount);
 
 export function addProductSideEffects(
 	startListening: ContributionsStartListening,
@@ -103,7 +106,7 @@ export function addProductSideEffects(
 	// in the product state and we can do this validation in the extraReducer for validateForm?
 	// Potentially a big job
 	startListening({
-		actionCreator: validateForm,
+		matcher: validatesOtherAmountField,
 		effect(_, listenerApi) {
 			const state = listenerApi.getState();
 			const { currencyId } = state.common.internationalisation;


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This tackles a couple of bugs related to validation and the payment request button.

We originally dispatched `validateForm` when clicking the PRB like we do for every other payment button, as we need to verify that the user hasn't entered an invalid custom amount. However this had the undesirable side effect of causing validation messages to show up beside personal details fields that the user doesn't actually need to fill out if they're paying with Apple/Google Pay (although it would not block them from making a payment and submitting the form). This changes the validation behaviour for the PRB so it _only_ validates the other amount field.

There was also an edge case where if the user opened the PRB interface but changed their mind, exited it, and tried to complete the form with another payment method, validation would behave abnormally as the form remained in a 'using the PRB' state. This adds a handler for the payment request `'cancel'` event so we can correctly respond to the user exiting the interface.

A lot of the Redux code relating to both payment request button state and the other amount field is still pretty sub-optimal, but this is something we can look at improving once we know the outcome of the test and can (hopefully) cease having to accommodate the old checkout code.

[**Trello Card**](https://trello.com/c/soqnkYlh)