### PR TITLE
Fix - Supporter Plus heading font-size

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/landingPageHeading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/landingPageHeading.tsx
@@ -11,18 +11,17 @@ const headingStyles = css`
 	color: ${neutral[100]};
 	display: inline-block;
 	${headline.medium({ fontWeight: 'bold' })}
-
-	${until.mobileMedium} {
-		font-size: 28px;
-	}
+	font-size: 28px;
+	max-width: 400px;
 
 	${from.tablet} {
-		font-size: 38px;
+		font-size: 34px;
+		max-width: 480px;
 	}
 
 	${until.desktop} {
 		margin: 0 auto;
-		margin-bottom: ${space[6]}px;
+		margin-bottom: ${space[5]}px;
 	}
 	${from.desktop} {
 		${headline.large({ fontWeight: 'bold' })}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This fixes the size and layout of the supporter plus LP heading on mobile breakpoints

[**Trello Card**](https://trello.com/c/4pSCeywm/864-font-size-on-headline-on-mobile-view)
