### PR TITLE
AmazonPay disabled for variant,  enabled for control

### DIFF
--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -80,11 +80,7 @@ function PaymentMethodSelectorContainer({
 		getSettings(),
 	);
 	const isSupporterPlus = participations.supporterPlus === 'variant';
-	console.log(
-		'PaymentSelectorContainer.isSupporterPlus',
-		isSupporterPlus,
-		participations.supporterPlus,
-	);
+
 	const availablePaymentMethods = getValidPaymentMethods(
 		contributionType,
 		switches,

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -1,5 +1,3 @@
-import type { Participations } from 'helpers/abTests/abtest';
-import { init as initAbTests } from 'helpers/abTests/abtest';
 import type { ContributionType } from 'helpers/contributions';
 import { contributionTypeIsRecurring } from 'helpers/contributions';
 import { getValidPaymentMethods } from 'helpers/forms/checkouts';
@@ -11,8 +9,6 @@ import {
 	getFullExistingPaymentMethods,
 	isUsableExistingPaymentMethod,
 } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
-import { getSettings } from 'helpers/globalsAndSwitches/globals';
-import { detect as detectCountry } from 'helpers/internationalisation/country';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import type { PaymentMethodSelectorProps } from './paymentMethodSelector';
@@ -74,12 +70,10 @@ function PaymentMethodSelectorContainer({
 	const { switches } = useContributionsSelector(
 		(state) => state.common.settings,
 	);
-	const participations: Participations = initAbTests(
-		detectCountry(),
-		countryGroupId,
-		getSettings(),
+	const { abParticipations } = useContributionsSelector(
+		(state) => state.common,
 	);
-	const isSupporterPlus = participations.supporterPlus === 'variant';
+	const isSupporterPlus = abParticipations.supporterPlus === 'variant';
 
 	const availablePaymentMethods = getValidPaymentMethods(
 		contributionType,

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -1,3 +1,5 @@
+import type { Participations } from 'helpers/abTests/abtest';
+import { init as initAbTests } from 'helpers/abTests/abtest';
 import type { ContributionType } from 'helpers/contributions';
 import { contributionTypeIsRecurring } from 'helpers/contributions';
 import { getValidPaymentMethods } from 'helpers/forms/checkouts';
@@ -9,6 +11,8 @@ import {
 	getFullExistingPaymentMethods,
 	isUsableExistingPaymentMethod,
 } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
+import { getSettings } from 'helpers/globalsAndSwitches/globals';
+import { detect as detectCountry } from 'helpers/internationalisation/country';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import type { PaymentMethodSelectorProps } from './paymentMethodSelector';
@@ -70,12 +74,23 @@ function PaymentMethodSelectorContainer({
 	const { switches } = useContributionsSelector(
 		(state) => state.common.settings,
 	);
-
+	const participations: Participations = initAbTests(
+		detectCountry(),
+		countryGroupId,
+		getSettings(),
+	);
+	const isSupporterPlus = participations.supporterPlus === 'variant';
+	console.log(
+		'PaymentSelectorContainer.isSupporterPlus',
+		isSupporterPlus,
+		participations.supporterPlus,
+	);
 	const availablePaymentMethods = getValidPaymentMethods(
 		contributionType,
 		switches,
 		countryId,
 		countryGroupId,
+		isSupporterPlus,
 	);
 
 	// We check on page init if we should try to retrieve existing payment methods from MDAPI

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -152,12 +152,6 @@ function getPaymentMethods(
 	countryId: IsoCountry,
 	countryGroupId: CountryGroupId,
 ): PaymentMethod[] {
-	const participations: Participations = initAbTests(
-		detectCountry(),
-		countryGroupId,
-		getSettings(),
-	);
-	const isSupporterPlus = participations.supporterPlus === 'variant';
 	if (contributionType !== 'ONE_OFF' && countryId === 'GB') {
 		return [DirectDebit, Stripe, PayPal];
 	} else if (countryId === 'US') {
@@ -166,6 +160,12 @@ function getPaymentMethods(
 			contributionType === 'ONE_OFF' ||
 			getQueryParameter('amazon-pay-recurring') === 'true'
 		) {
+			const participations: Participations = initAbTests(
+				detectCountry(),
+				countryGroupId,
+				getSettings(),
+			);
+			const isSupporterPlus = participations.supporterPlus === 'variant';
 			return isSupporterPlus ? [Stripe, PayPal] : [Stripe, PayPal, AmazonPay];
 		}
 


### PR DESCRIPTION
Disabled AmazonPay for variant only (in code), control will display depending on switch in RRCP switches (one-off AmazonPay) afterwards.

https://support.thegulocal.com/us/contribute#ab-supporterPlus=variant
Variant (After - no change)
![Screenshot 2022-11-11 at 17 21 38](https://user-images.githubusercontent.com/76729591/201395241-8a1b4d02-44f8-4c2a-b3e8-9b069cba6519.png)

https://support.thegulocal.com/us/contribute#ab-supporterPlus=control
Control (After - change)
![Screenshot 2022-11-11 at 17 21 53](https://user-images.githubusercontent.com/76729591/201395126-cb249dcb-260c-4c91-bac6-73f8478c0109.png)


[[**Trello Card**](https://trello.com)](https://trello.com/c/R8pjseOj/869-amazonpay-disabled-for-variant-enabled-for-control-one-off-usd)


## Is this an AB test?
- [x ] Yes
- [ ] No

