### PR TITLE
Support for joint patrons

### DIFF
--- a/stripe-patrons-data/build.sbt
+++ b/stripe-patrons-data/build.sbt
@@ -14,6 +14,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.0",
+  "com.stripe" % "stripe-java" % "20.128.0",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,

--- a/stripe-patrons-data/build.sbt
+++ b/stripe-patrons-data/build.sbt
@@ -14,7 +14,6 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.0",
-  "com.stripe" % "stripe-java" % "20.128.0",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/model/StripeSubscriptionsResponse.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/model/StripeSubscriptionsResponse.scala
@@ -12,11 +12,13 @@ case class StripeSubscription(
     customer: StripeCustomer,
     status: String,
 )
+
 @ConfiguredJsonCodec
-case class StripeCustomer(id: String, name: Option[String], email: String, metadata: Metadata){
+case class StripeCustomer(id: String, name: Option[String], email: String, metadata: Metadata) {
   val jointPatronEmail = metadata.jointPatronEmail
   val jointPatronName = metadata.jointPatronName
 }
+
 @ConfiguredJsonCodec
 case class Metadata(jointPatronEmail: Option[String], jointPatronName: Option[String])
 @ConfiguredJsonCodec

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/model/StripeSubscriptionsResponse.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/model/StripeSubscriptionsResponse.scala
@@ -13,7 +13,12 @@ case class StripeSubscription(
     status: String,
 )
 @ConfiguredJsonCodec
-case class StripeCustomer(id: String, name: Option[String], email: String)
+case class StripeCustomer(id: String, name: Option[String], email: String, metadata: Metadata){
+  val jointPatronEmail = metadata.jointPatronEmail
+  val jointPatronName = metadata.jointPatronName
+}
+@ConfiguredJsonCodec
+case class Metadata(jointPatronEmail: Option[String], jointPatronName: Option[String])
 @ConfiguredJsonCodec
 case class StripeSubscriptionsResponse(data: List[StripeSubscription], hasMore: Boolean)
 
@@ -42,6 +47,9 @@ object StripeSubscription {
   implicit val customConfig: Configuration = Configuration.default.withSnakeCaseMemberNames
 }
 
+object Metadata {
+  implicit val customConfig: Configuration = Configuration.default.withSnakeCaseMemberNames
+}
 object StripeCustomer {
   implicit val customConfig: Configuration = Configuration.default.withSnakeCaseMemberNames
 }

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/services/PatronsStripeService.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/services/PatronsStripeService.scala
@@ -2,7 +2,7 @@ package com.gu.patrons.services
 
 import com.gu.okhttp.RequestRunners.FutureHttpClient
 import com.gu.patrons.conf.PatronsStripeConfig
-import com.gu.patrons.model.{StripeError, StripeSubscriptionsResponse}
+import com.gu.patrons.model.{StripeCustomer, StripeError, StripeSubscriptionsResponse}
 import com.gu.rest.WebServiceHelper
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -32,5 +32,11 @@ class PatronsStripeService(val config: PatronsStripeConfig, client: FutureHttpCl
       ) ++ startingAfter.getOrElse(Nil),
     )
   }
+
+  def getCustomer(customerId: String) =
+    get[StripeCustomer](
+      s"customers/$customerId",
+      authHeader,
+    )
 
 }

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/services/StripeSubscriptionsProcessor.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/services/StripeSubscriptionsProcessor.scala
@@ -88,7 +88,7 @@ class CreateMissingIdentityProcessor(
   override def processSubscription(subscription: StripeSubscription) =
     for {
       _ <- processCustomerEmail(subscription.customer.email, subscription.customer.name, subscription)
-      _ <- checkForJointPatron(subscription)
+      _ <- maybeAddJointPatron(subscription)
     } yield {
       ()
     }
@@ -101,12 +101,12 @@ class CreateMissingIdentityProcessor(
     ()
   }
 
-  def checkForJointPatron(subscription: StripeSubscription) =
+  def maybeAddJointPatron(subscription: StripeSubscription) =
     subscription.customer.jointPatronEmail match {
       case Some(email) =>
-      SafeLogger.info(s"Customer ${subscription.customer.email} has an associated joint patron - $email")
+        SafeLogger.info(s"Customer ${subscription.customer.email} has an associated joint patron - $email")
         processCustomerEmail(email, subscription.customer.jointPatronName, subscription)
-      case _ => Future.successful(Unit)
+      case _ => Future.successful(())
     }
 }
 

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/services/StripeSubscriptionsProcessor.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/services/StripeSubscriptionsProcessor.scala
@@ -72,10 +72,10 @@ abstract class DynamoProcessor(
 
   def logDynamoResult(email: String, addSubscriptionsToQueueState: UpdateItemResponse) =
     if (addSubscriptionsToQueueState.sdkHttpResponse().statusCode() == 200)
-      SafeLogger.info(s"Dynamo record successfully written for ${email}")
+      SafeLogger.info(s"Dynamo record successfully written for $email")
     else
       SafeLogger.info(
-        s"Error response from Dynamo for ${email}. Status code was ${addSubscriptionsToQueueState.sdkHttpResponse().statusCode()}",
+        s"Error response from Dynamo for $email. Status code was ${addSubscriptionsToQueueState.sdkHttpResponse().statusCode()}",
       )
 }
 
@@ -87,11 +87,26 @@ class CreateMissingIdentityProcessor(
 
   override def processSubscription(subscription: StripeSubscription) =
     for {
-      identityId <- identityService.getOrCreateUserFromEmail(subscription.customer.email, subscription.customer.name)
-      dynamoResponse <- writeToDynamo(identityId, subscription)
-      _ = logDynamoResult(subscription.customer.email, dynamoResponse)
+      _ <- processCustomerEmail(subscription.customer.email, subscription.customer.name, subscription)
+      _ <- checkForJointPatron(subscription)
     } yield {
       ()
+    }
+
+  def processCustomerEmail(email: String, name: Option[String], subscription: StripeSubscription): Future[Unit] = for {
+    identityId <- identityService.getOrCreateUserFromEmail(email, name)
+    dynamoResponse <- writeToDynamo(identityId, subscription)
+    _ = logDynamoResult(subscription.customer.email, dynamoResponse)
+  } yield {
+    ()
+  }
+
+  def checkForJointPatron(subscription: StripeSubscription) =
+    subscription.customer.jointPatronEmail match {
+      case Some(email) =>
+      SafeLogger.info(s"Customer ${subscription.customer.email} has an associated joint patron - $email")
+        processCustomerEmail(email, subscription.customer.jointPatronName, subscription)
+      case _ => Future.successful(Unit)
     }
 }
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Some patrons subscriptions have a joint account holder. Currently these are only recorded in Salesforce however we want to ensure they receive their digital benefits when they sign into the apps or website.

This PR adds a mechanism for adding joint patrons to the SupporterProductData Dynamo db table so that they receive benefits. That mechanism is as follows:
- add two metadata fields `joint_patron_email` (mandatory) and `joint_patron_name` (optional) to the metadata of the existing patron customer record
- this metadata is picked up by the stripe-patrons-data lambda and the identity account for the email is either retrieved from identity or a new account created
- a patron record is created in SupporterProductData for this identity id 

[There are more details in this document](https://docs.google.com/document/d/1IbU_r-h71cIHbtSpWkm43E_TRTxoKNQtjb4-PekXRkI/edit#)

[**Trello Card**](https://trello.com/c/oo6Qj3wi/59-patron-joint-accounts)
