### PR TITLE
Add supporter plus support to acquisitions-firehose-transformer

### DIFF
--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/calculator/AnnualisedValueTwoCalculator.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/calculator/AnnualisedValueTwoCalculator.scala
@@ -61,7 +61,17 @@ object AnnualisedValueTwoCalculator {
       case (Monthly, AUD) => Right(0.8954700)
       case (Monthly, _) => Right(0.8586346)
       case (Annually, _) => Right(0.99)
-      case (_, _) => Left("Payment Frequency for recurring contributions must be MONTHLY")
+      case (_, _) => Left("Payment Frequency for recurring contributions must be MONTHLY or ANNUALLY")
+    }
+
+  def getSupporterPlusMargin(a: AcquisitionModel): Either[String, Double] =
+    (a.paymentFrequency, a.currency) match {
+      case (Monthly, GBP) => Right(0.8858596)
+      case (Monthly, USD) => Right(0.8348365)
+      case (Monthly, AUD) => Right(0.8954700)
+      case (Monthly, _) => Right(0.8586346)
+      case (Annually, _) => Right(0.99)
+      case (_, _) => Left("Payment Frequency for Supporter Plus must be MONTHLY or ANNUALLY")
     }
 
   def getMembershipSupporterAV(a: AcquisitionModel): Either[String, Double] =
@@ -140,10 +150,11 @@ object AnnualisedValueTwoCalculator {
     a.product match {
       case AcquisitionProduct.Contribution => getContributionMargin(a)
       case AcquisitionProduct.RecurringContribution => getRecurringMargin(a)
+      case AcquisitionProduct.SupporterPlus => getRecurringMargin(a)
       case _ => Left("Business logic not yet implemented for product")
     }
 
-  def getContributionAV(a: AcquisitionModel): Either[String, Double] =
+  def getContributionOrSupporterPlusAV(a: AcquisitionModel): Either[String, Double] =
     for {
       margin <- getMargin(a)
       paymentFrequencyMultiplier <- getPaymentFrequencyMultiplyer(a.paymentFrequency)
@@ -153,11 +164,12 @@ object AnnualisedValueTwoCalculator {
 
   def getAnnualisedValue(a: AcquisitionModel): Either[String, Double] =
     a.product match {
-      case AcquisitionProduct.Contribution => getContributionAV(a)
-      case AcquisitionProduct.RecurringContribution => getContributionAV(a)
+      case AcquisitionProduct.Contribution => getContributionOrSupporterPlusAV(a)
+      case AcquisitionProduct.RecurringContribution => getContributionOrSupporterPlusAV(a)
       case AcquisitionProduct.DigitalSubscription => getDigitalSubscriptionAV(a)
       case AcquisitionProduct.GuardianWeekly => getPrintAV(a)
       case AcquisitionProduct.Paper => getPrintAV(a)
+      case AcquisitionProduct.SupporterPlus => getContributionOrSupporterPlusAV(a)
       case AcquisitionProduct.AppPremiumTier => Left("App premium tier not implemented yet")
       case _ => Left("Business logic not yet implemented for product")
     }

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
@@ -108,9 +108,10 @@ object AcquisitionProduct {
   case object AppPremiumTier extends AcquisitionProduct("APP_PREMIUM_TIER")
 
   def fromString(code: String): Option[AcquisitionProduct] = {
-    List(Contribution, RecurringContribution, DigitalSubscription, Paper, GuardianWeekly, AppPremiumTier).find(
-      _.value == code,
-    )
+    List(Contribution, RecurringContribution, SupporterPlus, DigitalSubscription, Paper, GuardianWeekly, AppPremiumTier)
+      .find(
+        _.value == code,
+      )
   }
 
   implicit val decoder: Decoder[AcquisitionProduct] =

--- a/support-modules/acquisition-events/src/test/scala/com/gu/support/acquisitions/calculator/AnnualisedValueTwoCalculatorSpec.scala
+++ b/support-modules/acquisition-events/src/test/scala/com/gu/support/acquisitions/calculator/AnnualisedValueTwoCalculatorSpec.scala
@@ -1,0 +1,29 @@
+package com.gu.support.acquisitions.calculator
+
+import com.gu.support.acquisitions.models.AcquisitionProduct
+import com.gu.support.acquisitions.models.PaymentFrequency.Monthly
+import com.gu.support.acquisitions.models.PaymentProvider.Stripe
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AnnualisedValueTwoCalculatorSpec extends AnyFlatSpec with Matchers with EitherValues {
+  "getAnnualisedValue" should "return the annualised value for a Supporter Plus acquisition" in {
+    val supporterPlusAcq = AcquisitionModel(
+      amount = 20.0,
+      product = AcquisitionProduct.SupporterPlus,
+      currency = "GBP",
+      paymentFrequency = Monthly,
+      paymentProvider = Some(Stripe),
+      printOptions = None,
+    )
+
+    val result = AnnualisedValueTwoCalculator.getAnnualisedValue(supporterPlusAcq)
+
+    result.isRight should be(true)
+    result.map { av =>
+      val roundedAv = BigDecimal(av).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
+      roundedAv should be(212.61)
+    }
+  }
+}


### PR DESCRIPTION
## What are you doing in this PR?

Adding support for Supporter Plus to the acquisitions-firehose-transformer lambda.

[**Trello Card**](https://trello.com/c/hOVJ6jSz/926-ticker-include-supporter)

## Why are you doing this?

We want to include Supporter Plus in the ticker and RRCP super mode, which both rely on the acquisitions-firehose-lambda.

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [x] No