### PR TITLE
Re-run form validation when attempting to open the PayPal pop-up

### DIFF
--- a/support-frontend/assets/components/payPalPaymentButton/payPalButtonProps.ts
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalButtonProps.ts
@@ -80,5 +80,6 @@ export function getPayPalButtonProps({
 				logException((error as Error).message);
 			}
 		},
+		onError: () => null,
 	};
 }

--- a/support-frontend/assets/components/payPalPaymentButton/payPalRecurringContainer.tsx
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalRecurringContainer.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'preact/hooks';
 import { useState } from 'react';
 import type { PayPalCheckoutDetails } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 import { PayPal } from 'helpers/forms/paymentMethods';
+import { validateForm } from 'helpers/redux/checkout/checkoutActions';
 import { setUpPayPalPayment } from 'helpers/redux/checkout/payment/payPal/thunks';
 import {
 	useContributionsDispatch,
@@ -45,8 +46,10 @@ export function PayPalButtonRecurringContainer({
 		);
 	}
 
-	const onWindowOpen: OnPaypalWindowOpen = (resolve, reject) =>
+	const onWindowOpen: OnPaypalWindowOpen = (resolve, reject) => {
+		dispatch(validateForm('PayPal'));
 		void dispatch(setUpPayPalPayment({ resolve, reject }));
+	};
 
 	const buttonProps = getPayPalButtonProps({
 		csrf,

--- a/support-frontend/assets/helpers/redux/checkout/payment/payPal/thunks.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/payPal/thunks.ts
@@ -3,6 +3,7 @@ import { fetchJson } from 'helpers/async/fetch';
 import { billingPeriodFromContrib } from 'helpers/contributions';
 import { loadPayPalRecurring } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
+import { contributionsFormHasErrors } from 'helpers/redux/selectors/formValidation';
 import { routes } from 'helpers/urls/routes';
 import { logException } from 'helpers/utilities/logger';
 import { getContributionType } from '../../product/selectors/productType';
@@ -25,6 +26,12 @@ export const setUpPayPalPayment = createAsyncThunk<
 >('paypal/setUpPayment', async function setUp({ resolve, reject }, thunkApi) {
 	try {
 		const state = thunkApi.getState();
+		const errorsPreventOpening = contributionsFormHasErrors(state);
+
+		if (errorsPreventOpening) {
+			reject(new Error('form invalid'));
+		}
+
 		const { currencyId } = state.common.internationalisation;
 		const csrfToken = state.page.checkoutForm.csrf.token ?? '';
 		const contributionType = getContributionType(state);

--- a/support-frontend/window.d.ts
+++ b/support-frontend/window.d.ts
@@ -33,6 +33,7 @@ declare global {
 		) => void;
 		// This function is called when the user finishes with PayPal interface (approves payment).
 		onAuthorize: (data: Record<string, unknown>) => void;
+		onError?: () => void;
 	};
 
 	interface Window {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes an issue on the new checkout where if form validation issues are introduced _after_ selecting to pay with PayPal it's possible to proceed with payment.

This **does** cause other issues due to our use of a deprecated PayPal SDK- please see [the write-up here](https://docs.google.com/document/d/1q8G1ZuelCyIm8GT7d-GT-b3d0NL3LpfpfKvDC7N3p4E/edit#heading=h.bminhblhkoif)

[**Trello Card**](https://trello.com/c/e1X68Isz)
