### PR TITLE
Add localised placeholders to the state select field for the supporter plus checkout

### DIFF
--- a/support-frontend/assets/components/personalDetails/stateSelect.tsx
+++ b/support-frontend/assets/components/personalDetails/stateSelect.tsx
@@ -48,7 +48,11 @@ export function StateSelect({
 					error={error}
 				>
 					<>
-						<Option value="">&nbsp;</Option>
+						<Option value="">
+							{`Select your ${
+								stateDescriptors[countryGroupId]?.toLowerCase() ?? 'state'
+							}`}
+						</Option>
 						{Object.entries(statesList).map(([abbreviation, name]) => {
 							return (
 								<Option value={abbreviation} selected={abbreviation === state}>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds a localised placeholder message to the state select component on the new checkout.

[**Trello Card**](https://trello.com/c/SZVSFZhC)

## Screenshots

### US
<img width="536" alt="Screenshot 2022-11-22 at 14 37 17" src="https://user-images.githubusercontent.com/29146931/203342053-abab3609-5a61-4d48-b15e-949f04b9ab4d.png">

### Australia
<img width="548" alt="Screenshot 2022-11-22 at 14 37 34" src="https://user-images.githubusercontent.com/29146931/203342099-5a532094-fd71-450b-83c2-a5b1c95c01a2.png">

### Canada
<img width="538" alt="Screenshot 2022-11-22 at 14 37 51" src="https://user-images.githubusercontent.com/29146931/203342176-4098f92d-55e5-418b-8894-b2eefe672ea6.png">
