### PR TITLE
Fix error in supporter-product-data caused by compression of a zuora http response

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=11.0.16-amzn

--- a/supporter-product-data/cloudformation/cfn.yaml
+++ b/supporter-product-data/cloudformation/cfn.yaml
@@ -48,6 +48,8 @@ Resources:
           - Id: DeleteAllOldFiles
             Status: Enabled
             ExpirationInDays: 14
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
 
   SupporterProductDataLambdaRole:
     Type: AWS::IAM::Role

--- a/supporter-product-data/src/main/scala/com/gu/lambdas/FetchResultsLambda.scala
+++ b/supporter-product-data/src/main/scala/com/gu/lambdas/FetchResultsLambda.scala
@@ -41,7 +41,7 @@ object FetchResultsLambda extends StrictLogging {
         fileResponse.isSuccessful,
         s"File download for job with id $jobId failed with http code ${fileResponse.code}",
       )
-      _ <- S3Service.streamToS3(stage, filename, fileResponse.body.byteStream, fileResponse.body.contentLength)
+      _ = S3Service.streamToS3(stage, filename, fileResponse.body.byteStream, fileResponse.body.contentLength)
     } yield {
       logger.info(s"Successfully wrote file $filename to S3 with ${batch.recordCount} records for jobId $jobId")
       if (batch.recordCount == 0)

--- a/supporter-product-data/src/main/scala/com/gu/services/S3Service.scala
+++ b/supporter-product-data/src/main/scala/com/gu/services/S3Service.scala
@@ -1,18 +1,16 @@
 package com.gu.services
 
-import com.amazonaws.event.ProgressEventType._
-import com.amazonaws.event.{ProgressEvent, ProgressListener}
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.s3.model.{GetObjectRequest, ObjectMetadata, PutObjectRequest}
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder
 import com.gu.aws.CredentialsProvider
 import com.gu.supporterdata.model.Stage
+import com.typesafe.scalalogging.StrictLogging
 
 import java.io.InputStream
-import scala.concurrent.Promise
 
-object S3Service {
+object S3Service extends StrictLogging {
   val s3Client = AmazonS3ClientBuilder.standard
     .withRegion(Regions.EU_WEST_1)
     .withCredentials(CredentialsProvider)
@@ -24,32 +22,17 @@ object S3Service {
   def bucketName(stage: Stage) = s"supporter-product-data-export-${stage.value.toLowerCase}"
 
   def streamToS3(stage: Stage, filename: String, inputStream: InputStream, length: Long) = {
+    logger.info(s"Trying to stream to S3 - bucketName: ${bucketName(stage)}, filename: $filename, length: $length")
     val objectMetadata = new ObjectMetadata()
     objectMetadata.setContentLength(length)
+
     val putObjectRequest = new PutObjectRequest(bucketName(stage), filename, inputStream, objectMetadata)
-    val progressListener = new TransferProgressListener(filename)
-    putObjectRequest.setGeneralProgressListener(progressListener)
-    transferManager.upload(putObjectRequest)
-    progressListener.future
+    val transfer = transferManager.upload(putObjectRequest)
+
+    transfer.waitForCompletion()
   }
 
   def streamFromS3(stage: Stage, filename: String) =
     s3Client.getObject(new GetObjectRequest(bucketName(stage), filename))
 
-}
-
-class TransferProgressListener(filename: String) extends ProgressListener {
-
-  private val promise = Promise[Unit]()
-  def future = promise.future
-
-  override def progressChanged(progressEvent: ProgressEvent): Unit =
-    progressEvent.getEventType match {
-      case TRANSFER_COMPLETED_EVENT => promise.success(())
-      case TRANSFER_PART_FAILED_EVENT =>
-        promise.failure(new RuntimeException(s"There was a partial failure while transferring $filename"))
-      case TRANSFER_FAILED_EVENT | TRANSFER_CANCELED_EVENT =>
-        promise.failure(new RuntimeException(s"Transfer failed for $filename"))
-      case _ => ()
-    }
 }

--- a/supporter-product-data/src/main/scala/com/gu/services/ZuoraQuerierService.scala
+++ b/supporter-product-data/src/main/scala/com/gu/services/ZuoraQuerierService.scala
@@ -22,6 +22,7 @@ class ZuoraQuerierService(val config: ZuoraQuerierConfig, client: FutureHttpClie
   val authHeaders = Map(
     "apiSecretAccessKey" -> config.password,
     "apiAccessKeyId" -> config.username,
+    "Accept-Encoding" -> "identity", // Required to ensure that response content-length header is available. We need this when we transfer results to S3. See https://github.com/square/okhttp/issues/1542 for details
   )
 
   def postQuery(queryType: QueryType): Future[BatchQueryResponse] = {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Recently executions of the supporter-product-data-DEV (for example [this one](https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/v2/executions/details/arn:aws:states:eu-west-1:865473395570:execution:supporter-product-data-DEV:15e359bc-8cef-46f3-782d-a37e9fb768a3)) step function have started failing with the error `The request signature we calculated does not match the signature you provided. Check your key and signing method.`
It turns out that this was actually because we were passing the wrong content length for the Zuora CSV results file we were trying to transfer to S3 and that the reason that the content length was wrong was because Zuora had stopped returning the `Content-length` header on the file response. 

As this was only happening in the sandbox environment it is not obvious why this started happening, also it only occurred when making a request via OkHttp, not when using Curl.
There are some differences in the Zuora response between production and sandbox, most noticably that sandbox is using Http 2 whereas prod is using Http 1.1.

I found [an issue on the OkHttp repo](https://github.com/square/okhttp/issues/1542) which described the same issue caused by a compressed response and provides a solution which is to add an additional header to the request. My best guess for why this error has suddenly started happening is that some change Zuora has made to their sandbox servers has caused responses to start being compressed by default whereas previously they weren't.
