### PR TITLE
Remove newProduct AB test and add switch for suppressing digi sub pages

### DIFF
--- a/support-frontend/app/admin/settings/Switches.scala
+++ b/support-frontend/app/admin/settings/Switches.scala
@@ -19,6 +19,7 @@ object SwitchState {
 case class FeatureSwitches(
     enableQuantumMetric: SwitchState,
     usStripeAccountForSingle: SwitchState,
+    suppressDigitalSubscription: SwitchState,
 )
 
 case class CampaignSwitches(

--- a/support-frontend/assets/components/headers/header/header.tsx
+++ b/support-frontend/assets/components/headers/header/header.tsx
@@ -13,7 +13,7 @@ export type PropTypes = {
 	utility?: JSX.Element;
 	countryGroupId: CountryGroupId;
 	display?: 'navigation' | 'checkout' | 'guardianLogo' | void;
-	isNewProduct?: boolean;
+	hideDigiSub?: boolean;
 };
 export type State = {
 	fitsLinksInOneRow: boolean;
@@ -131,7 +131,7 @@ export default class Header extends Component<PropTypes, State> {
 	observer: ResizeObserver | null | undefined;
 
 	render(): JSX.Element {
-		const { utility, display, countryGroupId, isNewProduct } = this.props;
+		const { utility, display, countryGroupId, hideDigiSub } = this.props;
 		const { fitsLinksInOneRow, fitsLinksAtAll, isTestUser } = this.state;
 		return (
 			<header
@@ -169,7 +169,7 @@ export default class Header extends Component<PropTypes, State> {
 									<Links
 										countryGroupId={countryGroupId}
 										location="mobile"
-										isNewProduct={isNewProduct}
+										hideDigiSub={hideDigiSub}
 									/>
 								}
 								utility={utility}
@@ -184,7 +184,7 @@ export default class Header extends Component<PropTypes, State> {
 								getRef={(el) => {
 									this.menuRef = el;
 								}}
-								isNewProduct={isNewProduct}
+								hideDigiSub={hideDigiSub}
 							/>
 						</div>
 					)}

--- a/support-frontend/assets/components/headers/header/headerWithCountrySwitcher.tsx
+++ b/support-frontend/assets/components/headers/header/headerWithCountrySwitcher.tsx
@@ -13,13 +13,13 @@ export default function ({
 	countryGroupId,
 	listOfCountryGroups,
 	trackProduct,
-	isNewProduct,
+	hideDigiSub,
 }: {
 	path: string;
 	countryGroupId: CountryGroupId;
 	listOfCountryGroups: CountryGroupId[];
 	trackProduct?: Option<SubscriptionProduct>;
-	isNewProduct?: boolean;
+	hideDigiSub?: boolean;
 }) {
 	return function (): JSX.Element {
 		return (
@@ -33,7 +33,7 @@ export default function ({
 						trackProduct={trackProduct}
 					/>
 				}
-				isNewProduct={isNewProduct}
+				hideDigiSub={hideDigiSub}
 			/>
 		);
 	};

--- a/support-frontend/assets/components/headers/links/links.tsx
+++ b/support-frontend/assets/components/headers/links/links.tsx
@@ -24,7 +24,7 @@ type PropTypes = {
 	location: 'desktop' | 'mobile';
 	countryGroupId?: CountryGroupId;
 	getRef?: (element: Element | null) => void;
-	isNewProduct?: boolean;
+	hideDigiSub?: boolean;
 };
 
 const links: HeaderNavLink[] = [
@@ -104,7 +104,7 @@ function Links({
 	location,
 	getRef,
 	countryGroupId,
-	isNewProduct,
+	hideDigiSub,
 }: PropTypes): JSX.Element {
 	const { protocol, host, pathname } = window.location;
 	const urlWithoutParams = `${protocol}//${host}${pathname}`;
@@ -124,7 +124,7 @@ function Links({
 							(text === 'Newspaper' && isNotUk) ||
 							(text === 'Subscriptions' && isNotUk)
 						) {
-							if (isNewProduct) {
+							if (hideDigiSub) {
 								return false;
 							}
 						}

--- a/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.tsx
+++ b/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.tsx
@@ -26,7 +26,6 @@ type PropTypes = {
 	campaignSettings: CampaignSettings | null;
 	amount: number;
 	currency: IsoCurrency;
-	userInNewProductTest: boolean;
 };
 
 // ----- Component ----- //
@@ -147,7 +146,7 @@ function TermsPrivacy(props: PropTypes): ReactElement {
 	return (
 		<>
 			<div className="component-terms-privacy">
-				{props.contributionType !== 'ONE_OFF' && !props.userInNewProductTest && (
+				{props.contributionType !== 'ONE_OFF' && (
 					<div className="component-terms-privacy__change">
 						{recurringCopy()}{' '}
 						<strong>

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -133,25 +133,6 @@ export const tests: Tests = {
 		seed: 13,
 		optimizeId: 'LFdPJnrvTu6re1oxnYdSvA',
 	},
-	newProduct: {
-		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'variant',
-			},
-		],
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		isActive: false,
-		referrerControlled: false,
-		seed: 14,
-	},
 	supporterPlus: {
 		variants: [
 			{

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -285,8 +285,6 @@ const getContributeButtonCopy = (
 	maybeOtherAmount: string | null,
 	selectedAmounts: SelectedAmounts,
 	currency: IsoCurrency,
-	showBenefitsMessaging: boolean,
-	userInBenefitsVariant: boolean,
 ): string => {
 	const frequency = getFrequency(contributionType);
 	const amount =
@@ -303,9 +301,7 @@ const getContributeButtonCopy = (
 		  )
 		: '';
 
-	const verb =
-		showBenefitsMessaging && userInBenefitsVariant ? 'Pay' : 'Contribute';
-	return `${verb} ${amountCopy} ${frequency}`;
+	return `Contribute ${amountCopy} ${frequency}`;
 };
 
 const getContributeButtonCopyWithPaymentType = (
@@ -314,8 +310,6 @@ const getContributeButtonCopyWithPaymentType = (
 	selectedAmounts: SelectedAmounts,
 	currency: IsoCurrency,
 	paymentMethod: PaymentMethod,
-	showBenefitsMessaging: boolean,
-	userInBenefitsVariant: boolean,
 ): string => {
 	const paymentDescriptionCopy = getPaymentDescription(
 		contributionType,
@@ -326,8 +320,6 @@ const getContributeButtonCopyWithPaymentType = (
 		maybeOtherAmount,
 		selectedAmounts,
 		currency,
-		showBenefitsMessaging,
-		userInBenefitsVariant,
 	);
 	return `${contributionButtonCopy} ${paymentDescriptionCopy}`;
 };

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.tsx
@@ -67,8 +67,6 @@ import ContributionErrorMessage from './ContributionErrorMessage';
 import ContributionFormFields from './ContributionFormFields';
 import ContributionSubmit from './ContributionSubmit';
 import ContributionTypeTabs from './ContributionTypeTabs';
-import BenefitsBulletPoints from './DigiSubBenefits/BenefitsBulletPoints';
-import { shouldShowBenefitsMessaging } from './DigiSubBenefits/helpers';
 import StripeCardFormContainer from './StripeCardForm/StripeCardFormContainer';
 import StripePaymentRequestButton from './StripePaymentRequestButton';
 
@@ -123,9 +121,6 @@ const mapStateToProps = (state: ContributionsState) => {
 		sepa: state.page.checkoutForm.payment.sepa,
 		productSetAbTestVariant:
 			state.common.abParticipations.productSetTest === 'variant',
-		isInNewProductTest:
-			state.common.abParticipations.newProduct === 'variant' &&
-			contributionType !== 'ONE_OFF',
 		switches: state.common.settings.switches,
 	};
 };
@@ -178,13 +173,6 @@ function PaymentMethodSelectorLegend() {
 function ContributionForm(props: PropTypes): JSX.Element {
 	const baseClass = 'form';
 	const classModifiers = ['contribution', 'with-labels'];
-
-	const showBenefitsMessaging = shouldShowBenefitsMessaging(
-		props.contributionType,
-		props.selectedAmounts,
-		props.otherAmounts,
-		props.countryGroupId,
-	);
 
 	function setUseLocalCurrency(
 		useLocalCurrency: boolean,
@@ -387,16 +375,6 @@ function ContributionForm(props: PropTypes): JSX.Element {
 					</CheckboxGroup>
 				)}
 			</div>
-
-			{props.isInNewProductTest && (
-				<BenefitsBulletPoints
-					showBenefitsMessaging={showBenefitsMessaging}
-					countryGroupId={props.countryGroupId}
-					contributionType={props.contributionType}
-					setSelectedAmount={props.setSelectedAmount}
-				/>
-			)}
-
 			<StripePaymentRequestButton
 				contributionType={props.contributionType}
 				isTestUser={props.isTestUser}
@@ -483,8 +461,6 @@ function ContributionForm(props: PropTypes): JSX.Element {
 
 				<ContributionSubmit
 					onPaymentAuthorisation={props.onPaymentAuthorisation}
-					showBenefitsMessaging={showBenefitsMessaging}
-					userInNewProductTest={props.isInNewProductTest}
 				/>
 			</div>
 
@@ -498,7 +474,6 @@ function ContributionForm(props: PropTypes): JSX.Element {
 					props.otherAmounts,
 					props.contributionType,
 				)}
-				userInNewProductTest={props.isInNewProductTest}
 			/>
 			{props.isWaiting ? (
 				<ProgressMessage message={['Processing transaction', 'Please wait']} />

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.tsx
@@ -54,8 +54,6 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 
 type PropTypes = ConnectedProps<typeof connector> & {
 	onPaymentAuthorisation: (arg0: PaymentAuthorisation) => void;
-	showBenefitsMessaging: boolean;
-	userInNewProductTest: boolean;
 };
 
 // ----- Render ----- //
@@ -80,8 +78,6 @@ function ContributionSubmit(props: PropTypes) {
 		props.selectedAmounts,
 		props.currency,
 		props.paymentMethod,
-		props.showBenefitsMessaging,
-		props.userInNewProductTest,
 	);
 
 	const { loginObject, paymentsObject } = useAmazonPayObjects(

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.tsx
@@ -25,7 +25,6 @@ import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import type { User } from 'helpers/user/userReducer';
 import { largeDonations } from 'pages/supporter-plus-thank-you/supporterPlusThankYou';
-import { showBenefitsThankYouText as shouldShowBenefitsThankYouText } from '../DigiSubBenefits/helpers';
 import ContributionThankYouAusMap from './ContributionThankYouAusMap';
 import ContributionThankYouHeader from './ContributionThankYouHeader';
 import ContributionThankYouMarketingConsent from './ContributionThankYouMarketingConsent';
@@ -166,7 +165,6 @@ const mapStateToProps = (state: ContributionsState) => {
 		paymentMethod: state.page.checkoutForm.payment.paymentMethod.name,
 		countryId: state.common.internationalisation.countryId,
 		campaignCode: state.common.referrerAcquisitionData.campaignCode,
-		isInNewProductTest: state.common.abParticipations.newProduct === 'variant',
 	};
 };
 
@@ -182,7 +180,6 @@ function ContributionThankYou({
 	paymentMethod,
 	countryId,
 	campaignCode,
-	isInNewProductTest,
 }: ContributionThankYouProps) {
 	const isNewAccount = userTypeFromIdentityResponse === 'new';
 
@@ -274,10 +271,6 @@ function ContributionThankYou({
 	const firstColumn = shownComponents.slice(0, numberOfComponentsInFirstColumn);
 	const secondColumn = shownComponents.slice(numberOfComponentsInFirstColumn);
 
-	const showNewProductThankYouText =
-		isInNewProductTest &&
-		shouldShowBenefitsThankYouText(countryId, amount, contributionType);
-
 	return (
 		<div css={container}>
 			<div css={headerContainer}>
@@ -293,7 +286,6 @@ function ContributionThankYou({
 						contributionType,
 						paymentMethod,
 					)}
-					showNewProductThankYouText={showNewProductThankYouText}
 				/>
 			</div>
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.tsx
@@ -143,7 +143,6 @@ type ContributionThankYouProps = {
 	paymentMethod: PaymentMethod;
 	countryId: IsoCountry;
 	campaignCode?: string;
-	isInNewProductTest: boolean;
 };
 
 const mapStateToProps = (state: ContributionsState) => {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.tsx
@@ -54,26 +54,20 @@ type ContributionThankYouHeaderProps = {
 	amount: number;
 	currency: IsoCurrency;
 	shouldShowLargeDonationMessage: boolean;
-	showNewProductThankYouText: boolean;
 };
 
 const MAX_DISPLAY_NAME_LENGTH = 10;
 
 function AdditionalCopy({
 	shouldShowLargeDonationMessage,
-	showNewProductThankYouText,
 	contributionType,
 }: {
 	shouldShowLargeDonationMessage: boolean;
-	showNewProductThankYouText: boolean;
 	contributionType: ContributionType;
 }) {
 	const mainText = shouldShowLargeDonationMessage
 		? 'It’s not every day we receive such a generous contribution – thank you. We’ll be in touch to bring you closer to our journalism. Please select the extra add-ons that suit you best. '
 		: 'To support us further, and enhance your experience with the Guardian, select the add-ons that suit you best. As you’re now a valued supporter, we’ll be in touch to bring you closer to our journalism. ';
-
-	const benefitsThresholdIsMetText =
-		'You have unlocked access to the Guardian’s digital subscription, offering you the best possible experience of our independent journalism. Look out for emails from us shortly, so you can activate your exclusive extras. In the meantime, please select the add-ons that suit you best.';
 
 	function MarketingCopy() {
 		return (
@@ -86,10 +80,8 @@ function AdditionalCopy({
 
 	return (
 		<>
-			{showNewProductThankYouText ? benefitsThresholdIsMetText : mainText}
-			{!showNewProductThankYouText && contributionType !== 'ONE_OFF' && (
-				<MarketingCopy />
-			)}
+			{mainText}
+			{contributionType !== 'ONE_OFF' && <MarketingCopy />}
 		</>
 	);
 }
@@ -115,14 +107,12 @@ function Title({
 	amount,
 	currency,
 	contributionType,
-	showNewProductThankYouText,
 }: {
 	name: string | null;
 	paymentMethod: PaymentMethod;
 	amount: number;
 	currency: IsoCurrency;
 	contributionType: ContributionType;
-	showNewProductThankYouText: boolean;
 }) {
 	const nameAndTrailingSpace: string =
 		name && name.length < MAX_DISPLAY_NAME_LENGTH ? `${name} ` : '';
@@ -157,10 +147,7 @@ function Title({
 		case 'MONTHLY':
 			return (
 				<div>
-					Thank you {nameAndTrailingSpace}for{' '}
-					{showNewProductThankYouText
-						? 'supporting us with'
-						: 'choosing to contribute'}{' '}
+					Thank you {nameAndTrailingSpace} for choosing to contribute{' '}
 					{currencyAndAmount} each month ❤️
 				</div>
 			);
@@ -168,10 +155,7 @@ function Title({
 		case 'ANNUAL':
 			return (
 				<div>
-					Thank you {nameAndTrailingSpace}for{' '}
-					{showNewProductThankYouText
-						? 'supporting us with'
-						: 'choosing to contribute'}{' '}
+					Thank you {nameAndTrailingSpace} for choosing to contribute{' '}
 					{currencyAndAmount} each year ❤️
 				</div>
 			);
@@ -193,7 +177,6 @@ function ContributionThankYouHeader({
 	amount,
 	currency,
 	shouldShowLargeDonationMessage,
-	showNewProductThankYouText,
 }: ContributionThankYouHeaderProps): JSX.Element {
 	return (
 		<header css={header}>
@@ -204,7 +187,6 @@ function ContributionThankYouHeader({
 					amount={amount}
 					currency={currency}
 					contributionType={contributionType}
-					showNewProductThankYouText={showNewProductThankYouText}
 				/>
 			</h1>
 			<p css={headerSupportingText}>
@@ -212,7 +194,6 @@ function ContributionThankYouHeader({
 				<AdditionalCopy
 					shouldShowLargeDonationMessage={shouldShowLargeDonationMessage}
 					contributionType={contributionType}
-					showNewProductThankYouText={showNewProductThankYouText}
 				/>
 			</p>
 		</header>

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.tsx
@@ -147,7 +147,7 @@ function Title({
 		case 'MONTHLY':
 			return (
 				<div>
-					Thank you {nameAndTrailingSpace} for choosing to contribute{' '}
+					Thank you {nameAndTrailingSpace}for choosing to contribute{' '}
 					{currencyAndAmount} each month ❤️
 				</div>
 			);
@@ -155,7 +155,7 @@ function Title({
 		case 'ANNUAL':
 			return (
 				<div>
-					Thank you {nameAndTrailingSpace} for choosing to contribute{' '}
+					Thank you {nameAndTrailingSpace}for choosing to contribute{' '}
 					{currencyAndAmount} each year ❤️
 				</div>
 			);

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.tsx
@@ -82,7 +82,7 @@ describe('Paper order summary', () => {
 		expect(await screen.findByText('Change')).toHaveAttribute('href', '/page');
 	});
 
-	it('displays a second product when the digital subscription is included', async () => {
+	it.skip('displays a second product when the digital subscription is included', async () => {
 		expect(await screen.findByText('Digital subscription')).toBeInTheDocument();
 	});
 
@@ -95,7 +95,7 @@ describe('Paper order summary', () => {
 		).toBeInTheDocument();
 	});
 
-	it('displays the correct short summary for mobile', async () => {
+	it.skip('displays the correct short summary for mobile', async () => {
 		expect(
 			await screen.findByText('Every day subscription card + digital'),
 		).toBeInTheDocument();
@@ -110,7 +110,7 @@ describe('Paper order summary', () => {
 		).toBeInTheDocument();
 	});
 
-	it('displays the separate price for the digital subscription', async () => {
+	it.skip('displays the separate price for the digital subscription', async () => {
 		expect(
 			await screen.findByText("You'll pay £5 per month"),
 		).toBeInTheDocument();

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.tsx
@@ -34,14 +34,8 @@ export type OrderSummaryProps = {
 function getMobileSummaryTitle(
 	productOption: ProductOptions,
 	fulfilmentOption: FulfilmentOptions,
-	includesDigiSub: boolean | null | undefined = false,
 ) {
-	return (
-		<>
-			{getOrderSummaryTitle(productOption, fulfilmentOption)}
-			{includesDigiSub && <> +&nbsp;digital</>}
-		</>
-	);
+	return getOrderSummaryTitle(productOption, fulfilmentOption);
 }
 
 function mapStateToProps(state: SubscriptionsState) {
@@ -128,11 +122,7 @@ function PaperOrderSummary(props: PropTypes) {
 		: total;
 
 	const mobileSummary = {
-		title: getMobileSummaryTitle(
-			props.productOption,
-			props.fulfilmentOption,
-			props.includesDigiSub,
-		),
+		title: getMobileSummaryTitle(props.productOption, props.fulfilmentOption),
 		price: mobilePriceStatement,
 	};
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -9,7 +9,6 @@ import {
 	TextArea,
 } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
-import * as React from 'react';
 import { connect } from 'react-redux';
 import type { ConnectedProps } from 'react-redux';
 import type { Dispatch } from 'redux';
@@ -80,7 +79,6 @@ import {
 	formatMachineDate,
 	formatUserDate,
 } from 'helpers/utilities/dateConversions';
-import AddDigiSubCta from 'pages/paper-subscription-checkout/components/addDigiSubCta';
 import PaperOrderSummary from 'pages/paper-subscription-checkout/components/orderSummary/orderSummary';
 import { getDays } from 'pages/paper-subscription-checkout/helpers/options';
 import {
@@ -217,7 +215,7 @@ function PaperCheckoutForm(props: PropTypes) {
 	}
 
 	const [digiSubPriceString, setDigiSubPriceString] = useState<string>('');
-	const [includesDigiSub, setIncludesDigiSub] = useState<boolean>(false);
+	const [includesDigiSub] = useState<boolean>(false);
 
 	const simplePrice = digiSubPriceString.replace(/\/(.*)/, ''); // removes anything after the /
 
@@ -228,11 +226,6 @@ function PaperCheckoutForm(props: PropTypes) {
 		: simplePrice; // removes decimal point if there are no pence
 
 	const expandedPricingText = `${cleanedPrice} per month`;
-
-	function addDigitalSubscription(event: React.ChangeEvent<HTMLInputElement>) {
-		setIncludesDigiSub(event.target.checked);
-		props.setAddDigitalSubscription(event.target.checked);
-	}
 
 	useEffect(() => {
 		// Price of the 'Plus' product that corresponds to the selected product option
@@ -435,13 +428,6 @@ function PaperCheckoutForm(props: PropTypes) {
 								</Text>
 							</Rows>
 						</FormSection>
-					) : null}
-					{props.participations.newProduct ===
-					'Hide this for the time being because it is not working correctly. We can delete it when the new prop is launched and tested' ? (
-						<AddDigiSubCta
-							digiSubPrice={expandedPricingText}
-							addDigitalSubscription={addDigitalSubscription}
-						/>
 					) : null}
 					{paymentMethods.length > 0 ? (
 						<FormSection

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
@@ -81,7 +81,7 @@ function PaperLandingPage({
 			header={
 				<Header
 					countryGroupId={GBPCountries}
-					isNewProduct={hideDigitalSubscription}
+					hideDigiSub={hideDigitalSubscription}
 				/>
 			}
 			footer={paperSubsFooter}

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
@@ -7,6 +7,7 @@ import Footer from 'components/footerCompliant/Footer';
 import Header from 'components/headers/header/header';
 import Block from 'components/page/block';
 import Page from 'components/page/page';
+import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 import { setUpTrackingAndConsents } from 'helpers/page/page';
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
@@ -45,9 +46,11 @@ const pageQaId = 'qa-paper-subscriptions';
 function PaperLandingPage({
 	productPrices,
 	promotionCopy,
-	participations,
 }: PaperLandingPropTypes) {
-	const isNewProduct = participations.newProduct === 'variant';
+	const hideDigitalSubscription = isSwitchOn(
+		'featureSwitches.suppressDigitalSubscription',
+	);
+
 	const sanitisedPromoCopy = getPromotionCopy(promotionCopy);
 	const fulfilment: PaperFulfilmentOptions = window.location.pathname.includes(
 		'delivery',
@@ -76,7 +79,10 @@ function PaperLandingPage({
 		<Page
 			id={pageQaId}
 			header={
-				<Header countryGroupId={GBPCountries} isNewProduct={isNewProduct} />
+				<Header
+					countryGroupId={GBPCountries}
+					isNewProduct={hideDigitalSubscription}
+				/>
 			}
 			footer={paperSubsFooter}
 		>

--- a/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsLandingContent.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsLandingContent.tsx
@@ -1,4 +1,5 @@
 // components
+import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import { getSubscriptionCopy } from '../copy/subscriptionCopy';
 import type { SubscriptionsLandingPropTypes } from '../subscriptionsLandingProps';
 import FeatureHeader from './featureHeader';
@@ -15,15 +16,15 @@ function SubscriptionsLandingContent({
 		return null;
 	}
 
-	const isNewProduct = participations.newProduct === 'variant';
-	const supportMsg = isNewProduct
+	const hideDigiSub = isSwitchOn('featureSwitches.suppressDigitalSubscription');
+	const supportMsg = hideDigiSub
 		? 'Support the Guardian with a print subscription'
 		: 'Support the Guardian with a print or digital subscription';
 	const subscriptionCopy = getSubscriptionCopy(
 		countryGroupId,
 		pricingCopy,
 		participations,
-		isNewProduct,
+		hideDigiSub,
 	);
 	return (
 		<div

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
@@ -280,7 +280,7 @@ const getSubscriptionCopy = (
 	countryGroupId: CountryGroupId,
 	pricingCopy: PricingCopy,
 	participations: Participations,
-	isNewProduct?: boolean,
+	hideDigiSub?: boolean,
 ): ProductCopy[] => {
 	const isRegionWeeklyFirst = [
 		GBPCountries,
@@ -299,7 +299,7 @@ const getSubscriptionCopy = (
 			participations,
 		),
 	];
-	if (!isNewProduct) {
+	if (!hideDigiSub) {
 		if (isRegionWeeklyFirst) {
 			productcopy.push(
 				digital(countryGroupId, pricingCopy[DigitalPack], false),
@@ -313,7 +313,7 @@ const getSubscriptionCopy = (
 	if (countryGroupId === GBPCountries) {
 		productcopy.push(paper(countryGroupId, pricingCopy[Paper], false));
 	}
-	if (!isNewProduct) {
+	if (!hideDigiSub) {
 		productcopy.push(premiumApp(countryGroupId));
 	}
 	return productcopy;

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
@@ -3,6 +3,7 @@ import Footer from 'components/footerCompliant/Footer';
 import Header from 'components/headers/header/header';
 import headerWithCountrySwitcherContainer from 'components/headers/header/headerWithCountrySwitcher';
 import Page from 'components/page/page';
+import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import {
 	AUDCountries,
 	Canada,
@@ -26,7 +27,7 @@ function SubscriptionsLandingPage({
 	pricingCopy,
 	referrerAcquisitions,
 }: SubscriptionsLandingPropTypes) {
-	const isNewProduct = participations.newProduct === 'variant';
+	const hideDigiSub = isSwitchOn('featureSwitches.suppressDigitalSubscription');
 	const HeaderWithCountrySwitcher = headerWithCountrySwitcherContainer({
 		path: '/subscribe',
 		countryGroupId,
@@ -39,13 +40,13 @@ function SubscriptionsLandingPage({
 			NZDCountries,
 			International,
 		],
-		isNewProduct,
+		isNewProduct: hideDigiSub,
 	});
 	return (
 		<Page
 			header={
-				isNewProduct ? (
-					<Header countryGroupId={countryGroupId} isNewProduct={isNewProduct} />
+				hideDigiSub ? (
+					<Header countryGroupId={countryGroupId} isNewProduct={hideDigiSub} />
 				) : (
 					<HeaderWithCountrySwitcher />
 				)

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
@@ -40,13 +40,13 @@ function SubscriptionsLandingPage({
 			NZDCountries,
 			International,
 		],
-		isNewProduct: hideDigiSub,
+		hideDigiSub,
 	});
 	return (
 		<Page
 			header={
 				hideDigiSub ? (
-					<Header countryGroupId={countryGroupId} isNewProduct={hideDigiSub} />
+					<Header countryGroupId={countryGroupId} hideDigiSub={hideDigiSub} />
 				) : (
 					<HeaderWithCountrySwitcher />
 				)

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -6,6 +6,7 @@ import headerWithCountrySwitcherContainer from 'components/headers/header/header
 import Block from 'components/page/block';
 import Page from 'components/page/page';
 import GiftNonGiftCta from 'components/product/giftNonGiftCta';
+import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
 	AUDCountries,
@@ -67,7 +68,7 @@ function WeeklyLandingPage({
 	const sanitisedPromoCopy = getPromotionCopy(promotionCopy, orderIsAGift);
 	// ID for Selenium tests
 	const pageQaId = `qa-guardian-weekly${orderIsAGift ? '-gift' : ''}`;
-	const isNewProduct = participations.newProduct === 'variant';
+	const hideDigiSub = isSwitchOn('featureSwitches.suppressDigitalSubscription');
 	const Header = headerWithCountrySwitcherContainer({
 		path,
 		countryGroupId,
@@ -81,7 +82,7 @@ function WeeklyLandingPage({
 			International,
 		],
 		trackProduct: 'GuardianWeekly',
-		isNewProduct,
+		isNewProduct: hideDigiSub,
 	});
 	return (
 		<Page

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -82,7 +82,7 @@ function WeeklyLandingPage({
 			International,
 		],
 		trackProduct: 'GuardianWeekly',
-		isNewProduct: hideDigiSub,
+		hideDigiSub,
 	});
 	return (
 		<Page

--- a/support-frontend/test/admin/settings/SwitchesSpec.scala
+++ b/support-frontend/test/admin/settings/SwitchesSpec.scala
@@ -120,6 +120,10 @@ class SwitchesSpec extends AnyWordSpec with Matchers {
           |      "usStripeAccountForSingle" : {
           |        "description" : "US Stripe account for single contributions",
           |        "state" : "On"
+          |      },
+          |      "suppressDigitalSubscription" : {
+          |        "description" : "Hide links to the digital subscription landing page and checkout",
+          |        "state" : "On"
           |      }
           |    }
           |  },
@@ -158,7 +162,7 @@ class SwitchesSpec extends AnyWordSpec with Matchers {
           recurringPaymentMethods = RecurringPaymentMethodSwitches(On, On, On, On, On, On, On, Off, Off),
           subscriptionsPaymentMethods = SubscriptionsPaymentMethodSwitches(On, On, On),
           subscriptionsSwitches = SubscriptionsSwitches(On, On, On),
-          featureSwitches = FeatureSwitches(On, On),
+          featureSwitches = FeatureSwitches(On, On, On),
           campaignSwitches = CampaignSwitches(Off, Off),
           recaptchaSwitches = RecaptchaSwitches(On, On),
         ),

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -77,7 +77,7 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
         recurringPaymentMethods = RecurringPaymentMethodSwitches(On, On, On, On, Off, On, On, On, Off),
         subscriptionsPaymentMethods = SubscriptionsPaymentMethodSwitches(On, On, On),
         subscriptionsSwitches = SubscriptionsSwitches(On, On, On),
-        featureSwitches = FeatureSwitches(On, On),
+        featureSwitches = FeatureSwitches(On, On, On),
         campaignSwitches = CampaignSwitches(On, On),
         recaptchaSwitches = RecaptchaSwitches(On, On),
       ),

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -655,7 +655,7 @@ object TestData {
     recurringPaymentMethodSwitches,
     subscriptionsPaymentMethodSwitches,
     SubscriptionsSwitches(On, On, On),
-    FeatureSwitches(On, On),
+    FeatureSwitches(On, On, On),
     CampaignSwitches(On, On),
     RecaptchaSwitches(On, On),
   )


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This removes all aspects of the old `newProduct` AB test from the contributions checkout, and moves the aspect of that test that hid links to the digi sub landing page to be behind a new feature switch instead.

The switch has been added to the switchboard in all environments, so can be tested with this branch in CODE.

[**Trello Card**](https://trello.com/c/IsN6u3MO)

## Why are you doing this?

We're no longer running any testing for offering benefits on the old contributions checkout, but need to retain the ability to easily hide links to the digital subscription pages.
