### PR TITLE
Scala upgrade to 2.13.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val release = Seq[ReleaseStep](
 inThisBuild(
   Seq(
     organization := "com.gu",
-    scalaVersion := "2.13.8",
+    scalaVersion := "2.13.10",
     // https://www.scala-sbt.org/1.x/docs/Cached-Resolution.html
     updateOptions := updateOptions.value.withCachedResolution(true),
     resolvers ++= Seq(Resolver.sonatypeRepo("releases")), // libraries that haven't yet synced to maven central

--- a/support-lambdas/it-test-runner/build.sbt
+++ b/support-lambdas/it-test-runner/build.sbt
@@ -3,7 +3,7 @@ import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport.riffRaffManifestProj
 import sbt.Keys.libraryDependencies
 
 version := "0.1-SNAPSHOT"
-scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings")
+scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-release:8", "-Xfatal-warnings")
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",

--- a/support-payment-api/src/test/scala/conf/ConfigLoaderProvider.scala
+++ b/support-payment-api/src/test/scala/conf/ConfigLoaderProvider.scala
@@ -15,8 +15,9 @@ trait ConfigLoaderProvider extends BeforeAndAfterAll { self: Suite =>
   private val ssm: AWSSimpleSystemsManagement = AWSClientBuilder.buildAWSSimpleSystemsManagementClient()
   private val configLoader = new ConfigLoader(ssm)
 
-  def configForTestEnvironment[A: ParameterStoreLoadable[Environment, ?]: ClassTag](): A =
+  def configForTestEnvironment[A: ParameterStoreLoadable[Environment, *]: ClassTag](): A = {
     configLoader.loadConfig[Environment, A](Environment.Test).valueOr(throw _)
+  }
 
   override protected def afterAll(): Unit = {
     ssm.shutdown()

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -3,7 +3,7 @@ import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport.riffRaffManifestProj
 import sbt.Keys.libraryDependencies
 
 version := "0.1-SNAPSHOT"
-scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings")
+scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-release:8", "-Xfatal-warnings")
 
 libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "2.2.2",

--- a/supporter-product-data/src/test/scala/com/gu/services/S3ServiceSpec.scala
+++ b/supporter-product-data/src/test/scala/com/gu/services/S3ServiceSpec.scala
@@ -18,8 +18,6 @@ class S3ServiceSpec extends AsyncFlatSpec with Matchers {
     val filename = s"test-file-${UUID.randomUUID().toString}"
     S3Service
       .streamToS3(DEV, filename, stream, initialString.length)
-      .map(_ =>
-        Source.fromInputStream(S3Service.streamFromS3(DEV, filename).getObjectContent).mkString shouldBe initialString,
-      )
+        Source.fromInputStream(S3Service.streamFromS3(DEV, filename).getObjectContent).mkString shouldBe initialString
   }
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Upgrading Scala to 2.13.10.This  fixes security vulnerability

[**Trello Card**](https://trello.com/c/x3O4ppp3/727-scala-213x-critical-vulnerability)

## Why are you doing this?
Flagged by DevX Security a critical-severity vulnerability was discovered in Scala versions 2.13.x, and fixed in Scala 2.13.10.
