### PR TITLE
Handle bad email errors from Identity

### DIFF
--- a/support-frontend/app/actions/CustomActionBuilders.scala
+++ b/support-frontend/app/actions/CustomActionBuilders.scala
@@ -7,7 +7,7 @@ import com.gu.aws.{AwsCloudWatchMetricPut, AwsCloudWatchMetricSetup}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger.Sanitizer
 import com.gu.support.config.Stage
-import models.identity.responses.IdentityErrorResponse.IdentityError.{InvalidEmailAddress,BadEmailAddress}
+import models.identity.responses.IdentityErrorResponse.IdentityError.{InvalidEmailAddress, BadEmailAddress}
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.filters.csrf._

--- a/support-frontend/app/actions/CustomActionBuilders.scala
+++ b/support-frontend/app/actions/CustomActionBuilders.scala
@@ -7,7 +7,7 @@ import com.gu.aws.{AwsCloudWatchMetricPut, AwsCloudWatchMetricSetup}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger.Sanitizer
 import com.gu.support.config.Stage
-import models.identity.responses.IdentityErrorResponse.IdentityError.InvalidEmailAddress
+import models.identity.responses.IdentityErrorResponse.IdentityError.{InvalidEmailAddress,BadEmailAddress}
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.filters.csrf._
@@ -45,6 +45,8 @@ class CustomActionBuilders(
       if (
         result.header.status.toString.head != '2' && !result.header.reasonPhrase.contains(
           InvalidEmailAddress.errorReasonCode,
+        ) && !result.header.reasonPhrase.contains(
+          BadEmailAddress.errorReasonCode,
         )
       ) {
         SafeLogger.error(scrub"pushing alarm metric - non 2xx response ${result.toString()}")

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -17,7 +17,7 @@ import io.circe.generic.semiauto._
 import io.circe.syntax._
 import lib.PlayImplicits._
 import models.identity.responses.IdentityErrorResponse.IdentityError
-import models.identity.responses.IdentityErrorResponse.IdentityError.InvalidEmailAddress
+import models.identity.responses.IdentityErrorResponse.IdentityError.{InvalidEmailAddress,BadEmailAddress}
 import org.joda.time.DateTime
 import play.api.http.Writeable
 import play.api.libs.circe.Circe
@@ -137,6 +137,8 @@ class CreateSubscriptionController(
   private def mapIdentityErrorToCreateSubscriptionError(identityError: IdentityError) =
     if (IdentityError.isDisallowedEmailError(identityError))
       RequestValidationError(InvalidEmailAddress.errorReasonCode)
+    else if (IdentityError.isBadEmailError(identityError))
+      RequestValidationError(BadEmailAddress.errorReasonCode)
     else
       ServerError(identityError.description)
 

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -17,7 +17,7 @@ import io.circe.generic.semiauto._
 import io.circe.syntax._
 import lib.PlayImplicits._
 import models.identity.responses.IdentityErrorResponse.IdentityError
-import models.identity.responses.IdentityErrorResponse.IdentityError.{InvalidEmailAddress,BadEmailAddress}
+import models.identity.responses.IdentityErrorResponse.IdentityError.{InvalidEmailAddress, BadEmailAddress}
 import org.joda.time.DateTime
 import play.api.http.Writeable
 import play.api.libs.circe.Circe

--- a/support-frontend/app/models/identity/responses/IdentityErrorResponse.scala
+++ b/support-frontend/app/models/identity/responses/IdentityErrorResponse.scala
@@ -29,12 +29,14 @@ object IdentityErrorResponse {
   case class IdentityError(
       message: String,
       description: String,
+      context: String = "primaryEmailAddress",
   )
 
   object IdentityError {
     object InvalidEmailAddress {
-      val message = "Registration Error"
-      val description = "Please sign up using an email address from a different provider"
+      val message = "Invalid emailAddress:"
+      val description = "Please enter a valid email address"
+      val context = "primaryEmailAddress"
       val errorReasonCode = "invalid_email_address"
     }
 

--- a/support-frontend/app/models/identity/responses/IdentityErrorResponse.scala
+++ b/support-frontend/app/models/identity/responses/IdentityErrorResponse.scala
@@ -29,20 +29,27 @@ object IdentityErrorResponse {
   case class IdentityError(
       message: String,
       description: String,
-      context: String = "primaryEmailAddress",
   )
 
   object IdentityError {
     object InvalidEmailAddress {
-      val message = "Invalid emailAddress:"
-      val description = "Please enter a valid email address"
-      val context = "primaryEmailAddress"
+      val message = "Registration Error"
+      val description = "Please sign up using an email address from a different provider"
       val errorReasonCode = "invalid_email_address"
     }
 
+    object BadEmailAddress {
+      val message = "Invalid emailAddress:"
+      val description = "Please enter a valid email address"
+      val errorReasonCode = "bad_email_address"
+    }
     def isDisallowedEmailError(identityError: IdentityError): Boolean =
       identityError.message == InvalidEmailAddress.message &&
         identityError.description == InvalidEmailAddress.description
+
+    def isBadEmailError(identityError: IdentityError): Boolean =
+      identityError.message == BadEmailAddress.message &&
+        identityError.description == BadEmailAddress.description
 
     implicit val reads: Reads[IdentityError] = Json.reads[IdentityError]
   }

--- a/support-frontend/assets/helpers/forms/errorReasons.ts
+++ b/support-frontend/assets/helpers/forms/errorReasons.ts
@@ -68,7 +68,7 @@ function appropriateErrorMessage(errorReason: ErrorReason | string): string {
 			return 'Please complete all relevant fields for your saved cards and billing addresses within your browser settings and try your payment again. Alternatively, you can use the form below.';
 
 		case 'invalid_email_address':
-			return 'Please use an email address from a different provider';
+			return 'Please enter a valid email address';
 
 		default:
 			return 'The transaction was temporarily declined. Please try entering your payment details again. Alternatively, try another payment method.';

--- a/support-frontend/assets/helpers/forms/errorReasons.ts
+++ b/support-frontend/assets/helpers/forms/errorReasons.ts
@@ -70,8 +70,8 @@ function appropriateErrorMessage(errorReason: ErrorReason | string): string {
 		case 'invalid_email_address':
 			return 'Please use an email address from a different provider';
 
-    case 'bad_email_address':
-      return 'Please enter a valid email address';
+		case 'bad_email_address':
+			return 'Please enter a valid email address';
 
 		default:
 			return 'The transaction was temporarily declined. Please try entering your payment details again. Alternatively, try another payment method.';

--- a/support-frontend/assets/helpers/forms/errorReasons.ts
+++ b/support-frontend/assets/helpers/forms/errorReasons.ts
@@ -68,7 +68,10 @@ function appropriateErrorMessage(errorReason: ErrorReason | string): string {
 			return 'Please complete all relevant fields for your saved cards and billing addresses within your browser settings and try your payment again. Alternatively, you can use the form below.';
 
 		case 'invalid_email_address':
-			return 'Please enter a valid email address';
+			return 'Please use an email address from a different provider';
+
+    case 'bad_email_address':
+      return 'Please enter a valid email address';
 
 		default:
 			return 'The transaction was temporarily declined. Please try entering your payment details again. Alternatively, try another payment method.';


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

PR to handle bad email error from Identity

[**Trello Card**](https://trello.com/c/dmVAQEHA/873-handle-bad-email-error-from-identity)

## Why are you doing this?

We have the issue of "bad" email addresses being submitted on our checkouts /create endpoint.We frequently get alarms triggered by users unsuccessfully attempting to checkout on our recurring contributions / subscriptions checkouts. A lot of these alarms are down to users entering email addresses which Identity considers valid but Okta doesn't: [test@gmail.com](mailto:test@gmail.com)123.This issue occurs when we're posting to the endpoint https://idapi.code.dev-theguardian.com/guest when creating a guest identity account as part of the checkout process.

The issue we've had is in the past we've received a generic 500 from Identity which triggers a generic 500 alarm on our endpoint that calls Identity, and these generic alarms require investigation.
However Identity have recently made a change so now the /guest endpoint will return a 400 response with exactly the same body as the one returned by IDAPI's internal email validator: [guardian/identity: Pull Request 2157](https://github.com/guardian/identity/pull/2157)

This PR will
1) Report a meaningful validation error to the user and
 2) Not trigger an alarm in this scenario.
## Is this an AB test?
- [ ] Yes
- [x ] No
