### PR TITLE
Pd contribs amazonpay validation

### DIFF
--- a/support-frontend/assets/components/amazonPayForm/amazonPayForm.tsx
+++ b/support-frontend/assets/components/amazonPayForm/amazonPayForm.tsx
@@ -36,6 +36,7 @@ type PropTypes = {
 	isTestUser: boolean;
 	contributionType: ContributionType;
 	checkoutFormHasBeenSubmitted: boolean;
+	errors: AmazonPayState['errors'];
 };
 
 const getSellerId = (isTestUser: boolean): string =>

--- a/support-frontend/assets/components/amazonPayForm/amazonPayForm.tsx
+++ b/support-frontend/assets/components/amazonPayForm/amazonPayForm.tsx
@@ -151,20 +151,20 @@ function AmazonPayForm(props: PropTypes): JSX.Element | null {
 		trackComponentLoad('amazon-pay-wallet-loaded');
 		return (
 			<div>
-				{props.checkoutFormHasBeenSubmitted &&
-					!props.amazonPay.paymentSelected && (
-						<InlineError>Please select a payment method</InlineError>
-					)}
+				{props.errors.paymentSelected && (
+					<InlineError id="paymentSelected">
+						Please select a payment method
+					</InlineError>
+				)}
 				<div css={walletWidget} id="WalletWidgetDiv" />
 
 				{props.contributionType !== 'ONE_OFF' && (
 					<div>
-						{props.checkoutFormHasBeenSubmitted &&
-							!props.amazonPay.amazonBillingAgreementConsentStatus && (
-								<InlineError>
-									Please tick the box to agree to a recurring payment
-								</InlineError>
-							)}
+						{props.errors.consentStatus && (
+							<InlineError id="consentStatus">
+								Please tick the box to agree to a recurring payment
+							</InlineError>
+						)}
 						<div css={consentWidget} id="ConsentWidgetDiv" />
 					</div>
 				)}

--- a/support-frontend/assets/components/amazonPayForm/amazonPayFormContainer.tsx
+++ b/support-frontend/assets/components/amazonPayForm/amazonPayFormContainer.tsx
@@ -10,6 +10,7 @@ import {
 	setAmazonPayWalletIsStale,
 } from 'helpers/redux/checkout/payment/amazonPay/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import { getAmazonPayFormErrors } from 'helpers/redux/selectors/formValidation/paymentValidation';
 import {
 	useContributionsDispatch,
 	useContributionsSelector,
@@ -54,9 +55,8 @@ export function AmazonPayFormContainer(): JSX.Element {
 	const checkoutFormHasBeenSubmitted = useContributionsSelector(
 		(state) => state.page.form.formData.checkoutFormHasBeenSubmitted,
 	);
-	const errors = useContributionsSelector(
-		(state) => state.page.checkoutForm.payment.amazonPay.errors,
-	);
+
+	const errors = useContributionsSelector(getAmazonPayFormErrors);
 
 	function onAmazonPayWalletIsStale(isStale: boolean) {
 		dispatch(setAmazonPayWalletIsStale(isStale));

--- a/support-frontend/assets/components/amazonPayForm/amazonPayFormContainer.tsx
+++ b/support-frontend/assets/components/amazonPayForm/amazonPayFormContainer.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@guardian/source-react-components';
 import { useAmazonPayObjects } from 'helpers/customHooks/useAmazonPayObjects';
-import { useFormValidation } from 'helpers/customHooks/useFormValidation';
 import { AmazonPay } from 'helpers/forms/paymentMethods';
 import {
 	setAmazonPayBillingAgreementConsentStatus,
@@ -72,7 +71,7 @@ export function AmazonPayFormContainer(): JSX.Element {
 		dispatch(setAmazonPayBillingAgreementConsentStatus(consentStatus));
 	}
 
-	const loginWithAmazonPay = useFormValidation(function login() {
+	const loginWithAmazonPay = function login() {
 		dispatch(paymentWaiting(true));
 		trackComponentClick('amazon-pay-login-click');
 		const loginOptions = {
@@ -89,7 +88,7 @@ export function AmazonPayFormContainer(): JSX.Element {
 			});
 			dispatch(paymentWaiting(false));
 		}
-	});
+	};
 
 	return (
 		<>

--- a/support-frontend/assets/components/amazonPayForm/amazonPayFormContainer.tsx
+++ b/support-frontend/assets/components/amazonPayForm/amazonPayFormContainer.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@guardian/source-react-components';
+import { Button, InlineError } from '@guardian/source-react-components';
 import { useAmazonPayObjects } from 'helpers/customHooks/useAmazonPayObjects';
 import { AmazonPay } from 'helpers/forms/paymentMethods';
 import {
@@ -54,6 +54,9 @@ export function AmazonPayFormContainer(): JSX.Element {
 	const checkoutFormHasBeenSubmitted = useContributionsSelector(
 		(state) => state.page.form.formData.checkoutFormHasBeenSubmitted,
 	);
+	const errors = useContributionsSelector(
+		(state) => state.page.checkoutForm.payment.amazonPay.errors,
+	);
 
 	function onAmazonPayWalletIsStale(isStale: boolean) {
 		dispatch(setAmazonPayWalletIsStale(isStale));
@@ -107,16 +110,24 @@ export function AmazonPayFormContainer(): JSX.Element {
 					isTestUser={userInNewProductTest ? userInNewProductTest : false}
 					contributionType={contributionType}
 					checkoutFormHasBeenSubmitted={checkoutFormHasBeenSubmitted}
+					errors={errors}
 				/>
 			)}
 			{!hasAccessToken && amazonPayEnabled && (
-				<Button
-					type="submit"
-					aria-label={'Proceed with Amazon Pay'}
-					onClick={loginWithAmazonPay}
-				>
-					{'Proceed with Amazon Pay'}
-				</Button>
+				<>
+					{errors.paymentSelected && (
+						<InlineError id="paymentSelected">
+							Please click button to proceed
+						</InlineError>
+					)}
+					<Button
+						type="submit"
+						aria-label={'Proceed with Amazon Pay'}
+						onClick={loginWithAmazonPay}
+					>
+						{'Proceed with Amazon Pay'}
+					</Button>
+				</>
 			)}
 		</>
 	);

--- a/support-frontend/assets/components/amazonPayForm/amazonPaymentButton.tsx
+++ b/support-frontend/assets/components/amazonPayForm/amazonPaymentButton.tsx
@@ -34,7 +34,7 @@ export function AmazonPaymentButton(): JSX.Element {
 	return (
 		<DefaultPaymentButtonContainer
 			onClick={payWithAmazonPay}
-			createButtonText={(amount) => `Pay ${amount} with AmazonPay`}
+			createButtonText={(amount) => `Pay ${amount} with Amazon Pay`}
 		/>
 	);
 }

--- a/support-frontend/assets/helpers/redux/checkout/payment/amazonPay/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/amazonPay/reducer.ts
@@ -38,7 +38,7 @@ export const amazonPaySlice = createSlice({
 		builder.addCase(validateForm, (state, action) => {
 			if (action.payload === 'AmazonPay') {
 				if (!state.paymentSelected) {
-					state.errors.paymentSelected = ['Please select a payment method'];
+					state.errors.paymentSelected = ['Please proceed with Amazon Pay'];
 				}
 				if (!state.amazonBillingAgreementConsentStatus) {
 					state.errors.consentStatus = [

--- a/support-frontend/assets/helpers/redux/checkout/payment/amazonPay/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/amazonPay/reducer.ts
@@ -1,5 +1,6 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
+import { validateForm } from '../../checkoutActions';
 import { initialAmazonPayState } from './state';
 
 export const amazonPaySlice = createSlice({
@@ -17,6 +18,7 @@ export const amazonPaySlice = createSlice({
 		},
 		setAmazonPayPaymentSelected(state, action: PayloadAction<boolean>) {
 			state.paymentSelected = action.payload;
+			delete state.errors.paymentSelected;
 		},
 		setAmazonPayOrderReferenceId(state, action: PayloadAction<string>) {
 			state.orderReferenceId = action.payload;
@@ -29,7 +31,22 @@ export const amazonPaySlice = createSlice({
 			action: PayloadAction<boolean>,
 		) {
 			state.amazonBillingAgreementConsentStatus = action.payload;
+			delete state.errors.consentStatus;
 		},
+	},
+	extraReducers: (builder) => {
+		builder.addCase(validateForm, (state, action) => {
+			if (action.payload === 'AmazonPay') {
+				if (!state.paymentSelected) {
+					state.errors.paymentSelected = ['Please select a payment method'];
+				}
+				if (!state.amazonBillingAgreementConsentStatus) {
+					state.errors.consentStatus = [
+						'Please tick the box to agree to a recurring payment',
+					];
+				}
+			}
+		});
 	},
 });
 

--- a/support-frontend/assets/helpers/redux/checkout/payment/amazonPay/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/amazonPay/state.ts
@@ -6,6 +6,10 @@ export interface AmazonPayState {
 	orderReferenceId: string | null;
 	amazonBillingAgreementId?: string;
 	amazonBillingAgreementConsentStatus: boolean;
+	errors: {
+		paymentSelected?: string[];
+		consentStatus?: string[];
+	};
 }
 
 export const initialAmazonPayState: AmazonPayState = {
@@ -15,4 +19,5 @@ export const initialAmazonPayState: AmazonPayState = {
 	hasAccessToken: false,
 	fatalError: false,
 	amazonBillingAgreementConsentStatus: false,
+	errors: {},
 };

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
@@ -48,6 +48,9 @@ export function getPaymentMethodErrors(
 		case 'Sepa':
 			return payment.sepa.errors;
 
+		case 'AmazonPay':
+			return payment.amazonPay.errors;
+
 		default:
 			return {};
 	}

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
@@ -4,6 +4,7 @@ import {
 	hasPaymentRequestInterfaceClosed,
 	hasPaymentRequestPaymentFailed,
 } from 'helpers/redux/checkout/payment/paymentRequestButton/selectors';
+import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import { getOtherAmountErrors } from 'helpers/redux/selectors/formValidation/otherAmountValidation';
 import { getPersonalDetailsErrors } from './personalDetailsValidation';
@@ -32,6 +33,21 @@ export function getStripeFormErrors(
 	return { ...errors, robot_checkbox: recaptchaErrors };
 }
 
+export function getAmazonPayFormErrors(
+	state: ContributionsState,
+): ErrorCollection {
+	const contributionType = getContributionType(state);
+
+	const { errors } = state.page.checkoutForm.payment.amazonPay;
+
+	if (contributionType === 'ONE_OFF') {
+		return {
+			paymentSelected: errors.paymentSelected,
+		};
+	}
+	return errors;
+}
+
 export function getPaymentMethodErrors(
 	state: ContributionsState,
 ): ErrorCollection {
@@ -49,7 +65,7 @@ export function getPaymentMethodErrors(
 			return payment.sepa.errors;
 
 		case 'AmazonPay':
-			return payment.amazonPay.errors;
+			return getAmazonPayFormErrors(state);
 
 		default:
 			return {};


### PR DESCRIPTION
AmazonPayButton - integration with the new validation system (USD, Single Contribution, AmazonPay)

An example of the generic multi-use form validation for SupporterPlus as described here->
https://github.com/guardian/support-frontend/wiki/Form-validation

Errors include Email missing+Proceed not pressed->
![Screenshot 2022-11-25 at 16 01 51](https://user-images.githubusercontent.com/76729591/204021678-3147b0bf-ec5a-48e2-8105-7ee8e64b54f6.png)


https://trello.com/c/SH6Fl37v/895-amazonpaybutton-integration-with-the-new-validation-system

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [x] Yes
- [ ] No

To Preview ->
[https://support.thegulocal.com/us/contribute#ab-supporterPlus=variant](https://support.thegulocal.com/uk/contribute#ab-supporterPlus=variant)
