### PR TITLE
Fix warning about a discarded value

### DIFF
--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -108,7 +108,7 @@ class CreateSubscriptionController(
           case false => Left(RequestValidationError("Recaptcha validation failed"))
         }
     } else {
-      EitherT.rightT(true)
+      EitherT.rightT(())
     }
   }
 


### PR DESCRIPTION
I believe what’s happening here is that the `true` doesn’t typecheck (as the type of the expression is `EitherT[Future, ..., Unit]`), and so the compiler allows the `true` to be discarded and replaced with unit, in a similar way to the description in [this stack overflow question](https://stackoverflow.com/questions/28564324/in-scala-why-can-i-use-unit-as-return-type-here).

Replacing `true` with `()` removes the warning.