### PR TITLE
Use the new default-promos file

### DIFF
--- a/support-frontend/app/services/pricing/DefaultPromotionService.scala
+++ b/support-frontend/app/services/pricing/DefaultPromotionService.scala
@@ -38,7 +38,7 @@ class DefaultPromotionServiceS3(
 
   private val s3Uri = {
     val env = TouchPointEnvironments.fromStage(stage)
-    new AmazonS3URI(s"s3://gu-promotions-tool-private/${env.envValue}/defaultPromos.json")
+    new AmazonS3URI(s"s3://support-admin-console/${env.envValue}/default-promos.json")
   }
   private val defaultPromoCodes = new AtomicReference[DefaultPromotions](
     DefaultPromotions(guardianWeekly = Nil, paper = Nil),

--- a/support-frontend/app/services/pricing/DefaultPromotionService.scala
+++ b/support-frontend/app/services/pricing/DefaultPromotionService.scala
@@ -38,7 +38,7 @@ class DefaultPromotionServiceS3(
 
   private val s3Uri = {
     val env = TouchPointEnvironments.fromStage(stage)
-    new AmazonS3URI(s"s3://support-admin-console/${env.envValue}/default-promos.json")
+    new AmazonS3URI(s"s3://support-admin-console/$stage/default-promos.json")
   }
   private val defaultPromoCodes = new AtomicReference[DefaultPromotions](
     DefaultPromotions(guardianWeekly = Nil, paper = Nil),


### PR DESCRIPTION
## Why are you doing this?
This is part of the work to create a new default promotions tools page in RRCP (https://github.com/guardian/support-admin-console/pull/409). We need to update support-frontend to use the new default-promos.json file stored in the support-admin-console bucket. 

[**Trello Card**](https://trello.com/c/HPAIvddZ/954-use-new-defaultpromotions-file)

## Is this an AB test?
- [ ] Yes
- [x] No



