### PR TITLE
Filter invalid delivery dates from paper checkout

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -182,7 +182,17 @@ function setSubsCardStartDateInState(
 function PaperCheckoutForm(props: PropTypes) {
 	useCsrCustomerData(props.setCsrCustomerData);
 
-	const days = getDays(props.fulfilmentOption, props.productOption);
+	const invalidDeliveryDates = ['-12-25', '-01-01'];
+
+	const days = getDays(props.fulfilmentOption, props.productOption).filter(
+		(day) => {
+			const date = formatMachineDate(day);
+			return !invalidDeliveryDates.some((dateSuffix) =>
+				date.endsWith(dateSuffix),
+			);
+		},
+	);
+
 	const isHomeDelivery = props.fulfilmentOption === HomeDelivery;
 
 	const fulfilmentOptionDescriptor = isHomeDelivery
@@ -412,6 +422,7 @@ function PaperCheckoutForm(props: PropTypes) {
 											formatUserDate(day),
 											formatMachineDate(day),
 										];
+
 										return (
 											<Radio
 												label={userDate}


### PR DESCRIPTION
## What are you doing in this PR?

We need to hide some invalid delivery dates that we're currently offering from the paper checkout on support site...

Before....

![image (11)](https://user-images.githubusercontent.com/1590704/204557531-1db82991-836d-4f7c-993f-b7135d0d8d2e.png)

After...

<img width="309" alt="Screenshot 2022-11-29 at 14 35 50" src="https://user-images.githubusercontent.com/1590704/204557690-b3e1023c-660a-434e-acb4-f4a0472ab4c6.png">

