### PR TITLE
Enable SnapStart on support-workers lambdas

### DIFF
--- a/support-modules/aws/src/main/scala/com/gu/aws/AwsS3Client.scala
+++ b/support-modules/aws/src/main/scala/com/gu/aws/AwsS3Client.scala
@@ -14,7 +14,7 @@ object AwsS3Client extends AwsS3Client {
     AmazonS3ClientBuilder
       .standard()
       .withRegion(Regions.EU_WEST_1)
-      .withCredentials(CredentialsProvider)
+//      .withCredentials(CredentialsProvider)
       .build()
 
   def withStream[RESULT](block: InputStream => Try[RESULT])(uri: AmazonS3URI): Try[RESULT] = for {

--- a/support-workers/cloud-formation/src/templates/lambda.yaml
+++ b/support-workers/cloud-formation/src/templates/lambda.yaml
@@ -12,5 +12,5 @@
       S3Key: !Sub support/${Stage}/support-workers/support-workers.jar
     Runtime: "java11"
     Timeout: "60"
-#    SnapStart:
-#      ApplyOn: PublishedVersions
+    SnapStart:
+      ApplyOn: PublishedVersions

--- a/support-workers/cloud-formation/src/templates/lambda.yaml
+++ b/support-workers/cloud-formation/src/templates/lambda.yaml
@@ -12,3 +12,5 @@
       S3Key: !Sub support/${Stage}/support-workers/support-workers.jar
     Runtime: "java11"
     Timeout: "60"
+    SnapStart:
+      ApplyOn: PublishedVersions

--- a/support-workers/cloud-formation/src/templates/lambda.yaml
+++ b/support-workers/cloud-formation/src/templates/lambda.yaml
@@ -12,5 +12,5 @@
       S3Key: !Sub support/${Stage}/support-workers/support-workers.jar
     Runtime: "java11"
     Timeout: "60"
-    SnapStart:
-      ApplyOn: PublishedVersions
+#    SnapStart:
+#      ApplyOn: PublishedVersions

--- a/support-workers/src/main/scala/com/gu/services/Services.scala
+++ b/support-workers/src/main/scala/com/gu/services/Services.scala
@@ -28,7 +28,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 trait ServiceProvider {
-  private val config = Configuration.load()
+  private lazy val config = Configuration.load()
   private lazy val defaultServices: Services = new Services(false, config)
   private lazy val uatServices: Services = new Services(true, config)
   def forUser(isTestUser: Boolean): Services = if (isTestUser) uatServices else defaultServices

--- a/support-workers/src/main/scala/com/gu/services/Services.scala
+++ b/support-workers/src/main/scala/com/gu/services/Services.scala
@@ -28,7 +28,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 trait ServiceProvider {
-  private lazy val config = Configuration.load()
+  private val config = Configuration.load()
   private lazy val defaultServices: Services = new Services(false, config)
   private lazy val uatServices: Services = new Services(true, config)
   def forUser(isTestUser: Boolean): Services = if (isTestUser) uatServices else defaultServices


### PR DESCRIPTION
we need to upgrade java first - `java8.al2 is not supported for SnapStart enabled functions.`
https://aws.amazon.com/blogs/aws/new-accelerate-your-lambda-functions-with-lambda-snapstart/
*Edit*: java has been upgraded

*Edit*: tested this in CODE - no significant difference in warm-up times.
But - looking at how each lambda spends its time, they all fetch `support-workers.private.conf` from S3 during a cold start and this takes 6-7 seconds. The bad part of the cold start for these lambdas is not the init phase, it's the s3 fetch.
Some ideas -
- don't use s3, maybe parameter store?
- load config once in the first lambda and pass it through the state machine