### PR TITLE
Fix - Digi Sub gifting client-side datepicker validation

### DIFF
--- a/support-frontend/assets/components/datePicker/datePicker.tsx
+++ b/support-frontend/assets/components/datePicker/datePicker.tsx
@@ -77,7 +77,15 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
 	}
 
 	getDateString = (): string =>
-		`${this.state.year}-${this.state.month}-${this.state.day}`;
+		`${this.state.year}-${this.padZero(this.state.month)}-${this.padZero(
+			this.state.day,
+		)}`;
+
+	padZero = (singleDigit: string): string => {
+		const doubleDigit =
+			(singleDigit.length === 1 && +singleDigit < 10 ? '0' : '') + singleDigit;
+		return doubleDigit;
+	};
 
 	getDateConfirmationText = (): string => {
 		const { value } = this.props;
@@ -152,21 +160,25 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
 
 	handleInput = (value: string, field: keyof StateTypes): void => {
 		if (/^[0-9]+$/.test(value)) {
-			this.setState((prevState) => ({
-				...prevState,
-				[field]: value,
-				dateError: '',
-				dateValidated: false,
-			}));
-			this.updateStartDate();
+			this.setState(
+				(prevState) => ({
+					...prevState,
+					[field]: value,
+					dateError: '',
+					dateValidated: false,
+				}),
+				this.updateStartDate,
+			);
 		} else {
-			this.setState((prevState) => ({
-				...prevState,
-				[field]: '',
-				dateError: '',
-				dateValidated: false,
-			}));
-			this.updateStartDate();
+			this.setState(
+				(prevState) => ({
+					...prevState,
+					[field]: '',
+					dateError: '',
+					dateValidated: false,
+				}),
+				this.updateStartDate,
+			);
 		}
 	};
 

--- a/support-frontend/assets/components/datePicker/datePicker.tsx
+++ b/support-frontend/assets/components/datePicker/datePicker.tsx
@@ -77,15 +77,10 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
 	}
 
 	getDateString = (): string =>
-		`${this.state.year}-${this.padZero(this.state.month)}-${this.padZero(
-			this.state.day,
-		)}`;
-
-	padZero = (singleDigit: string): string => {
-		const doubleDigit =
-			(singleDigit.length === 1 && +singleDigit < 10 ? '0' : '') + singleDigit;
-		return doubleDigit;
-	};
+		`${this.state.year}-${this.state.month.padStart(
+			2,
+			'0',
+		)}-${this.state.day.padStart(2, '0')}`;
 
 	getDateConfirmationText = (): string => {
 		const { value } = this.props;

--- a/support-frontend/assets/components/datePicker/helpers.ts
+++ b/support-frontend/assets/components/datePicker/helpers.ts
@@ -17,7 +17,11 @@ const getLatestAvailableDateText = () => {
 
 const dateIsOutsideRange = (date: Date) => {
 	const rangeDate = getRange();
-	return DateUtils.isDayAfter(date, rangeDate);
+	const startDate = new Date();
+	return (
+		DateUtils.isDayAfter(date, rangeDate) ||
+		DateUtils.isDayBefore(date, startDate)
+	);
 };
 
 export { dateIsOutsideRange, getRange, getLatestAvailableDateText };

--- a/support-frontend/assets/components/datePicker/helpers.ts
+++ b/support-frontend/assets/components/datePicker/helpers.ts
@@ -2,20 +2,20 @@ import { DateUtils } from 'react-day-picker';
 import { daysFromNowForGift } from 'pages/digital-subscription-checkout/components/helpers';
 import { monthText } from 'pages/paper-subscription-checkout/helpers/subsCardDays';
 
-const getRange = () => {
+const getRange = (): Date => {
 	const rangeDate = new Date();
 	rangeDate.setDate(rangeDate.getDate() + daysFromNowForGift);
 	return rangeDate;
 };
 
-const getLatestAvailableDateText = () => {
+const getLatestAvailableDateText = (): string => {
 	const rangeDate = getRange();
 	return `${rangeDate.getDate()} ${
 		monthText[rangeDate.getMonth()]
 	} ${rangeDate.getFullYear()}`;
 };
 
-const dateIsOutsideRange = (date: Date) => {
+const dateIsOutsideRange = (date: Date): boolean => {
 	const rangeDate = getRange();
 	const startDate = new Date();
 	return (


### PR DESCRIPTION
Fix - Digi Sub gifting client-side datepicker validation

Bug 1
The Digi Subs Gifting checkout allows the gifter to select a date in the future on which the giftee will receive the gift via email. However the form's client side validation is not blocking invalid dates and dates in the past from being submitted. eg. I can submit the form with 01/01/2022 as my chosen gift date, or 01/01/202.

If a date in the past is accidentally submitted the email will be sent immediately - Retention have received a bug report from the contact centre about such an incident.

Bug 2
There's also another bug on the form related to the date picker. If I click the "Check date" button we see a message "Your gift will be delivered on NaN undefined Nan"

Bug 3 
Calendar should not allow dates to be selected before the current day.

## Is this an AB test?
- [ ] Yes
- [x] No


Before
<img width="368" alt="Screenshot_2022-11-30_at_15 08 12" src="https://user-images.githubusercontent.com/76729591/205089955-4a260583-5ed9-44bc-853f-b36b4c7d5fd9.png">

After
![Screenshot 2022-12-01 at 15 16 25](https://user-images.githubusercontent.com/76729591/205089982-55bde4c3-d50f-4a3e-b236-0a2336e66dea.png)



