### PR TITLE
Update it-test java version

### DIFF
--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -31,7 +31,7 @@ Resources:
         Bucket: support-workers-dist
         Key: !Sub support/${Stage}/it-test-runner/it-test-runner.jar
       MemorySize: 2048
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 300
       Environment:
         Variables:


### PR DESCRIPTION
The [it-test-runner](https://github.com/guardian/support-frontend/wiki/Automated-IT-Tests) is failing because of a recent java upgrade of support-workers. This lambda shares a build with support-workers despite being in a different part of the mono repo