### PR TITLE
Update circe to 0.14.3

### DIFF
--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -1,5 +1,5 @@
 object LibraryVersions {
-  val circeVersion = "0.14.1"
+  val circeVersion = "0.14.3"
 
   val awsClientVersion = "1.12.352"
   val awsClientVersion2 = "2.17.52"

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -25,7 +25,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
-  "io.circe" %% "circe-optics" % circeVersion,
+  "io.circe" %% "circe-optics" % "0.14.1",
   "joda-time" % "joda-time" % "2.9.9",
   "com.gu.identity" %% "identity-auth-play" % "3.255",
   "com.gu" %% "identity-test-users" % "0.8",

--- a/support-lambdas/acquisitions-firehose-transformer/build.sbt
+++ b/support-lambdas/acquisitions-firehose-transformer/build.sbt
@@ -18,3 +18,10 @@ riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := s"support:lambdas:${name.value}"
 riffRaffArtifactResources += (file(s"support-lambdas/${name.value}/cfn.yaml"), "cfn/cfn.yaml")
+
+assembly / assemblyMergeStrategy := {
+  case PathList("deriving.conf") => MergeStrategy.concat
+  case y =>
+    val oldStrategy = (assembly / assemblyMergeStrategy).value
+    oldStrategy(y)
+}


### PR DESCRIPTION
However, don’t update circe-optics, the newest version of which is still 0.14.1

Question for PR reviewers: is it ok for these versions to be different? The [release notes for circe v0.14.1](https://github.com/circe/circe/releases/tag/v0.14.1) suggest to me that it is ok, plus that there are no 0.14.2 and 0.14.3 releases for circe-optics.

This is a manual update, as the automated update failed.