### PR TITLE
Remove sixForSixSuppression A/B test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -115,24 +115,6 @@ export const tests: Tests = {
 		seed: 10,
 		optimizeId: 'dQCXBc3QQIW7M1Di_qSCHw',
 	},
-	sixForSixSuppression: {
-		variants: [
-			{
-				id: 'variant',
-			},
-		],
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		isActive: true,
-		referrerControlled: false,
-		targetPage: pageUrlRegexes.subscriptions.subsShowcaseAndWeeklyPages,
-		seed: 13,
-		optimizeId: 'LFdPJnrvTu6re1oxnYdSvA',
-	},
 	supporterPlus: {
 		variants: [
 			{

--- a/support-frontend/assets/helpers/productPrice/billingPeriods.ts
+++ b/support-frontend/assets/helpers/productPrice/billingPeriods.ts
@@ -25,13 +25,7 @@ export type WeeklyBillingPeriod =
 
 export type ContributionBillingPeriod = typeof Monthly | typeof Annual;
 
-const weeklyBillingPeriods = (
-	enableSixForSix: boolean,
-): WeeklyBillingPeriod[] => {
-	if (enableSixForSix) {
-		return [SixWeekly, postIntroductorySixForSixBillingPeriod, Annual];
-	}
-
+const weeklyBillingPeriods = (): WeeklyBillingPeriod[] => {
 	return [Monthly, Quarterly, Annual];
 };
 

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
@@ -16,12 +16,7 @@ import {
 	GBPCountries,
 	NZDCountries,
 } from 'helpers/internationalisation/countryGroup';
-import {
-	currencies,
-	detect,
-	fromCountryGroupId,
-	glyph,
-} from 'helpers/internationalisation/currency';
+import { currencies, detect } from 'helpers/internationalisation/currency';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import { Monthly } from 'helpers/productPrice/billingPeriods';
 import {
@@ -91,11 +86,7 @@ const getDisplayPriceGWGiftingChristmas = (
 	return `${currency}${fixDecimals(prices[countryGroupId])}/Annual`;
 };
 
-function getGuardianWeeklyOfferCopy(
-	countryGroupId: CountryGroupId,
-	discountCopy: string,
-	participations: Participations,
-) {
+function getGuardianWeeklyOfferCopy(discountCopy: string) {
 	/**
 	 * Temporary solution promoting Guardian Weekly Gifting Christmas
 	 * offer in the Guardian Weekly section of subs landing page
@@ -106,12 +97,7 @@ function getGuardianWeeklyOfferCopy(
 		return discountCopy;
 	}
 
-	if (participations.sixForSixSuppression === 'variant') {
-		return undefined;
-	}
-
-	const currency = glyph(fromCountryGroupId(countryGroupId));
-	return `6 issues for ${currency}6`;
+	return '';
 }
 
 const getDigitalImage = (isTop: boolean, countryGroupId: CountryGroupId) => {
@@ -176,11 +162,7 @@ const guardianWeekly = (
 	subtitle: getDisplayPriceGWGiftingChristmas(countryGroupId),
 	description:
 		'Give someone answers and insights that go beyond the headlines, and into the issues that matter most. They can enjoy handpicked articles from the Guardian and Observer, curated into one magazine and delivered for free, wherever they are in the world. Plus, for a limited time, gift a whole year’s subscription, for half the usual price.',
-	offer: getGuardianWeeklyOfferCopy(
-		countryGroupId,
-		priceCopy.discountCopy,
-		participations,
-	),
+	offer: getGuardianWeeklyOfferCopy(priceCopy.discountCopy),
 	buttons: [
 		{
 			ctaButtonText: 'See gift options',

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -101,7 +101,6 @@ function mapStateToProps(state: SubscriptionsState) {
 		currencyId:
 			currencyFromCountryCode(deliveryAddress.fields.country) ?? 'USD',
 		payPalHasLoaded: state.page.checkoutForm.payment.payPal.hasLoaded,
-		participations: state.common.abParticipations,
 		price: selectPriceForProduct(state),
 	};
 }
@@ -323,9 +322,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 					<BillingPeriodSelector
 						fulfilmentOption={props.fulfilmentOption}
 						onChange={(billingPeriod) => props.setBillingPeriod(billingPeriod)}
-						billingPeriods={weeklyBillingPeriods(
-							props.participations.sixForSixSuppression !== 'variant',
-						)}
+						billingPeriods={weeklyBillingPeriods()}
 						pricingCountry={props.deliveryCountry}
 						productPrices={props.productPrices}
 						selected={props.billingPeriod}

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
@@ -1,5 +1,4 @@
 import type { Product } from 'components/product/productOption';
-import type { Participations } from 'helpers/abTests/abtest';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { currencies } from 'helpers/internationalisation/currency';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
@@ -110,18 +109,16 @@ type WeeklyProductPricesProps = {
 	countryId: IsoCountry;
 	productPrices: ProductPrices | null | undefined;
 	orderIsAGift: boolean;
-	participations: Participations;
 };
 
 const getProducts = ({
 	countryId,
 	productPrices,
 	orderIsAGift,
-	participations,
 }: WeeklyProductPricesProps): Product[] => {
 	const billingPeriodsToUse = orderIsAGift
 		? weeklyGiftBillingPeriods
-		: weeklyBillingPeriods(participations.sixForSixSuppression !== 'variant');
+		: weeklyBillingPeriods();
 
 	return billingPeriodsToUse.map((billingPeriod) => {
 		const productPrice = productPrices
@@ -145,7 +142,6 @@ function WeeklyProductPrices({
 	countryId,
 	productPrices,
 	orderIsAGift,
-	participations,
 }: WeeklyProductPricesProps): JSX.Element | null {
 	if (!productPrices) {
 		return null;
@@ -155,7 +151,6 @@ function WeeklyProductPrices({
 		countryId,
 		productPrices,
 		orderIsAGift,
-		participations,
 	});
 	return <Prices products={products} orderIsAGift={orderIsAGift} />;
 }

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -115,7 +115,6 @@ function WeeklyLandingPage({
 						countryId={countryId}
 						productPrices={productPrices}
 						orderIsAGift={orderIsAGift ?? false}
-						participations={participations}
 					/>
 				</CentredContainer>
 			</FullWidthContainer>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This removes the `sixForSixSuppression` A/B test and makes excluding the six for six offer the default on Guardian Weekly pages.

[**Trello Card**](https://trello.com/c/QoztCe0Z)

## Why are you doing this?

The test was obsolete as 100% of users were in the variant.