### PR TITLE
Updated alarms for SupporterPlus post CD failure in Riff-Raff

### DIFF
--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -222,9 +222,9 @@ Resources:
       Statistic: Sum
     DependsOn: SupportWorkersPROD
 
-  NoPayPalContributionsInTwoHoursAlarm:
+  NoPaypalContributionsInTwoHoursAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: CreateCodeResources
+    Condition: CreateProdResources
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
@@ -271,11 +271,11 @@ Resources:
       Threshold: 0
       EvaluationPeriods: 24
       TreatMissingData: breaching
-    DependsOn: SupportWorkersCODE
+    DependsOn: SupportWorkersPROD
 
   NoStripeContributionsInTwoHoursAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: CreateCodeResources
+    Condition: CreateProdResources
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
@@ -322,7 +322,7 @@ Resources:
       Threshold: 0
       EvaluationPeriods: 24
       TreatMissingData: breaching
-    DependsOn: SupportWorkersCODE
+    DependsOn: SupportWorkersPROD
 
   # Why 10 hours for gocardless? Well...
   #
@@ -337,7 +337,7 @@ Resources:
   #
   NoGocardlessContributionsInTenHoursAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: CreateCodeResources
+    Condition: CreateProdResources
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
@@ -384,7 +384,7 @@ Resources:
       Threshold: 0
       EvaluationPeriods: 120
       TreatMissingData: breaching
-    DependsOn: SupportWorkersCODE
+    DependsOn: SupportWorkersPROD
 
   # This alarm is for the PaymentSuccess metric where
   # ProductType == Paper AND PaymentProvider in [Stripe, Gocardless, Paypal]

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -222,7 +222,7 @@ Resources:
       Statistic: Sum
     DependsOn: SupportWorkersPROD
 
-  NoPayPalContributionsInTwoHoursAlarm:
+  NoPaypalContributionsInTwoHoursAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateCodeResources
     Properties:

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -224,7 +224,7 @@ Resources:
 
   NoPayPalContributionsInTwoHoursAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: CreateProdResources
+    Condition: CreateCodeResources
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
@@ -273,11 +273,11 @@ Resources:
       EvaluationPeriods: 2
       Statistic: Sum
       TreatMissingData: breaching
-    DependsOn: SupportWorkersPROD
+    DependsOn: SupportWorkersCODE
 
   NoStripeContributionsInTwoHoursAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: CreateProdResources
+    Condition: CreateCodeResources
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
@@ -326,7 +326,7 @@ Resources:
       EvaluationPeriods: 2
       Statistic: Sum
       TreatMissingData: breaching
-    DependsOn: SupportWorkersPROD
+    DependsOn: SupportWorkersCODE
 
   # Why 10 hours for gocardless? Well...
   #
@@ -341,7 +341,7 @@ Resources:
   #
   NoGocardlessContributionsInTenHoursAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: CreateProdResources
+    Condition: CreateCodeResources
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
@@ -390,7 +390,7 @@ Resources:
       EvaluationPeriods: 10
       Statistic: Sum
       TreatMissingData: breaching
-    DependsOn: SupportWorkersPROD
+    DependsOn: SupportWorkersCODE
 
   # This alarm is for the PaymentSuccess metric where
   # ProductType == Paper AND PaymentProvider in [Stripe, Gocardless, Paypal]

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -269,9 +269,7 @@ Resources:
           ReturnData: false
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 0
-      Period: 3600
-      EvaluationPeriods: 2
-      Statistic: Sum
+      EvaluationPeriods: 24
       TreatMissingData: breaching
     DependsOn: SupportWorkersCODE
 
@@ -322,9 +320,7 @@ Resources:
           ReturnData: false
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 0
-      Period: 3600
-      EvaluationPeriods: 2
-      Statistic: Sum
+      EvaluationPeriods: 24
       TreatMissingData: breaching
     DependsOn: SupportWorkersCODE
 
@@ -386,9 +382,7 @@ Resources:
           ReturnData: false
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 0
-      Period: 3600
-      EvaluationPeriods: 10
-      Statistic: Sum
+      EvaluationPeriods: 120
       TreatMissingData: breaching
     DependsOn: SupportWorkersCODE
 

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -222,7 +222,7 @@ Resources:
       Statistic: Sum
     DependsOn: SupportWorkersPROD
 
-  NoPaypalContributionsInTwoHoursAlarm:
+  NoPayPalContributionsInTwoHoursAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateCodeResources
     Properties:


### PR DESCRIPTION

Co-authored by : **Emily Bourke**

## What are you doing in this PR?
PR to update New Alarm: No successful recurring [PAYMENT METHOD] SupporterPlus contributions for two hours as the Continuous Deployment  through Riff-Raff failed  to update the alarms.


[**Trello Card**](https://trello.com/c/bXhgCQUs/907-new-alarm-no-successful-recurring-payment-method-supporterplus-contributions-for-two-hours)

## Why are you doing this?
Continuous Deployment  through Riff-Raff failed  to update the alarms due  to duplicate alarm names and unnecessary setting of Statistic  field.


