### PR TITLE
Set up reducer for existing payment methods

### DIFF
--- a/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
+++ b/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
@@ -8,15 +8,15 @@ import { onThirdPartyPaymentAuthorised } from 'pages/contributions-landing/contr
 
 export function ExistingCardPaymentButton(): JSX.Element {
 	const dispatch = useContributionsDispatch();
-	const { existingPaymentMethod } = useContributionsSelector(
-		(state) => state.page.form,
+	const { selectedPaymentMethod } = useContributionsSelector(
+		(state) => state.page.checkoutForm.payment.existingPaymentMethods,
 	);
 
 	const payWithExistingCard = useFormValidation(function pay() {
 		void dispatch(
 			onThirdPartyPaymentAuthorised({
 				paymentMethod: 'ExistingCard',
-				billingAccountId: existingPaymentMethod?.billingAccountId ?? '',
+				billingAccountId: selectedPaymentMethod?.billingAccountId ?? '',
 			}),
 		);
 	});

--- a/support-frontend/assets/components/existingMethodPaymentButton/existingDirectDebitPaymentButton.tsx
+++ b/support-frontend/assets/components/existingMethodPaymentButton/existingDirectDebitPaymentButton.tsx
@@ -8,15 +8,15 @@ import { onThirdPartyPaymentAuthorised } from 'pages/contributions-landing/contr
 
 export function ExistingDirectDebitPaymentButton(): JSX.Element {
 	const dispatch = useContributionsDispatch();
-	const { existingPaymentMethod } = useContributionsSelector(
-		(state) => state.page.form,
+	const { selectedPaymentMethod } = useContributionsSelector(
+		(state) => state.page.checkoutForm.payment.existingPaymentMethods,
 	);
 
 	const payWithExistingDD = useFormValidation(function pay() {
 		void dispatch(
 			onThirdPartyPaymentAuthorised({
 				paymentMethod: 'ExistingDirectDebit',
-				billingAccountId: existingPaymentMethod?.billingAccountId ?? '',
+				billingAccountId: selectedPaymentMethod?.billingAccountId ?? '',
 			}),
 		);
 	});

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -65,7 +65,7 @@ function PaymentMethodSelectorContainer({
 		(state) => state.page.form,
 	);
 	const { existingPaymentMethods } = useContributionsSelector(
-		(state) => state.common,
+		(state) => state.page.checkoutForm.payment,
 	);
 	const { switches } = useContributionsSelector(
 		(state) => state.common.settings,
@@ -78,25 +78,19 @@ function PaymentMethodSelectorContainer({
 		countryGroupId,
 	);
 
-	// We check on page init if we should try to retrieve existing payment methods from MDAPI
-	// If we are in the process of retrieving them but the request is still pending, the value will be undefined.
-	// If we know we're not retrieving them the value is immediately set to an empty array
-	// TODO: Do this in a less weird way with a proper thunk and pending state!
-	const pendingExistingPaymentMethods = existingPaymentMethods === undefined;
-
 	return render({
 		availablePaymentMethods: availablePaymentMethods,
 		paymentMethod: name,
 		existingPaymentMethod,
 		existingPaymentMethodList: existingPaymentMethodsToDisplay(
 			contributionType,
-			existingPaymentMethods,
+			existingPaymentMethods.paymentMethods,
 		),
 		validationError: errors?.[0],
-		pendingExistingPaymentMethods,
+		pendingExistingPaymentMethods: existingPaymentMethods.status === 'pending',
 		showReauthenticateLink: showReauthenticationLink(
 			contributionType,
-			existingPaymentMethods,
+			existingPaymentMethods.paymentMethods,
 		),
 	});
 }

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -1,11 +1,19 @@
+import { useEffect } from 'react';
 import { getValidPaymentMethods } from 'helpers/forms/checkouts';
+import type { RecentlySignedInExistingPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
+import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import {
 	ExistingCard,
 	ExistingDirectDebit,
 } from 'helpers/forms/paymentMethods';
+import { selectExistingPaymentMethod } from 'helpers/redux/checkout/payment/existingPaymentMethods/actions';
 import type { ExistingPaymentMethodsState } from 'helpers/redux/checkout/payment/existingPaymentMethods/state';
+import { setPaymentMethod } from 'helpers/redux/checkout/payment/paymentMethod/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
-import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
 import type { PaymentMethodSelectorProps } from './paymentMethodSelector';
 
 function getExistingPaymentMethodProps(
@@ -39,6 +47,7 @@ function PaymentMethodSelectorContainer({
 		paymentMethodSelectorProps: PaymentMethodSelectorProps,
 	) => JSX.Element;
 }): JSX.Element {
+	const dispatch = useContributionsDispatch();
 	const contributionType = useContributionsSelector(getContributionType);
 
 	const { countryId, countryGroupId } = useContributionsSelector(
@@ -66,11 +75,26 @@ function PaymentMethodSelectorContainer({
 			methodName !== ExistingCard && methodName !== ExistingDirectDebit,
 	);
 
+	function onSelectPaymentMethod(
+		paymentMethod: PaymentMethod,
+		existingPaymentMethod?: RecentlySignedInExistingPaymentMethod,
+	) {
+		dispatch(setPaymentMethod(paymentMethod));
+		existingPaymentMethod &&
+			dispatch(selectExistingPaymentMethod(existingPaymentMethod));
+	}
+
+	useEffect(() => {
+		availablePaymentMethods.length === 1 &&
+			dispatch(setPaymentMethod(availablePaymentMethods[0]));
+	}, []);
+
 	return render({
 		availablePaymentMethods: availablePaymentMethods,
 		paymentMethod: name,
 		validationError: errors?.[0],
 		...getExistingPaymentMethodProps(existingPaymentMethods),
+		onSelectPaymentMethod,
 	});
 }
 

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -61,9 +61,6 @@ function PaymentMethodSelectorContainer({
 		(state) => state.page.checkoutForm.payment.paymentMethod,
 	);
 
-	const { existingPaymentMethod } = useContributionsSelector(
-		(state) => state.page.form,
-	);
 	const { existingPaymentMethods } = useContributionsSelector(
 		(state) => state.page.checkoutForm.payment,
 	);
@@ -81,7 +78,7 @@ function PaymentMethodSelectorContainer({
 	return render({
 		availablePaymentMethods: availablePaymentMethods,
 		paymentMethod: name,
-		existingPaymentMethod,
+		existingPaymentMethod: existingPaymentMethods.selectedPaymentMethod,
 		existingPaymentMethodList: existingPaymentMethodsToDisplay(
 			contributionType,
 			existingPaymentMethods.paymentMethods,

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -1,4 +1,8 @@
 import { getValidPaymentMethods } from 'helpers/forms/checkouts';
+import {
+	ExistingCard,
+	ExistingDirectDebit,
+} from 'helpers/forms/paymentMethods';
 import type { ExistingPaymentMethodsState } from 'helpers/redux/checkout/payment/existingPaymentMethods/state';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
@@ -7,20 +11,24 @@ import type { PaymentMethodSelectorProps } from './paymentMethodSelector';
 function getExistingPaymentMethodProps(
 	existingPaymentMethods: ExistingPaymentMethodsState,
 ) {
-	const showReauthenticateLink =
-		existingPaymentMethods.showExistingPaymentMethods &&
-		existingPaymentMethods.showReauthenticateLink;
+	if (existingPaymentMethods.showExistingPaymentMethods) {
+		const showReauthenticateLink =
+			existingPaymentMethods.showReauthenticateLink;
 
-	const existingPaymentMethodList =
-		existingPaymentMethods.showExistingPaymentMethods
-			? existingPaymentMethods.paymentMethods
-			: [];
+		const existingPaymentMethodList = existingPaymentMethods.paymentMethods;
 
+		return {
+			existingPaymentMethod: existingPaymentMethods.selectedPaymentMethod,
+			existingPaymentMethodList,
+			pendingExistingPaymentMethods:
+				existingPaymentMethods.status === 'pending',
+			showReauthenticateLink,
+		};
+	}
 	return {
-		existingPaymentMethod: existingPaymentMethods.selectedPaymentMethod,
-		existingPaymentMethodList,
+		existingPaymentMethodList: [],
 		pendingExistingPaymentMethods: existingPaymentMethods.status === 'pending',
-		showReauthenticateLink,
+		showReauthenticateLink: false,
 	};
 }
 
@@ -53,6 +61,9 @@ function PaymentMethodSelectorContainer({
 		switches,
 		countryId,
 		countryGroupId,
+	).filter(
+		(methodName) =>
+			methodName !== ExistingCard && methodName !== ExistingDirectDebit,
 	);
 
 	return render({

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -9,10 +9,10 @@ import AnimatedDots from 'components/spinners/animatedDots';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import { mapExistingPaymentMethodToPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
+import { selectExistingPaymentMethod } from 'helpers/redux/checkout/payment/existingPaymentMethods/actions';
 import { setPaymentMethod } from 'helpers/redux/checkout/payment/paymentMethod/actions';
 import { useContributionsDispatch } from 'helpers/redux/storeHooks';
 import ContributionChoicesHeader from 'pages/contributions-landing/components/ContributionChoicesHeader';
-import { updateSelectedExistingPaymentMethod } from 'pages/contributions-landing/contributionsLandingActions';
 import { paymentMethodData } from './paymentMethodData';
 import {
 	AvailablePaymentMethodAccordionRow,
@@ -147,9 +147,7 @@ export function PaymentMethodSelector({
 											onChange={() => {
 												dispatch(setPaymentMethod(paymentType));
 												dispatch(
-													updateSelectedExistingPaymentMethod(
-														preExistingPaymentMethod,
-													),
+													selectExistingPaymentMethod(preExistingPaymentMethod),
 												);
 											}}
 											accordionBody={

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/utils';
 import { from, headline, space } from '@guardian/source-foundations';
 import { Accordion, RadioGroup } from '@guardian/source-react-components';
-import { useEffect } from 'react';
 import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';
 import { SecureTransactionIndicator } from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import AnimatedDots from 'components/spinners/animatedDots';
@@ -13,9 +12,6 @@ import {
 	subscriptionToExplainerPart,
 } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
-import { selectExistingPaymentMethod } from 'helpers/redux/checkout/payment/existingPaymentMethods/actions';
-import { setPaymentMethod } from 'helpers/redux/checkout/payment/paymentMethod/actions';
-import { useContributionsDispatch } from 'helpers/redux/storeHooks';
 import ContributionChoicesHeader from 'pages/contributions-landing/components/ContributionChoicesHeader';
 import { paymentMethodData } from './paymentMethodData';
 import { AvailablePaymentMethodAccordionRow } from './paymentMethodSelectorAccordionRow';
@@ -60,6 +56,10 @@ export interface PaymentMethodSelectorProps {
 	existingPaymentMethodList: RecentlySignedInExistingPaymentMethod[];
 	pendingExistingPaymentMethods?: boolean;
 	showReauthenticateLink?: boolean;
+	onSelectPaymentMethod: (
+		paymentMethod: PaymentMethod,
+		existingPaymentMethod?: RecentlySignedInExistingPaymentMethod,
+	) => void;
 }
 
 export function PaymentMethodSelector({
@@ -70,14 +70,8 @@ export function PaymentMethodSelector({
 	existingPaymentMethodList,
 	pendingExistingPaymentMethods,
 	showReauthenticateLink,
+	onSelectPaymentMethod,
 }: PaymentMethodSelectorProps): JSX.Element {
-	const dispatch = useContributionsDispatch();
-
-	useEffect(() => {
-		availablePaymentMethods.length === 1 &&
-			dispatch(setPaymentMethod(availablePaymentMethods[0]));
-	}, []);
-
 	if (
 		existingPaymentMethodList.length < 1 &&
 		availablePaymentMethods.length < 1
@@ -144,9 +138,9 @@ export function PaymentMethodSelector({
 												),
 											)}`}
 											onChange={() => {
-												dispatch(setPaymentMethod(paymentType));
-												dispatch(
-													selectExistingPaymentMethod(preExistingPaymentMethod),
+												onSelectPaymentMethod(
+													paymentType,
+													preExistingPaymentMethod,
 												);
 											}}
 											accordionBody={
@@ -164,7 +158,7 @@ export function PaymentMethodSelector({
 									label={paymentMethodData[method].label}
 									name="paymentMethod"
 									checked={paymentMethod === method}
-									onChange={() => dispatch(setPaymentMethod(method))}
+									onChange={() => onSelectPaymentMethod(method)}
 									accordionBody={paymentMethodData[method].accordionBody}
 								/>
 							))}

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -7,17 +7,18 @@ import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMess
 import { SecureTransactionIndicator } from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import AnimatedDots from 'components/spinners/animatedDots';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
-import { mapExistingPaymentMethodToPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
+import {
+	getExistingPaymentMethodLabel,
+	subscriptionsToExplainerList,
+	subscriptionToExplainerPart,
+} from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import { selectExistingPaymentMethod } from 'helpers/redux/checkout/payment/existingPaymentMethods/actions';
 import { setPaymentMethod } from 'helpers/redux/checkout/payment/paymentMethod/actions';
 import { useContributionsDispatch } from 'helpers/redux/storeHooks';
 import ContributionChoicesHeader from 'pages/contributions-landing/components/ContributionChoicesHeader';
 import { paymentMethodData } from './paymentMethodData';
-import {
-	AvailablePaymentMethodAccordionRow,
-	ExistingPaymentMethodAccordionRow,
-} from './paymentMethodSelectorAccordionRow';
+import { AvailablePaymentMethodAccordionRow } from './paymentMethodSelectorAccordionRow';
 import { ReauthenticateLink } from './reauthenticateLink';
 
 const container = css`
@@ -126,24 +127,22 @@ export function PaymentMethodSelector({
 											: 'ExistingDirectDebit';
 
 									return (
-										<ExistingPaymentMethodAccordionRow
-											expanded={
-												paymentMethod ===
-													mapExistingPaymentMethodToPaymentMethod(
-														preExistingPaymentMethod,
-													) &&
-												existingPaymentMethod === preExistingPaymentMethod
-											}
-											paymentMethod={paymentMethod}
-											preExistingPaymentMethod={preExistingPaymentMethod}
-											existingPaymentMethod={existingPaymentMethod}
+										<AvailablePaymentMethodAccordionRow
+											id={`paymentMethod-existing${preExistingPaymentMethod.billingAccountId}`}
+											name="paymentMethod"
+											label={getExistingPaymentMethodLabel(
+												preExistingPaymentMethod,
+											)}
+											image={paymentMethodData[paymentType].icon}
 											checked={
-												paymentMethod ===
-													mapExistingPaymentMethodToPaymentMethod(
-														preExistingPaymentMethod,
-													) &&
+												paymentMethod === paymentType &&
 												existingPaymentMethod === preExistingPaymentMethod
 											}
+											supportingText={`Used for your ${subscriptionsToExplainerList(
+												preExistingPaymentMethod.subscriptions.map(
+													subscriptionToExplainerPart,
+												),
+											)}`}
 											onChange={() => {
 												dispatch(setPaymentMethod(paymentType));
 												dispatch(

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelectorAccordionRow.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelectorAccordionRow.tsx
@@ -9,18 +9,6 @@ import {
 	space,
 	transitions,
 } from '@guardian/source-foundations';
-import {
-	SvgCreditCard,
-	SvgDirectDebit,
-} from '@guardian/source-react-components';
-import type { RecentlySignedInExistingPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
-import {
-	getExistingPaymentMethodLabel,
-	mapExistingPaymentMethodToPaymentMethod,
-	subscriptionsToExplainerList,
-	subscriptionToExplainerPart,
-} from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
-import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import { RadioWithImage } from './radioWithImage';
 
 const radio = css`
@@ -29,9 +17,7 @@ const radio = css`
 	${from.mobileLandscape} {
 		padding: ${space[2]}px ${space[4]}px;
 	}
-`;
 
-const existingPaymentMethodOverrides = css`
 	/* Normalise the positioning of the radio button when we have supporting text */
 	& > div {
 		align-items: center;
@@ -85,80 +71,13 @@ const collapsedBody = css`
 	overflow: hidden;
 `;
 
-interface ExistingPaymentMethodAccordionRowProps {
-	expanded: boolean;
-	preExistingPaymentMethod: RecentlySignedInExistingPaymentMethod;
-	onChange: () => void;
-	paymentMethod: PaymentMethod | null;
-	existingPaymentMethod: RecentlySignedInExistingPaymentMethod | undefined;
-	accordionBody?: () => JSX.Element;
-	checked: boolean;
-}
-
-export function ExistingPaymentMethodAccordionRow({
-	paymentMethod,
-	preExistingPaymentMethod,
-	existingPaymentMethod,
-	onChange,
-	expanded,
-	accordionBody,
-	checked,
-}: ExistingPaymentMethodAccordionRowProps): EmotionJSX.Element {
-	const image =
-		preExistingPaymentMethod.paymentType === 'Card' ? (
-			<SvgCreditCard />
-		) : (
-			<SvgDirectDebit />
-		);
-
-	return (
-		<div css={checked ? focused : notFocused}>
-			<div css={[...(checked && accordionBody ? [borderBottom] : [])]}>
-				<RadioWithImage
-					id={`paymentMethod-existing${preExistingPaymentMethod.billingAccountId}`}
-					name="paymentMethod"
-					onChange={onChange}
-					checked={
-						paymentMethod ===
-							mapExistingPaymentMethodToPaymentMethod(
-								preExistingPaymentMethod,
-							) && existingPaymentMethod === preExistingPaymentMethod
-					}
-					cssOverrides={[
-						radio,
-						...(checked && accordionBody ? [borderBottom] : []),
-						existingPaymentMethodOverrides,
-					]}
-					isSupporterPlus={true}
-					image={image}
-					label={getExistingPaymentMethodLabel(preExistingPaymentMethod)}
-					supportingText={`Used for your ${subscriptionsToExplainerList(
-						preExistingPaymentMethod.subscriptions.map(
-							subscriptionToExplainerPart,
-						),
-					)}`}
-				/>
-			</div>
-
-			{/* Accordion Body */}
-			<div
-				css={[
-					expanded ? expandedBody : collapsedBody,
-					...(expanded && accordionBody ? [accordionBodyPadding] : []),
-				]}
-			>
-				<div hidden={!expanded}>{accordionBody?.()}</div>
-			</div>
-		</div>
-	);
-}
-
 interface AvailablePaymentMethodAccordionRowProps {
 	id: string;
 	image: JSX.Element;
 	label: string;
 	name: string;
 	checked: boolean;
+	supportingText?: string;
 	onChange: () => void;
 	accordionBody?: () => JSX.Element;
 }
@@ -169,6 +88,7 @@ export function AvailablePaymentMethodAccordionRow({
 	label,
 	name,
 	checked,
+	supportingText,
 	accordionBody,
 	onChange,
 }: AvailablePaymentMethodAccordionRowProps): EmotionJSX.Element {
@@ -182,6 +102,7 @@ export function AvailablePaymentMethodAccordionRow({
 					name={name}
 					checked={checked}
 					onChange={onChange}
+					supportingText={supportingText}
 					cssOverrides={[
 						radio,
 						...(checked && accordionBody ? [borderBottom] : []),

--- a/support-frontend/assets/components/svgs/amazonPayLogoDs.tsx
+++ b/support-frontend/assets/components/svgs/amazonPayLogoDs.tsx
@@ -10,10 +10,10 @@ export default function SvgAmazonPayLogoDs(): JSX.Element {
 			preserveAspectRatio="xMinYMid"
 			aria-hidden="true"
 			focusable="false"
-			aria-labelledby="svgDescription"
+			aria-labelledby="svgDescriptionAmazonPay"
 			role="img"
 		>
-			<desc id="svgDescription">Amazon Pay badge</desc>
+			<desc id="svgDescriptionAmazonPay">Amazon Pay badge</desc>
 			<path
 				fillRule="evenodd"
 				clipRule="evenodd"

--- a/support-frontend/assets/components/svgs/directDebitSymbol.tsx
+++ b/support-frontend/assets/components/svgs/directDebitSymbol.tsx
@@ -7,10 +7,10 @@ export default function SvgDirectDebitSymbol(): JSX.Element {
 			preserveAspectRatio="xMinYMid"
 			fill="#212121"
 			xmlns="http://www.w3.org/2000/svg"
-			aria-labelledby="svgDescription"
+			aria-labelledby="svgDescriptionDirectDebit"
 			role="img"
 		>
-			<desc id="svgDescription">Direct Debit symbol</desc>
+			<desc id="svgDescriptionDirectDebit">Direct Debit symbol</desc>
 			<path d="M18.254 9.655v13.73s-7.444-1.436-7.444-6.893c0-4.353 5.51-6.272 7.444-6.837zm-14.618 6.55c0 3.2 5.371 7.878 14.119 8 .345 0 10.282-.41 10.129-11.817-.129-9.582-6.834-11.26-8.978-11.552V.252c8.548.58 15.27 6.078 15.27 12.75 0 7.06-7.52 12.804-16.766 12.804C8.163 25.806.68 20.06.68 13.003.681 5.945 8.163.2 17.41.2c.283 0 .565.005.844.016V9.4c-4.474-.346-14.618 1.897-14.618 6.805z" />
 		</svg>
 	);

--- a/support-frontend/assets/components/svgs/directDebitSymbolDs.tsx
+++ b/support-frontend/assets/components/svgs/directDebitSymbolDs.tsx
@@ -10,10 +10,10 @@ export default function SvgDirectDebitSymbolDs(): JSX.Element {
 			preserveAspectRatio="xMinYMid"
 			aria-hidden="true"
 			focusable="false"
-			aria-labelledby="svgDescription"
+			aria-labelledby="svgDescriptionDirectDebit"
 			role="img"
 		>
-			<desc id="svgDescription">Direct Debit symbol</desc>
+			<desc id="svgDescriptionDirectDebit">Direct Debit symbol</desc>
 			<path
 				d="M21.7332 9.79047C21.738 5.35714 19.0713 3.45238 16.0428 2.75238V2.52381C21.5428 2.80952 25.5904 6.1619 25.5904 10C25.5904 14.3809 20.8285 17.5048 14.9809 17.5C9.13323 17.4952 4.3999 14.1333 4.3999 9.98571C4.3999 5.63333 8.52847 2.5 15.5618 2.5V7.90476L13.8999 7.87143C10.338 7.99047 6.21419 9.54285 6.20943 11.6286C6.20466 13.9286 10.1142 16.6905 14.8237 16.6905C18.6332 16.6905 21.7332 13.9381 21.7332 9.79047Z"
 				fill="#052962"

--- a/support-frontend/assets/components/svgs/downChevronDs.tsx
+++ b/support-frontend/assets/components/svgs/downChevronDs.tsx
@@ -10,10 +10,10 @@ export default function DownChevronDs(): JSX.Element {
 			xmlns="http://www.w3.org/2000/svg"
 			aria-hidden="true"
 			focusable="false"
-			aria-labelledby="svgDescription"
+			aria-labelledby="svgDescriptionDownArrow"
 			role="img"
 		>
-			<desc id="svgDescription">Down arrow symbol</desc>
+			<desc id="svgDescriptionDownArrow">Down arrow symbol</desc>
 			<path
 				fillRule="evenodd"
 				clipRule="evenodd"

--- a/support-frontend/assets/components/svgs/newCreditCardDs.tsx
+++ b/support-frontend/assets/components/svgs/newCreditCardDs.tsx
@@ -12,10 +12,10 @@ export default function SvgNewCreditCardDs(): JSX.Element {
 			preserveAspectRatio="xMinYMid"
 			aria-hidden="true"
 			focusable="false"
-			aria-labelledby="svgDescription"
+			aria-labelledby="svgDescriptionCreditCard"
 			role="img"
 		>
-			<desc id="svgDescription">Credit card symbol</desc>
+			<desc id="svgDescriptionCreditCard">Credit card symbol</desc>
 			<path
 				fillRule="evenodd"
 				clipRule="evenodd"

--- a/support-frontend/assets/components/svgs/paypalDs.tsx
+++ b/support-frontend/assets/components/svgs/paypalDs.tsx
@@ -11,10 +11,10 @@ export default function SvgPayPalDs(): JSX.Element {
 			className="svg-paypal" // preserveAspectRatio="xMinYMid"
 			aria-hidden="true"
 			focusable="false"
-			aria-labelledby="svgDescription"
+			aria-labelledby="svgDescriptionPayPal"
 			role="img"
 		>
-			<desc id="svgTitle">PayPal logo</desc>
+			<desc id="svgDescriptionPayPal">PayPal logo</desc>
 			<path
 				d="M20.2203 6.06506C20.2055 6.15997 20.1885 6.257 20.1694 6.35668C19.5136 9.72401 17.2697 10.8873 14.404 10.8873H12.9449C12.5944 10.8873 12.2991 11.1418 12.2445 11.4875L11.4974 16.2254L11.2858 17.5684C11.2503 17.7953 11.4253 18 11.6543 18H14.2423C14.5487 18 14.8091 17.7773 14.8573 17.4751L14.8828 17.3436L15.37 14.2514L15.4013 14.0818C15.449 13.7785 15.7099 13.5558 16.0163 13.5558H16.4034C18.9107 13.5558 20.8735 12.5378 21.4472 9.59199C21.6869 8.36138 21.5628 7.33384 20.9287 6.61117C20.7368 6.39326 20.4987 6.21246 20.2203 6.06506Z"
 				fill="#A7B4C8"

--- a/support-frontend/assets/components/svgs/sepa.tsx
+++ b/support-frontend/assets/components/svgs/sepa.tsx
@@ -9,10 +9,10 @@ export default function SvgSepa(): JSX.Element {
 			aria-hidden="true"
 			focusable="false"
 			fill="#272727"
-			aria-labelledby="svgDescription"
+			aria-labelledby="svgDescriptionSepa"
 			role="img"
 		>
-			<desc id="svgDescription">SEPA logo</desc>
+			<desc id="svgDescriptionSepa">SEPA logo</desc>
 			<path
 				d="M0.8,18.8c2.2,0,4.3,0,6.5,0c0,0.3,0,0.6,0,0.8c0,1.4,0.7,2.3,2.1,2.3c1.6,0.1,3.2,0,4.8-0.1
   c0.9,0,1.6-0.7,1.7-1.7c0.1-0.6,0.1-1.2,0-1.8c-0.1-0.8-0.7-1.3-1.5-1.4c-1.4-0.1-2.9-0.2-4.3-0.4c-1.6-0.2-3.2-0.3-4.7-0.6

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
@@ -1,6 +1,12 @@
 // ----- Imports ----- //
 
-import { DirectDebit, PayPal, Stripe } from 'helpers/forms/paymentMethods';
+import {
+	DirectDebit,
+	ExistingCard,
+	ExistingDirectDebit,
+	PayPal,
+	Stripe,
+} from 'helpers/forms/paymentMethods';
 import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
@@ -36,7 +42,13 @@ describe('checkouts', () => {
 					countryId,
 					countryGroupId,
 				),
-			).toEqual([DirectDebit, Stripe, PayPal]);
+			).toEqual([
+				DirectDebit,
+				ExistingCard,
+				ExistingDirectDebit,
+				Stripe,
+				PayPal,
+			]);
 
 			expect(
 				getPaymentMethodToSelect(

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -149,18 +149,25 @@ function getPaymentMethods(
 	countryId: IsoCountry,
 	countryGroupId: CountryGroupId,
 ): PaymentMethod[] {
+	const nonRegionSpecificPaymentMethods: PaymentMethod[] = [
+		ExistingCard,
+		ExistingDirectDebit,
+		Stripe,
+		PayPal,
+	];
+
 	if (contributionType !== 'ONE_OFF' && countryId === 'GB') {
-		return [DirectDebit, Stripe, PayPal];
+		return [DirectDebit, ...nonRegionSpecificPaymentMethods];
 	} else if (countryId === 'US') {
-		return [Stripe, PayPal, AmazonPay];
+		return [...nonRegionSpecificPaymentMethods, AmazonPay];
 	} else if (
 		contributionType !== 'ONE_OFF' &&
 		countryGroupId === 'EURCountries'
 	) {
-		return [Sepa, Stripe, PayPal];
+		return [Sepa, ...nonRegionSpecificPaymentMethods];
 	}
 
-	return [Stripe, PayPal];
+	return nonRegionSpecificPaymentMethods;
 }
 
 function switchKeyForContributionType(

--- a/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/actions.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/actions.ts
@@ -1,0 +1,4 @@
+import { existingPaymentMethodsSlice } from './reducer';
+
+export const { selectExistingPaymentMethod } =
+	existingPaymentMethodsSlice.actions;

--- a/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/reducer.ts
@@ -1,6 +1,8 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import { Completed, Failed, Pending } from 'helpers/types/asyncStatus';
 import { logException } from 'helpers/utilities/logger';
+import type { RecentlySignedInExistingPaymentMethod } from './state';
 import { initialState } from './state';
 import { getExistingPaymentMethods } from './thunks';
 import { getExistingPaymentMethodSwitchState } from './utils';
@@ -8,7 +10,14 @@ import { getExistingPaymentMethodSwitchState } from './utils';
 export const existingPaymentMethodsSlice = createSlice({
 	name: 'existingPaymentMethods',
 	initialState,
-	reducers: {},
+	reducers: {
+		selectExistingPaymentMethod(
+			state,
+			action: PayloadAction<RecentlySignedInExistingPaymentMethod>,
+		) {
+			state.selectedPaymentMethod = action.payload;
+		},
+	},
 	extraReducers: (builder) => {
 		builder.addCase(getExistingPaymentMethods.pending, (state) => {
 			state.status = Pending;

--- a/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/reducer.ts
@@ -30,8 +30,11 @@ export const existingPaymentMethodsSlice = createSlice({
 					(paymentType === 'Card' && switchState.card) ||
 					(paymentType === 'DirectDebit' && switchState.directDebit),
 			);
-			state.existingPaymentMethods = switchedOnExistingPaymentMethods;
+			state.paymentMethods = switchedOnExistingPaymentMethods;
 			state.status = Completed;
 		});
 	},
 });
+
+export const existingPaymentMethodsReducer =
+	existingPaymentMethodsSlice.reducer;

--- a/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/reducer.ts
@@ -1,0 +1,37 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { Completed, Failed, Pending } from 'helpers/types/asyncStatus';
+import { logException } from 'helpers/utilities/logger';
+import { initialState } from './state';
+import { getExistingPaymentMethods } from './thunks';
+import { getExistingPaymentMethodSwitchState } from './utils';
+
+export const existingPaymentMethodsSlice = createSlice({
+	name: 'existingPaymentMethods',
+	initialState,
+	reducers: {},
+	extraReducers: (builder) => {
+		builder.addCase(getExistingPaymentMethods.pending, (state) => {
+			state.status = Pending;
+		});
+
+		builder.addCase(getExistingPaymentMethods.rejected, (state, action) => {
+			logException(
+				'Failed to get existing payment options',
+				action.error as Record<string, unknown>,
+			);
+			state.status = Failed;
+		});
+
+		builder.addCase(getExistingPaymentMethods.fulfilled, (state, action) => {
+			const switchState = getExistingPaymentMethodSwitchState();
+
+			const switchedOnExistingPaymentMethods = action.payload.filter(
+				({ paymentType }) =>
+					(paymentType === 'Card' && switchState.card) ||
+					(paymentType === 'DirectDebit' && switchState.directDebit),
+			);
+			state.existingPaymentMethods = switchedOnExistingPaymentMethods;
+			state.status = Completed;
+		});
+	},
+});

--- a/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/state.ts
@@ -29,6 +29,7 @@ export type ExistingPaymentMethod =
 export type ExistingPaymentMethodsState = {
 	status: AsyncStatus;
 	paymentMethods: ExistingPaymentMethod[];
+	selectedPaymentMethod?: RecentlySignedInExistingPaymentMethod;
 };
 
 export const initialState: ExistingPaymentMethodsState = {

--- a/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/state.ts
@@ -1,0 +1,37 @@
+import type { AsyncStatus } from 'helpers/types/asyncStatus';
+import { Initial } from 'helpers/types/asyncStatus';
+
+type ExistingPaymentType = 'Card' | 'DirectDebit';
+
+export type ExistingPaymentMethodSubscription = {
+	isActive: boolean;
+	isCancelled: boolean;
+	name: string;
+	billingAccountId?: string;
+};
+
+export type NotRecentlySignedInExistingPaymentMethod = {
+	paymentType: ExistingPaymentType;
+};
+
+export type RecentlySignedInExistingPaymentMethod = {
+	paymentType: ExistingPaymentType;
+	billingAccountId: string;
+	subscriptions: ExistingPaymentMethodSubscription[];
+	card?: string;
+	mandate?: string;
+};
+
+export type ExistingPaymentMethod =
+	| NotRecentlySignedInExistingPaymentMethod
+	| RecentlySignedInExistingPaymentMethod;
+
+export type ExistingPaymentMethodsState = {
+	status: AsyncStatus;
+	existingPaymentMethods: ExistingPaymentMethod[];
+};
+
+export const initialState: ExistingPaymentMethodsState = {
+	status: Initial,
+	existingPaymentMethods: [],
+};

--- a/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/state.ts
@@ -28,10 +28,10 @@ export type ExistingPaymentMethod =
 
 export type ExistingPaymentMethodsState = {
 	status: AsyncStatus;
-	existingPaymentMethods: ExistingPaymentMethod[];
+	paymentMethods: ExistingPaymentMethod[];
 };
 
 export const initialState: ExistingPaymentMethodsState = {
 	status: Initial,
-	existingPaymentMethods: [],
+	paymentMethods: [],
 };

--- a/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/state.ts
@@ -28,11 +28,15 @@ export type ExistingPaymentMethod =
 
 export type ExistingPaymentMethodsState = {
 	status: AsyncStatus;
-	paymentMethods: ExistingPaymentMethod[];
+	showExistingPaymentMethods: boolean;
+	showReauthenticateLink: boolean;
+	paymentMethods: RecentlySignedInExistingPaymentMethod[];
 	selectedPaymentMethod?: RecentlySignedInExistingPaymentMethod;
 };
 
 export const initialState: ExistingPaymentMethodsState = {
 	status: Initial,
+	showExistingPaymentMethods: true,
+	showReauthenticateLink: false,
 	paymentMethods: [],
 };

--- a/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/thunks.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/thunks.ts
@@ -1,0 +1,49 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { fetchJson } from 'helpers/async/fetch';
+import type { ExistingPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
+import { getGlobal } from 'helpers/globalsAndSwitches/globals';
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import type { ContributionsState } from 'helpers/redux/contributionsStore';
+import type { SubscriptionsState } from 'helpers/redux/subscriptionsStore';
+import { getExistingPaymentMethodSwitchState } from './utils';
+
+function isValidPaymentList(
+	paymentMethodList: unknown,
+): paymentMethodList is ExistingPaymentMethod[] {
+	return Array.isArray(paymentMethodList);
+}
+
+export const getExistingPaymentMethods = createAsyncThunk<
+	ExistingPaymentMethod[],
+	IsoCurrency,
+	{
+		state: SubscriptionsState | ContributionsState;
+	}
+>(
+	'existingPaymentMethods/getExistingPaymentMethods',
+	async function fetchExistingPaymentMethods(currency) {
+		const mdapiUrl = getGlobal<string>('mdapiUrl');
+
+		if (mdapiUrl) {
+			const existingPaymentMethods = await fetchJson(
+				`${mdapiUrl}/user-attributes/me/existing-payment-options?currencyFilter=${currency}`,
+				{
+					mode: 'cors',
+					credentials: 'include',
+				},
+			);
+			if (isValidPaymentList(existingPaymentMethods)) {
+				return existingPaymentMethods;
+			} else {
+				return [];
+			}
+		}
+		return [];
+	},
+	{
+		condition: () => {
+			const switchState = getExistingPaymentMethodSwitchState();
+			return switchState.card || switchState.directDebit;
+		},
+	},
+);

--- a/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/utils.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/utils.ts
@@ -1,4 +1,8 @@
 import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
+import type {
+	ExistingPaymentMethod,
+	RecentlySignedInExistingPaymentMethod,
+} from './state';
 
 type ExistingPaymentMethodSwitchState = {
 	directDebit: boolean;
@@ -10,4 +14,32 @@ export function getExistingPaymentMethodSwitchState(): ExistingPaymentMethodSwit
 		card: isSwitchOn('recurringPaymentMethods.existingCard'),
 		directDebit: isSwitchOn('recurringPaymentMethods.existingDirectDebit'),
 	};
+}
+
+function isUsableExistingPaymentMethod(
+	existingPaymentMethod: ExistingPaymentMethod,
+): existingPaymentMethod is RecentlySignedInExistingPaymentMethod {
+	if ('billingAccountId' in existingPaymentMethod) {
+		return !!existingPaymentMethod.billingAccountId;
+	}
+	return false;
+}
+
+export function getUsableExistingPaymentMethods(
+	paymentMethods: ExistingPaymentMethod[],
+): RecentlySignedInExistingPaymentMethod[] {
+	const switchState = getExistingPaymentMethodSwitchState();
+
+	return paymentMethods.filter<RecentlySignedInExistingPaymentMethod>(
+		(paymentMethod): paymentMethod is RecentlySignedInExistingPaymentMethod => {
+			if (isUsableExistingPaymentMethod(paymentMethod)) {
+				return (
+					(paymentMethod.paymentType === 'Card' && switchState.card) ||
+					(paymentMethod.paymentType === 'DirectDebit' &&
+						switchState.directDebit)
+				);
+			}
+			return false;
+		},
+	);
 }

--- a/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/utils.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/utils.ts
@@ -1,0 +1,13 @@
+import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
+
+type ExistingPaymentMethodSwitchState = {
+	directDebit: boolean;
+	card: boolean;
+};
+
+export function getExistingPaymentMethodSwitchState(): ExistingPaymentMethodSwitchState {
+	return {
+		card: isSwitchOn('recurringPaymentMethods.existingCard'),
+		directDebit: isSwitchOn('recurringPaymentMethods.existingDirectDebit'),
+	};
+}

--- a/support-frontend/assets/helpers/redux/checkout/payment/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/reducer.ts
@@ -3,6 +3,8 @@ import { amazonPayReducer } from './amazonPay/reducer';
 import type { AmazonPayState } from './amazonPay/state';
 import { directDebitReducer } from './directDebit/reducer';
 import type { DirectDebitState } from './directDebit/state';
+import { existingPaymentMethodsReducer } from './existingPaymentMethods/reducer';
+import type { ExistingPaymentMethodsState } from './existingPaymentMethods/state';
 import { paymentMethodReducer } from './paymentMethod/reducer';
 import type { PaymentMethodState } from './paymentMethod/state';
 import { paymentRequestButtonReducer } from './paymentRequestButton/reducer';
@@ -25,6 +27,7 @@ export type PaymentState = {
 	stripe: StripeCardState;
 	stripeAccountDetails: StripeAccountDetailsState;
 	paymentRequestButton: PaymentRequestButtonState;
+	existingPaymentMethods: ExistingPaymentMethodsState;
 };
 
 export const paymentReducer = combineReducers({
@@ -36,4 +39,5 @@ export const paymentReducer = combineReducers({
 	stripe: stripeCardReducer,
 	stripeAccountDetails: stripeAccountDetailsReducer,
 	paymentRequestButton: paymentRequestButtonReducer,
+	existingPaymentMethods: existingPaymentMethodsReducer,
 });

--- a/support-frontend/assets/helpers/redux/commonState/actions.ts
+++ b/support-frontend/assets/helpers/redux/commonState/actions.ts
@@ -3,7 +3,6 @@ import { commonSlice } from './reducer';
 export const {
 	setInitialCommonState,
 	setCountryInternationalisation,
-	setExistingPaymentMethods,
 	setContributionTypes,
 	setCurrencyId,
 	setUseLocalCurrencyFlag,

--- a/support-frontend/assets/helpers/redux/commonState/reducer.ts
+++ b/support-frontend/assets/helpers/redux/commonState/reducer.ts
@@ -4,7 +4,6 @@ import type {
 	ContributionAmounts,
 	ContributionTypes,
 } from 'helpers/contributions';
-import type { ExistingPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { fromCountry } from 'helpers/internationalisation/countryGroup';
 import { fromCountryGroupId } from 'helpers/internationalisation/currency';
@@ -85,12 +84,6 @@ export const commonSlice = createSlice({
 					state.internationalisation,
 				),
 			};
-		},
-		setExistingPaymentMethods(
-			state,
-			action: PayloadAction<ExistingPaymentMethod[]>,
-		) {
-			state.existingPaymentMethods = action.payload;
 		},
 		setContributionTypes(state, action: PayloadAction<ContributionTypes>) {
 			state.settings.contributionTypes = action.payload;

--- a/support-frontend/assets/helpers/types/asyncStatus.ts
+++ b/support-frontend/assets/helpers/types/asyncStatus.ts
@@ -1,0 +1,10 @@
+export const Initial = 'initial';
+export const Pending = 'pending';
+export const Completed = 'completed';
+export const Failed = 'failed';
+
+export type AsyncStatus =
+	| typeof Initial
+	| typeof Pending
+	| typeof Completed
+	| typeof Failed;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.tsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.tsx
@@ -331,6 +331,8 @@ function ContributionForm(props: PropTypes): JSX.Element {
 		props.switches,
 		props.country,
 		props.countryGroupId,
+	).filter(
+		(method) => method !== 'ExistingCard' && method !== 'ExistingDirectDebit',
 	);
 
 	const onPaymentMethodUpdate = (paymentMethod: PaymentMethod) => {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.ts
@@ -12,14 +12,7 @@ import {
 	getValidContributionTypesFromUrlOrElse,
 	getValidPaymentMethods,
 } from 'helpers/forms/checkouts';
-import {
-	isUsableExistingPaymentMethod,
-	mapExistingPaymentMethodToPaymentMethod,
-	sendGetExistingPaymentMethodsRequest,
-} from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
-import type { ExistingPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
-import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import type { Switches } from 'helpers/globalsAndSwitches/settings';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -33,23 +26,15 @@ import {
 	setOtherAmount,
 	setProductType,
 } from 'helpers/redux/checkout/product/actions';
-import {
-	setContributionTypes,
-	setExistingPaymentMethods,
-} from 'helpers/redux/commonState/actions';
+import { setContributionTypes } from 'helpers/redux/commonState/actions';
 import type {
 	ContributionsDispatch,
 	ContributionsState,
 	ContributionsStore,
 } from 'helpers/redux/contributionsStore';
 import * as storage from 'helpers/storage/storage';
-import { getQueryParameter } from 'helpers/urls/url';
-import { doesUserAppearToBeSignedIn } from 'helpers/user/user';
 import { loadRecaptchaV2 } from '../../helpers/forms/recaptcha';
-import {
-	setUserTypeFromIdentityResponse,
-	updateSelectedExistingPaymentMethod,
-} from './contributionsLandingActions';
+import { setUserTypeFromIdentityResponse } from './contributionsLandingActions';
 import type { State } from './contributionsLandingReducer';
 
 // ----- Functions ----- //
@@ -99,64 +84,6 @@ function getInitialContributionType(
 	return defaultContributionType
 		? defaultContributionType.contributionType
 		: contributionTypes[countryGroupId][0].contributionType;
-}
-
-// TODO: delete this function when we turn off the old checkout
-function initialisePaymentMethods(
-	state: State,
-	dispatch: ContributionsDispatch,
-) {
-	const { currencyId } = state.common.internationalisation;
-	// initiate fetch of existing payment methods
-	const userAppearsLoggedIn = doesUserAppearToBeSignedIn();
-	const existingDirectDebitON = isSwitchOn(
-		'recurringPaymentMethods.existingDirectDebit',
-	);
-	const existingCardON = isSwitchOn('recurringPaymentMethods.existingCard');
-	const existingPaymentsEnabledViaUrlParam =
-		getQueryParameter('displayExistingPaymentOptions') === 'true';
-
-	if (
-		userAppearsLoggedIn &&
-		(existingCardON || existingDirectDebitON) &&
-		existingPaymentsEnabledViaUrlParam
-	) {
-		sendGetExistingPaymentMethodsRequest(
-			currencyId,
-			(allExistingPaymentMethods: ExistingPaymentMethod[]) => {
-				const switchedOnExistingPaymentMethods =
-					allExistingPaymentMethods.filter(
-						(existingPaymentMethod) =>
-							(existingPaymentMethod.paymentType === 'Card' &&
-								existingCardON) ||
-							(existingPaymentMethod.paymentType === 'DirectDebit' &&
-								existingDirectDebitON),
-					);
-				dispatch(setExistingPaymentMethods(switchedOnExistingPaymentMethods));
-				const firstExistingPaymentMethod = switchedOnExistingPaymentMethods[0];
-				const allowDefaultSelectedPaymentMethod =
-					state.common.abParticipations.defaultPaymentMethodTest === 'control';
-
-				if (
-					allowDefaultSelectedPaymentMethod &&
-					isUsableExistingPaymentMethod(firstExistingPaymentMethod)
-				) {
-					dispatch(
-						setPaymentMethod(
-							mapExistingPaymentMethodToPaymentMethod(
-								firstExistingPaymentMethod,
-							),
-						),
-					);
-					dispatch(
-						updateSelectedExistingPaymentMethod(firstExistingPaymentMethod),
-					);
-				}
-			},
-		);
-	} else {
-		dispatch(setExistingPaymentMethods([]));
-	}
 }
 
 function selectInitialAmounts(
@@ -267,7 +194,6 @@ const init = (store: ContributionsStore): void => {
 	dispatch(setContributionTypes(contributionTypes));
 	getStoredEmail(dispatch);
 	void dispatch(getExistingPaymentMethods());
-	initialisePaymentMethods(state, dispatch);
 	const contributionType = selectInitialContributionTypeAndPaymentMethod(
 		state,
 		dispatch,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.ts
@@ -24,6 +24,7 @@ import type { Switches } from 'helpers/globalsAndSwitches/settings';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { setBillingState } from 'helpers/redux/checkout/address/actions';
+import { getExistingPaymentMethods } from 'helpers/redux/checkout/payment/existingPaymentMethods/thunks';
 import { setPaymentMethod } from 'helpers/redux/checkout/payment/paymentMethod/actions';
 import { setEmail } from 'helpers/redux/checkout/personalDetails/actions';
 import { getUserTypeFromIdentity } from 'helpers/redux/checkout/personalDetails/thunks';
@@ -264,6 +265,7 @@ const init = (store: ContributionsStore): void => {
 	const contributionTypes = getContributionTypes(state);
 	dispatch(setContributionTypes(contributionTypes));
 	getStoredEmail(dispatch);
+	void dispatch(getExistingPaymentMethods());
 	initialisePaymentMethods(state, dispatch);
 	const contributionType = selectInitialContributionTypeAndPaymentMethod(
 		state,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.ts
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.ts
@@ -101,6 +101,7 @@ function getInitialContributionType(
 		: contributionTypes[countryGroupId][0].contributionType;
 }
 
+// TODO: delete this function when we turn off the old checkout
 function initialisePaymentMethods(
 	state: State,
 	dispatch: ContributionsDispatch,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds an RTK slice for existing payment methods- card or direct debit payment methods that a user has already used to pay for another Guardian product, which we may offer them the option to re-use when they land on the support site from MMA. The conditional logic around when and how to fetch this data has been refactored into a thunk for better encapsulation. The supporter plus checkout code now uses this new slice.

I've also:
- Refactored the `PaymentMethodSelector` component to remove its explicit dependency on Redux and use the same component for regular and existing payment methods
- Fixed an accessibility issue with our payment SVG icons that was being flagged up in Storybook
- Added an existing payment to the `PaymentMethodSelector` stories, and a story for the component in an error state

**NOTE:** Existing payment methods are currently turned off via the switchboard as we can't use them for products other than contributions. There's a separate card to address that.

[**Trello Card**](https://trello.com/c/xjRHZXmA)

## Why are you doing this?

This functionality needed a refactor to include it properly with other payment methods and better encapsulate the fetching behaviour.
