### PR TITLE
Amend Chromatic workflow to exclude scala steward PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,6 +3,7 @@ on:
   push:
 jobs:
   upload-storybook:
+    if: ${{ github.actor != 'gu-scala-steward-public-repos[bot]' }}
     runs-on: ubuntu-latest
     defaults:
      run:


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This amends the config for our Chromatic workflow to exclude PRs raised by scala-steward. It's impossible for these PRs to affect our stories so it's a waste of money to create Chromatic builds for them.
