### PR TITLE
Update Scaffeine to 5.2.1

### DIFF
--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
   "org.scalatestplus" %% "mockito-3-4" % "3.2.1.0" % "test",
   "org.mockito" % "mockito-core" % "4.8.1",
   "org.typelevel" %% "cats-core" % catsVersion,
-  "com.github.blemale" %% "scaffeine" % "4.1.0",
+  "com.github.blemale" %% "scaffeine" % "5.2.1",
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,


### PR DESCRIPTION
## What are you doing in this PR?

Update Scala dependency scaffeine manually as it failed checks when updating from 4.1.0  to 5.2.1

[**Trello Card**](https://trello.com/c/RB0PmAQG/504-support-frontend-update-scaffeine-dependency)

