### PR TITLE
Update kind-projector_2.13.4 to 0.13.2

### DIFF
--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -8,7 +8,7 @@ scalacOptions ++= Seq(
   "-Ymacro-annotations",
 )
 
-addCompilerPlugin("org.typelevel" % "kind-projector_2.13.4" % "0.11.3")
+addCompilerPlugin("org.typelevel" % "kind-projector_2.13.4" % "0.13.2")
 
 libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.2.11",


### PR DESCRIPTION
## What are you doing in this PR?
Update Scala dependency kind-projector_2.13.4 manually as it failed checks when updating from 0.11.3 to 0.13.2

[**Trello Card**](https://trello.com/c/oX9HK0tX/502-support-frontend-update-kind-projector-dependency)

