### PR TITLE
Change the page title on the supporter plus checkout

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -187,7 +187,7 @@ class Application(
     val uatMode = testUsers.isTestUser(request)
 
     views.html.contributions(
-      title = "Support the Guardian | Make a Contribution",
+      title = "Support the Guardian",
       id = s"contributions-landing-page-$countryCode",
       mainElement = mainElement,
       js = js,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This changes the page title on the supporter plus checkout page from "Support the Guardian | Make a Contribution" to just "Support the Guardian".

[**Trello Card**](https://trello.com/c/uOXFgnMa)

## Why are you doing this?

This is a part of the work to make the new supporter plus checkout the default, in place of the old contributions checkout.