### PR TITLE
Remove Patrons from Aus / NZ support pages

### DIFF
--- a/support-frontend/assets/components/headers/links/links.tsx
+++ b/support-frontend/assets/components/headers/links/links.tsx
@@ -1,8 +1,10 @@
 import cx from 'classnames';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
+	AUDCountries,
 	countryGroups,
 	GBPCountries,
+	NZDCountries,
 } from 'helpers/internationalisation/countryGroup';
 import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
 import { getPatronsLink } from 'helpers/urls/externalLinks';
@@ -17,6 +19,7 @@ type HeaderNavLink = {
 	internal: boolean;
 	opensInNewWindow?: boolean;
 	include?: CountryGroupId[];
+	exclude?: CountryGroupId[];
 	additionalClasses?: string;
 };
 
@@ -71,6 +74,7 @@ const links: HeaderNavLink[] = [
 		text: 'Patrons',
 		trackAs: 'patrons',
 		opensInNewWindow: true,
+		exclude: [AUDCountries, NZDCountries],
 		internal: false,
 	},
 ];
@@ -130,14 +134,19 @@ function Links({
 						}
 						return true;
 					})
-					.filter(({ include }) => {
+					.filter(({ include, exclude }) => {
 						// If there is no country group ID for the link, return true and include the link in the rendering.
 						if (!countryGroupId) {
 							return true;
 						}
 
-						// If the link is not meant to be rendered for a specific CountryGroupID, do not include.
+						// If the link is not meant to be included for a specific CountryGroupID, do not include in array.
 						if (include && !include.includes(countryGroupId)) {
+							return false;
+						}
+
+						// If the link is meant to be excluded for a specific CountryGroupID, exclude from array.
+						if (exclude?.includes(countryGroupId)) {
 							return false;
 						}
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This removes Patrons from Support pages in Australia / NZ

[**Trello Card**](https://trello.com/c/bcA6f2iB/931-remove-patrons-from-support-pages-aus-navigation)

## Why are you doing this?
Patrons is not a marketable product is Australia / NZ

## Screenshots
| Aus | NZ |
| --- | ---- |
| <img width="1317" alt="Screenshot 2022-12-16 at 11 56 09" src="https://user-images.githubusercontent.com/44685872/208094160-2ee115a2-7603-4dba-8ec4-ed152da9af7f.png"> | <img width="1317" alt="Screenshot 2022-12-16 at 12 04 16" src="https://user-images.githubusercontent.com/44685872/208094328-8b029e27-7029-4ad0-a89a-36dd447b9abd.png"> |

