### PR TITLE
Increase the memory allocation of two lambdas

### DIFF
--- a/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
+++ b/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
@@ -450,7 +450,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
         },
         "FunctionName": "stripe-patrons-data-PROD",
         "Handler": "com.gu.patrons.lambdas.ProcessStripeSubscriptionsLambda::handleRequest",
-        "MemorySize": 1024,
+        "MemorySize": 1536,
         "Role": {
           "Fn::GetAtt": [
             "StripePatronsDataPRODServiceRoleF56253CB",
@@ -814,7 +814,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
         },
         "FunctionName": "stripe-patrons-data-cancelled-PROD",
         "Handler": "com.gu.patrons.lambdas.PatronCancelledEventLambda::handleRequest",
-        "MemorySize": 1024,
+        "MemorySize": 1536,
         "Role": {
           "Fn::GetAtt": [
             "stripepatronsdatacancelledServiceRole157E3052",

--- a/cdk/lib/stripe-patrons-data.ts
+++ b/cdk/lib/stripe-patrons-data.ts
@@ -54,6 +54,7 @@ class StripePatronsDataLambda extends GuScheduledLambda {
       monitoringConfiguration: monitoringForEnvironment(scope.stage),
       rules: [{ schedule: scheduleRateForEnvironment(scope.stage) }],
       runtime: Runtime.JAVA_11,
+      memorySize: 1536,
       timeout: Duration.minutes(15),
     });
 
@@ -90,6 +91,7 @@ class PatronCancelledLambda extends GuLambdaFunction {
       handler:
         "com.gu.patrons.lambdas.PatronCancelledEventLambda::handleRequest",
       runtime: Runtime.JAVA_11,
+      memorySize: 1536,
       timeout: Duration.minutes(15),
     });
 


### PR DESCRIPTION
Increase the memory allocation of two lambdas in the stripe-patrons-data project.

These lambdas are called by Stripe webhooks and occasionally the webhook times out so the call appears to have failed in Stripe. These usually succeed on retry but increasing the memory allocation of the lambda should speed the execution up and allow it to complete more reliably.