### PR TITLE
Remove temporary GW gift offer from subs page

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
@@ -65,34 +65,7 @@ const getDisplayPrice = (
 	return `${currency}${fixDecimals(price)}/${billingPeriod}`;
 };
 
-/**
- * Temporary solution promoting Guardian Weekly Gifting Christmas
- * offer in the Guardian Weekly section of subs landing page
- * between 01/12/2022 and 23/12/2022GW
- */
-const getDisplayPriceGWGiftingChristmas = (
-	countryGroupId: CountryGroupId,
-): string => {
-	const currency = currencies[detect(countryGroupId)].glyph;
-	const prices = {
-		GBPCountries: 82.5,
-		UnitedStates: 165,
-		AUDCountries: 216,
-		EURCountries: 141,
-		NZDCountries: 273,
-		Canada: 180,
-		International: 180,
-	};
-	return `${currency}${fixDecimals(prices[countryGroupId])}/Annual`;
-};
-
 function getGuardianWeeklyOfferCopy(discountCopy: string) {
-	/**
-	 * Temporary solution promoting Guardian Weekly Gifting Christmas
-	 * offer in the Guardian Weekly section of subs landing page
-	 * between 01/12/2022 and 23/12/2022
-	 */
-	return '50% off annual gifting subscription';
 	if (discountCopy !== '') {
 		return discountCopy;
 	}
@@ -159,26 +132,26 @@ const guardianWeekly = (
 	participations: Participations,
 ): ProductCopy => ({
 	title: 'Guardian Weekly',
-	subtitle: getDisplayPriceGWGiftingChristmas(countryGroupId),
+	subtitle: getDisplayPrice(countryGroupId, priceCopy.price),
 	description:
-		'Give someone answers and insights that go beyond the headlines, and into the issues that matter most. They can enjoy handpicked articles from the Guardian and Observer, curated into one magazine and delivered for free, wherever they are in the world. Plus, for a limited time, gift a whole year’s subscription, for half the usual price.',
+		'Gain a deeper understanding of the issues that matter with the Guardian Weekly magazine. Every week, take your time over handpicked articles from the Guardian and Observer, delivered for free to wherever you are in the world.',
 	offer: getGuardianWeeklyOfferCopy(priceCopy.discountCopy),
 	buttons: [
 		{
-			ctaButtonText: 'See gift options',
-			link: guardianWeeklyLanding(countryGroupId, true),
+			ctaButtonText: 'Find out more',
+			link: guardianWeeklyLanding(countryGroupId, false),
 			analyticsTracking: sendTrackingEventsOnClick({
-				id: 'weekly_cta_gift',
+				id: 'weekly_cta',
 				product: 'GuardianWeekly',
 				componentType: 'ACQUISITIONS_BUTTON',
 			}),
 			modifierClasses: 'guardian-weekly',
 		},
 		{
-			ctaButtonText: 'See personal subscriptions',
-			link: guardianWeeklyLanding(countryGroupId, false),
+			ctaButtonText: 'See gift options',
+			link: guardianWeeklyLanding(countryGroupId, true),
 			analyticsTracking: sendTrackingEventsOnClick({
-				id: 'weekly_cta',
+				id: 'weekly_cta_gift',
 				product: 'GuardianWeekly',
 				componentType: 'ACQUISITIONS_BUTTON',
 			}),


### PR DESCRIPTION
## What are you doing in this PR?

This PR reverts the changes made here which temporarily hardcoded a Guardian Weekly gifting offer for promotion: https://github.com/guardian/support-frontend/pull/4495