### PR TITLE
Fix bundle analyser gh action

### DIFF
--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -5,35 +5,48 @@ on:
       - main
 
 jobs:
-    build_check:
-      if: github.event.pull_request.head.repo.owner.login == 'guardian'
-      name: Bundle Analyser
-      defaults:
-        run:
+  context_check:
+    steps:
+      - name: Head owner
+        run: echo "head owner = ${{ github.event.pull_request.head.repo.owner.login }}"
+
+      - name: Base owner
+        run: echo "base owner = ${{ github.event.pull_request.base.repo.owner.login }}"
+
+      - name: Pull request
+        run: echo "pull request = ${{ github.event.pull_request }}"
+
+      - name: Repo owner
+        run: echo "github.repository_owner == 'guardian'"
+
+  build_check:
+    if: github.event.pull_request.head.repo.owner.login == 'guardian'
+    name: Bundle Analyser
+    defaults:
+      run:
+        working-directory: support-frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Node
+        uses: guardian/actions-setup-node@main
+
+      # Cache npm dependencies using https://github.com/bahmutov/npm-install
+      - name: Cache dependencies
+        uses: bahmutov/npm-install@v1
+        with:
           working-directory: support-frontend
-      runs-on: ubuntu-latest
-      steps:
 
-        - name: Checkout code
-          uses: actions/checkout@v2
+      - name: Install
+        run: yarn
 
-        - name: Install Node
-          uses: guardian/actions-setup-node@main
+      - name: Generate production build for github action
+        run: yarn build-github-action
 
-        # Cache npm dependencies using https://github.com/bahmutov/npm-install
-        - name: Cache dependencies
-          uses: bahmutov/npm-install@v1
-          with:
-            working-directory: support-frontend
-
-        - name: Install
-          run: yarn
-
-        - name: Generate production build for github action
-          run: yarn build-github-action
-
-        - name: Run Bundle Analyser
-          uses: actions/upload-artifact@v2
-          with:
-            name: bundle-analyser-report
-            path: support-frontend/public/compiled-assets/webpack-stats.html
+      - name: Run Bundle Analyser
+        uses: actions/upload-artifact@v2
+        with:
+          name: bundle-analyser-report
+          path: support-frontend/public/compiled-assets/webpack-stats.html

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -13,6 +13,12 @@ jobs:
         working-directory: support-frontend
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Node
+        uses: guardian/actions-setup-node@main
+
       - name: Head owner
         run: echo "head owner = ${{ github.event.pull_request.head.repo.owner.login }}"
 
@@ -24,12 +30,6 @@ jobs:
 
       - name: Repo owner
         run: echo "github.repository_owner == 'guardian'"
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Install Node
-        uses: guardian/actions-setup-node@main
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - name: Cache dependencies

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -6,7 +6,12 @@ on:
       - mo-fix-bundle-analyser
 
 jobs:
-  context_check:
+  build_check:
+    name: Bundle Analyser
+    defaults:
+      run:
+        working-directory: support-frontend
+    runs-on: ubuntu-latest
     steps:
       - name: Head owner
         run: echo "head owner = ${{ github.event.pull_request.head.repo.owner.login }}"
@@ -20,14 +25,6 @@ jobs:
       - name: Repo owner
         run: echo "github.repository_owner == 'guardian'"
 
-  build_check:
-    if: github.event.pull_request.head.repo.owner.login == 'guardian'
-    name: Bundle Analyser
-    defaults:
-      run:
-        working-directory: support-frontend
-    runs-on: ubuntu-latest
-    steps:
       - name: Checkout code
         uses: actions/checkout@v2
 

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build_check:
-    if: github.repository_owner == "guardian"
+    if: github.repository_owner == 'guardian'
     name: Bundle Analyser
     defaults:
       run:

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - mo-fix-bundle-analyser
 
 jobs:
   context_check:

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -3,11 +3,10 @@ on:
   push:
     branches:
       - main
-      - mo-fix-bundle-analyser
 
 jobs:
   build_check:
-    if: github.repository_owner == 'guardian'
+    if: github.repository_owner == "guardian"
     name: Bundle Analyser
     defaults:
       run:

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -20,16 +20,16 @@ jobs:
         uses: guardian/actions-setup-node@main
 
       - name: Head owner
-        run: echo "head owner = ${{ github.event.pull_request.head.repo.owner.login }}"
+        run: echo 'head owner = ${{ github.event.pull_request.head.repo.owner.login }}'
 
       - name: Base owner
-        run: echo "base owner = ${{ github.event.pull_request.base.repo.owner.login }}"
+        run: echo 'base owner = ${{ github.event.pull_request.base.repo.owner.login }}'
 
       - name: Pull request
-        run: echo "pull request = ${{ github.event.pull_request }}"
+        run: echo 'pull request = ${{ github.event.pull_request }}'
 
       - name: Repo owner
-        run: echo "github.repository_owner == 'guardian'"
+        run: echo '${{ github.repository_owner }}'
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - name: Cache dependencies

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build_check:
+    if: github.repository_owner == 'guardian'
     name: Bundle Analyser
     defaults:
       run:
@@ -18,18 +19,6 @@ jobs:
 
       - name: Install Node
         uses: guardian/actions-setup-node@main
-
-      - name: Head owner
-        run: echo 'head owner = ${{ github.event.pull_request.head.repo.owner.login }}'
-
-      - name: Base owner
-        run: echo 'base owner = ${{ github.event.pull_request.base.repo.owner.login }}'
-
-      - name: Pull request
-        run: echo 'pull request = ${{ github.event.pull_request }}'
-
-      - name: Repo owner
-        run: echo '${{ github.repository_owner }}'
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - name: Cache dependencies

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,18 +1,20 @@
 name: Chromatic
 on:
   push:
+    branches:
+      - main
 jobs:
   upload-storybook:
     if: ${{ github.actor != 'gu-scala-steward-public-repos[bot]' }}
     runs-on: ubuntu-latest
     defaults:
-     run:
-       working-directory: support-frontend
+      run:
+        working-directory: support-frontend
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-         fetch-depth: 0
+          fetch-depth: 0
       - name: Install Node
         uses: guardian/actions-setup-node@v2.4.1
 
@@ -29,6 +31,6 @@ jobs:
           workingDir: support-frontend
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          buildScriptName: 'build-storybook'
+          buildScriptName: "build-storybook"
           exitOnceUploaded: true
           onlyChanged: "!(main)" # only turbosnap on non-main branches

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,8 +1,6 @@
 name: Chromatic
 on:
   push:
-    branches:
-      - main
 jobs:
   upload-storybook:
     if: ${{ github.actor != 'gu-scala-steward-public-repos[bot]' }}

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   compressed_size:
-    if: github.event.pull_request.head.repo.owner.login == 'guardian'
+    if: github.repository_owner == 'guardian'
     name: Compressed Size
     defaults:
       run:

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   compressed_size:
-    if: github.repository_owner == 'guardian'
+    if: github.repository_owner == "guardian"
     name: Compressed Size
     defaults:
       run:

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   compressed_size:
-    if: github.repository_owner == "guardian"
+    if: github.repository_owner == 'guardian'
     name: Compressed Size
     defaults:
       run:

--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -15,7 +15,7 @@ jobs:
   payment_api_build:
     if: >-
       (github.actor != 'dependabot[bot]') &&
-        (github.event.pull_request.head.repo.owner.login == 'guardian' ||
+        (github.repository_owner == 'guardian' ||
           github.event_name == 'push')
 
     # Required by actions-assume-aws-role
@@ -35,8 +35,8 @@ jobs:
       - name: Setup Node for CDK
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
-          cache: 'yarn'
+          node-version: "16"
+          cache: "yarn"
           cache-dependency-path: cdk/yarn.lock
 
       - name: Build CFN from CDK
@@ -53,8 +53,8 @@ jobs:
       - name: Setup Java 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: "8"
+          distribution: "adopt"
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -15,7 +15,7 @@ jobs:
   payment_api_build:
     if: >-
       (github.actor != 'dependabot[bot]') &&
-        (github.repository_owner == 'guardian' ||
+        (github.repository_owner == "guardian" ||
           github.event_name == 'push')
 
     # Required by actions-assume-aws-role

--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -15,7 +15,7 @@ jobs:
   payment_api_build:
     if: >-
       (github.actor != 'dependabot[bot]') &&
-        (github.repository_owner == "guardian" ||
+        (github.repository_owner == 'guardian' ||
           github.event_name == 'push')
 
     # Required by actions-assume-aws-role

--- a/.github/workflows/stripe-patrons-data.yml
+++ b/.github/workflows/stripe-patrons-data.yml
@@ -12,7 +12,7 @@ jobs:
   support_frontend_build:
     if: >-
       (github.actor != 'dependabot[bot]') &&
-        (github.event.pull_request.head.repo.owner.login == 'guardian' ||
+        (github.repository_owner == 'guardian' ||
           github.event_name == 'push')
 
     # Required by actions-assume-aws-role
@@ -29,8 +29,8 @@ jobs:
       - name: Setup Node for CDK
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
-          cache: 'yarn'
+          node-version: "16"
+          cache: "yarn"
           cache-dependency-path: cdk/yarn.lock
 
       - name: Build CFN from CDK
@@ -47,8 +47,8 @@ jobs:
       - name: Setup Java 11
         uses: actions/setup-java@v3
         with:
-          distribution: 'corretto'
-          java-version: '11'
+          distribution: "corretto"
+          java-version: "11"
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/stripe-patrons-data.yml
+++ b/.github/workflows/stripe-patrons-data.yml
@@ -12,7 +12,7 @@ jobs:
   support_frontend_build:
     if: >-
       (github.actor != 'dependabot[bot]') &&
-        (github.repository_owner == 'guardian' ||
+        (github.repository_owner == "guardian" ||
           github.event_name == 'push')
 
     # Required by actions-assume-aws-role

--- a/.github/workflows/stripe-patrons-data.yml
+++ b/.github/workflows/stripe-patrons-data.yml
@@ -12,7 +12,7 @@ jobs:
   support_frontend_build:
     if: >-
       (github.actor != 'dependabot[bot]') &&
-        (github.repository_owner == "guardian" ||
+        (github.repository_owner == 'guardian' ||
           github.event_name == 'push')
 
     # Required by actions-assume-aws-role

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -14,7 +14,7 @@ jobs:
   support_frontend_build:
     if: >-
       (github.actor != 'dependabot[bot]') &&
-        (github.repository_owner == 'guardian' ||
+        (github.repository_owner == "guardian" ||
           github.event_name == 'push')
 
     # Required by actions-assume-aws-role

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -14,7 +14,7 @@ jobs:
   support_frontend_build:
     if: >-
       (github.actor != 'dependabot[bot]') &&
-        (github.repository_owner == "guardian" ||
+        (github.repository_owner == 'guardian' ||
           github.event_name == 'push')
 
     # Required by actions-assume-aws-role

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -14,7 +14,7 @@ jobs:
   support_frontend_build:
     if: >-
       (github.actor != 'dependabot[bot]') &&
-        (github.event.pull_request.head.repo.owner.login == 'guardian' ||
+        (github.repository_owner == 'guardian' ||
           github.event_name == 'push')
 
     # Required by actions-assume-aws-role
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node
         uses: guardian/actions-setup-node@v2.4.1
         with:
-          cache: 'yarn'
+          cache: "yarn"
           cache-dependency-path: |
             support-frontend/yarn.lock
             cdk/yarn.lock
@@ -66,8 +66,8 @@ jobs:
       - name: Setup Java 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: "8"
+          distribution: "adopt"
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/support-lambdas-build.yml
+++ b/.github/workflows/support-lambdas-build.yml
@@ -12,7 +12,7 @@ jobs:
   support_lambdas_build:
     if: >-
       (github.actor != 'dependabot[bot]') &&
-        (github.repository_owner == 'guardian' ||
+        (github.repository_owner == "guardian" ||
           github.event_name == 'push')
 
     # Required by actions-assume-aws-role

--- a/.github/workflows/support-lambdas-build.yml
+++ b/.github/workflows/support-lambdas-build.yml
@@ -12,7 +12,7 @@ jobs:
   support_lambdas_build:
     if: >-
       (github.actor != 'dependabot[bot]') &&
-        (github.event.pull_request.head.repo.owner.login == 'guardian' ||
+        (github.repository_owner == 'guardian' ||
           github.event_name == 'push')
 
     # Required by actions-assume-aws-role
@@ -39,8 +39,8 @@ jobs:
       - name: Setup Java 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: "8"
+          distribution: "adopt"
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/support-lambdas-build.yml
+++ b/.github/workflows/support-lambdas-build.yml
@@ -12,7 +12,7 @@ jobs:
   support_lambdas_build:
     if: >-
       (github.actor != 'dependabot[bot]') &&
-        (github.repository_owner == "guardian" ||
+        (github.repository_owner == 'guardian' ||
           github.event_name == 'push')
 
     # Required by actions-assume-aws-role

--- a/.github/workflows/support-workers-build.yml
+++ b/.github/workflows/support-workers-build.yml
@@ -14,7 +14,7 @@ jobs:
   support_workers_build:
     if: >-
       (github.actor != 'dependabot[bot]') &&
-        (github.repository_owner == 'guardian' ||
+        (github.repository_owner == "guardian" ||
           github.event_name == 'push')
 
     # Required by actions-assume-aws-role

--- a/.github/workflows/support-workers-build.yml
+++ b/.github/workflows/support-workers-build.yml
@@ -14,7 +14,7 @@ jobs:
   support_workers_build:
     if: >-
       (github.actor != 'dependabot[bot]') &&
-        (github.repository_owner == "guardian" ||
+        (github.repository_owner == 'guardian' ||
           github.event_name == 'push')
 
     # Required by actions-assume-aws-role

--- a/.github/workflows/support-workers-build.yml
+++ b/.github/workflows/support-workers-build.yml
@@ -14,7 +14,7 @@ jobs:
   support_workers_build:
     if: >-
       (github.actor != 'dependabot[bot]') &&
-        (github.event.pull_request.head.repo.owner.login == 'guardian' ||
+        (github.repository_owner == 'guardian' ||
           github.event_name == 'push')
 
     # Required by actions-assume-aws-role
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node
         uses: guardian/actions-setup-node@v2.4.1
         with:
-          cache: 'yarn'
+          cache: "yarn"
           cache-dependency-path: support-workers/cloud-formation/src/yarn.lock
 
       - name: Install
@@ -56,8 +56,8 @@ jobs:
       - name: Setup Java 11
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
-          distribution: 'corretto'
+          java-version: "11"
+          distribution: "corretto"
       - uses: actions/cache@v2
         with:
           path: |

--- a/support-frontend/assets/components/animations/giftHeadingAnimation.tsx
+++ b/support-frontend/assets/components/animations/giftHeadingAnimation.tsx
@@ -9,7 +9,7 @@ import {
 	toYouTyping,
 } from './giftHeadingAnimationStyles';
 
-function GiftHeadingAnimation() {
+function GiftHeadingAnimation(): JSX.Element {
 	return (
 		<div css={giftTag}>
 			<div css={toFromLines}>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Our bundle analyser github action was being skipped for some time due to a conditional check in the yaml file. This conditional had been introduced to prevent certain actions running on a fork. Although, in the bundle analyser check the value we were attempting to access i.e. `github.event.pull_request.head.repo.owner.login` was undefined. This uses an alternative github context value `github.repository_owner` for the repo owner conditional checks in our github actions.

[**Trello Card**](https://trello.com/c/cEiFq7u9/964-support-frontend-fix-bundle-analyser-action)
