### PR TITLE
Don’t do postcode lookup for long inputs

### DIFF
--- a/support-frontend/app/controllers/GetAddress.scala
+++ b/support-frontend/app/controllers/GetAddress.scala
@@ -3,6 +3,7 @@ package controllers
 import actions.CustomActionBuilders
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
+import com.gu.rest.{CodeBody, WebServiceHelperError}
 import com.gu.support.getaddressio.GetAddressIOService
 import io.circe.syntax._
 import play.api.libs.circe.Circe
@@ -10,6 +11,7 @@ import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponent
 import com.gu.support.getaddressio.FindAddressResultError
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class GetAddress(
     components: ControllerComponents,
@@ -20,14 +22,20 @@ class GetAddress(
   import actionRefiners._
 
   def findAddress(postCode: String): Action[AnyContent] = NoCacheAction().async { implicit request =>
-    getAddressService.find(postCode).map { result =>
-      Ok(result.asJson)
-    } recover {
-      case _: FindAddressResultError =>
-        BadRequest // The postcode was invalid
-      case error =>
-        SafeLogger.error(scrub"Failed to complete postcode lookup via getAddress.io due to: $error")
-        InternalServerError
+    if (postCode.length > 10) {
+      // the address service returns bad results (404s) for some long
+      // and weird input values; avoid calling it
+      Future(BadRequest)
+    } else {
+      getAddressService.find(postCode).map { result =>
+        Ok(result.asJson)
+      } recover {
+        case _: FindAddressResultError =>
+          BadRequest // The postcode was invalid
+        case error =>
+          SafeLogger.error(scrub"Failed to complete postcode lookup via getAddress.io due to: $error")
+          InternalServerError
+      }
     }
   }
 }


### PR DESCRIPTION
For certain very long input values, getAddress.io’s postcode lookup returns a 404 instead of the expected error. To guard against this, this change avoids calling the API for values too long to be a valid postcode.

I believe the longest valid postcodes are 8 characters; this check checks for inputs longer than 10 characters in case I’m mistaken or in case that changes.

This issue came up from an alarm investigation.