### PR TITLE
Switch off Digital Pack post deployment tests

### DIFF
--- a/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
@@ -34,18 +34,6 @@ class CheckoutsSpec
     driverConfig.quit()
   }
 
-  Feature("Digital Pack checkout") {
-    Scenario("User already logged in - Stripe checkout") {
-      testCheckout("Digital Pack", new DigitalPackCheckout, new DigitalPackProductPage, payWithStripe)
-    }
-  }
-
-  Feature("Digital Pack gift checkout") {
-    Scenario("User already logged in - Stripe checkout") {
-      testCheckout("Digital Pack gift", new DigitalPackGiftCheckout, new DigitalPackGiftProductPage, payWithStripe)
-    }
-  }
-
   Feature("Paper checkout") {
     Scenario("User already logged in - Direct Debit checkout") {
       testCheckout("Paper", new PaperCheckout, new PaperProductPage, payWithDirectDebit)

--- a/support-frontend/test/selenium/subscriptions/ProductPagesSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/ProductPagesSpec.scala
@@ -54,18 +54,6 @@ class ProductPagesSpec
     }
   }
 
-  Feature("Digital Pack product page") {
-    Scenario("Basic loading") {
-      testPageLoads(new DigitalPackProductPage())
-    }
-  }
-
-  Feature("Digital Pack gift product page") {
-    Scenario("Basic loading") {
-      testPageLoads(new DigitalPackGiftProductPage())
-    }
-  }
-
   def testPageLoads(page: ProductPage): Unit = {
     Given("that a user goes to the page")
     goTo(page)


### PR DESCRIPTION
## What are you doing in this PR?
Remove Digital Pack post deployment tests  from CheckoutsSpec and ProductPagesSpec files as we are deprecating  Digital Subscriptions.

[**Trello Card**](https://trello.com/c/lKwIz0Cy/695-switch-off-digital-pack-post-deployment-tests-before-adding-redirects-to-https-supporttheguardiancom-uk-subscribe-digital-routes)

## Why are you doing this?
Switch off Digital Pack post deployment tests before adding redirects to https://support.theguardian.com/uk/subscribe/digital/* routes

