### PR TITLE
Fix problem with Patron cancellations

### DIFF
--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/model/Errors.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/model/Errors.scala
@@ -14,4 +14,6 @@ case class UserNotFoundIdentityError(message: String) extends Error
 
 case class UserNotFoundStripeError(message: String) extends Error
 
+case class SubscriptionNotFoundDynamo(message: String) extends Error
+
 case class DynamoDbError(message: String) extends Error

--- a/stripe-patrons-data/src/test/scala/com/gu/patrons/services/SupporterDataDynamoServiceSpec.scala
+++ b/stripe-patrons-data/src/test/scala/com/gu/patrons/services/SupporterDataDynamoServiceSpec.scala
@@ -1,0 +1,37 @@
+package com.gu.patrons.services
+
+import com.gu.supporterdata.model.Stage.DEV
+import com.gu.supporterdata.services.SupporterDataDynamoService
+import com.gu.test.tags.annotations.IntegrationTest
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+@IntegrationTest
+class SupporterDataDynamoServiceSpec extends AsyncFlatSpec with Matchers {
+  "SupporterDataDynamoService" should "return false if a subscription doesn't exist" in {
+    val identityId = "non_existent_identity_id"
+    val subscriptionId = "non_existent_subscription_id"
+    val dynamoService = SupporterDataDynamoService(DEV)
+    dynamoService.subscriptionExists(identityId, subscriptionId).flatMap {
+      case Right(userExists) if userExists =>
+        fail(s"Subscription $subscriptionId should not exist")
+      case Right(_) =>
+        succeed
+      case Left(errorMessage) => fail(errorMessage)
+    }
+  }
+  "SupporterDataDynamoService" should "return true if a subscription does exist" ignore {
+    // This test relies on a record being present in the dev data store so
+    // I'm marking it as ignored in case that record gets deleted
+    val identityId = "200065441"
+    val subscriptionId = "A-S00445804"
+    val dynamoService = SupporterDataDynamoService(DEV)
+    dynamoService.subscriptionExists(identityId, subscriptionId).flatMap {
+      case Right(userExists) if userExists =>
+        succeed
+      case Right(_) =>
+        fail(s"Subscription $subscriptionId should exist")
+      case Left(errorMessage) => fail(errorMessage)
+    }
+  }
+}

--- a/support-modules/supporter-product-data-dynamo/src/main/scala/com/gu/supporterdata/services/SupporterDataDynamoService.scala
+++ b/support-modules/supporter-product-data-dynamo/src/main/scala/com/gu/supporterdata/services/SupporterDataDynamoService.scala
@@ -25,6 +25,20 @@ import scala.util.{Failure, Success, Try}
 
 class SupporterDataDynamoService(client: DynamoDbAsyncClient, tableName: String) {
 
+  def subscriptionExists(identityId: String, subscriptionId: String)(implicit executionContext: ExecutionContext) = {
+    val key = Map(
+      identityIdField -> AttributeValue.builder.s(identityId).build,
+      subscriptionNameField -> AttributeValue.builder.s(subscriptionId).build,
+    ).asJava
+    val request = GetItemRequest.builder.key(key).tableName(tableName).build()
+
+    client.getItem(request).toScala.transform {
+      case Success(item) =>
+        Try(Right(!item.item().isEmpty))
+      case Failure(exception) => Try(Left(exception.getMessage))
+    }
+  }
+
   def cancelSubscription(
       identityIdToCancel: String,
       subscriptionId: String,


### PR DESCRIPTION
## What are you doing in this PR?
We have been getting a number of alarms caused by incomplete data for Patrons subscriptions in the SupporterProductData dynamo table. Upon investigation it appears that what is happening is the following:

- All subscriptions have a [TTL (time to live)](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html) setting in Dynamo which is set to the term end date of the subscription. This means that when this date is reached the record will automatically be deleted from the data store.
- There is also a Stripe webhook which triggers when a subscription is cancelled to enable us to mark these subs as cancelled by adding a cancellation date to the record - this is mostly to take care of accounts which are cancelled mid-term
- It appears that in some (all?) cases the webhook triggers after the record has been deleted which due to the nature of Dynamo creates a new record with just the partition key, the sort key and the cancellation date - this then causes an error when members-data-api tries to read this record as it has required fields missing.

This PR fixes this issue by checking that a subscription actually exists in Dynamo before attempting to update it with a cancellation date. There will also be some cleanup required for corrupted records which I will do manually.

