### PR TITLE
Student beans link

### DIFF
--- a/support-frontend/assets/components/containers/centredContainer.tsx
+++ b/support-frontend/assets/components/containers/centredContainer.tsx
@@ -12,6 +12,12 @@ const centredContainer = css`
 	margin: 0 auto;
 	max-width: 1290px;
 
+  ${from.phablet} {
+    display: flex;
+	  flex-direction: row;
+    justify-content: space-evenly:
+  }
+
 	${from.desktop} {
 		width: calc(100% - 110px);
 	}

--- a/support-frontend/assets/components/product/giftNonGiftCta.tsx
+++ b/support-frontend/assets/components/product/giftNonGiftCta.tsx
@@ -6,11 +6,12 @@ import {
 } from '@guardian/source-react-components';
 import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
 
-type GiftableProduct = 'digital' | 'Guardian Weekly';
+type SubscriptionProduct = 'digital' | 'Guardian Weekly' | 'Student';
 type PropTypes = {
 	href: string;
-	product: GiftableProduct;
-	orderIsAGift: boolean;
+	product: SubscriptionProduct;
+	orderIsAGift?: boolean;
+	isStudent?: boolean;
 };
 const giftOrPersonal = css`
 	padding: ${space[3]}px ${space[3]}px ${space[12]}px;
@@ -25,16 +26,27 @@ const giftOrPersonalHeading = css`
 	})};
 `;
 
-function GiftOrPersonal({ href, product, orderIsAGift }: PropTypes) {
+function GiftOrPersonalOrStudent({
+	href,
+	product,
+	orderIsAGift,
+	isStudent,
+}: PropTypes) {
 	return (
 		<section css={giftOrPersonal}>
 			<div css={giftOrPersonalCopy}>
 				<h2 css={giftOrPersonalHeading}>
-					{orderIsAGift
+					{isStudent
+						? 'Student subscriptions'
+						: orderIsAGift
 						? 'Looking for a subscription for yourself?'
 						: 'Gift subscriptions'}
 				</h2>
-				{!orderIsAGift && <p>A {product} subscription makes a great gift.</p>}
+				{isStudent ? (
+					<p>{product}s get 70% off a Guardian Weekly subscription.</p>
+				) : (
+					!orderIsAGift && <p>A {product} subscription makes a great gift.</p>
+				)}
 			</div>
 			<LinkButton
 				icon={<SvgArrowRightStraight />}
@@ -44,15 +56,21 @@ function GiftOrPersonal({ href, product, orderIsAGift }: PropTypes) {
 				href={href}
 				onClick={() => {
 					sendTrackingEventsOnClick({
-						id: `${orderIsAGift ? 'personal' : 'gift'}_subscriptions_cta`,
+						id: `${
+							isStudent ? 'student' : orderIsAGift ? 'personal' : 'gift'
+						}_subscriptions_cta`,
 						componentType: 'ACQUISITIONS_BUTTON',
-					})();
+					});
 				}}
 			>
-				{orderIsAGift ? 'See personal subscriptions' : 'See gift subscriptions'}
+				{isStudent
+					? `I'm a student`
+					: orderIsAGift
+					? 'See personal subscriptions'
+					: 'See gift subscriptions'}
 			</LinkButton>
 		</section>
 	);
 }
 
-export default GiftOrPersonal;
+export default GiftOrPersonalOrStudent;

--- a/support-frontend/assets/components/product/giftNonGiftCta.tsx
+++ b/support-frontend/assets/components/product/giftNonGiftCta.tsx
@@ -10,7 +10,7 @@ type SubscriptionProduct = 'digital' | 'Guardian Weekly' | 'Student';
 type PropTypes = {
 	href: string;
 	product: SubscriptionProduct;
-	orderIsAGift?: boolean;
+	orderIsAGift: boolean;
 	isStudent?: boolean;
 };
 const giftOrPersonal = css`
@@ -32,6 +32,9 @@ function GiftOrPersonalOrStudent({
 	orderIsAGift,
 	isStudent,
 }: PropTypes) {
+	if (isStudent && orderIsAGift) {
+		return null;
+	}
 	return (
 		<section css={giftOrPersonal}>
 			<div css={giftOrPersonalCopy}>

--- a/support-frontend/assets/helpers/urls/routes.ts
+++ b/support-frontend/assets/helpers/urls/routes.ts
@@ -36,6 +36,8 @@ const routes: Record<string, string> = {
 		'/subscribe/paper/delivery#subscribe',
 	guardianWeeklySubscriptionLanding: '/subscribe/weekly',
 	guardianWeeklySubscriptionLandingGift: '/subscribe/weekly/gift',
+	guardianWeeklyStudent:
+		'https://connect.studentbeans.com/v4/hosted/the-guardian-weekly/uk',
 	postcodeLookup: '/postcode-lookup',
 	createSignInUrl: '/identity/signin-url',
 	stripeSetupIntentRecaptcha: '/stripe/create-setup-intent/recaptcha',

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -128,6 +128,7 @@ function WeeklyLandingPage({
 					<GiftNonGiftCta
 						product="Student"
 						href={routes.guardianWeeklyStudent}
+						orderIsAGift={orderIsAGift ?? false}
 						isStudent={true}
 					/>
 				</CentredContainer>

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -125,6 +125,11 @@ function WeeklyLandingPage({
 						href={giftNonGiftLink}
 						orderIsAGift={orderIsAGift ?? false}
 					/>
+					<GiftNonGiftCta
+						product="Student"
+						href={routes.guardianWeeklyStudent}
+						isStudent={true}
+					/>
 				</CentredContainer>
 			</FullWidthContainer>
 		</Page>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->

1) Add new ''Student subscriptions'' element to GW landing page (See design)
2) Link out to Student Beans portal (url below)

Where to link from GW landing page: https://connect.studentbeans.com/v4/hosted/the-guardian-weekly/uk

After student status verification via this portal, users will be directed to GW offer landing page to subscribe.

[**Trello Card**](https://trello.com/c/31VRnK2G/975-dev-enable-student-beans-link-in-gw-landing-page)

Print Publishing have engaged Student Beans, a student promotion platform, to test whether a student proposition for GW will be effective. They have asked for a new ' Student subscriptions'' element to be added next to '' Gift subscriptions'' and to link out to the Student Beans site, where students can verify their student status and claim for their offer code

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [x] No

## Screenshots
<img width="939" alt="Screenshot 2023-01-04 at 17 58 03" src="https://user-images.githubusercontent.com/76729591/210619545-52214e1b-e459-458d-96db-eb4599729683.png">

