### PR TITLE
Quantum Metric: Get contribution amount from session storage for one off paypal contributions

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
@@ -17,7 +17,7 @@ const amountText = css`
 interface HeadingProps {
 	name: string | null;
 	isOneOffPayPal: boolean;
-	amount: number;
+	amount: number | undefined;
 	currency: IsoCurrency;
 	contributionType: ContributionType;
 }

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader.tsx
@@ -40,7 +40,7 @@ type ThankYouHeaderProps = {
 	showDirectDebitMessage: boolean;
 	isOneOffPayPal: boolean;
 	contributionType: ContributionType;
-	amount: number;
+	amount: number | undefined;
 	currency: IsoCurrency;
 	shouldShowLargeDonationMessage: boolean;
 	amountIsAboveThreshold: boolean;

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -17,6 +17,7 @@ import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import { DirectDebit, PayPal } from 'helpers/forms/paymentMethods';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import { getSession } from 'helpers/storage/storage';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { sendEventContributionCheckoutConversion } from 'helpers/tracking/quantumMetric';
 import {
@@ -65,6 +66,14 @@ const buttonContainer = css`
 	padding: ${space[12]}px 0;
 `;
 
+function getAmountFromSessionStorage(): number | undefined {
+	const amount = getSession('contributionAmount');
+
+	if (amount) {
+		return parseFloat(amount);
+	}
+}
+
 export const largeDonations: Record<ContributionType, number> = {
 	MONTHLY: 20,
 	ANNUAL: 100,
@@ -89,17 +98,6 @@ export function SupporterPlusThankYou(): JSX.Element {
 		() => getCampaignSettings(campaignCode),
 		[],
 	);
-
-	useEffect(() => {
-		trackUserData(
-			paymentMethod,
-			contributionType,
-			isSignedIn,
-			!isNewAccount,
-			isLargeDonation(amount, contributionType, paymentMethod),
-		);
-	}, []);
-
 	const { countryId, countryGroupId, currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
@@ -120,15 +118,31 @@ export function SupporterPlusThankYou(): JSX.Element {
 	const { isSignedIn } = useContributionsSelector((state) => state.page.user);
 	const contributionType = useContributionsSelector(getContributionType);
 	const isNewAccount = userTypeFromIdentityResponse === 'new';
-
-	const amount = getAmount(selectedAmounts, otherAmounts, contributionType);
+	const isOneOffPayPal =
+		paymentMethod === PayPal && contributionType === 'ONE_OFF';
+	const amount = isOneOffPayPal
+		? getAmountFromSessionStorage()
+		: getAmount(selectedAmounts, otherAmounts, contributionType);
+	const isAmountLargeDonation = amount
+		? isLargeDonation(amount, contributionType, paymentMethod)
+		: false;
 
 	useEffect(() => {
-		sendEventContributionCheckoutConversion(
-			amount,
-			contributionType,
-			currencyId,
-		);
+		if (amount) {
+			sendEventContributionCheckoutConversion(
+				amount,
+				contributionType,
+				currencyId,
+			);
+
+			trackUserData(
+				paymentMethod,
+				contributionType,
+				isSignedIn,
+				!isNewAccount,
+				isAmountLargeDonation,
+			);
+		}
 	}, []);
 
 	const amountIsAboveThreshold = shouldShowBenefitsMessaging(
@@ -137,9 +151,6 @@ export function SupporterPlusThankYou(): JSX.Element {
 		otherAmounts,
 		countryGroupId,
 	);
-
-	const isOneOffPayPal =
-		paymentMethod === PayPal && contributionType === 'ONE_OFF';
 
 	const thankYouModuleData = getThankYouModuleData(
 		countryId,
@@ -202,11 +213,7 @@ export function SupporterPlusThankYou(): JSX.Element {
 							contributionType={contributionType}
 							amount={amount}
 							currency={currencyId}
-							shouldShowLargeDonationMessage={isLargeDonation(
-								amount,
-								contributionType,
-								paymentMethod,
-							)}
+							shouldShowLargeDonationMessage={isAmountLargeDonation}
 							amountIsAboveThreshold={amountIsAboveThreshold}
 							isSignedIn={isSignedIn}
 							userTypeFromIdentityResponse={userTypeFromIdentityResponse}


### PR DESCRIPTION
## What are you doing in this PR?

There's a bug on [supporterPlusThankYou.tsx](https://github.com/guardian/support-frontend/blob/00468e02176ea94faed4a3982c2a585befcf8527/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx) for One Off Paypal contributions, it's passing the wrong `amount` to Quantum Metric via the `sendEventContributionCheckoutConversion` function.

 It should be pulling the `contributionAmount` from session storage if `isOneOffPayPal` is true, but we're not making the check so it looks like it's pulling the `amount` from Redux, which is set to the default and therefore it's reporting the wrong amount to Quantum Metric.

This PR gets the`contributionAmount` from session storage if `isOneOffPayPal` is true and assigns that to the `amount` variable on the `supporterPlusThankYou.tsx` page. 

We have to retrieve the amount from session storage as the Thank You page is displayed via a new page load following a redirect via the Paypal site for  for one off paypal contributions, so the amount contributed is not held in the redux store as it is for all other payment types/frequency combinations.

[**Trello Card**](https://trello.com/c/WEXCLqCj/970-quantum-metric-sendevent-for-paypal-single-contribution-conversions-reporting-wrong-contribution-amount)