### PR TITLE
Update github actions to use Node 16

### DIFF
--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Node
         uses: guardian/actions-setup-node@main

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,7 +10,7 @@ jobs:
         working-directory: support-frontend
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install Node

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Node
         uses: guardian/actions-setup-node@v2.4.1

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -24,7 +24,7 @@ jobs:
 
     # ---- Setup ---- #
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
         uses: guardian/actions-setup-node@v2.4.1

--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -30,10 +30,10 @@ jobs:
         run: env
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node for CDK
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: "16"
           cache: "yarn"

--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node for CDK
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: 16
           cache: "yarn"
           cache-dependency-path: cdk/yarn.lock
 

--- a/.github/workflows/stripe-patrons-data.yml
+++ b/.github/workflows/stripe-patrons-data.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node for CDK
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: "16"
           cache: "yarn"

--- a/.github/workflows/stripe-patrons-data.yml
+++ b/.github/workflows/stripe-patrons-data.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node for CDK
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: 16
           cache: "yarn"
           cache-dependency-path: cdk/yarn.lock
 

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -29,7 +29,7 @@ jobs:
         run: env
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # (Respects .nvmrc)
       - name: Setup Node

--- a/.github/workflows/support-frontend-eslint.yml
+++ b/.github/workflows/support-frontend-eslint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
         uses: guardian/actions-setup-node@v2.4.1

--- a/.github/workflows/support-frontend-typescript.yml
+++ b/.github/workflows/support-frontend-typescript.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
         uses: guardian/actions-setup-node@v2.4.1

--- a/.github/workflows/support-lambdas-build.yml
+++ b/.github/workflows/support-lambdas-build.yml
@@ -27,7 +27,7 @@ jobs:
         run: env
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Required by sbt riffRaffUpload
       - name: Configure AWS credentials

--- a/.github/workflows/support-workers-build.yml
+++ b/.github/workflows/support-workers-build.yml
@@ -29,7 +29,7 @@ jobs:
         run: env
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # (Respects .nvmrc)
       - name: Setup Node


### PR DESCRIPTION
## What are you doing in this PR?

We're seeing Github Actions fail with a warning related to dependent actions they use: `actions/setup-node@v2` and `actions/setup-node@v2`. Both these actions used Node 12 which is now deprecated (see screenshot below). Updates to https://github.com/actions/checkout and https://github.com/actions/setup-node to there latest `v3` versions should resolve this.

<img width="1260" alt="Screenshot 2023-01-06 at 14 32 24" src="https://user-images.githubusercontent.com/1590704/211033640-0711213c-5246-4bff-8cdc-4ef69ed84fc9.png">
