### PR TITLE
Update github actions to use Node 16

### DIFF
--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -51,7 +51,7 @@ jobs:
           aws-region: eu-west-1
 
       - name: Setup Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: "8"
           distribution: "adopt"

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -64,7 +64,7 @@ jobs:
           aws-region: eu-west-1
 
       - name: Setup Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: "8"
           distribution: "adopt"

--- a/.github/workflows/support-lambdas-build.yml
+++ b/.github/workflows/support-lambdas-build.yml
@@ -37,7 +37,7 @@ jobs:
           aws-region: eu-west-1
 
       - name: Setup Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: "8"
           distribution: "adopt"


### PR DESCRIPTION
## What are you doing in this PR?

Follow up to https://github.com/guardian/support-frontend/pull/4621, we also need to update the dependent action `actions/setup-java@v2` to `actions/setup-java@v3` (https://github.com/actions/setup-java), as `v2` uses a deprecated version of Node.
