### PR TITLE
Quantum Metric payment method

### DIFF
--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -14,6 +14,7 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
+import { sendEventContributionPaymentMethod } from 'helpers/tracking/quantumMetric';
 import type { PaymentMethodSelectorProps } from './paymentMethodSelector';
 
 function getExistingPaymentMethodProps(
@@ -79,6 +80,7 @@ function PaymentMethodSelectorContainer({
 		paymentMethod: PaymentMethod,
 		existingPaymentMethod?: RecentlySignedInExistingPaymentMethod,
 	) {
+		sendEventContributionPaymentMethod(paymentMethod);
 		dispatch(setPaymentMethod(paymentMethod));
 		existingPaymentMethod &&
 			dispatch(selectExistingPaymentMethod(existingPaymentMethod));

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -12,7 +12,6 @@ import {
 	subscriptionToExplainerPart,
 } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
-import { sendEventContributionPaymentMethod } from 'helpers/tracking/quantumMetric';
 import ContributionChoicesHeader from 'pages/contributions-landing/components/ContributionChoicesHeader';
 import { paymentMethodData } from './paymentMethodData';
 import { AvailablePaymentMethodAccordionRow } from './paymentMethodSelectorAccordionRow';
@@ -85,11 +84,6 @@ export function PaymentMethodSelector({
 			/>
 		);
 	}
-	console.log(
-		'PaymentMethodSelector.sendEventContributionPaymentMethod',
-		paymentMethod,
-	);
-	sendEventContributionPaymentMethod(paymentMethod);
 
 	return (
 		<div css={container}>

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -12,6 +12,7 @@ import {
 	subscriptionToExplainerPart,
 } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
+import { sendEventContributionPaymentMethod } from 'helpers/tracking/quantumMetric';
 import ContributionChoicesHeader from 'pages/contributions-landing/components/ContributionChoicesHeader';
 import { paymentMethodData } from './paymentMethodData';
 import { AvailablePaymentMethodAccordionRow } from './paymentMethodSelectorAccordionRow';
@@ -84,6 +85,11 @@ export function PaymentMethodSelector({
 			/>
 		);
 	}
+	console.log(
+		'PaymentMethodSelector.sendEventContributionPaymentMethod',
+		paymentMethod,
+	);
+	sendEventContributionPaymentMethod(paymentMethod);
 
 	return (
 		<div css={container}>

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -277,11 +277,6 @@ function sendEventContributionCartValue(
 					sourceCurrency,
 				);
 				if (convertedValue) {
-					console.log(
-						'sendEventContributionCartValue.sendEvent(sendEventId, false, Math.round(convertedValue).toString())',
-						sendEventId,
-						Math.round(convertedValue).toString(),
-					);
 					sendEvent(sendEventId, false, Math.round(convertedValue).toString());
 				}
 			};
@@ -300,11 +295,6 @@ function sendEventContributionPaymentMethod(
 				const sendEventWhenReady = () => {
 					const sendEventId =
 						SendEventContributionPaymentMethodUpdate.PaymentMethod;
-					console.log(
-						'sendEventContributionPaymentMethod.sendEvent(sendEventId, false, paymentMethod)',
-						sendEventId,
-						paymentMethod,
-					);
 					sendEvent(sendEventId, false, paymentMethod.toString());
 				};
 

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -1,6 +1,7 @@
 import { loadScript } from '@guardian/libs';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { ContributionType } from 'helpers/contributions';
+import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
@@ -38,6 +39,10 @@ enum SendEventContributionAmountUpdate {
 	RecurringContribution = 72,
 }
 
+enum SendEventContributionPaymentMethodUpdate {
+	PaymentMethod = 103,
+}
+
 enum SendEventContributionCheckoutConversion {
 	SingleContribution = 73,
 	RecurringContribution = 74,
@@ -48,7 +53,8 @@ type SendEventId =
 	| SendEventSubscriptionCheckoutStart
 	| SendEventSubscriptionCheckoutConversion
 	| SendEventContributionAmountUpdate
-	| SendEventContributionCheckoutConversion;
+	| SendEventContributionCheckoutConversion
+	| SendEventContributionPaymentMethodUpdate;
 
 // ---- sendEvent logic ---- //
 
@@ -271,6 +277,11 @@ export function sendEventContributionCartValue(
 					sourceCurrency,
 				);
 				if (convertedValue) {
+					console.log(
+						'sendEventContributionCartValue.sendEvent(sendEventId, false, Math.round(convertedValue).toString())',
+						sendEventId,
+						Math.round(convertedValue).toString(),
+					);
 					sendEvent(sendEventId, false, Math.round(convertedValue).toString());
 				}
 			};
@@ -278,6 +289,29 @@ export function sendEventContributionCartValue(
 			sendEventWhenReadyTrigger(sendEventWhenReady);
 		}
 	});
+}
+
+export function sendEventContributionPaymentMethod(
+	paymentMethod: PaymentMethod | null,
+): void {
+	if (paymentMethod) {
+		void canRunQuantumMetric().then((canRun) => {
+			if (canRun) {
+				const sendEventWhenReady = () => {
+					const sendEventId =
+						SendEventContributionPaymentMethodUpdate.PaymentMethod;
+					console.log(
+						'sendEventContributionPaymentMethod.sendEvent(sendEventId, false, paymentMethod)',
+						sendEventId,
+						paymentMethod,
+					);
+					sendEvent(sendEventId, false, paymentMethod.toString());
+				};
+
+				sendEventWhenReadyTrigger(sendEventWhenReady);
+			}
+		});
+	}
 }
 
 function sendEventABTestParticipations(participations: Participations): void {

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -192,7 +192,7 @@ function checkoutEvents(
 	return { start, conversion };
 }
 
-export function sendEventSubscriptionCheckoutStart(
+function sendEventSubscriptionCheckoutStart(
 	product: SubscriptionProduct,
 	orderIsAGift: boolean,
 	productPrice: ProductPrice,
@@ -210,7 +210,7 @@ export function sendEventSubscriptionCheckoutStart(
 	}
 }
 
-export function sendEventSubscriptionCheckoutConversion(
+function sendEventSubscriptionCheckoutConversion(
 	product: SubscriptionProduct,
 	orderIsAGift: boolean,
 	productPrice: ProductPrice,
@@ -228,7 +228,7 @@ export function sendEventSubscriptionCheckoutConversion(
 	}
 }
 
-export function sendEventContributionCheckoutConversion(
+function sendEventContributionCheckoutConversion(
 	amount: number,
 	contributionType: ContributionType,
 	sourceCurrency: IsoCurrency,
@@ -255,7 +255,7 @@ export function sendEventContributionCheckoutConversion(
 	});
 }
 
-export function sendEventContributionCartValue(
+function sendEventContributionCartValue(
 	amount: string,
 	contributionType: ContributionType,
 	sourceCurrency: IsoCurrency,
@@ -291,7 +291,7 @@ export function sendEventContributionCartValue(
 	});
 }
 
-export function sendEventContributionPaymentMethod(
+function sendEventContributionPaymentMethod(
 	paymentMethod: PaymentMethod | null,
 ): void {
 	if (paymentMethod) {
@@ -364,7 +364,7 @@ function addQM() {
 	});
 }
 
-export function init(participations: Participations): void {
+function init(participations: Participations): void {
 	void canRunQuantumMetric().then((canRun) => {
 		if (canRun) {
 			void addQM().then(() => {
@@ -377,3 +377,12 @@ export function init(participations: Participations): void {
 		}
 	});
 }
+
+export {
+	init,
+	sendEventSubscriptionCheckoutStart,
+	sendEventSubscriptionCheckoutConversion,
+	sendEventContributionCheckoutConversion,
+	sendEventContributionCartValue,
+	sendEventContributionPaymentMethod,
+};


### PR DESCRIPTION
Quantum Metric set-up a Payment Method Click event, which should be called when a user clicks on a payment method. The syntax required for supporting this event is:

QuantumMetricAPI.sendEvent(103,0,"Insert Name of Payment Method Here");

eg : DirectDebit , Stripe, PayPal (selection passed through to Quantum Metric)
![Screenshot 2023-01-06 at 19 15 33](https://user-images.githubusercontent.com/76729591/211083491-b8969452-23c5-41e2-9366-c3b645f622b3.png)


[**Trello Card**](https://trello.com/c/vWt8G9MY/954-quantum-metric-send-payment-method-event-to-qm)

## Why are you doing this?
On the Supporter Plus (variant) checkout It would be useful to send the name of the payment method selected to Quantum Metric.


## Is this an AB test?
- [ ] Yes
- [x] No
