### PR TITLE
Enable Student Beans link in GW landing page, layout correction

### DIFF
--- a/support-frontend/assets/components/containers/centredContainer.tsx
+++ b/support-frontend/assets/components/containers/centredContainer.tsx
@@ -12,12 +12,6 @@ const centredContainer = css`
 	margin: 0 auto;
 	max-width: 1290px;
 
-  ${from.phablet} {
-    display: flex;
-	  flex-direction: row;
-    justify-content: space-evenly:
-  }
-
 	${from.desktop} {
 		width: calc(100% - 110px);
 	}

--- a/support-frontend/assets/components/product/giftNonGiftCta.tsx
+++ b/support-frontend/assets/components/product/giftNonGiftCta.tsx
@@ -6,11 +6,12 @@ import {
 } from '@guardian/source-react-components';
 import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
 
-type GiftableProduct = 'digital' | 'Guardian Weekly';
+type SubscriptionProduct = 'digital' | 'Guardian Weekly' | 'Student';
 type PropTypes = {
 	href: string;
-	product: GiftableProduct;
+	product: SubscriptionProduct;
 	orderIsAGift: boolean;
+	isStudent?: boolean;
 };
 const giftOrPersonal = css`
 	padding: ${space[3]}px ${space[3]}px ${space[12]}px;
@@ -25,16 +26,30 @@ const giftOrPersonalHeading = css`
 	})};
 `;
 
-function GiftOrPersonal({ href, product, orderIsAGift }: PropTypes) {
+function GiftOrPersonalOrStudent({
+	href,
+	product,
+	orderIsAGift,
+	isStudent,
+}: PropTypes) {
+	if (isStudent && orderIsAGift) {
+		return null;
+	}
 	return (
 		<section css={giftOrPersonal}>
 			<div css={giftOrPersonalCopy}>
 				<h2 css={giftOrPersonalHeading}>
-					{orderIsAGift
+					{isStudent
+						? 'Student subscriptions'
+						: orderIsAGift
 						? 'Looking for a subscription for yourself?'
 						: 'Gift subscriptions'}
 				</h2>
-				{!orderIsAGift && <p>A {product} subscription makes a great gift.</p>}
+				{isStudent ? (
+					<p>{product}s get 70% off a Guardian Weekly subscription.</p>
+				) : (
+					!orderIsAGift && <p>A {product} subscription makes a great gift.</p>
+				)}
 			</div>
 			<LinkButton
 				icon={<SvgArrowRightStraight />}
@@ -44,15 +59,21 @@ function GiftOrPersonal({ href, product, orderIsAGift }: PropTypes) {
 				href={href}
 				onClick={() => {
 					sendTrackingEventsOnClick({
-						id: `${orderIsAGift ? 'personal' : 'gift'}_subscriptions_cta`,
+						id: `${
+							isStudent ? 'student' : orderIsAGift ? 'personal' : 'gift'
+						}_subscriptions_cta`,
 						componentType: 'ACQUISITIONS_BUTTON',
-					})();
+					});
 				}}
 			>
-				{orderIsAGift ? 'See personal subscriptions' : 'See gift subscriptions'}
+				{isStudent
+					? `I'm a student`
+					: orderIsAGift
+					? 'See personal subscriptions'
+					: 'See gift subscriptions'}
 			</LinkButton>
 		</section>
 	);
 }
 
-export default GiftOrPersonal;
+export default GiftOrPersonalOrStudent;

--- a/support-frontend/assets/helpers/urls/routes.ts
+++ b/support-frontend/assets/helpers/urls/routes.ts
@@ -36,6 +36,8 @@ const routes: Record<string, string> = {
 		'/subscribe/paper/delivery#subscribe',
 	guardianWeeklySubscriptionLanding: '/subscribe/weekly',
 	guardianWeeklySubscriptionLandingGift: '/subscribe/weekly/gift',
+	guardianWeeklyStudent:
+		'https://connect.studentbeans.com/v4/hosted/the-guardian-weekly/uk',
 	postcodeLookup: '/postcode-lookup',
 	createSignInUrl: '/identity/signin-url',
 	stripeSetupIntentRecaptcha: '/stripe/create-setup-intent/recaptcha',

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -134,12 +134,14 @@ function WeeklyLandingPage({
 							href={giftNonGiftLink}
 							orderIsAGift={orderIsAGift ?? false}
 						/>
-						<GiftNonGiftCta
-							product="Student"
-							href={routes.guardianWeeklyStudent}
-							orderIsAGift={orderIsAGift ?? false}
-							isStudent={true}
-						/>
+						{countryGroupId === 'GBPCountries' && (
+							<GiftNonGiftCta
+								product="Student"
+								href={routes.guardianWeeklyStudent}
+								orderIsAGift={orderIsAGift ?? false}
+								isStudent={true}
+							/>
+						)}
 					</div>
 				</CentredContainer>
 			</FullWidthContainer>

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -1,5 +1,6 @@
 // ----- Imports ----- //
 import { css } from '@emotion/react';
+import { from } from '@guardian/source-foundations';
 import CentredContainer from 'components/containers/centredContainer';
 import FullWidthContainer from 'components/containers/fullWidthContainer';
 import headerWithCountrySwitcherContainer from 'components/headers/header/headerWithCountrySwitcher';
@@ -46,6 +47,13 @@ const reactElementId: Record<CountryGroupId, string> = {
 const closeGapAfterPageTitle = css`
 	margin-top: 0;
 `;
+
+const displayRowEvenly = css`
+  ${from.phablet} {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly:
+}`;
 
 // ----- Render ----- //
 function WeeklyLandingPage({
@@ -120,17 +128,19 @@ function WeeklyLandingPage({
 			</FullWidthContainer>
 			<FullWidthContainer theme="white">
 				<CentredContainer>
-					<GiftNonGiftCta
-						product="Guardian Weekly"
-						href={giftNonGiftLink}
-						orderIsAGift={orderIsAGift ?? false}
-					/>
-					<GiftNonGiftCta
-						product="Student"
-						href={routes.guardianWeeklyStudent}
-						orderIsAGift={orderIsAGift ?? false}
-						isStudent={true}
-					/>
+					<div css={displayRowEvenly}>
+						<GiftNonGiftCta
+							product="Guardian Weekly"
+							href={giftNonGiftLink}
+							orderIsAGift={orderIsAGift ?? false}
+						/>
+						<GiftNonGiftCta
+							product="Student"
+							href={routes.guardianWeeklyStudent}
+							orderIsAGift={orderIsAGift ?? false}
+							isStudent={true}
+						/>
+					</div>
 				</CentredContainer>
 			</FullWidthContainer>
 		</Page>


### PR DESCRIPTION
Enable Student Beans link in GW landing page (UK-only)

1) Add new ''Student subscriptions'' element to GW landing page (See design)
2) Link out to Student Beans portal (url below)


[**Trello Card**](https://trello.com/c/31VRnK2G/975-dev-enable-student-beans-link-in-gw-landing-page)

![Screenshot 2023-01-09 at 11 58 20](https://user-images.githubusercontent.com/76729591/211303165-7d6349a8-57a8-45a8-9e0c-ad7c4a58722f.png)

## Is this an AB test?
- [ ] Yes
- [x] No