### PR TITLE
Change lambda scheduling

### DIFF
--- a/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
+++ b/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
@@ -756,9 +756,9 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "StripePatronsDataPRODStripePatronsDataPRODrate15minutes0115BF571": {
+    "StripePatronsDataPRODStripePatronsDataPRODrate30minutes028F3FD32": {
       "Properties": {
-        "ScheduleExpression": "rate(15 minutes)",
+        "ScheduleExpression": "rate(30 minutes)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -774,7 +774,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Events::Rule",
     },
-    "StripePatronsDataPRODStripePatronsDataPRODrate15minutes0AllowEventRuleStripePatronsDataPRODBF7BDE5FC0DAF728": {
+    "StripePatronsDataPRODStripePatronsDataPRODrate30minutes0AllowEventRuleStripePatronsDataPRODBF7BDE5FE71C5129": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -786,7 +786,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "StripePatronsDataPRODStripePatronsDataPRODrate15minutes0115BF571",
+            "StripePatronsDataPRODStripePatronsDataPRODrate30minutes028F3FD32",
             "Arn",
           ],
         },

--- a/cdk/lib/stripe-patrons-data.ts
+++ b/cdk/lib/stripe-patrons-data.ts
@@ -67,14 +67,14 @@ class StripePatronsDataLambda extends GuScheduledLambda {
           alarmDescription: `Triggers if there are errors from ${appName} on ${stage}`,
           snsTopicName: "reader-revenue-dev",
           toleratedErrorPercentage: 1,
-          numberOfMinutesAboveThresholdBeforeAlarm: 46, // The lambda runs every 15 mins so alarm if it fails 3 times in a row
+          numberOfMinutesAboveThresholdBeforeAlarm: 46,
         };
       }
       return { noMonitoring: true };
     }
 
     function scheduleRateForEnvironment(stage: string) {
-      return Schedule.rate(Duration.minutes(stage == "PROD" ? 15 : 60));
+      return Schedule.rate(Duration.minutes(stage == "PROD" ? 30 : 24 * 60));
     }
 
     this.addToRolePolicy(parameterStorePolicy(scope, appName));

--- a/supporter-product-data/cloudformation/cfn.yaml
+++ b/supporter-product-data/cloudformation/cfn.yaml
@@ -18,17 +18,17 @@ Mappings:
   StageVariables:
     DEV:
       S3Bucket: supporter-product-data-export-dev
-      # Every 10 mins between 7am and 7pm Mon-Fri
-      scheduleRate: "cron(*/10 7-19 ? * 1-5 *)"
+      # Run once at 6am Mon-Fri
+      scheduleRate: "cron(0 6 * * 1-5)"
       lambdaConcurrency: 30
     UAT:
       S3Bucket: supporter-product-data-export-uat
-      scheduleRate: "cron(*/10 7-19 ? * 1-5 *)"
+      scheduleRate: "cron(0 6 * * 1-5)"
       lambdaConcurrency: 30
     PROD:
       S3Bucket: supporter-product-data-export-prod
-      # Every 5 mins
-      scheduleRate: "cron(*/5 * ? * * *)"
+      # Every 15 mins
+      scheduleRate: "cron(*/15 * ? * * *)"
       lambdaConcurrency: 50 # May need to reduce this number if we see downstream systems getting overwhelmed during a full refresh, I've tested with 30 and that was fine
 
 Resources:


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Costs for running  the supporter product data update step function have increased out AWS  bill noticeably and are the single largest step function cost by a long way.

While it is important that the SupporterProductData dynamo table (which is used by members-data-api to work out which products a user has) is kept up to date, it is already updated separately by support-workers when a purchase is made via the support site so it is only for purchases made via CSRs that we are wholly reliant on this step function. Since these are much lower volume and due to their nature (via a phone call) are probably less time sensitive I think it is reasonable to decrease the frequency of the execution of this step function. I have also decreased the frequency in the DEV and UAT environments to once a day.

I have also reduced the frequency of the stripe-patrons-data scheduled lambda as acquisition of patrons is very low volume so we are probably wasting money buy running it more frequently - ultimately we should change this to a Stripe webhook and removed the scheduling completely.