### PR TITLE
Fix supporter-product-data schedule cron

### DIFF
--- a/supporter-product-data/cloudformation/cfn.yaml
+++ b/supporter-product-data/cloudformation/cfn.yaml
@@ -19,11 +19,11 @@ Mappings:
     DEV:
       S3Bucket: supporter-product-data-export-dev
       # Run once at 6am Mon-Fri
-      scheduleRate: "cron(0 6 * * 1-5)"
+      scheduleRate: "cron(0 6 ? * 1-5 *)"
       lambdaConcurrency: 30
     UAT:
       S3Bucket: supporter-product-data-export-uat
-      scheduleRate: "cron(0 6 * * 1-5)"
+      scheduleRate: "cron(0 6 ? * 1-5 *)"
       lambdaConcurrency: 30
     PROD:
       S3Bucket: supporter-product-data-export-prod


### PR DESCRIPTION
Based on [the docs](https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents-expressions.html), I believe either day-of-week or day-of-month should be a question mark. I think builds are currently failing in UAT.