### PR TITLE
Redirect for Support-Landing-Page

### DIFF
--- a/support-frontend/app/controllers/SiteMap.scala
+++ b/support-frontend/app/controllers/SiteMap.scala
@@ -26,13 +26,13 @@ class SiteMap(
   private def supportLandingPages()(implicit req: RequestHeader) = {
     <url>
       <loc>{
-      routes.Application.showcase("uk").absoluteURL(secure = true)
+      contributionsLandingPageUK()
     }</loc>
       <xhtml:link rel="alternate" hreflang="en-us" href={
       contributionsLandingPageUS()
     }/>
       <xhtml:link rel="alternate" hreflang="en" href={
-      routes.Application.showcase("uk").absoluteURL(secure = true)
+      contributionsLandingPageUK()
     }/>
       <priority>1.0</priority>
     </url>
@@ -47,7 +47,7 @@ class SiteMap(
       contributionsLandingPageUS()
     }/>
       <xhtml:link rel="alternate" hreflang="en" href={
-      routes.Application.showcase("uk").absoluteURL(secure = true)
+      contributionsLandingPageUK()
     }/>
       <priority>1.0</priority>
     </url>
@@ -61,5 +61,15 @@ class SiteMap(
       )
       .absoluteURL(secure = true)
   }
+
+  private def contributionsLandingPageUK()(implicit req: RequestHeader) = {
+    routes.Application
+      .contributionsLanding(
+        country = "uk",
+        campaignCode = "",
+      )
+      .absoluteURL(secure = true)
+  }
+
 
 }

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -28,16 +28,15 @@ GET /eu                                                            controllers.A
 GET /int                                                           controllers.Application.redirect(location="/int/contribute")
 GET /nz                                                            controllers.Application.redirect(location="/nz/contribute")
 GET /ca                                                            controllers.Application.redirect(location="/ca/contribute")
-GET /uk                                                            controllers.Application.redirect(location="/uk/support")
+GET /uk                                                            controllers.Application.redirect(location="/uk/contribute")
 GET /                                                              controllers.Application.geoRedirect()
 
 
 # ----- Bundles Landing Page ----- #
 
-GET /support                                                       controllers.Application.supportGeoRedirect()
-GET /$country<(uk|us|au|eu|int|nz|ca)>/support                     controllers.Application.showcase(country: String)
-# redirect from old ab test
-GET /showcase                                                      controllers.Application.permanentRedirect(location="/uk/support")
+GET /support                                                       controllers.Application.permanentRedirect(location="/contribute")
+GET /$country<(uk|us|au|eu|int|nz|ca)>/support                     controllers.Application.permanentRedirectWithCountry(country, location="/contribute")
+GET /showcase                                                      controllers.Application.permanentRedirect(location="/contribute")
 
 
 # ----- Events Redirect ----- #


### PR DESCRIPTION
## What are you doing in this PR?

Add redirect for Support Landing Page https://support.theguardian.com/uk/support route

[**Trello Card**](https://trello.com/c/qm0grN61/654-epic-remove-dig-subs-3-8-add-redirect-for-support-landing-page-https-supporttheguardiancom-uk-support-route)

## Why are you doing this?

We plan to deprecate the support landing page at the /support route. The link will be removed from the navigation (when we turn on the "hide all links to the digital subscription..." switch in the RRCP)
However we also need to add a redirects on https://support.theguardian.com/uk/support to the Supporter Plus checkout.

## Is this an AB test?
- [ ] Yes
- [x ] No

