### PR TITLE
Scala Steward PR grouping: use full group name

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,5 @@
 pullRequests.frequency = "0 10 * * 1-5" #10 am Monday to Friday
 pullRequests.grouping = [
-  { name = "aws", "title" = "AWS Scala dependency updates", "filter" = [{"group" = "software.amazon"}, {"group" = "com.amazonaws"}] },
+  { name = "aws", "title" = "AWS Scala dependency updates", "filter" = [{"group" = "software.amazon.awssdk"}, {"group" = "com.amazonaws"}] },
   { name = "non_aws", "title" = "Non AWS Scala dependency updates", "filter" = [{"group" = "*"}] }
 ]


### PR DESCRIPTION
Not sure if this will fully resolve the problems with Scala Steward not respecting the `pullRequests.grouping` setting, but from testing on another repo (https://github.com/guardian/play-secret-rotation), I did find that the full group name must be specified (so `software.amazon.awssdk`, not `software.amazon`, changed with https://github.com/guardian/play-secret-rotation/commit/c1cbc2a8a2096a96c5b9f79f607d2436118102cd).

* https://github.com/guardian/play-secret-rotation/pull/381 - ❌ incorrectly grouped & named "Non AWS", Scala Steward conf was `"group" = "software.amazon"`
* https://github.com/guardian/play-secret-rotation/pull/382 - ✅ correctly grouped & named "AWS", Scala Steward conf was `"group" = "software.amazon.awssdk"`

See also the discussion in https://github.com/scala-steward-org/scala-steward/pull/2714#issuecomment-1378924242.
