### PR TITLE
Supporter Product Data Step function Fixes

### DIFF
--- a/supporter-product-data/cloudformation/cfn.yaml
+++ b/supporter-product-data/cloudformation/cfn.yaml
@@ -27,8 +27,8 @@ Mappings:
       lambdaConcurrency: 30
     PROD:
       S3Bucket: supporter-product-data-export-prod
-      # Every 15 mins
-      scheduleRate: "cron(*/15 * ? * * *)"
+      # Every 5 mins
+      scheduleRate: "cron(*/5 * ? * * *)"
       lambdaConcurrency: 50 # May need to reduce this number if we see downstream systems getting overwhelmed during a full refresh, I've tested with 30 and that was fine
 
 Resources:

--- a/supporter-product-data/cloudformation/cfn.yaml
+++ b/supporter-product-data/cloudformation/cfn.yaml
@@ -447,7 +447,7 @@ Resources:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
       AlarmName: There was a csv read failure when loading supporter product data into DynamoDB
       AlarmDescription: >
-        Search for 'CSV read failures' in the AddSupporterRatePlanItemToQueueLambda Cloudwatch logs:
+        Search for 'CSV read failure' in the AddSupporterRatePlanItemToQueueLambda Cloudwatch logs:
         https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fsupport-SupporterProductDataAddSupporterRatePlanItemToQueue-PROD
       MetricName: CsvReadFailure
       Namespace: supporter-product-data

--- a/supporter-product-data/src/main/scala/com/gu/services/SelectActiveRatePlansQuery.scala
+++ b/supporter-product-data/src/main/scala/com/gu/services/SelectActiveRatePlansQuery.scala
@@ -52,7 +52,8 @@ object SelectActiveRatePlansQuery {
    this makes sure that cancellations come after the active version of the sub in case we have both (we shouldn't but you never know!)
    */
 
-  def query(discountProductRatePlanIds: List[String]): String =
+  def query(discountProductRatePlanIds: List[String]): String = {
+    // If this query changes then we MUST run a full sync in all environments or we will continue to use the old version
     s"""SELECT
           $subscriptionName,
           Subscription.Version,
@@ -73,5 +74,6 @@ object SelectActiveRatePlansQuery {
             ($isNotDSGift OR $isRedeemedDSGift)
           ORDER BY $identityId, $contractEffectiveDate, $subscriptionName, Subscription.Version
     """
+  }
 
 }

--- a/supporter-product-data/src/test/scala/com/gu/lambdas/AddSupporterRatePlanItemToQueueIntegrationTest.scala
+++ b/supporter-product-data/src/test/scala/com/gu/lambdas/AddSupporterRatePlanItemToQueueIntegrationTest.scala
@@ -1,0 +1,30 @@
+package com.gu.lambdas
+
+import com.gu.model.states.AddSupporterRatePlanItemToQueueState
+import com.gu.supporterdata.model.Stage.DEV
+import com.gu.test.tags.annotations.IntegrationTest
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.ZonedDateTime
+
+@IntegrationTest
+class AddSupporterRatePlanItemToQueueIntegrationTest extends AsyncFlatSpec with Matchers {
+
+  "AddSupporterRatePlanItemToQueueLambda" should "process records correctly" in {
+    val csvFilename = "select-active-rate-plans-2023-01-12T05:59:45.210958.csv"
+    AddSupporterRatePlanItemToQueueLambda.addToQueue(
+      DEV,
+      AddSupporterRatePlanItemToQueueState(
+        csvFilename,
+        248,
+        0,
+        ZonedDateTime.parse("2023-01-11T21:59:53.743208-08:00[America/Los_Angeles]"),
+      ),
+      new TimeOutCheck {
+        override def timeRemainingMillis: Int = 1000 * 60 * 5
+      },
+    )
+  }.map(outState => outState.processedCount shouldBe 248)
+
+}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We recently noticed some issues with the [supporter-product-data-UAT](https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/statemachines/view/arn:aws:states:eu-west-1:865473395570:stateMachine:supporter-product-data-UAT) step function which meant it had been failing repeatedly for many months. This PR makes some changes to try to prevent this happening again.

## What happened
The supporter product data step function extracts data from Zuora on a scheduled basis using a stateful Aqua query: https://knowledgecenter.zuora.com/Zuora_Central_Platform/API/AB_Aggregate_Query_API/BA_Stateless_and_Stateful_Modes

This means that it has two modes of running - Full or Incremental specified by the value that is passed into it eg
{
  "queryType": "incremental"
}

when a full extract is required the SupporterProductDataQueryZuora lambda passes in the query statement to Zuora eg.
```
SELECT RatePlan.AmendmentType, Subscription.Id, Account.IdentityId__c, Subscription.GifteeIdentityId__c, RatePlan.Id, ProductRatePlan.Id, ProductRatePlan.Name, Subscription.TermEndDate 
FROM rateplan 
WHERE Subscription.TermEndDate >= '2021-03-16' 
AND (Subscription.Status = 'Active' OR (Subscription.Status = 'Cancelled' 
AND ProductRatePlan.Id != '2c92c0f85ab269be015acd9d014549b7' 
AND ProductRatePlan.Id != '2c92c0f95e1d5c9c015e38f8c87d19a1')) 
AND (RatePlan.AmendmentType is null OR RatePlan.AmendmentType = 'NewProduct' OR RatePlan.AmendmentType = 'UpdateProduct') 
AND ProductRatePlan.Id != '2c92c0f953078a5601531299dae54a4d' 
AND Account.IdentityId__c like '_%' 
AND ((Subscription.RedemptionCode__c = '' OR Subscription.RedemptionCode__c is null) OR (Subscription.RedemptionCode__c like '_%' AND Subscription.GifteeIdentityId__c like '_%'))
```
however when an incremental update is required it only passes the last query time and the query from the last full extract is used.

What  this means is that if the fields returned by the query change we MUST run a full sync in all environments or we will be continuing to use the old query in our executions. In this case a change in the select fields led a CSV parsing error when we tried to read the results.

## The fixes
- I have added  code to make the `AddSupporterRatePlanItemToQueueLambda` fail if it comes across an empty CSV file or if it is unable to read any items from the CSV. Previously we would keep processing and alarm if there were read errors but in all likelihood if one row can't be read, none will be and it is better to exit the lambda and terminate the step function execution.
- I have added a comment where the zuora query is defined to make it clear that any change to the query will require a full data refresh in all environments.

I have also reverted the scheduling frequency of the PROD version of the lambda to 5 minutes as this was reduced to try to reduce the processing cost but it turned out that the cost was actually down to the errors in the DEV and UAT configurations, not the amount of processing in PROD
