### PR TITLE
update monthly MIN value for other amount field

### DIFF
--- a/support-frontend/assets/helpers/contributions.ts
+++ b/support-frontend/assets/helpers/contributions.ts
@@ -189,7 +189,7 @@ const config: Record<CountryGroupId, Config> = {
 	AUDCountries: {
 		ANNUAL: defaultConfig.ANNUAL,
 		MONTHLY: {
-			min: 10,
+			min: 2,
 			minInWords: numbersInWords['10'],
 			max: 200,
 			maxInWords: numbersInWords['200'],
@@ -236,7 +236,7 @@ const config: Record<CountryGroupId, Config> = {
 	International: {
 		ANNUAL: defaultConfig.ANNUAL,
 		MONTHLY: {
-			min: 5,
+			min: 2,
 			minInWords: numbersInWords['5'],
 			max: 166,
 			maxInWords: numbersInWords['166'],
@@ -247,7 +247,7 @@ const config: Record<CountryGroupId, Config> = {
 	NZDCountries: {
 		ANNUAL: defaultConfig.ANNUAL,
 		MONTHLY: {
-			min: 10,
+			min: 2,
 			minInWords: numbersInWords['10'],
 			max: 200,
 			maxInWords: numbersInWords['200'],
@@ -258,7 +258,7 @@ const config: Record<CountryGroupId, Config> = {
 	Canada: {
 		ANNUAL: defaultConfig.ANNUAL,
 		MONTHLY: {
-			min: 5,
+			min: 2,
 			minInWords: numbersInWords['5'],
 			max: 166,
 			maxInWords: numbersInWords['166'],

--- a/support-frontend/assets/helpers/contributions.ts
+++ b/support-frontend/assets/helpers/contributions.ts
@@ -190,7 +190,7 @@ const config: Record<CountryGroupId, Config> = {
 		ANNUAL: defaultConfig.ANNUAL,
 		MONTHLY: {
 			min: 2,
-			minInWords: numbersInWords['10'],
+			minInWords: numbersInWords['2'],
 			max: 200,
 			maxInWords: numbersInWords['200'],
 			default: 20,
@@ -237,7 +237,7 @@ const config: Record<CountryGroupId, Config> = {
 		ANNUAL: defaultConfig.ANNUAL,
 		MONTHLY: {
 			min: 2,
-			minInWords: numbersInWords['5'],
+			minInWords: numbersInWords['2'],
 			max: 166,
 			maxInWords: numbersInWords['166'],
 			default: 10,
@@ -248,7 +248,7 @@ const config: Record<CountryGroupId, Config> = {
 		ANNUAL: defaultConfig.ANNUAL,
 		MONTHLY: {
 			min: 2,
-			minInWords: numbersInWords['10'],
+			minInWords: numbersInWords['2'],
 			max: 200,
 			maxInWords: numbersInWords['200'],
 			default: 20,
@@ -259,7 +259,7 @@ const config: Record<CountryGroupId, Config> = {
 		ANNUAL: defaultConfig.ANNUAL,
 		MONTHLY: {
 			min: 2,
-			minInWords: numbersInWords['5'],
+			minInWords: numbersInWords['2'],
 			max: 166,
 			maxInWords: numbersInWords['166'],
 			default: 10,


### PR DESCRIPTION
## What are you doing in this PR?

This PR sets the MIN value users are allowed to submit in the "Other amount" field on the monthly tab at https://support.theguardian.com/contribute to `2` in all regions. 

## Why are you doing this?

We've seen when AB testing choice card amounts that the MIN value in the code is sometimes greater than the lowest value choice card, so isn't really the MIN, this leads to confusing UX, as shown below:

<img width="517" alt="Screenshot 2023-01-13 at 15 44 30" src="https://user-images.githubusercontent.com/1590704/212368937-1c36bd72-99d6-4eb6-8739-cad124943b0a.png">

The current MIN values also contradict some support messaging on www.theguardian.com that states "you can give from as little as £/$2 a month".

It's been agreed that the smallest monthly choice card in an amounts AB test will not be less than 2.
