### PR TITLE
Show discount vs retail for newspaper

### DIFF
--- a/support-frontend/assets/helpers/productPrice/productPrices.test.ts
+++ b/support-frontend/assets/helpers/productPrice/productPrices.test.ts
@@ -1,0 +1,8 @@
+import { getDiscountVsRetail } from './productPrices';
+
+describe('getDiscountVsRetail', () => {
+	it('calculates total discount vs retail', () => {
+		const discount = getDiscountVsRetail(48.79, 27, 20);
+		expect(discount).toEqual(42);
+	});
+});

--- a/support-frontend/assets/helpers/productPrice/productPrices.ts
+++ b/support-frontend/assets/helpers/productPrice/productPrices.ts
@@ -126,6 +126,22 @@ function getCurrency(country: IsoCountry): IsoCurrency {
 	return currency;
 }
 
+/**
+ * @param discountedPrice - price after promo discount applied to online price
+ * @param onlineVsRetailPerc - % discount of normal online price vs retail price
+ * @param discountedVsOnlinePerc - % discount of discountedPrice against normal online price
+ */
+const getDiscountVsRetail = (
+	discountedPrice: number,
+	onlineVsRetailPerc: number,
+	discountedVsOnlinePerc: number,
+): number => {
+	const onlinePrice = discountedPrice / (1 - discountedVsOnlinePerc / 100);
+	const retailPrice = onlinePrice / (1 - onlineVsRetailPerc / 100);
+	const totalSavingVsRetail = (1 - discountedPrice / retailPrice) * 100;
+	return Math.round(totalSavingVsRetail);
+};
+
 export {
 	getProductPrice,
 	getFirstValidPrice,
@@ -135,4 +151,5 @@ export {
 	showPrice,
 	displayPrice,
 	isNumeric,
+	getDiscountVsRetail,
 };

--- a/support-frontend/assets/pages/paper-subscription-landing/components/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/paperPrices.tsx
@@ -8,6 +8,7 @@ import type {
 } from 'helpers/productPrice/productPrices';
 import {
 	finalPrice,
+	getDiscountVsRetail,
 	getProductPrice,
 	showPrice,
 } from 'helpers/productPrice/productPrices';
@@ -57,6 +58,18 @@ const autumnPromoCodes = [
 ];
 
 const getOfferText = (price: ProductPrice) => {
+	const winterPromo = (price.promotions ?? []).find((p) =>
+		p.promoCode.startsWith('WINTER'),
+	);
+	if (winterPromo && price.savingVsRetail && winterPromo.discount?.amount) {
+		const discount = getDiscountVsRetail(
+			price.price,
+			price.savingVsRetail,
+			winterPromo.discount.amount,
+		);
+		return `Save ${discount}% on retail price`;
+	}
+
 	if (
 		price.promotions?.some((promo) =>
 			autumnPromoCodes.includes(promo.promoCode),

--- a/support-frontend/assets/pages/paper-subscription-landing/components/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/paperPrices.tsx
@@ -49,7 +49,11 @@ const getOfferText = (price: ProductPrice, promo?: Promotion) => {
 			price.savingVsRetail,
 			promo.discount.amount,
 		);
-		return `Save ${discount}% on retail price`;
+		if (discount > 0) {
+			return `Save ${discount}% on retail price`;
+		} else {
+			return '';
+		}
 	}
 
 	if (price.savingVsRetail && price.savingVsRetail > 0) {

--- a/support-frontend/assets/pages/paper-subscription-landing/components/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/paperPrices.tsx
@@ -13,6 +13,7 @@ import {
 	showPrice,
 } from 'helpers/productPrice/productPrices';
 import { getAppliedPromo } from 'helpers/productPrice/promotions';
+import type { Promotion } from 'helpers/productPrice/promotions';
 import {
 	sendTrackingEventsOnClick,
 	sendTrackingEventsOnView,
@@ -41,42 +42,16 @@ const getPriceCopyString = (
 	return <>per month{productCopy}</>;
 };
 
-const autumnPromoCodes = [
-	'AUTUMNEVERYDAY10HD',
-	'AUTUMNSAT10',
-	'AUTUMNSAT10HD',
-	'AUTUMNSIXDAY10',
-	'AUTUMNSIXDAY10HD',
-	'AUTUMNSUN10',
-	'AUTUMNSUN10HD',
-	'AUTUMNWEEKEND10',
-	'AUTUMNWEEKEND10HD',
-	'AUTUMN14',
-	'FESTIVAL20',
-	'AUTUMN20',
-	'AUTUMN30',
-];
-
-const getOfferText = (price: ProductPrice) => {
-	const winterPromo = (price.promotions ?? []).find((p) =>
-		p.promoCode.startsWith('WINTER'),
-	);
-	if (winterPromo && price.savingVsRetail && winterPromo.discount?.amount) {
+const getOfferText = (price: ProductPrice, promo?: Promotion) => {
+	if (promo && price.savingVsRetail && promo.discount?.amount) {
 		const discount = getDiscountVsRetail(
 			price.price,
 			price.savingVsRetail,
-			winterPromo.discount.amount,
+			promo.discount.amount,
 		);
 		return `Save ${discount}% on retail price`;
 	}
 
-	if (
-		price.promotions?.some((promo) =>
-			autumnPromoCodes.includes(promo.promoCode),
-		)
-	) {
-		return '';
-	}
 	if (price.savingVsRetail && price.savingVsRetail > 0) {
 		return `Save ${price.savingVsRetail}% on retail price`;
 	}
@@ -195,7 +170,7 @@ const getPlans = (
 				nonDiscountedPrice,
 				copy[fulfilmentOption][productOption],
 			),
-			offerCopy: getOfferText(priceAfterPromosApplied),
+			offerCopy: getOfferText(priceAfterPromosApplied, promotion),
 			label: labelText,
 		};
 	});


### PR DESCRIPTION
Currently in the newspaper product page the price cards only show the normal online vs retail discount, even if a promo is applied.
We only have the `savingVsRetail`, so the logic is a bit fiddly.

### collection before (the price is with the promo discount, but the % is for normal online price vs retail)
![Screenshot 2023-01-16 at 15 47 25](https://user-images.githubusercontent.com/1513454/212718039-80ecb6dd-60d6-4269-b077-da3c5720cc7d.png)


### collection after
![Screenshot 2023-01-16 at 15 46 49](https://user-images.githubusercontent.com/1513454/212718082-7bb42ab0-b138-4728-9dff-8944fbcb9b08.png)

### delivery before
![Screenshot 2023-01-16 at 15 48 14](https://user-images.githubusercontent.com/1513454/212718341-621efe74-e702-4247-9e9e-43f5042df979.png)


### delivery after
![Screenshot 2023-01-16 at 15 48 08](https://user-images.githubusercontent.com/1513454/212718368-3ffd4dd0-75ab-4875-9189-b3276e16d335.png)
