### PR TITLE
Fix UpdateSupporterProductData lambda

### DIFF
--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -123,11 +123,7 @@ Resources:
             - Effect: Allow
               Action:
               - dynamodb:PutItem
-              - dynamodb:GetItem
               - dynamodb:UpdateItem
-              - dynamodb:DeleteItem
-              - dynamodb:BatchGetItem
-              - dynamodb:DescribeTable
               Resource:
               - Fn::ImportValue: supporter-product-data-tables-UAT-SupporterProductDataTable
               - Fn::ImportValue: !FindInMap [ StageVariables, !Ref Stage, SupporterProductDataTable ]

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
@@ -1,7 +1,7 @@
 package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
-import com.gu.supporterdata
+import com.gu.monitoring.SafeLogger
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.catalog._
 import com.gu.support.workers.RequestInfo
@@ -10,9 +10,11 @@ import com.gu.support.workers.states.SendThankYouEmailState.{
   SendThankYouEmailContributionState,
   SendThankYouEmailDigitalSubscriptionCorporateRedemptionState,
   SendThankYouEmailDigitalSubscriptionDirectPurchaseState,
+  SendThankYouEmailDigitalSubscriptionGiftPurchaseState,
   SendThankYouEmailDigitalSubscriptionGiftRedemptionState,
   SendThankYouEmailGuardianWeeklyState,
   SendThankYouEmailPaperState,
+  SendThankYouEmailSupporterPlusState,
 }
 import com.gu.support.workers.states.{SendAcquisitionEventState, SendThankYouEmailState}
 import com.gu.support.zuora.api.ReaderType.{Corporate, Direct, Gift}
@@ -45,14 +47,23 @@ class UpdateSupporterProductData(serviceProvider: ServiceProvider)
       catalogService: CatalogService,
       supporterDataDynamoService: SupporterDataDynamoService,
   ) = {
+    SafeLogger.info(s"Attempting to update user ${state.user.id}")
     getSupporterRatePlanItemFromState(state, catalogService) match {
       case Right(Some(supporterRatePlanItem)) =>
-        supporterDataDynamoService.writeItem(supporterRatePlanItem).map(_ => ())
-      case Right(None) => Future.successful(())
-      case Left(_) =>
+        SafeLogger.info(s"Attempting to write supporterRatePlanItem $supporterRatePlanItem")
+        supporterDataDynamoService.writeItem(supporterRatePlanItem).map { _ =>
+          SafeLogger.info(s"Successfully updated supporterRatePlanItem for user ${state.user.id}")
+          ()
+        }
+      case Right(None) =>
+        SafeLogger.info(
+          s"Skipping write to SupporterProductData dynamo table because product is ${state.product.describe}",
+        )
+        Future.successful(())
+      case Left(errMessage) =>
         Future.failed(
           new RuntimeException(
-            s"Unable to update the SupporterProductData dynamo table because we couldn't create a SupporterRatePlanItem from state: $state",
+            s"Unable to update the SupporterProductData dynamo table because $errMessage",
           ),
         )
     }
@@ -65,61 +76,88 @@ object UpdateSupporterProductData {
   def getSupporterRatePlanItemFromState(
       state: SendThankYouEmailState,
       catalogService: CatalogService,
-  ): Either[Unit, Option[SupporterRatePlanItem]] =
+  ): Either[String, Option[SupporterRatePlanItem]] =
     state match {
       case SendThankYouEmailContributionState(user, product, _, _, subscriptionNumber) =>
         catalogService
           .getProductRatePlan(Contribution, product.billingPeriod, NoFulfilmentOptions, NoProductOptions)
           .map(productRatePlan =>
-            supporterRatePlanItem(
-              subscriptionName = subscriptionNumber,
-              identityId = user.id,
-              productRatePlanId = productRatePlan.id,
-              productRatePlanName = s"support-workers added ${product.describe}",
-              Some(ContributionAmount(product.amount, product.currency.iso)),
+            Some(
+              supporterRatePlanItem(
+                subscriptionName = subscriptionNumber,
+                identityId = user.id,
+                productRatePlanId = productRatePlan.id,
+                productRatePlanName = s"support-workers added ${product.describe}",
+                Some(ContributionAmount(product.amount, product.currency.iso)),
+              ),
             ),
           )
-          .toRight(())
-          .map(Some(_))
+          .toRight(s"Unable to create SupporterRatePlanItem from state $state")
+
+      case SendThankYouEmailSupporterPlusState(user, product, _, _, subscriptionNumber) =>
+        catalogService
+          .getProductRatePlan(SupporterPlus, product.billingPeriod, NoFulfilmentOptions, NoProductOptions)
+          .map(productRatePlan =>
+            Some(
+              supporterRatePlanItem(
+                subscriptionName = subscriptionNumber,
+                identityId = user.id,
+                productRatePlanId = productRatePlan.id,
+                productRatePlanName = s"support-workers added ${product.describe}",
+                Some(ContributionAmount(product.amount, product.currency.iso)),
+              ),
+            ),
+          )
+          .toRight(s"Unable to create SupporterRatePlanItem from state $state")
+
       case SendThankYouEmailDigitalSubscriptionDirectPurchaseState(user, product, _, _, _, _, subscriptionNumber) =>
         catalogService
           .getProductRatePlan(DigitalPack, product.billingPeriod, NoFulfilmentOptions, NoProductOptions)
           .map(productRatePlan =>
-            supporterRatePlanItem(
-              subscriptionName = subscriptionNumber,
-              identityId = user.id,
-              productRatePlanId = productRatePlan.id,
-              productRatePlanName = s"support-workers added ${product.describe}",
+            Some(
+              supporterRatePlanItem(
+                subscriptionName = subscriptionNumber,
+                identityId = user.id,
+                productRatePlanId = productRatePlan.id,
+                productRatePlanName = s"support-workers added ${product.describe}",
+              ),
             ),
           )
-          .toRight(())
-          .map(Some(_))
+          .toRight(s"Unable to create SupporterRatePlanItem from state $state")
+
       case SendThankYouEmailDigitalSubscriptionCorporateRedemptionState(user, product, _, subscriptionNumber) =>
         catalogService
           .getProductRatePlan(DigitalPack, product.billingPeriod, NoFulfilmentOptions, NoProductOptions, Corporate)
           .map(productRatePlan =>
-            supporterRatePlanItem(
-              subscriptionName = subscriptionNumber,
-              identityId = user.id,
-              productRatePlanId = productRatePlan.id,
-              productRatePlanName = s"support-workers added ${product.describe}",
+            Some(
+              supporterRatePlanItem(
+                subscriptionName = subscriptionNumber,
+                identityId = user.id,
+                productRatePlanId = productRatePlan.id,
+                productRatePlanName = s"support-workers added ${product.describe}",
+              ),
             ),
           )
-          .toRight(())
-          .map(Some(_))
+          .toRight(s"Unable to create SupporterRatePlanItem from state $state")
+
       case SendThankYouEmailDigitalSubscriptionGiftRedemptionState(user, product, subscriptionNumber, _) =>
         catalogService
           .getProductRatePlan(DigitalPack, product.billingPeriod, NoFulfilmentOptions, NoProductOptions, Gift)
           .map(productRatePlan =>
-            supporterRatePlanItem(
-              subscriptionName = subscriptionNumber,
-              identityId = user.id,
-              productRatePlanId = productRatePlan.id,
-              productRatePlanName = s"support-workers added ${product.describe}",
+            Some(
+              supporterRatePlanItem(
+                subscriptionName = subscriptionNumber,
+                identityId = user.id,
+                productRatePlanId = productRatePlan.id,
+                productRatePlanName = s"support-workers added ${product.describe}",
+              ),
             ),
           )
-          .toRight(())
-          .map(Some(_))
+          .toRight(s"Unable to create SupporterRatePlanItem from state $state")
+      case SendThankYouEmailDigitalSubscriptionGiftPurchaseState(_, _, _, _, _, _, _, _, _, _, _) =>
+        Right(
+          None,
+        ) // We don't want to write DS gift purchases to the data store because they don't give the purchaser DS benefits
       case SendThankYouEmailGuardianWeeklyState(user, product, giftRecipient, _, _, _, _, subscriptionNumber, _) =>
         val readerType = if (giftRecipient.isDefined) Gift else Direct
         catalogService
@@ -131,32 +169,34 @@ object UpdateSupporterProductData {
             readerType,
           )
           .map(productRatePlan =>
-            supporterRatePlanItem(
-              subscriptionName = subscriptionNumber,
-              identityId = user.id,
-              productRatePlanId = productRatePlan.id,
-              productRatePlanName = s"support-workers added ${product.describe}-$readerType",
+            Some(
+              supporterRatePlanItem(
+                subscriptionName = subscriptionNumber,
+                identityId = user.id,
+                productRatePlanId = productRatePlan.id,
+                productRatePlanName = s"support-workers added ${product.describe}-$readerType",
+              ),
             ),
           )
-          .toRight(())
-          .map(Some(_))
+          .toRight(s"Unable to create SupporterRatePlanItem from state $state")
       case SendThankYouEmailPaperState(user, product, _, _, _, _, subscriptionNumber, _) =>
         catalogService
           .getProductRatePlan(Paper, product.billingPeriod, product.fulfilmentOptions, product.productOptions)
           .map(productRatePlan =>
-            supporterRatePlanItem(
-              subscriptionName = subscriptionNumber,
-              identityId = user.id,
-              productRatePlanId = productRatePlan.id,
-              productRatePlanName = s"support-workers added ${product.describe}",
+            Some(
+              supporterRatePlanItem(
+                subscriptionName = subscriptionNumber,
+                identityId = user.id,
+                productRatePlanId = productRatePlan.id,
+                productRatePlanName = s"support-workers added ${product.describe}",
+              ),
             ),
           )
-          .toRight(())
-          .map(Some(_))
-      case _ => Right(None)
+          .toRight(s"Unable to create SupporterRatePlanItem from state $state")
+      case _ => Left(s"Unknown product in state: $state")
     }
 
-  def supporterRatePlanItem(
+  private def supporterRatePlanItem(
       subscriptionName: String,
       identityId: String,
       productRatePlanId: String,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
I noticed an issue with the UpdateSupporterProductData lambda which updates the Dynamo cache when a user purchases a product. When we were working out what type of record to insert, we returned an Option to represent the fact that for Digital Subscription gift purchases we don't insert a record (because gift purchases don't receive the benefits, the giftee does). However the code was actually returning `None` for any unknown product not just DS gifts and because the function wasn't updated when Supporter Plus was released we were returning `None` for all S+ purchases and not writing a record to the data store.

The impact of this would be that purchasers of Supporter Plus would not have been recognised by members-data-api until up to 5 minutes after their purchase. In some cases if a user received a response from mdapi during those 5 minutes, that response would have been cached for a day so in the worst case a user may not have been recognised as a S+ subscriber until a day after their purchase.

I have also removed some unnecessary AWS permissions from the support-workers lambda role
