### PR TITLE
Validate postCode length on server side

### DIFF
--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -281,9 +281,9 @@ object GuardianWeeklyValidation {
           hasAddressLine1AndCity(createSupportWorkersRequest.billingAddress) and
           hasAddressLine1AndCity(address) and
           hasValidPostcodeLength(address.postCode, "Delivery") and hasValidPostcodeLength(
-          createSupportWorkersRequest.billingAddress.postCode,
-          "Billing",
-        )
+            createSupportWorkersRequest.billingAddress.postCode,
+            "Billing",
+          )
       case None => Invalid("missing delivery address")
     }
 
@@ -317,9 +317,9 @@ object PaperValidation {
         hasAddressLine1AndCity(createSupportWorkersRequest.billingAddress) and
         deliveryAddressHasAddressLine1AndCity and
         validPostcode and hasValidPostcodeLength(address.postCode, "Delivery") and hasValidPostcodeLength(
-        createSupportWorkersRequest.billingAddress.postCode,
-        "Billing",
-      )
+          createSupportWorkersRequest.billingAddress.postCode,
+          "Billing",
+        )
 
     }
 

--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -180,16 +180,14 @@ object AddressAndCurrencyValidationRules {
     ) {
       stateFromRequest.isDefined.otherwise(s"state is required for $countryFromRequest")
     } else Valid
+
+//    hasValidPostcodeLength checks if the length of postCodeIsShortEnoughForSalesforce(must be less than or equal to 20 characters)
   def hasValidPostcodeLength(postcodeFromRequest: Option[String], addressType: String): Result = {
     val validPostCode = postcodeFromRequest match {
-      case Some(postCode) if (postCode.length <= 20) => true
-      case None => true
-      case _ => false
+      case Some(postCode) if (postCode.length > 20) => Invalid(s"$addressType PostCode length must not be greater than 20 characters")
+      case _ => Valid
     }
-    if (validPostCode)
-      Valid
-    else
-      Invalid(s"$addressType PostCode length must be less than 20 characters")
+    validPostCode
   }
 
   def hasPostcodeIfRequired(countryFromRequest: Country, postcodeFromRequest: Option[String]): Result =

--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -32,9 +32,9 @@ object CheckoutValidationRules {
   case class Invalid(message: String) extends Result
   case object Valid extends Result
   def checkSubscriptionPaymentMethodEnabled(
-                                             switches: SubscriptionsPaymentMethodSwitches,
-                                             paymentFields: Either[PaymentFields, RedemptionData],
-                                           ) = paymentFields match {
+      switches: SubscriptionsPaymentMethodSwitches,
+      paymentFields: Either[PaymentFields, RedemptionData],
+  ) = paymentFields match {
     case Left(_: PayPalPaymentFields) =>
       if (switches.paypal.isOn) Valid else Invalid("Invalid Payment Method")
     case Left(_: DirectDebitPaymentFields) =>
@@ -46,9 +46,9 @@ object CheckoutValidationRules {
   }
 
   def checkContributionPaymentMethodEnabled(
-                                             switches: RecurringPaymentMethodSwitches,
-                                             paymentFields: Either[PaymentFields, RedemptionData],
-                                           ) = paymentFields match {
+      switches: RecurringPaymentMethodSwitches,
+      paymentFields: Either[PaymentFields, RedemptionData],
+  ) = paymentFields match {
     case Left(_: PayPalPaymentFields) =>
       if (switches.payPal.isOn) Valid else Invalid("Invalid Payment Method")
     case Left(_: DirectDebitPaymentFields) =>
@@ -77,10 +77,10 @@ object CheckoutValidationRules {
 
   }
   def checkPaymentMethodEnabled(
-                                 product: ProductType,
-                                 paymentFields: Either[PaymentFields, RedemptionData],
-                                 switches: Switches,
-                               ) =
+      product: ProductType,
+      paymentFields: Either[PaymentFields, RedemptionData],
+      switches: Switches,
+  ) =
     product match {
       case _: Contribution | _: SupporterPlus =>
         checkContributionPaymentMethodEnabled(
@@ -195,9 +195,9 @@ object AddressAndCurrencyValidationRules {
   def hasPostcodeIfRequired(countryFromRequest: Country, postcodeFromRequest: Option[String]): Result =
     if (
       countryFromRequest == Country.UK ||
-        countryFromRequest == Country.US ||
-        countryFromRequest == Country.Canada ||
-        countryFromRequest == Country.Australia
+      countryFromRequest == Country.US ||
+      countryFromRequest == Country.Canada ||
+      countryFromRequest == Country.Australia
     ) {
       postcodeFromRequest.isDefined.otherwise(s"postcode is required for $countryFromRequest")
     } else Valid
@@ -1660,4 +1660,3 @@ object PaperValidation {
   val M25_POSTCODE_PREFIXES = M25_POSTCODE_OLD_PREFIXES ++ M25_NEW_PREFIXES
 
 }
-

--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -184,7 +184,8 @@ object AddressAndCurrencyValidationRules {
 //    hasValidPostcodeLength checks if the length of postCodeIsShortEnoughForSalesforce(must be less than or equal to 20 characters)
   def hasValidPostcodeLength(postcodeFromRequest: Option[String], addressType: String): Result = {
     val validPostCode = postcodeFromRequest match {
-      case Some(postCode) if (postCode.length > 20) => Invalid(s"$addressType PostCode length must not be greater than 20 characters")
+      case Some(postCode) if (postCode.length > 20) =>
+        Invalid(s"$addressType PostCode length must not be greater than 20 characters")
       case _ => Valid
     }
     validPostCode

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -344,6 +344,7 @@ class PaymentSwitchValidationTest extends AnyFlatSpec with Matchers {
   }
 
 }
+
 class SimpleCheckoutFormValidationTest extends AnyFlatSpec with Matchers {
 
   import TestData.validDigitalPackRequest
@@ -482,6 +483,15 @@ class DigitalPackValidationTest extends AnyFlatSpec with Matchers {
     DigitalPackValidation.passes(corporateSub, product) shouldBe Valid
   }
 
+  it should "fail if there are more than 20 characters in Billing Address postCode" in {
+    val requestDigiSubPostCode = validDigitalPackRequest.copy(
+      billingAddress = validDigitalPackRequest.billingAddress
+        .copy(country = Country.UK, postCode = Some("Testcase11111111111111111111")),
+      product = DigitalPack(Currency.GBP, Annual),
+    )
+    DigitalPackValidation.passes(requestDigiSubPostCode, monthlyDirectUSDProduct) shouldBe an[Invalid]
+  }
+
   it should "succeed when there is a valid gift sub purchase" in {
     val product = DigitalPack(USD, Monthly, Gift)
     val giftPurchase = validDigitalPackRequest.copy(
@@ -583,6 +593,19 @@ class PaperValidationTest extends AnyFlatSpec with Matchers {
     PaperValidation.passes(requestWithCorporateRedemption, Collection) shouldBe an[Invalid]
   }
 
+  it should "fail if there are more than 20 characters in Billing Address postCode" in {
+    val requestPostCode = validPaperRequest.copy(billingAddress =
+      validPaperRequest.billingAddress.copy(postCode = Some("Test111111111111111111111111")),
+    )
+    PaperValidation.passes(requestPostCode, Collection) shouldBe an[Invalid]
+  }
+  it should "fail if there are more than 20 characters in Delivery Address postCode" in {
+    val requestDeliveryPostCode = validPaperRequest.copy(deliveryAddress =
+      validPaperRequest.deliveryAddress map (_.copy(postCode = Some("Test22222222222222222222"))),
+    )
+    PaperValidation.passes(requestDeliveryPostCode, Collection) shouldBe an[Invalid]
+  }
+
 }
 
 class GuardianWeeklyValidationTest extends AnyFlatSpec with Matchers {
@@ -608,6 +631,18 @@ class GuardianWeeklyValidationTest extends AnyFlatSpec with Matchers {
   it should "fail if there is no first delivery date" in {
     val requestDeliveredToUs = validWeeklyRequest.copy(firstDeliveryDate = None)
     GuardianWeeklyValidation.passes(requestDeliveredToUs) shouldBe an[Invalid]
+  }
+  it should "fail if there are more than 20 characters in Billing Address postCode" in {
+    val requestPostCode = validWeeklyRequest.copy(billingAddress =
+      validWeeklyRequest.billingAddress.copy(postCode = Some("Test111111111111111111111111")),
+    )
+    GuardianWeeklyValidation.passes(requestPostCode) shouldBe an[Invalid]
+  }
+  it should "fail if there are more than 20 characters in Delivery Address postCode" in {
+    val requestDeliveryPostCode = validWeeklyRequest.copy(deliveryAddress =
+      validWeeklyRequest.deliveryAddress map (_.copy(postCode = Some("Test22222222222222222222"))),
+    )
+    GuardianWeeklyValidation.passes(requestDeliveryPostCode) shouldBe an[Invalid]
   }
 
   it should "fail when missing an address data for billing address" in {
@@ -646,11 +681,11 @@ class GuardianWeeklyValidationTest extends AnyFlatSpec with Matchers {
 
 object TestData {
   def buildSwitches(
-      recurringPaymentMethodSwitches: RecurringPaymentMethodSwitches =
-        RecurringPaymentMethodSwitches(On, On, On, On, On, On, On, On, On),
-      subscriptionsPaymentMethodSwitches: SubscriptionsPaymentMethodSwitches =
-        SubscriptionsPaymentMethodSwitches(On, On, On),
-  ): Switches = Switches(
+                     recurringPaymentMethodSwitches: RecurringPaymentMethodSwitches =
+                     RecurringPaymentMethodSwitches(On, On, On, On, On, On, On, On, On),
+                     subscriptionsPaymentMethodSwitches: SubscriptionsPaymentMethodSwitches =
+                     SubscriptionsPaymentMethodSwitches(On, On, On),
+                   ): Switches = Switches(
     OneOffPaymentMethodSwitches(On, On, On, On, On),
     recurringPaymentMethodSwitches,
     subscriptionsPaymentMethodSwitches,
@@ -750,3 +785,4 @@ object TestData {
   )
 
 }
+

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -681,10 +681,10 @@ class GuardianWeeklyValidationTest extends AnyFlatSpec with Matchers {
 object TestData {
   def buildSwitches(
       recurringPaymentMethodSwitches: RecurringPaymentMethodSwitches =
-      RecurringPaymentMethodSwitches(On, On, On, On, On, On, On, On, On),
+        RecurringPaymentMethodSwitches(On, On, On, On, On, On, On, On, On),
       subscriptionsPaymentMethodSwitches: SubscriptionsPaymentMethodSwitches =
-      SubscriptionsPaymentMethodSwitches(On, On, On),
-   ): Switches = Switches(
+        SubscriptionsPaymentMethodSwitches(On, On, On),
+  ): Switches = Switches(
     OneOffPaymentMethodSwitches(On, On, On, On, On),
     recurringPaymentMethodSwitches,
     subscriptionsPaymentMethodSwitches,
@@ -784,4 +784,3 @@ object TestData {
   )
 
 }
-

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -344,7 +344,6 @@ class PaymentSwitchValidationTest extends AnyFlatSpec with Matchers {
   }
 
 }
-
 class SimpleCheckoutFormValidationTest extends AnyFlatSpec with Matchers {
 
   import TestData.validDigitalPackRequest
@@ -681,11 +680,11 @@ class GuardianWeeklyValidationTest extends AnyFlatSpec with Matchers {
 
 object TestData {
   def buildSwitches(
-                     recurringPaymentMethodSwitches: RecurringPaymentMethodSwitches =
-                     RecurringPaymentMethodSwitches(On, On, On, On, On, On, On, On, On),
-                     subscriptionsPaymentMethodSwitches: SubscriptionsPaymentMethodSwitches =
-                     SubscriptionsPaymentMethodSwitches(On, On, On),
-                   ): Switches = Switches(
+      recurringPaymentMethodSwitches: RecurringPaymentMethodSwitches =
+      RecurringPaymentMethodSwitches(On, On, On, On, On, On, On, On, On),
+      subscriptionsPaymentMethodSwitches: SubscriptionsPaymentMethodSwitches =
+      SubscriptionsPaymentMethodSwitches(On, On, On),
+   ): Switches = Switches(
     OneOffPaymentMethodSwitches(On, On, On, On, On),
     recurringPaymentMethodSwitches,
     subscriptionsPaymentMethodSwitches,


### PR DESCRIPTION
## What are you doing in this PR?

Validate PostCode  length on server side for Guardian Weekly and Paper 

[**Trello Card**](https://trello.com/c/hgXWkPCo/663-validate-length-on-postcode-field)

## Why are you doing this?
Salesforce cannot accept postcodes greater than 20 characters in length, but we currently do not validate the length of this field on the server side. The client side validation for postCode field is in place.
We use Salesforce for all Subscriptions (Newspaper, Guardian Weekly) and Recurring Contributions, so any checkout for these products which has a postcode field should adopt this rule. As we're removing Digital Subs making the change this checkout is not a priority.
## Is this an AB test?
- [ ] Yes
- [x ] No
