### PR TITLE
Try to fix existing payment methods

### DIFF
--- a/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
+++ b/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
@@ -21,5 +21,10 @@ export function ExistingCardPaymentButton(): JSX.Element {
 		);
 	});
 
-	return <DefaultPaymentButtonContainer onClick={payWithExistingCard} />;
+	return (
+		<DefaultPaymentButtonContainer
+			onClick={payWithExistingCard}
+			disabled={!!selectedPaymentMethod?.billingAccountId}
+		/>
+	);
 }

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButton.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButton.tsx
@@ -15,16 +15,23 @@ export type DefaultPaymentButtonProps = {
 	id?: string;
 	buttonText: string;
 	onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+	disabled?: boolean;
 };
 
 export function DefaultPaymentButton({
 	id,
 	buttonText,
 	onClick,
+	disabled = false,
 }: DefaultPaymentButtonProps): JSX.Element {
 	return (
 		<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-			<Button id={id} cssOverrides={buttonOverrides} onClick={onClick}>
+			<Button
+				id={id}
+				cssOverrides={buttonOverrides}
+				onClick={onClick}
+				disabled={disabled}
+			>
 				{buttonText}
 			</Button>
 		</ThemeProvider>

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -23,6 +23,7 @@ type ButtonTextCreator = (
 export type DefaultPaymentContainerProps = {
 	onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
 	createButtonText?: ButtonTextCreator;
+	disabled?: boolean;
 };
 
 function getButtonText(
@@ -42,6 +43,7 @@ function getButtonText(
 export function DefaultPaymentButtonContainer({
 	onClick,
 	createButtonText = getButtonText,
+	disabled = false,
 }: DefaultPaymentContainerProps): JSX.Element {
 	const { currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
@@ -81,6 +83,7 @@ export function DefaultPaymentButtonContainer({
 			id={testId}
 			buttonText={buttonText}
 			onClick={onClick}
+			disabled={disabled}
 		/>
 	);
 }


### PR DESCRIPTION
## What are you doing in this PR?

We enabled existing card payment methods, which worked in testing but then ran into errors in production. This PR is to fix the errors that have cropped up.

~~Specifically, the errors we’ve had have the following form: `Failed to create new Annual-SupporterPlus-USD-120, due to RequestValidationError(validation of the request body failed with existing billing account id missing...`. From looking at the [failed step function](https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/v2/executions/details/arn:aws:states:eu-west-1:865473395570:execution:support-workers-PROD:a6266d8b-83c4-4fa2-919e-ee30ef8ae5dc) that produced that error, and examining [the code the error came from](https://github.com/guardian/support-frontend/blob/6dd1b1268557cec9cb94919fd15e80779e3a1c53/support-frontend/app/utils/CheckoutValidationRules.scala#L156), I have concluded that the client side isn’t sending the billing account ID to the server.~~

~~Looking at the redux state in the browser for the contributions form, I can see that selecting an existing payment method sets the payment methods details at `state.page.checkoutForm.payment.existingPaymentMethods.selectedPaymentMethod`, which is not where [the mapping from state to props](https://github.com/guardian/support-frontend/blob/6dd1b1268557cec9cb94919fd15e80779e3a1c53/support-frontend/assets/pages/contributions-landing/components/ContributionForm.tsx#L82) is looking for it.~~

~~So I have updated the mapping, but I’m not super confident this is the correct change to make: it works, but I don’t understand how the data flow all fits together, so there may still be some redundancy in there.~~

[**Trello Card**](https://trello.com/c/4DYyBs1a/993-server-side-validation-failing-for-users-trying-to-checkout-with-an-existing-card-for-recurring-contributions-supporterplus)