### PR TITLE
Use CSS media queries to show/hide mobile menu on Support site Landing pages

### DIFF
--- a/support-frontend/assets/components/headers/header/header.scss
+++ b/support-frontend/assets/components/headers/header/header.scss
@@ -288,7 +288,6 @@ $header-links-min-width: gu-span(12);
 				flex: 0 0 490px;
 				color: gu-colour(neutral-100);
 				@include gu-fontset-body-sans;
-				border-right: 1px solid gu-colour(brand-pastel);
 
 				@include mq($until: tablet) {
 					flex: none;

--- a/support-frontend/assets/components/headers/header/header.scss
+++ b/support-frontend/assets/components/headers/header/header.scss
@@ -136,7 +136,20 @@ $header-links-min-width: gu-span(12);
 		width: gu-span(5);
 		background-color: gu-colour(brand-main);
 		float: right;
+    .component-header--one-row-from-tablet & {
+		  border-left: 1px solid gu-colour(brand-pastel);
+		  z-index: 10;
+		  position: relative;
+    }
 	}
+
+  @include mq($from: desktop) {
+    .component-header--one-row-from-desktop & {
+		  border-left: 1px solid gu-colour(brand-pastel);
+		  z-index: 10;
+		  position: relative;
+    }
+  }
 
 	@include mq($from: wide) {
 		padding-right: gu-span(1) + $gu-h-spacing;
@@ -160,7 +173,7 @@ $header-links-min-width: gu-span(12);
 	border-top: 1px solid gu-colour(brand-pastel);
 	z-index: 9;
 	white-space: nowrap;
-	margin: 0 ($gu-h-spacing * -2) 0 0 -($gu-h-spacing * 0.5);
+	margin: 0 ($gu-h-spacing * -2) 0 0;
 	box-sizing: border-box;
 
 	@media (min-width: $header-links-min-width + 40) {
@@ -169,10 +182,25 @@ $header-links-min-width: gu-span(12);
 		border-right: 1px solid gu-colour(brand-pastel);
 	}
 
-	.component-header-links__ul {
-    @include mq($until: desktop) {
-      margin-left: -($gu-h-spacing * 0.5)px;
+  @include mq($from: tablet) {
+    .component-header--one-row-from-tablet & {
+      position: absolute;
+      bottom: 0;
+      left: $gu-h-spacing * 0.5;
+      right: gu-span(5);
     }
+  }
+
+  @include mq($from: desktop) {
+    .component-header--one-row-from-desktop & {
+      position: absolute;
+      bottom: 0;
+      left: $gu-h-spacing * 0.5;
+      right: gu-span(5);
+    }
+  }
+
+	.component-header-links__ul {
 		list-style: none;
 		display: inline-flex;
 		width: auto;

--- a/support-frontend/assets/components/headers/header/header.scss
+++ b/support-frontend/assets/components/headers/header/header.scss
@@ -52,10 +52,10 @@ $header-links-min-width: gu-span(12);
 }
 
 .component-header-mobile-menu-toggler {
+  @include mq($until: tablet) {
+    display: block;
+  }
 	display: none;
-	.component-header--display-veggie-burger & {
-		display: block;
-	}
 	[data-not-hydrated] & {
 		display: none;
 	}
@@ -123,6 +123,12 @@ $header-links-min-width: gu-span(12);
 
 .component-header-topnav__utility {
 	padding-top: $gu-v-spacing * 0.5;
+
+  .component-country-group-switcher {
+    @include mq($until: tablet) {
+      display: none;
+    }
+  }
 }
 
 .component-header-topnav-logo {
@@ -130,12 +136,8 @@ $header-links-min-width: gu-span(12);
 		width: gu-span(5);
 		background-color: gu-colour(brand-main);
 		float: right;
-		.component-header--one-row & {
-			border-left: 1px solid gu-colour(brand-pastel);
-			z-index: 10;
-			position: relative;
-		}
 	}
+
 	@include mq($from: wide) {
 		padding-right: gu-span(1) + $gu-h-spacing;
 	}
@@ -148,13 +150,17 @@ $header-links-min-width: gu-span(12);
 }
 
 .component-header-links--desktop {
-	display: flex;
+  @include mq($until: tablet) {
+    display: none;
+  }
+
+  display: flex;
 	justify-content: flex-start;
 	background-color: gu-colour(brand-main);
 	border-top: 1px solid gu-colour(brand-pastel);
 	z-index: 9;
 	white-space: nowrap;
-	margin: 0 ($gu-h-spacing * -2) 0 0;
+	margin: 0 ($gu-h-spacing * -2) 0 0 -($gu-h-spacing * 0.5);
 	box-sizing: border-box;
 
 	@media (min-width: $header-links-min-width + 40) {
@@ -163,19 +169,10 @@ $header-links-min-width: gu-span(12);
 		border-right: 1px solid gu-colour(brand-pastel);
 	}
 
-	.component-header--display-veggie-burger & {
-		position: absolute;
-		height: 0;
-		overflow: hidden;
-	}
-	.component-header--one-row & {
-		position: absolute;
-		bottom: 0;
-		left: $gu-h-spacing * 0.5;
-		right: gu-span(5);
-	}
-
 	.component-header-links__ul {
+    @include mq($until: desktop) {
+      margin-left: -($gu-h-spacing * 0.5)px;
+    }
 		list-style: none;
 		display: inline-flex;
 		width: auto;

--- a/support-frontend/assets/components/headers/header/header.scss
+++ b/support-frontend/assets/components/headers/header/header.scss
@@ -143,8 +143,8 @@ $header-links-min-width: gu-span(12);
     }
 	}
 
-  @include mq($from: desktop) {
-    .component-header--one-row-from-desktop & {
+  @include mq($from: leftCol) {
+    .component-header--one-row-from-leftCol & {
 		  border-left: 1px solid gu-colour(brand-pastel);
 		  z-index: 10;
 		  position: relative;
@@ -191,8 +191,8 @@ $header-links-min-width: gu-span(12);
     }
   }
 
-  @include mq($from: desktop) {
-    .component-header--one-row-from-desktop & {
+  @include mq($from: leftCol) {
+    .component-header--one-row-from-leftCol & {
       position: absolute;
       bottom: 0;
       left: $gu-h-spacing * 0.5;

--- a/support-frontend/assets/components/headers/header/header.scss
+++ b/support-frontend/assets/components/headers/header/header.scss
@@ -333,6 +333,9 @@ $header-links-min-width: gu-span(12);
 	}
 
 	.component-header-topnav-logo {
+    @include mq($from: desktop) {
+      border-left: 1px solid gu-colour(brand-pastel);
+    }
 		padding-right: $gu-h-spacing * 0.5;
 		padding-top: $gu-v-spacing * 0.5;
 	}

--- a/support-frontend/assets/components/headers/header/header.tsx
+++ b/support-frontend/assets/components/headers/header/header.tsx
@@ -101,6 +101,9 @@ export default class Header extends Component<PropTypes, State> {
 		return (
 			<header
 				className={classNameWithModifiers('component-header', [
+					countryGroupId !== 'GBPCountries'
+						? 'one-row-from-tablet'
+						: 'one-row-from-desktop',
 					display === 'navigation' ? 'display-navigation' : null,
 					display === 'checkout' ? 'display-checkout' : null,
 				])}

--- a/support-frontend/assets/components/headers/header/header.tsx
+++ b/support-frontend/assets/components/headers/header/header.tsx
@@ -15,36 +15,7 @@ export type PropTypes = {
 	display?: 'navigation' | 'checkout' | 'guardianLogo' | void;
 };
 export type State = {
-	fitsLinksInOneRow: boolean;
-	fitsLinksAtAll: boolean;
 	isTestUser: boolean | null | undefined;
-};
-
-// ----- Metrics ----- //
-const getMenuStateMetrics = ({
-	menuRef,
-	logoRef,
-	containerRef,
-}: {
-	menuRef: Element;
-	logoRef: Element;
-	containerRef: Element;
-}): State => {
-	const [logoLeft, menuWidth, containerLeft, containerWidth] = [
-		logoRef.getBoundingClientRect().left,
-		menuRef.getBoundingClientRect().width,
-		containerRef.getBoundingClientRect().left,
-		containerRef.getBoundingClientRect().width,
-	];
-	const fitsLinksAtAll = containerWidth - menuWidth > 0;
-	const fitsLinksInOneRow =
-		fitsLinksAtAll && logoLeft - containerLeft - menuWidth > 0;
-	const isTestUser = getGlobal<boolean>('isTestUser');
-	return {
-		fitsLinksInOneRow,
-		fitsLinksAtAll,
-		isTestUser,
-	};
 };
 
 // ----- Component ----- //
@@ -89,8 +60,6 @@ export default class Header extends Component<PropTypes, State> {
 		display: 'navigation',
 	};
 	state = {
-		fitsLinksInOneRow: false,
-		fitsLinksAtAll: false,
 		isTestUser: getGlobal<boolean>('isTestUser'),
 	};
 
@@ -103,13 +72,9 @@ export default class Header extends Component<PropTypes, State> {
 			containerRef
 		) {
 			this.observer = new window.ResizeObserver(() => {
-				this.setState(
-					getMenuStateMetrics({
-						menuRef,
-						logoRef,
-						containerRef,
-					}),
-				);
+				this.setState({
+					isTestUser: getGlobal<boolean>('isTestUser'),
+				});
 			});
 
 			this.observer.observe(menuRef);
@@ -131,13 +96,12 @@ export default class Header extends Component<PropTypes, State> {
 
 	render(): JSX.Element {
 		const { utility, display, countryGroupId } = this.props;
-		const { fitsLinksInOneRow, fitsLinksAtAll, isTestUser } = this.state;
+		const { isTestUser } = this.state;
+
 		return (
 			<header
 				className={classNameWithModifiers('component-header', [
-					fitsLinksInOneRow ? 'one-row' : null,
 					display === 'navigation' ? 'display-navigation' : null,
-					!fitsLinksAtAll ? 'display-veggie-burger' : null,
 					display === 'checkout' ? 'display-checkout' : null,
 				])}
 			>
@@ -155,9 +119,7 @@ export default class Header extends Component<PropTypes, State> {
 					<div className="component-header__row">
 						<TopNav
 							display={display}
-							utility={
-								display === 'navigation' && fitsLinksAtAll ? utility : undefined
-							}
+							utility={display === 'navigation' ? utility : undefined}
 							getLogoRef={(el) => {
 								this.logoRef = el;
 							}}

--- a/support-frontend/assets/components/headers/header/header.tsx
+++ b/support-frontend/assets/components/headers/header/header.tsx
@@ -22,11 +22,10 @@ export type State = {
 
 type TopNavPropTypes = {
 	utility?: JSX.Element;
-	getLogoRef: (arg0: Element | null | undefined) => void;
 	display: 'navigation' | 'checkout' | 'guardianLogo' | void;
 };
 
-function TopNav({ display, getLogoRef, utility }: TopNavPropTypes) {
+function TopNav({ display, utility }: TopNavPropTypes) {
 	return (
 		<div className="component-header-topnav">
 			<div className="component-header-topnav__utility">{utility}</div>
@@ -41,7 +40,7 @@ function TopNav({ display, getLogoRef, utility }: TopNavPropTypes) {
 					</div>
 				</div>
 			)}
-			<div className="component-header-topnav-logo" ref={getLogoRef}>
+			<div className="component-header-topnav-logo">
 				<a
 					className="component-header-topnav-logo__graun"
 					href="https://www.theguardian.com"
@@ -64,35 +63,12 @@ export default class Header extends Component<PropTypes, State> {
 	};
 
 	componentDidMount(): void {
-		const { menuRef, logoRef, containerRef } = this;
-		if (
-			this.props.display === 'navigation' &&
-			menuRef &&
-			logoRef &&
-			containerRef
-		) {
-			this.observer = new window.ResizeObserver(() => {
-				this.setState({
-					isTestUser: getGlobal<boolean>('isTestUser'),
-				});
+		if (this.props.display === 'navigation') {
+			this.setState({
+				isTestUser: getGlobal<boolean>('isTestUser'),
 			});
-
-			this.observer.observe(menuRef);
-			this.observer.observe(logoRef);
-			this.observer.observe(containerRef);
 		}
 	}
-
-	componentWillUnmount(): void {
-		if (this.observer) {
-			this.observer.disconnect();
-		}
-	}
-
-	logoRef: Element | null | undefined;
-	menuRef: Element | null | undefined;
-	containerRef: Element | null | undefined;
-	observer: ResizeObserver | null | undefined;
 
 	render(): JSX.Element {
 		const { utility, display, countryGroupId } = this.props;
@@ -113,19 +89,11 @@ export default class Header extends Component<PropTypes, State> {
 						<span>You are a test user</span>
 					</div>
 				)}
-				<div
-					className="component-header__wrapper"
-					ref={(el) => {
-						this.containerRef = el;
-					}}
-				>
+				<div className="component-header__wrapper">
 					<div className="component-header__row">
 						<TopNav
 							display={display}
 							utility={display === 'navigation' ? utility : undefined}
-							getLogoRef={(el) => {
-								this.logoRef = el;
-							}}
 						/>
 						{display === 'navigation' && (
 							<MobileMenuToggler
@@ -138,13 +106,7 @@ export default class Header extends Component<PropTypes, State> {
 					</div>
 					{display === 'navigation' && (
 						<div className="component-header__row">
-							<Links
-								countryGroupId={countryGroupId}
-								location="desktop"
-								getRef={(el) => {
-									this.menuRef = el;
-								}}
-							/>
+							<Links countryGroupId={countryGroupId} location="desktop" />
 						</div>
 					)}
 					{display === 'checkout' && (

--- a/support-frontend/assets/components/headers/header/header.tsx
+++ b/support-frontend/assets/components/headers/header/header.tsx
@@ -103,7 +103,7 @@ export default class Header extends Component<PropTypes, State> {
 				className={classNameWithModifiers('component-header', [
 					countryGroupId !== 'GBPCountries'
 						? 'one-row-from-tablet'
-						: 'one-row-from-desktop',
+						: 'one-row-from-leftCol',
 					display === 'navigation' ? 'display-navigation' : null,
 					display === 'checkout' ? 'display-checkout' : null,
 				])}


### PR DESCRIPTION
## What are you doing in this PR?

This PR fixes some inconsistencies in the way the nav was appearing across regions on the GW landing page, we had some logic in the JS that would decide whether to show the veggie-burger or non-veggie-burger menu. In all regions other than the UK this logic was concluding to show the non-veggie-burger menu on mobile devices (a side effect of removing some links when deprecating Digi Subs). 

The issue is the non-veggie-burger doesn't look great on Mobile and shifts the contents of the page down, as shown below:

<img width="360" alt="Screenshot 2023-01-18 at 13 20 24" src="https://user-images.githubusercontent.com/1590704/213187291-98fede93-bce4-4efe-baef-ab842eba2e25.png">

**Ideally we'd be consistent and show the veggie-burger menu in ALL regions at the mobile breakpoint.**

I've therefore replaced this JavaScript logic that calculates whether to add the CSS class name modifiers to the `.component-header` element, with something more simple. 

Before this PR we were using JS to calculate the widths of navigation links vs the overall width of the menu to decide whether to display the "one-row" or "veggie-burger" variations of the menu, or the default version. Now we always show the "veggie-burger" until the tablet breakpoint. If we're NOT in the UK we show the "one row" navigation from the `tablet` breakpoint up, and if we're in the UK we show the  the "one row" navigation from the `leftCol` breakpoint up.

## Screenshots

### Veggie Burger (All regions until tablet)

<img width="360" alt="Screenshot 2023-01-18 at 13 20 00" src="https://user-images.githubusercontent.com/1590704/213186013-b59f773e-ef22-44e3-9a50-dd70e98fa71e.png">

### One Row (Non-UK regions from tablet and UK from leftCol)

#### Non-UK regions

<img width="1203" alt="Screenshot 2023-01-18 at 13 40 00" src="https://user-images.githubusercontent.com/1590704/213186423-0b9d0e6f-a12b-4f34-b610-13ffcdf27379.png">

#### UK

<img width="1203" alt="Screenshot 2023-01-18 at 13 40 12" src="https://user-images.githubusercontent.com/1590704/213186400-9b17ec3d-dbe2-4eee-8896-d672e3be2c5e.png">

### Default (UK only, from tablet until leftCol)

<img width="820" alt="Screenshot 2023-01-18 at 13 41 29" src="https://user-images.githubusercontent.com/1590704/213186645-e66f0f14-5e82-438e-80ae-2e42d6750520.png">

