### PR TITLE
Clear State property in Redux on Country Change

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/address/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/reducer.ts
@@ -78,7 +78,7 @@ function getAddressFieldsSlice(type: AddressType) {
 
 				if (country) {
 					state.country = country;
-					state.state = getInitialAddressFieldsState().state;
+					state.state = '';
 				}
 			},
 			setFormErrors(state, action: PayloadAction<AddressFormFieldError[]>) {

--- a/support-frontend/assets/helpers/redux/checkout/address/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/reducer.ts
@@ -78,6 +78,7 @@ function getAddressFieldsSlice(type: AddressType) {
 
 				if (country) {
 					state.country = country;
+					state.state = getInitialAddressFieldsState().state;
 				}
 			},
 			setFormErrors(state, action: PayloadAction<AddressFormFieldError[]>) {


### PR DESCRIPTION
## What are you doing in this PR?

Guardian Weekly checkout: Clear "State" property in Redux on Country Change

[**Trello Card**](https://trello.com/c/DKx4hYQG/751-guardian-weekly-checkout-clear-state-property-in-redux-on-country-change)

## Why are you doing this?

We've seen errors when users try to create Guardian Weekly subscriptions, sent back from Zuora such as "FL not a valid ISO state in CA".
Upon inspection we found it's possible for a user to select state in the checkout for one country then change country, without the state altering in Redux state - resulting in a possible bad submission

