### PR TITLE
Remove showcase page (server side)

### DIFF
--- a/support-frontend/app/config/StringsConfig.scala
+++ b/support-frontend/app/config/StringsConfig.scala
@@ -6,7 +6,6 @@ import config.ConfigImplicits._
 class StringsConfig {
   val config = ConfigFactory.load("strings.conf")
 
-  val showcaseLandingDescription = config.getOptionalString("showcaseLanding.description")
   val contributionsLandingDescription = config.getOptionalString("contributionsLanding.description")
   val subscriptionsLandingDescription = config.getOptionalString("subscriptionsLanding.description")
   val digitalPackLandingDescription = config.getOptionalString("digitalPackLanding.description")

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -216,20 +216,6 @@ class Application(
     )
   }
 
-  def showcase(country: String): Action[AnyContent] = CachedAction() { implicit request =>
-    implicit val settings: AllSettings = settingsProvider.getAllSettings()
-    Ok(
-      views.html.main(
-        title = "Support the Guardian",
-        mainElement = assets.getSsrCacheContentsAsHtml("showcase-landing-page", "showcase.html"),
-        mainJsBundle = Left(RefPath("showcasePage.js")),
-        mainStyleBundle = Left(RefPath("showcasePage.css")),
-        description = stringsConfig.showcaseLandingDescription,
-        canonicalLink = Some(buildCanonicalShowcaseLink("uk")),
-      )(),
-    ).withSettingsSurrogateKey
-  }
-
   val ausMomentMapSocialImageUrl =
     "https://i.guim.co.uk/img/media/3c2c30cccd48c91f55217bd0d961dbd20cf07274/0_0_1000_525/1000.png?quality=85&s=b1394cf888724cd40646850b807659f0"
 

--- a/support-frontend/app/controllers/SiteMap.scala
+++ b/support-frontend/app/controllers/SiteMap.scala
@@ -26,13 +26,13 @@ class SiteMap(
   private def supportLandingPages()(implicit req: RequestHeader) = {
     <url>
       <loc>{
-      routes.Application.showcase("uk").absoluteURL(secure = true)
+      routes.Application.contributionsLanding("uk", "").absoluteURL(secure = true)
     }</loc>
       <xhtml:link rel="alternate" hreflang="en-us" href={
       contributionsLandingPageUS()
     }/>
       <xhtml:link rel="alternate" hreflang="en" href={
-      routes.Application.showcase("uk").absoluteURL(secure = true)
+      routes.Application.contributionsLanding("uk", "").absoluteURL(secure = true)
     }/>
       <priority>1.0</priority>
     </url>
@@ -47,7 +47,7 @@ class SiteMap(
       contributionsLandingPageUS()
     }/>
       <xhtml:link rel="alternate" hreflang="en" href={
-      routes.Application.showcase("uk").absoluteURL(secure = true)
+      routes.Application.contributionsLanding("uk", "").absoluteURL(secure = true)
     }/>
       <priority>1.0</priority>
     </url>

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -35,7 +35,7 @@ GET /                                                              controllers.A
 # ----- Bundles Landing Page ----- #
 
 GET /support                                                       controllers.Application.supportGeoRedirect()
-GET /$country<(uk|us|au|eu|int|nz|ca)>/support                     controllers.Application.showcase(country: String)
+GET /$country<(uk|us|au|eu|int|nz|ca)>/support                     controllers.Application.contributionsLanding(country: String, campaignCode = "")
 # redirect from old ab test
 GET /showcase                                                      controllers.Application.permanentRedirect(location="/uk/support")
 

--- a/support-frontend/conf/strings.conf
+++ b/support-frontend/conf/strings.conf
@@ -1,4 +1,3 @@
-showcaseLanding.description="Help us deliver the independent journalism the world needs. Support the Guardian by making a contribution or getting a subscription."
 contributionsLanding.description="Help us deliver the independent journalism the world needs. Support the Guardian by making a contribution."
 subscriptionsLanding.description="Help us deliver the independent journalism the world needs. Support the Guardian by getting a subscription."
 digitalPackLanding.description="Subscribe and enjoy an enhanced experience of the Guardian's digital journalism with access to two innovative apps and ad-free reading on theguardian.com."


### PR DESCRIPTION
## What are you doing in this PR?

Removing the server-side code responsible for the current showcase page.

Trello card: https://trello.com/c/KHY6bcbI/938-remove-server-side-code-for-showcase-landing-page-from-codebase

The redirects in Fastly can’t be removed till this change is live, if I understand correctly.

## Why are you doing this?

We no longer want this page, as part of removing digisubs and moving to supporter-plus.