### PR TITLE
 Fix for Supporter Plus checkout country dropdown layout bug

### DIFF
--- a/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.module.scss
+++ b/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.module.scss
@@ -11,6 +11,7 @@
 
 	:global(.svg-dropdown-arrow) {
 		position: inline-block;
+    margin-top: $gu-h-spacing*0.25;
 		margin-left: $gu-h-spacing*0.25;
 		path {
 			fill: currentColor;

--- a/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
+++ b/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
@@ -42,7 +42,7 @@
 	}
 
 	.component-select-input__label {
-		//@include visually-hidden;
+		@include visually-hidden;
 	}
 
 }

--- a/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
+++ b/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
@@ -36,9 +36,13 @@
 		.svg-dropdown-arrow path {
 			fill: gu-colour(highlight-main);
 		}
+    .svg-dropdown-arrow{
+      transform: rotate(180deg);
+    }
 	}
 
 	.component-select-input__label {
-		@include visually-hidden;
+		//@include visually-hidden;
 	}
+
 }

--- a/support-frontend/assets/components/dialog/dialog.scss
+++ b/support-frontend/assets/components/dialog/dialog.scss
@@ -14,7 +14,7 @@
 
 .component-dialog--open {
 	visibility: visible;
-	position: fixed;
+	position: absolute;
 	height: 100%;
 	width: 100%;
 	top: 0;

--- a/support-frontend/assets/components/menu/menu.module.scss
+++ b/support-frontend/assets/components/menu/menu.module.scss
@@ -8,11 +8,11 @@
 
 	@include mq($until: tablet) {
 		position: fixed !important;
-		top: auto !important;
+		top: 3rem !important;
 		left: 0 !important;
 		right: 0 !important;
 		bottom: 0 !important;
-		max-height: 70vh;
+		max-height: 50vh;
 		border-bottom-left-radius: 0;
 		border-bottom-right-radius: 0;
 		/*accomodate iphone safari bottom bar popping out*/

--- a/support-frontend/assets/components/menu/menu.module.scss
+++ b/support-frontend/assets/components/menu/menu.module.scss
@@ -11,7 +11,6 @@
 		top: 3rem !important;
 		left: 0 !important;
 		right: 0 !important;
-		bottom: 0 !important;
 		max-height: 70vh;
 		border-bottom-left-radius: 0;
 		border-bottom-right-radius: 0;

--- a/support-frontend/assets/components/menu/menu.module.scss
+++ b/support-frontend/assets/components/menu/menu.module.scss
@@ -12,7 +12,7 @@
 		left: 0 !important;
 		right: 0 !important;
 		bottom: 0 !important;
-		max-height: 50vh;
+		max-height: 70vh;
 		border-bottom-left-radius: 0;
 		border-bottom-right-radius: 0;
 		/*accomodate iphone safari bottom bar popping out*/


### PR DESCRIPTION
## What are you doing in this PR?
Supporter Plus checkout: Fix layout bug with the country dropdown

[**Trello Card**](https://trello.com/c/CeJ4lNs4/932-supporter-plus-checkout-fix-layout-bug-with-the-country-dropdown)

## Why are you doing this?
Dropdown of country picker doesn't align properly when it's open.
Also, a small tweaks needs to be done on the 320 breakpoint to align the chevron with the link.

## Screenshots
Before Change
![Frame_2077](https://user-images.githubusercontent.com/73653255/213686109-79782266-e9a3-411a-af64-e01783f6ab92.jpeg)


After Change
<img width="764" alt="image" src="https://user-images.githubusercontent.com/73653255/214271667-6900e8cb-f1bb-45c5-a71a-d82cb5a7d725.png">

