### PR TITLE
scala format supporter-product-data

### DIFF
--- a/supporter-product-data/src/main/scala/com/gu/lambdas/AddSupporterRatePlanItemToQueueLambda.scala
+++ b/supporter-product-data/src/main/scala/com/gu/lambdas/AddSupporterRatePlanItemToQueueLambda.scala
@@ -47,7 +47,7 @@ object AddSupporterRatePlanItemToQueueLambda extends StrictLogging {
 
     if (csvReader.isEmpty) {
       s3Object.close()
-      alarmAndExit( alarmService, s"The specified CSV file ${state.filename} was empty")
+      alarmAndExit(alarmService, s"The specified CSV file ${state.filename} was empty")
     }
 
     val unProcessed = getUnprocessedItems(csvReader, state.processedCount)
@@ -59,10 +59,11 @@ object AddSupporterRatePlanItemToQueueLambda extends StrictLogging {
     val invalidUnprocessedIndexes = unProcessed.collect { case (Left(_), index) => index }
 
     if (invalidUnprocessedIndexes.nonEmpty) {
-      alarmAndExit(alarmService, s"there were ${invalidUnprocessedIndexes.length} read failures from file ${state.filename} with line numbers ${
-        invalidUnprocessedIndexes
-          .mkString(",")
-      }")
+      alarmAndExit(
+        alarmService,
+        s"there were ${invalidUnprocessedIndexes.length} read failures from file ${state.filename} with line numbers ${invalidUnprocessedIndexes
+            .mkString(",")}",
+      )
     }
 
     val batches = validUnprocessed.grouped(10).toList


### PR DESCRIPTION
this is causing build failures:
`[error] (Compile / scalafmtCheck) scalafmt: 1 files must be formatted (/opt/teamcity/buildAgent/work/2c6b1421bde49969/supporter-product-data)`
