### PR TITLE
Build supporter-product-data with github actions

### DIFF
--- a/.github/workflows/supporter-product-data.yml
+++ b/.github/workflows/supporter-product-data.yml
@@ -1,0 +1,56 @@
+name: Build supporter-product-data
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  supporter_product_data_build:
+    if: >-
+      (github.actor != 'dependabot[bot]') &&
+        (github.repository_owner == 'guardian' ||
+          github.event_name == 'push')
+
+    # Required by actions-assume-aws-role
+    permissions:
+      id-token: write
+      contents: read
+
+    name: supporter-product-data build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Env
+        run: env
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      # Required by sbt riffRaffUpload
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+
+      - name: Setup Java 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: "11"
+          distribution: "corretto"
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+            ~/.coursier
+          key: sbt
+
+      - name: Build and upload supporter-product-data to RiffRaff
+        run: |
+          export LAST_TEAMCITY_BUILD=6000
+          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+          sbt "project supporter-product-data" riffRaffUpload
+

--- a/supporter-product-data/build-tc
+++ b/supporter-product-data/build-tc
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-# build scala
-cd ..
-./sbt "project supporter-product-data" test riffRaffUpload


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Use Github actions rather than TeamCity to build the supporter-product-data project. This gives us better visibility of failures as the current TC project doesn't report status back to GH.