### PR TITLE
Add single contributions into the supporter product data Dynamo store

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -211,8 +211,8 @@ lazy val `support-payment-api` = (project in file("support-payment-api"))
     scalacOptions += "-Ytasty-reader",
     scalafmtSettings,
   )
-  .dependsOn(`support-models`, `support-internationalisation`, `module-acquisition-events`)
-  .aggregate(`support-models`, `support-internationalisation`, `module-acquisition-events`)
+  .dependsOn(`support-models`, `support-internationalisation`, `module-acquisition-events`, `supporter-product-data-dynamo`)
+  .aggregate(`support-models`, `support-internationalisation`, `module-acquisition-events`, `supporter-product-data-dynamo`)
 
 lazy val `support-models` = (project in file("support-models"))
   .configs(IntegrationTest)

--- a/support-payment-api/src/main/scala/backend/BackendError.scala
+++ b/support-payment-api/src/main/scala/backend/BackendError.scala
@@ -34,6 +34,7 @@ object BackendError {
   final case class AcquisitionsStreamError(error: String) extends BackendError
   final case class GoogleAnalyticsError(error: String) extends BackendError
   final case class Database(error: ContributionsStoreService.Error) extends BackendError
+  final case class SupporterProductDataError(error: String) extends BackendError
   final case class IdentityServiceError(error: IdentityClient.ContextualError) extends BackendError
   final case class PaypalApiError(error: PaypalAPIError) extends BackendError
   final case class StripeApiError(error: StripeError) extends BackendError

--- a/support-payment-api/src/main/scala/backend/PaypalBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaypalBackend.scala
@@ -45,6 +45,7 @@ class PaypalBackend(
     val acquisitionsStreamService: AcquisitionsStreamService,
     emailService: EmailService,
     cloudWatchService: CloudWatchService,
+    val supporterProductDataService: SupporterProductDataService,
     switchService: SwitchService,
 )(implicit pool: DefaultThreadPool)
     extends StrictLogging
@@ -262,6 +263,7 @@ object PaypalBackend {
       acquisitionsStreamService: AcquisitionsStreamService,
       emailService: EmailService,
       cloudWatchService: CloudWatchService,
+      supporterProductDataService: SupporterProductDataService,
       switchService: SwitchService,
   )(implicit pool: DefaultThreadPool): PaypalBackend = {
     new PaypalBackend(
@@ -273,6 +275,7 @@ object PaypalBackend {
       acquisitionsStreamService,
       emailService,
       cloudWatchService,
+      supporterProductDataService,
       switchService,
     )
   }
@@ -309,6 +312,7 @@ object PaypalBackend {
         .loadConfig[Environment, EmailConfig](env)
         .andThen(EmailService.fromEmailConfig): InitializationResult[EmailService],
       new CloudWatchService(cloudWatchAsyncClient, env).valid: InitializationResult[CloudWatchService],
+      new SupporterProductDataService(env).valid: InitializationResult[SupporterProductDataService],
       new SwitchService(env)(awsClient, system, paypalThreadPool).valid: InitializationResult[SwitchService],
     ).mapN(PaypalBackend.apply)
   }

--- a/support-payment-api/src/main/scala/backend/StripeBackend.scala
+++ b/support-payment-api/src/main/scala/backend/StripeBackend.scala
@@ -47,6 +47,7 @@ class StripeBackend(
     emailService: EmailService,
     recaptchaService: RecaptchaService,
     cloudWatchService: CloudWatchService,
+    val supporterProductDataService: SupporterProductDataService,
     switchService: SwitchService,
     environment: Environment,
 )(implicit pool: DefaultThreadPool, WSClient: WSClient)
@@ -348,6 +349,7 @@ object StripeBackend {
       emailService: EmailService,
       recaptchaService: RecaptchaService,
       cloudWatchService: CloudWatchService,
+      supporterProductDataService: SupporterProductDataService,
       switchService: SwitchService,
       environment: Environment,
   )(implicit pool: DefaultThreadPool, WSClient: WSClient, awsClient: AmazonS3): StripeBackend = {
@@ -361,6 +363,7 @@ object StripeBackend {
       emailService,
       recaptchaService,
       cloudWatchService,
+      supporterProductDataService,
       switchService,
       environment,
     )
@@ -401,6 +404,7 @@ object StripeBackend {
         .loadConfig[Environment, RecaptchaConfig](env)
         .andThen(RecaptchaService.fromRecaptchaConfig): InitializationResult[RecaptchaService],
       new CloudWatchService(cloudWatchAsyncClient, env).valid: InitializationResult[CloudWatchService],
+      new SupporterProductDataService(env).valid: InitializationResult[SupporterProductDataService],
       new SwitchService(env)(awsClient, system, stripeThreadPool).valid: InitializationResult[SwitchService],
       env.valid: InitializationResult[Environment],
     ).mapN(StripeBackend.apply)

--- a/support-payment-api/src/main/scala/services/SupporterProductDataService.scala
+++ b/support-payment-api/src/main/scala/services/SupporterProductDataService.scala
@@ -24,17 +24,16 @@ class SupporterProductDataService(environment: Environment) {
         contributionData.identityId
           .map(idAsLong =>
             SupporterRatePlanItem(
-              subscriptionName = contributionData.paymentId,
+              subscriptionName = s"${contributionData.paymentProvider.entryName} - ${contributionData.paymentId}",
               identityId = idAsLong.toString,
               gifteeIdentityId = None,
               productRatePlanId = "single_contribution",
               productRatePlanName = "Single Contribution",
-              termEndDate = LocalDate
-                .now()
+              termEndDate = contributionData.created.toLocalDate
                 .plusYears(
                   999,
                 ), // I don't think we need these to expire as they are for information only, no benefits attached
-              contractEffectiveDate = LocalDate.now(),
+              contractEffectiveDate = contributionData.created.toLocalDate,
               contributionAmount = Some(
                 ContributionAmount(contributionData.amount, contributionData.currency.toString),
               ),

--- a/support-payment-api/src/main/scala/services/SupporterProductDataService.scala
+++ b/support-payment-api/src/main/scala/services/SupporterProductDataService.scala
@@ -1,0 +1,59 @@
+package services
+
+import cats.data.EitherT
+import com.gu.supporterdata.model.{ContributionAmount, SupporterRatePlanItem}
+import com.gu.supporterdata.model.Stage.{DEV, PROD}
+import com.gu.supporterdata.services.SupporterDataDynamoService
+import model.db.ContributionData
+import model.Environment
+import model.Environment.Live
+
+import java.time.LocalDate
+import scala.concurrent.{ExecutionContext, Future}
+
+class SupporterProductDataService(environment: Environment) {
+  val dynamoService = SupporterDataDynamoService(environment match {
+    case Live => PROD
+    case _ => DEV
+  })
+  def insertContributionData(
+      contributionData: ContributionData,
+  )(implicit executionContext: ExecutionContext): EitherT[Future, String, Unit] =
+    for {
+      item <- EitherT.fromEither[Future](
+        contributionData.identityId
+          .map(idAsLong =>
+            SupporterRatePlanItem(
+              subscriptionName = contributionData.paymentId,
+              identityId = idAsLong.toString,
+              gifteeIdentityId = None,
+              productRatePlanId = "single_contribution",
+              productRatePlanName = "Single Contribution",
+              termEndDate = LocalDate
+                .now()
+                .plusYears(
+                  999,
+                ), // I don't think we need these to expire as they are for information only, no benefits attached
+              contractEffectiveDate = LocalDate.now(),
+              contributionAmount = Some(
+                ContributionAmount(contributionData.amount, contributionData.currency.toString),
+              ),
+            ),
+          )
+          .toRight(
+            s"Missing identity id for contribution $contributionData this is a primary key of the data store so we can't continue",
+          ),
+      )
+      response <- EitherT(
+        dynamoService
+          .writeItem(item)
+          .map(_ => Right(()))
+          .recover { case err: Throwable =>
+            Left(
+              s"An error occurred while writing to the supporter product data dynamo store: ${err.getMessage}",
+            )
+          },
+      )
+    } yield response
+
+}

--- a/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
@@ -78,6 +78,10 @@ class PaypalBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
     EitherT.right(Future.successful(()))
   val databaseResponseError: EitherT[Future, ContributionsStoreService.Error, Unit] =
     EitherT.left(Future.successful(dbError))
+  val supporterProductDataResponse: EitherT[Future, String, Unit] =
+    EitherT.right(Future.successful(()))
+  val supporterProductDataResponseError: EitherT[Future, String, Unit] =
+    EitherT.left(Future.successful("an error from supporter product data"))
   val bigQueryResponse: EitherT[Future, List[String], Unit] =
     EitherT.right(Future.successful(()))
   val bigQueryErrorMessage = "a BigQuery error"
@@ -123,6 +127,7 @@ class PaypalBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
   val mockEmailService: EmailService = mock[EmailService]
   val mockCloudWatchService: CloudWatchService = mock[CloudWatchService]
   val mockAcquisitionsStreamService: AcquisitionsStreamService = mock[AcquisitionsStreamService]
+  val mockSupporterProductDataService: SupporterProductDataService = mock[SupporterProductDataService]
   val mockSwitchService: SwitchService = mock[SwitchService]
 
   // -- test obj
@@ -135,6 +140,7 @@ class PaypalBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
     mockAcquisitionsStreamService,
     mockEmailService,
     mockCloudWatchService,
+    mockSupporterProductDataService,
     mockSwitchService,
   )(new DefaultThreadPool(ec))
 
@@ -259,6 +265,8 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
             EnrichedPaypalPayment(paymentMock, Some(paymentMock.getPayer.getPayerInfo.getEmail))
           when(mockSwitchService.allSwitches).thenReturn(switchServiceOnResponse)
           when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
+          when(mockSupporterProductDataService.insertContributionData(any())(any()))
+            .thenReturn(supporterProductDataResponseError)
           when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
           when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
             .thenReturn(streamResponseError)
@@ -276,6 +284,8 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
           EnrichedPaypalPayment(paymentMock, Some(paymentMock.getPayer.getPayerInfo.getEmail))
         when(mockSwitchService.allSwitches).thenReturn(switchServiceOnResponse)
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
+        when(mockSupporterProductDataService.insertContributionData(any())(any()))
+          .thenReturn(supporterProductDataResponseError)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
           .thenReturn(streamResponseError)
@@ -314,12 +324,14 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
 
     "tracking the contribution" should {
 
-      "return just a DB error if BigQuery succeeds but DB fails" in new PaypalBackendFixture {
+      "return just a DB error if BigQuery and SupporterProductData succeed but DB fails" in new PaypalBackendFixture {
         populatePaymentMock()
         when(mockSwitchService.allSwitches).thenReturn(switchServiceOnResponse)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponse)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
+        when(mockSupporterProductDataService.insertContributionData(any())(any()))
+          .thenReturn(supporterProductDataResponse)
 
         val trackContribution = PrivateMethod[Future[List[BackendError]]](Symbol("trackContribution"))
         val result = paypalBackend invokePrivate trackContribution(
@@ -337,6 +349,8 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
         populatePaymentMock()
         when(mockSwitchService.allSwitches).thenReturn(switchServiceOnResponse)
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponse)
+        when(mockSupporterProductDataService.insertContributionData(any())(any()))
+          .thenReturn(supporterProductDataResponse)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
           .thenReturn(streamResponseError)


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This  PR adds code to the payment-api to write single contributions into the Supporter Product Data Dynamo store.

Doing this will allow mean that  we don't need to query the contributions data store from members-data-api whenever we get a request to retrieve a users single contributions - we can get both single contributions and subscriptions from the same store.  

This will be both more performant and reduce the load on the postgres database  as well as simplifying the code base.