### PR TITLE
Remove large runner from support-frontend-build

### DIFF
--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
 
     name: support-frontend build
-    runs-on: 4core-ubuntu-latest-testing
+    runs-on: ubuntu-latest
     steps:
       - name: Env
         run: env


### PR DESCRIPTION
## What are you doing in this PR?

Remove large runner from support-frontend-build workflow 


[**Trello Card**](https://trello.com/c/nrDQctko/716-test-using-larger-runners-to-speed-up-support-frontend-build)

