### PR TITLE
Use /contribute over /support in geoRedirect

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -64,16 +64,16 @@ class Application(
   }
 
   def geoRedirect: Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
-    val redirectUrl = request.geoData.countryGroup match {
-      case Some(UK) => buildCanonicalShowcaseLink("uk")
-      case Some(US) => buildCanonicalShowcaseLink("us")
-      case Some(Australia) => buildCanonicalShowcaseLink("au")
-      case Some(Europe) => "/eu/contribute"
-      case Some(Canada) => "/ca/contribute"
-      case Some(NewZealand) => "/nz/contribute"
-      case Some(RestOfTheWorld) => "/int/contribute"
-      case _ => "/uk/contribute"
-    }
+    val redirectUrl = buildCanonicalContributeLink(request.geoData.countryGroup match {
+      case Some(UK) => "uk"
+      case Some(US) => "us"
+      case Some(Australia) => "au"
+      case Some(Europe) => "eu"
+      case Some(Canada) => "ca"
+      case Some(NewZealand) => "nz"
+      case Some(RestOfTheWorld) => "int"
+      case _ => "uk"
+    })
 
     RedirectWithEncodedQueryString(redirectUrl, request.queryString, status = FOUND)
   }
@@ -85,7 +85,11 @@ class Application(
       case _ => "uk"
     }
 
-    RedirectWithEncodedQueryString(buildCanonicalShowcaseLink(supportPageVariant), request.queryString, status = FOUND)
+    RedirectWithEncodedQueryString(
+      buildCanonicalContributeLink(supportPageVariant),
+      request.queryString,
+      status = FOUND,
+    )
   }
 
   def contributeGeoRedirect(campaignCode: String): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>

--- a/support-frontend/app/controllers/CanonicalLinks.scala
+++ b/support-frontend/app/controllers/CanonicalLinks.scala
@@ -16,7 +16,7 @@ trait CanonicalLinks {
     if (orderIsAGift) s"${supportUrl}/${countryCode}/subscribe/weekly/gift"
     else s"${supportUrl}/${countryCode}/subscribe/weekly"
 
-  def buildCanonicalShowcaseLink(countryCode: String): String =
-    s"${supportUrl}/${countryCode}/support"
+  def buildCanonicalContributeLink(countryCode: String): String =
+    s"${supportUrl}/${countryCode}/contribute"
 
 }


### PR DESCRIPTION
When running locally, we now redirect to `/support` in a couple of places, while our site is actually at `/contribute`. This PR updates those places to redirect straight to `/contribute`. Since we’re redirecting with Fastly anyway (in code and prod), this isn’t essential, but it’s a small change and makes things more consistent.