### PR TITLE
Revert " Fix for Supporter Plus checkout country dropdown layout bug"

### DIFF
--- a/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.module.scss
+++ b/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.module.scss
@@ -11,7 +11,6 @@
 
 	:global(.svg-dropdown-arrow) {
 		position: inline-block;
-    margin-top: $gu-h-spacing*0.25;
 		margin-left: $gu-h-spacing*0.25;
 		path {
 			fill: currentColor;

--- a/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
+++ b/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
@@ -36,13 +36,9 @@
 		.svg-dropdown-arrow path {
 			fill: gu-colour(highlight-main);
 		}
-    .svg-dropdown-arrow{
-      transform: rotate(180deg);
-    }
 	}
 
 	.component-select-input__label {
 		@include visually-hidden;
 	}
-
 }

--- a/support-frontend/assets/components/dialog/dialog.scss
+++ b/support-frontend/assets/components/dialog/dialog.scss
@@ -14,7 +14,7 @@
 
 .component-dialog--open {
 	visibility: visible;
-	position: absolute;
+	position: fixed;
 	height: 100%;
 	width: 100%;
 	top: 0;

--- a/support-frontend/assets/components/menu/menu.module.scss
+++ b/support-frontend/assets/components/menu/menu.module.scss
@@ -8,9 +8,10 @@
 
 	@include mq($until: tablet) {
 		position: fixed !important;
-		top: 3rem !important;
+		top: auto !important;
 		left: 0 !important;
 		right: 0 !important;
+		bottom: 0 !important;
 		max-height: 70vh;
 		border-bottom-left-radius: 0;
 		border-bottom-right-radius: 0;


### PR DESCRIPTION
Reverts guardian/support-frontend#4680

Caused an error on the weekly checkout – the drop-down menu gets stuck behind content it should be in front of.

<img width="1036" alt="Screenshot 2023-01-25 at 15 50 00" src="https://user-images.githubusercontent.com/23191049/214609814-652e1e20-b0dc-414e-b8c4-919d5ee6f08b.png">
