### PR TITLE
Country drop down supporter plus fix

### DIFF
--- a/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.module.scss
+++ b/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.module.scss
@@ -10,7 +10,8 @@
 	@include gu-fontset-body-sans;
 
 	:global(.svg-dropdown-arrow) {
-		position: inline-block;
+		position: absolute;
+    margin-top: $gu-h-spacing*0.25;
 		margin-left: $gu-h-spacing*0.25;
 		path {
 			fill: currentColor;

--- a/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
+++ b/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
@@ -40,6 +40,5 @@
 
 	.component-select-input__label {
 		@include visually-hidden;
-
 	}
 }

--- a/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
+++ b/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
@@ -27,18 +27,19 @@
 		&::-ms-expand {
 			display: none;
 		}
+    .svg-dropdown-arrow path {
+      fill: currentColor;
+    }
 	}
 
 	&:hover {
 		.component-select-input__select {
 			color: gu-colour(highlight-main);
 		}
-		.svg-dropdown-arrow path {
-			fill: gu-colour(highlight-main);
-		}
 	}
 
 	.component-select-input__label {
 		@include visually-hidden;
+
 	}
 }

--- a/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx
+++ b/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx
@@ -84,7 +84,7 @@ function CountryGroupSwitcher({
 			>
 				<Menu
 					style={{
-						top: bounds.top,
+						top: bounds.top + 30,
 						left: bounds.left,
 						position: 'absolute',
 					}}

--- a/support-frontend/assets/components/menu/menu.module.scss
+++ b/support-frontend/assets/components/menu/menu.module.scss
@@ -8,10 +8,9 @@
 
 	@include mq($until: tablet) {
 		position: fixed !important;
-		top: auto !important;
+		top: auto;
 		left: 0 !important;
 		right: 0 !important;
-		bottom: 0 !important;
 		max-height: 70vh;
 		border-bottom-left-radius: 0;
 		border-bottom-right-radius: 0;


### PR DESCRIPTION
## What are you doing in this PR?
Supporter Plus checkout: Fix layout bug with the country dropdown

[**Trello Card**](https://trello.com/c/CeJ4lNs4/932-supporter-plus-checkout-fix-layout-bug-with-the-country-dropdown)

## Why are you doing this?
Dropdown of country picker doesn't align properly when it's open.
Also, a small tweaks needs to be done on the 320 breakpoint to align the chevron with the link.

## Screenshots
Before Change
![Frame_2077](https://user-images.githubusercontent.com/73653255/213686109-79782266-e9a3-411a-af64-e01783f6ab92.jpeg)


After Change
<img width="598" alt="image" src="https://user-images.githubusercontent.com/73653255/215061815-f068a529-fa24-4db1-9373-7f2a956b9bff.png">

<img width="598" alt="image" src="https://user-images.githubusercontent.com/73653255/215061895-c72f6650-ab18-4067-a66a-97e313e29139.png">
