### PR TITLE
Add lambda for patron sign-up stripe webhook

### DIFF
--- a/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
+++ b/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
@@ -211,12 +211,15 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC5031415bce23b484655df855d90ebafb1d3": {
+    "RestApiDeployment180EC5033fc0c8ea808241777537b04b239b12f5": {
       "DependsOn": [
         "RestApipatron1DDE9314",
         "RestApipatronsubscriptioncancelcountryIdPOSTFA2082F3",
         "RestApipatronsubscriptioncancelcountryId57A3F9F4",
         "RestApipatronsubscriptioncancel0F56DD38",
+        "RestApipatronsubscriptioncreatecountryIdPOST1E68C8CD",
+        "RestApipatronsubscriptioncreatecountryId97F3026B",
+        "RestApipatronsubscriptioncreateC44D8A79",
         "RestApipatronsubscriptionAE58DC90",
       ],
       "Properties": {
@@ -233,7 +236,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC5031415bce23b484655df855d90ebafb1d3",
+          "Ref": "RestApiDeployment180EC5033fc0c8ea808241777537b04b239b12f5",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -428,6 +431,148 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApipatronsubscriptioncreateC44D8A79": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApipatronsubscriptionAE58DC90",
+        },
+        "PathPart": "create",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApipatronsubscriptioncreatecountryId97F3026B": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApipatronsubscriptioncreateC44D8A79",
+        },
+        "PathPart": "{countryId}",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApipatronsubscriptioncreatecountryIdPOST1E68C8CD": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "POST",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "stripepatronsdatasignup4E7F0A3F",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "RestApipatronsubscriptioncreatecountryId97F3026B",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApipatronsubscriptioncreatecountryIdPOSTApiPermissionStripePatronsDataPRODRestApi790D3BDCPOSTpatronsubscriptioncreatecountryId951BC4E4": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "stripepatronsdatasignup4E7F0A3F",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/POST/patron/subscription/create/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApipatronsubscriptioncreatecountryIdPOSTApiPermissionTestStripePatronsDataPRODRestApi790D3BDCPOSTpatronsubscriptioncreatecountryId97211607": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "stripepatronsdatasignup4E7F0A3F",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/POST/patron/subscription/create/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "StripePatronsDataPROD61F45521": {
       "DependsOn": [
@@ -1028,6 +1173,246 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
         "Roles": [
           {
             "Ref": "stripepatronsdatacancelledServiceRole157E3052",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "stripepatronsdatasignup4E7F0A3F": {
+      "DependsOn": [
+        "stripepatronsdatasignupServiceRoleDefaultPolicy299A4882",
+        "stripepatronsdatasignupServiceRoleC639AAC9",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "support/PROD/stripe-patrons-data/stripe-patrons-data.jar",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "stripe-patrons-data",
+            "STACK": "support",
+            "STAGE": "PROD",
+          },
+        },
+        "FunctionName": "stripe-patrons-data-sign-up-PROD",
+        "Handler": "com.gu.patrons.lambdas.PatronSignUpEventLambda::handleRequest",
+        "MemorySize": 1536,
+        "Role": {
+          "Fn::GetAtt": [
+            "stripepatronsdatasignupServiceRoleC639AAC9",
+            "Arn",
+          ],
+        },
+        "Runtime": "java11",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "stripe-patrons-data",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "stripepatronsdatasignupServiceRoleC639AAC9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "stripe-patrons-data",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "stripepatronsdatasignupServiceRoleDefaultPolicy299A4882": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/support/PROD/stripe-patrons-data/stripe-patrons-data.jar",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/stripe-patrons-data",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/stripe-patrons-data/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/stripe-patrons-data/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:Scan",
+                "dynamodb:UpdateItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:Query",
+                "dynamodb:DescribeTable",
+              ],
+              "Effect": "Allow",
+              "Resource": "arn:aws:dynamodb:*:*:table/SupporterProductData-PROD",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "stripepatronsdatasignupServiceRoleDefaultPolicy299A4882",
+        "Roles": [
+          {
+            "Ref": "stripepatronsdatasignupServiceRoleC639AAC9",
           },
         ],
       },

--- a/stripe-patrons-data/build.sbt
+++ b/stripe-patrons-data/build.sbt
@@ -53,6 +53,7 @@ deployToCode := {
   List(
     "stripe-patrons-data-CODE",
     "stripe-patrons-data-cancelled-CODE",
+    "stripe-patrons-data-sign-up-CODE",
   ).foreach(functionPartial => {
     System.out.println(s"Updating function $functionPartial")
     s"aws lambda update-function-code --function-name $functionPartial --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!

--- a/stripe-patrons-data/riff-raff.yaml
+++ b/stripe-patrons-data/riff-raff.yaml
@@ -18,6 +18,7 @@ deployments:
       functionNames:
         - stripe-patrons-data-
         - stripe-patrons-data-cancelled-
+        - stripe-patrons-data-sign-up-
       fileName: stripe-patrons-data.jar
       prefixStack: false
     dependencies: [ cfn ]

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/conf/PatronsStripeConfig.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/conf/PatronsStripeConfig.scala
@@ -3,7 +3,7 @@ package com.gu.patrons.conf
 import com.gu.patrons.services.{ConfigService, ParameterStoreService}
 import com.gu.supporterdata.model.Stage
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext}
 
 case class PatronsStripeConfig(
     apiKey: String,

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/conf/PatronsStripeConfig.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/conf/PatronsStripeConfig.scala
@@ -7,7 +7,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 case class PatronsStripeConfig(
     apiKey: String,
-    signingSecret: String,
+    apiKeyAu: String,
+    cancelledHookSigningSecret: String,
+    cancelledHookSigningSecretAu: String,
+    signUpHookSigningSecret: String,
+    signUpHookSigningSecretAustralia: String,
 )
 
 object PatronsStripeConfig extends ConfigService {
@@ -18,7 +22,11 @@ object PatronsStripeConfig extends ConfigService {
     ParameterStoreService(stage).getParametersByPath(stripeConfigPath).map { params =>
       PatronsStripeConfig(
         findParameterOrThrow("api-key", params),
-        findParameterOrThrow("signing-secret", params),
+        findParameterOrThrow("api-key-au", params),
+        findParameterOrThrow("cancelled-hook-signing-secret", params),
+        findParameterOrThrow("cancelled-hook-signing-secret-au", params),
+        findParameterOrThrow("sign-up-hook-signing-secret", params),
+        findParameterOrThrow("sign-up-hook-signing-secret-au", params),
       )
     }
   }

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/lambdas/PatronCancelledEventLambda.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/lambdas/PatronCancelledEventLambda.scala
@@ -13,7 +13,6 @@ import com.gu.patrons.model.{
   InvalidRequestError,
   StageConstructors,
   ExpandedStripeCustomer,
-  StripeCustomer,
   SubscriptionNotFoundDynamo,
   UserNotFoundIdentityError,
   UserNotFoundStripeError,

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/lambdas/PatronSignUpEventLambda.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/lambdas/PatronSignUpEventLambda.scala
@@ -12,7 +12,6 @@ import com.gu.patrons.model.{
   InvalidRequestError,
   StripeGetCustomerFailedError,
   StageConstructors,
-  StripeCustomer,
   ExpandedStripeCustomer,
   UnexpandedStripeCustomer,
   StripeSubscription,
@@ -34,9 +33,7 @@ import com.typesafe.scalalogging.StrictLogging
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 import io.circe.parser.decode
-import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse
 
-import java.time.LocalDate
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.{Duration, DurationInt, MINUTES}
@@ -62,7 +59,7 @@ object PatronSignUpEventLambda extends StrictLogging {
       stripeConfig <- getStripeConfig(stage)
       identityConfig <- getIdentityConfig(stage)
       identityService = new PatronsIdentityService(identityConfig, runner)
-      val account = if (event.getPathParameters.get("countryId") == "au") GnmPatronSchemeAus else GnmPatronScheme
+      account = if (event.getPathParameters.get("countryId") == "au") GnmPatronSchemeAus else GnmPatronScheme
       payload <- getPayload(
         event,
         account match {

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/lambdas/PatronSignUpEventLambda.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/lambdas/PatronSignUpEventLambda.scala
@@ -1,0 +1,185 @@
+package com.gu.patrons.lambdas
+
+import cats.data.EitherT
+import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
+import com.gu.monitoring.SafeLogger
+import com.gu.okhttp.RequestRunners.configurableFutureRunner
+import com.gu.patrons.conf.{PatronsIdentityConfig, PatronsStripeConfig}
+import com.gu.patrons.model.{
+  ConfigLoadingError,
+  SignUpError,
+  InvalidJsonError,
+  InvalidRequestError,
+  StripeGetCustomerFailedError,
+  StageConstructors,
+  StripeCustomer,
+  ExpandedStripeCustomer,
+  UnexpandedStripeCustomer,
+  StripeSubscription,
+  SubscriptionProcessingError,
+}
+import com.gu.patrons.services.{
+  PatronsIdentityService,
+  PatronsStripeService,
+  PatronsStripeAccount,
+  GnmPatronScheme,
+  GnmPatronSchemeAus,
+  SubscriptionProcessor,
+  CreateMissingIdentityProcessor,
+}
+import com.gu.supporterdata.model.Stage
+import com.gu.supporterdata.services.SupporterDataDynamoService
+import com.stripe.net.Webhook
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import io.circe.parser.decode
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse
+
+import java.time.LocalDate
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.{Duration, DurationInt, MINUTES}
+import scala.jdk.CollectionConverters.MapHasAsScala
+import scala.util.{Failure, Success, Try}
+
+object PatronSignUpEventLambda extends StrictLogging {
+  val runner = configurableFutureRunner(60.seconds)
+
+  def handleRequest(event: APIGatewayProxyRequestEvent): APIGatewayProxyResponseEvent = {
+    Await.result(
+      signUpCustomerInDynamoDb(event, StageConstructors.fromEnvironment),
+      Duration(15, MINUTES),
+    )
+  }
+
+  def signUpCustomerInDynamoDb(
+      event: APIGatewayProxyRequestEvent,
+      stage: Stage,
+  ): Future[APIGatewayProxyResponseEvent] = {
+    implicit val stage = StageConstructors.fromEnvironment
+    (for {
+      stripeConfig <- getStripeConfig(stage)
+      identityConfig <- getIdentityConfig(stage)
+      identityService = new PatronsIdentityService(identityConfig, runner)
+      val account = if (event.getPathParameters.get("countryId") == "au") GnmPatronSchemeAus else GnmPatronScheme
+      payload <- getPayload(
+        event,
+        account match {
+          case GnmPatronSchemeAus => stripeConfig.signUpHookSigningSecretAustralia
+          case GnmPatronScheme => stripeConfig.signUpHookSigningSecret
+        },
+      )
+      event <- getEvent(payload)
+      customer <- getCustomer(stripeConfig, account, event.data.`object`.customer.id)
+      dynamoService = SupporterDataDynamoService(stage)
+      unit <- processSubscription(
+        new CreateMissingIdentityProcessor(identityService, dynamoService),
+        StripeSubscription.expandCustomerInfo(customer, event.data.`object`),
+      )
+    } yield unit).value.map(getAPIGatewayResult(_))
+  }
+
+  def getAPIGatewayResult(result: Either[SignUpError, Unit]) = {
+    val response = new APIGatewayProxyResponseEvent()
+    result match {
+      case Left(error @ (ConfigLoadingError(_) | SubscriptionProcessingError(_) | StripeGetCustomerFailedError(_))) =>
+        logger.error(error.message)
+        response.setStatusCode(500)
+        response.setBody(error.message)
+      case Left(error @ (InvalidRequestError(_) | InvalidJsonError(_))) =>
+        logger.error(error.message)
+        response.setStatusCode(400)
+        response.setBody(error.message)
+      case Right(_) =>
+        logger.info("Successfully created Patron subscription")
+        response.setStatusCode(200)
+        response.setBody("Successfully created Patron subscription")
+    }
+    response
+  }
+
+  def getStripeConfig(stage: Stage): EitherT[Future, SignUpError, PatronsStripeConfig] = {
+    logger.info("Attempting to fetch Stripe config information from parameter store")
+    val futureConfig: Future[Either[SignUpError, PatronsStripeConfig]] = PatronsStripeConfig
+      .fromParameterStore(stage)
+      .transform {
+        case Success(config) => Try(Right(config))
+        case Failure(err) => Try(Left(ConfigLoadingError(err.getMessage)))
+      }
+    EitherT(futureConfig)
+  }
+
+  def getIdentityConfig(stage: Stage): EitherT[Future, SignUpError, PatronsIdentityConfig] = {
+    logger.info("Attempting to fetch Identity config information from parameter store")
+    val futureConfig: Future[Either[SignUpError, PatronsIdentityConfig]] = PatronsIdentityConfig
+      .fromParameterStore(stage)
+      .transform {
+        case Success(config) => Try(Right(config))
+        case Failure(err) => Try(Left(ConfigLoadingError(err.getMessage)))
+      }
+    EitherT(futureConfig)
+  }
+
+  def getPayload(
+      event: APIGatewayProxyRequestEvent,
+      signingSecret: String,
+  ): EitherT[Future, SignUpError, String] = {
+    logger.info("Attempting to verify event payload")
+    EitherT.fromEither(for {
+      payload <- Option(event.getBody).toRight(InvalidRequestError("Missing body"))
+      _ = SafeLogger.info(s"payload is ${payload.replace("\n", "")}")
+      sigHeader <- event.getHeaders.asScala.get("Stripe-Signature").toRight(InvalidRequestError("Missing sig header"))
+      _ <- Try(
+        Webhook.Signature.verifyHeader(payload, sigHeader, signingSecret, 300),
+      ).toEither.left.map(e => InvalidRequestError(e.getMessage))
+      _ = logger.info(s"payload successfully verified")
+    } yield payload)
+  }
+
+  def getEvent(payload: String): EitherT[Future, SignUpError, PatronSignUpEvent] = {
+    logger.info(s"Attempting to decode event from payload")
+    EitherT.fromEither(decode[PatronSignUpEvent](payload).left.map(e => InvalidJsonError(e.getMessage)))
+  }
+
+  def getCustomer(
+      config: PatronsStripeConfig,
+      account: PatronsStripeAccount,
+      customerId: String,
+  ): EitherT[Future, SignUpError, ExpandedStripeCustomer] = {
+    logger.info(s"Attempting to retrieve customer with id $customerId from Stripe")
+    val stripeService = new PatronsStripeService(config, runner)
+    val futureCustomer = stripeService.getCustomer(account, customerId).transform {
+      case Success(customer) => Try(Right(customer))
+      case Failure(err) =>
+        Try(
+          Left(
+            StripeGetCustomerFailedError(
+              s"Couldn't retrieve customer with id $customerId from Stripe because of error - ${err.getMessage}",
+            ),
+          ),
+        )
+    }
+    EitherT(futureCustomer)
+  }
+
+  def processSubscription(
+      processor: SubscriptionProcessor,
+      subscription: StripeSubscription[ExpandedStripeCustomer],
+  ): EitherT[Future, SignUpError, Unit] = {
+    logger.info(s"Attempting to process subscription")
+    EitherT(processor.processSubscription(subscription).transform {
+      case Success(()) => Try(Right(()))
+      case Failure(err) => Try(Left(SubscriptionProcessingError(err.getMessage)))
+    })
+  }
+
+}
+
+case class PatronSignUpEvent(data: PatronSignUpData)
+case class PatronSignUpData(`object`: StripeSubscription[UnexpandedStripeCustomer])
+
+object PatronSignUpEvent {
+  implicit val decoder: Decoder[PatronSignUpEvent] = deriveDecoder
+  implicit val dataDecoder: Decoder[PatronSignUpData] = deriveDecoder
+}

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/model/Errors.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/model/Errors.scala
@@ -1,19 +1,27 @@
 package com.gu.patrons.model
 
-sealed trait Error {
+sealed trait CancelError {
   val message: String
 }
 
-case class ConfigLoadingError(message: String) extends Error
+sealed trait SignUpError {
+  val message: String
+}
 
-case class InvalidRequestError(message: String) extends Error
+case class ConfigLoadingError(message: String) extends CancelError with SignUpError
 
-case class InvalidJsonError(message: String) extends Error
+case class InvalidRequestError(message: String) extends CancelError with SignUpError
 
-case class UserNotFoundIdentityError(message: String) extends Error
+case class InvalidJsonError(message: String) extends CancelError with SignUpError
 
-case class UserNotFoundStripeError(message: String) extends Error
+case class UserNotFoundIdentityError(message: String) extends CancelError
 
-case class SubscriptionNotFoundDynamo(message: String) extends Error
+case class UserNotFoundStripeError(message: String) extends CancelError
 
-case class DynamoDbError(message: String) extends Error
+case class SubscriptionNotFoundDynamo(message: String) extends CancelError
+
+case class DynamoDbError(message: String) extends CancelError
+
+case class StripeGetCustomerFailedError(message: String) extends SignUpError
+
+case class SubscriptionProcessingError(message: String) extends SignUpError

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/services/StripeSubscriptionsProcessor.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/services/StripeSubscriptionsProcessor.scala
@@ -1,7 +1,7 @@
 package com.gu.patrons.services
 
 import com.gu.monitoring.SafeLogger
-import com.gu.patrons.model.{StripeCustomer, ExpandedStripeCustomer, StripeSubscription, StripeSubscriptionsResponse}
+import com.gu.patrons.model.{ExpandedStripeCustomer, StripeSubscription}
 import com.gu.supporterdata.model.SupporterRatePlanItem
 import com.gu.supporterdata.services.SupporterDataDynamoService
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse

--- a/stripe-patrons-data/src/test/scala/com/gu/patrons/lambdas/ProcessStripeSubscriptionsLambdaSpec.scala
+++ b/stripe-patrons-data/src/test/scala/com/gu/patrons/lambdas/ProcessStripeSubscriptionsLambdaSpec.scala
@@ -4,11 +4,12 @@ import com.gu.supporterdata.model.Stage.DEV
 import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
+import com.gu.patrons.services.GnmPatronScheme
 
 @IntegrationTest
 class ProcessStripeSubscriptionsLambdaSpec extends AsyncFlatSpec with Matchers {
 
   ProcessStripeSubscriptionsLambda.getClass.getSimpleName should "process subscriptions" in {
-    ProcessStripeSubscriptionsLambda.processSubscriptions(DEV).map(result => result shouldBe ())
+    ProcessStripeSubscriptionsLambda.processSubscriptions(GnmPatronScheme, DEV).map(result => result shouldBe ())
   }
 }

--- a/stripe-patrons-data/src/test/scala/com/gu/patrons/services/Fixtures.scala
+++ b/stripe-patrons-data/src/test/scala/com/gu/patrons/services/Fixtures.scala
@@ -492,4 +492,173 @@ object Fixtures {
     }
     """
 
+  val patronSignUpEventJson = """
+{
+  "id": "evt_1MX3M1JETvkRwpwqAQ6JAXKW",
+  "object": "event",
+  "api_version": "2018-07-27",
+  "created": 1675346492,
+  "data": {
+    "object": {
+      "id": "sub_1MX3LyJETvkRwpwqyBQPVmqs",
+      "object": "subscription",
+      "application": null,
+      "application_fee_percent": null,
+      "automatic_tax": {
+        "enabled": false
+      },
+      "billing": "charge_automatically",
+      "billing_cycle_anchor": 1675346490,
+      "billing_thresholds": null,
+      "cancel_at": null,
+      "cancel_at_period_end": false,
+      "canceled_at": null,
+      "collection_method": "charge_automatically",
+      "created": 1675346490,
+      "currency": "usd",
+      "current_period_end": 1677765690,
+      "current_period_start": 1675346490,
+      "customer": "cus_NHcbq5RLIqP2ph",
+      "days_until_due": null,
+      "default_payment_method": null,
+      "default_source": null,
+      "default_tax_rates": [
+      ],
+      "description": null,
+      "discount": null,
+      "ended_at": null,
+      "invoice_customer_balance_settings": {
+        "consume_applied_balance_on_void": true
+      },
+      "items": {
+        "object": "list",
+        "data": [
+          {
+            "id": "si_NHcb50foRmNuDf",
+            "object": "subscription_item",
+            "billing_thresholds": null,
+            "created": 1675346490,
+            "metadata": {
+            },
+            "plan": {
+              "id": "price_1MX3LwJETvkRwpwqfjzAmon3",
+              "object": "plan",
+              "active": true,
+              "aggregate_usage": null,
+              "amount": 1500,
+              "amount_decimal": "1500",
+              "billing_scheme": "per_unit",
+              "created": 1675346488,
+              "currency": "usd",
+              "interval": "month",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {
+              },
+              "nickname": null,
+              "product": "prod_NHcbhQxmqs2uhX",
+              "tiers": null,
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "price": {
+              "id": "price_1MX3LwJETvkRwpwqfjzAmon3",
+              "object": "price",
+              "active": true,
+              "billing_scheme": "per_unit",
+              "created": 1675346488,
+              "currency": "usd",
+              "custom_unit_amount": null,
+              "livemode": false,
+              "lookup_key": null,
+              "metadata": {
+              },
+              "nickname": null,
+              "product": "prod_NHcbhQxmqs2uhX",
+              "recurring": {
+                "aggregate_usage": null,
+                "interval": "month",
+                "interval_count": 1,
+                "trial_period_days": null,
+                "usage_type": "licensed"
+              },
+              "tax_behavior": "unspecified",
+              "tiers_mode": null,
+              "transform_quantity": null,
+              "type": "recurring",
+              "unit_amount": 1500,
+              "unit_amount_decimal": "1500"
+            },
+            "quantity": 1,
+            "subscription": "sub_1MX3LyJETvkRwpwqyBQPVmqs",
+            "tax_rates": [
+            ]
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/subscription_items?subscription=sub_1MX3LyJETvkRwpwqyBQPVmqs"
+      },
+      "latest_invoice": "in_1MX3LyJETvkRwpwqqc7U7For",
+      "livemode": false,
+      "metadata": {
+      },
+      "next_pending_invoice_item_invoice": null,
+      "on_behalf_of": null,
+      "pause_collection": null,
+      "payment_settings": {
+        "payment_method_options": null,
+        "payment_method_types": null,
+        "save_default_payment_method": "off"
+      },
+      "pending_invoice_item_interval": null,
+      "pending_setup_intent": null,
+      "pending_update": null,
+      "plan": {
+        "id": "price_1MX3LwJETvkRwpwqfjzAmon3",
+        "object": "plan",
+        "active": true,
+        "aggregate_usage": null,
+        "amount": 1500,
+        "amount_decimal": "1500",
+        "billing_scheme": "per_unit",
+        "created": 1675346488,
+        "currency": "usd",
+        "interval": "month",
+        "interval_count": 1,
+        "livemode": false,
+        "metadata": {
+        },
+        "nickname": null,
+        "product": "prod_NHcbhQxmqs2uhX",
+        "tiers": null,
+        "tiers_mode": null,
+        "transform_usage": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      },
+      "quantity": 1,
+      "schedule": null,
+      "start": 1675346490,
+      "start_date": 1675346490,
+      "status": "active",
+      "tax_percent": null,
+      "test_clock": null,
+      "transfer_data": null,
+      "trial_end": null,
+      "trial_start": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_9ZXeimLfCZX3H6",
+    "idempotency_key": "5fa1e180-2617-4f92-bc13-8e28835d4a38"
+  },
+  "type": "customer.subscription.created"
+}
+"""
+
 }

--- a/stripe-patrons-data/src/test/scala/com/gu/patrons/services/PatronsStripeServiceSpec.scala
+++ b/stripe-patrons-data/src/test/scala/com/gu/patrons/services/PatronsStripeServiceSpec.scala
@@ -17,7 +17,7 @@ class PatronsStripeServiceSpec extends AsyncFlatSpec with Matchers {
       .fromParameterStore(DEV)
       .flatMap { config =>
         val stripeService = new PatronsStripeService(config, configurableFutureRunner(60.seconds))
-        stripeService.getSubscriptions(1).map { response =>
+        stripeService.getSubscriptions(GnmPatronScheme, 1).map { response =>
           response.data.length should be > 0
           response.hasMore shouldBe true
           response.data.head.customer.email.length should be > 0

--- a/stripe-patrons-data/src/test/scala/com/gu/patrons/services/SerialisationSpec.scala
+++ b/stripe-patrons-data/src/test/scala/com/gu/patrons/services/SerialisationSpec.scala
@@ -1,7 +1,7 @@
 package com.gu.patrons.services
 
-import com.gu.patrons.lambdas.PatronCancelledEvent
-import com.gu.patrons.model.StripeSubscription
+import com.gu.patrons.lambdas.{PatronCancelledEvent, PatronSignUpEvent}
+import com.gu.patrons.model.{ExpandedStripeCustomer, StripeSubscription}
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.parser._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 class SerialisationSpec extends AnyFlatSpec with Matchers with LazyLogging {
 
   "StripeSubscription" should "deserialise successfully" in {
-    decode[StripeSubscription](Fixtures.subscriptionJson) match {
+    decode[StripeSubscription[ExpandedStripeCustomer]](Fixtures.subscriptionJson) match {
       case Left(err) =>
         fail(err.getMessage)
       case Right(sub) =>
@@ -30,4 +30,13 @@ class SerialisationSpec extends AnyFlatSpec with Matchers with LazyLogging {
     }
   }
 
+  "PatronSignUpEvent" should "deserialise successfully" in {
+    decode[PatronSignUpEvent](Fixtures.patronSignUpEventJson) match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right(event) =>
+        logger.info(event.data.`object`.id)
+        event.data.`object`.id should be("sub_1MX3LyJETvkRwpwqyBQPVmqs")
+    }
+  }
 }

--- a/stripe-patrons-data/src/test/scala/com/gu/patrons/services/StripeSubscriptionsProcessorSpec.scala
+++ b/stripe-patrons-data/src/test/scala/com/gu/patrons/services/StripeSubscriptionsProcessorSpec.scala
@@ -3,7 +3,7 @@ package com.gu.patrons.services
 import com.gu.monitoring.SafeLogger
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.patrons.conf.{PatronsIdentityConfig, PatronsStripeConfig}
-import com.gu.patrons.model.StripeSubscription
+import com.gu.patrons.model.{StripeSubscription, ExpandedStripeCustomer}
 import com.gu.supporterdata.model.Stage.{DEV, PROD}
 import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.flatspec.AsyncFlatSpec
@@ -23,12 +23,12 @@ class StripeSubscriptionsProcessorSpec extends AsyncFlatSpec with Matchers {
       identityService = new PatronsIdentityService(identityConfig, runner)
       loggingProcessor = new LoggingSubscriptionProcessor(identityService)
       processor = new StripeSubscriptionsProcessor(stripeService, loggingProcessor)
-      _ <- processor.processSubscriptions(100)
+      _ <- processor.processSubscriptions(GnmPatronScheme, 100)
     } yield succeed
   }
 
   class LoggingSubscriptionProcessor(identityService: PatronsIdentityService) extends SubscriptionProcessor {
-    override def processSubscription(subscription: StripeSubscription) =
+    override def processSubscription(subscription: StripeSubscription[ExpandedStripeCustomer]) =
       identityService
         .getUserIdFromEmail(subscription.customer.email)
         .map(maybeIdentityId =>


### PR DESCRIPTION
At the moment, there is a scheduled lambda which gets information from stripe about newly-signed-up patrons and adds it to the SupporterProductDataPROD DynamoDB table. This PR makes a new lambda which can do the same job but is triggered by a stripe webhook rather than a schedule.

[**Trello Card**](https://trello.com/c/1LKM0HEu/998-change-stripe-patrons-lambda-into-a-webhook-rather-than-a-scheduled-lambda)

In more detail, this change:

- Makes that new lambda
- Adds an API gateway endpoint for calling it
- Adds necessary config for it to be called from both patron stripe accounts (GNM Patron Scheme and GNM Patron Scheme AUS)
- Adds necessary config for the existing cancel-event lambda to be called from GNM Patron Scheme AUS
- Changes existing stripe service calls to specify which account they’re calling (so that, for example, we can look up a customer in the right account, depending on which account’s webhook called the lambda)

We’ve tested this by deploying it to CODE, creating the necessary parameter store config for CODE, and triggering events on the stripe accounts in test mode, which show the calls succeeding.

## Post-Deployment Steps

Once this change is deployed, there are some post-deployment steps, which need to happen in order:

- Create a (non-test-mode) webhook (initially disabled) to call the sign-up event lambda:
  - [ ] On the GNM Patron Scheme account
  - [ ] On the GNM Patron Scheme AUS account
- Create a (non-test-mode) webhook (initially disabled) to call the cancel event lambda:
  - [ ] On the GNM Patron Scheme AUS account
- Add the following AWS Parameter Store entries:
  - [ ] /PROD/support/stripe-patrons-data/stripe-config/api-key-au
  - [ ] /PROD/support/stripe-patrons-data/stripe-config/cancelled-hook-signing-secret
  - [ ] /PROD/support/stripe-patrons-data/stripe-config/cancelled-hook-signing-secret-au
  - [ ] /PROD/support/stripe-patrons-data/stripe-config/sign-up-hook-signing-secret
  - [ ] /PROD/support/stripe-patrons-data/stripe-config/sign-up-hook-signing-secret-au
- [ ] Enable the new webhooks
- [ ] Remove the schedule from the existing lambda
- Remove these AWS Parameter Store entries:
  - [ ] /CODE/support/stripe-patrons-data/stripe-config/signing-secret
  - [ ] /PROD/support/stripe-patrons-data/stripe-config/signing-secret
