### PR TITLE
Supporter plus nudge annual

### DIFF
--- a/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
@@ -108,6 +108,7 @@ export type CheckoutNudgeProps = {
 	nudgeTitleCopySection1: string;
 	nudgeTitleCopySection2: string;
 	nudgeParagraphCopy: string;
+	nudgeLinkCopy: string;
 	onNudgeClose: () => void;
 	onNudgeClick: () => void;
 };
@@ -118,6 +119,7 @@ export function CheckoutNudge({
 	nudgeTitleCopySection1,
 	nudgeTitleCopySection2,
 	nudgeParagraphCopy,
+	nudgeLinkCopy,
 	onNudgeClose,
 	onNudgeClick,
 }: CheckoutNudgeProps): JSX.Element | null {
@@ -136,7 +138,7 @@ export function CheckoutNudge({
 				<p css={para}>{nudgeParagraphCopy}</p>
 				<div css={link}>
 					<a onClick={onNudgeClick} css={alink}>
-						See monthly
+						{nudgeLinkCopy}
 					</a>
 				</div>
 			</div>

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -31,15 +31,17 @@ export function CheckoutNudgeContainer({
 	const [displayNudge, setDisplayNudge] = useState(!isControl);
 
 	const currencyGlyph = glyph(detect(countryGroupId));
-	const minAmount = config[countryGroupId]['MONTHLY'].min;
-	const paragraphCopyVariantA = `Regular, reliable funding from readers is vital for our future. It protects our independence long term, so we can report freely and without outside influence. Support us monthly from just ${currencyGlyph}${minAmount}.`;
-	const paragraphCopyVariantB = `Regular, reliable support powers Guardian journalism in perpetuity. If you can, please consider setting up a monthly payment today from just ${currencyGlyph}${minAmount} – it takes less than a minute.`;
+	const recurringType =
+		abParticipations.singleToRecurring === 'variantA' ? 'MONTHLY' : 'ANNUAL';
+	const minAmount = config[countryGroupId][recurringType].min;
+	const paragraphCopyVariantA = `Regular, reliable support powers Guardian journalism in perpetuity. If you can, please consider setting up a annual payment today from just  ${currencyGlyph}${minAmount} – it takes less than a minute.`;
+	const paragraphCopyVariantB = `Regular, reliable support powers Guardian journalism in perpetuity. If you can, please consider setting up a annual payment today from just ${currencyGlyph}${minAmount} – it takes less than a minute.`;
 
 	function onNudgeClose() {
 		setDisplayNudge(false);
 	}
 	function onNudgeClick() {
-		dispatch(setProductType('MONTHLY'));
+		dispatch(setProductType(recurringType));
 	}
 
 	return renderNudge({
@@ -47,12 +49,12 @@ export function CheckoutNudgeContainer({
 		nudgeDisplay: displayNudge,
 		nudgeTitleCopySection1:
 			abParticipations.singleToRecurring === 'variantA'
-				? 'Consider monthly'
+				? 'Make a bigger impact'
 				: 'Make a bigger impact',
 		nudgeTitleCopySection2:
 			abParticipations.singleToRecurring === 'variantA'
-				? 'to sustain us long term'
-				: 'Support us every month',
+				? 'Support us every month'
+				: 'Support us every year',
 		nudgeParagraphCopy:
 			abParticipations.singleToRecurring === 'variantA'
 				? paragraphCopyVariantA

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -51,6 +51,7 @@ export function CheckoutNudgeContainer({
 			recurringType === 'MONTHLY' ? 'month' : 'year'
 		}`,
 		nudgeParagraphCopy: paragraphCopyVariant,
+		nudgeLinkCopy: `See ${recurringType.toLowerCase()}`,
 		onNudgeClose,
 		onNudgeClick,
 	});

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -34,7 +34,9 @@ export function CheckoutNudgeContainer({
 		abParticipations.singleToRecurring === 'variantA' ? 'MONTHLY' : 'ANNUAL';
 	const currencyGlyph = glyph(detect(countryGroupId));
 	const minAmount = config[countryGroupId][recurringType].min;
-	const paragraphCopyVariant = `Regular, reliable support powers Guardian journalism in perpetuity. If you can, please consider setting up a annual payment today from just  ${currencyGlyph}${minAmount} – it takes less than a minute.`;
+	const paragraphCopyVariant = `Regular, reliable support powers Guardian journalism in perpetuity. If you can, please consider setting up ${
+		recurringType === 'MONTHLY' ? 'a' : 'an'
+	} ${recurringType.toLowerCase()} payment today from just  ${currencyGlyph}${minAmount} – it takes less than a minute.`;
 
 	function onNudgeClose() {
 		setDisplayNudge(false);

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -28,8 +28,8 @@ export function CheckoutNudgeContainer({
 	const [displayNudge, setDisplayNudge] = useState(true);
 
 	const recurringType =
-		abParticipations.singleToRecurring === 'control' ||
-		!abParticipations.singleToRecurring
+		abParticipations.singleToRecurringV2 === 'control' ||
+		!abParticipations.singleToRecurringV2
 			? 'MONTHLY'
 			: 'ANNUAL';
 	const currencyGlyph = glyph(detect(countryGroupId));

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -30,12 +30,11 @@ export function CheckoutNudgeContainer({
 		!abParticipations.singleToRecurring;
 	const [displayNudge, setDisplayNudge] = useState(!isControl);
 
-	const currencyGlyph = glyph(detect(countryGroupId));
 	const recurringType =
 		abParticipations.singleToRecurring === 'variantA' ? 'MONTHLY' : 'ANNUAL';
+	const currencyGlyph = glyph(detect(countryGroupId));
 	const minAmount = config[countryGroupId][recurringType].min;
-	const paragraphCopyVariantA = `Regular, reliable support powers Guardian journalism in perpetuity. If you can, please consider setting up a annual payment today from just  ${currencyGlyph}${minAmount} – it takes less than a minute.`;
-	const paragraphCopyVariantB = `Regular, reliable support powers Guardian journalism in perpetuity. If you can, please consider setting up a annual payment today from just ${currencyGlyph}${minAmount} – it takes less than a minute.`;
+	const paragraphCopyVariant = `Regular, reliable support powers Guardian journalism in perpetuity. If you can, please consider setting up a annual payment today from just  ${currencyGlyph}${minAmount} – it takes less than a minute.`;
 
 	function onNudgeClose() {
 		setDisplayNudge(false);
@@ -47,18 +46,11 @@ export function CheckoutNudgeContainer({
 	return renderNudge({
 		contributionType,
 		nudgeDisplay: displayNudge,
-		nudgeTitleCopySection1:
-			abParticipations.singleToRecurring === 'variantA'
-				? 'Make a bigger impact'
-				: 'Make a bigger impact',
-		nudgeTitleCopySection2:
-			abParticipations.singleToRecurring === 'variantA'
-				? 'Support us every month'
-				: 'Support us every year',
-		nudgeParagraphCopy:
-			abParticipations.singleToRecurring === 'variantA'
-				? paragraphCopyVariantA
-				: paragraphCopyVariantB,
+		nudgeTitleCopySection1: 'Make a bigger impact',
+		nudgeTitleCopySection2: `Support us every ${
+			recurringType === 'MONTHLY' ? 'month' : 'year'
+		}`,
+		nudgeParagraphCopy: paragraphCopyVariant,
 		onNudgeClose,
 		onNudgeClick,
 	});

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -25,13 +25,13 @@ export function CheckoutNudgeContainer({
 		(state) => state.common,
 	);
 
-	const isControl =
-		abParticipations.singleToRecurring === 'control' ||
-		!abParticipations.singleToRecurring;
-	const [displayNudge, setDisplayNudge] = useState(!isControl);
+	const [displayNudge, setDisplayNudge] = useState(true);
 
 	const recurringType =
-		abParticipations.singleToRecurring === 'variantA' ? 'MONTHLY' : 'ANNUAL';
+		abParticipations.singleToRecurring === 'control' ||
+		!abParticipations.singleToRecurring
+			? 'MONTHLY'
+			: 'ANNUAL';
 	const currencyGlyph = glyph(detect(countryGroupId));
 	const minAmount = config[countryGroupId][recurringType].min;
 	const paragraphCopyVariant = `Regular, reliable support powers Guardian journalism in perpetuity. If you can, please consider setting up ${

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -39,7 +39,7 @@ export const pageUrlRegexes = {
 	},
 };
 export const tests: Tests = {
-	singleToRecurring: {
+	singleToRecurringV2: {
 		variants: [
 			{
 				id: 'control',

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -45,10 +45,7 @@ export const tests: Tests = {
 				id: 'control',
 			},
 			{
-				id: 'variantA',
-			},
-			{
-				id: 'variantB',
+				id: 'variant',
 			},
 		],
 		audiences: {


### PR DESCRIPTION
Nudging component, encouraging single to monthly or annual recurring contributions
Rename test  to 'ab-singleToRecurringV2'

[**Trello Card**](https://trello.com/c/4bRuTMkx/1028-nudging-recurring-to-annual-build)

Features->
- copy change,
- differing minimum contributions,
- differing link (copy and location)

![NudgeVariants](https://user-images.githubusercontent.com/76729591/216317414-e894f000-eb1e-4da9-88f2-fbec6fbd698e.jpg)

2-cohort A/B test for implementation ->
https://support.thegulocal.com/uk/contribute#ab-singleToRecurringV2=control (Monthly)
https://support.thegulocal.com/uk/contribute#ab-singleToRecurringV2=variant (Annual)

## Is this an AB test?
- [x] Yes
- [ ] No

