### PR TITLE
Add a new integration test to create a supporter plus sub in Austria

### DIFF
--- a/support-frontend/.husky/pre-commit
+++ b/support-frontend/.husky/pre-commit
@@ -2,3 +2,16 @@
 . "$(dirname "$0")/_/husky.sh"
 
 cd support-frontend && yarn lint-staged
+
+if git diff-index --cached  --diff-filter=AM --name-only  HEAD | grep --quiet .scala$
+then
+  echo "Running scalafmtCheckAll to check for Scala formatting errors"
+  cd ..
+  if ! sbt scalafmtCheckAll
+  then
+    echo "There were formatting errors found, running scalafmtAll"
+    sbt scalafmtAll
+    exit 1
+  fi
+fi
+

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -1,7 +1,8 @@
 package com.gu.support.workers
 
-import com.gu.i18n.Currency.GBP
 import com.gu.i18n.{Country, Currency, Title}
+import com.gu.i18n.Country.UK
+import com.gu.i18n.Currency.GBP
 import com.gu.salesforce.Fixtures.{emailAddress, idId}
 import com.gu.salesforce.Salesforce.SalesforceContactRecords
 import com.gu.support.catalog.{Domestic, Everyday, HomeDelivery, RestOfWorld}
@@ -9,6 +10,7 @@ import com.gu.support.promotions.PromoCode
 import com.gu.support.redemptions.{RedemptionCode, RedemptionData}
 import com.gu.support.workers.GiftRecipient.{DigitalSubscriptionGiftRecipient, WeeklyGiftRecipient}
 import com.gu.support.workers.encoding.Conversions.StringInputStreamConversions
+import com.gu.support.workers.states.{AnalyticsInfo, CreateZuoraSubscriptionProductState, CreateZuoraSubscriptionState}
 import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.{
   ContributionState,
   DigitalSubscriptionCorporateRedemptionState,
@@ -19,7 +21,6 @@ import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.{
   PaperState,
   SupporterPlusState,
 }
-import com.gu.support.workers.states.{AnalyticsInfo, CreateZuoraSubscriptionProductState, CreateZuoraSubscriptionState}
 import com.gu.support.zuora.api.StripeGatewayDefault
 import io.circe.parser
 import io.circe.syntax._
@@ -38,7 +39,7 @@ object JsonFixtures {
       RequestInfo(testUser = false, failed = false, Nil, accountExists = false),
     ).asJson.noSpaces.asInputStream
 
-  def user(id: String = idId): User =
+  def user(id: String = idId, country: Country = UK): User =
     User(
       id,
       emailAddress,
@@ -51,7 +52,7 @@ object JsonFixtures {
         Some("london"),
         None,
         Some("n1 9gu"),
-        Country.UK,
+        country,
       ),
       deliveryInstructions = Some("Leave with neighbour"),
     )
@@ -457,16 +458,16 @@ object JsonFixtures {
         }
       """
 
-  def createContributionZuoraSubscriptionJson(billingPeriod: BillingPeriod = Monthly): String =
+  def createContributionZuoraSubscriptionJson(amount: BigDecimal = 5, billingPeriod: BillingPeriod = Monthly): String =
     CreateZuoraSubscriptionState(
       ContributionState(
-        Contribution(5, GBP, billingPeriod),
+        Contribution(amount, GBP, billingPeriod),
         stripePaymentMethodObj,
         salesforceContact,
       ),
       UUID.randomUUID(),
       user(),
-      Contribution(5, GBP, billingPeriod),
+      Contribution(amount, GBP, billingPeriod),
       AnalyticsInfo(false, Stripe),
       None,
       None,
@@ -475,16 +476,16 @@ object JsonFixtures {
       None,
     ).asJson.spaces2
 
-  val createSupporterPlusZuoraSubscriptionJson =
+  def createSupporterPlusZuoraSubscriptionJson(amount: BigDecimal, currency: Currency, country: Country = UK) =
     CreateZuoraSubscriptionState(
       SupporterPlusState(
-        SupporterPlus(12, GBP, Monthly),
+        SupporterPlus(amount, currency, Monthly),
         stripePaymentMethodObj,
         salesforceContact,
       ),
       UUID.randomUUID(),
-      user("9999998"),
-      SupporterPlus(12, GBP, Monthly),
+      user("9999998", country),
+      SupporterPlus(amount, currency, Monthly),
       AnalyticsInfo(false, Stripe),
       None,
       None,


### PR DESCRIPTION
Because they tax digital news products so it is useful to have some being created in Zuora on a regular basis.

I've also added a git pre-commit hook to run `scalafmtCheckAll` if the commit contains Scala files, to avoid the annoying situation where you push files and they then fail the build with a formatting error.
