### PR TITLE
GridImage GridPicture Storybook controls / docs updated

### DIFF
--- a/support-frontend/stories/images/GridImage.stories.tsx
+++ b/support-frontend/stories/images/GridImage.stories.tsx
@@ -1,9 +1,10 @@
 import { Container } from '@guardian/source-react-components';
 import React from 'react';
+import type { GridImg } from 'components/gridImage/gridImage';
 import GridImage from 'components/gridImage/gridImage';
 
 export default {
-	title: 'Grid Images/Image',
+	title: 'Grid Images/GridImage',
 	component: GridImage,
 	decorators: [
 		(Story: React.FC): JSX.Element => (
@@ -24,16 +25,16 @@ export default {
 	],
 };
 
-export function Image(): JSX.Element {
-	return (
-		<GridImage
-			gridId="weeklyCampaignHeroImg"
-			srcSizes={[1000, 500, 140]}
-			sizes="(max-width: 740px) 100%,
-  (max-width: 1067px) 150%,
-  500px"
-			imgType="png"
-			altText="A collection of Guardian Weekly magazines"
-		/>
-	);
+function Template(args: GridImg) {
+	return <GridImage {...args} />;
 }
+Template.args = {} as GridImg;
+
+export const WeeklyCampaignHero = Template.bind({});
+WeeklyCampaignHero.args = {
+	gridId: 'weeklyCampaignHeroImg',
+	srcSizes: [1000, 500, 140],
+	sizes: '(max-width: 740px) 140px,(max-width: 1067px) 500px,1000px',
+	altText: 'A collection of Guardian Weekly magazines',
+	imgType: 'png',
+};

--- a/support-frontend/stories/images/GridImage.stories.tsx
+++ b/support-frontend/stories/images/GridImage.stories.tsx
@@ -15,14 +15,19 @@ export default {
 						textAlign: 'center',
 						maxWidth: '50%',
 					}}
-				>
-					The GridImage component is responsive and will request different sizes
-					of the image at the specified breakpoints
-				</p>
+				/>
 				<Story />
 			</Container>
 		),
 	],
+	parameters: {
+		docs: {
+			description: {
+				component: `The GridImage component is responsive and will request different sizes
+        of the image at the specified breakpoints`,
+			},
+		},
+	},
 };
 
 function Template(args: GridImg) {

--- a/support-frontend/stories/images/GridPicture.stories.tsx
+++ b/support-frontend/stories/images/GridPicture.stories.tsx
@@ -1,9 +1,10 @@
 import { Container } from '@guardian/source-react-components';
 import React from 'react';
+import type { PropTypes } from 'components/gridPicture/gridPicture';
 import GridPicture from 'components/gridPicture/gridPicture';
 
 export default {
-	title: 'Grid Images/Picture',
+	title: 'Grid Images/GridPicture',
 	component: GridPicture,
 	decorators: [
 		(Story: React.FC): JSX.Element => (
@@ -24,29 +25,31 @@ export default {
 	],
 };
 
-export function Picture(): JSX.Element {
-	return (
-		<GridPicture
-			sources={[
-				{
-					gridId: 'editionsPackshot',
-					srcSizes: [500, 140],
-					imgType: 'png',
-					sizes: '(min-width: 740px) 500px, 100vw',
-					media: '(max-width: 1139px)',
-				},
-				{
-					gridId: 'editionsPackshotAus',
-					srcSizes: [500],
-					imgType: 'png',
-					sizes: '(min-width: 1140px) 500px',
-					media: '(min-width: 1140px)',
-				},
-			]}
-			fallback="editionsPackshot"
-			fallbackSize={500}
-			altText=""
-			fallbackImgType="png"
-		/>
-	);
+function Template(args: PropTypes) {
+	return <GridPicture {...args} />;
 }
+Template.args = {} as PropTypes;
+
+export const EditionsPackshot = Template.bind({});
+EditionsPackshot.args = {
+	sources: [
+		{
+			gridId: 'editionsPackshot',
+			srcSizes: [500, 140],
+			imgType: 'png',
+			sizes: '(min-width: 740px) 500px, 140vw',
+			media: '(max-width: 1139px)',
+		},
+		{
+			gridId: 'editionsPackshotAus',
+			srcSizes: [500],
+			imgType: 'png',
+			sizes: '(min-width: 1140px) 500px',
+			media: '(min-width: 1140px)',
+		},
+	],
+	fallback: 'editionsPackshot',
+	fallbackSize: 500,
+	altText: '',
+	fallbackImgType: 'png',
+};

--- a/support-frontend/stories/images/GridPicture.stories.tsx
+++ b/support-frontend/stories/images/GridPicture.stories.tsx
@@ -15,14 +15,19 @@ export default {
 						textAlign: 'center',
 						maxWidth: '50%',
 					}}
-				>
-					The GridPicture component can show completely different images at
-					different breakpoints
-				</p>
+				/>
 				<Story />
 			</Container>
 		),
 	],
+	parameters: {
+		docs: {
+			description: {
+				component: `The GridPicture component can show completely different images at
+        different breakpoints`,
+			},
+		},
+	},
 };
 
 function Template(args: PropTypes) {


### PR DESCRIPTION
Documenting the GridImage and GridPicture controls.

This has been done in Storybook (alongside Wiki update).

[AFTER]
GridImage controls ->
![Screenshot 2023-02-03 at 10 42 27](https://user-images.githubusercontent.com/76729591/216581886-cd33c717-09ba-4980-a671-3bb70e3f7594.png)
GridImage docs ->
![Screenshot 2023-02-03 at 10 44 18](https://user-images.githubusercontent.com/76729591/216582066-d6afc615-124e-4c1b-8766-0a47b7a408fb.png)

GridPicture controls ->
![Screenshot 2023-02-03 at 10 43 14](https://user-images.githubusercontent.com/76729591/216582217-907d0347-1994-4057-8542-a8e04230449c.png)
GridPicture docs ->
![Screenshot 2023-02-03 at 10 44 45](https://user-images.githubusercontent.com/76729591/216582292-e4937a5e-d746-43a8-a4ad-c286d727ca79.png)

[**Trello Card**](https://trello.com/c/e4Jy9UDh/720-supportfrontend-wiki-add-helpercomponent-section-document-gridimage-gridpicture)

## Why are you doing this?
To provide GridPicture & GridImage documentation

## Is this an AB test?
- [ ] Yes
- [x] No