### PR TITLE
Add branded payment icons on mobile breakpoints

### DIFF
--- a/support-frontend/assets/components/paymentMethodSelector/creditDebitIcons.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/creditDebitIcons.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/react';
-import { brand, from } from '@guardian/source-foundations';
+import { brand } from '@guardian/source-foundations';
 import type { IconSize } from '@guardian/source-react-components';
 import { SvgCreditCard } from '@guardian/source-react-components';
 
 const creditCardIcon = css`
-	${from.mobileMedium} {
+	@media (min-width: 355px) {
 		display: none;
 	}
 `;
@@ -13,7 +13,7 @@ const brandedIcons = css`
 	display: none;
 	width: 100%;
 
-	${from.mobileMedium} {
+	@media (min-width: 355px) {
 		display: flex;
 	}
 `;
@@ -55,7 +55,7 @@ export function CreditDebitIcons(): JSX.Element {
 	);
 }
 
-function BrandedIcons(): JSX.Element {
+export function BrandedIcons(): JSX.Element {
 	return (
 		<svg
 			width="110"

--- a/support-frontend/assets/components/paymentMethodSelector/creditDebitIcons.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/creditDebitIcons.tsx
@@ -1,11 +1,9 @@
 import { css } from '@emotion/react';
-import { from } from '@guardian/source-foundations';
+import { brand, from } from '@guardian/source-foundations';
+import type { IconSize } from '@guardian/source-react-components';
 import { SvgCreditCard } from '@guardian/source-react-components';
 
 const creditCardIcon = css`
-	display: flex;
-	width: 100%;
-
 	${from.mobileMedium} {
 		display: none;
 	}
@@ -20,11 +18,34 @@ const brandedIcons = css`
 	}
 `;
 
+export function SvgCreditCardWithTheme({
+	color = brand[400],
+	size = 'medium',
+}: {
+	color?: string;
+	size?: IconSize;
+}): JSX.Element {
+	const creditCard = css`
+		display: flex;
+		width: 100%;
+
+		& svg {
+			fill: ${color};
+		}
+	`;
+
+	return (
+		<div css={creditCard}>
+			<SvgCreditCard size={size} />
+		</div>
+	);
+}
+
 export function CreditDebitIcons(): JSX.Element {
 	return (
 		<>
 			<div css={creditCardIcon}>
-				<SvgCreditCard size="medium" />
+				<SvgCreditCardWithTheme />
 			</div>
 
 			<div css={brandedIcons}>

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodData.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodData.tsx
@@ -1,7 +1,4 @@
-import {
-	SvgCreditCard,
-	SvgDirectDebitWide,
-} from '@guardian/source-react-components';
+import { SvgDirectDebitWide } from '@guardian/source-react-components';
 import { AmazonPayFormContainer } from 'components/amazonPayForm/amazonPayFormContainer';
 import type { SepaFormProps } from 'components/sepaForm/SepaForm';
 import { SepaForm } from 'components/sepaForm/SepaForm';
@@ -10,7 +7,7 @@ import { StripeCardFormContainer } from 'components/stripeCardForm/stripeCardFor
 import SvgAmazonPayLogoDs from 'components/svgs/amazonPayLogoDs';
 import SvgSepa from 'components/svgs/sepa';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
-import { CreditDebitIcons } from './creditDebitIcons';
+import { CreditDebitIcons, SvgCreditCardWithTheme } from './creditDebitIcons';
 import { PaypalIcon } from './paypalIcon';
 
 interface PaymentMethodData {
@@ -58,7 +55,7 @@ export const paymentMethodData: Record<PaymentMethod, PaymentMethodData> = {
 	ExistingCard: {
 		id: 'qa-existing-card',
 		label: 'Credit/Debit card',
-		icon: <SvgCreditCard size="medium" />,
+		icon: <SvgCreditCardWithTheme />,
 	},
 	ExistingDirectDebit: {
 		id: 'qa-existing-direct-debit',
@@ -68,6 +65,6 @@ export const paymentMethodData: Record<PaymentMethod, PaymentMethodData> = {
 	None: {
 		id: 'qa-none',
 		label: 'Other Payment Method',
-		icon: <SvgCreditCard size="medium" />,
+		icon: <SvgCreditCardWithTheme />,
 	},
 };

--- a/support-frontend/assets/components/stripeCardForm/elementDecorator.tsx
+++ b/support-frontend/assets/components/stripeCardForm/elementDecorator.tsx
@@ -14,6 +14,7 @@ import type {
 	StripeElementStyleVariant,
 } from '@stripe/stripe-js';
 import { useState } from 'react';
+import { BrandedIcons } from 'components/paymentMethodSelector/creditDebitIcons';
 
 const inlineMessageMargin = css`
 	margin-top: 2px;
@@ -39,6 +40,8 @@ like our own inputs from Source.
 const stripeElementStyles = (isFocused: boolean, error?: string) => css`
 	display: block;
 	flex-grow: 1;
+	// credit card icons positioned absolutely on mobile breakpoints
+	position: relative;
 
 	& > div:first-child {
 		margin-bottom: ${space[1]}px;
@@ -53,6 +56,16 @@ const stripeElementStyles = (isFocused: boolean, error?: string) => css`
 	${isFocused && stripeElementFocusStyles};
 
 	${error && stripeElementErrorStyles}
+`;
+
+const mobileCreditDebitIcons = css`
+	position: absolute;
+	top: 0;
+	right: 0;
+
+	@media (min-width: 355px) {
+		display: none;
+	}
 `;
 
 type ElementRenderProps = {
@@ -106,6 +119,11 @@ export function ElementDecorator({
 				onFocus: () => setIsFocused(true),
 				onBlur: () => setIsFocused(false),
 			})}
+			{id === 'cardNumber' && (
+				<p css={mobileCreditDebitIcons}>
+					<BrandedIcons />
+				</p>
+			)}
 		</Label>
 	);
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This adds branded payment icons on mobile breakpoints. 

[**Trello Card**](https://trello.com/c/ceVVc9KJ/1016-add-payment-branded-icons-on-small-breakpoints-in-the-checkout)

## Screenshots

| Under 355px (320px) |  Over 355px (360px) |
| -- | -- |
| <img width="320" alt="Screenshot 2023-02-09 at 15 18 09" src="https://user-images.githubusercontent.com/44685872/217855518-666bb7ba-1528-4db0-9c1a-f670966aa4d9.png"> | <img width="360" alt="Screenshot 2023-02-09 at 15 18 26" src="https://user-images.githubusercontent.com/44685872/217855523-daf9154c-5c57-4cf5-9474-c33bc36ec274.png"> |
