### PR TITLE
Support Amounts AB testing in the Epic choice cards component

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -203,17 +203,14 @@ function getServerSideParticipations(): Participations | null | undefined {
 }
 
 function getAmountsTestFromURL(data: AcquisitionABTest[]) {
-	console.log('getAmountsTestFromURL', data);
 	const amountTests = data.filter((t) => t.testType === 'AMOUNTS_TEST');
 
 	if (amountTests.length) {
 		const test = amountTests[0];
-		console.log('getAmountsTestFromURL - SUCCESS');
 		return {
 			[test.name]: test.variant,
 		};
 	}
-	console.log('getAmountsTestFromURL - FAIL');
 	return null;
 }
 

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -44,6 +44,7 @@ export type Audiences = {
 type AcquisitionABTest = {
 	name: string;
 	variant: string;
+	testType?: string;
 };
 
 export type Variant = {
@@ -94,6 +95,7 @@ export function init(
 	const amountsTestParticipations = getAmountsTestParticipations(
 		countryGroupId,
 		settings,
+		acquisitionDataTests,
 	);
 
 	return {
@@ -200,9 +202,25 @@ function getServerSideParticipations(): Participations | null | undefined {
 	return null;
 }
 
+function getAmountsTestFromURL(data: AcquisitionABTest[]) {
+	console.log('getAmountsTestFromURL', data);
+	const amountTests = data.filter((t) => t.testType === 'AMOUNTS_TEST');
+
+	if (amountTests.length) {
+		const test = amountTests[0];
+		console.log('getAmountsTestFromURL - SUCCESS');
+		return {
+			[test.name]: test.variant,
+		};
+	}
+	console.log('getAmountsTestFromURL - FAIL');
+	return null;
+}
+
 function getAmountsTestParticipations(
 	countryGroupId: CountryGroupId,
 	settings: Settings,
+	acquisitionDataTests: AcquisitionABTest[],
 ): Participations | null | undefined {
 	if (
 		!targetPageMatches(
@@ -211,6 +229,12 @@ function getAmountsTestParticipations(
 		)
 	) {
 		return null;
+	}
+
+	// Amounts test/variant has been set in the Epic and coded into the Epic CTA URL
+	const urlTest = getAmountsTestFromURL(acquisitionDataTests);
+	if (urlTest != null) {
+		return urlTest;
 	}
 
 	const { test } = settings.amounts?.[countryGroupId] ?? {};


### PR DESCRIPTION
## What are you doing in this PR?
Relates to changes to the Epic CTA URL string made in this PR in `support-dotcom-components` repo https://github.com/guardian/support-dotcom-components/pull/839 

[**Trello Card**](https://trello.com/c/1viEFveD)

## Why are you doing this?
We have a request from Marketing colleagues that, for cases where they are running an `Amounts AB test` in support-frontend, the amounts data for the user's selected variant of that test should also display in the `ContributionEpicChoiceCard` when that user sees an Epic marketing message on the main site.

This PR updates the `support-frontend` Amounts AB testing allocation code to look for an amounts test variant detailed in the URL query string and use that variant if found, otherwise continuing to allocate the user to an Amounts test variant as happened before.

## Testing
See testing section in Spike doc - https://docs.google.com/document/d/1iGdp5Dww8v4_qfyHbFwfCK-RzEKfzQmGtZwZBd_ejGk/edit?pli=1#heading=h.unqn26s817xq

Results: tests passing