### PR TITLE
Fix for NaN error with  Other Amount Field

### DIFF
--- a/support-frontend/assets/components/paymentRequestButton/hooks/usePaymentRequest.ts
+++ b/support-frontend/assets/components/paymentRequestButton/hooks/usePaymentRequest.ts
@@ -38,7 +38,7 @@ export function usePaymentRequest(stripe: StripeJs | null): PaymentRequestData {
 
 	// Check if we can use the PRB once the Stripe SDK is available
 	useEffect(() => {
-		if (stripe) {
+		if (stripe && !Number.isNaN(amount)) {
 			const paymentRequestSdk = stripe.paymentRequest({
 				country: countryId,
 				currency: currencyId.toLowerCase(),


### PR DESCRIPTION
## What are you doing in this PR?

Click on single, then click on other amount button. Then (without touching the exposed other amount field) click on monthly, and then click on single again. We get a NaN error in the console.This PR fixes that

[**Trello Card**](https://trello.com/c/DrwJf6ix/1054-nan-error-with-other-amount-field)

## Screenshots
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/73653255/218144670-007a4521-37b2-4e35-82a4-c48362a5d0e9.png">

