### PR TITLE
Restore contribution validation

### DIFF
--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -100,8 +100,7 @@ object CheckoutValidationRules {
       case d: DigitalPack => DigitalPackValidation.passes(createSupportWorkersRequest, d)
       case p: Paper => PaperValidation.passes(createSupportWorkersRequest, p.fulfilmentOptions)
       case _: GuardianWeekly => GuardianWeeklyValidation.passes(createSupportWorkersRequest)
-      case _: Contribution =>
-        Valid // this wasn't getting called anyway - TODO put it back later - PaidProductValidation.passes(createSupportWorkersRequest)
+      case _: Contribution => PaidProductValidation.passes(createSupportWorkersRequest)
     }) match {
       case Invalid(message) =>
         Invalid(s"validation of the request body failed with $message - body was $createSupportWorkersRequest")


### PR DESCRIPTION
This validation is currently disabled for recurring contributions below the threshold for supporter plus. It was disabled [in October 2021](https://github.com/guardian/support-frontend/commit/0ef5a8277d5b45209752e123a8c4a36b51b5adbd#diff-a6dbd081ad177ddb469e4501b720b5bf9bbb45801fa6ad382c6c0be4e28c25daL18), and I don’t think it should stay disabled any longer, as it would now be called if enabled.

I’ve tested in CODE, verified that the validation is called (by curling the endpoint with an empty billing account ID), and that I can still get through some normal user journeys (new recurring contribution with existing card, new recurring contribution with new card, new recurring contribution with new direct debit). The plan is to merge this and keep an eye out for any errors, though I don’t _think_ there will be any.