### PR TITLE
Only render existing payment methods that have a valid billingAccountId

### DIFF
--- a/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
+++ b/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
@@ -13,6 +13,7 @@ export function ExistingCardPaymentButton(): JSX.Element {
 	);
 
 	const payWithExistingCard = useFormValidation(function pay() {
+		console.log('payWithExistingCard --->', selectedPaymentMethod);
 		void dispatch(
 			onThirdPartyPaymentAuthorised({
 				paymentMethod: 'ExistingCard',

--- a/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
+++ b/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
@@ -21,6 +21,8 @@ export function ExistingCardPaymentButton(): JSX.Element {
 		);
 	});
 
+	console.log('selectedPaymentMethod --->', selectedPaymentMethod);
+
 	return (
 		<DefaultPaymentButtonContainer
 			onClick={payWithExistingCard}

--- a/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
+++ b/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
@@ -8,9 +8,12 @@ import { onThirdPartyPaymentAuthorised } from 'pages/supporter-plus-landing/setu
 
 export function ExistingCardPaymentButton(): JSX.Element {
 	const dispatch = useContributionsDispatch();
+
 	const { selectedPaymentMethod } = useContributionsSelector(
 		(state) => state.page.checkoutForm.payment.existingPaymentMethods,
 	);
+
+	console.log('selectedPaymentMethod --->', selectedPaymentMethod);
 
 	const payWithExistingCard = useFormValidation(function pay() {
 		void dispatch(

--- a/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
+++ b/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
@@ -27,7 +27,7 @@ export function ExistingCardPaymentButton(): JSX.Element {
 	return (
 		<DefaultPaymentButtonContainer
 			onClick={payWithExistingCard}
-			disabled={!!selectedPaymentMethod?.billingAccountId}
+			disabled={!selectedPaymentMethod?.billingAccountId}
 		/>
 	);
 }

--- a/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
+++ b/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
@@ -13,7 +13,6 @@ export function ExistingCardPaymentButton(): JSX.Element {
 	);
 
 	const payWithExistingCard = useFormValidation(function pay() {
-		console.log('payWithExistingCard --->', selectedPaymentMethod);
 		void dispatch(
 			onThirdPartyPaymentAuthorised({
 				paymentMethod: 'ExistingCard',
@@ -22,12 +21,5 @@ export function ExistingCardPaymentButton(): JSX.Element {
 		);
 	});
 
-	console.log('selectedPaymentMethod --->', selectedPaymentMethod);
-
-	return (
-		<DefaultPaymentButtonContainer
-			onClick={payWithExistingCard}
-			disabled={!selectedPaymentMethod?.billingAccountId}
-		/>
-	);
+	return <DefaultPaymentButtonContainer onClick={payWithExistingCard} />;
 }

--- a/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
+++ b/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
@@ -13,8 +13,6 @@ export function ExistingCardPaymentButton(): JSX.Element {
 		(state) => state.page.checkoutForm.payment.existingPaymentMethods,
 	);
 
-	console.log('selectedPaymentMethod --->', selectedPaymentMethod);
-
 	const payWithExistingCard = useFormValidation(function pay() {
 		void dispatch(
 			onThirdPartyPaymentAuthorised({

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButton.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButton.tsx
@@ -22,16 +22,10 @@ export function DefaultPaymentButton({
 	id,
 	buttonText,
 	onClick,
-	disabled = false,
 }: DefaultPaymentButtonProps): JSX.Element {
 	return (
 		<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-			<Button
-				id={id}
-				cssOverrides={buttonOverrides}
-				onClick={onClick}
-				disabled={disabled}
-			>
+			<Button id={id} cssOverrides={buttonOverrides} onClick={onClick}>
 				{buttonText}
 			</Button>
 		</ThemeProvider>

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -43,10 +43,7 @@ function getButtonText(
 export function DefaultPaymentButtonContainer({
 	onClick,
 	createButtonText = getButtonText,
-	disabled = false,
 }: DefaultPaymentContainerProps): JSX.Element {
-	console.log('DefaultPaymentButtonContainer --->', disabled);
-
 	const { currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
@@ -85,7 +82,6 @@ export function DefaultPaymentButtonContainer({
 			id={testId}
 			buttonText={buttonText}
 			onClick={onClick}
-			disabled={disabled}
 		/>
 	);
 }

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -45,6 +45,8 @@ export function DefaultPaymentButtonContainer({
 	createButtonText = getButtonText,
 	disabled = false,
 }: DefaultPaymentContainerProps): JSX.Element {
+	console.log('DefaultPaymentButtonContainer --->', disabled);
+
 	const { currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -102,48 +102,54 @@ export function PaymentMethodSelector({
 				>
 					{[
 						<>
-							{existingPaymentMethodList.map(
-								(
-									preExistingPaymentMethod: RecentlySignedInExistingPaymentMethod,
-								) => {
-									const existingPaymentMethodType =
-										preExistingPaymentMethod.paymentType;
+							{existingPaymentMethodList
+								.filter(
+									(
+										preExistingPaymentMethod: RecentlySignedInExistingPaymentMethod,
+									) => !!preExistingPaymentMethod.billingAccountId,
+								)
+								.map(
+									(
+										preExistingPaymentMethod: RecentlySignedInExistingPaymentMethod,
+									) => {
+										const existingPaymentMethodType =
+											preExistingPaymentMethod.paymentType;
 
-									const paymentType: PaymentMethod =
-										existingPaymentMethodType === 'Card'
-											? 'ExistingCard'
-											: 'ExistingDirectDebit';
+										const paymentType: PaymentMethod =
+											existingPaymentMethodType === 'Card'
+												? 'ExistingCard'
+												: 'ExistingDirectDebit';
 
-									return (
-										<AvailablePaymentMethodAccordionRow
-											id={`paymentMethod-existing${preExistingPaymentMethod.billingAccountId}`}
-											name="paymentMethod"
-											label={getExistingPaymentMethodLabel(
-												preExistingPaymentMethod,
-											)}
-											image={paymentMethodData[paymentType].icon}
-											checked={
-												paymentMethod === paymentType &&
-												existingPaymentMethod === preExistingPaymentMethod
-											}
-											supportingText={`Used for your ${subscriptionsToExplainerList(
-												preExistingPaymentMethod.subscriptions.map(
-													subscriptionToExplainerPart,
-												),
-											)}`}
-											onChange={() => {
-												onSelectPaymentMethod(
-													paymentType,
+										return (
+											<AvailablePaymentMethodAccordionRow
+												id={`paymentMethod-existing${preExistingPaymentMethod.billingAccountId}`}
+												name="paymentMethod"
+												label={getExistingPaymentMethodLabel(
 													preExistingPaymentMethod,
-												);
-											}}
-											accordionBody={
-												paymentMethodData[paymentType].accordionBody
-											}
-										/>
-									);
-								},
-							)}
+												)}
+												image={paymentMethodData[paymentType].icon}
+												checked={
+													paymentMethod === paymentType &&
+													existingPaymentMethod === preExistingPaymentMethod
+												}
+												supportingText={`Used for your ${subscriptionsToExplainerList(
+													preExistingPaymentMethod.subscriptions.map(
+														subscriptionToExplainerPart,
+													),
+												)}`}
+												onChange={() => {
+													onSelectPaymentMethod(
+														paymentType,
+														preExistingPaymentMethod,
+													);
+												}}
+												accordionBody={
+													paymentMethodData[paymentType].accordionBody
+												}
+											/>
+										);
+									},
+								)}
 
 							{availablePaymentMethods.map((method) => (
 								<AvailablePaymentMethodAccordionRow


### PR DESCRIPTION
After we enabled existing payment methods on the new checkout we began seeing failed checkouts in our Step Function executions. These were caused by an empty string for the `paymentMethod`'s `billingAccountId` in the Step Function's input JSON, which causes the failure.

In response we introduced a change (https://github.com/guardian/support-frontend/pull/4667) that aimed to block users from checking out if the existing payment method they selected had an invalid `billingAccountId`.  It would block checking out by disabling the submit button on the checkout.

Unfortunately there was an issue with the condition used for disabling/enabling the button, and we were disabling it for users with a valid `billingAccount` and enabling for those without.

Rather than fix I've removed that logic as I'm not sure disabling the submit button is the best in terms of UX as visually there's nothing to indicate it's disabled or why it's disabled, it just doesn't respond to clicks. Instead I've made a change that filters the  
`existingPaymentMethodList` list in the `paymentMethodSelector` and removes existing payment methods with an invalid `billingAccountId`, so they shouldn't even be rendered.
 