### PR TITLE
Remove schedule from StripePatronsDataLambda

### DIFF
--- a/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
+++ b/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
@@ -901,43 +901,6 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "StripePatronsDataPRODStripePatronsDataPRODrate30minutes028F3FD32": {
-      "Properties": {
-        "ScheduleExpression": "rate(30 minutes)",
-        "State": "ENABLED",
-        "Targets": [
-          {
-            "Arn": {
-              "Fn::GetAtt": [
-                "StripePatronsDataPROD61F45521",
-                "Arn",
-              ],
-            },
-            "Id": "Target0",
-          },
-        ],
-      },
-      "Type": "AWS::Events::Rule",
-    },
-    "StripePatronsDataPRODStripePatronsDataPRODrate30minutes0AllowEventRuleStripePatronsDataPRODBF7BDE5FE71C5129": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "StripePatronsDataPROD61F45521",
-            "Arn",
-          ],
-        },
-        "Principal": "events.amazonaws.com",
-        "SourceArn": {
-          "Fn::GetAtt": [
-            "StripePatronsDataPRODStripePatronsDataPRODrate30minutes028F3FD32",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
     "stripepatronsdatacancelled2E3CED96": {
       "DependsOn": [
         "stripepatronsdatacancelledServiceRoleDefaultPolicy46825C35",

--- a/cdk/lib/stripe-patrons-data.ts
+++ b/cdk/lib/stripe-patrons-data.ts
@@ -1,14 +1,12 @@
-import { GuApiGatewayWithLambdaByPath, GuScheduledLambda } from "@guardian/cdk";
+import { GuApiGatewayWithLambdaByPath} from "@guardian/cdk";
 import type {
   GuLambdaErrorPercentageMonitoringProps,
-  NoMonitoring,
 } from "@guardian/cdk/lib/constructs/cloudwatch";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack } from "@guardian/cdk/lib/constructs/core";
 import { GuLambdaFunction } from "@guardian/cdk/lib/constructs/lambda";
 import type { App } from "aws-cdk-lib";
 import { Duration } from "aws-cdk-lib";
-import { Schedule } from "aws-cdk-lib/aws-events";
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
 
@@ -43,7 +41,7 @@ function parameterStorePolicy(scope: GuStack, appName: string) {
   });
 }
 
-class StripePatronsDataLambda extends GuScheduledLambda {
+class StripePatronsDataLambda extends GuLambdaFunction {
   constructor(scope: GuStack, id: string, appName: string) {
     super(scope, id, {
       app: appName,
@@ -51,8 +49,7 @@ class StripePatronsDataLambda extends GuScheduledLambda {
       functionName: `${appName}-${scope.stage}`,
       handler:
         "com.gu.patrons.lambdas.ProcessStripeSubscriptionsLambda::handleRequest",
-      monitoringConfiguration: monitoringForEnvironment(scope.stage),
-      rules: [{ schedule: scheduleRateForEnvironment(scope.stage) }],
+      errorPercentageMonitoring: monitoringForEnvironment(scope.stage),
       runtime: Runtime.JAVA_11,
       memorySize: 1536,
       timeout: Duration.minutes(15),
@@ -60,7 +57,7 @@ class StripePatronsDataLambda extends GuScheduledLambda {
 
     function monitoringForEnvironment(
       stage: string
-    ): NoMonitoring | GuLambdaErrorPercentageMonitoringProps {
+    ): GuLambdaErrorPercentageMonitoringProps | undefined {
       if (stage == "PROD") {
         return {
           alarmName: `${appName}-${stage}-ErrorAlarm`,
@@ -70,11 +67,7 @@ class StripePatronsDataLambda extends GuScheduledLambda {
           numberOfMinutesAboveThresholdBeforeAlarm: 46,
         };
       }
-      return { noMonitoring: true };
-    }
-
-    function scheduleRateForEnvironment(stage: string) {
-      return Schedule.rate(Duration.minutes(stage == "PROD" ? 30 : 24 * 60));
+      return undefined;
     }
 
     this.addToRolePolicy(parameterStorePolicy(scope, appName));


### PR DESCRIPTION
Now that sign-up is being handled by a webhook, we don’t need this schedule. We do want to keep the lambda though, in case we want to run it again sometime.

This PR is post-deployment work needed for [this Trello card](https://trello.com/c/1LKM0HEu/998-change-stripe-patrons-lambda-into-a-webhook-rather-than-a-scheduled-lambda), as detailed in https://github.com/guardian/support-frontend/pull/4719
