### PR TITLE
Add QM event to track payment method at the point of conversion

### DIFF
--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -41,6 +41,7 @@ enum SendEventContributionAmountUpdate {
 
 enum SendEventContributionPaymentMethodUpdate {
 	PaymentMethod = 103,
+	PaymentMethodAtConversion = 110,
 }
 
 enum SendEventContributionCheckoutConversion {
@@ -78,6 +79,14 @@ const cartValueEventIds: SendEventId[] = [
 	SingleContribution,
 	RecurringContribution,
 ];
+
+async function ifQmPermitted(callback: () => void) {
+	const canRun = await canRunQuantumMetric();
+
+	if (canRun) {
+		callback();
+	}
+}
 
 function sendEvent(
 	id: SendEventId,
@@ -126,28 +135,26 @@ function sendEventSubscriptionCheckoutEvent(
 	billingPeriod: BillingPeriod,
 	isConversion: boolean,
 ): void {
-	void canRunQuantumMetric().then((canRun) => {
-		if (canRun) {
-			const sendEventWhenReady = () => {
-				const sourceCurrency = productPrice.currency;
-				const targetCurrency: IsoCurrency = 'GBP';
-				const value = getSubscriptionAnnualValue(productPrice, billingPeriod);
+	void ifQmPermitted(() => {
+		const sendEventWhenReady = () => {
+			const sourceCurrency = productPrice.currency;
+			const targetCurrency: IsoCurrency = 'GBP';
+			const value = getSubscriptionAnnualValue(productPrice, billingPeriod);
 
-				if (!value) {
-					return;
-				} else if (window.QuantumMetricAPI?.isOn()) {
-					const convertedValue: number =
-						window.QuantumMetricAPI.currencyConvertFromToValue(
-							value,
-							sourceCurrency,
-							targetCurrency,
-						);
-					sendEvent(id, isConversion, Math.round(convertedValue).toString());
-				}
-			};
+			if (!value) {
+				return;
+			} else if (window.QuantumMetricAPI?.isOn()) {
+				const convertedValue: number =
+					window.QuantumMetricAPI.currencyConvertFromToValue(
+						value,
+						sourceCurrency,
+						targetCurrency,
+					);
+				sendEvent(id, isConversion, Math.round(convertedValue).toString());
+			}
+		};
 
-			sendEventWhenReadyTrigger(sendEventWhenReady);
-		}
+		sendEventWhenReadyTrigger(sendEventWhenReady);
 	});
 }
 
@@ -233,25 +240,23 @@ function sendEventContributionCheckoutConversion(
 	contributionType: ContributionType,
 	sourceCurrency: IsoCurrency,
 ): void {
-	void canRunQuantumMetric().then((canRun) => {
-		if (canRun) {
-			const sendEventWhenReady = () => {
-				const sendEventId =
-					contributionType === 'ONE_OFF'
-						? SendEventContributionCheckoutConversion.SingleContribution
-						: SendEventContributionCheckoutConversion.RecurringContribution;
-				const convertedValue = getContributionAnnualValue(
-					contributionType,
-					amount,
-					sourceCurrency,
-				);
-				if (convertedValue) {
-					sendEvent(sendEventId, true, Math.round(convertedValue).toString());
-				}
-			};
+	void ifQmPermitted(() => {
+		const sendEventWhenReady = () => {
+			const sendEventId =
+				contributionType === 'ONE_OFF'
+					? SendEventContributionCheckoutConversion.SingleContribution
+					: SendEventContributionCheckoutConversion.RecurringContribution;
+			const convertedValue = getContributionAnnualValue(
+				contributionType,
+				amount,
+				sourceCurrency,
+			);
+			if (convertedValue) {
+				sendEvent(sendEventId, true, Math.round(convertedValue).toString());
+			}
+		};
 
-			sendEventWhenReadyTrigger(sendEventWhenReady);
-		}
+		sendEventWhenReadyTrigger(sendEventWhenReady);
 	});
 }
 
@@ -264,25 +269,23 @@ function sendEventContributionCartValue(
 		return;
 	}
 
-	void canRunQuantumMetric().then((canRun) => {
-		if (canRun) {
-			const sendEventWhenReady = () => {
-				const sendEventId =
-					contributionType === 'ONE_OFF'
-						? SendEventContributionAmountUpdate.SingleContribution
-						: SendEventContributionAmountUpdate.RecurringContribution;
-				const convertedValue = getContributionAnnualValue(
-					contributionType,
-					parseInt(amount),
-					sourceCurrency,
-				);
-				if (convertedValue) {
-					sendEvent(sendEventId, false, Math.round(convertedValue).toString());
-				}
-			};
+	void ifQmPermitted(() => {
+		const sendEventWhenReady = () => {
+			const sendEventId =
+				contributionType === 'ONE_OFF'
+					? SendEventContributionAmountUpdate.SingleContribution
+					: SendEventContributionAmountUpdate.RecurringContribution;
+			const convertedValue = getContributionAnnualValue(
+				contributionType,
+				parseInt(amount),
+				sourceCurrency,
+			);
+			if (convertedValue) {
+				sendEvent(sendEventId, false, Math.round(convertedValue).toString());
+			}
+		};
 
-			sendEventWhenReadyTrigger(sendEventWhenReady);
-		}
+		sendEventWhenReadyTrigger(sendEventWhenReady);
 	});
 }
 
@@ -290,18 +293,26 @@ function sendEventContributionPaymentMethod(
 	paymentMethod: PaymentMethod | null,
 ): void {
 	if (paymentMethod) {
-		void canRunQuantumMetric().then((canRun) => {
-			if (canRun) {
-				const sendEventWhenReady = () => {
-					const sendEventId =
-						SendEventContributionPaymentMethodUpdate.PaymentMethod;
-					sendEvent(sendEventId, false, paymentMethod.toString());
-				};
+		void ifQmPermitted(() => {
+			const sendEventWhenReady = () => {
+				const sendEventId =
+					SendEventContributionPaymentMethodUpdate.PaymentMethod;
+				sendEvent(sendEventId, false, paymentMethod.toString());
+			};
 
-				sendEventWhenReadyTrigger(sendEventWhenReady);
-			}
+			sendEventWhenReadyTrigger(sendEventWhenReady);
 		});
 	}
+}
+
+function sendEventConversionPaymentMethod(paymentMethod: PaymentMethod): void {
+	void ifQmPermitted(() => {
+		sendEvent(
+			SendEventContributionPaymentMethodUpdate.PaymentMethodAtConversion,
+			false,
+			paymentMethod.toString(),
+		);
+	});
 }
 
 function sendEventABTestParticipations(participations: Participations): void {
@@ -355,16 +366,14 @@ function addQM() {
 }
 
 function init(participations: Participations): void {
-	void canRunQuantumMetric().then((canRun) => {
-		if (canRun) {
-			void addQM().then(() => {
-				/**
-				 * Quantum Metric's script has loaded so we can attempt to
-				 * send user AB test participations via the sendEvent function.
-				 */
-				sendEventABTestParticipations(participations);
-			});
-		}
+	void ifQmPermitted(() => {
+		void addQM().then(() => {
+			/**
+			 * Quantum Metric's script has loaded so we can attempt to
+			 * send user AB test participations via the sendEvent function.
+			 */
+			sendEventABTestParticipations(participations);
+		});
 	});
 }
 // ----- Exports ----- //
@@ -375,4 +384,5 @@ export {
 	sendEventContributionCheckoutConversion,
 	sendEventContributionCartValue,
 	sendEventContributionPaymentMethod,
+	sendEventConversionPaymentMethod,
 };

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -307,10 +307,12 @@ function sendEventContributionPaymentMethod(
 
 function sendEventConversionPaymentMethod(paymentMethod: PaymentMethod): void {
 	void ifQmPermitted(() => {
-		sendEvent(
-			SendEventContributionPaymentMethodUpdate.PaymentMethodAtConversion,
-			false,
-			paymentMethod.toString(),
+		sendEventWhenReadyTrigger(() =>
+			sendEvent(
+				SendEventContributionPaymentMethodUpdate.PaymentMethodAtConversion,
+				false,
+				paymentMethod.toString(),
+			),
 		);
 	});
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -68,6 +68,7 @@ import {
 	getSupportAbTests,
 } from 'helpers/tracking/acquisitions';
 import trackConversion from 'helpers/tracking/conversions';
+import { sendEventConversionPaymentMethod } from 'helpers/tracking/quantumMetric';
 import type { Option } from 'helpers/types/option';
 import { routes } from 'helpers/urls/routes';
 import { logException } from 'helpers/utilities/logger';
@@ -569,6 +570,10 @@ const onThirdPartyPaymentAuthorised =
 	): Promise<PaymentResult> => {
 		const state = getState();
 		const contributionType = getContributionType(state);
+		const paymentMethod = state.page.checkoutForm.payment.paymentMethod.name;
+
+		sendEventConversionPaymentMethod(paymentMethod);
+
 		return paymentAuthorisationHandlers[contributionType][
 			state.page.checkoutForm.payment.paymentMethod.name
 		](dispatch, state, paymentAuthorisation);


### PR DESCRIPTION
## What are you doing in this PR?

This adds a Quantum Metric event recording the user's selected payment method at the point of conversion, enabling us to better track conversions via payment method. It also refactors some repeated code in our various QM tracking functions to make it easier to establish when a call can be sent.

[**Trello Card**](https://trello.com/c/F1P7jkM6)
