### PR TITLE
Add GW price cards reordering AB test

### DIFF
--- a/support-frontend/assets/components/containers/centredContainer.tsx
+++ b/support-frontend/assets/components/containers/centredContainer.tsx
@@ -1,9 +1,10 @@
+import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { from } from '@guardian/source-foundations';
 import type { ReactNode } from 'react';
 
 type PropTypes = {
-	cssOverrides?: string;
+	cssOverrides?: SerializedStyles;
 	children: ReactNode;
 };
 const centredContainer = css`

--- a/support-frontend/assets/components/containers/fullWidthContainer.tsx
+++ b/support-frontend/assets/components/containers/fullWidthContainer.tsx
@@ -1,12 +1,12 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { brand, brandBackground, neutral } from '@guardian/source-foundations';
+import { brand, neutral, palette } from '@guardian/source-foundations';
 import type { ReactNode } from 'react';
 
 type Theme = 'light' | 'dark' | 'white' | 'brand';
 
 type PropTypes = {
-	cssOverrides?: string;
+	cssOverrides?: SerializedStyles;
 	children: ReactNode;
 	theme?: Theme;
 	hasOverlap?: boolean;
@@ -25,7 +25,7 @@ const containerThemes: Record<Theme, SerializedStyles> = {
 		color: ${neutral[7]};
 	`,
 	brand: css`
-		background-color: ${brandBackground.primary};
+		background-color: ${palette.brand[400]};
 		color: ${neutral[100]};
 	`,
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -59,4 +59,24 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		seed: 15,
 	},
+	guardianWeeklyPriceCards: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		isActive: false,
+		referrerControlled: false,
+		targetPage: pageUrlRegexes.subscriptions.subsWeeklyPages,
+		seed: 11,
+	},
 };

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
@@ -103,7 +103,6 @@ function Prices({
 	products,
 	isPriceCardsAbTestVariant,
 }: PropTypes): JSX.Element {
-	console.log({ isPriceCardsAbTestVariant });
 	return (
 		<section css={pricesSection} id="subscribe">
 			<h2

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
@@ -1,5 +1,11 @@
 import { css } from '@emotion/react';
-import { body, from, headline, space } from '@guardian/source-foundations';
+import {
+	body,
+	from,
+	headline,
+	neutral,
+	space,
+} from '@guardian/source-foundations';
 import { SvgGift, SvgInfo } from '@guardian/source-react-components';
 import FlexContainer from 'components/containers/flexContainer';
 import ProductInfoChip from 'components/product/productInfoChip';
@@ -9,10 +15,12 @@ import ProductOption from 'components/product/productOption';
 export type PropTypes = {
 	orderIsAGift: boolean;
 	products: Product[];
+	isPriceCardsAbTestVariant: boolean;
 };
 
 const pricesSection = css`
 	padding: 0 ${space[3]}px ${space[12]}px;
+	color: ${neutral[100]};
 `;
 
 const priceBoxes = css`
@@ -22,6 +30,10 @@ const priceBoxes = css`
 	${from.desktop} {
 		margin-top: ${space[9]}px;
 	}
+`;
+
+const priceBoxesVariant = css`
+	margin-top: ${space[4]}px;
 `;
 
 const productOverride = css`
@@ -53,9 +65,22 @@ const productOverrideWithLabel = css`
 `;
 
 const pricesHeadline = css`
-	${headline.medium({
+	${headline.xsmall({
 		fontWeight: 'bold',
 	})};
+
+	${from.tablet} {
+		font-size: 34px;
+	}
+`;
+
+const pricesHeadlineVariant = css`
+	margin-top: ${space[3]}px;
+	margin-bottom: ${space[4]}px;
+
+	${from.tablet} {
+		margin-top: ${space[9]}px;
+	}
 `;
 
 const pricesSubHeadline = css`
@@ -63,18 +88,49 @@ const pricesSubHeadline = css`
 	padding-bottom: ${space[2]}px;
 `;
 
+const pricesSubHeadlineVariant = css`
+	${from.tablet} {
+		margin-bottom: ${space[12]}px;
+	}
+`;
+
 const pricesInfo = css`
 	margin-top: ${space[6]}px;
 `;
 
-function Prices({ orderIsAGift, products }: PropTypes): JSX.Element {
+function Prices({
+	orderIsAGift,
+	products,
+	isPriceCardsAbTestVariant,
+}: PropTypes): JSX.Element {
+	console.log({ isPriceCardsAbTestVariant });
 	return (
 		<section css={pricesSection} id="subscribe">
-			<h2 css={pricesHeadline}>Subscribe to the Guardian Weekly today</h2>
-			<p css={pricesSubHeadline}>
+			<h2
+				css={
+					isPriceCardsAbTestVariant
+						? [pricesHeadline, pricesHeadlineVariant]
+						: pricesHeadline
+				}
+			>
+				Subscribe to the Guardian Weekly today
+			</h2>
+			<p
+				css={
+					isPriceCardsAbTestVariant
+						? [pricesSubHeadline, pricesSubHeadlineVariant]
+						: pricesSubHeadline
+				}
+			>
 				{orderIsAGift ? 'Select a gift period' : "Choose how you'd like to pay"}
 			</p>
-			<FlexContainer cssOverrides={priceBoxes}>
+			<FlexContainer
+				cssOverrides={
+					isPriceCardsAbTestVariant
+						? [priceBoxes, priceBoxesVariant]
+						: priceBoxes
+				}
+			>
 				{products.map((product) => (
 					<ProductOption
 						cssOverrides={

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/productInfo.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/productInfo.tsx
@@ -1,0 +1,148 @@
+import { css } from '@emotion/react';
+import {
+	body,
+	from,
+	headline,
+	palette,
+	space,
+} from '@guardian/source-foundations';
+import GridImage from 'components/gridImage/gridImage';
+import Hero from 'components/page/hero';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import {
+	detect,
+	GBPCountries,
+} from 'helpers/internationalisation/countryGroup';
+import type { PromotionCopy } from 'helpers/productPrice/promotions';
+import { promotionHTML } from 'helpers/productPrice/promotions';
+
+interface ProductInfoProps {
+	promotionCopy: PromotionCopy;
+	orderIsAGift: boolean;
+}
+
+const styles = {
+	heroOverrides: css`
+		background-color: #cadbe8;
+	`,
+	showOnMobile: css`
+		display: block;
+
+		${from.mobileLandscape} {
+			display: none;
+		}
+	`,
+	productCopy: css`
+		padding: 0 ${space[3]}px ${space[3]}px;
+		color: ${palette.neutral[7]};
+	`,
+	productTitle: css`
+		${headline.small({
+			fontWeight: 'bold',
+		})};
+		margin-bottom: ${space[3]}px;
+
+		${from.mobileLandscape} {
+			width: 75%;
+		}
+
+		${from.tablet} {
+			${headline.large({
+				fontWeight: 'bold',
+			})};
+			width: 100%;
+		}
+	`,
+	productParagraph: css`
+		${body.medium({
+			lineHeight: 'loose',
+		})}
+		margin-bottom: ${space[9]}px;
+
+		/* apply the same margin to paragraphs parsed from markdown from promo codes */
+		& p:not(:last-of-type) {
+			margin-bottom: ${space[9]}px;
+		}
+	`,
+};
+
+const getRegionalCopyFor = (region: CountryGroupId) =>
+	region === GBPCountries ? (
+		<span>
+			Find clarity
+			<br css={styles.showOnMobile} /> with the Guardian&apos;s global magazine
+		</span>
+	) : (
+		<span>
+			Read The
+			<br css={styles.showOnMobile} /> Guardian in print
+		</span>
+	);
+
+const getFirstParagraph = (
+	promotionCopy: PromotionCopy,
+	orderIsAGift: boolean,
+) => {
+	if (promotionCopy.description) {
+		return promotionHTML(promotionCopy.description);
+	}
+
+	if (orderIsAGift) {
+		return (
+			<>
+				<p>
+					Gift the Guardian Weekly magazine to someone today, so they can gain a
+					deeper understanding of the issues they care about. They’ll find
+					in-depth reporting, alongside news, opinion pieces and long reads from
+					around the globe. From unpicking the election results to debunking
+					climate misinformation, they can take time with the Guardian Weekly to
+					help them make sense of the world.
+				</p>
+			</>
+		);
+	}
+
+	return (
+		<>
+			The Guardian Weekly takes you beyond the headlines to give you a deeper
+			understanding of the issues that really matter. Inside you’ll find the
+			week’s most memorable stories brought to life with striking photography.
+			Featuring a roundup of global news, opinion and long reads, all handpicked
+			from the Guardian and Observer.
+		</>
+	);
+};
+
+function ProductInfo({
+	promotionCopy,
+	orderIsAGift,
+}: ProductInfoProps): JSX.Element {
+	const defaultTitle = orderIsAGift ? null : getRegionalCopyFor(detect());
+	const title = promotionCopy.title ?? defaultTitle;
+	const copy = getFirstParagraph(promotionCopy, orderIsAGift);
+
+	return (
+		<Hero
+			image={
+				<GridImage
+					gridId="weeklyCampaignHeroImg"
+					srcSizes={[1000, 500, 140]}
+					sizes="(max-width: 740px) 100%,
+            (max-width: 1067px) 150%,
+            500px"
+					imgType="png"
+					altText="A collection of Guardian Weekly magazines"
+				/>
+			}
+			roundelText={undefined}
+			cssOverrides={styles.heroOverrides}
+		>
+			<section css={styles.productCopy}>
+				<h2 css={styles.productTitle}>{title}</h2>
+				<p css={styles.productParagraph}>{copy}</p>
+			</section>
+		</Hero>
+	);
+}
+
+export default ProductInfo;

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/productInfo.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/productInfo.tsx
@@ -8,13 +8,9 @@ import {
 } from '@guardian/source-foundations';
 import GridImage from 'components/gridImage/gridImage';
 import Hero from 'components/page/hero';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import {
-	detect,
-	GBPCountries,
-} from 'helpers/internationalisation/countryGroup';
+import { detect } from 'helpers/internationalisation/countryGroup';
 import type { PromotionCopy } from 'helpers/productPrice/promotions';
-import { promotionHTML } from 'helpers/productPrice/promotions';
+import { getFirstParagraph, getRegionalCopyFor } from '../hero/hero';
 
 interface ProductInfoProps {
 	promotionCopy: PromotionCopy;
@@ -64,53 +60,6 @@ const styles = {
 			margin-bottom: ${space[9]}px;
 		}
 	`,
-};
-
-const getRegionalCopyFor = (region: CountryGroupId) =>
-	region === GBPCountries ? (
-		<span>
-			Find clarity
-			<br css={styles.showOnMobile} /> with the Guardian&apos;s global magazine
-		</span>
-	) : (
-		<span>
-			Read The
-			<br css={styles.showOnMobile} /> Guardian in print
-		</span>
-	);
-
-const getFirstParagraph = (
-	promotionCopy: PromotionCopy,
-	orderIsAGift: boolean,
-) => {
-	if (promotionCopy.description) {
-		return promotionHTML(promotionCopy.description);
-	}
-
-	if (orderIsAGift) {
-		return (
-			<>
-				<p>
-					Gift the Guardian Weekly magazine to someone today, so they can gain a
-					deeper understanding of the issues they care about. They’ll find
-					in-depth reporting, alongside news, opinion pieces and long reads from
-					around the globe. From unpicking the election results to debunking
-					climate misinformation, they can take time with the Guardian Weekly to
-					help them make sense of the world.
-				</p>
-			</>
-		);
-	}
-
-	return (
-		<>
-			The Guardian Weekly takes you beyond the headlines to give you a deeper
-			understanding of the issues that really matter. Inside you’ll find the
-			week’s most memorable stories brought to life with striking photography.
-			Featuring a roundup of global news, opinion and long reads, all handpicked
-			from the Guardian and Observer.
-		</>
-	);
 };
 
 function ProductInfo({

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
@@ -6,8 +6,8 @@ import {
 	brandAlt,
 	from,
 	headline,
+	palette,
 	space,
-	text,
 } from '@guardian/source-foundations';
 import {
 	buttonThemeDefault,
@@ -19,73 +19,90 @@ import GridImage from 'components/gridImage/gridImage';
 import Hero from 'components/page/hero';
 import OfferStrapline from 'components/page/offerStrapline';
 import PageTitle from 'components/page/pageTitle';
-import type { Participations } from 'helpers/abTests/abtest';
+import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
 	detect,
 	GBPCountries,
 } from 'helpers/internationalisation/countryGroup';
+import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { promotionHTML } from 'helpers/productPrice/promotions';
 import type { PromotionCopy } from 'helpers/productPrice/promotions';
 import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
 import { guardianWeeklyHeroBlue } from 'stylesheets/emotion/colours';
+import WeeklyProductPrices from '../weeklyProductPrices';
 
-type PropTypes = {
+type WeeklyHeroPropTypes = {
 	orderIsAGift: boolean;
-	countryGroupId: CountryGroupId;
 	promotionCopy: PromotionCopy;
-	participations: Participations;
 };
-const weeklyHeroCopy = css`
-	padding: 0 ${space[3]}px ${space[3]}px;
-	color: ${text.primary};
-`;
-const weeklyHeroTitle = css`
-	${headline.small({
-		fontWeight: 'bold',
-	})};
-	margin-bottom: ${space[3]}px;
 
-	${from.mobileLandscape} {
-		width: 75%;
-	}
+type PriceCardsWeeklyHeroPropTypes = {
+	orderIsAGift: boolean;
+	promotionCopy: PromotionCopy;
+	countryId: IsoCountry;
+	productPrices: ProductPrices;
+	isPriceCardsAbTestVariant: boolean;
+};
 
-	${from.tablet} {
-		${headline.large({
+const styles = {
+	weeklyHeroCopy: css`
+		padding: 0 ${space[3]}px ${space[3]}px;
+		color: ${palette.neutral[7]};
+	`,
+	weeklyHeroTitle: css`
+		${headline.small({
 			fontWeight: 'bold',
 		})};
+		margin-bottom: ${space[3]}px;
+
+		${from.mobileLandscape} {
+			width: 75%;
+		}
+
+		${from.tablet} {
+			${headline.large({
+				fontWeight: 'bold',
+			})};
+			width: 100%;
+		}
+	`,
+	pageTitleOverrides: css`
 		width: 100%;
-	}
-`;
-const weeklyHeroParagraph = css`
-	${body.medium({
-		lineHeight: 'loose',
-	})}
-	margin-bottom: ${space[9]}px;
-
-	/* apply the same margin to paragraphs parsed from markdown from promo codes */
-	& p:not(:last-of-type) {
+	`,
+	weeklyHeroParagraph: css`
+		${body.medium({
+			lineHeight: 'loose',
+		})}
 		margin-bottom: ${space[9]}px;
-	}
-`;
-const showOnMobile = css`
-	display: block;
 
-	${from.mobileLandscape} {
-		display: none;
-	}
-`;
+		/* apply the same margin to paragraphs parsed from markdown from promo codes */
+		& p:not(:last-of-type) {
+			margin-bottom: ${space[9]}px;
+		}
+	`,
+	showOnMobile: css`
+		display: block;
+
+		${from.mobileLandscape} {
+			display: none;
+		}
+	`,
+	priceCardsHeroContainer: css`
+		background-color: ${palette.brand[400]};
+	`,
+};
 
 const getRegionalCopyFor = (region: CountryGroupId) =>
 	region === GBPCountries ? (
 		<span>
 			Find clarity
-			<br css={showOnMobile} /> with the Guardian&apos;s global magazine
+			<br css={styles.showOnMobile} /> with the Guardian&apos;s global magazine
 		</span>
 	) : (
 		<span>
 			Read The
-			<br css={showOnMobile} /> Guardian in print
+			<br css={styles.showOnMobile} /> Guardian in print
 		</span>
 	);
 
@@ -123,7 +140,10 @@ const getFirstParagraph = (
 	);
 };
 
-function WeeklyHero({ orderIsAGift, promotionCopy }: PropTypes): JSX.Element {
+export function WeeklyHero({
+	orderIsAGift,
+	promotionCopy,
+}: WeeklyHeroPropTypes): JSX.Element {
 	const defaultRoundelText = 'Save up to 35% a year';
 	const defaultTitle = orderIsAGift ? null : getRegionalCopyFor(detect());
 	const title = promotionCopy.title ?? defaultTitle;
@@ -133,7 +153,7 @@ function WeeklyHero({ orderIsAGift, promotionCopy }: PropTypes): JSX.Element {
 		background-color: ${guardianWeeklyHeroBlue};
 	`;
 	const linkButtonColour = css`
-		color: ${text.primary};
+		color: ${palette.neutral[7]};
 		&:hover {
 			background: ${'#AEBDC8'};
 		}
@@ -146,7 +166,7 @@ function WeeklyHero({ orderIsAGift, promotionCopy }: PropTypes): JSX.Element {
 		>
 			<CentredContainer>
 				<OfferStrapline
-					fgCol={text.primary}
+					fgCol={palette.neutral[7]}
 					bgCol={brandAlt[400]}
 					copy={roundelText}
 					orderIsAGift={orderIsAGift}
@@ -166,9 +186,9 @@ function WeeklyHero({ orderIsAGift, promotionCopy }: PropTypes): JSX.Element {
 					roundelText={undefined}
 					cssOverrides={containerColour}
 				>
-					<section css={weeklyHeroCopy}>
-						<h2 css={weeklyHeroTitle}>{title}</h2>
-						<p css={weeklyHeroParagraph}>{copy}</p>
+					<section css={styles.weeklyHeroCopy}>
+						<h2 css={styles.weeklyHeroTitle}>{title}</h2>
+						<p css={styles.weeklyHeroParagraph}>{copy}</p>
 						<ThemeProvider theme={buttonThemeDefault}>
 							<LinkButton
 								onClick={sendTrackingEventsOnClick({
@@ -192,4 +212,40 @@ function WeeklyHero({ orderIsAGift, promotionCopy }: PropTypes): JSX.Element {
 	);
 }
 
-export { WeeklyHero };
+export function PriceCardsWeeklyHero({
+	orderIsAGift,
+	promotionCopy,
+	countryId,
+	productPrices,
+	isPriceCardsAbTestVariant,
+}: PriceCardsWeeklyHeroPropTypes): JSX.Element {
+	const defaultRoundelText = 'Save up to 35% a year';
+	const roundelText = promotionCopy.roundel ?? defaultRoundelText;
+
+	return (
+		<PageTitle
+			title={orderIsAGift ? 'Give the Guardian Weekly' : 'The Guardian Weekly'}
+			theme="weekly"
+			cssOverrides={styles.pageTitleOverrides}
+		>
+			<CentredContainer>
+				<OfferStrapline
+					fgCol={palette.neutral[7]}
+					bgCol={brandAlt[400]}
+					copy={roundelText}
+					orderIsAGift={orderIsAGift}
+				/>
+			</CentredContainer>
+			<div css={styles.priceCardsHeroContainer}>
+				<CentredContainer>
+					<WeeklyProductPrices
+						countryId={countryId}
+						productPrices={productPrices}
+						orderIsAGift={orderIsAGift}
+						isPriceCardsAbTestVariant={isPriceCardsAbTestVariant}
+					/>
+				</CentredContainer>
+			</div>
+		</PageTitle>
+	);
+}

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
@@ -93,7 +93,7 @@ const styles = {
 	`,
 };
 
-const getRegionalCopyFor = (region: CountryGroupId) =>
+export const getRegionalCopyFor = (region: CountryGroupId): JSX.Element =>
 	region === GBPCountries ? (
 		<span>
 			Find clarity
@@ -106,10 +106,10 @@ const getRegionalCopyFor = (region: CountryGroupId) =>
 		</span>
 	);
 
-const getFirstParagraph = (
+export const getFirstParagraph = (
 	promotionCopy: PromotionCopy,
 	orderIsAGift: boolean,
-) => {
+): JSX.Element | null => {
 	if (promotionCopy.description) {
 		return promotionHTML(promotionCopy.description);
 	}

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
@@ -123,7 +123,7 @@ const getFirstParagraph = (
 	);
 };
 
-const WeeklyHero: React.FC<PropTypes> = ({ orderIsAGift, promotionCopy }) => {
+function WeeklyHero({ orderIsAGift, promotionCopy }: PropTypes): JSX.Element {
 	const defaultRoundelText = 'Save up to 35% a year';
 	const defaultTitle = orderIsAGift ? null : getRegionalCopyFor(detect());
 	const title = promotionCopy.title ?? defaultTitle;
@@ -190,6 +190,6 @@ const WeeklyHero: React.FC<PropTypes> = ({ orderIsAGift, promotionCopy }) => {
 			</CentredContainer>
 		</PageTitle>
 	);
-};
+}
 
 export { WeeklyHero };

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
@@ -109,6 +109,7 @@ type WeeklyProductPricesProps = {
 	countryId: IsoCountry;
 	productPrices: ProductPrices | null | undefined;
 	orderIsAGift: boolean;
+	isPriceCardsAbTestVariant?: boolean;
 };
 
 const getProducts = ({
@@ -142,6 +143,7 @@ function WeeklyProductPrices({
 	countryId,
 	productPrices,
 	orderIsAGift,
+	isPriceCardsAbTestVariant,
 }: WeeklyProductPricesProps): JSX.Element | null {
 	if (!productPrices) {
 		return null;
@@ -151,8 +153,16 @@ function WeeklyProductPrices({
 		countryId,
 		productPrices,
 		orderIsAGift,
+		isPriceCardsAbTestVariant,
 	});
-	return <Prices products={products} orderIsAGift={orderIsAGift} />;
+
+	return (
+		<Prices
+			products={products}
+			orderIsAGift={orderIsAGift}
+			isPriceCardsAbTestVariant={isPriceCardsAbTestVariant ?? false}
+		/>
+	);
 }
 
 // ----- Exports ----- //

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -26,13 +26,18 @@ import 'stylesheets/skeleton/skeleton.scss';
 import { GuardianWeeklyFooter } from '../../components/footerCompliant/FooterWithPromoTerms';
 import Benefits from './components/content/benefits';
 import GiftBenefits from './components/content/giftBenefits';
-import { WeeklyHero } from './components/hero/hero';
+import ProductInfo from './components/content/productInfo';
+import { PriceCardsWeeklyHero, WeeklyHero } from './components/hero/hero';
 import WeeklyProductPrices from './components/weeklyProductPrices';
 import './weeklySubscriptionLanding.scss';
-import type { WeeklyLandingPropTypes } from './weeklySubscriptionLandingProps';
+import type {
+	WeeklyLandingPropTypes,
+	WeeklyLPContentPropTypes,
+} from './weeklySubscriptionLandingProps';
 import { weeklyLandingProps } from './weeklySubscriptionLandingProps';
-// ----- Internationalisation ----- //
+
 const countryGroupId: CountryGroupId = detect();
+
 const reactElementId: Record<CountryGroupId, string> = {
 	GBPCountries: 'weekly-landing-page-uk',
 	UnitedStates: 'weekly-landing-page-us',
@@ -43,16 +48,158 @@ const reactElementId: Record<CountryGroupId, string> = {
 	International: 'weekly-landing-page-int',
 };
 
-const closeGapAfterPageTitle = css`
-	margin-top: 0;
-`;
+const styles = {
+	closeGapAfterPageTitle: css`
+		margin-top: 0;
+	`,
+	displayRowEvenly: css`
+		${from.phablet} {
+			display: flex;
+			flex-direction: row;
+			justify-content: space-evenly:
+		}
+	`,
+	weeklyHeroContainerOverrides: css`
+		display: flex;
+	`,
+};
 
-const displayRowEvenly = css`
-  ${from.phablet} {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-evenly:
-}`;
+function WeeklyLPControl({
+	countryId,
+	productPrices,
+	promotionCopy,
+	orderIsAGift,
+	countryGroupId,
+	pageQaId,
+	header,
+	giftNonGiftLink,
+	isPriceCardsAbTestVariant,
+}: WeeklyLPContentPropTypes) {
+	return (
+		<Page
+			id={pageQaId}
+			header={header}
+			footer={
+				<GuardianWeeklyFooter
+					productPrices={productPrices}
+					orderIsAGift={!!orderIsAGift}
+					country={countryId}
+				/>
+			}
+		>
+			<WeeklyHero orderIsAGift={orderIsAGift} promotionCopy={promotionCopy} />
+			<FullWidthContainer>
+				<CentredContainer>
+					<Block cssOverrides={styles.closeGapAfterPageTitle}>
+						{orderIsAGift ? <GiftBenefits /> : <Benefits />}
+					</Block>
+				</CentredContainer>
+			</FullWidthContainer>
+			<FullWidthContainer theme="dark" hasOverlap>
+				<CentredContainer>
+					<WeeklyProductPrices
+						countryId={countryId}
+						productPrices={productPrices}
+						orderIsAGift={orderIsAGift}
+						isPriceCardsAbTestVariant={isPriceCardsAbTestVariant ?? false}
+					/>
+				</CentredContainer>
+			</FullWidthContainer>
+			<FullWidthContainer theme="white">
+				<CentredContainer>
+					<div css={styles.displayRowEvenly}>
+						<GiftNonGiftCta
+							product="Guardian Weekly"
+							href={giftNonGiftLink}
+							orderIsAGift={orderIsAGift}
+						/>
+						{countryGroupId === 'GBPCountries' && (
+							<GiftNonGiftCta
+								product="Student"
+								href={routes.guardianWeeklyStudent}
+								orderIsAGift={orderIsAGift}
+								isStudent={true}
+							/>
+						)}
+					</div>
+				</CentredContainer>
+			</FullWidthContainer>
+		</Page>
+	);
+}
+
+function WeeklyLPVariant({
+	countryId,
+	productPrices,
+	promotionCopy,
+	orderIsAGift,
+	countryGroupId,
+	pageQaId,
+	header,
+	giftNonGiftLink,
+	isPriceCardsAbTestVariant,
+}: WeeklyLPContentPropTypes) {
+	return (
+		<Page
+			id={pageQaId}
+			header={header}
+			footer={
+				<GuardianWeeklyFooter
+					productPrices={productPrices}
+					orderIsAGift={!!orderIsAGift}
+					country={countryId}
+				/>
+			}
+		>
+			<FullWidthContainer cssOverrides={styles.weeklyHeroContainerOverrides}>
+				<PriceCardsWeeklyHero
+					orderIsAGift={orderIsAGift}
+					promotionCopy={promotionCopy}
+					countryId={countryId}
+					productPrices={productPrices}
+					isPriceCardsAbTestVariant={isPriceCardsAbTestVariant ?? false}
+				/>
+			</FullWidthContainer>
+
+			<FullWidthContainer>
+				<CentredContainer>
+					<ProductInfo
+						promotionCopy={promotionCopy}
+						orderIsAGift={orderIsAGift}
+					/>
+				</CentredContainer>
+			</FullWidthContainer>
+
+			<FullWidthContainer>
+				<CentredContainer>
+					<Block cssOverrides={styles.closeGapAfterPageTitle}>
+						{orderIsAGift ? <GiftBenefits /> : <Benefits />}
+					</Block>
+				</CentredContainer>
+			</FullWidthContainer>
+
+			<FullWidthContainer theme="white">
+				<CentredContainer>
+					<div css={styles.displayRowEvenly}>
+						<GiftNonGiftCta
+							product="Guardian Weekly"
+							href={giftNonGiftLink}
+							orderIsAGift={orderIsAGift}
+						/>
+						{countryGroupId === 'GBPCountries' && (
+							<GiftNonGiftCta
+								product="Student"
+								href={routes.guardianWeeklyStudent}
+								orderIsAGift={orderIsAGift}
+								isStudent={true}
+							/>
+						)}
+					</div>
+				</CentredContainer>
+			</FullWidthContainer>
+		</Page>
+	);
+}
 
 // ----- Render ----- //
 function WeeklyLandingPage({
@@ -66,15 +213,18 @@ function WeeklyLandingPage({
 	if (!productPrices) {
 		return null;
 	}
+
 	const path = orderIsAGift
 		? routes.guardianWeeklySubscriptionLandingGift
 		: routes.guardianWeeklySubscriptionLanding;
 	const giftNonGiftLink = orderIsAGift
 		? routes.guardianWeeklySubscriptionLanding
 		: routes.guardianWeeklySubscriptionLandingGift;
+
 	const sanitisedPromoCopy = getPromotionCopy(promotionCopy, orderIsAGift);
 	// ID for Selenium tests
 	const pageQaId = `qa-guardian-weekly${orderIsAGift ? '-gift' : ''}`;
+
 	const Header = headerWithCountrySwitcherContainer({
 		path,
 		countryGroupId,
@@ -89,60 +239,36 @@ function WeeklyLandingPage({
 		],
 		trackProduct: 'GuardianWeekly',
 	});
-	return (
-		<Page
-			id={pageQaId}
+
+	const isPriceCardsAbTestVariant =
+		participations.guardianWeeklyPriceCards === 'variant';
+
+	return isPriceCardsAbTestVariant ? (
+		<WeeklyLPVariant
+			countryId={countryId}
+			countryGroupId={countryGroupId}
+			productPrices={productPrices}
+			promotionCopy={sanitisedPromoCopy}
+			orderIsAGift={orderIsAGift ?? false}
+			participations={participations}
+			pageQaId={pageQaId}
 			header={<Header />}
-			footer={
-				<GuardianWeeklyFooter
-					productPrices={productPrices}
-					orderIsAGift={!!orderIsAGift}
-					country={countryId}
-				/>
-			}
-		>
-			<WeeklyHero
-				orderIsAGift={orderIsAGift ?? false}
-				countryGroupId={countryGroupId}
-				promotionCopy={sanitisedPromoCopy}
-				participations={participations}
-			/>
-			<FullWidthContainer>
-				<CentredContainer>
-					<Block cssOverrides={closeGapAfterPageTitle}>
-						{orderIsAGift ? <GiftBenefits /> : <Benefits />}
-					</Block>
-				</CentredContainer>
-			</FullWidthContainer>
-			<FullWidthContainer theme="dark" hasOverlap>
-				<CentredContainer>
-					<WeeklyProductPrices
-						countryId={countryId}
-						productPrices={productPrices}
-						orderIsAGift={orderIsAGift ?? false}
-					/>
-				</CentredContainer>
-			</FullWidthContainer>
-			<FullWidthContainer theme="white">
-				<CentredContainer>
-					<div css={displayRowEvenly}>
-						<GiftNonGiftCta
-							product="Guardian Weekly"
-							href={giftNonGiftLink}
-							orderIsAGift={orderIsAGift ?? false}
-						/>
-						{countryGroupId === 'GBPCountries' && (
-							<GiftNonGiftCta
-								product="Student"
-								href={routes.guardianWeeklyStudent}
-								orderIsAGift={orderIsAGift ?? false}
-								isStudent={true}
-							/>
-						)}
-					</div>
-				</CentredContainer>
-			</FullWidthContainer>
-		</Page>
+			giftNonGiftLink={giftNonGiftLink}
+			isPriceCardsAbTestVariant={isPriceCardsAbTestVariant}
+		/>
+	) : (
+		<WeeklyLPControl
+			countryId={countryId}
+			countryGroupId={countryGroupId}
+			productPrices={productPrices}
+			promotionCopy={sanitisedPromoCopy}
+			orderIsAGift={orderIsAGift ?? false}
+			participations={participations}
+			pageQaId={pageQaId}
+			header={<Header />}
+			giftNonGiftLink={giftNonGiftLink}
+			isPriceCardsAbTestVariant={isPriceCardsAbTestVariant}
+		/>
 	);
 }
 

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingProps.ts
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingProps.ts
@@ -22,6 +22,19 @@ export type WeeklyLandingPropTypes = {
 	participations: Participations;
 };
 
+export type WeeklyLPContentPropTypes = {
+	countryId: IsoCountry;
+	countryGroupId: CountryGroupId;
+	productPrices: ProductPrices;
+	promotionCopy: PromotionCopy;
+	orderIsAGift: boolean;
+	participations: Participations;
+	pageQaId: string;
+	header: JSX.Element;
+	giftNonGiftLink: string;
+	isPriceCardsAbTestVariant?: boolean;
+};
+
 const countryGroupId = detectCountryGroup();
 
 export const weeklyLandingProps = (): WeeklyLandingPropTypes => ({


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This adds an AB test to change the order and position of price cards on the Guardian Weekly landing page. Please see attached screenshots for the control and variant.

[**Trello Card**](https://trello.com/c/fb1qK6jg/1032-change-position-and-order-of-price-cards-for-gw-on-mobile-build)

## Is this an AB test?
- [x] Yes
- [ ] No

## Screenshots
| | Mobile | Desktop |
| -- | -- | -- |
| Control | ![localhost_9211_uk_subscribe_weekly (2)](https://user-images.githubusercontent.com/44685872/219340745-d677d28e-5e1b-4717-8fb6-4872c22a5a17.png) | ![localhost_9211_uk_subscribe_weekly (1)](https://user-images.githubusercontent.com/44685872/219340023-f6215a69-da70-4c19-af97-ecaaa03d8ffb.png) | 
| Variant | ![localhost_9211_uk_subscribe_weekly (3)](https://user-images.githubusercontent.com/44685872/219340860-e157975f-2f95-456f-953f-c433e46d0a0b.png) | ![localhost_9211_uk_subscribe_weekly](https://user-images.githubusercontent.com/44685872/219340055-b82de9cf-1a66-47c8-909a-d303b5b93493.png) |


