### PR TITLE
Update minimist from 1.2.5 to 1.2.8

### DIFF
--- a/support-workers/cloud-formation/src/yarn.lock
+++ b/support-workers/cloud-formation/src/yarn.lock
@@ -40,9 +40,9 @@ js-yaml@^3.13.1:
     esprima "^4.0.0"
 
 minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 neo-async@^2.6.0:
   version "2.6.2"
@@ -60,11 +60,11 @@ sprintf-js@~1.0.2:
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 uglify-js@^3.1.4:
-  version "3.14.5"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.14.5.tgz#cdabb7d4954231d80cb4a927654c4655e51f4859"
-  integrity sha512-qZukoSxOG0urUTvjc2ERMTcAy+BiFh3weWAkeurLwjrCba73poHmG3E36XEjd/JGukMzwTL7uCxZiAexj8ppvQ==
+  version "3.17.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
+  integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==
 
 wordwrap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
-  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
+  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==


### PR DESCRIPTION
## What are you doing in this PR?

Update minimist from 1.2.5 to 1.2.8.

As this is dependency of "handlebars": "^4.7.7",I have run -yarn upgrade handlebars which in turn upgraded the below handlebars dependencies
1)Minimist from 1.2.5 to 1.2.8
<img width="1455" alt="image" src="https://user-images.githubusercontent.com/73653255/219428224-9f54c547-7e0d-4f36-894c-6c0e22ef2504.png">

2.uglify-js from 3.14.5 to 3.17.4
<img width="1455" alt="image" src="https://user-images.githubusercontent.com/73653255/219428348-355a729a-8511-4140-9a4f-6009d5b1f5d5.png">

3.wordwrap
<img width="1455" alt="image" src="https://user-images.githubusercontent.com/73653255/219429112-e86388f7-4afe-4eb8-ba38-5b4fb2f4a9b6.png">

[**Trello Card**](https://trello.com/c/NCivfZE1/755-support-frontend-update-minimist-from-125-to-127)

## Why are you doing this?
Patch update (1.2.5 to 1.2.7), and dependabot automated PRs are failing for this dependency, so we need to manually update.
Updates ->
minimist from 1.2.5 to 1.2.7 in /support-workers/cloud-formation/src #4275


## Is this an AB test?
- [ ] Yes
- [ x] No


