### PR TITLE
Update ScalaSteward config file by removing pull request frequency

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,4 +1,3 @@
-pullRequests.frequency = "0 10 * * 1-5" #10 am Monday to Friday
 pullRequests.grouping = [
   { name = "aws", "title" = "AWS Scala dependency updates", "filter" = [{"group" = "software.amazon.awssdk"}, {"group" = "com.amazonaws"}] },
   { name = "non_aws", "title" = "Non AWS Scala dependency updates", "filter" = [{"group" = "*"}] }


### PR DESCRIPTION
## What are you doing in this PR?
This is to remove the pullRequests.frequency = "0 10 * * 1-5" #10 am Monday to Friday from the  .scala-steward.conf file  as it wasn't parsed correctly

cron4s.InvalidCron: Either DayOfMonth and DayOfWeek must have a ? expression: DownField(frequency),DownField(pullRequests)

<img width="879" alt="image" src="https://user-images.githubusercontent.com/73653255/219615542-04dd9ec2-49ac-4140-8f87-b8c7d52376ef.png">

Please check comments from https://github.com/guardian/support-frontend/pull/4541
## Is this an AB test?
- [ ] Yes
- [ x] No

