### PR TITLE
Supporter plus nudge annual (variant) copy changes

### DIFF
--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -28,8 +28,8 @@ export function CheckoutNudgeContainer({
 	const [displayNudge, setDisplayNudge] = useState(true);
 
 	const recurringType =
-		abParticipations.singleToRecurringV2 === 'control' ||
-		!abParticipations.singleToRecurringV2
+		abParticipations.singleToRecurringV3 === 'control' ||
+		!abParticipations.singleToRecurringV3
 			? 'MONTHLY'
 			: 'ANNUAL';
 	const currencyGlyph = glyph(detect(countryGroupId));

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -34,9 +34,15 @@ export function CheckoutNudgeContainer({
 			: 'ANNUAL';
 	const currencyGlyph = glyph(detect(countryGroupId));
 	const minAmount = config[countryGroupId][recurringType].min;
-	const paragraphCopyVariant = `Regular, reliable support powers Guardian journalism in perpetuity. If you can, please consider setting up ${
-		recurringType === 'MONTHLY' ? 'a' : 'an'
-	} ${recurringType.toLowerCase()} payment today from just  ${currencyGlyph}${minAmount} – it takes less than a minute.`;
+
+	const minWeeklyAmount =
+		countryGroupId === 'GBPCountries'
+			? Math.ceil((minAmount * 100) / 52).toString() + `p`
+			: currencyGlyph +
+			  (Math.ceil((minAmount * 100) / 52) / 100).toFixed(2).toString();
+
+	const paragraphCopyMonthly = `Regular, reliable support powers Guardian journalism in perpetuity. If you can, please consider setting up a ${recurringType.toLowerCase()} payment today from just  ${currencyGlyph}${minAmount} – it takes less than a minute.`;
+	const paragraphCopyAnnual = `Regular, reliable support powers Guardian journalism in perpetuity. If you can, please consider setting up an ${recurringType.toLowerCase()} payment from ${currencyGlyph}${minAmount} – that’s just ${minWeeklyAmount} a week.`;
 
 	function onNudgeClose() {
 		setDisplayNudge(false);
@@ -52,7 +58,8 @@ export function CheckoutNudgeContainer({
 		nudgeTitleCopySection2: `Support us every ${
 			recurringType === 'MONTHLY' ? 'month' : 'year'
 		}`,
-		nudgeParagraphCopy: paragraphCopyVariant,
+		nudgeParagraphCopy:
+			recurringType === 'MONTHLY' ? paragraphCopyMonthly : paragraphCopyAnnual,
 		nudgeLinkCopy: `See ${recurringType.toLowerCase()}`,
 		onNudgeClose,
 		onNudgeClick,

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -39,7 +39,7 @@ export const pageUrlRegexes = {
 	},
 };
 export const tests: Tests = {
-	singleToRecurringV2: {
+	singleToRecurringV3: {
 		variants: [
 			{
 				id: 'control',


### PR DESCRIPTION
Nudging component, encouraging single to monthly or modified annual recurring contributions
Rename test  to 'ab-singleToRecurringV3'

[**Trello Card**](https://trello.com/c/0bPcisad/1082-ab-test-copy-change-for-the-single-nudge-on-the-checkout)

Annual Features->
- copy change variant (control stays monthly)
- minimum weekly contribution rounded (p = GPB Countries, displayCcy = remainder)



2-cohort A/B test for implementation ->
https://support.thegulocal.com/uk/contribute#ab-singleToRecurringV3=control (Monthly)
https://support.thegulocal.com/uk/contribute#ab-singleToRecurringV3=variant (NEW Annual)

## Is this an AB test?
- [x] Yes
- [ ] No



