### PR TITLE
Set up first mobile optimisation test for the supporter plus checkout

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
@@ -8,6 +8,7 @@ import {
 } from '@guardian/source-foundations';
 import CancelAnytimeTooltip from 'components/tooltip/Tooltip';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import type { CSSOverridable } from 'helpers/types/cssOverrideable';
 import type { CheckListData } from './checkoutBenefitsListData';
 
 const container = css`
@@ -62,21 +63,22 @@ const hr = (margin: string) => css`
 	margin: ${margin};
 `;
 
-export type CheckoutBenefitsListProps = {
+export interface CheckoutBenefitsListProps extends CSSOverridable {
 	title: string;
 	checkListData: CheckListData[];
 	buttonCopy: string | null;
 	handleButtonClick: () => void;
 	countryGroupId: CountryGroupId;
-};
+}
 
 export function CheckoutBenefitsList({
 	title,
 	checkListData,
 	countryGroupId,
+	cssOverrides,
 }: CheckoutBenefitsListProps): JSX.Element {
 	return (
-		<div css={container}>
+		<div css={[container, cssOverrides]}>
 			<h2 css={heading}>{title}</h2>
 			<hr css={hr(`${space[4]}px 0`)} />
 			<table css={table}>

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -24,6 +24,14 @@ const optimisedLayoutOverrides = css`
 		h2 {
 			${headline.xsmall({ fontWeight: 'bold' })}
 		}
+
+		tr {
+			border-bottom-width: 6px;
+		}
+
+		hr {
+			margin: 14px 0;
+		}
 	}
 `;
 

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -7,8 +7,8 @@ import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import {
-	checkUserAbTestStatus,
 	getMinimumContributionAmount,
+	isUserInAbVariant,
 } from 'helpers/redux/commonState/selectors';
 import {
 	useContributionsDispatch,
@@ -67,7 +67,7 @@ export function CheckoutBenefitsListContainer({
 	);
 
 	const useOptimisedMobileLayout = useContributionsSelector(
-		checkUserAbTestStatus('supporterPlusMobileTest1', 'variant'),
+		isUserInAbVariant('supporterPlusMobileTest1', 'variant'),
 	);
 
 	const currency = currencies[currencyId];

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -1,10 +1,15 @@
+import { css } from '@emotion/react';
+import { headline, until } from '@guardian/source-foundations';
 import type { ContributionType } from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import { currencies } from 'helpers/internationalisation/currency';
 import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
-import { getMinimumContributionAmount } from 'helpers/redux/commonState/selectors';
+import {
+	checkUserAbTestStatus,
+	getMinimumContributionAmount,
+} from 'helpers/redux/commonState/selectors';
 import {
 	useContributionsDispatch,
 	useContributionsSelector,
@@ -13,6 +18,14 @@ import { getThresholdPrice } from 'helpers/supporterPlus/benefitsThreshold';
 import { isOneOff } from 'helpers/supporterPlus/isContributionRecurring';
 import type { CheckoutBenefitsListProps } from './checkoutBenefitsList';
 import { checkListData } from './checkoutBenefitsListData';
+
+const optimisedLayoutOverrides = css`
+	${until.tablet} {
+		h2 {
+			${headline.xsmall({ fontWeight: 'bold' })}
+		}
+	}
+`;
 
 type CheckoutBenefitsListContainerProps = {
 	renderBenefitsList: (props: CheckoutBenefitsListProps) => JSX.Element;
@@ -51,6 +64,10 @@ export function CheckoutBenefitsListContainer({
 	const selectedAmount = useContributionsSelector(getUserSelectedAmount);
 	const minimumContributionAmount = useContributionsSelector(
 		getMinimumContributionAmount,
+	);
+
+	const useOptimisedMobileLayout = useContributionsSelector(
+		checkUserAbTestStatus('supporterPlusMobileTest1', 'variant'),
 	);
 
 	const currency = currencies[currencyId];
@@ -98,5 +115,8 @@ export function CheckoutBenefitsListContainer({
 		),
 		handleButtonClick,
 		countryGroupId,
+		cssOverrides: useOptimisedMobileLayout
+			? optimisedLayoutOverrides
+			: undefined,
 	});
 }

--- a/support-frontend/assets/components/layout/container.tsx
+++ b/support-frontend/assets/components/layout/container.tsx
@@ -1,3 +1,4 @@
+import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { from, neutral } from '@guardian/source-foundations';
 import { Container as SourceContainer } from '@guardian/source-react-components';
@@ -21,6 +22,7 @@ interface ContainerProps extends HTMLAttributes<HTMLElement> {
 	sideBorders?: boolean;
 	borderColor?: string;
 	backgroundColor?: string;
+	cssOverrides?: SerializedStyles;
 }
 
 const sidePaddingStyles = css`
@@ -65,6 +67,7 @@ export function Container({
 	sideBorders,
 	borderColor = neutral[86],
 	backgroundColor,
+	cssOverrides = css``,
 	...props
 }: ContainerProps): JSX.Element {
 	return (
@@ -77,6 +80,7 @@ export function Container({
 				sidePadding ? sidePaddingStyles : noPaddingStyles,
 				sideBorders ? sideBorderStyles(borderColor) : css``,
 				topBorder ? topBorderStyles(borderColor) : css``,
+				cssOverrides,
 			]}
 			{...props}
 		>

--- a/support-frontend/assets/components/paymentButton/paymentButtonController.tsx
+++ b/support-frontend/assets/components/paymentButton/paymentButtonController.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { space } from '@guardian/source-foundations';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import type { CSSOverridable } from 'helpers/types/cssOverrideable';
 import { DefaultPaymentButtonContainer } from './defaultPaymentButtonContainer';
 import { NoPaymentMethodButton } from './noPaymentMethodButton';
 
@@ -14,16 +15,17 @@ export type PaymentButtonComponentProps = {
 	DefaultButtonContainer: typeof DefaultPaymentButtonContainer;
 };
 
-type PaymentButtonControllerProps = {
+interface PaymentButtonControllerProps extends CSSOverridable {
 	paymentButtons: Partial<
 		Record<PaymentMethod, React.FC<PaymentButtonComponentProps>>
 	>;
 	defaultContainer?: typeof DefaultPaymentButtonContainer;
-};
+}
 
 export function PaymentButtonController({
 	paymentButtons,
 	defaultContainer = DefaultPaymentButtonContainer,
+	cssOverrides,
 }: PaymentButtonControllerProps): JSX.Element {
 	const paymentMethod = useContributionsSelector(
 		(state) => state.page.checkoutForm.payment.paymentMethod.name,
@@ -31,7 +33,7 @@ export function PaymentButtonController({
 	const ButtonToRender = paymentButtons[paymentMethod] ?? NoPaymentMethodButton;
 
 	return (
-		<div css={paymentButtonSpacing}>
+		<div css={[paymentButtonSpacing, cssOverrides]}>
 			<ButtonToRender DefaultButtonContainer={defaultContainer} />
 		</div>
 	);

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -1,3 +1,5 @@
+import { css } from '@emotion/react';
+import { headline, until } from '@guardian/source-foundations';
 import { useEffect } from 'react';
 import { getValidPaymentMethods } from 'helpers/forms/checkouts';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
@@ -10,6 +12,7 @@ import { selectExistingPaymentMethod } from 'helpers/redux/checkout/payment/exis
 import type { ExistingPaymentMethodsState } from 'helpers/redux/checkout/payment/existingPaymentMethods/state';
 import { setPaymentMethod } from 'helpers/redux/checkout/payment/paymentMethod/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import { checkUserAbTestStatus } from 'helpers/redux/commonState/selectors';
 import {
 	useContributionsDispatch,
 	useContributionsSelector,
@@ -20,6 +23,14 @@ import {
 } from 'helpers/tracking/behaviour';
 import { sendEventContributionPaymentMethod } from 'helpers/tracking/quantumMetric';
 import type { PaymentMethodSelectorProps } from './paymentMethodSelector';
+
+const optimisedLayoutOverrides = css`
+	${until.tablet} {
+		h2 {
+			${headline.xsmall({ fontWeight: 'bold' })}
+		}
+	}
+`;
 
 function getExistingPaymentMethodProps(
 	existingPaymentMethods: ExistingPaymentMethodsState,
@@ -70,6 +81,10 @@ function PaymentMethodSelectorContainer({
 		(state) => state.common.settings,
 	);
 
+	const useOptimisedMobileLayout = useContributionsSelector(
+		checkUserAbTestStatus('supporterPlusMobileTest1', 'variant'),
+	);
+
 	const availablePaymentMethods = getValidPaymentMethods(
 		contributionType,
 		switches,
@@ -113,6 +128,9 @@ function PaymentMethodSelectorContainer({
 		validationError: errors?.[0],
 		...getExistingPaymentMethodProps(existingPaymentMethods),
 		onPaymentMethodEvent,
+		cssOverrides: useOptimisedMobileLayout
+			? optimisedLayoutOverrides
+			: undefined,
 	});
 }
 

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -12,7 +12,7 @@ import { selectExistingPaymentMethod } from 'helpers/redux/checkout/payment/exis
 import type { ExistingPaymentMethodsState } from 'helpers/redux/checkout/payment/existingPaymentMethods/state';
 import { setPaymentMethod } from 'helpers/redux/checkout/payment/paymentMethod/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
-import { checkUserAbTestStatus } from 'helpers/redux/commonState/selectors';
+import { isUserInAbVariant } from 'helpers/redux/commonState/selectors';
 import {
 	useContributionsDispatch,
 	useContributionsSelector,
@@ -82,7 +82,7 @@ function PaymentMethodSelectorContainer({
 	);
 
 	const useOptimisedMobileLayout = useContributionsSelector(
-		checkUserAbTestStatus('supporterPlusMobileTest1', 'variant'),
+		isUserInAbVariant('supporterPlusMobileTest1', 'variant'),
 	);
 
 	const availablePaymentMethods = getValidPaymentMethods(

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -12,6 +12,7 @@ import {
 	subscriptionToExplainerPart,
 } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
+import type { CSSOverridable } from 'helpers/types/cssOverrideable';
 import { paymentMethodData } from './paymentMethodData';
 import { AvailablePaymentMethodAccordionRow } from './paymentMethodSelectorAccordionRow';
 import { ReauthenticateLink } from './reauthenticateLink';
@@ -43,7 +44,7 @@ function PaymentMethodSelectorLegend() {
 	);
 }
 
-export interface PaymentMethodSelectorProps {
+export interface PaymentMethodSelectorProps extends CSSOverridable {
 	cssOverrides?: SerializedStyles;
 	availablePaymentMethods: PaymentMethod[];
 	paymentMethod: PaymentMethod | null;
@@ -68,6 +69,7 @@ export function PaymentMethodSelector({
 	pendingExistingPaymentMethods,
 	showReauthenticateLink,
 	onPaymentMethodEvent,
+	cssOverrides,
 }: PaymentMethodSelectorProps): JSX.Element {
 	if (
 		existingPaymentMethodList.length < 1 &&
@@ -83,7 +85,7 @@ export function PaymentMethodSelector({
 	}
 
 	return (
-		<div css={container}>
+		<div css={[container, cssOverrides]}>
 			<PaymentMethodSelectorLegend />
 			<RadioGroup
 				id="paymentMethod"

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/utils';
 import { headline, space } from '@guardian/source-foundations';
-import { Accordion, RadioGroup } from '@guardian/source-react-components';
+import { Accordion, Hide, RadioGroup } from '@guardian/source-react-components';
 import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';
 import { SecureTransactionIndicator } from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import AnimatedDots from 'components/spinners/animatedDots';
@@ -36,7 +36,9 @@ function PaymentMethodSelectorLegend() {
 			<legend id="payment_method">
 				<h2 css={header}>Payment method</h2>
 			</legend>
-			<SecureTransactionIndicator position="middle" hideText={true} />
+			<Hide until="tablet">
+				<SecureTransactionIndicator hideText={true} />
+			</Hide>
 		</div>
 	);
 }

--- a/support-frontend/assets/components/priceCards/priceCards.tsx
+++ b/support-frontend/assets/components/priceCards/priceCards.tsx
@@ -4,6 +4,7 @@ import { ChoiceCardGroup } from '@guardian/source-react-components';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { currencies } from 'helpers/internationalisation/currency';
+import type { CSSOverridable } from 'helpers/types/cssOverrideable';
 import type { PriceCardPaymentInterval } from './priceCard';
 import { PriceCard } from './priceCard';
 
@@ -57,7 +58,7 @@ function getChoiceCardGroupStyles(lastButtonFullWidth: boolean) {
 	return [cardStyles, lastButtonFullWidthStyles, mobileGrid];
 }
 
-export type PriceCardsProps = {
+export interface PriceCardsProps extends CSSOverridable {
 	amounts: string[];
 	selectedAmount: string;
 	currency: IsoCurrency;
@@ -65,7 +66,7 @@ export type PriceCardsProps = {
 	paymentInterval?: PriceCardPaymentInterval;
 	otherAmountField?: React.ReactNode;
 	hideChooseYourAmount?: boolean;
-};
+}
 
 export function PriceCards({
 	amounts,
@@ -75,6 +76,7 @@ export function PriceCards({
 	paymentInterval,
 	otherAmountField,
 	hideChooseYourAmount,
+	cssOverrides,
 }: PriceCardsProps): JSX.Element {
 	// Override hideChooseYourAmount if no amounts supplied
 	const enableChooseYourAmountButton = !hideChooseYourAmount || !amounts.length;
@@ -84,7 +86,7 @@ export function PriceCards({
 	const lastButtonFullWidth = buttonCount % 2 !== 0;
 
 	return (
-		<div css={cardsContainer}>
+		<div css={[cardsContainer, cssOverrides]}>
 			<ChoiceCardGroup
 				cssOverrides={getChoiceCardGroupStyles(lastButtonFullWidth)}
 				name="amounts"

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -7,8 +7,8 @@ import {
 	setSelectedAmount,
 } from 'helpers/redux/checkout/product/actions';
 import {
-	checkUserAbTestStatus,
 	getMinimumContributionAmount,
+	isUserInAbVariant,
 } from 'helpers/redux/commonState/selectors';
 import { getOtherAmountErrors } from 'helpers/redux/selectors/formValidation/otherAmountValidation';
 import {
@@ -74,7 +74,7 @@ export function PriceCardsContainer({
 	const otherAmountErrors = useContributionsSelector(getOtherAmountErrors);
 
 	const useOptimisedMobileLayout = useContributionsSelector(
-		checkUserAbTestStatus('supporterPlusMobileTest1', 'variant'),
+		isUserInAbVariant('supporterPlusMobileTest1', 'variant'),
 	);
 
 	const otherAmount = otherAmounts[frequency].amount ?? '';

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -1,10 +1,15 @@
+import { css } from '@emotion/react';
+import { space, until } from '@guardian/source-foundations';
 import type { OtherAmountProps } from 'components/otherAmount/otherAmount';
 import type { ContributionType, SelectedAmounts } from 'helpers/contributions';
 import {
 	setOtherAmount,
 	setSelectedAmount,
 } from 'helpers/redux/checkout/product/actions';
-import { getMinimumContributionAmount } from 'helpers/redux/commonState/selectors';
+import {
+	checkUserAbTestStatus,
+	getMinimumContributionAmount,
+} from 'helpers/redux/commonState/selectors';
 import { getOtherAmountErrors } from 'helpers/redux/selectors/formValidation/otherAmountValidation';
 import {
 	useContributionsDispatch,
@@ -12,6 +17,14 @@ import {
 } from 'helpers/redux/storeHooks';
 import type { PriceCardPaymentInterval } from './priceCard';
 import type { PriceCardsProps } from './priceCards';
+
+const optimisedLayoutOverrides = css`
+	${until.tablet} {
+		&:not(:last-child) {
+			padding-bottom: ${space[1]}px;
+		}
+	}
+`;
 
 type PriceCardsRenderProps = PriceCardsProps & OtherAmountProps;
 
@@ -59,6 +72,11 @@ export function PriceCardsContainer({
 		defaultAmount,
 	).toString();
 	const otherAmountErrors = useContributionsSelector(getOtherAmountErrors);
+
+	const useOptimisedMobileLayout = useContributionsSelector(
+		checkUserAbTestStatus('supporterPlusMobileTest1', 'variant'),
+	);
+
 	const otherAmount = otherAmounts[frequency].amount ?? '';
 
 	function onAmountChange(newAmount: string) {
@@ -90,5 +108,8 @@ export function PriceCardsContainer({
 		onOtherAmountChange,
 		hideChooseYourAmount,
 		errors: otherAmountErrors,
+		cssOverrides: useOptimisedMobileLayout
+			? optimisedLayoutOverrides
+			: undefined,
 	});
 }

--- a/support-frontend/assets/components/secureTransactionIndicator/secureTransactionIndicator.tsx
+++ b/support-frontend/assets/components/secureTransactionIndicator/secureTransactionIndicator.tsx
@@ -1,53 +1,19 @@
 import { css } from '@emotion/react';
-import {
-	from,
-	neutral,
-	space,
-	textSans,
-	until,
-} from '@guardian/source-foundations';
+import { neutral, textSans } from '@guardian/source-foundations';
 import SecurePadlock from './securePadlock.svg';
 import SecurePadlockCircle from './securePadlockCircle.svg';
 
 export type SecureTransactionIndicatorProps = {
-	position: string;
 	hideText?: boolean;
 };
 
-const secureTransaction = (position: string) => css`
+const secureTransactionWithText = css`
 	display: flex;
 	align-items: center;
-
-	${position === 'top' &&
-	`
-    margin-bottom: 6px;
-
-    ${from.tablet} {
-      position: absolute;
-      visibility: hidden;
-      display: none;
-    }
-  `}
-
-	${position === 'middle' &&
-	`
-    margin-top: -${space[3]}px;
-
-    ${until.tablet} {
-      position: absolute;
-      visibility: hidden;
-      display: none;
-    }
-  `}
-
-	${position === 'center' &&
-	`
-    justify-content: center;
-    align-items: center;
-  `}
+	justify-content: center;
 `;
 
-const suppPlusPayMethodIndicator = css`
+const secureTransactionIcon = css`
 	display: flex;
 	align-items: center;
 `;
@@ -63,13 +29,10 @@ const text = css`
 `;
 
 export function SecureTransactionIndicator({
-	position,
 	hideText,
 }: SecureTransactionIndicatorProps): JSX.Element {
 	return (
-		<div
-			css={hideText ? suppPlusPayMethodIndicator : secureTransaction(position)}
-		>
+		<div css={hideText ? secureTransactionIcon : secureTransactionWithText}>
 			{hideText ? (
 				<SecurePadlockCircle css={padlock} />
 			) : (

--- a/support-frontend/assets/components/secureTransactionIndicator/secureTransactionIndicator.tsx
+++ b/support-frontend/assets/components/secureTransactionIndicator/secureTransactionIndicator.tsx
@@ -1,16 +1,23 @@
 import { css } from '@emotion/react';
 import { neutral, textSans } from '@guardian/source-foundations';
+import type { CSSOverridable } from 'helpers/types/cssOverrideable';
 import SecurePadlock from './securePadlock.svg';
 import SecurePadlockCircle from './securePadlockCircle.svg';
 
-export type SecureTransactionIndicatorProps = {
+export interface SecureTransactionIndicatorProps extends CSSOverridable {
+	align?: 'left' | 'right' | 'center';
+	theme?: 'dark' | 'light';
 	hideText?: boolean;
-};
+}
 
-const secureTransactionWithText = css`
+const theming = (theme: 'dark' | 'light') => css`
+	color: ${theme === 'dark' ? neutral[46] : neutral[100]};
+`;
+
+const secureTransactionWithText = (align: 'left' | 'right' | 'center') => css`
 	display: flex;
 	align-items: center;
-	justify-content: center;
+	justify-content: ${align};
 `;
 
 const secureTransactionIcon = css`
@@ -20,19 +27,28 @@ const secureTransactionIcon = css`
 
 const padlock = css`
 	margin-right: 5px;
+	path {
+		fill: currentColor;
+	}
 `;
 
 const text = css`
 	${textSans.xsmall({ fontWeight: 'bold' })};
-	color: ${neutral[46]};
 	letter-spacing: 0.01em;
 `;
 
 export function SecureTransactionIndicator({
+	align = 'center',
+	theme = 'dark',
 	hideText,
+	cssOverrides,
 }: SecureTransactionIndicatorProps): JSX.Element {
+	const mainCss = hideText
+		? secureTransactionIcon
+		: secureTransactionWithText(align);
+	const overrides = cssOverrides ?? css``;
 	return (
-		<div css={hideText ? secureTransactionIcon : secureTransactionWithText}>
+		<div css={[mainCss, theming(theme), overrides]}>
 			{hideText ? (
 				<SecurePadlockCircle css={padlock} />
 			) : (

--- a/support-frontend/assets/components/secureTransactionIndicator/secureTransactionIndicator.tsx
+++ b/support-frontend/assets/components/secureTransactionIndicator/secureTransactionIndicator.tsx
@@ -12,6 +12,7 @@ export interface SecureTransactionIndicatorProps extends CSSOverridable {
 
 const theming = (theme: 'dark' | 'light') => css`
 	color: ${theme === 'dark' ? neutral[46] : neutral[100]};
+	opacity: ${theme === 'dark' ? 1 : 0.9};
 `;
 
 const secureTransactionWithText = (align: 'left' | 'right' | 'center') => css`
@@ -27,6 +28,7 @@ const secureTransactionIcon = css`
 
 const padlock = css`
 	margin-right: 5px;
+	opacity: inherit;
 	path {
 		fill: currentColor;
 	}
@@ -35,6 +37,7 @@ const padlock = css`
 const text = css`
 	${textSans.xsmall({ fontWeight: 'bold' })};
 	letter-spacing: 0.01em;
+	opacity: inherit;
 `;
 
 export function SecureTransactionIndicator({

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -100,4 +100,28 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		seed: 1,
 	},
+	supporterPlusMobileTest1: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+				breakpoint: {
+					minWidth: 'mobile',
+					maxWidth: 'tablet',
+				},
+			},
+		},
+		isActive: false,
+		referrerControlled: false,
+		targetPage: pageUrlRegexes.subscriptions.subsWeeklyPages,
+		seed: 12,
+	},
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -121,7 +121,7 @@ export const tests: Tests = {
 		},
 		isActive: false,
 		referrerControlled: false,
-		targetPage: pageUrlRegexes.subscriptions.subsWeeklyPages,
+		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		seed: 12,
 	},
 };

--- a/support-frontend/assets/helpers/redux/commonState/selectors.ts
+++ b/support-frontend/assets/helpers/redux/commonState/selectors.ts
@@ -48,3 +48,10 @@ export function getMaximumContributionAmount(
 
 	return max;
 }
+
+export function checkUserAbTestStatus(abTestName: string, variantName: string) {
+	return function getAbTestStatus(state: ContributionsState): boolean {
+		const participations = state.common.abParticipations;
+		return participations[abTestName] === variantName;
+	};
+}

--- a/support-frontend/assets/helpers/redux/commonState/selectors.ts
+++ b/support-frontend/assets/helpers/redux/commonState/selectors.ts
@@ -49,7 +49,7 @@ export function getMaximumContributionAmount(
 	return max;
 }
 
-export function checkUserAbTestStatus(abTestName: string, variantName: string) {
+export function isUserInAbVariant(abTestName: string, variantName: string) {
 	return function getAbTestStatus(state: ContributionsState): boolean {
 		const participations = state.common.abParticipations;
 		return participations[abTestName] === variantName;

--- a/support-frontend/assets/pages/kindle-subscriber-checkout/kindleSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/kindle-subscriber-checkout/kindleSubscriptionLandingPage.tsx
@@ -167,7 +167,7 @@ export function SupporterPlusLandingPage({
 							<BoxContents>
 								{/* The same Stripe provider *must* enclose the Stripe card form and payment button(s). */}
 								<ContributionsStripe>
-									<SecureTransactionIndicator position="center" />
+									<SecureTransactionIndicator align="center" />
 									<PersonalDetailsContainer
 										renderPersonalDetails={(personalDetailsProps) => (
 											<PersonalDetails {...personalDetailsProps} />

--- a/support-frontend/assets/pages/supporter-plus-landing/components/checkoutDivider.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/checkoutDivider.tsx
@@ -1,0 +1,38 @@
+import { css } from '@emotion/react';
+import { brand, space, until } from '@guardian/source-foundations';
+import { Divider } from '@guardian/source-react-components-development-kitchen';
+import type { FinePrintTheme } from './finePrint';
+
+const looseSpacing = css`
+	margin: 40px 0 ${space[6]}px;
+`;
+
+const tightSpacing = css`
+	margin: ${space[4]}px 0;
+`;
+
+const lightColour = css`
+	${until.tablet} {
+		background-color: ${brand[600]};
+	}
+`;
+
+const divider = (spacing: DividerSpacing, theme: FinePrintTheme) => css`
+	max-width: 100%;
+	${spacing === 'tight' ? tightSpacing : looseSpacing};
+	${theme === 'light' ? lightColour : ''};
+`;
+
+type DividerSpacing = 'loose' | 'tight';
+
+type CheckoutDividerProps = {
+	spacing: DividerSpacing;
+	theme?: FinePrintTheme;
+};
+
+export function CheckoutDivider({
+	spacing,
+	theme = 'dark',
+}: CheckoutDividerProps): JSX.Element {
+	return <Divider size="full" cssOverrides={divider(spacing, theme)} />;
+}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/checkoutDivider.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/checkoutDivider.tsx
@@ -27,12 +27,12 @@ type DividerSpacing = 'loose' | 'tight';
 
 type CheckoutDividerProps = {
 	spacing: DividerSpacing;
-	theme?: FinePrintTheme;
+	mobileTheme?: FinePrintTheme;
 };
 
 export function CheckoutDivider({
 	spacing,
-	theme = 'dark',
+	mobileTheme = 'dark',
 }: CheckoutDividerProps): JSX.Element {
-	return <Divider size="full" cssOverrides={divider(spacing, theme)} />;
+	return <Divider size="full" cssOverrides={divider(spacing, mobileTheme)} />;
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/components/finePrint.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/finePrint.tsx
@@ -1,0 +1,23 @@
+import { css } from '@emotion/react';
+import { neutral, textSans, until } from '@guardian/source-foundations';
+
+const textStyles = (theme: FinePrintTheme) => css`
+	${textSans.xxsmall({ lineHeight: 'regular' })};
+	color: #606060;
+
+	/* TODO: Added for A/B test supporterPlusMobileTest1, may be removable in future */
+	${until.tablet} {
+		color: ${theme === 'dark' ? '#606060' : neutral[100]};
+	}
+`;
+
+export type FinePrintTheme = 'dark' | 'light';
+
+type FinePrintProps = {
+	theme: FinePrintTheme;
+	children: React.ReactNode;
+};
+
+export function FinePrint({ theme, children }: FinePrintProps): JSX.Element {
+	return <div css={textStyles(theme)}>{children}</div>;
+}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/finePrint.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/finePrint.tsx
@@ -5,7 +5,6 @@ const textStyles = (theme: FinePrintTheme) => css`
 	${textSans.xxsmall({ lineHeight: 'regular' })};
 	color: #606060;
 
-	/* TODO: Added for A/B test supporterPlusMobileTest1, may be removable in future */
 	${until.tablet} {
 		color: ${theme === 'dark' ? '#606060' : neutral[100]};
 	}
@@ -14,10 +13,13 @@ const textStyles = (theme: FinePrintTheme) => css`
 export type FinePrintTheme = 'dark' | 'light';
 
 type FinePrintProps = {
-	theme: FinePrintTheme;
+	mobileTheme: FinePrintTheme;
 	children: React.ReactNode;
 };
 
-export function FinePrint({ theme, children }: FinePrintProps): JSX.Element {
-	return <div css={textStyles(theme)}>{children}</div>;
+export function FinePrint({
+	mobileTheme,
+	children,
+}: FinePrintProps): JSX.Element {
+	return <div css={textStyles(mobileTheme)}>{children}</div>;
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/components/finePrint.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/finePrint.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
 import { neutral, textSans, until } from '@guardian/source-foundations';
 
-const textStyles = (theme: FinePrintTheme) => css`
-	${textSans.xxsmall({ lineHeight: 'regular' })};
+const textStyles = (theme: FinePrintTheme, size: FinePrintSize) => css`
+	${textSans[size]({ lineHeight: 'regular' })};
 	color: #606060;
 
 	${until.tablet} {
@@ -12,14 +12,18 @@ const textStyles = (theme: FinePrintTheme) => css`
 
 export type FinePrintTheme = 'dark' | 'light';
 
+type FinePrintSize = 'xsmall' | 'xxsmall';
+
 type FinePrintProps = {
 	mobileTheme: FinePrintTheme;
+	size?: FinePrintSize;
 	children: React.ReactNode;
 };
 
 export function FinePrint({
 	mobileTheme,
+	size = 'xxsmall',
 	children,
 }: FinePrintProps): JSX.Element {
-	return <div css={textStyles(mobileTheme)}>{children}</div>;
+	return <div css={textStyles(mobileTheme, size)}>{children}</div>;
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/components/guardianTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/guardianTsAndCs.tsx
@@ -2,12 +2,12 @@ import type { FinePrintTheme } from './finePrint';
 import { FinePrint } from './finePrint';
 
 export function GuardianTsAndCs({
-	theme = 'dark',
+	mobileTheme = 'dark',
 }: {
-	theme?: FinePrintTheme;
+	mobileTheme?: FinePrintTheme;
 }): JSX.Element {
 	return (
-		<FinePrint theme={theme}>
+		<FinePrint mobileTheme={mobileTheme}>
 			<p>
 				The ultimate owner of the Guardian is The Scott Trust Limited, whose
 				role it is to secure the editorial and financial independence of the

--- a/support-frontend/assets/pages/supporter-plus-landing/components/guardianTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/guardianTsAndCs.tsx
@@ -1,14 +1,13 @@
-import { css } from '@emotion/react';
-import { textSans } from '@guardian/source-foundations';
+import type { FinePrintTheme } from './finePrint';
+import { FinePrint } from './finePrint';
 
-const fontStyles = css`
-	${textSans.xxsmall({ lineHeight: 'regular' })};
-	color: #606060;
-`;
-
-export function GuardianTsAndCs(): JSX.Element {
+export function GuardianTsAndCs({
+	theme = 'dark',
+}: {
+	theme?: FinePrintTheme;
+}): JSX.Element {
 	return (
-		<div css={fontStyles}>
+		<FinePrint theme={theme}>
 			<p>
 				The ultimate owner of the Guardian is The Scott Trust Limited, whose
 				role it is to secure the editorial and financial independence of the
@@ -17,6 +16,6 @@ export function GuardianTsAndCs(): JSX.Element {
 				charitable donation, so it is not eligible for Gift Aid in the UK nor a
 				tax-deduction elsewhere.
 			</p>
-		</div>
+		</FinePrint>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/components/patronsMessage.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/patronsMessage.tsx
@@ -1,32 +1,30 @@
 import { css } from '@emotion/react';
-import { headline, space, textSans } from '@guardian/source-foundations';
+import { headline, space } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { getPatronsLink } from 'helpers/urls/externalLinks';
+import type { FinePrintTheme } from './finePrint';
+import { FinePrint } from './finePrint';
 
 const headingStyles = css`
 	${headline.xxxsmall({ fontWeight: 'bold' })};
-	color: #606060;
 	margin-bottom: ${space[1]}px;
-`;
-
-const copyStyles = css`
-	${textSans.xsmall({ lineHeight: 'regular' })};
-	color: #606060;
 `;
 
 const linkStyles = css`
 	font-size: inherit;
 	line-height: inherit;
-	color: #606060;
+	color: inherit;
 `;
 
 const intCMPParameter = 'gdnwb_copts_support_contributions_referral';
 
 export function PatronsMessage({
 	countryGroupId,
+	theme = 'dark',
 }: {
 	countryGroupId: CountryGroupId;
+	theme?: FinePrintTheme;
 }): JSX.Element {
 	const patronageAmountsWithGlyph = {
 		GBPCountries: '£100',
@@ -40,12 +38,12 @@ export function PatronsMessage({
 	const isUSA = countryGroupId === 'UnitedStates';
 
 	return (
-		<>
+		<FinePrint theme={theme}>
 			<h2 css={headingStyles}>
 				{isUSA ? 'Support another way' : 'Guardian Patrons programme'}
 			</h2>
 			{isUSA ? (
-				<p css={copyStyles}>
+				<p>
 					To learn more about other ways to support the Guardian, including
 					checks and tax-exempt options, please visit our{' '}
 					<Link
@@ -58,7 +56,7 @@ export function PatronsMessage({
 					on this topic.
 				</p>
 			) : (
-				<p css={copyStyles}>
+				<p>
 					If you would like to support us at a higher level, from{' '}
 					{patronageAmountsWithGlyph[countryGroupId]} a month, you can join us
 					as a Guardian Patron.{' '}
@@ -71,6 +69,6 @@ export function PatronsMessage({
 					</Link>
 				</p>
 			)}
-		</>
+		</FinePrint>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/components/patronsMessage.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/patronsMessage.tsx
@@ -38,7 +38,7 @@ export function PatronsMessage({
 	const isUSA = countryGroupId === 'UnitedStates';
 
 	return (
-		<FinePrint mobileTheme={mobileTheme}>
+		<FinePrint mobileTheme={mobileTheme} size="xsmall">
 			<h2 css={headingStyles}>
 				{isUSA ? 'Support another way' : 'Guardian Patrons programme'}
 			</h2>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/patronsMessage.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/patronsMessage.tsx
@@ -21,10 +21,10 @@ const intCMPParameter = 'gdnwb_copts_support_contributions_referral';
 
 export function PatronsMessage({
 	countryGroupId,
-	theme = 'dark',
+	mobileTheme = 'dark',
 }: {
 	countryGroupId: CountryGroupId;
-	theme?: FinePrintTheme;
+	mobileTheme?: FinePrintTheme;
 }): JSX.Element {
 	const patronageAmountsWithGlyph = {
 		GBPCountries: '£100',
@@ -38,7 +38,7 @@ export function PatronsMessage({
 	const isUSA = countryGroupId === 'UnitedStates';
 
 	return (
-		<FinePrint theme={theme}>
+		<FinePrint mobileTheme={mobileTheme}>
 			<h2 css={headingStyles}>
 				{isUSA ? 'Support another way' : 'Guardian Patrons programme'}
 			</h2>

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -37,6 +37,7 @@ export function AmountAndBenefits(): JSX.Element {
 									onOtherAmountChange,
 									hideChooseYourAmount,
 									errors,
+									cssOverrides,
 								}) => (
 									<>
 										<PriceCards
@@ -46,6 +47,7 @@ export function AmountAndBenefits(): JSX.Element {
 											paymentInterval={paymentInterval}
 											onAmountChange={onAmountChange}
 											hideChooseYourAmount={hideChooseYourAmount}
+											cssOverrides={cssOverrides}
 											otherAmountField={
 												<OtherAmount
 													currency={currency}

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -199,7 +199,9 @@ export function SupporterPlusLandingPage({
 				<Columns cssOverrides={checkoutContainer} collapseUntil="tablet">
 					<Column span={[0, 2, 5]}></Column>
 					<Column span={[1, 8, 7]}>
-						<Hide from="desktop">{heading}</Hide>
+						<Hide from="desktop">
+							{optimisedMobileLayout ? <SecureTransactionIndicator /> : heading}
+						</Hide>
 						<Box>
 							<AmountAndBenefits />
 						</Box>
@@ -207,7 +209,7 @@ export function SupporterPlusLandingPage({
 							<BoxContents>
 								{/* The same Stripe provider *must* enclose the Stripe card form and payment button(s). Also enclosing the PRB reduces re-renders. */}
 								<ContributionsStripe>
-									<SecureTransactionIndicator position="center" />
+									<SecureTransactionIndicator />
 									<PaymentRequestButtonContainer
 										CustomButton={SavedCardButton}
 									/>

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -200,7 +200,17 @@ export function SupporterPlusLandingPage({
 					<Column span={[0, 2, 5]}></Column>
 					<Column span={[1, 8, 7]}>
 						<Hide from="desktop">
-							{optimisedMobileLayout ? <SecureTransactionIndicator /> : heading}
+							{optimisedMobileLayout ? (
+								<SecureTransactionIndicator
+									align="left"
+									theme="light"
+									cssOverrides={css`
+										margin-bottom: 10px;
+									`}
+								/>
+							) : (
+								heading
+							)}
 						</Hide>
 						<Box>
 							<AmountAndBenefits />

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -1,5 +1,12 @@
 import { css } from '@emotion/react';
-import { from, neutral, space, textSans } from '@guardian/source-foundations';
+import {
+	brand,
+	from,
+	neutral,
+	space,
+	textSans,
+	until,
+} from '@guardian/source-foundations';
 import { Column, Columns, Hide } from '@guardian/source-react-components';
 import {
 	Divider,
@@ -68,6 +75,17 @@ const checkoutContainer = css`
 	}
 `;
 
+const backgroundContainer = css`
+	background-color: ${neutral[97]};
+`;
+
+const darkBackgroundContainerMobile = css`
+	${backgroundContainer}
+	${until.tablet} {
+		background-color: ${brand[400]};
+	}
+`;
+
 const divider = css`
 	max-width: 100%;
 	margin: 40px 0 ${space[6]}px;
@@ -102,11 +120,18 @@ export function SupporterPlusLandingPage({
 		countryGroupId,
 	);
 
+	const participations = useContributionsSelector(
+		(state) => state.common.abParticipations,
+	);
+
 	const { paymentComplete, isWaiting } = useContributionsSelector(
 		(state) => state.page.form,
 	);
 
 	const navigate = useNavigate();
+
+	const optimisedMobileLayout =
+		participations.supporterPlusMobileTest1 === 'variant';
 
 	const countrySwitcherProps: CountryGroupSwitcherProps = {
 		countryGroupIds: [
@@ -168,7 +193,14 @@ export function SupporterPlusLandingPage({
 					reporting on the events shaping our world.
 				</p>
 			</CheckoutHeading>
-			<Container sideBorders backgroundColor={neutral[97]}>
+			<Container
+				sideBorders
+				cssOverrides={
+					optimisedMobileLayout
+						? darkBackgroundContainerMobile
+						: backgroundContainer
+				}
+			>
 				<Columns cssOverrides={checkoutContainer} collapseUntil="tablet">
 					<Column span={[0, 2, 5]}></Column>
 					<Column span={[1, 8, 7]}>

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -246,9 +246,13 @@ export function SupporterPlusLandingPage({
 										)}
 									/>
 									<PaymentButtonController
-										cssOverrides={css`
-											margin-top: 30px;
-										`}
+										cssOverrides={
+											optimisedMobileLayout
+												? css`
+														margin-top: 30px;
+												  `
+												: css``
+										}
 										paymentButtons={getPaymentMethodButtons(
 											contributionType,
 											switches,

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -257,7 +257,7 @@ export function SupporterPlusLandingPage({
 						</Box>
 						<CheckoutDivider
 							spacing="loose"
-							theme={optimisedMobileLayout ? 'light' : 'dark'}
+							mobileTheme={optimisedMobileLayout ? 'light' : 'dark'}
 						/>
 						<PatronsMessage
 							countryGroupId={countryGroupId}
@@ -265,7 +265,7 @@ export function SupporterPlusLandingPage({
 						/>
 						<CheckoutDivider
 							spacing="tight"
-							theme={optimisedMobileLayout ? 'light' : 'dark'}
+							mobileTheme={optimisedMobileLayout ? 'light' : 'dark'}
 						/>
 						<GuardianTsAndCs
 							mobileTheme={optimisedMobileLayout ? 'light' : 'dark'}

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -45,7 +45,7 @@ import {
 } from 'helpers/internationalisation/countryGroup';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
-import { checkUserAbTestStatus } from 'helpers/redux/commonState/selectors';
+import { isUserInAbVariant } from 'helpers/redux/commonState/selectors';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { shouldShowSupporterPlusMessaging } from 'helpers/supporterPlus/showMessaging';
 import { CheckoutDivider } from './components/checkoutDivider';
@@ -126,7 +126,7 @@ export function SupporterPlusLandingPage({
 	);
 
 	const optimisedMobileLayout = useContributionsSelector(
-		checkUserAbTestStatus('supporterPlusMobileTest1', 'variant'),
+		isUserInAbVariant('supporterPlusMobileTest1', 'variant'),
 	);
 
 	const { paymentComplete, isWaiting } = useContributionsSelector(

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -83,6 +83,15 @@ const darkBackgroundContainerMobile = css`
 	${backgroundContainer}
 	${until.tablet} {
 		background-color: ${brand[400]};
+		border-bottom: 1px solid ${brand[600]};
+	}
+`;
+
+const shorterBoxMargin = css`
+	:not(:last-child) {
+		${until.tablet} {
+			margin-bottom: ${space[2]}px;
+		}
 	}
 `;
 
@@ -212,10 +221,14 @@ export function SupporterPlusLandingPage({
 								heading
 							)}
 						</Hide>
-						<Box>
+						<Box
+							cssOverrides={optimisedMobileLayout ? shorterBoxMargin : css``}
+						>
 							<AmountAndBenefits />
 						</Box>
-						<Box>
+						<Box
+							cssOverrides={optimisedMobileLayout ? shorterBoxMargin : css``}
+						>
 							<BoxContents>
 								{/* The same Stripe provider *must* enclose the Stripe card form and payment button(s). Also enclosing the PRB reduces re-renders. */}
 								<ContributionsStripe>
@@ -235,6 +248,9 @@ export function SupporterPlusLandingPage({
 										)}
 									/>
 									<PaymentButtonController
+										cssOverrides={css`
+											margin-top: 30px;
+										`}
 										paymentButtons={getPaymentMethodButtons(
 											contributionType,
 											switches,

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -45,6 +45,7 @@ import {
 } from 'helpers/internationalisation/countryGroup';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
+import { checkUserAbTestStatus } from 'helpers/redux/commonState/selectors';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { shouldShowSupporterPlusMessaging } from 'helpers/supporterPlus/showMessaging';
 import { CheckoutDivider } from './components/checkoutDivider';
@@ -124,8 +125,8 @@ export function SupporterPlusLandingPage({
 		countryGroupId,
 	);
 
-	const participations = useContributionsSelector(
-		(state) => state.common.abParticipations,
+	const optimisedMobileLayout = useContributionsSelector(
+		checkUserAbTestStatus('supporterPlusMobileTest1', 'variant'),
 	);
 
 	const { paymentComplete, isWaiting } = useContributionsSelector(
@@ -133,9 +134,6 @@ export function SupporterPlusLandingPage({
 	);
 
 	const navigate = useNavigate();
-
-	const optimisedMobileLayout =
-		participations.supporterPlusMobileTest1 === 'variant';
 
 	const countrySwitcherProps: CountryGroupSwitcherProps = {
 		countryGroupIds: [

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -9,7 +9,6 @@ import {
 } from '@guardian/source-foundations';
 import { Column, Columns, Hide } from '@guardian/source-react-components';
 import {
-	Divider,
 	FooterLinks,
 	FooterWithContents,
 } from '@guardian/source-react-components-development-kitchen';
@@ -48,6 +47,7 @@ import { getContributionType } from 'helpers/redux/checkout/product/selectors/pr
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { shouldShowSupporterPlusMessaging } from 'helpers/supporterPlus/showMessaging';
+import { CheckoutDivider } from './components/checkoutDivider';
 import { DirectDebitContainer } from './components/directDebitWrapper';
 import { ExistingRecurringContributorMessage } from './components/existingRecurringContributorMessage';
 import { GuardianTsAndCs } from './components/guardianTsAndCs';
@@ -84,11 +84,6 @@ const darkBackgroundContainerMobile = css`
 	${until.tablet} {
 		background-color: ${brand[400]};
 	}
-`;
-
-const divider = css`
-	max-width: 100%;
-	margin: 40px 0 ${space[6]}px;
 `;
 
 const subheading = css`
@@ -221,7 +216,7 @@ export function SupporterPlusLandingPage({
 											<PersonalDetails {...personalDetailsProps} />
 										)}
 									/>
-									<Divider size="full" cssOverrides={divider} />
+									<CheckoutDivider spacing="loose" />
 									<PaymentMethodSelectorContainer
 										render={(paymentMethodSelectorProps) => (
 											<PaymentMethodSelector {...paymentMethodSelectorProps} />
@@ -248,16 +243,19 @@ export function SupporterPlusLandingPage({
 								/>
 							</BoxContents>
 						</Box>
-						<Divider size="full" cssOverrides={divider} />
-						<PatronsMessage countryGroupId={countryGroupId} />
-						<Divider
-							size="full"
-							cssOverrides={css`
-								max-width: 100%;
-								margin: ${space[4]}px 0 ${space[4]}px;
-							`}
+						<CheckoutDivider
+							spacing="loose"
+							theme={optimisedMobileLayout ? 'light' : 'dark'}
 						/>
-						<GuardianTsAndCs />
+						<PatronsMessage
+							countryGroupId={countryGroupId}
+							theme={optimisedMobileLayout ? 'light' : 'dark'}
+						/>
+						<CheckoutDivider
+							spacing="tight"
+							theme={optimisedMobileLayout ? 'light' : 'dark'}
+						/>
+						<GuardianTsAndCs theme={optimisedMobileLayout ? 'light' : 'dark'} />
 					</Column>
 				</Columns>
 			</Container>

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -261,13 +261,15 @@ export function SupporterPlusLandingPage({
 						/>
 						<PatronsMessage
 							countryGroupId={countryGroupId}
-							theme={optimisedMobileLayout ? 'light' : 'dark'}
+							mobileTheme={optimisedMobileLayout ? 'light' : 'dark'}
 						/>
 						<CheckoutDivider
 							spacing="tight"
 							theme={optimisedMobileLayout ? 'light' : 'dark'}
 						/>
-						<GuardianTsAndCs theme={optimisedMobileLayout ? 'light' : 'dark'} />
+						<GuardianTsAndCs
+							mobileTheme={optimisedMobileLayout ? 'light' : 'dark'}
+						/>
 					</Column>
 				</Columns>
 			</Container>

--- a/support-frontend/stories/checkouts/SecureTransactionIndicator.stories.tsx
+++ b/support-frontend/stories/checkouts/SecureTransactionIndicator.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import React from 'react';
+import type { SecureTransactionIndicatorProps } from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import { SecureTransactionIndicator as SecureTransactionIndicatorComponent } from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import { withCenterAlignment } from '../../.storybook/decorators/withCenterAlignment';
 
@@ -19,12 +20,26 @@ export default {
 	],
 };
 
-export function SecureTransactionIndicator(args: {
-	position: string;
-}): JSX.Element {
-	return <SecureTransactionIndicatorComponent position={args.position} />;
+function Template(args: SecureTransactionIndicatorProps): JSX.Element {
+	return <SecureTransactionIndicatorComponent {...args} />;
 }
 
-SecureTransactionIndicator.args = {
-	position: 'center',
+Template.args = {} as SecureTransactionIndicatorProps;
+
+export const DarkTheme = Template.bind({});
+
+DarkTheme.args = {
+	theme: 'dark',
+};
+
+export const LightTheme = Template.bind({});
+
+LightTheme.args = {
+	theme: 'light',
+};
+
+export const IconOnly = Template.bind({});
+
+IconOnly.args = {
+	hideText: true,
 };

--- a/support-frontend/stories/checkouts/SecureTransactionIndicator.stories.tsx
+++ b/support-frontend/stories/checkouts/SecureTransactionIndicator.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { brand } from '@guardian/source-foundations';
 import React from 'react';
 import type { SecureTransactionIndicatorProps } from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import { SecureTransactionIndicator as SecureTransactionIndicatorComponent } from 'components/secureTransactionIndicator/secureTransactionIndicator';
@@ -25,6 +26,7 @@ function Template(args: SecureTransactionIndicatorProps): JSX.Element {
 }
 
 Template.args = {} as SecureTransactionIndicatorProps;
+Template.decorators = [] as unknown[];
 
 export const DarkTheme = Template.bind({});
 
@@ -37,6 +39,22 @@ export const LightTheme = Template.bind({});
 LightTheme.args = {
 	theme: 'light',
 };
+
+LightTheme.decorators = [
+	(Story: React.FC): JSX.Element => (
+		<div
+			css={[
+				maxWidth,
+				css`
+					background-color: ${brand[400]};
+				`,
+			]}
+		>
+			<Story />
+		</div>
+	),
+	withCenterAlignment,
+];
 
 export const IconOnly = Template.bind({});
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR sets up the first mobile optimisation test. I've also refactored a few components used in the checkout that were relevant to the test to make them a little more flexible and easier to apply conditional styling to.

[**Trello Card**](https://trello.com/c/zdqCSfuk)

## Why are you doing this?

This test aims to start to streamline the user flow on mobile.

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots
![Screenshot 2023-02-22 at 10-57-53 Support the Guardian](https://user-images.githubusercontent.com/29146931/220600886-0838852f-771c-467a-af23-87f4e1e16b6d.png)
