### PR TITLE
Revert "Only render existing payment methods that have a valid billingAccountId"

### DIFF
--- a/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
+++ b/support-frontend/assets/components/existingMethodPaymentButton/existingCardPaymentButton.tsx
@@ -8,7 +8,6 @@ import { onThirdPartyPaymentAuthorised } from 'pages/supporter-plus-landing/setu
 
 export function ExistingCardPaymentButton(): JSX.Element {
 	const dispatch = useContributionsDispatch();
-
 	const { selectedPaymentMethod } = useContributionsSelector(
 		(state) => state.page.checkoutForm.payment.existingPaymentMethods,
 	);
@@ -22,5 +21,10 @@ export function ExistingCardPaymentButton(): JSX.Element {
 		);
 	});
 
-	return <DefaultPaymentButtonContainer onClick={payWithExistingCard} />;
+	return (
+		<DefaultPaymentButtonContainer
+			onClick={payWithExistingCard}
+			disabled={!!selectedPaymentMethod?.billingAccountId}
+		/>
+	);
 }

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButton.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButton.tsx
@@ -22,10 +22,16 @@ export function DefaultPaymentButton({
 	id,
 	buttonText,
 	onClick,
+	disabled = false,
 }: DefaultPaymentButtonProps): JSX.Element {
 	return (
 		<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-			<Button id={id} cssOverrides={buttonOverrides} onClick={onClick}>
+			<Button
+				id={id}
+				cssOverrides={buttonOverrides}
+				onClick={onClick}
+				disabled={disabled}
+			>
 				{buttonText}
 			</Button>
 		</ThemeProvider>

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -43,6 +43,7 @@ function getButtonText(
 export function DefaultPaymentButtonContainer({
 	onClick,
 	createButtonText = getButtonText,
+	disabled = false,
 }: DefaultPaymentContainerProps): JSX.Element {
 	const { currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
@@ -82,6 +83,7 @@ export function DefaultPaymentButtonContainer({
 			id={testId}
 			buttonText={buttonText}
 			onClick={onClick}
+			disabled={disabled}
 		/>
 	);
 }

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -102,54 +102,48 @@ export function PaymentMethodSelector({
 				>
 					{[
 						<>
-							{existingPaymentMethodList
-								.filter(
-									(
-										preExistingPaymentMethod: RecentlySignedInExistingPaymentMethod,
-									) => !!preExistingPaymentMethod.billingAccountId,
-								)
-								.map(
-									(
-										preExistingPaymentMethod: RecentlySignedInExistingPaymentMethod,
-									) => {
-										const existingPaymentMethodType =
-											preExistingPaymentMethod.paymentType;
+							{existingPaymentMethodList.map(
+								(
+									preExistingPaymentMethod: RecentlySignedInExistingPaymentMethod,
+								) => {
+									const existingPaymentMethodType =
+										preExistingPaymentMethod.paymentType;
 
-										const paymentType: PaymentMethod =
-											existingPaymentMethodType === 'Card'
-												? 'ExistingCard'
-												: 'ExistingDirectDebit';
+									const paymentType: PaymentMethod =
+										existingPaymentMethodType === 'Card'
+											? 'ExistingCard'
+											: 'ExistingDirectDebit';
 
-										return (
-											<AvailablePaymentMethodAccordionRow
-												id={`paymentMethod-existing${preExistingPaymentMethod.billingAccountId}`}
-												name="paymentMethod"
-												label={getExistingPaymentMethodLabel(
+									return (
+										<AvailablePaymentMethodAccordionRow
+											id={`paymentMethod-existing${preExistingPaymentMethod.billingAccountId}`}
+											name="paymentMethod"
+											label={getExistingPaymentMethodLabel(
+												preExistingPaymentMethod,
+											)}
+											image={paymentMethodData[paymentType].icon}
+											checked={
+												paymentMethod === paymentType &&
+												existingPaymentMethod === preExistingPaymentMethod
+											}
+											supportingText={`Used for your ${subscriptionsToExplainerList(
+												preExistingPaymentMethod.subscriptions.map(
+													subscriptionToExplainerPart,
+												),
+											)}`}
+											onChange={() => {
+												onSelectPaymentMethod(
+													paymentType,
 													preExistingPaymentMethod,
-												)}
-												image={paymentMethodData[paymentType].icon}
-												checked={
-													paymentMethod === paymentType &&
-													existingPaymentMethod === preExistingPaymentMethod
-												}
-												supportingText={`Used for your ${subscriptionsToExplainerList(
-													preExistingPaymentMethod.subscriptions.map(
-														subscriptionToExplainerPart,
-													),
-												)}`}
-												onChange={() => {
-													onSelectPaymentMethod(
-														paymentType,
-														preExistingPaymentMethod,
-													);
-												}}
-												accordionBody={
-													paymentMethodData[paymentType].accordionBody
-												}
-											/>
-										);
-									},
-								)}
+												);
+											}}
+											accordionBody={
+												paymentMethodData[paymentType].accordionBody
+											}
+										/>
+									);
+								},
+							)}
 
 							{availablePaymentMethods.map((method) => (
 								<AvailablePaymentMethodAccordionRow


### PR DESCRIPTION
Reverts guardian/support-frontend#4766