### PR TITLE
Fix the Bug on error message for State / province dropdown (for US / AUS / CA pages)

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/address/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/reducer.ts
@@ -68,6 +68,12 @@ function getAddressFieldsSlice(type: AddressType) {
 			setState(state, action: PayloadAction<string>) {
 				state.state = action.payload;
 				state.errors = removeError('state', state.errors);
+				const validationResult = addressFieldsSchema.safeParse(state);
+				if (!validationResult.success) {
+					state.errorObject = getSliceErrorsFromZodResult(
+						validationResult.error.format(),
+					);
+				}
 			},
 			setPostcode(state, action: PayloadAction<string>) {
 				state.postCode = action.payload;

--- a/support-frontend/assets/helpers/redux/checkout/address/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/reducer.ts
@@ -68,12 +68,7 @@ function getAddressFieldsSlice(type: AddressType) {
 			setState(state, action: PayloadAction<string>) {
 				state.state = action.payload;
 				state.errors = removeError('state', state.errors);
-				const validationResult = addressFieldsSchema.safeParse(state);
-				if (!validationResult.success) {
-					state.errorObject = getSliceErrorsFromZodResult(
-						validationResult.error.format(),
-					);
-				}
+				delete state.errorObject?.state;
 			},
 			setPostcode(state, action: PayloadAction<string>) {
 				state.postCode = action.payload;


### PR DESCRIPTION
## What are you doing in this PR?

Fix the Bug on error message for State / province dropdown (for US / AUS / CA pages)

[**Trello Card**](https://trello.com/c/br9VGdKF/1100-bug-on-error-message-for-state-province-dropdown-for-us-aus-nz-pages)

## Why are you doing this?
Error messages is not dismissed when the users chooses an item from the dropdown for the State or Province dropdown on US / AUS and CA pages.

## Is this an AB test?
- [ ] Yes
- [x ] No

## Screenshots
**Before Change**
<img width="625" alt="image" src="https://user-images.githubusercontent.com/73653255/220499035-29be2119-145c-4518-a835-4f8f5b357f15.png">
<img width="625" alt="image" src="https://user-images.githubusercontent.com/73653255/220499075-f01e018f-fe92-4a90-8c38-5610959b769a.png">


**After Change**
<img width="625" alt="image" src="https://user-images.githubusercontent.com/73653255/220499152-bf040c18-6e2c-469c-ab29-9ac662693a5f.png">
<img width="625" alt="image" src="https://user-images.githubusercontent.com/73653255/220499180-a7bb98cf-e147-416b-b03d-2f4b380181ba.png">

