### PR TITLE
Simplify basis of detecting when a user is a test user

### DIFF
--- a/support-frontend/assets/helpers/user/reduxSetup.ts
+++ b/support-frontend/assets/helpers/user/reduxSetup.ts
@@ -7,39 +7,15 @@ import {
 	setTestUserStatus,
 } from 'helpers/redux/user/actions';
 import { get as getCookie } from 'helpers/storage/cookie';
-import { getSession } from 'helpers/storage/storage';
 import type { User } from './user';
-import {
-	doesUserAppearToBeSignedIn,
-	isPostDeployUser,
-	isTestUser,
-} from './user';
+import { isPostDeployUser, isTestUser } from './user';
 
 export function setUpUserState(
 	dispatch: ContributionsDispatch | SubscriptionsDispatch,
 ): void {
 	const windowHasUser = getGlobal<User>('user');
-	const userAppearsLoggedIn = doesUserAppearToBeSignedIn();
 
-	const emailFromBrowser = getGlobal<string>('email') ?? getSession('gu.email');
-
-	/*
-	 * Prevent use of the test stripe token if user is logged in, as support-workers will try it in live mode
-	 * if the identity cookie is present
-	 */
-	const emailMatchesTestUser = (): boolean => {
-		const testUsername = getCookie('_test_username');
-
-		if (emailFromBrowser && testUsername) {
-			return emailFromBrowser
-				.toLowerCase()
-				.startsWith(testUsername.toLowerCase());
-		}
-
-		return false;
-	};
-
-	if (isTestUser() && (!userAppearsLoggedIn || emailMatchesTestUser())) {
+	if (isTestUser()) {
 		dispatch(
 			setTestUserStatus({
 				isTestUser: true,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This simplifies the conditions around detecting when a user is using test credentials, to solve a bug that's arisen from merging user detection and setup logic between the contribution and subscriptions checkouts.