### PR TITLE
Change okhttp from 4.10.0 to 3.14.9 as it caused post deployment build failure

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -36,7 +36,7 @@ libraryDependencies ++= Seq(
   "org.seleniumhq.selenium" % "selenium-java" % "3.141.59" % "test",
   "org.scalatestplus" %% "scalatestplus-mockito" % "1.0.0-M2" % Test,
   "org.scalatestplus" %% "scalatestplus-selenium" % "1.0.0-M2" % Test,
-  "com.squareup.okhttp3" % "okhttp" % "4.10.0",
+  "com.squareup.okhttp3" % "okhttp" % "3.14.9",
   "com.gocardless" % "gocardless-pro" % "2.10.0",
   "com.googlecode.libphonenumber" % "libphonenumber" % "8.13.6",
   // This is required to force aws libraries to use the latest version of jackson


### PR DESCRIPTION

## What are you doing in this PR?

Change okhttp from 4.10.0 to 3.14.9 as it caused post deployment build failure

Scala Steward bot had upgraded okhttp to 4.10.0 from 3.14.9  in the  https://github.com/guardian/support-frontend/pull/4792.
But this caused post deployment test failures.So we need to revert it