### PR TITLE
Let metals update .scalafmt.conf

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,3 +4,11 @@ runner.dialect=scala213
 maxColumn = 120
 trailingCommas = always
 align.preset = none
+fileOverride {
+  "glob:**/support-internationalisation/src/test/scala/**" {
+     runner.dialect = scala3
+  }
+  "glob:**/support-internationalisation/src/main/scala/**" {
+     runner.dialect = scala3
+  }
+}


### PR DESCRIPTION
Emacs is using Metals to do some language server stuff for me, and it keeps asking to update .scalafmt.conf as follows. I assume it’s correct? We are using scala 3 in support-internationalisation, it looks like.