### PR TITLE
Add permission for it-test lambda to load the catalog

### DIFF
--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -61,12 +61,12 @@ Resources:
             - Effect: Allow
               Action: cloudwatch:PutMetricData
               Resource: "*"
-
         - Statement:
             - Effect: Allow
               Action: s3:GetObject
-              Resource: arn:aws:s3:::support-workers-private/CODE/support-workers.private.conf
-
+              Resource:
+               - arn:aws:s3:::support-workers-private/CODE/support-workers.private.conf
+               - arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-DEV/catalog.json
         - Statement:
             - Effect: Allow
               Action: dynamodb:Scan


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
#4474 introduced a new integration test for the creation of Supporter plus V2 subs but when this test runs in AWS via the [automated test runner](https://github.com/guardian/support-frontend/wiki/Automated-IT-Tests) it has been failing. 

This was because the runner lambda didn't have permission to load the catalog file from S3, this PR adds that permission.