### PR TITLE
nudge works at all  breakpoints

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -52,9 +52,6 @@ export const tests: Tests = {
 			ALL: {
 				offset: 0,
 				size: 1,
-				breakpoint: {
-					minWidth: 'tablet',
-				},
 			},
 		},
 		isActive: true,


### PR DESCRIPTION
Nudging component, encouraging single to monthly or modified annual recurring contributions
Rename test  to 'ab-singleToRecurringV3'

Annual Features->
- abtest to work at ALL breakpoints
- copy change variant (control stays monthly)
- minimum weekly contribution rounded (p = GPB Countries, displayCcy = remainder)
- 740px+ headline2 copy 
- <375px-739px headline2 copy font adjusted to fit in single line at 375px

control (All)
![Screenshot 2023-02-17 at 18 34 03](https://user-images.githubusercontent.com/76729591/219754000-4cd63b2a-4929-4926-bfbd-39ba83ef3371.png)

variant (All 740px+)
![Screenshot 2023-02-20 at 13 00 59](https://user-images.githubusercontent.com/76729591/220115995-968e1708-d5d8-48e5-9603-2a0612d6ad64.png)

variant (GBP / <375px->739px)
![Screenshot 2023-02-20 at 12 52 14](https://user-images.githubusercontent.com/76729591/220115206-e8cb200d-1709-4b38-9173-785c3c58624b.png)

variant (EUR / <375px->739px)
![Screenshot 2023-02-20 at 12 51 30](https://user-images.githubusercontent.com/76729591/220115253-a674057e-df3e-4d94-b6e4-105083eaf930.png)

variant (Others  / <375px->739px)
![Screenshot 2023-02-20 at 13 18 08](https://user-images.githubusercontent.com/76729591/220119635-02e32370-34b4-4cb5-a483-d77ba43320a3.png)


2-cohort A/B test for implementation ->
https://support.thegulocal.com/uk/contribute#ab-singleToRecurringV3=control (Monthly)
https://support.thegulocal.com/uk/contribute#ab-singleToRecurringV3=variant (NEW Annual)

## Is this an AB test?
- [x] Yes
- [ ] No




