### PR TITLE
Gh ophan payment method

### DIFF
--- a/support-frontend/assets/components/paymentFrequencyTabs/paymentFrequencyTabsContainer.tsx
+++ b/support-frontend/assets/components/paymentFrequencyTabs/paymentFrequencyTabsContainer.tsx
@@ -41,6 +41,7 @@ export function PaymentFrequencyTabsContainer({
 			countryId,
 			countryGroupId,
 		);
+
 		trackComponentClick(
 			`npf-contribution-type-toggle-${countryGroupId}-${contributionType}`,
 		);

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -14,7 +14,10 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
-import { trackComponentClick } from 'helpers/tracking/behaviour';
+import {
+	trackComponentClick,
+	trackComponentInsert,
+} from 'helpers/tracking/behaviour';
 import { sendEventContributionPaymentMethod } from 'helpers/tracking/quantumMetric';
 import type { PaymentMethodSelectorProps } from './paymentMethodSelector';
 
@@ -95,6 +98,23 @@ function PaymentMethodSelectorContainer({
 			dispatch(selectExistingPaymentMethod(existingPaymentMethod));
 	}
 
+	// TODO: Remove Duplication with onSelectPaymentMethod
+	function onRenderPaymentMethod(
+		paymentMethod: PaymentMethod,
+		existingPaymentMethod?: RecentlySignedInExistingPaymentMethod,
+	) {
+		const paymentMethodDescription = existingPaymentMethod
+			? existingPaymentMethod.paymentType
+			: paymentMethod;
+
+		console.log(
+			'onRenderPaymentMethod --->',
+			`payment-method-selector-${paymentMethodDescription}`,
+		);
+
+		trackComponentInsert(`payment-method-selector-${paymentMethodDescription}`);
+	}
+
 	useEffect(() => {
 		availablePaymentMethods.length === 1 &&
 			dispatch(setPaymentMethod(availablePaymentMethods[0]));
@@ -106,6 +126,7 @@ function PaymentMethodSelectorContainer({
 		validationError: errors?.[0],
 		...getExistingPaymentMethodProps(existingPaymentMethods),
 		onSelectPaymentMethod,
+		onRenderPaymentMethod,
 	});
 }
 

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -89,18 +89,16 @@ function PaymentMethodSelectorContainer({
 			? existingPaymentMethod.paymentType
 			: paymentMethod;
 
+		const trackingId = `payment-method-selector-${paymentMethodDescription}`;
+
 		if (event === 'select') {
-			trackComponentClick(
-				`payment-method-selector-${paymentMethodDescription}`,
-			);
+			trackComponentClick(trackingId);
 			sendEventContributionPaymentMethod(paymentMethodDescription);
 			dispatch(setPaymentMethod(paymentMethod));
 			existingPaymentMethod &&
 				dispatch(selectExistingPaymentMethod(existingPaymentMethod));
 		} else {
-			trackComponentInsert(
-				`payment-method-selector-${paymentMethodDescription}`,
-			);
+			trackComponentInsert(trackingId);
 		}
 	}
 

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -14,6 +14,7 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
+import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { sendEventContributionPaymentMethod } from 'helpers/tracking/quantumMetric';
 import type { PaymentMethodSelectorProps } from './paymentMethodSelector';
 
@@ -80,6 +81,15 @@ function PaymentMethodSelectorContainer({
 		paymentMethod: PaymentMethod,
 		existingPaymentMethod?: RecentlySignedInExistingPaymentMethod,
 	) {
+		// if (existingPaymentMethod) {
+		//   trackComponentClick({
+		//     `checkout`
+		//   })
+		// } else {
+		//   trackComponentClick({
+		//     `npf-contribution-amount-toggle-${countryGroupId}-${contributionType}-${amount}`
+		//   })
+		// }
 		sendEventContributionPaymentMethod(paymentMethod);
 		dispatch(setPaymentMethod(paymentMethod));
 		existingPaymentMethod &&

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -81,17 +81,16 @@ function PaymentMethodSelectorContainer({
 		paymentMethod: PaymentMethod,
 		existingPaymentMethod?: RecentlySignedInExistingPaymentMethod,
 	) {
-		// if (existingPaymentMethod) {
-		//   trackComponentClick({
-		//     `checkout`
-		//   })
-		// } else {
-		//   trackComponentClick({
-		//     `npf-contribution-amount-toggle-${countryGroupId}-${contributionType}-${amount}`
-		//   })
-		// }
-		sendEventContributionPaymentMethod(paymentMethod);
+		const paymentMethodDescription = existingPaymentMethod
+			? existingPaymentMethod.paymentType
+			: paymentMethod;
+
+		trackComponentClick(`payment-method-selector-${paymentMethodDescription}`);
+
+		sendEventContributionPaymentMethod(paymentMethodDescription);
+
 		dispatch(setPaymentMethod(paymentMethod));
+
 		existingPaymentMethod &&
 			dispatch(selectExistingPaymentMethod(existingPaymentMethod));
 	}

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -80,39 +80,28 @@ function PaymentMethodSelectorContainer({
 			methodName !== ExistingCard && methodName !== ExistingDirectDebit,
 	);
 
-	function onSelectPaymentMethod(
+	function onPaymentMethodEvent(
+		event: 'select' | 'render',
 		paymentMethod: PaymentMethod,
 		existingPaymentMethod?: RecentlySignedInExistingPaymentMethod,
-	) {
+	): void {
 		const paymentMethodDescription = existingPaymentMethod
 			? existingPaymentMethod.paymentType
 			: paymentMethod;
 
-		trackComponentClick(`payment-method-selector-${paymentMethodDescription}`);
-
-		sendEventContributionPaymentMethod(paymentMethodDescription);
-
-		dispatch(setPaymentMethod(paymentMethod));
-
-		existingPaymentMethod &&
-			dispatch(selectExistingPaymentMethod(existingPaymentMethod));
-	}
-
-	// TODO: Remove Duplication with onSelectPaymentMethod
-	function onRenderPaymentMethod(
-		paymentMethod: PaymentMethod,
-		existingPaymentMethod?: RecentlySignedInExistingPaymentMethod,
-	) {
-		const paymentMethodDescription = existingPaymentMethod
-			? existingPaymentMethod.paymentType
-			: paymentMethod;
-
-		console.log(
-			'onRenderPaymentMethod --->',
-			`payment-method-selector-${paymentMethodDescription}`,
-		);
-
-		trackComponentInsert(`payment-method-selector-${paymentMethodDescription}`);
+		if (event === 'select') {
+			trackComponentClick(
+				`payment-method-selector-${paymentMethodDescription}`,
+			);
+			sendEventContributionPaymentMethod(paymentMethodDescription);
+			dispatch(setPaymentMethod(paymentMethod));
+			existingPaymentMethod &&
+				dispatch(selectExistingPaymentMethod(existingPaymentMethod));
+		} else {
+			trackComponentInsert(
+				`payment-method-selector-${paymentMethodDescription}`,
+			);
+		}
 	}
 
 	useEffect(() => {
@@ -125,8 +114,7 @@ function PaymentMethodSelectorContainer({
 		paymentMethod: name,
 		validationError: errors?.[0],
 		...getExistingPaymentMethodProps(existingPaymentMethods),
-		onSelectPaymentMethod,
-		onRenderPaymentMethod,
+		onPaymentMethodEvent,
 	});
 }
 

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -50,11 +50,8 @@ export interface PaymentMethodSelectorProps {
 	existingPaymentMethodList: RecentlySignedInExistingPaymentMethod[];
 	pendingExistingPaymentMethods?: boolean;
 	showReauthenticateLink?: boolean;
-	onSelectPaymentMethod: (
-		paymentMethod: PaymentMethod,
-		existingPaymentMethod?: RecentlySignedInExistingPaymentMethod,
-	) => void;
-	onRenderPaymentMethod: (
+	onPaymentMethodEvent: (
+		event: 'select' | 'render',
 		paymentMethod: PaymentMethod,
 		existingPaymentMethod?: RecentlySignedInExistingPaymentMethod,
 	) => void;
@@ -68,8 +65,7 @@ export function PaymentMethodSelector({
 	existingPaymentMethodList,
 	pendingExistingPaymentMethods,
 	showReauthenticateLink,
-	onSelectPaymentMethod,
-	onRenderPaymentMethod,
+	onPaymentMethodEvent,
 }: PaymentMethodSelectorProps): JSX.Element {
 	if (
 		existingPaymentMethodList.length < 1 &&
@@ -143,7 +139,8 @@ export function PaymentMethodSelector({
 													),
 												)}`}
 												onChange={() => {
-													onSelectPaymentMethod(
+													onPaymentMethodEvent(
+														'select',
 														paymentType,
 														preExistingPaymentMethod,
 													);
@@ -152,7 +149,8 @@ export function PaymentMethodSelector({
 													paymentMethodData[paymentType].accordionBody
 												}
 												onRender={() => {
-													onRenderPaymentMethod(
+													onPaymentMethodEvent(
+														'render',
 														paymentType,
 														preExistingPaymentMethod,
 													);
@@ -169,9 +167,9 @@ export function PaymentMethodSelector({
 									label={paymentMethodData[method].label}
 									name="paymentMethod"
 									checked={paymentMethod === method}
-									onChange={() => onSelectPaymentMethod(method)}
+									onChange={() => onPaymentMethodEvent('select', method)}
 									accordionBody={paymentMethodData[method].accordionBody}
-									onRender={() => onRenderPaymentMethod(method)}
+									onRender={() => onPaymentMethodEvent('render', method)}
 								/>
 							))}
 						</>,

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -54,6 +54,10 @@ export interface PaymentMethodSelectorProps {
 		paymentMethod: PaymentMethod,
 		existingPaymentMethod?: RecentlySignedInExistingPaymentMethod,
 	) => void;
+	onRenderPaymentMethod: (
+		paymentMethod: PaymentMethod,
+		existingPaymentMethod?: RecentlySignedInExistingPaymentMethod,
+	) => void;
 }
 
 export function PaymentMethodSelector({
@@ -65,6 +69,7 @@ export function PaymentMethodSelector({
 	pendingExistingPaymentMethods,
 	showReauthenticateLink,
 	onSelectPaymentMethod,
+	onRenderPaymentMethod,
 }: PaymentMethodSelectorProps): JSX.Element {
 	if (
 		existingPaymentMethodList.length < 1 &&
@@ -146,6 +151,12 @@ export function PaymentMethodSelector({
 												accordionBody={
 													paymentMethodData[paymentType].accordionBody
 												}
+												onRender={() => {
+													onRenderPaymentMethod(
+														paymentType,
+														preExistingPaymentMethod,
+													);
+												}}
 											/>
 										);
 									},
@@ -160,6 +171,7 @@ export function PaymentMethodSelector({
 									checked={paymentMethod === method}
 									onChange={() => onSelectPaymentMethod(method)}
 									accordionBody={paymentMethodData[method].accordionBody}
+									onRender={() => onRenderPaymentMethod(method)}
 								/>
 							))}
 						</>,

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelectorAccordionRow.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelectorAccordionRow.tsx
@@ -9,6 +9,7 @@ import {
 	space,
 	transitions,
 } from '@guardian/source-foundations';
+import { useEffect } from 'preact/hooks';
 import { RadioWithImage } from './radioWithImage';
 
 const radio = css`
@@ -80,6 +81,7 @@ interface AvailablePaymentMethodAccordionRowProps {
 	supportingText?: string;
 	onChange: () => void;
 	accordionBody?: () => JSX.Element;
+	onRender: () => void;
 }
 
 export function AvailablePaymentMethodAccordionRow({
@@ -91,7 +93,10 @@ export function AvailablePaymentMethodAccordionRow({
 	supportingText,
 	accordionBody,
 	onChange,
+	onRender,
 }: AvailablePaymentMethodAccordionRowProps): EmotionJSX.Element {
+	useEffect(onRender, []);
+
 	return (
 		<div css={checked ? focused : notFocused}>
 			<div css={[...(checked && accordionBody ? [borderBottom] : [])]}>

--- a/support-frontend/assets/components/paymentRequestButton/paymentRequestButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentRequestButton/paymentRequestButtonContainer.tsx
@@ -48,7 +48,9 @@ export function PaymentRequestButtonContainer({
 		useOtherAmountValidation<StripePaymentRequestButtonElementClickEvent>(
 			function handleButtonClick() {
 				paymentRequest?.show();
-				trackComponentClick('apple-pay-clicked');
+				if (internalPaymentMethodName) {
+					trackComponentClick(`${internalPaymentMethodName}-${buttonType}`);
+				}
 				dispatch(setPaymentMethod(Stripe));
 			},
 			false,

--- a/support-frontend/assets/helpers/forms/existingPaymentMethods/existingPaymentMethods.ts
+++ b/support-frontend/assets/helpers/forms/existingPaymentMethods/existingPaymentMethods.ts
@@ -19,7 +19,7 @@ export type ExistingPaymentMethodSubscription = {
 	billingAccountId?: string;
 };
 
-type ExistingPaymentType = 'Card' | 'DirectDebit';
+export type ExistingPaymentType = 'Card' | 'DirectDebit';
 
 export type NotRecentlySignedInExistingPaymentMethod = {
 	paymentType: ExistingPaymentType;

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -10,6 +10,7 @@ import * as storage from 'helpers/storage/storage';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
 import { validateForm } from '../checkoutActions';
+import { setPaymentMethod } from '../payment/paymentMethod/actions';
 import {
 	setAllAmounts,
 	setOtherAmountError,

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -10,7 +10,6 @@ import * as storage from 'helpers/storage/storage';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
 import { validateForm } from '../checkoutActions';
-import { setPaymentMethod } from '../payment/paymentMethod/actions';
 import {
 	setAllAmounts,
 	setOtherAmountError,

--- a/support-frontend/assets/helpers/tracking/behaviour.ts
+++ b/support-frontend/assets/helpers/tracking/behaviour.ts
@@ -98,9 +98,20 @@ const trackComponentLoad = (componentId: string): void => {
 	});
 };
 
+const trackComponentInsert = (componentId: string): void => {
+	trackComponentEvents({
+		component: {
+			componentType: 'ACQUISITIONS_OTHER',
+			id: componentId,
+		},
+		action: 'INSERT',
+	});
+};
+
 export {
 	trackThankYouPageLoaded,
 	trackComponentClick,
 	trackCheckoutSubmitAttempt,
 	trackComponentLoad,
+	trackComponentInsert,
 };

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -1,6 +1,7 @@
 import { loadScript } from '@guardian/libs';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { ContributionType } from 'helpers/contributions';
+import type { ExistingPaymentType } from 'helpers/forms/existingPaymentMethods/existingPaymentMethods';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
@@ -290,7 +291,7 @@ function sendEventContributionCartValue(
 }
 
 function sendEventContributionPaymentMethod(
-	paymentMethod: PaymentMethod | null,
+	paymentMethod: PaymentMethod | ExistingPaymentType | null,
 ): void {
 	if (paymentMethod) {
 		void ifQmPermitted(() => {

--- a/support-frontend/stories/checkouts/paymentMethodSelector.stories.tsx
+++ b/support-frontend/stories/checkouts/paymentMethodSelector.stories.tsx
@@ -64,9 +64,11 @@ function Template(args: Partial<PaymentMethodSelectorProps>): JSX.Element {
 						card: '0123',
 					},
 				]}
-				onSelectPaymentMethod={(paymentMethod) =>
-					setPaymentMethod(paymentMethod)
-				}
+				onPaymentMethodEvent={(event, paymentMethod) => {
+					if (event === 'select') {
+						setPaymentMethod(paymentMethod);
+					}
+				}}
 			/>
 		</div>
 	);


### PR DESCRIPTION
## What are you doing in this PR?

When investigating issues with Existing Payment method on the new checkout it would've been helpful to have had details of payment methods displayed and interacted with in the data lake. Unfortunately when we queried the data we saw some tracking events were missing. The objective of this change is to address this by adding Ophan component events related to payment methods on the new checkout. The current situation in `PROD` is we track the following events:

**Stripe Payment Request Button rendered:**  Both these events are fired at the same time, and are incorrectly using the `VIEW` action...

```
{
    "component": {
        "componentType": "ACQUISITIONS_OTHER",
        "id": "StripePaymentRequestButton-displayed"
    },
    "action": "VIEW"
}
```

And...

```
{
    "component": {
        "componentType": "ACQUISITIONS_OTHER",
        "id": "StripePaymentRequestButton-loaded"
    },
    "action": "VIEW"
}
``` 

**Stripe Payment Request Button clicked:**   Even if the button is Google pay we fire...

```
{
    "component": {
        "componentType": "ACQUISITIONS_OTHER",
        "id": "apple-pay-clicked"
    },
    "action": "CLICK"
}
```

**Payment Method Selector (Direct Debit, Credit Card, Paypal, Amazon Pay) rendered:** No tracking

**Payment Method Selector (Direct Debit, Credit Card, Paypal, Amazon Pay) clicked:**  No tracking

I've addressed this is this PR by making the following changes:

**Stripe Payment Request Button rendered:**  I've replaced the 2 events previously fired with a single event that uses the`INSERT` action. The example below is "APPLE_PAY", but this could be "APPLE_PAY" | "GOOGLE_PAY" | "PAY_NOW".

```
{
    "component": {
        "componentType": "ACQUISITIONS_OTHER",
        "id": "StripePaymentRequestButton-APPLE_PAY" 
    },
    "action": "INSERT"
}
```

**Stripe Payment Request Button clicked:**    I've replaced the "apple-pay-clicked" with an event that accurately reflects the payment method displayed by this button. The example below is "APPLE_PAY", but this could be "APPLE_PAY" | "GOOGLE_PAY" | "PAY_NOW".


```
{
    "component": {
        "componentType": "ACQUISITIONS_OTHER",
         "id": "StripePaymentRequestButton-APPLE_PAY" 
    },
    "action": "CLICK"
}
```

**Payment Method Selector (Direct Debit, Credit Card, Paypal, Amazon Pay) rendered:** 

The example below is "DirectDebit", but this could be "Card" | "DirectDebit" | "Stripe" | "PayPal" | "Sepa" | "ExistingCard" | "ExistingDirectDebit" | "AmazonPay"

```
{
    "component": {
        "componentType": "ACQUISITIONS_OTHER",
        "id": "payment-method-selector-DirectDebit" 
    },
    "action": "INSERT"
}
```

**Payment Method Selector (Direct Debit, Credit Card, Paypal, Amazon Pay) clicked:** 

The example below is "DirectDebit", but this could be "Card" | "DirectDebit" | "Stripe" | "PayPal" | "Sepa" | "ExistingCard" | "ExistingDirectDebit" | "AmazonPay"

```
{
    "component": {
        "componentType": "ACQUISITIONS_OTHER",
         "id":  "payment-method-selector-DirectDebit" 
    },
    "action": "CLICK"
}
```




