### PR TITLE
Mj/upgrade ec2 instances to imdsv2

### DIFF
--- a/cdk/lib/__snapshots__/frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/frontend.test.ts.snap
@@ -175,6 +175,9 @@ exports[`The Frontend stack matches the snapshot 1`] = `
           "Ref": "AMIFrontend",
         },
         "InstanceType": "t4g.small",
+        "MetadataOptions": {
+          "HttpTokens": "required",
+        },
         "SecurityGroups": [
           {
             "Fn::GetAtt": [

--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -274,6 +274,9 @@ exports[`The Payment API stack matches the snapshot 1`] = `
           "Ref": "AMIPaymentapi",
         },
         "InstanceType": "t4g.small",
+        "MetadataOptions": {
+          "HttpTokens": "required",
+        },
         "SecurityGroups": [
           {
             "Fn::GetAtt": [

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -149,8 +149,7 @@ export class Frontend extends GuStack {
         additionalPolicies: policies,
       },
       scaling,
-      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
-      // withoutImdsv2: true,
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL)
     });
 
     // ---- Alarms ---- //

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -150,7 +150,7 @@ export class Frontend extends GuStack {
       },
       scaling,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
-      withoutImdsv2: true,
+      // withoutImdsv2: true,
     });
 
     // ---- Alarms ---- //

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -104,7 +104,6 @@ export class PaymentApi extends GuStack {
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
       scaling: props.scaling,
       userData,
-      withoutImdsv2: true,
       roleConfiguration: {
         additionalPolicies: [
           new GuAllowPolicy(this, "SupporterProductDataDynamo", {

--- a/support-frontend/conf/riff-raff.yaml
+++ b/support-frontend/conf/riff-raff.yaml
@@ -18,7 +18,7 @@ deployments:
         PROD: Frontend-PROD.template.json
       amiParameter: AMIFrontend
       amiTags:
-        Recipe: bionic-membership-ARM
+        Recipe: bionic-membership-ARM-unified-cloudwatch
         AmigoStage: PROD
       amiEncrypted: true
   frontend:

--- a/support-payment-api/src/main/resources/riff-raff.yaml
+++ b/support-payment-api/src/main/resources/riff-raff.yaml
@@ -7,7 +7,7 @@ deployments:
     parameters:
       amiParameter: AMIPaymentapi
       amiTags:
-        Recipe: bionic-membership-ARM
+        Recipe: bionic-membership-ARM-unified-cloudwatch
         AmigoStage: PROD
       amiEncrypted: true
       templateStagePaths:


### PR DESCRIPTION
This PR enables [IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) support on the `support-frontend` and `payment-api` EC2 instances, it is dependant on [this new AMI recipe](https://amigo.gutools.co.uk/recipes/bionic-membership-ARM-unified-cloudwatch), which includes the [AWS Unified CloudWatch Agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/UseCloudWatchUnifiedAgent.html).