### PR TITLE
Fail validation for create requests containing characters that would break Zuora

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx
@@ -17,7 +17,7 @@ import {
 	setRecaptchaToken,
 } from 'helpers/redux/checkout/recaptcha/actions';
 import type { CheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
-import { nonSillyCharacters } from 'helpers/subscriptionsForms/validation';
+import { zuoraCompatibleString } from 'helpers/subscriptionsForms/validation';
 import Form from './components/form';
 import Playback from './components/playback';
 import type { DirectDebitFieldName } from './types';
@@ -72,7 +72,7 @@ const fieldValidationFunctions: {
 	[key in DirectDebitFieldName]: (fieldValue: string) => boolean;
 } = {
 	accountHolderName: (fieldValue) =>
-		!!/^\D+$/.exec(fieldValue) && nonSillyCharacters(fieldValue),
+		!!/^\D+$/.exec(fieldValue) && zuoraCompatibleString(fieldValue),
 	sortCodeString: (fieldValue) => !!/^\d{6}$/.exec(fieldValue),
 	accountNumber: (fieldValue) => !!/^\d{6,8}$/.exec(fieldValue),
 	accountHolderConfirmation: (fieldValue) => !!fieldValue,

--- a/support-frontend/assets/helpers/forms/formValidation.ts
+++ b/support-frontend/assets/helpers/forms/formValidation.ts
@@ -63,7 +63,7 @@ export const maxTwoDecimals: (arg0: string) => boolean = (input) =>
 	new RegExp('^\\d+\\.?\\d{0,2}$').test(input);
 
 export const containsEmoji: (input: string | null) => boolean = (input) =>
-	/\p{Emoji_Presentation}/u.test(input ?? '');
+	/[\u{10000}-\u{10FFFF}]/u.test(input ?? '');
 
 export const notLongerThan = (
 	value: string | null,

--- a/support-frontend/assets/helpers/redux/checkout/address/validation.test.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/validation.test.ts
@@ -34,7 +34,7 @@ describe('applyBillingAddressRules', () => {
 		]);
 	});
 
-	it('returns an error if lineOne contains silly characters', () => {
+	it('returns an error if lineOne contains non-zuora-compatible characters', () => {
 		const fields = buildAddressFields({ lineOne: '🏡' });
 
 		const errors = applyBillingAddressRules(fields);
@@ -60,7 +60,7 @@ describe('applyBillingAddressRules', () => {
 		]);
 	});
 
-	it('returns an error if lineTwo contains silly characters', () => {
+	it('returns an error if lineTwo contains non-zuora-compatible characters', () => {
 		const fields = buildAddressFields({ lineTwo: '🏡' });
 
 		const errors = applyBillingAddressRules(fields);
@@ -86,7 +86,7 @@ describe('applyBillingAddressRules', () => {
 		]);
 	});
 
-	it('returns an error if city contains silly characters', () => {
+	it('returns an error if city contains non-zuora-compatible characters', () => {
 		const fields = buildAddressFields({ city: '🏡' });
 
 		const errors = applyBillingAddressRules(fields);
@@ -166,7 +166,7 @@ describe('applyBillingAddressRules', () => {
 		]);
 	});
 
-	it('returns an error if postCode contains silly characters', () => {
+	it('returns an error if postCode contains non-zuora-compatible characters', () => {
 		const fields = buildAddressFields({ postCode: '🏡' });
 
 		const errors = applyBillingAddressRules(fields);

--- a/support-frontend/assets/helpers/redux/checkout/address/validation.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/validation.ts
@@ -9,10 +9,10 @@ import type { Rule } from 'helpers/subscriptionsForms/validation';
 import {
 	formError,
 	nonEmptyString,
-	nonSillyCharacters,
 	notLongerThan,
 	notNull,
 	validate,
+	zuoraCompatibleString,
 } from 'helpers/subscriptionsForms/validation';
 import type { Option } from 'helpers/types/option';
 import type { AddressFields, AddressFormFieldError } from './state';
@@ -55,7 +55,7 @@ function getGenericRules(
 			),
 		},
 		{
-			rule: nonSillyCharacters(fields.lineOne),
+			rule: zuoraCompatibleString(fields.lineOne),
 			error: formError(
 				'lineOne',
 				'Please use only letters, numbers and punctuation.',
@@ -69,7 +69,7 @@ function getGenericRules(
 			),
 		},
 		{
-			rule: nonSillyCharacters(fields.lineTwo),
+			rule: zuoraCompatibleString(fields.lineTwo),
 			error: formError(
 				'lineTwo',
 				'Please use only letters, numbers and punctuation.',
@@ -80,7 +80,7 @@ function getGenericRules(
 			error: formError('city', `Please enter a ${addressType} city.`),
 		},
 		{
-			rule: nonSillyCharacters(fields.city),
+			rule: zuoraCompatibleString(fields.city),
 			error: formError(
 				'city',
 				'Please use only letters, numbers and punctuation.',
@@ -114,7 +114,7 @@ function getGenericRules(
 			rule:
 				isPostcodeOptional(fields.country) ||
 				(nonEmptyString(fields.postCode) &&
-					nonSillyCharacters(fields.postCode)),
+					zuoraCompatibleString(fields.postCode)),
 			error: formError('postCode', `Please enter a ${addressType} postcode.`),
 		},
 		{
@@ -125,7 +125,7 @@ function getGenericRules(
 			),
 		},
 		{
-			rule: nonSillyCharacters(fields.postCode),
+			rule: zuoraCompatibleString(fields.postCode),
 			error: formError(
 				'postCode',
 				'Please use only letters, numbers and punctuation.',

--- a/support-frontend/assets/helpers/redux/checkout/personalDetails/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/personalDetails/state.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import {
 	maxLengths,
-	nonSillyString,
+	zuoraCompatibleString,
 } from 'helpers/redux/utils/validation/commonRules';
 import type { SliceErrors } from 'helpers/redux/utils/validation/errors';
 import { getUser } from 'helpers/user/user';
@@ -14,7 +14,7 @@ export type UserTypeFromIdentityResponse =
 	| 'requestPending'
 	| 'requestFailed';
 
-export const emailRules = nonSillyString(
+export const emailRules = zuoraCompatibleString(
 	z
 		.string()
 		.email('Please enter a valid email address.')
@@ -25,13 +25,13 @@ export const emailRules = nonSillyString(
 export const personalDetailsSchema = z
 	.object({
 		title: z.optional(z.string()),
-		firstName: nonSillyString(
+		firstName: zuoraCompatibleString(
 			z
 				.string()
 				.min(1, { message: 'Please enter a first name.' })
 				.max(maxLengths.name, { message: 'First name is too long' }),
 		),
-		lastName: nonSillyString(
+		lastName: zuoraCompatibleString(
 			z
 				.string()
 				.min(1, 'Please enter a last name.')
@@ -42,7 +42,7 @@ export const personalDetailsSchema = z
 		// isSignedIn is maintained in personal details state purely for the email matching check
 		// It should be set only in response to the setIsSignedIn action from the user slice
 		isSignedIn: z.boolean(),
-		telephone: z.optional(nonSillyString(z.string())),
+		telephone: z.optional(zuoraCompatibleString(z.string())),
 	})
 	.refine(
 		({ email, confirmEmail, isSignedIn }) => {

--- a/support-frontend/assets/helpers/redux/utils/validation/commonRules.ts
+++ b/support-frontend/assets/helpers/redux/utils/validation/commonRules.ts
@@ -5,13 +5,13 @@ export const maxLengths = {
 	email: 80,
 };
 
-const containsEmojiRegex = /\p{Emoji_Presentation}/u;
+const takesFourBytesInUTF8Regex = /[\u{10000}-\u{10FFFF}]/u;
 
-export function nonSillyString(
+export function zuoraCompatibleString(
 	zodString: ZodString,
 	message = 'Please use only letters, numbers and punctuation.',
 ): ZodEffects<ZodString, string, string> {
-	return zodString.refine((string) => !containsEmojiRegex.test(string), {
+	return zodString.refine((string) => !takesFourBytesInUTF8Regex.test(string), {
 		message,
 	});
 }

--- a/support-frontend/assets/helpers/subscriptionsForms/__tests__/validationTest.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/__tests__/validationTest.ts
@@ -3,23 +3,27 @@ import {
 	firstError,
 	formError,
 	nonEmptyString,
-	nonSillyCharacters,
 	notLongerThan,
 	notNull,
 	validate,
+	zuoraCompatibleString,
 } from '../validation';
 
 // ----- Tests ----- //
 describe('validation', () => {
-	describe('non silly characters', () => {
-		it('should return false if string contains an emoji', () => {
-			expect(nonSillyCharacters('😊')).toBe(false);
-			expect(nonSillyCharacters('jane✅')).toBe(false);
+	describe('zuoraCompatibleString', () => {
+		it('should return false if string contains characters which take more than 3 bytes to represent in UTF-8', () => {
+			expect(zuoraCompatibleString('😊')).toBe(false);
+			expect(zuoraCompatibleString('𐀀')).toBe(false);
+			expect(zuoraCompatibleString('𠀀')).toBe(false);
 		});
 
-		it('should return true if string does not contain silly characters', () => {
-			expect(nonSillyCharacters('joe')).toBe(true);
-			expect(nonSillyCharacters("King's Place")).toBe(true);
+		it('should return true if string only contains characters which take 3 or fewer bytes to represent in UTF-8', () => {
+			expect(zuoraCompatibleString('joe')).toBe(true);
+			expect(zuoraCompatibleString('jane✅')).toBe(true);
+			expect(zuoraCompatibleString("King's Place")).toBe(true);
+			expect(zuoraCompatibleString('￿')).toBe(true);
+			expect(zuoraCompatibleString('࿿')).toBe(true);
 		});
 	});
 

--- a/support-frontend/assets/helpers/subscriptionsForms/rules.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/rules.ts
@@ -9,10 +9,10 @@ import type { FormField, FormFields } from './formFields';
 import {
 	formError,
 	nonEmptyString,
-	nonSillyCharacters,
 	notLongerThan,
 	notNull,
 	validate,
+	zuoraCompatibleString,
 } from './validation';
 import type { FormError } from './validation';
 
@@ -30,7 +30,7 @@ function applyPersonalDetailsRules(
 			error: formError('firstName', 'Please enter a first name.'),
 		},
 		{
-			rule: nonSillyCharacters(fields.firstName),
+			rule: zuoraCompatibleString(fields.firstName),
 			error: formError(
 				'firstName',
 				'Please use only letters, numbers and punctuation.',
@@ -45,7 +45,7 @@ function applyPersonalDetailsRules(
 			error: formError('lastName', 'Please enter a last name.'),
 		},
 		{
-			rule: nonSillyCharacters(fields.lastName),
+			rule: zuoraCompatibleString(fields.lastName),
 			error: formError(
 				'lastName',
 				'Please use only letters, numbers and punctuation.',
@@ -56,7 +56,7 @@ function applyPersonalDetailsRules(
 			error: formError('lastName', 'Last name is too long'),
 		},
 		{
-			rule: nonSillyCharacters(fields.telephone),
+			rule: zuoraCompatibleString(fields.telephone),
 			error: formError(
 				'telephone',
 				'Please use only letters, numbers and punctuation.',
@@ -94,7 +94,7 @@ function applyCheckoutRules(fields: FormFields): Array<FormError<FormField>> {
 			error: formError('firstName', 'Please enter a first name.'),
 		},
 		{
-			rule: nonSillyCharacters(fields.firstName),
+			rule: zuoraCompatibleString(fields.firstName),
 			error: formError(
 				'firstName',
 				'Please use only letters, numbers and punctuation.',
@@ -109,7 +109,7 @@ function applyCheckoutRules(fields: FormFields): Array<FormError<FormField>> {
 			error: formError('lastName', 'Please enter a last name.'),
 		},
 		{
-			rule: nonSillyCharacters(fields.lastName),
+			rule: zuoraCompatibleString(fields.lastName),
 			error: formError(
 				'lastName',
 				'Please use only letters, numbers and punctuation.',
@@ -120,7 +120,7 @@ function applyCheckoutRules(fields: FormFields): Array<FormError<FormField>> {
 			error: formError('lastName', 'Last name is too long'),
 		},
 		{
-			rule: nonSillyCharacters(fields.telephone),
+			rule: zuoraCompatibleString(fields.telephone),
 			error: formError(
 				'telephone',
 				'Please use only letters, numbers and punctuation.',
@@ -158,7 +158,7 @@ function applyCheckoutRules(fields: FormFields): Array<FormError<FormField>> {
 						),
 					},
 					{
-						rule: nonSillyCharacters(fields.firstNameGiftRecipient),
+						rule: zuoraCompatibleString(fields.firstNameGiftRecipient),
 						error: formError(
 							'firstNameGiftRecipient',
 							'Please use only letters, numbers and punctuation.',
@@ -172,7 +172,7 @@ function applyCheckoutRules(fields: FormFields): Array<FormError<FormField>> {
 						),
 					},
 					{
-						rule: nonSillyCharacters(fields.lastNameGiftRecipient),
+						rule: zuoraCompatibleString(fields.lastNameGiftRecipient),
 						error: formError(
 							'lastNameGiftRecipient',
 							'Please use only letters, numbers and punctuation.',
@@ -216,7 +216,7 @@ function applyCheckoutRules(fields: FormFields): Array<FormError<FormField>> {
 						),
 					},
 					{
-						rule: nonSillyCharacters(fields.firstNameGiftRecipient),
+						rule: zuoraCompatibleString(fields.firstNameGiftRecipient),
 						error: formError(
 							'firstNameGiftRecipient',
 							'Please use only letters, numbers and punctuation.',
@@ -230,7 +230,7 @@ function applyCheckoutRules(fields: FormFields): Array<FormError<FormField>> {
 						),
 					},
 					{
-						rule: nonSillyCharacters(fields.lastNameGiftRecipient),
+						rule: zuoraCompatibleString(fields.lastNameGiftRecipient),
 						error: formError(
 							'lastNameGiftRecipient',
 							'Please use only letters, numbers and punctuation.',
@@ -239,7 +239,7 @@ function applyCheckoutRules(fields: FormFields): Array<FormError<FormField>> {
 					{
 						rule:
 							checkOptionalEmail(fields.emailGiftRecipient) &&
-							nonSillyCharacters(fields.emailGiftRecipient),
+							zuoraCompatibleString(fields.emailGiftRecipient),
 						error: formError(
 							'emailGiftRecipient',
 							'Please use a valid email address for the recipient.',
@@ -263,6 +263,13 @@ function applyDeliveryRules(fields: FormFields): Array<FormError<FormField>> {
 			error: formError(
 				'billingAddressIsSame',
 				'Please indicate whether the billing address is the same as the delivery address',
+			),
+		},
+		{
+			rule: zuoraCompatibleString(fields.deliveryInstructions),
+			error: formError(
+				'deliveryInstructions',
+				'Please use only letters, numbers and punctuation.',
 			),
 		},
 	];

--- a/support-frontend/assets/helpers/subscriptionsForms/validation.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/validation.ts
@@ -24,16 +24,14 @@ function notLongerThan(
 	return value.length < maxLength;
 }
 
-function nonSillyCharacters(s: string | null | undefined): boolean {
-	// This is a unicode property escape
-	// cf. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes
-	const containsEmojiRegex = /\p{Emoji_Presentation}/u;
+function zuoraCompatibleString(s: string | null | undefined): boolean {
+	const takesFourBytesInUTF8Regex = /[\u{10000}-\u{10FFFF}]/u;
 
 	if (!s) {
 		return true;
 	}
 
-	return !containsEmojiRegex.test(s);
+	return !takesFourBytesInUTF8Regex.test(s);
 }
 
 // ----- Functions ----- //
@@ -80,5 +78,5 @@ export {
 	formError,
 	removeError,
 	validate,
-	nonSillyCharacters,
+	zuoraCompatibleString,
 };

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.test.tsx
@@ -212,11 +212,11 @@ describe('Newspaper checkout form', () => {
 			});
 		});
 
-		it('should display an error if a silly character is entered into an input field', async () => {
+		it('should display an error if a non-zuora-compatible character is entered into an input field', async () => {
 			const firstNameInput = await screen.findByLabelText('First name');
 			fireEvent.change(firstNameInput, {
 				target: {
-					value: 'jane✅',
+					value: 'jane 😊',
 				},
 			});
 			const creditDebit = await screen.findByLabelText('Credit/Debit card');
@@ -234,8 +234,8 @@ describe('Newspaper checkout form', () => {
 			expect(
 				screen.queryAllByText(
 					'Please use only letters, numbers and punctuation.',
-				),
-			).toBeTruthy();
+				).length,
+			).toBeGreaterThan(0);
 		});
 	});
 });

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.test.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.test.tsx
@@ -210,11 +210,11 @@ describe('Guardian Weekly checkout form', () => {
 			});
 		});
 
-		it('should display an error if a silly character is entered into an input field', async () => {
+		it('should display an error if a non-zuora-compatible character is entered into an input field', async () => {
 			const firstNameInput = await screen.findByLabelText('First name');
 			fireEvent.change(firstNameInput, {
 				target: {
-					value: 'jane✅',
+					value: 'jane 😊',
 				},
 			});
 			const creditDebit = await screen.findByLabelText('Credit/Debit card');

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -370,6 +370,24 @@ class SimpleCheckoutFormValidationTest extends AnyFlatSpec with Matchers {
     SimpleCheckoutFormValidation.passes(requestWithLongLastName) shouldBe an[Invalid]
   }
 
+  it should "reject invalid characters in strings" in {
+    SimpleCheckoutFormValidation.noFourByteUtf8Characters("test1", "hello😊") shouldBe an[Invalid];
+    SimpleCheckoutFormValidation.noFourByteUtf8Characters("test2", "𐀀goodbye") shouldBe an[Invalid];
+    SimpleCheckoutFormValidation.noFourByteUtf8Characters("test3", "wa𠀀it") shouldBe an[Invalid];
+  }
+
+  it should "not reject valid characters in strings" in {
+    SimpleCheckoutFormValidation.noFourByteUtf8Characters("test1", "hello✅") shouldBe Valid;
+    SimpleCheckoutFormValidation.noFourByteUtf8Characters("test2", "￿goodbye") shouldBe Valid;
+    SimpleCheckoutFormValidation.noFourByteUtf8Characters("test3", "wa퟿it") shouldBe Valid;
+    SimpleCheckoutFormValidation.noFourByteUtf8Characters("test4", "come  back!") shouldBe Valid;
+  }
+
+  it should "check fields for invalid characters" in {
+    SimpleCheckoutFormValidation.noFieldsHaveUnsupportedCharacters(
+      validDigitalPackRequest.copy(deliveryInstructions = Some("😊")),
+    ) shouldBe an[Invalid]
+  }
 }
 
 class DigitalPackValidationTest extends AnyFlatSpec with Matchers {

--- a/support-models/src/main/scala/com/gu/support/zuora/api/SubscribeRequest.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/SubscribeRequest.scala
@@ -26,7 +26,7 @@ object SubscribeRequest {
   implicit val encoder: Encoder[SubscribeRequest] = deriveEncoder
 }
 
-//The subscribe request documented here: https://www.zuora.com/developer/api-reference/#operation/Action_POSTsubscribe
+//The subscribe request documented here: https://www.zuora.com/developer/api-references/older-api/operation/Action_POSTsubscribe/
 //fields are upper case to match the expected json structure
 case class SubscribeRequest(subscribes: List[SubscribeItem])
 


### PR DESCRIPTION
Trello Card: https://trello.com/c/47aV3LRb/1102-block-entering-emojis-in-the-delivery-instructions-field-in-newspaper-home-delivery-checkout

## Why

Some characters cause Zuora's API to break, or at least the `/subscribe` endpoint – it’ll return a 200 with an error in the response body. Validating the input first avoids weird behaviour in our step functions (like retrying for a day because the response from Zuora doesn't look like an error), and by validating on the client as well we can help users catch/correct errors more quickly.

## How

The characters that break Zuora are those whose UTF-8 representation contains more than 3 bytes. [According to Wikipedia](https://en.wikipedia.org/wiki/UTF-8#Encoding), that’s those code points above U+FFFF.

I stole this regex method [from Identity](https://github.com/guardian/identity/blob/77488775d4a9f4db34e3b795dbcd28e2b96be4a1/identity-api/src/main/scala/com/gu/identity/api/services/UserCleaningService.scala#L11), so it’s consistent with how things are done elsewhere.

I considered a couple of alternatives to the regex:

- testing for surrogate characters (as JVM strings are UTF-16):

  If we check for surrogate characters under the assumption that Java’s Strings are encoded as UTF-16, what happens if that representation changes?

- explicitly encoding to UTF-8 and testing for a byte whose digits start
  with 11110:

  Converting to UTF-8 seems like wasted effort, especially when the result of the conversion is thrown away, and we later re-encode when converting the fields to JSON.

I’m not sure if the regex example is any faster/better than converting to UTF-8: we avoid the re-encoding I reckon, but it seems we’re then relying on the regex compiler to work out it can do a linear scan of the input. I think that’s probably fine.

## Testing

To test (local/code/prod):

- Insert a character over U+FFFF (e.g. 𠀀 or 𐀀 or 😊) into a field (for example, delivery instructions or company name – first name will be caught by Identity) and checkout
- Confirm that with these changes, the client-side validation rejects these characters, whereas on current prod it only rejects the emoji
- Make a successful call to create via the browser with something in the delivery instructions field, copy it as a curl from the network tab
- Re-do the curl with one of the bad characters in the delivery instructions field, see that the call to create fails with the new changes (and succeeds without, except for when the bad character is an emoji)
- Remember to stop any looping support-workers step function executions that you create while testing – better to save the money and energy (though I’m sure it’s not much)

To test against Zuora directly, here’s a sample subscribe request:

<details>
<summary>Expand for JSON</summary>
<p>

```json
{
  "subscribes": [
    {
    "Account": {
      "AutoPay": false,
      "Batch": "Batch1",
      "BillCycleDay": 1,
      "Currency": "USD",
      "Name": "West ✅Corporation",
      "PaymentTerm": "Due Upon Receipt"
    },
    "BillToContact": {
      "Address1": "312 2nd Ave W",
      "City": "Seattle",
      "Country": "United States",
      "FirstName": "Sarah✅",
      "LastName": "Smith",
      "PostalCode": "98119",
      "State": "Washington",
      "WorkEmail": "sarah@example.com",
      "SpecialDeliveryInstructions__c" : "✅"
    },
    "PaymentMethod": {
      "CreditCardAddress1": "312 2nd Ave W",
      "CreditCardCity": "Seattle",
      "CreditCardCountry": "United States",
      "CreditCardExpirationMonth": 12,
      "CreditCardExpirationYear": 2023,
      "CreditCardHolderName": "Ms Sarah Smith",
      "CreditCardNumber": "4111111111111111",
      "CreditCardPostalCode": "98119",
      "CreditCardState": "Washington",
      "CreditCardType": "Visa",
      "Type": "CreditCard"
    },
    "SubscribeOptions": {
      "GenerateInvoice": true,
      "ProcessPayments": false
    },
    "SubscriptionData": {
      "RatePlanData": [
        {
        "RatePlan": {
          "ProductRatePlanId": "8ad08e018499b108018499f163ac32e3"
        },
        "RatePlanChargeData": [
          {
          "RatePlanCharge": {
            "ChargeModel": "Discount-Percentage",
            "DiscountPercentage": "6.75",
            "ProductRatePlanChargeId": "8ad08e018499b108018499f163e132ef"
          }
        }
        ]
      }
      ],
      "Subscription": {
        "AutoRenew": true,
        "ContractAcceptanceDate": "2019-02-15",
        "ContractEffectiveDate": "2019-02-15",
        "InitialTerm": 12,
        "RenewalTerm": 6,
        "ServiceActivationDate": "2019-02-15",
        "TermType": "TERMED"
      }
    }
  }
  ]
}
```

</p>
</details>

And here’s how you could call the Zuora dev api with it:

```sh
curl -i -XPOST -d @subscribe.json -H "apiAccessKeyId: your.zuora.account.email@guardian.co.uk.dev" -H "apiSecretAccessKey: $yourZuoraDevPassword" -H "Content-Type: application/json; charset=utf-8"  https://rest.apisandbox.zuora.com/v1/action/subscribe
```