### PR TITLE
Newspaper Subscription Price Cards - move to top

### DIFF
--- a/support-frontend/assets/components/page/pageTitle.tsx
+++ b/support-frontend/assets/components/page/pageTitle.tsx
@@ -48,6 +48,7 @@ const header = css`
 	}
 
 	${from.desktop} {
+		width: 100%;
 		:before {
 			height: 370px;
 		}

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -79,6 +79,26 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.subscriptions.subsWeeklyPages,
 		seed: 11,
 	},
+	newspaperPriceCards: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		isActive: false,
+		referrerControlled: false,
+		targetPage: pageUrlRegexes.subscriptions.subsWeeklyPages,
+		seed: 3,
+	},
 	supporterPlusV2: {
 		variants: [
 			{

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
@@ -38,11 +38,9 @@ const pricesHeadline = css`
 `;
 
 const pricesHeadlineVariant = css`
-	margin-top: ${space[3]}px;
-	margin-bottom: ${space[4]}px;
-
+	margin-top: ${space[4]}px;
 	${from.tablet} {
-		margin-top: ${space[9]}px;
+		margin-top: ${space[6]}px;
 	}
 `;
 
@@ -54,7 +52,7 @@ const priceBoxes = css`
 	}
 `;
 const priceBoxesVariant = css`
-	margin-top: ${space[4]}px;
+	margin-top: 0px;
 `;
 
 const productOverride = css`
@@ -95,7 +93,7 @@ const pricesInfo = css`
 	margin-top: ${space[6]}px;
 `;
 const pricesTabs = css`
-	margin-top: ${space[6]}px;
+	margin-bottom: 13px;
 	display: flex;
 	border-bottom: 1px solid ${brand[600]};
 `;

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
@@ -99,7 +99,7 @@ const pricesTabs = css`
 	border-bottom: 1px solid ${brand[600]};
 `;
 
-function PaperPrices({
+export function PaperPrices({
 	activeTab,
 	setTabAction,
 	products,
@@ -154,5 +154,3 @@ function PaperPrices({
 		</section>
 	);
 }
-
-export default PaperPrices;

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
@@ -18,10 +18,11 @@ import {
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import LinkTo from './linkTo';
 
-export type PropTypes = {
+export type PaperPricesPropTypes = {
 	activeTab: PaperFulfilmentOptions;
 	setTabAction: (arg0: PaperFulfilmentOptions) => void;
 	products: Product[];
+	isPriceCardsAbTestVariant: boolean;
 };
 const pricesSection = css`
 	padding: 0 ${space[3]}px ${space[12]}px;
@@ -103,16 +104,29 @@ export function PaperPrices({
 	activeTab,
 	setTabAction,
 	products,
-}: PropTypes): JSX.Element {
+	isPriceCardsAbTestVariant,
+}: PaperPricesPropTypes): JSX.Element {
 	const infoText = `${
 		activeTab === HomeDelivery ? 'Delivery is included. ' : ''
 	}You can cancel your subscription at any time`;
 	return (
 		<section css={pricesSection} id="subscribe">
-			<h2 css={[pricesHeadline, pricesHeadlineVariant]}>
+			<h2
+				css={
+					isPriceCardsAbTestVariant
+						? [pricesHeadline, pricesHeadlineVariant]
+						: pricesHeadline
+				}
+			>
 				Pick your subscription package below
 			</h2>
-			<FlexContainer cssOverrides={[priceBoxes, priceBoxesVariant]}>
+			<FlexContainer
+				cssOverrides={
+					isPriceCardsAbTestVariant
+						? [priceBoxes, priceBoxesVariant]
+						: priceBoxes
+				}
+			>
 				{products.map((product) => (
 					<ProductOption
 						cssOverrides={

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
@@ -48,7 +48,7 @@ const priceBoxes = css`
 	margin-top: ${space[6]}px;
 	justify-content: flex-start;
 	${from.tablet} {
-		margin-top: ${space[12]}px;
+		margin-top: 56px;
 	}
 `;
 const priceBoxesVariant = css`

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
@@ -26,6 +26,25 @@ export type PropTypes = {
 const pricesSection = css`
 	padding: 0 ${space[3]}px ${space[12]}px;
 `;
+
+const pricesHeadline = css`
+	${headline.xsmall({
+		fontWeight: 'bold',
+	})};
+	${from.tablet} {
+		font-size: 34px;
+	}
+`;
+
+const pricesHeadlineVariant = css`
+	margin-top: ${space[3]}px;
+	margin-bottom: ${space[4]}px;
+
+	${from.tablet} {
+		margin-top: ${space[9]}px;
+	}
+`;
+
 const priceBoxes = css`
 	margin-top: ${space[6]}px;
 	justify-content: flex-start;
@@ -33,6 +52,10 @@ const priceBoxes = css`
 		margin-top: ${space[12]}px;
 	}
 `;
+const priceBoxesVariant = css`
+	margin-top: ${space[4]}px;
+`;
+
 const productOverride = css`
 	&:not(:first-of-type) {
 		margin-top: ${space[4]}px;
@@ -54,6 +77,7 @@ const productOverride = css`
 		}
 	}
 `;
+
 const productOverrideWithLabel = css`
 	${productOverride}
 	&:not(:first-of-type) {
@@ -65,11 +89,7 @@ const productOverrideWithLabel = css`
 		}
 	}
 `;
-const pricesHeadline = css`
-	${headline.medium({
-		fontWeight: 'bold',
-	})};
-`;
+
 const pricesInfo = css`
 	margin-top: ${space[6]}px;
 `;
@@ -79,14 +99,20 @@ const pricesTabs = css`
 	border-bottom: 1px solid ${brand[600]};
 `;
 
-function Prices({ activeTab, setTabAction, products }: PropTypes) {
+function PaperPrices({
+	activeTab,
+	setTabAction,
+	products,
+}: PropTypes): JSX.Element {
 	const infoText = `${
 		activeTab === HomeDelivery ? 'Delivery is included. ' : ''
 	}You can cancel your subscription at any time`;
 	return (
 		<section css={pricesSection} id="subscribe">
-			<h2 css={pricesHeadline}>Pick your subscription package below</h2>
-			<FlexContainer cssOverrides={priceBoxes}>
+			<h2 css={[pricesHeadline, pricesHeadlineVariant]}>
+				Pick your subscription package below
+			</h2>
+			<FlexContainer cssOverrides={[priceBoxes, priceBoxesVariant]}>
 				{products.map((product) => (
 					<ProductOption
 						cssOverrides={
@@ -129,4 +155,4 @@ function Prices({ activeTab, setTabAction, products }: PropTypes) {
 	);
 }
 
-export default Prices;
+export default PaperPrices;

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
@@ -120,6 +120,24 @@ export function PaperPrices({
 			>
 				Pick your subscription package below
 			</h2>
+			<div css={pricesTabs}>
+				<LinkTo
+					tab={Collection}
+					setTabAction={setTabAction}
+					activeTab={activeTab}
+					isPricesTabLink
+				>
+					Subscription card
+				</LinkTo>
+				<LinkTo
+					tab={HomeDelivery}
+					setTabAction={setTabAction}
+					activeTab={activeTab}
+					isPricesTabLink
+				>
+					Home Delivery
+				</LinkTo>
+			</div>
 			<FlexContainer
 				cssOverrides={
 					isPriceCardsAbTestVariant
@@ -144,24 +162,6 @@ export function PaperPrices({
 					/>
 				))}
 			</FlexContainer>
-			<div css={pricesTabs}>
-				<LinkTo
-					tab={Collection}
-					setTabAction={setTabAction}
-					activeTab={activeTab}
-					isPricesTabLink
-				>
-					Subscription card
-				</LinkTo>
-				<LinkTo
-					tab={HomeDelivery}
-					setTabAction={setTabAction}
-					activeTab={activeTab}
-					isPricesTabLink
-				>
-					Home Delivery
-				</LinkTo>
-			</div>
 			<div css={pricesInfo}>
 				<ProductInfoChip icon={<SvgInfo />}>{infoText}</ProductInfoChip>
 			</div>

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/paperProductInfo.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/paperProductInfo.tsx
@@ -1,0 +1,114 @@
+import { css } from '@emotion/react';
+import {
+	body,
+	brandAlt,
+	from,
+	headline,
+	space,
+} from '@guardian/source-foundations';
+import GridImage from 'components/gridImage/gridImage';
+import Hero from 'components/page/hero';
+import type { PromotionCopy } from 'helpers/productPrice/promotions';
+import { promotionHTML } from 'helpers/productPrice/promotions';
+
+interface PaperProductInfoProps {
+	promotionCopy: PromotionCopy;
+}
+
+const heroCopy = css`
+	padding: 0 ${space[3]}px ${space[3]}px;
+	${from.tablet} {
+		padding-bottom: ${space[9]}px;
+	}
+	${from.desktop} {
+		padding-bottom: ${space[24]}px;
+	}
+`;
+const heroTitle = css`
+	${headline.medium({
+		fontWeight: 'bold',
+	})};
+	margin-bottom: ${space[3]}px;
+
+	${from.tablet} {
+		${headline.large({
+			fontWeight: 'bold',
+		})};
+	}
+`;
+const heroTitleHighlight = css`
+	color: ${brandAlt[400]};
+`;
+const heroParagraph = css`
+	${body.medium({
+		lineHeight: 'loose',
+	})}
+	margin-bottom: ${space[6]}px;
+
+	/* apply the same margin to paragraphs parsed from markdown from promo codes */
+	& p:not(:last-of-type) {
+		margin-bottom: ${space[9]}px;
+	}
+
+	${from.desktop} {
+		max-width: 75%;
+		margin-bottom: ${space[9]}px;
+	}
+`;
+const mobileLineBreak = css`
+	${from.tablet} {
+		display: none;
+	}
+`;
+const tabletLineBreak = css`
+	${from.desktop} {
+		display: none;
+	}
+`;
+const defaultTitle = (
+	<>
+		Guardian <br css={mobileLineBreak} />
+		and&nbsp;Observer <br css={mobileLineBreak} />
+		newspaper subscriptions <br css={tabletLineBreak} />
+		<span css={heroTitleHighlight}>to suit every reader</span>
+	</>
+);
+const defaultCopy = (
+	<>
+		We offer a range of packages from every day to weekend, and different
+		subscription types depending on whether you want to collect your newspaper
+		in a shop or get it delivered.
+	</>
+);
+
+export function PaperProductInfo({
+	promotionCopy,
+}: PaperProductInfoProps): JSX.Element {
+	const title = promotionCopy.title ?? defaultTitle;
+	const copy =
+		promotionHTML(promotionCopy.description, {
+			tag: 'p',
+		}) ?? defaultCopy;
+	return (
+		<Hero
+			image={
+				<GridImage
+					gridId="printCampaignHeroHD"
+					srcSizes={[1000, 500, 140]}
+					sizes="(max-width: 740px) 100%,
+            (max-width: 1067px) 150%,
+            500px"
+					imgType="png"
+					altText="Newspapers"
+				/>
+			}
+			hideRoundelBelow="mobileMedium"
+			roundelElement={undefined}
+		>
+			<section css={heroCopy}>
+				<h2 css={heroTitle}>{title}</h2>
+				<p css={heroParagraph}>{copy}</p>
+			</section>
+		</Hero>
+	);
+}

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.tsx
@@ -18,6 +18,7 @@ import GridImage from 'components/gridImage/gridImage';
 import Hero from 'components/page/hero';
 import OfferStrapline from 'components/page/offerStrapline';
 import PageTitle from 'components/page/pageTitle';
+import type { Participations } from 'helpers/abTests/abtest';
 import { getMaxSavingVsRetail } from 'helpers/productPrice/paperSavingsVsRetail';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import type { PromotionCopy } from 'helpers/productPrice/promotions';
@@ -26,9 +27,16 @@ import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
 import { offerStraplineBlue } from 'stylesheets/emotion/colours';
 import { getDiscountCopy } from './discountCopy';
 
-type PropTypes = {
+type PaperHeroPropTypes = {
 	productPrices: ProductPrices;
 	promotionCopy: PromotionCopy;
+	participations: Participations;
+};
+
+type PriceCardsPaperHeroPropTypes = {
+	productPrices: ProductPrices;
+	promotionCopy: PromotionCopy;
+	participations: Participations;
 };
 
 const heroCopy = css`
@@ -97,10 +105,10 @@ const defaultCopy = (
 	</>
 );
 
-function PaperHero({
+export function PaperHero({
 	productPrices,
 	promotionCopy,
-}: PropTypes): JSX.Element | null {
+}: PaperHeroPropTypes): JSX.Element | null {
 	const maxSavingVsRetail = getMaxSavingVsRetail(productPrices) ?? 0;
 	const { roundel } = getDiscountCopy(maxSavingVsRetail);
 	const defaultRoundelText = roundel.length ? roundel.join(' ') : undefined;
@@ -159,4 +167,64 @@ function PaperHero({
 	);
 }
 
-export default PaperHero;
+export function PriceCardsPaperHero({
+	productPrices,
+	promotionCopy,
+}: PriceCardsPaperHeroPropTypes): JSX.Element | null {
+	const maxSavingVsRetail = getMaxSavingVsRetail(productPrices) ?? 0;
+	const { roundel } = getDiscountCopy(maxSavingVsRetail);
+	const defaultRoundelText = roundel.length ? roundel.join(' ') : undefined;
+
+	const title = promotionCopy.title ?? defaultTitle;
+	const copy =
+		promotionHTML(promotionCopy.description, {
+			tag: 'p',
+		}) ?? defaultCopy;
+	const roundelText = promotionCopy.roundel ?? defaultRoundelText;
+	return (
+		<PageTitle title="Newspaper subscription" theme="paper">
+			<CentredContainer>
+				<OfferStrapline
+					fgCol={text.primary}
+					bgCol={offerStraplineBlue}
+					copy={roundelText}
+				/>
+				<Hero
+					image={
+						<GridImage
+							gridId="printCampaignHeroHD"
+							srcSizes={[1000, 500, 140]}
+							sizes="(max-width: 740px) 100%,
+            (max-width: 1067px) 150%,
+            500px"
+							imgType="png"
+							altText="Newspapers"
+						/>
+					}
+					hideRoundelBelow="mobileMedium"
+					roundelElement={undefined}
+				>
+					<section css={heroCopy}>
+						<h2 css={heroTitle}>{title}</h2>
+						<p css={heroParagraph}>{copy}</p>
+						<ThemeProvider theme={buttonThemeBrand}>
+							<LinkButton
+								onClick={sendTrackingEventsOnClick({
+									id: 'options_cta_click',
+									product: 'Paper',
+									componentType: 'ACQUISITIONS_BUTTON',
+								})}
+								priority="tertiary"
+								iconSide="right"
+								icon={<SvgArrowDownStraight />}
+								href="#subscribe"
+							>
+								See pricing options
+							</LinkButton>
+						</ThemeProvider>
+					</section>
+				</Hero>
+			</CentredContainer>
+		</PageTitle>
+	);
+}

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.tsx
@@ -175,11 +175,6 @@ export function PriceCardsPaperHero({
 	const { roundel } = getDiscountCopy(maxSavingVsRetail);
 	const defaultRoundelText = roundel.length ? roundel.join(' ') : undefined;
 
-	const title = promotionCopy.title ?? defaultTitle;
-	const copy =
-		promotionHTML(promotionCopy.description, {
-			tag: 'p',
-		}) ?? defaultCopy;
 	const roundelText = promotionCopy.roundel ?? defaultRoundelText;
 	return (
 		<PageTitle title="Newspaper subscription" theme="paper">
@@ -189,41 +184,6 @@ export function PriceCardsPaperHero({
 					bgCol={offerStraplineBlue}
 					copy={roundelText}
 				/>
-				<Hero
-					image={
-						<GridImage
-							gridId="printCampaignHeroHD"
-							srcSizes={[1000, 500, 140]}
-							sizes="(max-width: 740px) 100%,
-            (max-width: 1067px) 150%,
-            500px"
-							imgType="png"
-							altText="Newspapers"
-						/>
-					}
-					hideRoundelBelow="mobileMedium"
-					roundelElement={undefined}
-				>
-					<section css={heroCopy}>
-						<h2 css={heroTitle}>{title}</h2>
-						<p css={heroParagraph}>{copy}</p>
-						<ThemeProvider theme={buttonThemeBrand}>
-							<LinkButton
-								onClick={sendTrackingEventsOnClick({
-									id: 'options_cta_click',
-									product: 'Paper',
-									componentType: 'ACQUISITIONS_BUTTON',
-								})}
-								priority="tertiary"
-								iconSide="right"
-								icon={<SvgArrowDownStraight />}
-								href="#subscribe"
-							>
-								See pricing options
-							</LinkButton>
-						</ThemeProvider>
-					</section>
-				</Hero>
 			</CentredContainer>
 		</PageTitle>
 	);

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.tsx
@@ -18,7 +18,6 @@ import GridImage from 'components/gridImage/gridImage';
 import Hero from 'components/page/hero';
 import OfferStrapline from 'components/page/offerStrapline';
 import PageTitle from 'components/page/pageTitle';
-import type { Participations } from 'helpers/abTests/abtest';
 import { getMaxSavingVsRetail } from 'helpers/productPrice/paperSavingsVsRetail';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import type { PromotionCopy } from 'helpers/productPrice/promotions';
@@ -30,13 +29,11 @@ import { getDiscountCopy } from './discountCopy';
 type PaperHeroPropTypes = {
 	productPrices: ProductPrices;
 	promotionCopy: PromotionCopy;
-	participations: Participations;
 };
 
 type PriceCardsPaperHeroPropTypes = {
 	productPrices: ProductPrices;
 	promotionCopy: PromotionCopy;
-	participations: Participations;
 };
 
 const heroCopy = css`

--- a/support-frontend/assets/pages/paper-subscription-landing/components/paperProductPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/paperProductPrices.tsx
@@ -21,7 +21,7 @@ import {
 import type { TrackingProperties } from 'helpers/productPrice/subscriptions';
 import { paperCheckoutUrl } from 'helpers/urls/routes';
 import { getTitle } from '../helpers/products';
-import PaperPrices from './content/paperPrices';
+import { PaperPrices } from './content/paperPrices';
 
 // ---- Helpers ----- //
 const getPriceCopyString = (

--- a/support-frontend/assets/pages/paper-subscription-landing/components/paperProductPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/paperProductPrices.tsx
@@ -21,7 +21,7 @@ import {
 import type { TrackingProperties } from 'helpers/productPrice/subscriptions';
 import { paperCheckoutUrl } from 'helpers/urls/routes';
 import { getTitle } from '../helpers/products';
-import Prices from './content/prices';
+import PaperPrices from './content/paperPrices';
 
 // ---- Helpers ----- //
 const getPriceCopyString = (
@@ -196,7 +196,11 @@ function PaperProductPrices({
 
 	const products = getPlans(tab, productPrices);
 	return (
-		<Prices activeTab={tab} products={products} setTabAction={setTabAction} />
+		<PaperPrices
+			activeTab={tab}
+			products={products}
+			setTabAction={setTabAction}
+		/>
 	);
 }
 

--- a/support-frontend/assets/pages/paper-subscription-landing/components/paperProductPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/paperProductPrices.tsx
@@ -183,12 +183,14 @@ type PaperProductPricesProps = {
 	productPrices: ProductPrices | null | undefined;
 	tab: PaperFulfilmentOptions;
 	setTabAction: (arg0: PaperFulfilmentOptions) => void;
+	isPriceCardsAbTestVariant?: boolean;
 };
 
 function PaperProductPrices({
 	productPrices,
 	tab,
 	setTabAction,
+	isPriceCardsAbTestVariant,
 }: PaperProductPricesProps): JSX.Element | null {
 	if (!productPrices) {
 		return null;
@@ -200,6 +202,7 @@ function PaperProductPrices({
 			activeTab={tab}
 			products={products}
 			setTabAction={setTabAction}
+			isPriceCardsAbTestVariant={isPriceCardsAbTestVariant ?? false}
 		/>
 	);
 }

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
@@ -1,5 +1,7 @@
 // ----- Imports ----- //
 
+import { css } from '@emotion/react';
+import { between, space } from '@guardian/source-foundations';
 import { useState } from 'react';
 import CentredContainer from 'components/containers/centredContainer';
 import FullWidthContainer from 'components/containers/fullWidthContainer';
@@ -18,12 +20,12 @@ import { getPromotionCopy } from 'helpers/productPrice/promotions';
 import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
 import { renderPage } from 'helpers/rendering/render';
 import { paperSubsUrl } from 'helpers/urls/routes';
+import { PaperProductInfo } from './components/content/paperProductInfo';
 import { PaperHero, PriceCardsPaperHero } from './components/hero/hero';
 import Prices from './components/paperPrices';
 import Tabs from './components/tabs';
 import type { PaperLandingPropTypes } from './paperSubscriptionLandingProps';
 import { paperLandingProps } from './paperSubscriptionLandingProps';
-import { tabsTabletSpacing } from './paperSubscriptionLandingStyles';
 import 'stylesheets/skeleton/skeleton.scss';
 import './paperSubscriptionLanding.scss';
 
@@ -38,6 +40,16 @@ const paperSubsFooter = (
 );
 
 // ----- Render ----- //
+
+const tabsTabletSpacing = css`
+	${between.tablet.and.leftCol} {
+		padding: 0 ${space[5]}px;
+	}
+`;
+
+const paperHeroContainerOverrides = css`
+	display: flex;
+`;
 
 // ID for Selenium tests
 const pageQaId = 'qa-paper-subscriptions';
@@ -94,6 +106,7 @@ function PaperLandingPageControl({
 					</Block>
 				</CentredContainer>
 			</FullWidthContainer>
+
 			<FullWidthContainer theme="dark" hasOverlap>
 				<CentredContainer>
 					<Prices
@@ -142,7 +155,12 @@ function PaperLandingPageVariant({
 			header={<Header countryGroupId={GBPCountries} />}
 			footer={paperSubsFooter}
 		>
-			<FullWidthContainer theme="dark" hasOverlap>
+			<PriceCardsPaperHero
+				productPrices={productPrices}
+				promotionCopy={sanitisedPromoCopy}
+				participations={participations}
+			/>
+			<FullWidthContainer theme="dark">
 				<CentredContainer>
 					<Prices
 						productPrices={productPrices}
@@ -151,11 +169,11 @@ function PaperLandingPageVariant({
 					/>
 				</CentredContainer>
 			</FullWidthContainer>
-			<PriceCardsPaperHero
-				productPrices={productPrices}
-				promotionCopy={sanitisedPromoCopy}
-				participations={participations}
-			/>
+			<FullWidthContainer cssOverrides={paperHeroContainerOverrides}>
+				<CentredContainer>
+					<PaperProductInfo promotionCopy={sanitisedPromoCopy} />
+				</CentredContainer>
+			</FullWidthContainer>
 			<FullWidthContainer>
 				<CentredContainer>
 					<Block>

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
@@ -24,7 +24,10 @@ import { PaperProductInfo } from './components/content/paperProductInfo';
 import { PaperHero, PriceCardsPaperHero } from './components/hero/hero';
 import PaperProductPrices from './components/paperProductPrices';
 import Tabs from './components/tabs';
-import type { PaperLandingPropTypes } from './paperSubscriptionLandingProps';
+import type {
+	PaperLandingContentPropTypes,
+	PaperLandingPropTypes,
+} from './paperSubscriptionLandingProps';
 import { paperLandingProps } from './paperSubscriptionLandingProps';
 import 'stylesheets/skeleton/skeleton.scss';
 import './paperSubscriptionLanding.scss';
@@ -57,8 +60,7 @@ const pageQaId = 'qa-paper-subscriptions';
 function PaperLandingPageControl({
 	productPrices,
 	promotionCopy,
-	participations,
-}: PaperLandingPropTypes) {
+}: PaperLandingContentPropTypes) {
 	const sanitisedPromoCopy = getPromotionCopy(promotionCopy);
 	const fulfilment: PaperFulfilmentOptions = window.location.pathname.includes(
 		'delivery',
@@ -92,7 +94,6 @@ function PaperLandingPageControl({
 			<PaperHero
 				productPrices={productPrices}
 				promotionCopy={sanitisedPromoCopy}
-				participations={participations}
 			/>
 			<FullWidthContainer>
 				<CentredContainer>
@@ -123,8 +124,8 @@ function PaperLandingPageControl({
 function PaperLandingPageVariant({
 	productPrices,
 	promotionCopy,
-	participations,
-}: PaperLandingPropTypes) {
+	isPriceCardsAbTestVariant,
+}: PaperLandingContentPropTypes) {
 	const sanitisedPromoCopy = getPromotionCopy(promotionCopy);
 	const fulfilment: PaperFulfilmentOptions = window.location.pathname.includes(
 		'delivery',
@@ -159,7 +160,6 @@ function PaperLandingPageVariant({
 				<PriceCardsPaperHero
 					productPrices={productPrices}
 					promotionCopy={sanitisedPromoCopy}
-					participations={participations}
 				/>
 			</FullWidthContainer>
 			<FullWidthContainer theme="dark">
@@ -168,6 +168,7 @@ function PaperLandingPageVariant({
 						productPrices={productPrices}
 						tab={selectedTab}
 						setTabAction={setSelectedTab}
+						isPriceCardsAbTestVariant={isPriceCardsAbTestVariant}
 					/>
 				</CentredContainer>
 			</FullWidthContainer>
@@ -203,13 +204,12 @@ function PaperLandingPage({
 		<PaperLandingPageVariant
 			productPrices={productPrices}
 			promotionCopy={promotionCopy}
-			participations={participations}
+			isPriceCardsAbTestVariant={isPriceCardsAbTestVariant}
 		/>
 	) : (
 		<PaperLandingPageControl
 			productPrices={productPrices}
 			promotionCopy={promotionCopy}
-			participations={participations}
 		/>
 	);
 }

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
@@ -22,7 +22,7 @@ import { renderPage } from 'helpers/rendering/render';
 import { paperSubsUrl } from 'helpers/urls/routes';
 import { PaperProductInfo } from './components/content/paperProductInfo';
 import { PaperHero, PriceCardsPaperHero } from './components/hero/hero';
-import Prices from './components/paperPrices';
+import Prices from './components/paperProductPrices';
 import Tabs from './components/tabs';
 import type { PaperLandingPropTypes } from './paperSubscriptionLandingProps';
 import { paperLandingProps } from './paperSubscriptionLandingProps';
@@ -155,11 +155,13 @@ function PaperLandingPageVariant({
 			header={<Header countryGroupId={GBPCountries} />}
 			footer={paperSubsFooter}
 		>
-			<PriceCardsPaperHero
-				productPrices={productPrices}
-				promotionCopy={sanitisedPromoCopy}
-				participations={participations}
-			/>
+			<FullWidthContainer cssOverrides={paperHeroContainerOverrides}>
+				<PriceCardsPaperHero
+					productPrices={productPrices}
+					promotionCopy={sanitisedPromoCopy}
+					participations={participations}
+				/>
+			</FullWidthContainer>
 			<FullWidthContainer theme="dark">
 				<CentredContainer>
 					<Prices

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
@@ -124,7 +124,6 @@ function PaperLandingPageControl({
 function PaperLandingPageVariant({
 	productPrices,
 	promotionCopy,
-	isPriceCardsAbTestVariant,
 }: PaperLandingContentPropTypes) {
 	const sanitisedPromoCopy = getPromotionCopy(promotionCopy);
 	const fulfilment: PaperFulfilmentOptions = window.location.pathname.includes(
@@ -168,7 +167,7 @@ function PaperLandingPageVariant({
 						productPrices={productPrices}
 						tab={selectedTab}
 						setTabAction={setSelectedTab}
-						isPriceCardsAbTestVariant={isPriceCardsAbTestVariant}
+						isPriceCardsAbTestVariant={true}
 					/>
 				</CentredContainer>
 			</FullWidthContainer>
@@ -198,13 +197,10 @@ function PaperLandingPage({
 	promotionCopy,
 	participations,
 }: PaperLandingPropTypes) {
-	const isPriceCardsAbTestVariant =
-		participations.newspaperPriceCards === 'variant';
-	return isPriceCardsAbTestVariant ? (
+	return participations.newspaperPriceCards === 'variant' ? (
 		<PaperLandingPageVariant
 			productPrices={productPrices}
 			promotionCopy={promotionCopy}
-			isPriceCardsAbTestVariant={isPriceCardsAbTestVariant}
 		/>
 	) : (
 		<PaperLandingPageControl

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
@@ -22,7 +22,7 @@ import { renderPage } from 'helpers/rendering/render';
 import { paperSubsUrl } from 'helpers/urls/routes';
 import { PaperProductInfo } from './components/content/paperProductInfo';
 import { PaperHero, PriceCardsPaperHero } from './components/hero/hero';
-import Prices from './components/paperProductPrices';
+import PaperProductPrices from './components/paperProductPrices';
 import Tabs from './components/tabs';
 import type { PaperLandingPropTypes } from './paperSubscriptionLandingProps';
 import { paperLandingProps } from './paperSubscriptionLandingProps';
@@ -109,7 +109,7 @@ function PaperLandingPageControl({
 
 			<FullWidthContainer theme="dark" hasOverlap>
 				<CentredContainer>
-					<Prices
+					<PaperProductPrices
 						productPrices={productPrices}
 						tab={selectedTab}
 						setTabAction={setSelectedTab}
@@ -164,7 +164,7 @@ function PaperLandingPageVariant({
 			</FullWidthContainer>
 			<FullWidthContainer theme="dark">
 				<CentredContainer>
-					<Prices
+					<PaperProductPrices
 						productPrices={productPrices}
 						tab={selectedTab}
 						setTabAction={setSelectedTab}

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingProps.ts
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingProps.ts
@@ -10,6 +10,12 @@ import { detect as detectCountryGroup } from 'helpers/internationalisation/count
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import type { PromotionCopy } from 'helpers/productPrice/promotions';
 
+export type PaperLandingContentPropTypes = {
+	productPrices: ProductPrices | null | undefined;
+	promotionCopy: PromotionCopy | null | undefined;
+	isPriceCardsAbTestVariant?: boolean;
+};
+
 export type PaperLandingPropTypes = {
 	productPrices: ProductPrices | null | undefined;
 	promotionCopy: PromotionCopy | null | undefined;

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingProps.ts
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingProps.ts
@@ -13,7 +13,6 @@ import type { PromotionCopy } from 'helpers/productPrice/promotions';
 export type PaperLandingContentPropTypes = {
 	productPrices: ProductPrices | null | undefined;
 	promotionCopy: PromotionCopy | null | undefined;
-	isPriceCardsAbTestVariant?: boolean;
 };
 
 export type PaperLandingPropTypes = {

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingStyles.ts
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingStyles.ts
@@ -1,8 +1,0 @@
-import { css } from '@emotion/react';
-import { between, space } from '@guardian/source-foundations';
-
-export const tabsTabletSpacing = css`
-	${between.tablet.and.leftCol} {
-		padding: 0 ${space[5]}px;
-	}
-`;


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds an AB test to change the order and position of price cards on the Newspaper Subscriptions landing page ->

#ab-newspaperPriceCards=control / #ab-newspaperPriceCards=variant

Please see attached screenshots for the control and variant.

[**Trello Card**](https://trello.com/c/fhBoFK3Y/1124-newspaper-price-cards-move-to-top-engineering)

## Is this an AB test?
- [x] Yes
- [ ] No

## Screenshots
| | Mobile | Desktop |
| -- | -- | -- |
| Control | ![Screenshot 2023-03-03 at 10 45 35](https://user-images.githubusercontent.com/76729591/222701203-e4341f83-4041-45fc-9046-e88f41027782.png) | ![Screenshot 2023-03-03 at 10 46 52](https://user-images.githubusercontent.com/76729591/222701297-8e42901a-81c2-4176-b229-73f2210bcf79.png)
| Variant | ![Screenshot 2023-03-03 at 10 52 02](https://user-images.githubusercontent.com/76729591/222702134-a4325ab3-e99a-4354-ba7f-70910f28173a.png) | ![Screenshot 2023-03-03 at 10 52 15](https://user-images.githubusercontent.com/76729591/222702194-f94f854e-a0b0-432d-b1b9-831c47b2cc6c.png) |
