### PR TITLE
Set up a new thank you page for migrating Kindle subscribers

### DIFF
--- a/support-frontend/assets/components/thankYou/appDownload/appDownloadItems.tsx
+++ b/support-frontend/assets/components/thankYou/appDownload/appDownloadItems.tsx
@@ -17,3 +17,14 @@ export function AppDownloadBodyCopy(): JSX.Element {
 		</span>
 	);
 }
+
+export const appDownloadDigiSubHeader =
+	'Download The Guardian and Guardian Editions app';
+
+export function AppDownloadDigiSubBodyCopy(): JSX.Element {
+	return (
+		<span css={downloadCopy}>
+			Unlock full access to both of our quality news apps today
+		</span>
+	);
+}

--- a/support-frontend/assets/components/thankYou/appDownload/appDownloadItems.tsx
+++ b/support-frontend/assets/components/thankYou/appDownload/appDownloadItems.tsx
@@ -18,10 +18,10 @@ export function AppDownloadBodyCopy(): JSX.Element {
 	);
 }
 
-export const appDownloadDigiSubHeader =
+export const appDownloadKindleHeader =
 	'Download The Guardian and Guardian Editions app';
 
-export function AppDownloadDigiSubBodyCopy(): JSX.Element {
+export function AppDownloadKindleBodyCopy(): JSX.Element {
 	return (
 		<span css={downloadCopy}>
 			Unlock full access to both of our quality news apps today

--- a/support-frontend/assets/components/thankYou/thankYouModule.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModule.tsx
@@ -146,6 +146,7 @@ const marginTop = css`
 
 export type ThankYouModuleType =
 	| 'appDownload'
+	| 'appDownloadDigiSub'
 	| 'ausMap'
 	| 'feedback'
 	| 'marketingConsent'

--- a/support-frontend/assets/components/thankYou/thankYouModule.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModule.tsx
@@ -146,7 +146,7 @@ const marginTop = css`
 
 export type ThankYouModuleType =
 	| 'appDownload'
-	| 'appDownloadDigiSub'
+	| 'appDownloadKindle'
 	| 'ausMap'
 	| 'feedback'
 	| 'marketingConsent'

--- a/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
@@ -13,6 +13,8 @@ import {
 import AppDownloadBadges from './appDownload/AppDownloadBadges';
 import {
 	AppDownloadBodyCopy,
+	AppDownloadDigiSubBodyCopy,
+	appDownloadDigiSubHeader,
 	appDownloadHeader,
 } from './appDownload/appDownloadItems';
 import { ausMapBodyCopy, AusMapCTA, ausMapHeader } from './ausMap/ausMapItems';
@@ -63,6 +65,12 @@ export const getThankYouModuleData = (
 			header: appDownloadHeader,
 			bodyCopy: <AppDownloadBodyCopy />,
 			ctas: <AppDownloadBadges countryGroupId={countryGroupId} />,
+		},
+		appDownloadDigiSub: {
+			icon: getThankYouModuleIcon('appDownload'),
+			header: appDownloadDigiSubHeader,
+			bodyCopy: <AppDownloadDigiSubBodyCopy />,
+			ctas: null,
 		},
 		ausMap: {
 			icon: getThankYouModuleIcon('ausMap'),

--- a/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
@@ -13,9 +13,9 @@ import {
 import AppDownloadBadges from './appDownload/AppDownloadBadges';
 import {
 	AppDownloadBodyCopy,
-	AppDownloadDigiSubBodyCopy,
-	appDownloadDigiSubHeader,
 	appDownloadHeader,
+	AppDownloadKindleBodyCopy,
+	appDownloadKindleHeader,
 } from './appDownload/appDownloadItems';
 import { ausMapBodyCopy, AusMapCTA, ausMapHeader } from './ausMap/ausMapItems';
 import {
@@ -66,10 +66,10 @@ export const getThankYouModuleData = (
 			bodyCopy: <AppDownloadBodyCopy />,
 			ctas: <AppDownloadBadges countryGroupId={countryGroupId} />,
 		},
-		appDownloadDigiSub: {
+		appDownloadKindle: {
 			icon: getThankYouModuleIcon('appDownload'),
-			header: appDownloadDigiSubHeader,
-			bodyCopy: <AppDownloadDigiSubBodyCopy />,
+			header: appDownloadKindleHeader,
+			bodyCopy: <AppDownloadKindleBodyCopy />,
 			ctas: null,
 		},
 		ausMap: {

--- a/support-frontend/assets/pages/kindle-subscriber-checkout/kindleSubscriptionRouter.tsx
+++ b/support-frontend/assets/pages/kindle-subscriber-checkout/kindleSubscriptionRouter.tsx
@@ -12,7 +12,7 @@ import { initReduxForContributions } from 'helpers/redux/contributionsStore';
 import { renderPage } from 'helpers/rendering/render';
 import { gaEvent } from 'helpers/tracking/googleTagManager';
 import { SupporterPlusLandingPage } from 'pages/kindle-subscriber-checkout/kindleSubscriptionLandingPage';
-import { SupporterPlusThankYou } from 'pages/supporter-plus-thank-you/supporterPlusThankYou';
+import { KindleSubscriptionThankYou } from 'pages/kindle-subscriber-thank-you/kindleSubscriptionThankYou';
 import { setUpRedux } from './setup/setUpRedux';
 
 if (!isDetailsSupported) {
@@ -79,7 +79,7 @@ const router = () => {
 					{countryIds.map((countryId) => (
 						<Route
 							path={`/${countryId}/kindle/thankyou`}
-							element={<SupporterPlusThankYou />}
+							element={<KindleSubscriptionThankYou />}
 						/>
 					))}
 				</Routes>

--- a/support-frontend/assets/pages/kindle-subscriber-thank-you/components/heading.tsx
+++ b/support-frontend/assets/pages/kindle-subscriber-thank-you/components/heading.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import type { ContributionType } from 'helpers/contributions';
 import { formatAmount } from 'helpers/forms/checkouts';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
@@ -6,17 +5,12 @@ import {
 	currencies,
 	spokenCurrencies,
 } from 'helpers/internationalisation/currency';
+import { amountText } from 'pages/supporter-plus-thank-you/components/thankYouHeader/heading';
 
 const MAX_DISPLAY_NAME_LENGTH = 10;
 
-export const amountText = css`
-	background-color: #ffe500;
-	padding: 0 5px;
-`;
-
 interface HeadingProps {
 	name: string | null;
-	isOneOffPayPal: boolean;
 	amount: number | undefined;
 	currency: IsoCurrency;
 	contributionType: ContributionType;
@@ -24,7 +18,6 @@ interface HeadingProps {
 
 function Heading({
 	name,
-	isOneOffPayPal,
 	amount,
 	currency,
 	contributionType,
@@ -32,11 +25,11 @@ function Heading({
 	const maybeNameAndTrailingSpace: string =
 		name && name.length < MAX_DISPLAY_NAME_LENGTH ? `${name} ` : '';
 
-	// Do not show special header to paypal/one-off as we don't have the relevant info after the redirect
-	if (isOneOffPayPal || !amount) {
+	if (!amount || contributionType === 'ONE_OFF') {
 		return (
 			<div>
-				Thank you {maybeNameAndTrailingSpace}for your valuable contribution
+				Thank you {maybeNameAndTrailingSpace}for supporting us with a Digital
+				Subscription ❤️
 			</div>
 		);
 	}
@@ -53,16 +46,11 @@ function Heading({
 	);
 
 	switch (contributionType) {
-		case 'ONE_OFF':
-			return (
-				<div>Thank you for supporting us today with {currencyAndAmount} ❤️</div>
-			);
-
 		case 'MONTHLY':
 			return (
 				<div>
 					Thank you {maybeNameAndTrailingSpace}for supporting us with{' '}
-					{currencyAndAmount} each month ❤️
+					{currencyAndAmount} each month for your first year ❤️
 				</div>
 			);
 
@@ -77,7 +65,8 @@ function Heading({
 		default:
 			return (
 				<div>
-					Thank you {maybeNameAndTrailingSpace}for your valuable contribution
+					Thank you {maybeNameAndTrailingSpace}for supporting us with a Digital
+					Subscription ❤️
 				</div>
 			);
 	}

--- a/support-frontend/assets/pages/kindle-subscriber-thank-you/components/heading.tsx
+++ b/support-frontend/assets/pages/kindle-subscriber-thank-you/components/heading.tsx
@@ -1,10 +1,10 @@
-import type { ContributionType } from 'helpers/contributions';
 import { formatAmount } from 'helpers/forms/checkouts';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import {
 	currencies,
 	spokenCurrencies,
 } from 'helpers/internationalisation/currency';
+import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import { amountText } from 'pages/supporter-plus-thank-you/components/thankYouHeader/heading';
 
 const MAX_DISPLAY_NAME_LENGTH = 10;
@@ -13,19 +13,19 @@ interface HeadingProps {
 	name: string | null;
 	amount: number | undefined;
 	currency: IsoCurrency;
-	contributionType: ContributionType;
+	billingPeriod: BillingPeriod;
 }
 
 function Heading({
 	name,
 	amount,
 	currency,
-	contributionType,
+	billingPeriod,
 }: HeadingProps): JSX.Element {
 	const maybeNameAndTrailingSpace: string =
 		name && name.length < MAX_DISPLAY_NAME_LENGTH ? `${name} ` : '';
 
-	if (!amount || contributionType === 'ONE_OFF') {
+	if (!amount) {
 		return (
 			<div>
 				Thank you {maybeNameAndTrailingSpace}for supporting us with a Digital
@@ -45,31 +45,30 @@ function Heading({
 		</span>
 	);
 
-	switch (contributionType) {
-		case 'MONTHLY':
-			return (
-				<div>
-					Thank you {maybeNameAndTrailingSpace}for supporting us with{' '}
-					{currencyAndAmount} each month for your first year ❤️
-				</div>
-			);
-
-		case 'ANNUAL':
-			return (
-				<div>
-					Thank you {maybeNameAndTrailingSpace}for supporting us with{' '}
-					{currencyAndAmount} each year ❤️
-				</div>
-			);
-
-		default:
-			return (
-				<div>
-					Thank you {maybeNameAndTrailingSpace}for supporting us with a Digital
-					Subscription ❤️
-				</div>
-			);
+	if (billingPeriod === 'Monthly') {
+		return (
+			<div>
+				Thank you {maybeNameAndTrailingSpace}for supporting us with{' '}
+				{currencyAndAmount} each month for your first year ❤️
+			</div>
+		);
 	}
+
+	if (billingPeriod === 'Annual') {
+		return (
+			<div>
+				Thank you {maybeNameAndTrailingSpace}for supporting us with{' '}
+				{currencyAndAmount} each year ❤️
+			</div>
+		);
+	}
+
+	return (
+		<div>
+			Thank you {maybeNameAndTrailingSpace}for supporting us with a Digital
+			Subscription ❤️
+		</div>
+	);
 }
 
 export default Heading;

--- a/support-frontend/assets/pages/kindle-subscriber-thank-you/components/subheading.tsx
+++ b/support-frontend/assets/pages/kindle-subscriber-thank-you/components/subheading.tsx
@@ -2,7 +2,7 @@
 // 	amountIsAboveSupporterPlusThreshold: boolean;
 // 	isSignedIn: boolean;
 // 	userTypeFromIdentityResponse: UserTypeFromIdentityResponse;
-// 	contributionType?: ContributionType;
+// billingPeriod: BillingPeriod // Monthly or Annual for digiSub
 // }
 
 function MarketingCopy(): JSX.Element {

--- a/support-frontend/assets/pages/kindle-subscriber-thank-you/components/subheading.tsx
+++ b/support-frontend/assets/pages/kindle-subscriber-thank-you/components/subheading.tsx
@@ -1,0 +1,62 @@
+// interface SubheadingProps {
+// 	amountIsAboveSupporterPlusThreshold: boolean;
+// 	isSignedIn: boolean;
+// 	userTypeFromIdentityResponse: UserTypeFromIdentityResponse;
+// 	contributionType?: ContributionType;
+// }
+
+function MarketingCopy(): JSX.Element {
+	return (
+		<span>
+			Adjust your email preferences at any time via{' '}
+			<a href="https://manage.theguardian.com">your account</a>.
+		</span>
+	);
+}
+
+function SubHeadingCopy() {
+	// The following would allow us to display different copy depending on:
+	// - whether the user is signed in
+	// - whether the selected amount is above a specified threshold amount
+	//
+	// const maybeIsSignedIn =
+	// 	userTypeFromIdentityResponse === 'current' || isSignedIn
+	// 		? 'isSignedIn'
+	// 		: 'notSignedIn';
+	//
+	// const recurringCopy = (amountIsAboveSupporterPlusThreshold: boolean) => {
+	// 	return {
+	// 		isSignedIn: amountIsAboveSupporterPlusThreshold ? (
+	// 			<span>Signed In Above Threshold</span>
+	// 		) : (
+	// 			<span>Signed In Below Threshold</span>
+	// 		),
+	// 		notSignedIn: amountIsAboveSupporterPlusThreshold ? (
+	// 			<span>NOT Signed In Above Threshold</span>
+	// 		) : (
+	// 			<span>NOT Signed In Below Threshold</span>
+	// 		),
+	// 	};
+	// };
+	//
+	// return recurringCopy(amountIsAboveSupporterPlusThreshold)[maybeIsSignedIn];
+
+	return (
+		<span>
+			Look out for your exclusive newsletter from our supporter editor. We’ll
+			also be in touch with other great ways to get closer to Guardian
+			journalism.{' '}
+		</span>
+	);
+}
+
+function Subheading(): JSX.Element {
+	return (
+		<>
+			<SubHeadingCopy />
+			<MarketingCopy />
+		</>
+	);
+}
+
+export default Subheading;

--- a/support-frontend/assets/pages/kindle-subscriber-thank-you/components/subheading.tsx
+++ b/support-frontend/assets/pages/kindle-subscriber-thank-you/components/subheading.tsx
@@ -2,7 +2,7 @@
 // 	amountIsAboveSupporterPlusThreshold: boolean;
 // 	isSignedIn: boolean;
 // 	userTypeFromIdentityResponse: UserTypeFromIdentityResponse;
-// billingPeriod: BillingPeriod // Monthly or Annual for digiSub
+//  billingPeriod: BillingPeriod // Monthly or Annual for kindle subscribers
 // }
 
 function MarketingCopy(): JSX.Element {

--- a/support-frontend/assets/pages/kindle-subscriber-thank-you/components/thankYouHeader.tsx
+++ b/support-frontend/assets/pages/kindle-subscriber-thank-you/components/thankYouHeader.tsx
@@ -1,5 +1,5 @@
-import type { ContributionType } from 'helpers/contributions';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import DirectDebitMessage from 'pages/supporter-plus-thank-you/components/thankYouHeader/directDebitMessage';
 import {
 	header,
@@ -13,7 +13,7 @@ type ThankYouHeaderProps = {
 	name: string | null;
 	showDirectDebitMessage: boolean;
 	amount: number | undefined;
-	contributionType: ContributionType;
+	billingPeriod: BillingPeriod;
 	currency: IsoCurrency;
 
 	// Props needed for the Subheading component - currently unused
@@ -27,7 +27,7 @@ function ThankYouHeader({
 	name,
 	showDirectDebitMessage,
 	amount,
-	contributionType,
+	billingPeriod,
 	currency,
 }: ThankYouHeaderProps): JSX.Element {
 	return (
@@ -36,7 +36,7 @@ function ThankYouHeader({
 				<Heading
 					name={name}
 					amount={amount}
-					contributionType={contributionType}
+					billingPeriod={billingPeriod}
 					currency={currency}
 				/>
 			</h1>

--- a/support-frontend/assets/pages/kindle-subscriber-thank-you/components/thankYouHeader.tsx
+++ b/support-frontend/assets/pages/kindle-subscriber-thank-you/components/thankYouHeader.tsx
@@ -1,0 +1,51 @@
+import type { ContributionType } from 'helpers/contributions';
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import DirectDebitMessage from 'pages/supporter-plus-thank-you/components/thankYouHeader/directDebitMessage';
+import {
+	header,
+	headerSupportingText,
+	headerTitleText,
+} from 'pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader';
+import Heading from './heading';
+import Subheading from './subheading';
+
+type ThankYouHeaderProps = {
+	name: string | null;
+	showDirectDebitMessage: boolean;
+	amount: number | undefined;
+	contributionType: ContributionType;
+	currency: IsoCurrency;
+
+	// Props needed for the Subheading component - currently unused
+	//
+	// amountIsAboveSupporterPlusThreshold: boolean;
+	// isSignedIn: boolean;
+	// userTypeFromIdentityResponse: UserTypeFromIdentityResponse;
+};
+
+function ThankYouHeader({
+	name,
+	showDirectDebitMessage,
+	amount,
+	contributionType,
+	currency,
+}: ThankYouHeaderProps): JSX.Element {
+	return (
+		<header css={header}>
+			<h1 css={headerTitleText}>
+				<Heading
+					name={name}
+					amount={amount}
+					contributionType={contributionType}
+					currency={currency}
+				/>
+			</h1>
+			<p css={headerSupportingText}>
+				{showDirectDebitMessage && <DirectDebitMessage />}
+				<Subheading />
+			</p>
+		</header>
+	);
+}
+
+export default ThankYouHeader;

--- a/support-frontend/assets/pages/kindle-subscriber-thank-you/kindleSubscriptionThankYou.tsx
+++ b/support-frontend/assets/pages/kindle-subscriber-thank-you/kindleSubscriptionThankYou.tsx
@@ -92,23 +92,22 @@ export function KindleSubscriptionThankYou(): JSX.Element {
 		moduleType: ThankYouModuleType,
 	): ThankYouModuleType[] => (condtion ? [moduleType] : []);
 
-	// NB: We do not show marketing consent or support reminder modules for recurring
 	const thankYouModules: ThankYouModuleType[] = [
 		...maybeThankYouModule(isNewAccount, 'signUp'),
 		...maybeThankYouModule(
 			!isNewAccount && !isSignedIn && email.length > 0,
 			'signIn',
 		),
-		// Disable App Download module
-		// ...maybeThankYouModule(amountIsAboveThreshold, 'appDownload'),
+		'appDownloadDigiSub',
 		// Disable Feedback module
 		// 'feedback',
 		...maybeThankYouModule(countryId === 'AU', 'ausMap'),
 		'socialShare',
 	];
 
-	const firstColumn = thankYouModules.slice(0, 1);
-	const secondColumn = thankYouModules.slice(1);
+	const numberOfModulesInFirstColumn = thankYouModules.length === 3 ? 1 : 2;
+	const firstColumn = thankYouModules.slice(0, numberOfModulesInFirstColumn);
+	const secondColumn = thankYouModules.slice(numberOfModulesInFirstColumn);
 
 	return (
 		<PageScaffold

--- a/support-frontend/assets/pages/kindle-subscriber-thank-you/kindleSubscriptionThankYou.tsx
+++ b/support-frontend/assets/pages/kindle-subscriber-thank-you/kindleSubscriptionThankYou.tsx
@@ -13,12 +13,8 @@ import { getAmount } from 'helpers/contributions';
 import { DirectDebit } from 'helpers/forms/paymentMethods';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
-import {
-	OPHAN_COMPONENT_ID_RETURN_TO_GUARDIAN,
-	trackUserData,
-} from 'helpers/thankYouPages/utils/ophan';
+import { OPHAN_COMPONENT_ID_RETURN_TO_GUARDIAN } from 'helpers/thankYouPages/utils/ophan';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
-import { sendEventContributionCheckoutConversion } from 'helpers/tracking/quantumMetric';
 import ThankYouFooter from 'pages/supporter-plus-thank-you/components/thankYouFooter';
 import {
 	buttonContainer,
@@ -26,7 +22,6 @@ import {
 	columnContainer,
 	firstColumnContainer,
 	headerContainer,
-	isLargeDonation,
 } from 'pages/supporter-plus-thank-you/supporterPlusThankYou';
 import ThankYouHeader from './components/thankYouHeader';
 
@@ -55,26 +50,26 @@ export function KindleSubscriptionThankYou(): JSX.Element {
 	const contributionType = useContributionsSelector(getContributionType);
 	const isNewAccount = userTypeFromIdentityResponse === 'new';
 	const amount = getAmount(selectedAmounts, otherAmounts, contributionType);
-	const isAmountLargeDonation = amount
-		? isLargeDonation(amount, contributionType, paymentMethod)
-		: false;
+	// const isAmountLargeDonation = amount
+	// 	? isLargeDonation(amount, contributionType, paymentMethod)
+	// 	: false;
 
 	useEffect(() => {
-		// TO-DO
 		if (amount) {
-			sendEventContributionCheckoutConversion(
-				amount,
-				contributionType,
-				currencyId,
-			);
-
-			trackUserData(
-				paymentMethod,
-				contributionType,
-				isSignedIn,
-				!isNewAccount,
-				isAmountLargeDonation,
-			);
+			// TO-DO - add DigiSub tracking for DigiSub
+			//
+			// sendEventContributionCheckoutConversion(
+			// 	amount,
+			// 	contributionType,
+			// 	currencyId,
+			// );
+			// trackUserData(
+			// 	paymentMethod,
+			// 	contributionType,
+			// 	isSignedIn,
+			// 	!isNewAccount,
+			// 	isAmountLargeDonation,
+			// );
 		}
 	}, []);
 

--- a/support-frontend/assets/pages/kindle-subscriber-thank-you/kindleSubscriptionThankYou.tsx
+++ b/support-frontend/assets/pages/kindle-subscriber-thank-you/kindleSubscriptionThankYou.tsx
@@ -1,0 +1,171 @@
+import { Column, Columns, LinkButton } from '@guardian/source-react-components';
+import { FooterWithContents } from '@guardian/source-react-components-development-kitchen';
+import { useEffect, useMemo } from 'preact/hooks';
+import { Header } from 'components/headers/simpleHeader/simpleHeader';
+import { Container } from 'components/layout/container';
+import { PageScaffold } from 'components/page/pageScaffold';
+import type { ThankYouModuleType } from 'components/thankYou/thankYouModule';
+import ThankYouModule from 'components/thankYou/thankYouModule';
+import { getThankYouModuleData } from 'components/thankYou/thankYouModuleData';
+import type { CampaignSettings } from 'helpers/campaigns/campaigns';
+import { getCampaignSettings } from 'helpers/campaigns/campaigns';
+import { getAmount } from 'helpers/contributions';
+import { DirectDebit } from 'helpers/forms/paymentMethods';
+import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import {
+	OPHAN_COMPONENT_ID_RETURN_TO_GUARDIAN,
+	trackUserData,
+} from 'helpers/thankYouPages/utils/ophan';
+import { trackComponentClick } from 'helpers/tracking/behaviour';
+import { sendEventContributionCheckoutConversion } from 'helpers/tracking/quantumMetric';
+import ThankYouFooter from 'pages/supporter-plus-thank-you/components/thankYouFooter';
+import {
+	buttonContainer,
+	checkoutContainer,
+	columnContainer,
+	firstColumnContainer,
+	headerContainer,
+	isLargeDonation,
+} from 'pages/supporter-plus-thank-you/supporterPlusThankYou';
+import ThankYouHeader from './components/thankYouHeader';
+
+export function KindleSubscriptionThankYou(): JSX.Element {
+	const campaignSettings = useMemo<CampaignSettings | null>(
+		() => getCampaignSettings(campaignCode),
+		[],
+	);
+	const { countryId, countryGroupId, currencyId } = useContributionsSelector(
+		(state) => state.common.internationalisation,
+	);
+	const { csrf } = useContributionsSelector((state) => state.page.checkoutForm);
+	const { campaignCode } = useContributionsSelector(
+		(state) => state.common.referrerAcquisitionData,
+	);
+	const { firstName, email, userTypeFromIdentityResponse } =
+		useContributionsSelector(
+			(state) => state.page.checkoutForm.personalDetails,
+		);
+	const paymentMethod = useContributionsSelector(
+		(state) => state.page.checkoutForm.payment.paymentMethod.name,
+	);
+	const { selectedAmounts, otherAmounts, billingPeriod } =
+		useContributionsSelector((state) => state.page.checkoutForm.product);
+	const { isSignedIn } = useContributionsSelector((state) => state.page.user);
+	const contributionType = useContributionsSelector(getContributionType);
+	const isNewAccount = userTypeFromIdentityResponse === 'new';
+	const amount = getAmount(selectedAmounts, otherAmounts, contributionType);
+	const isAmountLargeDonation = amount
+		? isLargeDonation(amount, contributionType, paymentMethod)
+		: false;
+
+	useEffect(() => {
+		// TO-DO
+		if (amount) {
+			sendEventContributionCheckoutConversion(
+				amount,
+				contributionType,
+				currencyId,
+			);
+
+			trackUserData(
+				paymentMethod,
+				contributionType,
+				isSignedIn,
+				!isNewAccount,
+				isAmountLargeDonation,
+			);
+		}
+	}, []);
+
+	const thankYouModuleData = getThankYouModuleData(
+		countryId,
+		countryGroupId,
+		campaignSettings?.createReferralCodes ?? false,
+		csrf,
+		email,
+		campaignSettings?.campaignCode,
+	);
+
+	const maybeThankYouModule = (
+		condtion: boolean,
+		moduleType: ThankYouModuleType,
+	): ThankYouModuleType[] => (condtion ? [moduleType] : []);
+
+	// NB: We do not show marketing consent or support reminder modules for recurring
+	const thankYouModules: ThankYouModuleType[] = [
+		...maybeThankYouModule(isNewAccount, 'signUp'),
+		...maybeThankYouModule(
+			!isNewAccount && !isSignedIn && email.length > 0,
+			'signIn',
+		),
+		// Disable App Download module
+		// ...maybeThankYouModule(amountIsAboveThreshold, 'appDownload'),
+		// Disable Feedback module
+		// 'feedback',
+		...maybeThankYouModule(countryId === 'AU', 'ausMap'),
+		'socialShare',
+	];
+
+	const firstColumn = thankYouModules.slice(0, 1);
+	const secondColumn = thankYouModules.slice(1);
+
+	return (
+		<PageScaffold
+			id="supporter-plus-thank-you"
+			header={<Header />}
+			footer={
+				<FooterWithContents>
+					<ThankYouFooter />
+				</FooterWithContents>
+			}
+		>
+			<div css={checkoutContainer}>
+				<Container>
+					<div css={headerContainer}>
+						<ThankYouHeader
+							name={firstName}
+							showDirectDebitMessage={paymentMethod === DirectDebit}
+							billingPeriod={billingPeriod}
+							amount={amount}
+							currency={currencyId}
+						/>
+					</div>
+
+					<Columns collapseUntil="desktop">
+						<Column cssOverrides={[columnContainer, firstColumnContainer]}>
+							{firstColumn.map((moduleType) => (
+								<ThankYouModule
+									moduleType={moduleType}
+									isSignedIn={isSignedIn}
+									{...thankYouModuleData[moduleType]}
+								/>
+							))}
+						</Column>
+						<Column cssOverrides={columnContainer}>
+							{secondColumn.map((moduleType) => (
+								<ThankYouModule
+									moduleType={moduleType}
+									isSignedIn={isSignedIn}
+									{...thankYouModuleData[moduleType]}
+								/>
+							))}
+						</Column>
+					</Columns>
+
+					<div css={buttonContainer}>
+						<LinkButton
+							href="https://www.theguardian.com"
+							priority="tertiary"
+							onClick={() =>
+								trackComponentClick(OPHAN_COMPONENT_ID_RETURN_TO_GUARDIAN)
+							}
+						>
+							Return to the Guardian
+						</LinkButton>
+					</div>
+				</Container>
+			</div>
+		</PageScaffold>
+	);
+}

--- a/support-frontend/assets/pages/kindle-subscriber-thank-you/kindleSubscriptionThankYou.tsx
+++ b/support-frontend/assets/pages/kindle-subscriber-thank-you/kindleSubscriptionThankYou.tsx
@@ -56,7 +56,7 @@ export function KindleSubscriptionThankYou(): JSX.Element {
 
 	useEffect(() => {
 		if (amount) {
-			// TO-DO - add DigiSub tracking for DigiSub
+			// TO-DO - add tracking for Kindle
 			//
 			// sendEventContributionCheckoutConversion(
 			// 	amount,
@@ -93,9 +93,9 @@ export function KindleSubscriptionThankYou(): JSX.Element {
 			!isNewAccount && !isSignedIn && email.length > 0,
 			'signIn',
 		),
-		'appDownloadDigiSub',
+		'appDownloadKindle',
 		// Disable Feedback module
-		// 'feedback',
+		// 'feedbackKindle', // we will need to create this
 		...maybeThankYouModule(countryId === 'AU', 'ausMap'),
 		'socialShare',
 	];

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader.tsx
@@ -7,7 +7,7 @@ import DirectDebitMessage from './directDebitMessage';
 import Heading from './heading';
 import Subheading from './subheading';
 
-const header = css`
+export const header = css`
 	background: white;
 	padding-top: ${space[4]}px;
 	padding-bottom: ${space[5]}px;
@@ -17,7 +17,7 @@ const header = css`
 	}
 `;
 
-const headerTitleText = css`
+export const headerTitleText = css`
 	${titlepiece.small()};
 	font-size: 24px;
 
@@ -26,7 +26,7 @@ const headerTitleText = css`
 	}
 `;
 
-const headerSupportingText = css`
+export const headerSupportingText = css`
 	${body.small()};
 	padding-top: ${space[3]}px;
 

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -29,13 +29,13 @@ import { sendEventContributionCheckoutConversion } from 'helpers/tracking/quantu
 import ThankYouFooter from './components/thankYouFooter';
 import ThankYouHeader from './components/thankYouHeader/thankYouHeader';
 
-const checkoutContainer = css`
+export const checkoutContainer = css`
 	${from.tablet} {
 		background-color: ${sport[800]};
 	}
 `;
 
-const columnContainer = css`
+export const columnContainer = css`
 	> *:not(:last-child) {
 		${from.tablet} {
 			margin-bottom: ${space[6]}px;
@@ -47,13 +47,13 @@ const columnContainer = css`
 	}
 `;
 
-const firstColumnContainer = css`
+export const firstColumnContainer = css`
 	${between.tablet.and.desktop} {
 		margin-bottom: ${space[6]}px;
 	}
 `;
 
-const headerContainer = css`
+export const headerContainer = css`
 	${from.desktop} {
 		width: 60%;
 	}
@@ -62,11 +62,11 @@ const headerContainer = css`
 	}
 `;
 
-const buttonContainer = css`
+export const buttonContainer = css`
 	padding: ${space[12]}px 0;
 `;
 
-function getAmountFromSessionStorage(): number | undefined {
+export function getAmountFromSessionStorage(): number | undefined {
 	const amount = getSession('contributionAmount');
 
 	if (amount) {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Following https://github.com/guardian/support-frontend/pull/4811 which adds a new checkout page for migrating Kindle subscribers, this adds the accompanying thank you page. This page is based on the preexisting Supporter Plus(S+) thank you page, with a few key differences:

- We do not show the [marketing consent](https://62e115310aef0868687b2322-rxpdpiiwpg.chromatic.com/?path=/story/checkouts-thank-you-module--marketing-consent) or [support reminder](https://62e115310aef0868687b2322-rxpdpiiwpg.chromatic.com/?path=/story/checkouts-thank-you-module--support-reminder) thank you page modules as they are only displayed for users who make a `ONE_OFF` contribution for S+
- We are not currently showing the [feedback](https://62e115310aef0868687b2322-rxpdpiiwpg.chromatic.com/?path=/story/checkouts-thank-you-module--feedback) module as we are not running currently running a survey
- The new download the app module will only contain copy (for now) as opposed to the [supporter plus download the app module](https://62e115310aef0868687b2322-rxpdpiiwpg.chromatic.com/?path=/story/checkouts-thank-you-module--download-the-app-signed-in) 
- The `Subheading` component contains a fair amount of commented out code that would allow us to display different copy depending on:
> - whether the user is signed in
> - whether the selected amount is above or below a specified threshold 
> - the billing type i.e. `Monthly` or `Annual`

Note: This does not currently have tracking as we are yet to replicate the functionality on the supporter plus thank you page. This should be done in a follow up PR.

[**Trello Card**](https://trello.com/c/P95iUTKt/1133-digi-subs-on-new-checkout-for-kindle)

## Screenshots
| Monthly | Annual |
| -- | -- |
| ![localhost_9211_uk_kindle](https://user-images.githubusercontent.com/44685872/222738066-c8a5f734-9902-4895-92db-6972b3828861.png) | ![localhost_9211_uk_kindle (1)](https://user-images.githubusercontent.com/44685872/222738036-864a9b14-69d2-498c-aec1-3264f1e05fe2.png) |
