### PR TITLE
Ensure we send the relevant promo code for Kindle digi sub purchases

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/subscriptionPrice.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/subscriptionPrice.ts
@@ -4,7 +4,7 @@ import {
 	showPrice,
 } from 'helpers/productPrice/productPrices';
 import type { Promotion } from 'helpers/productPrice/promotions';
-import { getPromotion } from 'helpers/productPrice/promotions';
+import { getAppliedPromo, getPromotion } from 'helpers/productPrice/promotions';
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
 
 export function getSubscriptionPrices(
@@ -92,6 +92,23 @@ export function getSubscriptionPromotions(
 			productOption,
 		),
 	};
+}
+
+export function getSubscriptionPromotionForBillingPeriod(
+	state: ContributionsState,
+): Promotion | undefined {
+	const { countryId } = state.common.internationalisation;
+	const { productPrices, fulfilmentOption, productOption, billingPeriod } =
+		state.page.checkoutForm.product;
+	return getAppliedPromo(
+		getProductPrice(
+			productPrices,
+			countryId,
+			billingPeriod,
+			fulfilmentOption,
+			productOption,
+		).promotions,
+	);
 }
 
 export function getSubscriptionPriceForBillingPeriod(

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -60,6 +60,7 @@ import {
 import { setPaymentRequestError } from 'helpers/redux/checkout/payment/paymentRequestButton/actions';
 import { isSupporterPlusPurchase } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import { getSubscriptionPromotionForBillingPeriod } from 'helpers/redux/checkout/product/selectors/subscriptionPrice';
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import * as cookie from 'helpers/storage/cookie';
 import {
@@ -190,6 +191,17 @@ function getBillingCountryAndState(
 	};
 }
 
+// This exists *only* to support the purchase of digi subs for migrating Kindle subscribers
+function getPromoCode(state: ContributionsState) {
+	const promotion = getSubscriptionPromotionForBillingPeriod(state);
+	if (promotion) {
+		return {
+			promoCode: promotion.promoCode,
+		};
+	}
+	return {};
+}
+
 function getProductFields(
 	state: ContributionsState,
 	amount: number,
@@ -258,6 +270,7 @@ function regularPaymentRequestFromAuthorisation(
 			...regularPaymentFieldsFromAuthorisation(authorisation),
 			recaptchaToken,
 		},
+		...getPromoCode(state),
 		ophanIds: getOphanIds(),
 		referrerAcquisitionData: state.common.referrerAcquisitionData,
 		supportAbTests: getSupportAbTests(state.common.abParticipations),


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes an issue where we were not sending the `promoCode` field in the payload when submitting a digi sub purchase on the new checkout.