### PR TITLE
Do not try to retrieve product price on S+

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/subscriptionPrice.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/subscriptionPrice.ts
@@ -98,8 +98,16 @@ export function getSubscriptionPromotionForBillingPeriod(
 	state: ContributionsState,
 ): Promotion | undefined {
 	const { countryId } = state.common.internationalisation;
-	const { productPrices, fulfilmentOption, productOption, billingPeriod } =
-		state.page.checkoutForm.product;
+	const {
+		productPrices,
+		fulfilmentOption,
+		productOption,
+		billingPeriod,
+		productType,
+	} = state.page.checkoutForm.product;
+	if (productType !== 'DigitalPack') {
+		return;
+	}
 	return getAppliedPromo(
 		getProductPrice(
 			productPrices,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes a bug introduced by #4817 that affects the supporter plus checkout.
