### PR TITLE
Guardian Weekly and Newspaper Prices Card move - Activate

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -77,7 +77,7 @@ export const tests: Tests = {
 		isActive: true,
 		referrerControlled: false,
 		targetPage: pageUrlRegexes.subscriptions.subsWeeklyPages,
-		seed: 3,
+		seed: 11,
 	},
 	newspaperPriceCards: {
 		variants: [

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -74,7 +74,7 @@ export const tests: Tests = {
 				size: 1,
 			},
 		},
-		isActive: false,
+		isActive: true,
 		referrerControlled: false,
 		targetPage: pageUrlRegexes.subscriptions.subsWeeklyPages,
 		seed: 11,
@@ -94,9 +94,10 @@ export const tests: Tests = {
 				size: 1,
 			},
 		},
-		isActive: false,
+		isActive: true,
 		referrerControlled: false,
-		targetPage: pageUrlRegexes.subscriptions.subsWeeklyPages,
+		targetPage:
+			pageUrlRegexes.subscriptions.paper.paperLandingWithGuestCheckout,
 		seed: 3,
 	},
 	supporterPlusV2: {

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -96,6 +96,8 @@ export const tests: Tests = {
 		},
 		isActive: true,
 		referrerControlled: false,
+		targetPage:
+			pageUrlRegexes.subscriptions.paper.paperLandingWithGuestCheckout,
 		seed: 11,
 	},
 	supporterPlusV2: {

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -77,7 +77,7 @@ export const tests: Tests = {
 		isActive: true,
 		referrerControlled: false,
 		targetPage: pageUrlRegexes.subscriptions.subsWeeklyPages,
-		seed: 11,
+		seed: 3,
 	},
 	newspaperPriceCards: {
 		variants: [
@@ -96,9 +96,7 @@ export const tests: Tests = {
 		},
 		isActive: true,
 		referrerControlled: false,
-		targetPage:
-			pageUrlRegexes.subscriptions.paper.paperLandingWithGuestCheckout,
-		seed: 3,
+		seed: 11,
 	},
 	supporterPlusV2: {
 		variants: [


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

ACTIVATE PRICE CARDS ABTEST

This adds an AB test to change the order and position of price cards on the Newspaper Subscriptions landing page ->

#ab-newspaperPriceCards=control / #ab-newspaperPriceCards=variant

Please see attached screenshots for the control and variant.

[**Trello Card**](https://trello.com/c/fhBoFK3Y/1124-newspaper-price-cards-move-to-top-engineering)

## Is this an AB test?
- [x] Yes
- [ ] No

## Screenshots
| | Mobile | Desktop |
| -- | -- | -- |
| Control | ![Screenshot 2023-03-03 at 10 45 35](https://user-images.githubusercontent.com/76729591/222701203-e4341f83-4041-45fc-9046-e88f41027782.png) | ![Screenshot 2023-03-03 at 10 46 52](https://user-images.githubusercontent.com/76729591/222701297-8e42901a-81c2-4176-b229-73f2210bcf79.png)
| Variant | ![Screenshot 2023-03-03 at 10 52 02](https://user-images.githubusercontent.com/76729591/222702134-a4325ab3-e99a-4354-ba7f-70910f28173a.png) | ![Screenshot 2023-03-03 at 10 52 15](https://user-images.githubusercontent.com/76729591/222702194-f94f854e-a0b0-432d-b1b9-831c47b2cc6c.png) |
