### PR TITLE
Upgrade payment-api to ubuntu jammy

### DIFF
--- a/support-payment-api/src/main/resources/riff-raff.yaml
+++ b/support-payment-api/src/main/resources/riff-raff.yaml
@@ -7,7 +7,7 @@ deployments:
     parameters:
       amiParameter: AMIPaymentapi
       amiTags:
-        Recipe: bionic-membership-ARM-unified-cloudwatch
+        Recipe: jammy-membership-java8
         AmigoStage: PROD
       amiEncrypted: true
       templateStagePaths:


### PR DESCRIPTION
Ubuntu Bionic is approaching end of life. This PR updates the metering api to use an AMI based on Jammy.

Tested with a contribution in CODE