### PR TITLE
Migrate BigQuery code to storage write API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -280,7 +280,7 @@ lazy val `module-acquisition-events` = (project in file("support-modules/acquisi
     scalacOptions += "-Ytasty-reader",
     libraryDependencies ++= commonDependencies,
   )
-  .dependsOn(`support-config`)
+  .dependsOn(`support-config`, `module-aws`, `support-services`)
 
 lazy val `support-internationalisation` = (project in file("support-internationalisation"))
   .configs(IntegrationTest)

--- a/support-modules/acquisition-events/build.sbt
+++ b/support-modules/acquisition-events/build.sbt
@@ -16,3 +16,5 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
 )
+
+scalacOptions += "-Xlint:unused"

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/bigquery/AcquisitionDataRowMapper.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/bigquery/AcquisitionDataRowMapper.scala
@@ -1,26 +1,27 @@
 package com.gu.support.acquisitions
 
 import com.gu.support.acquisitions.models._
-import com.gu.support.workers._
 import org.joda.time.format.ISODateTimeFormat
+import org.json.{JSONArray, JSONObject}
 import scala.jdk.CollectionConverters._
 
-import java.util
-
 object AcquisitionDataRowMapper {
+  def mapToTableRow(acquisition: AcquisitionDataRow): JSONObject = {
 
-  def mapToTableRow(acquisition: AcquisitionDataRow): util.Map[String, Any] = {
-
-    val optionalFields = List(
+    val optionalFields: Map[String, Object] = List(
       acquisition.promoCode.map("promo_code" -> _),
       acquisition.paymentProvider.map("payment_provider" -> _.value),
       acquisition.printOptions.map(p =>
-        "print_options" -> Map(
-          "product" -> p.product.value,
-          "delivery_country_code" -> p.deliveryCountry.alpha2,
-        ).asJava,
+        "print_options" -> new JSONObject(
+          Map(
+            "product" -> p.product.value,
+            "delivery_country_code" -> p.deliveryCountry.alpha2,
+          ).asJava,
+        ),
       ),
-      acquisition.amount.map("amount" -> _),
+      acquisition.amount.map({ amount: BigDecimal =>
+        "amount" -> (amount.doubleValue.toDouble: java.lang.Double)
+      }),
       acquisition.identityId.map("identity_id" -> _),
       acquisition.pageViewId.map("page_view_id" -> _),
       acquisition.browserId.map("browser_id" -> _),
@@ -29,29 +30,30 @@ object AcquisitionDataRowMapper {
       acquisition.componentId.map("component_id" -> _),
       acquisition.componentType.map("component_type" -> _),
       acquisition.source.map("source" -> _),
-      acquisition.campaignCode.map("campaign_codes" -> List(_).asJava),
+      acquisition.campaignCode.map(code => "campaign_codes" -> new JSONArray(List(code).asJava)),
       acquisition.zuoraAccountNumber.map("zuora_account_number" -> _),
       acquisition.zuoraSubscriptionNumber.map("zuora_subscription_number" -> _),
       acquisition.contributionId.map("contribution_id" -> _),
       acquisition.paymentId.map("payment_id" -> _),
     ).flatten.toMap
 
-    (Map(
-      "event_timestamp" -> ISODateTimeFormat.dateTime().print(acquisition.eventTimeStamp),
-      "product" -> acquisition.product.value,
-      "payment_frequency" -> acquisition.paymentFrequency.value,
-      "country_code" -> acquisition.country.alpha2,
-      "currency" -> acquisition.currency.iso,
-      "reused_existing_payment_method" -> acquisition.reusedExistingPaymentMethod,
-      "acquisition_type" -> acquisition.acquisitionType.value,
-      "reader_type" -> acquisition.readerType.value.toUpperCase,
-      "query_parameters" -> acquisition.queryParameters,
-      "ab_tests" -> mapAbTests(acquisition.abTests),
-      "query_parameters" -> mapQueryParameters(acquisition.queryParameters),
-      "labels" -> acquisition.labels.asJava,
-      "platform" -> acquisition.platform.map(mapPlatformName).getOrElse("SUPPORT"),
-    ) ++ optionalFields).asJava
-
+    new JSONObject(
+      (Map(
+        "event_timestamp" -> ISODateTimeFormat.dateTime().print(acquisition.eventTimeStamp),
+        "product" -> acquisition.product.value,
+        "payment_frequency" -> acquisition.paymentFrequency.value,
+        "country_code" -> acquisition.country.alpha2,
+        "currency" -> acquisition.currency.iso,
+        "reused_existing_payment_method" -> acquisition.reusedExistingPaymentMethod,
+        "acquisition_type" -> acquisition.acquisitionType.value,
+        "reader_type" -> acquisition.readerType.value.toUpperCase,
+        "query_parameters" -> new JSONArray(acquisition.queryParameters.asJava),
+        "ab_tests" -> mapAbTests(acquisition.abTests),
+        "query_parameters" -> mapQueryParameters(acquisition.queryParameters),
+        "labels" -> new JSONArray(acquisition.labels.asJava),
+        "platform" -> acquisition.platform.map(mapPlatformName).getOrElse("SUPPORT"),
+      ) ++ optionalFields).asJava,
+    )
   }
 
   def mapPlatformName(name: String) =
@@ -61,24 +63,31 @@ object AcquisitionDataRowMapper {
       case _ => name
     }
 
-  private def mapAbTests(abtests: List[AbTest]) =
-    abtests
-      .map(abTest =>
-        Map(
-          "name" -> abTest.name,
-          "variant" -> abTest.variant,
-        ).asJava,
-      )
-      .asJava
+  private def mapAbTests(abtests: List[AbTest]): JSONArray =
+    new JSONArray(
+      abtests
+        .map(abTest =>
+          new JSONObject(
+            Map(
+              "name" -> abTest.name,
+              "variant" -> abTest.variant,
+            ).asJava,
+          ),
+        )
+        .asJava,
+    )
 
-  private def mapQueryParameters(queryParameters: List[QueryParameter]) =
-    queryParameters
-      .map(queryParam =>
-        Map(
-          "key" -> queryParam.name,
-          "value" -> queryParam.value,
-        ).asJava,
-      )
-      .asJava
-
+  private def mapQueryParameters(queryParameters: List[QueryParameter]): JSONArray =
+    new JSONArray(
+      queryParameters
+        .map(queryParam =>
+          new JSONObject(
+            Map(
+              "key" -> queryParam.name,
+              "value" -> queryParam.value,
+            ).asJava,
+          ),
+        )
+        .asJava,
+    )
 }

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/bigquery/BigQueryService.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/bigquery/BigQueryService.scala
@@ -66,9 +66,7 @@ class BigQueryService(config: BigQueryConfig) {
       .build()
   lazy val bigQueryWriteClient = BigQueryWriteClient.create(bigQueryWriteSettings)
 
-  def sendAcquisition(acquisitionDataRow: AcquisitionDataRow)(implicit
-      executionContext: ExecutionContext,
-  ): EitherT[Future, String, Unit] =
+  def sendAcquisition(acquisitionDataRow: AcquisitionDataRow): EitherT[Future, String, Unit] =
     EitherT(
       send(acquisitionDataRow),
     )

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/bigquery/BigQueryService.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/bigquery/BigQueryService.scala
@@ -1,18 +1,38 @@
 package com.gu.support.acquisitions
 
 import cats.data.EitherT
+import com.google.api.core.ApiFutureCallback
+import com.google.api.core.ApiFutures
+import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.auth.oauth2.ServiceAccountCredentials
-import com.google.cloud.bigquery.{BigQueryException, BigQueryOptions, InsertAllRequest, TableId}
+import com.google.cloud.bigquery.storage.v1.{
+  AppendRowsResponse,
+  BigQueryWriteClient,
+  BigQueryWriteSettings,
+  JsonStreamWriter,
+  TableName,
+}
+import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializtionError
+import com.google.cloud.bigquery.BigQueryOptions
+import com.gu.aws.AwsCloudWatchMetricPut
+import com.gu.aws.AwsCloudWatchMetricPut.{client => cloudwatchClient}
+import com.gu.aws.AwsCloudWatchMetricSetup.writeAcquisitionDataToBigQueryFailure
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger.Sanitizer
 import com.gu.support.acquisitions.AcquisitionEventTable.{datasetName, tableName}
 import com.gu.support.acquisitions.models.AcquisitionDataRow
-
-import scala.jdk.CollectionConverters._
-import scala.concurrent.{ExecutionContext, Future, blocking}
 import com.gu.support.acquisitions.utils.Retry
+import com.gu.support.config.Stage
+import com.gu.support.config.Stages._
+import org.json.{JSONArray, JSONObject}
+
+import java.util.concurrent.Executors
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.jdk.CollectionConverters._
 
 class BigQueryService(config: BigQueryConfig) {
+  private val stage: Stage = sys.env.get("STAGE").flatMap(Stage.fromString).getOrElse(CODE)
+
   lazy val bigQuery =
     BigQueryOptions
       .newBuilder()
@@ -28,43 +48,85 @@ class BigQueryService(config: BigQueryConfig) {
       )
       .build()
       .getService
+  lazy val bigQueryWriteSettings =
+    BigQueryWriteSettings
+      .newBuilder()
+      .setQuotaProjectId(config.projectId)
+      .setCredentialsProvider(
+        FixedCredentialsProvider.create(
+          ServiceAccountCredentials.fromPkcs8(
+            config.clientId,
+            config.clientEmail,
+            config.privateKey,
+            config.privateKeyId,
+            Nil.asJavaCollection,
+          ),
+        ),
+      )
+      .build()
+  lazy val bigQueryWriteClient = BigQueryWriteClient.create(bigQueryWriteSettings)
 
-  def tableInsertRow(acquisitionDataRow: AcquisitionDataRow)(implicit
+  def sendAcquisition(acquisitionDataRow: AcquisitionDataRow)(implicit
       executionContext: ExecutionContext,
   ): EitherT[Future, String, Unit] =
     EitherT(
-      Future(
-        blocking(
-          // The BigQuery sdk isn't asynchronous so wrap it in a blocking future as documented here:
-          // https://docs.scala-lang.org/overviews/core/futures.html#blocking-inside-a-future
-          blockingInsert(acquisitionDataRow),
-        ),
-      ),
+      send(acquisitionDataRow),
     )
 
   def tableInsertRowWithRetry(acquisitionDataRow: AcquisitionDataRow, maxRetries: Int)(implicit
       executionContext: ExecutionContext,
-  ): EitherT[Future, List[String], Unit] = Retry(maxRetries)(tableInsertRow(acquisitionDataRow))
+  ): EitherT[Future, List[String], Unit] = Retry(maxRetries)(sendAcquisition(acquisitionDataRow))
 
-  private def blockingInsert(acquisitionDataRow: AcquisitionDataRow): Either[String, Unit] =
+  private def send(
+      acquisitionDataRow: AcquisitionDataRow,
+  ): Future[Either[String, Unit]] = {
+    val tableId = TableName.of(config.projectId, datasetName, tableName)
+    val rowContent: JSONObject = AcquisitionDataRowMapper.mapToTableRow(acquisitionDataRow)
+    SafeLogger.info(s"Attempting to append row ($rowContent) created from ($acquisitionDataRow)")
+    val streamWriter = JsonStreamWriter.newBuilder(tableId.toString(), bigQueryWriteClient).build();
+    val promise = Promise[Either[String, Unit]]()
     try {
-      val tableId = TableId.of(datasetName, tableName)
-      val rowContent = AcquisitionDataRowMapper.mapToTableRow(acquisitionDataRow)
-      val insertRequest = InsertAllRequest.newBuilder(tableId).addRow(rowContent).build
-
-      val response = bigQuery.insertAll(insertRequest)
-
-      if (response.hasErrors) {
-        val errors = response.getInsertErrors.entrySet.asScala.mkString(", ").stripSuffix(", ")
-        SafeLogger.error(scrub"Failed to insert row into $tableName: $errors")
-        Left(s"Failed to insert row into $tableName: $errors")
-      } else {
-        SafeLogger.info(s"Rows successfully inserted into table $tableName")
-        Right(())
-      }
+      val responseFuture = streamWriter.append(new JSONArray(List(rowContent).asJava));
+      val callback = new BigQueryService.AppendCompleteCallback(stage, promise);
+      ApiFutures.addCallback(
+        responseFuture,
+        callback,
+        callback.executor,
+      )
     } catch {
-      case e: BigQueryException =>
-        SafeLogger.error(scrub"There was an exception inserting a row into $tableName", e)
-        Left(s"There was an exception inserting a row into $tableName: ${e.getMessage}")
+      case e: AppendSerializtionError =>
+        val errorMessage =
+          e.getRowIndexToErrorMessage().asScala.map { case (i, message) => s"$i: $message" }.mkString(", ")
+        SafeLogger.error(scrub"There was an exception appending to $tableName: $errorMessage", e)
+        promise.success(Left(s"Error appending to table $tableName: $errorMessage"))
     }
+    promise.future
+  }
+}
+
+object BigQueryService {
+  case class AppendCompleteCallback(stage: Stage, promise: Promise[Either[String, Unit]])
+      extends ApiFutureCallback[AppendRowsResponse] {
+    val executor = Executors.newSingleThreadExecutor();
+
+    def onSuccess(response: AppendRowsResponse): Unit = {
+      SafeLogger.info(s"Rows successfully inserted into table $tableName")
+      promise.success(Right(()))
+      executor.shutdown()
+    }
+    def onFailure(throwable: Throwable): Unit = {
+      val detail: String = throwable match {
+        case e: AppendSerializtionError => {
+          e.getRowIndexToErrorMessage().asScala.map { case (i, message) => s"$i: $message" }.mkString(", ")
+        }
+        case _ => ""
+      }
+      SafeLogger.error(scrub"There was an exception inserting a row into $tableName: $detail", throwable)
+      AwsCloudWatchMetricPut(cloudwatchClient)(writeAcquisitionDataToBigQueryFailure(stage))
+      promise.success(
+        Left(s"There was an exception inserting a row into $tableName: ${throwable.getMessage}; $detail"),
+      )
+      executor.shutdown()
+    }
+  }
 }

--- a/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
+++ b/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
@@ -71,6 +71,14 @@ object AwsCloudWatchMetricSetup {
       ),
     )
 
+  def writeAcquisitionDataToBigQueryFailure(stage: Stage): MetricRequest =
+    getMetricRequest(
+      MetricName("WriteAcquisitionDataToBigQueryFailure"),
+      Map(
+        MetricDimensionName("Stage") -> MetricDimensionValue(stage.toString),
+      ),
+    )
+
   private def getMetricRequest(
       name: MetricName,
       dimensions: Map[MetricDimensionName, MetricDimensionValue],

--- a/support-workers/src/test/scala/com/gu/acquisitions/BigQuerySpec.scala
+++ b/support-workers/src/test/scala/com/gu/acquisitions/BigQuerySpec.scala
@@ -88,7 +88,7 @@ class BigQuerySpec extends AsyncFlatSpec with Matchers with LazyLogging {
       None,
     )
 
-    service.tableInsertRow(dataRow).value.map(_ shouldBe Right(()))
+    service.sendAcquisition(dataRow).value.map(_ shouldBe Right(()))
   }
 
 }


### PR DESCRIPTION
Trello card: https://trello.com/c/x5ipW2Ty/475-migrate-bigquery-code-from-streaming-api-to-the-storage-write-api

The storage write API is a newer API than the legacy streaming API we currently use, and google recommends changing to it because it has [lower pricing and more robust features](https://cloud.google.com/bigquery/docs/streaming-data-into-bigquery) such as exactly-once delivery semantics. This change moves our code to the new API, but uses the default stream and so _doesn’t_ provide exactly-once delivery semantics (instead it provides at-most-once semantics).

Changing the API we’re using involves:

1. Converting the data to the org.json types

  - To do this, Maps are wrapped in JSONObjects and Lists in JSONArrays

2. Replacing the existing blocking future with a promise-based one

  - The google API uses its own future type that allows you to execute a callback, so using a promise which is marked as successful from the callback enables providing a non-blocking Future back to the scala code (I think).

  - I was a little worried the `Retry` wouldn’t work here, because the append itself is a side-effect of the creation of the promise (i.e. the call to `insertForPromise`), rather than contained in a Future. However, I’ve tested a mock version of this code at the repl and it does seem to work: side-effects before the creation of the promise are retried. I believe this works because `Retry` takes its second argument lazily, so it’s an expression that’s re-evaluated to a Future on each retry. I’m still a little uncomfortable with this, but I’m not sure if it needs changing.

  - I’ve used a `DirectExecutor` for the callback, which logs the result and marks the promise as successful. I think this is ok because those should be quick actions, so it’s ok for that to take time on a serialisation thread or one of the play threads. An alternative would be to manage an explicit thread pool here, but I think that adds unnecessary complexity.

3. Explicitly converting the `amount` (which is a `BigDecimal`) to a
   `Double`.

   - With the old API we were able to directly send a BigDecimal, but the JSON conversion here seems to break that, turning each one into JSON object (without the value in it!) rather than a number. The data type in BigQuery is a floating data type anyway, so I think it’s ok for us to convert this to a double here.