### PR TITLE
Existing Payment Method: update “Supporter Plus” in user facing copy

### DIFF
--- a/support-frontend/assets/helpers/forms/existingPaymentMethods/existingPaymentMethods.ts
+++ b/support-frontend/assets/helpers/forms/existingPaymentMethods/existingPaymentMethods.ts
@@ -106,14 +106,20 @@ function subscriptionToExplainerPart(
 	subscription: ExistingPaymentMethodSubscription,
 ): string {
 	const activeOrRecentPrefix = subscription.isActive ? 'current' : 'recent';
-	const subscriptionName =
-		subscription.name === 'Supporter Plus'
-			? 'support'
-			: subscription.name === 'Guardian Weekly' ||
-			  subscription.name === 'Newspaper Digital Voucher' ||
-			  subscription.name === 'Newspaper Delivery'
-			? subscription.name
-			: subscription.name.toLowerCase();
+	let subscriptionName: string;
+	switch (subscription.name) {
+		case 'Supporter Plus':
+			subscriptionName = 'support';
+			break;
+		case 'Guardian Weekly':
+		case 'Newspaper Digital Voucher':
+		case 'Newspaper Delivery':
+			subscriptionName = subscription.name;
+			break;
+		default:
+			subscriptionName = subscription.name.toLowerCase();
+			break;
+	}
 	return `${
 		subscription.isCancelled ? 'recently cancelled' : activeOrRecentPrefix
 	} ${subscriptionName}`;

--- a/support-frontend/assets/helpers/forms/existingPaymentMethods/existingPaymentMethods.ts
+++ b/support-frontend/assets/helpers/forms/existingPaymentMethods/existingPaymentMethods.ts
@@ -106,9 +106,17 @@ function subscriptionToExplainerPart(
 	subscription: ExistingPaymentMethodSubscription,
 ): string {
 	const activeOrRecentPrefix = subscription.isActive ? 'current' : 'recent';
+	const subscriptionName =
+		subscription.name === 'Supporter Plus'
+			? 'support'
+			: subscription.name === 'Guardian Weekly' ||
+			  subscription.name === 'Newspaper Digital Voucher' ||
+			  subscription.name === 'Newspaper Delivery'
+			? subscription.name
+			: subscription.name.toLowerCase();
 	return `${
 		subscription.isCancelled ? 'recently cancelled' : activeOrRecentPrefix
-	} ${subscription.name}`;
+	} ${subscriptionName}`;
 }
 
 function subscriptionsToExplainerList(subscriptionParts: string[]): string {


### PR DESCRIPTION
## What are you doing in this PR?
Existing Payment Method: update “Supporter Plus” in user facing copy

[**Trello Card**](https://trello.com/c/056jJ3Pt/1157-existing-payment-method-update-supporter-plus-in-user-facing-copy)

## Why are you doing this?

Existing payment methods for recurring contributions are currently switched OFF. Before we can switch them ON we need to stop using “Supporter Plus” in user facing copy in the Existing payment method component.

It was suggested, we simply use 'Used for your current monthly support' .Also we need to watch out for capping here. For example it should be: 'Used for your current monthly contribution / single contribution / annual contribution / monthly support / annual support' etc.
You might find my recently created style guide quite handy! Especially this [section](https://www.figma.com/proto/n1wlWnSQSJQyA2yOZ8Mu45/2460154---Guardian_Support_IC_0722?page-id=827%3A8530&node-id=1069%3A39774&viewport=4196%2C-2126%2C0.5&scaling=scale-down&starting-point-node-id=827%3A12289) 


To force an existing payment method to appear on CODE follow these steps:
1) Make sure existing payment methods are enabled for recurring contributions on the CODE switchboard at: https://support.code.dev-gutools.co.uk/switches
2) Purchase a recurring contribution on CODE as a new user, using a new email address. eg. [george.haberis+existing-cc-test@guardian.co.uk](mailto:george.haberis+existing-cc-test@guardian.co.uk)
3) Complete registration on CODE for this new identity account by clicking the complete registration email's link.
4) Visit [Support the Guardian](https://support.code.dev-theguardian.com/uk/contribute?displayExistingPaymentOptions=true).

## Is this an AB test?
- [ ] Yes
- [x ] No


## Screenshots
Currently the text given below are used  in the user facing copy for Existing Payment Method option.
> current Monthly Contribution
> current Annual Contribution
> current Supporter Plus(irrespective of Monthly/Annual support)
> current Guardian Weekly(same for all the 3 options-Monthly/Quarterly/Annual)
> current Newspaper Delivery(same for all 5 Home Delivery options-Everyday, Sixday, Weekend,Saturday,Sunday)
> current Newspaper Digital Voucher ( same for all 5 Subscription Card options-Everyday,Sixday,Weekend,Saturday,Sunday)

Existing Payment Method Option is not provided for One -off contributions
<img width="1108" alt="Screenshot 2023-03-16 at 18 11 22" src="https://user-images.githubusercontent.com/73653255/225722714-81ade5c9-6de3-4be9-97b5-b965b74e06a3.png">

***After Change***
current Supporter Plus >>changed to >> current support
current Monthly Contribution>>changed to >>current monthly contribution
current Annual Contribution>>changed to >>current annual contribution


<img width="1221" alt="Screenshot 2023-03-16 at 19 37 09" src="https://user-images.githubusercontent.com/73653255/225734033-e088750e-cfe2-486c-9eb5-6bbd88bc8a09.png">


It's difficult to add current **monthly/annual** support  for Supporter Plus as the data passed from Members-data-api- just provides subscriptions.name ="Supporter Plus"

<img width="1655" alt="Screenshot 2023-03-16 at 19 45 40" src="https://user-images.githubusercontent.com/73653255/225735927-9b3ce947-069d-4a01-9ba0-99b183df97c1.png">
