### PR TITLE
Add masking data-atrribute to existing payment method label

### DIFF
--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -127,7 +127,7 @@ export function PaymentMethodSelector({
 
 										return (
 											<AvailablePaymentMethodAccordionRow
-												data-qm-masking="blocklist"
+												addQuantumMetricBlockListAttribute={true}
 												id={`paymentMethod-existing${preExistingPaymentMethod.billingAccountId}`}
 												name="paymentMethod"
 												label={getExistingPaymentMethodLabel(

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -127,6 +127,7 @@ export function PaymentMethodSelector({
 
 										return (
 											<AvailablePaymentMethodAccordionRow
+												data-qm-masking="blocklist"
 												id={`paymentMethod-existing${preExistingPaymentMethod.billingAccountId}`}
 												name="paymentMethod"
 												label={getExistingPaymentMethodLabel(

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelectorAccordionRow.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelectorAccordionRow.tsx
@@ -82,6 +82,7 @@ interface AvailablePaymentMethodAccordionRowProps {
 	onChange: () => void;
 	accordionBody?: () => JSX.Element;
 	onRender: () => void;
+	addQuantumMetricBlockListAttribute?: boolean;
 }
 
 export function AvailablePaymentMethodAccordionRow({
@@ -94,12 +95,22 @@ export function AvailablePaymentMethodAccordionRow({
 	accordionBody,
 	onChange,
 	onRender,
+	addQuantumMetricBlockListAttribute,
 }: AvailablePaymentMethodAccordionRowProps): EmotionJSX.Element {
 	useEffect(onRender, []);
 
+	const quantumMetricBlockListAttribute = addQuantumMetricBlockListAttribute
+		? {
+				'data-qm-masking': 'blocklist',
+		  }
+		: {};
+
 	return (
 		<div css={checked ? focused : notFocused}>
-			<div css={[...(checked && accordionBody ? [borderBottom] : [])]}>
+			<div
+				{...quantumMetricBlockListAttribute}
+				css={[...(checked && accordionBody ? [borderBottom] : [])]}
+			>
 				<RadioWithImage
 					id={id}
 					image={image}


### PR DESCRIPTION
## What are you doing in this PR?

Before we turn on existing payment methods on the new checkout we have a task to add the `data-qm-masking="blocklist"` data attribute (explained here: https://github.com/guardian/support-frontend/pull/3789 ) to the payment method label. This will block QM for recording this info.

## Screenshot

<img width="331" alt="Screenshot 2023-03-24 at 14 45 28" src="https://user-images.githubusercontent.com/1590704/227557761-49113b80-724d-4522-9d4b-41910fd674c2.png">

