### PR TITLE
Switching to braze-emails queue (from contribution-thanks).

### DIFF
--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -82,7 +82,8 @@ Resources:
               Action:
                 - sqs:SendMessage
                 - sqs:GetQueueUrl
-              Resource: arn:aws:sqs:*:*:contributions-thanks-dev
+              Resource:
+                Fn::ImportValue: !Sub "comms-${Stage}-EmailQueueArn"
 
   LambdaLogGroup:
     Type: AWS::Logs::LogGroup

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -77,12 +77,8 @@ Resources:
               Action:
               - sqs:GetQueueUrl
               - sqs:SendMessage
-              Resource: arn:aws:sqs:eu-west-1:865473395570:contributions-thanks
-            - Effect: Allow
-              Action:
-              - sqs:GetQueueUrl
-              - sqs:SendMessage
-              Resource: arn:aws:sqs:eu-west-1:865473395570:contributions-thanks-dev
+              Resource:
+                Fn::ImportValue: !Sub "comms-${Stage}-EmailQueueArn"
         - PolicyName: CloudWatchLogging
           PolicyDocument:
             Version: '2012-10-17'

--- a/support-workers/cloud-formation/src/templates/environment-variables.yaml
+++ b/support-workers/cloud-formation/src/templates/environment-variables.yaml
@@ -3,3 +3,6 @@ Environment:
     "SENTRY_DSN" : "https://55945d73ad654abd856d1523de4f9d56:cf9b33aaff3c483899dfa986abce55df@sentry.io/1212214"
     "SENTRY_ENVIRONMENT" : !Ref Stage
     "GU_SUPPORT_WORKERS_STAGE" : !Ref Stage
+    "EMAIL_QUEUE_NAME":
+      Fn::ImportValue:
+        !Sub "comms-${Stage}-EmailQueueName"

--- a/support-workers/src/main/resources/application.conf
+++ b/support-workers/src/main/resources/application.conf
@@ -25,6 +25,4 @@ touchpoint.backend.environments {
   }
 }
 
-email.thankYou.queueName = contributions-thanks-dev
-
 kinesis.streamName = ""

--- a/support-workers/src/main/scala/com/gu/config/Configuration.scala
+++ b/support-workers/src/main/scala/com/gu/config/Configuration.scala
@@ -34,6 +34,7 @@ object Configuration {
     .forEnvironment(Configuration.loadFromS3)
     .load(Configuration.stage, ConfigFactory.load(this.getClass.getClassLoader))
 
+  lazy val emailQueueName = System.getenv("EMAIL_QUEUE_NAME")
 }
 
 case class Configuration(config: Config) {
@@ -47,8 +48,6 @@ case class Configuration(config: Config) {
   val promotionsConfigProvider = new PromotionsConfigProvider(config, stage)
   val goCardlessConfigProvider = new GoCardlessConfigProvider(config, stage)
   val bigQueryConfigProvider = new BigQueryConfigProvider(config, stage)
-
-  val contributionThanksQueueName = config.getString("email.thankYou.queueName")
 
   val acquisitionsKinesisStreamName = config.getString("kinesis.streamName")
 }

--- a/support-workers/src/main/scala/com/gu/emailservices/EmailService.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/EmailService.scala
@@ -9,14 +9,14 @@ import com.gu.monitoring.SafeLogger._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class EmailService(contributionThanksQueueName: String)(implicit val executionContext: ExecutionContext) {
+class EmailService(emailQueueName: String)(implicit val executionContext: ExecutionContext) {
 
   private val sqsClient = AmazonSQSAsyncClientBuilder.standard
     .withCredentials(CredentialsProvider)
     .withRegion(Regions.EU_WEST_1)
     .build()
 
-  private val queueUrl = sqsClient.getQueueUrl(contributionThanksQueueName).getQueueUrl
+  private val queueUrl = sqsClient.getQueueUrl(emailQueueName).getQueueUrl
 
   def send(fields: EmailFields): Future[SendMessageResult] = {
     SafeLogger.info(s"Sending message to SQS queue $queueUrl")

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -21,7 +21,7 @@ import scala.concurrent.Future
 
 class FailureHandler(emailService: EmailService) extends Handler[FailureHandlerState, CheckoutFailureState] {
 
-  def this() = this(new EmailService(Configuration.load().contributionThanksQueueName))
+  def this() = this(new EmailService(Configuration.emailQueueName))
 
   override protected def handlerFuture(
       state: FailureHandlerState,

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -1,9 +1,7 @@
 package com.gu.support.workers.integration
 
 import java.io.ByteArrayOutputStream
-
 import com.amazonaws.services.sqs.model.SendMessageResult
-import com.gu.config.Configuration
 import com.gu.emailservices._
 import com.gu.i18n.Country
 import com.gu.i18n.Country.UK
@@ -19,6 +17,8 @@ import com.gu.support.workers._
 import com.gu.support.workers.encoding.Conversions.FromOutputStream
 import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.integration.TestData.{billingOnlyUser, directDebitPaymentMethod}
+import com.gu.support.workers.integration.util.EmailQueueName
+import com.gu.support.workers.integration.util.EmailQueueName.emailQueueName
 import com.gu.support.workers.lambdas.SendThankYouEmail
 import com.gu.support.workers.states.SendThankYouEmailState._
 import com.gu.support.zuora.api.ReaderType
@@ -28,14 +28,14 @@ import io.circe.Json
 import io.circe.generic.auto._
 import io.circe.parser._
 import org.joda.time.{DateTime, LocalDate}
+import org.mockito.ArgumentMatchers.any
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
 class SendThankYouEmailITSpec extends AsyncLambdaSpec with MockContext {
-
   "SendThankYouEmail lambda" should "add message to sqs queue" taggedAs IntegrationTest in {
-    val sendThankYouEmail = new SendThankYouEmail()
+    val sendThankYouEmail = new SendThankYouEmail(emailService = new EmailService(emailQueueName))
 
     val outStream = new ByteArrayOutputStream()
 
@@ -108,14 +108,12 @@ object SendThankYouEmailManualTest {
     SendWeeklySubscriptionGiftEmail.main(args)
   }
 
-  val queueName = Configuration.load().contributionThanksQueueName
-
   def send(eventualEF: Future[List[EmailFields]]): Unit = {
-    val service = new EmailService(queueName)
+    val service = new EmailService(emailQueueName)
     Await.ready(eventualEF.flatMap(efList => Future.sequence(efList.map(service.send))), Duration.Inf)
   }
   def sendSingle(ef: Future[EmailFields]): Unit = {
-    val service = new EmailService(queueName)
+    val service = new EmailService(emailQueueName)
     Await.ready(ef.flatMap(service.send), Duration.Inf)
   }
 }

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/util/EmailQueueName.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/util/EmailQueueName.scala
@@ -1,0 +1,5 @@
+package com.gu.support.workers.integration.util
+
+object EmailQueueName {
+  val emailQueueName = "braze-emails-CODE"
+}


### PR DESCRIPTION
We decided to retire all SQS queues that send emails in favour of single queue - braze-emails.
This change switches support-frontend to use braze-emails queue rather than contribution-thanks.
It also provides the queue name through CloudFormation / system environment rather than config.