### PR TITLE
Fix apple pay country & state logic

### DIFF
--- a/support-frontend/assets/components/paymentFrequencyTabs/paymentFrequencyTabsContainer.tsx
+++ b/support-frontend/assets/components/paymentFrequencyTabs/paymentFrequencyTabsContainer.tsx
@@ -47,7 +47,7 @@ export function PaymentFrequencyTabsContainer({
 		);
 
 		dispatch(setProductType(contributionType));
-		dispatch(setPaymentMethod(paymentMethodToSelect));
+		dispatch(setPaymentMethod({ paymentMethod: paymentMethodToSelect }));
 	}
 
 	const tabs: TabProps[] = contributionTypes[countryGroupId].map(

--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -109,7 +109,7 @@ function PaymentMethodSelectorContainer({
 		if (event === 'select') {
 			trackComponentClick(trackingId);
 			sendEventContributionPaymentMethod(paymentMethodDescription);
-			dispatch(setPaymentMethod(paymentMethod));
+			dispatch(setPaymentMethod({ paymentMethod }));
 			existingPaymentMethod &&
 				dispatch(selectExistingPaymentMethod(existingPaymentMethod));
 		} else {
@@ -119,7 +119,7 @@ function PaymentMethodSelectorContainer({
 
 	useEffect(() => {
 		availablePaymentMethods.length === 1 &&
-			dispatch(setPaymentMethod(availablePaymentMethods[0]));
+			dispatch(setPaymentMethod({ paymentMethod: availablePaymentMethods[0] }));
 	}, []);
 
 	return render({

--- a/support-frontend/assets/components/paymentRequestButton/hooks/usePaymentRequestCompletion.ts
+++ b/support-frontend/assets/components/paymentRequestButton/hooks/usePaymentRequestCompletion.ts
@@ -42,7 +42,7 @@ export function usePaymentRequestCompletion(
 
 	useEffect(() => {
 		if (errorsPreventSubmission) {
-			dispatch(setPaymentMethod('None'));
+			dispatch(setPaymentMethod({ paymentMethod: 'None' }));
 			resetPayerDetails(dispatch);
 			errorHandler('incomplete_payment_request_details');
 			return;

--- a/support-frontend/assets/components/paymentRequestButton/hooks/usePaymentRequestEvent.ts
+++ b/support-frontend/assets/components/paymentRequestButton/hooks/usePaymentRequestEvent.ts
@@ -72,7 +72,7 @@ export function usePaymentRequestEvent(
 				// cf. https://stripe.com/docs/js/payment_request/events/on_cancel
 				if (!paymentMethod) {
 					dispatch(unClickPaymentRequestButton(stripeAccount));
-					dispatch(setPaymentMethod('None'));
+					dispatch(setPaymentMethod({ paymentMethod: 'None' }));
 				}
 			});
 		}

--- a/support-frontend/assets/components/paymentRequestButton/paymentRequestButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentRequestButton/paymentRequestButtonContainer.tsx
@@ -51,7 +51,12 @@ export function PaymentRequestButtonContainer({
 				if (internalPaymentMethodName) {
 					trackComponentClick(`${internalPaymentMethodName}-${buttonType}`);
 				}
-				dispatch(setPaymentMethod(Stripe));
+				dispatch(
+					setPaymentMethod({
+						paymentMethod: Stripe,
+						stripePaymentMethod: internalPaymentMethodName ?? undefined,
+					}),
+				);
 			},
 			false,
 		);

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -46,9 +46,18 @@ import { logException } from 'helpers/utilities/logger';
 // ----- Types ----- //
 export type StripePaymentMethod =
 	| 'StripeCheckout'
+	| 'StripeElements'
+	// We use Stripe’s payment request button element
+	// (https://stripe.com/docs/stripe-js/elements/payment-request-button) for
+	// taking Apple Pay and Google Pay payments (and possibly a third wallet I’m
+	// unaware of).
+	// However, we still use these values to distinguish Apple Pay payments from
+	// non-Apple Pay payments. Therefore `StripeApplePay` means ”Apple Pay, via
+	// the payment request button”, and `StripePaymentRequestButton` means “any
+	// non-Apple-Pay payment method (wallet) that uses the payment request
+	// button”
 	| 'StripeApplePay'
-	| 'StripePaymentRequestButton'
-	| 'StripeElements';
+	| 'StripePaymentRequestButton';
 export type StripePaymentRequestButtonMethod = 'none' | StripePaymentMethod;
 type RegularContribution = {
 	productType: 'Contribution';

--- a/support-frontend/assets/helpers/forms/paymentMethods.ts
+++ b/support-frontend/assets/helpers/forms/paymentMethods.ts
@@ -1,3 +1,5 @@
+import type { StripePaymentMethod } from './paymentIntegrations/readerRevenueApis';
+
 const Stripe = 'Stripe';
 const PayPal = 'PayPal';
 const DirectDebit = 'DirectDebit';
@@ -27,6 +29,11 @@ export type PaymentMethod =
 	| typeof ExistingDirectDebit
 	| typeof AmazonPay
 	| typeof None;
+
+export type FullPaymentMethod = {
+	paymentMethod: PaymentMethod;
+	stripePaymentMethod?: StripePaymentMethod;
+};
 
 export const recaptchaRequiredPaymentMethods: PaymentMethod[] = [
 	DirectDebit,

--- a/support-frontend/assets/helpers/redux/checkout/payment/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/contributionsSideEffects.ts
@@ -8,7 +8,7 @@ export function addPaymentsSideEffects(
 	startListening({
 		actionCreator: setPaymentMethod,
 		effect(action) {
-			storage.setSession('selectedPaymentMethod', action.payload);
+			storage.setSession('selectedPaymentMethod', action.payload.paymentMethod);
 		},
 	});
 }

--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/reducer.ts
@@ -1,6 +1,6 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
-import type { PaymentMethod } from 'helpers/forms/paymentMethods';
+import type { FullPaymentMethod } from 'helpers/forms/paymentMethods';
 import { setDeliveryCountry } from '../../address/actions';
 import { validateForm } from '../../checkoutActions';
 import { initialState } from './state';
@@ -9,8 +9,9 @@ export const paymentMethodSlice = createSlice({
 	name: 'paymentMethod',
 	initialState,
 	reducers: {
-		setPaymentMethod(state, action: PayloadAction<PaymentMethod>) {
-			state.name = action.payload;
+		setPaymentMethod(state, action: PayloadAction<FullPaymentMethod>) {
+			state.name = action.payload.paymentMethod;
+			state.stripePaymentMethod = action.payload.stripePaymentMethod;
 			state.errors = [];
 		},
 	},

--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/state.ts
@@ -1,7 +1,9 @@
+import type { StripePaymentMethod } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 
 export type PaymentMethodState = {
 	name: PaymentMethod;
+	stripePaymentMethod?: StripePaymentMethod;
 	errors?: string[];
 };
 

--- a/support-frontend/assets/helpers/redux/checkout/payment/subscriptionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/subscriptionsSideEffects.ts
@@ -11,7 +11,7 @@ export function addPaymentsSideEffects(
 	startListening({
 		actionCreator: setPaymentMethod,
 		effect(action, listenerApi) {
-			const paymentMethod = action.payload;
+			const { paymentMethod } = action.payload;
 			const { payPal } = listenerApi.getState().page.checkoutForm.payment;
 
 			storage.setSession('selectedPaymentMethod', paymentMethod);

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -1,15 +1,24 @@
+import { fromCountry } from 'helpers/internationalisation/countryGroup';
 import { shouldCollectStateForContributions } from 'helpers/internationalisation/shouldCollectStateForContribs';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
+import { getBillingCountryAndState } from 'pages/supporter-plus-landing/setup/legacyActionCreators';
 import type { ErrorCollection } from './utils';
 
 export function getStateOrProvinceError(
 	state: ContributionsState,
 ): ErrorCollection {
-	const { countryGroupId } = state.common.internationalisation;
 	const contributionType = getContributionType(state);
-
-	if (shouldCollectStateForContributions(countryGroupId, contributionType)) {
+	const billingCountryGroup = fromCountry(
+		getBillingCountryAndState(
+			state.page.checkoutForm.payment.paymentMethod.name,
+			state,
+		).billingCountry,
+	);
+	if (
+		billingCountryGroup != null &&
+		shouldCollectStateForContributions(billingCountryGroup, contributionType)
+	) {
 		return {
 			state: state.page.checkoutForm.billingAddress.fields.errorObject?.state,
 		};

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -11,8 +11,9 @@ export function getStateOrProvinceError(
 	const contributionType = getContributionType(state);
 	const billingCountryGroup = fromCountry(
 		getBillingCountryAndState(
-			state.page.checkoutForm.payment.paymentMethod.name,
 			state,
+			state.page.checkoutForm.payment.paymentMethod.name,
+			state.page.checkoutForm.payment.paymentMethod.stripePaymentMethod,
 		).billingCountry,
 	);
 	if (

--- a/support-frontend/assets/pages/kindle-subscriber-checkout/setup/setUpRedux.ts
+++ b/support-frontend/assets/pages/kindle-subscriber-checkout/setup/setUpRedux.ts
@@ -175,7 +175,7 @@ function selectInitialContributionTypeAndPaymentMethod(
 		switches,
 	);
 	dispatch(setProductType('DigitalPack'));
-	dispatch(setPaymentMethod(paymentMethod));
+	dispatch(setPaymentMethod({ paymentMethod }));
 
 	return contributionType;
 }

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -452,7 +452,9 @@ function PaperCheckoutForm(props: PropTypes) {
 							<PaymentMethodSelector
 								availablePaymentMethods={paymentMethods}
 								paymentMethod={props.paymentMethod}
-								setPaymentMethod={props.setPaymentMethod}
+								setPaymentMethod={(paymentMethod) =>
+									props.setPaymentMethod({ paymentMethod })
+								}
 								validationError={firstError('paymentMethod', props.formErrors)}
 							/>
 						</FormSection>

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -28,6 +28,7 @@ import {
 	postRegularPaymentRequest,
 	regularPaymentFieldsFromAuthorisation,
 } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
+import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import {
 	AmazonPay,
 	DirectDebit,
@@ -137,7 +138,7 @@ const stripeChargeDataFromPaymentIntentAuthorisation = (
 	);
 
 function getBillingCountryAndState(
-	authorisation: PaymentAuthorisation,
+	paymentMethod: PaymentMethod,
 	state: ContributionsState,
 ): {
 	billingCountry: IsoCountry;
@@ -148,9 +149,7 @@ function getBillingCountryAndState(
 		state.page.checkoutForm.billingAddress.fields;
 
 	// If the user chose a Direct Debit payment method, then we must use the pageBaseCountry as the billingCountry.
-	if (
-		[DirectDebit, ExistingDirectDebit].includes(authorisation.paymentMethod)
-	) {
+	if ([DirectDebit, ExistingDirectDebit].includes(paymentMethod)) {
 		return {
 			billingCountry: pageBaseCountry,
 			billingState,
@@ -235,7 +234,7 @@ function regularPaymentRequestFromAuthorisation(
 ): RegularPaymentRequest {
 	const { actionHistory } = state.debug;
 	const { billingCountry, billingState } = getBillingCountryAndState(
-		authorisation,
+		authorisation.paymentMethod,
 		state,
 	);
 	const recaptchaToken = state.page.checkoutForm.recaptcha.token;
@@ -612,4 +611,5 @@ export {
 	paymentSuccess,
 	onThirdPartyPaymentAuthorised,
 	createOneOffPayPalPayment,
+	getBillingCountryAndState,
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/setUpRedux.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/setUpRedux.ts
@@ -177,7 +177,7 @@ function selectInitialContributionTypeAndPaymentMethod(
 		switches,
 	);
 	dispatch(setProductType(contributionType));
-	dispatch(setPaymentMethod(paymentMethod));
+	dispatch(setPaymentMethod({ paymentMethod }));
 
 	return contributionType;
 }

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -338,7 +338,9 @@ function WeeklyCheckoutForm(props: PropTypes) {
 							<PaymentMethodSelector
 								availablePaymentMethods={paymentMethods}
 								paymentMethod={props.paymentMethod}
-								setPaymentMethod={props.setPaymentMethod}
+								setPaymentMethod={(paymentMethod) =>
+									props.setPaymentMethod({ paymentMethod })
+								}
 								validationError={firstError('paymentMethod', props.formErrors)}
 							/>
 						</FormSection>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
@@ -372,7 +372,9 @@ function WeeklyCheckoutFormGifting(props: PropTypes): JSX.Element {
 							<PaymentMethodSelector
 								availablePaymentMethods={paymentMethods}
 								paymentMethod={props.paymentMethod}
-								setPaymentMethod={props.setPaymentMethod}
+								setPaymentMethod={(paymentMethod) =>
+									props.setPaymentMethod({ paymentMethod })
+								}
 								validationError={
 									firstError('paymentMethod', props.formErrors) as string
 								}

--- a/support-frontend/stories/screens/SupporterPlusLanding.stories.tsx
+++ b/support-frontend/stories/screens/SupporterPlusLanding.stories.tsx
@@ -34,7 +34,7 @@ store.dispatch(setProductType('MONTHLY'));
 store.dispatch(setFirstName(''));
 store.dispatch(setLastName(''));
 store.dispatch(setEmail(''));
-store.dispatch(setPaymentMethod('None'));
+store.dispatch(setPaymentMethod({ paymentMethod: 'None' }));
 
 export default {
 	component: SupporterPlusLandingPage,

--- a/support-frontend/stories/screens/supporterPlusThankYou/AusSupporterPlusThankYou.stories.tsx
+++ b/support-frontend/stories/screens/supporterPlusThankYou/AusSupporterPlusThankYou.stories.tsx
@@ -124,7 +124,7 @@ OneOffNotSignedIn.decorators = [
 		store.dispatch(setFirstName('Joe'));
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
-		store.dispatch(setPaymentMethod(paymentMethod));
+		store.dispatch(setPaymentMethod({ paymentMethod }));
 
 		store.dispatch(
 			setSelectedAmount(
@@ -171,7 +171,7 @@ OneOffSignedIn.decorators = [
 		store.dispatch(setFirstName('Joe'));
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
-		store.dispatch(setPaymentMethod(paymentMethod));
+		store.dispatch(setPaymentMethod({ paymentMethod }));
 
 		store.dispatch(
 			setSelectedAmount(
@@ -220,7 +220,7 @@ OneOffSignUp.decorators = [
 		store.dispatch(setFirstName('Joe'));
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
-		store.dispatch(setPaymentMethod(paymentMethod));
+		store.dispatch(setPaymentMethod({ paymentMethod }));
 
 		store.dispatch(
 			setSelectedAmount(
@@ -276,7 +276,7 @@ RecurringNotSignedIn.decorators = [
 		);
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
-		store.dispatch(setPaymentMethod(paymentMethod));
+		store.dispatch(setPaymentMethod({ paymentMethod }));
 
 		const thresholdPrice =
 			benefitsThresholdsByCountryGroup['AUDCountries'][
@@ -338,7 +338,7 @@ RecurringSignedIn.decorators = [
 		);
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
-		store.dispatch(setPaymentMethod(paymentMethod));
+		store.dispatch(setPaymentMethod({ paymentMethod }));
 
 		const thresholdPrice =
 			benefitsThresholdsByCountryGroup['AUDCountries'][
@@ -401,7 +401,7 @@ RecurringSignUp.decorators = [
 		);
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
-		store.dispatch(setPaymentMethod(paymentMethod));
+		store.dispatch(setPaymentMethod({ paymentMethod }));
 
 		const thresholdPrice =
 			benefitsThresholdsByCountryGroup['AUDCountries'][

--- a/support-frontend/stories/screens/supporterPlusThankYou/ROWSupporterPlusThankYou.stories.tsx
+++ b/support-frontend/stories/screens/supporterPlusThankYou/ROWSupporterPlusThankYou.stories.tsx
@@ -116,7 +116,7 @@ OneOffNotSignedIn.decorators = [
 		store.dispatch(setFirstName('Joe'));
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
-		store.dispatch(setPaymentMethod(paymentMethod));
+		store.dispatch(setPaymentMethod({ paymentMethod }));
 		store.dispatch(
 			setCountryInternationalisation(countryGroups[countryGroup].countries[0]),
 		);
@@ -168,7 +168,7 @@ OneOffSignedIn.decorators = [
 		store.dispatch(setFirstName('Joe'));
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
-		store.dispatch(setPaymentMethod(paymentMethod));
+		store.dispatch(setPaymentMethod({ paymentMethod }));
 		store.dispatch(
 			setCountryInternationalisation(countryGroups[countryGroup].countries[0]),
 		);
@@ -221,7 +221,7 @@ OneOffSignUp.decorators = [
 		store.dispatch(setFirstName('Joe'));
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
-		store.dispatch(setPaymentMethod(paymentMethod));
+		store.dispatch(setPaymentMethod({ paymentMethod }));
 		store.dispatch(
 			setCountryInternationalisation(countryGroups[countryGroup].countries[0]),
 		);
@@ -281,7 +281,7 @@ RecurringNotSignedIn.decorators = [
 		);
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
-		store.dispatch(setPaymentMethod(paymentMethod));
+		store.dispatch(setPaymentMethod({ paymentMethod }));
 		store.dispatch(
 			setCountryInternationalisation(countryGroups[countryGroup].countries[0]),
 		);
@@ -347,7 +347,7 @@ RecurringSignedIn.decorators = [
 		);
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
-		store.dispatch(setPaymentMethod(paymentMethod));
+		store.dispatch(setPaymentMethod({ paymentMethod }));
 		store.dispatch(
 			setCountryInternationalisation(countryGroups[countryGroup].countries[0]),
 		);
@@ -414,7 +414,7 @@ RecurringSignUp.decorators = [
 		);
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
-		store.dispatch(setPaymentMethod(paymentMethod));
+		store.dispatch(setPaymentMethod({ paymentMethod }));
 		store.dispatch(
 			setCountryInternationalisation(countryGroups[countryGroup].countries[0]),
 		);

--- a/support-payment-api/src/main/scala/backend/StripeBackend.scala
+++ b/support-payment-api/src/main/scala/backend/StripeBackend.scala
@@ -121,7 +121,7 @@ class StripeBackend(
       clientBrowserInfo: ClientBrowserInfo,
   ): EitherT[Future, StripeApiError, StripePaymentIntentsApiResponse] = {
 
-    def isApplePay = request.paymentData.stripePaymentMethod match {
+    def isApplePayOrPaymentRequestButton = request.paymentData.stripePaymentMethod match {
       case Some(StripeApplePay) | Some(StripePaymentRequestButton) => true
       case _ => false
     }
@@ -132,7 +132,7 @@ class StripeBackend(
       recaptchaEnabled.map {
         case true =>
           environment match {
-            case Live if isApplePay =>
+            case Live if isApplePayOrPaymentRequestButton =>
               false
             case Live =>
               true


### PR DESCRIPTION
Trello card: https://trello.com/c/PBBDfgCy/1159-check-on-client-side-validation-for-state-field-when-using-apple-pay-or-google-pay

# Background

We’ve had some examples recently of users paying via Apple Pay where the currency is GBP and the credit card country is GB, but the billing address country is US and the `state` field is the empty string. This then fails in support-workers because the state isn’t allowed to be empty when the country is US. Some users then try another payment, and unfortunately the country and state data from Apple Pay is reused on subsequent submissions, preventing them from continuing.

# Changes

## Use correct country to check if state is required

At the moment, if a user is on the UK page but uses Apple Pay and we get a billing address that’s in the US, we don’t require a non-empty state on the client-side. We then send the request to the backend, which fails.

To fix this, this commit uses the same logic for determining the country when checking whether a state is required as is used when sending the info to the backend. This way the client-side and server-side validation should be consistent.

## Add stripePaymentMethod to state, only use payment-request-button-provided country and state when the payment request button is being used

Another option might be to change the logic in [getBillingCountryAndState](https://github.com/guardian/support-frontend/blob/a24606d40e5ab5cf920af265cd67dbc00d5ee69f/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts#L139) to check the current payment method. Conceptually I’m more comfortable with that option, because it doesn’t require co-ordinating the logic in two places, but I don’t think the payment method detail (i.e. more specific than the `PaymentMethod` type) is easily available there.

At the moment, if a payment via Apple Pay (or presumably other stripe request button payment methods) fails, the country and state will get reused for subsequent card payments, potentially causing further failure. I saw this recently where we got US as the country and no state from Apple Pay, and when that failed the user retried with card, which also failed. Retrying with direct debit fixed the problem for this user, but it shouldn’t be necessary.

Paul Brown fixed this bug for some payment types in [PR 2378](https://github.com/guardian/support-frontend/pull/2378) (in commit 14b6a2b351fdcd5a198d1958b359ad0467daae34) by clearing the country and state on payment failures. However, since the else branch isn’t taken when the payment method is Apple Pay, the bug can still happen in that case.

Rather than deleting the country and state when payment fails, this change keeps track of whether the current/most recently used payment method is the payment request button, and only sends the country and state obtained from the button if it is.

This should fix the bug for Apple Pay users, but I have not verified that it does – I don’t know how to test it, because Apple Pay won’t let me add an invalid card, or one that has an invalid billing address, or a test card. I have confirmed that the happy path still works: using a US Apple Pay card on the UK page or vice-versa works fine (and the billing address is set correctly) if the address has a state when needed.

I wanted to set the `stripePaymentMethod` correctly when using Stripe without the payment request button as well, but it was hard to determine whether the correct value should be `StripeCheckout` or `StripeElements`, or a mix of the two. Currently we use a mix: mostly `StripeCheckout` but with `StripeElements` used once.

I believe the original intended meaning was that `StripeCheckout` meant Stripe’s low-code integration (https://stripe.com/docs/payments/checkout), and `StripeElements` meant the prebuilt UI components that we later switched to (https://stripe.com/docs/payments/elements). However, we aren’t using the types that way: as far as I can see we don’t use the low-code integration at all anymore, but we do still use `StripeCheckout`.

I wanted to clarify the situation (and maybe get rid of one of the two), but don’t want to spend more time on this. Maybe we can update this in the future.