### PR TITLE
Support Acquisition API GuCDK Migration-Recreate existing CFN template using CDK constructs

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -82,3 +82,24 @@ new AcquisitionEventsApi(app, "Acquisition-Events-API-PROD", {
   stack: "support",
   stage: "PROD",
 });
+
+export const codeProps: AcquisitionEventsApiProps = {
+  stack: "support",
+  stage: "CODE",
+  app: "acquisition-events-api",
+  certificateId:"b384a6a0-2f54-4874-b99b-96eeff96c009",
+  domainName: "acquisition-events-code.support.guardianapis.com",
+  hostedZoneName:"support.guardianapis.com.",
+};
+
+export const prodProps: AcquisitionEventsApiProps = {
+  stack: "support",
+  stage: "PROD",
+  app: "acquisition-events-api",
+  certificateId: "b384a6a0-2f54-4874-b99b-96eeff96c009",
+  domainName: "acquisition-events.support.guardianapis.com",
+  hostedZoneName: "support.guardianapis.com.",
+};
+
+new AcquisitionEventsApi(app, "AcquisitionEventsApi-CODE", codeProps);
+new AcquisitionEventsApi(app, "AcquisitionEventsApi-PROD", prodProps);

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,10 +1,10 @@
 import "source-map-support/register";
 import { App } from "aws-cdk-lib";
-import { AcquisitionEventsApi , AcquisitionEventsApiProps} from "../lib/acquisition-events-api";
+import { AcquisitionEventsApi } from "../lib/acquisition-events-api";
+import type { AcquisitionEventsApiProps} from "../lib/acquisition-events-api";
 import { Frontend } from "../lib/frontend";
 import {PaymentApi} from "../lib/payment-api";
 import { StripePatronsData } from "../lib/stripe-patrons-data";
-
 
 
 const app = new App();

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,6 +1,6 @@
 import "source-map-support/register";
 import { App } from "aws-cdk-lib";
-import {AcquisitionEventsApi} from "../lib/acquisition-events-api";
+import { AcquisitionEventsApi , AcquisitionEventsApiProps} from "../lib/acquisition-events-api";
 import { Frontend } from "../lib/frontend";
 import {PaymentApi} from "../lib/payment-api";
 import { StripePatronsData } from "../lib/stripe-patrons-data";
@@ -73,16 +73,6 @@ new PaymentApi(app, "Payment-API-PROD", {
   },
 });
 
-new AcquisitionEventsApi(app, "Acquisition-Events-API-CODE", {
-  stack: "support",
-  stage: "CODE",
-});
-
-new AcquisitionEventsApi(app, "Acquisition-Events-API-PROD", {
-  stack: "support",
-  stage: "PROD",
-});
-
 export const codeProps: AcquisitionEventsApiProps = {
   stack: "support",
   stage: "CODE",
@@ -90,6 +80,7 @@ export const codeProps: AcquisitionEventsApiProps = {
   certificateId:"b384a6a0-2f54-4874-b99b-96eeff96c009",
   domainName: "acquisition-events-code.support.guardianapis.com",
   hostedZoneName:"support.guardianapis.com.",
+  hostedZoneId:"Z3KO35ELNWZMSX",
 };
 
 export const prodProps: AcquisitionEventsApiProps = {
@@ -99,6 +90,7 @@ export const prodProps: AcquisitionEventsApiProps = {
   certificateId: "b384a6a0-2f54-4874-b99b-96eeff96c009",
   domainName: "acquisition-events.support.guardianapis.com",
   hostedZoneName: "support.guardianapis.com.",
+  hostedZoneId: "Z3KO35ELNWZMSX",
 };
 
 new AcquisitionEventsApi(app, "AcquisitionEventsApi-CODE", codeProps);

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,7 +1,6 @@
 import "source-map-support/register";
 import { App } from "aws-cdk-lib";
-import { AcquisitionEventsApi } from "../lib/acquisition-events-api";
-import type { AcquisitionEventsApiProps} from "../lib/acquisition-events-api";
+import {AcquisitionEventsApi} from "../lib/acquisition-events-api";
 import { Frontend } from "../lib/frontend";
 import {PaymentApi} from "../lib/payment-api";
 import { StripePatronsData } from "../lib/stripe-patrons-data";
@@ -73,25 +72,20 @@ new PaymentApi(app, "Payment-API-PROD", {
   },
 });
 
-export const codeProps: AcquisitionEventsApiProps = {
+new AcquisitionEventsApi(app, "Acquisition-Events-API-CODE", {
   stack: "support",
   stage: "CODE",
-  app: "acquisition-events-api",
   certificateId:"b384a6a0-2f54-4874-b99b-96eeff96c009",
   domainName: "acquisition-events-code.support.guardianapis.com",
   hostedZoneName:"support.guardianapis.com.",
   hostedZoneId:"Z3KO35ELNWZMSX",
-};
+});
 
-export const prodProps: AcquisitionEventsApiProps = {
+new AcquisitionEventsApi(app, "Acquisition-Events-API-PROD", {
   stack: "support",
   stage: "PROD",
-  app: "acquisition-events-api",
   certificateId: "b384a6a0-2f54-4874-b99b-96eeff96c009",
   domainName: "acquisition-events.support.guardianapis.com",
   hostedZoneName: "support.guardianapis.com.",
   hostedZoneId: "Z3KO35ELNWZMSX",
-};
-
-new AcquisitionEventsApi(app, "AcquisitionEventsApi-CODE", codeProps);
-new AcquisitionEventsApi(app, "AcquisitionEventsApi-PROD", prodProps);
+});

--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -4,11 +4,6 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [
-      "GuStringParameter",
-      "GuStringParameter",
-      "GuStringParameter",
-      "GuStringParameter",
-      "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuApiLambda",
       "GuApiGateway5xxPercentageAlarm",
@@ -16,14 +11,14 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
     "gu:cdk:version": "TEST",
   },
   "Outputs": {
-    "acquisitioneventsapiEndpointD259492D": {
+    "acquisitioneventsapilambdaacquisitioneventsapiCODEEndpointB2A2695C": {
       "Value": {
         "Fn::Join": [
           "",
           [
             "https://",
             {
-              "Ref": "acquisitioneventsapi0E58E9EF",
+              "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
             },
             ".execute-api.",
             {
@@ -35,7 +30,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
             },
             "/",
             {
-              "Ref": "acquisitioneventsapiDeploymentStageprodB989F67D",
+              "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEDeploymentStageprodB0270C0A",
             },
             "/",
           ],
@@ -44,33 +39,866 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
     },
   },
   "Parameters": {
-    "App": {
-      "Description": "Acquisition Events Api",
-      "Type": "String",
-    },
-    "CertificateArn": {
-      "Description": "ARN of the certificate",
-      "Type": "String",
-    },
-    "DeployBucket": {
-      "Description": "Bucket to copy files to",
-      "Type": "String",
-    },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "Stack": {
-      "Description": "Stack name",
-      "Type": "String",
+  },
+  "Resources": {
+    "ApiDomainName": {
+      "Properties": {
+        "DomainName": "acquisition-events-code.support.guardianapis.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL",
+          ],
+        },
+        "RegionalCertificateArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:acm:eu-west-1:",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":certificate/b384a6a0-2f54-4874-b99b-96eeff96c009",
+            ],
+          ],
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::DomainName",
     },
-    "Stage": {
-      "Description": "Set by RiffRaff on each deploy",
-      "Type": "String",
+    "ApiGatewayHigh5xxPercentageAlarmAcquisitioneventsapi36134E2A": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":conversion-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "acquisition-events-api exceeded 5% error rate",
+        "AlarmName": "High 5XX error % from acquisition-events-api (ApiGateway) in CODE",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "% of 5XX responses served for acquisition-events-api",
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "support-CODE-acquisition-events-api-CODE",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "support-CODE-acquisition-events-api-CODE",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 5,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ApiMapping": {
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiDomainName",
+        },
+        "RestApiId": {
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+        },
+        "Stage": {
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEDeploymentStageprodB0270C0A",
+        },
+      },
+      "Type": "AWS::ApiGateway::BasePathMapping",
+    },
+    "DNSRecord": {
+      "Properties": {
+        "HostedZoneId": "Z3KO35ELNWZMSX",
+        "Name": "acquisition-events-code.support.guardianapis.com",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "ApiDomainName",
+              "RegionalDomainName",
+            ],
+          },
+        ],
+        "TTL": "60",
+        "Type": "CNAME",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
+    "acquisitioneventsapilambda0E3B27C9": {
+      "DependsOn": [
+        "acquisitioneventsapilambdaServiceRoleDefaultPolicy5303DF29",
+        "acquisitioneventsapilambdaServiceRoleAA8836BB",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "support/CODE/acquisition-events-api/acquisition-events-api.jar",
+        },
+        "Description": "A lambda for acquisitions events api",
+        "Environment": {
+          "Variables": {
+            "APP": "acquisition-events-api",
+            "App": "acquisition-events-api",
+            "STACK": "support",
+            "STAGE": "CODE",
+            "Stack": "support",
+            "Stage": "CODE",
+          },
+        },
+        "FunctionName": "acquisition-events-api-cdk-CODE",
+        "Handler": "com.gu.acquisitionEventsApi.Lambda::handler",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapilambdaServiceRoleAA8836BB",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "acquisition-events-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "acquisitioneventsapilambdaServiceRoleAA8836BB": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "acquisition-events-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "acquisitioneventsapilambdaServiceRoleDefaultPolicy5303DF29": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/support/CODE/acquisition-events-api/acquisition-events-api.jar",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/support/acquisition-events-api",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/support/acquisition-events-api/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "acquisitioneventsapilambdaServiceRoleDefaultPolicy5303DF29",
+        "Roles": [
+          {
+            "Ref": "acquisitioneventsapilambdaServiceRoleAA8836BB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiCODEANY880AF78B": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "acquisitioneventsapilambda0E3B27C9",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": {
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiCODEANYApiPermissionAcquisitionEventsAPICODEacquisitioneventsapilambdaacquisitioneventsapiCODE719AC0DAANY02445B17": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapilambda0E3B27C9",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+              },
+              "/",
+              {
+                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEDeploymentStageprodB0270C0A",
+              },
+              "/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiCODEANYApiPermissionTestAcquisitionEventsAPICODEacquisitioneventsapilambdaacquisitioneventsapiCODE719AC0DAANY227DBB57": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapilambda0E3B27C9",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+              },
+              "/test-invoke-stage/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiCODEAccount97DCB29C": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapilambdaacquisitioneventsapiCODECloudWatchRoleC25FDF48",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9": {
+      "Properties": {
+        "Description": "API Gateway created by CDK",
+        "Name": "support-CODE-acquisition-events-api-CODE",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "acquisition-events-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiCODECloudWatchRoleC25FDF48": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "acquisition-events-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiCODEDeployment32F6DECE82150dce4985ff012211db1099f5686a": {
+      "DependsOn": [
+        "acquisitioneventsapilambdaacquisitioneventsapiCODEproxyANY5CDC12CF",
+        "acquisitioneventsapilambdaacquisitioneventsapiCODEproxy5CE0A29A",
+        "acquisitioneventsapilambdaacquisitioneventsapiCODEANY880AF78B",
+      ],
+      "Properties": {
+        "Description": "API Gateway created by CDK",
+        "RestApiId": {
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiCODEDeploymentStageprodB0270C0A": {
+      "DependsOn": [
+        "acquisitioneventsapilambdaacquisitioneventsapiCODEAccount97DCB29C",
+      ],
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEDeployment32F6DECE82150dce4985ff012211db1099f5686a",
+        },
+        "RestApiId": {
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+        },
+        "StageName": "prod",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "acquisition-events-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiCODEproxy5CE0A29A": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": {
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiCODEproxyANY5CDC12CF": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "acquisitioneventsapilambda0E3B27C9",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEproxy5CE0A29A",
+        },
+        "RestApiId": {
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiCODEproxyANYApiPermissionAcquisitionEventsAPICODEacquisitioneventsapilambdaacquisitioneventsapiCODE719AC0DAANYproxy21E0C51F": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapilambda0E3B27C9",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+              },
+              "/",
+              {
+                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEDeploymentStageprodB0270C0A",
+              },
+              "/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiCODEproxyANYApiPermissionTestAcquisitionEventsAPICODEacquisitioneventsapilambdaacquisitioneventsapiCODE719AC0DAANYproxy127295D0": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapilambda0E3B27C9",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+              },
+              "/test-invoke-stage/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+}
+`;
+
+exports[`The Acquisition Events API stack matches the snapshot 2`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuDistributionBucketParameter",
+      "GuApiLambda",
+      "GuApiGateway5xxPercentageAlarm",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Outputs": {
+    "acquisitioneventsapilambdaacquisitioneventsapiPRODEndpoint866DED2A": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            {
+              "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODDeploymentStageprod6B277DBD",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": {
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
   "Resources": {
+    "ApiDomainName": {
+      "Properties": {
+        "DomainName": "acquisition-events.support.guardianapis.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL",
+          ],
+        },
+        "RegionalCertificateArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:acm:eu-west-1:",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":certificate/b384a6a0-2f54-4874-b99b-96eeff96c009",
+            ],
+          ],
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::DomainName",
+    },
     "ApiGatewayHigh5xxPercentageAlarmAcquisitioneventsapi36134E2A": {
       "Properties": {
         "ActionsEnabled": true,
@@ -109,7 +937,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
                 "Dimensions": [
                   {
                     "Name": "ApiName",
-                    "Value": "support-PROD-acquisition-events-api",
+                    "Value": "support-PROD-acquisition-events-api-PROD",
                   },
                 ],
                 "MetricName": "5XXError",
@@ -127,7 +955,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
                 "Dimensions": [
                   {
                     "Name": "ApiName",
-                    "Value": "support-PROD-acquisition-events-api",
+                    "Value": "support-PROD-acquisition-events-api-PROD",
                   },
                 ],
                 "MetricName": "Count",
@@ -144,196 +972,66 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "acquisitioneventsapi0E58E9EF": {
+    "ApiMapping": {
       "Properties": {
-        "Description": "API Gateway created by CDK",
-        "Name": "support-PROD-acquisition-events-api",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "acquisition-events-api",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-frontend",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::ApiGateway::RestApi",
-    },
-    "acquisitioneventsapiANY52A84AA6": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "ANY",
-        "Integration": {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                {
-                  "Fn::GetAtt": [
-                    "acquisitioneventsapiBCD7A32B",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": {
-          "Fn::GetAtt": [
-            "acquisitioneventsapi0E58E9EF",
-            "RootResourceId",
-          ],
+        "DomainName": {
+          "Ref": "ApiDomainName",
         },
         "RestApiId": {
-          "Ref": "acquisitioneventsapi0E58E9EF",
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
+        },
+        "Stage": {
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODDeploymentStageprod6B277DBD",
         },
       },
-      "Type": "AWS::ApiGateway::Method",
+      "Type": "AWS::ApiGateway::BasePathMapping",
     },
-    "acquisitioneventsapiANYApiPermissionAcquisitionEventsAPIPRODacquisitioneventsapiBBE1A355ANY7C16FA16": {
+    "DNSRecord": {
       "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "acquisitioneventsapiBCD7A32B",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "acquisitioneventsapi0E58E9EF",
-              },
-              "/",
-              {
-                "Ref": "acquisitioneventsapiDeploymentStageprodB989F67D",
-              },
-              "/*/",
+        "HostedZoneId": "Z3KO35ELNWZMSX",
+        "Name": "acquisition-events.support.guardianapis.com",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "ApiDomainName",
+              "RegionalDomainName",
             ],
-          ],
-        },
+          },
+        ],
+        "TTL": "60",
+        "Type": "CNAME",
       },
-      "Type": "AWS::Lambda::Permission",
+      "Type": "AWS::Route53::RecordSet",
     },
-    "acquisitioneventsapiANYApiPermissionTestAcquisitionEventsAPIPRODacquisitioneventsapiBBE1A355ANYFD7CEEBE": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "acquisitioneventsapiBCD7A32B",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "acquisitioneventsapi0E58E9EF",
-              },
-              "/test-invoke-stage/*/",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "acquisitioneventsapiAccount5551F103": {
-      "DeletionPolicy": "Retain",
+    "acquisitioneventsapilambda0E3B27C9": {
       "DependsOn": [
-        "acquisitioneventsapi0E58E9EF",
-      ],
-      "Properties": {
-        "CloudWatchRoleArn": {
-          "Fn::GetAtt": [
-            "acquisitioneventsapiCloudWatchRole9BC90D98",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::ApiGateway::Account",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "acquisitioneventsapiBCD7A32B": {
-      "DependsOn": [
-        "acquisitioneventsapiServiceRoleDefaultPolicy4CE1975A",
-        "acquisitioneventsapiServiceRoleF09F7C6A",
+        "acquisitioneventsapilambdaServiceRoleDefaultPolicy5303DF29",
+        "acquisitioneventsapilambdaServiceRoleAA8836BB",
       ],
       "Properties": {
         "Code": {
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "support/PROD/acquisition-events-api/\${Stack}/\${Stage}/\${App}/\${App}.jar",
+          "S3Key": "support/PROD/acquisition-events-api/acquisition-events-api.jar",
         },
+        "Description": "A lambda for acquisitions events api",
         "Environment": {
           "Variables": {
             "APP": "acquisition-events-api",
+            "App": "acquisition-events-api",
             "STACK": "support",
             "STAGE": "PROD",
+            "Stack": "support",
+            "Stage": "PROD",
           },
         },
-        "Handler": "com.gu.acquisitionEventsApi.Lambda.handler",
+        "FunctionName": "acquisition-events-api-cdk-PROD",
+        "Handler": "com.gu.acquisitionEventsApi.Lambda::handler",
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
-            "acquisitioneventsapiServiceRoleF09F7C6A",
+            "acquisitioneventsapilambdaServiceRoleAA8836BB",
             "Arn",
           ],
         },
@@ -360,11 +1058,330 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
             "Value": "PROD",
           },
         ],
-        "Timeout": 30,
+        "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
     },
-    "acquisitioneventsapiCloudWatchRole9BC90D98": {
+    "acquisitioneventsapilambdaServiceRoleAA8836BB": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "acquisition-events-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "acquisitioneventsapilambdaServiceRoleDefaultPolicy5303DF29": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/support/PROD/acquisition-events-api/acquisition-events-api.jar",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/acquisition-events-api",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/acquisition-events-api/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "acquisitioneventsapilambdaServiceRoleDefaultPolicy5303DF29",
+        "Roles": [
+          {
+            "Ref": "acquisitioneventsapilambdaServiceRoleAA8836BB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiPRODANY445492D9": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "acquisitioneventsapilambda0E3B27C9",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": {
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiPRODANYApiPermissionAcquisitionEventsAPIPRODacquisitioneventsapilambdaacquisitioneventsapiPROD11709F75ANY3AE10E6A": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapilambda0E3B27C9",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
+              },
+              "/",
+              {
+                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODDeploymentStageprod6B277DBD",
+              },
+              "/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiPRODANYApiPermissionTestAcquisitionEventsAPIPRODacquisitioneventsapilambdaacquisitioneventsapiPROD11709F75ANYB569BDAD": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapilambda0E3B27C9",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
+              },
+              "/test-invoke-stage/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiPRODAccountE5185D6F": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapilambdaacquisitioneventsapiPRODCloudWatchRole6D8DFEDB",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D": {
+      "Properties": {
+        "Description": "API Gateway created by CDK",
+        "Name": "support-PROD-acquisition-events-api-PROD",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "acquisition-events-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "acquisitioneventsapilambdaacquisitioneventsapiPRODCloudWatchRole6D8DFEDB": {
       "DeletionPolicy": "Retain",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -419,30 +1436,30 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "acquisitioneventsapiDeployment0C5233D3debb32b022e009ff5ebbf41787082324": {
+    "acquisitioneventsapilambdaacquisitioneventsapiPRODDeployment61ED8FC65155e8ed9947476245eac2856cb9e1c9": {
       "DependsOn": [
-        "acquisitioneventsapiproxyANY71BF4D66",
-        "acquisitioneventsapiproxy045FC27B",
-        "acquisitioneventsapiANY52A84AA6",
+        "acquisitioneventsapilambdaacquisitioneventsapiPRODproxyANY79327E2F",
+        "acquisitioneventsapilambdaacquisitioneventsapiPRODproxy7DAF9818",
+        "acquisitioneventsapilambdaacquisitioneventsapiPRODANY445492D9",
       ],
       "Properties": {
         "Description": "API Gateway created by CDK",
         "RestApiId": {
-          "Ref": "acquisitioneventsapi0E58E9EF",
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
         },
       },
       "Type": "AWS::ApiGateway::Deployment",
     },
-    "acquisitioneventsapiDeploymentStageprodB989F67D": {
+    "acquisitioneventsapilambdaacquisitioneventsapiPRODDeploymentStageprod6B277DBD": {
       "DependsOn": [
-        "acquisitioneventsapiAccount5551F103",
+        "acquisitioneventsapilambdaacquisitioneventsapiPRODAccountE5185D6F",
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "acquisitioneventsapiDeployment0C5233D3debb32b022e009ff5ebbf41787082324",
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODDeployment61ED8FC65155e8ed9947476245eac2856cb9e1c9",
         },
         "RestApiId": {
-          "Ref": "acquisitioneventsapi0E58E9EF",
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
         },
         "StageName": "prod",
         "Tags": [
@@ -470,175 +1487,22 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Stage",
     },
-    "acquisitioneventsapiServiceRoleDefaultPolicy4CE1975A": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                    ],
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                      "/support/PROD/acquisition-events-api/\${Stack}/\${Stage}/\${App}/\${App}.jar",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "ssm:GetParametersByPath",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/PROD/support/acquisition-events-api",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/PROD/support/acquisition-events-api/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "acquisitioneventsapiServiceRoleDefaultPolicy4CE1975A",
-        "Roles": [
-          {
-            "Ref": "acquisitioneventsapiServiceRoleF09F7C6A",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "acquisitioneventsapiServiceRoleF09F7C6A": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "acquisition-events-api",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-frontend",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "acquisitioneventsapiproxy045FC27B": {
+    "acquisitioneventsapilambdaacquisitioneventsapiPRODproxy7DAF9818": {
       "Properties": {
         "ParentId": {
           "Fn::GetAtt": [
-            "acquisitioneventsapi0E58E9EF",
+            "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
             "RootResourceId",
           ],
         },
         "PathPart": "{proxy+}",
         "RestApiId": {
-          "Ref": "acquisitioneventsapi0E58E9EF",
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
         },
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "acquisitioneventsapiproxyANY71BF4D66": {
+    "acquisitioneventsapilambdaacquisitioneventsapiPRODproxyANY79327E2F": {
       "Properties": {
         "AuthorizationType": "NONE",
         "HttpMethod": "ANY",
@@ -660,7 +1524,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
                 ":lambda:path/2015-03-31/functions/",
                 {
                   "Fn::GetAtt": [
-                    "acquisitioneventsapiBCD7A32B",
+                    "acquisitioneventsapilambda0E3B27C9",
                     "Arn",
                   ],
                 },
@@ -670,20 +1534,20 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
           },
         },
         "ResourceId": {
-          "Ref": "acquisitioneventsapiproxy045FC27B",
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODproxy7DAF9818",
         },
         "RestApiId": {
-          "Ref": "acquisitioneventsapi0E58E9EF",
+          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
         },
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "acquisitioneventsapiproxyANYApiPermissionAcquisitionEventsAPIPRODacquisitioneventsapiBBE1A355ANYproxyCB64D64F": {
+    "acquisitioneventsapilambdaacquisitioneventsapiPRODproxyANYApiPermissionAcquisitionEventsAPIPRODacquisitioneventsapilambdaacquisitioneventsapiPROD11709F75ANYproxyE8D681EC": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "acquisitioneventsapiBCD7A32B",
+            "acquisitioneventsapilambda0E3B27C9",
             "Arn",
           ],
         },
@@ -706,11 +1570,11 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
               },
               ":",
               {
-                "Ref": "acquisitioneventsapi0E58E9EF",
+                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
               },
               "/",
               {
-                "Ref": "acquisitioneventsapiDeploymentStageprodB989F67D",
+                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODDeploymentStageprod6B277DBD",
               },
               "/*/*",
             ],
@@ -719,12 +1583,12 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "acquisitioneventsapiproxyANYApiPermissionTestAcquisitionEventsAPIPRODacquisitioneventsapiBBE1A355ANYproxy19F44506": {
+    "acquisitioneventsapilambdaacquisitioneventsapiPRODproxyANYApiPermissionTestAcquisitionEventsAPIPRODacquisitioneventsapilambdaacquisitioneventsapiPROD11709F75ANYproxy4206C8E6": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "acquisitioneventsapiBCD7A32B",
+            "acquisitioneventsapilambda0E3B27C9",
             "Arn",
           ],
         },
@@ -747,7 +1611,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
               },
               ":",
               {
-                "Ref": "acquisitioneventsapi0E58E9EF",
+                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
               },
               "/test-invoke-stage/*/*",
             ],

--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -260,7 +260,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
           },
           "S3Key": "support/CODE/acquisition-events-api/support/CODE/acquisition-events-api/acquisition-events-api.jar",
         },
-        "Description": "A lambda for acquisitions events api",
+        "Description": "A lambda that Sends in-app acquisitions (subscriptions) to BigQuery",
         "Environment": {
           "Variables": {
             "APP": "acquisition-events-api",
@@ -1129,7 +1129,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
           },
           "S3Key": "support/PROD/acquisition-events-api/support/PROD/acquisition-events-api/acquisition-events-api.jar",
         },
-        "Description": "A lambda for acquisitions events api",
+        "Description": "A lambda that Sends in-app acquisitions (subscriptions) to BigQuery",
         "Environment": {
           "Variables": {
             "APP": "acquisition-events-api",

--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -191,6 +191,63 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::DomainName",
     },
+    "S3inlinepolicy3B07399A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3::*:membership-dist/*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "S3inlinepolicy3B07399A",
+        "Roles": [
+          {
+            "Ref": "acquisitioneventsapicdklambdaServiceRole3289A569",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SSMinlinepolicyB56CB2A2": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/acquisition-events-api/bigquery-config/CODE/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SSMinlinepolicyB56CB2A2",
+        "Roles": [
+          {
+            "Ref": "acquisitioneventsapicdklambdaServiceRole3289A569",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "acquisitioneventsapicdklambda964B2B53": {
       "DependsOn": [
         "acquisitioneventsapicdklambdaServiceRoleDefaultPolicyE1C6ED02",
@@ -1002,6 +1059,63 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::ApiGateway::DomainName",
+    },
+    "S3inlinepolicy3B07399A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3::*:membership-dist/*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "S3inlinepolicy3B07399A",
+        "Roles": [
+          {
+            "Ref": "acquisitioneventsapicdklambdaServiceRole3289A569",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SSMinlinepolicyB56CB2A2": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/acquisition-events-api/bigquery-config/PROD/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SSMinlinepolicyB56CB2A2",
+        "Roles": [
+          {
+            "Ref": "acquisitioneventsapicdklambdaServiceRole3289A569",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "acquisitioneventsapicdklambda964B2B53": {
       "DependsOn": [

--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -214,7 +214,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
             "Stage": "CODE",
           },
         },
-        "FunctionName": "acquisition-events-api-CODE-cdk",
+        "FunctionName": "acquisition-events-api-cdk-CODE",
         "Handler": "com.gu.acquisitionEventsApi.Lambda::handler",
         "MemorySize": 512,
         "Role": {
@@ -624,7 +624,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeployment956B1309c4ad08381b18e5e55eab06c1bc667c03": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeployment956B130990ded7266015c7967956b54b7b69a4df": {
       "DependsOn": [
         "acquisitioneventsapicdklambdaacquisitioneventsapiCODEproxyANY0D8D3990",
         "acquisitioneventsapicdklambdaacquisitioneventsapiCODEproxy4473084F",
@@ -644,7 +644,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeployment956B1309c4ad08381b18e5e55eab06c1bc667c03",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeployment956B130990ded7266015c7967956b54b7b69a4df",
         },
         "RestApiId": {
           "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
@@ -1026,7 +1026,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
             "Stage": "PROD",
           },
         },
-        "FunctionName": "acquisition-events-api-PROD-cdk",
+        "FunctionName": "acquisition-events-api-cdk-PROD",
         "Handler": "com.gu.acquisitionEventsApi.Lambda::handler",
         "MemorySize": 512,
         "Role": {
@@ -1436,7 +1436,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeployment5D86426Bf345160ba8ec976044fb570006dc3f92": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeployment5D86426Bfd37a23db7e90bdd870479dca7dc4d79": {
       "DependsOn": [
         "acquisitioneventsapicdklambdaacquisitioneventsapiPRODproxyANY1BE80837",
         "acquisitioneventsapicdklambdaacquisitioneventsapiPRODproxyE717EAC5",
@@ -1456,7 +1456,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeployment5D86426Bf345160ba8ec976044fb570006dc3f92",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeployment5D86426Bfd37a23db7e90bdd870479dca7dc4d79",
         },
         "RestApiId": {
           "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",

--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -2,35 +2,49 @@
 
 exports[`The Acquisition Events API stack matches the snapshot 1`] = `
 {
-  "AWSTemplateFormatVersion": "2010-09-09",
-  "Conditions": {
-    "IsProd": {
-      "Fn::Equals": [
-        "PROD",
-        "PROD",
-      ],
-    },
-  },
-  "Description": "API for acquisition events",
-  "Mappings": {
-    "StageMap": {
-      "CODE": {
-        "CorsOrigin": "'*'",
-        "DomainName": "acquisition-events-code.support.guardianapis.com",
-      },
-      "PROD": {
-        "CorsOrigin": "'*'",
-        "DomainName": "acquisition-events.support.guardianapis.com",
-      },
-    },
-  },
   "Metadata": {
-    "gu:cdk:constructs": [],
+    "gu:cdk:constructs": [
+      "GuStringParameter",
+      "GuStringParameter",
+      "GuStringParameter",
+      "GuStringParameter",
+      "GuStringParameter",
+      "GuDistributionBucketParameter",
+      "GuApiLambda",
+      "GuApiGateway5xxPercentageAlarm",
+    ],
     "gu:cdk:version": "TEST",
+  },
+  "Outputs": {
+    "acquisitioneventsapiEndpointD259492D": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "acquisitioneventsapi0E58E9EF",
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            {
+              "Ref": "acquisitioneventsapiDeploymentStageprodB989F67D",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
   },
   "Parameters": {
     "App": {
-      "Default": "acquisition-events-api",
       "Description": "Acquisition Events Api",
       "Type": "String",
     },
@@ -39,395 +53,106 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       "Type": "String",
     },
     "DeployBucket": {
-      "Default": "membership-dist",
       "Description": "Bucket to copy files to",
       "Type": "String",
     },
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "Stack": {
-      "Default": "support",
       "Description": "Stack name",
+      "Type": "String",
+    },
+    "Stage": {
+      "Description": "Set by RiffRaff on each deploy",
       "Type": "String",
     },
   },
   "Resources": {
-    "ApiGateway4XXAlarm": {
-      "Condition": "IsProd",
+    "ApiGatewayHigh5xxPercentageAlarmAcquisitioneventsapi36134E2A": {
       "Properties": {
+        "ActionsEnabled": true,
         "AlarmActions": [
           {
-            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:contributions-dev",
-          },
-        ],
-        "AlarmDescription": "Acquisition Events API received an invalid request",
-        "AlarmName": {
-          "Fn::Sub": "acquisition-events-api-PROD API gateway 4XX response",
-        },
-        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "Dimensions": [
-          {
-            "Name": "ApiName",
-            "Value": {
-              "Fn::Sub": "acquisition-events-api-PROD",
-            },
-          },
-          {
-            "Name": "Method",
-            "Value": "POST",
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "4XXError",
-        "Namespace": "AWS/ApiGateway",
-        "Period": 300,
-        "Statistic": "Sum",
-        "Threshold": 1,
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "ApiGateway5XXAlarm": {
-      "Condition": "IsProd",
-      "Properties": {
-        "AlarmActions": [
-          {
-            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:contributions-dev",
-          },
-        ],
-        "AlarmDescription": "Acquisition events API failed to process an event",
-        "AlarmName": {
-          "Fn::Sub": "acquisition-events-api-PROD API gateway 5XX response",
-        },
-        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "Dimensions": [
-          {
-            "Name": "ApiName",
-            "Value": {
-              "Fn::Sub": "acquisition-events-api-PROD",
-            },
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "5XXError",
-        "Namespace": "AWS/ApiGateway",
-        "Period": 60,
-        "Statistic": "Sum",
-        "Threshold": 1,
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "BasePathMapping": {
-      "DependsOn": [
-        "ServerlessRestApiProdStage",
-      ],
-      "Properties": {
-        "DomainName": {
-          "Ref": "DomainName",
-        },
-        "RestApiId": {
-          "Ref": "ServerlessRestApi",
-        },
-        "Stage": {
-          "Fn::Sub": "Prod",
-        },
-      },
-      "Type": "AWS::ApiGateway::BasePathMapping",
-    },
-    "DNSRecord": {
-      "Properties": {
-        "Comment": {
-          "Fn::Sub": "CNAME for acquisition events endpoints PROD",
-        },
-        "HostedZoneName": "support.guardianapis.com.",
-        "Name": {
-          "Fn::FindInMap": [
-            "StageMap",
-            "PROD",
-            "DomainName",
-          ],
-        },
-        "ResourceRecords": [
-          {
-            "Fn::GetAtt": [
-              "DomainName",
-              "RegionalDomainName",
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":conversion-dev",
+              ],
             ],
           },
         ],
-        "TTL": "120",
-        "Type": "CNAME",
-      },
-      "Type": "AWS::Route53::RecordSet",
-    },
-    "DomainName": {
-      "Properties": {
-        "DomainName": {
-          "Fn::FindInMap": [
-            "StageMap",
-            "PROD",
-            "DomainName",
-          ],
-        },
-        "EndpointConfiguration": {
-          "Types": [
-            "REGIONAL",
-          ],
-        },
-        "RegionalCertificateArn": {
-          "Ref": "CertificateArn",
-        },
-        "Tags": [
+        "AlarmDescription": "acquisition-events-api exceeded 5% error rate",
+        "AlarmName": "High 5XX error % from acquisition-events-api (ApiGateway) in PROD",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
           {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "% of 5XX responses served for acquisition-events-api",
           },
           {
-            "Key": "gu:repo",
-            "Value": "guardian/support-frontend",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::ApiGateway::DomainName",
-    },
-    "Lambda": {
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "DeployBucket",
-          },
-          "S3Key": {
-            "Fn::Sub": "\${Stack}/PROD/\${App}/\${App}.jar",
-          },
-        },
-        "Description": "A lambda for acquisitions events api",
-        "Environment": {
-          "Variables": {
-            "STAGE": "PROD",
-          },
-        },
-        "FunctionName": {
-          "Fn::Sub": "\${App}-PROD",
-        },
-        "Handler": "com.gu.acquisitionEventsApi.Lambda::handler",
-        "MemorySize": 512,
-        "Role": {
-          "Fn::GetAtt": [
-            "LambdaRole",
-            "Arn",
-          ],
-        },
-        "Runtime": "java8.al2",
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-frontend",
-          },
-          {
-            "Key": "lambda:createdBy",
-            "Value": "SAM",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "Timeout": 300,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "LambdaAcquisitionEventPermissionProd": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Ref": "Lambda",
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws:execute-api:\${AWS::Region}:\${AWS::AccountId}:\${__ApiId__}/\${__Stage__}/POST/acquisition",
-            {
-              "__ApiId__": {
-                "Ref": "ServerlessRestApi",
-              },
-              "__Stage__": "*",
-            },
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "LambdaRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole",
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-        ],
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": {
-                "Action": [
-                  "ssm:GetParametersByPath",
-                ],
-                "Effect": "Allow",
-                "Resource": [
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
                   {
-                    "Fn::Sub": "arn:aws:ssm:\${AWS::Region}:\${AWS::AccountId}:parameter/acquisition-events-api/bigquery-config/PROD/*",
+                    "Name": "ApiName",
+                    "Value": "support-PROD-acquisition-events-api",
                   },
                 ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
               },
+              "Period": 60,
+              "Stat": "Sum",
             },
-            "PolicyName": "LambdaRolePolicy1",
+            "ReturnData": false,
           },
           {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": "s3:GetObject",
-                  "Effect": "Allow",
-                  "Resource": [
-                    "arn:aws:s3::*:membership-dist/*",
-                  ],
-                },
-              ],
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "support-PROD-acquisition-events-api",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "SampleCount",
             },
-            "PolicyName": "LambdaRolePolicy2",
+            "ReturnData": false,
           },
         ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-frontend",
-          },
-          {
-            "Key": "lambda:createdBy",
-            "Value": "SAM",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
+        "Threshold": 5,
+        "TreatMissingData": "notBreaching",
       },
-      "Type": "AWS::IAM::Role",
+      "Type": "AWS::CloudWatch::Alarm",
     },
-    "ServerlessRestApi": {
+    "acquisitioneventsapi0E58E9EF": {
       "Properties": {
-        "Body": {
-          "info": {
-            "title": {
-              "Ref": "AWS::StackName",
-            },
-            "version": "1.0",
-          },
-          "paths": {
-            "/acquisition": {
-              "options": {
-                "consumes": [
-                  "application/json",
-                ],
-                "produces": [
-                  "application/json",
-                ],
-                "responses": {
-                  "200": {
-                    "description": "Default response for CORS method",
-                    "headers": {
-                      "Access-Control-Allow-Headers": {
-                        "type": "string",
-                      },
-                      "Access-Control-Allow-Methods": {
-                        "type": "string",
-                      },
-                      "Access-Control-Allow-Origin": {
-                        "type": "string",
-                      },
-                    },
-                  },
-                },
-                "summary": "CORS support",
-                "x-amazon-apigateway-integration": {
-                  "requestTemplates": {
-                    "application/json": "{
-  "statusCode" : 200
-}
-",
-                  },
-                  "responses": {
-                    "default": {
-                      "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
-                        "method.response.header.Access-Control-Allow-Methods": "'*'",
-                        "method.response.header.Access-Control-Allow-Origin": {
-                          "Fn::FindInMap": [
-                            "StageMap",
-                            "PROD",
-                            "CorsOrigin",
-                          ],
-                        },
-                      },
-                      "responseTemplates": {
-                        "application/json": "{}
-",
-                      },
-                      "statusCode": "200",
-                    },
-                  },
-                  "type": "mock",
-                },
-              },
-              "post": {
-                "responses": {},
-                "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
-                  "uri": {
-                    "Fn::Sub": "arn:aws:apigateway:\${AWS::Region}:lambda:path/2015-03-31/functions/\${Lambda.Arn}/invocations",
-                  },
-                },
-              },
-            },
-          },
-          "swagger": "2.0",
-        },
+        "Description": "API Gateway created by CDK",
+        "Name": "support-PROD-acquisition-events-api",
         "Tags": [
+          {
+            "Key": "App",
+            "Value": "acquisition-events-api",
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -448,26 +173,283 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "ServerlessRestApiDeployment0eaecd80e2": {
+    "acquisitioneventsapiANY52A84AA6": {
       "Properties": {
-        "Description": "RestApi deployment id: 0eaecd80e2ee9fd80faf745412676700de78c061",
-        "RestApiId": {
-          "Ref": "ServerlessRestApi",
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "acquisitioneventsapiBCD7A32B",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
         },
-        "StageName": "Stage",
+        "ResourceId": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapi0E58E9EF",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": {
+          "Ref": "acquisitioneventsapi0E58E9EF",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "acquisitioneventsapiANYApiPermissionAcquisitionEventsAPIPRODacquisitioneventsapiBBE1A355ANY7C16FA16": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapiBCD7A32B",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "acquisitioneventsapi0E58E9EF",
+              },
+              "/",
+              {
+                "Ref": "acquisitioneventsapiDeploymentStageprodB989F67D",
+              },
+              "/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "acquisitioneventsapiANYApiPermissionTestAcquisitionEventsAPIPRODacquisitioneventsapiBBE1A355ANYFD7CEEBE": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapiBCD7A32B",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "acquisitioneventsapi0E58E9EF",
+              },
+              "/test-invoke-stage/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "acquisitioneventsapiAccount5551F103": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "acquisitioneventsapi0E58E9EF",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapiCloudWatchRole9BC90D98",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "acquisitioneventsapiBCD7A32B": {
+      "DependsOn": [
+        "acquisitioneventsapiServiceRoleDefaultPolicy4CE1975A",
+        "acquisitioneventsapiServiceRoleF09F7C6A",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "support/PROD/acquisition-events-api/\${Stack}/\${Stage}/\${App}/\${App}.jar",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "acquisition-events-api",
+            "STACK": "support",
+            "STAGE": "PROD",
+          },
+        },
+        "Handler": "com.gu.acquisitionEventsApi.Lambda.handler",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapiServiceRoleF09F7C6A",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "acquisition-events-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "acquisitioneventsapiCloudWatchRole9BC90D98": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "acquisition-events-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "acquisitioneventsapiDeployment0C5233D3debb32b022e009ff5ebbf41787082324": {
+      "DependsOn": [
+        "acquisitioneventsapiproxyANY71BF4D66",
+        "acquisitioneventsapiproxy045FC27B",
+        "acquisitioneventsapiANY52A84AA6",
+      ],
+      "Properties": {
+        "Description": "API Gateway created by CDK",
+        "RestApiId": {
+          "Ref": "acquisitioneventsapi0E58E9EF",
+        },
       },
       "Type": "AWS::ApiGateway::Deployment",
     },
-    "ServerlessRestApiProdStage": {
+    "acquisitioneventsapiDeploymentStageprodB989F67D": {
+      "DependsOn": [
+        "acquisitioneventsapiAccount5551F103",
+      ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment0eaecd80e2",
+          "Ref": "acquisitioneventsapiDeployment0C5233D3debb32b022e009ff5ebbf41787082324",
         },
         "RestApiId": {
-          "Ref": "ServerlessRestApi",
+          "Ref": "acquisitioneventsapi0E58E9EF",
         },
-        "StageName": "Prod",
+        "StageName": "prod",
         "Tags": [
+          {
+            "Key": "App",
+            "Value": "acquisition-events-api",
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -487,6 +469,292 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::ApiGateway::Stage",
+    },
+    "acquisitioneventsapiServiceRoleDefaultPolicy4CE1975A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/support/PROD/acquisition-events-api/\${Stack}/\${Stage}/\${App}/\${App}.jar",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/acquisition-events-api",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/support/acquisition-events-api/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "acquisitioneventsapiServiceRoleDefaultPolicy4CE1975A",
+        "Roles": [
+          {
+            "Ref": "acquisitioneventsapiServiceRoleF09F7C6A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "acquisitioneventsapiServiceRoleF09F7C6A": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "acquisition-events-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "acquisitioneventsapiproxy045FC27B": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapi0E58E9EF",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": {
+          "Ref": "acquisitioneventsapi0E58E9EF",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "acquisitioneventsapiproxyANY71BF4D66": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "acquisitioneventsapiBCD7A32B",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "acquisitioneventsapiproxy045FC27B",
+        },
+        "RestApiId": {
+          "Ref": "acquisitioneventsapi0E58E9EF",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "acquisitioneventsapiproxyANYApiPermissionAcquisitionEventsAPIPRODacquisitioneventsapiBBE1A355ANYproxyCB64D64F": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapiBCD7A32B",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "acquisitioneventsapi0E58E9EF",
+              },
+              "/",
+              {
+                "Ref": "acquisitioneventsapiDeploymentStageprodB989F67D",
+              },
+              "/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "acquisitioneventsapiproxyANYApiPermissionTestAcquisitionEventsAPIPRODacquisitioneventsapiBBE1A355ANYproxy19F44506": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapiBCD7A32B",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "acquisitioneventsapi0E58E9EF",
+              },
+              "/test-invoke-stage/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
   },
 }

--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -11,14 +11,14 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
     "gu:cdk:version": "TEST",
   },
   "Outputs": {
-    "acquisitioneventsapilambdaacquisitioneventsapiCODEEndpointB2A2695C": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEEndpoint07C195A6": {
       "Value": {
         "Fn::Join": [
           "",
           [
             "https://",
             {
-              "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+              "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
             },
             ".execute-api.",
             {
@@ -30,7 +30,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
             },
             "/",
             {
-              "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEDeploymentStageprodB0270C0A",
+              "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeploymentStageprod29285704",
             },
             "/",
           ],
@@ -46,47 +46,6 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
-    "ApiDomainName": {
-      "Properties": {
-        "DomainName": "acquisition-events-code.support.guardianapis.com",
-        "EndpointConfiguration": {
-          "Types": [
-            "REGIONAL",
-          ],
-        },
-        "RegionalCertificateArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:aws:acm:eu-west-1:",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":certificate/b384a6a0-2f54-4874-b99b-96eeff96c009",
-            ],
-          ],
-        },
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-frontend",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-      },
-      "Type": "AWS::ApiGateway::DomainName",
-    },
     "ApiGatewayHigh5xxPercentageAlarmAcquisitioneventsapi36134E2A": {
       "Properties": {
         "ActionsEnabled": true,
@@ -160,16 +119,16 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "ApiMapping": {
+    "BasePathMapping": {
       "Properties": {
         "DomainName": {
-          "Ref": "ApiDomainName",
+          "Ref": "DomainName",
         },
         "RestApiId": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
         },
         "Stage": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEDeploymentStageprodB0270C0A",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeploymentStageprod29285704",
         },
       },
       "Type": "AWS::ApiGateway::BasePathMapping",
@@ -181,7 +140,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
         "ResourceRecords": [
           {
             "Fn::GetAtt": [
-              "ApiDomainName",
+              "DomainName",
               "RegionalDomainName",
             ],
           },
@@ -191,17 +150,58 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Route53::RecordSet",
     },
-    "acquisitioneventsapilambda0E3B27C9": {
+    "DomainName": {
+      "Properties": {
+        "DomainName": "acquisition-events-code.support.guardianapis.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL",
+          ],
+        },
+        "RegionalCertificateArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:acm:eu-west-1:",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":certificate/b384a6a0-2f54-4874-b99b-96eeff96c009",
+            ],
+          ],
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::DomainName",
+    },
+    "acquisitioneventsapicdklambda964B2B53": {
       "DependsOn": [
-        "acquisitioneventsapilambdaServiceRoleDefaultPolicy5303DF29",
-        "acquisitioneventsapilambdaServiceRoleAA8836BB",
+        "acquisitioneventsapicdklambdaServiceRoleDefaultPolicyE1C6ED02",
+        "acquisitioneventsapicdklambdaServiceRole3289A569",
       ],
       "Properties": {
         "Code": {
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "support/CODE/acquisition-events-api/acquisition-events-api.jar",
+          "S3Key": "support/CODE/acquisition-events-api/support/CODE/acquisition-events-api/acquisition-events-api.jar",
         },
         "Description": "A lambda for acquisitions events api",
         "Environment": {
@@ -214,16 +214,16 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
             "Stage": "CODE",
           },
         },
-        "FunctionName": "acquisition-events-api-cdk-CODE",
+        "FunctionName": "acquisition-events-api-CODE-cdk",
         "Handler": "com.gu.acquisitionEventsApi.Lambda::handler",
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
-            "acquisitioneventsapilambdaServiceRoleAA8836BB",
+            "acquisitioneventsapicdklambdaServiceRole3289A569",
             "Arn",
           ],
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "java8",
         "Tags": [
           {
             "Key": "App",
@@ -250,7 +250,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "acquisitioneventsapilambdaServiceRoleAA8836BB": {
+    "acquisitioneventsapicdklambdaServiceRole3289A569": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -303,7 +303,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "acquisitioneventsapilambdaServiceRoleDefaultPolicy5303DF29": {
+    "acquisitioneventsapicdklambdaServiceRoleDefaultPolicyE1C6ED02": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -342,7 +342,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/support/CODE/acquisition-events-api/acquisition-events-api.jar",
+                      "/support/CODE/acquisition-events-api/support/CODE/acquisition-events-api/acquisition-events-api.jar",
                     ],
                   ],
                 },
@@ -394,153 +394,16 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "acquisitioneventsapilambdaServiceRoleDefaultPolicy5303DF29",
+        "PolicyName": "acquisitioneventsapicdklambdaServiceRoleDefaultPolicyE1C6ED02",
         "Roles": [
           {
-            "Ref": "acquisitioneventsapilambdaServiceRoleAA8836BB",
+            "Ref": "acquisitioneventsapicdklambdaServiceRole3289A569",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "acquisitioneventsapilambdaacquisitioneventsapiCODEANY880AF78B": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "ANY",
-        "Integration": {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                {
-                  "Fn::GetAtt": [
-                    "acquisitioneventsapilambda0E3B27C9",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": {
-          "Fn::GetAtt": [
-            "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
-            "RootResourceId",
-          ],
-        },
-        "RestApiId": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "acquisitioneventsapilambdaacquisitioneventsapiCODEANYApiPermissionAcquisitionEventsAPICODEacquisitioneventsapilambdaacquisitioneventsapiCODE719AC0DAANY02445B17": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "acquisitioneventsapilambda0E3B27C9",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
-              },
-              "/",
-              {
-                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEDeploymentStageprodB0270C0A",
-              },
-              "/*/",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "acquisitioneventsapilambdaacquisitioneventsapiCODEANYApiPermissionTestAcquisitionEventsAPICODEacquisitioneventsapilambdaacquisitioneventsapiCODE719AC0DAANY227DBB57": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "acquisitioneventsapilambda0E3B27C9",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
-              },
-              "/test-invoke-stage/*/",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "acquisitioneventsapilambdaacquisitioneventsapiCODEAccount97DCB29C": {
-      "DeletionPolicy": "Retain",
-      "DependsOn": [
-        "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
-      ],
-      "Properties": {
-        "CloudWatchRoleArn": {
-          "Fn::GetAtt": [
-            "acquisitioneventsapilambdaacquisitioneventsapiCODECloudWatchRoleC25FDF48",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::ApiGateway::Account",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E": {
       "Properties": {
         "Description": "API Gateway created by CDK",
         "Name": "support-CODE-acquisition-events-api-CODE",
@@ -569,7 +432,144 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "acquisitioneventsapilambdaacquisitioneventsapiCODECloudWatchRoleC25FDF48": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEANYApiPermissionAcquisitionEventsAPICODEacquisitioneventsapicdklambdaacquisitioneventsapiCODE4A2BE0EEANY0D5E6D8C": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapicdklambda964B2B53",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
+              },
+              "/",
+              {
+                "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeploymentStageprod29285704",
+              },
+              "/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEANYApiPermissionTestAcquisitionEventsAPICODEacquisitioneventsapicdklambdaacquisitioneventsapiCODE4A2BE0EEANY773A8E45": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapicdklambda964B2B53",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
+              },
+              "/test-invoke-stage/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEANYED33E000": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "acquisitioneventsapicdklambda964B2B53",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": {
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEAccount055A410A": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapicdklambdaacquisitioneventsapiCODECloudWatchRole8AAB5301",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "acquisitioneventsapicdklambdaacquisitioneventsapiCODECloudWatchRole8AAB5301": {
       "DeletionPolicy": "Retain",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -624,30 +624,30 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "acquisitioneventsapilambdaacquisitioneventsapiCODEDeployment32F6DECE82150dce4985ff012211db1099f5686a": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeployment956B1309c4ad08381b18e5e55eab06c1bc667c03": {
       "DependsOn": [
-        "acquisitioneventsapilambdaacquisitioneventsapiCODEproxyANY5CDC12CF",
-        "acquisitioneventsapilambdaacquisitioneventsapiCODEproxy5CE0A29A",
-        "acquisitioneventsapilambdaacquisitioneventsapiCODEANY880AF78B",
+        "acquisitioneventsapicdklambdaacquisitioneventsapiCODEproxyANY0D8D3990",
+        "acquisitioneventsapicdklambdaacquisitioneventsapiCODEproxy4473084F",
+        "acquisitioneventsapicdklambdaacquisitioneventsapiCODEANYED33E000",
       ],
       "Properties": {
         "Description": "API Gateway created by CDK",
         "RestApiId": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
         },
       },
       "Type": "AWS::ApiGateway::Deployment",
     },
-    "acquisitioneventsapilambdaacquisitioneventsapiCODEDeploymentStageprodB0270C0A": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeploymentStageprod29285704": {
       "DependsOn": [
-        "acquisitioneventsapilambdaacquisitioneventsapiCODEAccount97DCB29C",
+        "acquisitioneventsapicdklambdaacquisitioneventsapiCODEAccount055A410A",
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEDeployment32F6DECE82150dce4985ff012211db1099f5686a",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeployment956B1309c4ad08381b18e5e55eab06c1bc667c03",
         },
         "RestApiId": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
         },
         "StageName": "prod",
         "Tags": [
@@ -675,22 +675,22 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Stage",
     },
-    "acquisitioneventsapilambdaacquisitioneventsapiCODEproxy5CE0A29A": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEproxy4473084F": {
       "Properties": {
         "ParentId": {
           "Fn::GetAtt": [
-            "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+            "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
             "RootResourceId",
           ],
         },
         "PathPart": "{proxy+}",
         "RestApiId": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
         },
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "acquisitioneventsapilambdaacquisitioneventsapiCODEproxyANY5CDC12CF": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEproxyANY0D8D3990": {
       "Properties": {
         "AuthorizationType": "NONE",
         "HttpMethod": "ANY",
@@ -712,7 +712,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
                 ":lambda:path/2015-03-31/functions/",
                 {
                   "Fn::GetAtt": [
-                    "acquisitioneventsapilambda0E3B27C9",
+                    "acquisitioneventsapicdklambda964B2B53",
                     "Arn",
                   ],
                 },
@@ -722,20 +722,20 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
           },
         },
         "ResourceId": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEproxy5CE0A29A",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODEproxy4473084F",
         },
         "RestApiId": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
         },
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "acquisitioneventsapilambdaacquisitioneventsapiCODEproxyANYApiPermissionAcquisitionEventsAPICODEacquisitioneventsapilambdaacquisitioneventsapiCODE719AC0DAANYproxy21E0C51F": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEproxyANYApiPermissionAcquisitionEventsAPICODEacquisitioneventsapicdklambdaacquisitioneventsapiCODE4A2BE0EEANYproxy2789BC98": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "acquisitioneventsapilambda0E3B27C9",
+            "acquisitioneventsapicdklambda964B2B53",
             "Arn",
           ],
         },
@@ -758,11 +758,11 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
               },
               ":",
               {
-                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+                "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
               },
               "/",
               {
-                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEDeploymentStageprodB0270C0A",
+                "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeploymentStageprod29285704",
               },
               "/*/*",
             ],
@@ -771,12 +771,12 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "acquisitioneventsapilambdaacquisitioneventsapiCODEproxyANYApiPermissionTestAcquisitionEventsAPICODEacquisitioneventsapilambdaacquisitioneventsapiCODE719AC0DAANYproxy127295D0": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEproxyANYApiPermissionTestAcquisitionEventsAPICODEacquisitioneventsapicdklambdaacquisitioneventsapiCODE4A2BE0EEANYproxy42EB793D": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "acquisitioneventsapilambda0E3B27C9",
+            "acquisitioneventsapicdklambda964B2B53",
             "Arn",
           ],
         },
@@ -799,7 +799,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
               },
               ":",
               {
-                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiCODEC89CD5E9",
+                "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
               },
               "/test-invoke-stage/*/*",
             ],
@@ -823,14 +823,14 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
     "gu:cdk:version": "TEST",
   },
   "Outputs": {
-    "acquisitioneventsapilambdaacquisitioneventsapiPRODEndpoint866DED2A": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODEndpointB644BDA6": {
       "Value": {
         "Fn::Join": [
           "",
           [
             "https://",
             {
-              "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
+              "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",
             },
             ".execute-api.",
             {
@@ -842,7 +842,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
             },
             "/",
             {
-              "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODDeploymentStageprod6B277DBD",
+              "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeploymentStageprodE31383C6",
             },
             "/",
           ],
@@ -858,47 +858,6 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
     },
   },
   "Resources": {
-    "ApiDomainName": {
-      "Properties": {
-        "DomainName": "acquisition-events.support.guardianapis.com",
-        "EndpointConfiguration": {
-          "Types": [
-            "REGIONAL",
-          ],
-        },
-        "RegionalCertificateArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:aws:acm:eu-west-1:",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":certificate/b384a6a0-2f54-4874-b99b-96eeff96c009",
-            ],
-          ],
-        },
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-frontend",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::ApiGateway::DomainName",
-    },
     "ApiGatewayHigh5xxPercentageAlarmAcquisitioneventsapi36134E2A": {
       "Properties": {
         "ActionsEnabled": true,
@@ -972,16 +931,16 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "ApiMapping": {
+    "BasePathMapping": {
       "Properties": {
         "DomainName": {
-          "Ref": "ApiDomainName",
+          "Ref": "DomainName",
         },
         "RestApiId": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",
         },
         "Stage": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODDeploymentStageprod6B277DBD",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeploymentStageprodE31383C6",
         },
       },
       "Type": "AWS::ApiGateway::BasePathMapping",
@@ -993,7 +952,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
         "ResourceRecords": [
           {
             "Fn::GetAtt": [
-              "ApiDomainName",
+              "DomainName",
               "RegionalDomainName",
             ],
           },
@@ -1003,17 +962,58 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       },
       "Type": "AWS::Route53::RecordSet",
     },
-    "acquisitioneventsapilambda0E3B27C9": {
+    "DomainName": {
+      "Properties": {
+        "DomainName": "acquisition-events.support.guardianapis.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL",
+          ],
+        },
+        "RegionalCertificateArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:acm:eu-west-1:",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":certificate/b384a6a0-2f54-4874-b99b-96eeff96c009",
+            ],
+          ],
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::DomainName",
+    },
+    "acquisitioneventsapicdklambda964B2B53": {
       "DependsOn": [
-        "acquisitioneventsapilambdaServiceRoleDefaultPolicy5303DF29",
-        "acquisitioneventsapilambdaServiceRoleAA8836BB",
+        "acquisitioneventsapicdklambdaServiceRoleDefaultPolicyE1C6ED02",
+        "acquisitioneventsapicdklambdaServiceRole3289A569",
       ],
       "Properties": {
         "Code": {
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "support/PROD/acquisition-events-api/acquisition-events-api.jar",
+          "S3Key": "support/PROD/acquisition-events-api/support/PROD/acquisition-events-api/acquisition-events-api.jar",
         },
         "Description": "A lambda for acquisitions events api",
         "Environment": {
@@ -1026,16 +1026,16 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
             "Stage": "PROD",
           },
         },
-        "FunctionName": "acquisition-events-api-cdk-PROD",
+        "FunctionName": "acquisition-events-api-PROD-cdk",
         "Handler": "com.gu.acquisitionEventsApi.Lambda::handler",
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
-            "acquisitioneventsapilambdaServiceRoleAA8836BB",
+            "acquisitioneventsapicdklambdaServiceRole3289A569",
             "Arn",
           ],
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "java8",
         "Tags": [
           {
             "Key": "App",
@@ -1062,7 +1062,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "acquisitioneventsapilambdaServiceRoleAA8836BB": {
+    "acquisitioneventsapicdklambdaServiceRole3289A569": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -1115,7 +1115,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "acquisitioneventsapilambdaServiceRoleDefaultPolicy5303DF29": {
+    "acquisitioneventsapicdklambdaServiceRoleDefaultPolicyE1C6ED02": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -1154,7 +1154,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/support/PROD/acquisition-events-api/acquisition-events-api.jar",
+                      "/support/PROD/acquisition-events-api/support/PROD/acquisition-events-api/acquisition-events-api.jar",
                     ],
                   ],
                 },
@@ -1206,153 +1206,16 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "acquisitioneventsapilambdaServiceRoleDefaultPolicy5303DF29",
+        "PolicyName": "acquisitioneventsapicdklambdaServiceRoleDefaultPolicyE1C6ED02",
         "Roles": [
           {
-            "Ref": "acquisitioneventsapilambdaServiceRoleAA8836BB",
+            "Ref": "acquisitioneventsapicdklambdaServiceRole3289A569",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "acquisitioneventsapilambdaacquisitioneventsapiPRODANY445492D9": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "ANY",
-        "Integration": {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                {
-                  "Fn::GetAtt": [
-                    "acquisitioneventsapilambda0E3B27C9",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": {
-          "Fn::GetAtt": [
-            "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
-            "RootResourceId",
-          ],
-        },
-        "RestApiId": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "acquisitioneventsapilambdaacquisitioneventsapiPRODANYApiPermissionAcquisitionEventsAPIPRODacquisitioneventsapilambdaacquisitioneventsapiPROD11709F75ANY3AE10E6A": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "acquisitioneventsapilambda0E3B27C9",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
-              },
-              "/",
-              {
-                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODDeploymentStageprod6B277DBD",
-              },
-              "/*/",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "acquisitioneventsapilambdaacquisitioneventsapiPRODANYApiPermissionTestAcquisitionEventsAPIPRODacquisitioneventsapilambdaacquisitioneventsapiPROD11709F75ANYB569BDAD": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "acquisitioneventsapilambda0E3B27C9",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
-              },
-              "/test-invoke-stage/*/",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "acquisitioneventsapilambdaacquisitioneventsapiPRODAccountE5185D6F": {
-      "DeletionPolicy": "Retain",
-      "DependsOn": [
-        "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
-      ],
-      "Properties": {
-        "CloudWatchRoleArn": {
-          "Fn::GetAtt": [
-            "acquisitioneventsapilambdaacquisitioneventsapiPRODCloudWatchRole6D8DFEDB",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::ApiGateway::Account",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4": {
       "Properties": {
         "Description": "API Gateway created by CDK",
         "Name": "support-PROD-acquisition-events-api-PROD",
@@ -1381,7 +1244,144 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "acquisitioneventsapilambdaacquisitioneventsapiPRODCloudWatchRole6D8DFEDB": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODANYApiPermissionAcquisitionEventsAPIPRODacquisitioneventsapicdklambdaacquisitioneventsapiPROD744C4B0EANY624B6DF1": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapicdklambda964B2B53",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",
+              },
+              "/",
+              {
+                "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeploymentStageprodE31383C6",
+              },
+              "/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODANYApiPermissionTestAcquisitionEventsAPIPRODacquisitioneventsapicdklambdaacquisitioneventsapiPROD744C4B0EANY9FDBF1AD": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapicdklambda964B2B53",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",
+              },
+              "/test-invoke-stage/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODANYB36C6883": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "acquisitioneventsapicdklambda964B2B53",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": {
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODAccount1A4962D4": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapicdklambdaacquisitioneventsapiPRODCloudWatchRole65AD9A7F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODCloudWatchRole65AD9A7F": {
       "DeletionPolicy": "Retain",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -1436,30 +1436,30 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "acquisitioneventsapilambdaacquisitioneventsapiPRODDeployment61ED8FC65155e8ed9947476245eac2856cb9e1c9": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeployment5D86426Bf345160ba8ec976044fb570006dc3f92": {
       "DependsOn": [
-        "acquisitioneventsapilambdaacquisitioneventsapiPRODproxyANY79327E2F",
-        "acquisitioneventsapilambdaacquisitioneventsapiPRODproxy7DAF9818",
-        "acquisitioneventsapilambdaacquisitioneventsapiPRODANY445492D9",
+        "acquisitioneventsapicdklambdaacquisitioneventsapiPRODproxyANY1BE80837",
+        "acquisitioneventsapicdklambdaacquisitioneventsapiPRODproxyE717EAC5",
+        "acquisitioneventsapicdklambdaacquisitioneventsapiPRODANYB36C6883",
       ],
       "Properties": {
         "Description": "API Gateway created by CDK",
         "RestApiId": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",
         },
       },
       "Type": "AWS::ApiGateway::Deployment",
     },
-    "acquisitioneventsapilambdaacquisitioneventsapiPRODDeploymentStageprod6B277DBD": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeploymentStageprodE31383C6": {
       "DependsOn": [
-        "acquisitioneventsapilambdaacquisitioneventsapiPRODAccountE5185D6F",
+        "acquisitioneventsapicdklambdaacquisitioneventsapiPRODAccount1A4962D4",
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODDeployment61ED8FC65155e8ed9947476245eac2856cb9e1c9",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeployment5D86426Bf345160ba8ec976044fb570006dc3f92",
         },
         "RestApiId": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",
         },
         "StageName": "prod",
         "Tags": [
@@ -1487,22 +1487,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       },
       "Type": "AWS::ApiGateway::Stage",
     },
-    "acquisitioneventsapilambdaacquisitioneventsapiPRODproxy7DAF9818": {
-      "Properties": {
-        "ParentId": {
-          "Fn::GetAtt": [
-            "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
-            "RootResourceId",
-          ],
-        },
-        "PathPart": "{proxy+}",
-        "RestApiId": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "acquisitioneventsapilambdaacquisitioneventsapiPRODproxyANY79327E2F": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODproxyANY1BE80837": {
       "Properties": {
         "AuthorizationType": "NONE",
         "HttpMethod": "ANY",
@@ -1524,7 +1509,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
                 ":lambda:path/2015-03-31/functions/",
                 {
                   "Fn::GetAtt": [
-                    "acquisitioneventsapilambda0E3B27C9",
+                    "acquisitioneventsapicdklambda964B2B53",
                     "Arn",
                   ],
                 },
@@ -1534,20 +1519,20 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
           },
         },
         "ResourceId": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODproxy7DAF9818",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPRODproxyE717EAC5",
         },
         "RestApiId": {
-          "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",
         },
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "acquisitioneventsapilambdaacquisitioneventsapiPRODproxyANYApiPermissionAcquisitionEventsAPIPRODacquisitioneventsapilambdaacquisitioneventsapiPROD11709F75ANYproxyE8D681EC": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODproxyANYApiPermissionAcquisitionEventsAPIPRODacquisitioneventsapicdklambdaacquisitioneventsapiPROD744C4B0EANYproxy4394C974": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "acquisitioneventsapilambda0E3B27C9",
+            "acquisitioneventsapicdklambda964B2B53",
             "Arn",
           ],
         },
@@ -1570,11 +1555,11 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
               },
               ":",
               {
-                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
+                "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",
               },
               "/",
               {
-                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODDeploymentStageprod6B277DBD",
+                "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeploymentStageprodE31383C6",
               },
               "/*/*",
             ],
@@ -1583,12 +1568,12 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "acquisitioneventsapilambdaacquisitioneventsapiPRODproxyANYApiPermissionTestAcquisitionEventsAPIPRODacquisitioneventsapilambdaacquisitioneventsapiPROD11709F75ANYproxy4206C8E6": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODproxyANYApiPermissionTestAcquisitionEventsAPIPRODacquisitioneventsapicdklambdaacquisitioneventsapiPROD744C4B0EANYproxy5110C041": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "acquisitioneventsapilambda0E3B27C9",
+            "acquisitioneventsapicdklambda964B2B53",
             "Arn",
           ],
         },
@@ -1611,7 +1596,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
               },
               ":",
               {
-                "Ref": "acquisitioneventsapilambdaacquisitioneventsapiPRODB9324F3D",
+                "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",
               },
               "/test-invoke-stage/*/*",
             ],
@@ -1619,6 +1604,21 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
         },
       },
       "Type": "AWS::Lambda::Permission",
+    },
+    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODproxyE717EAC5": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": {
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
     },
   },
 }

--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -250,7 +250,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "TTL": "60",
+        "TTL": "120",
         "Type": "CNAME",
       },
       "Type": "AWS::Route53::RecordSet",
@@ -656,7 +656,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "support/CODE/acquisition-events-api/support/CODE/acquisition-events-api/acquisition-events-api.jar",
+          "S3Key": "support/CODE/acquisition-events-api/acquisition-events-api.jar",
         },
         "Description": "A lambda that Sends in-app acquisitions (subscriptions) to BigQuery",
         "Environment": {
@@ -797,7 +797,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/support/CODE/acquisition-events-api/support/CODE/acquisition-events-api/acquisition-events-api.jar",
+                      "/support/CODE/acquisition-events-api/acquisition-events-api.jar",
                     ],
                   ],
                 },
@@ -1517,7 +1517,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
             ],
           },
         ],
-        "TTL": "60",
+        "TTL": "120",
         "Type": "CNAME",
       },
       "Type": "AWS::Route53::RecordSet",
@@ -1923,7 +1923,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "support/PROD/acquisition-events-api/support/PROD/acquisition-events-api/acquisition-events-api.jar",
+          "S3Key": "support/PROD/acquisition-events-api/acquisition-events-api.jar",
         },
         "Description": "A lambda that Sends in-app acquisitions (subscriptions) to BigQuery",
         "Environment": {
@@ -2064,7 +2064,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/support/PROD/acquisition-events-api/support/PROD/acquisition-events-api/acquisition-events-api.jar",
+                      "/support/PROD/acquisition-events-api/acquisition-events-api.jar",
                     ],
                   ],
                 },

--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -29,6 +29,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       "GuDistributionBucketParameter",
       "GuApiLambda",
       "GuApiGateway5xxPercentageAlarm",
+      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -112,6 +113,39 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
             "Value": "POST",
           },
         ],
+        "EvaluationPeriods": 1,
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ApiGateway4XXAlarm59D14AA2": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":contributions-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Impact - Acquisition Events API received an invalid request. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
+        "AlarmName": "URGENT 9-5 - CODE API gateway 4XX response",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "EvaluationPeriods": 1,
         "MetricName": "4XXError",
         "Namespace": "AWS/ApiGateway",
@@ -1296,6 +1330,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       "GuDistributionBucketParameter",
       "GuApiLambda",
       "GuApiGateway5xxPercentageAlarm",
+      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -1379,6 +1414,39 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
             "Value": "POST",
           },
         ],
+        "EvaluationPeriods": 1,
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ApiGateway4XXAlarm59D14AA2": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":contributions-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Impact - Acquisition Events API received an invalid request. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
+        "AlarmName": "URGENT 9-5 - PROD API gateway 4XX response",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "EvaluationPeriods": 1,
         "MetricName": "4XXError",
         "Namespace": "AWS/ApiGateway",

--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -2,6 +2,28 @@
 
 exports[`The Acquisition Events API stack matches the snapshot 1`] = `
 {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "IsProd": {
+      "Fn::Equals": [
+        "CODE",
+        "PROD",
+      ],
+    },
+  },
+  "Description": "API for acquisition events",
+  "Mappings": {
+    "StageMap": {
+      "CODE": {
+        "CorsOrigin": "'*'",
+        "DomainName": "acquisition-events-code.support.guardianapis.com",
+      },
+      "PROD": {
+        "CorsOrigin": "'*'",
+        "DomainName": "acquisition-events.support.guardianapis.com",
+      },
+    },
+  },
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
@@ -39,13 +61,96 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
     },
   },
   "Parameters": {
+    "App": {
+      "Default": "acquisition-events-api",
+      "Description": "Acquisition Events Api",
+      "Type": "String",
+    },
+    "CertificateArn": {
+      "Description": "ARN of the certificate",
+      "Type": "String",
+    },
+    "DeployBucket": {
+      "Default": "membership-dist",
+      "Description": "Bucket to copy files to",
+      "Type": "String",
+    },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "Stack": {
+      "Default": "support",
+      "Description": "Stack name",
+      "Type": "String",
+    },
   },
   "Resources": {
+    "ApiGateway4XXAlarm": {
+      "Condition": "IsProd",
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:contributions-dev",
+          },
+        ],
+        "AlarmDescription": "Acquisition Events API received an invalid request",
+        "AlarmName": {
+          "Fn::Sub": "acquisition-events-api-CODE API gateway 4XX response",
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "ApiName",
+            "Value": {
+              "Fn::Sub": "acquisition-events-api-CODE",
+            },
+          },
+          {
+            "Name": "Method",
+            "Value": "POST",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ApiGateway5XXAlarm": {
+      "Condition": "IsProd",
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:contributions-dev",
+          },
+        ],
+        "AlarmDescription": "Acquisition events API failed to process an event",
+        "AlarmName": {
+          "Fn::Sub": "acquisition-events-api-CODE API gateway 5XX response",
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "ApiName",
+            "Value": {
+              "Fn::Sub": "acquisition-events-api-CODE",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "ApiGatewayHigh5xxPercentageAlarmAcquisitioneventsapi36134E2A": {
       "Properties": {
         "ActionsEnabled": true,
@@ -191,6 +296,159 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::DomainName",
     },
+    "Lambda": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DeployBucket",
+          },
+          "S3Key": {
+            "Fn::Sub": "\${Stack}/CODE/\${App}/\${App}.jar",
+          },
+        },
+        "Description": "A lambda for acquisitions events api",
+        "Environment": {
+          "Variables": {
+            "STAGE": "CODE",
+          },
+        },
+        "FunctionName": {
+          "Fn::Sub": "\${App}-CODE",
+        },
+        "Handler": "com.gu.acquisitionEventsApi.Lambda::handler",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "LambdaRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "java8.al2",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "LambdaAcquisitionEventPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "Lambda",
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:\${AWS::Region}:\${AWS::AccountId}:\${__ApiId__}/\${__Stage__}/POST/acquisition",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi",
+              },
+              "__Stage__": "*",
+            },
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "LambdaRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": {
+                "Action": [
+                  "ssm:GetParametersByPath",
+                ],
+                "Effect": "Allow",
+                "Resource": [
+                  {
+                    "Fn::Sub": "arn:aws:ssm:\${AWS::Region}:\${AWS::AccountId}:parameter/acquisition-events-api/bigquery-config/CODE/*",
+                  },
+                ],
+              },
+            },
+            "PolicyName": "LambdaRolePolicy1",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "s3:GetObject",
+                  "Effect": "Allow",
+                  "Resource": [
+                    "arn:aws:s3::*:membership-dist/*",
+                  ],
+                },
+              ],
+            },
+            "PolicyName": "LambdaRolePolicy2",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
     "S3inlinepolicy3B07399A": {
       "Properties": {
         "PolicyDocument": {
@@ -247,6 +505,146 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "ServerlessRestApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName",
+            },
+            "version": "1.0",
+          },
+          "paths": {
+            "/acquisition": {
+              "options": {
+                "consumes": [
+                  "application/json",
+                ],
+                "produces": [
+                  "application/json",
+                ],
+                "responses": {
+                  "200": {
+                    "description": "Default response for CORS method",
+                    "headers": {
+                      "Access-Control-Allow-Headers": {
+                        "type": "string",
+                      },
+                      "Access-Control-Allow-Methods": {
+                        "type": "string",
+                      },
+                      "Access-Control-Allow-Origin": {
+                        "type": "string",
+                      },
+                    },
+                  },
+                },
+                "summary": "CORS support",
+                "x-amazon-apigateway-integration": {
+                  "requestTemplates": {
+                    "application/json": "{
+  "statusCode" : 200
+}
+",
+                  },
+                  "responses": {
+                    "default": {
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
+                        "method.response.header.Access-Control-Allow-Methods": "'*'",
+                        "method.response.header.Access-Control-Allow-Origin": {
+                          "Fn::FindInMap": [
+                            "StageMap",
+                            "CODE",
+                            "CorsOrigin",
+                          ],
+                        },
+                      },
+                      "responseTemplates": {
+                        "application/json": "{}
+",
+                      },
+                      "statusCode": "200",
+                    },
+                  },
+                  "type": "mock",
+                },
+              },
+              "post": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:\${AWS::Region}:lambda:path/2015-03-31/functions/\${Lambda.Arn}/invocations",
+                  },
+                },
+              },
+            },
+          },
+          "swagger": "2.0",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "ServerlessRestApiDeployment0eaecd80e2": {
+      "Properties": {
+        "Description": "RestApi deployment id: 0eaecd80e2ee9fd80faf745412676700de78c061",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi",
+        },
+        "StageName": "Stage",
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "ServerlessRestApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment0eaecd80e2",
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi",
+        },
+        "StageName": "Prod",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
     },
     "acquisitioneventsapicdklambda964B2B53": {
       "DependsOn": [
@@ -871,6 +1269,28 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
 
 exports[`The Acquisition Events API stack matches the snapshot 2`] = `
 {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "IsProd": {
+      "Fn::Equals": [
+        "PROD",
+        "PROD",
+      ],
+    },
+  },
+  "Description": "API for acquisition events",
+  "Mappings": {
+    "StageMap": {
+      "CODE": {
+        "CorsOrigin": "'*'",
+        "DomainName": "acquisition-events-code.support.guardianapis.com",
+      },
+      "PROD": {
+        "CorsOrigin": "'*'",
+        "DomainName": "acquisition-events.support.guardianapis.com",
+      },
+    },
+  },
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
@@ -908,13 +1328,96 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
     },
   },
   "Parameters": {
+    "App": {
+      "Default": "acquisition-events-api",
+      "Description": "Acquisition Events Api",
+      "Type": "String",
+    },
+    "CertificateArn": {
+      "Description": "ARN of the certificate",
+      "Type": "String",
+    },
+    "DeployBucket": {
+      "Default": "membership-dist",
+      "Description": "Bucket to copy files to",
+      "Type": "String",
+    },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "Stack": {
+      "Default": "support",
+      "Description": "Stack name",
+      "Type": "String",
+    },
   },
   "Resources": {
+    "ApiGateway4XXAlarm": {
+      "Condition": "IsProd",
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:contributions-dev",
+          },
+        ],
+        "AlarmDescription": "Acquisition Events API received an invalid request",
+        "AlarmName": {
+          "Fn::Sub": "acquisition-events-api-PROD API gateway 4XX response",
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "ApiName",
+            "Value": {
+              "Fn::Sub": "acquisition-events-api-PROD",
+            },
+          },
+          {
+            "Name": "Method",
+            "Value": "POST",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ApiGateway5XXAlarm": {
+      "Condition": "IsProd",
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Fn::Sub": "arn:aws:sns:\${AWS::Region}:\${AWS::AccountId}:contributions-dev",
+          },
+        ],
+        "AlarmDescription": "Acquisition events API failed to process an event",
+        "AlarmName": {
+          "Fn::Sub": "acquisition-events-api-PROD API gateway 5XX response",
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "ApiName",
+            "Value": {
+              "Fn::Sub": "acquisition-events-api-PROD",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "ApiGatewayHigh5xxPercentageAlarmAcquisitioneventsapi36134E2A": {
       "Properties": {
         "ActionsEnabled": true,
@@ -1060,6 +1563,159 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       },
       "Type": "AWS::ApiGateway::DomainName",
     },
+    "Lambda": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DeployBucket",
+          },
+          "S3Key": {
+            "Fn::Sub": "\${Stack}/PROD/\${App}/\${App}.jar",
+          },
+        },
+        "Description": "A lambda for acquisitions events api",
+        "Environment": {
+          "Variables": {
+            "STAGE": "PROD",
+          },
+        },
+        "FunctionName": {
+          "Fn::Sub": "\${App}-PROD",
+        },
+        "Handler": "com.gu.acquisitionEventsApi.Lambda::handler",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "LambdaRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "java8.al2",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "LambdaAcquisitionEventPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "Lambda",
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:\${AWS::Region}:\${AWS::AccountId}:\${__ApiId__}/\${__Stage__}/POST/acquisition",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi",
+              },
+              "__Stage__": "*",
+            },
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "LambdaRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": {
+                "Action": [
+                  "ssm:GetParametersByPath",
+                ],
+                "Effect": "Allow",
+                "Resource": [
+                  {
+                    "Fn::Sub": "arn:aws:ssm:\${AWS::Region}:\${AWS::AccountId}:parameter/acquisition-events-api/bigquery-config/PROD/*",
+                  },
+                ],
+              },
+            },
+            "PolicyName": "LambdaRolePolicy1",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "s3:GetObject",
+                  "Effect": "Allow",
+                  "Resource": [
+                    "arn:aws:s3::*:membership-dist/*",
+                  ],
+                },
+              ],
+            },
+            "PolicyName": "LambdaRolePolicy2",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
     "S3inlinepolicy3B07399A": {
       "Properties": {
         "PolicyDocument": {
@@ -1116,6 +1772,146 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "ServerlessRestApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName",
+            },
+            "version": "1.0",
+          },
+          "paths": {
+            "/acquisition": {
+              "options": {
+                "consumes": [
+                  "application/json",
+                ],
+                "produces": [
+                  "application/json",
+                ],
+                "responses": {
+                  "200": {
+                    "description": "Default response for CORS method",
+                    "headers": {
+                      "Access-Control-Allow-Headers": {
+                        "type": "string",
+                      },
+                      "Access-Control-Allow-Methods": {
+                        "type": "string",
+                      },
+                      "Access-Control-Allow-Origin": {
+                        "type": "string",
+                      },
+                    },
+                  },
+                },
+                "summary": "CORS support",
+                "x-amazon-apigateway-integration": {
+                  "requestTemplates": {
+                    "application/json": "{
+  "statusCode" : 200
+}
+",
+                  },
+                  "responses": {
+                    "default": {
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Headers": "'Content-Type'",
+                        "method.response.header.Access-Control-Allow-Methods": "'*'",
+                        "method.response.header.Access-Control-Allow-Origin": {
+                          "Fn::FindInMap": [
+                            "StageMap",
+                            "PROD",
+                            "CorsOrigin",
+                          ],
+                        },
+                      },
+                      "responseTemplates": {
+                        "application/json": "{}
+",
+                      },
+                      "statusCode": "200",
+                    },
+                  },
+                  "type": "mock",
+                },
+              },
+              "post": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:\${AWS::Region}:lambda:path/2015-03-31/functions/\${Lambda.Arn}/invocations",
+                  },
+                },
+              },
+            },
+          },
+          "swagger": "2.0",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "ServerlessRestApiDeployment0eaecd80e2": {
+      "Properties": {
+        "Description": "RestApi deployment id: 0eaecd80e2ee9fd80faf745412676700de78c061",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi",
+        },
+        "StageName": "Stage",
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "ServerlessRestApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment0eaecd80e2",
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi",
+        },
+        "StageName": "Prod",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
     },
     "acquisitioneventsapicdklambda964B2B53": {
       "DependsOn": [

--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -669,7 +669,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
             "Stage": "CODE",
           },
         },
-        "FunctionName": "acquisition-events-api-CODE-CDK",
+        "FunctionName": "acquisition-events-api-cdk-CODE",
         "Handler": "com.gu.acquisitionEventsApi.Lambda::handler",
         "MemorySize": 512,
         "Role": {
@@ -1079,7 +1079,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeployment956B13099c613d98ef0412621975dac0e0e33a77": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeployment956B130990ded7266015c7967956b54b7b69a4df": {
       "DependsOn": [
         "acquisitioneventsapicdklambdaacquisitioneventsapiCODEproxyANY0D8D3990",
         "acquisitioneventsapicdklambdaacquisitioneventsapiCODEproxy4473084F",
@@ -1099,7 +1099,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeployment956B13099c613d98ef0412621975dac0e0e33a77",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeployment956B130990ded7266015c7967956b54b7b69a4df",
         },
         "RestApiId": {
           "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
@@ -1936,7 +1936,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
             "Stage": "PROD",
           },
         },
-        "FunctionName": "acquisition-events-api-PROD-CDK",
+        "FunctionName": "acquisition-events-api-cdk-PROD",
         "Handler": "com.gu.acquisitionEventsApi.Lambda::handler",
         "MemorySize": 512,
         "Role": {
@@ -2346,7 +2346,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeployment5D86426B579e69890250dbae99802a41e3383857": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeployment5D86426Bfd37a23db7e90bdd870479dca7dc4d79": {
       "DependsOn": [
         "acquisitioneventsapicdklambdaacquisitioneventsapiPRODproxyANY1BE80837",
         "acquisitioneventsapicdklambdaacquisitioneventsapiPRODproxyE717EAC5",
@@ -2366,7 +2366,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeployment5D86426B579e69890250dbae99802a41e3383857",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeployment5D86426Bfd37a23db7e90bdd870479dca7dc4d79",
         },
         "RestApiId": {
           "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",

--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -669,7 +669,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
             "Stage": "CODE",
           },
         },
-        "FunctionName": "acquisition-events-api-cdk-CODE",
+        "FunctionName": "acquisition-events-api-CODE-CDK",
         "Handler": "com.gu.acquisitionEventsApi.Lambda::handler",
         "MemorySize": 512,
         "Role": {
@@ -1079,7 +1079,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeployment956B130990ded7266015c7967956b54b7b69a4df": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeployment956B13099c613d98ef0412621975dac0e0e33a77": {
       "DependsOn": [
         "acquisitioneventsapicdklambdaacquisitioneventsapiCODEproxyANY0D8D3990",
         "acquisitioneventsapicdklambdaacquisitioneventsapiCODEproxy4473084F",
@@ -1099,7 +1099,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeployment956B130990ded7266015c7967956b54b7b69a4df",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODEDeployment956B13099c613d98ef0412621975dac0e0e33a77",
         },
         "RestApiId": {
           "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiCODE1A986C8E",
@@ -1936,7 +1936,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
             "Stage": "PROD",
           },
         },
-        "FunctionName": "acquisition-events-api-cdk-PROD",
+        "FunctionName": "acquisition-events-api-PROD-CDK",
         "Handler": "com.gu.acquisitionEventsApi.Lambda::handler",
         "MemorySize": 512,
         "Role": {
@@ -2346,7 +2346,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeployment5D86426Bfd37a23db7e90bdd870479dca7dc4d79": {
+    "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeployment5D86426B579e69890250dbae99802a41e3383857": {
       "DependsOn": [
         "acquisitioneventsapicdklambdaacquisitioneventsapiPRODproxyANY1BE80837",
         "acquisitioneventsapicdklambdaacquisitioneventsapiPRODproxyE717EAC5",
@@ -2366,7 +2366,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeployment5D86426Bfd37a23db7e90bdd870479dca7dc4d79",
+          "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPRODDeployment5D86426B579e69890250dbae99802a41e3383857",
         },
         "RestApiId": {
           "Ref": "acquisitioneventsapicdklambdaacquisitioneventsapiPROD939774E4",

--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -122,7 +122,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "ApiGateway4XXAlarm59D14AA2": {
+    "ApiGateway4XXAlarmCDKC83EACCA": {
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [
@@ -1423,7 +1423,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "ApiGateway4XXAlarm59D14AA2": {
+    "ApiGateway4XXAlarmCDKC83EACCA": {
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [

--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -124,7 +124,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
     },
     "ApiGateway4XXAlarmCDKC83EACCA": {
       "Properties": {
-        "ActionsEnabled": true,
+        "ActionsEnabled": false,
         "AlarmActions": [
           {
             "Fn::Join": [

--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -144,8 +144,14 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
           },
         ],
         "AlarmDescription": "Impact - Acquisition Events API received an invalid request. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
-        "AlarmName": "URGENT 9-5 - CODE API gateway 4XX response",
+        "AlarmName": "ACQUISITION-EVENTS-API-CDK- CODE API gateway 4XX response",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "ApiName",
+            "Value": "acquisition-events-api-CODE",
+          },
+        ],
         "EvaluationPeriods": 1,
         "MetricName": "4XXError",
         "Namespace": "AWS/ApiGateway",
@@ -1445,8 +1451,14 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
           },
         ],
         "AlarmDescription": "Impact - Acquisition Events API received an invalid request. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
-        "AlarmName": "URGENT 9-5 - PROD API gateway 4XX response",
+        "AlarmName": "ACQUISITION-EVENTS-API-CDK- PROD API gateway 4XX response",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "ApiName",
+            "Value": "acquisition-events-api-PROD",
+          },
+        ],
         "EvaluationPeriods": 1,
         "MetricName": "4XXError",
         "Namespace": "AWS/ApiGateway",

--- a/cdk/lib/acquisition-events-api.test.ts
+++ b/cdk/lib/acquisition-events-api.test.ts
@@ -1,6 +1,7 @@
 import { App } from "aws-cdk-lib";
 import {Template} from "aws-cdk-lib/assertions";
-import {AcquisitionEventsApi} from "./acquisition-events-api";
+import { codeProps, prodProps } from "../bin/cdk";
+import { AcquisitionEventsApi} from "./acquisition-events-api";
 
 
 describe("The Acquisition Events API stack", () => {

--- a/cdk/lib/acquisition-events-api.test.ts
+++ b/cdk/lib/acquisition-events-api.test.ts
@@ -6,12 +6,17 @@ import {AcquisitionEventsApi} from "./acquisition-events-api";
 describe("The Acquisition Events API stack", () => {
   it("matches the snapshot", () => {
     const app = new App();
-    const stack = new AcquisitionEventsApi(app, "Acquisition-Events-API-PROD", {
-      stack: "support",
-      stage: "PROD",
-    });
-
-    const template = Template.fromStack(stack);
-    expect(template.toJSON()).toMatchSnapshot();
+    const codeStack = new AcquisitionEventsApi(
+      app,
+      "Acquisition-Events-API-CODE",
+      codeProps
+    );
+    const prodStack = new AcquisitionEventsApi(
+      app,
+      "Acquisition-Events-API-PROD",
+      prodProps
+    );
+    expect(Template.fromStack(codeStack).toJSON()).toMatchSnapshot();
+    expect(Template.fromStack(prodStack).toJSON()).toMatchSnapshot();
   });
 });

--- a/cdk/lib/acquisition-events-api.test.ts
+++ b/cdk/lib/acquisition-events-api.test.ts
@@ -1,22 +1,28 @@
 import { App } from "aws-cdk-lib";
 import {Template} from "aws-cdk-lib/assertions";
-import { codeProps, prodProps } from "../bin/cdk";
-import { AcquisitionEventsApi} from "./acquisition-events-api";
+import {AcquisitionEventsApi} from "./acquisition-events-api";
 
 
 describe("The Acquisition Events API stack", () => {
   it("matches the snapshot", () => {
     const app = new App();
-    const codeStack = new AcquisitionEventsApi(
-      app,
-      "Acquisition-Events-API-CODE",
-      codeProps
-    );
-    const prodStack = new AcquisitionEventsApi(
-      app,
-      "Acquisition-Events-API-PROD",
-      prodProps
-    );
+    const codeStack = new AcquisitionEventsApi(app, "Acquisition-Events-API-CODE", {
+      stack: "support",
+      stage: "CODE",
+      certificateId:"b384a6a0-2f54-4874-b99b-96eeff96c009",
+      domainName: "acquisition-events-code.support.guardianapis.com",
+      hostedZoneName: "support.guardianapis.com.",
+      hostedZoneId: "Z3KO35ELNWZMSX",
+    });
+    const prodStack = new AcquisitionEventsApi(app, "Acquisition-Events-API-PROD", {
+      stack: "support",
+      stage: "PROD",
+      certificateId:"b384a6a0-2f54-4874-b99b-96eeff96c009",
+      domainName: "acquisition-events.support.guardianapis.com",
+      hostedZoneName: "support.guardianapis.com.",
+      hostedZoneId: "Z3KO35ELNWZMSX",
+    });
+
     expect(Template.fromStack(codeStack).toJSON()).toMatchSnapshot();
     expect(Template.fromStack(prodStack).toJSON()).toMatchSnapshot();
   });

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -1,65 +1,87 @@
+import { join } from "path";
 import { GuApiLambda } from "@guardian/cdk";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack, GuStringParameter } from "@guardian/cdk/lib/constructs/core";
 import type { App } from "aws-cdk-lib";
+import { Duration } from "aws-cdk-lib";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
+import { CfnRecordSetGroup } from "aws-cdk-lib/aws-route53";
+import { CfnInclude } from "aws-cdk-lib/cloudformation-include";
+
+export interface AcquisitionEventsApiProps extends GuStackProps {
+  stack: string;
+  stage: string;
+  app: string;
+  certificateId: string;
+  domainName: string;
+  hostedZoneName: string;
+}
+
 
 export class AcquisitionEventsApi extends GuStack {
 
-  constructor(scope: App, id: string, props: GuStackProps) {
+  constructor(scope: App, id: string, props: AcquisitionEventsApiProps) {
     super(scope, id, props);
 
-    // ---- String Parameters ---- //
-    new GuStringParameter(
-      this,
-      "CertificateArn",
-      {
-        description:
-          "ARN of the certificate",
-      }
-    );
 
-    new GuStringParameter(
-      this,
-      "DeployBucket",
-      {
-        description:
-          "Bucket to copy files to",
-      }
-    );
+    const app = "acquisition-events-api";
 
-    new GuStringParameter(
-      this,
-      "App",
-      {
-        description:
-          "Acquisition Events Api",
-      }
-    );
+    const parameters = {
+      CertificateArn: new GuStringParameter(this, "CertificateArn", {
+        description: "ARN of the certificate",
+      }),
+      App: new GuStringParameter(this, "App", {
+        description: "Acquisition Events Api",
+      }),
+      DeployBucket: new GuStringParameter(this, "DeployBucket", {
+        description: "Bucket to copy files to",
+      }),
+      Stack: new GuStringParameter(this, "Stack", {
+        description: "Stack name",
+      }),
+      Stage: new GuStringParameter(this, "Stage", {
+        description: "Set by RiffRaff on each deploy",
+      }),
+    };
 
-    new GuStringParameter(
-      this,
-      "Stage",
-      {
-        description:
-          "Set by RiffRaff on each deploy",
-      }
-    );
 
-    new GuStringParameter(
-      this,
-      "Stack",
-      {
-        description:
-          "Stack name",
-      }
+     // ---- Existing CFN template ---- //
+    const yamlTemplateFilePath = join(
+      __dirname,
+      "../..",
+      "support-lambdas/acquisition-events-api/cfn.yaml"
     );
+    const yamlDefinedResources = new CfnInclude(this, "YamlTemplate", {
+      templateFile: yamlTemplateFilePath,
+      parameters: {
+        Stage: props.stage,
+      },
+    });
 
+    const commonEnvironmentVariables = {
+      App: app,
+      Stack: this.stack,
+      Stage: this.stage,
+    };
 // ---- API-triggered lambda functions ---- //
-    const acquisitionEventsApiLambda= new GuApiLambda(this, "acquisition-events-api", {
-      fileName: "${Stack}/${Stage}/${App}/${App}.jar",
-      handler: 'com.gu.acquisitionEventsApi.Lambda.handler',
+    const acquisitionEventsApiLambda= new GuApiLambda(this, "acquisition-events-api-lambda", {
+      description: 'A lambda for acquisitions events api',
+      functionName: {
+        "Fn::Sub": [`${app}-${this.stage}`]
+      },
+      fileName: "${stack}/${this.stage}/${app}/${app}.jar",
+      handler: 'com.gu.acquisitionEventsApi.Lambda::handler',
       runtime: Runtime.NODEJS_14_X,
+      memorySize: 512,
+      timeout:Duration.seconds(300),
+      Role: {
+        "Fn::GetAtt": ["LambdaRole", "Arn"]
+      },
+      environment: {
+        variables: {
+          STAGE: { 'Fn::ImportValue': 'Stage' },
+        },
+      },
       // Create an alarm
       monitoringConfiguration: {
         http5xxAlarm: {tolerated5xxPercentage: 5},
@@ -69,8 +91,35 @@ export class AcquisitionEventsApi extends GuStack {
       api: {
         id: "acquisition-events-api",
         description: "API Gateway created by CDK",
+
+      Tag.add(this, 'lambda:createdBy', 'SAM');
       },
     });
 
+    // ---- DNS ---- //
+    const certificateArn = `arn:aws:acm:eu-west-1:${this.account}:certificate/${props.certificateId}`;
+    const cfnDomainName = new CfnDomainName(this, "ApiDomainName", {
+      domainName: props.domainName,
+      certificateArn,
+    });
+
+    new CfnBasePathMapping(this, "ApiMapping", {
+      domainName: cfnDomainName.ref,
+      // Uncomment the lines below to reroute traffic to the new API Gateway instance
+      // restApiId: acquisitionEventsApi.api.restApiId,
+      // stage: acquisitionEventsApi.api.deploymentStage.stageName,
+      restApiId: yamlDefinedResources.getResource("acquisitionEventsApi").ref,
+      stage: props.stage,
+    });
+
+    new CfnRecordSetGroup(this, "ApiRoute53", {
+      hostedZoneId: props.hostedZoneId,
+      recordSets: [
+        {
+          name: props.domainName,
+          type: "CNAME",
+        },
+      ],
+  });
   }
 }

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -67,7 +67,7 @@ export class AcquisitionEventsApi extends GuStack {
     const acquisitionEventsApiLambda= new GuApiLambda(this, "acquisition-events-api-lambda", {
       description: 'A lambda for acquisitions events api',
       functionName: {
-        "Fn::Sub": [`${app}-${this.stage}`]
+        "Fn::Sub": [`${app}-cdk-${this.stage}`]
       },
       fileName: "${stack}/${this.stage}/${app}/${app}.jar",
       handler: 'com.gu.acquisitionEventsApi.Lambda::handler',

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -28,18 +28,18 @@ export class AcquisitionEventsApi extends GuStack {
 
     const app = "acquisition-events-api";
 
-     // ---- Existing CFN template ---- //
-    const yamlTemplateFilePath = join(
-      __dirname,
-      "../..",
-      "support-lambdas/acquisition-events-api/cfn.yaml"
-    );
-    const yamlDefinedResources = new CfnInclude(this, "YamlTemplate", {
-      templateFile: yamlTemplateFilePath,
-      parameters: {
-        Stage: props.stage,
-      },
-    });
+    //  // ---- Existing CFN template ---- //
+    // const yamlTemplateFilePath = join(
+    //   __dirname,
+    //   "../..",
+    //   "support-lambdas/acquisition-events-api/cfn.yaml"
+    // );
+    // const yamlDefinedResources = new CfnInclude(this, "YamlTemplate", {
+    //   templateFile: yamlTemplateFilePath,
+    //   parameters: {
+    //     Stage: props.stage,
+    //   },
+    // });
 
     const commonEnvironmentVariables = {
       App: app,

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -47,12 +47,12 @@ export class AcquisitionEventsApi extends GuStack {
       Stage: this.stage,
     };
 // ---- API-triggered lambda functions ---- //
-    const acquisitionEventsApiLambda= new GuApiLambda(this, "acquisition-events-api-lambda", {
+    const acquisitionEventsApiLambda= new GuApiLambda(this, "acquisition-events-api-cdk-lambda", {
       description: 'A lambda for acquisitions events api',
-      functionName: `${app}-cdk-${this.stage}`,
-      fileName: "acquisition-events-api.jar",
+      functionName: `${app}-${this.stage}-cdk`,
+      fileName: `${this.stack}/${this.stage}/${app}/${app}.jar`,
       handler: 'com.gu.acquisitionEventsApi.Lambda::handler',
-      runtime: Runtime.NODEJS_14_X,
+      runtime: Runtime.JAVA_8,
       memorySize: 512,
       timeout:Duration.seconds(300),
       environment:commonEnvironmentVariables,
@@ -70,7 +70,7 @@ export class AcquisitionEventsApi extends GuStack {
 
     // ---- DNS ---- //
     const certificateArn = `arn:aws:acm:eu-west-1:${this.account}:certificate/${props.certificateId}`;
-    const cfnDomainName = new CfnDomainName(this, "ApiDomainName", {
+    const cfnDomainName = new CfnDomainName(this, "DomainName", {
       domainName: props.domainName,
       regionalCertificateArn: certificateArn,
       endpointConfiguration: {
@@ -78,7 +78,7 @@ export class AcquisitionEventsApi extends GuStack {
       }
     });
 
-    new CfnBasePathMapping(this, "ApiMapping", {
+    new CfnBasePathMapping(this, "BasePathMapping", {
       domainName: cfnDomainName.ref,
       // Uncomment the lines below to reroute traffic to the new API Gateway instance
       restApiId: acquisitionEventsApiLambda.api.restApiId,

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -50,7 +50,7 @@ export class AcquisitionEventsApi extends GuStack {
 
 // ---- API-triggered lambda functions ---- //
     const acquisitionEventsApiLambda= new GuApiLambda(this, "acquisition-events-api-cdk-lambda", {
-      description: 'A lambda for acquisitions events api',
+      description: 'A lambda that Sends in-app acquisitions (subscriptions) to BigQuery',
       functionName: `${app}-cdk-${this.stage}`,
       fileName: `${this.stack}/${this.stage}/${app}/${app}.jar`,
       handler: 'com.gu.acquisitionEventsApi.Lambda::handler',
@@ -85,6 +85,7 @@ export class AcquisitionEventsApi extends GuStack {
       // Uncomment the lines below to reroute traffic to the new API Gateway instance
       restApiId: acquisitionEventsApiLambda.api.restApiId,
       stage: acquisitionEventsApiLambda.api.deploymentStage.stageName,
+      // Uncomment the lines below to reroute traffic to the old (existing) API Gateway instance
       // restApiId: yamlDefinedResources.getResource("ServerlessRestApi").ref,
       // stage: props.stage,
     });

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -49,7 +49,7 @@ export class AcquisitionEventsApi extends GuStack {
 // ---- API-triggered lambda functions ---- //
     const acquisitionEventsApiLambda= new GuApiLambda(this, "acquisition-events-api-cdk-lambda", {
       description: 'A lambda for acquisitions events api',
-      functionName: `${app}-${this.stage}-cdk`,
+      functionName: `${app}-cdk-${this.stage}`,
       fileName: `${this.stack}/${this.stage}/${app}/${app}.jar`,
       handler: 'com.gu.acquisitionEventsApi.Lambda::handler',
       runtime: Runtime.JAVA_8,

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -1,23 +1,95 @@
-import { join } from "path";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
-import { GuStack } from "@guardian/cdk/lib/constructs/core";
 import type { App } from "aws-cdk-lib";
-import { CfnInclude } from "aws-cdk-lib/cloudformation-include";
 
 
 export class AcquisitionEventsApi extends GuStack {
+
   constructor(scope: App, id: string, props: GuStackProps) {
     super(scope, id, props);
-    const yamlTemplateFilePath = join(
-      __dirname,
-      "../..",
-      "support-lambdas/acquisition-events-api/cfn.yaml"
+
+    // ---- String Parameters ---- //
+    new GuStringParameter(
+      this,
+      "CertificateArn",
+      {
+        description:
+          "ARN of the certificate",
+      }
     );
-    new CfnInclude(this, "YamlTemplate", {
-      templateFile: yamlTemplateFilePath,
-      parameters: {
-        Stage: props.stage,
+
+    new GuStringParameter(
+      this,
+      "DatalakeBucket",
+      {
+        description:
+          "Bucket to upload data for ingestion into BigQuery",
+      }
+    );
+
+    new GuStringParameter(
+      this,
+      "DeployBucket",
+      {
+        description:
+          "Bucket to copy files to",
+      }
+    );
+
+    new GuStringParameter(
+      this,
+      "App",
+      {
+        description:
+          "Acquisition Events Api",
+      }
+    );
+
+    new GuStringParameter(
+      this,
+      "Stage",
+      {
+        description:
+          "Set by RiffRaff on each deploy",
+      }
+    );
+
+    new GuStringParameter(
+      this,
+      "Stack",
+      {
+        description:
+          "Stack name",
+      }
+    );
+
+    // ---- DNS Records ---- //
+    // new GuCname(this, id: string, props: GuCnameProps)
+
+    // ---- Lambdas ---- //
+    const lambda=new GuApiLambda(stack, "acquisition-events-api", {
+      fileName: "${Stack}/${Stage}/${App}/${App}.jar",
+      handler: 'com.gu.acquisitionEventsApi.Lambda.handler',
+      runtime: Runtime.NODEJS_14_X,
+      functionName: `${app}-${stage}`,
+      code: lambda.Code.fromBucket(deployBucket, `${stackName || "support"}/${stage}/${app}/${fileName}`),
+      memorySize: 512,
+      role: lambdaRole,
+      timeout: cdk.Duration.seconds(300),
+      environment: {
+        STAGE: stage,
+      },
+      tags: {
+        "lambda:createdBy": "SAM",
+      },
+      // Create an alarm
+      monitoringConfiguration: {
+        http5xxAlarm: { tolerated5xxPercentage: 1 },
+        snsTopicName: "conversion-dev",
+      },
+      app: "acquisition-events-api",
+      api: {
+        id: props.api?.id || "default-api-id",
+        description: props.api?.description || "API Gateway created by CDK",
       },
     });
-  }
 }

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -50,7 +50,7 @@ export class AcquisitionEventsApi extends GuStack {
 // ---- API-triggered lambda functions ---- //
     const acquisitionEventsApiLambda= new GuApiLambda(this, "acquisition-events-api-cdk-lambda", {
       description: 'A lambda that Sends in-app acquisitions (subscriptions) to BigQuery',
-      functionName: `${app}-${this.stage}-CDK`,
+      functionName: `${app}-cdk-${this.stage}`,
       fileName: `${app}.jar`,
       handler: 'com.gu.acquisitionEventsApi.Lambda::handler',
       runtime: Runtime.JAVA_8,

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -51,7 +51,7 @@ export class AcquisitionEventsApi extends GuStack {
     const acquisitionEventsApiLambda= new GuApiLambda(this, "acquisition-events-api-cdk-lambda", {
       description: 'A lambda that Sends in-app acquisitions (subscriptions) to BigQuery',
       functionName: `${app}-cdk-${this.stage}`,
-      fileName: `${this.stack}/${this.stage}/${app}/${app}.jar`,
+      fileName: `${app}.jar`,
       handler: 'com.gu.acquisitionEventsApi.Lambda::handler',
       runtime: Runtime.JAVA_8,
       memorySize: 512,
@@ -93,7 +93,7 @@ export class AcquisitionEventsApi extends GuStack {
       name: props.domainName,
       type: "CNAME",
       hostedZoneId: props.hostedZoneId,
-      ttl: "60",
+      ttl: "120",
       resourceRecords: [
         cfnDomainName.attrRegionalDomainName
       ],

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -80,7 +80,7 @@ export class AcquisitionEventsApi extends GuStack {
     const alarmDescription = (description: string) =>
       `Impact - ${description}. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit`;
 
-    new GuAlarm(this, "ApiGateway4XXAlarm", {
+    new GuAlarm(this, "ApiGateway4XXAlarmCDK", {
       app,
       alarmName: alarmName("API gateway 4XX response"),
       alarmDescription: alarmDescription(

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import path from "path";
 import { GuApiLambda } from "@guardian/cdk";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack } from "@guardian/cdk/lib/constructs/core";
@@ -29,7 +29,7 @@ export class AcquisitionEventsApi extends GuStack {
     const app = "acquisition-events-api";
 
     //  // ---- Existing CFN template ---- //
-    const yamlTemplateFilePath = join(
+    const yamlTemplateFilePath = path.join(
       __dirname,
       "../..",
       "support-lambdas/acquisition-events-api/cfn.yaml"
@@ -50,7 +50,7 @@ export class AcquisitionEventsApi extends GuStack {
 // ---- API-triggered lambda functions ---- //
     const acquisitionEventsApiLambda= new GuApiLambda(this, "acquisition-events-api-cdk-lambda", {
       description: 'A lambda that Sends in-app acquisitions (subscriptions) to BigQuery',
-      functionName: `${app}-cdk-${this.stage}`,
+      functionName: `${app}-${this.stage}-CDK`,
       fileName: `${app}.jar`,
       handler: 'com.gu.acquisitionEventsApi.Lambda::handler',
       runtime: Runtime.JAVA_8,

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -89,7 +89,7 @@ export class AcquisitionEventsApi extends GuStack {
       evaluationPeriods: 1,
       threshold: 1,
       snsTopicName: "contributions-dev",
-      actionsEnabled: true,
+      actionsEnabled: this.stage === "PROD",
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       metric: new Metric({
         metricName: "4XXError",

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -75,7 +75,7 @@ export class AcquisitionEventsApi extends GuStack {
 
     // ---- Alarms ---- //
     const alarmName = (shortDescription: string) =>
-      `URGENT 9-5 - ${this.stage} ${shortDescription}`;
+      `ACQUISITION-EVENTS-API-CDK- ${this.stage} ${shortDescription}`;
 
     const alarmDescription = (description: string) =>
       `Impact - ${description}. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit`;
@@ -96,6 +96,9 @@ export class AcquisitionEventsApi extends GuStack {
         namespace: "AWS/ApiGateway",
         statistic: "Sum",
         period: Duration.seconds(300),
+        dimensionsMap: {
+          ApiName: `${app}-${this.stage}`,
+        },
       }),
     });
 

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -29,17 +29,17 @@ export class AcquisitionEventsApi extends GuStack {
     const app = "acquisition-events-api";
 
     //  // ---- Existing CFN template ---- //
-    // const yamlTemplateFilePath = join(
-    //   __dirname,
-    //   "../..",
-    //   "support-lambdas/acquisition-events-api/cfn.yaml"
-    // );
-    // const yamlDefinedResources = new CfnInclude(this, "YamlTemplate", {
-    //   templateFile: yamlTemplateFilePath,
-    //   parameters: {
-    //     Stage: props.stage,
-    //   },
-    // });
+    const yamlTemplateFilePath = join(
+      __dirname,
+      "../..",
+      "support-lambdas/acquisition-events-api/cfn.yaml"
+    );
+    const yamlDefinedResources = new CfnInclude(this, "YamlTemplate", {
+      templateFile: yamlTemplateFilePath,
+      parameters: {
+        Stage: props.stage,
+      },
+    });
 
     const commonEnvironmentVariables = {
       App: app,

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -1,13 +1,15 @@
 import path from "path";
 import { GuApiLambda } from "@guardian/cdk";
+import { GuAlarm } from "@guardian/cdk/lib/constructs/cloudwatch";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack } from "@guardian/cdk/lib/constructs/core";
 import type { App } from "aws-cdk-lib";
 import { Duration } from "aws-cdk-lib";
 import { CfnBasePathMapping, CfnDomainName } from "aws-cdk-lib/aws-apigateway";
-import {Effect, Policy, PolicyStatement} from "aws-cdk-lib/aws-iam";
+import { ComparisonOperator, Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { Effect, Policy, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
-import {CfnRecordSet} from "aws-cdk-lib/aws-route53";
+import { CfnRecordSet } from "aws-cdk-lib/aws-route53";
 import { CfnInclude } from "aws-cdk-lib/cloudformation-include";
 
 export interface AcquisitionEventsApiProps extends GuStackProps {
@@ -19,12 +21,9 @@ export interface AcquisitionEventsApiProps extends GuStackProps {
   hostedZoneId: string;
 }
 
-
 export class AcquisitionEventsApi extends GuStack {
-
   constructor(scope: App, id: string, props: AcquisitionEventsApiProps) {
     super(scope, id, props);
-
 
     const app = "acquisition-events-api";
 
@@ -47,26 +46,57 @@ export class AcquisitionEventsApi extends GuStack {
       Stage: this.stage,
     };
 
-// ---- API-triggered lambda functions ---- //
-    const acquisitionEventsApiLambda= new GuApiLambda(this, "acquisition-events-api-cdk-lambda", {
-      description: 'A lambda that Sends in-app acquisitions (subscriptions) to BigQuery',
-      functionName: `${app}-cdk-${this.stage}`,
-      fileName: `${app}.jar`,
-      handler: 'com.gu.acquisitionEventsApi.Lambda::handler',
-      runtime: Runtime.JAVA_8,
-      memorySize: 512,
-      timeout:Duration.seconds(300),
-      environment:commonEnvironmentVariables,
-      // Create an alarm
-      monitoringConfiguration: {
-        http5xxAlarm: {tolerated5xxPercentage: 5},
-        snsTopicName: "conversion-dev",
-      },
-      app: "acquisition-events-api",
-      api: {
-        id: `${app}-${this.stage}`,
-        description: "API Gateway created by CDK",
-      },
+    // ---- API-triggered lambda functions ---- //
+    const acquisitionEventsApiLambda = new GuApiLambda(
+      this,
+      "acquisition-events-api-cdk-lambda",
+      {
+        description:
+          "A lambda that Sends in-app acquisitions (subscriptions) to BigQuery",
+        functionName: `${app}-cdk-${this.stage}`,
+        fileName: `${app}.jar`,
+        handler: "com.gu.acquisitionEventsApi.Lambda::handler",
+        runtime: Runtime.JAVA_8,
+        memorySize: 512,
+        timeout: Duration.seconds(300),
+        environment: commonEnvironmentVariables,
+        // Create an alarm
+        monitoringConfiguration: {
+          http5xxAlarm: { tolerated5xxPercentage: 5 },
+          snsTopicName: "conversion-dev",
+        },
+        app: "acquisition-events-api",
+        api: {
+          id: `${app}-${this.stage}`,
+          description: "API Gateway created by CDK",
+        },
+      }
+    );
+
+    // ---- Alarms ---- //
+    const alarmName = (shortDescription: string) =>
+      `URGENT 9-5 - ${this.stage} ${shortDescription}`;
+
+    const alarmDescription = (description: string) =>
+      `Impact - ${description}. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit`;
+
+    new GuAlarm(this, "ApiGateway4XXAlarm", {
+      app,
+      alarmName: alarmName("API gateway 4XX response"),
+      alarmDescription: alarmDescription(
+        "Acquisition Events API received an invalid request"
+      ),
+      evaluationPeriods: 1,
+      threshold: 1,
+      snsTopicName: "contributions-dev",
+      actionsEnabled: true,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      metric: new Metric({
+        metricName: "4XXError",
+        namespace: "AWS/ApiGateway",
+        statistic: "Sum",
+        period: Duration.seconds(300),
+      }),
     });
 
     // ---- DNS ---- //
@@ -75,8 +105,8 @@ export class AcquisitionEventsApi extends GuStack {
       domainName: props.domainName,
       regionalCertificateArn: certificateArn,
       endpointConfiguration: {
-        types: ["REGIONAL"]
-      }
+        types: ["REGIONAL"],
+      },
     });
 
     new CfnBasePathMapping(this, "BasePathMapping", {
@@ -94,9 +124,7 @@ export class AcquisitionEventsApi extends GuStack {
       type: "CNAME",
       hostedZoneId: props.hostedZoneId,
       ttl: "120",
-      resourceRecords: [
-        cfnDomainName.attrRegionalDomainName
-      ],
+      resourceRecords: [cfnDomainName.attrRegionalDomainName],
     });
 
     // ---- Apply policies ---- //
@@ -104,32 +132,25 @@ export class AcquisitionEventsApi extends GuStack {
       statements: [
         new PolicyStatement({
           effect: Effect.ALLOW,
-          actions: [
-            "ssm:GetParametersByPath",
-            ],
+          actions: ["ssm:GetParametersByPath"],
           resources: [
             `arn:aws:ssm:${this.region}:${this.account}:parameter/acquisition-events-api/bigquery-config/${props.stage}/*`,
-            ]
+          ],
         }),
       ],
-    })
+    });
 
     const s3InlinePolicy: Policy = new Policy(this, "S3 inline policy", {
       statements: [
         new PolicyStatement({
           effect: Effect.ALLOW,
-          actions: [
-            "s3:GetObject"
-          ],
-          resources: [
-            "arn:aws:s3::*:membership-dist/*"
-          ]
+          actions: ["s3:GetObject"],
+          resources: ["arn:aws:s3::*:membership-dist/*"],
         }),
       ],
-    })
+    });
 
-
-    acquisitionEventsApiLambda.role?.attachInlinePolicy(ssmInlinePolicy)
-    acquisitionEventsApiLambda.role?.attachInlinePolicy(s3InlinePolicy)
+    acquisitionEventsApiLambda.role?.attachInlinePolicy(ssmInlinePolicy);
+    acquisitionEventsApiLambda.role?.attachInlinePolicy(s3InlinePolicy);
   }
 }

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -13,7 +13,6 @@ import { CfnInclude } from "aws-cdk-lib/cloudformation-include";
 export interface AcquisitionEventsApiProps extends GuStackProps {
   stack: string;
   stage: string;
-  app: string;
   certificateId: string;
   domainName: string;
   hostedZoneName: string;

--- a/support-lambdas/acquisition-events-api/cfn.yaml
+++ b/support-lambdas/acquisition-events-api/cfn.yaml
@@ -52,19 +52,19 @@ Resources:
       Period: 60
       EvaluationPeriods: 1
       Statistic: Sum
-  DomainName:
-    Type: AWS::ApiGateway::DomainName
-    Properties:
-      RegionalCertificateArn:
-        Ref: CertificateArn
-      DomainName:
-        Fn::FindInMap:
-          - StageMap
-          - Ref: Stage
-          - DomainName
-      EndpointConfiguration:
-        Types:
-          - REGIONAL
+#  DomainName:
+#    Type: AWS::ApiGateway::DomainName
+#    Properties:
+#      RegionalCertificateArn:
+#        Ref: CertificateArn
+#      DomainName:
+#        Fn::FindInMap:
+#          - StageMap
+#          - Ref: Stage
+#          - DomainName
+#      EndpointConfiguration:
+#        Types:
+#          - REGIONAL
   LambdaAcquisitionEventPermissionProd:
     Type: AWS::Lambda::Permission
     Properties:
@@ -148,33 +148,33 @@ Resources:
       Period: 300
       EvaluationPeriods: 1
       Statistic: Sum
-  BasePathMapping:
-    Type: AWS::ApiGateway::BasePathMapping
-    Properties:
-      RestApiId:
-        Ref: ServerlessRestApi
-      DomainName:
-        Ref: DomainName
-      Stage:
-        Fn::Sub: Prod
-    DependsOn: ServerlessRestApiProdStage
-  DNSRecord:
-    Type: AWS::Route53::RecordSet
-    Properties:
-      HostedZoneName: support.guardianapis.com.
-      Name:
-        Fn::FindInMap:
-          - StageMap
-          - Ref: Stage
-          - DomainName
-      Comment:
-        Fn::Sub: CNAME for acquisition events endpoints ${Stage}
-      Type: CNAME
-      TTL: '120'
-      ResourceRecords:
-        - Fn::GetAtt:
-            - DomainName
-            - RegionalDomainName
+#  BasePathMapping:
+#    Type: AWS::ApiGateway::BasePathMapping
+#    Properties:
+#      RestApiId:
+#        Ref: ServerlessRestApi
+#      DomainName:
+#        Ref: DomainName
+#      Stage:
+#        Fn::Sub: Prod
+#    DependsOn: ServerlessRestApiProdStage
+#  DNSRecord:
+#    Type: AWS::Route53::RecordSet
+#    Properties:
+#      HostedZoneName: support.guardianapis.com.
+#      Name:
+#        Fn::FindInMap:
+#          - StageMap
+#          - Ref: Stage
+#          - DomainName
+#      Comment:
+#        Fn::Sub: CNAME for acquisition events endpoints ${Stage}
+#      Type: CNAME
+#      TTL: '120'
+#      ResourceRecords:
+#        - Fn::GetAtt:
+#            - DomainName
+#            - RegionalDomainName
   ServerlessRestApi:
     Type: AWS::ApiGateway::RestApi
     Properties:

--- a/support-lambdas/acquisition-events-api/riff-raff.yaml
+++ b/support-lambdas/acquisition-events-api/riff-raff.yaml
@@ -7,8 +7,8 @@ deployments:
     parameters:
       bucket: membership-dist
       functionNames:
-       -acquisition-events-api-
-       -acquisition-events-api-cdk-
+       - acquisition-events-api-
+       - acquisition-events-api-cdk-
       fileName: acquisition-events-api.jar
       prefixStack: false
     dependencies: [ cfn ]

--- a/support-lambdas/acquisition-events-api/riff-raff.yaml
+++ b/support-lambdas/acquisition-events-api/riff-raff.yaml
@@ -6,7 +6,9 @@ deployments:
     type: aws-lambda
     parameters:
       bucket: membership-dist
-      functionNames: [acquisition-events-api-]
+      functionNames:
+       -acquisition-events-api-
+       -acquisition-events-api-cdk-
       fileName: acquisition-events-api.jar
       prefixStack: false
     dependencies: [ cfn ]


### PR DESCRIPTION
## What are you doing in this PR?
Recreate existing CFN template using CDK constructs, while retaining existing infrastructure for Acquisition-events-api.This is done for Support Acquisition API GuCDK Migration.



[**Trello Card**](https://trello.com/c/UMwD5nX3/1222-support-acquisition-api-gucdk-migration-recreate-existing-cfn-template-using-cdk-constructs-while-retaining-existing-infrastruct)

## Why are you doing this?

For apps where avoiding downtime is critical, a dual-stack migration strategy forGuCDK Migration is recommended . The idea is to duplicate the key parts of the stack using the pattern, test, and, once confident, switch DNS to point to the new stack.
In this phase  we create a new version of your app's infrastructure, according to CDK’s best practices. So, we should have a functional copy of the application, which can be used for testing purposes. Riff-Raff will have been configured to deploy to both versions of the infrastructure, so you can operate in this state for as long as you need to.


