### PR TITLE
Re-enable the stripe patrons scheduled data export

### DIFF
--- a/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
+++ b/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
@@ -901,6 +901,43 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
+    "StripePatronsDataPRODStripePatronsDataPRODrate30minutes028F3FD32": {
+      "Properties": {
+        "ScheduleExpression": "rate(30 minutes)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "StripePatronsDataPROD61F45521",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "StripePatronsDataPRODStripePatronsDataPRODrate30minutes0AllowEventRuleStripePatronsDataPRODBF7BDE5FE71C5129": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "StripePatronsDataPROD61F45521",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "StripePatronsDataPRODStripePatronsDataPRODrate30minutes028F3FD32",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
     "stripepatronsdatacancelled2E3CED96": {
       "DependsOn": [
         "stripepatronsdatacancelledServiceRoleDefaultPolicy46825C35",


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR reinstates the scheduled execution of the stripe-patrons-data lambda which pulls information about  Guardian Patrons from Stripe. 

The schedule was removed because we now have a separate lambda which is called by a Stripe webhook when a new subscription is created however this has some issues [described in this card](https://trello.com/c/5fquQCUe/1205-stripe-patrons-customer-update-details-webhook) so until they are fixed I am going to re-enable the scheduled full synchronisation.