### PR TITLE
Disambiguate error logs

### DIFF
--- a/support-lambdas/acquisition-events-api/src/main/scala/com/gu/acquisitionEventsApi/Lambda.scala
+++ b/support-lambdas/acquisition-events-api/src/main/scala/com/gu/acquisitionEventsApi/Lambda.scala
@@ -49,13 +49,13 @@ object Lambda extends LazyLogging {
         logger.info(s"$requestId: successfully processed the event: $rawBody")
         buildResponse(200)
       case Success(Left(ParseError(error))) =>
-        logger.error(s"$requestId: failed to process an event: $error")
+        logger.error(s"$requestId: failed to process an event due to ParseError($error)")
         buildResponse(400)
       case Success(Left(BigQueryError(error))) =>
-        logger.error(s"$requestId: failed to process an event: $error")
+        logger.error(s"$requestId: failed to process an event due to BigQueryError($error)")
         buildResponse(500)
       case Failure(error) =>
-        logger.error(s"$requestId: failed to process an event: $error")
+        logger.error(s"$requestId: failed to process an event due to Failure($error)")
         buildResponse(500)
     }
   }


### PR DESCRIPTION
We’ve had some errors recently that are coming from one of these lines, but we’re not entirely sure which. Rather than stripping the context (i.e. which kind of error we matched in the case), this change restores that info to the logs. Hopefully this should help us understand what’s causing the timeouts we’re seeing.