### PR TITLE
Rename Sandbox TouchPointEnvironment to CODE

### DIFF
--- a/support-config/README.md
+++ b/support-config/README.md
@@ -19,11 +19,11 @@ Stage represents a runtime environment for the applications which use this libra
 
 ### Touchpoint Environment
 Touchpoint Environment represents a logical environment for our backend systems, mainly Zuora and Salesforce.
-Environments are: SANDBOX or PROD
+Environments are: CODE or PROD
 
 Any environment *could* be used by any stage however in practice they are restricted to the following:
-DEV and CODE stages use the SANDBOX environment for all users
-PROD stage uses the PROD environment for non test users and SANDBOX for test users. See table below for full details.
+DEV and CODE stages use the CODE environment for all users
+PROD stage uses the PROD environment for non test users and CODE for test users. See table below for full details.
 
 
 --------------------------------------
@@ -32,12 +32,12 @@ PROD stage uses the PROD environment for non test users and SANDBOX for test use
 
 |support-frontend stage| Is test user?|support-workers stage|Touchpoint Environment |
 |----------------------|--------------|---------------------|-----------------------|
-|DEV                   |No            |CODE                 |SANDBOX                |
-|DEV                   |Yes           |CODE                 |SANDBOX                     |
-|CODE                  |No            |CODE                 |SANDBOX                |
-|CODE                  |Yes           |CODE                 |SANDBOX                     |
+|DEV                   |No            |CODE                 |CODE                |
+|DEV                   |Yes           |CODE                 |CODE                     |
+|CODE                  |No            |CODE                 |CODE                |
+|CODE                  |Yes           |CODE                 |CODE                     |
 |PROD                  |No            |PROD                 |PROD                   |
-|PROD                  |Yes           |PROD                 |SANDBOX                  |
+|PROD                  |Yes           |PROD                 |CODE                  |
 
 
 

--- a/support-config/src/main/resources/reference.conf
+++ b/support-config/src/main/resources/reference.conf
@@ -1,5 +1,5 @@
 //Used to provide defaults so that individual projects don't have to define settings they don't use
-include classpath("touchpoint.SANDBOX.conf")
+include classpath("touchpoint.CODE.conf")
 include classpath("touchpoint.PROD.conf")
 
 get-address-io-api.url = "https://api.getAddress.io/v2/uk/"

--- a/support-config/src/main/resources/touchpoint.CODE.conf
+++ b/support-config/src/main/resources/touchpoint.CODE.conf
@@ -1,5 +1,5 @@
 touchpoint.backend.environments {
-  SANDBOX {
+  CODE {
     stripe {
       AU {
         api.key.public = "pk_test_m0sjR1tGM22fpaz48csa49us"

--- a/support-config/src/main/scala/com/gu/support/config/TouchpointConfigProvider.scala
+++ b/support-config/src/main/scala/com/gu/support/config/TouchpointConfigProvider.scala
@@ -1,6 +1,6 @@
 package com.gu.support.config
 
-import TouchPointEnvironments.{SANDBOX, fromStage}
+import TouchPointEnvironments.{CODE, fromStage}
 import com.typesafe.config.{Config, ConfigValueFactory}
 
 /** Touchpoint represents 3rd party enterprise systems which have a number of different stages or environments (DEV, and
@@ -11,7 +11,7 @@ import com.typesafe.config.{Config, ConfigValueFactory}
 abstract class TouchpointConfigProvider[T](config: Config, defaultStage: Stage) {
 
   private lazy val defaultConfig: T = fromConfig(getTouchpointBackend(fromStage(defaultStage)))
-  private lazy val testConfig: T = fromConfig(getTouchpointBackend(SANDBOX))
+  private lazy val testConfig: T = fromConfig(getTouchpointBackend(CODE))
 
   def get(isTestUser: Boolean = false): T =
     if (isTestUser) testConfig else defaultConfig
@@ -20,6 +20,6 @@ abstract class TouchpointConfigProvider[T](config: Config, defaultStage: Stage) 
 
   private def getTouchpointBackend(environment: TouchPointEnvironment) =
     config
-      .getConfig(s"touchpoint.backend.environments.${environment.toString}")
-      .withValue("environment", ConfigValueFactory.fromAnyRef(environment.toString))
+      .getConfig(s"touchpoint.backend.environments.${environment.envValue}")
+      .withValue("environment", ConfigValueFactory.fromAnyRef(environment.envValue))
 }

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -24,13 +24,13 @@ import play.twirl.api.Html
 
 case class ContributionsPaymentMethodConfigs(
     oneOffDefaultStripeConfig: StripeConfig,
-    oneOffUatStripeConfig: StripeConfig,
+    oneOffTestStripeConfig: StripeConfig,
     regularDefaultStripeConfig: StripeConfig,
-    regularUatStripeConfig: StripeConfig,
+    regularTestStripeConfig: StripeConfig,
     regularDefaultPayPalConfig: PayPalConfig,
-    regularUatPayPalConfig: PayPalConfig,
+    regularTestPayPalConfig: PayPalConfig,
     defaultAmazonPayConfig: AmazonPayConfig,
-    uatAmazonPayConfig: AmazonPayConfig,
+    testAmazonPayConfig: AmazonPayConfig,
 )
 
 class Application(
@@ -180,7 +180,7 @@ class Application(
     )
 
     val serversideTests = generateParticipations(Nil)
-    val uatMode = testUsers.isTestUser(request)
+    val testMode = testUsers.isTestUser(request)
 
     views.html.contributions(
       title = "Support the Guardian",
@@ -191,13 +191,13 @@ class Application(
       description = stringsConfig.contributionsLandingDescription,
       paymentMethodConfigs = ContributionsPaymentMethodConfigs(
         oneOffDefaultStripeConfig = oneOffStripeConfigProvider.get(false),
-        oneOffUatStripeConfig = oneOffStripeConfigProvider.get(true),
+        oneOffTestStripeConfig = oneOffStripeConfigProvider.get(true),
         regularDefaultStripeConfig = regularStripeConfigProvider.get(false),
-        regularUatStripeConfig = regularStripeConfigProvider.get(true),
+        regularTestStripeConfig = regularStripeConfigProvider.get(true),
         regularDefaultPayPalConfig = payPalConfigProvider.get(false),
-        regularUatPayPalConfig = payPalConfigProvider.get(true),
+        regularTestPayPalConfig = payPalConfigProvider.get(true),
         defaultAmazonPayConfig = amazonPayConfigProvider.get(false),
-        uatAmazonPayConfig = amazonPayConfigProvider.get(true),
+        testAmazonPayConfig = amazonPayConfigProvider.get(true),
       ),
       paymentApiUrl = paymentAPIService.paymentAPIUrl,
       paymentApiPayPalEndpoint = paymentAPIService.payPalCreatePaymentEndpoint,
@@ -207,7 +207,7 @@ class Application(
       geoData = geoData,
       shareImageUrl = shareImageUrl(settings),
       shareUrl = "https://support.theguardian.com/contribute",
-      v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(uatMode).v2PublicKey,
+      v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(testMode).v2PublicKey,
       serversideTests = serversideTests,
     )
   }

--- a/support-frontend/app/controllers/DigitalSubscriptionController.scala
+++ b/support-frontend/app/controllers/DigitalSubscriptionController.scala
@@ -64,9 +64,9 @@ class DigitalSubscriptionController(
         val css = "kindleSubscriptionLandingPage.css"
         val csrf = CSRF.getToken.value
 
-        val uatMode = testUsers.isTestUser(request)
+        val testMode = testUsers.isTestUser(request)
         val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil)
-        val v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(uatMode).v2PublicKey
+        val v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(testMode).v2PublicKey
         val readerType = if (orderIsAGift) Gift else Direct
 
         Ok(
@@ -77,8 +77,8 @@ class DigitalSubscriptionController(
             css,
             Some(csrf),
             request.user,
-            uatMode,
-            priceSummaryServiceProvider.forUser(uatMode).getPrices(DigitalPack, promoCodes, readerType),
+            testMode,
+            priceSummaryServiceProvider.forUser(testMode).getPrices(DigitalPack, promoCodes, readerType),
             stripeConfigProvider.get(),
             stripeConfigProvider.get(true),
             payPalConfigProvider.get(),

--- a/support-frontend/app/controllers/DigitalSubscriptionFormController.scala
+++ b/support-frontend/app/controllers/DigitalSubscriptionFormController.scala
@@ -57,9 +57,9 @@ class DigitalSubscriptionFormController(
     val css = "digitalSubscriptionCheckoutPage.css"
     val csrf = CSRF.getToken.value
 
-    val uatMode = testUsers.isTestUser(request)
+    val testMode = testUsers.isTestUser(request)
     val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil)
-    val v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(uatMode).v2PublicKey
+    val v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(testMode).v2PublicKey
     val readerType = if (orderIsAGift) Gift else Direct
 
     subscriptionCheckout(
@@ -69,8 +69,8 @@ class DigitalSubscriptionFormController(
       css,
       Some(csrf),
       maybeIdUser,
-      uatMode,
-      priceSummaryServiceProvider.forUser(uatMode).getPrices(DigitalPack, promoCodes, readerType),
+      testMode,
+      priceSummaryServiceProvider.forUser(testMode).getPrices(DigitalPack, promoCodes, readerType),
       stripeConfigProvider.get(),
       stripeConfigProvider.get(true),
       payPalConfigProvider.get(),

--- a/support-frontend/app/controllers/PaperSubscriptionFormController.scala
+++ b/support-frontend/app/controllers/PaperSubscriptionFormController.scala
@@ -52,9 +52,9 @@ class PaperSubscriptionFormController(
     val css = "paperSubscriptionCheckoutPage.css"
     val csrf = CSRF.getToken.value
 
-    val uatMode = testUsers.isTestUser(request)
+    val testMode = testUsers.isTestUser(request)
     val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil)
-    val v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(isTestUser = uatMode).v2PublicKey
+    val v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(isTestUser = testMode).v2PublicKey
 
     subscriptionCheckout(
       title,
@@ -63,8 +63,8 @@ class PaperSubscriptionFormController(
       css,
       Some(csrf),
       maybeIdUser,
-      uatMode,
-      priceSummaryServiceProvider.forUser(uatMode).getPrices(Paper, promoCodes),
+      testMode,
+      priceSummaryServiceProvider.forUser(testMode).getPrices(Paper, promoCodes),
       stripeConfigProvider.get(false),
       stripeConfigProvider.get(true),
       payPalConfigProvider.get(false),

--- a/support-frontend/app/controllers/WeeklySubscriptionFormController.scala
+++ b/support-frontend/app/controllers/WeeklySubscriptionFormController.scala
@@ -52,10 +52,10 @@ class WeeklySubscriptionFormController(
     val css = "weeklySubscriptionCheckoutPage.css"
     val csrf = CSRF.getToken.value
 
-    val uatMode = testUsers.isTestUser(request)
+    val testMode = testUsers.isTestUser(request)
     val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil)
     val readerType = if (orderIsAGift) Gift else Direct
-    val v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(isTestUser = uatMode).v2PublicKey
+    val v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(isTestUser = testMode).v2PublicKey
 
     subscriptionCheckout(
       title,
@@ -64,8 +64,8 @@ class WeeklySubscriptionFormController(
       css,
       Some(csrf),
       maybeIdUser,
-      uatMode,
-      priceSummaryServiceProvider.forUser(uatMode).getPrices(GuardianWeekly, promoCodes, readerType),
+      testMode,
+      priceSummaryServiceProvider.forUser(testMode).getPrices(GuardianWeekly, promoCodes, readerType),
       stripeConfigProvider.get(),
       stripeConfigProvider.get(true),
       payPalConfigProvider.get(),

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -61,28 +61,28 @@
   window.guardian.stripeKeyDefaultCurrencies = {
     ONE_OFF: {
       default: "@paymentMethodConfigs.oneOffDefaultStripeConfig.defaultAccount.publicKey",
-      uat: "@paymentMethodConfigs.oneOffUatStripeConfig.defaultAccount.publicKey"
+      test: "@paymentMethodConfigs.oneOffTestStripeConfig.defaultAccount.publicKey"
     },
     REGULAR: {
       default: "@paymentMethodConfigs.regularDefaultStripeConfig.defaultAccount.publicKey",
-      uat: "@paymentMethodConfigs.regularUatStripeConfig.defaultAccount.publicKey"
+      test: "@paymentMethodConfigs.regularTestStripeConfig.defaultAccount.publicKey"
     }
   };
   window.guardian.stripeKeyAustralia = {
     ONE_OFF: {
       default: "@paymentMethodConfigs.oneOffDefaultStripeConfig.forCountry(Some(Country.Australia)).publicKey",
-      uat: "@paymentMethodConfigs.oneOffUatStripeConfig.forCountry(Some(Country.Australia)).publicKey"
+      test: "@paymentMethodConfigs.oneOffTestStripeConfig.forCountry(Some(Country.Australia)).publicKey"
     },
     REGULAR: {
       default: "@paymentMethodConfigs.regularDefaultStripeConfig.forCountry(Some(Country.Australia)).publicKey",
-      uat: "@paymentMethodConfigs.regularUatStripeConfig.forCountry(Some(Country.Australia)).publicKey"
+      test: "@paymentMethodConfigs.regularTestStripeConfig.forCountry(Some(Country.Australia)).publicKey"
     }
   };
   window.guardian.stripeKeyUnitedStates = {
     @if(settings.switches.featureSwitches.usStripeAccountForSingle.isOn) {
         ONE_OFF: {
             default: "@paymentMethodConfigs.oneOffDefaultStripeConfig.forCountry(Some(Country.US)).publicKey",
-            uat: "@paymentMethodConfigs.oneOffUatStripeConfig.forCountry(Some(Country.US)).publicKey"
+            test: "@paymentMethodConfigs.oneOffTestStripeConfig.forCountry(Some(Country.US)).publicKey"
         },
     } else {
       ONE_OFF: window.guardian.stripeKeyDefaultCurrencies.ONE_OFF,
@@ -91,15 +91,15 @@
   };
   window.guardian.payPalEnvironment = {
     default: "@paymentMethodConfigs.regularDefaultPayPalConfig.payPalEnvironment",
-    uat: "@paymentMethodConfigs.regularUatPayPalConfig.payPalEnvironment"
+    test: "@paymentMethodConfigs.regularTestPayPalConfig.payPalEnvironment"
   };
   window.guardian.amazonPaySellerId = {
     default: "@paymentMethodConfigs.defaultAmazonPayConfig.sellerId",
-    uat: "@paymentMethodConfigs.uatAmazonPayConfig.sellerId"
+    test: "@paymentMethodConfigs.testAmazonPayConfig.sellerId"
   };
   window.guardian.amazonPayClientId = {
     default: "@paymentMethodConfigs.defaultAmazonPayConfig.clientId",
-    uat: "@paymentMethodConfigs.uatAmazonPayConfig.clientId",
+    test: "@paymentMethodConfigs.testAmazonPayConfig.clientId",
   };
   window.guardian.paymentApiUrl = "@paymentApiUrl";
   window.guardian.paymentApiPayPalEndpoint = "@paymentApiPayPalEndpoint";

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -21,12 +21,12 @@
   css: String,
   csrf: Option[String],
   idUser: Option[IdUser],
-  uatMode: Boolean,
+  testMode: Boolean,
   productPrices: ProductPrices,
   defaultStripeConfig: StripeConfig,
-  uatStripeConfig: StripeConfig,
+  testStripeConfig: StripeConfig,
   defaultPayPalConfig: PayPalConfig,
-  uatPayPalConfig: PayPalConfig,
+  testPayPalConfig: PayPalConfig,
   v2recaptchaConfigPublicKey: String,
   orderIsAGift: Boolean = false,
   homeDeliveryPostcodes: Option[List[String]] = None,
@@ -63,19 +63,19 @@
       window.guardian.stripeKeyDefaultCurrencies = {
         REGULAR: {
           default: "@defaultStripeConfig.forCurrency(None).publicKey",
-          uat: "@uatStripeConfig.forCurrency(None).publicKey"
+          test: "@testStripeConfig.forCurrency(None).publicKey"
         }
       };
       window.guardian.stripeKeyAustralia = {
         REGULAR: {
           default: "@defaultStripeConfig.forCurrency(Some(AUD)).publicKey",
-          uat: "@uatStripeConfig.forCurrency(Some(AUD)).publicKey"
+          test: "@testStripeConfig.forCurrency(Some(AUD)).publicKey"
         }
       };
       window.guardian.stripeKeyUnitedStates = window.guardian.stripeKeyDefaultCurrencies;
       window.guardian.payPalEnvironment = {
         default: "@defaultPayPalConfig.payPalEnvironment",
-        uat: "@uatPayPalConfig.payPalEnvironment"
+        test: "@testPayPalConfig.payPalEnvironment"
       };
 
       window.guardian.checkoutPostcodeLookup = @settings.switches.subscriptionsSwitches.checkoutPostcodeLookup.isOn
@@ -84,7 +84,7 @@
 
       window.guardian.recaptchaEnabled = @settings.switches.recaptchaSwitches.enableRecaptchaFrontend.isOn
 
-      window.guardian.isTestUser = @uatMode
+      window.guardian.isTestUser = @testMode
 
     </script>
 

--- a/support-frontend/assets/components/amazonPayForm/amazonPayForm.tsx
+++ b/support-frontend/assets/components/amazonPayForm/amazonPayForm.tsx
@@ -40,7 +40,7 @@ type PropTypes = {
 
 const getSellerId = (isTestUser: boolean): string =>
 	isTestUser
-		? window.guardian.amazonPaySellerId.uat
+		? window.guardian.amazonPaySellerId.test
 		: window.guardian.amazonPaySellerId.default;
 
 function AmazonPayForm(props: PropTypes): JSX.Element | null {

--- a/support-frontend/assets/components/payPalPaymentButton/payPalButtonProps.ts
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalButtonProps.ts
@@ -37,7 +37,7 @@ export function getPayPalButtonProps({
 }: PayPalPropsRequirements): PayPalButtonProps {
 	return {
 		env: isTestUser
-			? window.guardian.payPalEnvironment.uat
+			? window.guardian.payPalEnvironment.test
 			: window.guardian.payPalEnvironment.default,
 		style: {
 			color: 'blue',

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/amazonPay/setup.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/amazonPay/setup.ts
@@ -100,5 +100,5 @@ const getAmazonRegion = (
 
 const getAmazonPayClientId = (isSandbox: boolean): string =>
 	isSandbox
-		? window.guardian.amazonPayClientId.uat
+		? window.guardian.amazonPayClientId.test
 		: window.guardian.amazonPayClientId.default;

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/payPalRecurringCheckout.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/payPalRecurringCheckout.ts
@@ -219,7 +219,7 @@ const setupPayment = (
 
 const getPayPalEnvironment = (isTestUser: boolean): string =>
 	isTestUser
-		? window.guardian.payPalEnvironment.uat
+		? window.guardian.payPalEnvironment.test
 		: window.guardian.payPalEnvironment.default;
 
 const createAgreement = async (

--- a/support-frontend/assets/helpers/forms/stripe.ts
+++ b/support-frontend/assets/helpers/forms/stripe.ts
@@ -28,11 +28,11 @@ const stripeAccountForContributionType: Record<
 
 export interface StripeKey {
 	ONE_OFF: {
-		uat: string;
+		test: string;
 		default: string;
 	};
 	REGULAR: {
-		uat: string;
+		test: string;
 		default: string;
 	};
 }
@@ -45,17 +45,17 @@ function getStripeKey(
 	switch (country) {
 		case 'AU':
 			return isTestUser
-				? window.guardian.stripeKeyAustralia[stripeAccount].uat
+				? window.guardian.stripeKeyAustralia[stripeAccount].test
 				: window.guardian.stripeKeyAustralia[stripeAccount].default;
 
 		case 'US':
 			return isTestUser
-				? window.guardian.stripeKeyUnitedStates[stripeAccount].uat
+				? window.guardian.stripeKeyUnitedStates[stripeAccount].test
 				: window.guardian.stripeKeyUnitedStates[stripeAccount].default;
 
 		default:
 			return isTestUser
-				? window.guardian.stripeKeyDefaultCurrencies[stripeAccount].uat
+				? window.guardian.stripeKeyDefaultCurrencies[stripeAccount].test
 				: window.guardian.stripeKeyDefaultCurrencies[stripeAccount].default;
 	}
 }

--- a/support-frontend/assets/helpers/user/user.ts
+++ b/support-frontend/assets/helpers/user/user.ts
@@ -36,9 +36,9 @@ function isTestUser(): boolean {
 	const isDefined = (x: boolean | string | null | undefined) =>
 		x !== null && x !== undefined;
 
-	const uatMode = window.guardian.uatMode;
+	const testMode = window.guardian.testMode;
 	const testCookie = cookie.get('_test_username');
-	return isDefined(uatMode) || isDefined(testCookie);
+	return isDefined(testMode) || isDefined(testCookie);
 }
 
 function getUserStateField(): string | undefined {

--- a/support-frontend/stories/screens/SupporterPlusLanding.stories.tsx
+++ b/support-frontend/stories/screens/SupporterPlusLanding.stories.tsx
@@ -17,8 +17,8 @@ import { SupporterPlusLandingPage } from 'pages/supporter-plus-landing/supporter
 global.window.guardian = {
 	...global.window.guardian,
 	stripeKeyDefaultCurrencies: {
-		ONE_OFF: { uat: '', default: '' },
-		REGULAR: { uat: '', default: '' },
+		ONE_OFF: { test: '', default: '' },
+		REGULAR: { test: '', default: '' },
 	},
 };
 

--- a/support-frontend/test/services/pricing/PriceSummaryServiceIntegrationSpec.scala
+++ b/support-frontend/test/services/pricing/PriceSummaryServiceIntegrationSpec.scala
@@ -21,7 +21,7 @@ class PriceSummaryServiceIntegrationSpec extends AsyncFlatSpec with Matchers wit
     new PriceSummaryService(
       PromotionServiceSpec.serviceWithDynamo,
       defaultPromotionsService,
-      CatalogService(TouchPointEnvironments.SANDBOX),
+      CatalogService(TouchPointEnvironments.CODE),
     )
 
   "PriceSummaryService" should "return prices" in {

--- a/support-frontend/window.d.ts
+++ b/support-frontend/window.d.ts
@@ -40,11 +40,11 @@ declare global {
 		guardian: {
 			amazonPayClientId: {
 				default: string;
-				uat: string;
+				test: string;
 			};
 			amazonPaySellerId: {
 				default: string;
-				uat: string;
+				test: string;
 			};
 			csrf?: CsrfState;
 			email?: string;
@@ -61,7 +61,7 @@ declare global {
 			paymentApiUrl: string;
 			payPalEnvironment: {
 				default: string;
-				uat: string;
+				test: string;
 			};
 			polyfillScriptLoaded?: boolean;
 			polyfillVersion?: string;
@@ -72,7 +72,7 @@ declare global {
 			stripeKeyAustralia: StripeKey;
 			stripeKeyDefaultCurrencies: StripeKey;
 			stripeKeyUnitedStates: StripeKey;
-			uatMode?: boolean;
+			testMode?: boolean;
 			user?: User;
 			v2recaptchaPublicKey: string;
 		};

--- a/support-models/src/main/scala/com/gu/support/catalog/Catalog.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Catalog.scala
@@ -1,7 +1,7 @@
 package com.gu.support.catalog
 
 import com.gu.i18n.Currency
-import com.gu.support.config.TouchPointEnvironments.{PROD, SANDBOX}
+import com.gu.support.config.TouchPointEnvironments.{PROD, CODE}
 import io.circe.Json.fromString
 import io.circe._
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
@@ -15,7 +15,7 @@ case class Catalog(
 object Catalog {
   lazy val productRatePlansWithPrices: List[ProductRatePlanId] = for {
     product <- List(SupporterPlus, DigitalPack, Paper, GuardianWeekly)
-    env <- List(PROD, SANDBOX)
+    env <- List(PROD, CODE)
     plan <- product.ratePlans(env)
   } yield plan.id
 

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -2,7 +2,7 @@ package com.gu.support.catalog
 
 import com.gu.i18n.CountryGroup
 import com.gu.support.config.TouchPointEnvironment
-import com.gu.support.config.TouchPointEnvironments.{PROD, SANDBOX}
+import com.gu.support.config.TouchPointEnvironments.{PROD, CODE}
 import com.gu.support.workers._
 import com.gu.support.zuora.api.ReaderType
 import com.gu.support.zuora.api.ReaderType.{Direct, Gift}
@@ -57,7 +57,7 @@ case object SupporterPlus extends Product {
         productRatePlan("8a128ed885fc6ded018602296ace3eb8", Monthly, SupporterPlusV2),
         productRatePlan("8a128ed885fc6ded01860228f77e3d5a", Annual, SupporterPlusV2),
       ),
-      SANDBOX -> List(
+      CODE -> List(
         productRatePlan("8ad09fc281de1ce70181de3b251736a4", Monthly, SupporterPlusV1),
         productRatePlan("8ad09fc281de1ce70181de3b28ee3783", Annual, SupporterPlusV1),
         productRatePlan("8ad08cbd8586721c01858804e3275376", Monthly, SupporterPlusV2),
@@ -83,7 +83,7 @@ case object DigitalPack extends Product {
         productRatePlan("2c92a00d779932ef0177a65430d30ac1", Quarterly, "Digital Subscription Three Month Gift", Gift),
         productRatePlan("2c92a00c77992ba70177a6596f710265", Annual, "Digital Subscription One Year Gift", Gift),
       ),
-      SANDBOX -> List(
+      CODE -> List(
         productRatePlan("2c92c0f84bbfec8b014bc655f4852d9d", Monthly, "Digital Subscription Monthly"),
         productRatePlan("2c92c0f94bbffaaa014bc6a4212e205b", Annual, "Digital Subscription Annual"),
         productRatePlan("2c92c0f8778bf8f60177915b477714aa", Quarterly, "Digital Subscription Three Month Gift", Gift),
@@ -111,7 +111,7 @@ case object Contribution extends Product {
           "Annual Contribution",
         ),
       ),
-      SANDBOX -> List(
+      CODE -> List(
         ProductRatePlan(
           "2c92c0f85a6b134e015a7fcd9f0c7855",
           Monthly,
@@ -160,20 +160,7 @@ case object Paper extends Product {
       collection("2c92a00870ec598001710740c78d2f13", Everyday, "Voucher Everyday"),
     )
 
-  private val uatCollection: List[ProductRatePlan[Paper.type]] = List(
-    collection("2c92c0f870f682820171070489d542da", SaturdayPlus, "Voucher Saturday+"),
-    collection("2c92c0f870f682820171070488df42ce", Saturday, "Voucher Saturday"),
-    collection("2c92c0f870f68282017107047b214214", SundayPlus, "Voucher Sunday+"),
-    collection("2c92c0f870f682820171070487f142c4", Sunday, "Voucher Sunday"),
-    collection("2c92c0f870f682820171070478d441f5", WeekendPlus, "Voucher Weekends+"),
-    collection("2c92c0f870f682820171070477d841e2", Weekend, "Voucher Weekend"),
-    collection("2c92c0f870f682820171070470ad4120", SixdayPlus, "Voucher Sixday+"),
-    collection("2c92c0f870f68282017107047d054230", Sixday, "Voucher Sixday"),
-    collection("2c92c0f870f682820171070481bf4264", EverydayPlus, "Voucher Everyday+"),
-    collection("2c92c0f870f682820171070474ee419d", Everyday, "Voucher Everyday"),
-  )
-
-  private val sandboxCollection: List[ProductRatePlan[Paper.type]] = List(
+  private val codeCollection: List[ProductRatePlan[Paper.type]] = List(
     collection("2c92c0f86fa49142016fa49eb1732a39", SaturdayPlus, "Voucher Saturday paper+"),
     collection("2c92c0f86fa49142016fa49ea442291b", Saturday, "Voucher Saturday paper"),
     collection("2c92c0f86fa49142016fa49ea90e2976", SundayPlus, "Voucher Sunday paper+"),
@@ -200,7 +187,7 @@ case object Paper extends Product {
         homeDelivery("2c92a0fd560d132301560e43cf041a3c", EverydayPlus, "Home Delivery Everyday+"),
         homeDelivery("2c92a0fd560d13880156136b72e50f0c", Everyday, "Home Delivery Everyday"),
       )),
-      SANDBOX -> (sandboxCollection ++ List(
+      CODE -> (codeCollection ++ List(
         homeDelivery("2c92c0f961f9cf300161fc4f71473a34", SaturdayPlus, "Home Delivery Saturday+"),
         homeDelivery("2c92c0f961f9cf300161fc4d2e3e3664", Saturday, "Home Delivery Saturday"),
         homeDelivery("2c92c0f955c3cf0f0155c5d9e83a3cb7", SundayPlus, "Home Delivery Sunday+"),
@@ -297,7 +284,7 @@ case object GuardianWeekly extends Product {
           readerType = Gift,
         ),
       ),
-      SANDBOX -> List(
+      CODE -> List(
         restOfWorld(
           "2c92c0f965f2122101660fbc75a16c38",
           SixWeekly,

--- a/support-models/src/main/scala/com/gu/support/config/TouchPointEnvironments.scala
+++ b/support-models/src/main/scala/com/gu/support/config/TouchPointEnvironments.scala
@@ -1,41 +1,35 @@
 package com.gu.support.config
 
-import com.gu.support.config.TouchPointEnvironments.{PROD, SANDBOX}
+import com.gu.support.config.TouchPointEnvironments.{PROD, CODE}
 
 /** TouchPointEnvironment represents a logical environment for our backend systems, mainly Zuora and Salesforce. Any
   * environment *could* be used by any stage (see Stages) however in practice they are restricted to the following: DEV
-  * and CODE stages use the SANDBOX environment for all users, the PROD stage uses the PROD environment for non test
-  * users and SANDBOX for test users
+  * and CODE stages use the CODE environment for all users, the PROD stage uses the PROD environment for non test users
+  * and CODE for test users
   */
 sealed trait TouchPointEnvironment {
   val envValue = this match {
-    case SANDBOX => "DEV"
-    case PROD => "PROD"
-  }
-
-  @deprecated // prefer envValue to gain type safety and easier static analysis
-  override def toString: String = this match {
-    case SANDBOX => "SANDBOX"
+    case CODE => "CODE"
     case PROD => "PROD"
   }
 }
 
 object TouchPointEnvironments {
 
-  case object SANDBOX extends TouchPointEnvironment // TODO rename SANDBOX to DEV
+  case object CODE extends TouchPointEnvironment
   case object PROD extends TouchPointEnvironment
 
   def fromStage(stage: Stage, isTestUser: Boolean = false): TouchPointEnvironment =
-    if (isTestUser) SANDBOX
+    if (isTestUser) CODE
     else
       stage match {
-        case Stages.DEV | Stages.CODE => SANDBOX
+        case Stages.DEV | Stages.CODE => CODE
         case Stages.PROD => PROD
       }
 
   def fromString(string: String): TouchPointEnvironment =
     string match {
       case "PROD" => PROD
-      case _ => SANDBOX
+      case _ => CODE
     }
 }

--- a/support-models/src/test/scala/com/gu/support/workers/ProductTypeRatePlansSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/ProductTypeRatePlansSpec.scala
@@ -2,7 +2,7 @@ package com.gu.support.workers
 
 import com.gu.i18n.Currency.{GBP, USD}
 import com.gu.support.catalog.{Domestic, Everyday, HomeDelivery}
-import com.gu.support.config.TouchPointEnvironments.SANDBOX
+import com.gu.support.config.TouchPointEnvironments.CODE
 import com.gu.support.workers.ProductTypeRatePlans._
 import com.gu.support.zuora.api.ReaderType.{Direct, Gift}
 import org.scalatest.OptionValues._
@@ -13,10 +13,10 @@ class ProductTypeRatePlansSpec extends AsyncFlatSpec with Matchers {
 
   "ProductTypeRatePlans" should "return the correct product rate plan for a given product type" in {
     val weekly = GuardianWeekly(GBP, Annual, Domestic)
-    weeklyRatePlan(weekly, SANDBOX, Direct).value.description shouldBe "Guardian Weekly annual, domestic delivery"
+    weeklyRatePlan(weekly, CODE, Direct).value.description shouldBe "Guardian Weekly annual, domestic delivery"
 
     val paper = Paper(USD, Monthly, HomeDelivery, Everyday)
-    paperRatePlan(paper, SANDBOX).value.id shouldBe "2c92c0f955c3cf0f0155c5d9e2493c43"
+    paperRatePlan(paper, CODE).value.id shouldBe "2c92c0f955c3cf0f0155c5d9e2493c43"
 
   }
 

--- a/support-services/src/main/scala/com/gu/support/catalog/CatalogJsonProvider.scala
+++ b/support-services/src/main/scala/com/gu/support/catalog/CatalogJsonProvider.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.s3.AmazonS3URI
 import com.gu.aws.AwsS3Client
 import com.gu.support.catalog.AwsS3ClientJson.fetchJson
 import com.gu.support.config.TouchPointEnvironment
-import com.gu.support.config.TouchPointEnvironments.SANDBOX
+import com.gu.support.config.TouchPointEnvironments.CODE
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.Json
 
@@ -21,8 +21,8 @@ class S3CatalogProvider(environment: TouchPointEnvironment) extends CatalogJsonP
   }
 
   private def keyFromEnvironment(environment: TouchPointEnvironment) = environment match {
-    case SANDBOX => "DEV"
-    case other: TouchPointEnvironment => other.toString
+    case CODE => "DEV" // TODO: remove this when we have a CODE catalog
+    case other: TouchPointEnvironment => other.envValue
   }
 }
 

--- a/support-services/src/test/scala/com/gu/aws/AwsCloudWatchMetricPutSpec.scala
+++ b/support-services/src/test/scala/com/gu/aws/AwsCloudWatchMetricPutSpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.matchers.should.Matchers
 class AwsCloudWatchMetricPutSpec extends AsyncFlatSpec with Matchers {
 
   "CatalogFailures" should "be logged to CloudWatch" in {
-    AwsCloudWatchMetricPut(AwsCloudWatchMetricPut.client)(catalogFailureRequest(TouchPointEnvironments.SANDBOX))
+    AwsCloudWatchMetricPut(AwsCloudWatchMetricPut.client)(catalogFailureRequest(TouchPointEnvironments.CODE))
       .fold(
         err => fail(err),
         _ => succeed,

--- a/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceIntegrationSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceIntegrationSpec.scala
@@ -1,7 +1,7 @@
 package com.gu.support.catalog
 
 import com.gu.support.config.TouchPointEnvironment
-import com.gu.support.config.TouchPointEnvironments.{PROD, SANDBOX}
+import com.gu.support.config.TouchPointEnvironments.{PROD, CODE}
 import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.Inspectors
 import org.scalatest.flatspec.AsyncFlatSpec
@@ -13,8 +13,8 @@ class CatalogServiceIntegrationSpec extends AsyncFlatSpec with Matchers with Ins
   "CatalogService" should "be able to find a price list for all product rate plans in all environments" in {
     Console.println("Testing PROD")
     testEnvironment(PROD)
-    Console.println("Testing SANDBOX")
-    testEnvironment(SANDBOX)
+    Console.println("Testing CODE")
+    testEnvironment(CODE)
   }
 
   private def testEnvironment(environment: TouchPointEnvironment) = {

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -38,9 +38,6 @@ Mappings:
       DynamoDBTables:
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-PROD
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-DEV
-      RedemptionTables:
-      - arn:aws:dynamodb:*:*:table/redemption-codes-UAT
-      - arn:aws:dynamodb:*:*:table/redemption-codes-PROD
       S3Files:
       - arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-PROD/catalog.json
       - arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-DEV/catalog.json

--- a/support-workers/src/main/resources/application.conf
+++ b/support-workers/src/main/resources/application.conf
@@ -9,7 +9,7 @@ config.private {
 }
 
 touchpoint.backend.environments {
-  SANDBOX {
+  CODE {
     salesforce {
       url = "https://test.salesforce.com"
       consumer {

--- a/support-workers/src/main/scala/com/gu/services/Services.scala
+++ b/support-workers/src/main/scala/com/gu/services/Services.scala
@@ -29,8 +29,8 @@ import scala.concurrent.duration._
 trait ServiceProvider {
   private lazy val config = Configuration.load()
   private lazy val defaultServices: Services = new Services(false, config)
-  private lazy val uatServices: Services = new Services(true, config)
-  def forUser(isTestUser: Boolean): Services = if (isTestUser) uatServices else defaultServices
+  private lazy val testServices: Services = new Services(true, config)
+  def forUser(isTestUser: Boolean): Services = if (isTestUser) testServices else defaultServices
 }
 
 object ServiceProvider extends ServiceProvider

--- a/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
@@ -1,7 +1,7 @@
 package com.gu.emailservices
 
 import com.gu.i18n.Currency.GBP
-import com.gu.support.config.TouchPointEnvironments.SANDBOX
+import com.gu.support.config.TouchPointEnvironments.CODE
 import com.gu.support.workers.integration.TestData
 import com.gu.support.workers.integration.TestData.{countryOnlyAddress, directDebitPaymentMethod}
 import com.gu.support.workers.states.SendThankYouEmailState._
@@ -90,7 +90,7 @@ class DigitalPackEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside
     val actual = new DigitalPackEmailFields(
       new PaperFieldsGenerator(TestData.promotionService, TestData.getMandate),
       TestData.getMandate,
-      SANDBOX,
+      CODE,
     ).build(
       SendThankYouEmailDigitalSubscriptionDirectPurchaseState(
         User("1234", "test@theguardian.com", None, "Mickey", "Mouse", billingAddress = countryOnlyAddress),
@@ -133,7 +133,7 @@ class DigitalPackEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside
     val actual = new DigitalPackEmailFields(
       new PaperFieldsGenerator(TestData.promotionService, TestData.getMandate),
       TestData.getMandate,
-      SANDBOX,
+      CODE,
     ).build(
       SendThankYouEmailDigitalSubscriptionGiftRedemptionState(
         User("1234", "test@theguardian.com", None, "Mickey", "Mouse", billingAddress = countryOnlyAddress),

--- a/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
@@ -86,7 +86,7 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
         config = ZuoraDigitalPackConfig(14, 2, "", ""),
         promotionService = null, // shouldn't be called for subs with no promo code
         DateGenerator(new LocalDate(2020, 6, 15)),
-        TouchPointEnvironments.SANDBOX,
+        TouchPointEnvironments.CODE,
         new SubscribeItemBuilder(
           requestId = UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
           user = User(

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -183,8 +183,8 @@ class CreateZuoraSubscriptionHelper(implicit executionContext: ExecutionContext)
 
   val realPromotionService = new PromotionService(realConfig.promotionsConfigProvider.get())
 
-  private val jsonProvider = new S3CatalogProvider(TouchPointEnvironments.SANDBOX)
-  lazy val realCatalogService = new CatalogService(TouchPointEnvironments.SANDBOX, jsonProvider)
+  private val jsonProvider = new S3CatalogProvider(TouchPointEnvironments.CODE)
+  lazy val realCatalogService = new CatalogService(TouchPointEnvironments.CODE, jsonProvider)
 
   lazy val mockZuoraService = {
     val mockZuora = mock[ZuoraService]

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -8,7 +8,7 @@ import com.gu.i18n.Country.UK
 import com.gu.i18n.Currency.GBP
 import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.support.catalog.{Collection, Domestic, Saturday}
-import com.gu.support.config.TouchPointEnvironments.SANDBOX
+import com.gu.support.config.TouchPointEnvironments.CODE
 import com.gu.support.config.{PromotionsConfig, PromotionsDiscountConfig, PromotionsTablesConfig}
 import com.gu.support.promotions.{PromotionService, SimplePromotionCollection}
 import com.gu.support.workers.GiftRecipient.DigitalSubscriptionGiftRecipient
@@ -194,7 +194,7 @@ object SendDigitalPackGiftRedemptionEmail extends App {
 object SendPaperSubscriptionEmail extends App {
 
   sendSingle(
-    new PaperEmailFields(paperFieldsGenerator, SANDBOX).build(
+    new PaperEmailFields(paperFieldsGenerator, CODE).build(
       SendThankYouEmailPaperState(
         officeUser,
         Paper(GBP, Monthly, Collection, Saturday),
@@ -212,7 +212,7 @@ object SendPaperSubscriptionEmail extends App {
 object SendWeeklySubscriptionEmail extends App {
 
   sendSingle(
-    new GuardianWeeklyEmailFields(paperFieldsGenerator, SANDBOX).build(
+    new GuardianWeeklyEmailFields(paperFieldsGenerator, CODE).build(
       SendThankYouEmailGuardianWeeklyState(
         officeUser,
         GuardianWeekly(GBP, Quarterly, Domestic),
@@ -236,7 +236,7 @@ object SendWeeklySubscriptionEmail extends App {
 object SendWeeklySubscriptionGiftEmail extends App {
 
   sendSingle(
-    new GuardianWeeklyEmailFields(paperFieldsGenerator, SANDBOX).build(
+    new GuardianWeeklyEmailFields(paperFieldsGenerator, CODE).build(
       SendThankYouEmailGuardianWeeklyState(
         officeUser,
         GuardianWeekly(GBP, Quarterly, Domestic),
@@ -318,7 +318,7 @@ object TestData {
       getMandate,
     ),
     getMandate,
-    SANDBOX,
+    CODE,
   )
 
 }

--- a/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
@@ -159,7 +159,7 @@ class ZuoraITSpec extends AsyncFlatSpec with Matchers {
   it should "work for a paper subscription" in doRequest(Right(directDebitSubscriptionRequestPaper))
 
   private def doRequest(request: Either[PreviewSubscribeRequest, SubscribeRequest]) = {
-    // Accounts will be created (or previewed) in Sandbox
+    // Accounts will be created (or previewed) in CODE
     val zuoraService = new ZuoraService(
       Configuration.load().zuoraConfigProvider.get(),
       RequestRunners.configurableFutureRunner(30.seconds),

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
@@ -6,7 +6,7 @@ import com.gu.i18n.Country.Australia
 import com.gu.i18n.Currency.GBP
 import com.gu.salesforce.Salesforce.SalesforceContactRecords
 import com.gu.support.acquisitions.{AbTest, AcquisitionData, OphanIds}
-import com.gu.support.config.TouchPointEnvironments.SANDBOX
+import com.gu.support.config.TouchPointEnvironments.CODE
 import com.gu.support.config.{TouchPointEnvironments, ZuoraDigitalPackConfig, ZuoraInvoiceTemplatesConfig}
 import com.gu.support.promotions.{Promotion, PromotionService, PromotionWithCode}
 import com.gu.support.redemption.gifting.GiftCodeValidator
@@ -201,7 +201,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
     ZuoraDigitalPackConfig(14, 2, monthlyChargeId = "monthlyChargeId", annualChargeId = "annualChargeId"),
     promotionService,
     DateGenerator(saleDate),
-    SANDBOX,
+    CODE,
     new SubscribeItemBuilder(
       UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
       User("1234", "hi@thegulocal.com", None, "bob", "smith", Address(None, None, None, None, None, Country.UK)),
@@ -214,7 +214,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
     promotionService,
     DateGenerator(saleDate),
     new GiftCodeGeneratorService,
-    SANDBOX,
+    CODE,
     new SubscribeItemBuilder(
       UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
       User("1234", "hi@thegulocal.com", None, "bob", "smith", Address(None, None, None, None, None, Country.UK)),

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/GuardianWeeklySubscriptionBuildersSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/GuardianWeeklySubscriptionBuildersSpec.scala
@@ -6,7 +6,7 @@ import com.gu.i18n.Country.Australia
 import com.gu.i18n.Currency.GBP
 import com.gu.salesforce.Salesforce.SalesforceContactRecords
 import com.gu.support.catalog.Domestic
-import com.gu.support.config.TouchPointEnvironments.SANDBOX
+import com.gu.support.config.TouchPointEnvironments.CODE
 import com.gu.support.config.ZuoraInvoiceTemplatesConfig
 import com.gu.support.promotions.{Promotion, PromotionService, PromotionWithCode}
 import com.gu.support.workers.GiftRecipient.WeeklyGiftRecipient
@@ -160,7 +160,7 @@ class GuardianWeeklySubscriptionBuildersSpec extends AnyFlatSpec with Matchers {
 
   lazy val gift: SubscriptionData = new GuardianWeeklySubscriptionBuilder(
     promotionService,
-    SANDBOX,
+    CODE,
     DateGenerator(saleDate),
     subscribeItemBuilder,
   ).build(
@@ -207,7 +207,7 @@ class GuardianWeeklySubscriptionBuildersSpec extends AnyFlatSpec with Matchers {
 
   lazy val nonGift = new GuardianWeeklySubscriptionBuilder(
     promotionService,
-    SANDBOX,
+    CODE,
     DateGenerator(saleDate),
     subscribeItemBuilder,
   ).build(
@@ -220,7 +220,7 @@ class GuardianWeeklySubscriptionBuildersSpec extends AnyFlatSpec with Matchers {
 
   lazy val csrSubscription = new GuardianWeeklySubscriptionBuilder(
     promotionService,
-    SANDBOX,
+    CODE,
     DateGenerator(saleDate),
     subscribeItemBuilder,
   ).build(
@@ -249,7 +249,7 @@ class GuardianWeeklySubscriptionBuildersSpec extends AnyFlatSpec with Matchers {
 
   lazy val nonGiftPatron = new GuardianWeeklySubscriptionBuilder(
     promotionService,
-    SANDBOX,
+    CODE,
     DateGenerator(saleDate),
     subscribeItemBuilder,
   ).build(
@@ -262,7 +262,7 @@ class GuardianWeeklySubscriptionBuildersSpec extends AnyFlatSpec with Matchers {
 
   lazy val nonGiftPromo = new GuardianWeeklySubscriptionBuilder(
     promotionService,
-    SANDBOX,
+    CODE,
     DateGenerator(saleDate),
     subscribeItemBuilder,
   ).build(


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR follows on from #4885 and continues the work described [in this doc](https://docs.google.com/document/d/1wg1kMk7U7ht3AmPpsPUimtz1FkVbu5BWjijjme2598s/edit#). Specifically it renames the non-standard `Sandbox` environment to `CODE` and updates any related usages 

- [x] update support-workers private config in S3
- [x] update support-frontend config in parameter store
- [x] test on code
