### PR TITLE
Enable browserstack network logs

### DIFF
--- a/support-frontend/test/selenium/util/DriverConfig.scala
+++ b/support-frontend/test/selenium/util/DriverConfig.scala
@@ -2,11 +2,12 @@ package selenium.util
 
 import java.net.URL
 import java.util.Date
-
 import io.github.bonigarcia.wdm.WebDriverManager
 import org.openqa.selenium.chrome.{ChromeDriver, ChromeOptions}
 import org.openqa.selenium.remote.RemoteWebDriver
 import org.openqa.selenium.{Cookie, JavascriptExecutor, WebDriver}
+
+import scala.collection.immutable.HashMap
 
 class DriverConfig {
 
@@ -30,6 +31,11 @@ class DriverConfig {
     val chromeOptions = new ChromeOptions
     chromeOptions.setCapability("platform", "WINDOWS")
     chromeOptions.setCapability("name", "support-frontend")
+
+    val networkLogsOptions = HashMap("captureContent" -> true)
+    chromeOptions.setCapability("browserstack.networkLogs", true)
+    chromeOptions.setCapability("browserstack.networkLogsOptions", networkLogsOptions)
+
     new RemoteWebDriver(new URL(Config.webDriverRemoteUrl), chromeOptions)
   }
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

We currently don't have network logs enabled for our post deploy tests but I think they would be useful so this PR enables them.

[Related docs](https://www.browserstack.com/docs/automate/selenium/debugging-options?_gl=1*1yjr133*_ga*MTc5MjUxMTM3Ni4xNjY5MjEyNDk2*_ga_BBS5LEDVRG*MTY4MTQwNDM1OS4zLjEuMTY4MTQwNDM5MS4yOC4wLjA.#enable-network-logs)