### PR TITLE
Turn on first mobile optimisation abtest for the supporter plus checkout

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -119,7 +119,7 @@ export const tests: Tests = {
 				},
 			},
 		},
-		isActive: false,
+		isActive: true,
 		referrerControlled: false,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		seed: 12,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This enables the test added in #4791.

[**Trello Card**](https://trello.com/c/sWdAjrUq/1254-enable-mobile-optimisation-variant-a-for-a-b-test)

## Why are you doing this?

It's time to run the first mobile optimisation test!

## Is this an AB test?
- [x] Yes
- [ ] No