### PR TITLE
mobile optimisation test, 2-line header change for the supporter plus checkout

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
@@ -17,7 +17,7 @@ const container = css`
 
 const heading = css`
 	${headline.small({ fontWeight: 'bold', lineHeight: 'tight' })};
-	max-width: 280px;
+	max-width: 250px;
 `;
 
 const checkListIcon = css`

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
@@ -18,6 +18,9 @@ const container = css`
 const heading = css`
 	${headline.small({ fontWeight: 'bold', lineHeight: 'tight' })};
 	max-width: 250px;
+	${from.desktop} {
+		max-width: 280px;
+	}
 `;
 
 const checkListIcon = css`


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Minor PR follows on from the first mobile optimisation test ->
https://github.com/guardian/support-frontend/pull/4791

Header resized to display over 2 lines

## Why are you doing this?

## Screenshots
![image](https://user-images.githubusercontent.com/76729591/232799954-9b2eb5f4-de6d-48ca-966d-5c43cb696948.png)

This test aims to start to streamline the user flow on mobile.
