### PR TITLE
Realign the build numbers for Acquisitions events api

### DIFF
--- a/.github/workflows/acquisition-events-api.yml
+++ b/.github/workflows/acquisition-events-api.yml
@@ -62,4 +62,6 @@ jobs:
 
       - name: Build and upload to RiffRaff
         run: |
+          export LAST_TEAMCITY_BUILD=6000
+          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
           sbt "project acquisition-events-api" riffRaffUpload

--- a/.github/workflows/acquisition-events-api.yml
+++ b/.github/workflows/acquisition-events-api.yml
@@ -62,6 +62,6 @@ jobs:
 
       - name: Build and upload to RiffRaff
         run: |
-          export LAST_TEAMCITY_BUILD=6000
+          export LAST_TEAMCITY_BUILD=20000
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
           sbt "project acquisition-events-api" riffRaffUpload


### PR DESCRIPTION
## What are you doing in this PR?
This is to update acquisition-events-api.yml to realign the build numbers  for Acquistion-events-api .

This is to resolve the issue 
### Unable to locate cloudformation template s3://riffraff-artifact/support:lambdas:acquisition-events-api/16122/cfn/AcquisitionEventsAPI-CODE.template.json

that occurred during the riff-raff deployment caused due to a mismatch in the build numbers 


<img width="1322" alt="image" src="https://user-images.githubusercontent.com/73653255/233100757-1a4af3a3-1eff-4228-841a-89a418dc4686.png">
