### PR TITLE
Add Emotional Benefit to checkout(first copy)

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -61,6 +61,12 @@ export function CheckoutBenefitsListContainer({
 }: CheckoutBenefitsListContainerProps): JSX.Element | null {
 	const dispatch = useContributionsDispatch();
 
+	const isEmotionalBenefitTestVariant = useContributionsSelector(
+		isUserInAbVariant('emotionalBenefitTest', 'variant'),
+	);
+
+	console.log('isEmotionalBenefitTestVariant', isEmotionalBenefitTestVariant);
+
 	const contributionType = useContributionsSelector(getContributionType);
 	if (isOneOff(contributionType)) {
 		return null;
@@ -77,6 +83,7 @@ export function CheckoutBenefitsListContainer({
 	const useOptimisedMobileLayout = useContributionsSelector(
 		isUserInAbVariant('supporterPlusMobileTest1', 'variant'),
 	);
+	console.log('useOptimisedMobileLayout', useOptimisedMobileLayout);
 
 	const currency = currencies[currencyId];
 
@@ -113,9 +120,12 @@ export function CheckoutBenefitsListContainer({
 			userSelectedAmountWithCurrency,
 			contributionType,
 		),
-		checkListData: checkListData({
-			higherTier,
-		}),
+		checkListData: checkListData(
+			{
+				higherTier,
+			},
+			isEmotionalBenefitTestVariant,
+		),
 		buttonCopy: getbuttonCopy(
 			higherTier,
 			thresholdPriceWithCurrency,

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -65,8 +65,6 @@ export function CheckoutBenefitsListContainer({
 		isUserInAbVariant('emotionalBenefitTest', 'variant'),
 	);
 
-	console.log('isEmotionalBenefitTestVariant', isEmotionalBenefitTestVariant);
-
 	const contributionType = useContributionsSelector(getContributionType);
 	if (isOneOff(contributionType)) {
 		return null;
@@ -83,7 +81,6 @@ export function CheckoutBenefitsListContainer({
 	const useOptimisedMobileLayout = useContributionsSelector(
 		isUserInAbVariant('supporterPlusMobileTest1', 'variant'),
 	);
-	console.log('useOptimisedMobileLayout', useOptimisedMobileLayout);
 
 	const currency = currencies[currencyId];
 

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -117,12 +117,10 @@ export function CheckoutBenefitsListContainer({
 			userSelectedAmountWithCurrency,
 			contributionType,
 		),
-		checkListData: checkListData(
-			{
-				higherTier,
-			},
+		checkListData: checkListData({
+			higherTier,
 			isEmotionalBenefitTestVariant,
-		),
+		}),
 		buttonCopy: getbuttonCopy(
 			higherTier,
 			thresholdPriceWithCurrency,

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
@@ -34,10 +34,23 @@ export const getSvgIcon = (isUnlocked: boolean): JSX.Element =>
 
 export const checkListData = (
 	{ higherTier }: TierUnlocks,
-	isemotionalBenefitTestVariant: boolean,
+	isEmotionalBenefitTestVariant: boolean,
 ): CheckListData[] => {
 	const maybeGreyedOutHigherTier = higherTier ? undefined : greyedOut;
-	const dataWithoutEmotionalBenefits = [
+	return [
+		...(isEmotionalBenefitTestVariant
+			? [
+					{
+						icon: getSvgIcon(true),
+						text: (
+							<p>
+								<span css={boldText}>Make a bigger impact. </span>Sustain open,
+								independent journalism long term
+							</p>
+						),
+					},
+			  ]
+			: []),
 		{
 			icon: getSvgIcon(true),
 			text: (
@@ -77,19 +90,4 @@ export const checkListData = (
 			maybeGreyedOut: maybeGreyedOutHigherTier,
 		},
 	];
-
-	return isemotionalBenefitTestVariant
-		? [
-				{
-					icon: getSvgIcon(true),
-					text: (
-						<p>
-							<span css={boldText}>Make a bigger impact. </span>Sustain open,
-							independent journalism long term
-						</p>
-					),
-				},
-				...dataWithoutEmotionalBenefits,
-		  ]
-		: dataWithoutEmotionalBenefits;
 };

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
@@ -32,10 +32,12 @@ export const getSvgIcon = (isUnlocked: boolean): JSX.Element =>
 		<SvgCrossRound isAnnouncedByScreenReader size="small" />
 	);
 
-export const checkListData = ({ higherTier }: TierUnlocks): CheckListData[] => {
+export const checkListData = (
+	{ higherTier }: TierUnlocks,
+	isemotionalBenefitTestVariant: boolean,
+): CheckListData[] => {
 	const maybeGreyedOutHigherTier = higherTier ? undefined : greyedOut;
-
-	return [
+	const dataWithoutEmotionalBenefits = [
 		{
 			icon: getSvgIcon(true),
 			text: (
@@ -75,4 +77,19 @@ export const checkListData = ({ higherTier }: TierUnlocks): CheckListData[] => {
 			maybeGreyedOut: maybeGreyedOutHigherTier,
 		},
 	];
+
+	return isemotionalBenefitTestVariant
+		? [
+				{
+					icon: getSvgIcon(true),
+					text: (
+						<p>
+							<span css={boldText}>Make a bigger impact. </span>Sustain open,
+							independent journalism long term
+						</p>
+					),
+				},
+				...dataWithoutEmotionalBenefits,
+		  ]
+		: dataWithoutEmotionalBenefits;
 };

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
@@ -15,8 +15,9 @@ const boldText = css`
 	font-weight: bold;
 `;
 
-type TierUnlocks = {
+type CheckListDataProps = {
 	higherTier: boolean;
+	isEmotionalBenefitTestVariant: boolean;
 };
 
 export type CheckListData = {
@@ -32,10 +33,10 @@ export const getSvgIcon = (isUnlocked: boolean): JSX.Element =>
 		<SvgCrossRound isAnnouncedByScreenReader size="small" />
 	);
 
-export const checkListData = (
-	{ higherTier }: TierUnlocks,
-	isEmotionalBenefitTestVariant: boolean,
-): CheckListData[] => {
+export const checkListData = ({
+	higherTier,
+	isEmotionalBenefitTestVariant,
+}: CheckListDataProps): CheckListData[] => {
 	const maybeGreyedOutHigherTier = higherTier ? undefined : greyedOut;
 	return [
 		...(isEmotionalBenefitTestVariant

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -124,4 +124,27 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		seed: 12,
 	},
+	emotionalBenefitTest: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+				breakpoint: {
+					minWidth: 'tablet',
+				},
+			},
+		},
+		isActive: true,
+		referrerControlled: false,
+		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+		seed: 13,
+	},
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -142,7 +142,7 @@ export const tests: Tests = {
 				},
 			},
 		},
-		isActive: true,
+		isActive: false,
 		referrerControlled: false,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		seed: 13,

--- a/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
@@ -45,7 +45,7 @@ export const AllBenefitsUnlocked = Template.bind({});
 
 AllBenefitsUnlocked.args = {
 	title: "For £12 per month, you'll unlock",
-	checkListData: checkListData({ higherTier: true },true),
+	checkListData: checkListData({ higherTier: true }, true),
 	buttonCopy: null,
 	countryGroupId: 'GBPCountries',
 };
@@ -54,7 +54,7 @@ export const LowerTierUnlocked = Template.bind({});
 
 LowerTierUnlocked.args = {
 	title: "For £5 per month, you'll unlock",
-	checkListData: checkListData({ higherTier: false },true),
+	checkListData: checkListData({ higherTier: false }, true),
 	buttonCopy: 'Switch to £12 per month to unlock all extras',
 	countryGroupId: 'GBPCountries',
 };

--- a/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
@@ -45,7 +45,7 @@ export const AllBenefitsUnlocked = Template.bind({});
 
 AllBenefitsUnlocked.args = {
 	title: "For £12 per month, you'll unlock",
-	checkListData: checkListData({ higherTier: true }),
+	checkListData: checkListData({ higherTier: true },true),
 	buttonCopy: null,
 	countryGroupId: 'GBPCountries',
 };
@@ -54,7 +54,7 @@ export const LowerTierUnlocked = Template.bind({});
 
 LowerTierUnlocked.args = {
 	title: "For £5 per month, you'll unlock",
-	checkListData: checkListData({ higherTier: false }),
+	checkListData: checkListData({ higherTier: false },true),
 	buttonCopy: 'Switch to £12 per month to unlock all extras',
 	countryGroupId: 'GBPCountries',
 };

--- a/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
@@ -45,7 +45,7 @@ export const AllBenefitsUnlocked = Template.bind({});
 
 AllBenefitsUnlocked.args = {
 	title: "For £12 per month, you'll unlock",
-	checkListData: checkListData({ higherTier: true }, true),
+	checkListData: checkListData({ higherTier: true ,isEmotionalBenefitTestVariant: true}),
 	buttonCopy: null,
 	countryGroupId: 'GBPCountries',
 };
@@ -54,7 +54,7 @@ export const LowerTierUnlocked = Template.bind({});
 
 LowerTierUnlocked.args = {
 	title: "For £5 per month, you'll unlock",
-	checkListData: checkListData({ higherTier: false }, true),
+	checkListData: checkListData({ higherTier: false , isEmotionalBenefitTestVariant: true }),
 	buttonCopy: 'Switch to £12 per month to unlock all extras',
 	countryGroupId: 'GBPCountries',
 };


### PR DESCRIPTION
## What are you doing in this PR?
Add Emotional Benefit to checkout

## Why are you doing this?
Test whether adding in an emotional benefit in to the benefits bullet points will increase conversion
Copy is:
Make a bigger impact. Sustain open, independent journalism long term

[**Trello Card**](https://trello.com/c/a2iskxQ7/1219-emotional-benefit-added-to-checkout-engineering)


## Is this an AB test?
- [x ] Yes
- [ ] No

TEST DETAILS:
Regions: All
A/B test: Yes
A/B test name: Emotional benefit
-control vs. variant with benefit
Primary metric: Conversion rate

This test should be configured to run on all non-mobile breakpoints

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)



## Screenshots
### After change-control
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/73653255/233342987-312106f1-0b2e-459f-be1d-f3827c8a4ff5.png">

### After change-variant
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/73653255/233342842-c5eb5849-c083-423b-a0ba-43041b04c6e6.png">

<img width="934" alt="image" src="https://user-images.githubusercontent.com/73653255/233347020-d6324412-b671-42cd-821e-c0cc15ec3606.png">

