### PR TITLE
Migrate delivery instructions and separate billing address toggle to RTK

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.test.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.test.tsx
@@ -75,7 +75,7 @@ describe('Direct debit form', () => {
 			page: {
 				checkout: {
 					formErrors: [],
-					billingAddressIsSame: true,
+					billingAddressMatchesDelivery: true,
 				},
 				checkoutForm: {
 					product: {

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -167,7 +167,7 @@ export type RegularPaymentRequest = {
 	supportAbTests: AcquisitionABTest[];
 	telephoneNumber?: string;
 	promoCode?: Option<string>;
-	deliveryInstructions?: Option<string>;
+	deliveryInstructions?: string;
 	csrUsername?: string;
 	salesforceCaseId?: string;
 	recaptchaToken?: string;

--- a/support-frontend/assets/helpers/redux/checkout/addressMeta/actions.ts
+++ b/support-frontend/assets/helpers/redux/checkout/addressMeta/actions.ts
@@ -1,4 +1,4 @@
 import { addressMetaSlice } from './reducer';
 
-export const { setIsBillingAddressSame, setDeliveryInstructions } =
+export const { setBillingAddressMatchesDelivery, setDeliveryInstructions } =
 	addressMetaSlice.actions;

--- a/support-frontend/assets/helpers/redux/checkout/addressMeta/actions.ts
+++ b/support-frontend/assets/helpers/redux/checkout/addressMeta/actions.ts
@@ -1,0 +1,4 @@
+import { addressMetaSlice } from './reducer';
+
+export const { setIsBillingAddressSame, setDeliveryInstructions } =
+	addressMetaSlice.actions;

--- a/support-frontend/assets/helpers/redux/checkout/addressMeta/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/addressMeta/reducer.ts
@@ -6,8 +6,8 @@ export const addressMetaSlice = createSlice({
 	name: 'addressMeta',
 	initialState,
 	reducers: {
-		setIsBillingAddressSame(state, action: PayloadAction<boolean>) {
-			state.billingAddressIsSame = action.payload;
+		setBillingAddressMatchesDelivery(state, action: PayloadAction<boolean>) {
+			state.billingAddressMatchesDelivery = action.payload;
 		},
 		setDeliveryInstructions(state, action: PayloadAction<string>) {
 			state.deliveryInstructions = action.payload;

--- a/support-frontend/assets/helpers/redux/checkout/addressMeta/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/addressMeta/reducer.ts
@@ -1,0 +1,18 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
+import { initialState } from './state';
+
+export const addressMetaSlice = createSlice({
+	name: 'addressMeta',
+	initialState,
+	reducers: {
+		setIsBillingAddressSame(state, action: PayloadAction<boolean>) {
+			state.billingAddressIsSame = action.payload;
+		},
+		setDeliveryInstructions(state, action: PayloadAction<string>) {
+			state.deliveryInstructions = action.payload;
+		},
+	},
+});
+
+export const addressMetaReducer = addressMetaSlice.reducer;

--- a/support-frontend/assets/helpers/redux/checkout/addressMeta/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/addressMeta/state.ts
@@ -1,8 +1,8 @@
 export type AddressMetaState = {
-	billingAddressIsSame: boolean;
+	billingAddressMatchesDelivery: boolean;
 	deliveryInstructions?: string;
 };
 
 export const initialState: AddressMetaState = {
-	billingAddressIsSame: true,
+	billingAddressMatchesDelivery: true,
 };

--- a/support-frontend/assets/helpers/redux/checkout/addressMeta/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/addressMeta/state.ts
@@ -1,0 +1,8 @@
+export type AddressMetaState = {
+	billingAddressIsSame: boolean;
+	deliveryInstructions?: string;
+};
+
+export const initialState: AddressMetaState = {
+	billingAddressIsSame: true,
+};

--- a/support-frontend/assets/helpers/subscriptionsForms/formActions.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formActions.ts
@@ -17,6 +17,10 @@ import {
 	setDeliveryTownCity,
 } from 'helpers/redux/checkout/address/actions';
 import {
+	setDeliveryInstructions,
+	setIsBillingAddressSame,
+} from 'helpers/redux/checkout/addressMeta/actions';
+import {
 	setEmail as setEmailGift,
 	setFirstName as setFirstNameGift,
 	setGiftDeliveryDate,
@@ -145,10 +149,7 @@ const formActionCreators = {
 	setStartDate,
 	setBillingPeriod,
 	setPaymentMethod,
-	setBillingAddressIsSame: (isSame: boolean): Action => ({
-		type: 'SET_BILLING_ADDRESS_IS_SAME',
-		isSame,
-	}),
+	setIsBillingAddressSame,
 	onPaymentAuthorised:
 		(authorisation: PaymentAuthorisation) =>
 		(
@@ -159,10 +160,7 @@ const formActionCreators = {
 			onPaymentAuthorised(authorisation, dispatch, state);
 		},
 	setGiftStatus: setOrderIsAGift,
-	setDeliveryInstructions: (instructions: string | null): Action => ({
-		type: 'SET_DELIVERY_INSTRUCTIONS',
-		instructions,
-	}),
+	setDeliveryInstructions,
 	setGiftMessage,
 	setDigitalGiftDeliveryDate: setGiftDeliveryDate,
 	setAddDigitalSubscription: setAddDigital,

--- a/support-frontend/assets/helpers/subscriptionsForms/formActions.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formActions.ts
@@ -72,16 +72,8 @@ export type Action =
 			formSubmitted: boolean;
 	  }
 	| {
-			type: 'SET_BILLING_ADDRESS_IS_SAME';
-			isSame: boolean;
-	  }
-	| {
 			type: 'SET_ORDER_IS_GIFT';
 			orderIsAGift: boolean;
-	  }
-	| {
-			type: 'SET_DELIVERY_INSTRUCTIONS';
-			instructions: Option<string>;
 	  }
 	| {
 			type: 'SET_GIFT_MESSAGE';

--- a/support-frontend/assets/helpers/subscriptionsForms/formActions.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formActions.ts
@@ -17,8 +17,8 @@ import {
 	setDeliveryTownCity,
 } from 'helpers/redux/checkout/address/actions';
 import {
+	setBillingAddressMatchesDelivery,
 	setDeliveryInstructions,
-	setIsBillingAddressSame,
 } from 'helpers/redux/checkout/addressMeta/actions';
 import {
 	setEmail as setEmailGift,
@@ -141,7 +141,7 @@ const formActionCreators = {
 	setStartDate,
 	setBillingPeriod,
 	setPaymentMethod,
-	setIsBillingAddressSame,
+	setBillingAddressMatchesDelivery,
 	onPaymentAuthorised:
 		(authorisation: PaymentAuthorisation) =>
 		(

--- a/support-frontend/assets/helpers/subscriptionsForms/formFields.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formFields.ts
@@ -37,7 +37,7 @@ export type FormFields = PersonalDetailsState &
 	GiftingFields &
 	ProductFields & {
 		paymentMethod: PaymentMethod;
-		billingAddressIsSame: boolean;
+		billingAddressMatchesDelivery: boolean;
 		deliveryInstructions?: string;
 		csrUsername?: string;
 		salesforceCaseId?: string;
@@ -49,6 +49,7 @@ export type FormState = Omit<
 	| keyof GiftingFields
 	| keyof ProductFields
 	| 'paymentMethod'
+	| 'billingAddressMatchesDelivery'
 > & {
 	stage: Stage;
 	formErrors: Array<FormError<FormField>>;
@@ -77,8 +78,8 @@ function getFormFields(state: SubscriptionsState): FormFields {
 		fulfilmentOption: state.page.checkoutForm.product.fulfilmentOption,
 		productOption: state.page.checkoutForm.product.productOption,
 		product: getSubscriptionType(state),
-		billingAddressIsSame:
-			state.page.checkoutForm.addressMeta.billingAddressIsSame,
+		billingAddressMatchesDelivery:
+			state.page.checkoutForm.addressMeta.billingAddressMatchesDelivery,
 		orderIsAGift: state.page.checkoutForm.product.orderIsAGift,
 		deliveryInstructions:
 			state.page.checkoutForm.addressMeta.deliveryInstructions,

--- a/support-frontend/assets/helpers/subscriptionsForms/formFields.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formFields.ts
@@ -38,7 +38,7 @@ export type FormFields = PersonalDetailsState &
 	ProductFields & {
 		paymentMethod: PaymentMethod;
 		billingAddressIsSame: boolean;
-		deliveryInstructions: Option<string>;
+		deliveryInstructions?: string;
 		csrUsername?: string;
 		salesforceCaseId?: string;
 	};
@@ -77,9 +77,11 @@ function getFormFields(state: SubscriptionsState): FormFields {
 		fulfilmentOption: state.page.checkoutForm.product.fulfilmentOption,
 		productOption: state.page.checkoutForm.product.productOption,
 		product: getSubscriptionType(state),
-		billingAddressIsSame: state.page.checkout.billingAddressIsSame,
+		billingAddressIsSame:
+			state.page.checkoutForm.addressMeta.billingAddressIsSame,
 		orderIsAGift: state.page.checkoutForm.product.orderIsAGift,
-		deliveryInstructions: state.page.checkout.deliveryInstructions,
+		deliveryInstructions:
+			state.page.checkoutForm.addressMeta.deliveryInstructions,
 		giftMessage: state.page.checkoutForm.gifting.giftMessage,
 		giftDeliveryDate: state.page.checkoutForm.gifting.giftDeliveryDate,
 	};

--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.ts
@@ -5,7 +5,6 @@ import type { FormState } from 'helpers/subscriptionsForms/formFields';
 function createFormReducer() {
 	const initialState: FormState = {
 		stage: 'checkout',
-		billingAddressIsSame: true,
 		formErrors: [],
 		submissionError: null,
 		formSubmitted: false,

--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.ts
@@ -1,7 +1,6 @@
 // ----- Reducer ----- //
 import type { Action } from 'helpers/subscriptionsForms/formActions';
 import type { FormState } from 'helpers/subscriptionsForms/formFields';
-import { removeError } from 'helpers/subscriptionsForms/validation';
 
 function createFormReducer() {
 	const initialState: FormState = {
@@ -10,7 +9,6 @@ function createFormReducer() {
 		formErrors: [],
 		submissionError: null,
 		formSubmitted: false,
-		deliveryInstructions: null,
 	};
 
 	return function (state: FormState = initialState, action: Action): FormState {
@@ -30,16 +28,6 @@ function createFormReducer() {
 
 			case 'SET_FORM_SUBMITTED':
 				return { ...state, formSubmitted: action.formSubmitted };
-
-			case 'SET_BILLING_ADDRESS_IS_SAME':
-				return {
-					...state,
-					billingAddressIsSame: action.isSame,
-					formErrors: removeError('billingAddressIsSame', state.formErrors),
-				};
-
-			case 'SET_DELIVERY_INSTRUCTIONS':
-				return { ...state, deliveryInstructions: action.instructions };
 
 			case 'SET_CSR_USERNAME':
 				return {

--- a/support-frontend/assets/helpers/subscriptionsForms/formValidation.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formValidation.ts
@@ -121,7 +121,7 @@ function withDeliveryValidation(state: SubscriptionsState): AnyErrorType[] {
 }
 
 function shouldValidateBillingAddress(fields: FormFields) {
-	return !fields.billingAddressIsSame;
+	return !fields.billingAddressMatchesDelivery;
 }
 
 function dispatchAllErrors(dispatch: Dispatch, allErrors: AnyErrorType[]) {

--- a/support-frontend/assets/helpers/subscriptionsForms/rules.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/rules.ts
@@ -259,9 +259,9 @@ function applyDeliveryRules(fields: FormFields): Array<FormError<FormField>> {
 			error: formError('startDate', 'Please select a start date'),
 		},
 		{
-			rule: notNull(fields.billingAddressIsSame),
+			rule: notNull(fields.billingAddressMatchesDelivery),
 			error: formError(
-				'billingAddressIsSame',
+				'billingAddressMatchesDelivery',
 				'Please indicate whether the billing address is the same as the delivery address',
 			),
 		},

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -69,7 +69,7 @@ function getAddresses(state: SubscriptionsState): Addresses {
 
 		return {
 			deliveryAddress: deliveryAddressFields,
-			billingAddress: state.page.checkout.billingAddressIsSame
+			billingAddress: state.page.checkoutForm.addressMeta.billingAddressIsSame
 				? deliveryAddressFields
 				: billingAddressFields,
 		};
@@ -148,8 +148,8 @@ function buildRegularPaymentRequest(
 	const { actionHistory } = state.debug;
 	const { title, firstName, lastName, email, telephone } =
 		state.page.checkoutForm.personalDetails;
-	const { deliveryInstructions, csrUsername, salesforceCaseId } =
-		state.page.checkout;
+	const { deliveryInstructions } = state.page.checkoutForm.addressMeta;
+	const { csrUsername, salesforceCaseId } = state.page.checkout;
 	const product = getProduct(state, currencyId);
 	const paymentFields =
 		regularPaymentFieldsFromAuthorisation(paymentAuthorisation);

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -69,7 +69,8 @@ function getAddresses(state: SubscriptionsState): Addresses {
 
 		return {
 			deliveryAddress: deliveryAddressFields,
-			billingAddress: state.page.checkoutForm.addressMeta.billingAddressIsSame
+			billingAddress: state.page.checkoutForm.addressMeta
+				.billingAddressMatchesDelivery
 				? deliveryAddressFields
 				: billingAddressFields,
 		};

--- a/support-frontend/assets/helpers/subscriptionsForms/subscriptionCheckoutReducer.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/subscriptionCheckoutReducer.ts
@@ -6,6 +6,7 @@ import {
 } from 'helpers/redux/checkout/address/reducer';
 import type { AddressState } from 'helpers/redux/checkout/address/state';
 import { addressMetaReducer } from 'helpers/redux/checkout/addressMeta/reducer';
+import type { AddressMetaState } from 'helpers/redux/checkout/addressMeta/state';
 import { csrfReducer } from 'helpers/redux/checkout/csrf/reducer';
 import type { CsrfState } from 'helpers/redux/checkout/csrf/state';
 import { giftingReducer } from 'helpers/redux/checkout/giftingState/reducer';
@@ -42,6 +43,7 @@ export type CheckoutFormState = {
 	recaptcha: RecaptchaState;
 	billingAddress: AddressState;
 	deliveryAddress: AddressState;
+	addressMeta: AddressMetaState;
 	payment: PaymentState;
 };
 

--- a/support-frontend/assets/helpers/subscriptionsForms/subscriptionCheckoutReducer.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/subscriptionCheckoutReducer.ts
@@ -5,6 +5,7 @@ import {
 	deliveryAddressReducer,
 } from 'helpers/redux/checkout/address/reducer';
 import type { AddressState } from 'helpers/redux/checkout/address/state';
+import { addressMetaReducer } from 'helpers/redux/checkout/addressMeta/reducer';
 import { csrfReducer } from 'helpers/redux/checkout/csrf/reducer';
 import type { CsrfState } from 'helpers/redux/checkout/csrf/state';
 import { giftingReducer } from 'helpers/redux/checkout/giftingState/reducer';
@@ -70,6 +71,7 @@ export function createReducer() {
 			recaptcha: recaptchaReducer,
 			deliveryAddress: deliveryAddressReducer,
 			billingAddress: billingAddressReducer,
+			addressMeta: addressMetaReducer,
 			payment: paymentReducer,
 			thankYou: thankYouReducer,
 		}),

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -237,6 +237,10 @@ function PaperCheckoutForm(props: PropTypes) {
 
 	const expandedPricingText = `${cleanedPrice} per month`;
 
+	const deliveryInstructionsError = props.formErrors.find(
+		(error) => error.field === 'deliveryInstructions',
+	);
+
 	useEffect(() => {
 		// Price of the 'Plus' product that corresponds to the selected product option
 		const plusPrice = includesDigiSub
@@ -351,6 +355,7 @@ function PaperCheckoutForm(props: PropTypes) {
 						<DeliveryAddress countries={newspaperCountries} />
 						{isHomeDelivery ? (
 							<TextArea
+								error={deliveryInstructionsError?.message}
 								css={controlTextAreaResizing}
 								id="delivery-instructions"
 								data-qm-masking="blocklist"

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -381,7 +381,7 @@ function PaperCheckoutForm(props: PropTypes) {
 									label="Yes"
 									name="billingAddressIsSame"
 									checked={props.billingAddressIsSame}
-									onChange={() => props.setBillingAddressIsSame(true)}
+									onChange={() => props.setIsBillingAddressSame(true)}
 								/>
 
 								<Radio
@@ -390,7 +390,7 @@ function PaperCheckoutForm(props: PropTypes) {
 									value="no"
 									name="billingAddressIsSame"
 									checked={!props.billingAddressIsSame}
-									onChange={() => props.setBillingAddressIsSame(false)}
+									onChange={() => props.setIsBillingAddressSame(false)}
 								/>
 							</RadioGroup>
 						</Rows>

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -208,7 +208,7 @@ function PaperCheckoutForm(props: PropTypes) {
 
 	const paymentMethods = supportedPaymentMethods(
 		props.currencyId,
-		props.billingAddressIsSame ? props.country : props.billingCountry,
+		props.billingAddressMatchesDelivery ? props.country : props.billingCountry,
 	);
 
 	const isSubscriptionCard = props.fulfilmentOption === Collection;
@@ -375,32 +375,35 @@ function PaperCheckoutForm(props: PropTypes) {
 							<RadioGroup
 								label="Is the billing address the same as the delivery address?"
 								hideLabel
-								id="billingAddressIsSame"
-								name="billingAddressIsSame"
+								id="billingAddressMatchesDelivery"
+								name="billingAddressMatchesDelivery"
 								orientation="vertical"
-								error={firstError('billingAddressIsSame', props.formErrors)}
+								error={firstError(
+									'billingAddressMatchesDelivery',
+									props.formErrors,
+								)}
 							>
 								<Radio
 									id="qa-billing-address-same"
 									value="yes"
 									label="Yes"
-									name="billingAddressIsSame"
-									checked={props.billingAddressIsSame}
-									onChange={() => props.setIsBillingAddressSame(true)}
+									name="billingAddressMatchesDelivery"
+									checked={props.billingAddressMatchesDelivery}
+									onChange={() => props.setBillingAddressMatchesDelivery(true)}
 								/>
 
 								<Radio
 									id="qa-billing-address-different"
 									label="No"
 									value="no"
-									name="billingAddressIsSame"
-									checked={!props.billingAddressIsSame}
-									onChange={() => props.setIsBillingAddressSame(false)}
+									name="billingAddressMatchesDelivery"
+									checked={!props.billingAddressMatchesDelivery}
+									onChange={() => props.setBillingAddressMatchesDelivery(false)}
 								/>
 							</RadioGroup>
 						</Rows>
 					</FormSection>
-					{!props.billingAddressIsSame ? (
+					{!props.billingAddressMatchesDelivery ? (
 						<FormSection title="Your billing address">
 							<BillingAddress countries={newspaperCountries} />
 						</FormSection>

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyReducer.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyReducer.ts
@@ -4,6 +4,8 @@ import { combineReducers } from 'redux';
 import type { ErrorReason } from 'helpers/forms/errorReasons';
 import { billingAddressReducer } from 'helpers/redux/checkout/address/reducer';
 import type { AddressState } from 'helpers/redux/checkout/address/state';
+import { addressMetaReducer } from 'helpers/redux/checkout/addressMeta/reducer';
+import type { AddressMetaState } from 'helpers/redux/checkout/addressMeta/state';
 import { csrfReducer } from 'helpers/redux/checkout/csrf/reducer';
 import type { CsrfState } from 'helpers/redux/checkout/csrf/state';
 import { marketingConsentReducer } from 'helpers/redux/checkout/marketingConsent/reducer';
@@ -40,6 +42,7 @@ export interface PageState {
 		recaptcha: RecaptchaState;
 		payment: PaymentState;
 		billingAddress: AddressState;
+		addressMeta: AddressMetaState;
 		thankYou: ThankYouState;
 	};
 	user: UserState;
@@ -90,6 +93,7 @@ function initReducer(): Reducer<PageState> {
 			recaptcha: recaptchaReducer,
 			payment: paymentReducer,
 			billingAddress: billingAddressReducer,
+			addressMeta: addressMetaReducer,
 			thankYou: thankYouReducer,
 		}),
 		user: userReducer,

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.test.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.test.tsx
@@ -85,7 +85,7 @@ describe('Guardian Weekly checkout form', () => {
 						},
 					},
 					addressMeta: {
-						billingAddressIsSame: true,
+						billingAddressMatchesDelivery: true,
 					},
 				},
 			},

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.test.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.test.tsx
@@ -63,7 +63,6 @@ describe('Guardian Weekly checkout form', () => {
 			page: {
 				checkout: {
 					formErrors: [],
-					billingAddressIsSame: true,
 				},
 				checkoutForm: {
 					product: {
@@ -84,6 +83,9 @@ describe('Guardian Weekly checkout form', () => {
 							country: 'GB',
 							errors: [],
 						},
+					},
+					addressMeta: {
+						billingAddressIsSame: true,
 					},
 				},
 			},

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -81,11 +81,12 @@ const marginBottom = css`
 
 // ----- Map State/Props ----- //
 function mapStateToProps(state: SubscriptionsState) {
-	const { billingAddress, deliveryAddress } = state.page.checkoutForm;
-	const { billingAddressIsSame } = state.page.checkout;
+	const { billingAddress, deliveryAddress, addressMeta } =
+		state.page.checkoutForm;
+	const { billingAddressMatchesDelivery } = addressMeta;
 	return {
 		...getFormFields(state),
-		billingCountry: billingAddressIsSame
+		billingCountry: billingAddressMatchesDelivery
 			? deliveryAddress.fields.country
 			: billingAddress.fields.country,
 		deliveryCountry: deliveryAddress.fields.country,
@@ -163,8 +164,8 @@ function WeeklyCheckoutForm(props: PropTypes) {
 			? 'Sorry there was a problem'
 			: 'Sorry we could not process your payment';
 
-	const setIsBillingAddressSameHandler = (newState: boolean) => {
-		props.setIsBillingAddressSame(newState);
+	const setBillingAddressMatchesDeliveryHandler = (newState: boolean) => {
+		props.setBillingAddressMatchesDelivery(newState);
 		props.setBillingCountry(props.deliveryCountry);
 	};
 
@@ -240,32 +241,37 @@ function WeeklyCheckoutForm(props: PropTypes) {
 							<RadioGroup
 								label="Is the billing address the same as the delivery address?"
 								hideLabel
-								id="billingAddressIsSame"
-								name="billingAddressIsSame"
+								id="billingAddressMatchesDelivery"
+								name="billingAddressMatchesDelivery"
 								orientation="vertical"
-								error={firstError('billingAddressIsSame', props.formErrors)}
+								error={firstError(
+									'billingAddressMatchesDelivery',
+									props.formErrors,
+								)}
 							>
 								<Radio
 									id="qa-billing-address-same"
 									value="yes"
 									label="Yes"
-									name="billingAddressIsSame"
-									checked={props.billingAddressIsSame}
-									onChange={() => setIsBillingAddressSameHandler(true)}
+									name="billingAddressMatchesDelivery"
+									checked={props.billingAddressMatchesDelivery}
+									onChange={() => setBillingAddressMatchesDeliveryHandler(true)}
 								/>
 
 								<Radio
 									id="qa-billing-address-different"
 									label="No"
 									value="no"
-									name="billingAddressIsSame"
-									checked={!props.billingAddressIsSame}
-									onChange={() => setIsBillingAddressSameHandler(false)}
+									name="billingAddressMatchesDelivery"
+									checked={!props.billingAddressMatchesDelivery}
+									onChange={() =>
+										setBillingAddressMatchesDeliveryHandler(false)
+									}
 								/>
 							</RadioGroup>
 						</Rows>
 					</FormSection>
-					{!props.billingAddressIsSame ? (
+					{!props.billingAddressMatchesDelivery ? (
 						<FormSection title="Your billing address">
 							<BillingAddress countries={weeklyDeliverableCountries} />
 						</FormSection>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -163,8 +163,8 @@ function WeeklyCheckoutForm(props: PropTypes) {
 			? 'Sorry there was a problem'
 			: 'Sorry we could not process your payment';
 
-	const setBillingAddressIsSameHandler = (newState: boolean) => {
-		props.setBillingAddressIsSame(newState);
+	const setIsBillingAddressSameHandler = (newState: boolean) => {
+		props.setIsBillingAddressSame(newState);
 		props.setBillingCountry(props.deliveryCountry);
 	};
 
@@ -251,7 +251,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 									label="Yes"
 									name="billingAddressIsSame"
 									checked={props.billingAddressIsSame}
-									onChange={() => setBillingAddressIsSameHandler(true)}
+									onChange={() => setIsBillingAddressSameHandler(true)}
 								/>
 
 								<Radio
@@ -260,7 +260,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 									value="no"
 									name="billingAddressIsSame"
 									checked={!props.billingAddressIsSame}
-									onChange={() => setBillingAddressIsSameHandler(false)}
+									onChange={() => setIsBillingAddressSameHandler(false)}
 								/>
 							</RadioGroup>
 						</Rows>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx
@@ -63,7 +63,7 @@ describe('Guardian Weekly checkout form', () => {
 						},
 					},
 					addressMeta: {
-						billingAddressIsSame: true,
+						billingAddressMatchesDelivery: true,
 					},
 				},
 			},

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx
@@ -41,7 +41,6 @@ describe('Guardian Weekly checkout form', () => {
 			page: {
 				checkout: {
 					formErrors: [],
-					billingAddressIsSame: true,
 				},
 				checkoutForm: {
 					product: {
@@ -62,6 +61,9 @@ describe('Guardian Weekly checkout form', () => {
 							country: 'GB',
 							errors: [],
 						},
+					},
+					addressMeta: {
+						billingAddressIsSame: true,
 					},
 				},
 			},

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
@@ -162,8 +162,8 @@ function WeeklyCheckoutFormGifting(props: PropTypes): JSX.Element {
 			? 'Sorry there was a problem'
 			: 'Sorry we could not process your payment';
 
-	const setBillingAddressIsSameHandler = (newState: boolean) => {
-		props.setBillingAddressIsSame(newState);
+	const setIsBillingAddressSameHandler = (newState: boolean) => {
+		props.setIsBillingAddressSame(newState);
 		props.setBillingCountry(props.deliveryCountry);
 	};
 
@@ -342,7 +342,7 @@ function WeeklyCheckoutFormGifting(props: PropTypes): JSX.Element {
 									label="Yes"
 									name="billingAddressIsSame"
 									checked={props.billingAddressIsSame}
-									onChange={() => setBillingAddressIsSameHandler(true)}
+									onChange={() => setIsBillingAddressSameHandler(true)}
 								/>
 
 								<Radio
@@ -351,7 +351,7 @@ function WeeklyCheckoutFormGifting(props: PropTypes): JSX.Element {
 									value="no"
 									name="billingAddressIsSame"
 									checked={!props.billingAddressIsSame}
-									onChange={() => setBillingAddressIsSameHandler(false)}
+									onChange={() => setIsBillingAddressSameHandler(false)}
 								/>
 							</RadioGroup>
 						</Rows>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
@@ -79,12 +79,13 @@ const marginBottom = css`
 
 // ----- Map State/Props ----- //
 function mapStateToProps(state: SubscriptionsState) {
-	const { billingAddress, deliveryAddress } = state.page.checkoutForm;
-	const { billingAddressIsSame } = state.page.checkout;
+	const { billingAddress, deliveryAddress, addressMeta } =
+		state.page.checkoutForm;
+	const { billingAddressMatchesDelivery } = addressMeta;
 
 	return {
 		...getFormFields(state),
-		billingCountry: billingAddressIsSame
+		billingCountry: billingAddressMatchesDelivery
 			? deliveryAddress.fields.country
 			: billingAddress.fields.country,
 		deliveryCountry: deliveryAddress.fields.country,
@@ -162,8 +163,8 @@ function WeeklyCheckoutFormGifting(props: PropTypes): JSX.Element {
 			? 'Sorry there was a problem'
 			: 'Sorry we could not process your payment';
 
-	const setIsBillingAddressSameHandler = (newState: boolean) => {
-		props.setIsBillingAddressSame(newState);
+	const setBillingAddressMatchesDeliveryHandler = (newState: boolean) => {
+		props.setBillingAddressMatchesDelivery(newState);
 		props.setBillingCountry(props.deliveryCountry);
 	};
 
@@ -330,33 +331,38 @@ function WeeklyCheckoutFormGifting(props: PropTypes): JSX.Element {
 							<RadioGroup
 								label="Is the billing address the same as the recipient's address?"
 								hideLabel
-								id="billingAddressIsSame"
-								name="billingAddressIsSame"
+								id="billingAddressMatchesDelivery"
+								name="billingAddressMatchesDelivery"
 								orientation="vertical"
 								error={
-									firstError('billingAddressIsSame', props.formErrors) as string
+									firstError(
+										'billingAddressMatchesDelivery',
+										props.formErrors,
+									) as string
 								}
 							>
 								<Radio
 									value="yes"
 									label="Yes"
-									name="billingAddressIsSame"
-									checked={props.billingAddressIsSame}
-									onChange={() => setIsBillingAddressSameHandler(true)}
+									name="billingAddressMatchesDelivery"
+									checked={props.billingAddressMatchesDelivery}
+									onChange={() => setBillingAddressMatchesDeliveryHandler(true)}
 								/>
 
 								<Radio
 									id="qa-billing-address-different"
 									label="No"
 									value="no"
-									name="billingAddressIsSame"
-									checked={!props.billingAddressIsSame}
-									onChange={() => setIsBillingAddressSameHandler(false)}
+									name="billingAddressMatchesDelivery"
+									checked={!props.billingAddressMatchesDelivery}
+									onChange={() =>
+										setBillingAddressMatchesDeliveryHandler(false)
+									}
 								/>
 							</RadioGroup>
 						</Rows>
 					</FormSection>
-					{!props.billingAddressIsSame ? (
+					{!props.billingAddressMatchesDelivery ? (
 						<FormSection title="Your billing address">
 							<BillingAddress countries={countries} />
 						</FormSection>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This creates an `addressMeta` slice that manages a couple of additional bits of address-related information:

- Delivery instructions for newspaper home delivery
- Whether or not the user's billing address is different to their delivery address

This also fixes a small bug where errors relating to the delivery instructions field- if users entered characters that aren't compatible with Zuora's database- were not being passed to the text area component to be displayed inline as well as in the error summary at the bottom of the form.

[**Trello Card**](https://trello.com/c/FeSSCuFe)

## Why are you doing this?

This is a bit of address-related state that we missed in the original address migration.