### PR TITLE
Fix bug with renewal date display in S+ terms & conditions

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
@@ -14,7 +14,10 @@ import { contributionsTermsLinks, privacyLink } from 'helpers/legal';
 import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
 import { benefitsThresholdsByCountryGroup } from 'helpers/supporterPlus/benefitsThreshold';
 import { manageSubsUrl } from 'helpers/urls/externalLinks';
-import { getDateWithOrdinal } from 'helpers/utilities/dateFormatting';
+import {
+	getDateWithOrdinal,
+	getLongMonth,
+} from 'helpers/utilities/dateFormatting';
 
 const marginTop = css`
 	margin-top: 4px;
@@ -55,6 +58,23 @@ const termsSupporterPlus = (linkText: string) => (
 		{linkText}
 	</a>
 );
+
+function TsAndCsRenewal({
+	contributionType,
+}: {
+	contributionType: ContributionType;
+}): JSX.Element {
+	const today = new Date();
+	if (contributionType === 'ANNUAL') {
+		return (
+			<>
+				on the {getDateWithOrdinal(today)} day of {getLongMonth(today)} every{' '}
+				year
+			</>
+		);
+	}
+	return <>on the {getDateWithOrdinal(today)} day of every month</>;
+}
 
 function TsAndCsFooterLinks({
 	countryGroupId,
@@ -112,12 +132,11 @@ export function PaymentTsAndCs({
 		return (
 			<>
 				<div>
-					We will attempt to take payment{amountCopy}, on the{' '}
-					{getDateWithOrdinal(new Date())} day of every{' '}
-					{frequencySingular(contributionType)}, from now until you cancel your
-					payment. Payments may take up to 6 days to be recorded in your bank
-					account. You can change how much you give or cancel your payment at
-					any time.
+					We will attempt to take payment{amountCopy},{' '}
+					<TsAndCsRenewal contributionType={contributionType} />, from now until
+					you cancel your payment. Payments may take up to 6 days to be recorded
+					in your bank account. You can change how much you give or cancel your
+					payment at any time.
 				</div>
 				<TsAndCsFooterLinks
 					countryGroupId={countryGroupId}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes a bug where a user signing up for an annual contribution of an amount below the Supporter Plus threshold would see an incorrect date in the terms and conditions.

[**Trello Card**](https://trello.com/c/uL6COPQL)

## Screenshots

**Before**
![Screenshot 2023-04-21 at 13 54 14](https://user-images.githubusercontent.com/29146931/233641770-bf337fcc-01fe-421e-afb6-0fcaa606a462.png)

**After**
![Screenshot 2023-04-21 at 13 53 49](https://user-images.githubusercontent.com/29146931/233641824-5ca7da05-1429-4889-8dbb-56bc84ba0901.png)
