### PR TITLE
Revert billing country logic change

### DIFF
--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -11,9 +11,8 @@ export function getStateOrProvinceError(
 	const contributionType = getContributionType(state);
 	const billingCountryGroup = fromCountry(
 		getBillingCountryAndState(
-			state,
 			state.page.checkoutForm.payment.paymentMethod.name,
-			state.page.checkoutForm.payment.paymentMethod.stripePaymentMethod,
+			state,
 		).billingCountry,
 	);
 	if (

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -138,9 +138,8 @@ const stripeChargeDataFromPaymentIntentAuthorisation = (
 	);
 
 function getBillingCountryAndState(
-	state: ContributionsState,
 	paymentMethod: PaymentMethod,
-	stripePaymentMethod?: StripePaymentMethod,
+	state: ContributionsState,
 ): {
 	billingCountry: IsoCountry;
 	billingState: Option<StateProvince>;
@@ -159,12 +158,8 @@ function getBillingCountryAndState(
 
 	// If the page form has a billingCountry, then it must have been provided by a wallet, ApplePay or
 	// Payment Request Button, which will already have filtered the billingState by stateProvinceFromString,
-	// so we can trust both values, verbatim, as long as the current payment method is one of those.
-	const isPaymentRequestButton =
-		paymentMethod == Stripe &&
-		(stripePaymentMethod === 'StripePaymentRequestButton' ||
-			stripePaymentMethod === 'StripeApplePay');
-	if (billingCountry && isPaymentRequestButton) {
+	// so we can trust both values, verbatim.
+	if (billingCountry) {
 		return {
 			billingCountry,
 			billingState,
@@ -239,11 +234,8 @@ function regularPaymentRequestFromAuthorisation(
 ): RegularPaymentRequest {
 	const { actionHistory } = state.debug;
 	const { billingCountry, billingState } = getBillingCountryAndState(
-		state,
 		authorisation.paymentMethod,
-		authorisation.paymentMethod === 'Stripe'
-			? authorisation.stripePaymentMethod
-			: undefined,
+		state,
 	);
 	const recaptchaToken = state.page.checkoutForm.recaptcha.token;
 	const contributionType = getContributionType(state);

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -186,7 +186,7 @@ function getBillingCountryAndState(
 	const fallbackCountry =
 		findIsoCountry(window.guardian.geoip?.countryCode) ?? pageBaseCountry;
 	const fallbackState = stateProvinceFromString(
-		billingCountry,
+		fallbackCountry,
 		window.guardian.geoip?.stateCode,
 	);
 	return {


### PR DESCRIPTION
## Revert billing country logic change

I changed this logic to fix a bug where incorrect payment request button country info was getting reused on subsequent payment attempts (with different payment methods). However, it caused another bug: [the fallback logic](https://github.com/guardian/support-frontend/blob/7c692d7212d169d8d026f3767debaa43e96f2613/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts#L183-L195) prioritises geolocation over detection of region based on the path of the page, unlike [the initial detection of the billing country on page load](https://github.com/guardian/support-frontend/blob/7c692d7212d169d8d026f3767debaa43e96f2613/support-frontend/assets/helpers/redux/checkout/address/state.ts#L50).

This meant that users trying to use a currency other than that of their current (inferred) location, e.g. U.S. users attempting to pay in Canadian dollars or vice-versa, were unable to checkout successfully: the geolocation would detect the other country, and the state they entered would no longer be valid. The only way they could correct the error was by returning to the form that matched the country the geolocation thought they were in (and the geolocation may have been wrong, making things extra confusing for them).

Since this case appears to be more frequent than the Apple Pay problems we’ve had (based on the rate of errors), we’ve decided to revert pending a comprehensive fix.

This PR partially reverts commit c4fae6dcf24baf017d53c7499729f08f70bca4d7.

## Missed renaming: billingCountry -> fallbackCountry

The variable `fallbackCountry` here used to be called `billingCountry`, and was renamed in [commit cc42b3734141947383233909287bac2a17b8b425](https://github.com/guardian/support-frontend/commit/cc42b3734141947383233909287bac2a17b8b425#diff-6479026456bf36aed9635d37b78393c9dfe3ba4de67ba0efdf75d7346e2a5e2cR266-R274). However, this usage wasn’t renamed, meaning that when we get to this fallback case the state will likely fail to parse, as it’s being parsed based on the wrong country.