### PR TITLE
Fix accessibility issues with the Tooltip component and make it more reusable

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
@@ -6,7 +6,7 @@ import {
 	space,
 	textSans,
 } from '@guardian/source-foundations';
-import CancelAnytimeTooltip from 'components/tooltip/Tooltip';
+import Tooltip from 'components/tooltip/Tooltip';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { CSSOverridable } from 'helpers/types/cssOverrideable';
 import type { CheckListData } from './checkoutBenefitsListData';
@@ -97,7 +97,14 @@ export function CheckoutBenefitsList({
 				))}
 			</table>
 			<hr css={hr(`${space[5]}px 0 ${space[4]}px`)} />
-			<CancelAnytimeTooltip countryGroupId={countryGroupId} />
+			<Tooltip promptText="Cancel anytime">
+				<p>
+					You can cancel
+					{countryGroupId === 'GBPCountries' ? '' : ' online'} anytime before
+					your next payment date. If you cancel in the first 14 days, you will
+					receive a full refund.
+				</p>
+			</Tooltip>
 		</div>
 	);
 }

--- a/support-frontend/assets/components/tooltip/Tooltip.tsx
+++ b/support-frontend/assets/components/tooltip/Tooltip.tsx
@@ -161,7 +161,7 @@ const arrowTop = css`
 	}
 `;
 
-type TooltipProps = {
+export type TooltipProps = {
 	promptText: string;
 	buttonLabel?: string;
 	children: React.ReactNode;

--- a/support-frontend/assets/components/tooltip/Tooltip.tsx
+++ b/support-frontend/assets/components/tooltip/Tooltip.tsx
@@ -20,7 +20,6 @@ import {
 } from '@guardian/source-foundations';
 import { Button, SvgCross } from '@guardian/source-react-components';
 import { useState } from 'react';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { InfoRound } from './InfoRound';
 
 const buttonAndTooltipContainer = css`
@@ -162,11 +161,17 @@ const arrowTop = css`
 	}
 `;
 
+type TooltipProps = {
+	promptText: string;
+	buttonLabel?: string;
+	children: React.ReactNode;
+};
+
 export default function Tooltip({
-	countryGroupId,
-}: {
-	countryGroupId: CountryGroupId;
-}): JSX.Element {
+	promptText,
+	buttonLabel = 'More information',
+	children,
+}: TooltipProps): JSX.Element {
 	const [open, setOpen] = useState(false);
 
 	const { x, y, refs, strategy, context } = useFloating({
@@ -204,7 +209,7 @@ export default function Tooltip({
 			ref={refs.setReference}
 			{...getReferenceProps()}
 		>
-			<p css={copy}>Cancel anytime</p>
+			<p css={copy}>{promptText}</p>
 			<div css={buttonAndTooltipContainer}>
 				<div>
 					<Button
@@ -213,7 +218,7 @@ export default function Tooltip({
 						priority="tertiary"
 						css={buttonOverrides}
 					>
-						More information
+						{buttonLabel}
 					</Button>
 				</div>
 				<FloatingPortal>
@@ -237,10 +242,7 @@ export default function Tooltip({
 						{...getFloatingProps()}
 					>
 						<div css={tooltipCss}>
-							You can cancel
-							{countryGroupId === 'GBPCountries' ? '' : ' online'} anytime
-							before your next payment date. If you cancel in the first 14 days,
-							you will receive a full refund.
+							{children}
 							<Button
 								onClick={() => setOpen(false)}
 								icon={<SvgCross size="xsmall" />}
@@ -248,7 +250,9 @@ export default function Tooltip({
 								hideLabel
 								priority="secondary"
 								cssOverrides={closeButtonOverrides}
-							/>
+							>
+								Close
+							</Button>
 							<div
 								css={context.placement === 'top' ? arrowBottom : arrowTop}
 							></div>

--- a/support-frontend/assets/components/tooltip/Tooltip.tsx
+++ b/support-frontend/assets/components/tooltip/Tooltip.tsx
@@ -8,9 +8,7 @@ import {
 	useClick,
 	useDismiss,
 	useFloating,
-	useFocus,
 	useInteractions,
-	useRole,
 } from '@floating-ui/react';
 import {
 	between,
@@ -18,6 +16,7 @@ import {
 	space,
 	textSans,
 	until,
+	visuallyHidden,
 } from '@guardian/source-foundations';
 import { Button, SvgCross } from '@guardian/source-react-components';
 import { useState } from 'react';
@@ -190,19 +189,13 @@ export default function Tooltip({
 	});
 
 	// Event listeners to change the open state
-	const click = useClick(context);
-	const focus = useFocus(context);
+	const click = useClick(context, { toggle: false });
 	const dismiss = useDismiss(context);
-
-	// Role props for screen readers
-	const role = useRole(context, { role: 'tooltip' });
 
 	// Merge all the interactions into prop getters
 	const { getReferenceProps, getFloatingProps } = useInteractions([
 		click,
-		focus,
 		dismiss,
-		role,
 	]);
 
 	return (
@@ -219,42 +212,48 @@ export default function Tooltip({
 						icon={<InfoRound />}
 						priority="tertiary"
 						css={buttonOverrides}
-					/>
+					>
+						More information
+					</Button>
 				</div>
 				<FloatingPortal>
-					{open ? (
-						<div css={tooltipContainer}>
+					<div
+						role="status"
+						css={[
+							tooltipContainer,
+							open
+								? css``
+								: css`
+										${visuallyHidden}
+								  `,
+						]}
+						ref={refs.setFloating}
+						style={{
+							// Positioning styles
+							position: strategy,
+							top: y ?? 0,
+							left: x ?? 0,
+						}}
+						{...getFloatingProps()}
+					>
+						<div css={tooltipCss}>
+							You can cancel
+							{countryGroupId === 'GBPCountries' ? '' : ' online'} anytime
+							before your next payment date. If you cancel in the first 14 days,
+							you will receive a full refund.
+							<Button
+								onClick={() => setOpen(false)}
+								icon={<SvgCross size="xsmall" />}
+								size="small"
+								hideLabel
+								priority="secondary"
+								cssOverrides={closeButtonOverrides}
+							/>
 							<div
-								css={tooltipCss}
-								ref={refs.setFloating}
-								style={{
-									// Positioning styles
-									position: strategy,
-									top: y ?? 0,
-									left: x ?? 0,
-								}}
-								{...getFloatingProps()}
-							>
-								You can cancel
-								{countryGroupId === 'GBPCountries' ? '' : ' online'} anytime
-								before your next payment date. If you cancel in the first 14
-								days, you will receive a full refund.
-								<Button
-									onClick={() => setOpen(false)}
-									icon={<SvgCross size="xsmall" />}
-									size="small"
-									hideLabel
-									priority="secondary"
-									cssOverrides={closeButtonOverrides}
-								/>
-								<div
-									css={context.placement === 'top' ? arrowBottom : arrowTop}
-								></div>
-							</div>
+								css={context.placement === 'top' ? arrowBottom : arrowTop}
+							></div>
 						</div>
-					) : (
-						<div />
-					)}
+					</div>
 				</FloatingPortal>
 			</div>
 		</div>

--- a/support-frontend/stories/content/Tooltip.stories.tsx
+++ b/support-frontend/stories/content/Tooltip.stories.tsx
@@ -1,0 +1,36 @@
+import type { TooltipProps } from 'components/tooltip/Tooltip';
+import TooltipComponent from 'components/tooltip/Tooltip';
+
+export default {
+	title: 'Content/Tooltip',
+	component: TooltipComponent,
+	decorators: [
+		(Story: React.FC): JSX.Element => (
+			<div
+				style={{
+					width: 'max-content',
+				}}
+			>
+				<Story />
+			</div>
+		),
+	],
+};
+
+function Template(args: TooltipProps): JSX.Element {
+	return <TooltipComponent {...args} />;
+}
+
+Template.args = {} as TooltipProps;
+
+export const Tooltip = Template.bind({});
+
+Tooltip.args = {
+	promptText: 'Cancel anytime',
+	children: (
+		<p>
+			You can cancel anytime before your next payment date. If you cancel in the
+			first 14 days, you will receive a full refund.
+		</p>
+	),
+};


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR fixes an issue where the activation button for the `Tooltip` component had no label, and the contents of the tooltip were not read by screenreaders. It also moves the specific cancellation-related text out of the component itself, so it's more reusable if we need it elsewhere in the future.

I've implemented a [toggletip](https://inclusive-components.design/tooltips-toggletips/) pattern here as it makes the interaction make the most sense for screen reader users- the tooltip will not appear or be read until the button is actually _activated_, rather than just focused. After experimenting with the accessibility options provided by the floating-ui/react library I couldn't find one that would assign a role that actually had the tooltip contents be read aloud when the tooltip is inserted, so instead I've manually assigned the `status` role to the element that gets inserted.

[**Trello Card**](https://trello.com/c/TsWbZTNW)

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)
