### PR TITLE
Store payment method country/state separately

### DIFF
--- a/support-frontend/assets/components/paymentRequestButton/hooks/payerDetails.ts
+++ b/support-frontend/assets/components/paymentRequestButton/hooks/payerDetails.ts
@@ -3,20 +3,17 @@ import type {
 	PaymentRequestPaymentMethodEvent,
 } from '@stripe/stripe-js';
 import {
-	detect as detectCountry,
 	findIsoCountry,
 	stateProvinceFromString,
 } from 'helpers/internationalisation/country';
-import {
-	setBillingCountry,
-	setBillingState,
-} from 'helpers/redux/checkout/address/actions';
+import { setPaymentMethodCountryAndState } from 'helpers/redux/checkout/payment/paymentMethod/actions';
 import {
 	setEmail,
 	setFirstName,
 	setLastName,
 } from 'helpers/redux/checkout/personalDetails/actions';
 import type { ContributionsDispatch } from 'helpers/redux/contributionsStore';
+import * as storage from 'helpers/storage/storage';
 import { logException } from 'helpers/utilities/logger';
 
 function setPayerName(
@@ -49,7 +46,7 @@ function setPayerEmail(
 	}
 }
 
-function setBillingCountryAndState(
+function dispatchPaymentMethodCountryAndState(
 	dispatch: ContributionsDispatch,
 	billingDetails: PaymentMethod.BillingDetails,
 ): void {
@@ -63,8 +60,12 @@ function setBillingCountryAndState(
 			state ?? undefined,
 		);
 
-		dispatch(setBillingCountry(validatedCountry));
-		dispatch(setBillingState(validatedState ?? ''));
+		dispatch(
+			setPaymentMethodCountryAndState([
+				validatedCountry,
+				validatedState ?? undefined,
+			]),
+		);
 	}
 }
 
@@ -75,13 +76,9 @@ export function addPayerDetailsToRedux(
 	const { paymentMethod, payerName, payerEmail } = paymentMethodEvent;
 	payerName && setPayerName(dispatch, payerName);
 	setPayerEmail(dispatch, payerEmail);
-	setBillingCountryAndState(dispatch, paymentMethod.billing_details);
+	dispatchPaymentMethodCountryAndState(dispatch, paymentMethod.billing_details);
 }
 
 export function resetPayerDetails(dispatch: ContributionsDispatch): void {
-	dispatch(setEmail(''));
-	dispatch(setFirstName(''));
-	dispatch(setLastName(''));
-	dispatch(setBillingCountry(detectCountry()));
-	dispatch(setBillingState(''));
+	dispatch(setEmail(storage.getSession('gu.email') ?? ''));
 }

--- a/support-frontend/assets/components/personalDetails/personalDetailsContainer.tsx
+++ b/support-frontend/assets/components/personalDetails/personalDetailsContainer.tsx
@@ -32,8 +32,8 @@ export function PersonalDetailsContainer({
 	const isSignedIn = useContributionsSelector(
 		(state) => state.page.user.isSignedIn,
 	);
-	const countryGroupId = useContributionsSelector(
-		(state) => state.common.internationalisation.countryGroupId,
+	const countryId = useContributionsSelector(
+		(state) => state.common.internationalisation.countryId,
 	);
 
 	function onEmailChange(email: string) {
@@ -65,7 +65,7 @@ export function PersonalDetailsContainer({
 		signOutLink: <Signout isSignedIn={isSignedIn} />,
 		contributionState: (
 			<StateSelect
-				countryGroupId={countryGroupId}
+				countryId={countryId}
 				contributionType={contributionType}
 				state={state}
 				onStateChange={onBillingStateChange}

--- a/support-frontend/assets/components/personalDetails/stateSelect.tsx
+++ b/support-frontend/assets/components/personalDetails/stateSelect.tsx
@@ -1,15 +1,17 @@
 import { Option, Select } from '@guardian/source-react-components';
 import type { ContributionType } from 'helpers/contributions';
+import type { IsoCountry } from 'helpers/internationalisation/country';
 import {
 	auStates,
 	caStates,
 	usStates,
 } from 'helpers/internationalisation/country';
+import { fromCountry } from 'helpers/internationalisation/countryGroup';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { shouldCollectStateForContributions } from 'helpers/internationalisation/shouldCollectStateForContribs';
 
 type StateSelectProps = {
-	countryGroupId: CountryGroupId;
+	countryId: IsoCountry;
 	contributionType: ContributionType;
 	state: string;
 	onStateChange: (newState: string) => void;
@@ -29,29 +31,30 @@ const stateLists: Partial<Record<CountryGroupId, Record<string, string>>> = {
 };
 
 export function StateSelect({
-	countryGroupId,
+	countryId,
 	contributionType,
 	state,
 	onStateChange,
 	error,
 }: StateSelectProps): JSX.Element | null {
-	const statesList = stateLists[countryGroupId] ?? {};
+	const countryGroupId = fromCountry(countryId);
+	const statesList = (countryGroupId ? stateLists[countryGroupId] : {}) ?? {};
+	const stateDescriptor =
+		(countryGroupId ? stateDescriptors[countryGroupId] : 'State') ?? 'State';
 
-	if (shouldCollectStateForContributions(countryGroupId, contributionType)) {
+	if (shouldCollectStateForContributions(countryId, contributionType)) {
 		return (
 			<div>
 				<Select
 					id="state"
-					label={stateDescriptors[countryGroupId] ?? 'State'}
+					label={stateDescriptor}
 					value={state}
 					onChange={(e) => onStateChange(e.target.value)}
 					error={error}
 				>
 					<>
 						<Option value="">
-							{`Select your ${
-								stateDescriptors[countryGroupId]?.toLowerCase() ?? 'state'
-							}`}
+							{`Select your ${stateDescriptor.toLowerCase()}`}
 						</Option>
 						{Object.entries(statesList).map(([abbreviation, name]) => {
 							return (

--- a/support-frontend/assets/helpers/__tests__/formValidation.ts
+++ b/support-frontend/assets/helpers/__tests__/formValidation.ts
@@ -1,19 +1,10 @@
 // ----- Imports ----- //
 import {
 	amountOrOtherAmountIsValid,
-	checkStateIfApplicable,
 	maxTwoDecimals,
 	notLongerThan,
 } from '../forms/formValidation';
-import {
-	AUDCountries,
-	Canada,
-	EURCountries,
-	GBPCountries,
-	International,
-	NZDCountries,
-	UnitedStates,
-} from '../internationalisation/countryGroup';
+import { UnitedStates } from '../internationalisation/countryGroup';
 
 // ----- Tests ----- //
 
@@ -42,124 +33,6 @@ describe('formValidation', () => {
 		});
 		it('should return false for empty string', () => {
 			expect(maxTwoDecimals('-12')).toEqual(false);
-		});
-	});
-	describe('checkStateIfApplicable', () => {
-		const contributionType = 'MONTHLY';
-
-		it('should return false if state is null', () => {
-			const state = null;
-			const countryGroupId = UnitedStates;
-			expect(
-				checkStateIfApplicable(state, countryGroupId, contributionType),
-			).toEqual(false);
-		});
-		it('should return true if countryGroupId is UnitedStates and state is a string', () => {
-			const state = 'CA';
-			const countryGroupId = UnitedStates;
-			expect(
-				checkStateIfApplicable(state, countryGroupId, contributionType),
-			).toEqual(true);
-		});
-		it('should return true if countryGroupId is Canada and state is a string', () => {
-			const state = 'AL';
-			const countryGroupId = Canada;
-			expect(
-				checkStateIfApplicable(state, countryGroupId, contributionType),
-			).toEqual(true);
-		});
-		it('should return true if countryGroupId is AUDCountries and state is a string', () => {
-			const state = 'NSW';
-			const countryGroupId = AUDCountries;
-			expect(
-				checkStateIfApplicable(state, countryGroupId, contributionType),
-			).toEqual(true);
-		});
-		it('should return true if countryGroupId is AUDCountries and country uses AUD but is not AU, false otherwise', () => {
-			const countryGroupId = AUDCountries;
-			const state = 'NSW';
-			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- disable for test
-			window.guardian = window.guardian || {};
-			window.guardian.geoip = window.guardian.geoip ?? { countryCode: 'TV' };
-			window.guardian.geoip.countryCode = 'TV';
-			expect(
-				checkStateIfApplicable(state, countryGroupId, contributionType),
-			).toEqual(true);
-			expect(
-				checkStateIfApplicable(null, countryGroupId, contributionType),
-			).toEqual(true);
-			expect(checkStateIfApplicable(null, countryGroupId, 'ONE_OFF')).toEqual(
-				true,
-			);
-			expect(checkStateIfApplicable(null, countryGroupId, 'ANNUAL')).toEqual(
-				true,
-			);
-			window.guardian.geoip.countryCode = 'AU';
-			expect(
-				checkStateIfApplicable(state, countryGroupId, contributionType),
-			).toEqual(true);
-			expect(
-				checkStateIfApplicable(null, countryGroupId, contributionType),
-			).toEqual(false);
-			expect(checkStateIfApplicable(null, countryGroupId, 'ONE_OFF')).toEqual(
-				true,
-			);
-			window.guardian.geoip.countryCode = 'GB';
-			expect(
-				checkStateIfApplicable(state, countryGroupId, contributionType),
-			).toEqual(true);
-			expect(
-				checkStateIfApplicable(null, countryGroupId, contributionType),
-			).toEqual(false);
-			expect(checkStateIfApplicable(null, countryGroupId, 'ONE_OFF')).toEqual(
-				true,
-			);
-			// This function tests for presence, it does not validate state and country
-			expect(
-				checkStateIfApplicable('NY', countryGroupId, contributionType),
-			).toEqual(true);
-			expect(checkStateIfApplicable(null, countryGroupId, 'ONE_OFF')).toEqual(
-				true,
-			);
-			// Function supports no geoip
-			delete window.guardian.geoip;
-			expect(
-				checkStateIfApplicable(state, countryGroupId, contributionType),
-			).toEqual(true);
-			expect(
-				checkStateIfApplicable(null, countryGroupId, contributionType),
-			).toEqual(false);
-			expect(checkStateIfApplicable(null, countryGroupId, 'ONE_OFF')).toEqual(
-				true,
-			);
-		});
-		it('should return true if countryGroupId is not Canada, AUDCountries or United States regardless of the state', () => {
-			let state: string | null = 'AL';
-			expect(
-				checkStateIfApplicable(state, GBPCountries, contributionType),
-			).toEqual(true);
-			expect(
-				checkStateIfApplicable(state, EURCountries, contributionType),
-			).toEqual(true);
-			expect(
-				checkStateIfApplicable(state, International, contributionType),
-			).toEqual(true);
-			expect(
-				checkStateIfApplicable(state, NZDCountries, contributionType),
-			).toEqual(true);
-			state = null;
-			expect(
-				checkStateIfApplicable(state, GBPCountries, contributionType),
-			).toEqual(true);
-			expect(
-				checkStateIfApplicable(state, EURCountries, contributionType),
-			).toEqual(true);
-			expect(
-				checkStateIfApplicable(state, International, contributionType),
-			).toEqual(true);
-			expect(
-				checkStateIfApplicable(state, NZDCountries, contributionType),
-			).toEqual(true);
 		});
 	});
 	describe('amountOrOtherAmountIsValid', () => {

--- a/support-frontend/assets/helpers/forms/formValidation.ts
+++ b/support-frontend/assets/helpers/forms/formValidation.ts
@@ -5,17 +5,7 @@ import type {
 	OtherAmounts,
 	SelectedAmounts,
 } from 'helpers/contributions';
-import { fromString as isoCountryFromString } from 'helpers/internationalisation/country';
-import type {
-	CountryGroup,
-	CountryGroupId,
-} from 'helpers/internationalisation/countryGroup';
-import {
-	AUDCountries,
-	Canada,
-	countryGroups,
-	UnitedStates,
-} from '../internationalisation/countryGroup';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { LocalCurrencyCountry } from '../internationalisation/localCurrencyCountry';
 
 const daysFromNowForGift = 89;
@@ -168,40 +158,6 @@ export const amountOrOtherAmountIsValid = (
 		localCurrencyCountry,
 		useLocalCurrency,
 	);
-};
-export const checkStateIfApplicable: (
-	arg0: string | null,
-	arg1: CountryGroupId,
-	arg2: ContributionType,
-) => boolean = (
-	billingState: string | null,
-	countryGroupId: CountryGroupId,
-	contributionType: ContributionType,
-) => {
-	if (contributionType !== 'ONE_OFF') {
-		if (countryGroupId === UnitedStates || countryGroupId === Canada) {
-			return checkBillingState(billingState);
-		} else if (countryGroupId === AUDCountries) {
-			// Allow no state to be selected if the user is GEO-IP'd to one of the non AU countries that use AUD.
-			if (window.guardian.geoip) {
-				const AUDCountryGroup: CountryGroup = countryGroups[AUDCountries];
-				const AUDCountriesWithNoStates = AUDCountryGroup.countries.filter(
-					(c) => c !== 'AU',
-				);
-
-				const geoCountry = isoCountryFromString(
-					window.guardian.geoip.countryCode,
-				);
-				if (geoCountry && AUDCountriesWithNoStates.includes(geoCountry)) {
-					return true;
-				}
-			}
-
-			return checkBillingState(billingState);
-		}
-	}
-
-	return true;
 };
 // ignores all spaces
 export const isValidIban = (iban?: string): boolean =>

--- a/support-frontend/assets/helpers/internationalisation/country.ts
+++ b/support-frontend/assets/helpers/internationalisation/country.ts
@@ -818,6 +818,10 @@ function fromGeolocation(): IsoCountry | null | undefined {
 	return null;
 }
 
+function fromOldGeolocation(): IsoCountry | null | undefined {
+	return findIsoCountry(window.guardian.geoip?.countryCode);
+}
+
 function setCountry(country: IsoCountry): void {
 	cookie.set('GU_country', country, 7);
 }
@@ -901,6 +905,7 @@ function detect(
 			fromQueryParameter() ??
 			fromCookie() ??
 			fromGeolocation() ??
+			fromOldGeolocation() ??
 			'GB';
 	}
 
@@ -908,9 +913,14 @@ function detect(
 	return country;
 }
 
+function detectState(country: IsoCountry): Option<StateProvince> {
+	return stateProvinceFromString(country, window.guardian.geoip?.stateCode);
+}
+
 // ----- Exports ----- //
 export {
 	detect,
+	detectState,
 	setCountry,
 	usStates,
 	caStates,

--- a/support-frontend/assets/helpers/internationalisation/shouldCollectStateForContribs.ts
+++ b/support-frontend/assets/helpers/internationalisation/shouldCollectStateForContribs.ts
@@ -1,43 +1,13 @@
 import type { ContributionType } from 'helpers/contributions';
-import { fromString as isoCountryFromString } from './country';
-import type { CountryGroup, CountryGroupId } from './countryGroup';
-import {
-	AUDCountries,
-	Canada,
-	countryGroups,
-	UnitedStates,
-} from './countryGroup';
+import type { IsoCountry } from './country';
 
 export function shouldCollectStateForContributions(
-	countryGroupId: CountryGroupId,
+	countryId: IsoCountry,
 	contributionType: ContributionType,
 ): boolean {
 	if (contributionType === 'ONE_OFF') return false;
 
-	if (countryGroupId === UnitedStates || countryGroupId === Canada) {
-		return true;
-	}
-	if (countryGroupId === AUDCountries) {
-		if (window.guardian.geoip) {
-			// Some countries, eg. Tuvalu, pay in Australian dollars but are obviously not
-			// in any Australian state/territory, so we do not need to collect their state
-			const AUDCountryGroup: CountryGroup = countryGroups[AUDCountries];
-			const AUDCountriesWithNoStates = AUDCountryGroup.countries.filter(
-				(c) => c !== 'AU',
-			);
-
-			const isoCountry = isoCountryFromString(
-				window.guardian.geoip.countryCode,
-			);
-
-			if (!isoCountry) {
-				return false;
-			}
-
-			const doesNotRequireState = AUDCountriesWithNoStates.includes(isoCountry);
-
-			return !doesNotRequireState;
-		}
+	if (countryId === 'US' || countryId === 'CA' || countryId === 'AU') {
 		return true;
 	}
 	return false;

--- a/support-frontend/assets/helpers/redux/checkout/address/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/state.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import type { PostcodeFinderResult } from 'components/subscriptionCheckouts/address/postcodeLookup';
-import { detect, isoCountries } from 'helpers/internationalisation/country';
+import {
+	detect,
+	detectState,
+	isoCountries,
+} from 'helpers/internationalisation/country';
 import type { SliceErrors } from 'helpers/redux/utils/validation/errors';
 import type { FormError } from 'helpers/subscriptionsForms/validation';
 import { isPostCodeValid } from './validationFunctions';
@@ -46,9 +50,10 @@ export type AddressFieldsState = AddressFields & {
 };
 
 export function getInitialAddressFieldsState(): AddressFieldsState {
+	const country = detect();
 	return {
-		country: detect(),
-		state: '',
+		country,
+		state: detectState(country) ?? '',
 		lineOne: null,
 		lineTwo: null,
 		postCode: '',

--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/actions.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/actions.ts
@@ -1,3 +1,4 @@
 import { paymentMethodSlice } from './reducer';
 
-export const { setPaymentMethod } = paymentMethodSlice.actions;
+export const { setPaymentMethod, setPaymentMethodCountryAndState } =
+	paymentMethodSlice.actions;

--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/reducer.ts
@@ -1,6 +1,10 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import type { FullPaymentMethod } from 'helpers/forms/paymentMethods';
+import type {
+	IsoCountry,
+	StateProvince,
+} from 'helpers/internationalisation/country';
 import { setDeliveryCountry } from '../../address/actions';
 import { validateForm } from '../../checkoutActions';
 import { initialState } from './state';
@@ -12,7 +16,16 @@ export const paymentMethodSlice = createSlice({
 		setPaymentMethod(state, action: PayloadAction<FullPaymentMethod>) {
 			state.name = action.payload.paymentMethod;
 			state.stripePaymentMethod = action.payload.stripePaymentMethod;
+			state.country = undefined;
+			state.state = undefined;
 			state.errors = [];
+		},
+		setPaymentMethodCountryAndState(
+			state,
+			action: PayloadAction<[IsoCountry, StateProvince | undefined]>,
+		) {
+			state.country = action.payload[0];
+			state.state = action.payload[1];
 		},
 	},
 	extraReducers: (builder) => {

--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/state.ts
@@ -1,9 +1,15 @@
 import type { StripePaymentMethod } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
+import type {
+	IsoCountry,
+	StateProvince,
+} from 'helpers/internationalisation/country';
 
 export type PaymentMethodState = {
 	name: PaymentMethod;
 	stripePaymentMethod?: StripePaymentMethod;
+	country?: IsoCountry;
+	state?: StateProvince;
 	errors?: string[];
 };
 

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -2,7 +2,6 @@ import { fromCountry } from 'helpers/internationalisation/countryGroup';
 import { shouldCollectStateForContributions } from 'helpers/internationalisation/shouldCollectStateForContribs';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
-import { getBillingCountryAndState } from 'pages/supporter-plus-landing/setup/legacyActionCreators';
 import type { ErrorCollection } from './utils';
 
 export function getStateOrProvinceError(
@@ -10,10 +9,7 @@ export function getStateOrProvinceError(
 ): ErrorCollection {
 	const contributionType = getContributionType(state);
 	const billingCountryGroup = fromCountry(
-		getBillingCountryAndState(
-			state.page.checkoutForm.payment.paymentMethod.name,
-			state,
-		).billingCountry,
+		state.page.checkoutForm.billingAddress.fields.country,
 	);
 	if (
 		billingCountryGroup != null &&

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -2,6 +2,7 @@ import { fromCountry } from 'helpers/internationalisation/countryGroup';
 import { shouldCollectStateForContributions } from 'helpers/internationalisation/shouldCollectStateForContribs';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
+import { getBillingCountryAndState } from 'pages/supporter-plus-landing/setup/legacyActionCreators';
 import type { ErrorCollection } from './utils';
 
 export function getStateOrProvinceError(
@@ -9,7 +10,7 @@ export function getStateOrProvinceError(
 ): ErrorCollection {
 	const contributionType = getContributionType(state);
 	const billingCountryGroup = fromCountry(
-		state.page.checkoutForm.billingAddress.fields.country,
+		getBillingCountryAndState(state).billingCountry,
 	);
 	if (
 		billingCountryGroup != null &&

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -1,4 +1,3 @@
-import { fromCountry } from 'helpers/internationalisation/countryGroup';
 import { shouldCollectStateForContributions } from 'helpers/internationalisation/shouldCollectStateForContribs';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
@@ -9,13 +8,8 @@ export function getStateOrProvinceError(
 	state: ContributionsState,
 ): ErrorCollection {
 	const contributionType = getContributionType(state);
-	const billingCountryGroup = fromCountry(
-		getBillingCountryAndState(state).billingCountry,
-	);
-	if (
-		billingCountryGroup != null &&
-		shouldCollectStateForContributions(billingCountryGroup, contributionType)
-	) {
+	const billingCountry = getBillingCountryAndState(state).billingCountry;
+	if (shouldCollectStateForContributions(billingCountry, contributionType)) {
 		return {
 			state: state.page.checkoutForm.billingAddress.fields.errorObject?.state,
 		};

--- a/support-frontend/stories/checkoutLayout/PersonalDetails.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/PersonalDetails.stories.tsx
@@ -6,10 +6,6 @@ import type { PersonalDetailsProps } from 'components/personalDetails/personalDe
 import { PersonalDetails } from 'components/personalDetails/personalDetails';
 import { StateSelect } from 'components/personalDetails/stateSelect';
 import Signout from 'components/signout/signout';
-import {
-	GBPCountries,
-	UnitedStates,
-} from 'helpers/internationalisation/countryGroup';
 
 export default {
 	title: 'Checkouts/Personal Details',
@@ -66,7 +62,7 @@ SingleContribSignedIn.args = {
 			state=""
 			onStateChange={() => null}
 			contributionType={'ONE_OFF'}
-			countryGroupId={GBPCountries}
+			countryId={'GB'}
 		/>
 	),
 };
@@ -85,7 +81,7 @@ SingleContribSignedOut.args = {
 			state=""
 			onStateChange={() => null}
 			contributionType={'ONE_OFF'}
-			countryGroupId={GBPCountries}
+			countryId={'GB'}
 		/>
 	),
 };
@@ -104,7 +100,7 @@ MultiContribSignedIn.args = {
 			state=""
 			onStateChange={() => null}
 			contributionType={'MONTHLY'}
-			countryGroupId={GBPCountries}
+			countryId={'GB'}
 		/>
 	),
 };
@@ -123,7 +119,7 @@ MultiContribSignedOut.args = {
 			state=""
 			onStateChange={() => null}
 			contributionType={'MONTHLY'}
-			countryGroupId={GBPCountries}
+			countryId={'GB'}
 		/>
 	),
 };
@@ -142,7 +138,7 @@ MultiContribUSSignedIn.args = {
 			state=""
 			onStateChange={() => null}
 			contributionType={'MONTHLY'}
-			countryGroupId={UnitedStates}
+			countryId={'US'}
 		/>
 	),
 };
@@ -161,7 +157,7 @@ MultiContribUSSignedOut.args = {
 			state=""
 			onStateChange={() => null}
 			contributionType={'MONTHLY'}
-			countryGroupId={UnitedStates}
+			countryId={'US'}
 		/>
 	),
 };
@@ -186,7 +182,7 @@ WithErrors.args = {
 			error="Please select your state, province or territory"
 			onStateChange={() => null}
 			contributionType={'MONTHLY'}
-			countryGroupId={UnitedStates}
+			countryId={'US'}
 		/>
 	),
 };


### PR DESCRIPTION
## What are you doing in this PR?

Trello Card: https://trello.com/c/ILKQJnOC/1262-support-checkout-client-side-validation-not-enforcing-required-state-field-for-recurring-supporters-in-usa-and-ca-paying-with-cr

This PR attempts to fix issues we’ve had with apple pay users by storing the payment-request-button-provided country and state separately from the form-entered or guessed ones, so that our code can choose to only use the payment-request-button-provided info when the payment request button is the current payment method. I’ve split the description of the changes for the three commits in the PR:


### Unify country-choosing logic

Rather than have two places in which country-guessing logic lives, this commit consolidates them into one: the country is guessed on page load, and not when sending data to the backend.

I’ve also removed the special case for direct debit: the new logic will already prioritise the page base country over geolocation, and I don’t think a more explicit case is needed.

### Store payment method country/state separately

Rather than overwriting the form values, this commit stores the country and state obtained from a payment request button wallet in a separate part of the redux state. Then when working out the billing country and state for validation or for submission to the backend, the code only uses the payment-method-provided country and state if the current payment method is the payment request button.

This should fix the following error we’ve encountered: If a user has invalid country/state info set in their Apple Pay details (e.g. the country is US but the state is empty), the payment will fail on the backend. If the user then tries another payment method, the country/state info from Apple Pay will still be in the redux state, and will be sent to the backend to fail again.

Another way to fix that issue would be to clear the payment-method-provided info on error: we already do that for errors earlier in the process, and we could plausibly do that if the support-workers execution fails. However, now that we’re doing the country determination at page load, we would’ve lost that info when overwriting it with the payment-method-provided info. We could save it somewhere and restore it, or run the determination function again, but I prefer this approach. One reason for that is that it puts the choice logic all in one place: the other approaches require an insertion and deletion to be co-ordinated in different parts of the code, but this approach only requires the insertions.

Something else I’m wondering about: if we clear a user’s email due to a payment failure with the payment request button, what if they’re signed in? Will they then have a disabled but empty email input on the form, with no way to tell us their email address? Should we ignore the email address from a payment method if the user is already signed in (and then we have an email address we can have high confidence in)? I suppose they can always sign out to make the email address editable again.

### Use country instead of country group

Before now, shouldCollectStateForContribs took a country group ID, then checked for some exception countries using window.guardian.geoip.countryCode. We have the country available everywhere shouldCollectStateForContribs is called, so this commit changes the function to take the country ID instead, meaning the geolocation access and the exception logic is no longer required.

The similar function `checkStateIfApplicable` is unused, so I’ve removed it.

## Testing

I have tested the happy path of using google pay on CODE for successful single and recurring payments.