### PR TITLE
Rename DEV to CODE in supporter product data

### DIFF
--- a/cdk/lib/stripe-patrons-data.ts
+++ b/cdk/lib/stripe-patrons-data.ts
@@ -12,9 +12,6 @@ import { Schedule } from "aws-cdk-lib/aws-events";
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
 
-function environmentFromStage(stage: string) {
-  return stage == "CODE" ? "DEV" : stage;
-}
 
 function dynamoPolicy(stage: string) {
   return new PolicyStatement({
@@ -27,9 +24,7 @@ function dynamoPolicy(stage: string) {
       "dynamodb:DescribeTable",
     ],
     resources: [
-      `arn:aws:dynamodb:*:*:table/SupporterProductData-${environmentFromStage(
-        stage
-      )}`,
+      `arn:aws:dynamodb:*:*:table/SupporterProductData-${stage}`,
     ],
   });
 }

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/model/StageConstructors.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/model/StageConstructors.scala
@@ -1,18 +1,18 @@
 package com.gu.patrons.model
 
 import com.gu.supporterdata.model.Stage
-import com.gu.supporterdata.model.Stage.{DEV, PROD}
+import com.gu.supporterdata.model.Stage.{CODE, PROD}
 
 object StageConstructors {
 
   def fromString(str: String): Option[Stage] =
-    List(DEV, PROD)
+    List(CODE, PROD)
       .find(_.value == str)
 
   def fromEnvironment: Stage =
     (for {
       stageAsString <- Option(System.getenv("STAGE"))
       stage <- fromString(stageAsString)
-    } yield stage).getOrElse(Stage.DEV)
+    } yield stage).getOrElse(Stage.CODE)
 
 }

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/services/ParameterStoreService.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/services/ParameterStoreService.scala
@@ -13,14 +13,14 @@ import com.amazonaws.services.simplesystemsmanagement.{
 }
 import com.gu.aws.{AwsAsync, CredentialsProvider}
 import com.gu.supporterdata.model.Stage
-import com.gu.supporterdata.model.Stage.DEV
+import com.gu.supporterdata.model.Stage.CODE
 
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
 class ParameterStoreService(client: AWSSimpleSystemsManagementAsync, stage: Stage) {
   def parameterKeyFromStage(stage: Stage) = stage match {
-    case DEV => "CODE"
+    case CODE => "CODE"
     case _ => stage.value
   }
   val configRoot = s"/${parameterKeyFromStage(stage)}/support/stripe-patrons-data"

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/services/ParameterStoreService.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/services/ParameterStoreService.scala
@@ -19,11 +19,7 @@ import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
 class ParameterStoreService(client: AWSSimpleSystemsManagementAsync, stage: Stage) {
-  def parameterKeyFromStage(stage: Stage) = stage match {
-    case CODE => "CODE"
-    case _ => stage.value
-  }
-  val configRoot = s"/${parameterKeyFromStage(stage)}/support/stripe-patrons-data"
+  val configRoot = s"/$stage/support/stripe-patrons-data"
 
   def getParametersByPath(path: String)(implicit executionContext: ExecutionContext) = {
     val request: GetParametersByPathRequest = new GetParametersByPathRequest()

--- a/stripe-patrons-data/src/test/scala/com/gu/patrons/lambdas/ProcessStripeSubscriptionsLambdaSpec.scala
+++ b/stripe-patrons-data/src/test/scala/com/gu/patrons/lambdas/ProcessStripeSubscriptionsLambdaSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.patrons.lambdas
 
-import com.gu.supporterdata.model.Stage.DEV
+import com.gu.supporterdata.model.Stage.CODE
 import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -10,6 +10,6 @@ import com.gu.patrons.services.GnmPatronScheme
 class ProcessStripeSubscriptionsLambdaSpec extends AsyncFlatSpec with Matchers {
 
   ProcessStripeSubscriptionsLambda.getClass.getSimpleName should "process subscriptions" in {
-    ProcessStripeSubscriptionsLambda.processSubscriptions(GnmPatronScheme, DEV).map(result => result shouldBe ())
+    ProcessStripeSubscriptionsLambda.processSubscriptions(GnmPatronScheme, CODE).map(result => result shouldBe ())
   }
 }

--- a/stripe-patrons-data/src/test/scala/com/gu/patrons/services/ConfigServiceSpec.scala
+++ b/stripe-patrons-data/src/test/scala/com/gu/patrons/services/ConfigServiceSpec.scala
@@ -1,7 +1,7 @@
 package com.gu.patrons.services
 
 import com.gu.patrons.conf.{PatronsIdentityConfig, PatronsStripeConfig}
-import com.gu.supporterdata.model.Stage.DEV
+import com.gu.supporterdata.model.Stage.CODE
 import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -11,7 +11,7 @@ class ConfigServiceSpec extends AsyncFlatSpec with Matchers {
 
   PatronsStripeConfig.getClass.getSimpleName should "load config from SSM" in {
     PatronsStripeConfig
-      .fromParameterStore(DEV)
+      .fromParameterStore(CODE)
       .map { config =>
         config.apiKey.length should be > 0
       }
@@ -19,7 +19,7 @@ class ConfigServiceSpec extends AsyncFlatSpec with Matchers {
 
   PatronsIdentityConfig.getClass.getSimpleName should "load config from SSM" in {
     PatronsIdentityConfig
-      .fromParameterStore(DEV)
+      .fromParameterStore(CODE)
       .map { config =>
         config.apiClientToken.length should be > 0
         config.apiUrl shouldBe "https://idapi.code.dev-theguardian.com"

--- a/stripe-patrons-data/src/test/scala/com/gu/patrons/services/PatronsIdentityServiceSpec.scala
+++ b/stripe-patrons-data/src/test/scala/com/gu/patrons/services/PatronsIdentityServiceSpec.scala
@@ -3,7 +3,7 @@ package com.gu.patrons.services
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.patrons.conf.PatronsIdentityConfig
 import com.gu.patrons.model.identity.IdentityErrorResponse
-import com.gu.supporterdata.model.Stage.DEV
+import com.gu.supporterdata.model.Stage.CODE
 import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -14,14 +14,14 @@ import scala.concurrent.duration.DurationInt
 @IntegrationTest
 class PatronsIdentityServiceSpec extends AsyncFlatSpec with Matchers {
   "PatronsIdentityService" should "get an identity id from an email address" in {
-    PatronsIdentityConfig.fromParameterStore(DEV).flatMap { config =>
+    PatronsIdentityConfig.fromParameterStore(CODE).flatMap { config =>
       val service = new PatronsIdentityService(config, configurableFutureRunner(60.seconds))
       service.getUserIdFromEmail("test@guardian.co.uk").map(id => id.isDefined shouldBe true)
     }
   }
 
   "PatronsIdentityService" should "not get an identity id from an unknown email address" in {
-    PatronsIdentityConfig.fromParameterStore(DEV).flatMap { config =>
+    PatronsIdentityConfig.fromParameterStore(CODE).flatMap { config =>
       val service = new PatronsIdentityService(config, configurableFutureRunner(60.seconds))
       val email = s"${UUID.randomUUID()}@gu.com"
       service
@@ -37,7 +37,7 @@ class PatronsIdentityServiceSpec extends AsyncFlatSpec with Matchers {
 
   // Ignored as we don't want to create a guest account in Identity every time this test runs
   "PatronsIdentityService" should "create a guest account for an unknown email address" ignore {
-    PatronsIdentityConfig.fromParameterStore(DEV).flatMap { config =>
+    PatronsIdentityConfig.fromParameterStore(CODE).flatMap { config =>
       val service = new PatronsIdentityService(config, configurableFutureRunner(60.seconds))
       val email = s"${UUID.randomUUID()}@gu.com"
       service

--- a/stripe-patrons-data/src/test/scala/com/gu/patrons/services/PatronsStripeServiceSpec.scala
+++ b/stripe-patrons-data/src/test/scala/com/gu/patrons/services/PatronsStripeServiceSpec.scala
@@ -2,7 +2,7 @@ package com.gu.patrons.services
 
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.patrons.conf.PatronsStripeConfig
-import com.gu.supporterdata.model.Stage.DEV
+import com.gu.supporterdata.model.Stage.CODE
 import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -14,7 +14,7 @@ class PatronsStripeServiceSpec extends AsyncFlatSpec with Matchers {
 
   "PatronsStripeService" should "get subscriptions from Stripe" in {
     PatronsStripeConfig
-      .fromParameterStore(DEV)
+      .fromParameterStore(CODE)
       .flatMap { config =>
         val stripeService = new PatronsStripeService(config, configurableFutureRunner(60.seconds))
         stripeService.getSubscriptions(GnmPatronScheme, 1).map { response =>

--- a/stripe-patrons-data/src/test/scala/com/gu/patrons/services/StripeSubscriptionsProcessorSpec.scala
+++ b/stripe-patrons-data/src/test/scala/com/gu/patrons/services/StripeSubscriptionsProcessorSpec.scala
@@ -4,7 +4,7 @@ import com.gu.monitoring.SafeLogger
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.patrons.conf.{PatronsIdentityConfig, PatronsStripeConfig}
 import com.gu.patrons.model.{StripeSubscription, ExpandedStripeCustomer}
-import com.gu.supporterdata.model.Stage.{DEV, PROD}
+import com.gu.supporterdata.model.Stage.{CODE, PROD}
 import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -14,7 +14,7 @@ import scala.concurrent.duration.DurationInt
 @IntegrationTest
 class StripeSubscriptionsProcessorSpec extends AsyncFlatSpec with Matchers {
   "StripeSubscriptionsProcessor" should "process subscriptions from Stripe" in {
-    val stage = DEV
+    val stage = CODE
     val runner = configurableFutureRunner(60.seconds)
     for {
       stripeConfig <- PatronsStripeConfig.fromParameterStore(stage)

--- a/stripe-patrons-data/src/test/scala/com/gu/patrons/services/SupporterDataDynamoServiceSpec.scala
+++ b/stripe-patrons-data/src/test/scala/com/gu/patrons/services/SupporterDataDynamoServiceSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.patrons.services
 
-import com.gu.supporterdata.model.Stage.DEV
+import com.gu.supporterdata.model.Stage.CODE
 import com.gu.supporterdata.services.SupporterDataDynamoService
 import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.flatspec.AsyncFlatSpec
@@ -11,7 +11,7 @@ class SupporterDataDynamoServiceSpec extends AsyncFlatSpec with Matchers {
   "SupporterDataDynamoService" should "return false if a subscription doesn't exist" in {
     val identityId = "non_existent_identity_id"
     val subscriptionId = "non_existent_subscription_id"
-    val dynamoService = SupporterDataDynamoService(DEV)
+    val dynamoService = SupporterDataDynamoService(CODE)
     dynamoService.subscriptionExists(identityId, subscriptionId).flatMap {
       case Right(userExists) if userExists =>
         fail(s"Subscription $subscriptionId should not exist")
@@ -25,7 +25,7 @@ class SupporterDataDynamoServiceSpec extends AsyncFlatSpec with Matchers {
     // I'm marking it as ignored in case that record gets deleted
     val identityId = "200065441"
     val subscriptionId = "A-S00445804"
-    val dynamoService = SupporterDataDynamoService(DEV)
+    val dynamoService = SupporterDataDynamoService(CODE)
     dynamoService.subscriptionExists(identityId, subscriptionId).flatMap {
       case Right(userExists) if userExists =>
         succeed

--- a/support-modules/supporter-product-data-dynamo/README.md
+++ b/support-modules/supporter-product-data-dynamo/README.md
@@ -1,6 +1,6 @@
 # supporter-product-data-dynamo
-This library provides a standard means of adding records to the SupporterProductData dynamo store. 
-It is releasable via Maven/Sonatype to allow us to use it from support-service-lambdas 
+This library provides a standard means of adding records to the SupporterProductData dynamo store.
+It is releasable via Maven/Sonatype to allow us to use it from support-service-lambdas
 
 Releasing to local repo
 ==================
@@ -34,14 +34,15 @@ You will need to give whatever application is using this library the the correct
       - Fn::ImportValue: supporter-product-data-tables-DEV-SupporterProductDataTable
 ```
 Then you can use it as follows:
+
 ```scala
-import com.gu.supporterdata.model.Stage.{DEV, PROD, UAT}
+import com.gu.supporterdata.model.Stage.{CODE, PROD}
 import com.gu.supporterdata.model.{Stage, SupporterRatePlanItem}
 import com.gu.supporterdata.services.SupporterDataDynamoService
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
 
-val dynamoService = SupporterDataDynamoService(DEV)
+val dynamoService = SupporterDataDynamoService(CODE)
 
 dynamoService
   .writeItem(

--- a/support-modules/supporter-product-data-dynamo/src/main/scala/com/gu/supporterdata/model/Stage.scala
+++ b/support-modules/supporter-product-data-dynamo/src/main/scala/com/gu/supporterdata/model/Stage.scala
@@ -4,7 +4,7 @@ sealed abstract class Stage(val value: String)
 
 object Stage {
 
-  case object DEV extends Stage("DEV")
+  case object CODE extends Stage("CODE")
 
   case object PROD extends Stage("PROD")
 

--- a/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
+++ b/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
@@ -16,7 +16,7 @@ import com.gu.support.acquisitions.{
   BigQueryConfig,
   BigQueryService,
 }
-import com.gu.supporterdata.model.Stage.{DEV, PROD}
+import com.gu.supporterdata.model.Stage.{CODE, PROD}
 import com.gu.supporterdata.services.SupporterDataDynamoService
 import com.typesafe.scalalogging.StrictLogging
 import conf.BigQueryConfigLoader.bigQueryConfigParameterStoreLoadable
@@ -32,7 +32,7 @@ import model.db.ContributionData
 import model.email.ContributorRow
 import model.Environment.Live
 import play.api.libs.ws.WSClient
-import services.{CloudWatchService, _}
+import services._
 import util.EnvironmentBasedBuilder
 
 import scala.concurrent.Future

--- a/support-payment-api/src/main/scala/services/SupporterProductDataService.scala
+++ b/support-payment-api/src/main/scala/services/SupporterProductDataService.scala
@@ -2,7 +2,7 @@ package services
 
 import cats.data.EitherT
 import com.gu.supporterdata.model.{ContributionAmount, SupporterRatePlanItem}
-import com.gu.supporterdata.model.Stage.{DEV, PROD}
+import com.gu.supporterdata.model.Stage.{CODE, PROD}
 import com.gu.supporterdata.services.SupporterDataDynamoService
 import com.typesafe.scalalogging.StrictLogging
 import model.db.ContributionData
@@ -15,7 +15,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class SupporterProductDataService(environment: Environment) extends StrictLogging {
   val dynamoService = SupporterDataDynamoService(environment match {
     case Live => PROD
-    case _ => DEV
+    case _ => CODE
   })
   def insertContributionData(
       contributionData: ContributionData,

--- a/support-workers/src/main/scala/com/gu/services/Services.scala
+++ b/support-workers/src/main/scala/com/gu/services/Services.scala
@@ -20,7 +20,7 @@ import com.gu.support.config.TouchPointEnvironments
 import com.gu.support.promotions.PromotionService
 import com.gu.support.redemption.gifting.generator.GiftCodeGeneratorService
 import com.gu.zuora.{ZuoraGiftService, ZuoraService}
-import com.gu.supporterdata.model.Stage.{DEV => DynamoStageDEV, PROD => DynamoStagePROD}
+import com.gu.supporterdata.model.Stage.{CODE => DynamoStageDEV, PROD => DynamoStagePROD}
 import com.gu.supporterdata.services.SupporterDataDynamoService
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/supporter-product-data/cloudformation/cfn.yaml
+++ b/supporter-product-data/cloudformation/cfn.yaml
@@ -16,7 +16,7 @@ Conditions:
 Mappings:
   StageVariables:
     CODE:
-      S3Bucket: supporter-product-data-export-dev
+      S3Bucket: supporter-product-data-export-code
       # Run once at 6am Mon-Fri
       scheduleRate: "cron(0 6 ? * 1-5 *)"
       lambdaConcurrency: 30

--- a/supporter-product-data/cloudformation/cfn.yaml
+++ b/supporter-product-data/cloudformation/cfn.yaml
@@ -7,15 +7,15 @@ Parameters:
     Type: String
     AllowedValues:
       - PROD
-      - DEV
-    Default: DEV
+      - CODE
+    Default: CODE
 
 Conditions:
   CreateProdResources: !Equals [!Ref "Stage", "PROD"]
 
 Mappings:
   StageVariables:
-    DEV:
+    CODE:
       S3Bucket: supporter-product-data-export-dev
       # Run once at 6am Mon-Fri
       scheduleRate: "cron(0 6 ? * 1-5 *)"
@@ -465,7 +465,7 @@ Resources:
       AlarmDescription: >
         Impact - On or more subscriber will not get their digital benefits
         For details of the record which failed search for 'Error writing item to Dynamo' in the ProcessSupporterRatePlanItemLambda Cloudwatch logs:
-        https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fsupport-SupporterProductDataProcessSupporterRatePlanItem-DEV
+        https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fsupport-SupporterProductDataProcessSupporterRatePlanItem-CODE
       MetricName: DynamoWriteFailure
       Namespace: supporter-product-data
       Dimensions:

--- a/supporter-product-data/cloudformation/create-table-stack.sh
+++ b/supporter-product-data/cloudformation/create-table-stack.sh
@@ -3,6 +3,6 @@
 # aws cloudformation delete-stack --stack-name supporter-product-data-tables-PROD
 aws cloudformation create-stack \
   --capabilities CAPABILITY_IAM  \
-  --stack-name supporter-product-data-tables-PROD \
+  --stack-name supporter-product-data-tables-CODE \
   --template-body file://dynamo-tables.yaml \
-  --parameters  ParameterKey=Stage,ParameterValue=PROD
+  --parameters  ParameterKey=Stage,ParameterValue=CODE

--- a/supporter-product-data/cloudformation/dynamo-tables.yaml
+++ b/supporter-product-data/cloudformation/dynamo-tables.yaml
@@ -6,12 +6,12 @@ Parameters:
     Type: String
     AllowedValues:
       - PROD
-      - DEV
-    Default: DEV
+      - CODE
+    Default: CODE
 
 Conditions:
   CreateProdResources: !Equals [!Ref "Stage", "PROD"]
-  CreateDevOrUatResources: !Not [ !Equals [ !Ref "Stage", "PROD"]]
+  CreateCodeResources: !Not [ !Equals [ !Ref "Stage", "PROD"]]
 
 Resources:
   ProdTable:
@@ -102,8 +102,8 @@ Resources:
         PredefinedMetricSpecification:
           PredefinedMetricType: DynamoDBWriteCapacityUtilization
 
-  DevOrUatTable:
-    Condition: CreateDevOrUatResources
+  CodeTable:
+    Condition: CreateCodeResources
     Type: "AWS::DynamoDB::Table"
     Properties:
       AttributeDefinitions:
@@ -134,7 +134,7 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-SupporterProductDataTable
   OnDemandTableOutput:
-    Condition: CreateDevOrUatResources
+    Condition: CreateCodeResources
     Description: This Dynamo table is used to store rate plan information about supporters
     Value: !GetAtt [ DevOrUatTable, "Arn" ]
     Export:

--- a/supporter-product-data/riff-raff.yaml
+++ b/supporter-product-data/riff-raff.yaml
@@ -1,7 +1,7 @@
 stacks: [support]
 regions: [eu-west-1]
 allowedStages:
-  - DEV
+  - CODE
   - PROD
 deployments:
   cfn:

--- a/supporter-product-data/src/main/scala/com/gu/lambdas/ProcessSupporterRatePlanItemLambda.scala
+++ b/supporter-product-data/src/main/scala/com/gu/lambdas/ProcessSupporterRatePlanItemLambda.scala
@@ -9,7 +9,7 @@ import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger.Sanitizer
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.services.{AlarmService, ConfigService, ZuoraSubscriptionService}
-import com.gu.supporterdata.model.Stage.{DEV, PROD}
+import com.gu.supporterdata.model.Stage.{CODE, PROD}
 import com.gu.supporterdata.model.{Stage, SupporterRatePlanItem}
 import com.gu.supporterdata.services.SupporterDataDynamoService
 import io.circe.parser._
@@ -99,6 +99,6 @@ class ContributionAmountFetcher(config: ZuoraQuerierConfig) {
 object ContributionIds {
   def forStage(stage: Stage) = stage match {
     case PROD => List("2c92a0fc5aacfadd015ad24db4ff5e97", "2c92a0fc5e1dc084015e37f58c200eea")
-    case DEV => List("2c92c0f85a6b134e015a7fcd9f0c7855", "2c92c0f85e2d19af015e3896e824092c")
+    case CODE => List("2c92c0f85a6b134e015a7fcd9f0c7855", "2c92c0f85e2d19af015e3896e824092c")
   }
 }

--- a/supporter-product-data/src/main/scala/com/gu/model/StageConstructors.scala
+++ b/supporter-product-data/src/main/scala/com/gu/model/StageConstructors.scala
@@ -1,18 +1,18 @@
 package com.gu.model
 
 import com.gu.supporterdata.model.Stage
-import com.gu.supporterdata.model.Stage.{DEV, PROD}
+import com.gu.supporterdata.model.Stage.{CODE, PROD}
 
 object StageConstructors {
 
   def fromString(str: String): Option[Stage] =
-    List(DEV, PROD)
+    List(CODE, PROD)
       .find(_.value == str)
 
   def fromEnvironment: Stage =
     (for {
       stageAsString <- Option(System.getenv("Stage"))
       stage <- fromString(stageAsString)
-    } yield stage).getOrElse(Stage.DEV)
+    } yield stage).getOrElse(Stage.CODE)
 
 }

--- a/supporter-product-data/src/main/scala/com/gu/services/ConfigService.scala
+++ b/supporter-product-data/src/main/scala/com/gu/services/ConfigService.scala
@@ -3,7 +3,7 @@ package com.gu.services
 import com.amazonaws.services.simplesystemsmanagement.model.Parameter
 import com.gu.conf.ZuoraQuerierConfig
 import com.gu.monitoring.SafeLogger
-import com.gu.supporterdata.model.Stage.{DEV, PROD}
+import com.gu.supporterdata.model.Stage.{CODE, PROD}
 import com.gu.services.ConfigService.{lastSuccessfulQueryTime, zuoraConfigPath}
 import com.gu.supporterdata.model.Stage
 import com.typesafe.scalalogging.StrictLogging
@@ -29,7 +29,7 @@ class ConfigService(stage: Stage) extends StrictLogging {
 
   private def getDiscountProductRatePlanIds(stage: Stage) =
     stage match {
-      case DEV => List("2c92c0f852f2ebb20152f9269f067819")
+      case CODE => List("2c92c0f852f2ebb20152f9269f067819")
       case PROD =>
         List(
           // These are all various types of discount so are there

--- a/supporter-product-data/src/main/scala/com/gu/services/SelectActiveRatePlansQuery.scala
+++ b/supporter-product-data/src/main/scala/com/gu/services/SelectActiveRatePlansQuery.scala
@@ -1,7 +1,7 @@
 package com.gu.services
 
 import com.gu.model.ZuoraFieldNames._
-import com.gu.supporterdata.model.Stage.{DEV, PROD}
+import com.gu.supporterdata.model.Stage.{CODE, PROD}
 import com.gu.supporterdata.model.Stage
 
 import java.time.LocalDate

--- a/supporter-product-data/src/test/scala/com/gu/lambdas/AddSupporterRatePlanItemToQueueIntegrationTest.scala
+++ b/supporter-product-data/src/test/scala/com/gu/lambdas/AddSupporterRatePlanItemToQueueIntegrationTest.scala
@@ -1,7 +1,7 @@
 package com.gu.lambdas
 
 import com.gu.model.states.AddSupporterRatePlanItemToQueueState
-import com.gu.supporterdata.model.Stage.DEV
+import com.gu.supporterdata.model.Stage.CODE
 import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -14,7 +14,7 @@ class AddSupporterRatePlanItemToQueueIntegrationTest extends AsyncFlatSpec with 
   "AddSupporterRatePlanItemToQueueLambda" should "process records correctly" in {
     val csvFilename = "select-active-rate-plans-2023-01-12T05:59:45.210958.csv"
     AddSupporterRatePlanItemToQueueLambda.addToQueue(
-      DEV,
+      CODE,
       AddSupporterRatePlanItemToQueueState(
         csvFilename,
         248,

--- a/supporter-product-data/src/test/scala/com/gu/lambdas/QueryZuoraLambdaSpec.scala
+++ b/supporter-product-data/src/test/scala/com/gu/lambdas/QueryZuoraLambdaSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.lambdas
 
-import com.gu.supporterdata.model.Stage.DEV
+import com.gu.supporterdata.model.Stage.CODE
 import com.gu.model.states.QueryType.Incremental
 import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.flatspec.AsyncFlatSpec
@@ -13,7 +13,7 @@ class QueryZuoraLambdaSpec extends AsyncFlatSpec with Matchers {
 
   "QueryZuoraLambda" should "be able to run a query" in {
     QueryZuoraLambda
-      .queryZuora(DEV, Incremental)
+      .queryZuora(CODE, Incremental)
       .map(resultState => resultState.attemptedQueryTime.toLocalDate shouldBe LocalDate.now)
   }
 }

--- a/supporter-product-data/src/test/scala/com/gu/services/ConfigServiceSpec.scala
+++ b/supporter-product-data/src/test/scala/com/gu/services/ConfigServiceSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.services
 
-import com.gu.supporterdata.model.Stage.DEV
+import com.gu.supporterdata.model.Stage.CODE
 import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class ConfigServiceSpec extends AsyncFlatSpec with Matchers {
 
   ConfigService.getClass.getSimpleName should "load config from SSM" in {
-    val config = ConfigService(DEV).load
+    val config = ConfigService(CODE).load
     config.url shouldBe "https://rest.apisandbox.zuora.com/v1/"
     config.username shouldNot be("")
     config.password shouldNot be("")

--- a/supporter-product-data/src/test/scala/com/gu/services/DynamoDBServiceSpec.scala
+++ b/supporter-product-data/src/test/scala/com/gu/services/DynamoDBServiceSpec.scala
@@ -1,7 +1,7 @@
 package com.gu.services
 
 import com.gu.{model, supporterdata}
-import com.gu.supporterdata.model.Stage.DEV
+import com.gu.supporterdata.model.Stage.CODE
 import com.gu.supporterdata.model.{ContributionAmount, SupporterRatePlanItem}
 import com.gu.supporterdata.services.SupporterDataDynamoService
 import com.gu.test.tags.annotations.IntegrationTest
@@ -14,7 +14,7 @@ import java.time.LocalDate
 class DynamoDBServiceSpec extends AsyncFlatSpec with Matchers {
 
   SupporterDataDynamoService.getClass.getSimpleName should "be able to insert an item with no contribution amount" in {
-    val service = SupporterDataDynamoService(DEV)
+    val service = SupporterDataDynamoService(CODE)
     val item = supporterdata.model.SupporterRatePlanItem(
       identityId = "999965",
       gifteeIdentityId = None,
@@ -31,7 +31,7 @@ class DynamoDBServiceSpec extends AsyncFlatSpec with Matchers {
   }
 
   SupporterDataDynamoService.getClass.getSimpleName should "be able to insert an item with a contribution amount" in {
-    val service = SupporterDataDynamoService(DEV)
+    val service = SupporterDataDynamoService(CODE)
     val item = supporterdata.model.SupporterRatePlanItem(
       identityId = "999965",
       gifteeIdentityId = None,

--- a/supporter-product-data/src/test/scala/com/gu/services/ParameterStoreServiceSpec.scala
+++ b/supporter-product-data/src/test/scala/com/gu/services/ParameterStoreServiceSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.services
 
-import com.gu.supporterdata.model.Stage.DEV
+import com.gu.supporterdata.model.Stage.CODE
 import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -14,7 +14,7 @@ class ParameterStoreServiceSpec extends AsyncFlatSpec with Matchers {
   ParameterStoreService.getClass.getSimpleName should "be able to put and get a parameter" in {
     val paramName = "integrationTestParam"
     val paramVal = LocalDateTime.now.format(DateTimeFormatter.ISO_DATE_TIME)
-    val service = ParameterStoreService(DEV)
+    val service = ParameterStoreService(CODE)
     for {
       _ <- service.putParameter(paramName, paramVal)
       result <- service.getParameter(paramName)

--- a/supporter-product-data/src/test/scala/com/gu/services/S3ServiceSpec.scala
+++ b/supporter-product-data/src/test/scala/com/gu/services/S3ServiceSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.services
 
-import com.gu.supporterdata.model.Stage.DEV
+import com.gu.supporterdata.model.Stage.CODE
 import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -17,7 +17,7 @@ class S3ServiceSpec extends AsyncFlatSpec with Matchers {
     val stream = new ByteArrayInputStream(initialString.getBytes())
     val filename = s"test-file-${UUID.randomUUID().toString}"
     S3Service
-      .streamToS3(DEV, filename, stream, initialString.length)
-    Source.fromInputStream(S3Service.streamFromS3(DEV, filename).getObjectContent).mkString shouldBe initialString
+      .streamToS3(CODE, filename, stream, initialString.length)
+    Source.fromInputStream(S3Service.streamFromS3(CODE, filename).getObjectContent).mkString shouldBe initialString
   }
 }

--- a/supporter-product-data/src/test/scala/com/gu/services/ZuoraQuerierServiceSpec.scala
+++ b/supporter-product-data/src/test/scala/com/gu/services/ZuoraQuerierServiceSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.services
 
-import com.gu.supporterdata.model.Stage.DEV
+import com.gu.supporterdata.model.Stage.CODE
 import com.gu.model.states.QueryType.Full
 import com.gu.model.zuora.response.JobStatus.Submitted
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
@@ -13,7 +13,7 @@ import scala.concurrent.duration._
 @IntegrationTest
 class ZuoraQuerierServiceSpec extends AsyncFlatSpec with Matchers {
   "ZuoraQuerierService" should "run a query successfully" in {
-    val config = ConfigService(DEV).load
+    val config = ConfigService(CODE).load
     val service = new ZuoraQuerierService(config, configurableFutureRunner(60.seconds))
 
     service.postQuery(Full).map { response =>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR continues the work started in #4889 and described in [this document](https://docs.google.com/document/d/1wg1kMk7U7ht3AmPpsPUimtz1FkVbu5BWjijjme2598s/edit#) to standardise environment names across the supporter revenue stacks.

The supporter product data stack (and stripe patrons data stacks) have their own definition of stages (to avoid pulling in a large number of dependencies from the support-frontend stack I think?), which was not changed in previous PRs but is updated here.