### PR TITLE
Update  okhttp3 to 4.11.0

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -36,7 +36,7 @@ libraryDependencies ++= Seq(
   "org.seleniumhq.selenium" % "selenium-java" % "3.141.59" % "test",
   "org.scalatestplus" %% "scalatestplus-mockito" % "1.0.0-M2" % Test,
   "org.scalatestplus" %% "scalatestplus-selenium" % "1.0.0-M2" % Test,
-  "com.squareup.okhttp3" % "okhttp" % "3.14.9",
+  "com.squareup.okhttp3" % "okhttp" % "4.11.0",
   "com.gocardless" % "gocardless-pro" % "2.10.0",
   "com.googlecode.libphonenumber" % "libphonenumber" % "8.13.6",
   // This is required to force aws libraries to use the latest version of jackson


### PR DESCRIPTION
## What are you doing in this PR?

Update  okhttp3 to 4.11.0(Snyk High-level vulnerability) manually.

[**Trello Card**](https://trello.com/c/u5rvh17F/1078-support-frontend-update-okhttp3-to-at-least-492-snyk-high-level-vulnerability)

## Why are you doing this?

In June 2022 we merged [a scala steward PR](https://github.com/guardian/support-frontend/pull/3892) that built successfully updating okhttp3 to v4.10, but the post-deployment tests failed to work with that version, so we reverted it .

But the okhttp3 dependency is listed as having a high-severity vulnerability by Snyk, so we have to upgrade it .

Upgrading to 4.10.0  showed issues like
java.lang.NoClassDefFoundError: Could not initialize class org.openqa.selenium.chrome.ChromeDriverCommandExecutor
and java.lang.NoSuchFieldError: Companion as in screenshots below

<img width="797" alt="image" src="https://user-images.githubusercontent.com/73653255/235879219-0ba58460-acf2-4f98-a0b8-77ebf80ad521.png">
<img width="996" alt="image" src="https://user-images.githubusercontent.com/73653255/235879323-46c7826a-b34c-4e8d-95cd-5035d2172e35.png">

But upgrading to 4.11.0 seems to eliminate these and post deployment tests are running fine locally.

