### PR TITLE
More DEV to CODE stuff

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -16,7 +16,7 @@ new Frontend(app, "Frontend-PROD", {
   membershipSubPromotionsTables:
     [
       "arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-PROD",
-      "arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-DEV",
+      "arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-CODE",
     ],
   domainName: "support.theguardian.com.origin.membership.guardianapis.com",
   scaling: {
@@ -30,7 +30,7 @@ new Frontend(app, "Frontend-CODE", {
   stack: "support",
   stage: "CODE",
   cloudFormationStackName,
-  membershipSubPromotionsTables: ["arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-DEV"],
+  membershipSubPromotionsTables: ["arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-CODE"],
   domainName: "support.code.theguardian.com.origin.membership.guardianapis.com",
   scaling: {
     minimumInstances: 1,

--- a/cdk/lib/__snapshots__/frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/frontend.test.ts.snap
@@ -1023,7 +1023,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
               "Effect": "Allow",
               "Resource": [
                 "arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-PROD/catalog.json",
-                "arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-DEV/catalog.json",
+                "arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-CODE/catalog.json",
               ],
             },
           ],

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -57,7 +57,7 @@ export class Frontend extends GuStack {
         bucketName: "gu-zuora-catalog",
         paths: [
           "PROD/Zuora-PROD/catalog.json",
-          "PROD/Zuora-DEV/catalog.json",
+          "PROD/Zuora-CODE/catalog.json",
         ],
       }),
       new GuGetS3ObjectsPolicy(this, "SettingsBucket", {

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -75,10 +75,6 @@ export class PaymentApi extends GuStack {
       description: "ARN of the KMS key for encrypting SQS data",
     });
 
-    function environmentFromStage(stage: string) {
-      return stage == "CODE" ? "DEV" : stage;
-    }
-
     // TODO: Should these remain as cloudformation parameters?
     const projectName = "payment-api";
     const projectVersion = "0.1";
@@ -116,9 +112,7 @@ export class PaymentApi extends GuStack {
               "dynamodb:DescribeTable",
             ],
             resources: [
-              `arn:aws:dynamodb:*:*:table/SupporterProductData-${environmentFromStage(
-                this.stage
-              )}`,
+              `arn:aws:dynamodb:*:*:table/SupporterProductData-${this.stage}`,
             ],
           }),
 

--- a/support-config/src/main/resources/touchpoint.CODE.conf
+++ b/support-config/src/main/resources/touchpoint.CODE.conf
@@ -69,8 +69,8 @@ touchpoint.backend.environments {
         productRatePlanChargeId="2c92c0f952f30dc30152f92b2ee62707"
       }
       tables {
-        promotions = "MembershipSub-Promotions-DEV"
-        campaigns = "MembershipSub-Campaigns-DEV"
+        promotions = "MembershipSub-Promotions-CODE"
+        campaigns = "MembershipSub-Campaigns-CODE"
       }
     }
   }

--- a/support-config/src/main/scala/com/gu/support/config/TouchpointConfigProvider.scala
+++ b/support-config/src/main/scala/com/gu/support/config/TouchpointConfigProvider.scala
@@ -3,8 +3,8 @@ package com.gu.support.config
 import TouchPointEnvironments.{CODE, fromStage}
 import com.typesafe.config.{Config, ConfigValueFactory}
 
-/** Touchpoint represents 3rd party enterprise systems which have a number of different stages or environments (DEV, and
-  * PROD) TouchpointConfig abstracts the details of talking to the correct environment based on the user details
+/** Touchpoint represents 3rd party enterprise systems which have a number of different stages or environments (CODE,
+  * and PROD) TouchpointConfig abstracts the details of talking to the correct environment based on the user details
   * contained in the request.
   */
 

--- a/support-config/src/test/scala/com/gu/support/config/PromotionsConfigSpec.scala
+++ b/support-config/src/test/scala/com/gu/support/config/PromotionsConfigSpec.scala
@@ -7,8 +7,12 @@ import org.scalatest.matchers.should.Matchers
 class PromotionsConfigSpec extends AsyncFlatSpec with Matchers {
   "PromotionsTablesConfigProvider" should "load successfully" in {
     val devConfig = new PromotionsConfigProvider(ConfigFactory.load(), Stages.DEV).get()
-    devConfig.tables.promotions shouldBe "MembershipSub-Promotions-DEV"
+    devConfig.tables.promotions shouldBe "MembershipSub-Promotions-CODE"
     devConfig.discount.productRatePlanChargeId shouldBe "2c92c0f952f30dc30152f92b2ee62707"
+
+    val codeConfig = new PromotionsConfigProvider(ConfigFactory.load(), Stages.CODE).get()
+    codeConfig.tables.promotions shouldBe "MembershipSub-Promotions-CODE"
+    codeConfig.discount.productRatePlanChargeId shouldBe "2c92c0f952f30dc30152f92b2ee62707"
 
     val prodConfig = new PromotionsConfigProvider(ConfigFactory.load(), Stages.PROD).get()
     prodConfig.tables.promotions shouldBe "MembershipSub-Promotions-PROD"

--- a/support-frontend/conf/riff-raff.yaml
+++ b/support-frontend/conf/riff-raff.yaml
@@ -1,5 +1,8 @@
 stacks: [support]
 regions: [eu-west-1]
+allowedStages:
+  - CODE
+  - PROD
 deployments:
   assets-static:
     type: aws-s3

--- a/support-lambdas/acquisition-events-api/riff-raff.yaml
+++ b/support-lambdas/acquisition-events-api/riff-raff.yaml
@@ -1,6 +1,8 @@
 stacks: [support]
 regions: [eu-west-1]
-
+allowedStages:
+  - CODE
+  - PROD
 deployments:
   acquisition-events-api:
     type: aws-lambda

--- a/support-lambdas/acquisitions-firehose-transformer/riff-raff.yaml
+++ b/support-lambdas/acquisitions-firehose-transformer/riff-raff.yaml
@@ -1,6 +1,8 @@
 stacks: [support]
 regions: [eu-west-1]
-
+allowedStages:
+  - CODE
+  - PROD
 deployments:
   acquisitions-firehose-transformer:
     type: aws-lambda

--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -66,11 +66,11 @@ Resources:
               Action: s3:GetObject
               Resource:
                - arn:aws:s3:::support-workers-private/CODE/support-workers.private.conf
-               - arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-DEV/catalog.json
+               - arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-CODE/catalog.json
         - Statement:
             - Effect: Allow
               Action: dynamodb:Scan
-              Resource: arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-DEV
+              Resource: arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-CODE
         - Statement:
             - Effect: Allow
               Action:
@@ -98,7 +98,7 @@ Resources:
           - 'IT Tests are failing'
       AlarmDescription: !Join
         - ' '
-        - - 'Impact - There may be improperly tested code in PROD or DEV test data is broken.'
+        - - 'Impact - There may be improperly tested code in PROD or CODE test data is broken.'
           - !FindInMap [ Constants, Alarm, Process ]
       Metrics:
         - Id: total

--- a/support-lambdas/it-test-runner/riff-raff.yaml
+++ b/support-lambdas/it-test-runner/riff-raff.yaml
@@ -1,5 +1,8 @@
 stacks: [support]
 regions: [eu-west-1]
+allowedStages:
+  - CODE
+  - PROD
 deployments:
   cfn:
     type: cloud-formation

--- a/support-lambdas/it-test-runner/src/main/scala/com/gu/RunITTests.scala
+++ b/support-lambdas/it-test-runner/src/main/scala/com/gu/RunITTests.scala
@@ -22,7 +22,7 @@ class RunITTests extends RequestStreamHandler {
 }
 object RunITTests {
 
-  lazy val stage = System.getenv().asScala.toMap.getOrElse("Stage", "DEV")
+  lazy val stage = System.getenv().asScala.toMap.getOrElse("Stage", "CODE")
   // todo should we also check the build id to make sure support-workers deploy is keeping the remote jar in sync?
 
   def main(args: Array[String]): Unit = {

--- a/support-lambdas/stripe-intent/riff-raff.yaml
+++ b/support-lambdas/stripe-intent/riff-raff.yaml
@@ -2,8 +2,10 @@ stacks:
 - support
 regions:
 - eu-west-1
+allowedStages:
+  - CODE
+  - PROD
 deployments:
-
   cfn:
     type: cloud-formation
     app: stripe-intent

--- a/support-modules/supporter-product-data-dynamo/README.md
+++ b/support-modules/supporter-product-data-dynamo/README.md
@@ -31,7 +31,7 @@ You will need to give whatever application is using this library the the correct
       - dynamodb:PutItem
       - dynamodb:UpdateItem
       Resource:
-      - Fn::ImportValue: supporter-product-data-tables-DEV-SupporterProductDataTable
+      - Fn::ImportValue: supporter-product-data-tables-CODE-SupporterProductDataTable
 ```
 Then you can use it as follows:
 

--- a/support-payment-api/src/main/resources/riff-raff.yaml
+++ b/support-payment-api/src/main/resources/riff-raff.yaml
@@ -1,5 +1,8 @@
 stacks: [support]
 regions: [eu-west-1]
+allowedStages:
+  - CODE
+  - PROD
 deployments:
   cfn:
     type: cloud-formation

--- a/support-services/src/main/scala/com/gu/support/catalog/CatalogJsonProvider.scala
+++ b/support-services/src/main/scala/com/gu/support/catalog/CatalogJsonProvider.scala
@@ -14,15 +14,10 @@ trait CatalogJsonProvider {
 
 class S3CatalogProvider(environment: TouchPointEnvironment) extends CatalogJsonProvider with LazyLogging {
   override def get: Option[Json] = {
-    val bucket = s"s3://gu-zuora-catalog/PROD/Zuora-${keyFromEnvironment(environment)}"
+    val bucket = s"s3://gu-zuora-catalog/PROD/Zuora-${environment}"
     logger.info(s"Attempting to load catalog from s3://$bucket/catalog.json")
     val catalog = new AmazonS3URI(bucket + "/catalog.json")
     fetchJson(AwsS3Client, catalog)
-  }
-
-  private def keyFromEnvironment(environment: TouchPointEnvironment) = environment match {
-    case CODE => "DEV" // TODO: remove this when we have a CODE catalog
-    case other: TouchPointEnvironment => other.envValue
   }
 }
 

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -62,7 +62,7 @@ IntegrationTest / assembly / test := {}
 assembly / aggregate := false
 
 lazy val deployToCode =
-  inputKey[Unit]("Directly update AWS lambda code from DEV instead of via RiffRaff for faster feedback loop")
+  inputKey[Unit]("Directly update AWS lambda code from CODE instead of via RiffRaff for faster feedback loop")
 
 deployToCode := {
   import scala.sys.process._

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -26,19 +26,19 @@ Mappings:
   StageVariables:
     CODE:
       DynamoDBTables:
-      - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-DEV
+      - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-CODE
       S3Files:
-      - arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-DEV/catalog.json
+      - arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-CODE/catalog.json
       - arn:aws:s3:::support-workers-private/*
-      SupporterProductDataTable: supporter-product-data-tables-DEV-SupporterProductDataTable
+      SupporterProductDataTable: supporter-product-data-tables-CODE-SupporterProductDataTable
       KinesisStreamArn: arn:aws:kinesis:eu-west-1:865473395570:stream/acquisitions-stream-CODE
     PROD:
       DynamoDBTables:
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-PROD
-      - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-DEV
+      - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-CODE
       S3Files:
       - arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-PROD/catalog.json
-      - arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-DEV/catalog.json
+      - arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-CODE/catalog.json
       - arn:aws:s3:::support-workers-private/*
       SupporterProductDataTable: supporter-product-data-tables-PROD-SupporterProductDataTable
       KinesisStreamArn: arn:aws:kinesis:eu-west-1:865473395570:stream/acquisitions-stream-PROD
@@ -113,7 +113,7 @@ Resources:
               - dynamodb:PutItem
               - dynamodb:UpdateItem
               Resource:
-              - Fn::ImportValue: supporter-product-data-tables-DEV-SupporterProductDataTable
+              - Fn::ImportValue: supporter-product-data-tables-CODE-SupporterProductDataTable
               - Fn::ImportValue: !FindInMap [ StageVariables, !Ref Stage, SupporterProductDataTable ]
   StatesExecutionRole:
     Type: "AWS::IAM::Role"

--- a/support-workers/riff-raff.yaml
+++ b/support-workers/riff-raff.yaml
@@ -1,5 +1,8 @@
 stacks: [support]
 regions: [eu-west-1]
+allowedStages:
+  - CODE
+  - PROD
 deployments:
   cfn:
     type: cloud-formation

--- a/support-workers/src/main/scala/com/gu/services/Services.scala
+++ b/support-workers/src/main/scala/com/gu/services/Services.scala
@@ -15,12 +15,12 @@ import com.gu.support.acquisitions.{
   BigQueryService,
 }
 import com.gu.support.catalog.CatalogService
-import com.gu.support.config.Stages.{CODE, DEV, PROD}
+import com.gu.support.config.Stages.PROD
 import com.gu.support.config.TouchPointEnvironments
 import com.gu.support.promotions.PromotionService
 import com.gu.support.redemption.gifting.generator.GiftCodeGeneratorService
 import com.gu.zuora.{ZuoraGiftService, ZuoraService}
-import com.gu.supporterdata.model.Stage.{CODE => DynamoStageDEV, PROD => DynamoStagePROD}
+import com.gu.supporterdata.model.Stage.{CODE => DynamoStageCODE, PROD => DynamoStagePROD}
 import com.gu.supporterdata.services.SupporterDataDynamoService
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -58,7 +58,7 @@ class Services(isTestUser: Boolean, val config: Configuration) {
   )
   val supporterDynamoStage = (Configuration.stage, isTestUser) match {
     case (PROD, false) => DynamoStagePROD
-    case _ => DynamoStageDEV
+    case _ => DynamoStageCODE
   }
   lazy val supporterDataDynamoService = SupporterDataDynamoService(supporterDynamoStage)
 }

--- a/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
@@ -30,7 +30,7 @@ class ZuoraITSpec extends AsyncFlatSpec with Matchers {
   def codeGiftService: ZuoraGiftService =
     new ZuoraGiftService(
       Configuration.load().zuoraConfigProvider.get(),
-      Stages.DEV,
+      Stages.CODE,
       RequestRunners.configurableFutureRunner(30.seconds),
     )
 

--- a/supporter-product-data/build.sbt
+++ b/supporter-product-data/build.sbt
@@ -38,12 +38,12 @@ assembly / assemblyMergeStrategy := {
 }
 
 lazy val deployToCode =
-  inputKey[Unit]("Directly update AWS lambda code from DEV instead of via RiffRaff for faster feedback loop")
+  inputKey[Unit]("Directly update AWS lambda code from CODE instead of via RiffRaff for faster feedback loop")
 
 deployToCode := {
   import scala.sys.process._
   val s3Bucket = "supporter-product-data-dist"
-  val s3Path = "support/DEV/supporter-product-data/supporter-product-data.jar"
+  val s3Path = "support/CODE/supporter-product-data/supporter-product-data.jar"
   (s"aws s3 cp ${assembly.value} s3://" + s3Bucket + "/" + s3Path + " --profile membership --region eu-west-1").!!
   List(
     "-SupporterProductDataQueryZuora-",
@@ -51,7 +51,7 @@ deployToCode := {
     "-SupporterProductDataAddSupporterRatePlanItemToQueue-",
     "-SupporterProductDataProcessSupporterRatePlanItem-",
   ).foreach(functionPartial =>
-    s"aws lambda update-function-code --function-name support${functionPartial}DEV --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!,
+    s"aws lambda update-function-code --function-name support${functionPartial}CODE --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!,
   )
 
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Following on from #4938 this PR switches over all projects to use the CODE version of the supporter product data and promotions tables and updates the cloudformation to apply the correct permissions.