### PR TITLE
Set-up Emotional benefit AB Test

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -4,7 +4,10 @@ import { currencies } from 'helpers/internationalisation/currency';
 import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
-import { getMinimumContributionAmount } from 'helpers/redux/commonState/selectors';
+import {
+	getMinimumContributionAmount,
+	isUserInAbVariant,
+} from 'helpers/redux/commonState/selectors';
 import {
 	useContributionsDispatch,
 	useContributionsSelector,
@@ -21,9 +24,13 @@ type CheckoutBenefitsListContainerProps = {
 function getBenefitsListTitle(
 	priceString: string,
 	contributionType: ContributionType,
+	isEmotionalBenefitTestVariant: boolean,
+	isAustralia: boolean,
 ) {
 	const billingPeriod = contributionType === 'MONTHLY' ? 'month' : 'year';
-	return `For ${priceString} per ${billingPeriod}, you’ll unlock`;
+	return isEmotionalBenefitTestVariant && !isAustralia
+		? `For ${priceString} per ${billingPeriod}`
+		: `For ${priceString} per ${billingPeriod}, you’ll unlock`;
 }
 
 const getbuttonCopy = (
@@ -52,6 +59,10 @@ export function CheckoutBenefitsListContainer({
 	const selectedAmount = useContributionsSelector(getUserSelectedAmount);
 	const minimumContributionAmount = useContributionsSelector(
 		getMinimumContributionAmount,
+	);
+
+	const isEmotionalBenefitTestVariant = useContributionsSelector(
+		isUserInAbVariant('emotionalBenefitTest', 'variant'),
 	);
 
 	const currency = currencies[currencyId];
@@ -88,10 +99,13 @@ export function CheckoutBenefitsListContainer({
 		title: getBenefitsListTitle(
 			userSelectedAmountWithCurrency,
 			contributionType,
+			isEmotionalBenefitTestVariant,
+			isAustralia,
 		),
 		checkListData: checkListData({
 			higherTier,
 			isAustralia,
+			isEmotionalBenefitTestVariant,
 		}),
 		buttonCopy: getbuttonCopy(
 			higherTier,

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
@@ -51,110 +51,114 @@ export const checkListData = ({
 }: CheckListDataProps): CheckListData[] => {
 	const maybeGreyedOutHigherTier = higherTier ? undefined : greyedOut;
 
+	const emotionalBenefits = [
+		{
+			icon: getSvgIcon(true),
+			text: (
+				<p>
+					<span css={boldText}>Fund fearless, independent reporting </span>
+					that's open and free for everyone
+				</p>
+			),
+		},
+		{
+			icon: getSvgIcon(true),
+			text: (
+				<p>
+					<span css={boldText}>Get a regular supporter newsletter </span> with
+					exclusive insights from our newsroom
+				</p>
+			),
+		},
+		{
+			icon: getSvgIcon(true),
+			text: (
+				<p>
+					<span css={boldText}>See fewer asks for support </span>so you can read
+					uninterrupted
+				</p>
+			),
+		},
+		{
+			icon: getSvgIcon(higherTier),
+			text: (
+				<p>
+					<span css={boldText}>Gain full access to our news app </span>to read
+					our reporting on the go
+				</p>
+			),
+			maybeGreyedOut: maybeGreyedOutHigherTier,
+		},
+		{
+			icon: getSvgIcon(higherTier),
+			text: (
+				<p>
+					<span css={boldText}>Read ad-free </span>on all devices
+				</p>
+			),
+			maybeGreyedOut: maybeGreyedOutHigherTier,
+		},
+	];
+
+	const existingBenefits = [
+		{
+			icon: getSvgIcon(true),
+			text: (
+				<p>
+					<span css={boldText}>A regular supporter newsletter. </span>Get
+					exclusive insight from our newsroom
+				</p>
+			),
+		},
+		{
+			icon: getSvgIcon(true),
+			text: (
+				<p>
+					<span css={boldText}>Uninterrupted reading. </span> See far fewer asks
+					for support
+				</p>
+			),
+		},
+		...(isAustralia
+			? [
+					{
+						icon: getSvgIcon(higherTier),
+						text: (
+							<p>
+								<span css={boldText}>
+									Limited-edition Guardian Australia tote bag.{' '}
+								</span>
+								<span css={highlightTextSpacing} />
+								<span css={highlightText}>Offer ends 31 May</span>
+							</p>
+						),
+						maybeGreyedOut: maybeGreyedOutHigherTier,
+					},
+			  ]
+			: []),
+		{
+			icon: getSvgIcon(higherTier),
+			text: (
+				<p>
+					<span css={boldText}>Full access to our news app. </span>Read our
+					reporting on the go
+				</p>
+			),
+			maybeGreyedOut: maybeGreyedOutHigherTier,
+		},
+		{
+			icon: getSvgIcon(higherTier),
+			text: (
+				<p>
+					<span css={boldText}>Ad-free reading. </span>Avoid ads on all your
+					devices
+				</p>
+			),
+			maybeGreyedOut: maybeGreyedOutHigherTier,
+		},
+	];
+
 	return isEmotionalBenefitTestVariant && !isAustralia
-		? [
-				{
-					icon: getSvgIcon(true),
-					text: (
-						<p>
-							<span css={boldText}>Fund fearless, independent reporting </span>
-							that's open and free for everyone
-						</p>
-					),
-				},
-				{
-					icon: getSvgIcon(true),
-					text: (
-						<p>
-							<span css={boldText}>Get a regular supporter newsletter </span>{' '}
-							with exclusive insights from our newsroom
-						</p>
-					),
-				},
-				{
-					icon: getSvgIcon(true),
-					text: (
-						<p>
-							<span css={boldText}>See fewer asks for support </span>so you can
-							read uninterrupted
-						</p>
-					),
-				},
-				{
-					icon: getSvgIcon(higherTier),
-					text: (
-						<p>
-							<span css={boldText}>Gain full access to our news app </span>to
-							read our reporting on the go
-						</p>
-					),
-					maybeGreyedOut: maybeGreyedOutHigherTier,
-				},
-				{
-					icon: getSvgIcon(higherTier),
-					text: (
-						<p>
-							<span css={boldText}>Read ad-free </span>on all devices
-						</p>
-					),
-					maybeGreyedOut: maybeGreyedOutHigherTier,
-				},
-		  ]
-		: [
-				{
-					icon: getSvgIcon(true),
-					text: (
-						<p>
-							<span css={boldText}>A regular supporter newsletter. </span>Get
-							exclusive insight from our newsroom
-						</p>
-					),
-				},
-				{
-					icon: getSvgIcon(true),
-					text: (
-						<p>
-							<span css={boldText}>Uninterrupted reading. </span> See far fewer
-							asks for support
-						</p>
-					),
-				},
-				...(isAustralia
-					? [
-							{
-								icon: getSvgIcon(higherTier),
-								text: (
-									<p>
-										<span css={boldText}>
-											Limited-edition Guardian Australia tote bag.{' '}
-										</span>
-										<span css={highlightTextSpacing} />
-										<span css={highlightText}>Offer ends 31 May</span>
-									</p>
-								),
-								maybeGreyedOut: maybeGreyedOutHigherTier,
-							},
-					  ]
-					: []),
-				{
-					icon: getSvgIcon(higherTier),
-					text: (
-						<p>
-							<span css={boldText}>Full access to our news app. </span>Read our
-							reporting on the go
-						</p>
-					),
-					maybeGreyedOut: maybeGreyedOutHigherTier,
-				},
-				{
-					icon: getSvgIcon(higherTier),
-					text: (
-						<p>
-							<span css={boldText}>Ad-free reading. </span>Avoid ads on all your
-							devices
-						</p>
-					),
-					maybeGreyedOut: maybeGreyedOutHigherTier,
-				},
-		  ];
+		? emotionalBenefits
+		: existingBenefits;
 };

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
@@ -28,6 +28,7 @@ const highlightTextSpacing = css`
 type CheckListDataProps = {
 	higherTier: boolean;
 	isAustralia: boolean;
+	isEmotionalBenefitTestVariant: boolean;
 };
 
 export type CheckListData = {
@@ -46,64 +47,114 @@ export const getSvgIcon = (isUnlocked: boolean): JSX.Element =>
 export const checkListData = ({
 	higherTier,
 	isAustralia,
+	isEmotionalBenefitTestVariant,
 }: CheckListDataProps): CheckListData[] => {
 	const maybeGreyedOutHigherTier = higherTier ? undefined : greyedOut;
 
-	return [
-		{
-			icon: getSvgIcon(true),
-			text: (
-				<p>
-					<span css={boldText}>A regular supporter newsletter. </span>Get
-					exclusive insight from our newsroom
-				</p>
-			),
-		},
-		{
-			icon: getSvgIcon(true),
-			text: (
-				<p>
-					<span css={boldText}>Uninterrupted reading. </span> See far fewer asks
-					for support
-				</p>
-			),
-		},
-		...(isAustralia
-			? [
-					{
-						icon: getSvgIcon(higherTier),
-						text: (
-							<p>
-								<span css={boldText}>
-									Limited-edition Guardian Australia tote bag.{' '}
-								</span>
-								<span css={highlightTextSpacing} />
-								<span css={highlightText}>Offer ends 31 May</span>
-							</p>
-						),
-						maybeGreyedOut: maybeGreyedOutHigherTier,
-					},
-			  ]
-			: []),
-		{
-			icon: getSvgIcon(higherTier),
-			text: (
-				<p>
-					<span css={boldText}>Full access to our news app. </span>Read our
-					reporting on the go
-				</p>
-			),
-			maybeGreyedOut: maybeGreyedOutHigherTier,
-		},
-		{
-			icon: getSvgIcon(higherTier),
-			text: (
-				<p>
-					<span css={boldText}>Ad-free reading. </span>Avoid ads on all your
-					devices
-				</p>
-			),
-			maybeGreyedOut: maybeGreyedOutHigherTier,
-		},
-	];
+	return isEmotionalBenefitTestVariant && !isAustralia
+		? [
+				{
+					icon: getSvgIcon(true),
+					text: (
+						<p>
+							<span css={boldText}>Fund fearless, independent reporting </span>
+							that's open and free for everyone
+						</p>
+					),
+				},
+				{
+					icon: getSvgIcon(true),
+					text: (
+						<p>
+							<span css={boldText}>Get a regular supporter newsletter </span>{' '}
+							with exclusive insights from our newsroom
+						</p>
+					),
+				},
+				{
+					icon: getSvgIcon(true),
+					text: (
+						<p>
+							<span css={boldText}>See fewer asks for support </span>so you can
+							read uninterrupted
+						</p>
+					),
+				},
+				{
+					icon: getSvgIcon(higherTier),
+					text: (
+						<p>
+							<span css={boldText}>Unlock all premium app features </span>to
+							enjoy our Live and Discover tabs
+						</p>
+					),
+					maybeGreyedOut: maybeGreyedOutHigherTier,
+				},
+				{
+					icon: getSvgIcon(higherTier),
+					text: (
+						<p>
+							<span css={boldText}>Read ad-free </span>on all devices
+						</p>
+					),
+					maybeGreyedOut: maybeGreyedOutHigherTier,
+				},
+		  ]
+		: [
+				{
+					icon: getSvgIcon(true),
+					text: (
+						<p>
+							<span css={boldText}>A regular supporter newsletter. </span>Get
+							exclusive insight from our newsroom
+						</p>
+					),
+				},
+				{
+					icon: getSvgIcon(true),
+					text: (
+						<p>
+							<span css={boldText}>Uninterrupted reading. </span> See far fewer
+							asks for support
+						</p>
+					),
+				},
+				...(isAustralia
+					? [
+							{
+								icon: getSvgIcon(higherTier),
+								text: (
+									<p>
+										<span css={boldText}>
+											Limited-edition Guardian Australia tote bag.{' '}
+										</span>
+										<span css={highlightTextSpacing} />
+										<span css={highlightText}>Offer ends 31 May</span>
+									</p>
+								),
+								maybeGreyedOut: maybeGreyedOutHigherTier,
+							},
+					  ]
+					: []),
+				{
+					icon: getSvgIcon(higherTier),
+					text: (
+						<p>
+							<span css={boldText}>Full access to our news app. </span>Read our
+							reporting on the go
+						</p>
+					),
+					maybeGreyedOut: maybeGreyedOutHigherTier,
+				},
+				{
+					icon: getSvgIcon(higherTier),
+					text: (
+						<p>
+							<span css={boldText}>Ad-free reading. </span>Avoid ads on all your
+							devices
+						</p>
+					),
+					maybeGreyedOut: maybeGreyedOutHigherTier,
+				},
+		  ];
 };

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
@@ -84,8 +84,8 @@ export const checkListData = ({
 					icon: getSvgIcon(higherTier),
 					text: (
 						<p>
-							<span css={boldText}>Unlock all premium app features </span>to
-							enjoy our Live and Discover tabs
+							<span css={boldText}>Gain full access to our news app </span>to
+							read our reporting on the go
 						</p>
 					),
 					maybeGreyedOut: maybeGreyedOutHigherTier,

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -100,4 +100,27 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		seed: 1,
 	},
+	emotionalBenefitTest: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+				breakpoint: {
+					minWidth: 'tablet',
+				},
+			},
+		},
+		isActive: false,
+		referrerControlled: false,
+		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+		seed: 13,
+	},
 };

--- a/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
@@ -45,7 +45,11 @@ export const AllBenefitsUnlocked = Template.bind({});
 
 AllBenefitsUnlocked.args = {
 	title: "For £12 per month, you'll unlock",
-	checkListData: checkListData({ higherTier: true, isAustralia: false }),
+	checkListData: checkListData({
+		higherTier: true,
+		isAustralia: false,
+		isEmotionalBenefitTestVariant: false,
+	}),
 	buttonCopy: null,
 	countryGroupId: 'GBPCountries',
 };
@@ -54,7 +58,11 @@ export const LowerTierUnlocked = Template.bind({});
 
 LowerTierUnlocked.args = {
 	title: "For £5 per month, you'll unlock",
-	checkListData: checkListData({ higherTier: false, isAustralia: false }),
+	checkListData: checkListData({
+		higherTier: false,
+		isAustralia: false,
+		isEmotionalBenefitTestVariant: false,
+	}),
 	buttonCopy: 'Switch to £12 per month to unlock all extras',
 	countryGroupId: 'GBPCountries',
 };


### PR DESCRIPTION
## What are you doing in this PR?
Set-up Emotional benefit AB Test

[**Trello Card**](https://trello.com/c/a2iskxQ7/1219-set-up-emotional-benefit-ab-test)

## Why are you doing this?

### Objective:
Test whether adding in an emotional benefit in to the benefits bullet points will increase conversion
### Context:
Following the latest copy changes and review, we have decided to change this to make more sense in a flow
### Changes:
Remove “you will” in title
change all benefits copy for variant

[**Figma link here**](https://www.figma.com/file/MQu0jaD3GR1C0CpdLLozOJ/MVP---optimisation---Q4?node-id=1672-87106&t=sIKUwyRJh6ZKQin9-0)

## Is this an AB test?
- [ x] Yes
- [ ] No
Test details:
this will be AB tested on desktop only, at the same time as mobile variant B
Metrics: This will be to test conversion rate
<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)

## Screenshots

### (Control-Desktop)

<img width="997" alt="image" src="https://user-images.githubusercontent.com/73653255/236184840-dae91cd2-0ab8-4fb2-afc3-d18146f6a2b1.png">

### (Variant-Desktop-Below Threshold)

<img width="890" alt="image" src="https://user-images.githubusercontent.com/73653255/236277305-2ef556dc-53a2-4b96-89bc-19538400784e.png">

### (Variant-Desktop-Above Threshold)

<img width="890" alt="image" src="https://user-images.githubusercontent.com/73653255/236277208-43597050-efe0-4a4c-a693-a7970c61ad67.png">

### (Control-Mobile)

<img width="505" alt="image" src="https://user-images.githubusercontent.com/73653255/236184638-0dc58576-8bd1-4e2d-a648-7a6361c392c5.png">

### (Variant-Mobile-same as control)

<img width="561" alt="image" src="https://user-images.githubusercontent.com/73653255/236185615-749160d7-70a0-43dc-9f7a-437cba8a58ab.png">


### (Control-Desktop-Australia)

<img width="997" alt="image" src="https://user-images.githubusercontent.com/73653255/236185062-b286d480-c03b-48a7-bc8b-a4ced74173ed.png">

### (Variant-Desktop-Australia-same as control)
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/73653255/236250420-6b78ded6-07f5-4604-ac48-77b229cac677.png">




