### PR TITLE
Add a 'special offer' variant of the print product option cards for 12for12

### DIFF
--- a/support-frontend/assets/components/product/productOption.tsx
+++ b/support-frontend/assets/components/product/productOption.tsx
@@ -1,15 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css, ThemeProvider } from '@emotion/react';
-import {
-	between,
-	brandAlt,
-	from,
-	headline,
-	neutral,
-	space,
-	textSans,
-	until,
-} from '@guardian/source-foundations';
+import { until } from '@guardian/source-foundations';
 import {
 	buttonThemeReaderRevenue,
 	LinkButton,
@@ -19,6 +10,21 @@ import { useEffect } from 'react';
 import { useHasBeenSeen } from 'helpers/customHooks/useHasBeenSeen';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import { Monthly } from 'helpers/productPrice/billingPeriods';
+import {
+	button,
+	buttonDiv,
+	priceCopyGridPlacement,
+	productOption,
+	productOptionHighlight,
+	productOptionOfferCopy,
+	productOptionPrice,
+	productOptionPriceCopy,
+	productOptionTitle,
+	productOptionUnderline,
+	productOptionVerticalLine,
+	specialOfferHighlight,
+	specialOfferOption,
+} from './productOptionStyles';
 
 export type Product = {
 	title: string;
@@ -33,154 +39,8 @@ export type Product = {
 	label?: string;
 	cssOverrides?: SerializedStyles;
 	billingPeriod?: BillingPeriod;
+	isSpecialOffer?: boolean;
 };
-
-const productOption = css`
-	${textSans.medium()}
-	position: relative;
-	display: grid;
-	grid-template-columns: 2fr 1fr;
-	grid-template-rows: min-content 1fr min-content;
-	grid-template-areas:
-		'. priceCopy'
-		'. priceCopy'
-		'button button';
-	width: 100%;
-	background-color: ${neutral[100]};
-	color: ${neutral[7]};
-	padding: ${space[3]}px;
-	${from.tablet} {
-		min-height: 272px;
-		width: 300px;
-		grid-template-columns: none;
-		grid-template-rows: 48px minmax(66px, max-content) minmax(100px, 1fr) 72px;
-		grid-template-areas: none;
-	}
-`;
-
-const productOptionUnderline = css`
-	${from.tablet} {
-		border-bottom: 1px solid ${neutral[86]};
-	}
-`;
-
-const productOptionVerticalLine = css`
-	${until.tablet} {
-		border-right: 1px solid ${neutral[86]};
-		margin-right: ${space[3]}px;
-		padding-right: ${space[3]}px;
-	}
-`;
-
-const productOptionTitle = css`
-	${headline.xsmall({
-		fontWeight: 'bold',
-	})};
-	padding-bottom: ${space[5]}px;
-	${from.tablet} {
-		margin-bottom: ${space[2]}px;
-	}
-	${between.tablet.and.leftCol} {
-		${headline.xxxsmall({
-			fontWeight: 'bold',
-		})};
-	}
-`;
-
-const productOptionOfferCopy = css`
-	${textSans.medium()};
-	${from.tablet} {
-		height: 100%;
-		padding-bottom: ${space[2]}px;
-	}
-	${between.tablet.and.leftCol} {
-		${textSans.small()};
-	}
-`;
-
-const productOptionPrice = css`
-	display: block;
-	padding-bottom: ${space[5]}px;
-	${headline.xsmall({
-		fontWeight: 'bold',
-	})};
-	${between.tablet.and.leftCol} {
-		${headline.small({
-			fontWeight: 'bold',
-		})};
-	}
-	${from.leftCol} {
-		${headline.large({
-			fontWeight: 'bold',
-		})};
-		padding-bottom: 0;
-	}
-`;
-
-const productOptionPriceCopy = css`
-	${textSans.xsmall()};
-	${from.tablet} {
-		height: 100%;
-		margin-bottom: ${space[4]}px;
-	}
-	${between.phablet.and.leftCol} {
-		${textSans.small()};
-	}
-	${from.leftCol} {
-		${textSans.medium()};
-	}
-`;
-
-const productOptionHighlight = css`
-	background-color: ${brandAlt[400]};
-	color: ${neutral[7]};
-	position: absolute;
-	left: 0;
-	top: 1px;
-	transform: translateY(-100%);
-	text-align: center;
-	padding: ${space[2]}px ${space[3]}px;
-	${headline.xxsmall({
-		fontWeight: 'bold',
-	})};
-`;
-
-const buttonDiv = css`
-	display: flex;
-	flex-direction: column;
-	align-items: stretch;
-	grid-area: button;
-	padding: ${space[3]}px 0;
-	${between.mobileLandscape.and.tablet} {
-		grid-area: 3 / 1 / span 1 / span 1;
-		border-right: 1px solid ${neutral[86]};
-		margin-right: ${space[3]}px;
-		padding-right: ${space[3]}px;
-	}
-	${from.tablet} {
-		grid-area: auto;
-		padding: 0;
-	}
-`;
-
-const button = css`
-	display: flex;
-	justify-content: center;
-	${from.mobileLandscape} {
-		grid-area: priceCopy;
-		display: inline-flex;
-	}
-	${from.tablet} {
-		grid-area: auto;
-		display: inline-flex;
-	}
-`;
-
-const priceCopyGridPlacement = css`
-	${until.tablet} {
-		grid-area: priceCopy;
-	}
-`;
 
 function ProductOption(props: Product): JSX.Element {
 	const [hasBeenSeen, setElementToObserve] = useHasBeenSeen({
@@ -219,13 +79,27 @@ function ProductOption(props: Product): JSX.Element {
 	return (
 		<div
 			ref={setElementToObserve}
-			css={[productOption, props.cssOverrides, productOptionMargin]}
+			css={[
+				productOption,
+				props.cssOverrides,
+				productOptionMargin,
+				props.isSpecialOffer ? specialOfferOption : css``,
+			]}
 		>
 			<div css={productOptionVerticalLine}>
 				<h3 css={[productOptionTitle, productOptionUnderline]}>
 					{props.title}
 				</h3>
-				{props.label && <span css={productOptionHighlight}>{props.label}</span>}
+				{props.label && (
+					<span
+						css={[
+							productOptionHighlight,
+							props.isSpecialOffer ? specialOfferHighlight : css``,
+						]}
+					>
+						{props.label}
+					</span>
+				)}
 				{props.children && props.children}
 			</div>
 			<div css={productOptionVerticalLine}>

--- a/support-frontend/assets/components/product/productOptionStyles.tsx
+++ b/support-frontend/assets/components/product/productOptionStyles.tsx
@@ -1,0 +1,169 @@
+import { css } from '@emotion/react';
+import {
+	between,
+	brandAlt,
+	from,
+	headline,
+	neutral,
+	space,
+	textSans,
+	until,
+} from '@guardian/source-foundations';
+
+export const productOption = css`
+	${textSans.medium()}
+	position: relative;
+	display: grid;
+	grid-template-columns: 2fr 1fr;
+	grid-template-rows: min-content 1fr min-content;
+	grid-template-areas:
+		'. priceCopy'
+		'. priceCopy'
+		'button button';
+	width: 100%;
+	background-color: ${neutral[100]};
+	color: ${neutral[7]};
+	padding: ${space[3]}px;
+	${from.tablet} {
+		min-height: 272px;
+		width: 300px;
+		grid-template-columns: none;
+		grid-template-rows: 48px minmax(66px, max-content) minmax(100px, 1fr) 72px;
+		grid-template-areas: none;
+	}
+`;
+
+export const specialOfferOption = css`
+	background-color: #fffdeb;
+	border: 5px solid ${brandAlt[400]};
+`;
+
+export const productOptionUnderline = css`
+	${from.tablet} {
+		border-bottom: 1px solid ${neutral[86]};
+	}
+`;
+
+export const productOptionVerticalLine = css`
+	${until.tablet} {
+		border-right: 1px solid ${neutral[86]};
+		margin-right: ${space[3]}px;
+		padding-right: ${space[3]}px;
+	}
+`;
+
+export const productOptionTitle = css`
+	${headline.xsmall({
+		fontWeight: 'bold',
+	})};
+	padding-bottom: ${space[5]}px;
+	${from.tablet} {
+		margin-bottom: ${space[2]}px;
+	}
+	${between.tablet.and.leftCol} {
+		${headline.xxxsmall({
+			fontWeight: 'bold',
+		})};
+	}
+`;
+
+export const productOptionOfferCopy = css`
+	${textSans.medium()};
+	${from.tablet} {
+		height: 100%;
+		padding-bottom: ${space[2]}px;
+	}
+	${between.tablet.and.leftCol} {
+		${textSans.small()};
+	}
+`;
+
+export const productOptionPrice = css`
+	display: block;
+	padding-bottom: ${space[5]}px;
+	${headline.xsmall({
+		fontWeight: 'bold',
+	})};
+	${between.tablet.and.leftCol} {
+		${headline.small({
+			fontWeight: 'bold',
+		})};
+	}
+	${from.leftCol} {
+		${headline.large({
+			fontWeight: 'bold',
+		})};
+		padding-bottom: 0;
+	}
+`;
+
+export const productOptionPriceCopy = css`
+	${textSans.xsmall()};
+	${from.tablet} {
+		height: 100%;
+		margin-bottom: ${space[4]}px;
+	}
+	${between.phablet.and.leftCol} {
+		${textSans.small()};
+	}
+	${from.leftCol} {
+		${textSans.medium()};
+	}
+`;
+
+export const productOptionHighlight = css`
+	background-color: ${brandAlt[400]};
+	color: ${neutral[7]};
+	position: absolute;
+	left: 0;
+	top: 1px;
+	transform: translateY(-100%);
+	text-align: center;
+	padding: ${space[2]}px ${space[3]}px;
+	${headline.xxsmall({
+		fontWeight: 'bold',
+	})};
+`;
+
+export const specialOfferHighlight = css`
+	width: calc(100% + 10px);
+	top: 0px;
+	left: -5px;
+`;
+
+export const buttonDiv = css`
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	grid-area: button;
+	padding: ${space[3]}px 0;
+	${between.mobileLandscape.and.tablet} {
+		grid-area: 3 / 1 / span 1 / span 1;
+		border-right: 1px solid ${neutral[86]};
+		margin-right: ${space[3]}px;
+		padding-right: ${space[3]}px;
+	}
+	${from.tablet} {
+		grid-area: auto;
+		padding: 0;
+	}
+`;
+
+export const button = css`
+	display: flex;
+	justify-content: center;
+	${from.mobileLandscape} {
+		grid-area: priceCopy;
+		display: inline-flex;
+	}
+	${from.tablet} {
+		grid-area: auto;
+		display: inline-flex;
+	}
+`;
+
+export const priceCopyGridPlacement = css`
+	${until.tablet} {
+		grid-area: priceCopy;
+	}
+`;

--- a/support-frontend/assets/components/product/productOptionStyles.tsx
+++ b/support-frontend/assets/components/product/productOptionStyles.tsx
@@ -36,6 +36,8 @@ export const productOption = css`
 export const specialOfferOption = css`
 	background-color: #fffdeb;
 	border: 5px solid ${brandAlt[400]};
+	/* Reduce top and bottom padding to account for the border */
+	padding: 7px ${space[3]}px;
 `;
 
 export const productOptionUnderline = css`

--- a/support-frontend/assets/components/product/productOptionStyles.tsx
+++ b/support-frontend/assets/components/product/productOptionStyles.tsx
@@ -11,7 +11,7 @@ import {
 } from '@guardian/source-foundations';
 
 export const productOption = css`
-	${textSans.medium()}
+	${textSans.medium()};
 	position: relative;
 	display: grid;
 	grid-template-columns: 2fr 1fr;

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -8,13 +8,13 @@ const coreBenefits = [
 		content: 'Every issue delivered with up to 35% off the cover price',
 	},
 	{
-		content: 'Access to the magazine's digital archive',
+		content: `Access to the magazine's digital archive`,
 	},
 	{
 		content: 'A weekly email newsletter from the editor',
 	},
 	{
-		content: 'The very best of the Guardian's puzzles',
+		content: `The very best of the Guardian's puzzles`,
 	},
 ];
 

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -14,7 +14,7 @@ const coreBenefits = [
 		content: 'A weekly email newsletter from the editor',
 	},
 	{
-		content: "The very best of the Guardian's puzzles",
+		content: 'The very best of the Guardian's puzzles',
 	},
 ];
 

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -8,13 +8,13 @@ const coreBenefits = [
 		content: 'Every issue delivered with up to 35% off the cover price',
 	},
 	{
-		content: `Access to the magazine's digital archive`,
+		content: "Access to the magazine's digital archive",
 	},
 	{
 		content: 'A weekly email newsletter from the editor',
 	},
 	{
-		content: `The very best of the Guardian's puzzles`,
+		content: "The very best of the Guardian's puzzles",
 	},
 ];
 

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -8,7 +8,7 @@ const coreBenefits = [
 		content: 'Every issue delivered with up to 35% off the cover price',
 	},
 	{
-		content: "Access to the magazine's digital archive",
+		content: 'Access to the magazine's digital archive',
 	},
 	{
 		content: 'A weekly email newsletter from the editor',

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -1,8 +1,37 @@
 import { List } from 'components/list/list';
+import type { IsoCountry } from 'helpers/internationalisation/country';
 import BenefitsContainer from './benefitsContainer';
 import BenefitsHeading from './benefitsHeading';
 
-function Benefits(): JSX.Element {
+const coreBenefits = [
+	{
+		content: 'Every issue delivered with up to 35% off the cover price',
+	},
+	{
+		content: "Access to the magazine's digital archive",
+	},
+	{
+		content: 'A weekly email newsletter from the editor',
+	},
+	{
+		content: "The very best of the Guardian's puzzles",
+	},
+];
+
+function getBenefits(countryId: IsoCountry) {
+	if (countryId === 'GB') {
+		return [
+			...coreBenefits,
+			{
+				content:
+					'A free Gift! £10 Guardian Bookshop voucher - exclusive to 12 for £12 quarterly subscribers',
+			},
+		];
+	}
+	return coreBenefits;
+}
+
+function Benefits({ countryId }: { countryId: IsoCountry }): JSX.Element {
 	return (
 		<BenefitsContainer
 			sections={[
@@ -11,23 +40,7 @@ function Benefits(): JSX.Element {
 					content: (
 						<>
 							<BenefitsHeading text="As a subscriber you’ll enjoy" />
-							<List
-								items={[
-									{
-										content:
-											'Every issue delivered with up to 35% off the cover price',
-									},
-									{
-										content: "Access to the magazine's digital archive",
-									},
-									{
-										content: 'A weekly email newsletter from the editor',
-									},
-									{
-										content: "The very best of the Guardian's puzzles",
-									},
-								]}
-							/>
+							<List items={getBenefits(countryId)} />
 						</>
 					),
 				},

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
@@ -144,6 +144,7 @@ function Prices({
 						onClick={product.onClick}
 						onView={product.onView}
 						label={product.label}
+						isSpecialOffer={product.isSpecialOffer}
 					/>
 				))}
 			</FlexContainer>

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
@@ -105,7 +105,7 @@ const pricesInfo = css`
 `;
 
 const termsLink = css`
-	${textSans.xxsmall()}
+	${textSans.xxsmall()};
 	margin-left: ${space[9]}px;
 	margin-top: -12px;
 `;

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
@@ -1,12 +1,18 @@
-import { css } from '@emotion/react';
+import { css, ThemeProvider } from '@emotion/react';
 import {
 	body,
 	from,
 	headline,
 	neutral,
 	space,
+	textSans,
 } from '@guardian/source-foundations';
-import { SvgGift, SvgInfo } from '@guardian/source-react-components';
+import {
+	Link,
+	linkThemeBrand,
+	SvgGift,
+	SvgInfo,
+} from '@guardian/source-react-components';
 import FlexContainer from 'components/containers/flexContainer';
 import ProductInfoChip from 'components/product/productInfoChip';
 import type { Product } from 'components/product/productOption';
@@ -98,6 +104,15 @@ const pricesInfo = css`
 	margin-top: ${space[6]}px;
 `;
 
+const termsLink = css`
+	${textSans.xxsmall()}
+	margin-left: ${space[9]}px;
+	margin-top: -12px;
+`;
+
+const termsConditionsLink =
+	'https://www.theguardian.com/info/2014/jul/10/guardian-weekly-print-subscription-services-terms-conditions';
+
 function Prices({
 	orderIsAGift,
 	products,
@@ -157,6 +172,13 @@ function Prices({
 				<ProductInfoChip icon={<SvgInfo />}>
 					Delivery cost included.{' '}
 					{!orderIsAGift && 'You can cancel your subscription at any time'}
+				</ProductInfoChip>
+				<ProductInfoChip>
+					<ThemeProvider theme={linkThemeBrand}>
+						<Link href={termsConditionsLink} cssOverrides={termsLink}>
+							Click here to see full Terms and Conditions
+						</Link>
+					</ThemeProvider>
 				</ProductInfoChip>
 			</div>
 		</section>

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
@@ -91,10 +91,10 @@ const weeklyProductProps = (
 	};
 
 	// TODO: remove/review this when the 12 for 12 offer is over
-	const isSpecialOffer = promotion?.promoCode === '12for12';
+	const isSpecialOffer = promotion?.promoCode.startsWith('12for12');
 	const label = isSpecialOffer
 		? `Special Offer: 12 for ${currencies[productPrice.currency].glyph}${
-				promotion.discountedPrice ?? '12'
+				promotion?.discountedPrice ?? '12'
 		  }`
 		: getPromotionLabel(promotion);
 

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
@@ -52,7 +52,7 @@ const getPriceWithSymbol = (currencyId: IsoCurrency, price: number) =>
 
 const getPromotionLabel = (promotion?: Promotion) => {
 	if (!promotion || !promotion.discount) {
-		return null;
+		return '';
 	}
 
 	return `Save ${Math.round(promotion.discount.amount)}%`;
@@ -90,6 +90,14 @@ const weeklyProductProps = (
 		componentType: 'ACQUISITIONS_BUTTON' as OphanComponentType,
 	};
 
+	// TODO: remove/review this when the 12 for 12 offer is over
+	const isSpecialOffer = promotion?.promoCode === '12for12';
+	const label = isSpecialOffer
+		? `Special Offer: 12 for ${currencies[productPrice.currency].glyph}${
+				promotion.discountedPrice ?? '12'
+		  }`
+		: getPromotionLabel(promotion);
+
 	return {
 		title: billingPeriodTitle(billingPeriod, orderIsAGift),
 		price: getPriceWithSymbol(productPrice.currency, mainDisplayPrice),
@@ -99,9 +107,10 @@ const weeklyProductProps = (
 		),
 		buttonCopy: 'Subscribe now',
 		href: getCheckoutUrl(billingPeriod, orderIsAGift),
-		label: getPromotionLabel(promotion) ?? '',
+		label,
 		onClick: sendTrackingEventsOnClick(trackingProperties),
 		onView: sendTrackingEventsOnView(trackingProperties),
+		isSpecialOffer,
 	};
 };
 

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -91,7 +91,11 @@ function WeeklyLPControl({
 			<FullWidthContainer>
 				<CentredContainer>
 					<Block cssOverrides={styles.closeGapAfterPageTitle}>
-						{orderIsAGift ? <GiftBenefits /> : <Benefits />}
+						{orderIsAGift ? (
+							<GiftBenefits />
+						) : (
+							<Benefits countryId={countryId} />
+						)}
 					</Block>
 				</CentredContainer>
 			</FullWidthContainer>
@@ -173,7 +177,11 @@ function WeeklyLPVariant({
 			<FullWidthContainer>
 				<CentredContainer>
 					<Block cssOverrides={styles.closeGapAfterPageTitle}>
-						{orderIsAGift ? <GiftBenefits /> : <Benefits />}
+						{orderIsAGift ? (
+							<GiftBenefits />
+						) : (
+							<Benefits countryId={countryId} />
+						)}
 					</Block>
 				</CentredContainer>
 			</FullWidthContainer>

--- a/support-frontend/stories/product/ProductOption.stories.tsx
+++ b/support-frontend/stories/product/ProductOption.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { Product } from 'components/product/productOption';
 import ProductOptionComponent from 'components/product/productOption';
 
 export default {
@@ -40,14 +41,7 @@ export default {
 	],
 };
 
-export function ProductOption(args: {
-	title: string;
-	price: string;
-	offerCopy: string;
-	priceCopy: string;
-	buttonCopy: string;
-	label: string;
-}): JSX.Element {
+function Template(args: Product) {
 	return (
 		<ProductOptionComponent
 			title={args.title}
@@ -56,12 +50,17 @@ export function ProductOption(args: {
 			priceCopy={args.priceCopy}
 			buttonCopy={args.buttonCopy}
 			label={args.label}
+			isSpecialOffer={args.isSpecialOffer}
 			onClick={() => undefined}
 			onView={() => undefined}
 			href=""
 		/>
 	);
 }
+
+Template.args = {} as Record<string, unknown>;
+
+export const ProductOption = Template.bind({});
 
 ProductOption.args = {
 	title: '6 for 6',
@@ -70,4 +69,16 @@ ProductOption.args = {
 	priceCopy: 'then £37.50 per quarter',
 	buttonCopy: 'Subscribe now',
 	label: 'Best deal',
+};
+
+export const SpecialOfferProductOption = Template.bind({});
+
+SpecialOfferProductOption.args = {
+	title: '12 for 12',
+	price: '£12',
+	offerCopy: '£12 for the first 6 issues',
+	priceCopy: 'then £13.50 per month',
+	buttonCopy: 'Subscribe now',
+	label: 'Special offer',
+	isSpecialOffer: true,
 };


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds a 'special offer' variant of our `ProductOption` component that adds a border, background, and full width top label, to support the upcoming '12 for £12' promotion for Guardian Weekly.

It also adds some promotion-specific logic to display this component variant, and an amendment to add a link to our terms and conditions below the product price cards.

[**Trello Card**](https://trello.com/c/YONhXPJM)

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

### Mobile, Google Pixel 6, Chrome
![Screenshot 2023-05-04 at 15 50 01](https://user-images.githubusercontent.com/29146931/236245103-4bb26ede-bd74-42dd-817d-0b37559b74d5.png)

### Tablet, iPad 8th gen, Safari
![Screenshot 2023-05-04 at 15 50 42](https://user-images.githubusercontent.com/29146931/236245243-c7a350f9-da02-4597-b66b-f57c7e500792.png)

### Desktop, macOS, Firefox
![Screenshot 2023-05-04 at 15-47-54 The Guardian Weekly Subscriptions The Guardian](https://user-images.githubusercontent.com/29146931/236245377-30905732-7012-4e67-96b4-27233af22cd5.png)
