### PR TITLE
Change price on Subscriptions landing page to £12 for 12 instead of 13.75/monthly for GW

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
@@ -71,6 +71,16 @@ const getWeeklyImage = (isTop: boolean) => {
 	return <GuardianWeeklyPackShot />;
 };
 
+function get12for12Subtitle(): string | undefined {
+	const today = new Date();
+	const startDate = new Date('2023-05-12');
+	const endDate = new Date('2023-06-12');
+
+	if (today >= startDate && today <= endDate) {
+		return '£12 for 12 issues';
+	}
+}
+
 const guardianWeekly = (
 	countryGroupId: CountryGroupId,
 	priceCopy: PriceCopy,
@@ -78,7 +88,8 @@ const guardianWeekly = (
 	participations: Participations,
 ): ProductCopy => ({
 	title: 'Guardian Weekly',
-	subtitle: getDisplayPrice(countryGroupId, priceCopy.price),
+	subtitle:
+		get12for12Subtitle() ?? getDisplayPrice(countryGroupId, priceCopy.price),
 	description:
 		'Gain a deeper understanding of the issues that matter with the Guardian Weekly magazine. Every week, take your time over handpicked articles from the Guardian and Observer, delivered for free to wherever you are in the world.',
 	offer: getGuardianWeeklyOfferCopy(priceCopy.discountCopy),


### PR DESCRIPTION
On Subscriptions landing page - price should say “£12 for 12 issues” instead of “13.75/monthly”

This should be for UK only- as this page is only visible in UK
This should be turned off 12th June and revert to original text of “13.75/monthly” (unhighlighted)

[**Trello Card**](https://trello.com/c/2wVVekB7/1275-gw-12for12-change-price-on-subscriptions-landing-page-to-12-for-12-instead-of-1375-monthly-for-gw)

## Why are you doing this?


## Is this an AB test?
- [ ] Yes
- [x] No
