### PR TITLE
Include identity endpoint in error messages

### DIFF
--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -140,7 +140,7 @@ class CreateSubscriptionController(
     else if (IdentityError.isBadEmailError(identityError))
       RequestValidationError(BadEmailAddress.errorReasonCode)
     else
-      ServerError(identityError.description)
+      ServerError(identityError.message.concat(identityError.description))
 
   private def logIncomingRequest(
       request: OptionalAuthRequest[CreateSupportWorkersRequest],

--- a/support-frontend/app/services/HttpIdentityService.scala
+++ b/support-frontend/app/services/HttpIdentityService.scala
@@ -164,6 +164,10 @@ class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient:
           ),
         )
         .map(userResponse => userResponse.user.id)
+    }.leftMap { e =>
+      e match {
+        case IdentityError(message, description) => IdentityError("Error calling /user:".concat(message), description)
+      }
     }
 
   def createUserIdFromEmailUser(
@@ -210,6 +214,10 @@ class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient:
           ),
         )
         .map(response => response.guestRegistrationRequest.userId)
+    }.leftMap { e =>
+      e match {
+        case IdentityError(message, description) => IdentityError("Error calling /guest:".concat(message), description)
+      }
     }
   }
 


### PR DESCRIPTION
We’ve had some timeouts recently, and it’d be helpful to know which endpoint we’re getting the timeout from: this should mean we see it in the logs.

This came up during alarm investigations: we considered raising the timeouts, but I’ve noticed that there’s retry logic in place: up to 2 retries, 3 seconds timeout per request. So raising to 5 seconds would mean it might take over 15 seconds, which is quite long to make the user wait. I’ll bring it up with Identity anyway, see what’s normal for a timeout.