### PR TITLE
Paypal total to include discount final amount

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/total/total.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/total/total.tsx
@@ -1,11 +1,6 @@
 import { extendedGlyph } from 'helpers/internationalisation/currency';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { displayPrice } from 'helpers/productPrice/priceDescriptions';
-import {
-	getAppliedPromo,
-	hasDiscount,
-	hasIntroductoryPrice,
-} from 'helpers/productPrice/promotions';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import * as styles from './totalStyles';
 
@@ -15,22 +10,9 @@ type Props = {
 	promotions?: Promotion[];
 };
 
-const getPrice = (promotion: Promotion | undefined, price: number): number => {
-	if (hasIntroductoryPrice(promotion)) {
-		return promotion.introductoryPrice.price;
-	}
-
-	if (hasDiscount(promotion)) {
-		return promotion.discountedPrice;
-	}
-
-	return price;
-};
-
-function Total({ price, currency, promotions }: Props) {
+function Total({ price, currency }: Props) {
 	const glyph = extendedGlyph(currency);
-	const appliedPromotion = getAppliedPromo(promotions);
-	const formattedPrice = displayPrice(glyph, getPrice(appliedPromotion, price));
+	const formattedPrice = displayPrice(glyph, price);
 	return (
 		<div css={styles.container}>
 			<div css={styles.wrapper}>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -425,9 +425,8 @@ function WeeklyCheckoutForm(props: PropTypes) {
 						errorHeading={submissionErrorHeading}
 					/>
 					<Total
-						price={props.price.price}
+						price={props.discountedPrice.price}
 						currency={props.currencyId}
-						promotions={props.price.promotions}
 					/>
 					<PaymentTerms paymentMethod={props.paymentMethod} />
 				</Form>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -44,7 +44,10 @@ import { NoProductOptions } from 'helpers/productPrice/productOptions';
 import { GuardianWeekly } from 'helpers/productPrice/subscriptions';
 import { setBillingCountry } from 'helpers/redux/checkout/address/actions';
 import { getUserTypeFromIdentity } from 'helpers/redux/checkout/personalDetails/thunks';
-import { selectPriceForProduct } from 'helpers/redux/checkout/product/selectors/productPrice';
+import {
+	selectDiscountedPrice,
+	selectPriceForProduct,
+} from 'helpers/redux/checkout/product/selectors/productPrice';
 import type {
 	SubscriptionsDispatch,
 	SubscriptionsState,
@@ -103,6 +106,7 @@ function mapStateToProps(state: SubscriptionsState) {
 			currencyFromCountryCode(deliveryAddress.fields.country) ?? 'USD',
 		payPalHasLoaded: state.page.checkoutForm.payment.payPal.hasLoaded,
 		price: selectPriceForProduct(state),
+		discountedPrice: selectDiscountedPrice(state),
 	};
 }
 
@@ -406,7 +410,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 							validateForm={props.validateForm}
 							isTestUser={props.isTestUser}
 							setupRecurringPayPalPayment={props.setupRecurringPayPalPayment}
-							amount={props.price.price}
+							amount={props.discountedPrice.price}
 							billingPeriod={props.billingPeriod}
 							// @ts-expect-error TODO: fix when we can fix error states for all checkouts
 							allErrors={[

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -56,7 +56,7 @@ const styles = {
 		${from.phablet} {
 			display: flex;
 			flex-direction: row;
-			justify-content: space-evenly:
+			justify-content: space-evenly;
 		}
 	`,
 	weeklyHeroContainerOverrides: css`


### PR DESCRIPTION
The 12for12 discount we've made for the GW doesn't work for PayPal customers, even if they've selected 'Quarterly' with the discount. They get shown full price not discounted price (for all offers). PayPal isn’t showing the discounted amount on checkout, it is still charging £12 in this offer case.

1. Compared `PaperCheckoutForm.tsx` with `weeklyCheckoutForm.tsx` as discounts prices were displayed correctly in the former.
2. Discount price was taken from redux state (function 'selectedDiscountedPrice') which we could apply to the `weeklyCheckoutForm.tsx` (first commit). Tested '_PayPalScreenTotal_' (below screenshot table).
3. `Total.tsx` discounted component price was calculated and displayed at mobile breakpoints. To simplify (reduce code) the calculation was removed and 'selectedDiscountedPrice' applied (second commit).  Tested '_MobileTotalDiscounted_'/'_MobileTotalNoDiscount_' remained the same (below screenshot table).

Also confirmed both payments were setup as part of 12for12 offer->
Step function: support-workers-CODE. It created 2 payments 3months apart, first for discounted rate, second for full price. As shown below->
![Untitled5](https://github.com/guardian/support-frontend/assets/76729591/6b9e85fe-4aa9-4192-82b5-dce96b053fac)

[**Trello Card**](https://trello.com/c/9VcwpRpQ/1300-12-for-12-bug-paypal-payments)

## Why are you doing this?
Paypal total to include discount final amount.

## Is this an AB test?
- [ ] Yes
- [x] No

## Screenshots

| | PayPalScreenTotal | MobileTotalDiscounted*  | MobileTotalNoDiscount*  |
| -- | -- | -- | -- |
| Before | ![Untitled](https://github.com/guardian/support-frontend/assets/76729591/2e2d0b07-73cd-4617-b1da-7266f1c61700) | ![Untitled2](https://github.com/guardian/support-frontend/assets/76729591/419819f8-1399-4bc2-bfec-66d658be97c2) | ![Untitled4](https://github.com/guardian/support-frontend/assets/76729591/5c603555-f60c-4e5d-afe9-ebe2ba8767a9) |
| After | ![Untitled1](https://github.com/guardian/support-frontend/assets/76729591/55e35ee8-9d2b-462b-92df-405b746f483d) | ![Untitled3](https://github.com/guardian/support-frontend/assets/76729591/596a13fc-dd3b-4378-8696-b7cefd7879be) | ![Untitled4](https://github.com/guardian/support-frontend/assets/76729591/5c603555-f60c-4e5d-afe9-ebe2ba8767a9) |

*Mobile Total's should remain the same


