### PR TITLE
Update scalafmt to 3.7.3

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Scala Steward: Reformat with scalafmt 3.4.3
 787c8816f2e0d45ee87c3b7eed6b6c32d48dd86f
+
+# Scala Steward: Reformat with scalafmt 3.7.3
+9ac01c4787ef47dfc40b0008ff1eee4647bf1ab5

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version=3.4.3
+version=3.7.3
 runner.dialect=scala213
 
 maxColumn = 120


### PR DESCRIPTION
Spun off from Scala Steward PR https://github.com/guardian/support-frontend/pull/4919

Builds are failing on that PR, so I’m spinning off each dependency manually to see if it’ll pass on its own.