### PR TITLE
Update circe-core to 0.14.5

### DIFF
--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -1,5 +1,5 @@
 object LibraryVersions {
-  val circeVersion = "0.14.3"
+  val circeVersion = "0.14.5"
 
   val awsClientVersion = "1.12.458"
   val awsClientVersion2 = "2.20.55"

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "com.dripower" %% "play-circe" % playCirceVersion,
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
-  "io.circe" %% "circe-generic-extras" % circeVersion,
+  "io.circe" %% "circe-generic-extras" % "0.14.3",
   "io.circe" %% "circe-parser" % circeVersion,
   "io.circe" %% "circe-optics" % "0.14.1",
   "joda-time" % "joda-time" % "2.9.9",

--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
-  "io.circe" %% "circe-generic-extras" % circeVersion,
+  "io.circe" %% "circe-generic-extras" % "0.14.3",
   "io.circe" %% "circe-parser" % circeVersion,
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,

--- a/support-modules/rest/build.sbt
+++ b/support-modules/rest/build.sbt
@@ -10,7 +10,7 @@ libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
-  "io.circe" %% "circe-generic-extras" % circeVersion,
+  "io.circe" %% "circe-generic-extras" % "0.14.3",
   "io.circe" %% "circe-parser" % circeVersion,
   "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
 )

--- a/support-payment-api/src/test/scala/controllers/StripeControllerSpec.scala
+++ b/support-payment-api/src/test/scala/controllers/StripeControllerSpec.scala
@@ -432,7 +432,7 @@ class StripeControllerSpec extends AnyWordSpec with Status with Matchers {
         val expectedBody =
           Json.obj(
             "type" -> "error",
-            "error" -> "Empty string is not permitted for this field: DownField(token),DownField(paymentData)",
+            "error" -> "DecodingFailure at .paymentData.token: Empty string is not permitted for this field",
           )
         contentAsJson(stripeControllerResult).mustBe(expectedBody)
 

--- a/support-payment-api/src/test/scala/model/paypal/PaypalRefundWebHookBodySpec.scala
+++ b/support-payment-api/src/test/scala/model/paypal/PaypalRefundWebHookBodySpec.scala
@@ -111,7 +111,7 @@ class PaypalRefundWebHookBodySpec extends AnyWordSpec with Matchers with EitherV
         val body = io.circe.parser.decode[PaypalRefundWebHookBody](event).left.value
 
         body.getMessage mustEqual
-          "event type PAYMENT.SALE.COMPLETED is not a valid refund event type: DownField(event_type)"
+          "DecodingFailure at .event_type: event type PAYMENT.SALE.COMPLETED is not a valid refund event type"
       }
     }
   }

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -27,7 +27,7 @@ libraryDependencies ++= Seq(
   "com.squareup.okhttp3" % "mockwebserver" % okhttpVersion % "it,test",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
-  "io.circe" %% "circe-generic-extras" % circeVersion,
+  "io.circe" %% "circe-generic-extras" % "0.14.3",
   "io.circe" %% "circe-parser" % circeVersion,
   "io.sentry" % "sentry-logback" % "1.7.30",
   "com.google.code.findbugs" % "jsr305" % "3.0.2",


### PR DESCRIPTION
Spun off from Scala Steward PR https://github.com/guardian/support-frontend/pull/4919

Builds are failing on that PR, so I’m spinning off each dependency manually to see if it’ll pass on its own.