### PR TITLE
Update jackson to 2.15.0

### DIFF
--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -5,7 +5,7 @@ object LibraryVersions {
   val awsClientVersion2 = "2.20.55"
 
   val catsVersion = "2.9.0"
-  val jacksonVersion = "2.14.2"
+  val jacksonVersion = "2.15.0"
   val jacksonDatabindVersion = "2.14.2"
   val okhttpVersion = "3.10.0"
   val scalaUriVersion = "4.0.3"

--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -6,7 +6,7 @@ object LibraryVersions {
 
   val catsVersion = "2.9.0"
   val jacksonVersion = "2.15.0"
-  val jacksonDatabindVersion = "2.14.2"
+  val jacksonDatabindVersion = "2.15.0"
   val okhttpVersion = "3.10.0"
   val scalaUriVersion = "4.0.3"
   val playCirceVersion = "2814.2"


### PR DESCRIPTION
Spun off from Scala Steward PR https://github.com/guardian/support-frontend/pull/4919

Builds are failing on that PR, so I’m spinning off each dependency manually to see if it’ll pass on its own.