### PR TITLE
Update joda-time to 2.12.5

### DIFF
--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -5,7 +5,7 @@ name := "support-models"
 description := "Scala library to provide shared step-function models to Guardian Support projects."
 
 libraryDependencies ++= Seq(
-  "joda-time" % "joda-time" % "2.12.2",
+  "joda-time" % "joda-time" % "2.12.5",
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,


### PR DESCRIPTION
Spun off from Scala Steward PR https://github.com/guardian/support-frontend/pull/4919

Builds are failing on that PR, so I’m spinning off each dependency manually to see if it’ll pass on its own.