### PR TITLE
Update scanamo to 1.0.0-M25

### DIFF
--- a/support-lambdas/acquisitions-firehose-transformer/build.sbt
+++ b/support-lambdas/acquisitions-firehose-transformer/build.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
-  "org.scanamo" %% "scanamo" % "1.0.0-M23",
+  "org.scanamo" %% "scanamo" % "1.0.0-M25",
 )
 
 assemblyJarName := s"${name.value}.jar"


### PR DESCRIPTION
Spun off from Scala Steward PR https://github.com/guardian/support-frontend/pull/4919

Builds are failing on that PR, so I’m spinning off each dependency manually to see if it’ll pass on its own.