### PR TITLE
Update google-cloud-bigquery to 2.25.0

### DIFF
--- a/support-modules/acquisition-events/build.sbt
+++ b/support-modules/acquisition-events/build.sbt
@@ -5,7 +5,7 @@ name := "module-acquisition-events"
 description := "Module for sending acquisition events"
 
 libraryDependencies ++= Seq(
-  "com.google.cloud" % "google-cloud-bigquery" % "2.22.0",
+  "com.google.cloud" % "google-cloud-bigquery" % "2.25.0",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "com.amazonaws" % "aws-java-sdk-kinesis" % awsClientVersion,


### PR DESCRIPTION
Spun off from Scala Steward PR https://github.com/guardian/support-frontend/pull/4919

Builds are failing on that PR, so I’m spinning off each dependency manually to see if it’ll pass on its own.