### PR TITLE
Only group minor and patch non-aws PRs

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,6 +1,6 @@
 pullRequests.grouping = [
   { name = "aws", "title" = "AWS Scala dependency updates", "filter" = [{"group" = "software.amazon.awssdk"}, {"group" = "com.amazonaws"}] },
-  { name = "non_aws", "title" = "Non AWS Scala dependency updates", "filter" = [{"group" = "*"}] }
+  { name = "minor_non_aws", "title" = "Non AWS Scala dependency updates", "filter" = [{"version" = "minor"}, {"version" = "patch"}] }
 ]
 
 dependencyOverrides = [


### PR DESCRIPTION
Grouping all non-AWS PRs leads to big failing PRs like [4919](https://github.com/guardian/support-frontend/pull/4919) where it’s unclear which dependency is causing the failure. Major version changes in dependencies are less likely to pass without attention, so let’s remove those from the group to improve the odds of getting large PRs with successful builds. If no group matches, individual PRs will be raised.

This configuration is described [here](https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md). I think it’s just minor, patch, and major that we need to worry about, but I’m not certain: maybe we should include pre-release and build-metadata? Should be easy to see if that happens anyway, and we can fix then.