### PR TITLE
Update scalatest to 3.2.16

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import LibraryVersions._
 
 import scala.sys.process._
 
-val scalatest = "org.scalatest" %% "scalatest" % "3.2.15"
+val scalatest = "org.scalatest" %% "scalatest" % "3.2.16"
 
 lazy val integrationTestSettings: Seq[Def.Setting[_]] = Defaults.itSettings ++ Seq(
   IntegrationTest / scalaSource := baseDirectory.value / "src" / "test" / "scala",

--- a/support-lambdas/it-test-runner/build.sbt
+++ b/support-lambdas/it-test-runner/build.sbt
@@ -14,7 +14,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "ch.qos.logback" % "logback-classic" % "1.2.11",
   "io.symphonia" % "lambda-logging" % "1.0.3",
-  "org.scalatest" %% "scalatest" % "3.2.15", // not a "Test" dependency, it's an actual one
+  "org.scalatest" %% "scalatest" % "3.2.16", // not a "Test" dependency, it's an actual one
 )
 
 riffRaffPackageType := assembly.value


### PR DESCRIPTION
Spun off from Scala Steward PR https://github.com/guardian/support-frontend/pull/4919

Builds are failing on that PR, so I’m spinning off each dependency manually to see if it’ll pass on its own.