### PR TITLE
Update kantan.csv-java8 and kantan.csv-generic to 0.7.0

### DIFF
--- a/supporter-product-data/build.sbt
+++ b/supporter-product-data/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2",
-  "com.nrinaudo" %% "kantan.csv-generic" % "0.6.2",
+  "com.nrinaudo" %% "kantan.csv-generic" % "0.7.0",
   "com.nrinaudo" %% "kantan.csv-java8" % "0.6.2",
 )
 

--- a/supporter-product-data/build.sbt
+++ b/supporter-product-data/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser" % circeVersion,
   "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2",
   "com.nrinaudo" %% "kantan.csv-generic" % "0.7.0",
-  "com.nrinaudo" %% "kantan.csv-java8" % "0.6.2",
+  "com.nrinaudo" %% "kantan.csv-java8" % "0.7.0",
 )
 
 riffRaffPackageType := assembly.value


### PR DESCRIPTION
Spun off from Scala Steward PR https://github.com/guardian/support-frontend/pull/4919

Builds are failing on that PR, so I’m spinning off each dependency manually to see if it’ll pass on its own.