### PR TITLE
Update sbt-buildinfo to 0.11.0

### DIFF
--- a/project/BuildInfoSettings.scala
+++ b/project/BuildInfoSettings.scala
@@ -14,9 +14,9 @@ object BuildInfoSettings {
 
   val buildInfoKeys: Seq[BuildInfoKey] = Seq[BuildInfoKey](
     name,
-    BuildInfoKey.constant("buildNumber", env("BUILD_NUMBER", "DEV")),
-    BuildInfoKey.constant("buildTime", System.currentTimeMillis),
-    BuildInfoKey.constant("gitCommitId", Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse commitId()),
+    "buildNumber" -> env("BUILD_NUMBER", "DEV"),
+    "buildTime" -> System.currentTimeMillis,
+    "gitCommitId" -> (Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse commitId()),
   )
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin(
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
 


### PR DESCRIPTION
Spun off from Scala Steward PR https://github.com/guardian/support-frontend/pull/4919

Builds are failing on that PR, so I’m spinning off each dependency manually to see if it’ll pass on its own.