### PR TITLE
Update mockito-scala and mockito-scala-scalatest to 1.17.14

### DIFF
--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -21,7 +21,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "org.mockito" %% "mockito-scala" % "1.17.14" % "it,test",
-  "org.mockito" %% "mockito-scala-scalatest" % "1.17.12" % "it,test",
+  "org.mockito" %% "mockito-scala-scalatest" % "1.17.14" % "it,test",
   "org.scalatestplus" %% "scalatestplus-mockito" % "1.0.0-M2" % "it,test",
   "org.scalatestplus" %% "scalatestplus-selenium" % "1.0.0-M2" % "it,test",
   "com.squareup.okhttp3" % "mockwebserver" % okhttpVersion % "it,test",

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -20,7 +20,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
-  "org.mockito" %% "mockito-scala" % "1.17.12" % "it,test",
+  "org.mockito" %% "mockito-scala" % "1.17.14" % "it,test",
   "org.mockito" %% "mockito-scala-scalatest" % "1.17.12" % "it,test",
   "org.scalatestplus" %% "scalatestplus-mockito" % "1.0.0-M2" % "it,test",
   "org.scalatestplus" %% "scalatestplus-selenium" % "1.0.0-M2" % "it,test",


### PR DESCRIPTION
Spun off from Scala Steward PR https://github.com/guardian/support-frontend/pull/4919

Builds are failing on that PR, so I’m spinning off each dependency manually to see if it’ll pass on its own.