### PR TITLE
mobile optimisation variantb stickyCta floats with focus above all content

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/stickyCta.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/stickyCta.tsx
@@ -18,6 +18,7 @@ const stickyContainerCss = (isVisible: boolean) => css`
 	bottom: -4px;
 	background-color: ${brand[400]};
 	padding: ${space[5]}px 0 30px;
+	z-index: 10000; // ensure stickyCta remains selectable above all content in viewport
 
 	${isVisible ? '' : visuallyHidden}
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
<!-- -->
Quantum metric user replays highlighted a focus issue for the `mobileOptmisation2` AB-Test. When switching between single, monthly, annual tabs the benefits list can run underneath and take focus priority over the floating stickyCta. In this case, the stickyCta does not receive a click event because the benefit list has focus. A double press is required, not what is required.

![stickyCtaFocusIssue](https://github.com/guardian/support-frontend/assets/76729591/5d647cc3-e36d-4cc1-8595-071b6733ee47)

[**Trello Card**](https://trello.com/c/Sy5xzfu2/1317-mobile-optimisation-variant-b-build-stickycta-focus-repair)

## Resolution
<!-- -->
A  high z-index priority (10000 as used in overlays and progress messages) was required to be applied to the StickyCta container in order for it to respond to click events rather than the content underneath it.

## Is this an AB test?
- [x] Yes
- [ ] No

https://support.thegulocal.com/uk/contribute#ab-supporterPlusMobileTest2=variant
https://support.thegulocal.com/uk/contribute#ab-supporterPlusMobileTest2=control
