### PR TITLE
Pd supporter plus nudge annual copy minimum amount increase

### DIFF
--- a/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
@@ -91,13 +91,13 @@ const link = css`
 	}
 `;
 const alink = css`
-		color: ${brand[500]};
-		text-decoration: underline;
-		&:hover {
-      fontWeight:'bold';
-			cursor: pointer;
-		},
-	`;
+	color: ${brand[500]};
+	text-decoration: underline;
+	&:hover {
+		font-weight: 'bold';
+		cursor: pointer;
+	}
+`;
 
 export type CheckoutNudgeProps = {
 	contributionType: ContributionType;

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -33,7 +33,7 @@ export function CheckoutNudgeContainer({
 	const minWeeklyAmount =
 		countryGroupId === 'GBPCountries'
 			? minAmountRounded.toString() + `p`
-			: currencyGlyph + minAmountRounded.toFixed(2).toString();
+			: currencyGlyph + (minAmountRounded / 100).toFixed(2).toString();
 
 	const [title, subtitle, paragraph] = [
 		`Support us every year`,

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -26,12 +26,14 @@ export function CheckoutNudgeContainer({
 
 	const currencyGlyph = glyph(detect(countryGroupId));
 	const minAmount = config[countryGroupId]['ANNUAL'].min;
-
+	const roundToNearest = 10;
+	const minAmountRounded =
+		Math.round(Math.ceil((minAmount * 100) / 52) / roundToNearest) *
+		roundToNearest;
 	const minWeeklyAmount =
 		countryGroupId === 'GBPCountries'
-			? Math.ceil((minAmount * 100) / 52).toString() + `p`
-			: currencyGlyph +
-			  (Math.ceil((minAmount * 100) / 52) / 100).toFixed(2).toString();
+			? minAmountRounded.toString() + `p`
+			: currencyGlyph + minAmountRounded.toFixed(2).toString();
 
 	const [title, subtitle, paragraph] = [
 		`Support us every year`,

--- a/support-frontend/assets/helpers/contributions.ts
+++ b/support-frontend/assets/helpers/contributions.ts
@@ -163,8 +163,8 @@ const numbersInWords: Record<string, string> = {
 
 const defaultConfig: Config = {
 	ANNUAL: {
-		min: 10,
-		minInWords: numbersInWords['10'],
+		min: 30,
+		minInWords: numbersInWords['30'],
 		max: 2000,
 		maxInWords: numbersInWords['2000'],
 		default: 50,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
Increasing the minimum yearly contribution amount to 30 (all currencies) so the nudge displays this. 

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com/c/ML8m0urr/1295-increase-nudge-of-single-to-annual)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [? ] Yes
- [ ?] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

