### PR TITLE
Fix message structure when sending message to `soft-opt-in-consent-setter`

### DIFF
--- a/support-payment-api/src/main/scala/backend/PaymentBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaymentBackend.scala
@@ -70,7 +70,7 @@ trait PaymentBackend extends StrictLogging {
 
     softOptInsEnabled().flatMap {
       case true =>
-        softOptInsService.sendMessage(SoftOptInsService.Message(contributionData.identityId))
+        softOptInsService.sendMessage(contributionData.identityId)
       case false =>
         EitherT.rightT[Future, BackendError.SoftOptInsServiceError](())
     }

--- a/support-payment-api/src/main/scala/backend/PaymentBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaymentBackend.scala
@@ -66,9 +66,7 @@ trait PaymentBackend extends StrictLogging {
 
     val supporterDataFuture = insertContributionIntoSupporterProductData(contributionData)
 
-    val softOptInFuture = softOptInsService.sendMessage(SoftOptInsService.Message(contributionData.identityId))
-
-    softOptInsEnabled().flatMap {
+    val softOptInFuture = softOptInsEnabled().flatMap {
       case true =>
         softOptInsService.sendMessage(contributionData.identityId)
       case false =>

--- a/support-payment-api/src/main/scala/services/SoftOptInsService.scala
+++ b/support-payment-api/src/main/scala/services/SoftOptInsService.scala
@@ -18,19 +18,22 @@ import scala.util.Try
 class SoftOptInsService(sqsClient: AmazonSQSAsync, queueUrlResponse: Future[Either[SoftOptInsServiceError, String]])
     extends StrictLogging {
   def sendMessage(
-      message: Message,
+      identityId: Option[Long],
   )(implicit executionContext: ExecutionContext): EitherT[Future, SoftOptInsServiceError, Unit] = {
-    logger.info(s"Preparing to send message: ${message.asJson.noSpaces}")
-
-    message.identityId match {
+    identityId match {
       case None =>
         val error = SoftOptInsServiceError("Identity ID is None, soft opt-ins cannot be set")
         EitherT.leftT[Future, Unit](error)
 
-      case Some(_) =>
+      case Some(id) =>
+        val identityIdString = id.toString
+        val message = Message(identityIdString, "", "")
+
+        logger.info(s"Preparing to send message: ${message.asJson.noSpaces}")
+
         for {
           queueUrl <- EitherT(queueUrlResponse)
-          _ <- sendRequest(queueUrl, message)
+          _ <- sendRequest(queueUrl, Message(identityIdString))
         } yield ()
     }
   }
@@ -90,7 +93,7 @@ object SoftOptInsService extends StrictLogging {
   }
 
   case class Message(
-      identityId: Option[Long],
+      identityId: String,
       eventType: String = "Acquisition",
       productName: String = "Contribution",
   )

--- a/support-payment-api/src/main/scala/services/SoftOptInsService.scala
+++ b/support-payment-api/src/main/scala/services/SoftOptInsService.scala
@@ -27,13 +27,13 @@ class SoftOptInsService(sqsClient: AmazonSQSAsync, queueUrlResponse: Future[Eith
 
       case Some(id) =>
         val identityIdString = id.toString
-        val message = Message(identityIdString, "", "")
+        val message = Message(identityIdString)
 
         logger.info(s"Preparing to send message: ${message.asJson.noSpaces}")
 
         for {
           queueUrl <- EitherT(queueUrlResponse)
-          _ <- sendRequest(queueUrl, Message(identityIdString))
+          _ <- sendRequest(queueUrl, message)
         } yield ()
     }
   }

--- a/support-payment-api/src/test/scala/backend/AmazonPayBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/AmazonPayBackendSpec.scala
@@ -16,7 +16,7 @@ import model.amazonpay.BundledAmazonPayRequest.AmazonPayRequest
 import model.amazonpay.{AmazonPayApiError, AmazonPaymentData}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
-import org.mockito.Mockito.{verify, when}
+import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -224,6 +224,8 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
         when(mockIdentityService.getOrCreateIdentityIdFromEmail("email@thegulocal.com"))
           .thenReturn(identityResponseError)
         amazonPayBackend.makePayment(amazonPayRequest, clientBrowserInfo).futureRight mustBe ()
+
+        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
       }
     }
 
@@ -278,6 +280,8 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
           when(mockIdentityService.getOrCreateIdentityIdFromEmail("email@thegulocal.com"))
             .thenReturn(identityResponseError)
           amazonPayBackend.makePayment(amazonPayRequest, clientBrowserInfo).futureRight mustBe ()
+
+          verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
         }
 
       "return successful payment response with guestAccountRegistrationToken if available" in new AmazonPayBackendFixture {
@@ -297,8 +301,10 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponseError)
+
         when(mockSoftOptInsService.sendMessage(any())(any()))
           .thenReturn(softOptInsResponseError)
+
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
           .thenReturn(streamResponseError)
@@ -306,6 +312,8 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
         when(mockEmailService.sendThankYouEmail(any())).thenReturn(emailResponseError)
 
         amazonPayBackend.makePayment(amazonPayRequest, clientBrowserInfo).futureRight mustBe ()
+
+        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
       }
 
       "Not call setOrderRef if state is suspended" in new AmazonPayBackendFixture {

--- a/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
@@ -287,6 +287,8 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
           paypalBackend
             .executePayment(executePaypalPaymentData, clientBrowserInfo)
             .futureRight mustBe enrichedPaypalPaymentMock
+
+          verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
         }
 
       "return successful payment response with guestAccountRegistrationToken if available" in new PaypalBackendFixture {
@@ -308,6 +310,8 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
         paypalBackend
           .executePayment(executePaypalPaymentData, clientBrowserInfo)
           .futureRight mustBe enrichedPaypalPaymentMock
+
+        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
       }
     }
 
@@ -357,6 +361,8 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
         )
 
         result.futureValue mustBe List(BackendError.Database(dbError))
+
+        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
       }
 
       "return a combined error if stream and BigQuery fail" in new PaypalBackendFixture {
@@ -384,6 +390,8 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
           clientBrowserInfo,
         )
         result.futureValue mustEqual errors
+
+        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
       }
 
     }

--- a/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
@@ -314,6 +314,8 @@ class StripeBackendSpec
 
         stripeBackend.createPaymentIntent(createPaymentIntentWithStripeCheckout, clientBrowserInfo).futureRight mustBe
           StripePaymentIntentsApiResponse.Success()
+
+        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
       }
 
       "return Success if stripe apple pay switch is On in support-admin-console" in new StripeBackendFixture {
@@ -405,6 +407,8 @@ class StripeBackendSpec
             .futureRight mustBe StripeCreateChargeResponse.fromCharge(
             chargeMock,
           )
+
+          verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
         }
 
       "return successful payment response with guestAccountRegistrationToken if available" in new StripeBackendFixture {
@@ -422,6 +426,8 @@ class StripeBackendSpec
           .fromCharge(
             chargeMock,
           )
+
+        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
       }
     }
 
@@ -462,6 +468,8 @@ class StripeBackendSpec
         val result =
           stripeBackend invokePrivate trackContribution(chargeMock, stripeChargeRequest, None, clientBrowserInfo)
         result.futureValue mustBe List(BackendError.Database(dbError))
+
+        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
       }
 
       "return a combined error if BigQuery and DB fail" in new StripeBackendFixture {
@@ -481,6 +489,8 @@ class StripeBackendSpec
           BackendError.Database(dbError),
         )
         result.futureValue mustBe error
+
+        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
       }
     }
 
@@ -503,6 +513,8 @@ class StripeBackendSpec
 
         stripeBackend.createPaymentIntent(createPaymentIntent, clientBrowserInfo).futureRight mustBe
           StripePaymentIntentsApiResponse.Success()
+
+        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
       }
 
       "return RequiresAction if 3DS required" in new StripeBackendFixture {
@@ -555,6 +567,8 @@ class StripeBackendSpec
 
         stripeBackend.createPaymentIntent(createPaymentIntent, clientBrowserInfo).futureLeft mustBe
           StripeApiError.fromString(s"Stripe error", None)
+
+        verify(mockSoftOptInsService, times(0)).sendMessage(any())(any())
       }
     }
 
@@ -576,6 +590,8 @@ class StripeBackendSpec
 
         stripeBackend.confirmPaymentIntent(confirmPaymentIntent, clientBrowserInfo).futureRight mustBe
           StripePaymentIntentsApiResponse.Success()
+
+        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
       }
 
       "return an error if confirmation failed" in new StripeBackendFixture {


### PR DESCRIPTION
Message structure being sent to the `soft-opt-in-consent-setter` was incorrect, as the `identityId` must be converted to a string. The sending of the message to the queue was also not put behind the feature flag.

 Have also expanded tests to verify that the soft opt-ins service was called just once.