### PR TITLE
tooltip hidden paragraph overlaying components below

### DIFF
--- a/support-frontend/assets/components/tooltip/Tooltip.tsx
+++ b/support-frontend/assets/components/tooltip/Tooltip.tsx
@@ -59,8 +59,8 @@ const tooltipContainer = css`
 	}
 `;
 
-const tooltipCss = (hide: boolean) => css`
-	display: ${hide ? 'none' : 'block'};
+const tooltipCss = css`
+	overflow: hidden;
 	${textSans.small()};
 	background-color: #606060;
 	color: white;
@@ -242,7 +242,7 @@ export default function Tooltip({
 						}}
 						{...getFloatingProps()}
 					>
-						<div css={tooltipCss(!open)}>
+						<div css={tooltipCss}>
 							{children}
 							<Button
 								onClick={() => setOpen(false)}

--- a/support-frontend/assets/components/tooltip/Tooltip.tsx
+++ b/support-frontend/assets/components/tooltip/Tooltip.tsx
@@ -59,7 +59,8 @@ const tooltipContainer = css`
 	}
 `;
 
-const tooltipCss = css`
+const tooltipCss = (hide: boolean) => css`
+	display: ${hide ? 'none' : 'block'};
 	${textSans.small()};
 	background-color: #606060;
 	color: white;
@@ -241,7 +242,7 @@ export default function Tooltip({
 						}}
 						{...getFloatingProps()}
 					>
-						<div css={tooltipCss}>
+						<div css={tooltipCss(!open)}>
 							{children}
 							<Button
 								onClick={() => setOpen(false)}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
<!-- -->
Tooltip paragraph content/text box overlaps any content below it.
This appears to cause an un-selectable region below, as highlighted in the screenshot in blue.
ie. If you were to click in this region there would be no response, it could also possibly be an email box, GooglePay or ApplePay.

![TooltipFocusOverlay](https://github.com/guardian/support-frontend/assets/76729591/f396b9ab-723b-4d2f-bd2a-8f4fdc7198ec)

[**Trello Card**](https://trello.com/c/48pUZOtu/1318-tooltip-paragraph-text-box-overlay-repair)

## Solution
<!-- -->
`Tooltip.tsx` component 'open' state checked and containig div component css set to display:none if closed.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)