### PR TITLE
Use sonatypeOssRepos over sonatypeRepo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ inThisBuild(
     scalaVersion := "2.13.10",
     // https://www.scala-sbt.org/1.x/docs/Cached-Resolution.html
     updateOptions := updateOptions.value.withCachedResolution(true),
-    resolvers ++= Seq(Resolver.sonatypeRepo("releases")), // libraries that haven't yet synced to maven central
+    resolvers ++= Resolver.sonatypeOssRepos("releases"), // libraries that haven't yet synced to maven central
   ),
 )
 

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -55,7 +55,7 @@ libraryDependencies ++= Seq(
 
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
 
-resolvers += Resolver.sonatypeRepo("releases")
+resolvers ++= Resolver.sonatypeOssRepos("releases")
 
 debianPackageDependencies := Seq("openjdk-8-jre-headless")
 Debian / packageName := name.value


### PR DESCRIPTION
The latter [has been deprecated](https://github.com/sbt/librarymanagement/pull/393). I don’t fully understand why, but the new function uses both old and new sonatype repos somehow. This is a minor sbt change.