### PR TITLE
Update scaffeine to 5.2.1

### DIFF
--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -50,11 +50,11 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: actions/setup-java@v3
         with:
-          java-version: "8"
-          distribution: "adopt"
+          java-version: "11"
+          distribution: "corretto"
       - uses: actions/cache@v3
         with:
           path: |

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % "test",
   "org.mockito" % "mockito-core" % "4.11.0",
   "org.typelevel" %% "cats-core" % catsVersion,
-  "com.github.blemale" %% "scaffeine" % "4.1.0",
+  "com.github.blemale" %% "scaffeine" % "5.2.1",
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -49,7 +49,6 @@ libraryDependencies ++= Seq(
   jdbc,
   ws,
   "com.lihaoyi" %% "pprint" % "0.8.1",
-  "com.github.blemale" %% "scaffeine" % "3.1.0",
   "org.scala-lang.modules" %% "scala-xml" % "1.3.0",
 )
 

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -57,7 +57,7 @@ dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacks
 
 resolvers += Resolver.sonatypeRepo("releases")
 
-debianPackageDependencies := Seq("openjdk-8-jre-headless")
+debianPackageDependencies := Seq("openjdk-11-jre-headless")
 Debian / packageName := name.value
 packageSummary := "Payment API Play App"
 packageDescription := """API for reader revenue payments"""

--- a/support-payment-api/src/main/resources/riff-raff.yaml
+++ b/support-payment-api/src/main/resources/riff-raff.yaml
@@ -10,7 +10,7 @@ deployments:
     parameters:
       amiParameter: AMIPaymentapi
       amiTags:
-        Recipe: jammy-membership-java8
+        Recipe: jammy-membership-java11
         AmigoStage: PROD
       amiEncrypted: true
       templateStagePaths:

--- a/support-payment-api/src/main/scala/backend/BackendError.scala
+++ b/support-payment-api/src/main/scala/backend/BackendError.scala
@@ -25,6 +25,8 @@ sealed abstract class BackendError extends Exception {
     case BackendError.Email(err) => err.getMessage
     case BackendError.TrackingError(err) => err.getMessage
     case BackendError.MultipleErrors(errors) => errors.map(_.getMessage).mkString(" & ")
+    case BackendError.SoftOptInsServiceError(err) => err
+    case BackendError.SupporterProductDataError(err) => err
   }
 }
 


### PR DESCRIPTION
Spun off from Scala Steward PR https://github.com/guardian/support-frontend/pull/4919

Builds are failing on that PR, so I’m spinning off each dependency manually to see if it’ll pass on its own.