### PR TITLE
Update mockito-core to 5.3.1

### DIFF
--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "org.playframework.anorm" %% "anorm" % "2.7.0",
   "org.scalatest" %% "scalatest" % "3.0.9" % "test",
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % "test",
-  "org.mockito" % "mockito-core" % "4.11.0",
+  "org.mockito" % "mockito-core" % "5.3.1",
   "org.typelevel" %% "cats-core" % catsVersion,
   "com.github.blemale" %% "scaffeine" % "4.1.0",
   // This is required to force aws libraries to use the latest version of jackson


### PR DESCRIPTION
Spun off from Scala Steward PR https://github.com/guardian/support-frontend/pull/4919

Builds are failing on that PR, so I’m spinning off each dependency manually to see if it’ll pass on its own.