### PR TITLE
Update stripe-java to 22.19.0

### DIFF
--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -10,5 +10,5 @@ object LibraryVersions {
   val okhttpVersion = "3.14.9"
   val scalaUriVersion = "4.0.3"
   val playCirceVersion = "2814.2"
-  val stripeVersion = "21.15.0" // Supports API version 2019-05-16
+  val stripeVersion = "22.19.0" // Supports API version 2019-05-16
 }


### PR DESCRIPTION
Spun off from Scala Steward PR https://github.com/guardian/support-frontend/pull/4919

Builds are failing on that PR, so I’m spinning off each dependency manually to see if it’ll pass on its own.