### PR TITLE
Fix the capitalisation of Guardian in PayPal invoices

### DIFF
--- a/support-payment-api/src/main/scala/services/PaypalService.scala
+++ b/support-payment-api/src/main/scala/services/PaypalService.scala
@@ -103,7 +103,7 @@ class PaypalService(config: PaypalConfig)(implicit pool: PaypalThreadPool) exten
   private def buildPaypalTransactions(currencyCode: String, amount: BigDecimal): java.util.List[Transaction] = {
     import scala.jdk.CollectionConverters._
 
-    val description = "Contribution to the guardian"
+    val description = "Contribution to the Guardian"
     val stringAmount = amount.setScale(2, RoundingMode.HALF_UP).toString
 
     val paypalAmount = new Amount()

--- a/support-payment-api/src/test/scala/services/PaypalServiceSpec.scala
+++ b/support-payment-api/src/test/scala/services/PaypalServiceSpec.scala
@@ -36,8 +36,8 @@ class PaypalServiceSpec extends AnyFlatSpec with Matchers with MockitoSugar with
     val transaction: Transaction = transactionList.asScala.head
     transaction.getAmount.getCurrency mustBe ("GBP")
     transaction.getAmount.getTotal mustBe ("50.00")
-    transaction.getDescription mustBe ("Contribution to the guardian")
-    transaction.getItemList.getItems.asScala.head.getDescription mustBe ("Contribution to the guardian")
+    transaction.getDescription mustBe ("Contribution to the Guardian")
+    transaction.getItemList.getItems.asScala.head.getDescription mustBe ("Contribution to the Guardian")
     transaction.getItemList.getItems.asScala.head.getQuantity mustBe ("1")
     transaction.getItemList.getItems.asScala.head.getPrice mustBe ("50.00")
     transaction.getItemList.getItems.asScala.head.getCurrency mustBe ("GBP")


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes an issue where the PayPal invoice for single contributions had incorrect capitalisation of 'Guardian'.


[**Trello Card**](https://trello.com/c/fr1Y7yC6)