### PR TITLE
support-payment-api: update java version to 11 (from 8)

### DIFF
--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -50,7 +50,7 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
-      - name: Setup Java 11
+      - name: Setup Java 11  # upgrade from 8 to 11
         uses: actions/setup-java@v3
         with:
           java-version: "11"

--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -50,11 +50,11 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: actions/setup-java@v3
         with:
-          java-version: "8"
-          distribution: "adopt"
+          java-version: "11"
+          distribution: "corretto"
       - uses: actions/cache@v3
         with:
           path: |

--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -9,6 +9,6 @@ object LibraryVersions {
   val jacksonDatabindVersion = "2.15.0"
   val okhttpVersion = "3.14.9"
   val scalaUriVersion = "4.0.3"
-  val playCirceVersion = "2814.2"
+  val playCirceVersion = "2814.4"
   val stripeVersion = "21.15.0" // Supports API version 2019-05-16
 }

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -31,9 +31,9 @@ libraryDependencies ++= Seq(
   "org.playframework.anorm" %% "anorm" % "2.7.0",
   "org.scalatest" %% "scalatest" % "3.0.9" % "test",
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % "test",
-  "org.mockito" % "mockito-core" % "4.11.0",
+  "org.mockito" % "mockito-core" % "5.3.1",
   "org.typelevel" %% "cats-core" % catsVersion,
-  "com.github.blemale" %% "scaffeine" % "4.1.0",
+  "com.github.blemale" %% "scaffeine" % "5.2.0",
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -57,7 +57,6 @@ dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacks
 
 resolvers += Resolver.sonatypeRepo("releases")
 
-debianPackageDependencies := Seq("openjdk-11-jre-headless")
 Debian / packageName := name.value
 packageSummary := "Payment API Play App"
 packageDescription := """API for reader revenue payments"""

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -57,7 +57,7 @@ dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacks
 
 resolvers += Resolver.sonatypeRepo("releases")
 
-debianPackageDependencies := Seq("openjdk-8-jre-headless")
+debianPackageDependencies := Seq("openjdk-11-jre-headless")
 Debian / packageName := name.value
 packageSummary := "Payment API Play App"
 packageDescription := """API for reader revenue payments"""

--- a/support-payment-api/src/main/resources/riff-raff.yaml
+++ b/support-payment-api/src/main/resources/riff-raff.yaml
@@ -10,7 +10,7 @@ deployments:
     parameters:
       amiParameter: AMIPaymentapi
       amiTags:
-        Recipe: jammy-membership-java8
+        Recipe: jammy-membership-java11
         AmigoStage: PROD
       amiEncrypted: true
       templateStagePaths:


### PR DESCRIPTION
All apps [should move from java 8 to java 11](https://docs.google.com/document/d/1ZR-YnaXCT5_gLVmTCeGs0mWd3KPaAozPjQK8uUzHZ9w/edit?pli=1#), but this one is still on java 8. Some recent dependency upgrades like scaffeine are starting to require java 11 as well, so sticking with java 8 would mean sticking with some old dependency versions.

I have updated the github action for the CI, as well as which amigo recipe is used by riff raff. There’s also a debian package specified in the build.sbt: I’m not sure what this is used for, as I would’ve expected the JRE to be provided by amigo.