### PR TITLE
Remove Zuora Account Number from the AcquisitionDataRow

### DIFF
--- a/support-lambdas/acquisition-events-api/src/test/scala/com/gu/acquisitionEventsApi/LambdaSpec.scala
+++ b/support-lambdas/acquisition-events-api/src/test/scala/com/gu/acquisitionEventsApi/LambdaSpec.scala
@@ -39,7 +39,6 @@ class LambdaSpec extends AnyFlatSpec with Matchers {
     readerType = ReaderType.Direct,
     acquisitionType = AcquisitionType.Purchase,
     zuoraSubscriptionNumber = None,
-    zuoraAccountNumber = None,
     contributionId = None,
     paymentId = None,
     queryParameters = List(QueryParameter("name1", "value1"), QueryParameter("name2", "value2")),

--- a/support-lambdas/acquisitions-firehose-transformer/src/test/scala/com/gu/acquisitionFirehoseTransformer/LambdaSpec.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/test/scala/com/gu/acquisitionFirehoseTransformer/LambdaSpec.scala
@@ -84,7 +84,6 @@ class LambdaSpec extends AnyFlatSpec with Matchers {
       readerType = ReaderType.Direct,
       acquisitionType = AcquisitionType.Purchase,
       zuoraSubscriptionNumber = None,
-      zuoraAccountNumber = None,
       contributionId = None,
       paymentId = None,
       queryParameters = Nil,

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/bigquery/AcquisitionDataRowMapper.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/bigquery/AcquisitionDataRowMapper.scala
@@ -31,7 +31,6 @@ object AcquisitionDataRowMapper {
       acquisition.componentType.map("component_type" -> _),
       acquisition.source.map("source" -> _),
       acquisition.campaignCode.map(code => "campaign_codes" -> new JSONArray(List(code).asJava)),
-      acquisition.zuoraAccountNumber.map("zuora_account_number" -> _),
       acquisition.zuoraSubscriptionNumber.map("zuora_subscription_number" -> _),
       acquisition.contributionId.map("contribution_id" -> _),
       acquisition.paymentId.map("payment_id" -> _),

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
@@ -37,7 +37,6 @@ case class AcquisitionDataRow(
     readerType: ReaderType,
     acquisitionType: AcquisitionType,
     zuoraSubscriptionNumber: Option[String],
-    zuoraAccountNumber: Option[String],
     contributionId: Option[String],
     paymentId: Option[String],
     queryParameters: List[QueryParameter],

--- a/support-modules/acquisition-events/src/test/scala/com/gu/support/acquisitions/ga/GoogleAnalyticsServiceSpec.scala
+++ b/support-modules/acquisition-events/src/test/scala/com/gu/support/acquisitions/ga/GoogleAnalyticsServiceSpec.scala
@@ -59,7 +59,6 @@ class GoogleAnalyticsServiceSpec extends AsyncWordSpecLike with Matchers with La
     readerType = ReaderType.Direct,
     acquisitionType = AcquisitionType.Purchase,
     zuoraSubscriptionNumber = None,
-    zuoraAccountNumber = None,
     contributionId = None,
     paymentId = None,
     queryParameters = Nil,

--- a/support-payment-api/src/main/scala/model/acquisition/AcquisitionDataRowBuilder.scala
+++ b/support-payment-api/src/main/scala/model/acquisition/AcquisitionDataRowBuilder.scala
@@ -1,7 +1,7 @@
 package model.acquisition
 
 import com.gu.i18n.Currency._
-import com.gu.i18n.{Country, CountryGroup, Currency, OtherCurrency}
+import com.gu.i18n.{Country, CountryGroup, Currency}
 import com.gu.support.acquisitions.models.PaymentProvider.{
   AmazonPay,
   PayPal,
@@ -56,7 +56,6 @@ object AcquisitionDataRowBuilder {
       readerType = ReaderType.Direct,
       acquisitionType = AcquisitionType.Purchase,
       zuoraSubscriptionNumber = None,
-      zuoraAccountNumber = None,
       contributionId = Some(contributionData.contributionId.toString),
       paymentId = Some(contributionData.paymentId),
       queryParameters = acquisitionData.queryParameters.map(_.toList).getOrElse(Nil),
@@ -93,7 +92,6 @@ object AcquisitionDataRowBuilder {
       readerType = ReaderType.Direct,
       acquisitionType = AcquisitionType.Purchase,
       zuoraSubscriptionNumber = None,
-      zuoraAccountNumber = None,
       contributionId = Some(contributionData.contributionId.toString),
       paymentId = Some(contributionData.paymentId),
       queryParameters = acquisitionData.flatMap(_.queryParameters.map(_.toList)).getOrElse(Nil),
@@ -132,7 +130,6 @@ object AcquisitionDataRowBuilder {
       readerType = ReaderType.Direct,
       acquisitionType = AcquisitionType.Purchase,
       zuoraSubscriptionNumber = None,
-      zuoraAccountNumber = None,
       contributionId = Some(contributionData.contributionId.toString),
       paymentId = Some(contributionData.paymentId),
       queryParameters = acquisitionData.queryParameters.map(_.toList).getOrElse(Nil),

--- a/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
@@ -85,7 +85,6 @@ object AcquisitionDataRowBuilder {
       readerType = acquisitionTypeDetails.readerType,
       acquisitionType = acquisitionTypeDetails.acquisitionType,
       zuoraSubscriptionNumber = acquisitionTypeDetails.zuoraSubscriptionNumber,
-      zuoraAccountNumber = acquisitionTypeDetails.zuoraAccountNumber,
       contributionId = None,
       paymentId = None,
       queryParameters = state.acquisitionData.map(getQueryParameters).getOrElse(Nil),

--- a/support-workers/src/test/scala/com/gu/acquisitions/BigQuerySpec.scala
+++ b/support-workers/src/test/scala/com/gu/acquisitions/BigQuerySpec.scala
@@ -81,7 +81,6 @@ class BigQuerySpec extends AsyncFlatSpec with Matchers with LazyLogging {
       Direct,
       Purchase,
       Some("subscription number"),
-      Some("account number"),
       Some("contributionId"),
       Some("paymentId1234"),
       List(QueryParameter("foo", "bar")),


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
The Zuora Account number is not used in any downstream process of `datalake.fact_acquisition_event`. As the Zuora Subscription ID is already there, there should be no benefit to having the Billing Account number too, so this PR removes it to reduce complexity.

Hopefully just not providing the `zuora_account_number` key in the BigQuery post will still work, as it's always been optional - and so not sent in the JSON payload for non-Zuora acquisitions. 

FYI - I staged a PR to remove the column but it reported that the whole table would be dumped to achieve that, so I'll check in with Data Tech - see: https://github.com/guardian/datatech-tf-modules/pull/164. 

- This PR also paves the way in another PR to add the Zuora Payment ID during checkouts which take payment immediately (e.g. Recurring Contribution and Supporter+; but not Paper or Weekly)

## Screenshots
- My changes were deployed at 11:54 BST, these are the CODE acquisitions since then. I did a S+ at 11:55, Single, then Newspape, then Weekly acquisition at 11:01, then finally the local integration test at the top at 12:17.
<img width="1071" alt="Screenshot 2023-05-24 at 12 32 21" src="https://github.com/guardian/support-frontend/assets/1515970/4ad2598c-a622-4f34-8389-017176a4b09c">

## Testing
- [x] Tested in CODE