### PR TITLE
Revert "Bump Identity lib from 3.255 to 4.11"

### DIFF
--- a/support-frontend/app/wiring/Services.scala
+++ b/support-frontend/app/wiring/Services.scala
@@ -41,7 +41,7 @@ trait Services {
 
   lazy val testUsers = TestUserService(appConfig.identity.testUserSecret)
 
-  lazy val asyncAuthenticationService = AsyncAuthenticationService(appConfig.identity)
+  lazy val asyncAuthenticationService = AsyncAuthenticationService(appConfig.identity, testUsers)
 
   lazy val paymentAPIService = new PaymentAPIService(wsClient, appConfig.paymentApiUrl)
 

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -27,7 +27,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser" % circeVersion,
   "io.circe" %% "circe-optics" % "0.14.1",
   "joda-time" % "joda-time" % "2.9.9",
-  "com.gu.identity" %% "identity-auth-play" % "4.11",
+  "com.gu.identity" %% "identity-auth-play" % "3.255",
   "com.gu" %% "identity-test-users" % "0.8",
   "com.google.guava" % "guava" % "31.1-jre",
   "io.lemonlabs" %% "scala-uri" % scalaUriVersion,


### PR DESCRIPTION
Reverts guardian/support-frontend#4977 as causing errors when user is signed out.  But no public-facing problems.