### PR TITLE
Bump Identity lib from 3.255 to 4.11 (second attempt)

### DIFF
--- a/support-frontend/app/services/AuthenticationService.scala
+++ b/support-frontend/app/services/AuthenticationService.scala
@@ -4,7 +4,7 @@ import com.gu.identity.auth.IdentityClient.Error
 import com.gu.identity.auth.{IdapiAuthConfig, IdentityClient}
 import com.gu.identity.model.User
 import com.gu.identity.play.IdapiPlayAuthService
-import com.gu.identity.play.IdentityPlayAuthService.UserCredentialsMissingError
+import com.gu.identity.play.IdapiPlayAuthService.UserCredentialsMissingError
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
 import config.Identity

--- a/support-frontend/app/services/AuthenticationService.scala
+++ b/support-frontend/app/services/AuthenticationService.scala
@@ -1,38 +1,23 @@
 package services
 
-import com.gu.identity.auth.IdentityClient
 import com.gu.identity.auth.IdentityClient.Error
+import com.gu.identity.auth.{IdapiAuthConfig, IdentityClient}
 import com.gu.identity.model.User
-import com.gu.identity.play.IdentityPlayAuthService
+import com.gu.identity.play.IdapiPlayAuthService
 import com.gu.identity.play.IdentityPlayAuthService.UserCredentialsMissingError
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
 import config.Identity
 import org.http4s.Uri
-import play.api.mvc.{Cookie, RequestHeader}
+import play.api.mvc.RequestHeader
 
 import scala.concurrent.{ExecutionContext, Future}
 
-// The following classes were previously defined in identity-play-auth,
-// but have been removed as part of the changes to that library:
-// authenticating users via a call to identity API; removing periphery functionality.
-// They have been redefined here to reduce diff across PRs,
-// but these classes could get refactored / simplified / removed in subsequent PRs.
-sealed trait AccessCredentials
-object AccessCredentials {
-  case class Cookies(scGuU: String, guU: Option[String] = None) extends AccessCredentials {
-    val cookies: Seq[Cookie] = Seq(
-      Cookie(name = "SC_GU_U", scGuU),
-    ) ++ guU.map(c => Cookie(name = "GU_U", c))
-  }
-  case class Token(tokenText: String) extends AccessCredentials
-}
-
-class AsyncAuthenticationService(identityPlayAuthService: IdentityPlayAuthService)(implicit ec: ExecutionContext) {
+class AsyncAuthenticationService(identityPlayAuthService: IdapiPlayAuthService)(implicit ec: ExecutionContext) {
 
   def tryAuthenticateUser(requestHeader: RequestHeader): Future[Option[User]] =
     identityPlayAuthService
-      .getUserFromRequest(requestHeader)
+      .getUserFromRequestUsingSCGUUCookie(requestHeader)
       .map { case (_, user) => user }
       .unsafeToFuture()
       .map(user => Some(user))
@@ -58,13 +43,10 @@ object AsyncAuthenticationService {
 
   case class IdentityIdAndEmail(id: String, primaryEmailAddress: String)
 
-  def apply(config: Identity, testUserService: TestUserService)(implicit
-      ec: ExecutionContext,
-  ): AsyncAuthenticationService = {
+  def apply(config: Identity)(implicit ec: ExecutionContext): AsyncAuthenticationService = {
     val apiUrl = Uri.unsafeFromString(config.apiUrl)
-    // TOOD: targetClient could probably be None - check and release in subsequent PR.
     val identityPlayAuthService =
-      IdentityPlayAuthService.unsafeInit(apiUrl, config.apiClientToken, targetClient = Some("membership"))
+      IdapiPlayAuthService.unsafeInit(IdapiAuthConfig(identityApiUri = apiUrl, accessToken = config.apiClientToken))
     new AsyncAuthenticationService(identityPlayAuthService)
   }
 

--- a/support-frontend/app/wiring/Services.scala
+++ b/support-frontend/app/wiring/Services.scala
@@ -41,7 +41,7 @@ trait Services {
 
   lazy val testUsers = TestUserService(appConfig.identity.testUserSecret)
 
-  lazy val asyncAuthenticationService = AsyncAuthenticationService(appConfig.identity, testUsers)
+  lazy val asyncAuthenticationService = AsyncAuthenticationService(appConfig.identity)
 
   lazy val paymentAPIService = new PaymentAPIService(wsClient, appConfig.paymentApiUrl)
 

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -27,7 +27,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser" % circeVersion,
   "io.circe" %% "circe-optics" % "0.14.1",
   "joda-time" % "joda-time" % "2.9.9",
-  "com.gu.identity" %% "identity-auth-play" % "3.255",
+  "com.gu.identity" %% "identity-auth-play" % "4.11",
   "com.gu" %% "identity-test-users" % "0.8",
   "com.google.guava" % "guava" % "31.1-jre",
   "io.lemonlabs" %% "scala-uri" % scalaUriVersion,


### PR DESCRIPTION
This is identical to #4977 with the addition of dca129840101002ea4a9131970313d7c2d5660b5, which ensures that we don't log an exception when a user isn't signed in.  Users aren't necessarily expected to be signed in.

Tested in Code env.
Can subscribe signed in or signed out and there are no errors appearing in logs.
