### PR TITLE
12for12 benefits - uk discount increase

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -5,9 +5,6 @@ import BenefitsHeading from './benefitsHeading';
 
 const coreBenefits = [
 	{
-		content: 'Every issue delivered with up to 35% off the cover price',
-	},
-	{
 		content: "Access to the magazine's digital archive",
 	},
 	{
@@ -21,6 +18,9 @@ const coreBenefits = [
 function getBenefits(countryId: IsoCountry) {
 	if (countryId === 'GB') {
 		return [
+			{
+				content: 'Every issue delivered with up to 79% off the cover price',
+			},
 			...coreBenefits,
 			{
 				content:
@@ -28,7 +28,12 @@ function getBenefits(countryId: IsoCountry) {
 			},
 		];
 	}
-	return coreBenefits;
+	return [
+		{
+			content: 'Every issue delivered with up to 35% off the cover price',
+		},
+		...coreBenefits,
+	];
 }
 
 function Benefits({ countryId }: { countryId: IsoCountry }): JSX.Element {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

- bullet points under 12 for 12 UK (only) offer are inaccurate for this offer
- This is because during the campaign, the price per issue is £1. The retail price is £4.95, which is 79% off. This will help conversion and improve the UX flow of the page. Currently, 35% off the cover price doesn’t make sense in the context of the discount and may cause confusion.

![Screenshot 2023-05-24 at 13 14 02](https://github.com/guardian/support-frontend/assets/76729591/24e02887-0b1a-4d54-8c52-28be1ecdadf7)

![Screenshot 2023-05-24 at 13 13 42](https://github.com/guardian/support-frontend/assets/76729591/71de738c-c1fb-4b87-85ae-109c99120f7e)

UK => 79% discount (until June 9th when 12for12 ends, will need to be reverted alongside £10 bookshop voucher)
Non-Uk => 35% discount

[**Trello Card**](https://trello.com/c/udHn1NHi/1321-gw-support-amend-benefits-line-for-12for12-uk)

## Why are you doing this?
12 for 12 Offer

79% benefit discount
https://support.thegulocal.com/uk/subscribe/weekly

35% benefit discount
https://support.thegulocal.com/int/subscribe/weekly

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)
