### PR TITLE
Remove duplicate acquistion-events-api build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -333,4 +333,4 @@ lazy val `acquisition-events-api` = (project in file("support-lambdas/acquisitio
 
 lazy val `support-lambdas` = (project in file("support-lambdas"))
   .settings(scalafmtSettings)
-  .aggregate(`stripe-intent`, `it-test-runner`, `acquisitions-firehose-transformer`, `acquisition-events-api`)
+  .aggregate(`stripe-intent`, `it-test-runner`, `acquisitions-firehose-transformer`)


### PR DESCRIPTION
At the moment, there are frequently two deployments being attempted for the acquisition-events-api at the same time: one from the acquisition-events-api github action, and one from the support-lambdas github action. The latter always fails, I think because the acquisition-events-api now uses CDK but the support-lambdas github action doesn’t do the necessary CDK setup.

I don’t _think_ it makes sense for us to have this being built by two separate github actions, so I propose we remove it from the support-lambdas project (and thereby from the action).