### PR TITLE
Fall back to inferred state when payment request button state is null

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -142,7 +142,9 @@ function getBillingCountryAndState(state: ContributionsState): {
 	if (isPaymentRequestButton && paymentMethod.country) {
 		return {
 			billingCountry: paymentMethod.country,
-			billingState: paymentMethod.state ?? '',
+			billingState:
+				paymentMethod.state ??
+				(formCountry === paymentMethod.country ? formState : ''),
 		};
 	} else {
 		return {


### PR DESCRIPTION
If the payment request button state is null, we may still have worked out a sensible state from geolocation. This makes a reasonable fallback if the inferred country matches the payment method country.