### PR TITLE
Revert "Add tote bag to benefits in Australia"

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -48,7 +48,6 @@ export function CheckoutBenefitsListContainer({
 	const { countryGroupId, currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
-	const isAustralia = countryGroupId === 'AUDCountries' ? true : false;
 	const selectedAmount = useContributionsSelector(getUserSelectedAmount);
 	const minimumContributionAmount = useContributionsSelector(
 		getMinimumContributionAmount,
@@ -91,7 +90,6 @@ export function CheckoutBenefitsListContainer({
 		),
 		checkListData: checkListData({
 			higherTier,
-			isAustralia,
 		}),
 		buttonCopy: getbuttonCopy(
 			higherTier,

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
@@ -1,6 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { from, neutral, news } from '@guardian/source-foundations';
+import { neutral } from '@guardian/source-foundations';
 import { SvgCrossRound, SvgTickRound } from '@guardian/source-react-components';
 
 const greyedOut = css`
@@ -15,19 +15,8 @@ const boldText = css`
 	font-weight: bold;
 `;
 
-const highlightText = css`
-	color: ${news[500]};
-`;
-
-const highlightTextSpacing = css`
-	${from.tablet} {
-		display: block;
-	} ;
-`;
-
-type CheckListDataProps = {
+type TierUnlocks = {
 	higherTier: boolean;
-	isAustralia: boolean;
 };
 
 export type CheckListData = {
@@ -43,10 +32,7 @@ export const getSvgIcon = (isUnlocked: boolean): JSX.Element =>
 		<SvgCrossRound isAnnouncedByScreenReader size="small" />
 	);
 
-export const checkListData = ({
-	higherTier,
-	isAustralia,
-}: CheckListDataProps): CheckListData[] => {
+export const checkListData = ({ higherTier }: TierUnlocks): CheckListData[] => {
 	const maybeGreyedOutHigherTier = higherTier ? undefined : greyedOut;
 
 	return [
@@ -68,23 +54,6 @@ export const checkListData = ({
 				</p>
 			),
 		},
-		...(isAustralia
-			? [
-					{
-						icon: getSvgIcon(higherTier),
-						text: (
-							<p>
-								<span css={boldText}>
-									Limited-edition Guardian Australia tote bag.{' '}
-								</span>
-								<span css={highlightTextSpacing} />
-								<span css={highlightText}>Offer ends 31 May</span>
-							</p>
-						),
-						maybeGreyedOut: maybeGreyedOutHigherTier,
-					},
-			  ]
-			: []),
 		{
 			icon: getSvgIcon(higherTier),
 			text: (

--- a/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
@@ -45,7 +45,7 @@ export const AllBenefitsUnlocked = Template.bind({});
 
 AllBenefitsUnlocked.args = {
 	title: "For £12 per month, you'll unlock",
-	checkListData: checkListData({ higherTier: true, isAustralia: false }),
+	checkListData: checkListData({ higherTier: true }),
 	buttonCopy: null,
 	countryGroupId: 'GBPCountries',
 };
@@ -54,7 +54,7 @@ export const LowerTierUnlocked = Template.bind({});
 
 LowerTierUnlocked.args = {
 	title: "For £5 per month, you'll unlock",
-	checkListData: checkListData({ higherTier: false, isAustralia: false }),
+	checkListData: checkListData({ higherTier: false }),
 	buttonCopy: 'Switch to £12 per month to unlock all extras',
 	countryGroupId: 'GBPCountries',
 };


### PR DESCRIPTION
Reverts guardian/support-frontend#4917, as the 10-year anniversary campaign is coming to an end. Should be merged shortly before 3pm UTC+1 on the 31st of May.