### PR TITLE
support-payment-api: Catch missed error cases

### DIFF
--- a/support-payment-api/src/main/scala/backend/BackendError.scala
+++ b/support-payment-api/src/main/scala/backend/BackendError.scala
@@ -25,6 +25,8 @@ sealed abstract class BackendError extends Exception {
     case BackendError.Email(err) => err.getMessage
     case BackendError.TrackingError(err) => err.getMessage
     case BackendError.MultipleErrors(errors) => errors.map(_.getMessage).mkString(" & ")
+    case BackendError.SoftOptInsServiceError(err) => err
+    case BackendError.SupporterProductDataError(err) => err
   }
 }
 


### PR DESCRIPTION
Payment-api tests have been failing recently. With these cases covered, the payment-api tests no longer seem to fail. Interestingly, the null pointer exception still happens, but the subsequent test passes. I guess that’s ok?