### PR TITLE
12for12 Australia benefits Add (16/6/23)

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -19,9 +19,25 @@ function getBenefits(countryId: IsoCountry) {
 	if (countryId === 'AU') {
 		return [
 			{
+				content: 'Every issue delivered with up to 91% off the cover price',
+			},
+			...coreBenefits,
+			{
+				content:
+					'A free Guardian Weekly tote bag with every 12 for 12 subscription',
+			},
+		];
+	}
+	if (countryId === 'GB') {
+		return [
+			{
 				content: 'Every issue delivered with up to 79% off the cover price',
 			},
 			...coreBenefits,
+			{
+				content:
+					'A free Gift! £10 Guardian Bookshop voucher - exclusive to 12 for £12 quarterly subscribers',
+			},
 		];
 	}
 	return [

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -16,16 +16,12 @@ const coreBenefits = [
 ];
 
 function getBenefits(countryId: IsoCountry) {
-	if (countryId === 'GB') {
+	if (countryId === 'AU') {
 		return [
 			{
 				content: 'Every issue delivered with up to 79% off the cover price',
 			},
 			...coreBenefits,
-			{
-				content:
-					'A free Gift! £10 Guardian Bookshop voucher - exclusive to 12 for £12 quarterly subscribers',
-			},
 		];
 	}
 	return [


### PR DESCRIPTION
## What are you doing in this PR?
Can we hard code the line under ‘As a subscriber you’ll enjoy' as follows

AUS GW landing page ONLY (16th June to 15th July)
MODIFY: 'Every issue delivered with up to 35% off the cover price' -> 'Every issue delivered with up to 91% off the cover price'
ADD: 'A free Guardian Weekly tote bag with every 12 for 12 subscription'
N.B. we will then revert to original “35% off” when campaign is complete ( 16th July)


[**OLD Trello Card**](https://trello.com/c/Ci9sx7aI/1325-gw-support-amend-benefits-line-for-12for12-aus)
[**NEW Trello Card**](https://trello.com/c/oNQUt84d/1368-guardian-weekly-au-support-page-changes)

## Why are you doing this?
AUS offer period starts June 16th onwards
UK offer period finishes on June 25th.

|After|Desktop|Mobile|
|--------|--------|--------|
|AUS GW|![Screenshot 2023-06-06 at 16 22 24](https://github.com/guardian/support-frontend/assets/76729591/d32355d6-3e39-496a-bd01-1c2be26eac56)|![Screenshot 2023-06-06 at 16 20 10](https://github.com/guardian/support-frontend/assets/76729591/a89be782-e2d0-4d8e-8fe7-3c8cc158cb15)|

## Is this an AB test?
- [ ] Yes
- [x] No