### PR TITLE
Fix issues with broken Chromatic build

### DIFF
--- a/support-frontend/.storybook/preview-head.html
+++ b/support-frontend/.storybook/preview-head.html
@@ -1,1 +1,4 @@
+<script>
+  window.guardian = {};
+</script>
 <script src="https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?flags=gated&features=default"></script>

--- a/support-frontend/stories/screens/SupporterPlusLanding.stories.tsx
+++ b/support-frontend/stories/screens/SupporterPlusLanding.stories.tsx
@@ -56,4 +56,4 @@ function Template() {
 	return <SupporterPlusLandingPage thankYouRoute={'/uk/thankyou'} />;
 }
 
-export const LandingPage = Template.bind({});
+export const Default = Template.bind({});


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes an issue that arose with the migration to Storybook 7 where errors relating to the `window.guardian` object were cropping up in multiple stories.
