### PR TITLE
12for12 UK benefits remove (25/6/23)

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -15,8 +15,19 @@ const coreBenefits = [
 	},
 ];
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- per country benefits list will have frequent future use
 function getBenefits(countryId: IsoCountry) {
+	if (countryId === 'AU') {
+		return [
+			{
+				content: 'Every issue delivered with up to 91% off the cover price',
+			},
+			...coreBenefits,
+			{
+				content:
+					'A free Guardian Weekly tote bag with every 12 for 12 subscription',
+			},
+		];
+	}
 	return [
 		{
 			content: 'Every issue delivered with up to 35% off the cover price',

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -16,8 +16,13 @@ const coreBenefits = [
 ];
 
 function getBenefits(countryId: IsoCountry) {
-	if (countryId === 'GB') {
-		return [...coreBenefits];
+	if (countryId === 'AU') {
+		return [
+			{
+				content: 'Every issue delivered with up to 35% off the cover price',
+			},
+			...coreBenefits,
+		];
 	}
 	return [
 		{

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -15,15 +15,8 @@ const coreBenefits = [
 	},
 ];
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- per country benefits list will have frequent future use
 function getBenefits(countryId: IsoCountry) {
-	if (countryId === 'AU') {
-		return [
-			{
-				content: 'Every issue delivered with up to 35% off the cover price',
-			},
-			...coreBenefits,
-		];
-	}
 	return [
 		{
 			content: 'Every issue delivered with up to 35% off the cover price',

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -16,7 +16,7 @@ const coreBenefits = [
 ];
 
 function getBenefits(countryId: IsoCountry) {
-	if (countryId === 'AU') {
+	if (countryId === 'GB') {
 		return [...coreBenefits];
 	}
 	return [

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -1,5 +1,4 @@
 import { List } from 'components/list/list';
-import type { IsoCountry } from 'helpers/internationalisation/country';
 import BenefitsContainer from './benefitsContainer';
 import BenefitsHeading from './benefitsHeading';
 
@@ -15,19 +14,7 @@ const coreBenefits = [
 	},
 ];
 
-function getBenefits(countryId: IsoCountry) {
-	if (countryId === 'GB') {
-		return [
-			{
-				content: 'Every issue delivered with up to 79% off the cover price',
-			},
-			...coreBenefits,
-			{
-				content:
-					'A free Gift! £10 Guardian Bookshop voucher - exclusive to 12 for £12 quarterly subscribers',
-			},
-		];
-	}
+function getBenefits() {
 	return [
 		{
 			content: 'Every issue delivered with up to 35% off the cover price',
@@ -36,7 +23,7 @@ function getBenefits(countryId: IsoCountry) {
 	];
 }
 
-function Benefits({ countryId }: { countryId: IsoCountry }): JSX.Element {
+function Benefits(): JSX.Element {
 	return (
 		<BenefitsContainer
 			sections={[
@@ -45,7 +32,7 @@ function Benefits({ countryId }: { countryId: IsoCountry }): JSX.Element {
 					content: (
 						<>
 							<BenefitsHeading text="As a subscriber you’ll enjoy" />
-							<List items={getBenefits(countryId)} />
+							<List items={getBenefits()} />
 						</>
 					),
 				},

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -1,4 +1,5 @@
 import { List } from 'components/list/list';
+import type { IsoCountry } from 'helpers/internationalisation/country';
 import BenefitsContainer from './benefitsContainer';
 import BenefitsHeading from './benefitsHeading';
 
@@ -14,7 +15,10 @@ const coreBenefits = [
 	},
 ];
 
-function getBenefits() {
+function getBenefits(countryId: IsoCountry) {
+	if (countryId === 'AU') {
+		return [...coreBenefits];
+	}
 	return [
 		{
 			content: 'Every issue delivered with up to 35% off the cover price',
@@ -23,7 +27,7 @@ function getBenefits() {
 	];
 }
 
-function Benefits(): JSX.Element {
+function Benefits({ countryId }: { countryId: IsoCountry }): JSX.Element {
 	return (
 		<BenefitsContainer
 			sections={[
@@ -32,7 +36,7 @@ function Benefits(): JSX.Element {
 					content: (
 						<>
 							<BenefitsHeading text="As a subscriber you’ll enjoy" />
-							<List items={getBenefits()} />
+							<List items={getBenefits(countryId)} />
 						</>
 					),
 				},

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -91,11 +91,7 @@ function WeeklyLPControl({
 			<FullWidthContainer>
 				<CentredContainer>
 					<Block cssOverrides={styles.closeGapAfterPageTitle}>
-						{orderIsAGift ? (
-							<GiftBenefits />
-						) : (
-							<Benefits countryId={countryId} />
-						)}
+						{orderIsAGift ? <GiftBenefits /> : <Benefits />}
 					</Block>
 				</CentredContainer>
 			</FullWidthContainer>
@@ -177,11 +173,7 @@ function WeeklyLPVariant({
 			<FullWidthContainer>
 				<CentredContainer>
 					<Block cssOverrides={styles.closeGapAfterPageTitle}>
-						{orderIsAGift ? (
-							<GiftBenefits />
-						) : (
-							<Benefits countryId={countryId} />
-						)}
+						{orderIsAGift ? <GiftBenefits /> : <Benefits />}
 					</Block>
 				</CentredContainer>
 			</FullWidthContainer>

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -91,7 +91,11 @@ function WeeklyLPControl({
 			<FullWidthContainer>
 				<CentredContainer>
 					<Block cssOverrides={styles.closeGapAfterPageTitle}>
-						{orderIsAGift ? <GiftBenefits /> : <Benefits />}
+						{orderIsAGift ? (
+							<GiftBenefits />
+						) : (
+							<Benefits countryId={countryId} />
+						)}
 					</Block>
 				</CentredContainer>
 			</FullWidthContainer>
@@ -173,7 +177,11 @@ function WeeklyLPVariant({
 			<FullWidthContainer>
 				<CentredContainer>
 					<Block cssOverrides={styles.closeGapAfterPageTitle}>
-						{orderIsAGift ? <GiftBenefits /> : <Benefits />}
+						{orderIsAGift ? (
+							<GiftBenefits />
+						) : (
+							<Benefits countryId={countryId} />
+						)}
 					</Block>
 				</CentredContainer>
 			</FullWidthContainer>


### PR DESCRIPTION
## What are you doing in this PR?
Can we hard code the line under ‘As a subscriber you’ll enjoy' as follows

GBP GW landing page ONLY (25th June onwards)
MODIFY: 'Every issue delivered with up to 79% off the cover price' -> 'Every issue delivered with up to 35% off the cover price'
REMOVE:  'A free Gift! £10 Guardian Bookshop voucher - exclusive to 12 for £12 quarterly subscribers'

[**Trello Card**](https://trello.com/c/mULRBmjb/1326-gw-support-amend-benefits-line-for-12for12-uk-revert-to-original)

AUS GW landing page ONLY (16th June onwards)
MODIFY: 'Every issue delivered with up to 35% off the cover price' -> 'Every issue delivered with up to 91% off the cover price'
ADD: 'A free Guardian Weekly tote bag with every 12 for 12 subscription'

[OLD Trello Card](https://trello.com/c/Ci9sx7aI/1325-gw-support-amend-benefits-line-for-12for12-aus)
[NEW Trello Card](https://trello.com/c/oNQUt84d/1368-guardian-weekly-au-support-page-changes)

## Why are you doing this?
AUS offer period starts June 16th onwards
UK offer period finishes on June 25th.


|After|Desktop|Mobile|
|--------|--------|--------|
|UK GW|![Screenshot 2023-05-30 at 14 28 53](https://github.com/guardian/support-frontend/assets/76729591/202cdcea-5511-491b-bbf2-1f9dcbcf4a70)|![Screenshot 2023-05-30 at 14 29 16](https://github.com/guardian/support-frontend/assets/76729591/2871d598-9b2c-49bb-8194-9cf881581322)|
|AUS GW|![Screenshot 2023-06-06 at 16 22 24](https://github.com/guardian/support-frontend/assets/76729591/d32355d6-3e39-496a-bd01-1c2be26eac56)|![Screenshot 2023-06-06 at 16 20 10](https://github.com/guardian/support-frontend/assets/76729591/a89be782-e2d0-4d8e-8fe7-3c8cc158cb15)|


## Is this an AB test?
- [ ] Yes
- [x] No