### PR TITLE
Set the TTL for single contributions to 8 yrs & 1 week

### DIFF
--- a/support-payment-api/src/main/scala/services/SupporterProductDataService.scala
+++ b/support-payment-api/src/main/scala/services/SupporterProductDataService.scala
@@ -32,7 +32,7 @@ class SupporterProductDataService(environment: Environment) extends StrictLoggin
               productRatePlanName = "Single Contribution",
               termEndDate = contributionData.created.toLocalDate
                 .plusYears(8)
-                .plusMonths(1), // 8 years and 1 month is our standard data retention period. As there are no benefits attached to a single contribution we don't need to remove them sooner
+                .plusWeeks(1), // 8 years and 1 week is our standard data retention period. As there are no benefits attached to a single contribution we don't need to remove them sooner
               contractEffectiveDate = contributionData.created.toLocalDate,
               contributionAmount = Some(
                 ContributionAmount(contributionData.amount, contributionData.currency.toString),

--- a/support-payment-api/src/main/scala/services/SupporterProductDataService.scala
+++ b/support-payment-api/src/main/scala/services/SupporterProductDataService.scala
@@ -31,9 +31,8 @@ class SupporterProductDataService(environment: Environment) extends StrictLoggin
               productRatePlanId = "single_contribution",
               productRatePlanName = "Single Contribution",
               termEndDate = contributionData.created.toLocalDate
-                .plusYears(
-                  999,
-                ), // I don't think we need these to expire as they are for information only, no benefits attached
+                .plusYears(8)
+                .plusMonths(1), // 8 years and 1 month is our standard data retention period. As there are no benefits attached to a single contribution we don't need to remove them sooner
               contractEffectiveDate = contributionData.created.toLocalDate,
               contributionAmount = Some(
                 ContributionAmount(contributionData.amount, contributionData.currency.toString),


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Currently we are adding single contributions to the supporter product data store with a TTL of 999 years, this PR reduces that to 8 years and 1 week, the same as the [contributions data store](https://github.com/guardian/contributions-platform/tree/main/contributions-store/retention-policy)