### PR TITLE
Change price on Subscriptions landing page to £12 for 12 until 25th June

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
@@ -74,7 +74,7 @@ const getWeeklyImage = (isTop: boolean) => {
 function get12for12Subtitle(): string | undefined {
 	const today = new Date();
 	const startDate = new Date('2023-05-12');
-	const endDate = new Date('2023-06-12');
+	const endDate = new Date('2023-06-25');
 
 	if (today >= startDate && today <= endDate) {
 		return '£12 for 12 issues';


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Extension to June 25th of Uk Subscription landing copy change -> https://github.com/guardian/support-frontend/pull/4958


[**Trello Card**](https://trello.com/c/zLXHnIB8/1362-gw-support-revert-print-landing-page-updates-when-uk-12for12-campaign-ends-on-june-9th)