### PR TITLE
Single Less Prominent, copy text colour change

### DIFF
--- a/support-frontend/assets/components/cardClickable/cardClickable.tsx
+++ b/support-frontend/assets/components/cardClickable/cardClickable.tsx
@@ -16,7 +16,7 @@ const cardContainerCss = css`
 
 	padding: ${space[3]}px ${space[3]}px ${space[4]}px;
 	background-color: ${neutral[100]};
-	color: ${neutral[7]};
+	color: #606060;
 	border: 1px solid ${neutral[86]};
 	border-radius: ${space[3]}px;
 	&:hover {


### PR DESCRIPTION
## What are you doing in this PR?
Clickable Card copy text colour change
Minor Update PR ->  https://github.com/guardian/support-frontend/pull/4853 {shown below}

Build of the single less prominent designs. ab-test name 'singleLessProminent'

- Desktop web - designs below
- Mobile web - re-based on mobile optimisation variantA 
- Initial ONE_OFF only contribution types via URL query parameters or session storage need to be removed from the abtest group (not control or variant).

Variant Features/Assumptions->
1. Support Once entire component clickable (not just arrow).
2. Once clicked, Single tab remains visible (a refresh required to reset).

A ClickableCard component may be a more accessible way to contain multiple elements that can be mouse clicked (or the card itself can be tabbed onto and enter pressed to re-produce mouse-click). A working example of this is shown here (2nd solution) ->
https://css-tricks.com/creating-animated-clickable-cards-with-the-has-relational-pseudo-class/

Pre (Single,Monthly&Annual)->
| mobile <740px | dekstop >740px -|
|--------|--------|
|![Screenshot 2023-03-20 at 09 46 00](https://user-images.githubusercontent.com/76729591/226304150-0b7d0939-7a59-453c-97c4-b195e58c4da7.png)|![Screenshot 2023-03-20 at 09 45 12](https://user-images.githubusercontent.com/76729591/226304307-fc2289b5-f7a0-41f0-830e-c8def02ad138.png)|

Post (Annual&Monthly)->
| mobile <740px | dekstop >740px -|
|--------|--------|
| ![Screenshot 2023-03-20 at 09 46 19](https://user-images.githubusercontent.com/76729591/226304091-565e2fb6-c577-4c9b-b236-57271bd58e08.png)|![Screenshot 2023-03-20 at 09 44 45](https://user-images.githubusercontent.com/76729591/226304406-42c32143-b764-43a3-97a3-189c2559dff0.png)|

[**Trello Card**](https://trello.com/c/cbOAHNBc/1167-make-single-less-prominent-build)

## Is this an AB test?
- [x] Yes
- [ ] No

https://support.thegulocal.com/uk/contribute#ab-singleLessProminent=variant
https://support.thegulocal.com/uk/contribute#ab-singleLessProminent=control

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

