### PR TITLE
donot overide the selectors minimum amounts

### DIFF
--- a/support-frontend/assets/helpers/redux/commonState/selectors.ts
+++ b/support-frontend/assets/helpers/redux/commonState/selectors.ts
@@ -1,5 +1,5 @@
 import type { ContributionType } from 'helpers/contributions';
-import { config, getConfigAbTestMin } from 'helpers/contributions';
+import { config } from 'helpers/contributions';
 import { getValidContributionTypesFromUrlOrElse } from 'helpers/forms/checkouts';
 import { getContributionType } from '../checkout/product/selectors/productType';
 import type { ContributionsState } from '../contributionsStore';
@@ -25,17 +25,10 @@ export function getMinimumContributionAmount(
 	const { countryGroupId, useLocalCurrency, localCurrencyCountry } =
 		state.common.internationalisation;
 	const contributionType = getContributionType(state);
-	const nudgeMinVariantA =
-		state.common.abParticipations.nudgeMinAmountsTest === 'variantA';
-	const nudgeMinVariantB =
-		state.common.abParticipations.nudgeMinAmountsTest === 'variantB';
-	const min =
+	const { min } =
 		useLocalCurrency && localCurrencyCountry && contributionType === 'ONE_OFF'
-			? localCurrencyCountry.config[contributionType].min
-			: getConfigAbTestMin(countryGroupId, contributionType, {
-					variantA: nudgeMinVariantA,
-					variantB: nudgeMinVariantB,
-			  });
+			? localCurrencyCountry.config[contributionType]
+			: config[countryGroupId][contributionType];
 
 	return min;
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Correction to `Supporter plus nudge annual copy minimum amount increase PR`->https://github.com/guardian/support-frontend/pull/5000

Reverts 'choose your amount' minimum verified annual amounts from 10,  30 and 50 back to 10 regardless of limit on Nudge specified.

[**Trello Card**](https://trello.com/c/DVmMHOHx/1378-increase-nudge-of-single-to-annual-minimum-contribution-revert)

| version | Control | variantA | variantB |
|--------|--------|--------|--------|
|before|![Screenshot 2023-05-23 at 11 24 58](https://github.com/guardian/support-frontend/assets/76729591/6f801853-c1d4-4f4a-987d-a396e602bfb8)|![Screenshot 2023-05-23 at 11 24 17](https://github.com/guardian/support-frontend/assets/76729591/5edd9ebc-2573-42e8-8c75-8380d9cec9fe)|![Screenshot 2023-05-23 at 11 24 38](https://github.com/guardian/support-frontend/assets/76729591/2037cefb-c7f3-4bdb-9807-5dfcd3c975ec)|
|after|![Screenshot 2023-05-23 at 11 24 58](https://github.com/guardian/support-frontend/assets/76729591/6f801853-c1d4-4f4a-987d-a396e602bfb8)|![Screenshot 2023-05-23 at 11 24 58](https://github.com/guardian/support-frontend/assets/76729591/6f801853-c1d4-4f4a-987d-a396e602bfb8)|![Screenshot 2023-05-23 at 11 24 58](https://github.com/guardian/support-frontend/assets/76729591/6f801853-c1d4-4f4a-987d-a396e602bfb8)

## Is this an AB test?
- [x] Yes
- [ ] No

https://support.thegulocal.com/uk/contribute#ab-nudgeMinAmountsTest=control
https://support.thegulocal.com/uk/contribute#ab-nudgeMinAmountsTest=variantA
https://support.thegulocal.com/uk/contribute#ab-nudgeMinAmountsTest=variantB