### PR TITLE
Use better link in support-workers failure alarms

### DIFF
--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -173,7 +173,7 @@ Resources:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
       AlarmName: !Sub Support Workers Failure in ${Stage} (Recurring Contributions or Subscriptions Checkout)
-      AlarmDescription: There was a failure whilst setting up recurring payments after the user attempted to complete a checkout process. Check https://support-logs.gutools.co.uk/_plugin/kibana/goto/bcce8e6d0d4fbda9f2c58755c79e5332
+      AlarmDescription: There was a failure whilst setting up recurring payments after the user attempted to complete a checkout process. Check https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/statemachines/view/arn:aws:states:eu-west-1:865473395570:stateMachine:support-workers-${Stage}?statusFilter=FAILED
       MetricName: ExecutionsFailed
       Namespace: AWS/States
       Dimensions:


### PR DESCRIPTION
The old link gives me a 404, and our first step in alarm investigations is always to look at the list of failed executions – having a link in the alert should help investigate more quickly.