### PR TITLE
Don’t send state to backend unless required

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -44,6 +44,7 @@ import type {
 	IsoCountry,
 	StateProvince,
 } from 'helpers/internationalisation/country';
+import { shouldCollectStateForContributions } from 'helpers/internationalisation/shouldCollectStateForContribs';
 import { Annual, Monthly } from 'helpers/productPrice/billingPeriods';
 import {
 	setAmazonPayFatalError,
@@ -218,7 +219,12 @@ function regularPaymentRequestFromAuthorisation(
 			// required go cardless field
 			city: null,
 			// required go cardless field
-			state: billingState,
+			state: shouldCollectStateForContributions(
+				billingCountry,
+				contributionType,
+			)
+				? billingState
+				: null,
 			// required Zuora field if country is US or CA
 			postCode: null,
 			// required go cardless field


### PR DESCRIPTION
We’ve noticed in at least [one recent support-workers execution](https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/v2/executions/details/arn:aws:states:eu-west-1:865473395570:execution:support-workers-PROD:1578622a-578c-484f-b2bb-3a66c4f8c69a) that Zuora sometimes complains if the state in the address is set but the postcode isn’t.

Since we only _need_ the state on the backend for certain country values, this change only sends it when it’s needed. It’s not clear yet how many people are affected (from testing it seems to be just UK users attempting to use direct debit where Fastly’s geolocation has determined a state for them), but I reckon it’s worth fixing the bug even though we’re not certain of the impact.