### PR TITLE
Supporter plus nudge annual copy minimum amounts revised per region

### DIFF
--- a/support-frontend/assets/helpers/contributions.ts
+++ b/support-frontend/assets/helpers/contributions.ts
@@ -282,9 +282,29 @@ function getConfigAbTestMin(
 ): number {
 	if (contribType === 'ANNUAL') {
 		if (variantData.variantA) {
-			return 30;
+			if (
+				countryGroupId === 'GBPCountries' ||
+				countryGroupId === 'EURCountries' ||
+				countryGroupId === 'UnitedStates'
+			) {
+				return 25;
+			} else if (
+				countryGroupId === 'AUDCountries' ||
+				countryGroupId === 'NZDCountries'
+			) {
+				return 40;
+			} else {
+				return 30;
+			}
 		} else if (variantData.variantB) {
-			return 50;
+			if (
+				countryGroupId === 'AUDCountries' ||
+				countryGroupId === 'NZDCountries'
+			) {
+				return 80;
+			} else {
+				return 50;
+			}
 		}
 	}
 	return config[countryGroupId][contribType].min;

--- a/support-frontend/assets/helpers/contributions.ts
+++ b/support-frontend/assets/helpers/contributions.ts
@@ -283,25 +283,29 @@ function getConfigAbTestMin(
 	if (contribType === 'ANNUAL') {
 		if (variantData.variantA) {
 			if (
-				countryGroupId === 'GBPCountries' ||
-				countryGroupId === 'EURCountries' ||
-				countryGroupId === 'UnitedStates'
-			) {
-				return 25;
-			} else if (
 				countryGroupId === 'AUDCountries' ||
 				countryGroupId === 'NZDCountries'
 			) {
 				return 40;
-			} else {
+			} else if (countryGroupId === 'Canada') {
+				return 35;
+			}
+			if (
+				countryGroupId === 'EURCountries' ||
+				countryGroupId === 'International'
+			) {
 				return 30;
+			} else {
+				return 25;
 			}
 		} else if (variantData.variantB) {
 			if (
 				countryGroupId === 'AUDCountries' ||
 				countryGroupId === 'NZDCountries'
 			) {
-				return 80;
+				return 75;
+			} else if (countryGroupId === 'Canada') {
+				return 60;
 			} else {
 				return 50;
 			}

--- a/support-frontend/assets/helpers/contributions.ts
+++ b/support-frontend/assets/helpers/contributions.ts
@@ -282,32 +282,31 @@ function getConfigAbTestMin(
 ): number {
 	if (contribType === 'ANNUAL') {
 		if (variantData.variantA) {
-			if (
-				countryGroupId === 'AUDCountries' ||
-				countryGroupId === 'NZDCountries'
-			) {
-				return 40;
-			} else if (countryGroupId === 'Canada') {
-				return 35;
-			}
-			if (
-				countryGroupId === 'EURCountries' ||
-				countryGroupId === 'International'
-			) {
-				return 30;
-			} else {
-				return 25;
+			switch (countryGroupId) {
+				case 'AUDCountries':
+				case 'NZDCountries':
+					return 40;
+				case 'Canada':
+					return 35;
+				case 'EURCountries':
+				case 'International':
+					return 30;
+				case 'GBPCountries':
+				case 'UnitedStates':
+					return 25;
 			}
 		} else if (variantData.variantB) {
-			if (
-				countryGroupId === 'AUDCountries' ||
-				countryGroupId === 'NZDCountries'
-			) {
-				return 75;
-			} else if (countryGroupId === 'Canada') {
-				return 60;
-			} else {
-				return 50;
+			switch (countryGroupId) {
+				case 'AUDCountries':
+				case 'NZDCountries':
+					return 75;
+				case 'Canada':
+					return 60;
+				case 'EURCountries':
+				case 'International':
+				case 'GBPCountries':
+				case 'UnitedStates':
+					return 50;
 			}
 		}
 	}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Due to changes in pricing requirements, we need to change the nudge pricing for all regions. The new prices are as shown below ->
UK
Control: 10
VariantA: 25
VariantB:50
US
Control: 10
VariantA: 25
VariantB:50
EU
Control: 10
VariantA: 30
VariantB:50
AU
Control: 10
VariantA: 40
VariantB: 75
INT
Control: 10
VariantA: 30
VariantB: 50
CA
Control: 10
VariantA: 35
VariantB: 60
NZ
Control: 10
VariantA: 40
VariantB: 75

[**Trello Card**](https://trello.com/c/Gd9Ff20Z/1405-increase-nudge-to-recurring-change-the-nudge-pricing-for-regions)

## Is this an AB test?
- [x] Yes
- [ ] No

https://support.thegulocal.com/uk/contribute#ab-nudgeMinAmountsTest=control
https://support.thegulocal.com/uk/contribute#ab-nudgeMinAmountsTest=variantA
https://support.thegulocal.com/uk/contribute#ab-nudgeMinAmountsTest=variantB

## Accessibility test checklist
 - [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)