### PR TITLE
Use Okta access token to authorise call to Mdapi

### DIFF
--- a/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala
+++ b/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala
@@ -53,7 +53,7 @@ class UserFromAuthCookiesActionBuilder(
       processRequestWithoutUser()
     } else {
 
-      val accessScopes = config.oauthScopes.split(" ").map(scope => ClientAccessScope(scope)).toList
+      val accessScopes = config.oauthScopes.trim.split("\\s+").map(scope => ClientAccessScope(scope)).toList
 
       val result: Either[ValidationError, Future[Result]] = for {
         idTokenCookie <- request.cookies

--- a/support-frontend/app/controllers/AuthCodeFlowController.scala
+++ b/support-frontend/app/controllers/AuthCodeFlowController.scala
@@ -159,7 +159,7 @@ object AuthCodeFlow {
   }
 
   def secureCookie(name: String, value: String): Cookie =
-    Cookie(name, value, maxAge = Some(3600), secure = true, httpOnly = true, sameSite = Some(SameSite.Lax))
+    Cookie(name, value, maxAge = Some(3600), secure = true, httpOnly = false, sameSite = Some(SameSite.Lax))
 
   /*
    * Methods to help with Proof Keys for Code Exchange (PKCE).

--- a/support-frontend/app/controllers/AuthCodeFlowController.scala
+++ b/support-frontend/app/controllers/AuthCodeFlowController.scala
@@ -49,7 +49,7 @@ class AuthCodeFlowController(cc: ControllerComponents, authService: AsyncAuthent
       "response_type" -> "code",
       "client_id" -> config.oauthClientId,
       "redirect_uri" -> config.oauthCallbackUrl,
-      "scope" -> config.oauthScopes,
+      "scope" -> config.oauthScopes.trim.replaceAll("\\s+", " "),
       "state" -> state,
       "code_challenge" -> codeChallenge,
       "code_challenge_method" -> "S256",

--- a/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/thunks.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/thunks.ts
@@ -7,6 +7,7 @@ import type { SubscriptionsState } from 'helpers/redux/subscriptionsStore';
 import * as cookie from 'helpers/storage/cookie';
 import { getQueryParameter } from 'helpers/urls/url';
 import { doesUserAppearToBeSignedIn } from 'helpers/user/user';
+import { oktaAuthHeader } from '../../../../utilities/authorisation';
 import { getExistingPaymentMethodSwitchState } from './utils';
 
 function isValidPaymentList(
@@ -35,18 +36,13 @@ export const getExistingPaymentMethods = createAsyncThunk<
 			// No point in making the call if we don't have an access token as we know it's going to fail
 			if (authWithOkta && !accessToken) return [];
 
-			// Okta authorization uses the Authorization header rather than a cookie
-			const authHeader =
-				authWithOkta && accessToken
-					? { Authorization: `Bearer ${accessToken}` }
-					: undefined;
-
 			const existingPaymentMethods = await fetchJson(
 				`${mdapiUrl}/user-attributes/me/existing-payment-options?currencyFilter=${currencyId}`,
 				{
 					mode: 'cors',
 					credentials: 'include',
-					headers: authHeader,
+					// Okta authorization uses the Authorization header rather than a cookie
+					headers: oktaAuthHeader(authWithOkta, accessToken!),
 				},
 			);
 			if (isValidPaymentList(existingPaymentMethods)) {

--- a/support-frontend/assets/helpers/redux/user/thunks.ts
+++ b/support-frontend/assets/helpers/redux/user/thunks.ts
@@ -2,6 +2,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { fetchJson } from 'helpers/async/fetch';
 import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import * as cookie from 'helpers/storage/cookie';
+import { oktaAuthHeader } from '../../utilities/authorisation';
 import type { SupporterStatus } from './state';
 
 type UserAttributes = {
@@ -22,18 +23,13 @@ export const getRecurringContributorStatus = createAsyncThunk<
 		// No point in making the call if we don't have an access token as we know it's going to fail
 		if (authWithOkta && !accessToken) return {};
 
-		// Okta authorization uses the Authorization header rather than a cookie
-		const authHeader =
-			authWithOkta && accessToken
-				? { Authorization: `Bearer ${accessToken}` }
-				: undefined;
-
 		const attributes = (await fetchJson(
 			`${window.guardian.mdapiUrl}/user-attributes/me`,
 			{
 				mode: 'cors',
 				credentials: 'include',
-				headers: authHeader,
+				// Okta authorization uses the Authorization header rather than a cookie
+				headers: oktaAuthHeader(authWithOkta, accessToken!),
 			},
 		)) as UserAttributes;
 

--- a/support-frontend/assets/helpers/redux/user/thunks.ts
+++ b/support-frontend/assets/helpers/redux/user/thunks.ts
@@ -1,5 +1,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { fetchJson } from 'helpers/async/fetch';
+import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
+import * as cookie from 'helpers/storage/cookie';
 import type { SupporterStatus } from './state';
 
 type UserAttributes = {
@@ -14,11 +16,24 @@ export const getRecurringContributorStatus = createAsyncThunk<
 >(
 	'user/getRecurringContributorStatus',
 	async function getIsRecurringContributor() {
+		const authWithOkta = isSwitchOn('featureSwitches.authenticateWithOkta');
+		const accessToken = cookie.get('GU_ACCESS_TOKEN');
+
+		// No point in making the call if we don't have an access token as we know it's going to fail
+		if (authWithOkta && !accessToken) return {};
+
+		// Okta authorization uses the Authorization header rather than a cookie
+		const authHeader =
+			authWithOkta && accessToken
+				? { Authorization: `Bearer ${accessToken}` }
+				: undefined;
+
 		const attributes = (await fetchJson(
 			`${window.guardian.mdapiUrl}/user-attributes/me`,
 			{
 				mode: 'cors',
 				credentials: 'include',
+				headers: authHeader,
 			},
 		)) as UserAttributes;
 

--- a/support-frontend/assets/helpers/user/user.ts
+++ b/support-frontend/assets/helpers/user/user.ts
@@ -1,5 +1,5 @@
 // ----- Imports ----- //
-import { getGlobal } from 'helpers/globalsAndSwitches/globals';
+import { getGlobal, isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import * as cookie from 'helpers/storage/cookie';
 import type { Option } from 'helpers/types/option';
 import { getSignoutUrl } from 'helpers/urls/externalLinks';
@@ -53,7 +53,10 @@ const signOut = (): void => {
 	window.location.href = getSignoutUrl();
 };
 
-const doesUserAppearToBeSignedIn = (): boolean => !!cookie.get('GU_U');
+const doesUserAppearToBeSignedIn = (): boolean =>
+	isSwitchOn('featureSwitches.authenticateWithOkta')
+		? !!cookie.get('GU_ID_TOKEN')
+		: !!cookie.get('GU_U');
 
 // JTL: The user cookie is built to have particular values at
 // particular indices by design. Index 7 in the cookie object represents

--- a/support-frontend/assets/helpers/utilities/authorisation.ts
+++ b/support-frontend/assets/helpers/utilities/authorisation.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns the Okta authorization header iff we want to authorize the request with Okta,
+ * otherwise returns undefined.
+ */
+const oktaAuthHeader = (
+	authWithOkta: boolean,
+	oktaAccessToken: string,
+): { Authorization: string } | undefined =>
+	authWithOkta ? { Authorization: `Bearer ${oktaAccessToken}` } : undefined;
+
+export { oktaAuthHeader };

--- a/support-frontend/conf/application.conf
+++ b/support-frontend/conf/application.conf
@@ -15,5 +15,12 @@ identity {
   signed.out.cookie.name = "GU_SO"
   id.token.cookie.name = "GU_ID_TOKEN"
   access.token.cookie.name = "GU_ACCESS_TOKEN"
-  oauth.scopes = "openid profile email"
+  oauth.scopes = """
+    openid
+    profile
+    email
+    id_token.profile.support
+    guardian.members-data-api.read.self
+    guardian.members-data-api.complete.read.self.secure
+  """
 }

--- a/support-frontend/test/controllers/AuthCodeFlowControllerTest.scala
+++ b/support-frontend/test/controllers/AuthCodeFlowControllerTest.scala
@@ -74,6 +74,7 @@ class AuthCodeFlowControllerTest extends AnyWordSpec with Matchers {
           maxAge = Some(3600),
           secure = true,
           sameSite = Some(Lax),
+          httpOnly = false,
         ),
       )
       cookies(result).get(config.accessTokenCookieName) must contain(
@@ -83,6 +84,7 @@ class AuthCodeFlowControllerTest extends AnyWordSpec with Matchers {
           maxAge = Some(3600),
           secure = true,
           sameSite = Some(Lax),
+          httpOnly = false,
         ),
       )
       session(result).get(SessionKey.originUrl) must be(None)


### PR DESCRIPTION
## What are you doing in this PR?

This modifies calls out to the members' data API so that they include an authorization header containing an Okta access token when the feature switch `authenticateWithOkta` is on.  When the feature switch is on but a user isn't signed in, calls to members' data API won't occur at all as they are bound to fail without authorisation.  When the switch is off, the authorization header is omitted and the legacy `SC_GU_U` cookie is used for authorisation.

[**Trello Card**](https://trello.com/c/yun441Ni/4437-support-migrate-clientside-calls-to-mdapi-to-use-okta-access-tokens)


## To test

Smoke test is:

1. Feature switch `authenticateWithOkta` off:
All functionality is same as before. Calls out to members' data API give a successful response in browser console network tab when user is signed in with a legacy Identity cookie.

2. Feature switch `authenticateWithOkta` on:
When user is signed in, calls out to members' data API have an authorization request header and give a successful response in browser console network tab.
When user isn't signed in, there are no calls out to members' data API appearing in the browser console network tab.

No new errors in browser console or in Cloudwatch logs.


## Still to do

- [x] Complete Okta config to give access to scopes that will provide ID claims


## Related PRs

- #4997 
- #5024
- guardian/identity-platform#648
