### PR TITLE
Supporter plus nudge annual copy variant subtitle change

### DIFF
--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -46,9 +46,11 @@ export function CheckoutNudgeContainer({
 			  (weeklyMinAmount / 100)
 					.toFixed(weeklyMinAmount % 100 === 0 ? 0 : 2)
 					.toString();
+	const subTitleStart =
+		nudgeMinVariantA || nudgeMinVariantB ? `for` : `from just`;
 	const [title, subtitle, paragraph] = [
 		`Support us every year`,
-		`from just ${
+		`${subTitleStart} ${
 			currencyGlyph + minAmount.toString()
 		} (${minWeeklyAmount} a week)`,
 		`Funding Guardian journalism every year doesn’t need to be expensive. Make a bigger impact today, and protect our independence long term. Please consider annual support.`,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Changes Nudge Subtitle Copy For Variants Only
FROM
'from just'
TO
'for'

| ScreenSize | Control | variantA | variantB |
|--------|--------|--------|--------|
| desktop |![unnamed (5)](https://github.com/guardian/support-frontend/assets/76729591/67b09833-ecce-4011-9560-61cefb184e04)|![unnamed (6)](https://github.com/guardian/support-frontend/assets/76729591/8fb9ed17-daac-40ed-9d64-a1dbd28f03d0)|![unnamed (4)](https://github.com/guardian/support-frontend/assets/76729591/78a086fc-cbe0-462b-99d9-8592e3a4265f)|

## Is this an AB test?
- [x] Yes
- [ ] No

https://support.thegulocal.com/uk/contribute#ab-nudgeMinAmountsTest=control
https://support.thegulocal.com/uk/contribute#ab-nudgeMinAmountsTest=variantA
https://support.thegulocal.com/uk/contribute#ab-nudgeMinAmountsTest=variantB

## Accessibility test checklist
 - [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)