### PR TITLE
Don’t guess state from geolocation data

### DIFF
--- a/support-frontend/assets/helpers/internationalisation/country.ts
+++ b/support-frontend/assets/helpers/internationalisation/country.ts
@@ -913,14 +913,9 @@ function detect(
 	return country;
 }
 
-function detectState(country: IsoCountry): Option<StateProvince> {
-	return stateProvinceFromString(country, window.guardian.geoip?.stateCode);
-}
-
 // ----- Exports ----- //
 export {
 	detect,
-	detectState,
 	setCountry,
 	usStates,
 	caStates,

--- a/support-frontend/assets/helpers/redux/checkout/address/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/state.ts
@@ -1,10 +1,6 @@
 import { z } from 'zod';
 import type { PostcodeFinderResult } from 'components/subscriptionCheckouts/address/postcodeLookup';
-import {
-	detect,
-	detectState,
-	isoCountries,
-} from 'helpers/internationalisation/country';
+import { detect, isoCountries } from 'helpers/internationalisation/country';
 import type { SliceErrors } from 'helpers/redux/utils/validation/errors';
 import type { FormError } from 'helpers/subscriptionsForms/validation';
 import { isPostCodeValid } from './validationFunctions';
@@ -53,7 +49,7 @@ export function getInitialAddressFieldsState(): AddressFieldsState {
 	const country = detect();
 	return {
 		country,
-		state: detectState(country) ?? '',
+		state: '',
 		lineOne: null,
 		lineTwo: null,
 		postCode: '',

--- a/support-frontend/assets/helpers/user/user.ts
+++ b/support-frontend/assets/helpers/user/user.ts
@@ -43,7 +43,7 @@ function isTestUser(): boolean {
 
 function getUserStateField(): string | undefined {
 	const user = getGlobal<User>('user');
-	return user?.address4 ?? window.guardian.geoip?.stateCode;
+	return user?.address4;
 }
 
 const isPostDeployUser = (): boolean =>


### PR DESCRIPTION
At the moment, we guess a user’s state on page load based on geolocation data provided by Fastly. This allows users to avoid needing to fill out the state field on the form.

However, the guessed state is wrong relatively often, and has been causing us trouble. For example, a US user may have a geolocation-guessed state that is in Canada (presumably if they are near the border), and then our client-side validation needs to check that the current state value fits with the current country value.

Since it doesn’t seem like too much effort to ask the user to go to to enter their state along with the other info we ask them for, this commit stops the site guessing the user’s state from Fastly’s geolocation data.

I tested this by hardcoding the geolocation data on the backend (see commit a2d337309a36c148c6765619ebc28d0119629540) and confirming that the state wasn’t filled in the redux state (at page > checkoutForm > billingAddress > fields > state). I also submitted without selecting a state and confirmed that I get a client-side validation error.