### PR TITLE
£12for12 UK Guardian Weekly benefits remove

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -28,18 +28,6 @@ function getBenefits(countryId: IsoCountry) {
 			},
 		];
 	}
-	if (countryId === 'GB') {
-		return [
-			{
-				content: 'Every issue delivered with up to 79% off the cover price',
-			},
-			...coreBenefits,
-			{
-				content:
-					'A free Gift! £10 Guardian Bookshop voucher - exclusive to 12 for £12 quarterly subscribers',
-			},
-		];
-	}
 	return [
 		{
 			content: 'Every issue delivered with up to 35% off the cover price',


### PR DESCRIPTION
## What are you doing in this PR?
Can we hard code the line under ‘As a subscriber you’ll enjoy' as follows

GBP GW landing page ONLY (25th June onwards)
MODIFY: 'Every issue delivered with up to 79% off the cover price' -> 'Every issue delivered with up to 35% off the cover price'
REMOVE:  'A free Gift! £10 Guardian Bookshop voucher - exclusive to 12 for £12 quarterly subscribers'

Note: UK Subscription Landing Page `£12 for 12 issues` subtitle copy will automatically remove. A separate revert to PR https://github.com/guardian/support-frontend/pull/5055 needs to be applied afterwards.

[**Trello Card**](https://trello.com/c/mULRBmjb/1326-gw-support-amend-benefits-line-for-12for12-uk-revert-to-original)

## Why are you doing this?
UK offer period finishes on June 25th.

before->
![image](https://github.com/guardian/support-frontend/assets/76729591/57e67660-a001-4b69-ad5f-38ef76995b20)

after->
![image](https://github.com/guardian/support-frontend/assets/76729591/7a51f0e3-2a4d-4afb-a0e1-2adaae4fa247)

## Is this an AB test?
- [ ] Yes
- [x] No