### PR TITLE
£12for12 UK Subscriptions Landing page subtitle remove

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
@@ -71,16 +71,6 @@ const getWeeklyImage = (isTop: boolean) => {
 	return <GuardianWeeklyPackShot />;
 };
 
-function get12for12Subtitle(): string | undefined {
-	const today = new Date();
-	const startDate = new Date('2023-05-12');
-	const endDate = new Date('2023-06-25');
-
-	if (today >= startDate && today <= endDate) {
-		return '£12 for 12 issues';
-	}
-}
-
 const guardianWeekly = (
 	countryGroupId: CountryGroupId,
 	priceCopy: PriceCopy,
@@ -88,8 +78,7 @@ const guardianWeekly = (
 	participations: Participations,
 ): ProductCopy => ({
 	title: 'Guardian Weekly',
-	subtitle:
-		get12for12Subtitle() ?? getDisplayPrice(countryGroupId, priceCopy.price),
+	subtitle: getDisplayPrice(countryGroupId, priceCopy.price),
 	description:
 		'Gain a deeper understanding of the issues that matter with the Guardian Weekly magazine. Every week, take your time over handpicked articles from the Guardian and Observer, delivered for free to wherever you are in the world.',
 	offer: getGuardianWeeklyOfferCopy(priceCopy.discountCopy),


### PR DESCRIPTION
## What are you doing in this PR?
On Subscriptions landing page - price should say “13.75/monthly” instead of “£12 for 12 issues”

This should be for UK only- as this page is only visible in UK

[**Trello Card**](https://trello.com/c/mULRBmjb/1326-gw-support-amend-benefits-line-for-12for12-uk-revert-to-original)

## Why are you doing this?
UK offer period finishes on June 25th.

## Is this an AB test?
- [ ] Yes
- [x] No