### PR TITLE
Make the V2 version of SupporterPlus the only one available

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -59,26 +59,6 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.subscriptions.subsWeeklyPages,
 		seed: 11,
 	},
-	supporterPlusV2: {
-		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'variant',
-			},
-		],
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 0, //opt-in only at this stage
-			},
-		},
-		isActive: true,
-		referrerControlled: false,
-		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
-		seed: 1,
-	},
 	supporterPlusOnly: {
 		variants: [
 			{

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -18,12 +18,19 @@ sealed trait Product {
       productOptions: ProductOptions,
       readerType: ReaderType = Direct,
   ): Option[ProductRatePlan[Product]] =
-    ratePlans(environment).find(prp =>
+    ratePlans(environment).filter(prp =>
       prp.billingPeriod == billingPeriod &&
         prp.fulfilmentOptions == fulfilmentOptions &&
         prp.productOptions == productOptions &&
         prp.readerType == readerType,
-    )
+    ) match {
+      case Nil => None
+      case head :: Nil => Some(head)
+      case _ =>
+        throw new IllegalStateException(
+          s"Multiple rate plans found for $this with billing period $billingPeriod, fulfilment options $fulfilmentOptions and product options $productOptions and reader type $readerType",
+        )
+    }
 
   def getProductRatePlans(environment: TouchPointEnvironment) = ratePlans(environment)
 
@@ -51,14 +58,10 @@ case object SupporterPlus extends Product {
   lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[SupporterPlus.type]]] =
     Map(
       PROD -> List(
-        productRatePlan("8a12865b8219d9b401822106192b64dc", Monthly),
-        productRatePlan("8a12865b8219d9b40182210618a464ba", Annual),
         productRatePlan("8a128ed885fc6ded018602296ace3eb8", Monthly),
         productRatePlan("8a128ed885fc6ded01860228f77e3d5a", Annual),
       ),
       CODE -> List(
-        productRatePlan("8ad09fc281de1ce70181de3b251736a4", Monthly),
-        productRatePlan("8ad09fc281de1ce70181de3b28ee3783", Annual),
         productRatePlan("8ad08cbd8586721c01858804e3275376", Monthly),
         productRatePlan("8ad08e1a8586721801858805663f6fab", Annual),
       ),

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -39,29 +39,28 @@ case object SupporterPlus extends Product {
   private def productRatePlan(
       id: String,
       billingPeriod: BillingPeriod,
-      versionOptions: SupporterPlusVersionOptions,
   ) =
     ProductRatePlan(
       id,
       billingPeriod,
       NoFulfilmentOptions,
-      versionOptions,
+      NoProductOptions,
       s"Supporter Plus ${billingPeriod.getClass.getSimpleName}",
     )
 
   lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[SupporterPlus.type]]] =
     Map(
       PROD -> List(
-        productRatePlan("8a12865b8219d9b401822106192b64dc", Monthly, SupporterPlusV1),
-        productRatePlan("8a12865b8219d9b40182210618a464ba", Annual, SupporterPlusV1),
-        productRatePlan("8a128ed885fc6ded018602296ace3eb8", Monthly, SupporterPlusV2),
-        productRatePlan("8a128ed885fc6ded01860228f77e3d5a", Annual, SupporterPlusV2),
+        productRatePlan("8a12865b8219d9b401822106192b64dc", Monthly),
+        productRatePlan("8a12865b8219d9b40182210618a464ba", Annual),
+        productRatePlan("8a128ed885fc6ded018602296ace3eb8", Monthly),
+        productRatePlan("8a128ed885fc6ded01860228f77e3d5a", Annual),
       ),
       CODE -> List(
-        productRatePlan("8ad09fc281de1ce70181de3b251736a4", Monthly, SupporterPlusV1),
-        productRatePlan("8ad09fc281de1ce70181de3b28ee3783", Annual, SupporterPlusV1),
-        productRatePlan("8ad08cbd8586721c01858804e3275376", Monthly, SupporterPlusV2),
-        productRatePlan("8ad08e1a8586721801858805663f6fab", Annual, SupporterPlusV2),
+        productRatePlan("8ad09fc281de1ce70181de3b251736a4", Monthly),
+        productRatePlan("8ad09fc281de1ce70181de3b28ee3783", Annual),
+        productRatePlan("8ad08cbd8586721c01858804e3275376", Monthly),
+        productRatePlan("8ad08e1a8586721801858805663f6fab", Annual),
       ),
     )
 }

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -28,7 +28,7 @@ sealed trait Product {
       case head :: Nil => Some(head)
       case _ =>
         throw new IllegalStateException(
-          s"Multiple rate plans found for $this with billing period $billingPeriod, fulfilment options $fulfilmentOptions and product options $productOptions and reader type $readerType",
+          s"Multiple rate plans found for $this with billing period $billingPeriod, fulfilment options $fulfilmentOptions, product options $productOptions and reader type $readerType",
         )
     }
 

--- a/support-models/src/main/scala/com/gu/support/catalog/ProductOptions.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/ProductOptions.scala
@@ -30,15 +30,9 @@ case object EverydayPlus extends PaperProductOptions(true)
 
 case object Everyday extends PaperProductOptions(false)
 
-sealed abstract class SupporterPlusVersionOptions extends ProductOptions
-
-case object SupporterPlusV1 extends SupporterPlusVersionOptions
-
-case object SupporterPlusV2 extends SupporterPlusVersionOptions
-
 object ProductOptions {
   val allProductOptions =
-    NoProductOptions :: PaperProductOptions.productOptions ++ SupporterPlusVersionOptions.productOptions
+    NoProductOptions :: PaperProductOptions.productOptions
 
   def fromString[T](code: String, productOptions: List[T]): Option[T] =
     productOptions.find(_.getClass.getSimpleName == s"$code$$")
@@ -63,16 +57,4 @@ object PaperProductOptions {
     Decoder.decodeString.emap(code => fromString(code, productOptions).toRight(s"unrecognised product options '$code'"))
 
   implicit val encode: Encoder[PaperProductOptions] = Encoder.encodeString.contramap[PaperProductOptions](_.toString)
-}
-
-object SupporterPlusVersionOptions {
-  val productOptions: List[SupporterPlusVersionOptions] = List(SupporterPlusV1, SupporterPlusV2)
-
-  implicit val decoder: Decoder[SupporterPlusVersionOptions] =
-    Decoder.decodeString.emap(code =>
-      fromString(code, productOptions).toRight(s"unrecognised supporter plus version '$code'"),
-    )
-
-  implicit val encode: Encoder[SupporterPlusVersionOptions] =
-    Encoder.encodeString.contramap[SupporterPlusVersionOptions](_.toString)
 }

--- a/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
@@ -2,7 +2,7 @@ package com.gu.support.workers
 
 import com.gu.support.catalog
 import com.gu.support.catalog.GuardianWeekly.postIntroductorySixForSixBillingPeriod
-import com.gu.support.catalog.{Product, ProductRatePlan, SupporterPlusV1, SupporterPlusV2}
+import com.gu.support.catalog.ProductRatePlan
 import com.gu.support.config.TouchPointEnvironment
 import com.gu.support.zuora.api.ReaderType
 
@@ -47,27 +47,13 @@ object ProductTypeRatePlans {
         productRatePlan.billingPeriod == product.billingPeriod && productRatePlan.readerType == product.readerType,
       )
 
-  def supporterPlusRatePlanV1(
+  def supporterPlusRatePlan(
       product: SupporterPlus,
       environment: TouchPointEnvironment,
   ): Option[ProductRatePlan[catalog.SupporterPlus.type]] =
     catalog.SupporterPlus.ratePlans
       .getOrElse(environment, Nil)
-      .find(productRatePlan =>
-        productRatePlan.billingPeriod == product.billingPeriod &&
-          productRatePlan.productOptions == SupporterPlusV1,
-      )
-
-  def supporterPlusRatePlanV2(
-      product: SupporterPlus,
-      environment: TouchPointEnvironment,
-  ): Option[ProductRatePlan[catalog.SupporterPlus.type]] =
-    catalog.SupporterPlus.ratePlans
-      .getOrElse(environment, Nil)
-      .find(productRatePlan =>
-        productRatePlan.billingPeriod == product.billingPeriod &&
-          productRatePlan.productOptions == SupporterPlusV2,
-      )
+      .find(productRatePlan => productRatePlan.billingPeriod == product.billingPeriod)
 
   def paperRatePlan(product: Paper, environment: TouchPointEnvironment): Option[ProductRatePlan[catalog.Paper.type]] =
     catalog.Paper.ratePlans

--- a/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
@@ -35,7 +35,6 @@ object SendThankYouEmailState {
       paymentMethod: PaymentMethod,
       accountNumber: String,
       subscriptionNumber: String,
-      abTests: Option[Set[AbTest]],
   ) extends SendThankYouEmailState
 
   case class SendThankYouEmailDigitalSubscriptionDirectPurchaseState(

--- a/support-models/src/test/scala/com/gu/support/catalog/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/catalog/SerialisationSpec.scala
@@ -12,9 +12,8 @@ import org.scalatest.flatspec.AsyncFlatSpec
 class SerialisationSpec extends AsyncFlatSpec with SerialisationTestHelpers with LazyLogging {
 
   "The full Catalog" should "decode successfully" in {
-    val supporterPlusV1MonthlyId = "8a12865b8219d9b401822106192b64dc"
-    val supporterPlusV2MonthlyId = "8a128ed885fc6ded018602296ace3eb8"
-    val supporterPlusV2AnnualId = "8a128ed885fc6ded01860228f77e3d5a"
+    val supporterPlusMonthlyId = "8a128ed885fc6ded018602296ace3eb8"
+    val supporterPlusAnnualId = "8a128ed885fc6ded01860228f77e3d5a"
     val digitalPackId = "2c92a0fb4edd70c8014edeaa4eae220a"
     val guardianWeeklyAnnualDomesticId = "2c92a0fe6619b4b901661aa8e66c1692"
     val numberOfPriceLists =
@@ -27,9 +26,8 @@ class SerialisationSpec extends AsyncFlatSpec with SerialisationTestHelpers with
       zuoraCatalog => {
         val catalog = Catalog.convert(zuoraCatalog)
         catalog.prices.length shouldBe numberOfPriceLists
-        checkPrice(catalog, supporterPlusV1MonthlyId, GBP, 10)
-        checkPrice(catalog, supporterPlusV2MonthlyId, GBP, 10)
-        checkPrice(catalog, supporterPlusV2AnnualId, GBP, 95)
+        checkPrice(catalog, supporterPlusMonthlyId, GBP, 10)
+        checkPrice(catalog, supporterPlusAnnualId, GBP, 95)
         checkPrice(catalog, digitalPackId, GBP, 11.99)
         checkPrice(catalog, guardianWeeklyAnnualDomesticId, GBP, 165)
       },

--- a/support-services/src/test/scala/com/gu/support/catalog/ProductRatePlanSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/catalog/ProductRatePlanSpec.scala
@@ -1,0 +1,84 @@
+package com.gu.support.catalog
+
+import com.gu.support.config.TouchPointEnvironment
+import com.gu.support.config.TouchPointEnvironments.{CODE, PROD}
+import com.gu.support.workers.{Annual, BillingPeriod, Monthly, Quarterly}
+import com.typesafe.scalalogging.LazyLogging
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+case class TestData(
+    product: Product,
+    billingPeriods: List[BillingPeriod],
+    fulfilmentOptions: List[FulfilmentOptions],
+    productOptions: List[ProductOptions],
+)
+
+class ProductRatePlanSpec extends AnyFlatSpec with Matchers {
+
+  val testData = List(
+    TestData(
+      DigitalPack,
+      List(Monthly, Annual),
+      List(NoFulfilmentOptions),
+      List(NoProductOptions),
+    ),
+    TestData(
+      SupporterPlus,
+      List(Monthly, Annual),
+      List(NoFulfilmentOptions),
+      List(NoProductOptions),
+    ),
+    TestData(
+      Paper,
+      List(Monthly),
+      List(HomeDelivery, Collection),
+      List(Everyday, Sixday),
+    ),
+    TestData(
+      GuardianWeekly,
+      List(Monthly, Quarterly, Annual),
+      List(Domestic, RestOfWorld),
+      List(NoProductOptions),
+    ),
+    TestData(
+      Contribution,
+      List(Monthly, Annual),
+      List(NoFulfilmentOptions),
+      List(NoProductOptions),
+    ),
+  )
+
+  "Products defined in Product.scala" should "have exactly one product rate plan for every product configuration" in {
+    val environments = List(PROD, CODE)
+    for {
+      environment <- environments
+      testDatum <- testData
+      _ = println(s"Testing ${testDatum.product} in $environment")
+      result = testProduct(environment, testDatum)
+    } yield result
+    succeed
+  }
+
+  def testProduct(environment: TouchPointEnvironment, testDatum: TestData) = {
+    for {
+      billingPeriod <- testDatum.billingPeriods
+      fulfilmentOption <- testDatum.fulfilmentOptions
+      productOption <- testDatum.productOptions
+    } yield {
+      testDatum.product.getProductRatePlan(environment, billingPeriod, fulfilmentOption, productOption) match {
+        case Some(_) =>
+          println(
+            s"Found a single product rate plan for ${testDatum.product} $billingPeriod $fulfilmentOption $productOption",
+          )
+        case None =>
+          println(
+            s"Couldn't find a product rate plan for ${testDatum.product} $billingPeriod $fulfilmentOption $productOption",
+          )
+          fail()
+      }
+      succeed
+    }
+
+  }
+}

--- a/support-workers/src/main/scala/com/gu/helpers/SupportWorkersV2Helper.scala
+++ b/support-workers/src/main/scala/com/gu/helpers/SupportWorkersV2Helper.scala
@@ -1,8 +1,0 @@
-package com.gu.helpers
-
-import com.gu.support.acquisitions.AbTest
-
-object SupportWorkersV2Helper {
-  def isV2SupporterPlus(abTests: Option[Set[AbTest]]) =
-    abTests.flatMap(_.find(test => test.name == "supporterPlusV2" && test.variant == "variant")).isDefined
-}

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -35,7 +35,6 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
           state,
           zuoraSubscriptionState.csrUsername,
           zuoraSubscriptionState.salesforceCaseId,
-          zuoraSubscriptionState.acquisitionData.map(_.supportAbTests),
         )
       case state: DigitalSubscriptionGiftRedemptionState =>
         zuoraDigitalSubscriptionGiftRedemptionHandler.redeemGift(state)

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
@@ -1,7 +1,6 @@
 package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
-import com.gu.helpers.SupportWorkersV2Helper.isV2SupporterPlus
 import com.gu.monitoring.SafeLogger
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.catalog._
@@ -94,10 +93,9 @@ object UpdateSupporterProductData {
           )
           .toRight(s"Unable to create SupporterRatePlanItem from state $state")
 
-      case SendThankYouEmailSupporterPlusState(user, product, _, _, subscriptionNumber, abTests) =>
-        val supporterPlusVersion = if (isV2SupporterPlus(abTests)) SupporterPlusV2 else SupporterPlusV1
+      case SendThankYouEmailSupporterPlusState(user, product, _, _, subscriptionNumber) =>
         catalogService
-          .getProductRatePlan(SupporterPlus, product.billingPeriod, NoFulfilmentOptions, supporterPlusVersion)
+          .getProductRatePlan(SupporterPlus, product.billingPeriod, NoFulfilmentOptions, NoProductOptions)
           .map(productRatePlan =>
             Some(
               supporterRatePlanItem(

--- a/support-workers/src/main/scala/com/gu/zuora/productHandlers/ZuoraSupporterPlusHandler.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/productHandlers/ZuoraSupporterPlusHandler.scala
@@ -23,11 +23,10 @@ class ZuoraSupporterPlusHandler(
       state: SupporterPlusState,
       csrUsername: Option[String],
       salesforceCaseId: Option[String],
-      abTests: Option[Set[AbTest]],
   ) =
     for {
       (account, sub) <- zuoraSubscriptionCreator.ensureSubscriptionCreated(
-        supporterPlusSubscriptionBuilder.build(state, csrUsername, salesforceCaseId, abTests),
+        supporterPlusSubscriptionBuilder.build(state, csrUsername, salesforceCaseId),
       )
     } yield SendThankYouEmailSupporterPlusState(
       user,
@@ -35,7 +34,6 @@ class ZuoraSupporterPlusHandler(
       state.paymentMethod,
       account.value,
       sub.value,
-      abTests,
     )
 
 }

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/SupporterPlusSubcriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/SupporterPlusSubcriptionBuilder.scala
@@ -1,17 +1,15 @@
 package com.gu.zuora.subscriptionBuilders
 
 import com.gu.helpers.DateGenerator
-import com.gu.helpers.SupportWorkersV2Helper.isV2SupporterPlus
 import com.gu.i18n.Currency
-import com.gu.support.acquisitions.AbTest
-import com.gu.support.catalog.{CatalogService, Pricelist, ProductRatePlanId, SupporterPlus}
+import com.gu.support.catalog.{CatalogService, ProductRatePlanId}
 import com.gu.support.config.{TouchPointEnvironment, ZuoraSupporterPlusConfig}
-import com.gu.support.workers.{BillingPeriod, Monthly}
-import com.gu.support.workers.ProductTypeRatePlans.{supporterPlusRatePlanV1, supporterPlusRatePlanV2}
+import com.gu.support.workers.Monthly
+import com.gu.support.workers.ProductTypeRatePlans.supporterPlusRatePlan
 import com.gu.support.workers.exceptions.CatalogDataNotFoundException
 import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.SupporterPlusState
-import com.gu.support.zuora.api._
 import com.gu.support.zuora.api.ReaderType.Direct
+import com.gu.support.zuora.api._
 import com.gu.zuora.subscriptionBuilders.ProductSubscriptionBuilders.validateRatePlan
 
 class SupporterPlusSubcriptionBuilder(
@@ -26,40 +24,9 @@ class SupporterPlusSubcriptionBuilder(
       state: SupporterPlusState,
       csrUsername: Option[String],
       salesforceCaseId: Option[String],
-      abTests: Option[Set[AbTest]],
-  ): SubscribeItem =
-    if (isV2SupporterPlus(abTests))
-      buildV2(state, csrUsername, salesforceCaseId)
-    else
-      buildV1(state, csrUsername, salesforceCaseId)
-
-  def buildV1(state: SupporterPlusState, csrUsername: Option[String], salesforceCaseId: Option[String]) = {
+  ): SubscribeItem = {
     val productRatePlanId =
-      validateRatePlan(supporterPlusRatePlanV1(state.product, environment), state.product.describe)
-    val ratePlanChargeId = if (state.product.billingPeriod == Monthly) config.monthlyChargeId else config.annualChargeId
-    val todaysDate = dateGenerator.today
-
-    val subscriptionData = subscribeItemBuilder.buildProductSubscription(
-      productRatePlanId = productRatePlanId,
-      ratePlanCharges = List(
-        RatePlanChargeData(
-          RatePlanChargeOverride(
-            ratePlanChargeId,
-            price = state.product.amount, // Pass the amount the user selected into Zuora
-          ),
-        ),
-      ),
-      contractEffectiveDate = todaysDate,
-      contractAcceptanceDate = todaysDate,
-      readerType = Direct,
-      csrUsername = csrUsername,
-      salesforceCaseId = salesforceCaseId,
-    )
-    subscribeItemBuilder.build(subscriptionData, state.salesForceContact, Some(state.paymentMethod), None)
-  }
-  def buildV2(state: SupporterPlusState, csrUsername: Option[String], salesforceCaseId: Option[String]) = {
-    val productRatePlanId =
-      validateRatePlan(supporterPlusRatePlanV2(state.product, environment), state.product.describe)
+      validateRatePlan(supporterPlusRatePlan(state.product, environment), state.product.describe)
     val contributionRatePlanChargeId =
       if (state.product.billingPeriod == Monthly) config.v2.monthlyContributionChargeId
       else config.v2.annualContributionChargeId

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -468,12 +468,12 @@ object JsonFixtures {
   def createSupporterPlusZuoraSubscriptionJson(
       amount: BigDecimal,
       currency: Currency,
+      billingPeriod: BillingPeriod,
       country: Country = UK,
-      acquisitionData: Option[AcquisitionData] = None,
   ) =
     CreateZuoraSubscriptionState(
       SupporterPlusState(
-        SupporterPlus(amount, currency, Monthly),
+        SupporterPlus(amount, currency, billingPeriod),
         stripePaymentMethodObj,
         salesforceContact,
       ),
@@ -485,7 +485,7 @@ object JsonFixtures {
       None,
       None,
       None,
-      acquisitionData,
+      None,
     ).asJson.spaces2
 
   val createDigiPackZuoraSubscriptionJson =

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -49,23 +49,16 @@ class CreateZuoraSubscriptionSpec extends AsyncLambdaSpec with MockServicesCreat
       })
   }
 
-  it should "create a Supporter Plus subscription" in {
+  it should "create a monthly Supporter Plus subscription" in {
     createZuoraHelper
-      .createSubscription(createSupporterPlusZuoraSubscriptionJson(20, GBP))
+      .createSubscription(createSupporterPlusZuoraSubscriptionJson(20, GBP, Monthly))
       .map(_ should matchPattern { case _: SendThankYouEmailSupporterPlusState =>
       })
   }
 
-  it should "create a Supporter Plus V2 subscription" in {
-    val acquisitionData = Some(
-      AcquisitionData(
-        OphanIds(None, None),
-        ReferrerAcquisitionData(None, None, None, None, None, None, None, None, None, None, None, None, None),
-        Set(AbTest("supporterPlusV2", "variant")),
-      ),
-    )
+  it should "create an annual Supporter Plus subscription" in {
     createZuoraHelper
-      .createSubscription(createSupporterPlusZuoraSubscriptionJson(20, GBP, acquisitionData = acquisitionData))
+      .createSubscription(createSupporterPlusZuoraSubscriptionJson(95, GBP, Annual))
       .map(_ should matchPattern { case _: SendThankYouEmailSupporterPlusState =>
       })
   }
@@ -73,7 +66,7 @@ class CreateZuoraSubscriptionSpec extends AsyncLambdaSpec with MockServicesCreat
   it should "create a Supporter Plus subscription in a country where it is taxed" in {
     val austria = CountryGroup.Europe.countries.find(_.alpha2 == "AT").get // Fail here if we can't find it
     createZuoraHelper
-      .createSubscription(createSupporterPlusZuoraSubscriptionJson(10, EUR, austria))
+      .createSubscription(createSupporterPlusZuoraSubscriptionJson(10, EUR, Monthly, austria))
       .map(_ should matchPattern { case _: SendThankYouEmailSupporterPlusState =>
       })
   }

--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/UpdateSupporterProductDataSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/UpdateSupporterProductDataSpec.scala
@@ -6,7 +6,7 @@ import com.gu.support.workers.lambdas.UpdateSupporterProductDataSpec.{
   digitalSubscriptionGiftRedemptionState,
   digitalSusbcriptionGiftPurchaseState,
   serviceWithFixtures,
-  supporterPlusV2State,
+  supporterPlusState,
 }
 import com.gu.support.workers.states.SendThankYouEmailState
 import com.gu.supporterdata.model.ContributionAmount
@@ -41,7 +41,7 @@ class UpdateSupporterProductDataSpec extends AnyFlatSpec {
   }
 
   "UpdateSupporterProductData" should "return a valid SupporterRatePlanItem for a Supporter Plus V2 purchase" in {
-    val state = decode[SendThankYouEmailState](supporterPlusV2State)
+    val state = decode[SendThankYouEmailState](supporterPlusState)
     state.isRight shouldBe true
     val supporterRatePlanItem = UpdateSupporterProductData
       .getSupporterRatePlanItemFromState(state.toOption.get, serviceWithFixtures)
@@ -54,7 +54,7 @@ class UpdateSupporterProductDataSpec extends AnyFlatSpec {
 
 object UpdateSupporterProductDataSpec {
 
-  val supporterPlusV2State =
+  val supporterPlusState =
     """
       {
           "user": {

--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/UpdateSupporterProductDataSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/UpdateSupporterProductDataSpec.scala
@@ -40,7 +40,7 @@ class UpdateSupporterProductDataSpec extends AnyFlatSpec {
     }
   }
 
-  "UpdateSupporterProductData" should "return a valid SupporterRatePlanItem for a Supporter Plus V2 purchase" in {
+  "UpdateSupporterProductData" should "return a valid SupporterRatePlanItem for a Supporter Plus purchase" in {
     val state = decode[SendThankYouEmailState](supporterPlusState)
     state.isRight shouldBe true
     val supporterRatePlanItem = UpdateSupporterProductData

--- a/supporter-product-data/src/main/scala/com/gu/services/S3Service.scala
+++ b/supporter-product-data/src/main/scala/com/gu/services/S3Service.scala
@@ -32,7 +32,9 @@ object S3Service extends StrictLogging {
     transfer.waitForCompletion()
   }
 
-  def streamFromS3(stage: Stage, filename: String) =
+  def streamFromS3(stage: Stage, filename: String) = {
+    logger.info(s"Trying to stream from S3 - bucketName: ${bucketName(stage)}, filename: $filename")
     s3Client.getObject(new GetObjectRequest(bucketName(stage), filename))
+  }
 
 }

--- a/supporter-product-data/src/test/scala/com/gu/lambdas/AddSupporterRatePlanItemToQueueIntegrationTest.scala
+++ b/supporter-product-data/src/test/scala/com/gu/lambdas/AddSupporterRatePlanItemToQueueIntegrationTest.scala
@@ -12,7 +12,7 @@ import java.time.ZonedDateTime
 class AddSupporterRatePlanItemToQueueIntegrationTest extends AsyncFlatSpec with Matchers {
 
   "AddSupporterRatePlanItemToQueueLambda" should "process records correctly" in {
-    val csvFilename = "select-active-rate-plans-2023-01-12T05:59:45.210958.csv"
+    val csvFilename = "test-fixture.csv"
     AddSupporterRatePlanItemToQueueLambda.addToQueue(
       CODE,
       AddSupporterRatePlanItemToQueueState(
@@ -25,6 +25,6 @@ class AddSupporterRatePlanItemToQueueIntegrationTest extends AsyncFlatSpec with 
         override def timeRemainingMillis: Int = 1000 * 60 * 5
       },
     )
-  }.map(outState => outState.processedCount shouldBe 248)
+  }.map(outState => outState.processedCount shouldBe 9)
 
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Supporter plus V2 is a reconfiguration of the Zuora product to make it more tax efficient

The high level overview [doc is here](https://docs.google.com/document/d/1_5BG0oj6npvz6X2MSs6XYIsW9uvL4d3tNqeYAG0C8Y8/edit#heading=h.y0059xq85tiu)
A folder containing other related documents, mostly technical spikes [is here](https://drive.google.com/drive/folders/1p8zVX2DfCeVZgFHZnA2ibJtPhFxX4Hz1?usp=drive_link)

Currently we have a 0% AB test which allows us to opt-in to purchasing version 2 of supporter plus but customers are still purchasing version 1, this PR switches that so that all supporter plus purchases are of version 2.

The user experience is unchanged however the terms and conditions page (lives on dotcom, updated through composer) will need to be updated at the same time as this is released.
