### PR TITLE
Add components for Supporter Plus Only checkout test

### DIFF
--- a/support-frontend/assets/components/checkmarkList/checkmarkList.tsx
+++ b/support-frontend/assets/components/checkmarkList/checkmarkList.tsx
@@ -5,7 +5,7 @@ import { SvgCrossRound, SvgTickRound } from '@guardian/source-react-components';
 
 const checkListIconCss = (style: CheckmarkListStyle) => css`
 	vertical-align: top;
-	padding-right: 10px;
+	padding-right: ${style === 'compact' ? '4px' : '10px'};
 	line-height: 0;
 
 	svg {

--- a/support-frontend/assets/components/checkmarkList/checkmarkList.tsx
+++ b/support-frontend/assets/components/checkmarkList/checkmarkList.tsx
@@ -1,15 +1,15 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { from, palette, space } from '@guardian/source-foundations';
+import { from, palette, space, textSans } from '@guardian/source-foundations';
 import { SvgCrossRound, SvgTickRound } from '@guardian/source-react-components';
 
-const checkListIconCss = css`
+const checkListIconCss = (style: CheckmarkListStyle) => css`
 	vertical-align: top;
 	padding-right: 10px;
 	line-height: 0;
 
 	svg {
-		fill: ${palette.brand[500]};
+		fill: ${style === 'compact' ? palette.success[400] : palette.brand[500]};
 	}
 `;
 
@@ -25,7 +25,11 @@ const checkListTextCss = css`
 	}
 `;
 
-const tableCss = css`
+const tableCss = (style: CheckmarkListStyle) => css`
+	${style === 'standard'
+		? textSans.medium({ lineHeight: 'tight' })
+		: textSans.small()}
+
 	padding-top: ${space[4]}px;
 
 	& tr:not(:last-child) {
@@ -45,28 +49,44 @@ export type CheckListData = {
 	maybeGreyedOut?: SerializedStyles;
 };
 
+type CheckmarkListStyle = 'standard' | 'compact';
+
 export type CheckmarkListProps = {
 	checkListData: CheckListData[];
+	style?: CheckmarkListStyle;
 };
 
-function ChecklistItemIcon({ checked }: { checked: boolean }): JSX.Element {
+function ChecklistItemIcon({
+	checked,
+	style,
+}: {
+	checked: boolean;
+	style: CheckmarkListStyle;
+}): JSX.Element {
 	return checked ? (
-		<SvgTickRound isAnnouncedByScreenReader size="small" />
+		<SvgTickRound
+			isAnnouncedByScreenReader
+			size={style === 'standard' ? 'small' : 'xsmall'}
+		/>
 	) : (
-		<SvgCrossRound isAnnouncedByScreenReader size="small" />
+		<SvgCrossRound
+			isAnnouncedByScreenReader
+			size={style === 'standard' ? 'small' : 'xsmall'}
+		/>
 	);
 }
 
 export function CheckmarkList({
 	checkListData,
+	style = 'standard',
 }: CheckmarkListProps): JSX.Element {
 	return (
-		<table css={tableCss}>
+		<table css={tableCss(style)}>
 			{checkListData.map((item) => (
 				<tr>
-					<td css={[checkListIconCss, item.maybeGreyedOut]}>
-						<div css={iconContainerCss}>
-							<ChecklistItemIcon checked={item.isChecked} />
+					<td css={[checkListIconCss(style), item.maybeGreyedOut]}>
+						<div css={style === 'standard' ? iconContainerCss : css``}>
+							<ChecklistItemIcon checked={item.isChecked} style={style} />
 						</div>
 					</td>
 					<td css={[checkListTextCss, item.maybeGreyedOut]}>{item.text}</td>

--- a/support-frontend/assets/components/checkmarkList/checkmarkList.tsx
+++ b/support-frontend/assets/components/checkmarkList/checkmarkList.tsx
@@ -1,0 +1,77 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import { from, palette, space } from '@guardian/source-foundations';
+import { SvgCrossRound, SvgTickRound } from '@guardian/source-react-components';
+
+const checkListIconCss = css`
+	vertical-align: top;
+	padding-right: 10px;
+	line-height: 0;
+
+	svg {
+		fill: ${palette.brand[500]};
+	}
+`;
+
+const iconContainerCss = css`
+	margin-top: -2px;
+`;
+
+const checkListTextCss = css`
+	display: inline-block;
+
+	& p {
+		line-height: 1.35;
+	}
+`;
+
+const tableCss = css`
+	padding-top: ${space[4]}px;
+
+	& tr:not(:last-child) {
+		border-bottom: 6px solid transparent;
+	}
+
+	${from.mobileLandscape} {
+		& tr:not(:last-child) {
+			border-bottom: ${space[3]}px solid transparent;
+		}
+	}
+`;
+
+export type CheckListData = {
+	isChecked: boolean;
+	text?: JSX.Element;
+	maybeGreyedOut?: SerializedStyles;
+};
+
+export type CheckmarkListProps = {
+	checkListData: CheckListData[];
+};
+
+function ChecklistItemIcon({ checked }: { checked: boolean }): JSX.Element {
+	return checked ? (
+		<SvgTickRound isAnnouncedByScreenReader size="small" />
+	) : (
+		<SvgCrossRound isAnnouncedByScreenReader size="small" />
+	);
+}
+
+export function CheckmarkList({
+	checkListData,
+}: CheckmarkListProps): JSX.Element {
+	return (
+		<table css={tableCss}>
+			{checkListData.map((item) => (
+				<tr>
+					<td css={[checkListIconCss, item.maybeGreyedOut]}>
+						<div css={iconContainerCss}>
+							<ChecklistItemIcon checked={item.isChecked} />
+						</div>
+					</td>
+					<td css={[checkListTextCss, item.maybeGreyedOut]}>{item.text}</td>
+				</tr>
+			))}
+		</table>
+	);
+}

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
@@ -1,15 +1,15 @@
 import { css } from '@emotion/react';
 import {
-	brand,
 	from,
 	headline,
 	space,
 	textSans,
 	until,
 } from '@guardian/source-foundations';
+import { CheckmarkList } from 'components/checkmarkList/checkmarkList';
+import type { CheckListData } from 'components/checkmarkList/checkmarkList';
 import Tooltip from 'components/tooltip/Tooltip';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import type { CheckListData } from './checkoutBenefitsListData';
 
 const containerCss = css`
 	${textSans.medium({ lineHeight: 'tight' })};
@@ -24,42 +24,6 @@ const headingCss = css`
 	max-width: 250px;
 	${from.desktop} {
 		max-width: 280px;
-	}
-`;
-
-const checkListIconCss = css`
-	vertical-align: top;
-	padding-right: 10px;
-	line-height: 0;
-
-	svg {
-		fill: ${brand[500]};
-	}
-`;
-
-const iconContainerCss = css`
-	margin-top: -2px;
-`;
-
-const checkListTextCss = css`
-	display: inline-block;
-
-	& p {
-		line-height: 1.35;
-	}
-`;
-
-const tableCss = css`
-	padding-top: ${space[4]}px;
-
-	& tr:not(:last-child) {
-		border-bottom: 6px solid transparent;
-	}
-
-	${from.mobileLandscape} {
-		& tr:not(:last-child) {
-			border-bottom: ${space[3]}px solid transparent;
-		}
 	}
 `;
 
@@ -90,16 +54,7 @@ export function CheckoutBenefitsList({
 		<div css={containerCss}>
 			<h2 css={headingCss}>{title}</h2>
 			<hr css={hrCss(`${space[4]}px 0`)} />
-			<table css={tableCss}>
-				{checkListData.map((item) => (
-					<tr>
-						<td css={[checkListIconCss, item.maybeGreyedOut]}>
-							<div css={iconContainerCss}>{item.icon}</div>
-						</td>
-						<td css={[checkListTextCss, item.maybeGreyedOut]}>{item.text}</td>
-					</tr>
-				))}
-			</table>
+			<CheckmarkList checkListData={checkListData} />
 			<hr css={hrCss(`${space[5]}px 0 ${space[4]}px`)} />
 			<Tooltip promptText="Cancel anytime">
 				<p>

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
@@ -1,13 +1,13 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { neutral } from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 import { SvgCrossRound, SvgTickRound } from '@guardian/source-react-components';
 
 const greyedOut = css`
-	color: ${neutral[60]};
+	color: ${palette.neutral[60]};
 
 	svg {
-		fill: ${neutral[60]};
+		fill: ${palette.neutral[60]};
 	}
 `;
 
@@ -20,7 +20,7 @@ type TierUnlocks = {
 };
 
 export type CheckListData = {
-	icon: JSX.Element;
+	isChecked: boolean;
 	text?: JSX.Element;
 	maybeGreyedOut?: SerializedStyles;
 };
@@ -37,7 +37,7 @@ export const checkListData = ({ higherTier }: TierUnlocks): CheckListData[] => {
 
 	return [
 		{
-			icon: getSvgIcon(true),
+			isChecked: true,
 			text: (
 				<p>
 					<span css={boldText}>A regular supporter newsletter. </span>Get
@@ -46,7 +46,7 @@ export const checkListData = ({ higherTier }: TierUnlocks): CheckListData[] => {
 			),
 		},
 		{
-			icon: getSvgIcon(true),
+			isChecked: true,
 			text: (
 				<p>
 					<span css={boldText}>Uninterrupted reading. </span> See far fewer asks
@@ -55,7 +55,7 @@ export const checkListData = ({ higherTier }: TierUnlocks): CheckListData[] => {
 			),
 		},
 		{
-			icon: getSvgIcon(higherTier),
+			isChecked: higherTier,
 			text: (
 				<p>
 					<span css={boldText}>Full access to our news app. </span>Read our
@@ -65,7 +65,7 @@ export const checkListData = ({ higherTier }: TierUnlocks): CheckListData[] => {
 			maybeGreyedOut: maybeGreyedOutHigherTier,
 		},
 		{
-			icon: getSvgIcon(higherTier),
+			isChecked: higherTier,
 			text: (
 				<p>
 					<span css={boldText}>Ad-free reading. </span>Avoid ads on all your

--- a/support-frontend/assets/components/infoBlock/infoBlock.tsx
+++ b/support-frontend/assets/components/infoBlock/infoBlock.tsx
@@ -1,0 +1,38 @@
+import { css } from '@emotion/react';
+import { palette, space, textSans } from '@guardian/source-foundations';
+
+const infoBlock = css`
+	${textSans.small()};
+	background: ${palette.neutral[97]};
+	border-radius: 8px;
+	padding: ${space[3]}px;
+`;
+
+const hrCss = css`
+	border: none;
+	height: 1px;
+	background-color: ${palette.neutral[86]};
+`;
+
+const infoBlockContent = css`
+	color: #606060;
+	ul {
+		list-style: disc;
+		padding-left: ${space[4]}px;
+	}
+`;
+
+export type InfoBlockProps = {
+	header: React.ReactNode;
+	content: React.ReactNode;
+};
+
+export function InfoBlock({ header, content }: InfoBlockProps): JSX.Element {
+	return (
+		<div css={infoBlock}>
+			{header}
+			<hr css={hrCss} />
+			<div css={infoBlockContent}>{content}</div>
+		</div>
+	);
+}

--- a/support-frontend/assets/components/priceCards/simplePriceCards.tsx
+++ b/support-frontend/assets/components/priceCards/simplePriceCards.tsx
@@ -1,0 +1,140 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headline,
+	palette,
+	space,
+	textSans,
+	until,
+} from '@guardian/source-foundations';
+import {
+	Button,
+	ChoiceCard,
+	ChoiceCardGroup,
+	SvgChevronDownSingle,
+} from '@guardian/source-react-components';
+import { useState } from 'react';
+import type { RegularContributionType } from 'helpers/contributions';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { fromCountryGroupId } from 'helpers/internationalisation/currency';
+import { Tooltip } from '../../../stories/content/Tooltip.stories';
+
+const containerCss = css`
+	${textSans.medium({ lineHeight: 'tight' })};
+`;
+
+const headingCss = css`
+	${headline.xsmall({ fontWeight: 'bold' })}
+	${from.tablet} {
+		font-size: 28px;
+		line-height: 115%;
+	}
+`;
+
+const hrCss = (margin: string) => css`
+	border: none;
+	height: 1px;
+	background-color: ${palette.neutral[86]};
+	margin: ${margin};
+	${until.tablet} {
+		margin: 14px 0 0;
+	}
+`;
+
+const buttonOverrides = css`
+	width: 100%;
+	justify-content: center;
+	text-decoration: none;
+`;
+
+const iconCss = (flip: boolean) => css`
+	svg {
+		transition: transform 0.3s ease-in-out;
+
+		${flip && 'transform: rotate(180deg);'}
+	}
+`;
+
+type Prices = {
+	monthly: number;
+	annual: number;
+};
+
+type PriceSelection = {
+	contributionType: RegularContributionType;
+	amount: number;
+};
+
+export type SimplePriceCardsProps = {
+	title: string;
+	tagline: string;
+	prices: Prices;
+	onPriceChange: (priceSelection: PriceSelection) => void;
+	countryGroupId: CountryGroupId;
+	children: React.ReactNode;
+};
+
+export function SimplePriceCards(props: SimplePriceCardsProps): JSX.Element {
+	const [showDetails, setShowDetails] = useState(false);
+
+	return (
+		<div css={containerCss}>
+			<h2 css={headingCss}>{props.title}</h2>
+			<ChoiceCardGroup name="paymentFrequency" columns={2}>
+				<ChoiceCard
+					id="monthly"
+					key="monthly"
+					name="frequency"
+					onChange={() =>
+						props.onPriceChange({
+							contributionType: 'MONTHLY',
+							amount: props.prices.monthly,
+						})
+					}
+					checked={false}
+					value="monthly"
+					label={`${fromCountryGroupId(props.countryGroupId)}${
+						props.prices.monthly
+					} per month`}
+				/>
+				<ChoiceCard
+					id="annual"
+					key="annual"
+					name="frequency"
+					onChange={() =>
+						props.onPriceChange({
+							contributionType: 'ANNUAL',
+							amount: props.prices.annual,
+						})
+					}
+					checked={false}
+					value="annual"
+					label={`${fromCountryGroupId(props.countryGroupId)}${
+						props.prices.annual
+					} per year`}
+				/>
+			</ChoiceCardGroup>
+			<p>{props.tagline}</p>
+			<Tooltip promptText="Cancel anytime">
+				<p>
+					You can cancel
+					{props.countryGroupId === 'GBPCountries' ? '' : ' online'} anytime
+					before your next payment date. If you cancel in the first 14 days, you
+					will receive a full refund.
+				</p>
+			</Tooltip>
+			<hr css={hrCss(`${space[4]}px 0 0`)} />
+			<Button
+				priority="subdued"
+				aria-expanded={showDetails ? 'true' : 'false'}
+				onClick={() => setShowDetails(!showDetails)}
+				icon={<SvgChevronDownSingle />}
+				iconSide="right"
+				cssOverrides={[buttonOverrides, iconCss(showDetails)]}
+			>
+				view details
+			</Button>
+			{showDetails && <div>{props.children}</div>}
+		</div>
+	);
+}

--- a/support-frontend/assets/components/priceCards/simplePriceCards.tsx
+++ b/support-frontend/assets/components/priceCards/simplePriceCards.tsx
@@ -122,10 +122,6 @@ function getLabel(
 	if (contributionType === 'ANNUAL') {
 		return (
 			<span>
-				<s>
-					{currencyGlyph}
-					{prices.monthly * 12}
-				</s>{' '}
 				{currencyGlyph}
 				{prices.annual}/year
 			</span>

--- a/support-frontend/assets/components/priceCards/simplePriceCards.tsx
+++ b/support-frontend/assets/components/priceCards/simplePriceCards.tsx
@@ -55,13 +55,13 @@ const hrCss = css`
 	border: none;
 	height: 1px;
 	background-color: ${palette.neutral[86]};
-	margin: 14px -${space[3]}px 12px;
+	margin: 14px -${space[3]}px ${space[3]}px;
 	${from.tablet} {
-		margin: ${space[4]}px -${space[5]}px 12px;
+		margin: ${space[4]}px -${space[5]}px ${space[3]}px;
 	}
 
 	${from.desktop} {
-		margin: ${space[4]}px -${space[6]}px 12px;
+		margin: ${space[4]}px -${space[6]}px ${space[3]}px;
 	}
 `;
 
@@ -82,6 +82,15 @@ const iconCss = (flip: boolean) => css`
 
 		${flip && 'transform: rotate(180deg);'}
 	}
+`;
+
+const detailsSection = css`
+	display: flex;
+	flex-direction: column-reverse;
+`;
+
+const detailsContainer = css`
+	margin-bottom: ${space[3]}px;
 `;
 
 type Prices = {
@@ -106,10 +115,28 @@ export type SimplePriceCardsProps = {
 
 function getLabel(
 	countryGroupId: CountryGroupId,
-	amount: number,
-	period: string,
+	prices: Prices,
+	contributionType: ContributionType,
 ) {
-	return `${glyph(fromCountryGroupId(countryGroupId))}${amount}/${period}`;
+	const currencyGlyph = glyph(fromCountryGroupId(countryGroupId));
+	if (contributionType === 'ANNUAL') {
+		return (
+			<span>
+				<s>
+					{currencyGlyph}
+					{prices.monthly * 12}
+				</s>{' '}
+				{currencyGlyph}
+				{prices.annual}/year
+			</span>
+		);
+	}
+	return (
+		<span>
+			{currencyGlyph}
+			{prices.monthly}/month
+		</span>
+	);
 }
 
 function getTaglinePrice(
@@ -144,7 +171,7 @@ export function SimplePriceCards(props: SimplePriceCardsProps): JSX.Element {
 					}
 					checked={props.contributionType === 'ANNUAL'}
 					value="annual"
-					label={getLabel(props.countryGroupId, props.prices.annual, 'year')}
+					label={getLabel(props.countryGroupId, props.prices, 'ANNUAL')}
 				/>
 				<ChoiceCard
 					id="monthly"
@@ -158,7 +185,7 @@ export function SimplePriceCards(props: SimplePriceCardsProps): JSX.Element {
 					}
 					checked={props.contributionType === 'MONTHLY'}
 					value="monthly"
-					label={getLabel(props.countryGroupId, props.prices.monthly, 'month')}
+					label={getLabel(props.countryGroupId, props.prices, 'MONTHLY')}
 				/>
 			</ChoiceCardGroup>
 			<p>
@@ -173,17 +200,19 @@ export function SimplePriceCards(props: SimplePriceCardsProps): JSX.Element {
 				</strong>
 			</p>
 			<hr css={hrCss} />
-			{showDetails && <div>{props.children}</div>}
-			<Button
-				priority="subdued"
-				aria-expanded={showDetails ? 'true' : 'false'}
-				onClick={() => setShowDetails(!showDetails)}
-				icon={<SvgChevronDownSingle />}
-				iconSide="right"
-				cssOverrides={[buttonOverrides, iconCss(showDetails)]}
-			>
-				{showDetails ? 'Hide details' : 'View details'}
-			</Button>
+			<div css={detailsSection}>
+				<Button
+					priority="subdued"
+					aria-expanded={showDetails ? 'true' : 'false'}
+					onClick={() => setShowDetails(!showDetails)}
+					icon={<SvgChevronDownSingle />}
+					iconSide="right"
+					cssOverrides={[buttonOverrides, iconCss(showDetails)]}
+				>
+					{showDetails ? 'Hide details' : 'View details'}
+				</Button>
+				{showDetails && <div css={detailsContainer}>{props.children}</div>}
+			</div>
 		</div>
 	);
 }

--- a/support-frontend/assets/components/priceCards/simplePriceCards.tsx
+++ b/support-frontend/assets/components/priceCards/simplePriceCards.tsx
@@ -14,9 +14,15 @@ import {
 	SvgChevronDownSingle,
 } from '@guardian/source-react-components';
 import { useState } from 'react';
-import type { RegularContributionType } from 'helpers/contributions';
+import type {
+	ContributionType,
+	RegularContributionType,
+} from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { fromCountryGroupId } from 'helpers/internationalisation/currency';
+import {
+	fromCountryGroupId,
+	glyph,
+} from 'helpers/internationalisation/currency';
 import { Tooltip } from '../../../stories/content/Tooltip.stories';
 
 const containerCss = css`
@@ -70,9 +76,18 @@ export type SimplePriceCardsProps = {
 	tagline: string;
 	prices: Prices;
 	onPriceChange: (priceSelection: PriceSelection) => void;
+	contributionType: ContributionType;
 	countryGroupId: CountryGroupId;
 	children: React.ReactNode;
 };
+
+function getLabel(
+	countryGroupId: CountryGroupId,
+	amount: number,
+	period: string,
+) {
+	return `${glyph(fromCountryGroupId(countryGroupId))}${amount} per ${period}`;
+}
 
 export function SimplePriceCards(props: SimplePriceCardsProps): JSX.Element {
 	const [showDetails, setShowDetails] = useState(false);
@@ -91,11 +106,9 @@ export function SimplePriceCards(props: SimplePriceCardsProps): JSX.Element {
 							amount: props.prices.monthly,
 						})
 					}
-					checked={false}
+					checked={props.contributionType === 'MONTHLY'}
 					value="monthly"
-					label={`${fromCountryGroupId(props.countryGroupId)}${
-						props.prices.monthly
-					} per month`}
+					label={getLabel(props.countryGroupId, props.prices.monthly, 'month')}
 				/>
 				<ChoiceCard
 					id="annual"
@@ -107,11 +120,9 @@ export function SimplePriceCards(props: SimplePriceCardsProps): JSX.Element {
 							amount: props.prices.annual,
 						})
 					}
-					checked={false}
+					checked={props.contributionType === 'ANNUAL'}
 					value="annual"
-					label={`${fromCountryGroupId(props.countryGroupId)}${
-						props.prices.annual
-					} per year`}
+					label={getLabel(props.countryGroupId, props.prices.annual, 'year')}
 				/>
 			</ChoiceCardGroup>
 			<p>{props.tagline}</p>

--- a/support-frontend/assets/pages/kindle-subscriber-checkout/components/subscriptionBenefitsListData.tsx
+++ b/support-frontend/assets/pages/kindle-subscriber-checkout/components/subscriptionBenefitsListData.tsx
@@ -1,28 +1,14 @@
-import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { SvgCrossRound, SvgTickRound } from '@guardian/source-react-components';
+import type { CheckListData } from 'components/checkmarkList/checkmarkList';
 
 const boldText = css`
 	font-weight: bold;
 `;
 
-export type CheckListData = {
-	icon: JSX.Element;
-	text?: JSX.Element;
-	maybeGreyedOut?: SerializedStyles;
-};
-
-export const getSvgIcon = (isUnlocked: boolean): JSX.Element =>
-	isUnlocked ? (
-		<SvgTickRound isAnnouncedByScreenReader size="small" />
-	) : (
-		<SvgCrossRound isAnnouncedByScreenReader size="small" />
-	);
-
 export const checkListData = (): CheckListData[] => {
 	return [
 		{
-			icon: getSvgIcon(true),
+			isChecked: true,
 			text: (
 				<p>
 					<span css={boldText}>The Editions app. </span>Enjoy the Guardian and
@@ -31,7 +17,7 @@ export const checkListData = (): CheckListData[] => {
 			),
 		},
 		{
-			icon: getSvgIcon(true),
+			isChecked: true,
 			text: (
 				<p>
 					<span css={boldText}>A regular supporter newsletter. </span>Get
@@ -40,7 +26,7 @@ export const checkListData = (): CheckListData[] => {
 			),
 		},
 		{
-			icon: getSvgIcon(true),
+			isChecked: true,
 			text: (
 				<p>
 					<span css={boldText}>Uninterrupted reading. </span> See far fewer asks
@@ -49,7 +35,7 @@ export const checkListData = (): CheckListData[] => {
 			),
 		},
 		{
-			icon: getSvgIcon(true),
+			isChecked: true,
 			text: (
 				<p>
 					<span css={boldText}>Full access to our news app. </span>Read our
@@ -58,7 +44,7 @@ export const checkListData = (): CheckListData[] => {
 			),
 		},
 		{
-			icon: getSvgIcon(true),
+			isChecked: true,
 			text: (
 				<p>
 					<span css={boldText}>Ad-free reading. </span>Avoid ads on all your
@@ -67,7 +53,7 @@ export const checkListData = (): CheckListData[] => {
 			),
 		},
 		{
-			icon: getSvgIcon(true),
+			isChecked: true,
 			text: (
 				<p>
 					<span css={boldText}>Free 14 day trial. </span>Enjoy a free trial of

--- a/support-frontend/stories/checkouts/SimplePriceCards.stories.tsx
+++ b/support-frontend/stories/checkouts/SimplePriceCards.stories.tsx
@@ -5,6 +5,7 @@ import type { SimplePriceCardsProps } from 'components/priceCards/simplePriceCar
 import { SimplePriceCards } from 'components/priceCards/simplePriceCards';
 import { withCenterAlignment } from '../../.storybook/decorators/withCenterAlignment';
 import { withSourceReset } from '../../.storybook/decorators/withSourceReset';
+import { Default as InfoBlock } from '../content/InfoBlock.stories';
 
 export default {
 	title: 'Checkouts/Simple Price Cards',
@@ -65,5 +66,9 @@ Default.args = {
 		monthly: 10,
 		annual: 95,
 	},
-	children: <p>Details go here</p>,
+	children: (
+		<div>
+			<InfoBlock {...InfoBlock.args} />
+		</div>
+	),
 };

--- a/support-frontend/stories/checkouts/SimplePriceCards.stories.tsx
+++ b/support-frontend/stories/checkouts/SimplePriceCards.stories.tsx
@@ -57,8 +57,8 @@ Template.args = {} as Omit<SimplePriceCardsProps, 'onPriceChange'>;
 export const Default = Template.bind({});
 
 Default.args = {
-	title: 'Start your recurring support with exclusive extras',
-	tagline: 'Extras include unlimited access to the app',
+	title: 'Support Guardian journalism',
+	subtitle: 'and unlock exclusive extras',
 	contributionType: 'MONTHLY',
 	countryGroupId: 'GBPCountries',
 	prices: {

--- a/support-frontend/stories/checkouts/SimplePriceCards.stories.tsx
+++ b/support-frontend/stories/checkouts/SimplePriceCards.stories.tsx
@@ -1,10 +1,12 @@
 import { css } from '@emotion/react';
+import { textSans } from '@guardian/source-foundations';
 import { Column, Columns } from '@guardian/source-react-components';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import type { SimplePriceCardsProps } from 'components/priceCards/simplePriceCards';
 import { SimplePriceCards } from 'components/priceCards/simplePriceCards';
 import { withCenterAlignment } from '../../.storybook/decorators/withCenterAlignment';
 import { withSourceReset } from '../../.storybook/decorators/withSourceReset';
+import { Compact as List } from '../content/CheckmarkList.stories';
 import { Default as InfoBlock } from '../content/InfoBlock.stories';
 
 export default {
@@ -68,6 +70,22 @@ Default.args = {
 	},
 	children: (
 		<div>
+			<h2
+				css={css`
+					${textSans.small()};
+					color: #606060;
+					margin-bottom: 10px;
+				`}
+			>
+				Exclusive extras include:
+			</h2>
+			<div
+				css={css`
+					margin-bottom: 16px;
+				`}
+			>
+				<List {...List.args} />
+			</div>
 			<InfoBlock {...InfoBlock.args} />
 		</div>
 	),

--- a/support-frontend/stories/checkouts/SimplePriceCards.stories.tsx
+++ b/support-frontend/stories/checkouts/SimplePriceCards.stories.tsx
@@ -60,7 +60,7 @@ export const Default = Template.bind({});
 Default.args = {
 	title: 'Support Guardian journalism',
 	subtitle: 'and unlock exclusive extras',
-	contributionType: 'MONTHLY',
+	contributionType: 'ANNUAL',
 	countryGroupId: 'GBPCountries',
 	prices: {
 		monthly: 10,

--- a/support-frontend/stories/checkouts/SimplePriceCards.stories.tsx
+++ b/support-frontend/stories/checkouts/SimplePriceCards.stories.tsx
@@ -12,17 +12,17 @@ export default {
 	argTypes: {
 		onPriceChange: { action: 'price changed' },
 		countryGroupId: {
+			options: [
+				'GBPCountries',
+				'UnitedStates',
+				'AUDCountries',
+				'EURCountries',
+				'NZDCountries',
+				'Canada',
+				'International',
+			],
 			control: {
 				type: 'select',
-				options: [
-					'GBPCountries',
-					'UnitedStates',
-					'AUDCountries',
-					'EURCountries',
-					'NZDCountries',
-					'Canada',
-					'International',
-				],
 			},
 		},
 	},
@@ -52,18 +52,18 @@ function Template(args: SimplePriceCardsProps) {
 	return <SimplePriceCards {...args} />;
 }
 
-Template.args = {} as SimplePriceCardsProps;
+Template.args = {} as Omit<SimplePriceCardsProps, 'onPriceChange'>;
 
 export const Default = Template.bind({});
 
 Default.args = {
 	title: 'Start your recurring support with exclusive extras',
 	tagline: 'Extras include unlimited access to the app',
+	contributionType: 'MONTHLY',
 	countryGroupId: 'GBPCountries',
 	prices: {
 		monthly: 10,
 		annual: 95,
 	},
-	onPriceChange: () => undefined,
 	children: <p>Details go here</p>,
 };

--- a/support-frontend/stories/checkouts/SimplePriceCards.stories.tsx
+++ b/support-frontend/stories/checkouts/SimplePriceCards.stories.tsx
@@ -1,0 +1,69 @@
+import { css } from '@emotion/react';
+import { Column, Columns } from '@guardian/source-react-components';
+import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
+import type { SimplePriceCardsProps } from 'components/priceCards/simplePriceCards';
+import { SimplePriceCards } from 'components/priceCards/simplePriceCards';
+import { withCenterAlignment } from '../../.storybook/decorators/withCenterAlignment';
+import { withSourceReset } from '../../.storybook/decorators/withSourceReset';
+
+export default {
+	title: 'Checkouts/Simple Price Cards',
+	component: SimplePriceCards,
+	argTypes: {
+		onPriceChange: { action: 'price changed' },
+		countryGroupId: {
+			control: {
+				type: 'select',
+				options: [
+					'GBPCountries',
+					'UnitedStates',
+					'AUDCountries',
+					'EURCountries',
+					'NZDCountries',
+					'Canada',
+					'International',
+				],
+			},
+		},
+	},
+	decorators: [
+		(Story: React.FC): JSX.Element => (
+			<Columns
+				collapseUntil="tablet"
+				cssOverrides={css`
+					width: 100%;
+				`}
+			>
+				<Column span={[1, 8, 7]}>
+					<Box>
+						<BoxContents>
+							<Story />
+						</BoxContents>
+					</Box>
+				</Column>
+			</Columns>
+		),
+		withCenterAlignment,
+		withSourceReset,
+	],
+};
+
+function Template(args: SimplePriceCardsProps) {
+	return <SimplePriceCards {...args} />;
+}
+
+Template.args = {} as SimplePriceCardsProps;
+
+export const Default = Template.bind({});
+
+Default.args = {
+	title: 'Start your recurring support with exclusive extras',
+	tagline: 'Extras include unlimited access to the app',
+	countryGroupId: 'GBPCountries',
+	prices: {
+		monthly: 10,
+		annual: 95,
+	},
+	onPriceChange: () => undefined,
+	children: <p>Details go here</p>,
+};

--- a/support-frontend/stories/content/CheckmarkList.stories.tsx
+++ b/support-frontend/stories/content/CheckmarkList.stories.tsx
@@ -1,0 +1,52 @@
+import { css } from '@emotion/react';
+import { Column, Columns } from '@guardian/source-react-components';
+import type { CheckmarkListProps } from 'components/checkmarkList/checkmarkList';
+import { CheckmarkList } from 'components/checkmarkList/checkmarkList';
+import { checkListData } from 'components/checkoutBenefits/checkoutBenefitsListData';
+import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
+import { withCenterAlignment } from '../../.storybook/decorators/withCenterAlignment';
+import { withSourceReset } from '../../.storybook/decorators/withSourceReset';
+
+export default {
+	title: 'Content/Checkmark List',
+	component: CheckmarkList,
+	decorators: [
+		(Story: React.FC): JSX.Element => (
+			<Columns
+				collapseUntil="tablet"
+				cssOverrides={css`
+					width: 100%;
+				`}
+			>
+				<Column span={[1, 8, 7]}>
+					<Box>
+						<BoxContents>
+							<Story />
+						</BoxContents>
+					</Box>
+				</Column>
+			</Columns>
+		),
+		withCenterAlignment,
+		withSourceReset,
+	],
+};
+
+function Template(args: CheckmarkListProps) {
+	return <CheckmarkList {...args} />;
+}
+
+Template.args = {} as CheckmarkListProps;
+
+export const Default = Template.bind({});
+
+Default.args = {
+	checkListData: checkListData({ higherTier: true }),
+};
+
+export const Compact = Template.bind({});
+
+Compact.args = {
+	checkListData: checkListData({ higherTier: true }),
+	style: 'compact',
+};

--- a/support-frontend/stories/content/InfoBlock.stories.tsx
+++ b/support-frontend/stories/content/InfoBlock.stories.tsx
@@ -1,0 +1,70 @@
+import { css } from '@emotion/react';
+import { Column, Columns } from '@guardian/source-react-components';
+import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
+import type { InfoBlockProps } from 'components/infoBlock/infoBlock';
+import { InfoBlock } from 'components/infoBlock/infoBlock';
+import { withCenterAlignment } from '../../.storybook/decorators/withCenterAlignment';
+import { withSourceReset } from '../../.storybook/decorators/withSourceReset';
+
+export default {
+	title: 'Content/Info Block',
+	component: InfoBlock,
+	decorators: [
+		(Story: React.FC): JSX.Element => (
+			<Columns
+				collapseUntil="tablet"
+				cssOverrides={css`
+					width: 100%;
+				`}
+			>
+				<Column span={[1, 8, 7]}>
+					<Box>
+						<BoxContents>
+							<Story />
+						</BoxContents>
+					</Box>
+				</Column>
+			</Columns>
+		),
+		withCenterAlignment,
+		withSourceReset,
+	],
+};
+
+function Template(args: InfoBlockProps) {
+	return <InfoBlock {...args} />;
+}
+
+Template.args = {} as InfoBlockProps;
+
+export const Default = Template.bind({});
+
+Default.args = {
+	header: (
+		<div
+			css={css`
+				display: flex;
+				justify-content: space-between;
+			`}
+		>
+			<span>Total due today</span>
+			{''}
+			<strong
+				css={css`
+					font-weight: 700;
+				`}
+			>
+				£95
+			</strong>
+		</div>
+	),
+	content: (
+		<ul>
+			<li>Next billing date will be XX Month Year.</li>
+			<li>
+				Cancel or change your support anytime. If you cancel within the first 14
+				days, you will receive a full refund.
+			</li>
+		</ul>
+	),
+};


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds the following new components:

- A simplified price cards component limited to two options, with an accordion section for product details
- An extracted checklist component from the existing checkout with a new 'compact' variation
- An 'info box' component to display price and renewal information

[**Trello Card**](https://trello.com/c/xa882tGK)

## Why are you doing this?

These components are for use in an upcoming A/B test.

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

![Screenshot 2023-06-21 at 13 27 44](https://github.com/guardian/support-frontend/assets/29146931/de05b3c4-0675-405d-983c-282df4edf8a2)

![Screenshot 2023-06-21 at 13 27 34](https://github.com/guardian/support-frontend/assets/29146931/c206d87c-d1c8-47c7-90e0-04ac40103295)
