### PR TITLE
Add post-purchase motivation survey links for supporter plus

### DIFF
--- a/support-frontend/assets/components/thankYou/feedback/FeedbackItems.tsx
+++ b/support-frontend/assets/components/thankYou/feedback/FeedbackItems.tsx
@@ -59,11 +59,12 @@ function FeedbackBodyCopy({
 	);
 }
 
-function FeedbackCTA(): JSX.Element {
+function FeedbackCTA({
+	feedbackSurveyLink,
+}: {
+	feedbackSurveyLink: string;
+}): JSX.Element {
 	const dispatch = useContributionsDispatch();
-
-	const SURVEY_LINK =
-		'https://guardiannewsandmedia.formstack.com/forms/guardian_supporter';
 
 	const onClick = () => {
 		trackComponentClick(OPHAN_COMPONENT_ID_SURVEY);
@@ -73,7 +74,7 @@ function FeedbackCTA(): JSX.Element {
 	return (
 		<LinkButton
 			onClick={onClick}
-			href={SURVEY_LINK}
+			href={feedbackSurveyLink}
 			target="_blank"
 			rel="noopener noreferrer"
 			priority="primary"

--- a/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
@@ -89,7 +89,13 @@ export const getThankYouModuleData = (
 					feedbackSurveyHasBeenCompleted={feedbackSurveyHasBeenCompleted}
 				/>
 			),
-			ctas: feedbackSurveyHasBeenCompleted ? null : <FeedbackCTA />,
+			ctas: feedbackSurveyHasBeenCompleted ? null : (
+				<FeedbackCTA
+					feedbackSurveyLink={
+						'https://guardiannewsandmedia.formstack.com/forms/guardian_supporter'
+					}
+				/>
+			),
 			trackComponentLoadId: OPHAN_COMPONENT_ID_SURVEY,
 		},
 		marketingConsent: {

--- a/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
@@ -56,6 +56,8 @@ export const getThankYouModuleData = (
 	countryGroupId: CountryGroupId,
 	csrf: CsrfState,
 	email: string,
+	isOneOff: boolean,
+	amountIsAboveThreshold: boolean,
 	campaignCode?: string,
 ): Record<ThankYouModuleType, ThankYouModuleData> => {
 	const { feedbackSurveyHasBeenCompleted, marketingConsent, supportReminder } =
@@ -92,7 +94,11 @@ export const getThankYouModuleData = (
 			ctas: feedbackSurveyHasBeenCompleted ? null : (
 				<FeedbackCTA
 					feedbackSurveyLink={
-						'https://guardiannewsandmedia.formstack.com/forms/guardian_supporter'
+						isOneOff
+							? 'https://guardiannewsandmedia.formstack.com/forms/guardian_supporter_single'
+							: amountIsAboveThreshold
+							? 'https://guardiannewsandmedia.formstack.com/forms/guardian_supporter_above'
+							: 'https://guardiannewsandmedia.formstack.com/forms/guardian_supporter_below'
 					}
 				/>
 			),

--- a/support-frontend/assets/pages/kindle-subscriber-thank-you/kindleSubscriptionThankYou.tsx
+++ b/support-frontend/assets/pages/kindle-subscriber-thank-you/kindleSubscriptionThankYou.tsx
@@ -10,8 +10,10 @@ import { getThankYouModuleData } from 'components/thankYou/thankYouModuleData';
 import type { CampaignSettings } from 'helpers/campaigns/campaigns';
 import { getCampaignSettings } from 'helpers/campaigns/campaigns';
 import { DirectDebit } from 'helpers/forms/paymentMethods';
+import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { getSubscriptionPrices } from 'helpers/redux/checkout/product/selectors/subscriptionPrice';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import { shouldShowSupporterPlusMessaging } from 'helpers/supporterPlus/showMessaging';
 import { OPHAN_COMPONENT_ID_RETURN_TO_GUARDIAN } from 'helpers/thankYouPages/utils/ophan';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import ThankYouFooter from 'pages/supporter-plus-thank-you/components/thankYouFooter';
@@ -43,14 +45,22 @@ export function KindleSubscriptionThankYou(): JSX.Element {
 	const paymentMethod = useContributionsSelector(
 		(state) => state.page.checkoutForm.payment.paymentMethod.name,
 	);
-	const { billingPeriod } = useContributionsSelector(
-		(state) => state.page.checkoutForm.product,
-	);
+	const { selectedAmounts, otherAmounts, billingPeriod } =
+		useContributionsSelector((state) => state.page.checkoutForm.product);
 	const { isSignedIn } = useContributionsSelector((state) => state.page.user);
 	const isNewAccount = userTypeFromIdentityResponse === 'new';
 	const { monthlyPrice, annualPrice } = useContributionsSelector(
 		getSubscriptionPrices,
 	);
+	const contributionType = useContributionsSelector(getContributionType);
+	const isOneOff = contributionType === 'ONE_OFF';
+	const amountIsAboveThreshold = shouldShowSupporterPlusMessaging(
+		contributionType,
+		selectedAmounts,
+		otherAmounts,
+		countryGroupId,
+	);
+
 	// const isAmountLargeDonation = amount
 	// 	? isLargeDonation(amount, contributionType, paymentMethod)
 	// 	: false;
@@ -79,6 +89,8 @@ export function KindleSubscriptionThankYou(): JSX.Element {
 		countryGroupId,
 		csrf,
 		email,
+		isOneOff,
+		amountIsAboveThreshold,
 		campaignSettings?.campaignCode,
 	);
 

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -188,6 +188,7 @@ export function SupporterPlusThankYou(): JSX.Element {
 			'supportReminder',
 		),
 		// 'feedback', // <-- Temporarily disable supporter plus thank you page survey
+		...maybeThankYouModule(email.length > 0, 'feedback'),
 		...maybeThankYouModule(countryId === 'AU', 'ausMap'),
 		'socialShare',
 	];

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -120,6 +120,7 @@ export function SupporterPlusThankYou(): JSX.Element {
 	const isNewAccount = userTypeFromIdentityResponse === 'new';
 	const isOneOffPayPal =
 		paymentMethod === PayPal && contributionType === 'ONE_OFF';
+	const isOneOff = contributionType === 'ONE_OFF';
 	const amount = isOneOffPayPal
 		? getAmountFromSessionStorage()
 		: getAmount(selectedAmounts, otherAmounts, contributionType);
@@ -161,6 +162,8 @@ export function SupporterPlusThankYou(): JSX.Element {
 		countryGroupId,
 		csrf,
 		email,
+		isOneOff,
+		amountIsAboveThreshold,
 		campaignSettings?.campaignCode,
 	);
 
@@ -187,7 +190,6 @@ export function SupporterPlusThankYou(): JSX.Element {
 			contributionType === 'ONE_OFF' && email.length > 0,
 			'supportReminder',
 		),
-		// 'feedback', // <-- Temporarily disable supporter plus thank you page survey
 		...maybeThankYouModule(email.length > 0, 'feedback'),
 		...maybeThankYouModule(countryId === 'AU', 'ausMap'),
 		'socialShare',

--- a/support-frontend/stories/checkouts/thankYouModule.stories.tsx
+++ b/support-frontend/stories/checkouts/thankYouModule.stories.tsx
@@ -160,7 +160,13 @@ Feedback.args = {
 	icon: getThankYouModuleIcon('feedback'),
 	header: getFeedbackHeader(false),
 	bodyCopy: <FeedbackBodyCopy feedbackSurveyHasBeenCompleted={false} />,
-	ctas: <FeedbackCTA />,
+	ctas: (
+		<FeedbackCTA
+			feedbackSurveyLink={
+				'https://guardiannewsandmedia.formstack.com/forms/guardian_supporter'
+			}
+		/>
+	),
 };
 
 Feedback.decorators = [


### PR DESCRIPTION
## Why are you doing this?
Post-purchase surveys live for supporter-plus (ONLY) to build out a portfolio of supporter and subscriber motivations, spanning both digital and print products.These surveys are built using Formstack links.

## What are you doing in this PR?

- Supporter sees survey element on post-purchase ‘thank you’ screen (location?)
- Depending on the type of purchase, the relevant survey link is used.

The change this time is that we’d like to link to 3 different surveys, conditional on the type of purchase:

1. [Recurring, below ‘extras’ threshold](https://guardiannewsandmedia.formstack.com/forms/guardian_supporter_below)
2. [Recurring, above ‘extras’ threshold](https://guardiannewsandmedia.formstack.com/forms/guardian_supporter_above)
3. [Single contributions](https://guardiannewsandmedia.formstack.com/forms/guardian_supporter_single)

## Screenshot
<img width="1400" alt="Screenshot 2023-06-23 at 15 29 54" src="https://github.com/guardian/support-frontend/assets/76729591/e4b5a945-7dbc-4c59-a799-f361e2e59528">

[**Trello Card**](https://trello.com/c/Mm7a1qeP/1268-add-post-purchase-motivation-survey-links-for-supporter-plus)

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)


