### PR TITLE
Set up referrer-controlled A/B test with a limited checkout

### DIFF
--- a/support-frontend/assets/components/infoBlock/infoBlock.tsx
+++ b/support-frontend/assets/components/infoBlock/infoBlock.tsx
@@ -16,6 +16,7 @@ const hrCss = css`
 
 const infoBlockContent = css`
 	color: #606060;
+	font-size: 13px;
 	ul {
 		list-style: disc;
 		padding-left: ${space[4]}px;

--- a/support-frontend/assets/components/priceCards/simplePriceCards.tsx
+++ b/support-frontend/assets/components/priceCards/simplePriceCards.tsx
@@ -77,7 +77,7 @@ const buttonOverrides = css`
 
 const iconCss = (flip: boolean) => css`
 	svg {
-		max-width: 12px;
+		max-width: ${space[3]}px;
 		transition: transform 0.3s ease-in-out;
 
 		${flip && 'transform: rotate(180deg);'}

--- a/support-frontend/assets/components/priceCards/simplePriceCards.tsx
+++ b/support-frontend/assets/components/priceCards/simplePriceCards.tsx
@@ -5,6 +5,7 @@ import {
 	palette,
 	space,
 	textSans,
+	until,
 } from '@guardian/source-foundations';
 import {
 	Button,
@@ -24,15 +25,28 @@ import {
 } from 'helpers/internationalisation/currency';
 
 const containerCss = css`
-	${textSans.medium({ lineHeight: 'tight' })};
+	${textSans.small()}
+	${from.desktop} {
+		${textSans.medium()};
+	}
 `;
 
 const headingCss = css`
-	${headline.xsmall({ fontWeight: 'bold' })}
+	${headline.xsmall({ fontWeight: 'bold', lineHeight: 'tight' })}
 	${from.tablet} {
-		${headline.small({ fontWeight: 'bold' })}
+		${headline.small({ fontWeight: 'bold', lineHeight: 'tight' })}
 		font-size: 28px;
 		line-height: 115%;
+	}
+`;
+
+const mobileGrid = css`
+	> div {
+		${until.mobileLandscape} {
+			display: grid;
+			column-gap: ${space[2]}px;
+			grid-template-columns: repeat(2, 1fr);
+		}
 	}
 `;
 
@@ -154,7 +168,11 @@ export function SimplePriceCards(props: SimplePriceCardsProps): JSX.Element {
 			<h2 css={headingCss}>
 				{props.title} <span css={headingSubtitle}>{props.subtitle}</span>
 			</h2>
-			<ChoiceCardGroup name="paymentFrequency" columns={2} css={cardsContainer}>
+			<ChoiceCardGroup
+				name="paymentFrequency"
+				columns={2}
+				cssOverrides={[cardsContainer, mobileGrid]}
+			>
 				<ChoiceCard
 					id="annual"
 					key="annual"

--- a/support-frontend/assets/components/priceCards/simplePriceCards.tsx
+++ b/support-frontend/assets/components/priceCards/simplePriceCards.tsx
@@ -94,8 +94,8 @@ const detailsContainer = css`
 `;
 
 type Prices = {
-	monthly: number;
-	annual: number;
+	MONTHLY: number;
+	ANNUAL: number;
 };
 
 type PriceSelection = {
@@ -123,14 +123,14 @@ function getLabel(
 		return (
 			<span>
 				{currencyGlyph}
-				{prices.annual}/year
+				{prices.ANNUAL}/year
 			</span>
 		);
 	}
 	return (
 		<span>
 			{currencyGlyph}
-			{prices.monthly}/month
+			{prices.MONTHLY}/month
 		</span>
 	);
 }
@@ -141,7 +141,7 @@ function getTaglinePrice(
 	contributionType: ContributionType,
 ) {
 	const period = contributionType === 'ANNUAL' ? 'year' : 'month';
-	const price = contributionType === 'ANNUAL' ? prices.annual : prices.monthly;
+	const price = contributionType === 'ANNUAL' ? prices.ANNUAL : prices.MONTHLY;
 
 	return `${glyph(fromCountryGroupId(countryGroupId))}${price} per ${period}`;
 }
@@ -162,7 +162,7 @@ export function SimplePriceCards(props: SimplePriceCardsProps): JSX.Element {
 					onChange={() =>
 						props.onPriceChange({
 							contributionType: 'ANNUAL',
-							amount: props.prices.annual,
+							amount: props.prices.ANNUAL,
 						})
 					}
 					checked={props.contributionType === 'ANNUAL'}
@@ -176,7 +176,7 @@ export function SimplePriceCards(props: SimplePriceCardsProps): JSX.Element {
 					onChange={() =>
 						props.onPriceChange({
 							contributionType: 'MONTHLY',
-							amount: props.prices.monthly,
+							amount: props.prices.MONTHLY,
 						})
 					}
 					checked={props.contributionType === 'MONTHLY'}

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -102,4 +102,23 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		seed: 9,
 	},
+	supporterPlusOnly: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 0,
+			},
+		},
+		isActive: true,
+		referrerControlled: true,
+		seed: 2,
+	},
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/limitedPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/limitedPriceCards.tsx
@@ -1,0 +1,63 @@
+import { css } from '@emotion/react';
+import { textSans } from '@guardian/source-foundations';
+import { BoxContents } from 'components/checkoutBox/checkoutBox';
+import { CheckoutErrorSummary } from 'components/errorSummary/errorSummary';
+import { CheckoutErrorSummaryContainer } from 'components/errorSummary/errorSummaryContainer';
+import { PaymentFrequencyTabsContainer } from 'components/paymentFrequencyTabs/paymentFrequencyTabsContainer';
+import { PriceCardsContainer } from 'components/priceCards/priceCardsContainer';
+import { SimplePriceCards } from 'components/priceCards/simplePriceCards';
+
+const accordionHeading = css`
+	${textSans.small()};
+	color: #606060;
+	margin-bottom: 10px;
+`;
+
+export function LimitedPriceCards(): JSX.Element {
+	return (
+		<PaymentFrequencyTabsContainer
+			render={({ onTabChange }) => (
+				<BoxContents>
+					<CheckoutErrorSummaryContainer
+						renderSummary={({ errorList }) => (
+							<CheckoutErrorSummary errorList={errorList} />
+						)}
+					/>
+					<PriceCardsContainer
+						frequency="ANNUAL"
+						renderPriceCards={({
+							selectedAmount,
+							currency,
+							paymentInterval,
+							onAmountChange,
+						}) => (
+							<SimplePriceCards
+								title="Support Guardian journalism"
+								subtitle="and unlock exclusive extras"
+								contributionType="ANNUAL"
+								countryGroupId="GBPCountries"
+								prices={{
+									monthly: 10,
+									annual: 95,
+								}}
+								onPriceChange={console.log}
+							>
+								<div>
+									<h2 css={accordionHeading}>Exclusive extras include:</h2>
+									<div
+										css={css`
+											margin-bottom: 16px;
+										`}
+									>
+										{/* <List {...List.args} /> */}
+									</div>
+									{/* <InfoBlock {...InfoBlock.args} /> */}
+								</div>
+							</SimplePriceCards>
+						)}
+					/>
+				</BoxContents>
+			)}
+		/>
+	);
+}

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/limitedPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/limitedPriceCards.tsx
@@ -14,10 +14,7 @@ import {
 	fromCountryGroupId,
 	glyph,
 } from 'helpers/internationalisation/currency';
-import {
-	setProductType,
-	setSelectedAmount,
-} from 'helpers/redux/checkout/product/actions';
+import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import {
 	useContributionsDispatch,
@@ -50,8 +47,17 @@ const testCheckListData = (): CheckListData[] => {
 			isChecked: true,
 			text: (
 				<p>
-					<span css={boldText}>A regular supporter newsletter. </span>Get
-					exclusive insight from our newsroom
+					<span css={boldText}>Full access to the Guardian app. </span>Enjoy
+					unlimited articles and enhanced offline reading
+				</p>
+			),
+		},
+		{
+			isChecked: true,
+			text: (
+				<p>
+					<span css={boldText}>Ad-free reading. </span>Avoid ads on all your
+					devices
 				</p>
 			),
 		},
@@ -68,17 +74,8 @@ const testCheckListData = (): CheckListData[] => {
 			isChecked: true,
 			text: (
 				<p>
-					<span css={boldText}>Full access to the Guardian app. </span>Enjoy
-					unlimited articles and enhanced offline reading
-				</p>
-			),
-		},
-		{
-			isChecked: true,
-			text: (
-				<p>
-					<span css={boldText}>Ad-free reading. </span>Avoid ads on all your
-					devices
+					<span css={boldText}>A regular supporter newsletter. </span>Get
+					exclusive insight from our newsroom
 				</p>
 			),
 		},
@@ -94,12 +91,14 @@ export function LimitedPriceCards(): JSX.Element {
 	const contributionType = useContributionsSelector(getContributionType);
 
 	useEffect(() => {
-		dispatch(setProductType('ANNUAL'));
+		// The contribution type will be set by the query param to be either MONTHLY or ANNUAL, but we
+		// need to eliminate ONE_OFF for the type check
+		const type = contributionType !== 'ONE_OFF' ? contributionType : 'ANNUAL';
 		dispatch(
 			setSelectedAmount({
-				contributionType: 'ANNUAL',
+				contributionType,
 				amount:
-					benefitsThresholdsByCountryGroup[countryGroupId].ANNUAL.toString(),
+					benefitsThresholdsByCountryGroup[countryGroupId][type].toString(),
 			}),
 		);
 	}, []);

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/limitedPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/limitedPriceCards.tsx
@@ -1,11 +1,29 @@
 import { css } from '@emotion/react';
 import { textSans } from '@guardian/source-foundations';
+import { useEffect } from 'react';
+import { CheckmarkList } from 'components/checkmarkList/checkmarkList';
+import { checkListData } from 'components/checkoutBenefits/checkoutBenefitsListData';
 import { BoxContents } from 'components/checkoutBox/checkoutBox';
 import { CheckoutErrorSummary } from 'components/errorSummary/errorSummary';
 import { CheckoutErrorSummaryContainer } from 'components/errorSummary/errorSummaryContainer';
+import { InfoBlock } from 'components/infoBlock/infoBlock';
 import { PaymentFrequencyTabsContainer } from 'components/paymentFrequencyTabs/paymentFrequencyTabsContainer';
 import { PriceCardsContainer } from 'components/priceCards/priceCardsContainer';
 import { SimplePriceCards } from 'components/priceCards/simplePriceCards';
+import {
+	fromCountryGroupId,
+	glyph,
+} from 'helpers/internationalisation/currency';
+import {
+	setProductType,
+	setSelectedAmount,
+} from 'helpers/redux/checkout/product/actions';
+import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
+import { benefitsThresholdsByCountryGroup } from 'helpers/supporterPlus/benefitsThreshold';
 
 const accordionHeading = css`
 	${textSans.small()};
@@ -13,10 +31,41 @@ const accordionHeading = css`
 	margin-bottom: 10px;
 `;
 
+const listSpacing = css`
+	margin-bottom: 16px;
+`;
+
+const infoBlockHeading = css`
+	display: flex;
+	justify-content: space-between;
+`;
+
+const boldText = css`
+	font-weight: 700;
+`;
+
 export function LimitedPriceCards(): JSX.Element {
+	const dispatch = useContributionsDispatch();
+	const { countryGroupId } = useContributionsSelector(
+		(state) => state.common.internationalisation,
+	);
+
+	const contributionType = useContributionsSelector(getContributionType);
+
+	useEffect(() => {
+		dispatch(setProductType('ANNUAL'));
+		dispatch(
+			setSelectedAmount({
+				contributionType: 'ANNUAL',
+				amount:
+					benefitsThresholdsByCountryGroup[countryGroupId].ANNUAL.toString(),
+			}),
+		);
+	}, []);
+
 	return (
 		<PaymentFrequencyTabsContainer
-			render={({ onTabChange }) => (
+			render={({ onTabChange, selectedTab }) => (
 				<BoxContents>
 					<CheckoutErrorSummaryContainer
 						renderSummary={({ errorList }) => (
@@ -24,34 +73,54 @@ export function LimitedPriceCards(): JSX.Element {
 						)}
 					/>
 					<PriceCardsContainer
-						frequency="ANNUAL"
-						renderPriceCards={({
-							selectedAmount,
-							currency,
-							paymentInterval,
-							onAmountChange,
-						}) => (
+						frequency={contributionType}
+						renderPriceCards={({ selectedAmount }) => (
 							<SimplePriceCards
 								title="Support Guardian journalism"
 								subtitle="and unlock exclusive extras"
-								contributionType="ANNUAL"
-								countryGroupId="GBPCountries"
-								prices={{
-									monthly: 10,
-									annual: 95,
+								contributionType={selectedTab}
+								countryGroupId={countryGroupId}
+								prices={benefitsThresholdsByCountryGroup[countryGroupId]}
+								onPriceChange={({ contributionType, amount }) => {
+									onTabChange(contributionType);
+									dispatch(
+										setSelectedAmount({
+											contributionType,
+											amount: amount.toString(),
+										}),
+									);
 								}}
-								onPriceChange={console.log}
 							>
 								<div>
 									<h2 css={accordionHeading}>Exclusive extras include:</h2>
-									<div
-										css={css`
-											margin-bottom: 16px;
-										`}
-									>
-										{/* <List {...List.args} /> */}
+									<div css={listSpacing}>
+										<CheckmarkList
+											checkListData={checkListData({ higherTier: true })}
+											style="compact"
+										/>
 									</div>
-									{/* <InfoBlock {...InfoBlock.args} /> */}
+									<InfoBlock
+										header={
+											<h3 css={infoBlockHeading}>
+												<span>Total due today</span>
+												{''}
+												<strong css={boldText}>
+													{glyph(fromCountryGroupId(countryGroupId))}
+													{selectedAmount}
+												</strong>
+											</h3>
+										}
+										content={
+											<ul>
+												<li>Next billing date will be XX Month Year.</li>
+												<li>
+													Cancel or change your support anytime. If you cancel
+													within the first 14 days, you will receive a full
+													refund.
+												</li>
+											</ul>
+										}
+									/>
 								</div>
 							</SimplePriceCards>
 						)}

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/limitedPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/limitedPriceCards.tsx
@@ -117,7 +117,7 @@ export function LimitedPriceCards(): JSX.Element {
 						renderPriceCards={({ selectedAmount }) => (
 							<SimplePriceCards
 								title="Support Guardian journalism"
-								subtitle="and unlock exclusive extras"
+								subtitle="and&nbsp;unlock exclusive extras"
 								contributionType={selectedTab}
 								countryGroupId={countryGroupId}
 								prices={benefitsThresholdsByCountryGroup[countryGroupId]}
@@ -132,7 +132,7 @@ export function LimitedPriceCards(): JSX.Element {
 								}}
 							>
 								<div>
-									<h2 css={accordionHeading}>Exclusive extras include:</h2>
+									<h3 css={accordionHeading}>Exclusive extras include:</h3>
 									<div css={listSpacing}>
 										<CheckmarkList
 											checkListData={testCheckListData()}

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/limitedPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/limitedPriceCards.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
 import { textSans } from '@guardian/source-foundations';
 import { useEffect } from 'react';
+import type { CheckListData } from 'components/checkmarkList/checkmarkList';
 import { CheckmarkList } from 'components/checkmarkList/checkmarkList';
-import { checkListData } from 'components/checkoutBenefits/checkoutBenefitsListData';
 import { BoxContents } from 'components/checkoutBox/checkoutBox';
 import { CheckoutErrorSummary } from 'components/errorSummary/errorSummary';
 import { CheckoutErrorSummaryContainer } from 'components/errorSummary/errorSummaryContainer';
@@ -43,6 +43,47 @@ const infoBlockHeading = css`
 const boldText = css`
 	font-weight: 700;
 `;
+
+const testCheckListData = (): CheckListData[] => {
+	return [
+		{
+			isChecked: true,
+			text: (
+				<p>
+					<span css={boldText}>A regular supporter newsletter. </span>Get
+					exclusive insight from our newsroom
+				</p>
+			),
+		},
+		{
+			isChecked: true,
+			text: (
+				<p>
+					<span css={boldText}>Uninterrupted reading. </span> See far fewer asks
+					for support
+				</p>
+			),
+		},
+		{
+			isChecked: true,
+			text: (
+				<p>
+					<span css={boldText}>Full access to the Guardian app. </span>Enjoy
+					unlimited articles and enhanced offline reading
+				</p>
+			),
+		},
+		{
+			isChecked: true,
+			text: (
+				<p>
+					<span css={boldText}>Ad-free reading. </span>Avoid ads on all your
+					devices
+				</p>
+			),
+		},
+	];
+};
 
 export function LimitedPriceCards(): JSX.Element {
 	const dispatch = useContributionsDispatch();
@@ -95,7 +136,7 @@ export function LimitedPriceCards(): JSX.Element {
 									<h2 css={accordionHeading}>Exclusive extras include:</h2>
 									<div css={listSpacing}>
 										<CheckmarkList
-											checkListData={checkListData({ higherTier: true })}
+											checkListData={testCheckListData()}
 											style="compact"
 										/>
 									</div>
@@ -111,14 +152,11 @@ export function LimitedPriceCards(): JSX.Element {
 											</h3>
 										}
 										content={
-											<ul>
-												<li>Next billing date will be XX Month Year.</li>
-												<li>
-													Cancel or change your support anytime. If you cancel
-													within the first 14 days, you will receive a full
-													refund.
-												</li>
-											</ul>
+											<p>
+												Cancel or change your support anytime. If you cancel
+												within the first 14 days, you will receive a full
+												refund.
+											</p>
 										}
 									/>
 								</div>

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -55,6 +55,7 @@ import { PatronsMessage } from './components/patronsMessage';
 import { PaymentFailureMessage } from './components/paymentFailure';
 import { PaymentTsAndCs } from './components/paymentTsAndCs';
 import { AmountAndBenefits } from './formSections/amountAndBenefits';
+import { LimitedPriceCards } from './formSections/limitedPriceCards';
 import { getPaymentMethodButtons } from './paymentButtons';
 
 const checkoutContainer = css`
@@ -115,6 +116,12 @@ export function SupporterPlusLandingPage({
 		otherAmounts,
 		countryGroupId,
 	);
+	const { abParticipations } = useContributionsSelector(
+		(state) => state.common,
+	);
+
+	const displayLimitedPriceCards =
+		abParticipations.supporterPlusOnly === 'variant';
 
 	const { paymentComplete, isWaiting } = useContributionsSelector(
 		(state) => state.page.form,
@@ -196,7 +203,11 @@ export function SupporterPlusLandingPage({
 							/>
 						</Hide>
 						<Box cssOverrides={shorterBoxMargin}>
-							<AmountAndBenefits />
+							{displayLimitedPriceCards ? (
+								<LimitedPriceCards />
+							) : (
+								<AmountAndBenefits />
+							)}
 						</Box>
 						<Box cssOverrides={shorterBoxMargin}>
 							<BoxContents>

--- a/support-frontend/stories/checkouts/SimplePriceCards.stories.tsx
+++ b/support-frontend/stories/checkouts/SimplePriceCards.stories.tsx
@@ -65,8 +65,8 @@ Default.args = {
 	contributionType: 'ANNUAL',
 	countryGroupId: 'GBPCountries',
 	prices: {
-		monthly: 10,
-		annual: 95,
+		MONTHLY: 10,
+		ANNUAL: 95,
 	},
 	children: (
 		<div>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This sets up the limited, supporter plus only checkout for the upcoming email test. Users will be opted into the variant of a referrer-controlled A/B test based on the URL used to direct them to the page. The components merged in #5086 are now integrated with the checkout for users in the test variant, mostly reusing our existing data provider components and render functions.

[**Trello Card**](https://trello.com/c/k55jjs1M)

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

### Mobile - Pixel 6, Chrome
<img width="386" alt="Screenshot 2023-06-27 at 14 24 05" src="https://github.com/guardian/support-frontend/assets/29146931/f0cb519f-942f-461d-9898-f50d5ca4432f">

<img width="386" alt="Screenshot 2023-06-27 at 14 24 14" src="https://github.com/guardian/support-frontend/assets/29146931/a6a8f73a-55e9-4efd-9844-3ab66237981c">

### Tablet - iPad 9th gen, Safari
<img width="583" alt="Screenshot 2023-06-27 at 14 26 59" src="https://github.com/guardian/support-frontend/assets/29146931/a9573eec-12fb-4ddb-8dd0-dd8959314256">

### Desktop - macOS, Firefox
![Screenshot 2023-06-27 at 14-21-57 Support the Guardian](https://github.com/guardian/support-frontend/assets/29146931/664c0c70-4d5a-42b9-b074-9f24aaec996e)
