### PR TITLE
Do not auto-select a payment method when switching contribution frequency

### DIFF
--- a/support-frontend/assets/components/paymentFrequencyTabs/paymentFrequencyTabsContainer.tsx
+++ b/support-frontend/assets/components/paymentFrequencyTabs/paymentFrequencyTabsContainer.tsx
@@ -1,9 +1,5 @@
 import type { ContributionType } from 'helpers/contributions';
-import {
-	getPaymentMethodToSelect,
-	toHumanReadableContributionType,
-} from 'helpers/forms/checkouts';
-import { setPaymentMethod } from 'helpers/redux/checkout/payment/paymentMethod/actions';
+import { toHumanReadableContributionType } from 'helpers/forms/checkouts';
 import { setProductType } from 'helpers/redux/checkout/product/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import {
@@ -23,28 +19,20 @@ export function PaymentFrequencyTabsContainer({
 	render,
 }: PaymentFrequencyTabsContainerProps): JSX.Element {
 	const dispatch = useContributionsDispatch();
-	const { contributionTypes, switches } = useContributionsSelector(
+	const { contributionTypes } = useContributionsSelector(
 		(state) => state.common.settings,
 	);
-	const { countryGroupId, countryId } = useContributionsSelector(
+	const { countryGroupId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
 	const productType = useContributionsSelector(getContributionType);
 
 	function onTabChange(contributionType: ContributionType) {
-		const paymentMethodToSelect = getPaymentMethodToSelect(
-			contributionType,
-			switches,
-			countryId,
-			countryGroupId,
-		);
-
 		trackComponentClick(
 			`npf-contribution-type-toggle-${countryGroupId}-${contributionType}`,
 		);
 
 		dispatch(setProductType(contributionType));
-		dispatch(setPaymentMethod({ paymentMethod: paymentMethodToSelect }));
 	}
 
 	const tabs = contributionTypes[countryGroupId].map(({ contributionType }) => {

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
@@ -9,10 +9,7 @@ import {
 } from 'helpers/forms/paymentMethods';
 import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import {
-	getPaymentMethodToSelect,
-	getValidPaymentMethods,
-} from '../forms/checkouts';
+import { getValidPaymentMethods } from '../forms/checkouts';
 
 jest.mock('helpers/globalsAndSwitches/globals', () => ({
 	__esModule: true,
@@ -24,7 +21,7 @@ const mock = (mockFn: unknown) => mockFn as jest.Mock;
 // ----- Tests ----- //
 
 describe('checkouts', () => {
-	describe('getValidPaymentMethods and getPaymentMethodToSelect', () => {
+	describe('getValidPaymentMethods', () => {
 		const allSwitches = {
 			experiments: {},
 		};
@@ -49,15 +46,6 @@ describe('checkouts', () => {
 				Stripe,
 				PayPal,
 			]);
-
-			expect(
-				getPaymentMethodToSelect(
-					contributionType,
-					allSwitches,
-					countryId,
-					countryGroupId,
-				),
-			).toEqual(DirectDebit);
 		});
 
 		it("should return en empty array/'None' for Monthly Recurring UK when switches are all off", () => {
@@ -74,14 +62,6 @@ describe('checkouts', () => {
 					countryGroupId,
 				),
 			).toEqual([]);
-			expect(
-				getPaymentMethodToSelect(
-					contributionType,
-					allSwitches,
-					countryId,
-					countryGroupId,
-				),
-			).toEqual('None');
 		});
 
 		it('should return just Stripe for One Off US when only Stripe is on', () => {
@@ -100,15 +80,6 @@ describe('checkouts', () => {
 					countryGroupId,
 				),
 			).toEqual([Stripe]);
-
-			expect(
-				getPaymentMethodToSelect(
-					contributionType,
-					allSwitches,
-					countryId,
-					countryGroupId,
-				),
-			).toEqual(Stripe);
 		});
 	});
 });

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -193,21 +193,6 @@ function getValidPaymentMethods(
 	);
 }
 
-function getPaymentMethodToSelect(
-	contributionType: ContributionType,
-	allSwitches: Switches,
-	countryId: IsoCountry,
-	countryGroupId: CountryGroupId,
-): PaymentMethod {
-	const validPaymentMethods = getValidPaymentMethods(
-		contributionType,
-		allSwitches,
-		countryId,
-		countryGroupId,
-	);
-	return validPaymentMethods[0] || 'None';
-}
-
 function getPaymentMethodFromSession(): PaymentMethod | null | undefined {
 	const pm: string | null | undefined = storage.getSession(
 		'selectedPaymentMethod',
@@ -374,7 +359,6 @@ export {
 	getAmountFromUrl,
 	toHumanReadableContributionType,
 	getValidPaymentMethods,
-	getPaymentMethodToSelect,
 	getPaymentMethodFromSession,
 	getPaymentDescription,
 	getPaymentLabel,

--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/reducer.ts
@@ -7,6 +7,7 @@ import type {
 } from 'helpers/internationalisation/country';
 import { setDeliveryCountry } from '../../address/actions';
 import { validateForm } from '../../checkoutActions';
+import { setProductType } from '../../product/actions';
 import { initialState } from './state';
 
 export const paymentMethodSlice = createSlice({
@@ -31,6 +32,10 @@ export const paymentMethodSlice = createSlice({
 	extraReducers: (builder) => {
 		// Not all payment methods are available for all countries, so reset if the delivery country changes
 		builder.addCase(setDeliveryCountry, (state) => {
+			state.name = 'None';
+		});
+
+		builder.addCase(setProductType, (state) => {
 			state.name = 'None';
 		});
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR removes the existing feature where we automatically pre-select a payment method for users when they switch their contribution frequency, eg. switching from a monthly to a single contribution. It also reverts the selected payment method back to 'None' when the user switches contribution frequency, in order to avoid users attempting to pay with a disallowed payment method, eg. direct debit with a single contribution.

[**Trello Card**](https://trello.com/c/R3YkoxDd)

## Why are you doing this?

This is to reduce user confusion when selecting a payment method, and improve the overall user journey.
