### PR TITLE
Add Checkout Nudge Story

### DIFF
--- a/support-frontend/stories/checkoutLayout/CheckoutNudge.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutNudge.stories.tsx
@@ -1,0 +1,55 @@
+import { css } from '@emotion/react';
+import { neutral } from '@guardian/source-foundations';
+import { Column, Columns, Container } from '@guardian/source-react-components';
+import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
+import type { CheckoutNudgeProps } from 'components/checkoutNudge/checkoutNudge';
+import { CheckoutNudge } from 'components/checkoutNudge/checkoutNudge';
+
+export default {
+	title: 'Checkouts/Nudge',
+	component: CheckoutNudge,
+	argTypes: {
+		onNudgeClose: { action: 'button clicked' },
+		onNudgeClick: { action: 'button clicked' },
+	},
+	decorators: [
+		(Story: React.FC): JSX.Element => (
+			<Container backgroundColor={neutral[97]}>
+				<Columns
+					collapseUntil="tablet"
+					cssOverrides={css`
+						justify-content: center;
+						padding: 1rem 0;
+					`}
+				>
+					<Column width={[1, 3 / 4, 1 / 2]}>
+						<Box>
+							<BoxContents>
+								<Story />
+							</BoxContents>
+						</Box>
+					</Column>
+				</Columns>
+			</Container>
+		),
+	],
+};
+
+function Template(args: CheckoutNudgeProps) {
+	return <CheckoutNudge {...args} />;
+}
+
+Template.args = {} as Omit<CheckoutNudgeProps, 'onNudgeClose' | 'onNudgeClick'>;
+
+export const OneOffNudge = Template.bind({});
+
+OneOffNudge.args = {
+	contributionType: 'ONE_OFF',
+	nudgeDisplay: true,
+	nudgeTitle: 'Support us every year',
+	nudgeSubtitle: 'for £50 (£1 a week)',
+	nudgeParagraph:
+		'Funding Guardian journalism every year is great value on a weekly basis. Make a bigger impact today, and protect our independence long term. Please consider annual support.',
+	nudgeLinkCopy: 'See annual',
+	countryGroupId: 'GBPCountries',
+};


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This adds a checkout nudge story

[**Trello Card**](https://trello.com)

## Why are you doing this?
So there is a corresponding story file for the checkout nudge

## Is this an AB test?
- [ ] Yes
- [x] No

## Screenshots
<img width="1420" alt="Screenshot 2023-07-04 at 15 20 27" src="https://github.com/guardian/support-frontend/assets/44685872/fdf5a08b-b45d-4793-a311-bf115d9bc63f">
