### PR TITLE
send `paymentId` to soft opt-in setter as `contributionId`, as the la…

### DIFF
--- a/support-payment-api/src/main/scala/backend/PaymentBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaymentBackend.scala
@@ -62,7 +62,7 @@ trait PaymentBackend extends StrictLogging {
 
     val supporterDataFuture = insertContributionIntoSupporterProductData(contributionData)
 
-    val softOptInFuture = softOptInsService.sendMessage(contributionData.identityId)
+    val softOptInFuture = softOptInsService.sendMessage(contributionData.identityId, contributionData.paymentId)
 
     Future
       .sequence(

--- a/support-payment-api/src/main/scala/backend/PaymentBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaymentBackend.scala
@@ -62,7 +62,7 @@ trait PaymentBackend extends StrictLogging {
 
     val supporterDataFuture = insertContributionIntoSupporterProductData(contributionData)
 
-    val softOptInFuture = softOptInsService.sendMessage(contributionData.identityId, contributionData.paymentId)
+    val softOptInFuture = softOptInsService.sendMessage(contributionData.identityId, contributionData.contributionId)
 
     Future
       .sequence(

--- a/support-payment-api/src/main/scala/services/SoftOptInsService.scala
+++ b/support-payment-api/src/main/scala/services/SoftOptInsService.scala
@@ -19,6 +19,7 @@ class SoftOptInsService(sqsClient: AmazonSQSAsync, queueUrlResponse: Future[Eith
     extends StrictLogging {
   def sendMessage(
       identityId: Option[Long],
+      paymentId: String,
   )(implicit executionContext: ExecutionContext): EitherT[Future, SoftOptInsServiceError, Unit] = {
     identityId match {
       case None =>
@@ -27,7 +28,8 @@ class SoftOptInsService(sqsClient: AmazonSQSAsync, queueUrlResponse: Future[Eith
 
       case Some(id) =>
         val identityIdString = id.toString
-        val message = Message(identityIdString)
+        val subscriptionIdString = paymentId
+        val message = Message(identityId = identityIdString, subscriptionId = subscriptionIdString)
 
         logger.info(s"Preparing to send message: ${message.asJson.noSpaces}")
 
@@ -93,6 +95,7 @@ object SoftOptInsService extends StrictLogging {
   }
 
   case class Message(
+      subscriptionId: String,
       identityId: String,
       eventType: String = "Acquisition",
       productName: String = "Contribution",

--- a/support-payment-api/src/main/scala/services/SoftOptInsService.scala
+++ b/support-payment-api/src/main/scala/services/SoftOptInsService.scala
@@ -13,13 +13,14 @@ import model.Environment
 import model.Environment.Live
 import services.SoftOptInsService.Message
 
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 class SoftOptInsService(sqsClient: AmazonSQSAsync, queueUrlResponse: Future[Either[SoftOptInsServiceError, String]])
     extends StrictLogging {
   def sendMessage(
       identityId: Option[Long],
-      paymentId: String,
+      contributionId: UUID,
   )(implicit executionContext: ExecutionContext): EitherT[Future, SoftOptInsServiceError, Unit] = {
     identityId match {
       case None =>
@@ -28,8 +29,11 @@ class SoftOptInsService(sqsClient: AmazonSQSAsync, queueUrlResponse: Future[Eith
 
       case Some(id) =>
         val identityIdString = id.toString
-        val subscriptionIdString = paymentId
-        val message = Message(identityId = identityIdString, subscriptionId = subscriptionIdString)
+        val contributionIdString = contributionId.toString
+        val message = Message(
+          identityId = identityIdString,
+          subscriptionId = contributionIdString,
+        ) // we send the contribution ID as a stand-in for a sub ID
 
         logger.info(s"Preparing to send message: ${message.asJson.noSpaces}")
 

--- a/support-payment-api/src/test/scala/backend/AmazonPayBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/AmazonPayBackendSpec.scala
@@ -216,7 +216,7 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponseError)
-        when(mockSoftOptInsService.sendMessage(any())(any()))
+        when(mockSoftOptInsService.sendMessage(any(), any())(any()))
           .thenReturn(softOptInsResponseError)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
@@ -225,7 +225,7 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
           .thenReturn(identityResponseError)
         amazonPayBackend.makePayment(amazonPayRequest, clientBrowserInfo).futureRight mustBe ()
 
-        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
+        verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
       }
     }
 
@@ -272,7 +272,7 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
           when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
           when(mockSupporterProductDataService.insertContributionData(any())(any()))
             .thenReturn(supporterProductDataResponseError)
-          when(mockSoftOptInsService.sendMessage(any())(any()))
+          when(mockSoftOptInsService.sendMessage(any(), any())(any()))
             .thenReturn(softOptInsResponseError)
           when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
           when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
@@ -281,7 +281,7 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
             .thenReturn(identityResponseError)
           amazonPayBackend.makePayment(amazonPayRequest, clientBrowserInfo).futureRight mustBe ()
 
-          verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
+          verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
         }
 
       "return successful payment response with guestAccountRegistrationToken if available" in new AmazonPayBackendFixture {
@@ -302,7 +302,7 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponseError)
 
-        when(mockSoftOptInsService.sendMessage(any())(any()))
+        when(mockSoftOptInsService.sendMessage(any(), any())(any()))
           .thenReturn(softOptInsResponseError)
 
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
@@ -313,7 +313,7 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
 
         amazonPayBackend.makePayment(amazonPayRequest, clientBrowserInfo).futureRight mustBe ()
 
-        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
+        verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
       }
 
       "Not call setOrderRef if state is suspended" in new AmazonPayBackendFixture {

--- a/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
@@ -276,7 +276,7 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
           when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
           when(mockSupporterProductDataService.insertContributionData(any())(any()))
             .thenReturn(supporterProductDataResponseError)
-          when(mockSoftOptInsService.sendMessage(any())(any()))
+          when(mockSoftOptInsService.sendMessage(any(), any())(any()))
             .thenReturn(softOptInsServiceResponseError)
           when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
           when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
@@ -288,7 +288,7 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
             .executePayment(executePaypalPaymentData, clientBrowserInfo)
             .futureRight mustBe enrichedPaypalPaymentMock
 
-          verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
+          verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
         }
 
       "return successful payment response with guestAccountRegistrationToken if available" in new PaypalBackendFixture {
@@ -299,7 +299,7 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponseError)
-        when(mockSoftOptInsService.sendMessage(any())(any()))
+        when(mockSoftOptInsService.sendMessage(any(), any())(any()))
           .thenReturn(softOptInsServiceResponseError)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
@@ -311,7 +311,7 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
           .executePayment(executePaypalPaymentData, clientBrowserInfo)
           .futureRight mustBe enrichedPaypalPaymentMock
 
-        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
+        verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
       }
     }
 
@@ -349,7 +349,7 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponse)
-        when(mockSoftOptInsService.sendMessage(any())(any())).thenReturn(softOptInsServiceResponse)
+        when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsServiceResponse)
 
         val trackContribution = PrivateMethod[Future[List[BackendError]]](Symbol("trackContribution"))
         val result = paypalBackend invokePrivate trackContribution(
@@ -362,7 +362,7 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
 
         result.futureValue mustBe List(BackendError.Database(dbError))
 
-        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
+        verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
       }
 
       "return a combined error if stream and BigQuery fail" in new PaypalBackendFixture {
@@ -371,7 +371,7 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponse)
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponse)
-        when(mockSoftOptInsService.sendMessage(any())(any()))
+        when(mockSoftOptInsService.sendMessage(any(), any())(any()))
           .thenReturn(softOptInsServiceResponse)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
@@ -391,7 +391,7 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
         )
         result.futureValue mustEqual errors
 
-        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
+        verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
       }
 
     }

--- a/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
@@ -302,7 +302,7 @@ class StripeBackendSpec
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponseError)
-        when(mockSoftOptInsService.sendMessage(any())(any())).thenReturn(softOptInsResponseError)
+        when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponseError)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponse)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         when(mockStripeService.createPaymentIntent(createPaymentIntentWithStripeCheckout))
@@ -315,7 +315,7 @@ class StripeBackendSpec
         stripeBackend.createPaymentIntent(createPaymentIntentWithStripeCheckout, clientBrowserInfo).futureRight mustBe
           StripePaymentIntentsApiResponse.Success()
 
-        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
+        verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
       }
 
       "return Success if stripe apple pay switch is On in support-admin-console" in new StripeBackendFixture {
@@ -335,7 +335,7 @@ class StripeBackendSpec
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponseError)
-        when(mockSoftOptInsService.sendMessage(any())(any())).thenReturn(softOptInsResponseError)
+        when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponseError)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponse)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         when(mockStripeService.createPaymentIntent(createPaymentIntentWithStripeApplePay))
@@ -366,7 +366,7 @@ class StripeBackendSpec
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponseError)
-        when(mockSoftOptInsService.sendMessage(any())(any())).thenReturn(softOptInsResponseError)
+        when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponseError)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponse)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         when(mockStripeService.createPaymentIntent(createPaymentIntentWithStripePaymentRequest))
@@ -396,7 +396,7 @@ class StripeBackendSpec
           when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
           when(mockSupporterProductDataService.insertContributionData(any())(any()))
             .thenReturn(supporterProductDataResponseError)
-          when(mockSoftOptInsService.sendMessage(any())(any())).thenReturn(softOptInsResponseError)
+          when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponseError)
           when(mockStripeService.createCharge(stripeChargeRequest)).thenReturn(paymentServiceResponse)
           when(mockIdentityService.getOrCreateIdentityIdFromEmail("email@email.com")).thenReturn(identityResponseError)
           when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
@@ -408,7 +408,7 @@ class StripeBackendSpec
             chargeMock,
           )
 
-          verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
+          verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
         }
 
       "return successful payment response with guestAccountRegistrationToken if available" in new StripeBackendFixture {
@@ -416,7 +416,7 @@ class StripeBackendSpec
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponseError)
-        when(mockSoftOptInsService.sendMessage(any())(any())).thenReturn(softOptInsResponseError)
+        when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponseError)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponse)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         when(mockStripeService.createCharge(stripeChargeRequest)).thenReturn(paymentServiceResponse)
@@ -427,7 +427,7 @@ class StripeBackendSpec
             chargeMock,
           )
 
-        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
+        verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
       }
     }
 
@@ -461,7 +461,7 @@ class StripeBackendSpec
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponse)
-        when(mockSoftOptInsService.sendMessage(any())(any())).thenReturn(softOptInsResponse)
+        when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponse)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponse)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         val trackContribution = PrivateMethod[Future[List[BackendError]]]('trackContribution)
@@ -469,7 +469,7 @@ class StripeBackendSpec
           stripeBackend invokePrivate trackContribution(chargeMock, stripeChargeRequest, None, clientBrowserInfo)
         result.futureValue mustBe List(BackendError.Database(dbError))
 
-        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
+        verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
       }
 
       "return a combined error if BigQuery and DB fail" in new StripeBackendFixture {
@@ -478,7 +478,7 @@ class StripeBackendSpec
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponse)
-        when(mockSoftOptInsService.sendMessage(any())(any())).thenReturn(softOptInsResponse)
+        when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponse)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         val trackContribution = PrivateMethod[Future[List[BackendError]]]('trackContribution)
@@ -490,7 +490,7 @@ class StripeBackendSpec
         )
         result.futureValue mustBe error
 
-        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
+        verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
       }
     }
 
@@ -503,7 +503,7 @@ class StripeBackendSpec
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponse)
-        when(mockSoftOptInsService.sendMessage(any())(any())).thenReturn(softOptInsResponse)
+        when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponse)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponse)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         when(mockStripeService.createPaymentIntent(createPaymentIntent)).thenReturn(paymentServiceIntentResponse)
@@ -514,7 +514,7 @@ class StripeBackendSpec
         stripeBackend.createPaymentIntent(createPaymentIntent, clientBrowserInfo).futureRight mustBe
           StripePaymentIntentsApiResponse.Success()
 
-        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
+        verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
       }
 
       "return RequiresAction if 3DS required" in new StripeBackendFixture {
@@ -559,7 +559,7 @@ class StripeBackendSpec
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponse)
-        when(mockSoftOptInsService.sendMessage(any())(any())).thenReturn(softOptInsResponse)
+        when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponse)
         when(mockStripeService.createPaymentIntent(createPaymentIntent)).thenReturn(paymentServiceIntentResponse)
         when(mockIdentityService.getOrCreateIdentityIdFromEmail("email@email.com")).thenReturn(identityResponse)
         when(mockEmailService.sendThankYouEmail(any())).thenReturn(emailServiceErrorResponse)
@@ -568,7 +568,7 @@ class StripeBackendSpec
         stripeBackend.createPaymentIntent(createPaymentIntent, clientBrowserInfo).futureLeft mustBe
           StripeApiError.fromString(s"Stripe error", None)
 
-        verify(mockSoftOptInsService, times(0)).sendMessage(any())(any())
+        verify(mockSoftOptInsService, times(0)).sendMessage(any(), any())(any())
       }
     }
 
@@ -581,7 +581,7 @@ class StripeBackendSpec
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponse)
-        when(mockSoftOptInsService.sendMessage(any())(any())).thenReturn(softOptInsResponse)
+        when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponse)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponse)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         when(mockStripeService.confirmPaymentIntent(confirmPaymentIntent)).thenReturn(paymentServiceIntentResponse)
@@ -591,7 +591,7 @@ class StripeBackendSpec
         stripeBackend.confirmPaymentIntent(confirmPaymentIntent, clientBrowserInfo).futureRight mustBe
           StripePaymentIntentsApiResponse.Success()
 
-        verify(mockSoftOptInsService, times(1)).sendMessage(any())(any())
+        verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
       }
 
       "return an error if confirmation failed" in new StripeBackendFixture {


### PR DESCRIPTION
This sends `contributionId` as `subscriptionId` to the soft opt-in setter lambda, which requires a `subscriptionId` for its model.