### PR TITLE
Print debug info earlier

### DIFF
--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -62,6 +62,7 @@ class CreateSubscriptionController(
     LoggingAndAlarmOnFailure {
       MaybeAuthenticatedAction.async(circe.json[CreateSupportWorkersRequest]) { implicit request =>
         implicit val settings: AllSettings = settingsProvider.getAllSettings()
+        SafeLogger.info(s"${request.uuid}: debug info ${request.body.debugInfo}")
         val errorOrStatusResponse = for {
           _ <- getRecaptchaTokenFromRequest(request) match {
             case Some(token) => validateRecaptcha(token, testUsers.isTestUser(request))

--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -147,8 +147,6 @@ class SupportWorkersClient(
       user: User,
       requestId: UUID,
   ): EitherT[Future, String, StatusResponse] = {
-    SafeLogger.info(s"$requestId: debug info ${request.body.debugInfo}")
-
     for {
       giftRecipient <- EitherT.fromEither[Future](
         request.body.giftRecipient.map(getGiftRecipient(_, request.body.product)).sequence,


### PR DESCRIPTION
# Summary

Recently, I’ve noticed that some errors mean we don’t see the nicely formatted debug info. I think this is because the errors happen before we get to the line that’s currently doing that logging. Moving that earlier in the execution flow should make our debugging a bit nicer.

# Testing

To test this, run locally or deploy to CODE and check out using an email address whose domain is `qq.com`. In the support-frontend logs in CloudWatch, you should be able to see the log message that I’ve moved where the debug info is pretty printed. Without the change, the debug info would only be accessible in the request logging, where it is escaped inside a JSON string.
