### PR TITLE
Provide better feedback to user when their email provider is rejected

### DIFF
--- a/support-frontend/app/actions/CustomActionBuilders.scala
+++ b/support-frontend/app/actions/CustomActionBuilders.scala
@@ -8,7 +8,7 @@ import com.gu.aws.{AwsCloudWatchMetricPut, AwsCloudWatchMetricSetup}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger.Sanitizer
 import com.gu.support.config.Stage
-import models.identity.responses.IdentityErrorResponse.IdentityError.{BadEmailAddress, InvalidEmailAddress}
+import models.identity.responses.IdentityErrorResponse._
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.filters.csrf._
@@ -50,9 +50,9 @@ class CustomActionBuilders(
     private def maybePushAlarmMetric(result: Result) =
       if (
         result.header.status.toString.head != '2' && !result.header.reasonPhrase.contains(
-          InvalidEmailAddress.errorReasonCode,
+          emailProviderRejectedCode,
         ) && !result.header.reasonPhrase.contains(
-          BadEmailAddress.errorReasonCode,
+          invalidEmailAddressCode,
         )
       ) {
         SafeLogger.error(scrub"pushing alarm metric - non 2xx response ${result.toString()}")

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -136,7 +136,7 @@ class CreateSubscriptionController(
 
   private def mapIdentityErrorToCreateSubscriptionError(identityError: IdentityError) =
     identityError match {
-      case RejectedEmailProvider(_endpoint) => RequestValidationError(emailProviderRejectedCode)
+      case EmailProviderRejected(_endpoint) => RequestValidationError(emailProviderRejectedCode)
       case InvalidEmailAddress(_endpoint) => RequestValidationError(invalidEmailAddressCode)
       case OtherIdentityError(message, description, endpoint) =>
         endpoint match {

--- a/support-frontend/app/models/identity/responses/IdentityErrorResponse.scala
+++ b/support-frontend/app/models/identity/responses/IdentityErrorResponse.scala
@@ -1,7 +1,8 @@
 package models.identity.responses
 
 import models.identity.responses.IdentityErrorResponse.IdentityError
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.{Json, Reads, JsPath}
+import play.api.libs.functional.syntax._
 
 // Models and error returned by Identity
 //
@@ -25,32 +26,48 @@ case class IdentityErrorResponse(
 
 object IdentityErrorResponse {
   implicit val reads: Reads[IdentityErrorResponse] = Json.reads[IdentityErrorResponse]
+  val emailProviderRejectedCode = "invalid_email_address"
+  val invalidEmailAddressCode = "bad_email_address"
 
-  case class IdentityError(
-      message: String,
-      description: String,
-  )
+  sealed trait IdentityError {
+    def endpoint: Option[IdentityEndpoint]
+    def setEndpoint(e: IdentityEndpoint): IdentityError = {
+      this match {
+        case RejectedEmailProvider(_) => RejectedEmailProvider(Some(e))
+        case InvalidEmailAddress(_) => InvalidEmailAddress(Some(e))
+        case OtherIdentityError(m, d, _endpoint) => OtherIdentityError(m, d, endpoint = Some(e))
+      }
+    }
+  }
+
+  /** We don’t accept email addresses from this provider. */
+  case class RejectedEmailProvider(endpoint: Option[IdentityEndpoint]) extends IdentityError
+
+  /** The email address is invalid. */
+  case class InvalidEmailAddress(endpoint: Option[IdentityEndpoint]) extends IdentityError
+
+  /** Some other error occurred. */
+  case class OtherIdentityError(message: String, description: String, endpoint: Option[IdentityEndpoint])
+      extends IdentityError
+
+  sealed trait IdentityEndpoint
+  case object UserEndpoint extends IdentityEndpoint
+  case object GuestEndpoint extends IdentityEndpoint
 
   object IdentityError {
-    object InvalidEmailAddress {
-      val message = "Registration Error"
-      val description = "Please sign up using an email address from a different provider"
-      val errorReasonCode = "invalid_email_address"
+    implicit val reads: Reads[IdentityError] = (
+      (JsPath \ "message").read[String] and
+        (JsPath \ "description").read[String]
+    ) { (message, description) =>
+      if (
+        message == "Registration Error" && description == "Please sign up using an email address from a different provider"
+      ) {
+        RejectedEmailProvider(endpoint = None)
+      } else if (message == "Invalid emailAddress:" && description == "Please enter a valid email address") {
+        InvalidEmailAddress(endpoint = None)
+      } else {
+        OtherIdentityError(message, description, endpoint = None)
+      }
     }
-
-    object BadEmailAddress {
-      val message = "Invalid emailAddress:"
-      val description = "Please enter a valid email address"
-      val errorReasonCode = "bad_email_address"
-    }
-    def isDisallowedEmailError(identityError: IdentityError): Boolean =
-      identityError.message == InvalidEmailAddress.message &&
-        identityError.description == InvalidEmailAddress.description
-
-    def isBadEmailError(identityError: IdentityError): Boolean =
-      identityError.message == BadEmailAddress.message &&
-        identityError.description == BadEmailAddress.description
-
-    implicit val reads: Reads[IdentityError] = Json.reads[IdentityError]
   }
 }

--- a/support-frontend/app/models/identity/responses/IdentityErrorResponse.scala
+++ b/support-frontend/app/models/identity/responses/IdentityErrorResponse.scala
@@ -26,14 +26,14 @@ case class IdentityErrorResponse(
 
 object IdentityErrorResponse {
   implicit val reads: Reads[IdentityErrorResponse] = Json.reads[IdentityErrorResponse]
-  val emailProviderRejectedCode = "invalid_email_address"
-  val invalidEmailAddressCode = "bad_email_address"
+  val emailProviderRejectedCode = "email_provider_rejected"
+  val invalidEmailAddressCode = "invalid_email_address"
 
   sealed trait IdentityError {
     def endpoint: Option[IdentityEndpoint]
     def setEndpoint(e: IdentityEndpoint): IdentityError = {
       this match {
-        case RejectedEmailProvider(_) => RejectedEmailProvider(Some(e))
+        case EmailProviderRejected(_) => EmailProviderRejected(Some(e))
         case InvalidEmailAddress(_) => InvalidEmailAddress(Some(e))
         case OtherIdentityError(m, d, _endpoint) => OtherIdentityError(m, d, endpoint = Some(e))
       }
@@ -41,7 +41,7 @@ object IdentityErrorResponse {
   }
 
   /** We don’t accept email addresses from this provider. */
-  case class RejectedEmailProvider(endpoint: Option[IdentityEndpoint]) extends IdentityError
+  case class EmailProviderRejected(endpoint: Option[IdentityEndpoint]) extends IdentityError
 
   /** The email address is invalid. */
   case class InvalidEmailAddress(endpoint: Option[IdentityEndpoint]) extends IdentityError
@@ -62,7 +62,7 @@ object IdentityErrorResponse {
       if (
         message == "Registration Error" && description == "Please sign up using an email address from a different provider"
       ) {
-        RejectedEmailProvider(endpoint = None)
+        EmailProviderRejected(endpoint = None)
       } else if (message == "Invalid emailAddress:" && description == "Please enter a valid email address") {
         InvalidEmailAddress(endpoint = None)
       } else {

--- a/support-frontend/assets/helpers/forms/errorReasons.ts
+++ b/support-frontend/assets/helpers/forms/errorReasons.ts
@@ -18,6 +18,7 @@ export type ErrorReason =
 	| 'amazon_pay_try_other_card'
 	| 'amazon_pay_try_again'
 	| 'amazon_pay_fatal'
+	| 'email_provider_rejected'
 	| 'invalid_email_address'
 	| 'unknown';
 
@@ -67,10 +68,10 @@ function appropriateErrorMessage(errorReason: ErrorReason | string): string {
 		case 'incomplete_payment_request_details':
 			return 'Please complete all relevant fields for your saved cards and billing addresses within your browser settings and try your payment again. Alternatively, you can use the form below.';
 
-		case 'invalid_email_address':
+		case 'email_provider_rejected':
 			return 'Please use an email address from a different provider';
 
-		case 'bad_email_address':
+		case 'invalid_email_address':
 			return 'Please enter a valid email address';
 
 		default:

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -203,8 +203,8 @@ function PaperCheckoutForm(props: PropTypes) {
 
 	const submissionErrorHeading =
 		props.submissionError === 'personal_details_incorrect'
-			? 'Sorry there was a problem'
-			: 'Sorry we could not process your payment';
+			? 'Sorry, there was a problem'
+			: 'Sorry, we could not process your payment';
 
 	const paymentMethods = supportedPaymentMethods(
 		props.currencyId,

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -166,8 +166,8 @@ function WeeklyCheckoutForm(props: PropTypes) {
 
 	const submissionErrorHeading =
 		props.submissionError === 'personal_details_incorrect'
-			? 'Sorry there was a problem'
-			: 'Sorry we could not process your payment';
+			? 'Sorry, there was a problem'
+			: 'Sorry, we could not process your payment';
 
 	const setBillingAddressMatchesDeliveryHandler = (newState: boolean) => {
 		props.setBillingAddressMatchesDelivery(newState);

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
@@ -160,8 +160,8 @@ function WeeklyCheckoutFormGifting(props: PropTypes): JSX.Element {
 
 	const submissionErrorHeading =
 		props.submissionError === 'personal_details_incorrect'
-			? 'Sorry there was a problem'
-			: 'Sorry we could not process your payment';
+			? 'Sorry, there was a problem'
+			: 'Sorry, we could not process your payment';
 
 	const setBillingAddressMatchesDeliveryHandler = (newState: boolean) => {
 		props.setBillingAddressMatchesDelivery(newState);


### PR DESCRIPTION
## Changes

### Fix detection of specific identity errors

I broke this in commit 2020275389c3812d25992d8bca7c3655b017fa16, when I modified the error messages to add information about which endpoint was called. I forgot or didn’t realise that we were later checking those messages to check the specific kind of error.

To reduce the chance of this happening again, I’ve moved the specific error recognition to the JSON parsing, and used specific case classes for the specific errors (avoiding redundant info and checking error messages multiple times).

### Improve naming of specific identity errors

“bad_email_address” and “invalid_email_address” were too similar, and the latter seemed like the wrong name for the email provider having been rejected.

### Add comma to error message

These error messages read a bit weirdly without the comma, I reckon. Might be worth checking if this is the tone the site should strike at all, though?

## Testing

Run locally or deploy to CODE, and attempt to check out with an email address whose domain is `@qq.com`. You should see an error message in the frontend which tells you to use an email address from a different provider.