### PR TITLE
Update supporter plus disclaimer text

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
@@ -146,27 +146,35 @@ export function PaymentTsAndCs({
 		);
 	};
 
-	const thresholdDescriptions = () => {
+	const thresholdDescription = (contributionType: ContributionType) => {
 		const supporterPlusThresholds =
 			benefitsThresholdsByCountryGroup[countryGroupId];
-		return `${currencyGlyph}${supporterPlusThresholds['MONTHLY']} per month or ${currencyGlyph}${supporterPlusThresholds['ANNUAL']} per year`;
+		const threshold: number =
+			contributionType === 'MONTHLY'
+				? supporterPlusThresholds['MONTHLY']
+				: supporterPlusThresholds['ANNUAL'];
+		return `${currencyGlyph}${threshold} per ${frequencySingular(
+			contributionType,
+		)}`;
 	};
 
 	const copyAboveThreshold = (contributionType: ContributionType) => {
 		return (
 			<>
 				<div>
-					If you pay at least {thresholdDescriptions()}, you will receive the
-					Supporter Plus benefits on a subscription basis. If you pay more than{' '}
-					{thresholdDescriptions()}, these additional amounts will be a separate{' '}
-					{frequencyPlural(contributionType)} voluntary financial contribution
-					to the Guardian. The Supporter Plus subscription and any contributions
-					will auto-renew each {frequencySingular(contributionType)}. You will
-					be charged the subscription and contribution amounts using your chosen
-					payment method at each renewal unless you cancel. You can cancel your
-					subscription or change your contributions at any time before your next
-					renewal date. If you cancel within 14 days of taking out a Supporter
-					Plus subscription, you’ll receive a full refund (including of any
+					If you pay at least {thresholdDescription('MONTHLY')} or{' '}
+					{thresholdDescription('ANNUAL')}, you will receive the Supporter Plus
+					benefits on a subscription basis. If you pay more than{' '}
+					{thresholdDescription(contributionType)}, these additional amounts
+					will be separate {frequencyPlural(contributionType)} voluntary
+					financial contributions to the Guardian. The Supporter Plus
+					subscription and any contributions will auto-renew each{' '}
+					{frequencySingular(contributionType)}. You will be charged the
+					subscription and contribution amounts using your chosen payment method
+					at each renewal unless you cancel. You can cancel your subscription or
+					change your contributions at any time before your next renewal date.
+					If you cancel within 14 days of taking out a Supporter Plus
+					subscription, you’ll receive a full refund (including of any
 					contributions) and your subscription and any contribution will stop
 					immediately. Cancellation of your subscription (which will also cancel
 					any contribution) or cancellation of your contribution made after 14

--- a/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
@@ -146,26 +146,32 @@ export function PaymentTsAndCs({
 		);
 	};
 
-	const copyAboveThreshold = (contributionType: ContributionType) => {
+	const thresholdDescriptions = () => {
 		const supporterPlusThresholds =
 			benefitsThresholdsByCountryGroup[countryGroupId];
+		return `${currencyGlyph}${supporterPlusThresholds['MONTHLY']} per month or ${currencyGlyph}${supporterPlusThresholds['ANNUAL']} per year`;
+	};
 
+	const copyAboveThreshold = (contributionType: ContributionType) => {
 		return (
 			<>
 				<div>
-					This subscription auto-renews each{' '}
-					{frequencySingular(contributionType)}. You will be charged the
-					applicable {frequencyPlural(contributionType)} amount at each renewal
-					unless you cancel. You can cancel or change how much you pay for these
-					benefits at any time before your next renewal date, but{' '}
-					{currencyGlyph}
-					{supporterPlusThresholds['MONTHLY']} per month or {currencyGlyph}
-					{supporterPlusThresholds['ANNUAL']} per year is the minimum payment to
-					receive this subscription. If you cancel within 14 days of taking out
-					this subscription, you’ll receive a full refund and your benefits will
-					stop immediately. Changes to your payment amount or cancellation made
-					after 14 days will take effect at the end of your current subscription{' '}
-					{frequencySingular(contributionType)}. To cancel, go to{' '}
+					If you pay at least {thresholdDescriptions()}, you will receive the
+					Supporter Plus benefits on a subscription basis. If you pay more than{' '}
+					{thresholdDescriptions()}, these additional amounts will be a separate{' '}
+					{frequencyPlural(contributionType)} voluntary financial contribution
+					to the Guardian. The Supporter Plus subscription and any contributions
+					will auto-renew each {frequencySingular(contributionType)}. You will
+					be charged the subscription and contribution amounts using your chosen
+					payment method at each renewal unless you cancel. You can cancel your
+					subscription or change your contributions at any time before your next
+					renewal date. If you cancel within 14 days of taking out a Supporter
+					Plus subscription, you’ll receive a full refund (including of any
+					contributions) and your subscription and any contribution will stop
+					immediately. Cancellation of your subscription (which will also cancel
+					any contribution) or cancellation of your contribution made after 14
+					days will take effect at the end of your current{' '}
+					{frequencyPlural(contributionType)} payment period. To cancel, go to{' '}
 					{manageMyAccount} or see our {termsSupporterPlus('Terms')}.
 				</div>
 				<TsAndCsFooterLinks


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Now we have moved to version 2 of supporter plus we need to update the disclaimer text at the bottom of the supporter plus checkout.
## Screenshots
### Monthly
<img width="670" alt="Screenshot 2023-07-11 at 16 25 51" src="https://github.com/guardian/support-frontend/assets/181371/aba00c7f-d155-4842-b886-2194b81d77af">

### Annual
<img width="670" alt="Screenshot 2023-07-11 at 16 25 18" src="https://github.com/guardian/support-frontend/assets/181371/2ea1515e-e38b-44ce-9fe7-2ea9013bcaf1">


