### PR TITLE
acquisition-events-api: Disable 5xx monitoring

### DIFF
--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -6,7 +6,6 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
       "GuApiLambda",
-      "GuApiGateway5xxPercentageAlarm",
       "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
@@ -83,79 +82,6 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
         "Period": 300,
         "Statistic": "Sum",
         "Threshold": 1,
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "ApiGatewayHigh5xxPercentageAlarmAcquisitioneventsapi36134E2A": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":conversion-dev",
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "acquisition-events-api exceeded 5% error rate",
-        "AlarmName": "High 5XX error % from acquisition-events-api (ApiGateway) in CODE",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 1,
-        "Metrics": [
-          {
-            "Expression": "100*m1/m2",
-            "Id": "expr_1",
-            "Label": "% of 5XX responses served for acquisition-events-api",
-          },
-          {
-            "Id": "m1",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "ApiName",
-                    "Value": "support-CODE-acquisition-events-api-CODE",
-                  },
-                ],
-                "MetricName": "5XXError",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-          {
-            "Id": "m2",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "ApiName",
-                    "Value": "support-CODE-acquisition-events-api-CODE",
-                  },
-                ],
-                "MetricName": "Count",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 60,
-              "Stat": "SampleCount",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "Threshold": 5,
-        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -915,7 +841,6 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
       "GuApiLambda",
-      "GuApiGateway5xxPercentageAlarm",
       "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
@@ -992,79 +917,6 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
         "Period": 300,
         "Statistic": "Sum",
         "Threshold": 1,
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "ApiGatewayHigh5xxPercentageAlarmAcquisitioneventsapi36134E2A": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":conversion-dev",
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "acquisition-events-api exceeded 5% error rate",
-        "AlarmName": "High 5XX error % from acquisition-events-api (ApiGateway) in PROD",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 1,
-        "Metrics": [
-          {
-            "Expression": "100*m1/m2",
-            "Id": "expr_1",
-            "Label": "% of 5XX responses served for acquisition-events-api",
-          },
-          {
-            "Id": "m1",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "ApiName",
-                    "Value": "support-PROD-acquisition-events-api-PROD",
-                  },
-                ],
-                "MetricName": "5XXError",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-          {
-            "Id": "m2",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "ApiName",
-                    "Value": "support-PROD-acquisition-events-api-PROD",
-                  },
-                ],
-                "MetricName": "Count",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 60,
-              "Stat": "SampleCount",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "Threshold": 5,
-        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -47,8 +47,7 @@ export class AcquisitionEventsApi extends GuStack {
         environment: commonEnvironmentVariables,
         // Create an alarm
         monitoringConfiguration: {
-          http5xxAlarm: { tolerated5xxPercentage: 5 },
-          snsTopicName: "conversion-dev",
+          noMonitoring: true,
         },
         app: "acquisition-events-api",
         api: {


### PR DESCRIPTION
At the moment, the lambda that sends events to BigQuery frequently takes more than 30 seconds to run, which is the timeout limit for API Gateway: this causes the API Gateway to give up on the lambda and return a 5xx to the client, even though the lambda then succeeds shortly afterwards.

Since we can’t quickly fix the lambda to run in a shorter amount of time, this alarm isn’t worth having: it generates a really high level of (approximately) false positives.

Therefore this change disables the alarm for now, until we either speed up the lambda or replace it (possibly with the proposed new architecture where the API Gateway is connected directly to an event bus).