### PR TITLE
acquisition-events-api: Try increasing memory to prevent API Gateway timeouts

### DIFF
--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -6,6 +6,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
       "GuApiLambda",
+      "GuApiGateway5xxPercentageAlarm",
       "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
@@ -82,6 +83,79 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
         "Period": 300,
         "Statistic": "Sum",
         "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ApiGatewayHigh5xxPercentageAlarmAcquisitioneventsapi36134E2A": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":conversion-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "acquisition-events-api exceeded 5% error rate",
+        "AlarmName": "High 5XX error % from acquisition-events-api (ApiGateway) in CODE",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "% of 5XX responses served for acquisition-events-api",
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "support-CODE-acquisition-events-api-CODE",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "support-CODE-acquisition-events-api-CODE",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 5,
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -841,6 +915,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
       "GuApiLambda",
+      "GuApiGateway5xxPercentageAlarm",
       "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
@@ -917,6 +992,79 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
         "Period": 300,
         "Statistic": "Sum",
         "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ApiGatewayHigh5xxPercentageAlarmAcquisitioneventsapi36134E2A": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":conversion-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "acquisition-events-api exceeded 5% error rate",
+        "AlarmName": "High 5XX error % from acquisition-events-api (ApiGateway) in PROD",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "% of 5XX responses served for acquisition-events-api",
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "support-PROD-acquisition-events-api-PROD",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "ApiName",
+                    "Value": "support-PROD-acquisition-events-api-PROD",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 5,
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },

--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -239,7 +239,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
         },
         "FunctionName": "acquisition-events-api-cdk-CODE",
         "Handler": "com.gu.acquisitionEventsApi.Lambda::handler",
-        "MemorySize": 512,
+        "MemorySize": 1024,
         "Role": {
           "Fn::GetAtt": [
             "acquisitioneventsapicdklambdaServiceRole3289A569",
@@ -1074,7 +1074,7 @@ exports[`The Acquisition Events API stack matches the snapshot 2`] = `
         },
         "FunctionName": "acquisition-events-api-cdk-PROD",
         "Handler": "com.gu.acquisitionEventsApi.Lambda::handler",
-        "MemorySize": 512,
+        "MemorySize": 1024,
         "Role": {
           "Fn::GetAtt": [
             "acquisitioneventsapicdklambdaServiceRole3289A569",

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -42,7 +42,7 @@ export class AcquisitionEventsApi extends GuStack {
         fileName: `${app}.jar`,
         handler: "com.gu.acquisitionEventsApi.Lambda::handler",
         runtime: Runtime.JAVA_8,
-        memorySize: 512,
+        memorySize: 1024,
         timeout: Duration.seconds(300),
         environment: commonEnvironmentVariables,
         // Create an alarm

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -47,7 +47,8 @@ export class AcquisitionEventsApi extends GuStack {
         environment: commonEnvironmentVariables,
         // Create an alarm
         monitoringConfiguration: {
-          noMonitoring: true,
+          http5xxAlarm: { tolerated5xxPercentage: 5 },
+          snsTopicName: "conversion-dev",
         },
         app: "acquisition-events-api",
         api: {


### PR DESCRIPTION
Increasing the memory available to the lambda might help it run within the 30-second API Gateway timeout.