### PR TITLE
Add endpoints for calling PaperRound’s API

### DIFF
--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -77,8 +77,8 @@ jobs:
             ~/.coursier
           key: sbt
 
-      - name: Build and upload to RiffRaff
+      - name: Build, test, and upload to RiffRaff
         run: |
           export LAST_TEAMCITY_BUILD=10000
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt "project support-frontend" riffRaffUpload
+          sbt "project support-frontend" test riffRaffUpload

--- a/support-config/src/main/resources/reference.conf
+++ b/support-config/src/main/resources/reference.conf
@@ -2,6 +2,7 @@
 include classpath("touchpoint.CODE.conf")
 include classpath("touchpoint.PROD.conf")
 
+paper-round-api.url = "https://testapi.guardianhnd.co.uk/v1/guardian"
 get-address-io-api.url = "https://api.getAddress.io/v2/uk/"
 get-address-io-api.key = "hyj46rv0Uk2D1BtcW5M8jQ17434" //Test key, overridden in PROD
 AVCalculator {

--- a/support-config/src/main/scala/com/gu/support/config/PaperRoundConfig.scala
+++ b/support-config/src/main/scala/com/gu/support/config/PaperRoundConfig.scala
@@ -1,0 +1,13 @@
+package com.gu.support.config
+
+import com.typesafe.config.Config
+
+case class PaperRoundConfig(apiUrl: String, apiKey: String)
+
+object PaperRoundConfig {
+  def fromConfig(config: Config): PaperRoundConfig =
+    PaperRoundConfig(
+      config.getString("paper-round-api.url"),
+      config.getString("paper-round-api.key"),
+    )
+}

--- a/support-frontend/app/config/Configuration.scala
+++ b/support-frontend/app/config/Configuration.scala
@@ -20,6 +20,8 @@ class Configuration(config: TypesafeConfig) {
 
   lazy val getAddressIOConfig = GetAddressIOConfig.fromConfig(config)
 
+  lazy val paperRoundConfig = PaperRoundConfig.fromConfig(config)
+
   lazy val guardianDomain = GuardianDomain(config.getString("guardianDomain"))
 
   lazy val supportUrl = config.getString("support.url")

--- a/support-frontend/app/controllers/PaperRound.scala
+++ b/support-frontend/app/controllers/PaperRound.scala
@@ -1,0 +1,102 @@
+package controllers
+
+import actions.CustomActionBuilders
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
+import com.gu.rest.{CodeBody, WebServiceHelperError}
+import com.gu.support.paperround.PaperRoundService
+import com.gu.support.paperround.PaperRoundService.CoverageEndpoint
+import com.gu.support.paperround.PaperRoundService.CoverageEndpoint._
+import io.circe._
+import io.circe.generic.semiauto._
+import io.circe.syntax._
+import play.api.libs.circe.Circe
+import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class PaperRound(
+    components: ControllerComponents,
+    service: PaperRoundService,
+    actionRefiners: CustomActionBuilders,
+) extends AbstractController(components)
+    with Circe {
+  import actionRefiners._
+
+  def getAgents(postcode: String): Action[AnyContent] = NoCacheAction().async { implicit request =>
+    service.coverage(CoverageEndpoint.RequestBody(postcode = postcode)).map { result =>
+      result.data.status match {
+        case CO => Ok(toJson(Agents(result.data.agents.map(fromAgentsCoverage(_)))))
+        case NC => Ok(toJson(NotCovered))
+        case MP => NotFound(toJson(UnknownOrInvalidPostcode))
+        case IP => BadRequest(toJson(ProblemWithInput))
+        case IE =>
+          val errorMessage = s"${result.message}: ${result.data.message}"
+          SafeLogger.error(scrub"Got internal error from PaperRound: $errorMessage")
+          InternalServerError(toJson(PaperRoundError(errorMessage)))
+      }
+    } recover {
+      case PaperRoundService.Error(statusCode, message, errorCode) =>
+        val responseBody = s"$errorCode – Got $statusCode reponse with message $message"
+        SafeLogger.error(scrub"Error calling PaperRound, returning $responseBody")
+        InternalServerError(responseBody)
+      case error =>
+        SafeLogger.error(scrub"Failed to get agents from PaperRound due to: $error")
+        InternalServerError(s"Unknown error: $error")
+    }
+  }
+
+  def fromAgentsCoverage(ac: AgentsCoverage): Agent = {
+    Agent(
+      agentId = ac.agentId,
+      agentName = ac.agentName,
+      deliveryMethod = ac.deliveryMethod,
+      nbrDeliveryDays = ac.nbrDeliveryDays,
+      postcode = ac.postcode,
+      refGroupId = ac.refGroupId,
+      summary = ac.summary,
+    )
+  }
+
+  def toJson(x: GetAgentsResponse): Json = x.asJson
+}
+
+sealed trait GetAgentsResponse
+
+object GetAgentsResponse {
+  implicit val responseEncoder: Encoder[GetAgentsResponse] = new Encoder[GetAgentsResponse] {
+    final def apply(r: GetAgentsResponse): Json = r match {
+      case Agents(agents) => Json.obj("type" -> Json.fromString("Success"), "agents" -> agents.asJson)
+      case NotCovered => Json.obj("type" -> Json.fromString("NotCovered"))
+      case UnknownOrInvalidPostcode => Json.obj("type" -> Json.fromString("UnknownOrInvalidPostcode"))
+      case ProblemWithInput => Json.obj("type" -> Json.fromString("ProblemWithInput"))
+      case PaperRoundError(message) =>
+        Json.obj("type" -> Json.fromString("PaperRoundError"), "message" -> Json.fromString(message))
+    }
+  }
+}
+
+case class Agents(agents: List[Agent]) extends GetAgentsResponse
+case class Agent(
+    agentId: Integer,
+    agentName: String,
+    deliveryMethod: String,
+    nbrDeliveryDays: Integer,
+    postcode: String,
+    refGroupId: Integer,
+    summary: String,
+)
+
+object Agent {
+  implicit val encoder: Encoder[Agent] = deriveEncoder
+}
+
+/** There are no delivery agents for this postcode. */
+case object NotCovered extends GetAgentsResponse
+
+case object UnknownOrInvalidPostcode extends GetAgentsResponse
+
+case object ProblemWithInput extends GetAgentsResponse
+
+case class PaperRoundError(message: String) extends GetAgentsResponse

--- a/support-frontend/app/wiring/AppComponents.scala
+++ b/support-frontend/app/wiring/AppComponents.scala
@@ -72,6 +72,7 @@ trait AppComponents
     paperFormController,
     redemptionController,
     getAddressController,
+    paperRoundController,
     loginController,
     testUsersController,
     authCodeFlowController,

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -229,6 +229,12 @@ trait Controllers {
     actionRefiners,
   )
 
+  lazy val paperRoundController = new PaperRound(
+    controllerComponents,
+    paperRoundService,
+    actionRefiners,
+  )
+
   lazy val promotionsController = new Promotions(
     promotionServiceProvider,
     priceSummaryServiceProvider,

--- a/support-frontend/app/wiring/Services.scala
+++ b/support-frontend/app/wiring/Services.scala
@@ -8,6 +8,7 @@ import com.gu.aws.AwsS3Client
 import com.gu.identity.auth._
 import com.gu.okhttp.RequestRunners
 import com.gu.support.getaddressio.GetAddressIOService
+import com.gu.support.paperround.PaperRoundService
 import com.gu.support.promotions.PromotionServiceProvider
 import com.gu.zuora.ZuoraGiftLookupServiceProvider
 import play.api.BuiltInComponentsFromContext
@@ -75,6 +76,9 @@ trait Services {
 
   lazy val getAddressIOService: GetAddressIOService =
     new GetAddressIOService(appConfig.getAddressIOConfig, RequestRunners.futureRunner)
+
+  lazy val paperRoundService: PaperRoundService =
+    new PaperRoundService(appConfig.paperRoundConfig, RequestRunners.futureRunner)
 
   lazy val promotionServiceProvider = new PromotionServiceProvider(appConfig.promotionsConfigProvider)
 

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -129,6 +129,7 @@ GET  /subscribe/redeem/validate/:redemptionCode                    controllers.R
 GET  /r/:redemptionCode                                            controllers.RedemptionController.redirect(redemptionCode: String)
 
 GET /postcode-lookup/:postcode                                     controllers.GetAddress.findAddress(postcode: String)
+GET /delivery-agents/:postcode                                     controllers.PaperRound.getAgents(postcode: String)
 
 POST /subscribe/create                                             controllers.CreateSubscriptionController.create()
 

--- a/support-services/README.md
+++ b/support-services/README.md
@@ -4,16 +4,1353 @@
 
 Shared services used by support-workers and support-frontend
 
-Releasing to local repo
-==================
+## Releasing to local repo
 
 Run `sbt publishLocal`.
 
 
-Releasing to maven
-==================
+## Releasing to maven
 
 We use sbt to release to Maven. Please check notes here to ensure you are set up to release to Maven:
 https://docs.google.com/document/d/1rNXjoZDqZMsQblOVXPAIIOMWuwUKe3KzTCttuqS7AcY/edit?usp=sharing
 
 Then run `sbt release`.
+
+## PaperRound API
+
+This is a description of the PaperRound API made available to us for describing delivery agents. The API was described to us using [a Swagger page](https://testguardianapi.ppruk.net/swagger-ui/), and this document is an addition to that.
+
+A test version of the API is available at <https://testapi.guardianhnd.co.uk/v1/guardian>, and a prod version of the API will be available at <https://api.guardianhnd.co.uk/v1/guardian>.
+
+All endpoints require a POST request with content-type `x-www-form-urlencoded`, and a header `x-api-key` whose value is the API key we’ve been given. (The API key can be found [in the parameter store](https://eu-west-1.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-1&tab=Table#list_parameter_filters=Name:Contains:paper-round) if needed.)
+
+- swagger: https://testguardianapi.ppruk.net/swagger-ui/
+- url (test): https://testapi.guardianhnd.co.uk/v1/guardian
+- url (prod): https://api.guardianhnd.co.uk/v1/guardian
+- api key header: x-api-key
+- api key (in parameter store): https://eu-west-1.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-1&tab=Table#list_parameter_filters=Name:Contains:paper-round
+
+There are four endpoints in the API, which are described in more detail in the next sections:
+
+- /coverage
+- /agents
+- /chargebands
+- /../server_status
+
+### /coverage
+
+Given a postcode, the coverage endpoint returns whether that postcode is covered by any delivery agents, and gives the details of the agents if it is.
+
+There are two parameters for this endpoint: postcode and dayprojection. According to PaperRound we can ignore dayprojection, as it’s an extra that is not required for this project.
+
+The `data.status` field can return one of the following values, which defines the meaning of the response:
+
+- CO (postcode is covered; see agent list)
+- NC (postcode has no agent coverage)
+- MP (postcode is missing from the list of valid postcodes)
+- IP (problem with input)
+- IE (internal PaperRound system error)
+
+#### Covered
+
+If the status is `"CO"`, then the postcode is covered, and `data.agents` contains a list of agents for this postcode.
+
+For the test API, there are two postcodes that will return Covered:
+
+- DE10HN (returns a single agent)
+- DE10FD (returns multiple agents)
+
+Here is an example curl call and response:
+
+``` sh
+curl -i -H "x-api-key: $apiKey" -X POST https://testapi.guardianhnd.co.uk/v1/guardian/coverage --data-urlencode "postcode=DE1 0FD" --data-urlencode "dayprojection=10" -H "Accept: application/json" -H "Content-Type: application/x-www-form-urlencoded"
+```
+
+``` http
+HTTP/2 200 
+date: Wed, 19 Jul 2023 08:43:17 GMT
+content-type: application/json
+content-length: 722
+server: Apache
+x-frame-options: SAMEORIGIN
+cache-control: max-age=600
+expires: Wed, 19 Jul 2023 08:53:17 GMT
+vary: Accept-Encoding,User-Agent
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+
+{
+    "status_code": 200,
+    "data": {
+        "message": "",
+        "status": "CO",
+        "agents": [
+            {
+                "postcode": "DE10FD",
+                "deliverymethod": "Car",
+                "refgroupid": 46,
+                "nbrdeliverydays": 7,
+                "summary": "",
+                "agentid": 46,
+                "agentname": "Test Shop "
+            },
+            {
+                "postcode": "DE10FD",
+                "deliverymethod": "Car",
+                "refgroupid": 1099,
+                "nbrdeliverydays": 7,
+                "summary": "",
+                "agentid": 1816,
+                "agentname": "NewsTeam Group Ltd"
+            }
+        ]
+    },
+    "message": ""
+}
+```
+
+##### Type Description: GuardianAgentsCoverage
+
+Each entry in `data.agents` is a value of type `GuardianAgentsCoverage` (as called in the swagger). This section contains information on some of the fields of this type.
+
+###### postcode
+
+This seems to be the postcode used for the request. (Not, e.g., the postcode of the delivery agent.)
+
+###### deliverymethod
+
+This is a string describing the delivery method for the agent. I asked PaperRound if there’s a fixed set of values this could take (to see if we could use an enumeration to represent its values), but they said to treat it as just text for now.
+
+###### agentid and refgroupid
+
+I believe the `agentid` matches the `refid` field returned for this agent from the `/agents` endpoint.
+
+These two fields can be different when an agent is a group of shops or covers the whole country and is split into different areas. In these cases `refgroupid` is the id for the whole group, and `agentid` is the id for the specific instance.
+
+For example:
+
+> Spar Wheathamppstead would be 123 and the group would be 90
+> Spar Whitwell would be 234 and the group would be 90
+>
+> 90 is the Spar group
+
+###### nbrdeliverydays
+
+This is the number of days each week that the agent does deliveries: 7 means every day of the week, and 6 means Monday to Saturday. I believe we have agreed with PaperRound that only agents who deliver every day will be available, so this should always be 7.
+
+#### Not Covered
+
+If the status is `"NC"`, the postcode is not covered by any agents, and `data.agents` will be empty.
+
+Here is an example curl call and response:
+
+``` sh
+curl -i -H "x-api-key: $apiKey" -X POST https://testapi.guardianhnd.co.uk/v1/guardian/coverage --data-urlencode "postcode=B15 1HN" --data-urlencode "dayprojection=10" -H "Accept: application/json" -H "Content-Type: application/x-www-form-urlencoded"
+```
+
+``` http
+HTTP/2 200 
+date: Wed, 19 Jul 2023 08:42:56 GMT
+content-type: application/json
+content-length: 145
+server: Apache
+x-frame-options: SAMEORIGIN
+cache-control: max-age=600
+expires: Wed, 19 Jul 2023 08:52:56 GMT
+vary: Accept-Encoding,User-Agent
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+
+{
+    "status_code": 200,
+    "data": {
+        "message": "Not Covered",
+        "status": "NC",
+        "agents": []
+    },
+    "message": ""
+}
+```
+
+#### Missing Postcode
+
+If the status is `"MP"`, the postcode is missing from PaperRound’s list of valid postcodes. One postcode which produces this error is `BX5 5AT`, which is the VAT Central Unit of HM Revenue and Customs and is a non-geographic postcode (whatever that means). Note that the API may still return a 200 in this case.
+
+Here is an example curl call and response:
+
+``` sh
+curl -i -H "x-api-key: $apiKey" -X POST https://testapi.guardianhnd.co.uk/v1/guardian/coverage --data-urlencode "postcode=BX5 5AT" --data-urlencode "dayprojection=10" -H "Accept: application/json" -H "Content-Type: application/x-www-form-urlencoded"
+```
+
+``` http
+HTTP/2 200 
+date: Wed, 19 Jul 2023 08:43:40 GMT
+content-type: application/json
+content-length: 150
+server: Apache
+x-frame-options: SAMEORIGIN
+cache-control: max-age=600
+expires: Wed, 19 Jul 2023 08:53:40 GMT
+vary: Accept-Encoding,User-Agent
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+
+{
+    "status_code": 200,
+    "data": {
+        "message": "Missing Postcode",
+        "status": "MP",
+        "agents": []
+    },
+    "message": ""
+}
+```
+
+#### Input Problem
+
+If the status is `"IP"`, something is wrong with the input. Anything that doesn’t meet the right format for the postcode gives this error. Note that the API may still return a 200 in this case.
+
+``` sh
+curl -i -H "x-api-key: $apiKey" -X POST https://testapi.guardianhnd.co.uk/v1/guardian/coverage --data-urlencode "postcode=m" --data-urlencode "dayprojection=10" -H "Accept: application/json" -H "Content-Type: application/x-www-form-urlencoded"
+```
+
+``` http
+HTTP/2 200 
+date: Wed, 19 Jul 2023 08:43:58 GMT
+content-type: application/json
+content-length: 170
+server: Apache
+x-frame-options: SAMEORIGIN
+cache-control: max-age=600
+expires: Wed, 19 Jul 2023 08:53:58 GMT
+vary: Accept-Encoding,User-Agent
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+
+{
+    "status_code": 200,
+    "data": {
+        "message": "Problem with input",
+        "status": "IP",
+        "agents": []
+    },
+    "message": "Problem with input"
+}
+```
+
+#### Internal Error
+
+If the status is `"IE"`, PaperRound have had an internal error. I haven’t been able to reproduce this case, so I have no further information.
+
+### /agents
+
+The agents endpoint returns the full list of delivery agents available. There are no parameters for this endpoint.
+
+Here is an example curl call and response:
+
+``` sh
+curl -i -H "x-api-key: $apiKey" -X POST https://testapi.guardianhnd.co.uk/v1/guardian/agents -H "Accept: application/json" -H "Content-Type: application/json"
+```
+
+``` http
+HTTP/2 200 
+date: Wed, 19 Jul 2023 08:42:22 GMT
+content-type: application/json
+content-length: 1682
+server: Apache
+x-frame-options: SAMEORIGIN
+cache-control: max-age=600
+expires: Wed, 19 Jul 2023 08:52:22 GMT
+vary: Accept-Encoding,User-Agent
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+
+{
+    "status_code": 200,
+    "data": {
+        "agents": [
+            {
+                "refid": 46,
+                "postcode": "AL4 8HA",
+                "town": "Twn",
+                "startdate": "2022-05-10",
+                "address2": "Test",
+                "county": "Cnty",
+                "telephone": "01234 56789 / 0987 654321",
+                "enddate": "2100-01-00",
+                "refgroupid": 46,
+                "agentname": "Test Shop ",
+                "address1": "1",
+                "email": "test_email@test_email.co.uk"
+            },
+            {
+                "refid": 1533,
+                "postcode": "TN30 7LZ",
+                "town": "Smallhythe Road, Tenterden",
+                "startdate": "2023-07-10",
+                "address2": "",
+                "county": "Kent",
+                "telephone": "01580 763183",
+                "enddate": "2100-01-01",
+                "refgroupid": 1533,
+                "agentname": "Jackie's News Limited",
+                "address1": "Unit 6, Pickhill Business Centre",
+                "email": "mail@jackiesnews.co.uk"
+            },
+            {
+                "refid": 1816,
+                "postcode": "ST1 5LQ",
+                "town": "Hanley",
+                "startdate": "2022-05-10",
+                "address2": "43-45 Trinity Street",
+                "county": "",
+                "telephone": "01782 958565",
+                "enddate": "2100-01-00",
+                "refgroupid": 1099,
+                "agentname": "NewsTeam Group Ltd",
+                "address1": "Trinity House",
+                "email": "Reach@newsteamgroup.co.uk"
+            }
+        ]
+    },
+    "message": ""
+}
+```
+
+### /chargebands
+
+The chargebands endpoint takes no parameters.
+
+Here is an example curl call and response:
+
+``` sh
+curl -i -H "X-API-Key: $apiKey" -X POST https://testapi.guardianhnd.co.uk/v1/guardian/chargebands -H "Accept: application/json" -H "Content-Type: application/json"
+```
+
+<details>
+
+<summary>Response</summary>
+
+``` http
+HTTP/2 200 
+date: Wed, 19 Jul 2023 08:41:36 GMT
+content-type: application/json
+content-length: 28291
+server: Apache
+x-frame-options: SAMEORIGIN
+cache-control: max-age=600
+expires: Wed, 19 Jul 2023 08:51:36 GMT
+vary: Accept-Encoding,User-Agent
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+
+{
+    "status_code": 200,
+    "data": {
+        "bands": [
+            {
+                "Sun": 0.35,
+                "Fri": 0.35,
+                "Mon": 0.35,
+                "Thu": 0.35,
+                "description": "Standard 35p Mon-Sun RDH",
+                "Sat": 0.35,
+                "Tue": 0.35,
+                "deliverychargeid": 126,
+                "Wed": 0.35
+            },
+            {
+                "Sun": 0.4,
+                "Fri": 0.35,
+                "Mon": 0.35,
+                "Thu": 0.35,
+                "description": "35p Mon-Sat, 40p Sun",
+                "Sat": 0.35,
+                "Tue": 0.35,
+                "deliverychargeid": 127,
+                "Wed": 0.35
+            },
+            {
+                "Sun": 0.4,
+                "Fri": 0.4,
+                "Mon": 0.4,
+                "Thu": 0.4,
+                "description": "40p Mon-Sun",
+                "Sat": 0.4,
+                "Tue": 0.4,
+                "deliverychargeid": 128,
+                "Wed": 0.4
+            },
+            {
+                "Sun": 0.5,
+                "Fri": 0.4,
+                "Mon": 0.4,
+                "Thu": 0.4,
+                "description": "40p Mon-Fri 50p Sat-Sun",
+                "Sat": 0.5,
+                "Tue": 0.4,
+                "deliverychargeid": 129,
+                "Wed": 0.4
+            },
+            {
+                "Sun": 0.6,
+                "Fri": 0.4,
+                "Mon": 0.4,
+                "Thu": 0.4,
+                "description": "40p Mon-Fri 60p Sat-Sun",
+                "Sat": 0.6,
+                "Tue": 0.4,
+                "deliverychargeid": 130,
+                "Wed": 0.4
+            },
+            {
+                "Sun": 0.45,
+                "Fri": 0.45,
+                "Mon": 0.45,
+                "Thu": 0.45,
+                "description": "45p Mon-Sun",
+                "Sat": 0.45,
+                "Tue": 0.45,
+                "deliverychargeid": 131,
+                "Wed": 0.45
+            },
+            {
+                "Sun": 0.5,
+                "Fri": 0.45,
+                "Mon": 0.45,
+                "Thu": 0.45,
+                "description": "45p Mon-Sat 50p Sun",
+                "Sat": 0.45,
+                "Tue": 0.45,
+                "deliverychargeid": 132,
+                "Wed": 0.45
+            },
+            {
+                "Sun": 0.5,
+                "Fri": 0.45,
+                "Mon": 0.45,
+                "Thu": 0.45,
+                "description": "45p Mon-Fri 50p Sat-Sun",
+                "Sat": 0.5,
+                "Tue": 0.45,
+                "deliverychargeid": 133,
+                "Wed": 0.45
+            },
+            {
+                "Sun": 0.5,
+                "Fri": 0.5,
+                "Mon": 0.5,
+                "Thu": 0.5,
+                "description": "50p Mon-Sun",
+                "Sat": 0.5,
+                "Tue": 0.5,
+                "deliverychargeid": 134,
+                "Wed": 0.5
+            },
+            {
+                "Sun": 0.55,
+                "Fri": 0.55,
+                "Mon": 0.55,
+                "Thu": 0.55,
+                "description": "55p Mon-Sun",
+                "Sat": 0.55,
+                "Tue": 0.55,
+                "deliverychargeid": 135,
+                "Wed": 0.55
+            },
+            {
+                "Sun": 1.1,
+                "Fri": 0.55,
+                "Mon": 0.55,
+                "Thu": 0.55,
+                "description": "55p Mon-Fri 85p Sat, \u00a31.10 Sun",
+                "Sat": 0.85,
+                "Tue": 0.55,
+                "deliverychargeid": 136,
+                "Wed": 0.55
+            },
+            {
+                "Sun": 0.6,
+                "Fri": 0.6,
+                "Mon": 0.6,
+                "Thu": 0.6,
+                "description": "60p Mon-Sun",
+                "Sat": 0.6,
+                "Tue": 0.6,
+                "deliverychargeid": 137,
+                "Wed": 0.6
+            },
+            {
+                "Sun": 1.0,
+                "Fri": 0.6,
+                "Mon": 0.6,
+                "Thu": 0.6,
+                "description": "60p Mon-Fri, Sat-Sun \u00a31.00",
+                "Sat": 1.0,
+                "Tue": 0.6,
+                "deliverychargeid": 138,
+                "Wed": 0.6
+            },
+            {
+                "Sun": 0.65,
+                "Fri": 0.65,
+                "Mon": 0.65,
+                "Thu": 0.65,
+                "description": "65p Mon-Sun",
+                "Sat": 0.65,
+                "Tue": 0.65,
+                "deliverychargeid": 139,
+                "Wed": 0.65
+            },
+            {
+                "Sun": 0.7,
+                "Fri": 0.7,
+                "Mon": 0.7,
+                "Thu": 0.7,
+                "description": "70p Mon-Sun",
+                "Sat": 0.7,
+                "Tue": 0.7,
+                "deliverychargeid": 140,
+                "Wed": 0.7
+            },
+            {
+                "Sun": 0.75,
+                "Fri": 0.75,
+                "Mon": 0.75,
+                "Thu": 0.75,
+                "description": "75p Mon-Sun",
+                "Sat": 0.75,
+                "Tue": 0.75,
+                "deliverychargeid": 141,
+                "Wed": 0.75
+            },
+            {
+                "Sun": 0.8,
+                "Fri": 0.8,
+                "Mon": 0.8,
+                "Thu": 0.8,
+                "description": "80p Mon-Sun",
+                "Sat": 0.8,
+                "Tue": 0.8,
+                "deliverychargeid": 142,
+                "Wed": 0.8
+            },
+            {
+                "Sun": 0.85,
+                "Fri": 0.85,
+                "Mon": 0.85,
+                "Thu": 0.85,
+                "description": "85p Mon-Sun",
+                "Sat": 0.85,
+                "Tue": 0.85,
+                "deliverychargeid": 143,
+                "Wed": 0.85
+            },
+            {
+                "Sun": 0.9,
+                "Fri": 0.9,
+                "Mon": 0.9,
+                "Thu": 0.9,
+                "description": "90p Mon-Sun",
+                "Sat": 0.9,
+                "Tue": 0.9,
+                "deliverychargeid": 144,
+                "Wed": 0.9
+            },
+            {
+                "Sun": 0.95,
+                "Fri": 0.95,
+                "Mon": 0.95,
+                "Thu": 0.95,
+                "description": "95p Mon-Sun",
+                "Sat": 0.95,
+                "Tue": 0.95,
+                "deliverychargeid": 145,
+                "Wed": 0.95
+            },
+            {
+                "Sun": 1.0,
+                "Fri": 1.0,
+                "Mon": 1.0,
+                "Thu": 1.0,
+                "description": "\u00a31.00 Mon-Sun",
+                "Sat": 1.0,
+                "Tue": 1.0,
+                "deliverychargeid": 146,
+                "Wed": 1.0
+            },
+            {
+                "Sun": 0.5,
+                "Fri": 0.6,
+                "Mon": 0.6,
+                "Thu": 0.6,
+                "description": "60p Mon- Fri, 50p Sat-Sun",
+                "Sat": 0.6,
+                "Tue": 0.6,
+                "deliverychargeid": 147,
+                "Wed": 0.6
+            },
+            {
+                "Sun": 0.0,
+                "Fri": 0.5,
+                "Mon": 0.5,
+                "Thu": 0.5,
+                "description": "MONDAY to SATURDAY ONLY",
+                "Sat": 0.5,
+                "Tue": 0.5,
+                "deliverychargeid": 148,
+                "Wed": 0.5
+            },
+            {
+                "Sun": 0.5,
+                "Fri": 0.4,
+                "Mon": 0.4,
+                "Thu": 0.4,
+                "description": "40p Mon -Fri, 45p Sat, 50p Sun",
+                "Sat": 0.45,
+                "Tue": 0.4,
+                "deliverychargeid": 149,
+                "Wed": 0.4
+            },
+            {
+                "Sun": 0.75,
+                "Fri": 0.7,
+                "Mon": 0.7,
+                "Thu": 0.7,
+                "description": "70p Mon -Fri, 75p Sat & Sun",
+                "Sat": 0.75,
+                "Tue": 0.7,
+                "deliverychargeid": 150,
+                "Wed": 0.7
+            },
+            {
+                "Sun": 0.45,
+                "Fri": 0.35,
+                "Mon": 0.35,
+                "Thu": 0.35,
+                "description": "35p Mon- Fri, 40p Sat, 45p Sun",
+                "Sat": 0.4,
+                "Tue": 0.35,
+                "deliverychargeid": 151,
+                "Wed": 0.35
+            },
+            {
+                "Sun": 0.0,
+                "Fri": 0.0,
+                "Mon": 0.0,
+                "Thu": 0.0,
+                "description": "No delivery charge",
+                "Sat": 0.0,
+                "Tue": 0.0,
+                "deliverychargeid": 152,
+                "Wed": 0.0
+            },
+            {
+                "Sun": 0.8,
+                "Fri": 0.6,
+                "Mon": 0.6,
+                "Thu": 0.6,
+                "description": "60p Mon - Fri , 80p Sat & Sun",
+                "Sat": 0.8,
+                "Tue": 0.6,
+                "deliverychargeid": 153,
+                "Wed": 0.6
+            },
+            {
+                "Sun": 1.0,
+                "Fri": 0.5,
+                "Mon": 0.5,
+                "Thu": 0.5,
+                "description": "50p Mon-Fri; \u00a31 Sat & Sun",
+                "Sat": 1.0,
+                "Tue": 0.5,
+                "deliverychargeid": 154,
+                "Wed": 0.5
+            },
+            {
+                "Sun": 0.85,
+                "Fri": 0.75,
+                "Mon": 0.75,
+                "Thu": 0.75,
+                "description": "75p Mon_Fri; 85p Sat & Sun",
+                "Sat": 0.85,
+                "Tue": 0.75,
+                "deliverychargeid": 155,
+                "Wed": 0.75
+            },
+            {
+                "Sun": 0.4,
+                "Fri": 0.35,
+                "Mon": 0.35,
+                "Thu": 0.35,
+                "description": "35p Mon-Fri; 40p Sat & Sun",
+                "Sat": 0.4,
+                "Tue": 0.35,
+                "deliverychargeid": 156,
+                "Wed": 0.35
+            },
+            {
+                "Sun": 0.6,
+                "Fri": 0.5,
+                "Mon": 0.5,
+                "Thu": 0.5,
+                "description": "50p Mon-Fri; 60p Sat & Sun",
+                "Sat": 0.6,
+                "Tue": 0.5,
+                "deliverychargeid": 157,
+                "Wed": 0.5
+            },
+            {
+                "Sun": 0.45,
+                "Fri": 0.35,
+                "Mon": 0.35,
+                "Thu": 0.35,
+                "description": "35p Mon-Sat; 45p Sun",
+                "Sat": 0.45,
+                "Tue": 0.35,
+                "deliverychargeid": 158,
+                "Wed": 0.35
+            },
+            {
+                "Sun": 0.65,
+                "Fri": 0.55,
+                "Mon": 0.55,
+                "Thu": 0.55,
+                "description": "55p Mon-Fri; 65p Sat & Sun",
+                "Sat": 0.65,
+                "Tue": 0.55,
+                "deliverychargeid": 159,
+                "Wed": 0.55
+            },
+            {
+                "Sun": 1.0,
+                "Fri": 0.8,
+                "Mon": 0.8,
+                "Thu": 0.8,
+                "description": "80p Mon-Fri; \u00a31 Sat & Sun",
+                "Sat": 1.0,
+                "Tue": 0.8,
+                "deliverychargeid": 160,
+                "Wed": 0.8
+            },
+            {
+                "Sun": 0.55,
+                "Fri": 0.45,
+                "Mon": 0.45,
+                "Thu": 0.45,
+                "description": "45p Mon-Fri; 55p Sat & Sun",
+                "Sat": 0.55,
+                "Tue": 0.45,
+                "deliverychargeid": 161,
+                "Wed": 0.45
+            },
+            {
+                "Sun": 0.35,
+                "Fri": 0.45,
+                "Mon": 0.35,
+                "Thu": 0.35,
+                "description": "35p Mon-Fri; 45p Sat & Sun",
+                "Sat": 0.45,
+                "Tue": 0.35,
+                "deliverychargeid": 162,
+                "Wed": 0.35
+            },
+            {
+                "Sun": 0.8,
+                "Fri": 0.5,
+                "Mon": 0.5,
+                "Thu": 0.5,
+                "description": "50p Mon-Fri; 80p Sat & Sun",
+                "Sat": 0.8,
+                "Tue": 0.5,
+                "deliverychargeid": 163,
+                "Wed": 0.5
+            },
+            {
+                "Sun": 0.5,
+                "Fri": 0.35,
+                "Mon": 0.35,
+                "Thu": 0.35,
+                "description": "35p Mon-Sat; 50p Sun",
+                "Sat": 0.35,
+                "Tue": 0.35,
+                "deliverychargeid": 164,
+                "Wed": 0.35
+            },
+            {
+                "Sun": 0.65,
+                "Fri": 0.5,
+                "Mon": 0.5,
+                "Thu": 0.5,
+                "description": "50p Mon-Fri; 60p Sat; 65p Sun",
+                "Sat": 0.6,
+                "Tue": 0.5,
+                "deliverychargeid": 165,
+                "Wed": 0.5
+            },
+            {
+                "Sun": 0.75,
+                "Fri": 0.7,
+                "Mon": 0.7,
+                "Thu": 0.7,
+                "description": "65p Mon-Fri; 70p Sat; 75p Sun",
+                "Sat": 0.75,
+                "Tue": 0.7,
+                "deliverychargeid": 166,
+                "Wed": 0.7
+            },
+            {
+                "Sun": 1.05,
+                "Fri": 0.95,
+                "Mon": 0.95,
+                "Thu": 0.95,
+                "description": "95p Mon-Fri; \u00a31 Sat; \u00a31.05 Sun",
+                "Sat": 1.0,
+                "Tue": 0.95,
+                "deliverychargeid": 167,
+                "Wed": 0.95
+            },
+            {
+                "Sun": 0.75,
+                "Fri": 0.65,
+                "Mon": 0.65,
+                "Thu": 0.65,
+                "description": "65p Mon-Fri; 75p Sat & Sun",
+                "Sat": 0.75,
+                "Tue": 0.65,
+                "deliverychargeid": 168,
+                "Wed": 0.65
+            },
+            {
+                "Sun": 0.85,
+                "Fri": 0.55,
+                "Mon": 0.55,
+                "Thu": 0.55,
+                "description": "55p Mon-Fri; 85p Sat & Sun",
+                "Sat": 0.85,
+                "Tue": 0.55,
+                "deliverychargeid": 169,
+                "Wed": 0.55
+            },
+            {
+                "Sun": 0.5,
+                "Fri": 0.35,
+                "Mon": 0.35,
+                "Thu": 0.35,
+                "description": "35p Mon-Fri; 50p Sat & Sun",
+                "Sat": 0.5,
+                "Tue": 0.35,
+                "deliverychargeid": 170,
+                "Wed": 0.35
+            },
+            {
+                "Sun": 0.45,
+                "Fri": 0.4,
+                "Mon": 0.4,
+                "Thu": 0.4,
+                "description": "40p Mon-Fri; 45p Sat & Sun",
+                "Sat": 0.45,
+                "Tue": 0.4,
+                "deliverychargeid": 171,
+                "Wed": 0.4
+            },
+            {
+                "Sun": 2.1,
+                "Fri": 0.3,
+                "Mon": 0.3,
+                "Thu": 0.3,
+                "description": "30p Mon-Fri; \u00a32.10 Sat & Sun",
+                "Sat": 2.1,
+                "Tue": 0.3,
+                "deliverychargeid": 172,
+                "Wed": 0.3
+            },
+            {
+                "Sun": 2.1,
+                "Fri": 0.4,
+                "Mon": 0.4,
+                "Thu": 0.4,
+                "description": "40p Mon-Fri; \u00a32.10 Sat & Sun",
+                "Sat": 2.1,
+                "Tue": 0.4,
+                "deliverychargeid": 173,
+                "Wed": 0.4
+            },
+            {
+                "Sun": 2.1,
+                "Fri": 0.35,
+                "Mon": 0.35,
+                "Thu": 0.35,
+                "description": "35p Mon-Fri; \u00a32.10 Sat & Sun",
+                "Sat": 2.1,
+                "Tue": 0.35,
+                "deliverychargeid": 174,
+                "Wed": 0.35
+            },
+            {
+                "Sun": 2.1,
+                "Fri": 0.45,
+                "Mon": 0.45,
+                "Thu": 0.45,
+                "description": "45p Mon-Fri; \u00a32.10 Sat & Sun",
+                "Sat": 2.1,
+                "Tue": 0.45,
+                "deliverychargeid": 175,
+                "Wed": 0.45
+            },
+            {
+                "Sun": 2.1,
+                "Fri": 0.5,
+                "Mon": 0.5,
+                "Thu": 0.5,
+                "description": "50p Mon-Fri; \u00a32.10 Sat & Sun",
+                "Sat": 2.1,
+                "Tue": 0.5,
+                "deliverychargeid": 176,
+                "Wed": 0.5
+            },
+            {
+                "Sun": 0.55,
+                "Fri": 0.45,
+                "Mon": 0.45,
+                "Thu": 0.45,
+                "description": "45p Mon-Fri; 50p Sat; 55p Sun",
+                "Sat": 0.5,
+                "Tue": 0.45,
+                "deliverychargeid": 177,
+                "Wed": 0.45
+            },
+            {
+                "Sun": 0.7,
+                "Fri": 0.6,
+                "Mon": 0.6,
+                "Thu": 0.6,
+                "description": "60p Mon-Fri; 65p Sat; 70p Sun",
+                "Sat": 0.65,
+                "Tue": 0.6,
+                "deliverychargeid": 178,
+                "Wed": 0.6
+            },
+            {
+                "Sun": 0.75,
+                "Fri": 0.6,
+                "Mon": 0.6,
+                "Thu": 0.6,
+                "description": "60p Mon-Fri; 75p Sat & Sun",
+                "Sat": 0.75,
+                "Tue": 0.6,
+                "deliverychargeid": 179,
+                "Wed": 0.6
+            },
+            {
+                "Sun": 0.75,
+                "Fri": 0.5,
+                "Mon": 0.5,
+                "Thu": 0.5,
+                "description": "50p Mon-Fri; 75p Sat & Sun",
+                "Sat": 0.75,
+                "Tue": 0.5,
+                "deliverychargeid": 180,
+                "Wed": 0.5
+            },
+            {
+                "Sun": 0.6,
+                "Fri": 0.5,
+                "Mon": 0.5,
+                "Thu": 0.5,
+                "description": "50p Mon-Fri; 55p Sat; 60p Sun",
+                "Sat": 0.55,
+                "Tue": 0.5,
+                "deliverychargeid": 181,
+                "Wed": 0.5
+            },
+            {
+                "Sun": 0.7,
+                "Fri": 0.45,
+                "Mon": 0.45,
+                "Thu": 0.45,
+                "description": "45p Mon-Fri; 70p Sat & Sun",
+                "Sat": 0.7,
+                "Tue": 0.45,
+                "deliverychargeid": 182,
+                "Wed": 0.45
+            },
+            {
+                "Sun": 0.7,
+                "Fri": 0.55,
+                "Mon": 0.55,
+                "Thu": 0.55,
+                "description": "55p Mon-Fri; 70p Sat & Sun",
+                "Sat": 0.7,
+                "Tue": 0.55,
+                "deliverychargeid": 183,
+                "Wed": 0.55
+            },
+            {
+                "Sun": 0.55,
+                "Fri": 0.5,
+                "Mon": 0.5,
+                "Thu": 0.5,
+                "description": "50p Mon-Fri; 55p Sat & Sun",
+                "Sat": 0.55,
+                "Tue": 0.5,
+                "deliverychargeid": 184,
+                "Wed": 0.5
+            },
+            {
+                "Sun": 0.7,
+                "Fri": 0.5,
+                "Mon": 0.5,
+                "Thu": 0.5,
+                "description": "50p Mon-Fri; 70p Sat & Sun",
+                "Sat": 0.7,
+                "Tue": 0.5,
+                "deliverychargeid": 185,
+                "Wed": 0.5
+            },
+            {
+                "Sun": 0.75,
+                "Fri": 0.55,
+                "Mon": 0.55,
+                "Thu": 0.55,
+                "description": "55p Mon-Fri; 75p Sat & Sun",
+                "Sat": 0.75,
+                "Tue": 0.55,
+                "deliverychargeid": 186,
+                "Wed": 0.55
+            },
+            {
+                "Sun": 0.65,
+                "Fri": 0.55,
+                "Mon": 0.55,
+                "Thu": 0.55,
+                "description": "55p Mon-Fri; 60p Sat; 65p Sun",
+                "Sat": 0.6,
+                "Tue": 0.55,
+                "deliverychargeid": 187,
+                "Wed": 0.55
+            },
+            {
+                "Sun": 1.0,
+                "Fri": 0.75,
+                "Mon": 0.75,
+                "Thu": 0.75,
+                "description": "75p Mon-Fri; \u00a31 Sat & Sun",
+                "Sat": 1.0,
+                "Tue": 0.75,
+                "deliverychargeid": 188,
+                "Wed": 0.75
+            },
+            {
+                "Sun": 0.5,
+                "Fri": 0.35,
+                "Mon": 0.35,
+                "Thu": 0.35,
+                "description": "35p Mon-Fri; 40p Sat; 50p Sun",
+                "Sat": 0.4,
+                "Tue": 0.35,
+                "deliverychargeid": 189,
+                "Wed": 0.35
+            },
+            {
+                "Sun": 0.6,
+                "Fri": 0.55,
+                "Mon": 0.55,
+                "Thu": 0.55,
+                "description": "55p Mon-Fri; 60p Sat & Sun",
+                "Sat": 0.6,
+                "Tue": 0.55,
+                "deliverychargeid": 190,
+                "Wed": 0.55
+            },
+            {
+                "Sun": 0.85,
+                "Fri": 0.75,
+                "Mon": 0.75,
+                "Thu": 0.75,
+                "description": "75p Mon-Fri; 90p Sat; 85p Sun",
+                "Sat": 0.9,
+                "Tue": 0.75,
+                "deliverychargeid": 191,
+                "Wed": 0.75
+            },
+            {
+                "Sun": 0.7,
+                "Fri": 0.6,
+                "Mon": 0.6,
+                "Thu": 0.6,
+                "description": "60p Mon-Fri; 70p Sat & Sun",
+                "Sat": 0.7,
+                "Tue": 0.6,
+                "deliverychargeid": 192,
+                "Wed": 0.6
+            },
+            {
+                "Sun": 0.8,
+                "Fri": 0.75,
+                "Mon": 0.75,
+                "Thu": 0.75,
+                "description": "75p Mon-Sat; 80p Sun",
+                "Sat": 0.75,
+                "Tue": 0.75,
+                "deliverychargeid": 193,
+                "Wed": 0.75
+            },
+            {
+                "Sun": 1.0,
+                "Fri": 0.5,
+                "Mon": 0.5,
+                "Thu": 0.5,
+                "description": "50p Mon-Sat; \u00a31 Sun",
+                "Sat": 0.5,
+                "Tue": 0.5,
+                "deliverychargeid": 194,
+                "Wed": 0.5
+            },
+            {
+                "Sun": 1.5,
+                "Fri": 1.0,
+                "Mon": 1.0,
+                "Thu": 1.0,
+                "description": "\u00a31.00 Mon-Fri; \u00a31.50 Sat & Sun",
+                "Sat": 1.5,
+                "Tue": 1.0,
+                "deliverychargeid": 195,
+                "Wed": 1.0
+            },
+            {
+                "Sun": 0.7,
+                "Fri": 0.65,
+                "Mon": 0.65,
+                "Thu": 0.65,
+                "description": "65p Mon-Sat; 70p Sun",
+                "Sat": 0.65,
+                "Tue": 0.65,
+                "deliverychargeid": 196,
+                "Wed": 0.65
+            },
+            {
+                "Sun": 0.75,
+                "Fri": 0.45,
+                "Mon": 0.45,
+                "Thu": 0.45,
+                "description": "45p Mon-Fri; 65p Sat; 75p Sun",
+                "Sat": 0.65,
+                "Tue": 0.45,
+                "deliverychargeid": 197,
+                "Wed": 0.45
+            },
+            {
+                "Sun": 1.0,
+                "Fri": 0.5,
+                "Mon": 0.5,
+                "Thu": 0.5,
+                "description": "50p Mon-Fri; 75p Sat; \u00a31.00 Sun",
+                "Sat": 0.75,
+                "Tue": 0.5,
+                "deliverychargeid": 198,
+                "Wed": 0.5
+            },
+            {
+                "Sun": 0.65,
+                "Fri": 0.6,
+                "Mon": 0.6,
+                "Thu": 0.6,
+                "description": "60p Mon-Sat; 65p Sun",
+                "Sat": 0.6,
+                "Tue": 0.6,
+                "deliverychargeid": 199,
+                "Wed": 0.6
+            },
+            {
+                "Sun": 0.9,
+                "Fri": 0.85,
+                "Mon": 0.85,
+                "Thu": 0.85,
+                "description": "85p Mon-Sat; 90p Sun",
+                "Sat": 0.85,
+                "Tue": 0.85,
+                "deliverychargeid": 200,
+                "Wed": 0.85
+            },
+            {
+                "Sun": 0.75,
+                "Fri": 0.35,
+                "Mon": 0.35,
+                "Thu": 0.35,
+                "description": "35p Mon-Fri; 75p Sat & Sun",
+                "Sat": 0.75,
+                "Tue": 0.35,
+                "deliverychargeid": 201,
+                "Wed": 0.35
+            },
+            {
+                "Sun": 0.55,
+                "Fri": 0.4,
+                "Mon": 0.4,
+                "Thu": 0.4,
+                "description": "40p Mon-Fri; 55p Sat & Sun",
+                "Sat": 0.55,
+                "Tue": 0.4,
+                "deliverychargeid": 202,
+                "Wed": 0.4
+            },
+            {
+                "Sun": 1.6,
+                "Fri": 1.6,
+                "Mon": 1.6,
+                "Thu": 1.6,
+                "description": "\u00a31.60 Mon-Sun",
+                "Sat": 1.6,
+                "Tue": 1.6,
+                "deliverychargeid": 203,
+                "Wed": 1.6
+            },
+            {
+                "Sun": 0.55,
+                "Fri": 0.35,
+                "Mon": 0.35,
+                "Thu": 0.35,
+                "description": "35p Mon-Fri; 55p Sat & Sun",
+                "Sat": 0.55,
+                "Tue": 0.35,
+                "deliverychargeid": 204,
+                "Wed": 0.35
+            },
+            {
+                "Sun": 1.2,
+                "Fri": 1.2,
+                "Mon": 1.2,
+                "Thu": 1.2,
+                "description": "\u00a31.20 Mon-Sun",
+                "Sat": 1.2,
+                "Tue": 1.2,
+                "deliverychargeid": 205,
+                "Wed": 1.2
+            },
+            {
+                "Sun": 0.8,
+                "Fri": 0.75,
+                "Mon": 0.75,
+                "Thu": 0.75,
+                "description": "75p Mon-Fri; 80p Sat & Sun",
+                "Sat": 0.8,
+                "Tue": 0.75,
+                "deliverychargeid": 206,
+                "Wed": 0.75
+            },
+            {
+                "Sun": 0.65,
+                "Fri": 0.5,
+                "Mon": 0.5,
+                "Thu": 0.5,
+                "description": "50p Mon-Fri; 65p Sat & Sun",
+                "Sat": 0.65,
+                "Tue": 0.5,
+                "deliverychargeid": 207,
+                "Wed": 0.5
+            },
+            {
+                "Sun": 0.75,
+                "Fri": 0.4,
+                "Mon": 0.4,
+                "Thu": 0.4,
+                "description": "40p Mon-Sat; 75p Sun",
+                "Sat": 0.4,
+                "Tue": 0.4,
+                "deliverychargeid": 208,
+                "Wed": 0.4
+            },
+            {
+                "Sun": 0.3,
+                "Fri": 0.28,
+                "Mon": 0.28,
+                "Thu": 0.28,
+                "description": "28p Mon-Fri; 30p Sat & Sun",
+                "Sat": 0.3,
+                "Tue": 0.28,
+                "deliverychargeid": 209,
+                "Wed": 0.28
+            },
+            {
+                "Sun": 2.1,
+                "Fri": 0.5,
+                "Mon": 0.5,
+                "Thu": 0.5,
+                "description": "50p Mon-Fri; 60p Sat; \u00a32.10 Sun",
+                "Sat": 0.6,
+                "Tue": 0.5,
+                "deliverychargeid": 210,
+                "Wed": 0.5
+            },
+            {
+                "Sun": 2.1,
+                "Fri": 0.85,
+                "Mon": 0.85,
+                "Thu": 0.85,
+                "description": "85p Mon-Fri; 95p Sat; \u00a32.10 Sun",
+                "Sat": 0.95,
+                "Tue": 0.85,
+                "deliverychargeid": 211,
+                "Wed": 0.85
+            }
+        ]
+    },
+    "message": ""
+}
+```
+
+</details>
+
+### /../server_status
+
+The server status endpoint returns a string describing the current status of the server.
+
+``` sh
+curl -i -H "x-api-key: $apiKey" -X GET https://testapi.guardianhnd.co.uk/v1/guardian/../server_status -H "Accept: application/json" -H "Content-Type: application/json"
+```
+
+``` http
+HTTP/2 200 
+date: Wed, 26 Jul 2023 09:46:56 GMT
+content-type: application/json
+content-length: 95
+server: Apache
+x-frame-options: SAMEORIGIN
+cache-control: max-age=600
+expires: Wed, 26 Jul 2023 09:56:56 GMT
+vary: Accept-Encoding,User-Agent
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+
+{
+    "status_code": 200,
+    "data": {
+        "status": "Server is running correctly"
+    }
+}
+```
+
+### Open Questions
+
+#### Why is the timestamp field called “error_code”?
+
+i.e. is the naming/typing correct?
+
+#### What’s the error behaviour?
+
+Do we only get the error type when the status is non-2xx? Can we always distinguish the error and success types?
+
+#### What’s the `summary` field on `GuardianAgentsCoverage`?
+
+So far it seems to always be empty: what does it mean?
+
+#### Is it right that the postcode returned for each agent in the /coverage list is the same?
+
+Or should it match the postcode returned from the /agents endpoint?
+
+#### How often does the list of agents change? Can an agent suddenly stop being valid?
+
+If we offer a choice of agent to a user based on the /coverage response, how soon might that agent be taken off the list? (Could it happen before they complete checkout?)
+
+Do we need to check the `enddate` for a selected agent at checkout, and make the user choose another one if it’s in the past?

--- a/support-services/src/main/scala/com/gu/support/paperround/PaperRoundService.scala
+++ b/support-services/src/main/scala/com/gu/support/paperround/PaperRoundService.scala
@@ -1,0 +1,193 @@
+package com.gu.support.paperround
+
+import com.gu.okhttp.RequestRunners.FutureHttpClient
+import com.gu.rest.WebServiceHelper
+import com.gu.support.config.PaperRoundConfig
+import java.time.ZonedDateTime
+import io.circe._
+import io.circe.generic.semiauto._
+import io.circe.generic.extras.semiauto._
+import io.circe.generic.extras.decoding.ConfiguredDecoder
+import io.circe.generic.extras.Configuration
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import PaperRoundService.{AgentsEndpoint, CoverageEndpoint, ChargeBandsEndpoint}
+
+class PaperRoundService(config: PaperRoundConfig, client: FutureHttpClient)(implicit
+    executionContext: ExecutionContext,
+) extends WebServiceHelper[PaperRoundService.Error] {
+  override val wsUrl: String = config.apiUrl
+  override val httpClient: FutureHttpClient = client
+
+  def coverage(body: CoverageEndpoint.RequestBody): Future[CoverageEndpoint.Response] = {
+    postForm[CoverageEndpoint.Response](
+      endpoint = "coverage",
+      data = Map("postcode" -> List(body.postcode)),
+      headers = Map("x-api-key" -> config.apiKey),
+    )
+  }
+
+  def agents(): Future[AgentsEndpoint.Response] = {
+    postForm[AgentsEndpoint.Response](
+      endpoint = "agents",
+      data = Map.empty,
+      headers = Map("x-api-key" -> config.apiKey),
+    )
+  }
+
+  def chargebands(): Future[ChargeBandsEndpoint.Response] = {
+    postForm[ChargeBandsEndpoint.Response](
+      endpoint = "chargebands",
+      data = Map.empty,
+      headers = Map("x-api-key" -> config.apiKey),
+    )
+  }
+}
+
+object PaperRoundService {
+  val snakeCase: Configuration = Configuration.default.withSnakeCaseMemberNames
+  val lowercase: Configuration = Configuration.default.copy(transformMemberNames = _.toLowerCase)
+  case class Error(statusCode: Integer, message: String, errorCode: ZonedDateTime)
+      extends Throwable(s"Error(statusCode = $statusCode, message = $message, errorCode = $errorCode)")
+  object Error {
+    implicit val config = snakeCase
+    implicit val errorDecoder: Decoder[Error] = deriveConfiguredDecoder
+  }
+
+  object AgentsEndpoint {
+    case class Response(statusCode: Integer, message: String, data: AgentsList)
+
+    case class AgentsList(agents: List[AgentDetails])
+    case class AgentDetails(
+        agentName: String,
+        refId: Integer,
+        refGroupId: Integer,
+        startDate: String,
+        endDate: String,
+        address1: String,
+        address2: String,
+        town: String,
+        county: String,
+        postcode: String,
+        telephone: String,
+        email: String,
+    )
+    object AgentDetails {
+      implicit val config = lowercase
+      implicit val agentDetailsDecoder: Decoder[AgentDetails] = deriveConfiguredDecoder
+    }
+
+    implicit val config = snakeCase
+    implicit val responseDecoder: Decoder[Response] = deriveConfiguredDecoder
+    implicit val agentsListDecoder: Decoder[AgentsList] = deriveConfiguredDecoder
+  }
+
+  object ChargeBandsEndpoint {
+    case class Response(statusCode: Integer, data: DeliveryChargeProfiles)
+
+    case class DeliveryChargeProfiles(bands: List[DeliveryChargeProfile])
+    case class DeliveryChargeProfile(
+        deliveryChargeId: Integer,
+        description: String,
+        monday: Double,
+        tuesday: Double,
+        wednesday: Double,
+        thursday: Double,
+        friday: Double,
+        saturday: Double,
+        sunday: Double,
+    )
+
+    implicit val config = snakeCase
+    implicit val responseDecoder: Decoder[Response] = deriveConfiguredDecoder
+    implicit val deliveryChargeProfilesDecoder: Decoder[DeliveryChargeProfiles] = deriveConfiguredDecoder
+    implicit val deliveryChargeProfileDecoder: Decoder[DeliveryChargeProfile] = Decoder.forProduct9(
+      "deliverychargeid",
+      "description",
+      "Mon",
+      "Tue",
+      "Wed",
+      "Thu",
+      "Fri",
+      "Sat",
+      "Sun",
+    )(
+      (
+          dci: Integer,
+          d: String,
+          mon: Double,
+          tue: Double,
+          wed: Double,
+          thu: Double,
+          fri: Double,
+          sat: Double,
+          sun: Double,
+      ) =>
+        DeliveryChargeProfile(
+          deliveryChargeId = dci,
+          description = d,
+          monday = mon,
+          tuesday = tue,
+          wednesday = wed,
+          thursday = thu,
+          friday = fri,
+          saturday = sat,
+          sunday = sun,
+        ),
+    )
+  }
+
+  object CoverageEndpoint {
+    case class RequestBody(postcode: String)
+
+    case class Response(statusCode: Integer, message: String, data: PostcodeCoverage)
+
+    case class PostcodeCoverage(agents: List[AgentsCoverage], message: String, status: CoverageStatus)
+    case class AgentsCoverage(
+        agentId: Integer,
+        agentName: String,
+        deliveryMethod: String,
+        nbrDeliveryDays: Integer,
+        postcode: String,
+        refGroupId: Integer,
+        summary: String,
+    )
+    object AgentsCoverage {
+      implicit val config = lowercase
+      implicit val decoder: Decoder[AgentsCoverage] = deriveConfiguredDecoder
+    }
+
+    sealed trait CoverageStatus
+
+    /** Postcode is covered, see agent list. */
+    case object CO extends CoverageStatus
+
+    /** Postcode has no agent coverage. */
+    case object NC extends CoverageStatus
+
+    /** Postcode is missing from the list of valid postcodes. */
+    case object MP extends CoverageStatus
+
+    /** Problem with input. */
+    case object IP extends CoverageStatus
+
+    /** Internal PaperRound system error. */
+    case object IE extends CoverageStatus
+
+    implicit val config = snakeCase
+    implicit val responseDecoder: Decoder[Response] = deriveConfiguredDecoder
+    implicit val postcodeCoverageDecoder: Decoder[PostcodeCoverage] = deriveConfiguredDecoder
+    implicit val coverageStatusDecoder: Decoder[CoverageStatus] = deriveEnumerationDecoder
+  }
+
+  object ServerStatusEndpoint {
+    case class Response(statusCode: Integer, data: Server)
+
+    case class Server(status: String)
+
+    implicit val config = snakeCase
+    implicit val responseDecoder: Decoder[Response] = deriveConfiguredDecoder
+    implicit val serverDecoder: Decoder[Server] = deriveConfiguredDecoder
+  }
+}

--- a/support-services/src/test/scala/com/gu/support/paperround/SerialisationSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/paperround/SerialisationSpec.scala
@@ -1,0 +1,1145 @@
+package com.gu.support.paperround
+
+import com.gu.support.paperround.PaperRoundService.{AgentsEndpoint, ChargeBandsEndpoint, CoverageEndpoint}
+import com.gu.support.paperround.PaperRoundService.CoverageEndpoint._
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.{Decoder, Error}
+import io.circe.parser.{decode}
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AsyncFlatSpec
+
+class SerialisationSpec extends AsyncFlatSpec with LazyLogging {
+  "AgentsEndpoint.Response" should "deserialise correctly" in {
+    testDecoding[AgentsEndpoint.Response](s"$agentsSuccessJson")
+  }
+
+  "ChargeBandsEndpoint.Response" should "deserialise correctly" in {
+    testDecoding[ChargeBandsEndpoint.Response](s"$chargeBandsSuccessJson")
+  }
+
+  "CoverageEndpoint.Response" should "deserialise a Not Covered response correctly" in {
+    testDecoding[CoverageEndpoint.Response](s"$coverageSuccessNotCoveredJson", r => assert(r.data.status == NC))
+  }
+
+  it should "deserialise an Input Problem response correctly" in {
+    testDecoding[CoverageEndpoint.Response](s"$coverageSuccessInputProblemJson", r => assert(r.data.status == IP))
+  }
+
+  it should "deserialise a Missing Postcode response correctly" in {
+    testDecoding[CoverageEndpoint.Response](s"$coverageSuccessMissingPostcodeJson", r => assert(r.data.status == MP))
+  }
+
+  it should "deserialise a Covered response correctly" in {
+    testDecoding[CoverageEndpoint.Response](s"$coverageSuccessCoveredJson", r => assert(r.data.status == CO))
+  }
+
+  "PaperRoundService.Error" should "deserialise example value correctly" in {
+    testDecoding[PaperRoundService.Error](s"$errorJson")
+  }
+
+  def testDecoding[T: Decoder](fixture: String, objectChecks: T => Assertion = (_: T) => succeed): Assertion = {
+    val decodeResult = decode[T](fixture)
+    assertDecodingSucceeded(decodeResult, objectChecks)
+  }
+
+  def assertDecodingSucceeded[T](
+      decodeResult: Either[Error, T],
+      objectChecks: T => Assertion = (_: T) => succeed,
+  ): Assertion =
+    decodeResult.fold(
+      e => fail(e.getMessage),
+      result => objectChecks(result),
+    )
+
+  val agentsSuccessJson =
+    """
+      {
+          "status_code": 200,
+          "data": {
+              "agents": [
+                  {
+                      "refid": 46,
+                      "postcode": "AL4 8HA",
+                      "town": "Twn",
+                      "startdate": "2022-05-10",
+                      "address2": "Test",
+                      "county": "Cnty",
+                      "telephone": "01234 56789 / 0987 654321",
+                      "enddate": "2100-01-00",
+                      "refgroupid": 46,
+                      "agentname": "Test Shop ",
+                      "address1": "1",
+                      "email": "test_email@test_email.co.uk"
+                  },
+                  {
+                      "refid": 1533,
+                      "postcode": "TN30 7LZ",
+                      "town": "Smallhythe Road, Tenterden",
+                      "startdate": "2023-07-10",
+                      "address2": "",
+                      "county": "Kent",
+                      "telephone": "01580 763183",
+                      "enddate": "2100-01-01",
+                      "refgroupid": 1533,
+                      "agentname": "Jackie's News Limited",
+                      "address1": "Unit 6, Pickhill Business Centre",
+                      "email": "mail@jackiesnews.co.uk"
+                  },
+                  {
+                      "refid": 1816,
+                      "postcode": "ST1 5LQ",
+                      "town": "Hanley",
+                      "startdate": "2022-05-10",
+                      "address2": "43-45 Trinity Street",
+                      "county": "",
+                      "telephone": "01782 958565",
+                      "enddate": "2100-01-00",
+                      "refgroupid": 1099,
+                      "agentname": "NewsTeam Group Ltd",
+                      "address1": "Trinity House",
+                      "email": "Reach@newsteamgroup.co.uk"
+                  }
+              ]
+          },
+          "message": ""
+      }
+    """
+
+  val chargeBandsSuccessJson =
+    """
+      {
+          "status_code": 200,
+          "data": {
+              "bands": [
+                  {
+                      "Sun": 0.35,
+                      "Fri": 0.35,
+                      "Mon": 0.35,
+                      "Thu": 0.35,
+                      "description": "Standard 35p Mon-Sun RDH",
+                      "Sat": 0.35,
+                      "Tue": 0.35,
+                      "deliverychargeid": 126,
+                      "Wed": 0.35
+                  },
+                  {
+                      "Sun": 0.4,
+                      "Fri": 0.35,
+                      "Mon": 0.35,
+                      "Thu": 0.35,
+                      "description": "35p Mon-Sat, 40p Sun",
+                      "Sat": 0.35,
+                      "Tue": 0.35,
+                      "deliverychargeid": 127,
+                      "Wed": 0.35
+                  },
+                  {
+                      "Sun": 0.4,
+                      "Fri": 0.4,
+                      "Mon": 0.4,
+                      "Thu": 0.4,
+                      "description": "40p Mon-Sun",
+                      "Sat": 0.4,
+                      "Tue": 0.4,
+                      "deliverychargeid": 128,
+                      "Wed": 0.4
+                  },
+                  {
+                      "Sun": 0.5,
+                      "Fri": 0.4,
+                      "Mon": 0.4,
+                      "Thu": 0.4,
+                      "description": "40p Mon-Fri 50p Sat-Sun",
+                      "Sat": 0.5,
+                      "Tue": 0.4,
+                      "deliverychargeid": 129,
+                      "Wed": 0.4
+                  },
+                  {
+                      "Sun": 0.6,
+                      "Fri": 0.4,
+                      "Mon": 0.4,
+                      "Thu": 0.4,
+                      "description": "40p Mon-Fri 60p Sat-Sun",
+                      "Sat": 0.6,
+                      "Tue": 0.4,
+                      "deliverychargeid": 130,
+                      "Wed": 0.4
+                  },
+                  {
+                      "Sun": 0.45,
+                      "Fri": 0.45,
+                      "Mon": 0.45,
+                      "Thu": 0.45,
+                      "description": "45p Mon-Sun",
+                      "Sat": 0.45,
+                      "Tue": 0.45,
+                      "deliverychargeid": 131,
+                      "Wed": 0.45
+                  },
+                  {
+                      "Sun": 0.5,
+                      "Fri": 0.45,
+                      "Mon": 0.45,
+                      "Thu": 0.45,
+                      "description": "45p Mon-Sat 50p Sun",
+                      "Sat": 0.45,
+                      "Tue": 0.45,
+                      "deliverychargeid": 132,
+                      "Wed": 0.45
+                  },
+                  {
+                      "Sun": 0.5,
+                      "Fri": 0.45,
+                      "Mon": 0.45,
+                      "Thu": 0.45,
+                      "description": "45p Mon-Fri 50p Sat-Sun",
+                      "Sat": 0.5,
+                      "Tue": 0.45,
+                      "deliverychargeid": 133,
+                      "Wed": 0.45
+                  },
+                  {
+                      "Sun": 0.5,
+                      "Fri": 0.5,
+                      "Mon": 0.5,
+                      "Thu": 0.5,
+                      "description": "50p Mon-Sun",
+                      "Sat": 0.5,
+                      "Tue": 0.5,
+                      "deliverychargeid": 134,
+                      "Wed": 0.5
+                  },
+                  {
+                      "Sun": 0.55,
+                      "Fri": 0.55,
+                      "Mon": 0.55,
+                      "Thu": 0.55,
+                      "description": "55p Mon-Sun",
+                      "Sat": 0.55,
+                      "Tue": 0.55,
+                      "deliverychargeid": 135,
+                      "Wed": 0.55
+                  },
+                  {
+                      "Sun": 1.1,
+                      "Fri": 0.55,
+                      "Mon": 0.55,
+                      "Thu": 0.55,
+                      "description": "55p Mon-Fri 85p Sat, \u00a31.10 Sun",
+                      "Sat": 0.85,
+                      "Tue": 0.55,
+                      "deliverychargeid": 136,
+                      "Wed": 0.55
+                  },
+                  {
+                      "Sun": 0.6,
+                      "Fri": 0.6,
+                      "Mon": 0.6,
+                      "Thu": 0.6,
+                      "description": "60p Mon-Sun",
+                      "Sat": 0.6,
+                      "Tue": 0.6,
+                      "deliverychargeid": 137,
+                      "Wed": 0.6
+                  },
+                  {
+                      "Sun": 1.0,
+                      "Fri": 0.6,
+                      "Mon": 0.6,
+                      "Thu": 0.6,
+                      "description": "60p Mon-Fri, Sat-Sun \u00a31.00",
+                      "Sat": 1.0,
+                      "Tue": 0.6,
+                      "deliverychargeid": 138,
+                      "Wed": 0.6
+                  },
+                  {
+                      "Sun": 0.65,
+                      "Fri": 0.65,
+                      "Mon": 0.65,
+                      "Thu": 0.65,
+                      "description": "65p Mon-Sun",
+                      "Sat": 0.65,
+                      "Tue": 0.65,
+                      "deliverychargeid": 139,
+                      "Wed": 0.65
+                  },
+                  {
+                      "Sun": 0.7,
+                      "Fri": 0.7,
+                      "Mon": 0.7,
+                      "Thu": 0.7,
+                      "description": "70p Mon-Sun",
+                      "Sat": 0.7,
+                      "Tue": 0.7,
+                      "deliverychargeid": 140,
+                      "Wed": 0.7
+                  },
+                  {
+                      "Sun": 0.75,
+                      "Fri": 0.75,
+                      "Mon": 0.75,
+                      "Thu": 0.75,
+                      "description": "75p Mon-Sun",
+                      "Sat": 0.75,
+                      "Tue": 0.75,
+                      "deliverychargeid": 141,
+                      "Wed": 0.75
+                  },
+                  {
+                      "Sun": 0.8,
+                      "Fri": 0.8,
+                      "Mon": 0.8,
+                      "Thu": 0.8,
+                      "description": "80p Mon-Sun",
+                      "Sat": 0.8,
+                      "Tue": 0.8,
+                      "deliverychargeid": 142,
+                      "Wed": 0.8
+                  },
+                  {
+                      "Sun": 0.85,
+                      "Fri": 0.85,
+                      "Mon": 0.85,
+                      "Thu": 0.85,
+                      "description": "85p Mon-Sun",
+                      "Sat": 0.85,
+                      "Tue": 0.85,
+                      "deliverychargeid": 143,
+                      "Wed": 0.85
+                  },
+                  {
+                      "Sun": 0.9,
+                      "Fri": 0.9,
+                      "Mon": 0.9,
+                      "Thu": 0.9,
+                      "description": "90p Mon-Sun",
+                      "Sat": 0.9,
+                      "Tue": 0.9,
+                      "deliverychargeid": 144,
+                      "Wed": 0.9
+                  },
+                  {
+                      "Sun": 0.95,
+                      "Fri": 0.95,
+                      "Mon": 0.95,
+                      "Thu": 0.95,
+                      "description": "95p Mon-Sun",
+                      "Sat": 0.95,
+                      "Tue": 0.95,
+                      "deliverychargeid": 145,
+                      "Wed": 0.95
+                  },
+                  {
+                      "Sun": 1.0,
+                      "Fri": 1.0,
+                      "Mon": 1.0,
+                      "Thu": 1.0,
+                      "description": "\u00a31.00 Mon-Sun",
+                      "Sat": 1.0,
+                      "Tue": 1.0,
+                      "deliverychargeid": 146,
+                      "Wed": 1.0
+                  },
+                  {
+                      "Sun": 0.5,
+                      "Fri": 0.6,
+                      "Mon": 0.6,
+                      "Thu": 0.6,
+                      "description": "60p Mon- Fri, 50p Sat-Sun",
+                      "Sat": 0.6,
+                      "Tue": 0.6,
+                      "deliverychargeid": 147,
+                      "Wed": 0.6
+                  },
+                  {
+                      "Sun": 0.0,
+                      "Fri": 0.5,
+                      "Mon": 0.5,
+                      "Thu": 0.5,
+                      "description": "MONDAY to SATURDAY ONLY",
+                      "Sat": 0.5,
+                      "Tue": 0.5,
+                      "deliverychargeid": 148,
+                      "Wed": 0.5
+                  },
+                  {
+                      "Sun": 0.5,
+                      "Fri": 0.4,
+                      "Mon": 0.4,
+                      "Thu": 0.4,
+                      "description": "40p Mon -Fri, 45p Sat, 50p Sun",
+                      "Sat": 0.45,
+                      "Tue": 0.4,
+                      "deliverychargeid": 149,
+                      "Wed": 0.4
+                  },
+                  {
+                      "Sun": 0.75,
+                      "Fri": 0.7,
+                      "Mon": 0.7,
+                      "Thu": 0.7,
+                      "description": "70p Mon -Fri, 75p Sat & Sun",
+                      "Sat": 0.75,
+                      "Tue": 0.7,
+                      "deliverychargeid": 150,
+                      "Wed": 0.7
+                  },
+                  {
+                      "Sun": 0.45,
+                      "Fri": 0.35,
+                      "Mon": 0.35,
+                      "Thu": 0.35,
+                      "description": "35p Mon- Fri, 40p Sat, 45p Sun",
+                      "Sat": 0.4,
+                      "Tue": 0.35,
+                      "deliverychargeid": 151,
+                      "Wed": 0.35
+                  },
+                  {
+                      "Sun": 0.0,
+                      "Fri": 0.0,
+                      "Mon": 0.0,
+                      "Thu": 0.0,
+                      "description": "No delivery charge",
+                      "Sat": 0.0,
+                      "Tue": 0.0,
+                      "deliverychargeid": 152,
+                      "Wed": 0.0
+                  },
+                  {
+                      "Sun": 0.8,
+                      "Fri": 0.6,
+                      "Mon": 0.6,
+                      "Thu": 0.6,
+                      "description": "60p Mon - Fri , 80p Sat & Sun",
+                      "Sat": 0.8,
+                      "Tue": 0.6,
+                      "deliverychargeid": 153,
+                      "Wed": 0.6
+                  },
+                  {
+                      "Sun": 1.0,
+                      "Fri": 0.5,
+                      "Mon": 0.5,
+                      "Thu": 0.5,
+                      "description": "50p Mon-Fri; \u00a31 Sat & Sun",
+                      "Sat": 1.0,
+                      "Tue": 0.5,
+                      "deliverychargeid": 154,
+                      "Wed": 0.5
+                  },
+                  {
+                      "Sun": 0.85,
+                      "Fri": 0.75,
+                      "Mon": 0.75,
+                      "Thu": 0.75,
+                      "description": "75p Mon_Fri; 85p Sat & Sun",
+                      "Sat": 0.85,
+                      "Tue": 0.75,
+                      "deliverychargeid": 155,
+                      "Wed": 0.75
+                  },
+                  {
+                      "Sun": 0.4,
+                      "Fri": 0.35,
+                      "Mon": 0.35,
+                      "Thu": 0.35,
+                      "description": "35p Mon-Fri; 40p Sat & Sun",
+                      "Sat": 0.4,
+                      "Tue": 0.35,
+                      "deliverychargeid": 156,
+                      "Wed": 0.35
+                  },
+                  {
+                      "Sun": 0.6,
+                      "Fri": 0.5,
+                      "Mon": 0.5,
+                      "Thu": 0.5,
+                      "description": "50p Mon-Fri; 60p Sat & Sun",
+                      "Sat": 0.6,
+                      "Tue": 0.5,
+                      "deliverychargeid": 157,
+                      "Wed": 0.5
+                  },
+                  {
+                      "Sun": 0.45,
+                      "Fri": 0.35,
+                      "Mon": 0.35,
+                      "Thu": 0.35,
+                      "description": "35p Mon-Sat; 45p Sun",
+                      "Sat": 0.45,
+                      "Tue": 0.35,
+                      "deliverychargeid": 158,
+                      "Wed": 0.35
+                  },
+                  {
+                      "Sun": 0.65,
+                      "Fri": 0.55,
+                      "Mon": 0.55,
+                      "Thu": 0.55,
+                      "description": "55p Mon-Fri; 65p Sat & Sun",
+                      "Sat": 0.65,
+                      "Tue": 0.55,
+                      "deliverychargeid": 159,
+                      "Wed": 0.55
+                  },
+                  {
+                      "Sun": 1.0,
+                      "Fri": 0.8,
+                      "Mon": 0.8,
+                      "Thu": 0.8,
+                      "description": "80p Mon-Fri; \u00a31 Sat & Sun",
+                      "Sat": 1.0,
+                      "Tue": 0.8,
+                      "deliverychargeid": 160,
+                      "Wed": 0.8
+                  },
+                  {
+                      "Sun": 0.55,
+                      "Fri": 0.45,
+                      "Mon": 0.45,
+                      "Thu": 0.45,
+                      "description": "45p Mon-Fri; 55p Sat & Sun",
+                      "Sat": 0.55,
+                      "Tue": 0.45,
+                      "deliverychargeid": 161,
+                      "Wed": 0.45
+                  },
+                  {
+                      "Sun": 0.35,
+                      "Fri": 0.45,
+                      "Mon": 0.35,
+                      "Thu": 0.35,
+                      "description": "35p Mon-Fri; 45p Sat & Sun",
+                      "Sat": 0.45,
+                      "Tue": 0.35,
+                      "deliverychargeid": 162,
+                      "Wed": 0.35
+                  },
+                  {
+                      "Sun": 0.8,
+                      "Fri": 0.5,
+                      "Mon": 0.5,
+                      "Thu": 0.5,
+                      "description": "50p Mon-Fri; 80p Sat & Sun",
+                      "Sat": 0.8,
+                      "Tue": 0.5,
+                      "deliverychargeid": 163,
+                      "Wed": 0.5
+                  },
+                  {
+                      "Sun": 0.5,
+                      "Fri": 0.35,
+                      "Mon": 0.35,
+                      "Thu": 0.35,
+                      "description": "35p Mon-Sat; 50p Sun",
+                      "Sat": 0.35,
+                      "Tue": 0.35,
+                      "deliverychargeid": 164,
+                      "Wed": 0.35
+                  },
+                  {
+                      "Sun": 0.65,
+                      "Fri": 0.5,
+                      "Mon": 0.5,
+                      "Thu": 0.5,
+                      "description": "50p Mon-Fri; 60p Sat; 65p Sun",
+                      "Sat": 0.6,
+                      "Tue": 0.5,
+                      "deliverychargeid": 165,
+                      "Wed": 0.5
+                  },
+                  {
+                      "Sun": 0.75,
+                      "Fri": 0.7,
+                      "Mon": 0.7,
+                      "Thu": 0.7,
+                      "description": "65p Mon-Fri; 70p Sat; 75p Sun",
+                      "Sat": 0.75,
+                      "Tue": 0.7,
+                      "deliverychargeid": 166,
+                      "Wed": 0.7
+                  },
+                  {
+                      "Sun": 1.05,
+                      "Fri": 0.95,
+                      "Mon": 0.95,
+                      "Thu": 0.95,
+                      "description": "95p Mon-Fri; \u00a31 Sat; \u00a31.05 Sun",
+                      "Sat": 1.0,
+                      "Tue": 0.95,
+                      "deliverychargeid": 167,
+                      "Wed": 0.95
+                  },
+                  {
+                      "Sun": 0.75,
+                      "Fri": 0.65,
+                      "Mon": 0.65,
+                      "Thu": 0.65,
+                      "description": "65p Mon-Fri; 75p Sat & Sun",
+                      "Sat": 0.75,
+                      "Tue": 0.65,
+                      "deliverychargeid": 168,
+                      "Wed": 0.65
+                  },
+                  {
+                      "Sun": 0.85,
+                      "Fri": 0.55,
+                      "Mon": 0.55,
+                      "Thu": 0.55,
+                      "description": "55p Mon-Fri; 85p Sat & Sun",
+                      "Sat": 0.85,
+                      "Tue": 0.55,
+                      "deliverychargeid": 169,
+                      "Wed": 0.55
+                  },
+                  {
+                      "Sun": 0.5,
+                      "Fri": 0.35,
+                      "Mon": 0.35,
+                      "Thu": 0.35,
+                      "description": "35p Mon-Fri; 50p Sat & Sun",
+                      "Sat": 0.5,
+                      "Tue": 0.35,
+                      "deliverychargeid": 170,
+                      "Wed": 0.35
+                  },
+                  {
+                      "Sun": 0.45,
+                      "Fri": 0.4,
+                      "Mon": 0.4,
+                      "Thu": 0.4,
+                      "description": "40p Mon-Fri; 45p Sat & Sun",
+                      "Sat": 0.45,
+                      "Tue": 0.4,
+                      "deliverychargeid": 171,
+                      "Wed": 0.4
+                  },
+                  {
+                      "Sun": 2.1,
+                      "Fri": 0.3,
+                      "Mon": 0.3,
+                      "Thu": 0.3,
+                      "description": "30p Mon-Fri; \u00a32.10 Sat & Sun",
+                      "Sat": 2.1,
+                      "Tue": 0.3,
+                      "deliverychargeid": 172,
+                      "Wed": 0.3
+                  },
+                  {
+                      "Sun": 2.1,
+                      "Fri": 0.4,
+                      "Mon": 0.4,
+                      "Thu": 0.4,
+                      "description": "40p Mon-Fri; \u00a32.10 Sat & Sun",
+                      "Sat": 2.1,
+                      "Tue": 0.4,
+                      "deliverychargeid": 173,
+                      "Wed": 0.4
+                  },
+                  {
+                      "Sun": 2.1,
+                      "Fri": 0.35,
+                      "Mon": 0.35,
+                      "Thu": 0.35,
+                      "description": "35p Mon-Fri; \u00a32.10 Sat & Sun",
+                      "Sat": 2.1,
+                      "Tue": 0.35,
+                      "deliverychargeid": 174,
+                      "Wed": 0.35
+                  },
+                  {
+                      "Sun": 2.1,
+                      "Fri": 0.45,
+                      "Mon": 0.45,
+                      "Thu": 0.45,
+                      "description": "45p Mon-Fri; \u00a32.10 Sat & Sun",
+                      "Sat": 2.1,
+                      "Tue": 0.45,
+                      "deliverychargeid": 175,
+                      "Wed": 0.45
+                  },
+                  {
+                      "Sun": 2.1,
+                      "Fri": 0.5,
+                      "Mon": 0.5,
+                      "Thu": 0.5,
+                      "description": "50p Mon-Fri; \u00a32.10 Sat & Sun",
+                      "Sat": 2.1,
+                      "Tue": 0.5,
+                      "deliverychargeid": 176,
+                      "Wed": 0.5
+                  },
+                  {
+                      "Sun": 0.55,
+                      "Fri": 0.45,
+                      "Mon": 0.45,
+                      "Thu": 0.45,
+                      "description": "45p Mon-Fri; 50p Sat; 55p Sun",
+                      "Sat": 0.5,
+                      "Tue": 0.45,
+                      "deliverychargeid": 177,
+                      "Wed": 0.45
+                  },
+                  {
+                      "Sun": 0.7,
+                      "Fri": 0.6,
+                      "Mon": 0.6,
+                      "Thu": 0.6,
+                      "description": "60p Mon-Fri; 65p Sat; 70p Sun",
+                      "Sat": 0.65,
+                      "Tue": 0.6,
+                      "deliverychargeid": 178,
+                      "Wed": 0.6
+                  },
+                  {
+                      "Sun": 0.75,
+                      "Fri": 0.6,
+                      "Mon": 0.6,
+                      "Thu": 0.6,
+                      "description": "60p Mon-Fri; 75p Sat & Sun",
+                      "Sat": 0.75,
+                      "Tue": 0.6,
+                      "deliverychargeid": 179,
+                      "Wed": 0.6
+                  },
+                  {
+                      "Sun": 0.75,
+                      "Fri": 0.5,
+                      "Mon": 0.5,
+                      "Thu": 0.5,
+                      "description": "50p Mon-Fri; 75p Sat & Sun",
+                      "Sat": 0.75,
+                      "Tue": 0.5,
+                      "deliverychargeid": 180,
+                      "Wed": 0.5
+                  },
+                  {
+                      "Sun": 0.6,
+                      "Fri": 0.5,
+                      "Mon": 0.5,
+                      "Thu": 0.5,
+                      "description": "50p Mon-Fri; 55p Sat; 60p Sun",
+                      "Sat": 0.55,
+                      "Tue": 0.5,
+                      "deliverychargeid": 181,
+                      "Wed": 0.5
+                  },
+                  {
+                      "Sun": 0.7,
+                      "Fri": 0.45,
+                      "Mon": 0.45,
+                      "Thu": 0.45,
+                      "description": "45p Mon-Fri; 70p Sat & Sun",
+                      "Sat": 0.7,
+                      "Tue": 0.45,
+                      "deliverychargeid": 182,
+                      "Wed": 0.45
+                  },
+                  {
+                      "Sun": 0.7,
+                      "Fri": 0.55,
+                      "Mon": 0.55,
+                      "Thu": 0.55,
+                      "description": "55p Mon-Fri; 70p Sat & Sun",
+                      "Sat": 0.7,
+                      "Tue": 0.55,
+                      "deliverychargeid": 183,
+                      "Wed": 0.55
+                  },
+                  {
+                      "Sun": 0.55,
+                      "Fri": 0.5,
+                      "Mon": 0.5,
+                      "Thu": 0.5,
+                      "description": "50p Mon-Fri; 55p Sat & Sun",
+                      "Sat": 0.55,
+                      "Tue": 0.5,
+                      "deliverychargeid": 184,
+                      "Wed": 0.5
+                  },
+                  {
+                      "Sun": 0.7,
+                      "Fri": 0.5,
+                      "Mon": 0.5,
+                      "Thu": 0.5,
+                      "description": "50p Mon-Fri; 70p Sat & Sun",
+                      "Sat": 0.7,
+                      "Tue": 0.5,
+                      "deliverychargeid": 185,
+                      "Wed": 0.5
+                  },
+                  {
+                      "Sun": 0.75,
+                      "Fri": 0.55,
+                      "Mon": 0.55,
+                      "Thu": 0.55,
+                      "description": "55p Mon-Fri; 75p Sat & Sun",
+                      "Sat": 0.75,
+                      "Tue": 0.55,
+                      "deliverychargeid": 186,
+                      "Wed": 0.55
+                  },
+                  {
+                      "Sun": 0.65,
+                      "Fri": 0.55,
+                      "Mon": 0.55,
+                      "Thu": 0.55,
+                      "description": "55p Mon-Fri; 60p Sat; 65p Sun",
+                      "Sat": 0.6,
+                      "Tue": 0.55,
+                      "deliverychargeid": 187,
+                      "Wed": 0.55
+                  },
+                  {
+                      "Sun": 1.0,
+                      "Fri": 0.75,
+                      "Mon": 0.75,
+                      "Thu": 0.75,
+                      "description": "75p Mon-Fri; \u00a31 Sat & Sun",
+                      "Sat": 1.0,
+                      "Tue": 0.75,
+                      "deliverychargeid": 188,
+                      "Wed": 0.75
+                  },
+                  {
+                      "Sun": 0.5,
+                      "Fri": 0.35,
+                      "Mon": 0.35,
+                      "Thu": 0.35,
+                      "description": "35p Mon-Fri; 40p Sat; 50p Sun",
+                      "Sat": 0.4,
+                      "Tue": 0.35,
+                      "deliverychargeid": 189,
+                      "Wed": 0.35
+                  },
+                  {
+                      "Sun": 0.6,
+                      "Fri": 0.55,
+                      "Mon": 0.55,
+                      "Thu": 0.55,
+                      "description": "55p Mon-Fri; 60p Sat & Sun",
+                      "Sat": 0.6,
+                      "Tue": 0.55,
+                      "deliverychargeid": 190,
+                      "Wed": 0.55
+                  },
+                  {
+                      "Sun": 0.85,
+                      "Fri": 0.75,
+                      "Mon": 0.75,
+                      "Thu": 0.75,
+                      "description": "75p Mon-Fri; 90p Sat; 85p Sun",
+                      "Sat": 0.9,
+                      "Tue": 0.75,
+                      "deliverychargeid": 191,
+                      "Wed": 0.75
+                  },
+                  {
+                      "Sun": 0.7,
+                      "Fri": 0.6,
+                      "Mon": 0.6,
+                      "Thu": 0.6,
+                      "description": "60p Mon-Fri; 70p Sat & Sun",
+                      "Sat": 0.7,
+                      "Tue": 0.6,
+                      "deliverychargeid": 192,
+                      "Wed": 0.6
+                  },
+                  {
+                      "Sun": 0.8,
+                      "Fri": 0.75,
+                      "Mon": 0.75,
+                      "Thu": 0.75,
+                      "description": "75p Mon-Sat; 80p Sun",
+                      "Sat": 0.75,
+                      "Tue": 0.75,
+                      "deliverychargeid": 193,
+                      "Wed": 0.75
+                  },
+                  {
+                      "Sun": 1.0,
+                      "Fri": 0.5,
+                      "Mon": 0.5,
+                      "Thu": 0.5,
+                      "description": "50p Mon-Sat; \u00a31 Sun",
+                      "Sat": 0.5,
+                      "Tue": 0.5,
+                      "deliverychargeid": 194,
+                      "Wed": 0.5
+                  },
+                  {
+                      "Sun": 1.5,
+                      "Fri": 1.0,
+                      "Mon": 1.0,
+                      "Thu": 1.0,
+                      "description": "\u00a31.00 Mon-Fri; \u00a31.50 Sat & Sun",
+                      "Sat": 1.5,
+                      "Tue": 1.0,
+                      "deliverychargeid": 195,
+                      "Wed": 1.0
+                  },
+                  {
+                      "Sun": 0.7,
+                      "Fri": 0.65,
+                      "Mon": 0.65,
+                      "Thu": 0.65,
+                      "description": "65p Mon-Sat; 70p Sun",
+                      "Sat": 0.65,
+                      "Tue": 0.65,
+                      "deliverychargeid": 196,
+                      "Wed": 0.65
+                  },
+                  {
+                      "Sun": 0.75,
+                      "Fri": 0.45,
+                      "Mon": 0.45,
+                      "Thu": 0.45,
+                      "description": "45p Mon-Fri; 65p Sat; 75p Sun",
+                      "Sat": 0.65,
+                      "Tue": 0.45,
+                      "deliverychargeid": 197,
+                      "Wed": 0.45
+                  },
+                  {
+                      "Sun": 1.0,
+                      "Fri": 0.5,
+                      "Mon": 0.5,
+                      "Thu": 0.5,
+                      "description": "50p Mon-Fri; 75p Sat; \u00a31.00 Sun",
+                      "Sat": 0.75,
+                      "Tue": 0.5,
+                      "deliverychargeid": 198,
+                      "Wed": 0.5
+                  },
+                  {
+                      "Sun": 0.65,
+                      "Fri": 0.6,
+                      "Mon": 0.6,
+                      "Thu": 0.6,
+                      "description": "60p Mon-Sat; 65p Sun",
+                      "Sat": 0.6,
+                      "Tue": 0.6,
+                      "deliverychargeid": 199,
+                      "Wed": 0.6
+                  },
+                  {
+                      "Sun": 0.9,
+                      "Fri": 0.85,
+                      "Mon": 0.85,
+                      "Thu": 0.85,
+                      "description": "85p Mon-Sat; 90p Sun",
+                      "Sat": 0.85,
+                      "Tue": 0.85,
+                      "deliverychargeid": 200,
+                      "Wed": 0.85
+                  },
+                  {
+                      "Sun": 0.75,
+                      "Fri": 0.35,
+                      "Mon": 0.35,
+                      "Thu": 0.35,
+                      "description": "35p Mon-Fri; 75p Sat & Sun",
+                      "Sat": 0.75,
+                      "Tue": 0.35,
+                      "deliverychargeid": 201,
+                      "Wed": 0.35
+                  },
+                  {
+                      "Sun": 0.55,
+                      "Fri": 0.4,
+                      "Mon": 0.4,
+                      "Thu": 0.4,
+                      "description": "40p Mon-Fri; 55p Sat & Sun",
+                      "Sat": 0.55,
+                      "Tue": 0.4,
+                      "deliverychargeid": 202,
+                      "Wed": 0.4
+                  },
+                  {
+                      "Sun": 1.6,
+                      "Fri": 1.6,
+                      "Mon": 1.6,
+                      "Thu": 1.6,
+                      "description": "\u00a31.60 Mon-Sun",
+                      "Sat": 1.6,
+                      "Tue": 1.6,
+                      "deliverychargeid": 203,
+                      "Wed": 1.6
+                  },
+                  {
+                      "Sun": 0.55,
+                      "Fri": 0.35,
+                      "Mon": 0.35,
+                      "Thu": 0.35,
+                      "description": "35p Mon-Fri; 55p Sat & Sun",
+                      "Sat": 0.55,
+                      "Tue": 0.35,
+                      "deliverychargeid": 204,
+                      "Wed": 0.35
+                  },
+                  {
+                      "Sun": 1.2,
+                      "Fri": 1.2,
+                      "Mon": 1.2,
+                      "Thu": 1.2,
+                      "description": "\u00a31.20 Mon-Sun",
+                      "Sat": 1.2,
+                      "Tue": 1.2,
+                      "deliverychargeid": 205,
+                      "Wed": 1.2
+                  },
+                  {
+                      "Sun": 0.8,
+                      "Fri": 0.75,
+                      "Mon": 0.75,
+                      "Thu": 0.75,
+                      "description": "75p Mon-Fri; 80p Sat & Sun",
+                      "Sat": 0.8,
+                      "Tue": 0.75,
+                      "deliverychargeid": 206,
+                      "Wed": 0.75
+                  },
+                  {
+                      "Sun": 0.65,
+                      "Fri": 0.5,
+                      "Mon": 0.5,
+                      "Thu": 0.5,
+                      "description": "50p Mon-Fri; 65p Sat & Sun",
+                      "Sat": 0.65,
+                      "Tue": 0.5,
+                      "deliverychargeid": 207,
+                      "Wed": 0.5
+                  },
+                  {
+                      "Sun": 0.75,
+                      "Fri": 0.4,
+                      "Mon": 0.4,
+                      "Thu": 0.4,
+                      "description": "40p Mon-Sat; 75p Sun",
+                      "Sat": 0.4,
+                      "Tue": 0.4,
+                      "deliverychargeid": 208,
+                      "Wed": 0.4
+                  },
+                  {
+                      "Sun": 0.3,
+                      "Fri": 0.28,
+                      "Mon": 0.28,
+                      "Thu": 0.28,
+                      "description": "28p Mon-Fri; 30p Sat & Sun",
+                      "Sat": 0.3,
+                      "Tue": 0.28,
+                      "deliverychargeid": 209,
+                      "Wed": 0.28
+                  },
+                  {
+                      "Sun": 2.1,
+                      "Fri": 0.5,
+                      "Mon": 0.5,
+                      "Thu": 0.5,
+                      "description": "50p Mon-Fri; 60p Sat; \u00a32.10 Sun",
+                      "Sat": 0.6,
+                      "Tue": 0.5,
+                      "deliverychargeid": 210,
+                      "Wed": 0.5
+                  },
+                  {
+                      "Sun": 2.1,
+                      "Fri": 0.85,
+                      "Mon": 0.85,
+                      "Thu": 0.85,
+                      "description": "85p Mon-Fri; 95p Sat; \u00a32.10 Sun",
+                      "Sat": 0.95,
+                      "Tue": 0.85,
+                      "deliverychargeid": 211,
+                      "Wed": 0.85
+                  }
+              ]
+          },
+          "message": ""
+      }
+    """
+
+  val coverageSuccessNotCoveredJson =
+    """
+      {
+          "status_code": 200,
+          "data": {
+              "message": "Not Covered",
+              "status": "NC",
+              "agents": []
+          },
+          "message": ""
+      }
+    """
+
+  val coverageSuccessInputProblemJson =
+    """
+      {
+          "status_code": 200,
+          "data": {
+              "message": "Problem with input",
+              "status": "IP",
+              "agents": []
+          },
+          "message": "Problem with input"
+      }
+    """
+
+  val coverageSuccessMissingPostcodeJson =
+    """
+      {
+          "status_code": 200,
+          "data": {
+              "message": "Missing Postcode",
+              "status": "MP",
+              "agents": []
+          },
+          "message": ""
+      }
+    """
+
+  val coverageSuccessCoveredJson =
+    """
+      {
+          "status_code": 200,
+          "data": {
+              "message": "",
+              "status": "CO",
+              "agents": [
+                  {
+                      "postcode": "DE10FD",
+                      "deliverymethod": "Car",
+                      "refgroupid": 46,
+                      "nbrdeliverydays": 7,
+                      "summary": "",
+                      "agentid": 46,
+                      "agentname": "Test Shop "
+                  },
+                  {
+                      "postcode": "DE10FD",
+                      "deliverymethod": "Car",
+                      "refgroupid": 1099,
+                      "nbrdeliverydays": 7,
+                      "summary": "",
+                      "agentid": 1816,
+                      "agentname": "NewsTeam Group Ltd"
+                  }
+              ]
+          },
+          "message": ""
+      }
+    """
+
+  val errorJson =
+    """
+      {
+        "error_code": "2023-07-25T10:21:41.754Z",
+        "message": "string",
+        "status_code": 0
+      }
+    """
+}


### PR DESCRIPTION
To expand paper delivery outside the M25 using PaperRound, we’ll need to offer users a choice of delivery agents for their postcode. This change makes a prototype API on the support-frontend backend which calls PaperRound’s test API to check the agents available for a certain postcode. (I’ve also added the other API endpoints to the service while here.)

## Changes

### Model PaperRound API and write JSON decoders

- Fixtures taken from responses from the test API

### Write separate types for support-frontend

I wanted to change the structure received by the frontend, so I’ve used separate types for the API called by the frontend. I didn’t want to have decoders and encoders for the PaperRound types that don’t round-trip. It also seems a good idea to isolate the dependency on PaperRound’s types from the frontend, but I’m less confident about that one.

### Write custom json encoding for frontend

The derived encoding of the `GetAgentsResponse` ADT doesn’t seem very nice to handle from TypeScript, so I’ve written a custom one that I think will be nicer to consume from TypeScript.

### Add extra test step to CI workflow

We weren’t running all our tests in CI, which I noticed when I added the deserialisation tests. I think we should be running them all, so I’ve added the `test` task.

## Questions for Reviewers

- Is this the right place to put all this stuff? Should the API definitions be somewhere more reusable?
- Is using a new controller the right way to go? It seems like a lot of boilerplate.
- Should there be more logging?
- Is it clear what the new types mean?