### PR TITLE
Add new action that tries to authenticate using cookies only

### DIFF
--- a/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala
+++ b/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala
@@ -2,7 +2,7 @@ package actions
 
 import actions.AsyncAuthenticatedBuilder.OptionalAuthRequest
 import actions.UserFromAuthCookiesActionBuilder.UserClaims.toUser
-import actions.UserFromAuthCookiesActionBuilder.{ClientAccessScope, UserClaims}
+import actions.UserFromAuthCookiesActionBuilder.{UserClaims, processRequestWithoutUser, tryToProcessRequest}
 import com.gu.identity.auth._
 import com.gu.identity.model.{PrivateFields, User}
 import config.Identity
@@ -16,17 +16,8 @@ import play.api.mvc._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-/** Tries to authenticate the user from ID and access token cookies. Provides a [[User]] to the request if
-  * authentication is possible.
-  *
-  * @param parser
-  *   To parse the request body, if any
-  * @param oktaAuthService
-  *   To validate ID and access token cookies
-  * @param config
-  *   Auth config
-  * @param executionContext
-  *   Execution context to run the action in
+/** Tries to authenticate the user from ID and access token cookies. Provides a [[User]] to the request if cookies are
+  * present and authentication is possible.
   */
 class UserFromAuthCookiesActionBuilder(
     override val parser: BodyParser[AnyContent],
@@ -36,55 +27,84 @@ class UserFromAuthCookiesActionBuilder(
     extends ActionBuilder[OptionalAuthRequest, AnyContent]
     with Logging {
 
-  override def invokeBlock[A](request: Request[A], block: OptionalAuthRequest[A] => Future[Result]): Future[Result] = {
-
-    def processRequestWithoutUser() = {
-      def toDiscardingCookie(cookieName: String) = DiscardingCookie(name = cookieName, secure = true)
-      block(new AuthenticatedRequest(None, request)).map(result =>
-        // Discard token cookies as we know they're invalid
-        result.discardingCookies(
-          toDiscardingCookie(config.idTokenCookieName),
-          toDiscardingCookie(config.accessTokenCookieName),
-        ),
-      )
-    }
-
+  override def invokeBlock[A](request: Request[A], block: OptionalAuthRequest[A] => Future[Result]): Future[Result] =
     if (request.cookies.get(config.signedOutCookieName).isDefined) {
-      processRequestWithoutUser()
+      processRequestWithoutUser(config)(request, block)
     } else {
+      val result = tryToProcessRequest(config, oktaAuthService)(request, block)
+      result.left.map(_ => processRequestWithoutUser(config)(request, block)).merge
+    }
+}
 
-      val accessScopes = config.oauthScopes.trim.split("\\s+").map(scope => ClientAccessScope(scope)).toList
+/** Tries to authenticate the user from ID and access token cookies. If there are no cookies, queries the auth server to
+  * try to generate them. Provides a [[User]] to the request if authentication is possible.
+  */
+class UserFromAuthCookiesOrAuthServerActionBuilder(
+    override val parser: BodyParser[AnyContent],
+    oktaAuthService: OktaAuthService[DefaultAccessClaims, UserClaims],
+    config: Identity,
+)(implicit val executionContext: ExecutionContext)
+    extends ActionBuilder[OptionalAuthRequest, AnyContent]
+    with Logging {
 
-      val result: Either[ValidationError, Future[Result]] = for {
-        idTokenCookie <- request.cookies
-          .get(config.idTokenCookieName)
-          .toRight(GenericValidationError("No id token cookie"))
-        accessTokenCookie <- request.cookies
-          .get(config.accessTokenCookieName)
-          .toRight(GenericValidationError("No access token cookie"))
-        userClaims <- oktaAuthService.validateIdTokenLocally(IdToken(idTokenCookie.value), nonce = None)
-        _ <- oktaAuthService.validateAccessTokenLocally(AccessToken(accessTokenCookie.value), accessScopes)
-      } yield block(new AuthenticatedRequest(Some(toUser(userClaims)), request))
-
-      result.fold(
-        failure => {
+  override def invokeBlock[A](request: Request[A], block: OptionalAuthRequest[A] => Future[Result]): Future[Result] =
+    if (request.cookies.get(config.signedOutCookieName).isDefined) {
+      processRequestWithoutUser(config)(request, block)
+    } else {
+      val result = tryToProcessRequest(config, oktaAuthService)(request, block)
+      result.left
+        .map(failure => {
           logger.info(s"Request ${request.id} doesn't have valid token cookies: ${failure.message}")
           if (request.flash.get(authTried).isDefined) {
             // Already tried to authenticate this request so just pass it through without a user
-            processRequestWithoutUser()
+            processRequestWithoutUser(config)(request, block)
           } else {
             // Haven't tried to authenticate this request yet so redirect to auth
             val session = request.session + (originUrl -> request.uri)
             Future.successful(Redirect(routes.AuthCodeFlowController.authorize()).withSession(session))
           }
-        },
-        identity,
-      )
+        })
+        .merge
     }
-  }
 }
 
 object UserFromAuthCookiesActionBuilder {
+
+  /** Processes a request where the [[OptionalAuthRequest]] doesn't have a user. */
+  def processRequestWithoutUser[A](
+      config: Identity,
+  )(request: Request[A], block: OptionalAuthRequest[A] => Future[Result])(implicit
+      ctx: ExecutionContext,
+  ): Future[Result] = {
+    def toDiscardingCookie(cookieName: String) = DiscardingCookie(name = cookieName, secure = true)
+    block(new AuthenticatedRequest(None, request)).map(result =>
+      // Discard token cookies as we know they're invalid
+      result.discardingCookies(
+        toDiscardingCookie(config.idTokenCookieName),
+        toDiscardingCookie(config.accessTokenCookieName),
+      ),
+    )
+  }
+
+  /** Tries to process a request with the given block. If the request doesn't have valid token cookies, returns a
+    * [[ValidationError]].
+    */
+  def tryToProcessRequest[A](
+      config: Identity,
+      oktaAuthService: OktaAuthService[DefaultAccessClaims, UserClaims],
+  )(request: Request[A], block: OptionalAuthRequest[A] => Future[Result]): Either[ValidationError, Future[Result]] = {
+    val accessScopes = config.oauthScopes.trim.split("\\s+").map(scope => ClientAccessScope(scope)).toList
+    for {
+      idTokenCookie <- request.cookies
+        .get(config.idTokenCookieName)
+        .toRight(GenericValidationError("No id token cookie"))
+      accessTokenCookie <- request.cookies
+        .get(config.accessTokenCookieName)
+        .toRight(GenericValidationError("No access token cookie"))
+      userClaims <- oktaAuthService.validateIdTokenLocally(IdToken(idTokenCookie.value), nonce = None)
+      _ <- oktaAuthService.validateAccessTokenLocally(AccessToken(accessTokenCookie.value), accessScopes)
+    } yield block(new AuthenticatedRequest(Some(toUser(userClaims)), request))
+  }
 
   case class UserClaims(
       primaryEmailAddress: String,

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -60,7 +60,7 @@ class CreateSubscriptionController(
 
   def create: EssentialAction =
     LoggingAndAlarmOnFailure {
-      MaybeAuthenticatedAction.async(circe.json[CreateSupportWorkersRequest]) { implicit request =>
+      MaybeAuthenticatedActionOnFormSubmission.async(circe.json[CreateSupportWorkersRequest]) { implicit request =>
         implicit val settings: AllSettings = settingsProvider.getAllSettings()
         SafeLogger.info(s"${request.uuid}: debug info ${request.body.debugInfo}")
         val errorOrStatusResponse = for {

--- a/support-frontend/app/controllers/SupportWorkersStatus.scala
+++ b/support-frontend/app/controllers/SupportWorkersStatus.scala
@@ -20,7 +20,7 @@ class SupportWorkersStatus(
     extends AbstractController(components)
     with Circe {
   import actionRefiners._
-  def status(jobId: String): Action[AnyContent] = MaybeAuthenticatedAction.async { implicit request =>
+  def status(jobId: String): Action[AnyContent] = MaybeAuthenticatedActionOnFormSubmission.async { implicit request =>
     client
       .status(jobId, request.uuid)
       .fold(

--- a/support-frontend/app/wiring/ActionBuilders.scala
+++ b/support-frontend/app/wiring/ActionBuilders.scala
@@ -9,6 +9,7 @@ trait ActionBuilders {
 
   implicit lazy val actionRefiners = new CustomActionBuilders(
     asyncAuthenticationService = asyncAuthenticationService,
+    userFromAuthCookiesOrAuthServerActionBuilder = userFromAuthCookiesOrAuthServerActionBuilder,
     userFromAuthCookiesActionBuilder = userFromAuthCookiesActionBuilder,
     cc = controllerComponents,
     addToken = csrfAddToken,

--- a/support-frontend/app/wiring/Services.scala
+++ b/support-frontend/app/wiring/Services.scala
@@ -1,6 +1,6 @@
 package wiring
 
-import actions.UserFromAuthCookiesActionBuilder
+import actions.{UserFromAuthCookiesOrAuthServerActionBuilder, UserFromAuthCookiesActionBuilder}
 import actions.UserFromAuthCookiesActionBuilder.UserClaims
 import admin.settings.AllSettingsProvider
 import cats.syntax.either._
@@ -52,6 +52,12 @@ trait Services {
       clientId = Some(OktaClientId(appConfig.identity.oauthClientId)),
     ),
     defaultIdentityClaimsParser = UserClaims.parser,
+  )
+
+  lazy val userFromAuthCookiesOrAuthServerActionBuilder = new UserFromAuthCookiesOrAuthServerActionBuilder(
+    controllerComponents.parsers.defaultBodyParser,
+    oktaAuthService,
+    appConfig.identity,
   )
 
   lazy val userFromAuthCookiesActionBuilder = new UserFromAuthCookiesActionBuilder(

--- a/support-frontend/test/actions/ActionRefinerTest.scala
+++ b/support-frontend/test/actions/ActionRefinerTest.scala
@@ -28,6 +28,7 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
 
   trait Mocks {
     val asyncAuthenticationService = mock[AsyncAuthenticationService]
+    val userFromAuthCookiesOrAuthServerActionBuilder = mock[UserFromAuthCookiesOrAuthServerActionBuilder]
     val userFromAuthCookiesActionBuilder = mock[UserFromAuthCookiesActionBuilder]
   }
 
@@ -37,6 +38,7 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
       val actionRefiner =
         new CustomActionBuilders(
           asyncAuthenticationService,
+          userFromAuthCookiesOrAuthServerActionBuilder,
           userFromAuthCookiesActionBuilder,
           stubControllerComponents(),
           csrfAddToken,
@@ -61,6 +63,7 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
 
       val actionRefiner = new CustomActionBuilders(
         asyncAuthenticationService,
+        userFromAuthCookiesOrAuthServerActionBuilder,
         userFromAuthCookiesActionBuilder,
         stubControllerComponents(),
         csrfAddToken,
@@ -86,6 +89,7 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
       when(asyncAuthenticationService.tryAuthenticateUser(any())).thenReturn(Future.successful(None))
       val actionRefiner = new CustomActionBuilders(
         asyncAuthenticationService,
+        userFromAuthCookiesOrAuthServerActionBuilder,
         userFromAuthCookiesActionBuilder,
         cc = stubControllerComponents(),
         addToken = csrfAddToken,
@@ -111,6 +115,7 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
         .thenReturn(Future.successful(Some(mock[User])))
       val actionRefiner = new CustomActionBuilders(
         asyncAuthenticationService,
+        userFromAuthCookiesOrAuthServerActionBuilder,
         userFromAuthCookiesActionBuilder,
         cc = stubControllerComponents(),
         addToken = csrfAddToken,
@@ -127,6 +132,7 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
       when(asyncAuthenticationService.tryAuthenticateUser(any())).thenReturn(Future.successful(None))
       val actionRefiner = new CustomActionBuilders(
         asyncAuthenticationService,
+        userFromAuthCookiesOrAuthServerActionBuilder,
         userFromAuthCookiesActionBuilder,
         cc = stubControllerComponents(),
         addToken = csrfAddToken,

--- a/support-frontend/test/actions/UserFromAuthCookiesOrAuthServerActionBuilderTest.scala
+++ b/support-frontend/test/actions/UserFromAuthCookiesOrAuthServerActionBuilderTest.scala
@@ -20,7 +20,7 @@ import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, redirectLocati
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class UserFromAuthCookiesActionBuilderTest extends AnyWordSpec with Matchers {
+class UserFromAuthCookiesOrAuthServerActionBuilderTest extends AnyWordSpec with Matchers {
 
   private def toJson(request: OptionalAuthRequest[AnyContent]) =
     request.user.map(user => Json.obj("userId" -> user.id)).getOrElse(JsNull)
@@ -47,7 +47,7 @@ class UserFromAuthCookiesActionBuilderTest extends AnyWordSpec with Matchers {
       when(config.oauthScopes).thenReturn(accessScopes)
       val request = FakeRequest().withCookies(Cookie(name = config.signedOutCookieName, value = "1684759360"))
       def block(request: OptionalAuthRequest[AnyContent]) = Future.successful(Ok(toJson(request)))
-      val actionBuilder = new UserFromAuthCookiesActionBuilder(parser, authService, config)
+      val actionBuilder = new UserFromAuthCookiesOrAuthServerActionBuilder(parser, authService, config)
       val result = actionBuilder.invokeBlock(request, block)
       "give an OK response" in {
         status(result) mustBe 200
@@ -64,7 +64,7 @@ class UserFromAuthCookiesActionBuilderTest extends AnyWordSpec with Matchers {
       when(config.oauthScopes).thenReturn(accessScopes)
       val request = FakeRequest()
       def block(request: OptionalAuthRequest[AnyContent]) = Future.successful(Ok(toJson(request)))
-      val actionBuilder = new UserFromAuthCookiesActionBuilder(parser, authService, config)
+      val actionBuilder = new UserFromAuthCookiesOrAuthServerActionBuilder(parser, authService, config)
       val result = actionBuilder.invokeBlock(request, block)
       "be a redirect" in {
         status(result) mustBe 303
@@ -86,7 +86,7 @@ class UserFromAuthCookiesActionBuilderTest extends AnyWordSpec with Matchers {
       when(config.accessTokenCookieName).thenReturn(accessTokenCookieName)
       val request = FakeRequest().withCookies(Cookie(name = config.accessTokenCookieName, value = accessToken.value))
       def block(request: OptionalAuthRequest[AnyContent]) = Future.successful(Ok(toJson(request)))
-      val actionBuilder = new UserFromAuthCookiesActionBuilder(parser, authService, config)
+      val actionBuilder = new UserFromAuthCookiesOrAuthServerActionBuilder(parser, authService, config)
       val result = actionBuilder.invokeBlock(request, block)
       "be a redirect" in {
         status(result) mustBe 303
@@ -109,7 +109,7 @@ class UserFromAuthCookiesActionBuilderTest extends AnyWordSpec with Matchers {
       when(config.accessTokenCookieName).thenReturn(accessTokenCookieName)
       val request = FakeRequest().withCookies(Cookie(name = config.idTokenCookieName, value = idToken.value))
       def block(request: OptionalAuthRequest[AnyContent]) = Future.successful(Ok(toJson(request)))
-      val actionBuilder = new UserFromAuthCookiesActionBuilder(parser, authService, config)
+      val actionBuilder = new UserFromAuthCookiesOrAuthServerActionBuilder(parser, authService, config)
       val result = actionBuilder.invokeBlock(request, block)
       "be a redirect" in {
         status(result) mustBe 303
@@ -135,7 +135,7 @@ class UserFromAuthCookiesActionBuilderTest extends AnyWordSpec with Matchers {
         Cookie(name = config.idTokenCookieName, value = idToken.value),
         Cookie(name = config.accessTokenCookieName, value = accessToken.value),
       )
-      val actionBuilder = new UserFromAuthCookiesActionBuilder(parser, authService, config)
+      val actionBuilder = new UserFromAuthCookiesOrAuthServerActionBuilder(parser, authService, config)
       def block(request: OptionalAuthRequest[AnyContent]) = Future.successful(Ok(toJson(request)))
       val result = actionBuilder.invokeBlock(request, block)
       "give an OK response" in {
@@ -160,7 +160,7 @@ class UserFromAuthCookiesActionBuilderTest extends AnyWordSpec with Matchers {
         Cookie(name = config.accessTokenCookieName, value = accessToken.value),
       )
       def block(request: OptionalAuthRequest[AnyContent]) = Future.successful(Ok(toJson(request)))
-      val actionBuilder = new UserFromAuthCookiesActionBuilder(parser, authService, config)
+      val actionBuilder = new UserFromAuthCookiesOrAuthServerActionBuilder(parser, authService, config)
       val result = actionBuilder.invokeBlock(request, block)
       "be a redirect" in {
         status(result) mustBe 303
@@ -189,7 +189,7 @@ class UserFromAuthCookiesActionBuilderTest extends AnyWordSpec with Matchers {
         )
         .withFlash(authTried -> "true")
       def block(request: OptionalAuthRequest[AnyContent]) = Future.successful(Ok(toJson(request)))
-      val actionBuilder = new UserFromAuthCookiesActionBuilder(parser, authService, config)
+      val actionBuilder = new UserFromAuthCookiesOrAuthServerActionBuilder(parser, authService, config)
       val result = actionBuilder.invokeBlock(request, block)
       "give an OK response" in {
         status(result) mustBe 200

--- a/support-frontend/test/controllers/ApplicationTest.scala
+++ b/support-frontend/test/controllers/ApplicationTest.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import actions.{CustomActionBuilders, UserFromAuthCookiesActionBuilder}
+import actions.{CustomActionBuilders, UserFromAuthCookiesActionBuilder, UserFromAuthCookiesOrAuthServerActionBuilder}
 import admin.settings.{AllSettingsProvider, FeatureSwitches, On}
 import akka.util.Timeout
 import assets.AssetsResolver
@@ -25,6 +25,7 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
 
   val actionRefiner = new CustomActionBuilders(
     asyncAuthenticationService = mock[AsyncAuthenticationService],
+    userFromAuthCookiesOrAuthServerActionBuilder = mock[UserFromAuthCookiesOrAuthServerActionBuilder],
     userFromAuthCookiesActionBuilder = mock[UserFromAuthCookiesActionBuilder],
     cc = stubControllerComponents(),
     addToken = csrfAddToken,

--- a/support-frontend/test/controllers/SiteMapTest.scala
+++ b/support-frontend/test/controllers/SiteMapTest.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import actions.{CustomActionBuilders, UserFromAuthCookiesActionBuilder}
+import actions.{CustomActionBuilders, UserFromAuthCookiesActionBuilder, UserFromAuthCookiesOrAuthServerActionBuilder}
 import admin.settings.{FeatureSwitches, On}
 import akka.util.Timeout
 import com.gu.support.config.Stages
@@ -23,6 +23,7 @@ class SiteMapTest extends AnyWordSpec with Matchers with TestCSRFComponents {
 
   val actionRefiner = new CustomActionBuilders(
     asyncAuthenticationService = mock[AsyncAuthenticationService],
+    userFromAuthCookiesOrAuthServerActionBuilder = mock[UserFromAuthCookiesOrAuthServerActionBuilder],
     userFromAuthCookiesActionBuilder = mock[UserFromAuthCookiesActionBuilder],
     cc = stubControllerComponents(),
     addToken = csrfAddToken,

--- a/support-frontend/test/fixtures/DisplayFormMocks.scala
+++ b/support-frontend/test/fixtures/DisplayFormMocks.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import actions.{CustomActionBuilders, UserFromAuthCookiesActionBuilder}
+import actions.{CustomActionBuilders, UserFromAuthCookiesActionBuilder, UserFromAuthCookiesOrAuthServerActionBuilder}
 import admin.settings.{FeatureSwitches, Off, On}
 import assets.{AssetsResolver, RefPath}
 import com.gu.identity.model.{PublicFields, User}
@@ -40,6 +40,7 @@ trait DisplayFormMocks extends TestCSRFComponents {
 
   val loggedInActionRefiner = new CustomActionBuilders(
     asyncAuthenticationService,
+    userFromAuthCookiesOrAuthServerActionBuilder = mock[UserFromAuthCookiesOrAuthServerActionBuilder],
     userFromAuthCookiesActionBuilder = mock[UserFromAuthCookiesActionBuilder],
     cc = stubControllerComponents(),
     addToken = csrfAddToken,


### PR DESCRIPTION
## What are you doing in this PR?
Previously, we had a [UserFromAuthCookiesActionBuilder](https://github.com/guardian/support-frontend/blob/fd08fbdc015eece6c8193bb6ad9b0bd93dc49653/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala) that checked for cookies containing auth tokens and tried to fetch the tokens if the cookies didn't exist.
In this PR, we optimise the use of auth token cookies by renaming `UserFromAuthCookiesActionBuilder` to `UserFromAuthCookiesOrAuthServerActionBuilder` and introducing a new action builder called `UserFromAuthCookiesActionBuilder`.  Now,  `UserFromAuthCookiesOrAuthServerActionBuilder` either uses the cookies to authenticate or to tries to fetch them.  And the new `UserFromAuthCookiesActionBuilder` only tries to use the cookies to authenticate.  With this new action builder if the cookies aren't present or are invalid, we allow the action to continue but without a user - we don't bother trying to fetch auth tokens.

## Why are you doing this?
This is to avoid making calls to the auth server unnecessarily.  If, on page load, we find that the user isn't signed in, there doesn't seem much point in checking again on form submission.  It also means that where form submission is triggered from the browser we don't have security issues with async calls from the browser to the auth domain and back.

## Related PRs
- #4997 
- #5024 
- #5070 
