### PR TITLE
[RB] - update GW landing page discount copy for EU countries

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -1,5 +1,6 @@
 import { List } from 'components/list/list';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import BenefitsContainer from './benefitsContainer';
 import BenefitsHeading from './benefitsHeading';
 
@@ -15,7 +16,7 @@ const coreBenefits = [
 	},
 ];
 
-function getBenefits(countryId: IsoCountry) {
+function getBenefits(countryId: IsoCountry, countryGroupId: CountryGroupId) {
 	if (countryId === 'AU') {
 		return [
 			{
@@ -28,15 +29,22 @@ function getBenefits(countryId: IsoCountry) {
 			},
 		];
 	}
+	const discount = countryGroupId === 'EURCountries' ? '87' : '35';
 	return [
 		{
-			content: 'Every issue delivered with up to 35% off the cover price',
+			content: `Every issue delivered with up to ${discount}% off the cover price`,
 		},
 		...coreBenefits,
 	];
 }
 
-function Benefits({ countryId }: { countryId: IsoCountry }): JSX.Element {
+function Benefits({
+	countryId,
+	countryGroupId,
+}: {
+	countryId: IsoCountry;
+	countryGroupId: CountryGroupId;
+}): JSX.Element {
 	return (
 		<BenefitsContainer
 			sections={[
@@ -45,7 +53,7 @@ function Benefits({ countryId }: { countryId: IsoCountry }): JSX.Element {
 					content: (
 						<>
 							<BenefitsHeading text="As a subscriber you’ll enjoy" />
-							<List items={getBenefits(countryId)} />
+							<List items={getBenefits(countryId, countryGroupId)} />
 						</>
 					),
 				},

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -94,7 +94,7 @@ function WeeklyLPControl({
 						{orderIsAGift ? (
 							<GiftBenefits />
 						) : (
-							<Benefits countryId={countryId} />
+							<Benefits countryId={countryId} countryGroupId={countryGroupId} />
 						)}
 					</Block>
 				</CentredContainer>
@@ -180,7 +180,7 @@ function WeeklyLPVariant({
 						{orderIsAGift ? (
 							<GiftBenefits />
 						) : (
-							<Benefits countryId={countryId} />
+							<Benefits countryId={countryId} countryGroupId={countryGroupId} />
 						)}
 					</Block>
 				</CentredContainer>


### PR DESCRIPTION
## What are you doing in this PR?

This pr updates the copy on the Guardian Weekly landing page specifically for EU countries. For those countries the discount should be 87% not the default (excluding Australia) of 35%.

#### This change should be live between 17th July - 14th Aug.


[**Trello Card**](https://trello.com/c/Li371ilc/1408-guardian-weekly-12-for-12-eu-copy-change-on-landing-page)

## Screenshot
<img width="1359" alt="Screenshot 2023-07-17 at 10 52 36" src="https://github.com/guardian/support-frontend/assets/2510683/08d9ac4e-3f25-44fb-8745-ba811268e9ec">


