### PR TITLE
Stop redirecting in availability pre-check

### DIFF
--- a/support-frontend/test/selenium/util/Dependencies.scala
+++ b/support-frontend/test/selenium/util/Dependencies.scala
@@ -10,7 +10,8 @@ object Dependencies {
   trait Availability {
     val url: String
     def isAvailable: Boolean = {
-      val request = new Builder().url(url).build()
+      // Cookie is to avoid a chain of auth redirects as this check is purely to ensure site is up
+      val request = new Builder().url(url).addHeader("Cookie", "GU_SO=true").build()
       client.newCall(request).execute.isSuccessful
     }
   }


### PR DESCRIPTION
We're seeing errors in the post-deploy tests: `Too many follow-up requests`
eg. https://github.com/guardian/support-frontend/actions/runs/5597174208/jobs/10235302875#step:6:163

This appears to be because in the site availability pre-check for the post-deploy tests, the site root is being redirected to `uk/contribute` and then that is going through a failing auth flow, which should be stopped by a [flashed flag](https://github.com/guardian/support-frontend/blob/4fe24eedc0ede09316175b9b8a705067e268eeb3/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala#L58) in the request.  That doesn't appear to be happening in this case and we're getting an endless loop.

As this doesn't seem to be happening outside the Selenium pre-check, I'm adding a cookie that will stop the auth flow in the pre-check.  The cookie indicates that the user is signed out so it exits the auth flow [here](https://github.com/guardian/support-frontend/blob/4fe24eedc0ede09316175b9b8a705067e268eeb3/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala#L51-L52).  This shouldn't affect the tests themselves and we're still getting full coverage of the user journeys.
