### PR TITLE
Avoid unnecessary auth flow

### DIFF
--- a/support-frontend/app/controllers/DirectDebit.scala
+++ b/support-frontend/app/controllers/DirectDebit.scala
@@ -21,7 +21,7 @@ class DirectDebit(
   import actionBuilders._
 
   def checkAccount: Action[CheckBankAccountDetails] =
-    MaybeAuthenticatedAction.async(circe.json[CheckBankAccountDetails]) { implicit request =>
+    MaybeAuthenticatedActionOnFormSubmission.async(circe.json[CheckBankAccountDetails]) { implicit request =>
       {
         val goCardlessService = goCardlessServiceProvider.forUser(testUsers.isTestUser(request))
         goCardlessService.checkBankDetails(request.body).map { isAccountValid =>

--- a/support-frontend/app/controllers/PayPalOneOff.scala
+++ b/support-frontend/app/controllers/PayPalOneOff.scala
@@ -75,7 +75,7 @@ class PayPalOneOff(
   }
 
   def returnURL(paymentId: String, PayerID: String, email: String, country: String): Action[AnyContent] =
-    MaybeAuthenticatedAction.async { implicit request =>
+    MaybeAuthenticatedActionOnFormSubmission.async { implicit request =>
       val acquisitionData = (for {
         cookie <- request.cookies.get("acquisition_data")
         cookieAcquisitionData <- Try {


### PR DESCRIPTION
In some cases we're attempting to fetch auth tokens from the server when it's not necessary.  After the page has loaded any authenticated endpoints just need to check if auth token cookies are present.