### PR TITLE
Add eventbridge queue to supporter product data

### DIFF
--- a/supporter-product-data/cloudformation/cfn.yaml
+++ b/supporter-product-data/cloudformation/cfn.yaml
@@ -1,6 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: "Product data information for supporters."
-
 Parameters:
   Stage:
     Description: Stage name
@@ -16,11 +15,13 @@ Conditions:
 Mappings:
   StageVariables:
     CODE:
+      EventBusName: supporter-product-data-CODE
       S3Bucket: supporter-product-data-export-code
       # Run once at 6am Mon-Fri
       scheduleRate: "cron(0 6 ? * 1-5 *)"
       lambdaConcurrency: 30
     PROD:
+      EventBusName: supporter-product-data-PROD
       S3Bucket: supporter-product-data-export-prod
       # Every 5 mins
       scheduleRate: "cron(*/5 * ? * * *)"
@@ -384,6 +385,44 @@ Resources:
     DependsOn:
       - SupporterProductDataQueue
       - ProcessSupporterRatePlanItemLambda
+
+  EventBus:
+    Type: AWS::Events::EventBus
+    Properties:
+      Name: !FindInMap [StageVariables, !Ref Stage, EventBusName]
+
+  EventBridgeToSQSRule:
+    Type: AWS::Events::Rule
+    Properties:
+      EventPattern:
+        source:
+          - "com.gu.supporter-product-data.add-item"
+        detail-type:
+          - "SupporterRatePlanItem"
+      EventBusName: !FindInMap [StageVariables, !Ref Stage, EventBusName]
+      Targets:
+        - Arn: !GetAtt SupporterProductDataQueue.Arn
+          Id: EventBridgeToSQSRuleTarget
+          InputPath: $.detail
+    DependsOn:
+      - SupporterProductDataQueue
+      - EventBus
+
+  # Allow EventBridge to invoke SQS
+  EventBridgeToToSqsPolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: SQS:SendMessage
+            Resource:  !GetAtt SupporterProductDataQueue.Arn
+      Queues:
+        - Ref: SupporterProductDataQueue
+    DependsOn:
+      - SupporterProductDataQueue
 
   UnprocessedSupporterProductDataRecordAlarm:
     Type: 'AWS::CloudWatch::Alarm'

--- a/supporter-product-data/cloudformation/update-stack.sh
+++ b/supporter-product-data/cloudformation/update-stack.sh
@@ -1,0 +1,9 @@
+# aws s3 rm s3://supporter-product-data-export-code/ --recursive --profile membership
+# aws cloudformation delete-stack --stack-name support-CODE-supporter-product-data
+# aws cloudformation delete-stack --stack-name supporter-product-data-tables-CODE
+aws cloudformation update-stack \
+  --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_NAMED_IAM CAPABILITY_IAM  \
+  --stack-name support-CODE-supporter-product-data \
+  --template-body file://cfn.yaml \
+  --parameters  ParameterKey=Stage,ParameterValue=CODE \
+  > /dev/null

--- a/supporter-product-data/event.json
+++ b/supporter-product-data/event.json
@@ -1,0 +1,9 @@
+[
+  {
+    "DetailType": "SupporterRatePlanItem",
+    "Source": "com.gu.supporter-product-data.add-item",
+    "EventBusName": "supporter-product-data-CODE",
+    "Detail": "{\"subscriptionName\": \"A-S00614934\", \"identityId\": \"9999999\", \"gifteeIdentityId\": null, \"productRatePlanId\": \"2c92c0f85a6b134e015a7fcd9f0c7855\", \"productRatePlanName\": \"Monthly Contribution\", \"termEndDate\": \"2023-07-17\", \"contractEffectiveDate\": \"2023-07-16\", \"contributionAmount\": {  \"amount\": 20,  \"currency\": \"GBP\" }}"
+  }
+]
+

--- a/supporter-product-data/put-event.sh
+++ b/supporter-product-data/put-event.sh
@@ -1,0 +1,2 @@
+# Send a test event to the supporter-product-data-CODE event bus
+aws events put-events --entries file://event.json


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [ ] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

