### PR TITLE
Amend GW benefits line for Aus

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -19,7 +19,7 @@ function getBenefits(countryId: IsoCountry) {
 	if (countryId === 'AU') {
 		return [
 			{
-				content: 'Every issue delivered with up to 91% off the cover price',
+				content: 'Every issue delivered with up to 35% off the cover price',
 			},
 			...coreBenefits,
 			{


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This will update the GW benefits line in Aus from "Every issue delivered with up to 91% off the cover price" -> "Every issue delivered with up to 35% off the cover price"

[**Trello Card**](https://trello.com/c/VHPkOx08/1414-gw-support-amend-benefits-line-for-12for12-aus-revert-to-original-when-aus-campaign-ends-on-july-31st)
