### PR TITLE
[RB] - Fix support for class private fields in firefox 78

### DIFF
--- a/support-frontend/babel.config.json
+++ b/support-frontend/babel.config.json
@@ -12,7 +12,6 @@
   "plugins": [
     "@babel/plugin-transform-runtime",
     "@babel/plugin-transform-exponentiation-operator",
-    "@babel/plugin-proposal-class-properties",
     "@babel/plugin-syntax-dynamic-import",
     "babel-plugin-add-react-displayname"
   ],

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -120,7 +120,6 @@
   "devDependencies": {
     "@axe-core/react": "^4.2.1",
     "@babel/core": "^7.21.8",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-exponentiation-operator": "^7.18.6",
     "@babel/plugin-transform-runtime": "^7.21.4",
@@ -161,7 +160,6 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^24.9.0",
     "babel-loader": "^9.1.2",
-    "babel-loader-exclude-node-modules-except": "^1.2.1",
     "babel-plugin-add-react-displayname": "^0.0.5",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "chalk": "^4.1.0",

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -161,6 +161,7 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^24.9.0",
     "babel-loader": "^9.1.2",
+    "babel-loader-exclude-node-modules-except": "^1.2.1",
     "babel-plugin-add-react-displayname": "^0.0.5",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "chalk": "^4.1.0",

--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -115,7 +115,8 @@ module.exports = (cssFilename, jsFilename, minimizeCss) => ({
 		rules: [
 			{
 				test: /\.([jt]sx?|mjs)$/,
-        exclude: /node_modules\/(?!(\@guardian\/*)\/).*/,
+				exclude:
+					/node_modules\/(?!(\@guardian\/consent-management-platform|@guardian\/libs)\/).*/,
 				use: [
 					{
 						loader: 'babel-loader',

--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -5,7 +5,6 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const autoprefixer = require('autoprefixer');
 const pxtorem = require('postcss-pxtorem');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
-const babelLoaderExcludeNodeModulesExcept = require('babel-loader-exclude-node-modules-except');
 const { paletteAsSass } = require('./scripts/pasteup-sass');
 const { getClassName } = require('./scripts/css');
 const entryPoints = require('./webpack.entryPoints');
@@ -116,10 +115,7 @@ module.exports = (cssFilename, jsFilename, minimizeCss) => ({
 		rules: [
 			{
 				test: /\.([jt]sx?|mjs)$/,
-				exclude: babelLoaderExcludeNodeModulesExcept([
-					// es6 modules from node_modules/
-					'@guardian/*',
-				]),
+        exclude: /node_modules\/(?!(\@guardian\/*)\/).*/,
 				use: [
 					{
 						loader: 'babel-loader',

--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -5,6 +5,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const autoprefixer = require('autoprefixer');
 const pxtorem = require('postcss-pxtorem');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
+const babelLoaderExcludeNodeModulesExcept = require('babel-loader-exclude-node-modules-except');
 const { paletteAsSass } = require('./scripts/pasteup-sass');
 const { getClassName } = require('./scripts/css');
 const entryPoints = require('./webpack.entryPoints');
@@ -115,9 +116,10 @@ module.exports = (cssFilename, jsFilename, minimizeCss) => ({
 		rules: [
 			{
 				test: /\.([jt]sx?|mjs)$/,
-				exclude: {
-					and: [/node_modules/],
-				},
+				exclude: babelLoaderExcludeNodeModulesExcept([
+					// es6 modules from node_modules/
+					'@guardian/*',
+				]),
 				use: [
 					{
 						loader: 'babel-loader',

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -5674,6 +5674,13 @@ babel-jest@^24.9.0:
     chalk "^2.4.2"
     slash "^2.0.0"
 
+babel-loader-exclude-node-modules-except@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/babel-loader-exclude-node-modules-except/-/babel-loader-exclude-node-modules-except-1.2.1.tgz#ca9759a326106c04c1a9a86e38d384cc777af49e"
+  integrity sha512-kp/JcdRhhYKprE9fYRquyasqtrdRKXqBj0BVGB9OYxEzdBTpD/8e6w1K1gafyHgntj7f9JxLhi4phOrnCMKD6Q==
+  dependencies:
+    escape-string-regexp "2.0.0"
+
 babel-loader@^9.0.0, babel-loader@^9.1.2:
   version "9.1.2"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-9.1.2.tgz#a16a080de52d08854ee14570469905a5fc00d39c"
@@ -7622,15 +7629,15 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
+escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
-escape-string-regexp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
-  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## What are you doing in this PR?

This pr babelify's private class field usage in our codebase so that the site will run in Firefox v78 (still just about on the support list: https://github.com/guardian/csnx/tree/main/libs/@guardian/browserslist-config#readme).

The private class field usage was found in the CMP(https://github.com/guardian/consent-management-platform). CMP support ES2020 and nothing older (https://github.com/guardian/consent-management-platform#bundling) so we are responsible for bundling the CMP should we need to. This was not the case as we had a blanket exclude of all node_modules in our babel config. This pr adds an exception to the node_modules exclude so that the CMP is included in the babel process.

I have also removed the `@babel/plugin-proposal-class-properties` dependancy as the functionality should be covered in babel/preset-env (https://babeljs.io/docs/babel-plugin-transform-class-properties)

#### Note, this specific exclude rule could be removed when support for Firefox v78 ends