### PR TITLE
Enable address validation on supporter plus backend

### DIFF
--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -194,10 +194,14 @@ object SimpleCheckoutFormValidation {
 }
 
 object PaidProductValidation {
-
+  import AddressAndCurrencyValidationRules._
   def passes(createSupportWorkersRequest: CreateSupportWorkersRequest): Result =
     SimpleCheckoutFormValidation.passes(createSupportWorkersRequest) and
-      hasValidPaymentDetailsForPaidProduct(createSupportWorkersRequest.paymentFields)
+      hasValidPaymentDetailsForPaidProduct(createSupportWorkersRequest.paymentFields) and
+      hasStateIfRequired(
+        createSupportWorkersRequest.billingAddress.country,
+        createSupportWorkersRequest.billingAddress.state,
+      )
 
   def hasValidPaymentDetailsForPaidProduct(paymentDetails: Either[PaymentFields, RedemptionData]): Result =
     paymentDetails match {
@@ -243,7 +247,7 @@ object AddressAndCurrencyValidationRules {
       stateFromRequest.isDefined.otherwise(s"state is required for $countryFromRequest")
     } else Valid
 
-//    hasValidPostcodeLength checks if the length of postCodeIsShortEnoughForSalesforce(must be less than or equal to 20 characters)
+//     hasValidPostcodeLength checks if the length of postCodeIsShortEnoughForSalesforce(must be less than or equal to 20 characters)
   def hasValidPostcodeLength(postcodeFromRequest: Option[String], addressType: String): Result = {
     val validPostCode = postcodeFromRequest match {
       case Some(postCode) if (postCode.length > 20) =>
@@ -277,7 +281,6 @@ object AddressAndCurrencyValidationRules {
   }
 
 }
-
 object DigitalPackValidation {
 
   import AddressAndCurrencyValidationRules._

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -390,6 +390,26 @@ class SimpleCheckoutFormValidationTest extends AnyFlatSpec with Matchers {
   }
 }
 
+class PaidProductValidationTest extends AnyFlatSpec with Matchers {
+  import TestData.validDigitalPackRequest
+
+  "PaidProductValidation.passes" should " fail if the country is United States and there is no state" in {
+    val requestMissingState = validDigitalPackRequest.copy(
+      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.US, state = None),
+      product = SupporterPlus(50, Currency.USD, Annual),
+    )
+    PaidProductValidation.passes(requestMissingState) shouldBe an[Invalid]
+  }
+
+  it should "succeed  if the country is UK and there is no state" in {
+    val requestSupporterPlus = validDigitalPackRequest.copy(
+      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.UK, state = None),
+      product = SupporterPlus(50, Currency.GBP, Annual),
+    )
+    PaidProductValidation.passes(requestSupporterPlus) shouldBe Valid
+  }
+
+}
 class DigitalPackValidationTest extends AnyFlatSpec with Matchers {
 
   import TestData.validDigitalPackRequest


### PR DESCRIPTION
## What are you doing in this PR?
Enable address validation on supporter plus backend

[**Trello Card**](https://trello.com/c/NyRvsWdA/1346-enable-address-validation-on-supporter-plus-backend)

## Why are you doing this?

For supporter plus, our backend validation (before support-workers) [only runs the PaidProductValidation rules](https://github.com/guardian/support-frontend/blob/acaf1d05656b53ad9fc81763483fa3e2e8d435b2/support-frontend/app/utils/CheckoutValidationRules.scala#L100).
There’s also a rule on the AddressAndCurrencyValidationRules [that checks that a state has been provided if it’s required](https://github.com/guardian/support-frontend/blob/acaf1d05656b53ad9fc81763483fa3e2e8d435b2/support-frontend/app/utils/CheckoutValidationRules.scala#L239-L244).
We should enable this validation rule for supporter plus, as we know that the step function execution will fail if the rule isn’t met.

