### PR TITLE
Add new zuora product for national delivery

### DIFF
--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -5,7 +5,15 @@ import com.gu.i18n.Currency.GBP
 import com.gu.i18n.{Country, CountryGroup, Currency}
 import com.gu.support.abtests.BenefitsTest.isValidBenefitsTestPurchase
 import com.gu.support.acquisitions.AbTest
-import com.gu.support.catalog.{Collection, Domestic, FulfilmentOptions, HomeDelivery, NoFulfilmentOptions, RestOfWorld}
+import com.gu.support.catalog.{
+  Collection,
+  Domestic,
+  FulfilmentOptions,
+  NationalDelivery,
+  HomeDelivery,
+  NoFulfilmentOptions,
+  RestOfWorld,
+}
 import com.gu.support.redemptions.RedemptionData
 import com.gu.support.workers._
 import com.gu.support.zuora.api.ReaderType
@@ -368,7 +376,8 @@ object PaperValidation {
         deliveredToUkAndPaidInGbp(address.country, createSupportWorkersRequest.product.currency)
       val deliveryAddressHasAddressLine1AndCity = hasAddressLine1AndCity(address)
       val validPostcode = fulfilmentOptions match {
-        case HomeDelivery => postcodeIsWithinDeliveryArea(postCode)
+        case NationalDelivery => postcodeIsWithinNationalDeliveryArea(postCode)
+        case HomeDelivery => postcodeIsWithinHomeDeliveryArea(postCode)
         case Collection => Valid
         case Domestic => Invalid("domestic is not valid for paper")
         case RestOfWorld => Invalid("rest of world is not valid for paper")
@@ -398,7 +407,11 @@ object PaperValidation {
 
   }
 
-  def postcodeIsWithinDeliveryArea(postcode: String): Result =
+  def postcodeIsWithinNationalDeliveryArea(postcode: String): Result = {
+    Valid // TODO: determine valid postcodes
+  }
+
+  def postcodeIsWithinHomeDeliveryArea(postcode: String): Result =
     M25_POSTCODE_PREFIXES.contains(getPrefix(postcode)).otherwise(s"postcode $postcode is not within M25")
 
   val M25_POSTCODE_OLD_PREFIXES = List(

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -562,7 +562,8 @@ class PaperValidationTest extends AnyFlatSpec with Matchers {
   }
 
   it should "fail if the currency is USD" in {
-    val requestDeliveredToUs = validPaperRequest.copy(product = Paper(Currency.USD, Monthly, HomeDelivery, Everyday))
+    val requestDeliveredToUs =
+      validPaperRequest.copy(product = Paper(Currency.USD, Monthly, HomeDelivery, Everyday, None))
     PaperValidation.passes(requestDeliveredToUs, Collection) shouldBe an[Invalid]
   }
 
@@ -641,7 +642,8 @@ class GuardianWeeklyValidationTest extends AnyFlatSpec with Matchers {
   }
 
   it should "succeed if the currency is USD" in {
-    val requestDeliveredToUs = validWeeklyRequest.copy(product = Paper(Currency.USD, Monthly, HomeDelivery, Everyday))
+    val requestDeliveredToUs =
+      validWeeklyRequest.copy(product = GuardianWeekly(Currency.USD, Monthly, HomeDelivery))
     GuardianWeeklyValidation.passes(requestDeliveredToUs) shouldBe Valid
   }
 
@@ -755,7 +757,7 @@ object TestData {
     title = None,
     firstName = "grace",
     lastName = "hopper",
-    product = Paper(Currency.GBP, Monthly, HomeDelivery, Everyday),
+    product = Paper(Currency.GBP, Monthly, HomeDelivery, Everyday, Some("delivery agent (oho)")),
     firstDeliveryDate = Some(someDateNextMonth),
     paymentFields =
       Left(StripePaymentMethodPaymentFields(PaymentMethodId("test_token").get, Some(StripePaymentType.StripeCheckout))),

--- a/support-models/src/main/scala/com/gu/support/catalog/FulfilmentOptions.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/FulfilmentOptions.scala
@@ -6,6 +6,8 @@ sealed trait FulfilmentOptions
 
 case object HomeDelivery extends FulfilmentOptions
 
+case object NationalDelivery extends FulfilmentOptions
+
 case object Collection extends FulfilmentOptions
 
 case object Domestic extends FulfilmentOptions
@@ -15,7 +17,8 @@ case object RestOfWorld extends FulfilmentOptions
 case object NoFulfilmentOptions extends FulfilmentOptions
 
 object FulfilmentOptions {
-  lazy val allFulfilmentOptions = List(HomeDelivery, Collection, Domestic, RestOfWorld, NoFulfilmentOptions)
+  lazy val allFulfilmentOptions =
+    List(HomeDelivery, NationalDelivery, Collection, Domestic, RestOfWorld, NoFulfilmentOptions)
 
   def fromString(code: String): Option[FulfilmentOptions] =
     allFulfilmentOptions.find(_.getClass.getSimpleName == s"$code$$")

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -148,6 +148,13 @@ case object Paper extends Product {
   ): ProductRatePlan[Paper.type] =
     ProductRatePlan(productRatePlanId, Monthly, HomeDelivery, productOptions, description, List(CountryGroup.UK))
 
+  private def nationalDelivery(
+      productRatePlanId: ProductRatePlanId,
+      productOptions: ProductOptions,
+      description: String,
+  ): ProductRatePlan[Paper.type] =
+    ProductRatePlan(productRatePlanId, Monthly, NationalDelivery, productOptions, description, List(CountryGroup.UK))
+
   private val prodCollection: List[ProductRatePlan[Paper.type]] =
     List(
       collection("2c92a00870ec598001710740ce702ff0", SaturdayPlus, "Voucher Saturday+"),
@@ -200,6 +207,9 @@ case object Paper extends Product {
         homeDelivery("2c92c0f955c3cf0f0155c5d9ddf13bc5", Sixday, "Home Delivery Sixday"),
         homeDelivery("2c92c0f85aff3453015b10496b5e3d17", EverydayPlus, "Home Delivery Everyday+"),
         homeDelivery("2c92c0f955c3cf0f0155c5d9e2493c43", Everyday, "Home Delivery Everyday"),
+        nationalDelivery("8ad096ca8992481d018992a36256175e", Weekend, "National Delivery Weekend"),
+        nationalDelivery("8ad096ca8992481d018992a35f60171b", Sixday, "National Delivery Sixday"),
+        nationalDelivery("8ad096ca8992481d018992a363bd17ad", Everyday, "National Delivery Everyday"),
       )),
     )
 }

--- a/support-models/src/main/scala/com/gu/support/workers/Products.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/Products.scala
@@ -51,6 +51,7 @@ case class Paper(
     billingPeriod: BillingPeriod = Monthly,
     fulfilmentOptions: FulfilmentOptions,
     productOptions: PaperProductOptions,
+    deliveryAgent: Option[String],
 ) extends ProductType {
   override def describe: String = s"Paper-$fulfilmentOptions-$productOptions"
 }

--- a/support-models/src/main/scala/com/gu/support/zuora/api/SubscriptionData.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/SubscriptionData.scala
@@ -193,7 +193,8 @@ object Subscription {
       .renameField("GiftNotificationEmailDate", "GiftNotificationEmailDate__c")
       .renameField("AcquisitionSource", "AcquisitionSource__c")
       .renameField("CreatedByCsr", "CreatedByCSR__c")
-      .renameField("AcquisitionCase", "AcquisitionCase__c"),
+      .renameField("AcquisitionCase", "AcquisitionCase__c")
+      .renameField("DeliveryAgent", "DeliveryAgent__c"),
   )
 }
 
@@ -214,6 +215,7 @@ case class Subscription(
     acquisitionSource: Option[AcquisitionSource] = None,
     createdByCsr: Option[String] = None,
     acquisitionCase: Option[String] = None,
+    deliveryAgent: Option[String] = None,
 )
 
 object RatePlanChargeData {

--- a/support-models/src/test/scala/com/gu/support/workers/ProductTypeDecoderTest.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/ProductTypeDecoderTest.scala
@@ -37,7 +37,45 @@ class ProductTypeDecoderTest extends AnyWordSpec with SerialisationTestHelpers {
 
       testDecoding[Paper](
         json,
-        _ shouldBe Paper(GBP, Monthly, Collection, Sixday),
+        _ shouldBe Paper(GBP, Monthly, Collection, Sixday, None),
+      )
+    }
+
+    "decode a paper sub with a delivery agent" in {
+      val json =
+        """
+          |{
+          |  "billingPeriod": "Monthly",
+          |  "currency": "GBP",
+          |  "fulfilmentOptions": "Collection",
+          |  "productOptions": "Sixday",
+          |  "productType": "Paper",
+          |  "deliveryAgent": "delivery agent (aha!)"
+          |}
+        """.stripMargin
+
+      testDecoding[Paper](
+        json,
+        _ shouldBe Paper(GBP, Monthly, Collection, Sixday, Some("delivery agent (aha!)")),
+      )
+    }
+
+    "decode a paper sub with a null delivery agent" in {
+      val json =
+        """
+          |{
+          |  "billingPeriod": "Monthly",
+          |  "currency": "GBP",
+          |  "fulfilmentOptions": "Collection",
+          |  "productOptions": "Sixday",
+          |  "productType": "Paper",
+          |  "deliveryAgent": null
+          |}
+        """.stripMargin
+
+      testDecoding[Paper](
+        json,
+        _ shouldBe Paper(GBP, Monthly, Collection, Sixday, None),
       )
     }
 

--- a/support-models/src/test/scala/com/gu/support/workers/ProductTypeRatePlansSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/ProductTypeRatePlansSpec.scala
@@ -1,7 +1,7 @@
 package com.gu.support.workers
 
 import com.gu.i18n.Currency.{GBP, USD}
-import com.gu.support.catalog.{Domestic, Everyday, HomeDelivery}
+import com.gu.support.catalog.{Domestic, Everyday, HomeDelivery, NationalDelivery}
 import com.gu.support.config.TouchPointEnvironments.CODE
 import com.gu.support.workers.ProductTypeRatePlans._
 import com.gu.support.zuora.api.ReaderType.{Direct, Gift}
@@ -15,9 +15,12 @@ class ProductTypeRatePlansSpec extends AsyncFlatSpec with Matchers {
     val weekly = GuardianWeekly(GBP, Annual, Domestic)
     weeklyRatePlan(weekly, CODE, Direct).value.description shouldBe "Guardian Weekly annual, domestic delivery"
 
-    val paper = Paper(USD, Monthly, HomeDelivery, Everyday)
+    val paper = Paper(USD, Monthly, HomeDelivery, Everyday, Some("any delivery agent! It shouldn’t matter"))
     paperRatePlan(paper, CODE).value.id shouldBe "2c92c0f955c3cf0f0155c5d9e2493c43"
 
+    val nationalDeliveryPaper =
+      Paper(USD, Monthly, NationalDelivery, Everyday, Some("any delivery agent! It shouldn’t matter"))
+    paperRatePlan(nationalDeliveryPaper, CODE).value.id shouldBe "8ad096ca8992481d018992a363bd17ad"
   }
 
 }

--- a/support-models/src/test/scala/com/gu/support/workers/SendThankYouEmailStateSerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/SendThankYouEmailStateSerialisationSpec.scala
@@ -78,7 +78,11 @@ object ProductTypeCreatedTestData {
   )
   val paperCreated = SendThankYouEmailPaperState(
     user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),
-    Paper(fulfilmentOptions = Collection, productOptions = Saturday),
+    Paper(
+      fulfilmentOptions = Collection,
+      productOptions = Saturday,
+      deliveryAgent = Some("A delivery agent ID"),
+    ),
     PayPalReferenceTransaction("baid", "email@emaail.com"),
     PaymentSchedule(List(Payment(new LocalDate(2020, 6, 16), 1.49))),
     None,

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/ga/GoogleAnalyticsService.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/ga/GoogleAnalyticsService.scala
@@ -187,6 +187,7 @@ object GoogleAnalyticsService extends LazyLogging {
             HomeDeliveryWeekendPlus =>
           "PaperAndDigital"
         case PrintProduct.GuardianWeekly => "GuardianWeekly"
+        case NationalDeliveryEveryday | NationalDeliveryWeekend | NationalDeliverySixday => "PaperNationalDelivery"
       },
     )
   }

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
@@ -2,6 +2,7 @@ package com.gu.support.acquisitions.models
 
 import com.gu.i18n.{Country, Currency}
 import com.gu.support.acquisitions.{AbTest, QueryParameter}
+import com.gu.support.catalog.{FulfilmentOptions, ProductOptions}
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec.deriveCodec
 import com.gu.support.encoding.CustomCodecs._
@@ -144,6 +145,12 @@ object PrintProduct {
 
   case object HomeDeliverySundayPlus extends PrintProduct("HOME_DELIVERY_SUNDAY_PLUS")
 
+  case object NationalDeliveryEveryday extends PrintProduct("NATIONAL_DELIVERY_EVERYDAY")
+
+  case object NationalDeliverySixday extends PrintProduct("NATIONAL_DELIVERY_SIXDAY")
+
+  case object NationalDeliveryWeekend extends PrintProduct("NATIONAL_DELIVERY_WEEKEND")
+
   case object VoucherEveryday extends PrintProduct("VOUCHER_EVERYDAY")
 
   case object VoucherEverydayPlus extends PrintProduct("VOUCHER_EVERYDAY_PLUS")
@@ -178,6 +185,9 @@ object PrintProduct {
       HomeDeliverySaturdayPlus,
       HomeDeliverySunday,
       HomeDeliverySundayPlus,
+      NationalDeliveryEveryday,
+      NationalDeliverySixday,
+      NationalDeliveryWeekend,
       VoucherEveryday,
       VoucherEverydayPlus,
       VoucherSixday,

--- a/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
@@ -140,6 +140,9 @@ object AcquisitionDataRowBuilder {
         case (HomeDelivery, SaturdayPlus) => HomeDeliverySaturdayPlus
         case (HomeDelivery, Sunday) => HomeDeliverySunday
         case (HomeDelivery, SundayPlus) => HomeDeliverySundayPlus
+        case (NationalDelivery, Everyday) => NationalDeliveryEveryday
+        case (NationalDelivery, Sixday) => NationalDeliverySixday
+        case (NationalDelivery, Weekend) => NationalDeliveryWeekend
         case (Collection, Everyday) => VoucherEveryday
         case (Collection, EverydayPlus) => VoucherEverydayPlus
         case (Collection, Sixday) => VoucherSixday
@@ -149,7 +152,14 @@ object AcquisitionDataRowBuilder {
         case (Collection, Saturday) => VoucherSaturday
         case (Collection, SaturdayPlus) => VoucherSaturdayPlus
         case (Collection, Sunday) => VoucherSunday
-        case _ => VoucherSundayPlus
+        case (Collection, SundayPlus) => VoucherSundayPlus
+        case (NoFulfilmentOptions, _) | (_, NoProductOptions) | (Domestic, _) | (RestOfWorld, _) |
+            (NationalDelivery, Saturday) | (NationalDelivery, Sunday) | (NationalDelivery, EverydayPlus) |
+            (NationalDelivery, SixdayPlus) | (NationalDelivery, WeekendPlus) | (NationalDelivery, SaturdayPlus) |
+            (NationalDelivery, SundayPlus) =>
+          throw new RuntimeException(
+            s"Invalid combination of fulfilmentOptions ($fulfilmentOptions) and productOptions ($productOptions)",
+          )
       }
 
     product match {

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/PaperSubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/PaperSubscriptionBuilder.scala
@@ -34,6 +34,7 @@ class PaperSubscriptionBuilder(
       readerType = Direct,
       csrUsername = csrUsername,
       salesforceCaseId = salesforceCaseId,
+      deliveryAgent = product.deliveryAgent,
     )
 
     applyPromoCodeIfPresent(

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/SubscribeItemBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/SubscribeItemBuilder.scala
@@ -81,6 +81,7 @@ class SubscribeItemBuilder(
       giftNotificationEmailDate: Option[LocalDate] = None,
       csrUsername: Option[String] = None,
       salesforceCaseId: Option[String] = None,
+      deliveryAgent: Option[String] = None,
   ): SubscriptionData =
     SubscriptionData(
       List(
@@ -104,6 +105,7 @@ class SubscribeItemBuilder(
         createdByCsr = csrUsername,
         acquisitionSource = csrUsername.map(_ => CSR),
         acquisitionCase = salesforceCaseId,
+        deliveryAgent = deliveryAgent,
       ),
     )
 }

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -6,7 +6,7 @@ import com.gu.i18n.Currency.GBP
 import com.gu.salesforce.Fixtures.{emailAddress, idId}
 import com.gu.salesforce.Salesforce.SalesforceContactRecords
 import com.gu.support.acquisitions.{AbTest, AcquisitionData, OphanIds, ReferrerAcquisitionData}
-import com.gu.support.catalog.{Domestic, Everyday, HomeDelivery, RestOfWorld}
+import com.gu.support.catalog.{Domestic, Everyday, HomeDelivery, NationalDelivery, RestOfWorld}
 import com.gu.support.promotions.PromoCode
 import com.gu.support.redemptions.{RedemptionCode, RedemptionData}
 import com.gu.support.workers.GiftRecipient.{DigitalSubscriptionGiftRecipient, WeeklyGiftRecipient}
@@ -566,7 +566,7 @@ object JsonFixtures {
     CreateZuoraSubscriptionState(
       PaperState(
         userJsonWithDeliveryAddress,
-        Paper(GBP, Monthly, HomeDelivery, Everyday),
+        Paper(GBP, Monthly, HomeDelivery, Everyday, None),
         stripePaymentMethodObj,
         LocalDate.now(DateTimeZone.UTC),
         None,
@@ -574,7 +574,7 @@ object JsonFixtures {
       ),
       UUID.randomUUID(),
       userJsonWithDeliveryAddress,
-      Paper(GBP, Monthly, HomeDelivery, Everyday),
+      Paper(GBP, Monthly, HomeDelivery, Everyday, None),
       AnalyticsInfo(false, Stripe),
       None,
       None,
@@ -582,6 +582,29 @@ object JsonFixtures {
       None,
       None,
     ).asJson.spaces2
+
+  val createEverydayNationalDeliveryPaperSubscriptionJson = {
+    val paper = Paper(GBP, Monthly, NationalDelivery, Everyday, Some("Some delivery agent ID"))
+    CreateZuoraSubscriptionState(
+      PaperState(
+        userJsonWithDeliveryAddress,
+        paper,
+        stripePaymentMethodObj,
+        LocalDate.now(DateTimeZone.UTC),
+        None,
+        salesforceContact,
+      ),
+      UUID.randomUUID(),
+      userJsonWithDeliveryAddress,
+      paper,
+      AnalyticsInfo(false, Stripe),
+      None,
+      None,
+      None,
+      None,
+      None,
+    ).asJson.spaces2
+  }
 
   def createGuardianWeeklySubscriptionJson(
       billingPeriod: BillingPeriod,

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -5,7 +5,7 @@ import com.gu.i18n.CountryGroup
 import com.gu.i18n.Currency.{EUR, GBP}
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.support.acquisitions.{AbTest, AcquisitionData, OphanIds, ReferrerAcquisitionData}
-import com.gu.support.catalog.{CatalogService, Everyday, S3CatalogProvider}
+import com.gu.support.catalog.{CatalogService, Everyday, S3CatalogProvider, NationalDelivery}
 import com.gu.support.config.{Stages, TouchPointEnvironments}
 import com.gu.support.promotions.{DefaultPromotions, PromotionService}
 import com.gu.support.redemption.CodeAlreadyUsed
@@ -97,6 +97,15 @@ class CreateZuoraSubscriptionSpec extends AsyncLambdaSpec with MockServicesCreat
       .createSubscription(createEverydayPaperSubscriptionJson)
       .map(_ should matchPattern {
         case s: SendThankYouEmailPaperState if s.product.productOptions == Everyday =>
+      })
+  }
+
+  it should "create an everyday national-delivery paper subscription" in {
+    createZuoraHelper
+      .createSubscription(createEverydayNationalDeliveryPaperSubscriptionJson)
+      .map(_ should matchPattern {
+        case s: SendThankYouEmailPaperState
+            if s.product.productOptions == Everyday && s.product.fulfilmentOptions == NationalDelivery =>
       })
   }
 

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -197,7 +197,7 @@ object SendPaperSubscriptionEmail extends App {
     new PaperEmailFields(paperFieldsGenerator, CODE).build(
       SendThankYouEmailPaperState(
         officeUser,
-        Paper(GBP, Monthly, Collection, Saturday),
+        Paper(GBP, Monthly, Collection, Saturday, None),
         directDebitPaymentMethod,
         PaymentSchedule(List(Payment(new LocalDate(2019, 3, 25), 62.79))),
         None,

--- a/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -6,7 +6,7 @@ import com.gu.i18n.{Country, Currency}
 import com.gu.stripe.StripeServiceForCurrency
 import com.gu.support.acquisitions.ReferrerAcquisitionData
 import com.gu.support.catalog
-import com.gu.support.catalog.{Everyday, HomeDelivery}
+import com.gu.support.catalog.{Everyday, HomeDelivery, NationalDelivery}
 import com.gu.support.config.TouchPointEnvironments
 import com.gu.support.workers._
 import com.gu.support.zuora.api._
@@ -97,18 +97,30 @@ object Fixtures {
     ReferrerAcquisitionData(None, None, None, None, None, None, None, None, None, None, None, None, None)
 
   val touchpointEnvironment = TouchPointEnvironments.fromStage(Configuration.stage)
-  val everydayHDProductRatePlanId =
+  val everydayHomeDeliveryProductRatePlanId =
     catalog.Paper.getProductRatePlan(touchpointEnvironment, Monthly, HomeDelivery, Everyday) map (_.id)
+  val everydayNationalDeliveryProductRatePlanId =
+    catalog.Paper.getProductRatePlan(touchpointEnvironment, Monthly, NationalDelivery, Everyday) map (_.id)
 
   val everydayPaperSubscriptionData = SubscriptionData(
     List(
       RatePlanData(
-        RatePlan(everydayHDProductRatePlanId.get), // Everyday HD product
+        RatePlan(everydayHomeDeliveryProductRatePlanId.get),
         Nil,
         Nil,
       ),
     ),
     Subscription(date, date, date, "id123"),
+  )
+  val everydayNationalDeliveryPaperSubscriptionData = SubscriptionData(
+    List(
+      RatePlanData(
+        RatePlan(everydayNationalDeliveryProductRatePlanId.get),
+        Nil,
+        Nil,
+      ),
+    ),
+    Subscription(date, date, date, "id123", deliveryAgent = Some("delivery agent ID")),
   )
 
   def creditCardSubscriptionRequest(currency: Currency = GBP): SubscribeRequest =
@@ -148,6 +160,20 @@ object Fixtures {
           Some(differentContactDetails),
           Some(directDebitPaymentMethod),
           everydayPaperSubscriptionData,
+          SubscribeOptions(),
+        ),
+      ),
+    )
+
+  def directDebitSubscriptionRequestNationalDelivery: SubscribeRequest =
+    SubscribeRequest(
+      List(
+        SubscribeItem(
+          account(paymentGateway = DirectDebitGateway),
+          contactDetails,
+          Some(differentContactDetails),
+          Some(directDebitPaymentMethod),
+          everydayNationalDeliveryPaperSubscriptionData,
           SubscribeOptions(),
         ),
       ),

--- a/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
@@ -158,6 +158,10 @@ class ZuoraITSpec extends AsyncFlatSpec with Matchers {
 
   it should "work for a paper subscription" in doRequest(Right(directDebitSubscriptionRequestPaper))
 
+  it should "work for a national delivery paper subscription" in doRequest(
+    Right(directDebitSubscriptionRequestNationalDelivery),
+  )
+
   private def doRequest(request: Either[PreviewSubscribeRequest, SubscribeRequest]) = {
     // Accounts will be created (or previewed) in CODE
     val zuoraService = new ZuoraService(


### PR DESCRIPTION
This PR makes some of the changes in support-frontend required to handle new National Delivery products in Zuora. All Zuora changes I’ve made have been in the api sandbox, not in production.

Trello card: https://trello.com/c/4gIH3UcY/43-product-build-zuora-product-catalog-summary-journal

So far, I have:

- Created a [new product “Newspaper - National Delivery”](https://apisandbox.zuora.com/apps/Product.do?method=view&id=8ad096ca8992481d018992a35483159d) in CODE Zuora (the api sandbox) by cloning the existing [“Newspaper Delivery”](https://apisandbox.zuora.com/apps/Product.do?method=view&id=2c92c0f955c3cf0f0155c5d9ddc53bc3) product and making some changes.
  - Removed the …+, Legacy, and Echo-Legacy product rate plans, because we no longer sell these
  - Removed the Saturday and Sunday product rate plans, because we will not offer these for national delivery
- Added a new value “Newspaper - National Delivery” to [the ProductType custom field](https://apisandbox.zuora.com/apps/CustomField.do?method=viewDetail&id=2c92c0f845fed47e0146057243b161cd&objectType=Product) and used it for the new product
- Added a new `FulfilmentOptions` case
- Added a custom field in Zuora on the subscription for the “delivery agent” chosen by the customer, as well as a corresponding Salesforce field
  - Added this to the Paper product type and thereby the `CreateSupportWorkersRequest`
  - Is “delivery agent” an ok name for this? The designs done by Rob for the frontend use the phrase “delivery provider”, which I think I prefer.
- Modified the frontend to submit NationalDelivery products (so I could test them in CODE). (This change should not be merged, and has been removed from the PR.)
  - Made these zuora subscriptions in this way: https://apisandbox.zuora.com/platform/subscriptions/8ad081c689c0d7620189c1576e0e7bc3 and https://apisandbox.zuora.com/platform/subscriptions/8ad081c689de67b50189dfbe96ed661b
- Added the new chart of account entries
  - I added National Delivery, National Delivery M-F, National Delivery SAT, National Delivery SUN, and deferred versions of each of those, copying from the Home Delivery equivalents in production zuora.
  - I also set each product rate plan charge for national delivery to use these entries
  - I copied the Home Delivery tax code from production zuora as it didn’t exist in the sandbox: I assume we will use the existing one when we do this in production, rather than creating a new one


I have not yet:

- Added the holiday stop discounts

I would like to find out whether there’s a way to test that the Zuora setup is all correct, e.g. by generating a financial report as would be done in production.
