### PR TITLE
Point prout to subscribe page

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,7 +1,7 @@
 {
     "checkpoints": {
         "PROD": {
-            "url": "https://support.theguardian.com/uk",
+            "url": "https://support.theguardian.com/uk/subscribe",
             "overdue": "16M",
             "messages": {
                 "seen": "prout/seen.md"


### PR DESCRIPTION
The /contribute page now does an oauth redirect, which prout seems to be having trouble with. ([The logs](https://prout-bot.herokuapp.com/view/guardian/support-frontend) report `Could not read from this url, got java.net.ProtocolException: Too many follow-up requests: 21`.)

We think this is because the oauth redirects require cookies to be set in order to function correctly, while Prout doesn’t set cookies.

Handily, the /subscribe endpoint does not (currently) require an oauth redirect, and so this should fix the problem.