### PR TITLE
acquisition-events-api: Close JsonStreamWriter and BigQueryWriteClient

### DIFF
--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/bigquery/BigQueryService.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/bigquery/BigQueryService.scala
@@ -85,7 +85,7 @@ class BigQueryService(config: BigQueryConfig) {
     val promise = Promise[Either[String, Unit]]()
     try {
       val responseFuture = streamWriter.append(new JSONArray(List(rowContent).asJava));
-      val callback = new BigQueryService.AppendCompleteCallback(stage, promise);
+      val callback = new BigQueryService.AppendCompleteCallback(stage, promise, bigQueryWriteClient, streamWriter);
       ApiFutures.addCallback(
         responseFuture,
         callback,
@@ -103,13 +103,19 @@ class BigQueryService(config: BigQueryConfig) {
 }
 
 object BigQueryService {
-  case class AppendCompleteCallback(stage: Stage, promise: Promise[Either[String, Unit]])
-      extends ApiFutureCallback[AppendRowsResponse] {
+  case class AppendCompleteCallback(
+      stage: Stage,
+      promise: Promise[Either[String, Unit]],
+      client: BigQueryWriteClient,
+      writer: JsonStreamWriter,
+  ) extends ApiFutureCallback[AppendRowsResponse] {
     val executor = Executors.newSingleThreadExecutor();
 
     def onSuccess(response: AppendRowsResponse): Unit = {
       SafeLogger.info(s"Rows successfully inserted into table $tableName")
       promise.success(Right(()))
+      writer.close()
+      client.close()
       executor.shutdown()
     }
     def onFailure(throwable: Throwable): Unit = {
@@ -124,6 +130,8 @@ object BigQueryService {
       promise.success(
         Left(s"There was an exception inserting a row into $tableName: ${throwable.getMessage}; $detail"),
       )
+      writer.close()
+      client.close()
       executor.shutdown()
     }
   }


### PR DESCRIPTION
The code wasn’t closing the JsonStreamWriter or BigQueryWriteClient when finished with them, which is what’s been causing the OutOfMemoryErrors that we’ve seen in production. With this change we should stop seeing those.