### PR TITLE
[RB] - replace complex regex double exclusion

### DIFF
--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -113,9 +113,12 @@ module.exports = (cssFilename, jsFilename, minimizeCss) => ({
 
 	module: {
 		rules: [
-			{},
 			{
-				test: /^(assets|node_modules\/\@guardian\/consent-management-platform|node_modules\/\@guardian\/libs)\/.*\.([jt]sx?|mjs)$/,
+				test: /\.([jt]sx?|mjs)$/,
+				exclude: {
+					and: [/node_modules/],
+					not: [/@guardian\/consent-management-platform/, /@guardian\/libs/],
+				},
 				use: [
 					{
 						loader: 'babel-loader',

--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -113,10 +113,9 @@ module.exports = (cssFilename, jsFilename, minimizeCss) => ({
 
 	module: {
 		rules: [
+			{},
 			{
-				test: /\.([jt]sx?|mjs)$/,
-				exclude:
-					/node_modules\/(?!(\@guardian\/consent-management-platform|@guardian\/libs)\/).*/,
+				test: /^(assets|node_modules\/\@guardian\/consent-management-platform|node_modules\/\@guardian\/libs)\/.*\.([jt]sx?|mjs)$/,
 				use: [
 					{
 						loader: 'babel-loader',


### PR DESCRIPTION
## What are you doing in this PR?
This pr replaces the double exclusion regex pattern in the webpack common file used to decide which files should go through the babel transpilation process. (We want to include our own code and a few of the guardian node_modules dependencies).

The new pattern uses the 'and' and 'not' webpack conditions in order to make the process a bit more readable



