### PR TITLE
Stop passing AB test participations in GTM event data

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -406,11 +406,3 @@ export function targetPageMatches(
 
 	return locationPath.match(targetPage) != null;
 }
-
-export const getVariantsAsString = (participation: Participations): string => {
-	const variants: string[] = [];
-	Object.keys(participation).forEach((testId) => {
-		variants.push(`${testId}=${participation[testId]}`);
-	});
-	return variants.join('; ');
-};

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -1,6 +1,5 @@
 import type { Country } from '@guardian/consent-management-platform/dist/types/countries';
 import type { PaymentIntentResult } from '@stripe/stripe-js';
-import type { Participations } from 'helpers/abTests/abtest';
 import {
 	fetchJson,
 	getRequestOptions,
@@ -325,14 +324,13 @@ function regularPaymentFieldsFromAuthorisation(
  * - otherwise, we bubble up a success value
  */
 function checkRegularStatus(
-	participations: Participations,
 	csrf: CsrfState,
 ): (statusResponse: StatusResponse) => Promise<PaymentResult> {
 	const handleCompletion = (json: StatusResponse) => {
 		switch (json.status) {
 			case 'success':
 			case 'pending':
-				trackConversion(participations, routes.recurringContribPending);
+				trackConversion(routes.recurringContribPending);
 				return PaymentSuccess;
 
 			default: {
@@ -389,7 +387,6 @@ function checkRegularStatus(
 function postRegularPaymentRequest(
 	uri: string,
 	data: RegularPaymentRequest,
-	participations: Participations,
 	csrf: CsrfState,
 ): Promise<PaymentResult> {
 	return logPromise(
@@ -414,7 +411,7 @@ function postRegularPaymentRequest(
 				});
 			}
 
-			return response.json().then(checkRegularStatus(participations, csrf));
+			return response.json().then(checkRegularStatus(csrf));
 		})
 		.catch(() => {
 			logException(`Error while trying to interact with ${uri}`);

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -198,7 +198,6 @@ function onPaymentAuthorised(
 	const productType = getSubscriptionType(state);
 	const { paymentMethod } = state.page.checkoutForm.payment;
 	const { csrf } = state.page.checkoutForm;
-	const { abParticipations } = state.common;
 	const addresses = getAddresses(state);
 	const pricingCountry =
 		addresses.deliveryAddress?.country ?? addresses.billingAddress.country;
@@ -237,12 +236,9 @@ function onPaymentAuthorised(
 	};
 
 	dispatch(setFormSubmitted(true));
-	void postRegularPaymentRequest(
-		routes.subscriptionCreate,
-		data,
-		abParticipations,
-		csrf,
-	).then(handleSubscribeResult);
+	void postRegularPaymentRequest(routes.subscriptionCreate, data, csrf).then(
+		handleSubscribeResult,
+	);
 }
 
 function checkStripeUserType(

--- a/support-frontend/assets/helpers/tracking/conversions.ts
+++ b/support-frontend/assets/helpers/tracking/conversions.ts
@@ -1,14 +1,10 @@
-import type { Participations } from '../abTests/abtest';
 import { getAbsoluteURL } from '../urls/url';
 import { successfulConversion } from './googleTagManager';
 import { pageView } from './ophan';
 
-export default function trackConversion(
-	participations: Participations,
-	currentRoute: string,
-): void {
+export default function trackConversion(currentRoute: string): void {
 	// Fire GTM conversion events
-	successfulConversion(participations);
+	successfulConversion();
 	// Send an Ophan pageview. Because this function is used to track page views
 	// from client side routed thank you pages, the referrer will always be the current location
 	pageView(getAbsoluteURL(currentRoute), document.location.href);

--- a/support-frontend/assets/helpers/tracking/googleTagManager.ts
+++ b/support-frontend/assets/helpers/tracking/googleTagManager.ts
@@ -1,6 +1,4 @@
 import { v4 as uuidv4 } from 'uuid';
-import type { Participations } from 'helpers/abTests/abtest';
-import { getVariantsAsString } from 'helpers/abTests/abtest';
 import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
 import { detect as detectCurrency } from 'helpers/internationalisation/currency';
 import * as storage from 'helpers/storage/storage';
@@ -107,10 +105,7 @@ function push(data: Record<string, unknown>) {
 	window.googleTagManagerDataLayer.push(mapFields(data));
 }
 
-function getData(
-	event: EventType,
-	participations: Participations,
-): Record<string, unknown> {
+function getData(event: EventType): Record<string, unknown> {
 	const orderId = getOrderId();
 	const value = getContributionValue();
 	const currency = getCurrency();
@@ -134,14 +129,13 @@ function getData(
 		campaignCodeBusinessUnit: getQueryParameter('CMP_BUNIT') || undefined,
 		campaignCodeTeam: getQueryParameter('CMP_TU') || undefined,
 		internalCampaignCode: getQueryParameter('INTCMP') || undefined,
-		experience: getVariantsAsString(participations),
 		vendorConsentsLookup, // eg. "google-analytics,twitter"
 	};
 }
 
-function sendData(event: EventType, participations: Participations) {
+function sendData(event: EventType) {
 	const pushDataToGTM = () => {
-		const dataToPush = getData(event, participations);
+		const dataToPush = getData(event);
 		push(dataToPush);
 	};
 
@@ -197,7 +191,7 @@ function addTagManagerScript() {
 	}
 }
 
-async function init(participations: Participations): Promise<void> {
+async function init(): Promise<void> {
 	/**
 	 * The callback passed to onConsentChangeEvent is called
 	 * each time consent changes. EG. if a user consents via the CMP.
@@ -242,11 +236,11 @@ async function init(participations: Participations): Promise<void> {
 		},
 		vendorIds,
 	);
-	sendData('DataLayerReady', participations);
+	sendData('DataLayerReady');
 }
 
-function successfulConversion(participations: Participations): void {
-	sendData('SuccessfulConversion', participations);
+function successfulConversion(): void {
+	sendData('SuccessfulConversion');
 }
 
 // ----- Exports ---//

--- a/support-frontend/assets/pages/subscriptions-redemption/api.ts
+++ b/support-frontend/assets/pages/subscriptions-redemption/api.ts
@@ -248,7 +248,6 @@ function createSubscription(
 	postRegularPaymentRequest(
 		routes.subscriptionCreate,
 		data,
-		state.common.abParticipations,
 		state.page.checkoutForm.csrf,
 	)
 		.then(handleSubscribeResult)

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -282,10 +282,7 @@ const onPaymentResult =
 
 			switch (result.paymentStatus) {
 				case 'success':
-					trackConversion(
-						state.common.abParticipations,
-						'/contribute/thankyou',
-					);
+					trackConversion('/contribute/thankyou');
 					dispatch(paymentSuccess());
 					break;
 
@@ -418,7 +415,6 @@ function recurringPaymentAuthorisationHandler(
 		postRegularPaymentRequest(
 			routes.recurringContribCreate,
 			request,
-			state.common.abParticipations,
 			state.page.checkoutForm.csrf,
 		),
 		paymentAuthorisation,


### PR DESCRIPTION
## What are you doing in this PR?

Removes some information no longer necessary from the support sites Google Tag Manager events. We don't report on AB tests using this data anymore. 

## Why are you doing this?

Cleaning out unused data from GTM tracking events ahead of a refactor.