### PR TITLE
Only run scalafmt on files which have been changed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ lazy val integrationTestSettings: Seq[Def.Setting[_]] = Defaults.itSettings ++ S
 )
 
 lazy val scalafmtSettings = Seq(
+  scalafmtFilter.withRank(KeyRanks.Invisible) := "diff-dirty",
   (Test / test) := ((Test / test) dependsOn (Test / scalafmtCheckAll)).value,
   (Test / testOnly) := ((Test / testOnly) dependsOn (Test / scalafmtCheckAll)).evaluated,
   (Test / testQuick) := ((Test / testQuick) dependsOn (Test / scalafmtCheckAll)).evaluated,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Scalafmt was previously being run on all scala files if any had been updated, this PR changes it to only run on changed files.

[Docs are here](https://scalameta.org/scalafmt/docs/installation.html#settings)