### PR TITLE
BigQueryService: Close resources, but avoid closing client prematurely

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -86,8 +86,14 @@ class SendAcquisitionEvent(serviceProvider: ServiceProvider = ServiceProvider)
     } yield ()
 
     result.value.map {
-      case Left(errorMessage) => throw new RetryNone(errorMessage.mkString(" & "))
-      case Right(_) => HandlerResult((), requestInfo)
+      case Left(errorMessage) => {
+        services.bigQueryService.shutdown()
+        throw new RetryNone(errorMessage.mkString(" & "))
+      }
+      case Right(_) => {
+        services.bigQueryService.shutdown()
+        HandlerResult((), requestInfo)
+      }
     }
   }
 


### PR DESCRIPTION
In commit fc82dde5c51f863f7c8d1c479592204ba4390389, I began closing resources after each request. However, while the acquisition-events-api can handle this, the payment-api can’t! The former creates a new service on every request, but the latter doesn’t, so on the first request the client was closed and never reopened, causing single contributions to break. (These changes were reverted in commit 6dbcd65e785a0498adbe9d0cc709d6a6fa8760a4).

This PR moves the closing logic so the payment-api doesn’t close the big query client after the first request, while the acquisition-events-api can still close and re-open on every request.

Another option would’ve been to create a new service on every request to the payment api, but the storage write api seems designed to be used in more of a long-running server context like this.

Trello card: https://trello.com/c/S0BbUugE/1478-investigate-outofmemoryerrors-in-acquisition-events-api