### PR TITLE
Remove phasing from the Direct Debit Form

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
@@ -1,4 +1,3 @@
-// ----- Imports ----- //
 import * as React from 'react';
 import type { ConnectedProps } from 'react-redux';
 import { connect } from 'react-redux';
@@ -116,7 +115,6 @@ function DirectDebitForm(props: PropTypes) {
 			/>
 
 			<ConfirmationInput
-				phase={props.phase}
 				onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
 					props.setAccountHolderConfirmation(e.target.checked)
 				}
@@ -238,58 +236,33 @@ function RecaptchaInput(props: {
 }
 
 function ConfirmationInput(props: {
-	phase: Phase;
 	checked: boolean;
 	onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }) {
-	const editable = (
-		<span>
-			<div className="component-direct-debit-form__confirmation-css-checkbox">
-				<input
-					className="component-direct-debit-form__confirmation-input"
-					id="confirmation-input"
-					type="checkbox"
-					onChange={props.onChange}
-					checked={props.checked}
-				/>
-				<label
-					id="qa-confirmation-input"
-					className="component-direct-debit-form__confirmation-label"
-					htmlFor="confirmation-input"
-				/>
-			</div>
-			<span className="component-direct-debit-form__confirmation-text">
-				I confirm that I am the account holder and I am solely able to authorise
-				debit from the account
-			</span>
-		</span>
-	);
-	const locked = (
-		<span>
-			<label
-				htmlFor="confirmation-text__locked"
-				className="component-direct-debit-form__field-label"
-			>
-				Declaration
-			</label>
-			<div
-				id="confirmation-text__locked"
-				className="component-direct-debit-form__confirmation-text__locked"
-			>
-				I have confirmed that I am the account holder and that I am solely able
-				to authorise debit from the account
-			</div>
-			<div className="component-direct-debit-form__confirmation-guidance">
-				If the details above are correct press confirm to set up your direct
-				debit, otherwise press back to make changes
-			</div>
-		</span>
-	);
 	return (
 		<div className="component-direct-debit-form__account-holder-confirmation">
 			<div>
 				<label htmlFor="confirmation-input">
-					{props.phase === 'entry' ? editable : locked}
+					<span>
+						<div className="component-direct-debit-form__confirmation-css-checkbox">
+							<input
+								className="component-direct-debit-form__confirmation-input"
+								id="confirmation-input"
+								type="checkbox"
+								onChange={props.onChange}
+								checked={props.checked}
+							/>
+							<label
+								id="qa-confirmation-input"
+								className="component-direct-debit-form__confirmation-label"
+								htmlFor="confirmation-input"
+							/>
+						</div>
+						<span className="component-direct-debit-form__confirmation-text">
+							I confirm that I am the account holder and I am solely able to
+							authorise debit from the account
+						</span>
+					</span>
 				</label>
 			</div>
 		</div>
@@ -377,6 +350,6 @@ function LegalNotice(props: { countryGroupId: CountryGroupId }) {
 			<SvgDirectDebitSymbolAndText />
 		</div>
 	);
-} // ----- Exports ----- //
+}
 
 export default connector(DirectDebitForm);

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
@@ -94,7 +94,6 @@ function DirectDebitForm(props: PropTypes) {
 	return (
 		<div className="component-direct-debit-form">
 			<AccountHolderNameInput
-				phase={props.phase}
 				onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
 					props.setAccountHolderName(e.target.value)
 				}
@@ -201,21 +200,9 @@ function AccountNumberInput(props: {
  https://developer.gocardless.com/api-reference/
  * */
 function AccountHolderNameInput(props: {
-	phase: Phase;
 	value: string;
 	onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }) {
-	const editable = (
-		<input
-			id="account-holder-name-input"
-			data-qm-masking="blocklist"
-			value={props.value}
-			onChange={props.onChange}
-			maxLength={40}
-			className="component-direct-debit-form__text-field focus-target"
-		/>
-	);
-	const locked = <span>{props.value}</span>;
 	return (
 		<div className="component-direct-debit-form__account-holder-name">
 			<label
@@ -224,7 +211,14 @@ function AccountHolderNameInput(props: {
 			>
 				Account name
 			</label>
-			{props.phase === 'entry' ? editable : locked}
+			<input
+				id="account-holder-name-input"
+				data-qm-masking="blocklist"
+				value={props.value}
+				onChange={props.onChange}
+				maxLength={40}
+				className="component-direct-debit-form__text-field focus-target"
+			/>
 		</div>
 	);
 }

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
@@ -108,7 +108,6 @@ function DirectDebitForm(props: PropTypes) {
 			/>
 
 			<SortCodeInput
-				phase={props.phase}
 				onChange={(
 					index: SortCodeIndex,
 					e: React.ChangeEvent<HTMLInputElement>,

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
@@ -19,13 +19,9 @@ import {
 	setDDGuaranteeClose,
 	setDDGuaranteeOpen,
 	setFormError,
-	setPhase,
 	setSortCode,
 } from 'helpers/redux/checkout/payment/directDebit/actions';
-import type {
-	Phase,
-	SortCodeIndex,
-} from 'helpers/redux/checkout/payment/directDebit/state';
+import type { SortCodeIndex } from 'helpers/redux/checkout/payment/directDebit/state';
 import {
 	confirmAccountDetails,
 	directDebitErrorMessages,
@@ -38,7 +34,6 @@ import {
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import './directDebitForm.scss';
 
-// ----- Map State/Props ----- //
 function mapStateToProps(state: ContributionsState) {
 	return {
 		isDDGuaranteeOpen:
@@ -50,7 +45,6 @@ function mapStateToProps(state: ContributionsState) {
 		accountHolderConfirmation:
 			state.page.checkoutForm.payment.directDebit.accountHolderConfirmation,
 		formError: state.page.checkoutForm.payment.directDebit.formError,
-		phase: state.page.checkoutForm.payment.directDebit.phase,
 		countryGroupId: state.common.internationalisation.countryGroupId,
 		recaptchaCompleted: state.page.checkoutForm.recaptcha.completed,
 	};
@@ -59,7 +53,6 @@ function mapStateToProps(state: ContributionsState) {
 const mapDispatchToProps = {
 	confirmAccountDetails,
 	payWithDirectDebit,
-	setPhase,
 	setDDGuaranteeOpen,
 	setDDGuaranteeClose,
 	setSortCode,
@@ -82,6 +75,8 @@ const recaptchaId = 'robot_checkbox';
 // ----- Component ----- //
 function DirectDebitForm(props: PropTypes) {
 	function onSubmit() {
+		void props.confirmAccountDetails();
+
 		if (props.recaptchaCompleted) {
 			void props.payWithDirectDebit(props.onPaymentAuthorisation);
 		} else {
@@ -120,12 +115,10 @@ function DirectDebitForm(props: PropTypes) {
 				checked={props.accountHolderConfirmation}
 			/>
 
-			{props.phase === 'confirmation' && (
-				<RecaptchaInput
-					setRecaptchaToken={props.setRecaptchaToken}
-					expireRecaptchaToken={props.expireRecaptchaToken}
-				/>
-			)}
+			<RecaptchaInput
+				setRecaptchaToken={props.setRecaptchaToken}
+				expireRecaptchaToken={props.expireRecaptchaToken}
+			/>
 
 			{props.formError && (
 				<div className="component-direct-debit-form__error-message-container">
@@ -136,12 +129,7 @@ function DirectDebitForm(props: PropTypes) {
 				</div>
 			)}
 
-			<PaymentButton
-				phase={props.phase}
-				onPayClick={props.confirmAccountDetails}
-				onEditClick={() => props.setPhase('entry')}
-				onConfirmClick={onSubmit}
-			/>
+			<PaymentButton onConfirmClick={onSubmit} />
 
 			<LegalNotice countryGroupId={props.countryGroupId} />
 
@@ -268,49 +256,21 @@ function ConfirmationInput(props: {
 }
 
 function PaymentButton(props: {
-	phase: Phase;
-	onPayClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
-	onEditClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
 	onConfirmClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }) {
-	if (props.phase === 'entry') {
-		return (
-			<button
-				id="qa-submit-button-1"
-				className="component-direct-debit-form__cta component-direct-debit-form__cta--pay-button focus-target"
-				onClick={props.onPayClick}
-			>
-				<SvgDirectDebitSymbol />
-				<span className="component-direct-debit-form__cta-text">
-					Pay with Direct Debit
-				</span>
-				<SvgArrowRightStraight />
-			</button>
-		);
-	} else {
-		// confirmation phase
-		return (
-			<span>
-				<button
-					className="component-direct-debit-form__cta component-direct-debit-form__cta--edit-button focus-target"
-					onClick={props.onEditClick}
-				>
-					<SvgArrowRightStraight />
-					<span className="component-direct-debit-form__cta-text component-direct-debit-form__cta-text--inverse">
-						Back
-					</span>
-				</button>
-				<button
-					id="qa-submit-button-2"
-					className="component-direct-debit-form__cta component-direct-debit-form__cta--confirm-button focus-target"
-					onClick={props.onConfirmClick}
-				>
-					<span className="component-direct-debit-form__cta-text">Confirm</span>
-					<SvgArrowRightStraight />
-				</button>
+	return (
+		<button
+			id="qa-submit-button"
+			className="component-direct-debit-form__cta component-direct-debit-form__cta--pay-button focus-target"
+			onClick={props.onConfirmClick}
+		>
+			<SvgDirectDebitSymbol />
+			<span className="component-direct-debit-form__cta-text">
+				Pay with Direct Debit
 			</span>
-		);
-	}
+			<SvgArrowRightStraight />
+		</button>
+	);
 }
 
 function LegalNotice(props: { countryGroupId: CountryGroupId }) {

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
@@ -101,7 +101,6 @@ function DirectDebitForm(props: PropTypes) {
 			/>
 
 			<AccountNumberInput
-				phase={props.phase}
 				onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
 					props.setAccountNumber(e.target.value)
 				}
@@ -162,23 +161,9 @@ function DirectDebitForm(props: PropTypes) {
 
 // ----- Auxiliary components ----- //
 function AccountNumberInput(props: {
-	phase: Phase;
 	onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 	value: string;
 }) {
-	const editable = (
-		<input
-			id="account-number-input"
-			data-qm-masking="blocklist"
-			value={props.value}
-			onChange={props.onChange}
-			pattern="[0-9]*"
-			minLength={6}
-			maxLength={10}
-			className="component-direct-debit-form__text-field focus-target"
-		/>
-	);
-	const locked = <span>{props.value}</span>;
 	return (
 		<div className="component-direct-debit-form__account-number">
 			<label
@@ -187,7 +172,16 @@ function AccountNumberInput(props: {
 			>
 				Account number
 			</label>
-			{props.phase === 'entry' ? editable : locked}
+			<input
+				id="account-number-input"
+				data-qm-masking="blocklist"
+				value={props.value}
+				onChange={props.onChange}
+				pattern="[0-9]*"
+				minLength={6}
+				maxLength={10}
+				className="component-direct-debit-form__text-field focus-target"
+			/>
 		</div>
 	);
 }

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
@@ -74,7 +74,6 @@ const mapDispatchToProps = {
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
 type PropTypes = ConnectedProps<typeof connector> & {
-	buttonText: string;
 	onPaymentAuthorisation: (authorisation: PaymentAuthorisation) => void;
 };
 
@@ -138,7 +137,6 @@ function DirectDebitForm(props: PropTypes) {
 			)}
 
 			<PaymentButton
-				buttonText={props.buttonText}
 				phase={props.phase}
 				onPayClick={props.confirmAccountDetails}
 				onEditClick={() => props.setPhase('entry')}
@@ -270,7 +268,6 @@ function ConfirmationInput(props: {
 }
 
 function PaymentButton(props: {
-	buttonText: string;
 	phase: Phase;
 	onPayClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
 	onEditClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
@@ -285,7 +282,7 @@ function PaymentButton(props: {
 			>
 				<SvgDirectDebitSymbol />
 				<span className="component-direct-debit-form__cta-text">
-					{props.buttonText}
+					Pay with Direct Debit
 				</span>
 				<SvgArrowRightStraight />
 			</button>

--- a/support-frontend/assets/components/directDebit/directDebitForm/sortCodeInput.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/sortCodeInput.tsx
@@ -1,12 +1,7 @@
-// ----- Imports ----- //
 import * as React from 'react';
-import type {
-	Phase,
-	SortCodeIndex,
-} from 'helpers/redux/checkout/payment/directDebit/state';
+import type { SortCodeIndex } from 'helpers/redux/checkout/payment/directDebit/state';
 
 type SortCodePropTypes = {
-	phase: Phase;
 	sortCodeArray: string[];
 	onChange: (
 		index: SortCodeIndex,
@@ -14,51 +9,6 @@ type SortCodePropTypes = {
 	) => void;
 };
 
-function SortCodeInput(props: SortCodePropTypes): JSX.Element {
-	const editable = (
-		<span>
-			<SortCodeField
-				id="qa-sort-code-1"
-				value={props.sortCodeArray[0]}
-				onChange={(event) => props.onChange(0, event)}
-			/>
-			<span className="component-direct-debit-form__sort-code-separator">
-				&mdash;
-			</span>
-			<SortCodeField
-				id="qa-sort-code-2"
-				value={props.sortCodeArray[1]}
-				onChange={(event) => props.onChange(1, event)}
-			/>
-			<span className="component-direct-debit-form__sort-code-separator">
-				&mdash;
-			</span>
-			<SortCodeField
-				id="qa-sort-code-3"
-				value={props.sortCodeArray[2]}
-				onChange={(event) => props.onChange(2, event)}
-			/>
-		</span>
-	);
-	const locked = (
-		<span>
-			{props.sortCodeArray[0]}-{props.sortCodeArray[1]}-{props.sortCodeArray[2]}
-		</span>
-	);
-	return (
-		<div className="component-direct-debit-form__sort-code">
-			<label
-				htmlFor="sort-code-input"
-				className="component-direct-debit-form__field-label"
-			>
-				Sort Code
-			</label>
-			{props.phase === 'entry' ? editable : locked}
-		</div>
-	);
-}
-
-// ----- Auxiliary components ----- //
 function SortCodeField(props: {
 	id: string;
 	value: string;
@@ -77,6 +27,42 @@ function SortCodeField(props: {
 			className="component-direct-debit-form__sort-code-field focus-target"
 		/>
 	);
-} // ----- Exports ----- //
+}
+
+function SortCodeInput(props: SortCodePropTypes): JSX.Element {
+	return (
+		<div className="component-direct-debit-form__sort-code">
+			<label
+				htmlFor="sort-code-input"
+				className="component-direct-debit-form__field-label"
+			>
+				Sort Code
+			</label>
+			<span>
+				<SortCodeField
+					id="qa-sort-code-1"
+					value={props.sortCodeArray[0]}
+					onChange={(event) => props.onChange(0, event)}
+				/>
+				<span className="component-direct-debit-form__sort-code-separator">
+					&mdash;
+				</span>
+				<SortCodeField
+					id="qa-sort-code-2"
+					value={props.sortCodeArray[1]}
+					onChange={(event) => props.onChange(1, event)}
+				/>
+				<span className="component-direct-debit-form__sort-code-separator">
+					&mdash;
+				</span>
+				<SortCodeField
+					id="qa-sort-code-3"
+					value={props.sortCodeArray[2]}
+					onChange={(event) => props.onChange(2, event)}
+				/>
+			</span>
+		</div>
+	);
+}
 
 export default SortCodeInput;

--- a/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
+++ b/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
@@ -48,23 +48,6 @@
 	border-radius: 20px;
 }
 
-.component-direct-debit-pop-up-form__heading {
-	float: left;
-	font-family: $gu-headline;
-	font-weight: bolder;
-	font-size: 24px;
-	line-height: 30px;
-	max-width: 260px;
-	margin-top: $gu-v-spacing;
-	margin-bottom: $gu-v-spacing;
-	@include mq($from: mobileMedium) {
-		max-width: 280px;
-	}
-	@include mq($from: mobileLandscape) {
-		max-width: 400px;
-	}
-}
-
 .component-direct-debit-pop-up-form__heading--title {
 	display: block;
 	margin-left: 20px;

--- a/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
+++ b/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
@@ -48,11 +48,6 @@
 	border-radius: 20px;
 }
 
-.component-direct-debit-pop-up-form__heading--title {
-	display: block;
-	margin-left: 20px;
-}
-
 .component-direct-debit-pop-up-form__close-button {
 	border: solid 1px gu-colour(neutral-7);
 	border-radius: 800px;

--- a/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx
@@ -9,14 +9,12 @@ import {
 	resetFormError,
 	setPopupClose,
 } from 'helpers/redux/checkout/payment/directDebit/actions';
-import type { Phase } from 'helpers/redux/checkout/payment/directDebit/state';
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
 
 // ----- Map State/Props ----- //
 function mapStateToProps(state: ContributionsState) {
 	return {
 		isPopUpOpen: state.page.checkoutForm.payment.directDebit.isPopUpOpen,
-		phase: state.page.checkoutForm.payment.directDebit.phase,
 	};
 }
 
@@ -32,7 +30,6 @@ type PropTypes = ConnectedProps<typeof connector> & {
 	onPaymentAuthorisation: (authorisation: PaymentAuthorisation) => void;
 };
 
-// ----- Component ----- //
 function DirectDebitPopUpForm(props: PropTypes): JSX.Element {
 	function closePopup() {
 		props.setPopupClose();
@@ -43,9 +40,6 @@ function DirectDebitPopUpForm(props: PropTypes): JSX.Element {
 		return (
 			<div className="component-direct-debit-pop-up-form">
 				<div className="component-direct-debit-pop-up-form__content">
-					<h1 className="component-direct-debit-pop-up-form__heading">
-						<PageTitle phase={props.phase} />
-					</h1>
 					<button
 						id="qa-pay-with-direct-debit-close-pop-up"
 						className="component-direct-debit-pop-up-form__close-button focus-target"
@@ -66,32 +60,5 @@ function DirectDebitPopUpForm(props: PropTypes): JSX.Element {
 
 	return <></>;
 }
-
-// ----- Auxiliary Components ----- //
-function PageTitle(props: { phase: Phase }) {
-	if (props.phase === 'confirmation') {
-		return (
-			<span>
-				<span className="component-direct-debit-pop-up-form__heading--title">
-					Please confirm
-				</span>
-				<span className="component-direct-debit-pop-up-form__heading--title">
-					your details
-				</span>
-			</span>
-		);
-	}
-
-	return (
-		<span>
-			<span className="component-direct-debit-pop-up-form__heading--title">
-				Please enter
-			</span>
-			<span className="component-direct-debit-pop-up-form__heading--title">
-				your details below
-			</span>
-		</span>
-	);
-} // ----- Exports ----- //
 
 export default connector(DirectDebitPopUpForm);

--- a/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx
@@ -26,7 +26,6 @@ const mapDispatchToProps = {
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
 type PropTypes = ConnectedProps<typeof connector> & {
-	buttonText: string;
 	onPaymentAuthorisation: (authorisation: PaymentAuthorisation) => void;
 };
 
@@ -50,7 +49,6 @@ function DirectDebitPopUpForm(props: PropTypes): JSX.Element {
 						</span>
 					</button>
 					<DirectDebitForm
-						buttonText={props.buttonText}
 						onPaymentAuthorisation={props.onPaymentAuthorisation}
 					/>
 				</div>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/directDebitWrapper.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/directDebitWrapper.tsx
@@ -15,9 +15,6 @@ export function DirectDebitContainer(): JSX.Element {
 	}
 
 	return (
-		<DirectDebitPopUpForm
-			buttonText="Pay with Direct Debit"
-			onPaymentAuthorisation={onPaymentAuthorisation}
-		/>
+		<DirectDebitPopUpForm onPaymentAuthorisation={onPaymentAuthorisation} />
 	);
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This removes phasing from the direct debit form. Prior to this change, the popup form contained 2 phases, an initial 'input' phase as well as a 'confirmation' phase. This PR removes the confirmation phase.

[**Trello Card**](https://trello.com/c/TunDNvQi/1474-removing-phasing-from-directdebitpopupform-and-subcomponents)

## Why are you doing this?
As part of the work to transfer the direct debit popup form to the payment method selector
