### PR TITLE
Revert "BigQueryService: Close resources, but avoid closing client prematurely"

### DIFF
--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/bigquery/BigQueryService.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/bigquery/BigQueryService.scala
@@ -65,30 +65,23 @@ class BigQueryService(config: BigQueryConfig) {
       )
       .build()
   lazy val bigQueryWriteClient = BigQueryWriteClient.create(bigQueryWriteSettings)
-  lazy val tableId = TableName.of(config.projectId, datasetName, tableName)
-  lazy val streamWriter = JsonStreamWriter.newBuilder(tableId.toString(), bigQueryWriteClient).build();
-
-  def tableInsertRowWithRetry(acquisitionDataRow: AcquisitionDataRow, maxRetries: Int)(implicit
-      executionContext: ExecutionContext,
-  ): EitherT[Future, List[String], Unit] = Retry(maxRetries)(sendAcquisition(acquisitionDataRow))
 
   def sendAcquisition(acquisitionDataRow: AcquisitionDataRow): EitherT[Future, String, Unit] =
     EitherT(
       send(acquisitionDataRow),
     )
 
-  /** Release resources held by the service.
-    */
-  def shutdown(): Unit = {
-    streamWriter.close()
-    bigQueryWriteClient.close()
-  }
+  def tableInsertRowWithRetry(acquisitionDataRow: AcquisitionDataRow, maxRetries: Int)(implicit
+      executionContext: ExecutionContext,
+  ): EitherT[Future, List[String], Unit] = Retry(maxRetries)(sendAcquisition(acquisitionDataRow))
 
   private def send(
       acquisitionDataRow: AcquisitionDataRow,
   ): Future[Either[String, Unit]] = {
+    val tableId = TableName.of(config.projectId, datasetName, tableName)
     val rowContent: JSONObject = AcquisitionDataRowMapper.mapToTableRow(acquisitionDataRow)
     SafeLogger.info(s"Attempting to append row ($rowContent) created from ($acquisitionDataRow)")
+    val streamWriter = JsonStreamWriter.newBuilder(tableId.toString(), bigQueryWriteClient).build();
     val promise = Promise[Either[String, Unit]]()
     try {
       val responseFuture = streamWriter.append(new JSONArray(List(rowContent).asJava));

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -86,14 +86,8 @@ class SendAcquisitionEvent(serviceProvider: ServiceProvider = ServiceProvider)
     } yield ()
 
     result.value.map {
-      case Left(errorMessage) => {
-        services.bigQueryService.shutdown()
-        throw new RetryNone(errorMessage.mkString(" & "))
-      }
-      case Right(_) => {
-        services.bigQueryService.shutdown()
-        HandlerResult((), requestInfo)
-      }
+      case Left(errorMessage) => throw new RetryNone(errorMessage.mkString(" & "))
+      case Right(_) => HandlerResult((), requestInfo)
     }
   }
 


### PR DESCRIPTION
Reverts guardian/support-frontend#5171

Merging that appears to have broken support-workers’ acquisition event lambda: I don’t know why.