### PR TITLE
Hide benefits list when a user cannot contribute above the threshold

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -2,6 +2,7 @@ import type { ContributionType } from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import { currencies } from 'helpers/internationalisation/currency';
 import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
+import { shouldHideBenefitsList } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import { getMinimumContributionAmount } from 'helpers/redux/commonState/selectors';
@@ -41,7 +42,9 @@ export function CheckoutBenefitsListContainer({
 	const dispatch = useContributionsDispatch();
 
 	const contributionType = useContributionsSelector(getContributionType);
-	if (isOneOff(contributionType)) {
+	const benefitsListIsHidden = useContributionsSelector(shouldHideBenefitsList);
+
+	if (benefitsListIsHidden || isOneOff(contributionType)) {
 		return null;
 	}
 

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/isSupporterPlus.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/isSupporterPlus.ts
@@ -25,3 +25,23 @@ export function isSupporterPlusPurchase(state: ContributionsState): boolean {
 
 	return amountIsHighEnough;
 }
+
+export function shouldHideBenefitsList(state: ContributionsState): boolean {
+	const contributionType = getContributionType(state);
+
+	if (isOneOff(contributionType)) {
+		return true;
+	}
+
+	const thresholdPrice = getThresholdPrice(
+		state.common.internationalisation.countryGroupId,
+		contributionType,
+	);
+	const displayedAmounts = state.common.amounts[contributionType];
+	const customAmountIsHidden = displayedAmounts.hideChooseYourAmount ?? false;
+
+	const thresholdPriceIsNotOffered =
+		Math.max(...displayedAmounts.amounts) < thresholdPrice;
+
+	return thresholdPriceIsNotOffered && customAmountIsHidden;
+}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds a condition to the rendering of the benefits list to hide it if it is not possible for a user to contribute an amount over the threshold for receiving supporter plus benefits- ie. they cannot enter a custom amount, and the pre-set amounts are all under the threshold.

[**Trello Card**](https://trello.com/c/H63ql4Ua)

## Why are you doing this?

We need to be able to not sell supporter plus in specific countries or regions for tax reasons. Amounts can now be controlled on a per-country basis from the RRCP, so this simply avoids users seeing a list of benefits that they can't actually purchase.

## Is this an AB test?
- [ ] Yes
- [x] No

## Screenshots

![Screenshot 2023-08-08 at 12-27-08 Support the Guardian](https://github.com/guardian/support-frontend/assets/29146931/ffad5e13-6dea-494a-8da4-342347ddb37e)

