### PR TITLE
Increase timeout for calling idapi to 7 seconds

### DIFF
--- a/support-frontend/app/services/HttpIdentityService.scala
+++ b/support-frontend/app/services/HttpIdentityService.scala
@@ -151,7 +151,7 @@ class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient:
         .url(s"$apiUrl/user")
         .withHttpHeaders(List("X-GU-ID-Client-Access-Token" -> s"Bearer $apiClientToken"): _*)
         .withQueryStringParameters(List("emailAddress" -> email): _*)
-        .withRequestTimeout(5.seconds)
+        .withRequestTimeout(7.seconds)
         .withMethod("GET"),
     ) { resp =>
       resp.json
@@ -191,7 +191,7 @@ class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient:
           ).flattenValues: _*,
         )
         .withBody(body)
-        .withRequestTimeout(5.seconds)
+        .withRequestTimeout(7.seconds)
         .withMethod("POST")
         .withQueryStringParameters(
           List(


### PR DESCRIPTION
We’ve had a couple more timeouts recently (4 in the last 2 months). We’d like to increase the timeout length slightly more to see if that resolves them, as we understand that the calls can take a while because it involves calling Okta.
