### PR TITLE
Allow site to continue when identity gateway is down

### DIFF
--- a/support-frontend/app/services/AuthenticationService.scala
+++ b/support-frontend/app/services/AuthenticationService.scala
@@ -47,6 +47,13 @@ class AsyncAuthenticationService(identityPlayAuthService: IdapiPlayAuthService, 
     ws.url(config.oauthTokenUrl)
       .addHttpHeaders(CONTENT_TYPE -> FORM)
       .post(requestBody)
+
+  /** eventually true iff auth server is available for requests */
+  def isAuthServerUp(): Future[Boolean] =
+    ws.url(config.oauthAuthorizeUrl)
+      .head()
+      .map(_.status < 500)
+      .recover { case _ => false }
 }
 
 object AsyncAuthenticationService {

--- a/support-frontend/app/wiring/Services.scala
+++ b/support-frontend/app/wiring/Services.scala
@@ -1,7 +1,7 @@
 package wiring
 
-import actions.{UserFromAuthCookiesOrAuthServerActionBuilder, UserFromAuthCookiesActionBuilder}
 import actions.UserFromAuthCookiesActionBuilder.UserClaims
+import actions.{UserFromAuthCookiesActionBuilder, UserFromAuthCookiesOrAuthServerActionBuilder}
 import admin.settings.AllSettingsProvider
 import cats.syntax.either._
 import com.gu.aws.AwsS3Client
@@ -59,6 +59,7 @@ trait Services {
     controllerComponents.parsers.defaultBodyParser,
     oktaAuthService,
     appConfig.identity,
+    isAuthServerUp = asyncAuthenticationService.isAuthServerUp,
   )
 
   lazy val userFromAuthCookiesActionBuilder = new UserFromAuthCookiesActionBuilder(


### PR DESCRIPTION
## What are you doing in this PR?
This change ensures that when [gateway](https://profile.theguardian.com/) is down readers are still able to create subscriptions and make contributions.  It does this by making a server-side preflight call to the auth server to check that it's responding appropriately before starting the auth flow.  If the auth server is down the request will continue without user data, in the same way it would do if there were no signed-in user.

The preflight call will only take place if a call to the auth server is necessary for authentication.  In many cases, the cookies that are already present will be enough to authenticate the user.

## How to test
1. Go to /uk/contribute in Code in an Incognito window and inspect network tab to see that call to auth flow is being made.
2. Disable Code gateway and then go to /uk/contribute in Code in an Incognito window and inspect network tab to see that call to auth flow is not being made.  Failure to authenticate should be logged in Cloudwatch.

[**Trello Card**](https://trello.com/c/B50MXOR6/4493-support-site-should-continue-to-work-when-gateway-is-down)
