### PR TITLE
Migrate contribs/S+ direct debit components to use the Redux hooks pattern

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
@@ -1,7 +1,5 @@
 // ----- Imports ----- //
 import * as React from 'react';
-import type { ConnectedProps } from 'react-redux';
-import { connect } from 'react-redux';
 import DirectDebitGuarantee from 'components/directDebit/directDebitForm/directDebitGuarantee';
 import SortCodeInput from 'components/directDebit/directDebitForm/sortCodeInput';
 import ErrorMessage from 'components/errorMessage/errorMessage';
@@ -36,45 +34,13 @@ import {
 	expireRecaptchaToken,
 	setRecaptchaToken,
 } from 'helpers/redux/checkout/recaptcha/actions';
-import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import './directDebitForm.scss';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
 
-// ----- Map State/Props ----- //
-function mapStateToProps(state: ContributionsState) {
-	return {
-		isDDGuaranteeOpen:
-			state.page.checkoutForm.payment.directDebit.isDDGuaranteeOpen,
-		sortCodeArray: state.page.checkoutForm.payment.directDebit.sortCodeArray,
-		accountNumber: state.page.checkoutForm.payment.directDebit.accountNumber,
-		accountHolderName:
-			state.page.checkoutForm.payment.directDebit.accountHolderName,
-		accountHolderConfirmation:
-			state.page.checkoutForm.payment.directDebit.accountHolderConfirmation,
-		formError: state.page.checkoutForm.payment.directDebit.formError,
-		phase: state.page.checkoutForm.payment.directDebit.phase,
-		countryGroupId: state.common.internationalisation.countryGroupId,
-		recaptchaCompleted: state.page.checkoutForm.recaptcha.completed,
-	};
-}
-
-const mapDispatchToProps = {
-	confirmAccountDetails,
-	payWithDirectDebit,
-	setPhase,
-	setDDGuaranteeOpen,
-	setDDGuaranteeClose,
-	setSortCode,
-	setAccountHolderConfirmation,
-	setAccountHolderName,
-	setAccountNumber,
-	setFormError,
-	setRecaptchaToken,
-	expireRecaptchaToken,
-};
-
-const connector = connect(mapStateToProps, mapDispatchToProps);
-
-type PropTypes = ConnectedProps<typeof connector> & {
+type PropTypes = {
 	buttonText: string;
 	onPaymentAuthorisation: (authorisation: PaymentAuthorisation) => void;
 };
@@ -82,80 +48,99 @@ type PropTypes = ConnectedProps<typeof connector> & {
 const recaptchaId = 'robot_checkbox';
 
 // ----- Component ----- //
-function DirectDebitForm(props: PropTypes) {
+export default function DirectDebitForm(props: PropTypes): JSX.Element {
+	const {
+		isDDGuaranteeOpen,
+		sortCodeArray,
+		accountNumber,
+		accountHolderName,
+		accountHolderConfirmation,
+		formError,
+		phase,
+	} = useContributionsSelector(
+		(state) => state.page.checkoutForm.payment.directDebit,
+	);
+
+	const { countryGroupId } = useContributionsSelector(
+		(state) => state.common.internationalisation,
+	);
+
+	const recaptchaCompleted = useContributionsSelector(
+		(state) => state.page.checkoutForm.recaptcha.completed,
+	);
+
+	const dispatch = useContributionsDispatch();
+
 	function onSubmit() {
-		if (props.recaptchaCompleted) {
-			void props.payWithDirectDebit(props.onPaymentAuthorisation);
+		if (recaptchaCompleted) {
+			void dispatch(payWithDirectDebit(props.onPaymentAuthorisation));
 		} else {
-			props.setFormError(directDebitErrorMessages.notCompletedRecaptcha);
+			dispatch(setFormError(directDebitErrorMessages.notCompletedRecaptcha));
 		}
 	}
 
 	return (
 		<div className="component-direct-debit-form">
 			<AccountHolderNameInput
-				phase={props.phase}
+				phase={phase}
 				onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-					props.setAccountHolderName(e.target.value)
+					dispatch(setAccountHolderName(e.target.value))
 				}
-				value={props.accountHolderName}
+				value={accountHolderName}
 			/>
 
 			<AccountNumberInput
-				phase={props.phase}
+				phase={phase}
 				onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-					props.setAccountNumber(e.target.value)
+					dispatch(setAccountNumber(e.target.value))
 				}
-				value={props.accountNumber}
+				value={accountNumber}
 			/>
 
 			<SortCodeInput
-				phase={props.phase}
+				phase={phase}
 				onChange={(
 					index: SortCodeIndex,
 					e: React.ChangeEvent<HTMLInputElement>,
-				) => props.setSortCode({ index, partialSortCode: e.target.value })}
-				sortCodeArray={props.sortCodeArray}
+				) => dispatch(setSortCode({ index, partialSortCode: e.target.value }))}
+				sortCodeArray={sortCodeArray}
 			/>
 
 			<ConfirmationInput
-				phase={props.phase}
+				phase={phase}
 				onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-					props.setAccountHolderConfirmation(e.target.checked)
+					dispatch(setAccountHolderConfirmation(e.target.checked))
 				}
-				checked={props.accountHolderConfirmation}
+				checked={accountHolderConfirmation}
 			/>
 
-			{props.phase === 'confirmation' && (
+			{phase === 'confirmation' && (
 				<RecaptchaInput
-					setRecaptchaToken={props.setRecaptchaToken}
-					expireRecaptchaToken={props.expireRecaptchaToken}
+					setRecaptchaToken={(token) => dispatch(setRecaptchaToken(token))}
+					expireRecaptchaToken={() => dispatch(expireRecaptchaToken())}
 				/>
 			)}
 
-			{props.formError && (
+			{formError && (
 				<div className="component-direct-debit-form__error-message-container">
-					<ErrorMessage
-						message={props.formError}
-						svg={<SvgExclamationAlternate />}
-					/>
+					<ErrorMessage message={formError} svg={<SvgExclamationAlternate />} />
 				</div>
 			)}
 
 			<PaymentButton
 				buttonText={props.buttonText}
-				phase={props.phase}
-				onPayClick={props.confirmAccountDetails}
-				onEditClick={() => props.setPhase('entry')}
+				phase={phase}
+				onPayClick={() => dispatch(confirmAccountDetails())}
+				onEditClick={() => dispatch(setPhase('entry'))}
 				onConfirmClick={onSubmit}
 			/>
 
-			<LegalNotice countryGroupId={props.countryGroupId} />
+			<LegalNotice countryGroupId={countryGroupId} />
 
 			<DirectDebitGuarantee
-				isDDGuaranteeOpen={props.isDDGuaranteeOpen}
-				openDirectDebitGuarantee={props.setDDGuaranteeOpen}
-				closeDirectDebitGuarantee={props.setDDGuaranteeClose}
+				isDDGuaranteeOpen={isDDGuaranteeOpen}
+				openDirectDebitGuarantee={setDDGuaranteeOpen}
+				closeDirectDebitGuarantee={() => dispatch(setDDGuaranteeClose())}
 			/>
 		</div>
 	);
@@ -390,6 +375,4 @@ function LegalNotice(props: { countryGroupId: CountryGroupId }) {
 			<SvgDirectDebitSymbolAndText />
 		</div>
 	);
-} // ----- Exports ----- //
-
-export default connector(DirectDebitForm);
+}

--- a/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx
@@ -84,4 +84,4 @@ function PageTitle(props: { phase: Phase }) {
 			</span>
 		</span>
 	);
-} // ----- Exports ----- //
+}

--- a/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx
@@ -1,6 +1,4 @@
 // ----- Imports ----- //
-import type { ConnectedProps } from 'react-redux';
-import { connect } from 'react-redux';
 import DirectDebitForm from 'components/directDebit/directDebitForm/directDebitForm';
 import SvgCross from 'components/svgs/cross';
 import type { PaymentAuthorisation } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
@@ -10,41 +8,35 @@ import {
 	setPopupClose,
 } from 'helpers/redux/checkout/payment/directDebit/actions';
 import type { Phase } from 'helpers/redux/checkout/payment/directDebit/state';
-import type { ContributionsState } from 'helpers/redux/contributionsStore';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
 
-// ----- Map State/Props ----- //
-function mapStateToProps(state: ContributionsState) {
-	return {
-		isPopUpOpen: state.page.checkoutForm.payment.directDebit.isPopUpOpen,
-		phase: state.page.checkoutForm.payment.directDebit.phase,
-	};
-}
-
-const mapDispatchToProps = {
-	setPopupClose,
-	resetFormError,
-};
-
-const connector = connect(mapStateToProps, mapDispatchToProps);
-
-type PropTypes = ConnectedProps<typeof connector> & {
+type PropTypes = {
 	buttonText: string;
 	onPaymentAuthorisation: (authorisation: PaymentAuthorisation) => void;
 };
 
 // ----- Component ----- //
-function DirectDebitPopUpForm(props: PropTypes): JSX.Element {
+export default function DirectDebitPopUpForm(props: PropTypes): JSX.Element {
+	const { isPopUpOpen, phase } = useContributionsSelector(
+		(state) => state.page.checkoutForm.payment.directDebit,
+	);
+
+	const dispatch = useContributionsDispatch();
+
 	function closePopup() {
-		props.setPopupClose();
-		props.resetFormError();
+		dispatch(setPopupClose);
+		dispatch(resetFormError);
 	}
 
-	if (props.isPopUpOpen) {
+	if (isPopUpOpen) {
 		return (
 			<div className="component-direct-debit-pop-up-form">
 				<div className="component-direct-debit-pop-up-form__content">
 					<h1 className="component-direct-debit-pop-up-form__heading">
-						<PageTitle phase={props.phase} />
+						<PageTitle phase={phase} />
 					</h1>
 					<button
 						id="qa-pay-with-direct-debit-close-pop-up"
@@ -93,5 +85,3 @@ function PageTitle(props: { phase: Phase }) {
 		</span>
 	);
 } // ----- Exports ----- //
-
-export default connector(DirectDebitPopUpForm);


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This migrates our existing direct debit components to use the `useContributionsSelector` and `useContributionsDispatch` hooks rather than the deprecated connected props pattern.

[**Trello Card**](https://trello.com/c/DoAUCR1g)

## Why are you doing this?

This lays useful groundwork for ongoing work to replace this component with something more in line with the current design and UX of the checkout.
