### PR TITLE
No Benefits AB test

### DIFF
--- a/support-frontend/assets/components/tooltip/TooltipContainer.tsx
+++ b/support-frontend/assets/components/tooltip/TooltipContainer.tsx
@@ -1,0 +1,19 @@
+import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import { isOneOff } from 'helpers/supporterPlus/isContributionRecurring';
+
+type TooltipContainerProps = {
+	renderTooltip: () => JSX.Element;
+};
+
+export function TooltipContainer({
+	renderTooltip,
+}: TooltipContainerProps): JSX.Element | null {
+	const contributionType = useContributionsSelector(getContributionType);
+
+	if (isOneOff(contributionType)) {
+		return null;
+	}
+
+	return renderTooltip();
+}

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/isSupporterPlus.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/isSupporterPlus.ts
@@ -33,6 +33,18 @@ export function shouldHideBenefitsList(state: ContributionsState): boolean {
 		return true;
 	}
 
+	/**
+	 * Hide benefits if participating in RRCP
+	 * configured amounts test 2023-08-08_BENEFITS_GONE
+	 */
+	const { abParticipations } = state.common;
+	if (
+		abParticipations['2023-08-08_BENEFITS_GONE'] === 'V1' ||
+		abParticipations['2023-08-08_BENEFITS_GONE'] === 'V3'
+	) {
+		return true;
+	}
+
 	const thresholdPrice = getThresholdPrice(
 		state.common.internationalisation.countryGroupId,
 		contributionType,

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -11,6 +11,7 @@ import { PaymentFrequencyTabs } from 'components/paymentFrequencyTabs/paymentFre
 import { PriceCards } from 'components/priceCards/priceCards';
 import { PriceCardsContainer } from 'components/priceCards/priceCardsContainer';
 import Tooltip from 'components/tooltip/Tooltip';
+import { TooltipContainer } from 'components/tooltip/TooltipContainer';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 export function AmountAndBenefits({
@@ -71,14 +72,18 @@ export function AmountAndBenefits({
 									<CheckoutBenefitsList {...benefitsListProps} />
 								)}
 							/>
-							<Tooltip promptText="Cancel anytime">
-								<p>
-									You can cancel
-									{countryGroupId === 'GBPCountries' ? '' : ' online'} anytime
-									before your next payment date. If you cancel in the first 14
-									days, you will receive a full refund.
-								</p>
-							</Tooltip>
+							<TooltipContainer
+								renderTooltip={() => (
+									<Tooltip promptText="Cancel anytime">
+										<p>
+											You can cancel
+											{countryGroupId === 'GBPCountries' ? '' : ' online'}{' '}
+											anytime before your next payment date. If you cancel in
+											the first 14 days, you will receive a full refund.
+										</p>
+									</Tooltip>
+								)}
+							/>
 							<CheckoutNudgeContainer
 								renderNudge={(nudgeProps) => <CheckoutNudge {...nudgeProps} />}
 							/>


### PR DESCRIPTION
## What are you doing in this PR?

This PR hides the benefits list if a user is participating in the `2023-08-08_BENEFITS_GONE` RRCP configured Amounts test and has been assigned to either the `V1` or `V3` cohort.

Note: When looking at this I also noted an issue we introduced when moving the Tooltip out of the benefits list ( https://github.com/guardian/support-frontend/pull/5176), this inadvertently meant the "Cancel anytime" Tooltip started appearing on the Single tab. To address this I've put in an `isOneOff` check when deciding to render this "Cancel anytime" Tooltip, I've also put this in a `TooltipContainer` module to keep the logic out of the presentational `Tooltip` component.


[**Trello Card**](https://trello.com/c/j4eWBkHY/1471-removing-benefits-on-the-current-1-step-checkout-a-b-test-with-amounts)

