### PR TITLE
Remove country specific benefits (Australia GW landing page)

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -1,5 +1,4 @@
 import { List } from 'components/list/list';
-import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import BenefitsContainer from './benefitsContainer';
 import BenefitsHeading from './benefitsHeading';
@@ -16,19 +15,7 @@ const coreBenefits = [
 	},
 ];
 
-function getBenefits(countryId: IsoCountry, countryGroupId: CountryGroupId) {
-	if (countryId === 'AU') {
-		return [
-			{
-				content: 'Every issue delivered with up to 35% off the cover price',
-			},
-			...coreBenefits,
-			{
-				content:
-					'A free Guardian Weekly tote bag with every 12 for 12 subscription',
-			},
-		];
-	}
+function getBenefits(countryGroupId: CountryGroupId) {
 	const discount = countryGroupId === 'EURCountries' ? '87' : '35';
 	return [
 		{
@@ -39,10 +26,8 @@ function getBenefits(countryId: IsoCountry, countryGroupId: CountryGroupId) {
 }
 
 function Benefits({
-	countryId,
 	countryGroupId,
 }: {
-	countryId: IsoCountry;
 	countryGroupId: CountryGroupId;
 }): JSX.Element {
 	return (
@@ -53,7 +38,7 @@ function Benefits({
 					content: (
 						<>
 							<BenefitsHeading text="As a subscriber you’ll enjoy" />
-							<List items={getBenefits(countryId, countryGroupId)} />
+							<List items={getBenefits(countryGroupId)} />
 						</>
 					),
 				},

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -94,7 +94,7 @@ function WeeklyLPControl({
 						{orderIsAGift ? (
 							<GiftBenefits />
 						) : (
-							<Benefits countryId={countryId} countryGroupId={countryGroupId} />
+							<Benefits countryGroupId={countryGroupId} />
 						)}
 					</Block>
 				</CentredContainer>
@@ -180,7 +180,7 @@ function WeeklyLPVariant({
 						{orderIsAGift ? (
 							<GiftBenefits />
 						) : (
-							<Benefits countryId={countryId} countryGroupId={countryGroupId} />
+							<Benefits countryGroupId={countryGroupId} />
 						)}
 					</Block>
 				</CentredContainer>


### PR DESCRIPTION
Reverts https://github.com/guardian/support-frontend/pull/5036

AUS GW landing page ONLY:

Removes the hard coded lines under ‘As a subscriber you’ll enjoy' as follows->
MODIFY: 'Every issue delivered with up to 35% off the cover price' -> 'Every issue delivered with up to 91% off the cover price'
ADD: 'A free Guardian Weekly tote bag with every 12 for 12 subscription'

CountryId not required for benefits now, removed.