### PR TITLE
Iterate through possible hide benefits test names

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/isSupporterPlus.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/isSupporterPlus.ts
@@ -1,3 +1,4 @@
+import type { Participations } from 'helpers/abTests/abtest';
 import { getAmount } from 'helpers/contributions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
@@ -26,6 +27,31 @@ export function isSupporterPlusPurchase(state: ContributionsState): boolean {
 	return amountIsHighEnough;
 }
 
+function isInHideBenefitsTest(abParticipations: Participations): boolean {
+	const regionalSuffixList: string[] = [
+		'UK',
+		'US',
+		'CA',
+		'EU',
+		'AU',
+		'NZ',
+		'ROW',
+	];
+
+	return regionalSuffixList.reduce((hideBenefits, suffix): boolean => {
+		const testName = `2023-08-08_BENEFITS_GONE__${suffix}`;
+
+		if (
+			abParticipations[testName] === 'V1' ||
+			abParticipations[testName] === 'V3'
+		) {
+			return true;
+		}
+
+		return hideBenefits;
+	}, false);
+}
+
 export function shouldHideBenefitsList(state: ContributionsState): boolean {
 	const contributionType = getContributionType(state);
 
@@ -38,10 +64,8 @@ export function shouldHideBenefitsList(state: ContributionsState): boolean {
 	 * configured amounts test 2023-08-08_BENEFITS_GONE
 	 */
 	const { abParticipations } = state.common;
-	if (
-		abParticipations['2023-08-08_BENEFITS_GONE'] === 'V1' ||
-		abParticipations['2023-08-08_BENEFITS_GONE'] === 'V3'
-	) {
+
+	if (isInHideBenefitsTest(abParticipations)) {
 		return true;
 	}
 


### PR DESCRIPTION
## What are you doing in this PR?

It turns out the hide benefits test name in the RRCP is not '2023-08-08_BENEFITS_GONE', but that they're actually multiple tests (one per region) with the region code appended on the test name by convention when setting the test up in RRCP. So the actual test names are:

2023-08-08_BENEFITS_GONE__UK
2023-08-08_BENEFITS_GONE__US
2023-08-08_BENEFITS_GONE__CA
2023-08-08_BENEFITS_GONE__EU
2023-08-08_BENEFITS_GONE__AU
2023-08-08_BENEFITS_GONE__NZ
2023-08-08_BENEFITS_GONE__ROW

I've therefore had to update the check so we iterate over the possible test names.