### PR TITLE
remove countrygroup specific benefits  (EU GW landing page)

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -17,10 +17,6 @@ const coreBenefits = [
 	},
 ];
 
-function getBenefits() {
-	return coreBenefits;
-}
-
 function Benefits(): JSX.Element {
 	return (
 		<BenefitsContainer
@@ -30,7 +26,7 @@ function Benefits(): JSX.Element {
 					content: (
 						<>
 							<BenefitsHeading text="As a subscriber you’ll enjoy" />
-							<List items={getBenefits()} />
+							<List items={coreBenefits} />
 						</>
 					),
 				},

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -1,9 +1,11 @@
 import { List } from 'components/list/list';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import BenefitsContainer from './benefitsContainer';
 import BenefitsHeading from './benefitsHeading';
 
 const coreBenefits = [
+	{
+		content: `Every issue delivered with up to 35% off the cover price`,
+	},
 	{
 		content: "Access to the magazine's digital archive",
 	},
@@ -15,31 +17,11 @@ const coreBenefits = [
 	},
 ];
 
-function getBenefits(countryGroupId: CountryGroupId) {
-	const discount = getDiscountGW(countryGroupId);
-	return [
-		{
-			content: `Every issue delivered with up to ${discount}% off the cover price`,
-		},
-		...coreBenefits,
-	];
+function getBenefits() {
+	return coreBenefits;
 }
 
-function getDiscountGW(countryGroupId: CountryGroupId): number {
-	switch (countryGroupId) {
-		case 'Canada':
-		case 'UnitedStates':
-			return 50;
-		default:
-			return 20;
-	}
-}
-
-function Benefits({
-	countryGroupId,
-}: {
-	countryGroupId: CountryGroupId;
-}): JSX.Element {
+function Benefits(): JSX.Element {
 	return (
 		<BenefitsContainer
 			sections={[
@@ -48,7 +30,7 @@ function Benefits({
 					content: (
 						<>
 							<BenefitsHeading text="As a subscriber you’ll enjoy" />
-							<List items={getBenefits(countryGroupId)} />
+							<List items={getBenefits()} />
 						</>
 					),
 				},

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -1,9 +1,11 @@
 import { List } from 'components/list/list';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import BenefitsContainer from './benefitsContainer';
 import BenefitsHeading from './benefitsHeading';
 
 const coreBenefits = [
+	{
+		content: `Every issue delivered with up to 35% off the cover price`,
+	},
 	{
 		content: "Access to the magazine's digital archive",
 	},
@@ -15,21 +17,11 @@ const coreBenefits = [
 	},
 ];
 
-function getBenefits(countryGroupId: CountryGroupId) {
-	const discount = countryGroupId === 'EURCountries' ? '87' : '35';
-	return [
-		{
-			content: `Every issue delivered with up to ${discount}% off the cover price`,
-		},
-		...coreBenefits,
-	];
+function getBenefits() {
+	return coreBenefits;
 }
 
-function Benefits({
-	countryGroupId,
-}: {
-	countryGroupId: CountryGroupId;
-}): JSX.Element {
+function Benefits(): JSX.Element {
 	return (
 		<BenefitsContainer
 			sections={[
@@ -38,7 +30,7 @@ function Benefits({
 					content: (
 						<>
 							<BenefitsHeading text="As a subscriber you’ll enjoy" />
-							<List items={getBenefits(countryGroupId)} />
+							<List items={getBenefits()} />
 						</>
 					),
 				},

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -1,4 +1,5 @@
 import { List } from 'components/list/list';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import BenefitsContainer from './benefitsContainer';
 import BenefitsHeading from './benefitsHeading';
 
@@ -17,11 +18,31 @@ const coreBenefits = [
 	},
 ];
 
-function getBenefits() {
-	return coreBenefits;
+function getBenefits(countryGroupId: CountryGroupId) {
+	const discount = getDiscountGW(countryGroupId);
+	return [
+		{
+			content: `Every issue delivered with up to ${discount}% off the cover price`,
+		},
+		...coreBenefits,
+	];
 }
 
-function Benefits(): JSX.Element {
+function getDiscountGW(countryGroupId: CountryGroupId): number {
+	switch (countryGroupId) {
+		case 'Canada':
+		case 'UnitedStates':
+			return 50;
+		default:
+			return 20;
+	}
+}
+
+function Benefits({
+	countryGroupId,
+}: {
+	countryGroupId: CountryGroupId;
+}): JSX.Element {
 	return (
 		<BenefitsContainer
 			sections={[
@@ -30,7 +51,7 @@ function Benefits(): JSX.Element {
 					content: (
 						<>
 							<BenefitsHeading text="As a subscriber you’ll enjoy" />
-							<List items={getBenefits()} />
+							<List items={getBenefits(countryGroupId)} />
 						</>
 					),
 				},

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -5,9 +5,6 @@ import BenefitsHeading from './benefitsHeading';
 
 const coreBenefits = [
 	{
-		content: `Every issue delivered with up to 35% off the cover price`,
-	},
-	{
 		content: "Access to the magazine's digital archive",
 	},
 	{

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -91,7 +91,11 @@ function WeeklyLPControl({
 			<FullWidthContainer>
 				<CentredContainer>
 					<Block cssOverrides={styles.closeGapAfterPageTitle}>
-						{orderIsAGift ? <GiftBenefits /> : <Benefits />}
+						{orderIsAGift ? (
+							<GiftBenefits />
+						) : (
+							<Benefits countryGroupId={countryGroupId} />
+						)}
 					</Block>
 				</CentredContainer>
 			</FullWidthContainer>
@@ -173,7 +177,11 @@ function WeeklyLPVariant({
 			<FullWidthContainer>
 				<CentredContainer>
 					<Block cssOverrides={styles.closeGapAfterPageTitle}>
-						{orderIsAGift ? <GiftBenefits /> : <Benefits />}
+						{orderIsAGift ? (
+							<GiftBenefits />
+						) : (
+							<Benefits countryGroupId={countryGroupId} />
+						)}
 					</Block>
 				</CentredContainer>
 			</FullWidthContainer>

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -91,11 +91,7 @@ function WeeklyLPControl({
 			<FullWidthContainer>
 				<CentredContainer>
 					<Block cssOverrides={styles.closeGapAfterPageTitle}>
-						{orderIsAGift ? (
-							<GiftBenefits />
-						) : (
-							<Benefits countryGroupId={countryGroupId} />
-						)}
+						{orderIsAGift ? <GiftBenefits /> : <Benefits />}
 					</Block>
 				</CentredContainer>
 			</FullWidthContainer>
@@ -177,11 +173,7 @@ function WeeklyLPVariant({
 			<FullWidthContainer>
 				<CentredContainer>
 					<Block cssOverrides={styles.closeGapAfterPageTitle}>
-						{orderIsAGift ? (
-							<GiftBenefits />
-						) : (
-							<Benefits countryGroupId={countryGroupId} />
-						)}
+						{orderIsAGift ? <GiftBenefits /> : <Benefits />}
 					</Block>
 				</CentredContainer>
 			</FullWidthContainer>


### PR DESCRIPTION
Reverts https://github.com/guardian/support-frontend/pull/5138

Removes the copy on the Guardian Weekly landing page specifically for EU countries. For those countries the discount should be 35% not 87% now.

CountryGroupId not required for benefits currently so removed.