### PR TITLE
Create checkout summary component for the 2 step A/B test

### DIFF
--- a/support-frontend/assets/components/checkmarkList/checkmarkList.tsx
+++ b/support-frontend/assets/components/checkmarkList/checkmarkList.tsx
@@ -7,9 +7,11 @@ const checkListIconCss = (style: CheckmarkListStyle) => css`
 	vertical-align: top;
 	padding-right: ${style === 'compact' ? '4px' : '10px'};
 	line-height: 0;
+`;
 
+const checkListIconColor = (color: string) => css`
 	svg {
-		fill: ${style === 'compact' ? palette.success[400] : palette.brand[500]};
+		fill: ${color};
 	}
 `;
 
@@ -54,6 +56,7 @@ type CheckmarkListStyle = 'standard' | 'compact';
 export type CheckmarkListProps = {
 	checkListData: CheckListData[];
 	style?: CheckmarkListStyle;
+	iconColor?: string;
 };
 
 function ChecklistItemIcon({
@@ -79,12 +82,19 @@ function ChecklistItemIcon({
 export function CheckmarkList({
 	checkListData,
 	style = 'standard',
+	iconColor = style === 'compact' ? palette.success[400] : palette.brand[500],
 }: CheckmarkListProps): JSX.Element {
 	return (
 		<table css={tableCss(style)}>
 			{checkListData.map((item) => (
 				<tr>
-					<td css={[checkListIconCss(style), item.maybeGreyedOut]}>
+					<td
+						css={[
+							checkListIconCss(style),
+							checkListIconColor(iconColor),
+							item.maybeGreyedOut,
+						]}
+					>
 						<div css={style === 'standard' ? iconContainerCss : css``}>
 							<ChecklistItemIcon checked={item.isChecked} style={style} />
 						</div>

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
@@ -17,6 +17,7 @@ const boldText = css`
 
 type TierUnlocks = {
 	higherTier: boolean;
+	showUnchecked?: boolean;
 };
 
 export type CheckListData = {
@@ -32,28 +33,14 @@ export const getSvgIcon = (isUnlocked: boolean): JSX.Element =>
 		<SvgCrossRound isAnnouncedByScreenReader size="small" />
 	);
 
-export const checkListData = ({ higherTier }: TierUnlocks): CheckListData[] => {
+export const checkListData = ({
+	higherTier,
+	showUnchecked = true,
+}: TierUnlocks): CheckListData[] => {
 	const maybeGreyedOutHigherTier = higherTier ? undefined : greyedOut;
+	const showHigherTier = higherTier || showUnchecked;
 
-	return [
-		{
-			isChecked: true,
-			text: (
-				<p>
-					<span css={boldText}>A regular supporter newsletter. </span>Get
-					exclusive insight from our newsroom
-				</p>
-			),
-		},
-		{
-			isChecked: true,
-			text: (
-				<p>
-					<span css={boldText}>Uninterrupted reading. </span> See far fewer asks
-					for support
-				</p>
-			),
-		},
+	const higherTierItems = [
 		{
 			isChecked: higherTier,
 			text: (
@@ -74,5 +61,27 @@ export const checkListData = ({ higherTier }: TierUnlocks): CheckListData[] => {
 			),
 			maybeGreyedOut: maybeGreyedOutHigherTier,
 		},
+	];
+
+	return [
+		{
+			isChecked: true,
+			text: (
+				<p>
+					<span css={boldText}>A regular supporter newsletter. </span>Get
+					exclusive insight from our newsroom
+				</p>
+			),
+		},
+		{
+			isChecked: true,
+			text: (
+				<p>
+					<span css={boldText}>Uninterrupted reading. </span> See far fewer asks
+					for support
+				</p>
+			),
+		},
+		...(showHigherTier ? higherTierItems : []),
 	];
 };

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import {
+	from,
 	headline,
 	palette,
 	space,
@@ -26,7 +27,13 @@ const summaryRow = css`
 `;
 
 const rowSpacing = css`
-	margin-bottom: ${space[5]}px;
+	&:not(:last-child) {
+		margin-bottom: ${space[5]}px;
+
+		${from.desktop} {
+			margin-bottom: ${space[6]}px;
+		}
+	}
 `;
 
 const boldText = css`
@@ -35,6 +42,18 @@ const boldText = css`
 
 const headingRow = css`
 	padding-top: ${space[2]}px;
+
+	${from.desktop} {
+		padding-top: 0;
+	}
+`;
+
+const totalRow = (hasTsAncCs: boolean) => css`
+	${!hasTsAncCs ? `margin-bottom: ${space[3]}px;` : 'margin-bottom: 0;'}
+
+	${from.desktop} {
+		margin-bottom: 0;
+	}
 `;
 
 const heading = css`
@@ -165,7 +184,7 @@ export function ContributionsOrderSummary({
 				)}
 			</div>
 			<hr css={hrCss} />
-			<div css={[summaryRow, rowSpacing, boldText]}>
+			<div css={[summaryRow, rowSpacing, boldText, totalRow(!!tsAndCs)]}>
 				<p>Total</p>
 				<p>{totalWithFrequency(total, contributionType)}</p>
 			</div>

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -79,6 +79,7 @@ export type ContributionsOrderSummaryProps = {
 	contributionType: ContributionType;
 	total: string;
 	checkListData: CheckListData[];
+	onAccordionClick?: (opening: boolean) => void;
 	headerButton?: React.ReactNode;
 	tsAndCs?: React.ReactNode;
 };
@@ -105,6 +106,7 @@ export function ContributionsOrderSummary({
 	contributionType,
 	total,
 	checkListData,
+	onAccordionClick,
 	headerButton,
 	tsAndCs,
 }: ContributionsOrderSummaryProps): JSX.Element {
@@ -127,7 +129,10 @@ export function ContributionsOrderSummary({
 						<Button
 							priority="subdued"
 							aria-expanded={showDetails ? 'true' : 'false'}
-							onClick={() => setShowDetails(!showDetails)}
+							onClick={() => {
+								onAccordionClick?.(!showDetails);
+								setShowDetails(!showDetails);
+							}}
 							icon={<SvgChevronDownSingle />}
 							iconSide="right"
 							cssOverrides={[buttonOverrides, iconCss(showDetails)]}

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -26,11 +26,15 @@ const summaryRow = css`
 `;
 
 const rowSpacing = css`
-	margin-bottom: 18px;
+	margin-bottom: ${space[5]}px;
 `;
 
 const boldText = css`
 	font-weight: 700;
+`;
+
+const headingRow = css`
+	padding-top: ${space[2]}px;
 `;
 
 const heading = css`
@@ -50,11 +54,15 @@ const buttonOverrides = css`
 	text-decoration: none;
 	${textSans.xsmall()};
 	color: ${palette.neutral[20]};
+
+	.src-button-space {
+		width: ${space[1]}px;
+	}
 `;
 
 const iconCss = (flip: boolean) => css`
 	svg {
-		max-width: ${space[3]}px;
+		max-width: ${space[4]}px;
 		transition: transform 0.3s ease-in-out;
 
 		${flip && 'transform: rotate(180deg);'}
@@ -68,11 +76,16 @@ const checklistContainer = css`
 const detailsSection = css`
 	display: flex;
 	flex-direction: column;
+	margin-bottom: ${space[6]}px;
 `;
 
 const termsAndConditions = css`
 	${textSans.xxsmall()}
 	color: #606060;
+
+	p {
+		margin-top: ${space[1]}px;
+	}
 `;
 
 export type ContributionsOrderSummaryProps = {
@@ -117,12 +130,12 @@ export function ContributionsOrderSummary({
 
 	return (
 		<div css={componentStyles}>
-			<div css={[summaryRow, rowSpacing]}>
+			<div css={[summaryRow, rowSpacing, headingRow]}>
 				<h2 css={heading}>Your support</h2>
 				{headerButton}
 			</div>
 			<hr css={hrCss} />
-			<div css={[detailsSection, rowSpacing]}>
+			<div css={[rowSpacing, detailsSection]}>
 				<div css={summaryRow}>
 					<p>{supportTypes[contributionType]} support</p>
 					{showAccordion && (

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -10,6 +10,9 @@ import {
 	SvgChevronDownSingle,
 } from '@guardian/source-react-components';
 import { useState } from 'react';
+import type { CheckListData } from 'components/checkmarkList/checkmarkList';
+import { CheckmarkList } from 'components/checkmarkList/checkmarkList';
+import type { ContributionType } from 'helpers/contributions';
 
 const componentStyles = css`
 	${textSans.medium()}
@@ -58,18 +61,52 @@ const iconCss = (flip: boolean) => css`
 	}
 `;
 
+const checklistContainer = css`
+	margin-top: ${space[5]}px;
+`;
+
 const detailsSection = css`
 	display: flex;
 	flex-direction: column;
 `;
 
+const termsAndConditions = css`
+	${textSans.xxsmall()}
+	color: #606060;
+`;
+
 export type ContributionsOrderSummaryProps = {
+	contributionType: ContributionType;
+	total: string;
+	checkListData: CheckListData[];
 	headerButton?: React.ReactNode;
 	tsAndCs?: React.ReactNode;
 };
 
+const supportTypes = {
+	ONE_OFF: 'Single',
+	MONTHLY: 'Monthly',
+	ANNUAL: 'Annual',
+};
+
+const timePeriods = {
+	MONTHLY: 'month',
+	ANNUAL: 'year',
+};
+
+function totalWithFrequency(total: string, contributionType: ContributionType) {
+	if (contributionType === 'ONE_OFF') {
+		return total;
+	}
+	return `${total}/${timePeriods[contributionType]}`;
+}
+
 export function ContributionsOrderSummary({
+	contributionType,
+	total,
+	checkListData,
 	headerButton,
+	tsAndCs,
 }: ContributionsOrderSummaryProps): JSX.Element {
 	const [showDetails, setShowDetails] = useState(false);
 
@@ -82,7 +119,7 @@ export function ContributionsOrderSummary({
 			<hr css={hrCss} />
 			<div css={[detailsSection, rowSpacing]}>
 				<div css={summaryRow}>
-					<p>Monthly support</p>
+					<p>{supportTypes[contributionType]} support</p>
 					<Button
 						priority="subdued"
 						aria-expanded={showDetails ? 'true' : 'false'}
@@ -94,13 +131,25 @@ export function ContributionsOrderSummary({
 						{showDetails ? 'Hide details' : 'View details'}
 					</Button>
 				</div>
-				{showDetails && <div>hello</div>}
+				{showDetails && (
+					<div css={checklistContainer}>
+						<CheckmarkList checkListData={checkListData} style="compact" />
+					</div>
+				)}
 			</div>
 			<hr css={hrCss} />
 			<div css={[summaryRow, rowSpacing, boldText]}>
 				<p>Total</p>
-				<p>£10/month</p>
+				<p>{totalWithFrequency(total, contributionType)}</p>
 			</div>
+			{tsAndCs ? (
+				<div css={termsAndConditions}>
+					<hr css={hrCss} />
+					{tsAndCs}
+				</div>
+			) : (
+				<></>
+			)}
 		</div>
 	);
 }

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -1,0 +1,3 @@
+export function ContributionsOrderSummary(): JSX.Element {
+	return <div></div>;
+}

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -1,3 +1,106 @@
-export function ContributionsOrderSummary(): JSX.Element {
-	return <div></div>;
+import { css } from '@emotion/react';
+import {
+	headline,
+	palette,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
+import {
+	Button,
+	SvgChevronDownSingle,
+} from '@guardian/source-react-components';
+import { useState } from 'react';
+
+const componentStyles = css`
+	${textSans.medium()}
+`;
+
+const summaryRow = css`
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
+	padding-top: 4px;
+`;
+
+const rowSpacing = css`
+	margin-bottom: 18px;
+`;
+
+const boldText = css`
+	font-weight: 700;
+`;
+
+const heading = css`
+	${headline.xsmall({ fontWeight: 'bold' })}
+`;
+
+const hrCss = css`
+	border: none;
+	height: 1px;
+	background-color: ${palette.neutral[86]};
+	margin: 0;
+`;
+
+const buttonOverrides = css`
+	min-height: unset;
+	height: unset;
+	text-decoration: none;
+	${textSans.xsmall()};
+	color: ${palette.neutral[20]};
+`;
+
+const iconCss = (flip: boolean) => css`
+	svg {
+		max-width: ${space[3]}px;
+		transition: transform 0.3s ease-in-out;
+
+		${flip && 'transform: rotate(180deg);'}
+	}
+`;
+
+const detailsSection = css`
+	display: flex;
+	flex-direction: column;
+`;
+
+export type ContributionsOrderSummaryProps = {
+	headerButton?: React.ReactNode;
+	tsAndCs?: React.ReactNode;
+};
+
+export function ContributionsOrderSummary({
+	headerButton,
+}: ContributionsOrderSummaryProps): JSX.Element {
+	const [showDetails, setShowDetails] = useState(false);
+
+	return (
+		<div css={componentStyles}>
+			<div css={[summaryRow, rowSpacing]}>
+				<h2 css={heading}>Your support</h2>
+				{headerButton}
+			</div>
+			<hr css={hrCss} />
+			<div css={[detailsSection, rowSpacing]}>
+				<div css={summaryRow}>
+					<p>Monthly support</p>
+					<Button
+						priority="subdued"
+						aria-expanded={showDetails ? 'true' : 'false'}
+						onClick={() => setShowDetails(!showDetails)}
+						icon={<SvgChevronDownSingle />}
+						iconSide="right"
+						cssOverrides={[buttonOverrides, iconCss(showDetails)]}
+					>
+						{showDetails ? 'Hide details' : 'View details'}
+					</Button>
+				</div>
+				{showDetails && <div>hello</div>}
+			</div>
+			<hr css={hrCss} />
+			<div css={[summaryRow, rowSpacing, boldText]}>
+				<p>Total</p>
+				<p>£10/month</p>
+			</div>
+		</div>
+	);
 }

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -84,7 +84,7 @@ const iconCss = (flip: boolean) => css`
 		max-width: ${space[4]}px;
 		transition: transform 0.3s ease-in-out;
 
-		${flip && 'transform: rotate(180deg);'}
+		${flip ? 'transform: rotate(180deg);' : ''}
 	}
 `;
 

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -110,6 +110,9 @@ export function ContributionsOrderSummary({
 }: ContributionsOrderSummaryProps): JSX.Element {
 	const [showDetails, setShowDetails] = useState(false);
 
+	const showAccordion =
+		contributionType !== 'ONE_OFF' && checkListData.length > 0;
+
 	return (
 		<div css={componentStyles}>
 			<div css={[summaryRow, rowSpacing]}>
@@ -120,18 +123,20 @@ export function ContributionsOrderSummary({
 			<div css={[detailsSection, rowSpacing]}>
 				<div css={summaryRow}>
 					<p>{supportTypes[contributionType]} support</p>
-					<Button
-						priority="subdued"
-						aria-expanded={showDetails ? 'true' : 'false'}
-						onClick={() => setShowDetails(!showDetails)}
-						icon={<SvgChevronDownSingle />}
-						iconSide="right"
-						cssOverrides={[buttonOverrides, iconCss(showDetails)]}
-					>
-						{showDetails ? 'Hide details' : 'View details'}
-					</Button>
+					{showAccordion && (
+						<Button
+							priority="subdued"
+							aria-expanded={showDetails ? 'true' : 'false'}
+							onClick={() => setShowDetails(!showDetails)}
+							icon={<SvgChevronDownSingle />}
+							iconSide="right"
+							cssOverrides={[buttonOverrides, iconCss(showDetails)]}
+						>
+							{showDetails ? 'Hide details' : 'View details'}
+						</Button>
+					)}
 				</div>
-				{showDetails && (
+				{showAccordion && showDetails && (
 					<div css={checklistContainer}>
 						<CheckmarkList checkListData={checkListData} style="compact" />
 					</div>

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -188,13 +188,11 @@ export function ContributionsOrderSummary({
 				<p>Total</p>
 				<p>{totalWithFrequency(total, contributionType)}</p>
 			</div>
-			{tsAndCs ? (
+			{!!tsAndCs && (
 				<div css={termsAndConditions}>
 					<hr css={hrCss} />
 					{tsAndCs}
 				</div>
-			) : (
-				<></>
 			)}
 		</div>
 	);

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -143,7 +143,11 @@ export function ContributionsOrderSummary({
 				</div>
 				{showAccordion && showDetails && (
 					<div css={checklistContainer}>
-						<CheckmarkList checkListData={checkListData} style="compact" />
+						<CheckmarkList
+							checkListData={checkListData}
+							style="compact"
+							iconColor={palette.brand[500]}
+						/>
 					</div>
 				)}
 			</div>

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
@@ -21,13 +21,15 @@ function getTermsConditions(
 	const period = contributionType === 'MONTHLY' ? 'month' : 'year';
 
 	if (isSupporterPlus) {
-		<>
-			<p>Auto renews every {period} until you cancel.</p>
-			<p>
-				Cancel or change your support anytime. If you cancel within the first 14
-				days, you will receive a full refund.
-			</p>
-		</>;
+		return (
+			<>
+				<p>Auto renews every {period} until you cancel.</p>
+				<p>
+					Cancel or change your support anytime. If you cancel within the first
+					14 days, you will receive a full refund.
+				</p>
+			</>
+		);
 	}
 	return (
 		<>

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
@@ -1,0 +1,43 @@
+import { checkListData } from 'components/checkoutBenefits/checkoutBenefitsListData';
+import { simpleFormatAmount } from 'helpers/forms/checkouts';
+import { currencies } from 'helpers/internationalisation/currency';
+import { isSupporterPlusPurchase } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
+import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
+import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import type { ContributionsOrderSummaryProps } from './contributionsOrderSummary';
+
+type ContributionsOrderSummaryContainerProps = {
+	renderOrderSummary: (props: ContributionsOrderSummaryProps) => JSX.Element;
+};
+
+export function ContributionsOrderSummaryContainer({
+	renderOrderSummary,
+}: ContributionsOrderSummaryContainerProps): JSX.Element {
+	const contributionType = useContributionsSelector(getContributionType);
+
+	const { currencyId } = useContributionsSelector(
+		(state) => state.common.internationalisation,
+	);
+	const selectedAmount = useContributionsSelector(getUserSelectedAmount);
+	const isSupporterPlus = useContributionsSelector(isSupporterPlusPurchase);
+
+	const currency = currencies[currencyId];
+	const userSelectedAmountWithCurrency = simpleFormatAmount(
+		currency,
+		selectedAmount,
+	);
+
+	const checklist =
+		contributionType === 'ONE_OFF'
+			? []
+			: checkListData({
+					higherTier: isSupporterPlus,
+			  });
+
+	return renderOrderSummary({
+		contributionType,
+		total: userSelectedAmountWithCurrency,
+		checkListData: checklist,
+	});
+}

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
@@ -59,6 +59,7 @@ export function ContributionsOrderSummaryContainer({
 			? []
 			: checkListData({
 					higherTier: isSupporterPlus,
+					showUnchecked: false,
 			  });
 
 	function onAccordionClick(isOpen: boolean) {

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
@@ -1,15 +1,41 @@
 import { checkListData } from 'components/checkoutBenefits/checkoutBenefitsListData';
+import type { ContributionType } from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import { currencies } from 'helpers/internationalisation/currency';
 import { isSupporterPlusPurchase } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import { trackComponentClick } from 'helpers/tracking/behaviour';
 import type { ContributionsOrderSummaryProps } from './contributionsOrderSummary';
 
 type ContributionsOrderSummaryContainerProps = {
 	renderOrderSummary: (props: ContributionsOrderSummaryProps) => JSX.Element;
 };
+
+function getTermsConditions(
+	contributionType: ContributionType,
+	isSupporterPlus: boolean,
+) {
+	if (contributionType === 'ONE_OFF') return;
+	const period = contributionType === 'MONTHLY' ? 'month' : 'year';
+
+	if (isSupporterPlus) {
+		<>
+			<p>Auto renews every {period} until you cancel.</p>
+			<p>
+				Cancel or change your support anytime. If you cancel within the first 14
+				days, you will receive a full refund.
+			</p>
+		</>;
+	}
+	return (
+		<>
+			<p>Auto renews every {period} until you cancel.</p>
+			<p>Cancel or change your support anytime.</p>
+		</>
+	);
+}
 
 export function ContributionsOrderSummaryContainer({
 	renderOrderSummary,
@@ -35,9 +61,17 @@ export function ContributionsOrderSummaryContainer({
 					higherTier: isSupporterPlus,
 			  });
 
+	function onAccordionClick(isOpen: boolean) {
+		trackComponentClick(
+			`contribution-order-summary-${isOpen ? 'opened' : 'closed'}`,
+		);
+	}
+
 	return renderOrderSummary({
 		contributionType,
 		total: userSelectedAmountWithCurrency,
 		checkListData: checklist,
+		onAccordionClick,
+		tsAndCs: getTermsConditions(contributionType, isSupporterPlus),
 	});
 }

--- a/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
@@ -1,0 +1,48 @@
+import { css } from '@emotion/react';
+import { Button, Column, Columns } from '@guardian/source-react-components';
+import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
+import type { ContributionsOrderSummaryProps } from 'components/orderSummary/contributionsOrderSummary';
+import { ContributionsOrderSummary } from 'components/orderSummary/contributionsOrderSummary';
+import { withCenterAlignment } from '../../.storybook/decorators/withCenterAlignment';
+import { withSourceReset } from '../../.storybook/decorators/withSourceReset';
+
+export default {
+	title: 'Checkouts/Contributions Order Summary',
+	component: ContributionsOrderSummary,
+	decorators: [
+		(Story: React.FC): JSX.Element => (
+			<Columns
+				collapseUntil="tablet"
+				cssOverrides={css`
+					width: 100%;
+				`}
+			>
+				<Column span={[1, 8, 7]}>
+					<Box>
+						<BoxContents>
+							<Story />
+						</BoxContents>
+					</Box>
+				</Column>
+			</Columns>
+		),
+		withCenterAlignment,
+		withSourceReset,
+	],
+};
+
+function Template(props: ContributionsOrderSummaryProps) {
+	return <ContributionsOrderSummary {...props} />;
+}
+
+Template.args = {} as ContributionsOrderSummaryProps;
+
+export const Default = Template.bind({});
+
+Default.args = {
+	headerButton: (
+		<Button priority="tertiary" size="xsmall">
+			Change
+		</Button>
+	),
+};

--- a/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
@@ -44,7 +44,7 @@ export const Default = Template.bind({});
 Default.args = {
 	contributionType: 'MONTHLY',
 	total: '£10',
-	checkListData: checkListData({ higherTier: true }),
+	checkListData: checkListData({ higherTier: true, showUnchecked: false }),
 	headerButton: (
 		<Button priority="tertiary" size="xsmall">
 			Change
@@ -66,7 +66,7 @@ export const BelowThreshold = Template.bind({});
 BelowThreshold.args = {
 	contributionType: 'ANNUAL',
 	total: '$25',
-	checkListData: checkListData({ higherTier: false }),
+	checkListData: checkListData({ higherTier: false, showUnchecked: false }),
 	headerButton: (
 		<Button priority="tertiary" size="xsmall">
 			Change

--- a/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { Button, Column, Columns } from '@guardian/source-react-components';
+import { checkListData } from 'components/checkoutBenefits/checkoutBenefitsListData';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import type { ContributionsOrderSummaryProps } from 'components/orderSummary/contributionsOrderSummary';
 import { ContributionsOrderSummary } from 'components/orderSummary/contributionsOrderSummary';
@@ -40,9 +41,18 @@ Template.args = {} as ContributionsOrderSummaryProps;
 export const Default = Template.bind({});
 
 Default.args = {
+	contributionType: 'MONTHLY',
+	total: '£10',
+	checkListData: checkListData({ higherTier: true }),
 	headerButton: (
 		<Button priority="tertiary" size="xsmall">
 			Change
 		</Button>
+	),
+	tsAndCs: (
+		<>
+			<p>Auto renews every month until you cancel.</p>
+			<p>Cancel or change your support anytime.</p>
+		</>
 	),
 };

--- a/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
@@ -10,6 +10,7 @@ import { withSourceReset } from '../../.storybook/decorators/withSourceReset';
 export default {
 	title: 'Checkouts/Contributions Order Summary',
 	component: ContributionsOrderSummary,
+	argTypes: { onAccordionClick: { action: 'accordion clicked' } },
 	decorators: [
 		(Story: React.FC): JSX.Element => (
 			<Columns
@@ -73,7 +74,7 @@ BelowThreshold.args = {
 	),
 	tsAndCs: (
 		<>
-			<p>Auto renews every month until you cancel.</p>
+			<p>Auto renews every year until you cancel.</p>
 			<p>Cancel or change your support anytime.</p>
 		</>
 	),

--- a/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
@@ -52,7 +52,42 @@ Default.args = {
 	tsAndCs: (
 		<>
 			<p>Auto renews every month until you cancel.</p>
+			<p>
+				Cancel or change your support anytime. If you cancel within the first 14
+				days, you will receive a full refund.
+			</p>
+		</>
+	),
+};
+
+export const BelowThreshold = Template.bind({});
+
+BelowThreshold.args = {
+	contributionType: 'ANNUAL',
+	total: '$25',
+	checkListData: checkListData({ higherTier: false }),
+	headerButton: (
+		<Button priority="tertiary" size="xsmall">
+			Change
+		</Button>
+	),
+	tsAndCs: (
+		<>
+			<p>Auto renews every month until you cancel.</p>
 			<p>Cancel or change your support anytime.</p>
 		</>
+	),
+};
+
+export const SingleContribution = Template.bind({});
+
+SingleContribution.args = {
+	contributionType: 'ONE_OFF',
+	total: '$25',
+	checkListData: [],
+	headerButton: (
+		<Button priority="tertiary" size="xsmall">
+			Change
+		</Button>
 	),
 };


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds a checkout summary component for the contributions/supporter plus checkout, for use in the upcoming 2-step checkout test. I've also added an initial container component to supply it with Redux data, but this will likely need refinement once the component is actually integrated into the checkout.

[**Trello Card**](https://trello.com/c/0JQSs5Dt)

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

### Mobile
![Screenshot 2023-08-18 at 11 53 52](https://github.com/guardian/support-frontend/assets/29146931/4f6c932b-5dd9-4c0e-a285-fb70ddd11a8c)

### Desktop
![Screenshot 2023-08-18 at 11 54 09](https://github.com/guardian/support-frontend/assets/29146931/0b22bb6a-6d38-4841-a121-e5d51b5791e2)
