### PR TITLE
go away webpack error overlay

### DIFF
--- a/support-frontend/webpack.dev.js
+++ b/support-frontend/webpack.dev.js
@@ -14,7 +14,8 @@ module.exports = merge(common('[name].css', '[name].js', false), {
 			},
 		},
 		client: {
-			webSocketURL: 'https://support.thegulocal.com/ws'
+			webSocketURL: 'https://support.thegulocal.com/ws',
+      overlay: false,
 		},
 	},
 	resolve: {


### PR DESCRIPTION
## What are you doing in this PR?
stop webpack from showing an error overlay in the webpack dev config. (errors are still logged in the console and by default it doesn't do this in production)

## Screenshot
<img width="1892" alt="Screenshot 2023-08-18 at 15 53 11" src="https://github.com/guardian/support-frontend/assets/2510683/a8954e8e-d685-4f7d-8429-43664f38ca12">
