### PR TITLE
[RB] - only show refund copy in cancel tooltip if supporter plus thre…

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -16,8 +16,10 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 export function AmountAndBenefits({
 	countryGroupId,
+	amountIsAboveThreshold,
 }: {
 	countryGroupId: CountryGroupId;
+	amountIsAboveThreshold: boolean;
 }): JSX.Element {
 	return (
 		<PaymentFrequencyTabsContainer
@@ -78,8 +80,14 @@ export function AmountAndBenefits({
 										<p>
 											You can cancel
 											{countryGroupId === 'GBPCountries' ? '' : ' online'}{' '}
-											anytime before your next payment date. If you cancel in
-											the first 14 days, you will receive a full refund.
+											anytime before your next payment date.
+											{amountIsAboveThreshold && (
+												<>
+													{' '}
+													If you cancel in the first 14 days, you will receive a
+													full refund.
+												</>
+											)}
 										</p>
 									</Tooltip>
 								)}

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -206,7 +206,10 @@ export function SupporterPlusLandingPage({
 							{displayLimitedPriceCards ? (
 								<LimitedPriceCards />
 							) : (
-								<AmountAndBenefits countryGroupId={countryGroupId} />
+								<AmountAndBenefits
+									countryGroupId={countryGroupId}
+									amountIsAboveThreshold={amountIsAboveThreshold}
+								/>
 							)}
 						</Box>
 						<Box cssOverrides={shorterBoxMargin}>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/firstStepLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/firstStepLanding.tsx
@@ -56,7 +56,10 @@ export function SupporterPlusInitialLandingPage({
 				{displayLimitedPriceCards ? (
 					<LimitedPriceCards />
 				) : (
-					<AmountAndBenefits countryGroupId={countryGroupId} />
+					<AmountAndBenefits
+						countryGroupId={countryGroupId}
+						amountIsAboveThreshold={amountIsAboveThreshold}
+					/>
 				)}
 			</Box>
 			<Box cssOverrides={shorterBoxMargin}>


### PR DESCRIPTION
## What are you doing in this PR?
Only show refund copy in cancel tooltip if supporter plus threshold is met

[**Trello Card**](https://trello.com/c/dBwhFzhT/1514-change-copy-on-cancel-anytime-tooltip-checkout)

## Screenshots

### before
<img width="576" alt="Screenshot 2023-08-22 at 12 40 32" src="https://github.com/guardian/support-frontend/assets/2510683/ddd3afbb-6108-4dda-bf46-aec5a41f1841">


### after
below threshold            |  above threshold
:-------------------------:|:-------------------------:
![](https://github.com/guardian/support-frontend/assets/2510683/dc36f5ae-f789-4c40-bf44-2ec64c240936)  |  ![](https://github.com/guardian/support-frontend/assets/2510683/376f6489-f530-441d-8c61-5598a0a83ee2)




