### PR TITLE
Change fulfilmentOption when creating paper delivery checkout request

### DIFF
--- a/support-frontend/assets/helpers/productPrice/fulfilmentOptions.ts
+++ b/support-frontend/assets/helpers/productPrice/fulfilmentOptions.ts
@@ -3,6 +3,7 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
 
 const HomeDelivery = 'HomeDelivery';
+const NationalDelivery = 'NationalDelivery';
 const Collection = 'Collection';
 const Domestic = 'Domestic';
 const RestOfWorld = 'RestOfWorld';
@@ -18,12 +19,20 @@ export type DigitalPackFulfilmentOptions = typeof NoFulfilmentOptions;
 
 export type FulfilmentOptions =
 	| typeof HomeDelivery
+	| typeof NationalDelivery
 	| typeof Collection
 	| typeof Domestic
 	| typeof RestOfWorld
 	| typeof NoFulfilmentOptions;
 
-export { HomeDelivery, Collection, Domestic, RestOfWorld, NoFulfilmentOptions };
+export {
+	HomeDelivery,
+	NationalDelivery,
+	Collection,
+	Domestic,
+	RestOfWorld,
+	NoFulfilmentOptions,
+};
 
 const getWeeklyFulfilmentOption = (
 	country: IsoCountry,

--- a/support-frontend/assets/helpers/redux/checkout/address/validation.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/validation.ts
@@ -16,10 +16,7 @@ import {
 	zuoraCompatibleString,
 } from 'helpers/subscriptionsForms/validation';
 import type { Option } from 'helpers/types/option';
-import type {
-	DeliveryAgentsResponse,
-	DeliveryAgentState,
-} from '../addressMeta/state';
+import type { DeliveryAgentState } from '../addressMeta/state';
 import type { AddressFields, AddressFormFieldError } from './state';
 
 // ---- Validators ---- //
@@ -199,7 +196,7 @@ export const deliveryAgentChosen = (
 	if (fulfilmentOption === 'HomeDelivery' && postcode !== null) {
 		if (
 			!postcodeIsWithinDeliveryArea(postcode, allowedPrefixes) &&
-			deliveryAgentsAreAvailable(deliveryAgent.response)
+			deliveryAgentsAreAvailable(deliveryAgent)
 		) {
 			return deliveryAgentHasBeenChosen(deliveryAgent);
 		}
@@ -216,7 +213,7 @@ export const isHomeDeliveryAvailable = (
 ): boolean => {
 	if (fulfilmentOption === 'HomeDelivery' && postcode !== null) {
 		if (!postcodeIsWithinDeliveryArea(postcode, allowedPrefixes)) {
-			return deliveryAgentHasBeenChosen(deliveryAgent);
+			return deliveryAgentsAreAvailable(deliveryAgent);
 		}
 	}
 
@@ -228,8 +225,8 @@ const deliveryAgentHasBeenChosen = (
 ): boolean => (deliveryAgent.chosenAgent ? true : false);
 
 const deliveryAgentsAreAvailable = (
-	deliveryAgentResponse?: DeliveryAgentsResponse,
-): boolean => (deliveryAgentResponse?.agents.length ?? 0) > 0;
+	deliveryAgent: DeliveryAgentState,
+): boolean => (deliveryAgent.response?.agents.length ?? 0) > 0;
 
 export const isPostcodeOptional = (country: IsoCountry | null): boolean =>
 	country !== 'GB' && country !== 'AU' && country !== 'US' && country !== 'CA';

--- a/support-frontend/assets/helpers/redux/checkout/address/validation.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/validation.ts
@@ -155,7 +155,7 @@ function getDeliveryOnlyRules(
 	return [
 		{
 			rule:
-				abParticipations.nationalDelivery === 'variant' ||
+				abParticipations.nationalDelivery === 'control' ||
 				deliveryAgentChosen(fulfilmentOption, fields.postCode, deliveryAgent),
 			error: formError('postCode', 'Please select a delivery provider'),
 		},

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -15,7 +15,7 @@ import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import { DirectDebit, PayPal, Stripe } from 'helpers/forms/paymentMethods';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { Quarterly } from 'helpers/productPrice/billingPeriods';
-import type { type FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import {
 	HomeDelivery,
 	NationalDelivery,

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -15,6 +15,11 @@ import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import { DirectDebit, PayPal, Stripe } from 'helpers/forms/paymentMethods';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { Quarterly } from 'helpers/productPrice/billingPeriods';
+import type { type FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import {
+	HomeDelivery,
+	NationalDelivery,
+} from 'helpers/productPrice/fulfilmentOptions';
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
 import {
@@ -112,9 +117,19 @@ const getProduct = (
 		productType: Paper,
 		currency: currencyId ?? state.common.internationalisation.currencyId,
 		billingPeriod,
-		fulfilmentOptions: fulfilmentOption,
+		fulfilmentOptions: getPaperFulfilmentOption(fulfilmentOption, state),
 		productOptions: productOption,
 	};
+};
+
+const getPaperFulfilmentOption = (
+	fulfilmentOption: FulfilmentOptions,
+	state: SubscriptionsState,
+) => {
+	return fulfilmentOption === HomeDelivery &&
+		state.page.checkoutForm.addressMeta.deliveryAgent.chosenAgent
+		? NationalDelivery
+		: fulfilmentOption;
 };
 
 const getPromoCode = (promotions?: Promotion[]) => {


### PR DESCRIPTION

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR adds a function to change the fulfilment option of a payment request for a national delivery (outside M25). The logic is to check whether a delivery provider has been chosen - indicating the user has chosen a postcode outside the M25 area and seen a choice of suppliers. This will happen after validation

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com/c/7o4FzIyy/75-support-frontend-change-product-rate-plan-when-postcode-is-chosen)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [x ] No

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

