### PR TITLE
Update server-side validation to block support-workers executions with no state

### DIFF
--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -246,8 +246,6 @@ object AddressAndCurrencyValidationRules {
     ) {
       {
         val validState = stateFromRequest match {
-          case Some(validState) if (validState.isEmpty) =>
-            Invalid(s"state is required for $countryFromRequest")
           case None =>
             Invalid(s"state is required for $countryFromRequest")
           case Some("") =>

--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -244,15 +244,12 @@ object AddressAndCurrencyValidationRules {
     if (
       countryFromRequest == Country.US || countryFromRequest == Country.Canada || countryFromRequest == Country.Australia
     ) {
-      {
-        val validState = stateFromRequest match {
-          case None =>
-            Invalid(s"state is required for $countryFromRequest")
-          case Some("") =>
-            Invalid(s"state is required for $countryFromRequest")
-          case _ => Valid
-        }
-        validState
+      stateFromRequest match {
+        case None =>
+          Invalid(s"state is required for $countryFromRequest")
+        case Some("") =>
+          Invalid(s"state is required for $countryFromRequest")
+        case _ => Valid
       }
     } else Valid
 

--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -244,10 +244,21 @@ object AddressAndCurrencyValidationRules {
     if (
       countryFromRequest == Country.US || countryFromRequest == Country.Canada || countryFromRequest == Country.Australia
     ) {
-      stateFromRequest.isDefined.otherwise(s"state is required for $countryFromRequest")
+      {
+        val validState = stateFromRequest match {
+          case Some(validState) if (validState.isEmpty) =>
+            Invalid(s"state is required for $countryFromRequest")
+          case None =>
+            Invalid(s"state is required for $countryFromRequest")
+          case Some("") =>
+            Invalid(s"state is required for $countryFromRequest")
+          case _ => Valid
+        }
+        validState
+      }
     } else Valid
 
-//     hasValidPostcodeLength checks if the length of postCodeIsShortEnoughForSalesforce(must be less than or equal to 20 characters)
+  //     hasValidPostcodeLength checks if the length of postCodeIsShortEnoughForSalesforce(must be less than or equal to 20 characters)
   def hasValidPostcodeLength(postcodeFromRequest: Option[String], addressType: String): Result = {
     val validPostCode = postcodeFromRequest match {
       case Some(postCode) if (postCode.length > 20) =>

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -401,6 +401,22 @@ class PaidProductValidationTest extends AnyFlatSpec with Matchers {
     PaidProductValidation.passes(requestMissingState) shouldBe an[Invalid]
   }
 
+  it should " fail if the country is United States and there is no state for Contribution product" in {
+    val requestMissingState = validDigitalPackRequest.copy(
+      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.US, state = None),
+      product = SupporterPlus(5, Currency.USD, Annual),
+    )
+    PaidProductValidation.passes(requestMissingState) shouldBe an[Invalid]
+  }
+
+  it should " fail if the country is United States and there is empty string in state for Contribution product" in {
+    val requestMissingState = validDigitalPackRequest.copy(
+      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.US, state = Some("")),
+      product = SupporterPlus(5, Currency.USD, Annual),
+    )
+    PaidProductValidation.passes(requestMissingState) shouldBe an[Invalid]
+  }
+
   it should "succeed  if the country is UK and there is no state" in {
     val requestSupporterPlus = validDigitalPackRequest.copy(
       billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.UK, state = None),


### PR DESCRIPTION
## What are you doing in this PR?

Update server-side validation to  block support-workers executions with no state.

[**Trello Card**](https://trello.com/c/x9y6amch/1500-find-out-why-server-side-validation-didnt-block-support-workers-executions-with-no-state)
[The support-workers executions failed are attached to the trello card]
## Why are you doing this?

In alarm investigations, we found a few step functions where the support workers successfully went through CreatePaymentMethod step when the billing address details had an empty string in the State field for US .But later this caused a Step function failure at the CreateZuoraSubscription step  with the error "Taxation Requirement: State is required for Sold To Contact if the country is United States or Canada.\\\". Countries like US and CA should not have the empty State field.
Upon investigation, it was found that server side validation checks considers an empty string added in the Optional State field as Valid.

This issue was flagged  when the user was utilising the 'Payment Request Button"  and server-side checks  allowed form submission with an empty string in State field in billing address even when the client side validation  showed the error (if the State field was not selected from the checkout form) to the end user. Otherwise the client side validation checks should have prevented the form submission.
