### PR TITLE
National Delivery - Add Validation for Delivery Provider

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/address/validation.test.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/validation.test.ts
@@ -3,6 +3,7 @@ import type { AddressFields } from './state';
 import {
 	applyBillingAddressRules,
 	applyDeliveryAddressRules,
+	isHomeDeliveryAvailable,
 	isHomeDeliveryInM25,
 	isPostcodeOptional,
 	isStateNullable,
@@ -253,6 +254,74 @@ describe('isHomeDeliveryInM25 ', () => {
 		const result = isHomeDeliveryInM25(
 			fulfilmentOption,
 			postcode,
+			homeDeliveryPostcodes,
+		);
+
+		expect(result).toBeFalsy();
+	});
+
+	it('returns true when the fulfilment option is not home delivery', () => {
+		const fulfilmentOption = 'Collection';
+		const postcode = 'DA11 7NP';
+		const homeDeliveryPostcodes = ['SE23'];
+
+		const result = isHomeDeliveryInM25(
+			fulfilmentOption,
+			postcode,
+			homeDeliveryPostcodes,
+		);
+
+		expect(result).toBeTruthy();
+	});
+});
+
+describe('isHomeDeliveryAvailable', () => {
+	it('returns true when the order is a home delivery and the postcode is outside the M25 and a delivery agent is available', () => {
+		const fulfilmentOption = 'HomeDelivery';
+		const postcode = 'DE 2AB';
+		const homeDeliveryPostcodes = ['SE23'];
+
+		const result = isHomeDeliveryAvailable(
+			fulfilmentOption,
+			postcode,
+			{
+				isLoading: false,
+				response: {
+					type: 'Covered',
+					agents: [
+						{
+							agentId: 1,
+							agentName: 'Delivery Company',
+							deliveryMethod: 'Car',
+							nbrDeliveryDays: 7,
+							postcode: '',
+							refGroupId: 1,
+							summary: '',
+						},
+					],
+				},
+			},
+			homeDeliveryPostcodes,
+		);
+
+		expect(result).toBeTruthy();
+	});
+
+	it('returns false when the order is a home delivery and the postcode is outside the M25 and a delivery agent is NOT available', () => {
+		const fulfilmentOption = 'HomeDelivery';
+		const postcode = 'DE 2AB';
+		const homeDeliveryPostcodes = ['SE23'];
+
+		const result = isHomeDeliveryAvailable(
+			fulfilmentOption,
+			postcode,
+			{
+				isLoading: false,
+				response: {
+					type: 'Covered',
+					agents: [],
+				},
+			},
 			homeDeliveryPostcodes,
 		);
 

--- a/support-frontend/assets/helpers/redux/checkout/address/validation.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/validation.ts
@@ -152,12 +152,6 @@ function getDeliveryOnlyRules(
 	return [
 		{
 			rule:
-				abParticipations.nationalDelivery === 'control' ||
-				deliveryAgentChosen(fulfilmentOption, fields.postCode, deliveryAgent),
-			error: formError('postCode', 'Please select a delivery provider'),
-		},
-		{
-			rule:
 				abParticipations.nationalDelivery === 'variant'
 					? isHomeDeliveryAvailable(
 							fulfilmentOption,
@@ -187,24 +181,6 @@ export const isHomeDeliveryInM25 = (
 	return true;
 };
 
-export const deliveryAgentChosen = (
-	fulfilmentOption: FulfilmentOptions | null,
-	postcode: string | null,
-	deliveryAgent: DeliveryAgentState,
-	allowedPrefixes: string[] = M25_POSTCODE_PREFIXES,
-): boolean => {
-	if (fulfilmentOption === 'HomeDelivery' && postcode !== null) {
-		if (
-			!postcodeIsWithinDeliveryArea(postcode, allowedPrefixes) &&
-			deliveryAgentsAreAvailable(deliveryAgent)
-		) {
-			return deliveryAgentHasBeenChosen(deliveryAgent);
-		}
-	}
-
-	return true;
-};
-
 export const isHomeDeliveryAvailable = (
 	fulfilmentOption: FulfilmentOptions | null,
 	postcode: string | null,
@@ -220,13 +196,9 @@ export const isHomeDeliveryAvailable = (
 	return true;
 };
 
-const deliveryAgentHasBeenChosen = (
-	deliveryAgent: DeliveryAgentState,
-): boolean => (deliveryAgent.chosenAgent ? true : false);
-
 const deliveryAgentsAreAvailable = (
 	deliveryAgent: DeliveryAgentState,
-): boolean => (deliveryAgent.response?.agents.length ?? 0) > 0;
+): boolean => (deliveryAgent.response?.agents?.length ?? 0) > 0;
 
 export const isPostcodeOptional = (country: IsoCountry | null): boolean =>
 	country !== 'GB' && country !== 'AU' && country !== 'US' && country !== 'CA';

--- a/support-frontend/assets/helpers/redux/checkout/address/validation.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/validation.ts
@@ -8,6 +8,7 @@ import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { AddressType } from 'helpers/subscriptionsForms/addressType';
 import type { Rule } from 'helpers/subscriptionsForms/validation';
 import {
+	deliveryAgentsAreAvailable,
 	formError,
 	nonEmptyString,
 	notLongerThan,
@@ -195,10 +196,6 @@ export const isHomeDeliveryAvailable = (
 
 	return true;
 };
-
-const deliveryAgentsAreAvailable = (
-	deliveryAgent: DeliveryAgentState,
-): boolean => (deliveryAgent.response?.agents?.length ?? 0) > 0;
 
 export const isPostcodeOptional = (country: IsoCountry | null): boolean =>
 	country !== 'GB' && country !== 'AU' && country !== 'US' && country !== 'CA';

--- a/support-frontend/assets/helpers/redux/checkout/addressMeta/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/addressMeta/state.ts
@@ -23,7 +23,7 @@ export type DeliveryAgentsResponse = {
 		| 'UnknownPostcode'
 		| 'ProblemWithInput'
 		| 'PaperRoundError';
-	agents: DeliveryAgentOption[];
+	agents?: DeliveryAgentOption[];
 };
 
 export type DeliveryAgentOption = {

--- a/support-frontend/assets/helpers/redux/checkout/addressMeta/subscriptionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/addressMeta/subscriptionsSideEffects.ts
@@ -1,0 +1,42 @@
+import type { AnyAction } from '@reduxjs/toolkit';
+import { isAnyOf } from '@reduxjs/toolkit';
+import type { SubscriptionsStartListening } from 'helpers/redux/subscriptionsStore';
+import { enableOrDisableForm } from 'helpers/subscriptionsForms/checkoutFormIsSubmittableActions';
+import type { FormField } from 'helpers/subscriptionsForms/formFields';
+import type { AnyCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
+import { removeError } from 'helpers/subscriptionsForms/validation';
+import { setDeliveryAgent } from './actions';
+
+function removeErrorsForField(
+	fieldName: FormField,
+	state: AnyCheckoutState,
+): AnyAction {
+	return {
+		type: 'SET_FORM_ERRORS',
+		errors: removeError(fieldName, state.page.checkout.formErrors),
+	};
+}
+
+const shouldCheckFormEnabled = isAnyOf(setDeliveryAgent);
+
+const actionCreatorFieldNames: Record<string, FormField> = {
+	[setDeliveryAgent.type]: 'deliveryProvider',
+};
+
+export function addAddressMetaSideEffects(
+	startListening: SubscriptionsStartListening,
+): void {
+	startListening({
+		matcher: shouldCheckFormEnabled,
+		effect(action, listenerApi) {
+			listenerApi.dispatch(
+				removeErrorsForField(
+					actionCreatorFieldNames[action.type],
+					listenerApi.getState(),
+				),
+			);
+
+			listenerApi.dispatch(enableOrDisableForm());
+		},
+	});
+}

--- a/support-frontend/assets/helpers/redux/checkout/addressMeta/subscriptionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/addressMeta/subscriptionsSideEffects.ts
@@ -1,5 +1,4 @@
 import type { AnyAction } from '@reduxjs/toolkit';
-import { isAnyOf } from '@reduxjs/toolkit';
 import type { SubscriptionsStartListening } from 'helpers/redux/subscriptionsStore';
 import { enableOrDisableForm } from 'helpers/subscriptionsForms/checkoutFormIsSubmittableActions';
 import type { FormField } from 'helpers/subscriptionsForms/formFields';
@@ -16,24 +15,14 @@ function removeErrorsForField(
 		errors: removeError(fieldName, state.page.checkout.formErrors),
 	};
 }
-
-const shouldCheckFormEnabled = isAnyOf(setDeliveryAgent);
-
-const actionCreatorFieldNames: Record<string, FormField> = {
-	[setDeliveryAgent.type]: 'deliveryProvider',
-};
-
 export function addAddressMetaSideEffects(
 	startListening: SubscriptionsStartListening,
 ): void {
 	startListening({
-		matcher: shouldCheckFormEnabled,
-		effect(action, listenerApi) {
+		actionCreator: setDeliveryAgent,
+		effect(_action, listenerApi) {
 			listenerApi.dispatch(
-				removeErrorsForField(
-					actionCreatorFieldNames[action.type],
-					listenerApi.getState(),
-				),
+				removeErrorsForField('deliveryProvider', listenerApi.getState()),
 			);
 
 			listenerApi.dispatch(enableOrDisableForm());

--- a/support-frontend/assets/helpers/redux/subscriptionsStore.ts
+++ b/support-frontend/assets/helpers/redux/subscriptionsStore.ts
@@ -10,6 +10,7 @@ import { createReducer } from 'helpers/subscriptionsForms/subscriptionCheckoutRe
 import type { DateYMDString } from 'helpers/types/DateString';
 import { setUpUserState } from 'helpers/user/reduxSetup';
 import { addAddressSideEffects } from './checkout/address/subscriptionsSideEffects';
+import { addAddressMetaSideEffects } from './checkout/addressMeta/subscriptionsSideEffects';
 import { addPaymentsSideEffects } from './checkout/payment/subscriptionsSideEffects';
 import { addPersonalDetailsSideEffects } from './checkout/personalDetails/subscriptionsSideEffects';
 import {
@@ -68,6 +69,7 @@ export function initReduxForSubscriptions(
 		addPersonalDetailsSideEffects(startListening);
 		addAddressSideEffects(startListening);
 		addPaymentsSideEffects(startListening);
+		addAddressMetaSideEffects(startListening);
 		const initialState = getInitialState();
 
 		store.dispatch(setInitialCommonState(initialState));

--- a/support-frontend/assets/helpers/subscriptionsForms/__tests__/validationTest.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/__tests__/validationTest.ts
@@ -5,6 +5,7 @@ import {
 	nonEmptyString,
 	notLongerThan,
 	notNull,
+	requiredDeliveryAgentChosen,
 	validate,
 	zuoraCompatibleString,
 } from '../validation';
@@ -66,6 +67,65 @@ describe('validation', () => {
 
 		it('should return true if the value is shorter than the number', () => {
 			expect(notLongerThan('short string', 100)).toBe(true);
+		});
+	});
+
+	describe('requiredDeliveryAgentChosen', () => {
+		it('should return true if the fulfilment option is not HomeDelivery', () => {
+			expect(
+				requiredDeliveryAgentChosen('Collection', { isLoading: false }),
+			).toBe(true);
+		});
+
+		it('should return true if the fulfilment option is HomeDelivery and no agents are available', () => {
+			expect(
+				requiredDeliveryAgentChosen('HomeDelivery', { isLoading: false }),
+			).toBe(true);
+		});
+
+		it('should return true if the fulfilment option is HomeDelivery and agents are available and an agent is chosen', () => {
+			expect(
+				requiredDeliveryAgentChosen('HomeDelivery', {
+					isLoading: false,
+					response: {
+						type: 'Covered',
+						agents: [
+							{
+								agentId: 1,
+								agentName: 'Delivery Company',
+								deliveryMethod: 'Car',
+								nbrDeliveryDays: 7,
+								postcode: '',
+								refGroupId: 1,
+								summary: '',
+							},
+						],
+					},
+					chosenAgent: 1,
+				}),
+			).toBe(true);
+		});
+
+		it('should return false if the fulfilment option is HomeDelivery and agents are available but no agent is chosen', () => {
+			expect(
+				requiredDeliveryAgentChosen('HomeDelivery', {
+					isLoading: false,
+					response: {
+						type: 'Covered',
+						agents: [
+							{
+								agentId: 1,
+								agentName: 'Delivery Company',
+								deliveryMethod: 'Car',
+								nbrDeliveryDays: 7,
+								postcode: '',
+								refGroupId: 1,
+								summary: '',
+							},
+						],
+					},
+				}),
+			).toBe(false);
 		});
 	});
 

--- a/support-frontend/assets/helpers/subscriptionsForms/formFields.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formFields.ts
@@ -41,6 +41,7 @@ export type FormFields = PersonalDetailsState &
 		deliveryInstructions?: string;
 		csrUsername?: string;
 		salesforceCaseId?: string;
+		deliveryProvider?: number;
 	};
 export type FormField = keyof FormFields | 'recaptcha';
 export type FormState = Omit<
@@ -85,6 +86,8 @@ function getFormFields(state: SubscriptionsState): FormFields {
 			state.page.checkoutForm.addressMeta.deliveryInstructions,
 		giftMessage: state.page.checkoutForm.gifting.giftMessage,
 		giftDeliveryDate: state.page.checkoutForm.gifting.giftDeliveryDate,
+		deliveryProvider:
+			state.page.checkoutForm.addressMeta.deliveryAgent.chosenAgent,
 	};
 }
 

--- a/support-frontend/assets/helpers/subscriptionsForms/formValidation.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formValidation.ts
@@ -84,7 +84,11 @@ function checkoutValidation(state: SubscriptionsState): AnyErrorType[] {
 function withDeliveryValidation(state: SubscriptionsState): AnyErrorType[] {
 	const formFields = getFormFields(state);
 
-	const deliveryErrors = applyDeliveryRules(formFields);
+	const deliveryErrors = applyDeliveryRules(
+		formFields,
+		state.page.checkoutForm.addressMeta.deliveryAgent,
+	);
+
 	const deliveryErrorsList = getErrorList({
 		errors: deliveryErrors,
 		dispatchErrors: (dispatch) => dispatch(setFormErrors(deliveryErrors)),

--- a/support-frontend/assets/helpers/subscriptionsForms/rules.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/rules.ts
@@ -4,6 +4,7 @@ import {
 	emailAddressesMatch,
 	isValidEmail,
 } from 'helpers/forms/formValidation';
+import type { DeliveryAgentState } from 'helpers/redux/checkout/addressMeta/state';
 import type { PersonalDetailsState } from 'helpers/redux/checkout/personalDetails/state';
 import type { FormField, FormFields } from './formFields';
 import {
@@ -11,6 +12,7 @@ import {
 	nonEmptyString,
 	notLongerThan,
 	notNull,
+	requiredDeliveryAgentChosen,
 	validate,
 	zuoraCompatibleString,
 } from './validation';
@@ -252,7 +254,10 @@ function applyCheckoutRules(fields: FormFields): Array<FormError<FormField>> {
 	return validate(formFieldsToCheck);
 }
 
-function applyDeliveryRules(fields: FormFields): Array<FormError<FormField>> {
+function applyDeliveryRules(
+	fields: FormFields,
+	deliveryAgent: DeliveryAgentState,
+): Array<FormError<FormField>> {
 	const deliveryRules: CheckoutRule[] = [
 		{
 			rule: notNull(fields.startDate),
@@ -271,6 +276,10 @@ function applyDeliveryRules(fields: FormFields): Array<FormError<FormField>> {
 				'deliveryInstructions',
 				'Please use only letters, numbers and punctuation.',
 			),
+		},
+		{
+			rule: requiredDeliveryAgentChosen(fields.fulfilmentOption, deliveryAgent),
+			error: formError('deliveryProvider', 'Please select a delivery provider'),
 		},
 	];
 	return validate(deliveryRules).concat(applyCheckoutRules(fields));

--- a/support-frontend/assets/helpers/subscriptionsForms/validation.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/validation.ts
@@ -109,4 +109,5 @@ export {
 	validate,
 	zuoraCompatibleString,
 	requiredDeliveryAgentChosen,
+	deliveryAgentsAreAvailable,
 };

--- a/support-frontend/assets/helpers/subscriptionsForms/validation.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/validation.ts
@@ -1,3 +1,6 @@
+import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import type { DeliveryAgentState } from 'helpers/redux/checkout/addressMeta/state';
+
 // ----- Types ----- //
 export type Rule<Err> = {
 	rule: boolean;
@@ -32,6 +35,20 @@ function zuoraCompatibleString(s: string | null | undefined): boolean {
 	}
 
 	return !takesFourBytesInUTF8Regex.test(s);
+}
+
+function requiredDeliveryAgentChosen(
+	fulfilmentOption: FulfilmentOptions | null,
+	deliveryAgent: DeliveryAgentState,
+): boolean {
+	if (
+		fulfilmentOption === 'HomeDelivery' &&
+		deliveryAgentsAreAvailable(deliveryAgent)
+	) {
+		return deliveryAgentHasBeenChosen(deliveryAgent);
+	}
+
+	return true;
 }
 
 // ----- Functions ----- //
@@ -69,6 +86,18 @@ function validate<Err>(rules: Array<Rule<Err>>): Err[] {
 	);
 }
 
+function deliveryAgentHasBeenChosen(
+	deliveryAgent: DeliveryAgentState,
+): boolean {
+	return deliveryAgent.chosenAgent ? true : false;
+}
+
+function deliveryAgentsAreAvailable(
+	deliveryAgent: DeliveryAgentState,
+): boolean {
+	return (deliveryAgent.response?.agents?.length ?? 0) > 0;
+}
+
 // ----- Exports ----- //
 export {
 	nonEmptyString,
@@ -79,4 +108,5 @@ export {
 	removeError,
 	validate,
 	zuoraCompatibleString,
+	requiredDeliveryAgentChosen,
 };

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
@@ -7,6 +7,8 @@ import {
 import { InfoSummary } from '@guardian/source-react-components-development-kitchen';
 import type { ActionCreatorWithOptionalPayload } from '@reduxjs/toolkit';
 import type { DeliveryAgentsResponse } from 'helpers/redux/checkout/addressMeta/state';
+import type { FormError } from 'helpers/subscriptionsForms/validation';
+import { firstError } from 'helpers/subscriptionsForms/validation';
 
 const marginBottom = css`
 	margin-bottom: ${space[6]}px;
@@ -20,13 +22,14 @@ interface DeliveryAgentsSelectProps {
 		number | undefined,
 		'addressMeta/setDeliveryAgent'
 	>;
+	formErrors: Array<FormError<string>>;
 }
 
 export function DeliveryAgentsSelect(
 	props: DeliveryAgentsSelectProps,
 ): JSX.Element | null {
 	if (props.deliveryAgentsResponse?.type === 'Covered') {
-		if (props.deliveryAgentsResponse.agents.length === 1) {
+		if (props.deliveryAgentsResponse.agents?.length === 1) {
 			const singleDeliveryProvider = props.deliveryAgentsResponse.agents[0];
 			props.setDeliveryAgent(singleDeliveryProvider.agentId);
 			return (
@@ -49,10 +52,11 @@ export function DeliveryAgentsSelect(
 				id="delivery-provider"
 				css={marginBottom}
 				onChange={(e) => props.setDeliveryAgent(parseInt(e.target.value))}
+				error={firstError('deliveryProvider', props.formErrors)}
 			>
 				<OptionForSelect value="">Click to select</OptionForSelect>
 				<>
-					{props.deliveryAgentsResponse.agents.map((agent) => (
+					{props.deliveryAgentsResponse.agents?.map((agent) => (
 						<OptionForSelect value={agent.agentId}>
 							{agent.agentName}
 						</OptionForSelect>

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -374,6 +374,7 @@ function PaperCheckoutForm(props: PropTypes) {
 							<DeliveryAgentsSelect
 								deliveryAgentsResponse={props.deliveryAgentsResponse}
 								setDeliveryAgent={props.setDeliveryAgent}
+								formErrors={props.formErrors}
 							/>
 						)}
 						{isHomeDelivery ? (

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx
@@ -64,6 +64,9 @@ describe('Guardian Weekly checkout form', () => {
 					},
 					addressMeta: {
 						billingAddressMatchesDelivery: true,
+						deliveryAgent: {
+							isLoading: false,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

This PR adds validation to the paper checkout form field for selecting a delivery provider when one is available (based on postcode), as well as a side effect to clear the form error when one is selected. 

The validation itself is not behind the `nationalDelivery` AB test but the logic checks whether a delivery provider is available - which it won't be unless the user is in the AB test.

[**Trello Card**](https://trello.com/c/rpO50Bym/82-support-frontend-error-message-on-no-delivery-partner-chosen)

## Why are you doing this?

When inputting an address that requires a delivery partner, if a user doesn’t choose a partner, red error message should appear.

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [ ] No

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots
![image](https://github.com/guardian/support-frontend/assets/114918544/4f96ba8e-9020-4df9-b1c5-bb6d294a34f1)

