### PR TITLE
Two step checkout page 2 (checkout) layout/style amends

### DIFF
--- a/support-frontend/assets/components/checkoutHeading/checkoutHeading.tsx
+++ b/support-frontend/assets/components/checkoutHeading/checkoutHeading.tsx
@@ -41,6 +41,7 @@ export interface CheckoutHeadingProps extends CSSOverridable {
 	heading: React.ReactNode;
 	children?: React.ReactNode;
 	image?: React.ReactNode;
+	withTopborder?: true;
 }
 
 export function CheckoutHeading(props: CheckoutHeadingProps): JSX.Element {
@@ -48,6 +49,7 @@ export function CheckoutHeading(props: CheckoutHeadingProps): JSX.Element {
 		<div css={mainStyles}>
 			<Container
 				sideBorders={true}
+				topBorder={props.withTopborder}
 				borderColor={brand[600]}
 				backgroundColor={brand[400]}
 			>

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -58,6 +58,9 @@ const totalRow = (hasTsAncCs: boolean) => css`
 
 const heading = css`
 	${headline.xsmall({ fontWeight: 'bold' })}
+	${from.tablet} {
+		font-size: 28px;
+	}
 `;
 
 const hrCss = css`

--- a/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/paymentMethodSelector.tsx
@@ -32,12 +32,14 @@ const paymentLegendOverrides = css`
 	margin-bottom: ${space[3]}px;
 `;
 
-export type PaymentMethodSelectorLegendProps = {
+type PaymentMethodSelectorLegendProps = {
 	cssOverrides?: SerializedStyles;
+	overrideHeadingCopy?: string;
 };
 
 function PaymentMethodSelectorLegend({
 	cssOverrides,
+	overrideHeadingCopy,
 }: PaymentMethodSelectorLegendProps) {
 	return (
 		<div
@@ -47,7 +49,7 @@ function PaymentMethodSelectorLegend({
 			`}
 		>
 			<legend id="payment_method">
-				<h2 css={header}>Payment method</h2>
+				<h2 css={header}>{overrideHeadingCopy ?? 'Payment method'}</h2>
 			</legend>
 			<SecureTransactionIndicator
 				hideText={true}
@@ -70,6 +72,7 @@ export type PaymentMethodSelectorProps = {
 		paymentMethod: PaymentMethod,
 		existingPaymentMethod?: RecentlySignedInExistingPaymentMethod,
 	) => void;
+	overrideHeadingCopy?: string;
 };
 
 export function PaymentMethodSelector({
@@ -81,6 +84,7 @@ export function PaymentMethodSelector({
 	pendingExistingPaymentMethods,
 	showReauthenticateLink,
 	onPaymentMethodEvent,
+	overrideHeadingCopy,
 }: PaymentMethodSelectorProps): JSX.Element {
 	if (
 		existingPaymentMethodList.length < 1 &&
@@ -97,7 +101,10 @@ export function PaymentMethodSelector({
 
 	return (
 		<div css={container}>
-			<PaymentMethodSelectorLegend cssOverrides={paymentLegendOverrides} />
+			<PaymentMethodSelectorLegend
+				cssOverrides={paymentLegendOverrides}
+				overrideHeadingCopy={overrideHeadingCopy}
+			/>
 			<RadioGroup
 				id="paymentMethod"
 				role="radiogroup"

--- a/support-frontend/assets/components/personalDetails/personalDetails.tsx
+++ b/support-frontend/assets/components/personalDetails/personalDetails.tsx
@@ -1,18 +1,32 @@
 // ----- Imports ----- //
 import { css } from '@emotion/react';
-import { from, space, visuallyHidden } from '@guardian/source-foundations';
+import {
+	from,
+	headline,
+	space,
+	visuallyHidden,
+} from '@guardian/source-foundations';
 import { TextInput } from '@guardian/source-react-components';
 import type { ContributionType } from 'helpers/contributions';
 import { emailRegexPattern } from 'helpers/forms/formValidation';
 import type { PersonalDetailsState } from 'helpers/redux/checkout/personalDetails/state';
 
+const header = css`
+	${headline.xsmall({ fontWeight: 'bold' })};
+	margin-top: ${space[2]}px;
+	margin-bottom: ${space[4]}px;
+	${from.tablet} {
+		font-size: 28px;
+	}
+`;
+
 const hiddenHeading = css`
 	${visuallyHidden};
 `;
 
-const fieldGroupStyles = css`
+const fieldGroupStyles = (hideDetailsHeading?: boolean) => css`
 	position: relative;
-	margin-top: ${space[4]}px;
+	margin-top: ${hideDetailsHeading ? `${space[4]}px` : '0'};
 
 	& > *:not(:first-of-type) {
 		margin-top: ${space[3]}px;
@@ -35,6 +49,8 @@ export type PersonalDetailsProps = {
 	onLastNameChange: (lastName: string) => void;
 	signOutLink: React.ReactNode;
 	contributionState: React.ReactNode;
+	overrideHeadingCopy?: string;
+	hideDetailsHeading?: true;
 	errors?: PersonalDetailsState['errors'];
 };
 
@@ -50,10 +66,14 @@ export function PersonalDetails({
 	errors,
 	signOutLink,
 	contributionState,
+	hideDetailsHeading,
+	overrideHeadingCopy,
 }: PersonalDetailsProps): JSX.Element {
 	return (
-		<div css={fieldGroupStyles}>
-			<h3 css={hiddenHeading}>Your details</h3>
+		<div css={fieldGroupStyles(hideDetailsHeading)}>
+			<h2 css={[header, hideDetailsHeading && hiddenHeading]}>
+				{overrideHeadingCopy ?? 'Your details'}
+			</h2>
 			<div>
 				<TextInput
 					id="email"

--- a/support-frontend/assets/pages/kindle-subscriber-checkout/kindleSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/kindle-subscriber-checkout/kindleSubscriptionLandingPage.tsx
@@ -169,7 +169,10 @@ export function SupporterPlusLandingPage({
 									<SecureTransactionIndicator align="center" />
 									<PersonalDetailsContainer
 										renderPersonalDetails={(personalDetailsProps) => (
-											<PersonalDetails {...personalDetailsProps} />
+											<PersonalDetails
+												{...personalDetailsProps}
+												hideDetailsHeading
+											/>
 										)}
 									/>
 									<Divider size="full" cssOverrides={divider} />

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusLanding.tsx
@@ -223,7 +223,10 @@ export function SupporterPlusLandingPage({
 									/>
 									<PersonalDetailsContainer
 										renderPersonalDetails={(personalDetailsProps) => (
-											<PersonalDetails {...personalDetailsProps} />
+											<PersonalDetails
+												{...personalDetailsProps}
+												hideDetailsHeading
+											/>
 										)}
 									/>
 									<CheckoutDivider spacing="loose" />

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/checkoutScaffold.tsx
@@ -23,6 +23,7 @@ import { Container } from 'components/layout/container';
 import { LoadingOverlay } from 'components/loadingOverlay/loadingOverlay';
 import Nav from 'components/nav/nav';
 import { PageScaffold } from 'components/page/pageScaffold';
+import { SecureTransactionIndicator } from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import {
 	AUDCountries,
 	Canada,
@@ -38,13 +39,14 @@ import { GuardianTsAndCs } from '../components/guardianTsAndCs';
 import { LandingPageHeading } from '../components/landingPageHeading';
 import { PatronsMessage } from '../components/patronsMessage';
 
-const checkoutContainer = css`
+const checkoutContainer = (isPaymentPage?: boolean) => css`
 	position: relative;
 	color: ${palette.neutral[7]};
 	${textSans.medium()};
-	padding-top: ${space[6]}px;
+	padding-top: ${space[isPaymentPage ? 2 : 6]}px;
 	padding-bottom: ${space[9]}px;
 	${from.tablet} {
+		padding-top: 40px;
 		padding-bottom: ${space[12]}px;
 	}
 `;
@@ -62,12 +64,21 @@ const subHeading = css`
 	padding-right: ${space[2]}px;
 `;
 
+const secureIndicatorSpacing = css`
+	margin-bottom: ${space[3]}px;
+	${from.tablet} {
+		margin-bottom: ${space[4]}px;
+	}
+`;
+
 export function SupporterPlusCheckoutScaffold({
 	children,
 	thankYouRoute,
+	isPaymentPage,
 }: {
 	children: React.ReactNode;
 	thankYouRoute: string;
+	isPaymentPage?: true;
 }): JSX.Element {
 	const { countryGroupId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
@@ -106,13 +117,15 @@ export function SupporterPlusCheckoutScaffold({
 			header={
 				<>
 					<Header>
-						<Hide from="desktop">
-							<CountrySwitcherContainer>
-								<CountryGroupSwitcher {...countrySwitcherProps} />
-							</CountrySwitcherContainer>
-						</Hide>
+						{!isPaymentPage && (
+							<Hide from="desktop">
+								<CountrySwitcherContainer>
+									<CountryGroupSwitcher {...countrySwitcherProps} />
+								</CountrySwitcherContainer>
+							</Hide>
+						)}
 					</Header>
-					<Nav {...countrySwitcherProps} />
+					{!isPaymentPage && <Nav {...countrySwitcherProps} />}
 				</>
 			}
 			footer={
@@ -122,27 +135,43 @@ export function SupporterPlusCheckoutScaffold({
 			}
 		>
 			<CheckoutHeading
-				heading={heading}
+				heading={!isPaymentPage && heading}
 				image={
-					<GridImage
-						gridId="supporterPlusLanding"
-						srcSizes={[500]}
-						sizes="500px"
-						imgType="png"
-						altText=""
-					/>
+					!isPaymentPage && (
+						<GridImage
+							gridId="supporterPlusLanding"
+							srcSizes={[500]}
+							sizes="500px"
+							imgType="png"
+							altText=""
+						/>
+					)
 				}
+				withTopborder={isPaymentPage}
 			>
-				<p css={subHeading}>
-					As a reader-funded news organisation, we rely on your generosity.
-					Please give what you can, so millions can benefit from quality
-					reporting on the events shaping our world.
-				</p>
+				{!isPaymentPage && (
+					<p css={subHeading}>
+						As a reader-funded news organisation, we rely on your generosity.
+						Please give what you can, so millions can benefit from quality
+						reporting on the events shaping our world.
+					</p>
+				)}
 			</CheckoutHeading>
+
 			<Container sideBorders cssOverrides={darkBackgroundContainerMobile}>
-				<Columns cssOverrides={checkoutContainer} collapseUntil="tablet">
+				<Columns
+					cssOverrides={checkoutContainer(isPaymentPage)}
+					collapseUntil="tablet"
+				>
 					<Column span={[0, 2, 5]}></Column>
 					<Column span={[1, 8, 7]}>
+						{isPaymentPage && (
+							<SecureTransactionIndicator
+								align="center"
+								theme="light"
+								cssOverrides={secureIndicatorSpacing}
+							/>
+						)}
 						{children}
 						<CheckoutDivider spacing="loose" mobileTheme={'light'} />
 						<PatronsMessage

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/secondStepCheckout.tsx
@@ -1,7 +1,10 @@
 import { css } from '@emotion/react';
 import { space, until } from '@guardian/source-foundations';
-import { Link } from 'react-router-dom';
+import { Button } from '@guardian/source-react-components';
+import { useNavigate } from 'react-router-dom';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
+import { ContributionsOrderSummary } from 'components/orderSummary/contributionsOrderSummary';
+import { ContributionsOrderSummaryContainer } from 'components/orderSummary/contributionsOrderSummaryContainer';
 import { PaymentButtonController } from 'components/paymentButton/paymentButtonController';
 import { PaymentMethodSelector } from 'components/paymentMethodSelector/paymentMethodSelector';
 import PaymentMethodSelectorContainer from 'components/paymentMethodSelector/PaymentMethodSelectorContainer';
@@ -9,7 +12,6 @@ import { PaymentRequestButtonContainer } from 'components/paymentRequestButton/p
 import { PersonalDetails } from 'components/personalDetails/personalDetails';
 import { PersonalDetailsContainer } from 'components/personalDetails/personalDetailsContainer';
 import { SavedCardButton } from 'components/savedCardButton/savedCardButton';
-import { SecureTransactionIndicator } from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import { ContributionsStripe } from 'components/stripe/contributionsStripe';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
@@ -55,35 +57,56 @@ export function SupporterPlusCheckout({
 		countryGroupId,
 	);
 
+	const navigate = useNavigate();
+
+	const changeButton = (
+		<Button
+			priority="tertiary"
+			size="xsmall"
+			onClick={() =>
+				navigate(
+					`/${countryGroups[countryGroupId].supportInternationalisationId}/contribute`,
+				)
+			}
+		>
+			Change
+		</Button>
+	);
+
 	return (
-		<SupporterPlusCheckoutScaffold thankYouRoute={thankYouRoute}>
+		<SupporterPlusCheckoutScaffold thankYouRoute={thankYouRoute} isPaymentPage>
 			<Box cssOverrides={shorterBoxMargin}>
 				<BoxContents>
-					<p>
-						{amount} {contributionType}
-					</p>
-					<Link
-						to={`/${countryGroups[countryGroupId].supportInternationalisationId}/contribute`}
-					>
-						Changed your mind?
-					</Link>
+					<ContributionsOrderSummaryContainer
+						renderOrderSummary={(orderSummaryProps) => (
+							<ContributionsOrderSummary
+								{...orderSummaryProps}
+								headerButton={changeButton}
+							/>
+						)}
+					/>
 				</BoxContents>
 			</Box>
 			<Box cssOverrides={shorterBoxMargin}>
 				<BoxContents>
 					{/* The same Stripe provider *must* enclose the Stripe card form and payment button(s). Also enclosing the PRB reduces re-renders. */}
 					<ContributionsStripe>
-						<SecureTransactionIndicator />
 						<PaymentRequestButtonContainer CustomButton={SavedCardButton} />
 						<PersonalDetailsContainer
 							renderPersonalDetails={(personalDetailsProps) => (
-								<PersonalDetails {...personalDetailsProps} />
+								<PersonalDetails
+									{...personalDetailsProps}
+									overrideHeadingCopy="1. Your details"
+								/>
 							)}
 						/>
 						<CheckoutDivider spacing="loose" />
 						<PaymentMethodSelectorContainer
 							render={(paymentMethodSelectorProps) => (
-								<PaymentMethodSelector {...paymentMethodSelectorProps} />
+								<PaymentMethodSelector
+									{...paymentMethodSelectorProps}
+									overrideHeadingCopy="2. Payment method"
+								/>
 							)}
 						/>
 						<PaymentButtonController

--- a/support-frontend/stories/checkoutLayout/PersonalDetails.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/PersonalDetails.stories.tsx
@@ -65,11 +65,32 @@ SingleContribSignedIn.args = {
 			countryId={'GB'}
 		/>
 	),
+	hideDetailsHeading: true,
 };
 
 export const SingleContribSignedOut = Template.bind({});
 
 SingleContribSignedOut.args = {
+	email: '',
+	firstName: '',
+	lastName: '',
+	contributionType: 'ONE_OFF',
+	isSignedIn: false,
+	signOutLink: <Signout isSignedIn={false} />,
+	contributionState: (
+		<StateSelect
+			state=""
+			onStateChange={() => null}
+			contributionType={'ONE_OFF'}
+			countryId={'GB'}
+		/>
+	),
+	hideDetailsHeading: true,
+};
+
+export const SingleContribSignedOutWithVisibleHeader = Template.bind({});
+
+SingleContribSignedOutWithVisibleHeader.args = {
 	email: '',
 	firstName: '',
 	lastName: '',
@@ -103,6 +124,7 @@ MultiContribSignedIn.args = {
 			countryId={'GB'}
 		/>
 	),
+	hideDetailsHeading: true,
 };
 
 export const MultiContribSignedOut = Template.bind({});
@@ -122,6 +144,7 @@ MultiContribSignedOut.args = {
 			countryId={'GB'}
 		/>
 	),
+	hideDetailsHeading: true,
 };
 
 export const MultiContribUSSignedIn = Template.bind({});
@@ -141,6 +164,7 @@ MultiContribUSSignedIn.args = {
 			countryId={'US'}
 		/>
 	),
+	hideDetailsHeading: true,
 };
 
 export const MultiContribUSSignedOut = Template.bind({});
@@ -160,6 +184,7 @@ MultiContribUSSignedOut.args = {
 			countryId={'US'}
 		/>
 	),
+	hideDetailsHeading: true,
 };
 
 export const WithErrors = Template.bind({});
@@ -185,4 +210,5 @@ WithErrors.args = {
 			countryId={'US'}
 		/>
 	),
+	hideDetailsHeading: true,
 };


### PR DESCRIPTION
## What are you doing in this PR?
Layout and style amends to the second page of the two step checkout.

Currently behind the `twoStepCheckout` ab test here ->
[https://support.thegulocal.com/uk/contribute#ab-twoStepCheckout=variant](https://support.thegulocal.com/uk/contribute#ab-twoStepCheckout=variant)

[***Trello Card**](https://trello.com/c/VELeJraK/1493-2-step-checkout-implement-design-updates-to-page-2-of-2-step-checkout)

## Screenshots

#### single contribution
Before (AB variant)             |  After (AB variant)
:-------------------------:|:-------------------------:
![](https://github.com/guardian/support-frontend/assets/2510683/4ae56f13-f713-4048-ae75-2e81a335289a)  |  ![](https://github.com/guardian/support-frontend/assets/2510683/01604026-0c41-4a54-9808-94392abc8f96)

#### recurring contribution
Before (AB variant)             |  After (AB variant)
:-------------------------:|:-------------------------:
![](https://github.com/guardian/support-frontend/assets/2510683/1be2c89f-a23b-4c2c-8c2c-69ee54d582fd)  |  ![](https://github.com/guardian/support-frontend/assets/2510683/640d9aea-babb-4adf-90a2-a4a206d058c8)




