### PR TITLE
Fix - Direct Debit popup form close button

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.tsx
@@ -27,7 +27,7 @@ export default function DirectDebitPopUpForm(props: PropTypes): JSX.Element {
 	const dispatch = useContributionsDispatch();
 
 	function closePopup() {
-		dispatch(setPopupClose);
+		dispatch(setPopupClose());
 		dispatch(resetFormError);
 	}
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This is a small fix to the DD form popup close button. The redux state had recently been refactored to use the newer redux toolkit approach and therefore the function needed to close the button now need to be 'called'.

## Why are you doing this?
The popup form close button does not currently close the form.