### PR TITLE
Pass referrer through auth flow

### DIFF
--- a/support-frontend/test/actions/UserFromAuthCookiesOrAuthServerActionBuilderTest.scala
+++ b/support-frontend/test/actions/UserFromAuthCookiesOrAuthServerActionBuilderTest.scala
@@ -11,6 +11,7 @@ import org.mockito.Mockito.when
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
+import play.api.http.HeaderNames.REFERER
 import play.api.libs.json.{JsNull, Json}
 import play.api.mvc.Results._
 import play.api.mvc.{AnyContent, BodyParser, Cookie}
@@ -68,7 +69,7 @@ class UserFromAuthCookiesOrAuthServerActionBuilderTest extends AnyWordSpec with 
       val authService = mock[OktaAuthService[DefaultAccessClaims, UserClaims]]
       val config = mock[Identity]
       when(config.oauthScopes).thenReturn(accessScopes)
-      val request = FakeRequest()
+      val request = FakeRequest().withHeaders(REFERER -> "referrer")
       def block(request: OptionalAuthRequest[AnyContent]) = Future.successful(Ok(toJson(request)))
       val actionBuilder =
         new UserFromAuthCookiesOrAuthServerActionBuilder(
@@ -86,6 +87,9 @@ class UserFromAuthCookiesOrAuthServerActionBuilderTest extends AnyWordSpec with 
       }
       "include origin URL in response session" in {
         session(result).get(SessionKey.originUrl) mustBe Some(request.uri)
+      }
+      "include referrer URL in response session" in {
+        session(result).get(SessionKey.referringUrl) mustBe request.headers.get(REFERER)
       }
     }
 
@@ -96,7 +100,9 @@ class UserFromAuthCookiesOrAuthServerActionBuilderTest extends AnyWordSpec with 
       when(config.oauthScopes).thenReturn(accessScopes)
       when(config.idTokenCookieName).thenReturn(idTokenCookieName)
       when(config.accessTokenCookieName).thenReturn(accessTokenCookieName)
-      val request = FakeRequest().withCookies(Cookie(name = config.accessTokenCookieName, value = accessToken.value))
+      val request = FakeRequest()
+        .withHeaders(REFERER -> "referrer")
+        .withCookies(Cookie(name = config.accessTokenCookieName, value = accessToken.value))
       def block(request: OptionalAuthRequest[AnyContent]) = Future.successful(Ok(toJson(request)))
       val actionBuilder =
         new UserFromAuthCookiesOrAuthServerActionBuilder(
@@ -114,6 +120,9 @@ class UserFromAuthCookiesOrAuthServerActionBuilderTest extends AnyWordSpec with 
       }
       "include origin URL in response session" in {
         session(result).get(SessionKey.originUrl) mustBe Some(request.uri)
+      }
+      "include referrer URL in response session" in {
+        session(result).get(SessionKey.referringUrl) mustBe request.headers.get(REFERER)
       }
     }
 
@@ -125,7 +134,9 @@ class UserFromAuthCookiesOrAuthServerActionBuilderTest extends AnyWordSpec with 
       when(config.oauthScopes).thenReturn(accessScopes)
       when(config.idTokenCookieName).thenReturn(idTokenCookieName)
       when(config.accessTokenCookieName).thenReturn(accessTokenCookieName)
-      val request = FakeRequest().withCookies(Cookie(name = config.idTokenCookieName, value = idToken.value))
+      val request = FakeRequest()
+        .withHeaders(REFERER -> "referrer")
+        .withCookies(Cookie(name = config.idTokenCookieName, value = idToken.value))
       def block(request: OptionalAuthRequest[AnyContent]) = Future.successful(Ok(toJson(request)))
       val actionBuilder =
         new UserFromAuthCookiesOrAuthServerActionBuilder(
@@ -143,6 +154,9 @@ class UserFromAuthCookiesOrAuthServerActionBuilderTest extends AnyWordSpec with 
       }
       "include origin URL in response session" in {
         session(result).get(SessionKey.originUrl) mustBe Some(request.uri)
+      }
+      "include referrer URL in response session" in {
+        session(result).get(SessionKey.referringUrl) mustBe request.headers.get(REFERER)
       }
     }
 
@@ -185,10 +199,12 @@ class UserFromAuthCookiesOrAuthServerActionBuilderTest extends AnyWordSpec with 
       when(config.oauthScopes).thenReturn(accessScopes)
       when(config.idTokenCookieName).thenReturn(idTokenCookieName)
       when(config.accessTokenCookieName).thenReturn(accessTokenCookieName)
-      val request = FakeRequest().withCookies(
-        Cookie(name = config.idTokenCookieName, value = idToken.value),
-        Cookie(name = config.accessTokenCookieName, value = accessToken.value),
-      )
+      val request = FakeRequest()
+        .withHeaders(REFERER -> "referrer")
+        .withCookies(
+          Cookie(name = config.idTokenCookieName, value = idToken.value),
+          Cookie(name = config.accessTokenCookieName, value = accessToken.value),
+        )
       def block(request: OptionalAuthRequest[AnyContent]) = Future.successful(Ok(toJson(request)))
       val actionBuilder =
         new UserFromAuthCookiesOrAuthServerActionBuilder(
@@ -206,6 +222,9 @@ class UserFromAuthCookiesOrAuthServerActionBuilderTest extends AnyWordSpec with 
       }
       "include origin URL in response session" in {
         session(result).get(SessionKey.originUrl) mustBe Some(request.uri)
+      }
+      "include referrer URL in response session" in {
+        session(result).get(SessionKey.referringUrl) mustBe request.headers.get(REFERER)
       }
     }
 

--- a/support-frontend/test/controllers/AuthCodeFlowControllerTest.scala
+++ b/support-frontend/test/controllers/AuthCodeFlowControllerTest.scala
@@ -7,6 +7,7 @@ import org.mockito.Mockito.when
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
+import play.api.http.HeaderNames.{LOCATION, REFERER}
 import play.api.libs.json.Json
 import play.api.libs.ws.WSResponse
 import play.api.mvc.Cookie
@@ -31,7 +32,7 @@ class AuthCodeFlowControllerTest extends AnyWordSpec with Matchers {
       val controller = new AuthCodeFlowController(stubControllerComponents(), authService, config)
       val result = controller.authorize()(FakeRequest())
       status(result) mustEqual 303
-      val locationHeader = headers(result).get("Location").get
+      val locationHeader = headers(result).get(LOCATION).get
       locationHeader must startWith("authServerUrl?")
       locationHeader must include("state=")
       locationHeader must include("scope=a+b+c")
@@ -60,13 +61,14 @@ class AuthCodeFlowControllerTest extends AnyWordSpec with Matchers {
       val controller = new AuthCodeFlowController(stubControllerComponents(), authService, config)
       val request = FakeRequest().withSession(
         SessionKey.originUrl -> "origin",
+        SessionKey.referringUrl -> "referrer",
         SessionKey.codeVerifier -> "verifier",
         SessionKey.state -> "state",
       )
       val result =
         controller.callback(code = Some("code"), state = "state", error = None, errorDescription = None)(request)
       status(result) mustEqual 303
-      headers(result).get("Location") must contain("origin")
+      headers(result).get(LOCATION) must contain("origin?pre-auth-ref=referrer")
       cookies(result).get(config.idTokenCookieName) must contain(
         Cookie(
           name = "id_token",
@@ -88,6 +90,7 @@ class AuthCodeFlowControllerTest extends AnyWordSpec with Matchers {
         ),
       )
       session(result).get(SessionKey.originUrl) must be(None)
+      session(result).get(SessionKey.referringUrl) must be(None)
       session(result).get(SessionKey.codeVerifier) must be(None)
       session(result).get(SessionKey.state) must be(None)
       flash(result).get(FlashKey.authTried) must be(defined)
@@ -102,6 +105,7 @@ class AuthCodeFlowControllerTest extends AnyWordSpec with Matchers {
       val controller = new AuthCodeFlowController(stubControllerComponents(), authService, config)
       val request = FakeRequest().withSession(
         SessionKey.originUrl -> "origin",
+        SessionKey.referringUrl -> "referrer",
         SessionKey.codeVerifier -> "verifier",
         SessionKey.state -> "state",
       )
@@ -113,10 +117,11 @@ class AuthCodeFlowControllerTest extends AnyWordSpec with Matchers {
           errorDescription = Some("error desc"),
         )(request)
       status(result) mustEqual 303
-      headers(result).get("Location") must contain("origin")
+      headers(result).get(LOCATION) must contain("origin?pre-auth-ref=referrer")
       cookies(result).get(config.idTokenCookieName) must be(None)
       cookies(result).get(config.accessTokenCookieName) must be(None)
       session(result).get(SessionKey.originUrl) must be(None)
+      session(result).get(SessionKey.referringUrl) must be(None)
       session(result).get(SessionKey.codeVerifier) must be(None)
       session(result).get(SessionKey.state) must be(None)
       flash(result).get(FlashKey.authTried) must be(defined)


### PR DESCRIPTION
When an auth flow takes place on page load, we lose the referrer for that page.  To get around that, in this PR we store the referrer of the URL when the auth flow begins.  Then, at the end of the auth flow, we expose it as the value of a new query parameter called `pre-auth-ref` so that it can be used for attribution and other analytics.

See also https://github.com/guardian/ophan/pull/5528
