### PR TITLE
Fix client-side validation for the country and state provided by the payment request button

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/payment/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/contributionsSideEffects.ts
@@ -1,6 +1,13 @@
+import {
+	setBillingCountry,
+	setBillingState,
+} from 'helpers/redux/checkout/address/actions';
+import {
+	setPaymentMethod,
+	setPaymentMethodCountryAndState,
+} from 'helpers/redux/checkout/payment/paymentMethod/actions';
 import type { ContributionsStartListening } from 'helpers/redux/contributionsStore';
 import * as storage from 'helpers/storage/storage';
-import { setPaymentMethod } from './paymentMethod/actions';
 
 export function addPaymentsSideEffects(
 	startListening: ContributionsStartListening,
@@ -9,6 +16,15 @@ export function addPaymentsSideEffects(
 		actionCreator: setPaymentMethod,
 		effect(action) {
 			storage.setSession('selectedPaymentMethod', action.payload.paymentMethod);
+		},
+	});
+
+	startListening({
+		actionCreator: setPaymentMethodCountryAndState,
+		effect(action, listenerApi) {
+			listenerApi.dispatch(setBillingCountry(action.payload[0]));
+			action.payload[1] &&
+				listenerApi.dispatch(setBillingState(action.payload[1]));
 		},
 	});
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
As of [PR 4927](https://github.com/guardian/support-frontend/pull/4927), payment method address data is stored separately from the supporter plus form address data. Our existing address validation enforces that a state must be present for applicable countries but this validation is based on the form address data which has led to a recent series of errors. This PR adds a payment details side effect that updates the billing country and state whenever the payment method country and state is changed.

[**Trello Card**](https://trello.com/c/ChpoH4Qd/1501-fix-client-side-validation-for-the-country-and-state-provided-by-the-payment-request-button)
