### PR TITLE
scala-steward: Ignore simple-configuration-ssm

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -21,5 +21,6 @@ updates.ignore = [
   { groupId = "com.stripe", artifactId = "stripe-java" },
   { groupId = "org.mockito", artifactId = "mockito-core" },
   { groupId = "com.dripower", artifactId = "play-circe" },
-  { groupId = "org.seleniumhq.selenium", artifactId = "selenium-java" }
+  { groupId = "org.seleniumhq.selenium", artifactId = "selenium-java" },
+  { groupId = "com.gu", artifactId = "simple-configuration-ssm" }
 ]


### PR DESCRIPTION
This [will require a manual update](https://trello.com/c/mvIwywtl/308-support-frontend-support-frontend-update-comgusimple-configuration-ssm-to-158). Until we do that manual update, let’s get scala steward to ignore it so it doesn’t break our scala steward PRs.