### PR TITLE
Remove existing pre-auth-ref values before adding

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -104,7 +104,7 @@
     "emotion-theming": "^11.0.0",
     "framer-motion": "^1.11.1",
     "lodash.debounce": "^4.0.6",
-    "ophan-tracker-js": "^1.4.0",
+    "ophan-tracker-js": "^1.4.2",
     "react-day-picker": "^7.4.8",
     "react-is": "^18.2.0",
     "react-redux": "^8.1.0",

--- a/support-frontend/test/controllers/AuthCodeFlowControllerTest.scala
+++ b/support-frontend/test/controllers/AuthCodeFlowControllerTest.scala
@@ -7,7 +7,7 @@ import org.mockito.Mockito.when
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
-import play.api.http.HeaderNames.{LOCATION, REFERER}
+import play.api.http.HeaderNames.LOCATION
 import play.api.libs.json.Json
 import play.api.libs.ws.WSResponse
 import play.api.mvc.Cookie
@@ -181,6 +181,33 @@ class AuthCodeFlowControllerTest extends AnyWordSpec with Matchers {
       session(result).get(SessionKey.codeVerifier) must be(None)
       session(result).get(SessionKey.state) must be(None)
       flash(result).get(FlashKey.authTried) must be(None)
+    }
+  }
+
+  "AuthCodeFlow.replaceParam" should {
+    "add new query where one doesn't exist" in {
+      AuthCodeFlow.replaceParam("https://example.com", "param1", "value1") mustEqual "https://example.com?param1=value1"
+    }
+    "add new param to existing query" in {
+      AuthCodeFlow.replaceParam(
+        "https://example.com?param1=value1&param2=value2",
+        "param3",
+        "value3",
+      ) mustEqual "https://example.com?param1=value1&param2=value2&param3=value3"
+    }
+    "replace existing value of param with new value" in {
+      AuthCodeFlow.replaceParam(
+        "https://example.com?param1=value1",
+        "param1",
+        "value2",
+      ) mustEqual "https://example.com?param1=value2"
+    }
+    "replace existing value of param with new value where there are multiple params" in {
+      AuthCodeFlow.replaceParam(
+        "https://example.com?param1=value1&param2=value2",
+        "param1",
+        "value3",
+      ) mustEqual "https://example.com?param2=value2&param1=value3"
     }
   }
 }

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -8929,7 +8929,7 @@ glob@^10.0.0, glob@^10.2.5, glob@^10.3.3:
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
     path-scurry "^1.10.1"
 
-glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -8940,17 +8940,6 @@ glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-glob@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
-  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^5.0.1"
-    once "^1.3.0"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -11324,7 +11313,7 @@ minimalistic-assert@^1.0.0:
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.2:
+minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -11833,10 +11822,10 @@ opener@^1.5.2:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
-ophan-tracker-js@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.4.0.tgz#6c0e8f56157f2bd1473beaa6b79b54b99f5a7b1d"
-  integrity sha512-X5JoLOYxvfvNRI0Vo8xBT0UgJdiU9snPYOGgQUTk5ZnPYgX3xGW/yt7xdePeg9yM0eCuP5SeYQTLfF4bp0GFuw==
+ophan-tracker-js@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.4.2.tgz#75a5166fe7dc5a0971abbe9335043d869552550a"
+  integrity sha512-CRDcdVt9UUN0wdmMYJ5U1UxxwFYhOlF2G9wn7eUYlsTetWB2lme2iahMhe3fXQi6/IMy4WkzKdMp1ApmYNbnEA==
 
 optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"


### PR DESCRIPTION
Previously, if a URL already had a `pre-auth-ref` query param another one would be added.  This creates a confusing situation and the first value would probably be taken as the referrer.

In this PR the new value replaces any existing values so that it's very clear what the referrer actually is.

This PR also bumps the version of `ophan-tracker-js` in use for the sake of clarity, although it would actually be covered by the existing specification because only the patch version has changed.

For more context, see:
* #5221 
* https://github.com/guardian/ophan/pull/5529
