### PR TITLE
Add alarm and deadletter queue to bigquery-acquisitions-publisher.ts

### DIFF
--- a/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
+++ b/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
@@ -6,6 +6,7 @@ exports[`The BigqueryAcquisitionsPublisher stack matches the snapshot 1`] = `
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
+      "GuLambdaErrorPercentageAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -104,6 +105,93 @@ exports[`The BigqueryAcquisitionsPublisher stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
+    "bigqueryacquisitionspublisherLambdaErrorPercentageAlarmForLambdaA9607597": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":conversion-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Check the logs for details https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fbigquery-acquisitions-publisher-PROD",
+        "AlarmName": "big-query-acquisition-publisher lambda has failed",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": {
+              "Fn::Join": [
+                "",
+                [
+                  "Error % of ",
+                  {
+                    "Ref": "bigqueryacquisitionspublisherLambdaD7F059E6",
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "bigqueryacquisitionspublisherLambdaD7F059E6",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "bigqueryacquisitionspublisherLambdaD7F059E6",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "bigqueryacquisitionspublisherLambdaSqsEventSourceBigqueryAcquisitionsPublisherPRODbigqueryacquisitionspublisherQueue4510DFFB25270BDD": {
       "Properties": {
         "EventSourceArn": {
@@ -122,6 +210,15 @@ exports[`The BigqueryAcquisitionsPublisher stack matches the snapshot 1`] = `
       "DeletionPolicy": "Delete",
       "Properties": {
         "QueueName": "bigquery-acquisitions-publisher-queue-PROD",
+        "RedrivePolicy": {
+          "deadLetterTargetArn": {
+            "Fn::GetAtt": [
+              "deadlettersbigqueryacquisitionspublisherQueue2B5FA5C1",
+              "Arn",
+            ],
+          },
+          "maxReceiveCount": 1,
+        },
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -367,6 +464,32 @@ exports[`The BigqueryAcquisitionsPublisher stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "deadlettersbigqueryacquisitionspublisherQueue2B5FA5C1": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "QueueName": "dead-letters-bigquery-acquisitions-publisher-PROD",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
     },
   },
 }

--- a/cdk/lib/bigquery-acquisitions-publisher.ts
+++ b/cdk/lib/bigquery-acquisitions-publisher.ts
@@ -23,11 +23,18 @@ export class BigqueryAcquisitionsPublisher extends GuStack {
       eventBusName: busName,
     });
 
-    // SQS Queue
+    // SQS Queues
+    const deadLetterQueue = new Queue(this, `dead-letters-${appName}Queue`, {
+      queueName: `dead-letters-${appName}-${props.stage}`,
+    });
+
     const queue = new Queue(this, `${appName}Queue`, {
       queueName: `${appName}-queue-${props.stage}`,
       visibilityTimeout: Duration.minutes(2),
-      // TODO - dead letter queue?
+      deadLetterQueue: {
+        maxReceiveCount: 1, //The number of times a message can be unsuccessfully dequeued before being moved to the dead-letter queue.
+        queue: deadLetterQueue,
+      },
     });
 
     // Rule which passes events on to SQS
@@ -66,7 +73,17 @@ export class BigqueryAcquisitionsPublisher extends GuStack {
       })
     );
 
-    // TODO - alarms
+    const monitoring =
+      this.stage == "PROD"
+        ? {
+            toleratedErrorPercentage: 0,
+            snsTopicName: "conversion-dev",
+            alarmName: "big-query-acquisition-publisher lambda has failed",
+            alarmDescription:
+              "Check the logs for details https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fbigquery-acquisitions-publisher-PROD",
+          }
+        : undefined;
+
     new GuLambdaFunction(this, `${appName}Lambda`, {
       app: appName,
       runtime: Runtime.JAVA_8_CORRETTO,
@@ -76,6 +93,7 @@ export class BigqueryAcquisitionsPublisher extends GuStack {
       events: [eventSource],
       timeout: Duration.minutes(2),
       role,
+      errorPercentageMonitoring: monitoring,
     });
   }
 }

--- a/cdk/lib/bigquery-acquisitions-publisher.ts
+++ b/cdk/lib/bigquery-acquisitions-publisher.ts
@@ -32,7 +32,9 @@ export class BigqueryAcquisitionsPublisher extends GuStack {
       queueName: `${appName}-queue-${props.stage}`,
       visibilityTimeout: Duration.minutes(2),
       deadLetterQueue: {
-        maxReceiveCount: 1, //The number of times a message can be unsuccessfully dequeued before being moved to the dead-letter queue.
+        // The number of times a message can be unsuccessfully dequeued before being moved to the dead-letter queue.
+        // This has been set to 1 to avoid duplicate acquisition events being send to bigquery
+        maxReceiveCount: 1,
         queue: deadLetterQueue,
       },
     });


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
#4923 added a new stack for publishing acquisition events to BigQuery but there were a couple of TODOs in it
- add an alarm for the publisher lambda
- add a deadletter queue for the publisher SQS queue
this PR does that.