### PR TITLE
Add thread sleep time before thank you page

### DIFF
--- a/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
@@ -110,7 +110,7 @@ class CheckoutsSpec
     checkoutPage.clickStripeSubmit()
 
     And("the mock calls the backend using a test Stripe token")
-    Thread.sleep(1000)
+    Thread.sleep(100)
     thankYouPage(checkoutPage)
   }
 
@@ -135,7 +135,7 @@ class CheckoutsSpec
     When("they click Pay")
     checkoutPage.clickDirectDebitPay()
 
-    Thread.sleep(1000)
+    Thread.sleep(100)
     thankYouPage(checkoutPage)
   }
 

--- a/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
@@ -110,7 +110,7 @@ class CheckoutsSpec
     checkoutPage.clickStripeSubmit()
 
     And("the mock calls the backend using a test Stripe token")
-    Thread.sleep(100)
+    Thread.sleep(1000)
     thankYouPage(checkoutPage)
   }
 
@@ -135,6 +135,7 @@ class CheckoutsSpec
     When("they click Pay")
     checkoutPage.clickDirectDebitPay()
 
+    Thread.sleep(1000)
     thankYouPage(checkoutPage)
   }
 

--- a/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
@@ -100,6 +100,7 @@ trait CheckoutPage extends Page with Browser {
   def clickDirectDebitPay(): Unit = {
     Thread.sleep(1000)
     clickRecaptcha
+    Thread.sleep(1000)
     clickOn(directDebitPlaybackSubmit)
   }
 


### PR DESCRIPTION
## What are you doing in this PR?
Increasing the sleep time before thank you page.
This is an attempt to fix the intermittently failing post deployment tests

