### PR TITLE
Synchronise deliveryAgent on frontend and backend

### DIFF
--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -81,6 +81,7 @@ export type PaperSubscription = {
 	billingPeriod: BillingPeriod;
 	fulfilmentOptions: FulfilmentOptions;
 	productOptions: ProductOptions;
+	deliveryAgent?: number;
 };
 export type GuardianWeeklySubscription = {
 	productType: typeof GuardianWeekly;
@@ -169,7 +170,6 @@ export type RegularPaymentRequest = {
 	salesforceCaseId?: string;
 	recaptchaToken?: string;
 	debugInfo: string;
-	deliveryAgent?: number;
 };
 export type StripePaymentIntentAuthorisation = {
 	paymentMethod: typeof Stripe;

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -90,6 +90,7 @@ function getAddresses(state: SubscriptionsState): Addresses {
 const getProduct = (
 	state: SubscriptionsState,
 	currencyId?: Option<IsoCurrency>,
+	deliveryAgent?: number,
 ): SubscriptionProductFields => {
 	const { billingPeriod, fulfilmentOption, productOption, orderIsAGift } =
 		state.page.checkoutForm.product;
@@ -119,6 +120,7 @@ const getProduct = (
 		billingPeriod,
 		fulfilmentOptions: getPaperFulfilmentOption(fulfilmentOption, state),
 		productOptions: productOption,
+		deliveryAgent,
 	};
 };
 
@@ -165,16 +167,17 @@ function buildRegularPaymentRequest(
 	const { actionHistory } = state.debug;
 	const { title, firstName, lastName, email, telephone } =
 		state.page.checkoutForm.personalDetails;
-	const { deliveryInstructions, deliveryAgent } =
-		state.page.checkoutForm.addressMeta;
+	const {
+		deliveryInstructions,
+		deliveryAgent: { chosenAgent: chosenDeliveryAgent },
+	} = state.page.checkoutForm.addressMeta;
 	const { csrUsername, salesforceCaseId } = state.page.checkout;
-	const product = getProduct(state, currencyId);
+	const product = getProduct(state, currencyId, chosenDeliveryAgent);
 	const paymentFields =
 		regularPaymentFieldsFromAuthorisation(paymentAuthorisation);
 	const recaptchaToken = state.page.checkoutForm.recaptcha.token;
 	const promoCode = getPromoCode(promotions);
 	const giftRecipient = getGiftRecipient(state.page.checkoutForm.gifting);
-	const chosenDeliveryAgent = deliveryAgent.chosenAgent;
 
 	return {
 		title,
@@ -198,7 +201,6 @@ function buildRegularPaymentRequest(
 		csrUsername,
 		salesforceCaseId,
 		debugInfo: actionHistory,
-		deliveryAgent: chosenDeliveryAgent,
 	};
 }
 

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -773,7 +773,7 @@ object TestData {
     title = None,
     firstName = "grace",
     lastName = "hopper",
-    product = Paper(Currency.GBP, Monthly, HomeDelivery, Everyday, Some("delivery agent (oho)")),
+    product = Paper(Currency.GBP, Monthly, HomeDelivery, Everyday, Some(134789)),
     firstDeliveryDate = Some(someDateNextMonth),
     paymentFields =
       Left(StripePaymentMethodPaymentFields(PaymentMethodId("test_token").get, Some(StripePaymentType.StripeCheckout))),

--- a/support-models/src/main/scala/com/gu/support/workers/Products.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/Products.scala
@@ -51,7 +51,7 @@ case class Paper(
     billingPeriod: BillingPeriod = Monthly,
     fulfilmentOptions: FulfilmentOptions,
     productOptions: PaperProductOptions,
-    deliveryAgent: Option[String],
+    deliveryAgent: Option[Integer],
 ) extends ProductType {
   override def describe: String = s"Paper-$fulfilmentOptions-$productOptions"
 }

--- a/support-models/src/main/scala/com/gu/support/zuora/api/SubscriptionData.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/SubscriptionData.scala
@@ -215,7 +215,7 @@ case class Subscription(
     acquisitionSource: Option[AcquisitionSource] = None,
     createdByCsr: Option[String] = None,
     acquisitionCase: Option[String] = None,
-    deliveryAgent: Option[String] = None,
+    deliveryAgent: Option[Integer] = None,
 )
 
 object RatePlanChargeData {

--- a/support-models/src/test/scala/com/gu/support/workers/ProductTypeDecoderTest.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/ProductTypeDecoderTest.scala
@@ -50,13 +50,13 @@ class ProductTypeDecoderTest extends AnyWordSpec with SerialisationTestHelpers {
           |  "fulfilmentOptions": "Collection",
           |  "productOptions": "Sixday",
           |  "productType": "Paper",
-          |  "deliveryAgent": "delivery agent (aha!)"
+          |  "deliveryAgent": 67812
           |}
         """.stripMargin
 
       testDecoding[Paper](
         json,
-        _ shouldBe Paper(GBP, Monthly, Collection, Sixday, Some("delivery agent (aha!)")),
+        _ shouldBe Paper(GBP, Monthly, Collection, Sixday, Some(67812)),
       )
     }
 

--- a/support-models/src/test/scala/com/gu/support/workers/ProductTypeRatePlansSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/ProductTypeRatePlansSpec.scala
@@ -15,11 +15,11 @@ class ProductTypeRatePlansSpec extends AsyncFlatSpec with Matchers {
     val weekly = GuardianWeekly(GBP, Annual, Domestic)
     weeklyRatePlan(weekly, CODE, Direct).value.description shouldBe "Guardian Weekly annual, domestic delivery"
 
-    val paper = Paper(USD, Monthly, HomeDelivery, Everyday, Some("any delivery agent! It shouldn’t matter"))
+    val paper = Paper(USD, Monthly, HomeDelivery, Everyday, Some(0))
     paperRatePlan(paper, CODE).value.id shouldBe "2c92c0f955c3cf0f0155c5d9e2493c43"
 
     val nationalDeliveryPaper =
-      Paper(USD, Monthly, NationalDelivery, Everyday, Some("any delivery agent! It shouldn’t matter"))
+      Paper(USD, Monthly, NationalDelivery, Everyday, Some(8172))
     paperRatePlan(nationalDeliveryPaper, CODE).value.id shouldBe "8ad096ca8992481d018992a363bd17ad"
   }
 

--- a/support-models/src/test/scala/com/gu/support/workers/SendThankYouEmailStateSerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/SendThankYouEmailStateSerialisationSpec.scala
@@ -81,7 +81,7 @@ object ProductTypeCreatedTestData {
     Paper(
       fulfilmentOptions = Collection,
       productOptions = Saturday,
-      deliveryAgent = Some("A delivery agent ID"),
+      deliveryAgent = Some(-1),
     ),
     PayPalReferenceTransaction("baid", "email@emaail.com"),
     PaymentSchedule(List(Payment(new LocalDate(2020, 6, 16), 1.49))),

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/SubscribeItemBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/SubscribeItemBuilder.scala
@@ -81,7 +81,7 @@ class SubscribeItemBuilder(
       giftNotificationEmailDate: Option[LocalDate] = None,
       csrUsername: Option[String] = None,
       salesforceCaseId: Option[String] = None,
-      deliveryAgent: Option[String] = None,
+      deliveryAgent: Option[Integer] = None,
   ): SubscriptionData =
     SubscriptionData(
       List(

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -584,7 +584,7 @@ object JsonFixtures {
     ).asJson.spaces2
 
   val createEverydayNationalDeliveryPaperSubscriptionJson = {
-    val paper = Paper(GBP, Monthly, NationalDelivery, Everyday, Some("Some delivery agent ID"))
+    val paper = Paper(GBP, Monthly, NationalDelivery, Everyday, Some(-43))
     CreateZuoraSubscriptionState(
       PaperState(
         userJsonWithDeliveryAddress,

--- a/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -120,7 +120,7 @@ object Fixtures {
         Nil,
       ),
     ),
-    Subscription(date, date, date, "id123", deliveryAgent = Some("delivery agent ID")),
+    Subscription(date, date, date, "id123", deliveryAgent = Some(7583)),
   )
 
   def creditCardSubscriptionRequest(currency: Currency = GBP): SubscribeRequest =


### PR DESCRIPTION
These were out of sync, which I hadn’t noticed: the delivery agent returned from PaperRound’s API is a number, whereas the backend expected it from the frontend as a string – I’ve changed this to be a number everywhere.

Also, the backend expects it in the product but the frontend was sending it at the top level of the create request – I’ve moved this to the product.