### PR TITLE
Two step checkout page two nudge

### DIFF
--- a/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmounts.tsx
+++ b/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmounts.tsx
@@ -1,8 +1,3 @@
-import {
-	Button,
-	SvgArrowLeftStraight,
-	SvgArrowRightStraight,
-} from '@guardian/source-react-components';
 import { useState } from 'react';
 import {
 	amountOption,
@@ -12,80 +7,36 @@ import {
 	amountsContainer,
 	container,
 	hrCss,
-	progressBtnLeft,
-	progressBtnRight,
 	standfirst,
 	supportTotalContainer,
 	title,
 } from './checkoutTopUpAmountsStyles';
 
 export interface CheckoutTopUpAmountsProps {
-	currencyWord: string;
 	currencySymbol: string;
 	timePeriod: string;
 	amounts: number[];
+	isWithinThreshold: boolean;
+	handleAmountUpdate?: (updateAmountBy: number) => void;
 	customMargin?: string;
 }
 
 export function CheckoutTopUpAmounts({
-	currencyWord,
 	currencySymbol,
 	timePeriod,
 	amounts,
+	isWithinThreshold,
+	handleAmountUpdate,
 	customMargin,
 }: CheckoutTopUpAmountsProps): JSX.Element {
-	const [touchStart, setTouchStart] = useState<number | null>(null);
-	const [touchEnd, setTouchEnd] = useState<number | null>(null);
-	const [xOffset, setXOffset] = useState<number>(0);
 	const [selectedTopUpamount, setSelectedTopUpamount] = useState<number>(0);
-	const minSwipeDistance = 50;
-	const amountsOptionPercentageWidth = 25;
+	const amountsLength = amounts.length;
 
-	const totalPercentageWidth =
-		amounts.length * amountsOptionPercentageWidth + (amounts.length - 1) * 3;
-	const overflowPercentageWidth =
-		(totalPercentageWidth - 100) * (amounts.length - 1);
-
-	const onTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
-		setTouchEnd(null);
-		setTouchStart(e.targetTouches[0].clientX);
-	};
-
-	const onTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
-		setTouchEnd(e.targetTouches[0].clientX);
-	};
-
-	const onTouchEnd = () => {
-		if (!touchStart || !touchEnd) {
-			return;
-		}
-		const distance = touchStart - touchEnd;
-		const isLeftSwipe = distance > minSwipeDistance;
-		if (isLeftSwipe) {
-			setXOffset(Math.max(xOffset - 100, -overflowPercentageWidth));
-		}
-		const isRightSwipe = distance < -minSwipeDistance;
-		if (isRightSwipe) {
-			setXOffset(Math.min(xOffset + 100, 0));
-		}
-	};
-
-	const onLeftBtnClick = () => {
-		setXOffset(Math.min(xOffset + 100, 0));
-	};
-
-	const onRightBtnClick = () => {
-		setXOffset(Math.max(xOffset - 100, -overflowPercentageWidth));
-	};
-
-	const hasLeftSideOverflow: boolean = xOffset < 0;
-	const hasRightSideOverflow: boolean = xOffset > -overflowPercentageWidth;
-
-	return (
+	return isWithinThreshold ? (
 		<section css={container(customMargin)}>
-			<h3 css={title}>{`Every extra ${currencyWord} funds our journalism`}</h3>
+			<h3 css={title}>Your support funds our journalism</h3>
 			<p css={standfirst}>
-				If you can, please consider adding a top up to your support.
+				{`If you can, please consider adding a little more every ${timePeriod}.`}
 			</p>
 			<hr css={hrCss} />
 			<section css={supportTotalContainer}>
@@ -96,64 +47,35 @@ export function CheckoutTopUpAmounts({
 				</span>
 			</section>
 			<div css={amountsAndNavigationContainer}>
-				<div
-					css={amountsContainer(hasLeftSideOverflow, hasRightSideOverflow)}
-					onTouchStart={onTouchStart}
-					onTouchMove={onTouchMove}
-					onTouchEnd={onTouchEnd}
-				>
+				<div css={amountsContainer}>
 					{amounts.map((amount) => {
 						const isSelected = amount === selectedTopUpamount;
 						return (
 							<div
-								css={[
-									amountOption(
-										amountsOptionPercentageWidth,
-										xOffset,
-										isSelected,
-									),
-								]}
-								onClick={() => setSelectedTopUpamount(isSelected ? 0 : amount)}
+								css={[amountOption(isSelected, amountsLength)]}
+								onClick={() => {
+									if (handleAmountUpdate) {
+										handleAmountUpdate(
+											isSelected ? -amount : amount - selectedTopUpamount,
+										);
+									}
+									setSelectedTopUpamount(isSelected ? 0 : amount);
+								}}
 							>
 								<span css={[amountOptionValue(isSelected)]}>
 									{currencySymbol}
 									{amount}
 								</span>
 								<span css={[amountOptionAction(isSelected)]} data-amount-action>
-									{isSelected ? '- Remove' : '+ Add'}
+									{isSelected ? 'Remove' : 'Add'}
 								</span>
 							</div>
 						);
 					})}
 				</div>
-				{hasLeftSideOverflow && (
-					<Button
-						hideLabel
-						icon={<SvgArrowLeftStraight />}
-						iconSide="left"
-						priority="tertiary"
-						size="default"
-						cssOverrides={progressBtnLeft}
-						onClick={onLeftBtnClick}
-					>
-						Move to previous top up amounts
-					</Button>
-				)}
-
-				{hasRightSideOverflow && (
-					<Button
-						hideLabel
-						icon={<SvgArrowRightStraight />}
-						iconSide="left"
-						priority="tertiary"
-						size="default"
-						cssOverrides={progressBtnRight}
-						onClick={onRightBtnClick}
-					>
-						Move to next top up amounts
-					</Button>
-				)}
 			</div>
 		</section>
+	) : (
+		<></>
 	);
 }

--- a/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmounts.tsx
+++ b/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmounts.tsx
@@ -17,7 +17,7 @@ export interface CheckoutTopUpAmountsProps {
 	timePeriod: string;
 	amounts: number[];
 	isWithinThreshold: boolean;
-	handleAmountUpdate?: (updateAmountBy: number) => void;
+	handleAmountUpdate?: (updateAmountBy: number, index: number) => void;
 	customMargin?: string;
 }
 
@@ -48,7 +48,7 @@ export function CheckoutTopUpAmounts({
 			</section>
 			<div css={amountsAndNavigationContainer}>
 				<div css={amountsContainer}>
-					{amounts.map((amount) => {
+					{amounts.map((amount, index) => {
 						const isSelected = amount === selectedTopUpamount;
 						return (
 							<div
@@ -57,6 +57,7 @@ export function CheckoutTopUpAmounts({
 									if (handleAmountUpdate) {
 										handleAmountUpdate(
 											isSelected ? -amount : amount - selectedTopUpamount,
+											index,
 										);
 									}
 									setSelectedTopUpamount(isSelected ? 0 : amount);

--- a/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmounts.tsx
+++ b/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmounts.tsx
@@ -32,7 +32,8 @@ export function CheckoutTopUpAmounts({
 	const [selectedTopUpamount, setSelectedTopUpamount] = useState<number>(0);
 	const amountsLength = amounts.length;
 
-	return isWithinThreshold ? (
+	if (!isWithinThreshold) return <></>;
+	return (
 		<section css={container(customMargin)}>
 			<h3 css={title}>Your support funds our journalism</h3>
 			<p css={standfirst}>
@@ -76,7 +77,5 @@ export function CheckoutTopUpAmounts({
 				</div>
 			</div>
 		</section>
-	) : (
-		<></>
 	);
 }

--- a/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmounts.tsx
+++ b/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmounts.tsx
@@ -1,0 +1,159 @@
+import {
+	Button,
+	SvgArrowLeftStraight,
+	SvgArrowRightStraight,
+} from '@guardian/source-react-components';
+import { useState } from 'react';
+import {
+	amountOption,
+	amountOptionAction,
+	amountOptionValue,
+	amountsAndNavigationContainer,
+	amountsContainer,
+	container,
+	hrCss,
+	progressBtnLeft,
+	progressBtnRight,
+	standfirst,
+	supportTotalContainer,
+	title,
+} from './checkoutTopUpAmountsStyles';
+
+export interface CheckoutTopUpAmountsProps {
+	currencyWord: string;
+	currencySymbol: string;
+	timePeriod: string;
+	amounts: number[];
+	customMargin?: string;
+}
+
+export function CheckoutTopUpAmounts({
+	currencyWord,
+	currencySymbol,
+	timePeriod,
+	amounts,
+	customMargin,
+}: CheckoutTopUpAmountsProps): JSX.Element {
+	const [touchStart, setTouchStart] = useState<number | null>(null);
+	const [touchEnd, setTouchEnd] = useState<number | null>(null);
+	const [xOffset, setXOffset] = useState<number>(0);
+	const [selectedTopUpamount, setSelectedTopUpamount] = useState<number>(0);
+	const minSwipeDistance = 50;
+	const amountsOptionPercentageWidth = 25;
+
+	const totalPercentageWidth =
+		amounts.length * amountsOptionPercentageWidth + (amounts.length - 1) * 3;
+	const overflowPercentageWidth =
+		(totalPercentageWidth - 100) * (amounts.length - 1);
+
+	const onTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+		setTouchEnd(null);
+		setTouchStart(e.targetTouches[0].clientX);
+	};
+
+	const onTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
+		setTouchEnd(e.targetTouches[0].clientX);
+	};
+
+	const onTouchEnd = () => {
+		if (!touchStart || !touchEnd) {
+			return;
+		}
+		const distance = touchStart - touchEnd;
+		const isLeftSwipe = distance > minSwipeDistance;
+		if (isLeftSwipe) {
+			setXOffset(Math.max(xOffset - 100, -overflowPercentageWidth));
+		}
+		const isRightSwipe = distance < -minSwipeDistance;
+		if (isRightSwipe) {
+			setXOffset(Math.min(xOffset + 100, 0));
+		}
+	};
+
+	const onLeftBtnClick = () => {
+		setXOffset(Math.min(xOffset + 100, 0));
+	};
+
+	const onRightBtnClick = () => {
+		setXOffset(Math.max(xOffset - 100, -overflowPercentageWidth));
+	};
+
+	const hasLeftSideOverflow: boolean = xOffset < 0;
+	const hasRightSideOverflow: boolean = xOffset > -overflowPercentageWidth;
+
+	return (
+		<section css={container(customMargin)}>
+			<h3 css={title}>{`Every extra ${currencyWord} funds our journalism`}</h3>
+			<p css={standfirst}>
+				If you can, please consider adding a top up to your support.
+			</p>
+			<hr css={hrCss} />
+			<section css={supportTotalContainer}>
+				<span>Choose amount</span>
+				<span>
+					{currencySymbol}
+					{selectedTopUpamount}/{timePeriod}
+				</span>
+			</section>
+			<div css={amountsAndNavigationContainer}>
+				<div
+					css={amountsContainer(hasLeftSideOverflow, hasRightSideOverflow)}
+					onTouchStart={onTouchStart}
+					onTouchMove={onTouchMove}
+					onTouchEnd={onTouchEnd}
+				>
+					{amounts.map((amount) => {
+						const isSelected = amount === selectedTopUpamount;
+						return (
+							<div
+								css={[
+									amountOption(
+										amountsOptionPercentageWidth,
+										xOffset,
+										isSelected,
+									),
+								]}
+								onClick={() => setSelectedTopUpamount(isSelected ? 0 : amount)}
+							>
+								<span css={[amountOptionValue(isSelected)]}>
+									{currencySymbol}
+									{amount}
+								</span>
+								<span css={[amountOptionAction(isSelected)]} data-amount-action>
+									{isSelected ? '- Remove' : '+ Add'}
+								</span>
+							</div>
+						);
+					})}
+				</div>
+				{hasLeftSideOverflow && (
+					<Button
+						hideLabel
+						icon={<SvgArrowLeftStraight />}
+						iconSide="left"
+						priority="tertiary"
+						size="default"
+						cssOverrides={progressBtnLeft}
+						onClick={onLeftBtnClick}
+					>
+						Move to previous top up amounts
+					</Button>
+				)}
+
+				{hasRightSideOverflow && (
+					<Button
+						hideLabel
+						icon={<SvgArrowRightStraight />}
+						iconSide="left"
+						priority="tertiary"
+						size="default"
+						cssOverrides={progressBtnRight}
+						onClick={onRightBtnClick}
+					>
+						Move to next top up amounts
+					</Button>
+				)}
+			</div>
+		</section>
+	);
+}

--- a/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsContainer.tsx
+++ b/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsContainer.tsx
@@ -8,6 +8,7 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
+import { trackComponentClick } from 'helpers/tracking/behaviour';
 import type { CheckoutTopUpAmountsProps } from './checkoutTopUpAmounts';
 
 type CheckoutTopUpAmountsContainerProps = {
@@ -45,7 +46,7 @@ export function CheckoutTopUpAmountsContainer({
 
 	const timePeriod = timePeriods[contributionType];
 
-	const handleAmountUpdate = (updateAmountBy: number) => {
+	const handleAmountUpdate = (updateAmountBy: number, index: number) => {
 		dispatch(
 			setSelectedAmount({
 				contributionType: contributionType,
@@ -53,6 +54,11 @@ export function CheckoutTopUpAmountsContainer({
 			}),
 		);
 		setHasAmountChangedWithTopUp(true);
+		trackComponentClick(
+			`contribution-topup-amount-${
+				updateAmountBy > 0 ? 'select' : 'deselect'
+			}-${countryGroupId}-${contributionType}-option${index}`,
+		);
 	};
 
 	const amounts = Array.from(

--- a/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsContainer.tsx
+++ b/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsContainer.tsx
@@ -1,0 +1,44 @@
+import {
+	currencies,
+	spokenCurrencies,
+} from 'helpers/internationalisation/currency';
+import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import type { CheckoutTopUpAmountsProps } from './checkoutTopUpAmounts';
+
+type CheckoutTopUpAmountsContainerProps = {
+	renderCheckoutTopUpAmounts: (props: CheckoutTopUpAmountsProps) => JSX.Element;
+};
+
+export function CheckoutTopUpAmountsContainer({
+	renderCheckoutTopUpAmounts,
+}: CheckoutTopUpAmountsContainerProps): JSX.Element {
+	const { currencyId } = useContributionsSelector(
+		(state) => state.common.internationalisation,
+	);
+	const contributionType = useContributionsSelector(getContributionType);
+	const currencyWord = spokenCurrencies[currencyId].singular;
+	const currencySymbol = currencies[currencyId].glyph;
+
+	const timePeriods = {
+		ONE_OFF: 'one-off',
+		MONTHLY: 'month',
+		ANNUAL: 'year',
+	};
+
+	const timePeriod = timePeriods[contributionType];
+
+	// const selectedAmount = useContributionsSelector(getUserSelectedAmount);
+
+	const amounts = Array.from(
+		{ length: 5 },
+		(_, amountIndex) => amountIndex + 1,
+	);
+
+	return renderCheckoutTopUpAmounts({
+		currencyWord,
+		currencySymbol,
+		timePeriod,
+		amounts,
+	});
+}

--- a/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsContainer.tsx
+++ b/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsContainer.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from 'react';
 import { checkoutTopUpUpperThresholdsByCountryGroup } from 'helpers/checkoutTopUp/upperThreshold';
 import { currencies } from 'helpers/internationalisation/currency';
 import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
-import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
+import {
+	getUserSelectedAmount,
+	getUserSelectedAmountBeforeAmendment,
+} from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import {
 	useContributionsDispatch,
 	useContributionsSelector,
@@ -23,20 +25,18 @@ export function CheckoutTopUpAmountsContainer({
 		(state) => state.common.internationalisation,
 	);
 	const selectedAmount = useContributionsSelector(getUserSelectedAmount);
+	const amountBeforeAmendments = useContributionsSelector(
+		getUserSelectedAmountBeforeAmendment,
+	);
 	const contributionType = useContributionsSelector(getContributionType);
 	const currencySymbol = currencies[currencyId].glyph;
-	const [hasAmountChangedWithTopUp, setHasAmountChangedWithTopUp] =
-		useState<boolean>(false);
-	const [isWithinThreshold, setIsWithinThreshold] = useState<boolean>(
+
+	const isWithinThreshold =
 		contributionType !== 'ONE_OFF' &&
-			selectedAmount <=
-				checkoutTopUpUpperThresholdsByCountryGroup[countryGroupId][
-					contributionType
-				],
-	);
-	useEffect(() => {
-		hasAmountChangedWithTopUp && setIsWithinThreshold(true);
-	}, [selectedAmount]);
+		amountBeforeAmendments <=
+			checkoutTopUpUpperThresholdsByCountryGroup[countryGroupId][
+				contributionType
+			];
 
 	const timePeriods = {
 		ONE_OFF: 'one-off',
@@ -53,7 +53,6 @@ export function CheckoutTopUpAmountsContainer({
 				amount: `${selectedAmount + updateAmountBy}`,
 			}),
 		);
-		setHasAmountChangedWithTopUp(true);
 		trackComponentClick(
 			`contribution-topup-amount-${
 				updateAmountBy > 0 ? 'select' : 'deselect'

--- a/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsStyles.ts
+++ b/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsStyles.ts
@@ -49,15 +49,11 @@ export const amountsContainer = css`
 	transform: translateX(-${space[2]}px);
 	${from.mobileMedium} {
 		gap: ${fromMobileMediumOptionGap}px;
-	}
-	${from.mobileLandscape} {
-		width: calc(100% + 8px);
-		transform: translateX(-4px);
+		width: 100%;
+		transform: none;
 	}
 	${from.tablet} {
 		gap: ${fromTabletOptionGap}px;
-		width: 100%;
-		transform: none;
 	}
 `;
 
@@ -134,11 +130,5 @@ export const amountOptionAction = (
 	display: none;
 	${from.mobile} {
 		display: inline;
-	}
-	${from.tablet} {
-		:before {
-			content: '${isSelected ? '-' : '+'}';
-			margin-right: 2px;
-		}
 	}
 `;

--- a/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsStyles.ts
+++ b/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsStyles.ts
@@ -1,0 +1,137 @@
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import {
+	from,
+	palette,
+	space,
+	textSans,
+	until,
+} from '@guardian/source-foundations';
+
+export const container = (customMargin?: string): SerializedStyles => css`
+	background-color: #f0f6fe;
+	border-radius: ${space[2]}px;
+	padding: ${space[3]}px;
+	margin: ${customMargin ?? '0 0'};
+`;
+
+export const title = css`
+	${textSans.medium({ fontWeight: 'bold' })}
+	color: ${palette.neutral[7]};
+`;
+
+export const standfirst = css`
+	${textSans.xsmall()}
+	color: ${palette.neutral[7]};
+`;
+
+export const hrCss = css`
+	border: none;
+	height: 1px;
+	background-color: ${palette.neutral[86]};
+	margin: ${space[3]}px 0 ${space[2]}px;
+`;
+
+export const supportTotalContainer = css`
+	display: flex;
+	justify-content: space-between;
+	${textSans.small()}
+`;
+
+export const amountsAndNavigationContainer = css`
+	position: relative;
+	margin: ${space[6]}px 0 ${space[4]}px;
+`;
+
+export const amountsContainer = (
+	hasLeftSideOverflow: boolean,
+	hasRightSideOverflow: boolean,
+): SerializedStyles => css`
+	display: flex;
+	flex-wrap: nowrap;
+	gap: 3%;
+	overflow-x: hidden;
+	min-height: 20px;
+	mask-image: linear-gradient(
+		to right,
+		rgba(0, 0, 0, ${hasLeftSideOverflow ? '0' : '1'}),
+		rgba(0, 0, 0, 1) 15%,
+		rgba(0, 0, 0, 1) 85%,
+		rgba(0, 0, 0, ${hasRightSideOverflow ? '0' : '1'}) 100%
+	);
+`;
+
+export const amountOption = (
+	optionPercentageWidth: number,
+	xOffset: number,
+	isSelected: boolean,
+): SerializedStyles => css`
+	flex-shrink: 0;
+	flex-grow: 0;
+	flex-basis: ${optionPercentageWidth}%;
+	display: grid;
+	text-align: center;
+	border: ${isSelected ? 2 : 1}px solid
+		${isSelected ? palette.brand[500] : palette.neutral[60]};
+	background-color: ${isSelected ? '#e3f6ff' : palette.neutral[100]};
+	border-radius: 10px;
+	aspect-ratio: 1 / 1;
+	${from.tablet} {
+		aspect-ratio: 1.6 / 1;
+	}
+	cursor: pointer;
+	transition: transform 0.2s ease;
+	transform: translateX(${xOffset}%);
+	:hover {
+		border: 2px solid ${palette.brand[500]};
+		& span {
+			color: ${palette.brand[400]};
+		}
+		& span[data-amount-action] {
+			font-weight: bold;
+		}
+	}
+`;
+
+export const amountOptionValue = (isSelected: boolean): SerializedStyles => css`
+	${textSans.xlarge({ fontWeight: 'bold' })};
+	color: ${isSelected ? palette.brand[400] : palette.neutral[46]};
+	align-self: end;
+	pointer-events: none;
+	user-select: none;
+`;
+
+export const amountOptionAction = (
+	isSelected: boolean,
+): SerializedStyles => css`
+	${textSans.xxsmall({ fontWeight: isSelected ? 'bold' : 'regular' })};
+	${from.mobileMedium} {
+		${textSans.xsmall({ fontWeight: isSelected ? 'bold' : 'regular' })};
+	}
+	color: ${isSelected ? palette.brand[400] : palette.neutral[46]};
+	align-self: start;
+	pointer-events: none;
+	user-select: none;
+`;
+
+export const progressBtnLeft = css`
+	position: absolute;
+	top: 50%;
+	left: 0;
+	transform: translate(-${space[6] + space[1]}px, -50%);
+	background-color: ${palette.neutral[100]};
+	${until.tablet} {
+		display: none;
+	}
+`;
+
+export const progressBtnRight = css`
+	position: absolute;
+	top: 50%;
+	right: 0;
+	transform: translate(${space[6] + space[1]}px, -50%);
+	background-color: ${palette.neutral[100]};
+	${until.tablet} {
+		display: none;
+	}
+`;

--- a/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsStyles.ts
+++ b/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsStyles.ts
@@ -1,12 +1,6 @@
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
-import {
-	from,
-	palette,
-	space,
-	textSans,
-	until,
-} from '@guardian/source-foundations';
+import { from, palette, space, textSans } from '@guardian/source-foundations';
 
 export const container = (customMargin?: string): SerializedStyles => css`
 	background-color: #f0f6fe;
@@ -43,60 +37,85 @@ export const amountsAndNavigationContainer = css`
 	margin: ${space[6]}px 0 ${space[4]}px;
 `;
 
-export const amountsContainer = (
-	hasLeftSideOverflow: boolean,
-	hasRightSideOverflow: boolean,
-): SerializedStyles => css`
+const defaultOptionGap = space[2];
+const fromMobileMediumOptionGap = 10;
+const fromTabletOptionGap = space[3];
+
+export const amountsContainer = css`
 	display: flex;
 	flex-wrap: nowrap;
-	gap: 3%;
-	overflow-x: hidden;
-	min-height: 20px;
-	mask-image: linear-gradient(
-		to right,
-		rgba(0, 0, 0, ${hasLeftSideOverflow ? '0' : '1'}),
-		rgba(0, 0, 0, 1) 15%,
-		rgba(0, 0, 0, 1) 85%,
-		rgba(0, 0, 0, ${hasRightSideOverflow ? '0' : '1'}) 100%
-	);
+	gap: ${defaultOptionGap}px;
+	width: calc(100% + ${space[4]}px);
+	transform: translateX(-${space[2]}px);
+	${from.mobileMedium} {
+		gap: ${fromMobileMediumOptionGap}px;
+	}
+	${from.mobileLandscape} {
+		width: calc(100% + 8px);
+		transform: translateX(-4px);
+	}
+	${from.tablet} {
+		gap: ${fromTabletOptionGap}px;
+		width: 100%;
+		transform: none;
+	}
 `;
 
 export const amountOption = (
-	optionPercentageWidth: number,
-	xOffset: number,
 	isSelected: boolean,
-): SerializedStyles => css`
-	flex-shrink: 0;
-	flex-grow: 0;
-	flex-basis: ${optionPercentageWidth}%;
-	display: grid;
-	text-align: center;
-	border: ${isSelected ? 2 : 1}px solid
-		${isSelected ? palette.brand[500] : palette.neutral[60]};
-	background-color: ${isSelected ? '#e3f6ff' : palette.neutral[100]};
-	border-radius: 10px;
-	aspect-ratio: 1 / 1;
-	${from.tablet} {
-		aspect-ratio: 1.6 / 1;
-	}
-	cursor: pointer;
-	transition: transform 0.2s ease;
-	transform: translateX(${xOffset}%);
-	:hover {
-		border: 2px solid ${palette.brand[500]};
-		& span {
-			color: ${palette.brand[400]};
+	numOfOptions: number,
+): SerializedStyles => {
+	const defaultOptionWidth = `calc(${100 / numOfOptions}% - ${
+		(defaultOptionGap * (numOfOptions - 1)) / numOfOptions
+	}px)`;
+	const fromMobileMediumOptionWidth = `calc(${100 / numOfOptions}% - ${
+		(fromMobileMediumOptionGap * (numOfOptions - 1)) / numOfOptions
+	}px)`;
+	const fromTabletOptionWidth = `calc(${100 / numOfOptions}% - ${
+		(fromTabletOptionGap * (numOfOptions - 1)) / numOfOptions
+	}px)`;
+	return css`
+		width: ${defaultOptionWidth};
+		${from.mobileMedium} {
+			width: ${fromMobileMediumOptionWidth};
 		}
-		& span[data-amount-action] {
-			font-weight: bold;
+		${from.tablet} {
+			width: ${fromTabletOptionWidth};
 		}
-	}
-`;
+		display: grid;
+		text-align: center;
+		outline: ${isSelected ? 2 : 1}px solid
+			${isSelected ? palette.brand[500] : palette.neutral[60]};
+		background-color: ${isSelected ? '#e3f6ff' : palette.neutral[100]};
+		border-radius: 10px;
+		aspect-ratio: 1 / 1;
+		${from.mobileLandscape} {
+			aspect-ratio: 1.25 / 1;
+		}
+		cursor: pointer;
+		:hover {
+			outline: 2px solid ${palette.brand[500]};
+			& span {
+				color: ${palette.brand[400]};
+			}
+			& span[data-amount-action] {
+				font-weight: bold;
+			}
+		}
+	`;
+};
 
 export const amountOptionValue = (isSelected: boolean): SerializedStyles => css`
 	${textSans.xlarge({ fontWeight: 'bold' })};
+	line-height: 1;
+	${from.tablet} {
+		line-height: 1.25;
+	}
 	color: ${isSelected ? palette.brand[400] : palette.neutral[46]};
-	align-self: end;
+	align-self: center;
+	${from.mobile} {
+		align-self: end;
+	}
 	pointer-events: none;
 	user-select: none;
 `;
@@ -112,26 +131,14 @@ export const amountOptionAction = (
 	align-self: start;
 	pointer-events: none;
 	user-select: none;
-`;
-
-export const progressBtnLeft = css`
-	position: absolute;
-	top: 50%;
-	left: 0;
-	transform: translate(-${space[6] + space[1]}px, -50%);
-	background-color: ${palette.neutral[100]};
-	${until.tablet} {
-		display: none;
+	display: none;
+	${from.mobile} {
+		display: inline;
 	}
-`;
-
-export const progressBtnRight = css`
-	position: absolute;
-	top: 50%;
-	right: 0;
-	transform: translate(${space[6] + space[1]}px, -50%);
-	background-color: ${palette.neutral[100]};
-	${until.tablet} {
-		display: none;
+	${from.tablet} {
+		:before {
+			content: '${isSelected ? '-' : '+'}';
+			margin-right: 2px;
+		}
 	}
 `;

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -13,6 +13,8 @@ import {
 import { useState } from 'react';
 import type { CheckListData } from 'components/checkmarkList/checkmarkList';
 import { CheckmarkList } from 'components/checkmarkList/checkmarkList';
+import { CheckoutTopUpAmounts } from 'components/checkoutTopUpAmounts/checkoutTopUpAmounts';
+import { CheckoutTopUpAmountsContainer } from 'components/checkoutTopUpAmounts/checkoutTopUpAmountsContainer';
 import type { ContributionType } from 'helpers/contributions';
 
 const componentStyles = css`
@@ -117,6 +119,7 @@ export type ContributionsOrderSummaryProps = {
 	onAccordionClick?: (opening: boolean) => void;
 	headerButton?: React.ReactNode;
 	tsAndCs?: React.ReactNode;
+	showTopUpAmounts?: boolean;
 };
 
 const supportTypes = {
@@ -144,6 +147,7 @@ export function ContributionsOrderSummary({
 	onAccordionClick,
 	headerButton,
 	tsAndCs,
+	showTopUpAmounts,
 }: ContributionsOrderSummaryProps): JSX.Element {
 	const [showDetails, setShowDetails] = useState(false);
 
@@ -186,6 +190,16 @@ export function ContributionsOrderSummary({
 					</div>
 				)}
 			</div>
+			{showTopUpAmounts && (
+				<CheckoutTopUpAmountsContainer
+					renderCheckoutTopUpAmounts={(checkoutTopUpAmounts) => (
+						<CheckoutTopUpAmounts
+							{...checkoutTopUpAmounts}
+							customMargin={`${space[5]}px 0 ${space[4]}px`}
+						/>
+					)}
+				/>
+			)}
 			<hr css={hrCss} />
 			<div css={[summaryRow, rowSpacing, boldText, totalRow(!!tsAndCs)]}>
 				<p>Total</p>

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -16,13 +16,15 @@ import { CheckmarkList } from 'components/checkmarkList/checkmarkList';
 import { CheckoutTopUpAmounts } from 'components/checkoutTopUpAmounts/checkoutTopUpAmounts';
 import { CheckoutTopUpAmountsContainer } from 'components/checkoutTopUpAmounts/checkoutTopUpAmountsContainer';
 import type { ContributionType } from 'helpers/contributions';
+import { simpleFormatAmount } from 'helpers/forms/checkouts';
+import type { Currency } from 'helpers/internationalisation/currency';
 
 const componentStyles = css`
 	${textSans.medium()}
 `;
 
-const summaryRow = css`
-	display: flex;
+const summaryRow = (withFlexWrap?: boolean) => css`
+	display: ${withFlexWrap ? 'flex-wrap' : 'flex'};
 	justify-content: space-between;
 	align-items: baseline;
 	padding-top: 4px;
@@ -36,6 +38,11 @@ const rowSpacing = css`
 			margin-bottom: ${space[6]}px;
 		}
 	}
+`;
+
+const spaceBetween = css`
+	display: flex;
+	justify-content: space-between;
 `;
 
 const boldText = css`
@@ -114,7 +121,9 @@ const termsAndConditions = css`
 
 export type ContributionsOrderSummaryProps = {
 	contributionType: ContributionType;
-	total: string;
+	total: number;
+	totalBeforeAmended: number;
+	currency: Currency;
 	checkListData: CheckListData[];
 	onAccordionClick?: (opening: boolean) => void;
 	headerButton?: React.ReactNode;
@@ -143,6 +152,8 @@ function totalWithFrequency(total: string, contributionType: ContributionType) {
 export function ContributionsOrderSummary({
 	contributionType,
 	total,
+	totalBeforeAmended,
+	currency,
 	checkListData,
 	onAccordionClick,
 	headerButton,
@@ -156,14 +167,25 @@ export function ContributionsOrderSummary({
 
 	return (
 		<div css={componentStyles}>
-			<div css={[summaryRow, rowSpacing, headingRow]}>
+			<div css={[summaryRow(), rowSpacing, headingRow]}>
 				<h2 css={heading}>Your support</h2>
 				{headerButton}
 			</div>
 			<hr css={hrCss} />
 			<div css={[rowSpacing, detailsSection]}>
-				<div css={summaryRow}>
-					<p>{supportTypes[contributionType]} support</p>
+				<div css={summaryRow(showTopUpAmounts)}>
+					<p css={showTopUpAmounts && spaceBetween}>
+						{supportTypes[contributionType]} support
+						{showTopUpAmounts && (
+							<span>
+								{totalWithFrequency(
+									simpleFormatAmount(currency, totalBeforeAmended),
+									contributionType,
+								)}
+							</span>
+						)}
+					</p>
+
 					{showAccordion && (
 						<Button
 							priority="subdued"
@@ -201,9 +223,14 @@ export function ContributionsOrderSummary({
 				/>
 			)}
 			<hr css={hrCss} />
-			<div css={[summaryRow, rowSpacing, boldText, totalRow(!!tsAndCs)]}>
+			<div css={[summaryRow(), rowSpacing, boldText, totalRow(!!tsAndCs)]}>
 				<p>Total</p>
-				<p>{totalWithFrequency(total, contributionType)}</p>
+				<p>
+					{totalWithFrequency(
+						simpleFormatAmount(currency, total),
+						contributionType,
+					)}
+				</p>
 			</div>
 			{!!tsAndCs && (
 				<div css={termsAndConditions}>

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -23,7 +23,7 @@ const componentStyles = css`
 	${textSans.medium()}
 `;
 
-const summaryRow = (withFlexWrap?: boolean) => css`
+const summaryRow = (withFlexWrap = false) => css`
 	display: ${withFlexWrap ? 'flex-wrap' : 'flex'};
 	justify-content: space-between;
 	align-items: baseline;
@@ -129,6 +129,7 @@ export type ContributionsOrderSummaryProps = {
 	headerButton?: React.ReactNode;
 	tsAndCs?: React.ReactNode;
 	showTopUpAmounts?: boolean;
+	showPreAmendedTotal?: boolean;
 };
 
 const supportTypes = {
@@ -159,6 +160,7 @@ export function ContributionsOrderSummary({
 	headerButton,
 	tsAndCs,
 	showTopUpAmounts,
+	showPreAmendedTotal,
 }: ContributionsOrderSummaryProps): JSX.Element {
 	const [showDetails, setShowDetails] = useState(false);
 
@@ -173,10 +175,10 @@ export function ContributionsOrderSummary({
 			</div>
 			<hr css={hrCss} />
 			<div css={[rowSpacing, detailsSection]}>
-				<div css={summaryRow(showTopUpAmounts)}>
-					<p css={showTopUpAmounts && spaceBetween}>
+				<div css={summaryRow(showPreAmendedTotal)}>
+					<p css={showPreAmendedTotal && spaceBetween}>
 						{supportTypes[contributionType]} support
-						{showTopUpAmounts && (
+						{showPreAmendedTotal && (
 							<span>
 								{totalWithFrequency(
 									simpleFormatAmount(currency, totalBeforeAmended),

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
@@ -1,10 +1,12 @@
 import { checkListData } from 'components/checkoutBenefits/checkoutBenefitsListData';
 import type { ContributionType } from 'helpers/contributions';
-import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import { currencies } from 'helpers/internationalisation/currency';
 import { isSupporterPlusPurchase } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
-import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
+import {
+	getUserSelectedAmount,
+	getUserSelectedAmountBeforeAmendment,
+} from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import type { ContributionsOrderSummaryProps } from './contributionsOrderSummary';
@@ -48,13 +50,12 @@ export function ContributionsOrderSummaryContainer({
 		(state) => state.common.internationalisation,
 	);
 	const selectedAmount = useContributionsSelector(getUserSelectedAmount);
+	const selectedAmountBeforeAmendment = useContributionsSelector(
+		getUserSelectedAmountBeforeAmendment,
+	);
 	const isSupporterPlus = useContributionsSelector(isSupporterPlusPurchase);
 
 	const currency = currencies[currencyId];
-	const userSelectedAmountWithCurrency = simpleFormatAmount(
-		currency,
-		selectedAmount,
-	);
 
 	const checklist =
 		contributionType === 'ONE_OFF'
@@ -72,7 +73,9 @@ export function ContributionsOrderSummaryContainer({
 
 	return renderOrderSummary({
 		contributionType,
-		total: userSelectedAmountWithCurrency,
+		total: selectedAmount,
+		totalBeforeAmended: selectedAmountBeforeAmendment,
+		currency: currency,
 		checkListData: checklist,
 		onAccordionClick,
 		tsAndCs: getTermsConditions(contributionType, isSupporterPlus),

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -2,7 +2,9 @@ import type { OtherAmountProps } from 'components/otherAmount/otherAmount';
 import type { ContributionType, SelectedAmounts } from 'helpers/contributions';
 import {
 	setOtherAmount,
+	setOtherAmountBeforeAmendment,
 	setSelectedAmount,
+	setSelectedAmountBeforeAmendment,
 } from 'helpers/redux/checkout/product/actions';
 import { getMinimumContributionAmount } from 'helpers/redux/commonState/selectors';
 import { getOtherAmountErrors } from 'helpers/redux/selectors/formValidation/otherAmountValidation';
@@ -70,11 +72,23 @@ export function PriceCardsContainer({
 				amount: newAmount,
 			}),
 		);
+		dispatch(
+			setSelectedAmountBeforeAmendment({
+				contributionType: frequency,
+				amount: newAmount,
+			}),
+		);
 	}
 
 	function onOtherAmountChange(newAmount: string) {
 		dispatch(
 			setOtherAmount({
+				contributionType: frequency,
+				amount: newAmount,
+			}),
+		);
+		dispatch(
+			setOtherAmountBeforeAmendment({
 				contributionType: frequency,
 				amount: newAmount,
 			}),

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -84,7 +84,10 @@ export const tests: Tests = {
 				id: 'control',
 			},
 			{
-				id: 'variant',
+				id: 'variant_a',
+			},
+			{
+				id: 'variant_b',
 			},
 		],
 		audiences: {

--- a/support-frontend/assets/helpers/checkoutTopUp/upperThreshold.ts
+++ b/support-frontend/assets/helpers/checkoutTopUp/upperThreshold.ts
@@ -1,0 +1,36 @@
+import type { RegularContributionType } from 'helpers/contributions';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+
+export const checkoutTopUpUpperThresholdsByCountryGroup: Record<
+	CountryGroupId,
+	Record<RegularContributionType, number>
+> = {
+	GBPCountries: {
+		MONTHLY: 20,
+		ANNUAL: 120,
+	},
+	UnitedStates: {
+		MONTHLY: 20,
+		ANNUAL: 120,
+	},
+	EURCountries: {
+		MONTHLY: 20,
+		ANNUAL: 120,
+	},
+	International: {
+		MONTHLY: 22,
+		ANNUAL: 150,
+	},
+	AUDCountries: {
+		MONTHLY: 30,
+		ANNUAL: 170,
+	},
+	NZDCountries: {
+		MONTHLY: 30,
+		ANNUAL: 170,
+	},
+	Canada: {
+		MONTHLY: 22,
+		ANNUAL: 150,
+	},
+};

--- a/support-frontend/assets/helpers/redux/checkout/product/actions.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/actions.ts
@@ -10,6 +10,8 @@ export const {
 	setAllAmounts,
 	setSelectedAmount,
 	setOtherAmount,
+	setSelectedAmountBeforeAmendment,
+	setOtherAmountBeforeAmendment,
 	setCurrency,
 	setOrderIsAGift,
 	setStartDate,

--- a/support-frontend/assets/helpers/redux/checkout/product/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/reducer.ts
@@ -63,6 +63,7 @@ export const productSlice = createSlice({
 		},
 		setAllAmounts(state, action: PayloadAction<SelectedAmounts>) {
 			state.selectedAmounts = action.payload;
+			state.selectedAmountsBeforeAmendment = action.payload;
 		},
 		setSelectedAmount(state, action: PayloadAction<AmountChange>) {
 			const { contributionType, amount } = action.payload;
@@ -73,6 +74,18 @@ export const productSlice = createSlice({
 			const { contributionType, amount } = action.payload;
 			state.otherAmounts[contributionType].amount = amount;
 			state.errors.otherAmount = [];
+		},
+		setSelectedAmountBeforeAmendment(
+			state,
+			action: PayloadAction<AmountChange>,
+		) {
+			const { contributionType, amount } = action.payload;
+			const newAmount = amount === 'other' ? amount : Number.parseInt(amount);
+			state.selectedAmountsBeforeAmendment[contributionType] = newAmount;
+		},
+		setOtherAmountBeforeAmendment(state, action: PayloadAction<AmountChange>) {
+			const { contributionType, amount } = action.payload;
+			state.otherAmountsBeforeAmendment[contributionType].amount = amount;
 		},
 		setCurrency(state, action: PayloadAction<IsoCurrency>) {
 			state.currency = action.payload;

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/selectedAmount.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/selectedAmount.ts
@@ -14,3 +14,21 @@ export function getUserSelectedAmount(state: ContributionsState): number {
 
 	return priceCardAmountSelected;
 }
+
+export function getUserSelectedAmountBeforeAmendment(
+	state: ContributionsState,
+): number {
+	const contributionType = getContributionType(state);
+	const { selectedAmountsBeforeAmendment, otherAmountsBeforeAmendment } =
+		state.page.checkoutForm.product;
+	const priceCardAmountSelected =
+		selectedAmountsBeforeAmendment[contributionType];
+
+	if (priceCardAmountSelected === 'other') {
+		const customAmount = otherAmountsBeforeAmendment[contributionType];
+		// TODO: what do we do when this is NaN? Do we handle elsewhere?
+		return Number.parseFloat(customAmount.amount ?? '');
+	}
+
+	return priceCardAmountSelected;
+}

--- a/support-frontend/assets/helpers/redux/checkout/product/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/state.ts
@@ -48,6 +48,8 @@ export type ProductState = {
 	productPrices: ProductPrices;
 	selectedAmounts: SelectedAmounts;
 	otherAmounts: OtherAmounts;
+	selectedAmountsBeforeAmendment: SelectedAmounts;
+	otherAmountsBeforeAmendment: OtherAmounts;
 	currency: IsoCurrency;
 	orderIsAGift: boolean;
 	startDate: DateYMDString;
@@ -68,6 +70,22 @@ export const initialProductState: ProductState = {
 		ANNUAL: 0,
 	},
 	otherAmounts: {
+		ONE_OFF: {
+			amount: null,
+		},
+		MONTHLY: {
+			amount: null,
+		},
+		ANNUAL: {
+			amount: null,
+		},
+	},
+	selectedAmountsBeforeAmendment: {
+		ONE_OFF: 0,
+		MONTHLY: 0,
+		ANNUAL: 0,
+	},
+	otherAmountsBeforeAmendment: {
 		ONE_OFF: {
 			amount: null,
 		},

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/limitedPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/limitedPriceCards.tsx
@@ -14,7 +14,10 @@ import {
 	fromCountryGroupId,
 	glyph,
 } from 'helpers/internationalisation/currency';
-import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
+import {
+	setSelectedAmount,
+	setSelectedAmountBeforeAmendment,
+} from 'helpers/redux/checkout/product/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import {
 	useContributionsDispatch,
@@ -101,6 +104,13 @@ export function LimitedPriceCards(): JSX.Element {
 					benefitsThresholdsByCountryGroup[countryGroupId][type].toString(),
 			}),
 		);
+		dispatch(
+			setSelectedAmountBeforeAmendment({
+				contributionType,
+				amount:
+					benefitsThresholdsByCountryGroup[countryGroupId][type].toString(),
+			}),
+		);
 	}, []);
 
 	return (
@@ -125,6 +135,12 @@ export function LimitedPriceCards(): JSX.Element {
 									onTabChange(contributionType);
 									dispatch(
 										setSelectedAmount({
+											contributionType,
+											amount: amount.toString(),
+										}),
+									);
+									dispatch(
+										setSelectedAmountBeforeAmendment({
 											contributionType,
 											amount: amount.toString(),
 										}),

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -39,7 +39,9 @@ const {
 	common: { abParticipations },
 } = store.getState();
 
-const isInTwoStepTest = abParticipations.twoStepCheckout === 'variant';
+const isInTwoStepTest = abParticipations.twoStepCheckout !== 'control';
+const showCheckoutTopUpAmounts =
+	abParticipations.twoStepCheckout === 'variant_b';
 
 // ----- Render ----- //
 
@@ -78,7 +80,12 @@ const router = () => {
 			/>
 			<Route
 				path={`/${countryId}/contribute/checkout`}
-				element={<SupporterPlusCheckout thankYouRoute={thankYouRoute} />}
+				element={
+					<SupporterPlusCheckout
+						thankYouRoute={thankYouRoute}
+						showTopUpAmounts={showCheckoutTopUpAmounts}
+					/>
+				}
 			/>
 			<Route
 				path={`/${countryId}/thankyou`}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/secondStepCheckout.tsx
@@ -13,6 +13,7 @@ import { PersonalDetails } from 'components/personalDetails/personalDetails';
 import { PersonalDetailsContainer } from 'components/personalDetails/personalDetailsContainer';
 import { SavedCardButton } from 'components/savedCardButton/savedCardButton';
 import { ContributionsStripe } from 'components/stripe/contributionsStripe';
+import { checkoutTopUpUpperThresholdsByCountryGroup } from 'helpers/checkoutTopUp/upperThreshold';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
 import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
@@ -70,6 +71,14 @@ export function SupporterPlusCheckout({
 		countryGroupId,
 	);
 
+	const showPreAmendedTotal =
+		showTopUpAmounts &&
+		contributionType !== 'ONE_OFF' &&
+		amountBeforeAmendments <=
+			checkoutTopUpUpperThresholdsByCountryGroup[countryGroupId][
+				contributionType
+			];
+
 	const navigate = useNavigate();
 
 	const changeButton = (
@@ -102,6 +111,7 @@ export function SupporterPlusCheckout({
 								{...orderSummaryProps}
 								headerButton={changeButton}
 								showTopUpAmounts={showTopUpAmounts}
+								showPreAmendedTotal={showPreAmendedTotal}
 							/>
 						)}
 					/>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/secondStepCheckout.tsx
@@ -14,9 +14,16 @@ import { PersonalDetailsContainer } from 'components/personalDetails/personalDet
 import { SavedCardButton } from 'components/savedCardButton/savedCardButton';
 import { ContributionsStripe } from 'components/stripe/contributionsStripe';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
+import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
-import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
-import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import {
+	getUserSelectedAmount,
+	getUserSelectedAmountBeforeAmendment,
+} from 'helpers/redux/checkout/product/selectors/selectedAmount';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
 import { shouldShowSupporterPlusMessaging } from 'helpers/supporterPlus/showMessaging';
 import { CheckoutDivider } from '../components/checkoutDivider';
 import { DirectDebitContainer } from '../components/directDebitWrapper';
@@ -40,6 +47,7 @@ export function SupporterPlusCheckout({
 	thankYouRoute: string;
 	showTopUpAmounts: boolean;
 }): JSX.Element {
+	const dispatch = useContributionsDispatch();
 	const { countryGroupId, countryId, currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
@@ -51,6 +59,9 @@ export function SupporterPlusCheckout({
 	);
 	const contributionType = useContributionsSelector(getContributionType);
 	const amount = useContributionsSelector(getUserSelectedAmount);
+	const amountBeforeAmendments = useContributionsSelector(
+		getUserSelectedAmountBeforeAmendment,
+	);
 
 	const amountIsAboveThreshold = shouldShowSupporterPlusMessaging(
 		contributionType,
@@ -65,11 +76,17 @@ export function SupporterPlusCheckout({
 		<Button
 			priority="tertiary"
 			size="xsmall"
-			onClick={() =>
+			onClick={() => {
+				dispatch(
+					setSelectedAmount({
+						contributionType: contributionType,
+						amount: `${amountBeforeAmendments}`,
+					}),
+				);
 				navigate(
 					`/${countryGroups[countryGroupId].supportInternationalisationId}/contribute`,
-				)
-			}
+				);
+			}}
 		>
 			Change
 		</Button>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/secondStepCheckout.tsx
@@ -35,8 +35,10 @@ const shorterBoxMargin = css`
 
 export function SupporterPlusCheckout({
 	thankYouRoute,
+	showTopUpAmounts,
 }: {
 	thankYouRoute: string;
+	showTopUpAmounts: boolean;
 }): JSX.Element {
 	const { countryGroupId, countryId, currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
@@ -82,6 +84,7 @@ export function SupporterPlusCheckout({
 							<ContributionsOrderSummary
 								{...orderSummaryProps}
 								headerButton={changeButton}
+								showTopUpAmounts={showTopUpAmounts}
 							/>
 						)}
 					/>

--- a/support-frontend/stories/checkouts/CheckoutTopUpAmounts.stories.tsx
+++ b/support-frontend/stories/checkouts/CheckoutTopUpAmounts.stories.tsx
@@ -1,0 +1,61 @@
+import { CheckoutTopUpAmounts } from 'components/checkoutTopUpAmounts/checkoutTopUpAmounts';
+import type { CheckoutTopUpAmountsProps } from 'components/checkoutTopUpAmounts/checkoutTopUpAmounts';
+import { withCenterAlignment } from '../../.storybook/decorators/withCenterAlignment';
+
+export default {
+	title: 'Checkouts/TopUp Amounts',
+	component: CheckoutTopUpAmounts,
+	decorators: [
+		(Story: React.FC): JSX.Element => (
+			<div
+				style={{
+					width: '100%',
+					maxWidth: '500px',
+				}}
+			>
+				<Story />
+			</div>
+		),
+		withCenterAlignment,
+	],
+};
+
+function Template(args: CheckoutTopUpAmountsProps) {
+	return (
+		<CheckoutTopUpAmounts
+			currencySymbol={args.currencySymbol}
+			timePeriod={args.timePeriod}
+			amounts={args.amounts}
+			isWithinThreshold={args.isWithinThreshold}
+		/>
+	);
+}
+
+Template.args = {} as Record<string, unknown>;
+
+export const UKMonthlyTopUpAmounts = Template.bind({});
+
+UKMonthlyTopUpAmounts.args = {
+	currencySymbol: '£',
+	timePeriod: 'month',
+	amounts: [1, 2, 3, 4, 5],
+	isWithinThreshold: true,
+};
+
+export const UKYearlyTopUpAmounts = Template.bind({});
+
+UKYearlyTopUpAmounts.args = {
+	currencySymbol: '£',
+	timePeriod: 'year',
+	amounts: [1, 2, 3, 4, 5],
+	isWithinThreshold: true,
+};
+
+export const USMonthlyTopUpAmounts = Template.bind({});
+
+USMonthlyTopUpAmounts.args = {
+	currencySymbol: '$',
+	timePeriod: 'month',
+	amounts: [1, 2, 3, 4, 5],
+	isWithinThreshold: true,
+};

--- a/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
@@ -43,7 +43,14 @@ export const Default = Template.bind({});
 
 Default.args = {
 	contributionType: 'MONTHLY',
-	total: '£10',
+	total: 10,
+	totalBeforeAmended: 10,
+	currency: {
+		glyph: '£',
+		extendedGlyph: '£',
+		isSuffixGlyph: false,
+		isPaddedGlyph: false,
+	},
 	checkListData: checkListData({ higherTier: true, showUnchecked: false }),
 	headerButton: (
 		<Button priority="tertiary" size="xsmall">
@@ -65,7 +72,14 @@ export const BelowThreshold = Template.bind({});
 
 BelowThreshold.args = {
 	contributionType: 'ANNUAL',
-	total: '$25',
+	total: 25,
+	totalBeforeAmended: 25,
+	currency: {
+		glyph: '$',
+		extendedGlyph: 'US$',
+		isSuffixGlyph: false,
+		isPaddedGlyph: false,
+	},
 	checkListData: checkListData({ higherTier: false, showUnchecked: false }),
 	headerButton: (
 		<Button priority="tertiary" size="xsmall">
@@ -84,7 +98,14 @@ export const SingleContribution = Template.bind({});
 
 SingleContribution.args = {
 	contributionType: 'ONE_OFF',
-	total: '$25',
+	total: 25,
+	totalBeforeAmended: 25,
+	currency: {
+		glyph: '$',
+		extendedGlyph: 'US$',
+		isSuffixGlyph: false,
+		isPaddedGlyph: false,
+	},
 	checkListData: [],
 	headerButton: (
 		<Button priority="tertiary" size="xsmall">


### PR DESCRIPTION
This pr adds to the two step checkout a/b test to add another variant to the second page of the checkout where users are asked to top up the amount they choose on the first page.

[**Trello Card**](https://trello.com/c/NNBogC6e/1520-2-step-checkout-build-order-summary-component-with-the-nudge-for-page-2-of-2-step-checkout)

## Is this an AB test?
- [x] Yes
- [ ]

## Screenshots
Page 2 before | Page 2 after
--- | ---
![](https://github.com/guardian/support-frontend/assets/2510683/133441f6-d3e7-46aa-b354-d254e881ae3a) | ![](https://github.com/guardian/support-frontend/assets/2510683/e6a852ad-265f-4aa7-be21-81944d404715)

With amount selected
<img width="421" alt="mobile_amount_selected" src="https://github.com/guardian/support-frontend/assets/2510683/20f705e1-6bae-4a7f-bf95-2835740ced6d">

Contributing above threshold (page 1) | Contributing above threshold (page 2)
--- | ---
![](https://github.com/guardian/support-frontend/assets/2510683/906dcd32-fa53-4728-be06-e3a49e16c2ee) | ![](https://github.com/guardian/support-frontend/assets/2510683/1cb551c1-0e56-49c2-9361-1f1e359bc045)

Contributing above threshold - starting below (page 1) | Contributing above threshold - starting below (page 2)
--- | ---
![](https://github.com/guardian/support-frontend/assets/2510683/0c14c2bf-5d01-40c0-828e-251c32a83464) | ![](https://github.com/guardian/support-frontend/assets/2510683/c63521ce-409c-4d52-a74f-367026f7f419)

Page 2 - Desktop breakpoint
<img width="1349" alt="Screenshot 2023-09-11 at 11 41 18" src="https://github.com/guardian/support-frontend/assets/2510683/ffd14acc-348a-4738-9581-886364012768">

Page 2 - Desktop breakpoint US edition
<img width="1349" alt="Screenshot 2023-09-11 at 12 01 31" src="https://github.com/guardian/support-frontend/assets/2510683/a2684c4b-b869-460d-8f35-44c49ea4e025">

Page 2 - Desktop breakpoint Europe edition
<img width="1349" alt="Screenshot 2023-09-11 at 12 01 31" src="https://github.com/guardian/support-frontend/assets/2510683/d9692f86-56f2-42c8-bf47-194d4b1f773b">



