### PR TITLE
AB Test configuration - how to handle users viewing S+ only variant of checkout

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -90,10 +90,10 @@ export const tests: Tests = {
 		audiences: {
 			ALL: {
 				offset: 0,
-				size: 1,
+				size: 0,
 			},
 		},
-		isActive: true,
+		isActive: false,
 		referrerControlled: false,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		seed: 3,

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -90,10 +90,10 @@ export const tests: Tests = {
 		audiences: {
 			ALL: {
 				offset: 0,
-				size: 0,
+				size: 1,
 			},
 		},
-		isActive: false,
+		isActive: true,
 		referrerControlled: false,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		seed: 3,

--- a/support-frontend/assets/helpers/redux/commonState/reducer.ts
+++ b/support-frontend/assets/helpers/redux/commonState/reducer.ts
@@ -4,6 +4,7 @@ import type { ContributionTypes } from 'helpers/contributions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { fromCountry } from 'helpers/internationalisation/countryGroup';
 import { fromCountryGroupId } from 'helpers/internationalisation/currency';
+import type { Participations } from '../../abTests/abtest';
 import type { CommonStateSetupData, Internationalisation } from './state';
 import { initialCommonState } from './state';
 
@@ -21,11 +22,25 @@ function getInternationalisationFromCountry(
 	};
 }
 
+function getABTestNames(abParticipations: Participations) {
+	const isUserInSupporterPlusABTest = 'supporterPlusOnly' in abParticipations;
+
+	const abTestType = isUserInSupporterPlusABTest
+		? { supporterPlusOnly: abParticipations.supporterPlusOnly }
+		: abParticipations;
+
+	return abTestType;
+}
+
 export const commonSlice = createSlice({
 	name: 'common',
 	initialState: initialCommonState,
 	reducers: {
 		setInitialCommonState(state, action: PayloadAction<CommonStateSetupData>) {
+			action.payload.abParticipations = getABTestNames(
+				action.payload.abParticipations,
+			);
+			console.log('Yet', action.payload.abParticipations);
 			const {
 				campaign,
 				referrerAcquisitionData,
@@ -36,6 +51,7 @@ export const commonSlice = createSlice({
 				amounts,
 				defaultAmounts,
 			} = action.payload;
+
 			return {
 				...state,
 				campaign,

--- a/support-frontend/assets/helpers/redux/commonState/reducer.ts
+++ b/support-frontend/assets/helpers/redux/commonState/reducer.ts
@@ -24,9 +24,12 @@ function getInternationalisationFromCountry(
 
 function getABTestNames(abParticipations: Participations) {
 	const isUserInSupporterPlusABTest = 'supporterPlusOnly' in abParticipations;
+	const isUserInVATCompliantcountry = 'VAT_COMPLIANCE' in abParticipations;
 
 	const abTestType = isUserInSupporterPlusABTest
 		? { supporterPlusOnly: abParticipations.supporterPlusOnly }
+		: isUserInVATCompliantcountry
+		? { VAT_COMPLIANCE: abParticipations.VAT_COMPLIANCE }
 		: abParticipations;
 
 	return abTestType;
@@ -50,7 +53,6 @@ export const commonSlice = createSlice({
 				amounts,
 				defaultAmounts,
 			} = action.payload;
-
 			return {
 				...state,
 				campaign,

--- a/support-frontend/assets/helpers/redux/commonState/reducer.ts
+++ b/support-frontend/assets/helpers/redux/commonState/reducer.ts
@@ -23,13 +23,13 @@ function getInternationalisationFromCountry(
 }
 
 function getABTestNames(abParticipations: Participations) {
-	if ('supporterPlusOnly' in abParticipations) {
-		const abTestType = {
-			supporterPlusOnly: abParticipations.supporterPlusOnly,
-		};
-		return abTestType;
-	}
-	return abParticipations; // Return the original object if 'supporterPlusOnly' doesn't exist.
+	const isUserInSupporterPlusABTest = 'supporterPlusOnly' in abParticipations;
+
+	const abTestType = isUserInSupporterPlusABTest
+		? { supporterPlusOnly: abParticipations.supporterPlusOnly }
+		: abParticipations;
+
+	return abTestType;
 }
 
 export const commonSlice = createSlice({
@@ -40,7 +40,6 @@ export const commonSlice = createSlice({
 			action.payload.abParticipations = getABTestNames(
 				action.payload.abParticipations,
 			);
-			console.log('Yet', action.payload.abParticipations);
 			const {
 				campaign,
 				referrerAcquisitionData,

--- a/support-frontend/assets/helpers/redux/commonState/reducer.ts
+++ b/support-frontend/assets/helpers/redux/commonState/reducer.ts
@@ -23,13 +23,13 @@ function getInternationalisationFromCountry(
 }
 
 function getABTestNames(abParticipations: Participations) {
-	const isUserInSupporterPlusABTest = 'supporterPlusOnly' in abParticipations;
-
-	const abTestType = isUserInSupporterPlusABTest
-		? { supporterPlusOnly: abParticipations.supporterPlusOnly }
-		: abParticipations;
-
-	return abTestType;
+	if ('supporterPlusOnly' in abParticipations) {
+		const abTestType = {
+			supporterPlusOnly: abParticipations.supporterPlusOnly,
+		};
+		return abTestType;
+	}
+	return abParticipations; // Return the original object if 'supporterPlusOnly' doesn't exist.
 }
 
 export const commonSlice = createSlice({

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.test.tsx
@@ -68,6 +68,7 @@ describe('Guardian Weekly checkout form', () => {
 				},
 			},
 			common: {
+				abParticipations: {},
 				internationalisation: {
 					countryGroupId: 'GBPCountries',
 					countryId: 'GB',


### PR DESCRIPTION
## What are you doing in this PR?

Handle users viewing S+ only variant of checkout.
This change also includes the changes to check the VAT_COMPLIANCE test. On the 2-step checkout, we're going to need to do something to account for this VAT compliant (contributions only) checkout. Without doing anything users in the VAT compliant country list could be allocated to the 2-step checkout with the nudge component - which will allow them to contribute over the  threshold, and acquire S+.

[**Trello Card**](https://trello.com)

## Why are you doing this?

Currently we bucket all users who land on /contribute into our [abtestDefinitions](https://github.com/guardian/support-frontend/blob/main/support-frontend/assets/helpers/abTests/abtestDefinitions.ts) tests, including those landing on the Supporter Plus Only variant of the checkout.
This isn’t ideal as a lot of the tests we design are for the standard checkout w/ Single Contributions, Recurring Contributions and S+ Contributions. This could lead to misleading results when evaluating tests if we’re bucketing users landing on the Supporter Plus Only variant of the checkout.
We should have a way configure [abtestDefinitions](https://github.com/guardian/support-frontend/blob/main/support-frontend/assets/helpers/abTests/abtestDefinitions.ts) tests so we can choose whether to bucket users on the Supporter Plus Only version of the checkout or not.

## Is this an AB test?
- [x ] Yes
- [ ] No

If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)

## Screenshots

###Support site
<img width="1728" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/9b3ab62e-34ce-4626-b02b-375446aee8c3">

### Supporter Plus in variant
<img width="1728" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/d5fd05f6-be24-42de-9c45-72b1f0f13ef5">

### Supporter Plus in control
<img width="1728" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/c30b9794-9aff-4470-ac4c-2ca7e1293f63">


