### PR TITLE
Send new Ophan page view event when navigating between page 1 and 2 on the 2-step checkout

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -93,7 +93,7 @@ export const tests: Tests = {
 		audiences: {
 			ALL: {
 				offset: 0,
-				size: 1,
+				size: 0,
 			},
 		},
 		isActive: false,

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -80,9 +80,9 @@ export const tests: Tests = {
 	},
 	twoStepCheckout: {
 		variants: [
-			{
-				id: 'control',
-			},
+			// {
+			// 	id: 'control',
+			// },
 			{
 				id: 'variant_a',
 			},
@@ -93,10 +93,10 @@ export const tests: Tests = {
 		audiences: {
 			ALL: {
 				offset: 0,
-				size: 0,
+				size: 1,
 			},
 		},
-		isActive: false,
+		isActive: true,
 		referrerControlled: false,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		seed: 3,

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -80,9 +80,9 @@ export const tests: Tests = {
 	},
 	twoStepCheckout: {
 		variants: [
-			// {
-			// 	id: 'control',
-			// },
+			{
+				id: 'control',
+			},
 			{
 				id: 'variant_a',
 			},
@@ -96,7 +96,7 @@ export const tests: Tests = {
 				size: 1,
 			},
 		},
-		isActive: true,
+		isActive: false,
 		referrerControlled: false,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		seed: 3,

--- a/support-frontend/assets/helpers/tracking/ophan.ts
+++ b/support-frontend/assets/helpers/tracking/ophan.ts
@@ -1,8 +1,10 @@
 // ----- Imports ----- //
 import * as ophan from 'ophan';
+import type { NavigateFunction } from 'react-router';
 import type { Participations } from 'helpers/abTests/abtest';
 import { getLocal, setLocal } from 'helpers/storage/storage';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import { getAbsoluteURL } from 'helpers/urls/url';
 
 // ----- Types ----- //
 // These are to match Thrift definitions which can be found here:
@@ -127,9 +129,35 @@ const setReferrerDataInLocalStorage = (
 	}
 };
 
+const getPageViewId = (): string => ophan.viewId;
+
+/**
+ * To be used when navigating with React Router
+ * in order to generate new Page View event in Ophan
+ */
+const navigateWithPageView = (
+	navigate: NavigateFunction,
+	destination: string,
+): void => {
+	const reffererData = {
+		referrerUrl: document.location.href,
+		referrerPageviewId: getPageViewId(),
+	};
+
+	// store reffer data to be read and transmitted on manual pageView
+	setReferrerDataInLocalStorage(reffererData);
+
+	// navigate to next page
+	navigate(destination);
+
+	// manual pageView
+	pageView(document.location.href, getAbsoluteURL(destination));
+};
+
 export {
 	trackComponentEvents,
 	pageView,
 	trackAbTests,
 	setReferrerDataInLocalStorage,
+	navigateWithPageView,
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/firstStepLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/firstStepLanding.tsx
@@ -18,6 +18,7 @@ import { getContributionType } from 'helpers/redux/checkout/product/selectors/pr
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { getThresholdPrice } from 'helpers/supporterPlus/benefitsThreshold';
+import { navigateWithPageView } from 'helpers/tracking/ophan';
 import { AmountAndBenefits } from '../formSections/amountAndBenefits';
 import { LimitedPriceCards } from '../formSections/limitedPriceCards';
 import { SupporterPlusCheckoutScaffold } from './checkoutScaffold';
@@ -130,9 +131,8 @@ export function SupporterPlusInitialLandingPage({
 							size="default"
 							cssOverrides={checkoutBtnStyleOverrides}
 							onClick={() => {
-								navigate(
-									`checkout?selected-amount=${amount}&selected-contribution-type=${contributionType.toLowerCase()}`,
-								);
+								const destination = `checkout?selected-amount=${amount}&selected-contribution-type=${contributionType.toLowerCase()}`;
+								navigateWithPageView(navigate, destination);
 							}}
 						>
 							Continue to checkout

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/secondStepCheckout.tsx
@@ -26,6 +26,7 @@ import {
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
 import { shouldShowSupporterPlusMessaging } from 'helpers/supporterPlus/showMessaging';
+import { navigateWithPageView } from 'helpers/tracking/ophan';
 import { CheckoutDivider } from '../components/checkoutDivider';
 import { DirectDebitContainer } from '../components/directDebitWrapper';
 import { PaymentFailureMessage } from '../components/paymentFailure';
@@ -92,9 +93,8 @@ export function SupporterPlusCheckout({
 						amount: `${amountBeforeAmendments}`,
 					}),
 				);
-				navigate(
-					`/${countryGroups[countryGroupId].supportInternationalisationId}/contribute`,
-				);
+				const destination = `/${countryGroups[countryGroupId].supportInternationalisationId}/contribute`;
+				navigateWithPageView(navigate, destination);
 			}}
 		>
 			Change

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -104,7 +104,7 @@
     "emotion-theming": "^11.0.0",
     "framer-motion": "^1.11.1",
     "lodash.debounce": "^4.0.6",
-    "ophan-tracker-js": "^1.4.2",
+    "ophan-tracker-js": "^1.4.3",
     "react-day-picker": "^7.4.8",
     "react-is": "^18.2.0",
     "react-redux": "^8.1.0",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -11822,10 +11822,10 @@ opener@^1.5.2:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
-ophan-tracker-js@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.4.2.tgz#75a5166fe7dc5a0971abbe9335043d869552550a"
-  integrity sha512-CRDcdVt9UUN0wdmMYJ5U1UxxwFYhOlF2G9wn7eUYlsTetWB2lme2iahMhe3fXQi6/IMy4WkzKdMp1ApmYNbnEA==
+ophan-tracker-js@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.4.3.tgz#97366a58635a984b8b159080e8dc201e9e0d3304"
+  integrity sha512-rlF9rNazjUx6kr67j1cCYAejo71TXy6VLe88UdhipdOm6UVQamiWvc91/FZ9xxWIqPk/sQ4FVAJYgDF2x5j0og==
 
 optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"


### PR DESCRIPTION
## What are you doing in this PR?

When a user navigates from page 1 to 2 (and vice-versa) of the 2 step checkout this is done via React Router, so no additional network request is made by the browser. This means both page views are covered by a single page view event in the Page View table of the Data Lake.

We'd like each page view to have a separate page view event in the Page View table of the Data Lake, to do this we can use the `sendInitialEvent` function exposed by Ophan's tracker-js library to manually trigger a second Page View event when a user navigates from Page 1 to 2 (and vice-versa). 

This PR introduces a new function to our Ophan module `navigateWithPageView`, that takes care of setting the referral data used by Ophan in localStorage, navigating to the next page and triggering the new page view event.

I've also bumped `ophan` to `1.4.3` to get a change that generates a new page view id when `sendInitialEvent` is called: https://github.com/guardian/ophan/pull/5537

[**Trello Card**](https://trello.com/c/wGDOSGBd/1532-2-step-checkout-manually-trigger-new-page-view-on-react-router-navigate)
