### PR TITLE
Client-side: Set up A/B test for making zip code a mandatory field for US contributors

### DIFF
--- a/support-frontend/assets/components/personalDetails/personalDetails.tsx
+++ b/support-frontend/assets/components/personalDetails/personalDetails.tsx
@@ -49,6 +49,7 @@ export type PersonalDetailsProps = {
 	onLastNameChange: (lastName: string) => void;
 	signOutLink: React.ReactNode;
 	contributionState: React.ReactNode;
+	contributionZipcode?: React.ReactNode;
 	overrideHeadingCopy?: string;
 	hideDetailsHeading?: true;
 	errors?: PersonalDetailsState['errors'];
@@ -66,6 +67,7 @@ export function PersonalDetails({
 	errors,
 	signOutLink,
 	contributionState,
+	contributionZipcode,
 	hideDetailsHeading,
 	overrideHeadingCopy,
 }: PersonalDetailsProps): JSX.Element {
@@ -123,6 +125,8 @@ export function PersonalDetails({
 			) : null}
 
 			{contributionState}
+
+			{contributionZipcode}
 		</div>
 	);
 }

--- a/support-frontend/assets/components/personalDetails/personalDetailsContainer.tsx
+++ b/support-frontend/assets/components/personalDetails/personalDetailsContainer.tsx
@@ -1,5 +1,9 @@
+import { TextInput } from '@guardian/source-react-components';
 import Signout from 'components/signout/signout';
-import { setBillingState } from 'helpers/redux/checkout/address/actions';
+import {
+	setBillingPostcode,
+	setBillingState,
+} from 'helpers/redux/checkout/address/actions';
 import {
 	setEmail,
 	setFirstName,
@@ -22,11 +26,16 @@ export function PersonalDetailsContainer({
 }: PersonalDetailsContainerProps): JSX.Element {
 	const dispatch = useContributionsDispatch();
 
+	const { mandatoryZipCode } = useContributionsSelector(
+		(state) => state.common.abParticipations,
+	);
+
 	const { email, firstName, lastName, errors } = useContributionsSelector(
 		(state) => state.page.checkoutForm.personalDetails,
 	);
+
 	const contributionType = useContributionsSelector(getContributionType);
-	const { state, errorObject } = useContributionsSelector(
+	const { state, postCode, errorObject } = useContributionsSelector(
 		(state) => state.page.checkoutForm.billingAddress.fields,
 	);
 	const isSignedIn = useContributionsSelector(
@@ -35,6 +44,8 @@ export function PersonalDetailsContainer({
 	const countryId = useContributionsSelector(
 		(state) => state.common.internationalisation.countryId,
 	);
+
+	const showZipCodeField = mandatoryZipCode === 'variant' && countryId === 'US';
 
 	function onEmailChange(email: string) {
 		dispatch(setEmail(email));
@@ -50,6 +61,10 @@ export function PersonalDetailsContainer({
 
 	function onBillingStateChange(billingState: string) {
 		dispatch(setBillingState(billingState));
+	}
+
+	function onZipCodeChange(newZipCode: string) {
+		dispatch(setBillingPostcode(newZipCode));
 	}
 
 	return renderPersonalDetails({
@@ -72,5 +87,17 @@ export function PersonalDetailsContainer({
 				error={errorObject?.state?.[0]}
 			/>
 		),
+		contributionZipcode: showZipCodeField ? (
+			<div>
+				<TextInput
+					id="postCode"
+					name="zip-code"
+					label="ZIP code"
+					value={postCode}
+					error={errorObject?.postCode?.[0]}
+					onChange={(e) => onZipCodeChange(e.target.value)}
+				/>
+			</div>
+		) : undefined,
 	});
 }

--- a/support-frontend/assets/components/personalDetails/personalDetailsContainer.tsx
+++ b/support-frontend/assets/components/personalDetails/personalDetailsContainer.tsx
@@ -90,7 +90,7 @@ export function PersonalDetailsContainer({
 		contributionZipcode: showZipCodeField ? (
 			<div>
 				<TextInput
-					id="postCode"
+					id="zipCode"
 					name="zip-code"
 					label="ZIP code"
 					value={postCode}

--- a/support-frontend/assets/components/stripeCardForm/stripeCardFormContainer.tsx
+++ b/support-frontend/assets/components/stripeCardForm/stripeCardFormContainer.tsx
@@ -45,13 +45,18 @@ export function StripeCardFormContainer(): JSX.Element {
 	const zipCode = useContributionsSelector(
 		(state) => state.page.checkoutForm.billingAddress.fields.postCode,
 	);
-	const showZipCode = useContributionsSelector(
+	const { mandatoryZipCode } = useContributionsSelector(
+		(state) => state.common.abParticipations,
+	);
+	const isUsCustomer = useContributionsSelector(
 		(state) => state.common.internationalisation.countryId === 'US',
 	);
 	const { publicKey, stripeAccount } = useContributionsSelector(
 		(state) => state.page.checkoutForm.payment.stripeAccountDetails,
 	);
 	const { isTestUser } = useContributionsSelector((state) => state.page.user);
+
+	const showZipCode = isUsCustomer && mandatoryZipCode === 'control';
 
 	function onCardFieldChange(field: StripeField) {
 		return function onChange(event: StripeChangeEvents[typeof field]) {

--- a/support-frontend/assets/components/stripeCardForm/stripeCardFormContainer.tsx
+++ b/support-frontend/assets/components/stripeCardForm/stripeCardFormContainer.tsx
@@ -56,7 +56,7 @@ export function StripeCardFormContainer(): JSX.Element {
 	);
 	const { isTestUser } = useContributionsSelector((state) => state.page.user);
 
-	const showZipCode = isUsCustomer && mandatoryZipCode === 'control';
+	const showZipCode = isUsCustomer && mandatoryZipCode !== 'variant';
 
 	function onCardFieldChange(field: StripeField) {
 		return function onChange(event: StripeChangeEvents[typeof field]) {

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -126,7 +126,7 @@ export const tests: Tests = {
 		audiences: {
 			UnitedStates: {
 				offset: 0,
-				size: 0,
+				size: 1,
 			},
 		},
 		referrerControlled: false,

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -10,6 +10,7 @@ export const pageUrlRegexes = {
 		allLandingPagesAndThankyouPages: '/contribute|thankyou(/.*)?$',
 		notUkLandingPage: '/us|au|eu|int|nz|ca/contribute(/.*)?$',
 		auLandingPage: '/au/contribute(/.*)?$',
+		usLandingPage: '/us/contribute(/.*)?$',
 	},
 	subscriptions: {
 		subsDigiSubPages: '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)',
@@ -111,5 +112,25 @@ export const tests: Tests = {
 		audiences: {},
 		referrerControlled: false,
 		seed: 0,
+	},
+	mandatoryZipCode: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		isActive: false,
+		audiences: {
+			UnitedStates: {
+				offset: 0,
+				size: 0,
+			},
+		},
+		referrerControlled: false,
+		targetPage: pageUrlRegexes.contributions.usLandingPage,
+		seed: 4,
 	},
 };

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
@@ -14,9 +14,11 @@ import { errorCollectionHasErrors } from './utils';
 export function getStripeFormErrors(
 	state: ContributionsState,
 ): ErrorCollection {
+	const { abParticipations, internationalisation } = state.common;
 	const { errors, showErrors } = state.page.checkoutForm.payment.stripe;
 	const shouldShowZipCode =
-		state.common.internationalisation.countryId === 'US';
+		internationalisation.countryId === 'US' &&
+		abParticipations.mandatoryZipCode !== 'variant';
 	const recaptchaErrors = getRecaptchaError(state);
 
 	if (!showErrors) return {};

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -17,6 +17,23 @@ export function getStateOrProvinceError(
 	return {};
 }
 
+function getZipCodeErrors(state: ContributionsState): ErrorCollection {
+	const { abParticipations, internationalisation } = state.common;
+	const shouldShowZipCode =
+		internationalisation.countryId === 'US' &&
+		abParticipations.mandatoryZipCode === 'variant';
+
+	if (shouldShowZipCode) {
+		const zipCode =
+			state.page.checkoutForm.billingAddress.fields.errorObject?.postCode;
+		return {
+			zipCode,
+		};
+	}
+
+	return {};
+}
+
 export function getPersonalDetailsErrors(
 	state: ContributionsState,
 ): ErrorCollection {
@@ -26,11 +43,13 @@ export function getPersonalDetailsErrors(
 		state.page.checkoutForm.personalDetails.errors ?? {};
 
 	const stateOrProvinceErrors = getStateOrProvinceError(state);
+	const zipCodeErrors = getZipCodeErrors(state);
 
 	if (contributionType === 'ONE_OFF') {
 		return {
 			email,
 			...stateOrProvinceErrors,
+			...zipCodeErrors,
 		};
 	}
 	return {
@@ -38,5 +57,6 @@ export function getPersonalDetailsErrors(
 		firstName,
 		lastName,
 		...stateOrProvinceErrors,
+		...zipCodeErrors,
 	};
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This sets up an A/B test for making the zip code field mandatory for all contribution types and payment methods in the US, instead of only required when paying by card.

The zip code field is moved into the personal details section alongside the state field, and validation messaging is shown for it regardless of payment method if the user is in the A/B variant.

Postcode/zipcode data will be included in the payload for a recurring contribution/S+, but the client side **DOES NOT** currently send this field for one-off contributions. The back end will need to accept this as part of the payload before this can be changed client-side.

[**Trello Card**](https://trello.com/c/pufBPFJv)

## Why are you doing this?

This test is for improved targeting with US contributors.

## Screenshots

### Single contribution
![Screenshot 2023-09-12 at 12-23-34 Support the Guardian](https://github.com/guardian/support-frontend/assets/29146931/066ec178-8211-4727-8ed0-f55dcbca12db)

### Recurring contribution
![Screenshot 2023-09-12 at 12-23-59 Support the Guardian](https://github.com/guardian/support-frontend/assets/29146931/5746e9d1-517c-4980-83ad-56d22a112e90)

### Form validation
![Screenshot 2023-09-12 at 12-24-17 Support the Guardian](https://github.com/guardian/support-frontend/assets/29146931/ede7e06b-bfb5-452a-acef-3e14e96d7c77)
