### PR TITLE
Add omitCountries check on abTestDefinition

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -66,6 +66,7 @@ export type Test = {
 	// An optional regex that will be tested against the path of the current page
 	// before activating this test eg. '/(uk|us|au|ca|nz)/subscribe$'
 	targetPage?: string | RegExp;
+	omitCountries?: IsoCountry[];
 };
 
 export type Tests = Record<string, Test>;
@@ -143,6 +144,10 @@ function getParticipations(
 		}
 
 		if (test.canRun && !test.canRun()) {
+			return;
+		}
+
+		if (test.omitCountries?.includes(country)) {
 			return;
 		}
 

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -80,12 +80,12 @@ export const tests: Tests = {
 	},
 	twoStepCheckout: {
 		variants: [
-			// {
-			// 	id: 'control',
-			// },
-			// {
-			// 	id: 'variant_a',
-			// },
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant_a',
+			},
 			{
 				id: 'variant_b',
 			},
@@ -93,10 +93,10 @@ export const tests: Tests = {
 		audiences: {
 			ALL: {
 				offset: 0,
-				size: 1,
+				size: 0,
 			},
 		},
-		isActive: true,
+		isActive: false,
 		referrerControlled: false,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		seed: 3,

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -80,12 +80,12 @@ export const tests: Tests = {
 	},
 	twoStepCheckout: {
 		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'variant_a',
-			},
+			// {
+			// 	id: 'control',
+			// },
+			// {
+			// 	id: 'variant_a',
+			// },
 			{
 				id: 'variant_b',
 			},
@@ -93,13 +93,52 @@ export const tests: Tests = {
 		audiences: {
 			ALL: {
 				offset: 0,
-				size: 0,
+				size: 1,
 			},
 		},
-		isActive: false,
+		isActive: true,
 		referrerControlled: false,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		seed: 3,
+		omitCountries: [
+			'RS',
+			'EG',
+			'PK',
+			'MU',
+			'BH',
+			'MA',
+			'MC',
+			'OM',
+			'GE',
+			'NC',
+			'TZ',
+			'ZM',
+			'AL',
+			'BD',
+			'KZ',
+			'CW',
+			'DO',
+			'GP',
+			'MQ',
+			'PF',
+			'TN',
+			'BQ',
+			'AX',
+			'SN',
+			'AM',
+			'CM',
+			'AO',
+			'KG',
+			'GA',
+			'UZ',
+			'MD',
+			'DZ',
+			'TJ',
+			'LS',
+			'CG',
+			'TG',
+			'NE',
+		],
 	},
 	nationalDelivery: {
 		variants: [

--- a/support-frontend/assets/helpers/redux/commonState/reducer.ts
+++ b/support-frontend/assets/helpers/redux/commonState/reducer.ts
@@ -24,12 +24,9 @@ function getInternationalisationFromCountry(
 
 function getABTestNames(abParticipations: Participations) {
 	const isUserInSupporterPlusABTest = 'supporterPlusOnly' in abParticipations;
-	const isUserInVATCompliantcountry = 'VAT_COMPLIANCE' in abParticipations;
 
 	const abTestType = isUserInSupporterPlusABTest
 		? { supporterPlusOnly: abParticipations.supporterPlusOnly }
-		: isUserInVATCompliantcountry
-		? { VAT_COMPLIANCE: abParticipations.VAT_COMPLIANCE }
 		: abParticipations;
 
 	return abTestType;


### PR DESCRIPTION
## What are you doing in this PR?

Paired on with @LAKSHMIRPILLAI 

We added a rule in this PR https://github.com/guardian/support-frontend/pull/5251 that would make sure users allocated to the `VAT_COMPLIANCE` test were not included in any other test, implemented as we wanted to be sure they weren't allocated to the `twoStepCheckout` AB test. 

The change was implemented as we assumed the `VAT_COMPLIANCE` would appear in a user's `abParticipations` in state...unfortunately we were mistakenwith this assumption.

We therefore decided to revert back to an original plan for making sure users who experience the `VAT_COMPLIANCE` test are not allocated to the `twoStepCheckout` AB test. We did this by adding a new check when deciding on AB test participations in `abTest.ts`, this check checks a user's country against an `omitCountries` list that can be optionally assigned to an ab test definition. If the user's country is in that list they won't be allocated to the test.

We've set this up on the `twoStepCheckout` test, all the country codes listed are those in the `VAT_COMPLIANCE` list.

