### PR TITLE
Amend checkout benefits title break points

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import {
+	between,
 	from,
 	headline,
 	palette,
@@ -21,10 +22,18 @@ const containerWithBackgroundCss = css`
 	border-radius: 7px;
 `;
 
-const maxWidth = css`
+const smallMaxWidth = css`
 	max-width: 250px;
 	${from.desktop} {
 		max-width: 280px;
+	}
+`;
+const maxWidth = css`
+	${until.mobileLandscape} {
+		max-width: 15ch;
+	}
+	${between.tablet.and.desktop} {
+		max-width: 15ch;
 	}
 `;
 const headingCss = css`
@@ -68,7 +77,11 @@ export function CheckoutBenefitsList({
 					: [containerCss]
 			}
 		>
-			<h2 css={withBackground ? headingCss : [headingCss, maxWidth]}>
+			<h2
+				css={
+					withBackground ? [headingCss, maxWidth] : [headingCss, smallMaxWidth]
+				}
+			>
 				{title}
 			</h2>
 			<hr css={hrCss(`${space[4]}px 0`)} />


### PR DESCRIPTION
## What are you doing in this PR?
Amend checkout benefits title to break at a sensible width and … stretch to a single line where possible.

This only affects the two step checkout view, the mutli page (original/control) version stays the same.

## Why are you doing this?
Because Helene asked me to :p

## Screenshots
before | after
--- | ---
![](https://github.com/guardian/support-frontend/assets/2510683/18f60af0-b6d2-4c07-a188-39dd73c140ff) | ![](https://github.com/guardian/support-frontend/assets/2510683/59a47245-b394-46df-8e65-08c6cb2c7daa)

before | after
--- | ---
![](https://github.com/guardian/support-frontend/assets/2510683/4daf9ce7-20ec-4dfc-81a7-4f99a8b48d16) | ![](https://github.com/guardian/support-frontend/assets/2510683/5f355272-74f1-4e61-baf8-3762b0cc23ad)

before | after
--- | ---
![](https://github.com/guardian/support-frontend/assets/2510683/ace955a7-b84f-4949-bb27-49118fe18358) | ![](https://github.com/guardian/support-frontend/assets/2510683/b7660665-0de0-4b69-a366-d9d11c5dafb0)








