### PR TITLE
Checkout page 2 lower threshold check

### DIFF
--- a/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsContainer.tsx
+++ b/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsContainer.tsx
@@ -10,6 +10,7 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
+import { benefitsThresholdsByCountryGroup } from 'helpers/supporterPlus/benefitsThreshold';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import type { CheckoutTopUpAmountsProps } from './checkoutTopUpAmounts';
 
@@ -33,6 +34,8 @@ export function CheckoutTopUpAmountsContainer({
 
 	const isWithinThreshold =
 		contributionType !== 'ONE_OFF' &&
+		amountBeforeAmendments >=
+			benefitsThresholdsByCountryGroup[countryGroupId][contributionType] &&
 		amountBeforeAmendments <=
 			checkoutTopUpUpperThresholdsByCountryGroup[countryGroupId][
 				contributionType

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/secondStepCheckout.tsx
@@ -25,6 +25,7 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
+import { benefitsThresholdsByCountryGroup } from 'helpers/supporterPlus/benefitsThreshold';
 import { shouldShowSupporterPlusMessaging } from 'helpers/supporterPlus/showMessaging';
 import { CheckoutDivider } from '../components/checkoutDivider';
 import { DirectDebitContainer } from '../components/directDebitWrapper';
@@ -74,6 +75,8 @@ export function SupporterPlusCheckout({
 	const showPreAmendedTotal =
 		showTopUpAmounts &&
 		contributionType !== 'ONE_OFF' &&
+		amountBeforeAmendments >=
+			benefitsThresholdsByCountryGroup[countryGroupId][contributionType] &&
 		amountBeforeAmendments <=
 			checkoutTopUpUpperThresholdsByCountryGroup[countryGroupId][
 				contributionType


### PR DESCRIPTION
## What are you doing in this PR?
Do not show the checkout second page top up/nudge amounts to users that select an amount below the supporter plus threshold on the first page

## Screenshots
page 1 before | page 2 before
--- | ---
![](https://github.com/guardian/support-frontend/assets/2510683/43d2ae15-2c7e-47e3-a091-25bd62ea7654) | ![](https://github.com/guardian/support-frontend/assets/2510683/1f43e591-45f8-45f2-9688-e9b00d3387e1)

page 1 after | page 2 after
--- | ---
![](https://github.com/guardian/support-frontend/assets/2510683/43d2ae15-2c7e-47e3-a091-25bd62ea7654) | ![](https://github.com/guardian/support-frontend/assets/2510683/59d85c56-04af-49fe-911c-6f0347167857)


