### PR TITLE
Update payment api to java-11

### DIFF
--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -50,11 +50,11 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: actions/setup-java@v3
         with:
-          java-version: "8"
-          distribution: "adopt"
+          java-version: "11"
+          distribution: "corretto"
       - uses: actions/cache@v3
         with:
           path: |

--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -9,7 +9,7 @@ object LibraryVersions {
   val jacksonDatabindVersion = "2.15.2"
   val okhttpVersion = "3.14.9"
   val scalaUriVersion = "4.0.3"
-  val playCirceVersion = "2814.2"
+  val playCirceVersion = "2814.4"
   val stripeVersion = "21.15.0" // Supports API version 2019-05-16
   val oktaJwtVerifierVersion = "0.5.7"
 }

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -31,9 +31,9 @@ libraryDependencies ++= Seq(
   "org.playframework.anorm" %% "anorm" % "2.7.0",
   "org.scalatest" %% "scalatest" % "3.0.9" % "test",
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % "test",
-  "org.mockito" % "mockito-core" % "4.11.0",
+  "org.mockito" % "mockito-core" % "5.3.1",
   "org.typelevel" %% "cats-core" % catsVersion,
-  "com.github.blemale" %% "scaffeine" % "4.1.0",
+  "com.github.blemale" %% "scaffeine" % "5.2.0",
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
@@ -57,7 +57,6 @@ dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacks
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 
-debianPackageDependencies := Seq("openjdk-8-jre-headless")
 Debian / packageName := name.value
 packageSummary := "Payment API Play App"
 packageDescription := """API for reader revenue payments"""

--- a/support-payment-api/src/main/resources/riff-raff.yaml
+++ b/support-payment-api/src/main/resources/riff-raff.yaml
@@ -10,7 +10,7 @@ deployments:
     parameters:
       amiParameter: AMIPaymentapi
       amiTags:
-        Recipe: jammy-membership-java8
+        Recipe: jammy-membership-java
         AmigoStage: PROD
       amiEncrypted: true
       templateStagePaths:

--- a/support-payment-api/src/main/resources/riff-raff.yaml
+++ b/support-payment-api/src/main/resources/riff-raff.yaml
@@ -10,7 +10,7 @@ deployments:
     parameters:
       amiParameter: AMIPaymentapi
       amiTags:
-        Recipe: jammy-membership-java
+        Recipe: jammy-membership-java11
         AmigoStage: PROD
       amiEncrypted: true
       templateStagePaths:


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Update Payment API to JAVA 11
Along with that updating the below dependencies
1) support-payment-api: Update com.dripower:play-circe to 2814.4 from 2814.2
2) support-payment-api: Update mockito-core to 5.3.1 from 4.11.0
3) support-payment-api: Update scaffeine dependency to 5.2.0 from 4.1.0



[**Trello Card**](https://trello.com/c/Lj7Wu48p/1322-update-java-version-in-support-payment-api-from-8-to-11)

## Why are you doing this?

All apps [should move from java 8 to java 11](https://docs.google.com/document/d/1ZR-YnaXCT5_gLVmTCeGs0mWd3KPaAozPjQK8uUzHZ9w/edit?pli=1#), but this one is still on java 8. Some recent dependency upgrades like scaffeine are starting to require java 11 as well, so sticking with java 8 would mean sticking with some old dependency versions.

Have updated the github action for the CI, as well as which amigo recipe is used by riff raff. There’s also a debian package specified in the build.sbt: I’m not sure what this is used for, as I would’ve expected the JRE to be provided by amigo.
