### PR TITLE
Require zip code for US contributions (backend changes)

### DIFF
--- a/support-frontend/assets/helpers/tracking/__tests__/__snapshots__/acquisitionsTest.ts.snap
+++ b/support-frontend/assets/helpers/tracking/__tests__/__snapshots__/acquisitionsTest.ts.snap
@@ -30,6 +30,7 @@ Object {
   "labels": undefined,
   "pageviewId": "123456",
   "platform": "SUPPORT",
+  "postalCode": null,
   "queryParameters": Array [
     Object {
       "name": "param1",

--- a/support-frontend/assets/helpers/tracking/__tests__/acquisitionsTest.ts
+++ b/support-frontend/assets/helpers/tracking/__tests__/acquisitionsTest.ts
@@ -47,6 +47,7 @@ describe('acquisitions', () => {
 			const paymentApiAcquisitionData = derivePaymentApiAcquisitionData(
 				referrerAcquisitionData,
 				nativeAbParticipations,
+				'N1 9GU',
 			);
 
 			expect(paymentApiAcquisitionData).toMatchSnapshot();
@@ -55,6 +56,59 @@ describe('acquisitions', () => {
 			expect(paymentApiAcquisitionData.abTests?.length).toEqual(4);
 
 			expect(paymentApiAcquisitionData.campaignCodes?.length).toEqual(1);
+		});
+
+		it('should send the postal code only if in the mandatoryZipCode test variant', () => {
+			const referrerAcquisitionData = {
+				campaignCode: 'Example',
+				referrerPageviewId: '123456',
+				referrerUrl: 'https://example.com',
+				componentId: 'exampleComponentId',
+				componentType: 'exampleComponentType',
+				source: 'exampleSource',
+				abTests: [
+					{
+						name: 'referrerAbTest',
+						variant: 'value1',
+					},
+				],
+				queryParameters: [
+					{
+						name: 'param1',
+						value: 'value1',
+					},
+					{
+						name: 'param2',
+						value: 'value2',
+					},
+				],
+			};
+
+			const postcode = 'N1 9GU';
+
+			const nativeAbParticipations = {
+				mandatoryZipCode: 'variant',
+			};
+
+			const paymentApiAcquisitionData = derivePaymentApiAcquisitionData(
+				referrerAcquisitionData,
+				nativeAbParticipations,
+				postcode,
+			);
+
+			expect(paymentApiAcquisitionData.postalCode).toBe(postcode);
+
+			const nativeAbParticipationsControl = {
+				mandatoryZipCode: 'control',
+			};
+
+			const paymentApiAcquisitionDataControl = derivePaymentApiAcquisitionData(
+				referrerAcquisitionData,
+				nativeAbParticipationsControl,
+				postcode,
+			);
+
+			expect(paymentApiAcquisitionDataControl.postalCode).toBe(null);
 		});
 	});
 

--- a/support-frontend/assets/helpers/tracking/acquisitions.ts
+++ b/support-frontend/assets/helpers/tracking/acquisitions.ts
@@ -61,6 +61,7 @@ export type PaymentAPIAcquisitionData = {
 	gaId?: string | null;
 	queryParameters?: AcquisitionQueryParameters;
 	labels?: string[];
+	postalCode: string | null;
 };
 
 // ----- Setup ----- //
@@ -219,6 +220,7 @@ const getAbTests = (
 function derivePaymentApiAcquisitionData(
 	referrerAcquisitionData: ReferrerAcquisitionData,
 	nativeAbParticipations: Participations,
+	postalCode: string | null,
 ): PaymentAPIAcquisitionData {
 	const ophanIds: OphanIds = getOphanIds();
 	const abTests = getAbTests(referrerAcquisitionData, nativeAbParticipations);
@@ -240,6 +242,8 @@ function derivePaymentApiAcquisitionData(
 		gaId: getCookie('_ga'),
 		queryParameters: referrerAcquisitionData.queryParameters,
 		labels: referrerAcquisitionData.labels,
+		postalCode:
+			nativeAbParticipations.mandatoryZipCode === 'variant' ? postalCode : null,
 	};
 }
 

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -110,6 +110,7 @@ const buildStripeChargeDataFromAuthorisation = (
 	acquisitionData: derivePaymentApiAcquisitionData(
 		state.common.referrerAcquisitionData,
 		state.common.abParticipations,
+		state.page.checkoutForm.billingAddress.fields.postCode,
 	),
 	publicKey: getStripeKey(
 		stripeAccountForContributionType[getContributionType(state)],
@@ -267,6 +268,7 @@ const amazonPayDataFromAuthorisation = (
 	acquisitionData: derivePaymentApiAcquisitionData(
 		state.common.referrerAcquisitionData,
 		state.common.abParticipations,
+		state.page.checkoutForm.billingAddress.fields.postCode,
 	),
 });
 
@@ -342,6 +344,7 @@ const onCreateOneOffPayPalPaymentResponse =
 			const acquisitionData = derivePaymentApiAcquisitionData(
 				state.common.referrerAcquisitionData,
 				state.common.abParticipations,
+				state.page.checkoutForm.billingAddress.fields.postCode,
 			);
 			// We've only created a payment at this point, and the user has to get through
 			// the PayPal flow on their site before we can actually try and execute the payment.

--- a/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
+++ b/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
@@ -178,6 +178,7 @@ class AmazonPayBackend(
       acquisitionData.countryCode,
       clientBrowserInfo.countrySubdivisionCode,
       acquisitionData.amazonPayment.orderReferenceId,
+      acquisitionData.acquisitionData.flatMap(_.postalCode),
     )
     val gaData = ClientBrowserInfo.toGAData(clientBrowserInfo)
 

--- a/support-payment-api/src/main/scala/backend/PaypalBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaypalBackend.scala
@@ -184,7 +184,13 @@ class PaypalBackend(
       identityId: Option[Long],
       clientBrowserInfo: ClientBrowserInfo,
   ): Future[List[BackendError]] = {
-    ContributionData.fromPaypalCharge(payment, email, identityId, clientBrowserInfo.countrySubdivisionCode) match {
+    ContributionData.fromPaypalCharge(
+      payment,
+      email,
+      identityId,
+      clientBrowserInfo.countrySubdivisionCode,
+      acquisitionData.postalCode,
+    ) match {
       case Left(err) => Future.successful(List(BackendError.fromPaypalAPIError(err)))
       case Right(contributionData) =>
         val paypalAcquisition =

--- a/support-payment-api/src/main/scala/backend/StripeBackend.scala
+++ b/support-payment-api/src/main/scala/backend/StripeBackend.scala
@@ -286,6 +286,7 @@ class StripeBackend(
       identityId,
       charge,
       clientBrowserInfo.countrySubdivisionCode,
+      data.acquisitionData.postalCode,
       PaymentProvider.fromStripePaymentMethod(data.paymentData.stripePaymentMethod),
     )
 

--- a/support-payment-api/src/main/scala/model/AcquisitionData.scala
+++ b/support-payment-api/src/main/scala/model/AcquisitionData.scala
@@ -2,7 +2,7 @@ package model
 
 import com.gu.support.acquisitions.{AbTest, QueryParameter}
 
-//-- common for stripe and paypal
+//-- common for stripe, paypal, and amazon pay
 case class AcquisitionData(
     platform: Option[String],
     browserId: Option[String],
@@ -17,4 +17,5 @@ case class AcquisitionData(
     queryParameters: Option[Set[QueryParameter]],
     gaId: Option[String],
     labels: Option[Set[String]],
+    postalCode: Option[String],
 )

--- a/support-payment-api/src/main/scala/model/db/ContributionData.scala
+++ b/support-payment-api/src/main/scala/model/db/ContributionData.scala
@@ -27,6 +27,7 @@ case class ContributionData private (
     amount: BigDecimal,
     countryCode: Option[String],
     countrySubdivisionCode: Option[String],
+    postalCode: Option[String],
     // Used as primary key on current contribution_metadata and payment_hooks table
     // https://github.com/guardian/contributions-platform/blob/master/Postgres/schema.sql
     contributionId: UUID = UUID.randomUUID,
@@ -44,6 +45,7 @@ object ContributionData extends StrictLogging {
       identityId: Option[Long],
       charge: Charge,
       countrySubdivisionCode: Option[String],
+      postalCode: Option[String],
       paymentProvider: PaymentProvider,
   ): ContributionData =
     // TODO: error handling
@@ -61,6 +63,7 @@ object ContributionData extends StrictLogging {
       amount = BigDecimal(charge.getAmount, 2),
       countryCode = StripeCharge.getCountryCode(charge),
       countrySubdivisionCode = countrySubdivisionCode,
+      postalCode = postalCode,
     )
 
   import scala.jdk.CollectionConverters._
@@ -80,6 +83,7 @@ object ContributionData extends StrictLogging {
       email: String,
       identityId: Option[Long],
       countrySubdivisionCode: Option[String],
+      postalCode: Option[String],
   ): Either[PaypalApiError, ContributionData] = {
     for {
       transactions <- Either.fromOption(
@@ -110,6 +114,7 @@ object ContributionData extends StrictLogging {
       amount = amount,
       countryCode = Some(countryCode),
       countrySubdivisionCode = getPaypalCountrySubdivisionCode(payment),
+      postalCode = postalCode,
     )
   }
 
@@ -120,6 +125,7 @@ object ContributionData extends StrictLogging {
       countryCode: Option[String],
       countrySubdivisionCode: Option[String],
       orderRef: String,
+      postalCode: Option[String],
   ): ContributionData = {
     ContributionData(
       paymentProvider = AmazonPay,
@@ -137,6 +143,7 @@ object ContributionData extends StrictLogging {
       amount = BigDecimal(amazonPayment.getAuthorizationAmount.getAmount),
       countryCode = countryCode,
       countrySubdivisionCode = countrySubdivisionCode,
+      postalCode = postalCode,
     )
   }
 }

--- a/support-payment-api/src/main/scala/model/paypal/PaypalPaymentData.scala
+++ b/support-payment-api/src/main/scala/model/paypal/PaypalPaymentData.scala
@@ -34,6 +34,7 @@ object PaypalJsonDecoder {
       queryParameters <- downField("queryParameters").as[Option[Set[QueryParameter]]]
       gaId <- downField("gaId").as[Option[String]]
       labels <- downField("labels").as[Option[Set[String]]]
+      postalCode <- downField("postalCode").as[Option[String]]
     } yield {
       CapturePaypalPaymentData(
         paymentData = CapturePaymentData(
@@ -57,6 +58,7 @@ object PaypalJsonDecoder {
           queryParameters = queryParameters,
           gaId = gaId,
           labels = labels,
+          postalCode = postalCode,
         ),
         signedInUserEmail = None,
       )

--- a/support-payment-api/src/main/scala/model/stripe/StripeRequest.scala
+++ b/support-payment-api/src/main/scala/model/stripe/StripeRequest.scala
@@ -41,6 +41,7 @@ object StripeJsonDecoder {
       labels <- downField("labels").as[Option[Set[String]]]
       stripePaymentMethod <- downField("stripePaymentMethod").as[Option[StripePaymentMethod]]
       stripePublicKey <- downField("publicKey").as[Option[StripePublicKey]]
+      postalCode <- downField("postalCode").as[Option[String]]
     } yield {
       LegacyStripeChargeRequest(
         paymentData = LegacyStripePaymentData(
@@ -68,6 +69,7 @@ object StripeJsonDecoder {
           queryParameters = queryParameters,
           gaId = gaId,
           labels = labels,
+          postalCode = postalCode,
         ),
         publicKey = stripePublicKey,
       )

--- a/support-payment-api/src/test/scala/backend/AmazonPayBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/AmazonPayBackendSpec.scala
@@ -31,7 +31,22 @@ class AmazonPayBackendFixture(implicit ec: ExecutionContext) extends MockitoSuga
 
   // -- entities
   val acquisitionData =
-    AcquisitionData(Some("platform"), None, None, None, None, None, None, None, None, None, None, None, None)
+    AcquisitionData(
+      Some("platform"),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      Some("N1 9GU"),
+    )
   val countrySubdivisionCode = Some("NY")
   val dbError = ContributionsStoreService.Error(new Exception("DB error response"))
   val identityError = IdentityClient.ContextualError(

--- a/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
@@ -27,7 +27,22 @@ class PaypalBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
 
   // -- entities
   val acquisitionData =
-    AcquisitionData(Some("platform"), None, None, None, None, None, None, None, None, None, None, None, None)
+    AcquisitionData(
+      Some("platform"),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      Some("N1 9GU"),
+    )
   val capturePaypalPaymentData =
     CapturePaypalPaymentData(CapturePaymentData("paymentId"), acquisitionData, Some("email@email.com"))
   val countrySubdivisionCode = Some("NY")

--- a/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
@@ -38,14 +38,36 @@ class StripeBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
   val token = Json.fromString("token").as[NonEmptyString].right.get
   val recaptchaToken = "recaptchaToken"
   val acquisitionData =
-    AcquisitionData(Some("platform"), None, None, None, None, None, None, None, None, None, None, None, None)
+    AcquisitionData(
+      Some("platform"),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      Some("N1 9GU"),
+    )
   val stripePaymentData = StripePaymentData(email, Currency.USD, 12, None)
   val legacyStripePaymentData = LegacyStripePaymentData(email, Currency.USD, 12, None, token)
   val stripePublicKey = StripePublicKey("pk_test_FOOBAR")
   val stripeChargeRequest = LegacyStripeChargeRequest(legacyStripePaymentData, acquisitionData, Some(stripePublicKey))
   val createPaymentIntent =
-    CreatePaymentIntent("payment-method-id", stripePaymentData, acquisitionData, Some(stripePublicKey), recaptchaToken)
-  val confirmPaymentIntent = ConfirmPaymentIntent("id", stripePaymentData, acquisitionData, Some(stripePublicKey))
+    CreatePaymentIntent(
+      "payment-method-id",
+      stripePaymentData,
+      acquisitionData,
+      Some(stripePublicKey),
+      recaptchaToken,
+    )
+  val confirmPaymentIntent =
+    ConfirmPaymentIntent("id", stripePaymentData, acquisitionData, Some(stripePublicKey))
 
   val countrySubdivisionCode = Some("NY")
   val clientBrowserInfo = ClientBrowserInfo("", "", None, None, countrySubdivisionCode)

--- a/support-payment-api/src/test/scala/services/ContributionsStoreServiceSpec.scala
+++ b/support-payment-api/src/test/scala/services/ContributionsStoreServiceSpec.scala
@@ -26,6 +26,7 @@ class ContributionsStoreServiceSpec extends AnyFlatSpec with Matchers {
     countryCode = Some("GB"),
     countrySubdivisionCode = None,
     contributionId = uuid,
+    postalCode = Some("N1 9GU"),
   )
 
   val expectedJson = parse(
@@ -41,7 +42,8 @@ class ContributionsStoreServiceSpec extends AnyFlatSpec with Matchers {
       |    "amount" : 20,
       |    "countryCode" : "GB",
       |    "countrySubdivisionCode" : null,
-      |    "contributionId" : "$uuid"
+      |    "contributionId" : "$uuid",
+      |    "postalCode" : "N1 9GU"
       |  }
       |}""".stripMargin,
   ).right.get


### PR DESCRIPTION
We want to collect zip codes for US contributions, and this change adds an optional postal code field to requests to the payment API to hold these values. It also stores users’ addresses in Zuora for supporter plus and for contributions. Finally, I’ve changed the frontend to send the postal code to the backend for single contributions. This isn’t limited to the US: if we’ve collected a postal code it’ll be sent.

I’ve gone with “postal code” rather than “zip code” because even though we’re only storing it for US contributions at the moment, we may expand that in future, and “postal code” appears to be the more general term, judging by [the Wikipedia page](https://en.wikipedia.org/wiki/Postal_code).

- Trello Card: https://trello.com/c/VSe61QY5/1436-support-checkout-back-end-changes-card-move-zip-code-out-of-the-card-payment-section-across-both-single-recurring-in-us-and-make
