### PR TITLE
Update to actions/setup-node@v3

### DIFF
--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -17,8 +17,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Node
-        uses: guardian/actions-setup-node@main
-
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - name: Cache dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: .nvmrc
+          node-version-file: '.nvmrc'
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - name: Cache dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: .nvmrc
+          node-version-file: '.nvmrc'
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - name: Cache dependencies

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -14,7 +14,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Node
-        uses: guardian/actions-setup-node@v2.4.1
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - name: Cache dependencies

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: .nvmrc
+          node-version-file: '.nvmrc'
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - name: Cache dependencies

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -15,7 +15,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Node
-        uses: guardian/actions-setup-node@v2.4.1
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - name: Cache dependencies

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -27,8 +27,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: guardian/actions-setup-node@v2.4.1
+        uses: actions/setup-node@v3
         with:
+          node-version-file: .nvmrc
           cache: 'yarn'
           cache-dependency-path: support-frontend/yarn.lock
 

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: .nvmrc
+          node-version-file: '.nvmrc'
           cache: 'yarn'
           cache-dependency-path: support-frontend/yarn.lock
 

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -33,8 +33,9 @@ jobs:
 
       # (Respects .nvmrc)
       - name: Setup Node
-        uses: guardian/actions-setup-node@v2.4.1
+        uses: actions/setup-node@v3
         with:
+          node-version-file: .nvmrc
           cache: "yarn"
           cache-dependency-path: |
             support-frontend/yarn.lock

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: .nvmrc
+          node-version-file: '.nvmrc'
           cache: "yarn"
           cache-dependency-path: |
             support-frontend/yarn.lock

--- a/.github/workflows/support-frontend-eslint.yml
+++ b/.github/workflows/support-frontend-eslint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: .nvmrc
+          node-version-file: '.nvmrc'
           cache: 'yarn'
           cache-dependency-path: support-frontend/yarn.lock
 

--- a/.github/workflows/support-frontend-eslint.yml
+++ b/.github/workflows/support-frontend-eslint.yml
@@ -14,8 +14,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: guardian/actions-setup-node@v2.4.1
+        uses: actions/setup-node@v3
         with:
+          node-version-file: .nvmrc
           cache: 'yarn'
           cache-dependency-path: support-frontend/yarn.lock
 

--- a/.github/workflows/support-frontend-post-deploy-tests.yml
+++ b/.github/workflows/support-frontend-post-deploy-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: .nvmrc
+          node-version-file: '.nvmrc'
           cache: "yarn"
           cache-dependency-path: support-frontend/yarn.lock
 

--- a/.github/workflows/support-frontend-post-deploy-tests.yml
+++ b/.github/workflows/support-frontend-post-deploy-tests.yml
@@ -39,8 +39,9 @@ jobs:
 
       # (Respects .nvmrc)
       - name: Setup Node
-        uses: guardian/actions-setup-node@v2.4.1
+        uses: actions/setup-node@v3
         with:
+          node-version-file: .nvmrc
           cache: "yarn"
           cache-dependency-path: support-frontend/yarn.lock
 

--- a/.github/workflows/support-frontend-prettier.yml
+++ b/.github/workflows/support-frontend-prettier.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: .nvmrc
+          node-version-file: '.nvmrc'
           cache: 'yarn'
           cache-dependency-path: support-frontend/yarn.lock
 

--- a/.github/workflows/support-frontend-prettier.yml
+++ b/.github/workflows/support-frontend-prettier.yml
@@ -14,8 +14,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: guardian/actions-setup-node@v2.4.1
+        uses: actions/setup-node@v3
         with:
+          node-version-file: .nvmrc
           cache: 'yarn'
           cache-dependency-path: support-frontend/yarn.lock
 

--- a/.github/workflows/support-frontend-typescript.yml
+++ b/.github/workflows/support-frontend-typescript.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: .nvmrc
+          node-version-file: '.nvmrc'
           cache: 'yarn'
           cache-dependency-path: support-frontend/yarn.lock
 

--- a/.github/workflows/support-frontend-typescript.yml
+++ b/.github/workflows/support-frontend-typescript.yml
@@ -14,8 +14,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: guardian/actions-setup-node@v2.4.1
+        uses: actions/setup-node@v3
         with:
+          node-version-file: .nvmrc
           cache: 'yarn'
           cache-dependency-path: support-frontend/yarn.lock
 

--- a/.github/workflows/support-workers-build.yml
+++ b/.github/workflows/support-workers-build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: .nvmrc
+          node-version-file: '.nvmrc'
           cache: "yarn"
           cache-dependency-path: support-workers/cloud-formation/src/yarn.lock
 

--- a/.github/workflows/support-workers-build.yml
+++ b/.github/workflows/support-workers-build.yml
@@ -33,8 +33,9 @@ jobs:
 
       # (Respects .nvmrc)
       - name: Setup Node
-        uses: guardian/actions-setup-node@v2.4.1
+        uses: actions/setup-node@v3
         with:
+          node-version-file: .nvmrc
           cache: "yarn"
           cache-dependency-path: support-workers/cloud-formation/src/yarn.lock
 


### PR DESCRIPTION
## What are you doing in this PR?

Github Actions: Stop using guardian/actions-setup-node and use actions/setup-node instead

[**Trello Card**](https://trello.com/c/dlZA1kOt/1546-github-actions-stop-using-guardian-actions-setup-node-and-use-actions-setup-node-instead)

## Why are you doing this?

The [actions-setup-node repo ] (https://github.com/guardian/actions-setup-node) says that  has been archived by the owner on Dec 5, 2022 and will not be updated.

The official Github [actions/setup-node](https://github.com/marketplace/actions/setup-node-js-environment) now has [some support for node version files](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file).

You should use that instead.