### PR TITLE
Restore scroll position to the top of the page on navigation change with React Router

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
+import { useEffect } from 'react';
 import { Provider } from 'react-redux';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
 	countryGroups,
@@ -44,6 +45,18 @@ const isInTwoStepTest =
 	abParticipations.twoStepCheckout !== 'control';
 const showCheckoutTopUpAmounts =
 	abParticipations.twoStepCheckout === 'variant_b';
+
+// ----- ScrollToTop on Navigate: https://v5.reactrouter.com/web/guides/scroll-restoration ---- //
+
+function ScrollToTop() {
+	const { pathname } = useLocation();
+
+	useEffect(() => {
+		window.scrollTo(0, 0);
+	}, [pathname]);
+
+	return null;
+}
 
 // ----- Render ----- //
 
@@ -98,6 +111,7 @@ const router = () => {
 
 	return (
 		<BrowserRouter>
+			<ScrollToTop />
 			<Provider store={store}>
 				<Routes>{isInTwoStepTest ? twoStepRoutes : oneStepRoutes}</Routes>
 			</Provider>


### PR DESCRIPTION
## What are you doing in this PR?

When monitoring the `twoStepCheckout` test with Quantum Metric we noted some users on the 2 step checkout were experiencing an issue: If these user had to scroll down page 1 to click the navigate CTA, when page 2 loaded it retained the scroll position from page 1, meaning they would not see the order summary / nudge component.

This issue is related to the way we load the 2nd page, we use client-side routing, which doesn't trigger the page reload that would typically anchor a user at the top of the screen on a page load.

The solution applied here was recommended in React Router's docs: https://v5.reactrouter.com/web/guides/scroll-restoration