### PR TITLE
DO_NOT_MERGE: Hardcode some test agents

### DIFF
--- a/support-services/src/main/scala/com/gu/support/paperround/PaperRoundService.scala
+++ b/support-services/src/main/scala/com/gu/support/paperround/PaperRoundService.scala
@@ -20,12 +20,251 @@ class PaperRoundService(config: PaperRoundConfig, client: FutureHttpClient)(impl
   override val wsUrl: String = config.apiUrl
   override val httpClient: FutureHttpClient = client
 
-  def coverage(body: CoverageEndpoint.RequestBody): Future[CoverageEndpoint.Response] = {
-    postForm[CoverageEndpoint.Response](
-      endpoint = "coverage",
-      data = Map("postcode" -> List(body.postcode)),
-      headers = Map("x-api-key" -> config.apiKey),
+  private def coveredResponse(agents: List[CoverageEndpoint.AgentsCoverage]) = {
+    Future.successful(
+      CoverageEndpoint.Response(
+        statusCode = 200,
+        message = "",
+        data = CoverageEndpoint.PostcodeCoverage(
+          agents = agents,
+          message = "",
+          status = CoverageEndpoint.CO,
+        ),
+      ),
     )
+  }
+
+  private def testAgents(postcode: String) = List(
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 1,
+      agentName = "Test agent",
+      deliveryMethod = "Car",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 1,
+      summary = "A test delivery agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 2,
+      agentName = "Another test agent",
+      deliveryMethod = "Balloon",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 4,
+      summary = "An odd test delivery agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 3,
+      agentName = "Another other test agent",
+      deliveryMethod = "Zeppelin",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 3,
+      summary = "An odder test delivery agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 4,
+      agentName = "Agent 4",
+      deliveryMethod = "Car",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 4,
+      summary = "The fourth test agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 5,
+      agentName = "Agent 5",
+      deliveryMethod = "Motorcycle",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 5,
+      summary = "The fifth test agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 6,
+      agentName = "Agent 6",
+      deliveryMethod = "Bicycle",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 6,
+      summary = "The sixth test agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 7,
+      agentName = "Agent 7",
+      deliveryMethod = "By foot",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 7,
+      summary = "The seventh delivery agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 8,
+      agentName = "Agent 8",
+      deliveryMethod = "Truck",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 20,
+      summary = "The eighth test delivery agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 11,
+      agentName = "Test agent",
+      deliveryMethod = "Car",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 11,
+      summary = "A test delivery agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 12,
+      agentName = "Another test agent",
+      deliveryMethod = "Balloon",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 12,
+      summary = "An odd test delivery agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 13,
+      agentName = "Another other test agent",
+      deliveryMethod = "Zeppelin",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 13,
+      summary = "An odder test delivery agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 14,
+      agentName = "Agent 14",
+      deliveryMethod = "Car",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 14,
+      summary = "The fourth test agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 15,
+      agentName = "Agent 15",
+      deliveryMethod = "Motorcycle",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 15,
+      summary = "The fifth test agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 16,
+      agentName = "Agent 16",
+      deliveryMethod = "Bicycle",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 16,
+      summary = "The sixth test agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 17,
+      agentName = "Agent 17",
+      deliveryMethod = "By foot",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 17,
+      summary = "The seventh delivery agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 18,
+      agentName = "Agent 18",
+      deliveryMethod = "Truck",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 120,
+      summary = "The eighth test delivery agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 21,
+      agentName = "Test agent",
+      deliveryMethod = "Car",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 21,
+      summary = "A test delivery agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 22,
+      agentName = "Another test agent",
+      deliveryMethod = "Balloon",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 22,
+      summary = "An odd test delivery agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 23,
+      agentName = "Another other test agent",
+      deliveryMethod = "Zeppelin",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 23,
+      summary = "An odder test delivery agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 24,
+      agentName = "Agent 24",
+      deliveryMethod = "Car",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 24,
+      summary = "The fourth test agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 25,
+      agentName = "Agent 25",
+      deliveryMethod = "Motorcycle",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 25,
+      summary = "The fifth test agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 26,
+      agentName = "Agent 26",
+      deliveryMethod = "Bicycle",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 26,
+      summary = "The sixth test agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 27,
+      agentName = "Agent 27",
+      deliveryMethod = "By foot",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 27,
+      summary = "The seventh delivery agent",
+    ),
+    CoverageEndpoint.AgentsCoverage(
+      agentId = 28,
+      agentName = "Agent 28",
+      deliveryMethod = "Truck",
+      nbrDeliveryDays = 7,
+      postcode = postcode,
+      refGroupId = 220,
+      summary = "The eighth test delivery agent",
+    ),
+  )
+
+  def coverage(body: CoverageEndpoint.RequestBody): Future[CoverageEndpoint.Response] = {
+    if (body.postcode == "DE1 0FD" || body.postcode == "DE10FD") {
+      coveredResponse(testAgents(body.postcode))
+    } else if (body.postcode == "DE1 0HN" || body.postcode == "DE10HN") {
+      coveredResponse(testAgents(body.postcode).take(1))
+    } else {
+      postForm[CoverageEndpoint.Response](
+        endpoint = "coverage",
+        data = Map("postcode" -> List(body.postcode)),
+        headers = Map("x-api-key" -> config.apiKey),
+      )
+    }
   }
 
   def agents(): Future[AgentsEndpoint.Response] = {


### PR DESCRIPTION
PaperRound’s test API is currently not returning any agents for the postcodes we’ve been using. So that we can keep testing in CODE, this commit hardcodes responses for those postcodes.

This PR should not be merged.