### PR TITLE
Make storage of country and state consistent for Apple/Google Pay payments

### DIFF
--- a/support-frontend/assets/components/paymentRequestButton/hooks/payerDetails.ts
+++ b/support-frontend/assets/components/paymentRequestButton/hooks/payerDetails.ts
@@ -3,6 +3,7 @@ import type {
 	PaymentRequestPaymentMethodEvent,
 } from '@stripe/stripe-js';
 import {
+	detect as detectCountry,
 	findIsoCountry,
 	stateProvinceFromString,
 } from 'helpers/internationalisation/country';
@@ -80,4 +81,8 @@ export function addPayerDetailsToRedux(
 
 export function resetPayerDetails(dispatch: ContributionsDispatch): void {
 	dispatch(setEmail(storage.getSession('gu.email') ?? ''));
+	dispatch(setFirstName(''));
+	dispatch(setLastName(''));
+	dispatch(setBillingCountry(detectCountry()));
+	dispatch(setBillingState(''));
 }

--- a/support-frontend/assets/components/paymentRequestButton/hooks/payerDetails.ts
+++ b/support-frontend/assets/components/paymentRequestButton/hooks/payerDetails.ts
@@ -6,7 +6,10 @@ import {
 	findIsoCountry,
 	stateProvinceFromString,
 } from 'helpers/internationalisation/country';
-import { setPaymentMethodCountryAndState } from 'helpers/redux/checkout/payment/paymentMethod/actions';
+import {
+	setBillingCountry,
+	setBillingState,
+} from 'helpers/redux/checkout/address/actions';
 import {
 	setEmail,
 	setFirstName,
@@ -60,12 +63,8 @@ function dispatchPaymentMethodCountryAndState(
 			state ?? undefined,
 		);
 
-		dispatch(
-			setPaymentMethodCountryAndState([
-				validatedCountry,
-				validatedState ?? undefined,
-			]),
-		);
+		dispatch(setBillingCountry(validatedCountry));
+		dispatch(setBillingState(validatedState ?? ''));
 	}
 }
 

--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/actions.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/actions.ts
@@ -1,4 +1,3 @@
 import { paymentMethodSlice } from './reducer';
 
-export const { setPaymentMethod, setPaymentMethodCountryAndState } =
-	paymentMethodSlice.actions;
+export const { setPaymentMethod } = paymentMethodSlice.actions;

--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/reducer.ts
@@ -1,10 +1,6 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import type { FullPaymentMethod } from 'helpers/forms/paymentMethods';
-import type {
-	IsoCountry,
-	StateProvince,
-} from 'helpers/internationalisation/country';
 import { setDeliveryCountry } from '../../address/actions';
 import { validateForm } from '../../checkoutActions';
 import { setProductType } from '../../product/actions';
@@ -17,16 +13,7 @@ export const paymentMethodSlice = createSlice({
 		setPaymentMethod(state, action: PayloadAction<FullPaymentMethod>) {
 			state.name = action.payload.paymentMethod;
 			state.stripePaymentMethod = action.payload.stripePaymentMethod;
-			state.country = undefined;
-			state.state = undefined;
 			state.errors = [];
-		},
-		setPaymentMethodCountryAndState(
-			state,
-			action: PayloadAction<[IsoCountry, StateProvince | undefined]>,
-		) {
-			state.country = action.payload[0];
-			state.state = action.payload[1];
 		},
 	},
 	extraReducers: (builder) => {

--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentMethod/state.ts
@@ -1,15 +1,9 @@
 import type { StripePaymentMethod } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
-import type {
-	IsoCountry,
-	StateProvince,
-} from 'helpers/internationalisation/country';
 
 export type PaymentMethodState = {
 	name: PaymentMethod;
 	stripePaymentMethod?: StripePaymentMethod;
-	country?: IsoCountry;
-	state?: StateProvince;
 	errors?: string[];
 };
 

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -133,31 +133,17 @@ function getBillingCountryAndState(state: ContributionsState): {
 	billingState: Option<StateProvince>;
 	postCode: string;
 } {
-	const paymentMethod = state.page.checkoutForm.payment.paymentMethod;
-	const isPaymentRequestButton =
-		paymentMethod.name == Stripe &&
-		(paymentMethod.stripePaymentMethod === 'StripePaymentRequestButton' ||
-			paymentMethod.stripePaymentMethod === 'StripeApplePay');
 	const {
 		country: formCountry,
 		state: formState,
 		postCode,
 	} = state.page.checkoutForm.billingAddress.fields;
-	if (isPaymentRequestButton && paymentMethod.country) {
-		return {
-			billingCountry: paymentMethod.country,
-			billingState:
-				paymentMethod.state ??
-				(formCountry === paymentMethod.country ? formState : ''),
-			postCode,
-		};
-	} else {
-		return {
-			billingCountry: formCountry,
-			billingState: formState,
-			postCode,
-		};
-	}
+
+	return {
+		billingCountry: formCountry,
+		billingState: formState,
+		postCode,
+	};
 }
 
 // This exists *only* to support the purchase of digi subs for migrating Kindle subscribers


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This switches over the storage of country and state information for Apple and Google Pay payments from a separate section in the payment method reducer to using the address reducer that's used when a user fills out this information manually.

[**Trello Card**](https://trello.com/c/ChpoH4Qd)

## Why are you doing this?

This should help to address an issue where client-side validation is not correctly catching issues with a user's address information obtained from the payment request button interface. Using the address reducer means our existing validation for a user's country and state will run and should prevent form submission if there are any issues.
