### PR TITLE
docs: update README instructions for the support-payment-api app

### DIFF
--- a/support-payment-api/README.md
+++ b/support-payment-api/README.md
@@ -17,7 +17,13 @@ Run `sbt run` and the project will start up locally under:
 
 ## Running tests
 
-Run `sbt run`. No integration test provided so far.
+From the root of the `support-frontend` repository, run:
+
+```
+sbt "project support-payment-api" run
+```
+
+No integration test provided so far.
 
 ### Testing manually
 


### PR DESCRIPTION
## What are you doing in this PR?

I update the README instructions for running the `support-payment-api` app locally.

## Why are you doing this?

So that the next developer can successfully run the `support-payment-api` app locally at their first attempt.


