### PR TITLE
docs: update README instructions for the support-payment-api app

### DIFF
--- a/support-payment-api/README.md
+++ b/support-payment-api/README.md
@@ -11,19 +11,20 @@ The payment service provides an API for creating PayPal and Stripe payments.
 
 Get AWS credentials from Janus
 
-Run `sbt run` and the project will start up locally under:
+From the root of the `support-frontend` repository, run `sbt "project support-payment-api" run` and the project will start up locally under:
 
 `http://localhost:9000/healthcheck`
 
 ## Running tests
 
-Run `sbt run`. No integration test provided so far.
+No integration test provided so far.
 
 ### Testing manually
 
 You can import API calls into POSTMAN from [here](postman) or get request/response examples form the unit test controllers.
 
 ### SSH
+
 You must ssh via the bastion, e.g. using [ssm-scala](https://github.com/guardian/ssm-scala):
 
 `ssm ssh --profile membership --bastion-tags contributions-store-bastion,support,PROD --tags payment-api,support,CODE -a -x --newest`

--- a/support-payment-api/README.md
+++ b/support-payment-api/README.md
@@ -9,7 +9,7 @@ The payment service provides an API for creating PayPal and Stripe payments.
 
 ## Running Locally
 
-Get AWS credentials from Janus
+Get AWS credentials from Janus.
 
 From the root of the `support-frontend` repository, run `sbt "project support-payment-api" run` and the project will start up locally under:
 


### PR DESCRIPTION
## What are you doing in this PR?

I update the README instructions for running the `support-payment-api` app locally.

## Why are you doing this?

So that the next developer can successfully run the `support-payment-api` app locally at their first attempt.


