### PR TITLE
Revert "Update payment api to java-11"

### DIFF
--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -50,11 +50,11 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
-      - name: Setup Java 11
+      - name: Setup Java 8
         uses: actions/setup-java@v3
         with:
-          java-version: "11"
-          distribution: "corretto"
+          java-version: "8"
+          distribution: "adopt"
       - uses: actions/cache@v3
         with:
           path: |

--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -9,7 +9,7 @@ object LibraryVersions {
   val jacksonDatabindVersion = "2.15.2"
   val okhttpVersion = "3.14.9"
   val scalaUriVersion = "4.0.3"
-  val playCirceVersion = "2814.4"
+  val playCirceVersion = "2814.2"
   val stripeVersion = "21.15.0" // Supports API version 2019-05-16
   val oktaJwtVerifierVersion = "0.5.7"
 }

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -31,9 +31,9 @@ libraryDependencies ++= Seq(
   "org.playframework.anorm" %% "anorm" % "2.7.0",
   "org.scalatest" %% "scalatest" % "3.0.9" % "test",
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % "test",
-  "org.mockito" % "mockito-core" % "5.3.1",
+  "org.mockito" % "mockito-core" % "4.11.0",
   "org.typelevel" %% "cats-core" % catsVersion,
-  "com.github.blemale" %% "scaffeine" % "5.2.0",
+  "com.github.blemale" %% "scaffeine" % "4.1.0",
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
@@ -57,6 +57,7 @@ dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacks
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 
+debianPackageDependencies := Seq("openjdk-8-jre-headless")
 Debian / packageName := name.value
 packageSummary := "Payment API Play App"
 packageDescription := """API for reader revenue payments"""

--- a/support-payment-api/src/main/resources/riff-raff.yaml
+++ b/support-payment-api/src/main/resources/riff-raff.yaml
@@ -10,7 +10,7 @@ deployments:
     parameters:
       amiParameter: AMIPaymentapi
       amiTags:
-        Recipe: jammy-membership-java11
+        Recipe: jammy-membership-java8
         AmigoStage: PROD
       amiEncrypted: true
       templateStagePaths:


### PR DESCRIPTION
Reverts guardian/support-frontend#5270

support-frontend is still on java 8, so we can’t update circe just yet. Reverting this to get back to a good state, then we’ll do the payment-api java upgrade separate from the circe update.