### PR TITLE
Send acquisition events to BigQuery via the event bus

### DIFF
--- a/support-modules/acquisition-events/build.sbt
+++ b/support-modules/acquisition-events/build.sbt
@@ -9,6 +9,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "com.amazonaws" % "aws-java-sdk-kinesis" % awsClientVersion,
+  "com.amazonaws" % "aws-java-sdk-eventbridge" % awsClientVersion,
   "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
 
   // This is required to force aws libraries to use the latest version of jackson

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/eventbridge/AcquisitionsEventBusService.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/eventbridge/AcquisitionsEventBusService.scala
@@ -56,22 +56,12 @@ class AcquisitionsEventBusService(source: String, stage: Stage, client: AmazonEv
 }
 
 object AcquisitionsEventBusService {
-//  lazy val CredentialsProvider = AwsCredentialsProviderChain.builder
-//    .credentialsProviders(
-//      ProfileCredentialsProvider.builder.profileName(ProfileName).build,
-//      InstanceProfileCredentialsProvider.builder.asyncCredentialUpdateEnabled(false).build,
-//      EnvironmentVariableCredentialsProvider.create(),
-//    )
-//    .build
 
   lazy val eventBridgeClient = AmazonEventBridgeClient
     .builder()
     .withRegion(Regions.EU_WEST_1)
     .withCredentials(CredentialsProvider)
     .build
-//    .region(Region.EU_WEST_1)
-//    .credentialsProvider(CredentialsProvider)
-//    .build
 
   /** @param source
     *   \- A string which is passed to the source value of Eventbridge to identify the system that this event comes from

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/eventbridge/AcquisitionsEventBusService.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/eventbridge/AcquisitionsEventBusService.scala
@@ -1,0 +1,85 @@
+package com.gu.support.acquisitions.eventbridge
+
+import com.gu.aws.ProfileName
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger.Sanitizer
+import com.gu.support.acquisitions.AcquisitionDataRowMapper
+import com.gu.support.acquisitions.models.AcquisitionDataRow
+import com.gu.support.config.Stage
+import com.gu.support.config.Stages.CODE
+import org.json.JSONObject
+import software.amazon.awssdk.auth.credentials.{
+  AwsCredentialsProviderChain,
+  EnvironmentVariableCredentialsProvider,
+  InstanceProfileCredentialsProvider,
+  ProfileCredentialsProvider,
+}
+import software.amazon.awssdk.core.exception.SdkException
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient
+import software.amazon.awssdk.services.eventbridge.model.{PutEventsRequest, PutEventsRequestEntry}
+
+import java.time.Instant
+import scala.concurrent.Promise
+
+class AcquisitionsEventBusService(source: String, stage: Stage, client: EventBridgeClient) {
+  val eventBusName = s"acquisitions-bus-${stage.toString}"
+  val detailType = "AcquisitionsEvent"
+  def putAcquisitionEvent(acquisition: AcquisitionDataRow) = {
+    val acquisitionDataRow: JSONObject = AcquisitionDataRowMapper.mapToTableRow(acquisition)
+    SafeLogger.info(s"Attempting to send event $acquisitionDataRow")
+    val entry = PutEventsRequestEntry.builder
+      .eventBusName(eventBusName)
+      .source(source)
+      .detailType(detailType)
+      .detail(acquisitionDataRow.toString)
+      .time(Instant.now)
+      .build
+
+    val putEventsRequest = PutEventsRequest.builder.entries(entry).build
+
+    val promise = Promise[Either[String, Unit]]
+    try {
+      val result = client.putEvents(putEventsRequest)
+      if (result.failedEntryCount > 0) {
+        // We only ever send one event at a time
+        val failureMessage = result.entries.get(0).errorMessage
+        val errorMessage = s"There was failure writing $acquisitionDataRow to Eventbridge: $failureMessage"
+        SafeLogger.warn(s"$errorMessage")
+        promise.success(Left(errorMessage))
+      } else {
+        promise.success(Right(()))
+      }
+    } catch {
+      case e: SdkException =>
+        val errorMessage = s"There was an exception writing $acquisitionDataRow to Eventbridge: ${e.getMessage}"
+        SafeLogger.error(scrub"$errorMessage", e)
+        promise.success(Left(errorMessage))
+    }
+    promise.future
+  }
+}
+
+object AcquisitionsEventBusService {
+  lazy val CredentialsProvider = AwsCredentialsProviderChain.builder
+    .credentialsProviders(
+      ProfileCredentialsProvider.builder.profileName(ProfileName).build,
+      InstanceProfileCredentialsProvider.builder.asyncCredentialUpdateEnabled(false).build,
+      EnvironmentVariableCredentialsProvider.create(),
+    )
+    .build
+
+  lazy val eventBridgeClient = EventBridgeClient.builder
+    .region(Region.EU_WEST_1)
+    .credentialsProvider(CredentialsProvider)
+    .build
+
+  /** @param source
+    *   \- A string which is passed to the source value of Eventbridge to identify the system that this event comes from
+    * @param stage
+    * @param isTestUser
+    * @return
+    */
+  def apply(source: String, stage: Stage, isTestUser: Boolean) =
+    new AcquisitionsEventBusService(source, if (isTestUser) CODE else stage, eventBridgeClient)
+}

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/eventbridge/AcquisitionsEventBusService.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/eventbridge/AcquisitionsEventBusService.scala
@@ -1,50 +1,44 @@
 package com.gu.support.acquisitions.eventbridge
 
-import com.gu.aws.ProfileName
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.eventbridge.model.{PutEventsRequest, PutEventsRequestEntry}
+import com.amazonaws.services.eventbridge.{AmazonEventBridge, AmazonEventBridgeClient}
+import com.gu.aws.CredentialsProvider
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger.Sanitizer
-import com.gu.support.acquisitions.AcquisitionDataRowMapper
 import com.gu.support.acquisitions.models.AcquisitionDataRow
 import com.gu.support.config.Stage
 import com.gu.support.config.Stages.CODE
 import io.circe.syntax.EncoderOps
-import org.json.JSONObject
-import software.amazon.awssdk.auth.credentials.{
-  AwsCredentialsProviderChain,
-  EnvironmentVariableCredentialsProvider,
-  InstanceProfileCredentialsProvider,
-  ProfileCredentialsProvider,
-}
 import software.amazon.awssdk.core.exception.SdkException
-import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.eventbridge.EventBridgeClient
-import software.amazon.awssdk.services.eventbridge.model.{PutEventsRequest, PutEventsRequestEntry}
 
 import java.time.Instant
+import java.util.Date
 import scala.concurrent.Promise
+import scala.jdk.CollectionConverters.SeqHasAsJava
 
-class AcquisitionsEventBusService(source: String, stage: Stage, client: EventBridgeClient) {
+class AcquisitionsEventBusService(source: String, stage: Stage, client: AmazonEventBridge) {
   val eventBusName = s"acquisitions-bus-${stage.toString}"
   val detailType = "AcquisitionsEvent"
   def putAcquisitionEvent(acquisition: AcquisitionDataRow) = {
     val acquisitionJson = acquisition.asJson
     SafeLogger.info(s"Attempting to send event ${acquisitionJson.spaces2}")
-    val entry = PutEventsRequestEntry.builder
-      .eventBusName(eventBusName)
-      .source(source)
-      .detailType(detailType)
-      .detail(acquisitionJson.noSpaces)
-      .time(Instant.now)
-      .build
+    val entry = new PutEventsRequestEntry
+    entry.setEventBusName(eventBusName)
+    entry.setSource(source)
+    entry.setDetailType(detailType)
+    entry.setDetail(acquisitionJson.noSpaces)
+    entry.setTime(Date.from(Instant.now))
 
-    val putEventsRequest = PutEventsRequest.builder.entries(entry).build
+    val putEventsRequest = new PutEventsRequest
+    putEventsRequest.setEntries(List(entry).asJava)
 
     val promise = Promise[Either[String, Unit]]
     try {
       val result = client.putEvents(putEventsRequest)
-      if (result.failedEntryCount > 0) {
+      if (result.getFailedEntryCount > 0) {
         // We only ever send one event at a time
-        val failureMessage = result.entries.get(0).errorMessage
+        val failureMessage = result.getEntries.get(0).getErrorMessage
         val errorMessage = s"There was failure writing ${acquisitionJson.spaces2} to Eventbridge: $failureMessage"
         SafeLogger.warn(s"$errorMessage")
         promise.success(Left(errorMessage))
@@ -62,18 +56,22 @@ class AcquisitionsEventBusService(source: String, stage: Stage, client: EventBri
 }
 
 object AcquisitionsEventBusService {
-  lazy val CredentialsProvider = AwsCredentialsProviderChain.builder
-    .credentialsProviders(
-      ProfileCredentialsProvider.builder.profileName(ProfileName).build,
-      InstanceProfileCredentialsProvider.builder.asyncCredentialUpdateEnabled(false).build,
-      EnvironmentVariableCredentialsProvider.create(),
-    )
-    .build
+//  lazy val CredentialsProvider = AwsCredentialsProviderChain.builder
+//    .credentialsProviders(
+//      ProfileCredentialsProvider.builder.profileName(ProfileName).build,
+//      InstanceProfileCredentialsProvider.builder.asyncCredentialUpdateEnabled(false).build,
+//      EnvironmentVariableCredentialsProvider.create(),
+//    )
+//    .build
 
-  lazy val eventBridgeClient = EventBridgeClient.builder
-    .region(Region.EU_WEST_1)
-    .credentialsProvider(CredentialsProvider)
+  lazy val eventBridgeClient = AmazonEventBridgeClient
+    .builder()
+    .withRegion(Regions.EU_WEST_1)
+    .withCredentials(CredentialsProvider)
     .build
+//    .region(Region.EU_WEST_1)
+//    .credentialsProvider(CredentialsProvider)
+//    .build
 
   /** @param source
     *   \- A string which is passed to the source value of Eventbridge to identify the system that this event comes from

--- a/support-modules/aws/build.sbt
+++ b/support-modules/aws/build.sbt
@@ -7,6 +7,7 @@ description := "aws services only (sdk v1)"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
+  "software.amazon.awssdk" % "eventbridge" % awsClientVersion2,
 )
 
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion

--- a/support-modules/aws/build.sbt
+++ b/support-modules/aws/build.sbt
@@ -7,7 +7,6 @@ description := "aws services only (sdk v1)"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
-  "software.amazon.awssdk" % "eventbridge" % awsClientVersion2,
 )
 
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -32,6 +32,7 @@ Mappings:
       - arn:aws:s3:::support-workers-private/*
       SupporterProductDataTable: supporter-product-data-tables-CODE-SupporterProductDataTable
       KinesisStreamArn: arn:aws:kinesis:eu-west-1:865473395570:stream/acquisitions-stream-CODE
+      EventBusArn: arn:aws:events:eu-west-1:865473395570:event-bus/acquisitions-bus-CODE
     PROD:
       DynamoDBTables:
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-PROD
@@ -41,7 +42,7 @@ Mappings:
       - arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-CODE/catalog.json
       - arn:aws:s3:::support-workers-private/*
       SupporterProductDataTable: supporter-product-data-tables-PROD-SupporterProductDataTable
-      KinesisStreamArn: arn:aws:kinesis:eu-west-1:865473395570:stream/acquisitions-stream-PROD
+      EventBusArn: arn:aws:events:eu-west-1:865473395570:event-bus/acquisitions-bus-PROD
 Resources:
   LambdaExecutionRole:
     Type: "AWS::IAM::Role"
@@ -71,6 +72,14 @@ Resources:
               - sqs:SendMessage
               Resource:
                 Fn::ImportValue: !Sub "comms-${Stage}-EmailQueueArn"
+        - PolicyName: AcquisitionsEventBus
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              - events:PutEvents
+              Resource: !FindInMap [StageVariables, !Ref Stage, EventBusArn]
         - PolicyName: CloudWatchLogging
           PolicyDocument:
             Version: '2012-10-17'

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -42,6 +42,7 @@ Mappings:
       - arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-CODE/catalog.json
       - arn:aws:s3:::support-workers-private/*
       SupporterProductDataTable: supporter-product-data-tables-PROD-SupporterProductDataTable
+      KinesisStreamArn: arn:aws:kinesis:eu-west-1:865473395570:stream/acquisitions-stream-PROD
       EventBusArn: arn:aws:events:eu-west-1:865473395570:event-bus/acquisitions-bus-PROD
 Resources:
   LambdaExecutionRole:

--- a/support-workers/src/main/scala/com/gu/services/Services.scala
+++ b/support-workers/src/main/scala/com/gu/services/Services.scala
@@ -8,21 +8,20 @@ import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.paypal.PayPalService
 import com.gu.salesforce.SalesforceService
 import com.gu.stripe.StripeService
+import com.gu.support.acquisitions.eventbridge.AcquisitionsEventBusService
 import com.gu.support.acquisitions.{
   AcquisitionsStreamLambdaConfig,
   AcquisitionsStreamService,
   AcquisitionsStreamServiceImpl,
-  BigQueryService,
 }
 import com.gu.support.catalog.CatalogService
 import com.gu.support.config.Stages.PROD
 import com.gu.support.config.TouchPointEnvironments
 import com.gu.support.promotions.PromotionService
 import com.gu.support.redemption.gifting.generator.GiftCodeGeneratorService
-import com.gu.zuora.{ZuoraGiftService, ZuoraService}
 import com.gu.supporterdata.model.Stage.{CODE => DynamoStageCODE, PROD => DynamoStagePROD}
-import com.gu.support.config.Stages.{CODE => ConfigCode, PROD => ConfigProd}
 import com.gu.supporterdata.services.SupporterDataDynamoService
+import com.gu.zuora.{ZuoraGiftService, ZuoraService}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -53,10 +52,8 @@ class Services(isTestUser: Boolean, val config: Configuration) {
   lazy val goCardlessService = GoCardlessWorkersService(goCardlessConfigProvider.get(isTestUser))
   lazy val catalogService = CatalogService(TouchPointEnvironments.fromStage(stage, isTestUser))
   lazy val giftCodeGenerator = new GiftCodeGeneratorService
-  lazy val bigQueryService = BigQueryService.build(
-    if (Configuration.stage == PROD && !isTestUser) ConfigProd else ConfigCode,
-    bigQueryConfigProvider.get(isTestUser),
-  )
+  lazy val acquisitionsEventBusService = AcquisitionsEventBusService("support-workers", stage, isTestUser)
+
   lazy val acquisitionsStreamService: AcquisitionsStreamService = new AcquisitionsStreamServiceImpl(
     AcquisitionsStreamLambdaConfig(config.acquisitionsKinesisStreamName),
   )


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Following on from #4923 which created a new acquisition event bus, sqs queue and lambda to handle writing acquisition data to BigQuery, this PR update the support-workers `SendAcquisitionEvent` class to also use the event bus rather than writing to BigQuery directly.

The next step will be to do the same for the payment-api and then to trigger writes to the Kinesis stream from the event bus.

I have left a number of TODOs in the code, these will be removed in the upcoming PRs
