### PR TITLE
feat: send message to single-purpose queue after a contribution is made via support-frontend, to eventually create a single contribution record in Salesforce

### DIFF
--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -1260,7 +1260,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":single-contributions-queue-PROD",
+                    ":single-contributions-processor-queue-PROD",
                   ],
                 ],
               },

--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -1238,7 +1238,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "SingleContributionRecordSqsMessages2EC23518": {
+    "SingleContributionsSqsMessages35DDA378": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -1260,7 +1260,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":single-contribution-record-queue-PROD",
+                    ":single-contributions-queue-PROD",
                   ],
                 ],
               },
@@ -1268,7 +1268,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "SingleContributionRecordSqsMessages2EC23518",
+        "PolicyName": "SingleContributionsSqsMessages35DDA378",
         "Roles": [
           {
             "Ref": "InstanceRolePaymentapi2FA25312",

--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -1238,7 +1238,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "SingleContributionsSqsMessages35DDA378": {
+    "SingleContributionSalesforceWritesSqsMessages23EB1EFB": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -1260,7 +1260,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":single-contributions-processor-queue-PROD",
+                    ":single-contribution-salesforce-writes-queue-PROD",
                   ],
                 ],
               },
@@ -1268,7 +1268,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "SingleContributionsSqsMessages35DDA378",
+        "PolicyName": "SingleContributionSalesforceWritesSqsMessages23EB1EFB",
         "Roles": [
           {
             "Ref": "InstanceRolePaymentapi2FA25312",

--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -16,6 +16,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
       "GuAllowPolicy",
       "GuAllowPolicy",
       "GuAllowPolicy",
+      "GuAllowPolicy",
       "GuPutCloudwatchMetricsPolicy",
       "GuAllowPolicy",
       "GuAllowPolicy",
@@ -1229,6 +1230,45 @@ exports[`The Payment API stack matches the snapshot 1`] = `
           "Version": "2012-10-17",
         },
         "PolicyName": "SettingsBucket420EA4B0",
+        "Roles": [
+          {
+            "Ref": "InstanceRolePaymentapi2FA25312",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SingleContributionRecordSqsMessages2EC23518": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:GetQueueUrl",
+                "sqs:SendMessage",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:sqs:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":single-contribution-record-queue-PROD",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SingleContributionRecordSqsMessages2EC23518",
         "Roles": [
           {
             "Ref": "InstanceRolePaymentapi2FA25312",

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -149,8 +149,8 @@ export class PaymentApi extends GuStack {
             actions: ["sqs:GetQueueUrl", "sqs:SendMessage"],
             resources:
               this.stage === "PROD"
-                ? [`arn:aws:sqs:${this.region}:${this.account}:single-contributions-queue-PROD`,]
-                : [`arn:aws:sqs:${this.region}:${this.account}:single-contributions-queue-CODE`,],
+                ? [`arn:aws:sqs:${this.region}:${this.account}:single-contributions-processor-queue-PROD`,]
+                : [`arn:aws:sqs:${this.region}:${this.account}:single-contributions-processor-queue-CODE`,],
           }),
           new GuPutCloudwatchMetricsPolicy(this),
           new GuAllowPolicy(this, "AssumeOphanRole", {

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -145,12 +145,12 @@ export class PaymentApi extends GuStack {
                 ? [`arn:aws:sqs:${this.region}:${this.account}:soft-opt-in-consent-setter-queue-PROD`,]
                 : [`arn:aws:sqs:${this.region}:${this.account}:soft-opt-in-consent-setter-queue-DEV`,],
           }),
-          new GuAllowPolicy(this, "SingleContributionRecordSqsMessages", {
+          new GuAllowPolicy(this, "SingleContributionsSqsMessages", {
             actions: ["sqs:GetQueueUrl", "sqs:SendMessage"],
             resources:
               this.stage === "PROD"
-                ? [`arn:aws:sqs:${this.region}:${this.account}:single-contribution-record-queue-PROD`,]
-                : [`arn:aws:sqs:${this.region}:${this.account}:single-contribution-record-queue-CODE`,],
+                ? [`arn:aws:sqs:${this.region}:${this.account}:single-contributions-queue-PROD`,]
+                : [`arn:aws:sqs:${this.region}:${this.account}:single-contributions-queue-CODE`,],
           }),
           new GuPutCloudwatchMetricsPolicy(this),
           new GuAllowPolicy(this, "AssumeOphanRole", {

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -150,7 +150,7 @@ export class PaymentApi extends GuStack {
             resources:
               this.stage === "PROD"
                 ? [`arn:aws:sqs:${this.region}:${this.account}:single-contribution-record-queue-PROD`,]
-                : [`arn:aws:sqs:${this.region}:${this.account}:single-contribution-record-queue-DEV`,],
+                : [`arn:aws:sqs:${this.region}:${this.account}:single-contribution-record-queue-CODE`,],
           }),
           new GuPutCloudwatchMetricsPolicy(this),
           new GuAllowPolicy(this, "AssumeOphanRole", {

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -145,6 +145,13 @@ export class PaymentApi extends GuStack {
                 ? [`arn:aws:sqs:${this.region}:${this.account}:soft-opt-in-consent-setter-queue-PROD`,]
                 : [`arn:aws:sqs:${this.region}:${this.account}:soft-opt-in-consent-setter-queue-DEV`,],
           }),
+          new GuAllowPolicy(this, "SingleContributionRecordSqsMessages", {
+            actions: ["sqs:GetQueueUrl", "sqs:SendMessage"],
+            resources:
+              this.stage === "PROD"
+                ? [`arn:aws:sqs:${this.region}:${this.account}:single-contribution-record-queue-PROD`,]
+                : [`arn:aws:sqs:${this.region}:${this.account}:single-contribution-record-queue-DEV`,],
+          }),
           new GuPutCloudwatchMetricsPolicy(this),
           new GuAllowPolicy(this, "AssumeOphanRole", {
             actions: ["sts:AssumeRole"],

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -145,12 +145,12 @@ export class PaymentApi extends GuStack {
                 ? [`arn:aws:sqs:${this.region}:${this.account}:soft-opt-in-consent-setter-queue-PROD`,]
                 : [`arn:aws:sqs:${this.region}:${this.account}:soft-opt-in-consent-setter-queue-DEV`,],
           }),
-          new GuAllowPolicy(this, "SingleContributionsSqsMessages", {
+          new GuAllowPolicy(this, "SingleContributionSalesforceWritesSqsMessages", {
             actions: ["sqs:GetQueueUrl", "sqs:SendMessage"],
             resources:
               this.stage === "PROD"
-                ? [`arn:aws:sqs:${this.region}:${this.account}:single-contributions-processor-queue-PROD`,]
-                : [`arn:aws:sqs:${this.region}:${this.account}:single-contributions-processor-queue-CODE`,],
+                ? [`arn:aws:sqs:${this.region}:${this.account}:single-contribution-salesforce-writes-queue-PROD`,]
+                : [`arn:aws:sqs:${this.region}:${this.account}:single-contribution-salesforce-writes-queue-CODE`,],
           }),
           new GuPutCloudwatchMetricsPolicy(this),
           new GuAllowPolicy(this, "AssumeOphanRole", {

--- a/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
+++ b/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
@@ -39,7 +39,7 @@ class AmazonPayBackend(
     val databaseService: ContributionsStoreService,
     val supporterProductDataService: SupporterProductDataService,
     val softOptInsService: SoftOptInsService,
-    val singleContributionRecordService: SingleContributionRecordService,
+    val SingleContributionsService: SingleContributionsService,
     val switchService: SwitchService,
 )(implicit pool: DefaultThreadPool)
     extends StrictLogging
@@ -234,7 +234,7 @@ object AmazonPayBackend {
       cloudWatchService: CloudWatchService,
       supporterProductDataService: SupporterProductDataService,
       softOptInsService: SoftOptInsService,
-      singleContributionRecordService: SingleContributionRecordService,
+      SingleContributionsService: SingleContributionsService,
       switchService: SwitchService,
   )(implicit pool: DefaultThreadPool): AmazonPayBackend = {
     new AmazonPayBackend(
@@ -247,7 +247,7 @@ object AmazonPayBackend {
       databaseService,
       supporterProductDataService,
       softOptInsService,
-      singleContributionRecordService,
+      SingleContributionsService,
       switchService,
     )
   }
@@ -288,7 +288,7 @@ object AmazonPayBackend {
       new CloudWatchService(cloudWatchAsyncClient, env).valid: InitializationResult[CloudWatchService],
       new SupporterProductDataService(env).valid: InitializationResult[SupporterProductDataService],
       SoftOptInsService(env).valid: InitializationResult[SoftOptInsService],
-      SingleContributionRecordService(env).valid: InitializationResult[SingleContributionRecordService],
+      SingleContributionsService(env).valid: InitializationResult[SingleContributionsService],
       new SwitchService(env)(awsClient, system, defaultThreadPool).valid: InitializationResult[SwitchService],
     ).mapN(AmazonPayBackend.apply)
   }

--- a/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
+++ b/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
@@ -39,7 +39,7 @@ class AmazonPayBackend(
     val databaseService: ContributionsStoreService,
     val supporterProductDataService: SupporterProductDataService,
     val softOptInsService: SoftOptInsService,
-    val SingleContributionsService: SingleContributionsService,
+    val SingleContributionSalesforceWritesService: SingleContributionSalesforceWritesService,
     val switchService: SwitchService,
 )(implicit pool: DefaultThreadPool)
     extends StrictLogging
@@ -234,7 +234,7 @@ object AmazonPayBackend {
       cloudWatchService: CloudWatchService,
       supporterProductDataService: SupporterProductDataService,
       softOptInsService: SoftOptInsService,
-      SingleContributionsService: SingleContributionsService,
+      SingleContributionSalesforceWritesService: SingleContributionSalesforceWritesService,
       switchService: SwitchService,
   )(implicit pool: DefaultThreadPool): AmazonPayBackend = {
     new AmazonPayBackend(
@@ -247,7 +247,7 @@ object AmazonPayBackend {
       databaseService,
       supporterProductDataService,
       softOptInsService,
-      SingleContributionsService,
+      SingleContributionSalesforceWritesService,
       switchService,
     )
   }
@@ -288,7 +288,9 @@ object AmazonPayBackend {
       new CloudWatchService(cloudWatchAsyncClient, env).valid: InitializationResult[CloudWatchService],
       new SupporterProductDataService(env).valid: InitializationResult[SupporterProductDataService],
       SoftOptInsService(env).valid: InitializationResult[SoftOptInsService],
-      SingleContributionsService(env).valid: InitializationResult[SingleContributionsService],
+      SingleContributionSalesforceWritesService(env).valid: InitializationResult[
+        SingleContributionSalesforceWritesService,
+      ],
       new SwitchService(env)(awsClient, system, defaultThreadPool).valid: InitializationResult[SwitchService],
     ).mapN(AmazonPayBackend.apply)
   }

--- a/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
+++ b/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
@@ -39,6 +39,7 @@ class AmazonPayBackend(
     val databaseService: ContributionsStoreService,
     val supporterProductDataService: SupporterProductDataService,
     val softOptInsService: SoftOptInsService,
+    val singleContributionRecordService: SingleContributionRecordService,
     val switchService: SwitchService,
 )(implicit pool: DefaultThreadPool)
     extends StrictLogging
@@ -233,6 +234,7 @@ object AmazonPayBackend {
       cloudWatchService: CloudWatchService,
       supporterProductDataService: SupporterProductDataService,
       softOptInsService: SoftOptInsService,
+      singleContributionRecordService: SingleContributionRecordService,
       switchService: SwitchService,
   )(implicit pool: DefaultThreadPool): AmazonPayBackend = {
     new AmazonPayBackend(
@@ -245,6 +247,7 @@ object AmazonPayBackend {
       databaseService,
       supporterProductDataService,
       softOptInsService,
+      singleContributionRecordService,
       switchService,
     )
   }
@@ -285,6 +288,7 @@ object AmazonPayBackend {
       new CloudWatchService(cloudWatchAsyncClient, env).valid: InitializationResult[CloudWatchService],
       new SupporterProductDataService(env).valid: InitializationResult[SupporterProductDataService],
       SoftOptInsService(env).valid: InitializationResult[SoftOptInsService],
+      SingleContributionRecordService(env).valid: InitializationResult[SingleContributionRecordService],
       new SwitchService(env)(awsClient, system, defaultThreadPool).valid: InitializationResult[SwitchService],
     ).mapN(AmazonPayBackend.apply)
   }

--- a/support-payment-api/src/main/scala/backend/BackendError.scala
+++ b/support-payment-api/src/main/scala/backend/BackendError.scala
@@ -26,7 +26,7 @@ sealed abstract class BackendError extends Exception {
     case BackendError.TrackingError(err) => err.getMessage
     case BackendError.MultipleErrors(errors) => errors.map(_.getMessage).mkString(" & ")
     case BackendError.SoftOptInsServiceError(err) => err
-    case BackendError.SingleContributionRecordServiceError(err) => err
+    case BackendError.SingleContributionsServiceError(err) => err
     case BackendError.SupporterProductDataError(err) => err
   }
 }
@@ -39,7 +39,7 @@ object BackendError {
   final case class Database(error: ContributionsStoreService.Error) extends BackendError
   final case class SupporterProductDataError(error: String) extends BackendError
   final case class SoftOptInsServiceError(error: String) extends BackendError
-  final case class SingleContributionRecordServiceError(error: String) extends BackendError
+  final case class SingleContributionsServiceError(error: String) extends BackendError
   final case class IdentityServiceError(error: IdentityClient.ContextualError) extends BackendError
   final case class PaypalApiError(error: PaypalAPIError) extends BackendError
   final case class StripeApiError(error: StripeError) extends BackendError

--- a/support-payment-api/src/main/scala/backend/BackendError.scala
+++ b/support-payment-api/src/main/scala/backend/BackendError.scala
@@ -26,6 +26,7 @@ sealed abstract class BackendError extends Exception {
     case BackendError.TrackingError(err) => err.getMessage
     case BackendError.MultipleErrors(errors) => errors.map(_.getMessage).mkString(" & ")
     case BackendError.SoftOptInsServiceError(err) => err
+    case BackendError.SingleContributionRecordServiceError(err) => err
     case BackendError.SupporterProductDataError(err) => err
   }
 }
@@ -38,6 +39,7 @@ object BackendError {
   final case class Database(error: ContributionsStoreService.Error) extends BackendError
   final case class SupporterProductDataError(error: String) extends BackendError
   final case class SoftOptInsServiceError(error: String) extends BackendError
+  final case class SingleContributionRecordServiceError(error: String) extends BackendError
   final case class IdentityServiceError(error: IdentityClient.ContextualError) extends BackendError
   final case class PaypalApiError(error: PaypalAPIError) extends BackendError
   final case class StripeApiError(error: StripeError) extends BackendError

--- a/support-payment-api/src/main/scala/backend/BackendError.scala
+++ b/support-payment-api/src/main/scala/backend/BackendError.scala
@@ -26,7 +26,7 @@ sealed abstract class BackendError extends Exception {
     case BackendError.TrackingError(err) => err.getMessage
     case BackendError.MultipleErrors(errors) => errors.map(_.getMessage).mkString(" & ")
     case BackendError.SoftOptInsServiceError(err) => err
-    case BackendError.SingleContributionsServiceError(err) => err
+    case BackendError.SingleContributionSalesforceWritesServiceError(err) => err
     case BackendError.SupporterProductDataError(err) => err
   }
 }
@@ -39,7 +39,7 @@ object BackendError {
   final case class Database(error: ContributionsStoreService.Error) extends BackendError
   final case class SupporterProductDataError(error: String) extends BackendError
   final case class SoftOptInsServiceError(error: String) extends BackendError
-  final case class SingleContributionsServiceError(error: String) extends BackendError
+  final case class SingleContributionSalesforceWritesServiceError(error: String) extends BackendError
   final case class IdentityServiceError(error: IdentityClient.ContextualError) extends BackendError
   final case class PaypalApiError(error: PaypalAPIError) extends BackendError
   final case class StripeApiError(error: StripeError) extends BackendError

--- a/support-payment-api/src/main/scala/backend/PaymentBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaymentBackend.scala
@@ -10,7 +10,7 @@ import model.DefaultThreadPool
 import model.db.ContributionData
 import services.{
   ContributionsStoreService,
-  SingleContributionRecordService,
+  SingleContributionsService,
   SoftOptInsService,
   SupporterProductDataService,
   SwitchService,
@@ -25,7 +25,7 @@ trait PaymentBackend extends StrictLogging {
   val databaseService: ContributionsStoreService
   val supporterProductDataService: SupporterProductDataService
   val softOptInsService: SoftOptInsService
-  val singleContributionRecordService: SingleContributionRecordService
+  val SingleContributionsService: SingleContributionsService
   val switchService: SwitchService
 
   private def insertContributionDataIntoDatabase(
@@ -65,7 +65,7 @@ trait PaymentBackend extends StrictLogging {
 
     val softOptInFuture = softOptInsService.sendMessage(contributionData.identityId, contributionData.contributionId)
 
-    val singleContributionRecordFuture = singleContributionRecordService.sendMessage(contributionData)
+    val SingleContributionsFuture = SingleContributionsService.sendMessage(contributionData)
 
     Future
       .sequence(
@@ -75,7 +75,7 @@ trait PaymentBackend extends StrictLogging {
           dbFuture.value,
           supporterDataFuture.value,
           softOptInFuture.value,
-          singleContributionRecordFuture.value,
+          SingleContributionsFuture.value,
         ),
       )
       .map { results =>

--- a/support-payment-api/src/main/scala/backend/PaymentBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaymentBackend.scala
@@ -10,7 +10,7 @@ import model.DefaultThreadPool
 import model.db.ContributionData
 import services.{
   ContributionsStoreService,
-  SingleContributionsService,
+  SingleContributionSalesforceWritesService,
   SoftOptInsService,
   SupporterProductDataService,
   SwitchService,
@@ -25,7 +25,7 @@ trait PaymentBackend extends StrictLogging {
   val databaseService: ContributionsStoreService
   val supporterProductDataService: SupporterProductDataService
   val softOptInsService: SoftOptInsService
-  val SingleContributionsService: SingleContributionsService
+  val SingleContributionSalesforceWritesService: SingleContributionSalesforceWritesService
   val switchService: SwitchService
 
   private def insertContributionDataIntoDatabase(
@@ -65,7 +65,7 @@ trait PaymentBackend extends StrictLogging {
 
     val softOptInFuture = softOptInsService.sendMessage(contributionData.identityId, contributionData.contributionId)
 
-    val singleContributionFuture = SingleContributionsService.sendMessage(contributionData)
+    val singleContributionFuture = SingleContributionSalesforceWritesService.sendMessage(contributionData)
 
     Future
       .sequence(

--- a/support-payment-api/src/main/scala/backend/PaymentBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaymentBackend.scala
@@ -65,7 +65,7 @@ trait PaymentBackend extends StrictLogging {
 
     val softOptInFuture = softOptInsService.sendMessage(contributionData.identityId, contributionData.contributionId)
 
-    val SingleContributionsFuture = SingleContributionsService.sendMessage(contributionData)
+    val singleContributionFuture = SingleContributionsService.sendMessage(contributionData)
 
     Future
       .sequence(
@@ -75,7 +75,7 @@ trait PaymentBackend extends StrictLogging {
           dbFuture.value,
           supporterDataFuture.value,
           softOptInFuture.value,
-          SingleContributionsFuture.value,
+          singleContributionFuture.value,
         ),
       )
       .map { results =>

--- a/support-payment-api/src/main/scala/backend/PaypalBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaypalBackend.scala
@@ -47,7 +47,7 @@ class PaypalBackend(
     cloudWatchService: CloudWatchService,
     val supporterProductDataService: SupporterProductDataService,
     val softOptInsService: SoftOptInsService,
-    val singleContributionRecordService: SingleContributionRecordService,
+    val SingleContributionsService: SingleContributionsService,
     val switchService: SwitchService,
 )(implicit pool: DefaultThreadPool)
     extends StrictLogging
@@ -264,7 +264,7 @@ object PaypalBackend {
       cloudWatchService: CloudWatchService,
       supporterProductDataService: SupporterProductDataService,
       softOptInsService: SoftOptInsService,
-      singleContributionRecordService: SingleContributionRecordService,
+      SingleContributionsService: SingleContributionsService,
       switchService: SwitchService,
   )(implicit pool: DefaultThreadPool): PaypalBackend = {
     new PaypalBackend(
@@ -277,7 +277,7 @@ object PaypalBackend {
       cloudWatchService,
       supporterProductDataService,
       softOptInsService,
-      singleContributionRecordService,
+      SingleContributionsService,
       switchService,
     )
   }
@@ -320,7 +320,7 @@ object PaypalBackend {
       new CloudWatchService(cloudWatchAsyncClient, env).valid: InitializationResult[CloudWatchService],
       new SupporterProductDataService(env).valid: InitializationResult[SupporterProductDataService],
       SoftOptInsService(env).valid: InitializationResult[SoftOptInsService],
-      SingleContributionRecordService(env).valid: InitializationResult[SingleContributionRecordService],
+      SingleContributionsService(env).valid: InitializationResult[SingleContributionsService],
       new SwitchService(env)(awsClient, system, paypalThreadPool).valid: InitializationResult[SwitchService],
     ).mapN(PaypalBackend.apply)
   }

--- a/support-payment-api/src/main/scala/backend/PaypalBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaypalBackend.scala
@@ -47,6 +47,7 @@ class PaypalBackend(
     cloudWatchService: CloudWatchService,
     val supporterProductDataService: SupporterProductDataService,
     val softOptInsService: SoftOptInsService,
+    val singleContributionRecordService: SingleContributionRecordService,
     val switchService: SwitchService,
 )(implicit pool: DefaultThreadPool)
     extends StrictLogging
@@ -263,6 +264,7 @@ object PaypalBackend {
       cloudWatchService: CloudWatchService,
       supporterProductDataService: SupporterProductDataService,
       softOptInsService: SoftOptInsService,
+      singleContributionRecordService: SingleContributionRecordService,
       switchService: SwitchService,
   )(implicit pool: DefaultThreadPool): PaypalBackend = {
     new PaypalBackend(
@@ -275,6 +277,7 @@ object PaypalBackend {
       cloudWatchService,
       supporterProductDataService,
       softOptInsService,
+      singleContributionRecordService,
       switchService,
     )
   }
@@ -317,6 +320,7 @@ object PaypalBackend {
       new CloudWatchService(cloudWatchAsyncClient, env).valid: InitializationResult[CloudWatchService],
       new SupporterProductDataService(env).valid: InitializationResult[SupporterProductDataService],
       SoftOptInsService(env).valid: InitializationResult[SoftOptInsService],
+      SingleContributionRecordService(env).valid: InitializationResult[SingleContributionRecordService],
       new SwitchService(env)(awsClient, system, paypalThreadPool).valid: InitializationResult[SwitchService],
     ).mapN(PaypalBackend.apply)
   }

--- a/support-payment-api/src/main/scala/backend/PaypalBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaypalBackend.scala
@@ -47,7 +47,7 @@ class PaypalBackend(
     cloudWatchService: CloudWatchService,
     val supporterProductDataService: SupporterProductDataService,
     val softOptInsService: SoftOptInsService,
-    val SingleContributionsService: SingleContributionsService,
+    val SingleContributionSalesforceWritesService: SingleContributionSalesforceWritesService,
     val switchService: SwitchService,
 )(implicit pool: DefaultThreadPool)
     extends StrictLogging
@@ -264,7 +264,7 @@ object PaypalBackend {
       cloudWatchService: CloudWatchService,
       supporterProductDataService: SupporterProductDataService,
       softOptInsService: SoftOptInsService,
-      SingleContributionsService: SingleContributionsService,
+      SingleContributionSalesforceWritesService: SingleContributionSalesforceWritesService,
       switchService: SwitchService,
   )(implicit pool: DefaultThreadPool): PaypalBackend = {
     new PaypalBackend(
@@ -277,7 +277,7 @@ object PaypalBackend {
       cloudWatchService,
       supporterProductDataService,
       softOptInsService,
-      SingleContributionsService,
+      SingleContributionSalesforceWritesService,
       switchService,
     )
   }
@@ -320,7 +320,9 @@ object PaypalBackend {
       new CloudWatchService(cloudWatchAsyncClient, env).valid: InitializationResult[CloudWatchService],
       new SupporterProductDataService(env).valid: InitializationResult[SupporterProductDataService],
       SoftOptInsService(env).valid: InitializationResult[SoftOptInsService],
-      SingleContributionsService(env).valid: InitializationResult[SingleContributionsService],
+      SingleContributionSalesforceWritesService(env).valid: InitializationResult[
+        SingleContributionSalesforceWritesService,
+      ],
       new SwitchService(env)(awsClient, system, paypalThreadPool).valid: InitializationResult[SwitchService],
     ).mapN(PaypalBackend.apply)
   }

--- a/support-payment-api/src/main/scala/backend/StripeBackend.scala
+++ b/support-payment-api/src/main/scala/backend/StripeBackend.scala
@@ -48,6 +48,7 @@ class StripeBackend(
     cloudWatchService: CloudWatchService,
     val supporterProductDataService: SupporterProductDataService,
     val softOptInsService: SoftOptInsService,
+    val singleContributionRecordService: SingleContributionRecordService,
     val switchService: SwitchService,
     environment: Environment,
 )(implicit pool: DefaultThreadPool, WSClient: WSClient)
@@ -348,6 +349,7 @@ object StripeBackend {
       cloudWatchService: CloudWatchService,
       supporterProductDataService: SupporterProductDataService,
       softOptInsService: SoftOptInsService,
+      singleContributionRecordService: SingleContributionRecordService,
       switchService: SwitchService,
       environment: Environment,
   )(implicit pool: DefaultThreadPool, WSClient: WSClient, awsClient: AmazonS3): StripeBackend = {
@@ -362,6 +364,7 @@ object StripeBackend {
       cloudWatchService,
       supporterProductDataService,
       softOptInsService,
+      singleContributionRecordService,
       switchService,
       environment,
     )
@@ -408,6 +411,7 @@ object StripeBackend {
       new CloudWatchService(cloudWatchAsyncClient, env).valid: InitializationResult[CloudWatchService],
       new SupporterProductDataService(env).valid: InitializationResult[SupporterProductDataService],
       SoftOptInsService(env).valid: InitializationResult[SoftOptInsService],
+      SingleContributionRecordService(env).valid: InitializationResult[SingleContributionRecordService],
       new SwitchService(env)(awsClient, system, stripeThreadPool).valid: InitializationResult[SwitchService],
       env.valid: InitializationResult[Environment],
     ).mapN(StripeBackend.apply)

--- a/support-payment-api/src/main/scala/backend/StripeBackend.scala
+++ b/support-payment-api/src/main/scala/backend/StripeBackend.scala
@@ -48,7 +48,7 @@ class StripeBackend(
     cloudWatchService: CloudWatchService,
     val supporterProductDataService: SupporterProductDataService,
     val softOptInsService: SoftOptInsService,
-    val singleContributionRecordService: SingleContributionRecordService,
+    val SingleContributionsService: SingleContributionsService,
     val switchService: SwitchService,
     environment: Environment,
 )(implicit pool: DefaultThreadPool, WSClient: WSClient)
@@ -349,7 +349,7 @@ object StripeBackend {
       cloudWatchService: CloudWatchService,
       supporterProductDataService: SupporterProductDataService,
       softOptInsService: SoftOptInsService,
-      singleContributionRecordService: SingleContributionRecordService,
+      SingleContributionsService: SingleContributionsService,
       switchService: SwitchService,
       environment: Environment,
   )(implicit pool: DefaultThreadPool, WSClient: WSClient, awsClient: AmazonS3): StripeBackend = {
@@ -364,7 +364,7 @@ object StripeBackend {
       cloudWatchService,
       supporterProductDataService,
       softOptInsService,
-      singleContributionRecordService,
+      SingleContributionsService,
       switchService,
       environment,
     )
@@ -411,7 +411,7 @@ object StripeBackend {
       new CloudWatchService(cloudWatchAsyncClient, env).valid: InitializationResult[CloudWatchService],
       new SupporterProductDataService(env).valid: InitializationResult[SupporterProductDataService],
       SoftOptInsService(env).valid: InitializationResult[SoftOptInsService],
-      SingleContributionRecordService(env).valid: InitializationResult[SingleContributionRecordService],
+      SingleContributionsService(env).valid: InitializationResult[SingleContributionsService],
       new SwitchService(env)(awsClient, system, stripeThreadPool).valid: InitializationResult[SwitchService],
       env.valid: InitializationResult[Environment],
     ).mapN(StripeBackend.apply)

--- a/support-payment-api/src/main/scala/backend/StripeBackend.scala
+++ b/support-payment-api/src/main/scala/backend/StripeBackend.scala
@@ -48,7 +48,7 @@ class StripeBackend(
     cloudWatchService: CloudWatchService,
     val supporterProductDataService: SupporterProductDataService,
     val softOptInsService: SoftOptInsService,
-    val SingleContributionsService: SingleContributionsService,
+    val SingleContributionSalesforceWritesService: SingleContributionSalesforceWritesService,
     val switchService: SwitchService,
     environment: Environment,
 )(implicit pool: DefaultThreadPool, WSClient: WSClient)
@@ -349,7 +349,7 @@ object StripeBackend {
       cloudWatchService: CloudWatchService,
       supporterProductDataService: SupporterProductDataService,
       softOptInsService: SoftOptInsService,
-      SingleContributionsService: SingleContributionsService,
+      SingleContributionSalesforceWritesService: SingleContributionSalesforceWritesService,
       switchService: SwitchService,
       environment: Environment,
   )(implicit pool: DefaultThreadPool, WSClient: WSClient, awsClient: AmazonS3): StripeBackend = {
@@ -364,7 +364,7 @@ object StripeBackend {
       cloudWatchService,
       supporterProductDataService,
       softOptInsService,
-      SingleContributionsService,
+      SingleContributionSalesforceWritesService,
       switchService,
       environment,
     )
@@ -411,7 +411,9 @@ object StripeBackend {
       new CloudWatchService(cloudWatchAsyncClient, env).valid: InitializationResult[CloudWatchService],
       new SupporterProductDataService(env).valid: InitializationResult[SupporterProductDataService],
       SoftOptInsService(env).valid: InitializationResult[SoftOptInsService],
-      SingleContributionsService(env).valid: InitializationResult[SingleContributionsService],
+      SingleContributionSalesforceWritesService(env).valid: InitializationResult[
+        SingleContributionSalesforceWritesService,
+      ],
       new SwitchService(env)(awsClient, system, stripeThreadPool).valid: InitializationResult[SwitchService],
       env.valid: InitializationResult[Environment],
     ).mapN(StripeBackend.apply)

--- a/support-payment-api/src/main/scala/services/SingleContributionRecordService.scala
+++ b/support-payment-api/src/main/scala/services/SingleContributionRecordService.scala
@@ -1,0 +1,95 @@
+package services
+
+import aws.AWSClientBuilder
+import backend.BackendError.SingleContributionRecordServiceError
+import cats.data.EitherT
+import cats.implicits._
+import com.amazonaws.services.sqs.AmazonSQSAsync
+import com.amazonaws.services.sqs.model.{GetQueueUrlRequest, SendMessageRequest}
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.generic.auto._
+import io.circe.syntax.EncoderOps
+import model.db.ContributionData
+import model.Environment
+import model.Environment.Live
+import services.SingleContributionRecordService.Message
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+class SingleContributionRecordService(
+    sqsClient: AmazonSQSAsync,
+    queueUrlResponse: Future[Either[SingleContributionRecordServiceError, String]],
+) extends StrictLogging {
+  def sendMessage(
+      contributionData: ContributionData,
+  )(implicit executionContext: ExecutionContext): EitherT[Future, SingleContributionRecordServiceError, Unit] = {
+    val message = Message(
+      contributionData = contributionData,
+    )
+
+    logger.info(s"Preparing to send message: ${message.asJson.noSpaces}")
+
+    for {
+      queueUrl <- EitherT(queueUrlResponse)
+      _ <- sendRequest(queueUrl, message)
+    } yield ()
+  }
+
+  private def sendRequest(queueUrl: String, message: Message)(implicit
+      executionContext: ExecutionContext,
+  ): EitherT[Future, SingleContributionRecordServiceError, Unit] = {
+    val request = new SendMessageRequest()
+      .withQueueUrl(queueUrl)
+      .withMessageBody(message.asJson.noSpaces)
+
+    logger.info(s"Sending message to queue: $queueUrl")
+
+    val response = Try(sqsClient.sendMessage(request)).toEither
+    val responseConverted = response.left
+      .map(e =>
+        SingleContributionRecordServiceError(
+          s"An error occurred sending a message to the single contribution record queue with message: ${e.getMessage}",
+        ),
+      )
+      .map(_ => ())
+
+    EitherT.fromEither[Future](responseConverted)
+  }
+}
+
+object SingleContributionRecordService extends StrictLogging {
+  def apply(environment: Environment): SingleContributionRecordService = {
+    logger.info(s"Setting up SingleContributionRecordService for environment: $environment")
+
+    val sqsClient: AmazonSQSAsync = AWSClientBuilder.buildAmazonSQSAsyncClient()
+    val queueName = environment match {
+      case Live => "single-contribution-record-queue-PROD"
+      case _ => "single-contribution-record-queue-DEV"
+    }
+
+    val queueUrlResponse: Future[Either[SingleContributionRecordServiceError, String]] = getQueue(sqsClient, queueName)
+    new SingleContributionRecordService(sqsClient, queueUrlResponse)
+  }
+
+  private def getQueue(
+      sqsClient: AmazonSQSAsync,
+      queueName: String,
+  ): Future[Either[SingleContributionRecordServiceError, String]] = {
+    logger.info(s"Retrieving queue URL for queue name: $queueName")
+
+    val queueUrlRequest = new GetQueueUrlRequest(queueName)
+    val response = Try(sqsClient.getQueueUrl(queueUrlRequest).getQueueUrl)
+
+    Future.successful(
+      response.toEither.left.map(e =>
+        SingleContributionRecordServiceError(
+          s"An error occurred getting the queue for the SingleContributionRecordService with message: ${e.getMessage}",
+        ),
+      ),
+    )
+  }
+
+  case class Message(
+      contributionData: ContributionData,
+  )
+}

--- a/support-payment-api/src/main/scala/services/SingleContributionRecordService.scala
+++ b/support-payment-api/src/main/scala/services/SingleContributionRecordService.scala
@@ -63,8 +63,8 @@ object SingleContributionsService extends StrictLogging {
 
     val sqsClient: AmazonSQSAsync = AWSClientBuilder.buildAmazonSQSAsyncClient()
     val queueName = environment match {
-      case Live => "single-contributions-queue-PROD"
-      case _ => "single-contributions-queue-CODE"
+      case Live => "single-contributions-processor-queue-PROD"
+      case _ => "single-contributions-processor-queue-CODE"
     }
 
     val queueUrlResponse: Future[Either[SingleContributionsServiceError, String]] = getQueue(sqsClient, queueName)

--- a/support-payment-api/src/main/scala/services/SingleContributionRecordService.scala
+++ b/support-payment-api/src/main/scala/services/SingleContributionRecordService.scala
@@ -64,7 +64,7 @@ object SingleContributionRecordService extends StrictLogging {
     val sqsClient: AmazonSQSAsync = AWSClientBuilder.buildAmazonSQSAsyncClient()
     val queueName = environment match {
       case Live => "single-contribution-record-queue-PROD"
-      case _ => "single-contribution-record-queue-DEV"
+      case _ => "single-contribution-record-queue-CODE"
     }
 
     val queueUrlResponse: Future[Either[SingleContributionRecordServiceError, String]] = getQueue(sqsClient, queueName)

--- a/support-payment-api/src/test/scala/backend/AmazonPayBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/AmazonPayBackendSpec.scala
@@ -1,6 +1,6 @@
 package backend
 
-import backend.BackendError.{SingleContributionsServiceError, SoftOptInsServiceError}
+import backend.BackendError.{SingleContributionSalesforceWritesServiceError, SoftOptInsServiceError}
 import cats.data.EitherT
 import cats.implicits._
 import com.amazon.pay.response.ipn.model.{AuthorizationNotification, NotificationType}
@@ -96,8 +96,13 @@ class AmazonPayBackendFixture(implicit ec: ExecutionContext) extends MockitoSuga
     EitherT.left(Future.successful("an error from supporter product data"))
   val softOptInsResponseError: EitherT[Future, SoftOptInsServiceError, Unit] =
     EitherT.left(Future.successful(SoftOptInsServiceError("an error from soft opt-ins")))
-  val SingleContributionsServiceResponseError: EitherT[Future, SingleContributionsServiceError, Unit] =
-    EitherT.left(Future.successful(SingleContributionsServiceError("an error from single contributions")))
+  val SingleContributionSalesforceWritesServiceResponseError
+      : EitherT[Future, SingleContributionSalesforceWritesServiceError, Unit] =
+    EitherT.left(
+      Future.successful(
+        SingleContributionSalesforceWritesServiceError("an error from single contribution salesforce writes"),
+      ),
+    )
   val bigQueryResponse: EitherT[Future, List[String], Unit] =
     EitherT.right(Future.successful(()))
   val bigQueryResponseError: EitherT[Future, List[String], Unit] =
@@ -141,7 +146,8 @@ class AmazonPayBackendFixture(implicit ec: ExecutionContext) extends MockitoSuga
   val mockAcquisitionsStreamService: AcquisitionsStreamService = mock[AcquisitionsStreamService]
   val mockSupporterProductDataService: SupporterProductDataService = mock[SupporterProductDataService]
   val mockSoftOptInsService: SoftOptInsService = mock[SoftOptInsService]
-  val mockSingleContributionsService: SingleContributionsService = mock[SingleContributionsService]
+  val mockSingleContributionSalesforceWritesService: SingleContributionSalesforceWritesService =
+    mock[SingleContributionSalesforceWritesService]
   val mockSwitchService: SwitchService = mock[SwitchService]
 
   // -- test obj
@@ -155,7 +161,7 @@ class AmazonPayBackendFixture(implicit ec: ExecutionContext) extends MockitoSuga
     mockDatabaseService,
     mockSupporterProductDataService,
     mockSoftOptInsService,
-    mockSingleContributionsService,
+    mockSingleContributionSalesforceWritesService,
     mockSwitchService,
   )(new DefaultThreadPool(ec))
 
@@ -219,8 +225,8 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
           .thenReturn(supporterProductDataResponseError)
         when(mockSoftOptInsService.sendMessage(any(), any())(any()))
           .thenReturn(softOptInsResponseError)
-        when(mockSingleContributionsService.sendMessage(any())(any()))
-          .thenReturn(SingleContributionsServiceResponseError)
+        when(mockSingleContributionSalesforceWritesService.sendMessage(any())(any()))
+          .thenReturn(SingleContributionSalesforceWritesServiceResponseError)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
           .thenReturn(streamResponseError)
@@ -229,7 +235,7 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
         amazonPayBackend.makePayment(amazonPayRequest, clientBrowserInfo).futureRight mustBe ()
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
-        verify(mockSingleContributionsService, times(1)).sendMessage(any())(any())
+        verify(mockSingleContributionSalesforceWritesService, times(1)).sendMessage(any())(any())
       }
     }
 
@@ -278,8 +284,8 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
             .thenReturn(supporterProductDataResponseError)
           when(mockSoftOptInsService.sendMessage(any(), any())(any()))
             .thenReturn(softOptInsResponseError)
-          when(mockSingleContributionsService.sendMessage(any())(any()))
-            .thenReturn(SingleContributionsServiceResponseError)
+          when(mockSingleContributionSalesforceWritesService.sendMessage(any())(any()))
+            .thenReturn(SingleContributionSalesforceWritesServiceResponseError)
           when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
           when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
             .thenReturn(streamResponseError)
@@ -288,7 +294,7 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
           amazonPayBackend.makePayment(amazonPayRequest, clientBrowserInfo).futureRight mustBe ()
 
           verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
-          verify(mockSingleContributionsService, times(1)).sendMessage(any())(any())
+          verify(mockSingleContributionSalesforceWritesService, times(1)).sendMessage(any())(any())
         }
 
       "return successful payment response with guestAccountRegistrationToken if available" in new AmazonPayBackendFixture {
@@ -311,8 +317,8 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
 
         when(mockSoftOptInsService.sendMessage(any(), any())(any()))
           .thenReturn(softOptInsResponseError)
-        when(mockSingleContributionsService.sendMessage(any())(any()))
-          .thenReturn(SingleContributionsServiceResponseError)
+        when(mockSingleContributionSalesforceWritesService.sendMessage(any())(any()))
+          .thenReturn(SingleContributionSalesforceWritesServiceResponseError)
 
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
@@ -323,7 +329,7 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
         amazonPayBackend.makePayment(amazonPayRequest, clientBrowserInfo).futureRight mustBe ()
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
-        verify(mockSingleContributionsService, times(1)).sendMessage(any())(any())
+        verify(mockSingleContributionSalesforceWritesService, times(1)).sendMessage(any())(any())
       }
 
       "Not call setOrderRef if state is suspended" in new AmazonPayBackendFixture {

--- a/support-payment-api/src/test/scala/backend/AmazonPayBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/AmazonPayBackendSpec.scala
@@ -1,6 +1,6 @@
 package backend
 
-import backend.BackendError.{SingleContributionRecordServiceError, SoftOptInsServiceError}
+import backend.BackendError.{SingleContributionsServiceError, SoftOptInsServiceError}
 import cats.data.EitherT
 import cats.implicits._
 import com.amazon.pay.response.ipn.model.{AuthorizationNotification, NotificationType}
@@ -96,8 +96,8 @@ class AmazonPayBackendFixture(implicit ec: ExecutionContext) extends MockitoSuga
     EitherT.left(Future.successful("an error from supporter product data"))
   val softOptInsResponseError: EitherT[Future, SoftOptInsServiceError, Unit] =
     EitherT.left(Future.successful(SoftOptInsServiceError("an error from soft opt-ins")))
-  val singleContributionRecordServiceResponseError: EitherT[Future, SingleContributionRecordServiceError, Unit] =
-    EitherT.left(Future.successful(SingleContributionRecordServiceError("an error from single contribution record")))
+  val SingleContributionsServiceResponseError: EitherT[Future, SingleContributionsServiceError, Unit] =
+    EitherT.left(Future.successful(SingleContributionsServiceError("an error from single contributions")))
   val bigQueryResponse: EitherT[Future, List[String], Unit] =
     EitherT.right(Future.successful(()))
   val bigQueryResponseError: EitherT[Future, List[String], Unit] =
@@ -141,7 +141,7 @@ class AmazonPayBackendFixture(implicit ec: ExecutionContext) extends MockitoSuga
   val mockAcquisitionsStreamService: AcquisitionsStreamService = mock[AcquisitionsStreamService]
   val mockSupporterProductDataService: SupporterProductDataService = mock[SupporterProductDataService]
   val mockSoftOptInsService: SoftOptInsService = mock[SoftOptInsService]
-  val mockSingleContributionRecordService: SingleContributionRecordService = mock[SingleContributionRecordService]
+  val mockSingleContributionsService: SingleContributionsService = mock[SingleContributionsService]
   val mockSwitchService: SwitchService = mock[SwitchService]
 
   // -- test obj
@@ -155,7 +155,7 @@ class AmazonPayBackendFixture(implicit ec: ExecutionContext) extends MockitoSuga
     mockDatabaseService,
     mockSupporterProductDataService,
     mockSoftOptInsService,
-    mockSingleContributionRecordService,
+    mockSingleContributionsService,
     mockSwitchService,
   )(new DefaultThreadPool(ec))
 
@@ -219,8 +219,8 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
           .thenReturn(supporterProductDataResponseError)
         when(mockSoftOptInsService.sendMessage(any(), any())(any()))
           .thenReturn(softOptInsResponseError)
-        when(mockSingleContributionRecordService.sendMessage(any())(any()))
-          .thenReturn(singleContributionRecordServiceResponseError)
+        when(mockSingleContributionsService.sendMessage(any())(any()))
+          .thenReturn(SingleContributionsServiceResponseError)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
           .thenReturn(streamResponseError)
@@ -229,7 +229,7 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
         amazonPayBackend.makePayment(amazonPayRequest, clientBrowserInfo).futureRight mustBe ()
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
-        verify(mockSingleContributionRecordService, times(1)).sendMessage(any())(any())
+        verify(mockSingleContributionsService, times(1)).sendMessage(any())(any())
       }
     }
 
@@ -278,8 +278,8 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
             .thenReturn(supporterProductDataResponseError)
           when(mockSoftOptInsService.sendMessage(any(), any())(any()))
             .thenReturn(softOptInsResponseError)
-          when(mockSingleContributionRecordService.sendMessage(any())(any()))
-            .thenReturn(singleContributionRecordServiceResponseError)
+          when(mockSingleContributionsService.sendMessage(any())(any()))
+            .thenReturn(SingleContributionsServiceResponseError)
           when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
           when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
             .thenReturn(streamResponseError)
@@ -288,7 +288,7 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
           amazonPayBackend.makePayment(amazonPayRequest, clientBrowserInfo).futureRight mustBe ()
 
           verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
-          verify(mockSingleContributionRecordService, times(1)).sendMessage(any())(any())
+          verify(mockSingleContributionsService, times(1)).sendMessage(any())(any())
         }
 
       "return successful payment response with guestAccountRegistrationToken if available" in new AmazonPayBackendFixture {
@@ -311,8 +311,8 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
 
         when(mockSoftOptInsService.sendMessage(any(), any())(any()))
           .thenReturn(softOptInsResponseError)
-        when(mockSingleContributionRecordService.sendMessage(any())(any()))
-          .thenReturn(singleContributionRecordServiceResponseError)
+        when(mockSingleContributionsService.sendMessage(any())(any()))
+          .thenReturn(SingleContributionsServiceResponseError)
 
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
@@ -323,7 +323,7 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
         amazonPayBackend.makePayment(amazonPayRequest, clientBrowserInfo).futureRight mustBe ()
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
-        verify(mockSingleContributionRecordService, times(1)).sendMessage(any())(any())
+        verify(mockSingleContributionsService, times(1)).sendMessage(any())(any())
       }
 
       "Not call setOrderRef if state is suspended" in new AmazonPayBackendFixture {

--- a/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
@@ -1,6 +1,6 @@
 package backend
 
-import backend.BackendError.SoftOptInsServiceError
+import backend.BackendError.{SingleContributionRecordServiceError, SoftOptInsServiceError}
 import cats.data.EitherT
 import cats.implicits._
 import com.amazonaws.services.sqs.model.SendMessageResult
@@ -86,6 +86,10 @@ class PaypalBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
     EitherT.right(Future.successful(()))
   val softOptInsServiceResponseError: EitherT[Future, SoftOptInsServiceError, Unit] =
     EitherT.left(Future.successful(SoftOptInsServiceError("an error from soft opt-ins")))
+  val singleContributionRecordServiceResponse: EitherT[Future, SingleContributionRecordServiceError, Unit] =
+    EitherT.right(Future.successful(()))
+  val singleContributionRecordServiceResponseError: EitherT[Future, SingleContributionRecordServiceError, Unit] =
+    EitherT.left(Future.successful(SingleContributionRecordServiceError("an error from single contribution record")))
   val bigQueryResponse: EitherT[Future, List[String], Unit] =
     EitherT.right(Future.successful(()))
   val bigQueryErrorMessage = "a BigQuery error"
@@ -133,6 +137,7 @@ class PaypalBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
   val mockAcquisitionsStreamService: AcquisitionsStreamService = mock[AcquisitionsStreamService]
   val mockSupporterProductDataService: SupporterProductDataService = mock[SupporterProductDataService]
   val mockSoftOptInsService: SoftOptInsService = mock[SoftOptInsService]
+  val mockSingleContributionRecordService: SingleContributionRecordService = mock[SingleContributionRecordService]
   val mockSwitchService: SwitchService = mock[SwitchService]
 
   // -- test obj
@@ -146,6 +151,7 @@ class PaypalBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
     mockCloudWatchService,
     mockSupporterProductDataService,
     mockSoftOptInsService,
+    mockSingleContributionRecordService,
     mockSwitchService,
   )(new DefaultThreadPool(ec))
 
@@ -275,6 +281,8 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
             .thenReturn(supporterProductDataResponseError)
           when(mockSoftOptInsService.sendMessage(any(), any())(any()))
             .thenReturn(softOptInsServiceResponseError)
+          when(mockSingleContributionRecordService.sendMessage(any())(any()))
+            .thenReturn(singleContributionRecordServiceResponseError)
           when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
           when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
             .thenReturn(streamResponseError)
@@ -286,6 +294,7 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
             .futureRight mustBe enrichedPaypalPaymentMock
 
           verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
+          verify(mockSingleContributionRecordService, times(1)).sendMessage(any())(any())
         }
 
       "return successful payment response with guestAccountRegistrationToken if available" in new PaypalBackendFixture {
@@ -298,6 +307,8 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
           .thenReturn(supporterProductDataResponseError)
         when(mockSoftOptInsService.sendMessage(any(), any())(any()))
           .thenReturn(softOptInsServiceResponseError)
+        when(mockSingleContributionRecordService.sendMessage(any())(any()))
+          .thenReturn(singleContributionRecordServiceResponseError)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
           .thenReturn(streamResponseError)
@@ -309,6 +320,7 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
           .futureRight mustBe enrichedPaypalPaymentMock
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
+        verify(mockSingleContributionRecordService, times(1)).sendMessage(any())(any())
       }
     }
 
@@ -347,6 +359,8 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponse)
         when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsServiceResponse)
+        when(mockSingleContributionRecordService.sendMessage(any())(any()))
+          .thenReturn(singleContributionRecordServiceResponse)
 
         val trackContribution = PrivateMethod[Future[List[BackendError]]](Symbol("trackContribution"))
         val result = paypalBackend invokePrivate trackContribution(
@@ -360,6 +374,7 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
         result.futureValue mustBe List(BackendError.Database(dbError))
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
+        verify(mockSingleContributionRecordService, times(1)).sendMessage(any())(any())
       }
 
       "return a combined error if stream and BigQuery fail" in new PaypalBackendFixture {
@@ -370,6 +385,8 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
           .thenReturn(supporterProductDataResponse)
         when(mockSoftOptInsService.sendMessage(any(), any())(any()))
           .thenReturn(softOptInsServiceResponse)
+        when(mockSingleContributionRecordService.sendMessage(any())(any()))
+          .thenReturn(singleContributionRecordServiceResponse)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any()))
           .thenReturn(streamResponseError)
@@ -389,6 +406,7 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
         result.futureValue mustEqual errors
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
+        verify(mockSingleContributionRecordService, times(1)).sendMessage(any())(any())
       }
 
     }

--- a/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
@@ -1,7 +1,7 @@
 package backend
 
 import akka.actor.ActorSystem
-import backend.BackendError.{SingleContributionRecordServiceError, SoftOptInsServiceError}
+import backend.BackendError.{SingleContributionsServiceError, SoftOptInsServiceError}
 import cats.data.EitherT
 import cats.implicits._
 import com.amazonaws.services.s3.AmazonS3
@@ -95,10 +95,10 @@ class StripeBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
     EitherT.left(Future.successful(SoftOptInsServiceError("an error from soft opt-ins")))
   val softOptInsResponse: EitherT[Future, SoftOptInsServiceError, Unit] =
     EitherT.right(Future.successful(()))
-  val singleContributionRecordServiceResponse: EitherT[Future, SingleContributionRecordServiceError, Unit] =
+  val SingleContributionsServiceResponse: EitherT[Future, SingleContributionsServiceError, Unit] =
     EitherT.right(Future.successful(()))
-  val singleContributionRecordServiceResponseError: EitherT[Future, SingleContributionRecordServiceError, Unit] =
-    EitherT.left(Future.successful(SingleContributionRecordServiceError("an error from single contribution record")))
+  val SingleContributionsServiceResponseError: EitherT[Future, SingleContributionsServiceError, Unit] =
+    EitherT.left(Future.successful(SingleContributionsServiceError("an error from single contributions")))
   val bigQueryResponse: EitherT[Future, List[String], Unit] =
     EitherT.right(Future.successful(()))
   val bigQueryErrorMessage = "a BigQuery error"
@@ -169,7 +169,7 @@ class StripeBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
   val mockCloudWatchService: CloudWatchService = mock[CloudWatchService]
   val mockSupporterProductDataService: SupporterProductDataService = mock[SupporterProductDataService]
   val mockSoftOptInsService: SoftOptInsService = mock[SoftOptInsService]
-  val mockSingleContributionRecordService: SingleContributionRecordService = mock[SingleContributionRecordService]
+  val mockSingleContributionsService: SingleContributionsService = mock[SingleContributionsService]
   val mockSwitchService: SwitchService = mock[SwitchService]
   val mockAcquisitionsStreamService: AcquisitionsStreamService = mock[AcquisitionsStreamService]
   implicit val mockWsClient: WSClient = mock[WSClient]
@@ -191,7 +191,7 @@ class StripeBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
     mockCloudWatchService,
     mockSupporterProductDataService,
     mockSoftOptInsService,
-    mockSingleContributionRecordService,
+    mockSingleContributionsService,
     mockSwitchService,
     Live,
   )(new DefaultThreadPool(ec), mockWsClient)
@@ -306,8 +306,8 @@ class StripeBackendSpec
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponseError)
         when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponseError)
-        when(mockSingleContributionRecordService.sendMessage(any())(any()))
-          .thenReturn(singleContributionRecordServiceResponseError)
+        when(mockSingleContributionsService.sendMessage(any())(any()))
+          .thenReturn(SingleContributionsServiceResponseError)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponse)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         when(mockStripeService.createPaymentIntent(createPaymentIntentWithStripeCheckout))
@@ -321,7 +321,7 @@ class StripeBackendSpec
           StripePaymentIntentsApiResponse.Success()
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
-        verify(mockSingleContributionRecordService, times(1)).sendMessage(any())(any())
+        verify(mockSingleContributionsService, times(1)).sendMessage(any())(any())
       }
 
       "return Success if stripe apple pay switch is On in support-admin-console" in new StripeBackendFixture {
@@ -342,8 +342,8 @@ class StripeBackendSpec
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponseError)
         when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponseError)
-        when(mockSingleContributionRecordService.sendMessage(any())(any()))
-          .thenReturn(singleContributionRecordServiceResponseError)
+        when(mockSingleContributionsService.sendMessage(any())(any()))
+          .thenReturn(SingleContributionsServiceResponseError)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponse)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         when(mockStripeService.createPaymentIntent(createPaymentIntentWithStripeApplePay))
@@ -375,8 +375,8 @@ class StripeBackendSpec
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponseError)
         when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponseError)
-        when(mockSingleContributionRecordService.sendMessage(any())(any()))
-          .thenReturn(singleContributionRecordServiceResponseError)
+        when(mockSingleContributionsService.sendMessage(any())(any()))
+          .thenReturn(SingleContributionsServiceResponseError)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponse)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         when(mockStripeService.createPaymentIntent(createPaymentIntentWithStripePaymentRequest))
@@ -407,8 +407,8 @@ class StripeBackendSpec
           when(mockSupporterProductDataService.insertContributionData(any())(any()))
             .thenReturn(supporterProductDataResponseError)
           when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponseError)
-          when(mockSingleContributionRecordService.sendMessage(any())(any()))
-            .thenReturn(singleContributionRecordServiceResponseError)
+          when(mockSingleContributionsService.sendMessage(any())(any()))
+            .thenReturn(SingleContributionsServiceResponseError)
           when(mockStripeService.createCharge(stripeChargeRequest)).thenReturn(paymentServiceResponse)
           when(mockIdentityService.getOrCreateIdentityIdFromEmail("email@email.com")).thenReturn(identityResponseError)
           when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
@@ -421,7 +421,7 @@ class StripeBackendSpec
           )
 
           verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
-          verify(mockSingleContributionRecordService, times(1)).sendMessage(any())(any())
+          verify(mockSingleContributionsService, times(1)).sendMessage(any())(any())
         }
 
       "return successful payment response with guestAccountRegistrationToken if available" in new StripeBackendFixture {
@@ -430,8 +430,8 @@ class StripeBackendSpec
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponseError)
         when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponseError)
-        when(mockSingleContributionRecordService.sendMessage(any())(any()))
-          .thenReturn(singleContributionRecordServiceResponseError)
+        when(mockSingleContributionsService.sendMessage(any())(any()))
+          .thenReturn(SingleContributionsServiceResponseError)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponse)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         when(mockStripeService.createCharge(stripeChargeRequest)).thenReturn(paymentServiceResponse)
@@ -443,7 +443,7 @@ class StripeBackendSpec
           )
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
-        verify(mockSingleContributionRecordService, times(1)).sendMessage(any())(any())
+        verify(mockSingleContributionsService, times(1)).sendMessage(any())(any())
       }
     }
 
@@ -478,8 +478,8 @@ class StripeBackendSpec
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponse)
         when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponse)
-        when(mockSingleContributionRecordService.sendMessage(any())(any()))
-          .thenReturn(singleContributionRecordServiceResponse)
+        when(mockSingleContributionsService.sendMessage(any())(any()))
+          .thenReturn(SingleContributionsServiceResponse)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponse)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         val trackContribution = PrivateMethod[Future[List[BackendError]]]('trackContribution)
@@ -488,7 +488,7 @@ class StripeBackendSpec
         result.futureValue mustBe List(BackendError.Database(dbError))
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
-        verify(mockSingleContributionRecordService, times(1)).sendMessage(any())(any())
+        verify(mockSingleContributionsService, times(1)).sendMessage(any())(any())
       }
 
       "return a combined error if BigQuery and DB fail" in new StripeBackendFixture {
@@ -498,8 +498,8 @@ class StripeBackendSpec
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponse)
         when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponse)
-        when(mockSingleContributionRecordService.sendMessage(any())(any()))
-          .thenReturn(singleContributionRecordServiceResponse)
+        when(mockSingleContributionsService.sendMessage(any())(any()))
+          .thenReturn(SingleContributionsServiceResponse)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponseError)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         val trackContribution = PrivateMethod[Future[List[BackendError]]]('trackContribution)
@@ -512,7 +512,7 @@ class StripeBackendSpec
         result.futureValue mustBe error
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
-        verify(mockSingleContributionRecordService, times(1)).sendMessage(any())(any())
+        verify(mockSingleContributionsService, times(1)).sendMessage(any())(any())
       }
     }
 
@@ -526,8 +526,8 @@ class StripeBackendSpec
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponse)
         when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponse)
-        when(mockSingleContributionRecordService.sendMessage(any())(any()))
-          .thenReturn(singleContributionRecordServiceResponse)
+        when(mockSingleContributionsService.sendMessage(any())(any()))
+          .thenReturn(SingleContributionsServiceResponse)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponse)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         when(mockStripeService.createPaymentIntent(createPaymentIntent)).thenReturn(paymentServiceIntentResponse)
@@ -539,7 +539,7 @@ class StripeBackendSpec
           StripePaymentIntentsApiResponse.Success()
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
-        verify(mockSingleContributionRecordService, times(1)).sendMessage(any())(any())
+        verify(mockSingleContributionsService, times(1)).sendMessage(any())(any())
       }
 
       "return RequiresAction if 3DS required" in new StripeBackendFixture {
@@ -585,8 +585,8 @@ class StripeBackendSpec
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponse)
         when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponse)
-        when(mockSingleContributionRecordService.sendMessage(any())(any()))
-          .thenReturn(singleContributionRecordServiceResponse)
+        when(mockSingleContributionsService.sendMessage(any())(any()))
+          .thenReturn(SingleContributionsServiceResponse)
         when(mockStripeService.createPaymentIntent(createPaymentIntent)).thenReturn(paymentServiceIntentResponse)
         when(mockIdentityService.getOrCreateIdentityIdFromEmail("email@email.com")).thenReturn(identityResponse)
         when(mockEmailService.sendThankYouEmail(any())).thenReturn(emailServiceErrorResponse)
@@ -596,7 +596,7 @@ class StripeBackendSpec
           StripeApiError.fromString(s"Stripe error", None)
 
         verify(mockSoftOptInsService, times(0)).sendMessage(any(), any())(any())
-        verify(mockSingleContributionRecordService, times(0)).sendMessage(any())(any())
+        verify(mockSingleContributionsService, times(0)).sendMessage(any())(any())
       }
     }
 
@@ -610,8 +610,8 @@ class StripeBackendSpec
         when(mockSupporterProductDataService.insertContributionData(any())(any()))
           .thenReturn(supporterProductDataResponse)
         when(mockSoftOptInsService.sendMessage(any(), any())(any())).thenReturn(softOptInsResponse)
-        when(mockSingleContributionRecordService.sendMessage(any())(any()))
-          .thenReturn(singleContributionRecordServiceResponse)
+        when(mockSingleContributionsService.sendMessage(any())(any()))
+          .thenReturn(SingleContributionsServiceResponse)
         when(mockBigQueryService.tableInsertRowWithRetry(any(), any[Int])(any())).thenReturn(bigQueryResponse)
         when(mockAcquisitionsStreamService.putAcquisitionWithRetry(any(), any[Int])(any())).thenReturn(streamResponse)
         when(mockStripeService.confirmPaymentIntent(confirmPaymentIntent)).thenReturn(paymentServiceIntentResponse)
@@ -622,7 +622,7 @@ class StripeBackendSpec
           StripePaymentIntentsApiResponse.Success()
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
-        verify(mockSingleContributionRecordService, times(1)).sendMessage(any())(any())
+        verify(mockSingleContributionsService, times(1)).sendMessage(any())(any())
       }
 
       "return an error if confirmation failed" in new StripeBackendFixture {


### PR DESCRIPTION
## What are you doing in this PR?

- Add a new service called `SingleContributionSalesforceWritesService`, which sends a message to a single-purpose SQS queue after a contribution is made via support-frontend
- Update tests including the new service
- Add IAM policy to the Scala App to be able to communicate with the new queue

[**Trello Card**](https://trello.com/c/RbcNlxbD/334-single-contribution-record-epic-create-sqs-main-queue-and-dead-letter-queue)

## Why are you doing this?

To add a single contribution record in Salesforce asynchronously.

## Architecture

1. The `SingleContributionSalesforceWritesService` service sends a message to an SQS queue after a contribution is made via support-frontend:

```scala
// support-payment-api/src/main/scala/backend/PaymentBackend.scala
val singleContributionFuture = SingleContributionSalesforceWritesService.sendMessage(contributionData)
```
2. The message payload is:

```scala
// support-payment-api/src/main/scala/services/SingleContributionSalesforceWritesService.scala
case class Message(
     contributionData: ContributionData,
)
```
3. A lambda polls the SQS queue and creates a single contribution record in Salesforce (queue, DLQ and lambda not yet implemented):

![single-contribution-cropped-2](https://github.com/guardian/support-frontend/assets/39066365/683895e5-2f00-47dd-b94e-80808a2a5bc0)

## Notes

- The `SingleContributionSalesforceWritesService` implementation is exactly the same as the [SoftOptInsService](https://github.com/guardian/support-frontend/blob/main/support-payment-api/src/main/scala/services/SoftOptInsService.scala). The only differences are the `sendMessage` validation, the error messages and the message payload.

## How to test

1. Setup AWS credentials for the account `membership`

2. From the root of the `support-frontend` repository, run `sbt "project support-payment-api" test`

3. For manual test, start the server with `sbt "project support-payment-api" run` and run the following CURL command:

```
curl --location 'http://localhost:9000/contribute/one-off/stripe/create-payment' \
--header 'Content-Type: application/json' \
--data-raw '{
    "acquisitionData":{
        "abTests":[]
    },
    "paymentData":{
        "amount":60,
        "currency":"GBP",
        "email":"test@theguardian.com",
        "stripePaymentMethod":"StripeCheckout"
    },
    "paymentMethodId":"pm_card_visa",
    "publicKey":"pk_test_",
    "recaptchaToken":""
}'
```

4. Go to the AWS console and poll the message for the `single-contribution-salesforce-writes-queue-CODE` queue.

## Next steps

1. Create SQS queue and DLQ, in the [support-service-lambdas](https://github.com/guardian/support-service-lambdas) repository ([PR](https://github.com/guardian/support-service-lambdas/pull/2059))
6. Create lambda function in the [support-service-lambdas](https://github.com/guardian/support-service-lambdas) repository