### PR TITLE
Validate custom amounts before proceeding to the second step in the two-step checkout test

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/firstStepLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/firstStepLanding.tsx
@@ -14,6 +14,7 @@ import { useNavigate } from 'react-router';
 import { Box } from 'components/checkoutBox/checkoutBox';
 import { BrandedIcons } from 'components/paymentMethodSelector/creditDebitIcons';
 import { PaypalIcon } from 'components/paymentMethodSelector/paypalIcon';
+import { useOtherAmountValidation } from 'helpers/customHooks/useFormValidation';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
@@ -85,6 +86,11 @@ export function SupporterPlusInitialLandingPage({
 	const displayLimitedPriceCards =
 		abParticipations.supporterPlusOnly === 'variant';
 
+	const proceedToNextStep = useOtherAmountValidation(() => {
+		const destination = `checkout?selected-amount=${amount}&selected-contribution-type=${contributionType.toLowerCase()}`;
+		navigateWithPageView(navigate, destination);
+	}, false);
+
 	const paymentMethodsMarginOneOff = css`
 		margin: ${space[4]}px 0;
 		${from.tablet} {
@@ -130,10 +136,7 @@ export function SupporterPlusInitialLandingPage({
 							priority="primary"
 							size="default"
 							cssOverrides={checkoutBtnStyleOverrides}
-							onClick={() => {
-								const destination = `checkout?selected-amount=${amount}&selected-contribution-type=${contributionType.toLowerCase()}`;
-								navigateWithPageView(navigate, destination);
-							}}
+							onClick={proceedToNextStep}
 						>
 							Continue to checkout
 						</Button>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes an issue where users could proceed to the second step of the form in the two-step checkout test with an invalid custom amount, re-using the existing hook that validates any custom amount before opening the Apple/Google Pay interface.

[**Trello Card**](https://trello.com/c/Ei2JNRyt)

## Screenshots

![Screenshot 2023-09-22 at 12-25-43 Support the Guardian](https://github.com/guardian/support-frontend/assets/29146931/88c29592-94d6-40a5-ace3-f3e4809a4eff)

![Screenshot 2023-09-22 at 12-26-00 Support the Guardian](https://github.com/guardian/support-frontend/assets/29146931/e564b8a3-f647-4c7f-8176-c3f773744a5b)
