### PR TITLE
Send AB test data to Ophan after navigating to second step

### DIFF
--- a/support-frontend/assets/helpers/tracking/ophan.ts
+++ b/support-frontend/assets/helpers/tracking/ophan.ts
@@ -138,20 +138,25 @@ const getPageViewId = (): string => ophan.viewId;
 const navigateWithPageView = (
 	navigate: NavigateFunction,
 	destination: string,
+	participations?: Participations,
 ): void => {
-	const reffererData = {
+	const refererData = {
 		referrerUrl: document.location.href,
 		referrerPageviewId: getPageViewId(),
 	};
 
-	// store reffer data to be read and transmitted on manual pageView
-	setReferrerDataInLocalStorage(reffererData);
+	// store referer data to be read and transmitted on manual pageView
+	setReferrerDataInLocalStorage(refererData);
 
 	// navigate to next page
 	navigate(destination);
 
 	// manual pageView
 	pageView(document.location.href, getAbsoluteURL(destination));
+
+	if (participations) {
+		trackAbTests(participations);
+	}
 };
 
 export {

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/firstStepLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/firstStepLanding.tsx
@@ -88,7 +88,7 @@ export function SupporterPlusInitialLandingPage({
 
 	const proceedToNextStep = useOtherAmountValidation(() => {
 		const destination = `checkout?selected-amount=${amount}&selected-contribution-type=${contributionType.toLowerCase()}`;
-		navigateWithPageView(navigate, destination);
+		navigateWithPageView(navigate, destination, abParticipations);
 	}, false);
 
 	const paymentMethodsMarginOneOff = css`


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes an issue where A/B test data was not correctly associated with the new page view ID after navigating to the second step of the form. By sending the data again associated with the current page view ID we maintain the association as well as being able to track the transfer between pages.

[**Trello Card**](https://trello.com/c/SKdyDqD0)
