### PR TITLE
fix: Only pass content length to S3 if positive

### DIFF
--- a/supporter-product-data/src/main/scala/com/gu/lambdas/FetchResultsLambda.scala
+++ b/supporter-product-data/src/main/scala/com/gu/lambdas/FetchResultsLambda.scala
@@ -41,7 +41,8 @@ object FetchResultsLambda extends StrictLogging {
         fileResponse.isSuccessful,
         s"File download for job with id $jobId failed with http code ${fileResponse.code}",
       )
-      _ = S3Service.streamToS3(stage, filename, fileResponse.body.byteStream, fileResponse.body.contentLength)
+      val contentLength = if (fileResponse.body.contentLength >= 0) Some(fileResponse.body.contentLength) else None
+      _ = S3Service.streamToS3(stage, filename, fileResponse.body.byteStream, contentLength)
     } yield {
       logger.info(s"Successfully wrote file $filename to S3 with ${batch.recordCount} records for jobId $jobId")
       if (batch.recordCount == 0)

--- a/supporter-product-data/src/main/scala/com/gu/services/S3Service.scala
+++ b/supporter-product-data/src/main/scala/com/gu/services/S3Service.scala
@@ -21,11 +21,12 @@ object S3Service extends StrictLogging {
 
   def bucketName(stage: Stage) = s"supporter-product-data-export-${stage.value.toLowerCase}"
 
-  def streamToS3(stage: Stage, filename: String, inputStream: InputStream, length: Long) = {
+  def streamToS3(stage: Stage, filename: String, inputStream: InputStream, length: Option[Long]) = {
     logger.info(s"Trying to stream to S3 - bucketName: ${bucketName(stage)}, filename: $filename, length: $length")
     val objectMetadata = new ObjectMetadata()
-    objectMetadata.setContentLength(length)
-
+    if (length.isDefined) {
+      objectMetadata.setContentLength(length.get)
+    }
     val putObjectRequest = new PutObjectRequest(bucketName(stage), filename, inputStream, objectMetadata)
     val transfer = transferManager.upload(putObjectRequest)
 

--- a/supporter-product-data/src/test/scala/com/gu/services/S3ServiceSpec.scala
+++ b/supporter-product-data/src/test/scala/com/gu/services/S3ServiceSpec.scala
@@ -17,7 +17,7 @@ class S3ServiceSpec extends AsyncFlatSpec with Matchers {
     val stream = new ByteArrayInputStream(initialString.getBytes())
     val filename = s"test-file-${UUID.randomUUID().toString}"
     S3Service
-      .streamToS3(CODE, filename, stream, initialString.length)
+      .streamToS3(CODE, filename, stream, Some(initialString.length))
     Source.fromInputStream(S3Service.streamFromS3(CODE, filename).getObjectContent).mkString shouldBe initialString
   }
 }


### PR DESCRIPTION
This should fix errors writing the zuora batch request results to S3 when Zuora doesn’t include a Content-Length header in its response.