### PR TITLE
Check direct debit details before attempting form submission - expanding form

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
@@ -39,6 +39,20 @@ export default function DirectDebitForm(
 
 	return (
 		<div>
+			{props.formError && (
+				<div
+					id="directDebitDetails"
+					css={css`
+						margin-top: 8px;
+					`}
+				>
+					<ErrorMessage
+						message={props.formError}
+						svg={<SvgExclamationAlternate />}
+					/>
+				</div>
+			)}
+
 			{/** BACS requirement:
         "Name of the account holder, as known by the bank. Usually this is the
         same as the name stored with the linked creditor. This field will be
@@ -109,21 +123,6 @@ export default function DirectDebitForm(
 				</div>
 			)}
 
-			{props.formError && (
-				<div
-					css={css`
-						margin-top: 8px;
-					`}
-				>
-					<ErrorMessage
-						message={props.formError}
-						svg={<SvgExclamationAlternate />}
-					/>
-				</div>
-			)}
-
-			{/* <PaymentButton onConfirmClick={props.onSubmit} /> */}
-
 			<LegalNotice countryGroupId={props.countryGroupId} />
 
 			<DirectDebitGuarantee
@@ -134,24 +133,6 @@ export default function DirectDebitForm(
 		</div>
 	);
 }
-
-// function PaymentButton(props: {
-// 	onConfirmClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
-// }) {
-// 	return (
-// 		<button
-// 			id="qa-submit-button"
-// 			className="component-direct-debit-form__cta component-direct-debit-form__cta--pay-button focus-target"
-// 			onClick={props.onConfirmClick}
-// 		>
-// 			<SvgDirectDebitSymbol />
-// 			<span className="component-direct-debit-form__cta-text">
-// 				Pay with Direct Debit
-// 			</span>
-// 			<SvgArrowRightStraight />
-// 		</button>
-// 	);
-// }
 
 function LegalNotice(props: { countryGroupId: CountryGroupId }) {
 	return (

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
@@ -1,11 +1,12 @@
-import { css } from '@emotion/react';
-import { Checkbox, TextInput } from '@guardian/source-react-components';
+import {
+	Checkbox,
+	InlineError,
+	TextInput,
+} from '@guardian/source-react-components';
 import * as React from 'react';
 import { useState } from 'react';
 import DirectDebitGuarantee from 'components/directDebit/directDebitForm/directDebitGuarantee';
-import ErrorMessage from 'components/errorMessage/errorMessage';
 import { ElementDecorator } from 'components/stripeCardForm/elementDecorator';
-import SvgExclamationAlternate from 'components/svgs/exclamationAlternate';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { contributionsEmail } from 'helpers/legal';
 import {
@@ -40,16 +41,8 @@ export default function DirectDebitForm(
 	return (
 		<div>
 			{props.formError && (
-				<div
-					id="directDebitDetails"
-					css={css`
-						margin-top: 8px;
-					`}
-				>
-					<ErrorMessage
-						message={props.formError}
-						svg={<SvgExclamationAlternate />}
-					/>
+				<div id="directDebitDetails">
+					<InlineError>{props.formError}</InlineError>
 				</div>
 			)}
 

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitFormContainer.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitFormContainer.tsx
@@ -3,13 +3,8 @@ import {
 	setAccountHolderConfirmation,
 	setAccountHolderName,
 	setAccountNumber,
-	setFormError,
 	setSortCodeString,
 } from 'helpers/redux/checkout/payment/directDebit/actions';
-import {
-	confirmAccountDetails,
-	directDebitErrorMessages,
-} from 'helpers/redux/checkout/payment/directDebit/thunks';
 import {
 	expireRecaptchaToken,
 	setRecaptchaToken,
@@ -66,17 +61,6 @@ export function DirectDebitFormContainer({
 	function updateAccountHolderConfirmation(confirmed: boolean) {
 		dispatch(setAccountHolderConfirmation(confirmed));
 	}
-
-	// TODO: This functionality should be moving to a payment button in future
-	void function onSubmit() {
-		void confirmAccountDetails();
-
-		if (recaptchaCompleted) {
-			// void dispatch(payWithDirectDebit(props.onPaymentAuthorisation));
-		} else {
-			dispatch(setFormError(directDebitErrorMessages.notCompletedRecaptcha));
-		}
-	};
 
 	function onRecaptchaCompleted(token: string) {
 		trackComponentLoad('contributions-recaptcha-client-token-received');

--- a/support-frontend/assets/components/paymentButton/directDebitPaymentButton.tsx
+++ b/support-frontend/assets/components/paymentButton/directDebitPaymentButton.tsx
@@ -1,22 +1,24 @@
-import { useFormValidation } from 'helpers/customHooks/useFormValidation';
-import { setPopupOpen } from 'helpers/redux/checkout/payment/directDebit/actions';
-import {
-	useContributionsDispatch,
-	useContributionsSelector,
-} from 'helpers/redux/storeHooks';
+import { useDirectDebitValidation } from 'helpers/customHooks/useFormValidation';
+import type { PaymentAuthorisation } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
+import { payWithDirectDebit } from 'helpers/redux/checkout/payment/directDebit/thunks';
+import { useContributionsDispatch } from 'helpers/redux/storeHooks';
+import { onThirdPartyPaymentAuthorised } from 'pages/supporter-plus-landing/setup/legacyActionCreators';
 import type { PaymentButtonComponentProps } from './paymentButtonController';
 
 export function DirectDebitPaymentButton({
 	DefaultButtonContainer,
 }: PaymentButtonComponentProps): JSX.Element {
 	const dispatch = useContributionsDispatch();
-	const { paymentMethod } = useContributionsSelector(
-		(state) => state.page.checkoutForm.payment,
-	);
 
-	const payWithDirectDebit = useFormValidation(function openDDForm() {
-		dispatch(setPopupOpen());
-	}, paymentMethod.name !== 'DirectDebit');
+	function onSubmit() {
+		void dispatch(
+			payWithDirectDebit((paymentAuthorisation: PaymentAuthorisation) => {
+				void dispatch(onThirdPartyPaymentAuthorised(paymentAuthorisation));
+			}),
+		);
+	}
 
-	return <DefaultButtonContainer onClick={payWithDirectDebit} />;
+	const onClick = useDirectDebitValidation(onSubmit);
+
+	return <DefaultButtonContainer onClick={onClick} />;
 }

--- a/support-frontend/assets/helpers/customHooks/useFormValidation.ts
+++ b/support-frontend/assets/helpers/customHooks/useFormValidation.ts
@@ -114,9 +114,10 @@ export function useDirectDebitValidation<
 
 	const validateAndPay = useCallback(
 		function validateAndPay(event: EventType) {
+			dispatchPaymentWaiting && dispatch(paymentWaiting(true));
 			event.preventDefault();
-			void dispatch(confirmAccountDetails());
 			dispatch(validateForm());
+			void dispatch(confirmAccountDetails());
 			setClickEvent(event);
 		},
 		[dispatch],
@@ -124,12 +125,11 @@ export function useDirectDebitValidation<
 
 	useEffect(() => {
 		if (errorsPreventSubmission) {
+			dispatch(paymentWaiting(false));
 			setClickEvent(null);
 			return;
 		}
 		if (clickEvent && phase === 'confirmation') {
-			dispatchPaymentWaiting && dispatch(paymentWaiting(true));
-
 			paymentHandler(clickEvent);
 		}
 	}, [clickEvent, errorsPreventSubmission, phase]);

--- a/support-frontend/assets/helpers/customHooks/useFormValidation.ts
+++ b/support-frontend/assets/helpers/customHooks/useFormValidation.ts
@@ -116,7 +116,7 @@ export function useDirectDebitValidation<
 		function validateAndPay(event: EventType) {
 			dispatchPaymentWaiting && dispatch(paymentWaiting(true));
 			event.preventDefault();
-			dispatch(validateForm());
+			dispatch(validateForm('DirectDebit'));
 			void dispatch(confirmAccountDetails());
 			setClickEvent(event);
 		},

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
@@ -48,6 +48,20 @@ export function getAmazonPayFormErrors(
 	return errors;
 }
 
+function getDirectDebitFormErrors(state: ContributionsState): ErrorCollection {
+	const { errors, formError } = state.page.checkoutForm.payment.directDebit;
+	if (formError) {
+		return {
+			...errors,
+			directDebitDetails: [formError],
+		};
+	}
+
+	return {
+		...errors,
+	};
+}
+
 export function getPaymentMethodErrors(
 	state: ContributionsState,
 ): ErrorCollection {
@@ -58,7 +72,7 @@ export function getPaymentMethodErrors(
 			return getStripeFormErrors(state);
 
 		case 'DirectDebit':
-			return payment.directDebit.errors ?? {};
+			return getDirectDebitFormErrors(state);
 
 		case 'Sepa':
 			return payment.sepa.errors;


### PR DESCRIPTION
## What are you doing in this PR?

This hooks up the expanding direct debit form component to our existing form submission system, including form validation, and adds an additional validation step to verify the bank account details with the server before proceeding to attempt payment.

[**Trello Card**](https://trello.com/c/9TO5yLpO)

## Why are you doing this?

This is part of the ongoing work to migrate to a new direct debit form that matches our other payment method forms.

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots
![Screenshot 2023-09-27 at 13-23-34 Support the Guardian](https://github.com/guardian/support-frontend/assets/29146931/43d1fa41-fb73-4ecf-b203-950204f73bbf)

![Screenshot 2023-09-27 at 13-24-46 Support the Guardian](https://github.com/guardian/support-frontend/assets/29146931/695d0232-dc6e-4b64-8224-a04b76c4339d)
