### PR TITLE
National Delivery - swap Home Delivery and Sub card tabs

### DIFF
--- a/support-frontend/assets/components/headers/header/header.tsx
+++ b/support-frontend/assets/components/headers/header/header.tsx
@@ -14,7 +14,7 @@ export type PropTypes = {
 	utility?: JSX.Element;
 	countryGroupId: CountryGroupId;
 	display?: 'navigation' | 'checkout' | 'guardianLogo' | void;
-	participations: Participations;
+	participations?: Participations;
 };
 export type State = {
 	isTestUser: boolean | null | undefined;

--- a/support-frontend/assets/components/headers/header/header.tsx
+++ b/support-frontend/assets/components/headers/header/header.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 import { Component } from 'react';
 import SvgGuardianLogo from 'components/svgs/guardianLogo';
+import type { Participations } from 'helpers/abTests/abtest';
 import { getGlobal } from 'helpers/globalsAndSwitches/globals';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { classNameWithModifiers } from 'helpers/utilities/utilities';
@@ -13,6 +14,7 @@ export type PropTypes = {
 	utility?: JSX.Element;
 	countryGroupId: CountryGroupId;
 	display?: 'navigation' | 'checkout' | 'guardianLogo' | void;
+	participations: Participations;
 };
 export type State = {
 	isTestUser: boolean | null | undefined;
@@ -71,7 +73,7 @@ export default class Header extends Component<PropTypes, State> {
 	}
 
 	render(): JSX.Element {
-		const { utility, display, countryGroupId } = this.props;
+		const { utility, display, countryGroupId, participations } = this.props;
 		const { isTestUser } = this.state;
 
 		return (
@@ -98,7 +100,11 @@ export default class Header extends Component<PropTypes, State> {
 						{display === 'navigation' && (
 							<MobileMenuToggler
 								links={
-									<Links countryGroupId={countryGroupId} location="mobile" />
+									<Links
+										countryGroupId={countryGroupId}
+										location="mobile"
+										participations={participations}
+									/>
 								}
 								utility={utility}
 							/>
@@ -106,7 +112,11 @@ export default class Header extends Component<PropTypes, State> {
 					</div>
 					{display === 'navigation' && (
 						<div className="component-header__row">
-							<Links countryGroupId={countryGroupId} location="desktop" />
+							<Links
+								countryGroupId={countryGroupId}
+								location="desktop"
+								participations={participations}
+							/>
 						</div>
 					)}
 					{display === 'checkout' && (

--- a/support-frontend/assets/components/headers/header/headerWithCountrySwitcher.tsx
+++ b/support-frontend/assets/components/headers/header/headerWithCountrySwitcher.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
 import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import type { Participations } from 'helpers/abTests/abtest';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { SubscriptionProduct } from 'helpers/productPrice/subscriptions';
 import type { Option } from 'helpers/types/option';
@@ -13,12 +14,14 @@ export default function ({
 	countryGroupId,
 	listOfCountryGroups,
 	trackProduct,
+	participations,
 }: {
 	path: string;
 	countryGroupId: CountryGroupId;
 	listOfCountryGroups: CountryGroupId[];
 	trackProduct?: Option<SubscriptionProduct>;
 	hideDigiSub?: boolean;
+	participations: Participations;
 }) {
 	return function (): JSX.Element {
 		return (
@@ -32,6 +35,7 @@ export default function ({
 						trackProduct={trackProduct}
 					/>
 				}
+				participations={participations}
 			/>
 		);
 	};

--- a/support-frontend/assets/components/headers/links/links.tsx
+++ b/support-frontend/assets/components/headers/links/links.tsx
@@ -28,7 +28,7 @@ type PropTypes = {
 	location: 'desktop' | 'mobile';
 	countryGroupId?: CountryGroupId;
 	getRef?: (element: Element | null) => void;
-	participations: Participations;
+	participations?: Participations;
 };
 
 const links: HeaderNavLink[] = [
@@ -159,7 +159,7 @@ function Links({
 					.map((link) => {
 						// Link to Home Delivery tab if in the ab test
 						if (
-							participations.nationalDelivery === 'variant' &&
+							participations?.nationalDelivery === 'variant' &&
 							link.text === 'Newspaper'
 						) {
 							return {

--- a/support-frontend/assets/components/headers/links/links.tsx
+++ b/support-frontend/assets/components/headers/links/links.tsx
@@ -1,4 +1,5 @@
 import cx from 'classnames';
+import type { Participations } from 'helpers/abTests/abtest';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
 	AUDCountries,
@@ -27,6 +28,7 @@ type PropTypes = {
 	location: 'desktop' | 'mobile';
 	countryGroupId?: CountryGroupId;
 	getRef?: (element: Element | null) => void;
+	participations: Participations;
 };
 
 const links: HeaderNavLink[] = [
@@ -97,7 +99,12 @@ function getActiveLinkClassModifiers(
 }
 
 // Export
-function Links({ location, getRef, countryGroupId }: PropTypes): JSX.Element {
+function Links({
+	location,
+	getRef,
+	countryGroupId,
+	participations,
+}: PropTypes): JSX.Element {
 	const { protocol, host, pathname } = window.location;
 	const urlWithoutParams = `${protocol}//${host}${pathname}`;
 	const internationalisationIDValue = internationalisationID(countryGroupId);
@@ -148,6 +155,20 @@ function Links({ location, getRef, countryGroupId }: PropTypes): JSX.Element {
 							...link,
 							href: `/${internationalisationIDValue}${link.href}`,
 						};
+					})
+					.map((link) => {
+						// Link to Home Delivery tab if in the ab test
+						if (
+							participations.nationalDelivery === 'variant' &&
+							link.text === 'Newspaper'
+						) {
+							return {
+								...link,
+								href: routes.paperSubscriptionLandingHomeDelivery,
+							};
+						}
+
+						return link;
 					})
 					.map(
 						({ href, text, trackAs, opensInNewWindow, additionalClasses }) => (

--- a/support-frontend/assets/helpers/urls/routes.ts
+++ b/support-frontend/assets/helpers/urls/routes.ts
@@ -29,6 +29,7 @@ const routes: Record<string, string> = {
 	digitalSubscriptionLanding: '/subscribe/digital',
 	digitalSubscriptionLandingGift: '/subscribe/digital/gift',
 	paperSubscriptionLanding: '/subscribe/paper',
+	paperSubscriptionLandingHomeDelivery: '/subscribe/paper/delivery',
 	paperSubscriptionProductChoices: '/subscribe/paper#subscribe',
 	paperSubscriptionDeliveryProductChoices:
 		'/subscribe/paper/delivery#subscribe',

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
@@ -11,6 +11,7 @@ import FlexContainer from 'components/containers/flexContainer';
 import ProductInfoChip from 'components/product/productInfoChip';
 import type { Product } from 'components/product/productOption';
 import ProductOption from 'components/product/productOption';
+import type { Participations } from 'helpers/abTests/abtest';
 import {
 	Collection,
 	HomeDelivery,
@@ -23,6 +24,7 @@ export type PaperPricesPropTypes = {
 	setTabAction: (arg0: PaperFulfilmentOptions) => void;
 	products: Product[];
 	isPriceCardsAbTestVariant: boolean;
+	participations: Participations;
 };
 const pricesSection = css`
 	padding: 0 ${space[3]}px ${space[12]}px;
@@ -103,10 +105,33 @@ export function PaperPrices({
 	setTabAction,
 	products,
 	isPriceCardsAbTestVariant,
+	participations,
 }: PaperPricesPropTypes): JSX.Element {
 	const infoText = `${
 		activeTab === HomeDelivery ? 'Delivery is included. ' : ''
 	}You can cancel your subscription at any time`;
+
+	const collectionTab = (
+		<LinkTo
+			tab={Collection}
+			setTabAction={setTabAction}
+			activeTab={activeTab}
+			isPricesTabLink
+		>
+			Subscription card
+		</LinkTo>
+	);
+	const homeDeliveryTab = (
+		<LinkTo
+			tab={HomeDelivery}
+			setTabAction={setTabAction}
+			activeTab={activeTab}
+			isPricesTabLink
+		>
+			Home Delivery
+		</LinkTo>
+	);
+
 	return (
 		<section css={pricesSection} id="subscribe">
 			<h2
@@ -119,22 +144,18 @@ export function PaperPrices({
 				Pick your subscription package below
 			</h2>
 			<div css={pricesTabs}>
-				<LinkTo
-					tab={Collection}
-					setTabAction={setTabAction}
-					activeTab={activeTab}
-					isPricesTabLink
-				>
-					Subscription card
-				</LinkTo>
-				<LinkTo
-					tab={HomeDelivery}
-					setTabAction={setTabAction}
-					activeTab={activeTab}
-					isPricesTabLink
-				>
-					Home Delivery
-				</LinkTo>
+				{/* Show Home Delivery tab first if in ab test */}
+				{participations.nationalDelivery === 'variant' ? (
+					<>
+						{homeDeliveryTab}
+						{collectionTab}
+					</>
+				) : (
+					<>
+						{collectionTab}
+						{homeDeliveryTab}
+					</>
+				)}
 			</div>
 			<FlexContainer
 				cssOverrides={

--- a/support-frontend/assets/pages/paper-subscription-landing/components/paperProductPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/paperProductPrices.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { Participations } from 'helpers/abTests/abtest';
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
 import { ActivePaperProductTypes } from 'helpers/productPrice/productOptions';
@@ -184,6 +185,7 @@ type PaperProductPricesProps = {
 	tab: PaperFulfilmentOptions;
 	setTabAction: (arg0: PaperFulfilmentOptions) => void;
 	isPriceCardsAbTestVariant?: boolean;
+	participations: Participations;
 };
 
 function PaperProductPrices({
@@ -191,6 +193,7 @@ function PaperProductPrices({
 	tab,
 	setTabAction,
 	isPriceCardsAbTestVariant,
+	participations,
 }: PaperProductPricesProps): JSX.Element | null {
 	if (!productPrices) {
 		return null;
@@ -203,6 +206,7 @@ function PaperProductPrices({
 			products={products}
 			setTabAction={setTabAction}
 			isPriceCardsAbTestVariant={isPriceCardsAbTestVariant ?? false}
+			participations={participations}
 		/>
 	);
 }

--- a/support-frontend/assets/pages/paper-subscription-landing/components/tabs.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/tabs.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { Outset } from 'components/content/content';
 import Tabs from 'components/tabs/tabs';
+import type { Participations } from 'helpers/abTests/abtest';
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { paperSubsUrl } from 'helpers/urls/routes';
 import { ContentDeliveryFaqBlock } from './content/deliveryTab';
@@ -34,11 +35,21 @@ export const tabs: Record<PaperFulfilmentOptions, TabOptions> = {
 type PropTypes = {
 	selectedTab: PaperFulfilmentOptions;
 	setTabAction: (arg0: PaperFulfilmentOptions) => void;
+	participations: Participations;
 };
 
 // ----- Component ----- //
-function PaperTabs({ selectedTab, setTabAction }: PropTypes): JSX.Element {
-	const tabItems = (Object.keys(tabs) as PaperFulfilmentOptions[]).map(
+function PaperTabs({
+	selectedTab,
+	setTabAction,
+	participations,
+}: PropTypes): JSX.Element {
+	/* Show Home Delivery tab first if in ab test */
+	const tabOptions =
+		participations.nationalDelivery === 'variant'
+			? Object.keys(tabs).reverse()
+			: Object.keys(tabs);
+	const tabItems = (tabOptions as PaperFulfilmentOptions[]).map(
 		(fulfilmentMethod) => {
 			const TabContent = tabs[fulfilmentMethod].content;
 			return {

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
@@ -52,6 +52,7 @@ const pageQaId = 'qa-paper-subscriptions';
 function PaperLandingPage({
 	productPrices,
 	promotionCopy,
+	participations,
 }: PaperLandingContentPropTypes) {
 	const sanitisedPromoCopy = getPromotionCopy(promotionCopy);
 	const fulfilment: PaperFulfilmentOptions = window.location.pathname.includes(
@@ -80,7 +81,9 @@ function PaperLandingPage({
 	return (
 		<Page
 			id={pageQaId}
-			header={<Header countryGroupId={GBPCountries} />}
+			header={
+				<Header countryGroupId={GBPCountries} participations={participations} />
+			}
 			footer={paperSubsFooter}
 		>
 			<PaperHero
@@ -94,6 +97,7 @@ function PaperLandingPage({
 							<Tabs
 								selectedTab={selectedTab}
 								setTabAction={handleSetTabAction}
+								participations={participations}
 							/>
 						</div>
 					</Block>
@@ -106,6 +110,7 @@ function PaperLandingPage({
 						productPrices={productPrices}
 						tab={selectedTab}
 						setTabAction={setSelectedTab}
+						participations={participations}
 					/>
 				</CentredContainer>
 			</FullWidthContainer>

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingProps.ts
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingProps.ts
@@ -13,6 +13,7 @@ import type { PromotionCopy } from 'helpers/productPrice/promotions';
 export type PaperLandingContentPropTypes = {
 	productPrices: ProductPrices | null | undefined;
 	promotionCopy: PromotionCopy | null | undefined;
+	participations: Participations;
 };
 
 export type PaperLandingPropTypes = {

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
@@ -18,7 +18,12 @@ function SubscriptionsLandingPage({
 }: SubscriptionsLandingPropTypes) {
 	return (
 		<Page
-			header={<Header countryGroupId={countryGroupId} />}
+			header={
+				<Header
+					countryGroupId={countryGroupId}
+					participations={participations}
+				/>
+			}
 			footer={<Footer centred />}
 		>
 			<SubscriptionLandingContent

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -238,6 +238,7 @@ function WeeklyLandingPage({
 			International,
 		],
 		trackProduct: 'GuardianWeekly',
+		participations,
 	});
 
 	const isPriceCardsAbTestVariant =


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Swapping the Home delivery and Sub card tabs on the paper subscriptions landing page, as well as the header links to that page to ensure the HD tab opens first. (This is all behind a 0% AB Test).

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com/c/jzG8cDMw/61-support-frontend-flip-hnd-and-sub-card-options)

## Why are you doing this?

To give more prominence to home delivery once it has opened up outside the M25.

<!--
Remember, PRs are documentation for future contributors.
-->

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

Before
![image](https://github.com/guardian/support-frontend/assets/114918544/426014ec-9d26-4106-a609-8f1a78a6a1ef)

After
![image](https://github.com/guardian/support-frontend/assets/114918544/ab8d9315-5ccb-4c22-896c-c708c640402c)

