### PR TITLE
Fix SupporterDataDynamoService permission for stripe-patrons-data

### DIFF
--- a/support-modules/supporter-product-data-dynamo/src/main/scala/com/gu/supporterdata/services/SupporterDataDynamoService.scala
+++ b/support-modules/supporter-product-data-dynamo/src/main/scala/com/gu/supporterdata/services/SupporterDataDynamoService.scala
@@ -4,6 +4,7 @@ import com.gu.supporterdata.model.FieldNames._
 import com.gu.supporterdata.model.{Stage, SupporterRatePlanItem}
 import software.amazon.awssdk.auth.credentials.{
   AwsCredentialsProviderChain,
+  ContainerCredentialsProvider,
   EnvironmentVariableCredentialsProvider,
   InstanceProfileCredentialsProvider,
   ProfileCredentialsProvider,
@@ -140,6 +141,7 @@ object SupporterDataDynamoService {
       ProfileCredentialsProvider.builder.profileName(ProfileName).build,
       InstanceProfileCredentialsProvider.builder.asyncCredentialUpdateEnabled(false).build,
       EnvironmentVariableCredentialsProvider.create(),
+      ContainerCredentialsProvider.builder.build(),
     )
     .build
 


### PR DESCRIPTION
The previous PR to use snapstart needed to add a new credentials provider - [see here.](https://github.com/guardian/support-frontend/pull/4869/files#diff-2b20bde739cbd13a3d9c392f38c53ca2196a6531f4a25800cf013e5e824a5096R18)

But these lambdas also use a dynamodb service which defines its credentials provider differently (using the newer aws sdk). This means we get a permissions error when using dynamodb.

Tested in CODE by creating a test user with patron subscription and running the `stripe-patrons-data-CODE` lambda:
![Screenshot 2023-09-29 at 14 01 02](https://github.com/guardian/support-frontend/assets/1513454/6a9b3141-75a9-444c-88a8-5744a79e32f8)
