### PR TITLE
acquisitions-publisher: Shut down BigQueryService

### DIFF
--- a/support-lambdas/bigquery-acquisitions-publisher/src/main/scala/com/gu/bigqueryAcquisitionsPublisher/Lambda.scala
+++ b/support-lambdas/bigquery-acquisitions-publisher/src/main/scala/com/gu/bigqueryAcquisitionsPublisher/Lambda.scala
@@ -30,6 +30,8 @@ object Lambda extends LazyLogging {
           .map(message => processEvent(message, bigQuery))
           .collect { case Left(messageId) => messageId }
 
+        bigQuery.shutdown()
+
         new SQSBatchResponse(
           failedMessageIds.map(messageId => new BatchItemFailure(messageId)).asJava,
         )


### PR DESCRIPTION
The BigQueryService now needs to be shut down when it’s finished with, to close the underlying resources. When updating it recently, I missed the acquisitions-publisher, which has been intermittently throwing OutOfMemoryErrors.

- Trello Card: https://trello.com/c/J484F9Wz/1576-close-bigquery-stream-writer-resources-in-bigquery-acquisitions-publisher-lambda