### PR TITLE
Add .trim() to name validation on checkout

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/personalDetails/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/personalDetails/state.ts
@@ -28,12 +28,14 @@ export const personalDetailsSchema = z
 		firstName: zuoraCompatibleString(
 			z
 				.string()
+				.trim()
 				.min(1, { message: 'Please enter a first name.' })
 				.max(maxLengths.name, { message: 'First name is too long' }),
 		),
 		lastName: zuoraCompatibleString(
 			z
 				.string()
+				.trim()
 				.min(1, 'Please enter a last name.')
 				.max(maxLengths.name, 'Last name is too long'),
 		),


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Adding the `.trim()` command to validation for both first and last name fields on the checkout.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com/c/kvnhy64j/1575-last-name-field-validation-in-the-checkout-to-block-an-empty-space)

## Why are you doing this?
Currently the client side validation does not complain when those two text fields contain only blank spaces.

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [x] No



## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

