### PR TITLE
Fix national delivery checkout: set single delivery agent in reducer, not component

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/addressMeta/actions.ts
+++ b/support-frontend/assets/helpers/redux/checkout/addressMeta/actions.ts
@@ -4,5 +4,5 @@ export const {
 	setBillingAddressMatchesDelivery,
 	setDeliveryInstructions,
 	setDeliveryAgent,
-	setDeliveryAgentResponse,
+	clearDeliveryAgentResponse,
 } = addressMetaSlice.actions;

--- a/support-frontend/assets/helpers/redux/checkout/addressMeta/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/addressMeta/reducer.ts
@@ -17,11 +17,8 @@ export const addressMetaSlice = createSlice({
 		setDeliveryAgent(state, action: PayloadAction<number | undefined>) {
 			state.deliveryAgent.chosenAgent = action.payload;
 		},
-		setDeliveryAgentResponse(
-			state,
-			action: PayloadAction<DeliveryAgentsResponse | undefined>,
-		) {
-			state.deliveryAgent.response = action.payload;
+		clearDeliveryAgentResponse(state) {
+			state.deliveryAgent.response = undefined;
 		},
 	},
 	extraReducers: (builder) => {
@@ -34,6 +31,9 @@ export const addressMetaSlice = createSlice({
 			(state, action: PayloadAction<DeliveryAgentsResponse>) => {
 				state.deliveryAgent.isLoading = false;
 				state.deliveryAgent.response = action.payload;
+				if (action.payload.agents?.length === 1) {
+					state.deliveryAgent.chosenAgent = action.payload.agents[0].agentId;
+				}
 			},
 		);
 		builder.addCase(getDeliveryAgentsThunk.rejected, (state, action) => {

--- a/support-frontend/assets/helpers/redux/checkout/addressMeta/subscriptionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/addressMeta/subscriptionsSideEffects.ts
@@ -15,6 +15,7 @@ function removeErrorsForField(
 		errors: removeError(fieldName, state.page.checkout.formErrors),
 	};
 }
+
 export function addAddressMetaSideEffects(
 	startListening: SubscriptionsStartListening,
 ): void {

--- a/support-frontend/assets/helpers/subscriptionsForms/formActions.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formActions.ts
@@ -22,9 +22,9 @@ import {
 	setDeliveryTownCity,
 } from 'helpers/redux/checkout/address/actions';
 import {
+	clearDeliveryAgentResponse,
 	setBillingAddressMatchesDelivery,
 	setDeliveryAgent,
-	setDeliveryAgentResponse,
 	setDeliveryInstructions,
 } from 'helpers/redux/checkout/addressMeta/actions';
 import { getDeliveryAgentsThunk } from 'helpers/redux/checkout/addressMeta/thunks';
@@ -226,7 +226,7 @@ export function setPaperDeliveryPostcode(postcode: string) {
 			void dispatch(getDeliveryAgentsThunk(postcode));
 		} else {
 			dispatch(setDeliveryAgent());
-			dispatch(setDeliveryAgentResponse());
+			dispatch(clearDeliveryAgentResponse());
 		}
 		dispatch(setDeliveryPostcode(postcode));
 	};

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
@@ -31,7 +31,7 @@ export function DeliveryAgentsSelect(
 	if (props.deliveryAgentsResponse?.type === 'Covered') {
 		if (props.deliveryAgentsResponse.agents?.length === 1) {
 			const singleDeliveryProvider = props.deliveryAgentsResponse.agents[0];
-			props.setDeliveryAgent(singleDeliveryProvider.agentId);
+
 			return (
 				<InfoSummary
 					css={singleDeliveryProviderCss}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

@undergroundquizscene spotted a bug in the national delivery checkout - when choosing a postcode with a single provider option the page hangs (and was infinitely rerendering). 

We investigated and found that the cause was the `addAddressMetaSideEffects` listener listening for changes to the `setDeliveryAgent` redux action and also calling this action in the component (when only one provider is available).

This PR instead sets the chosen delivery agent when only one option is available in the reducer.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [x] No


## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

