### PR TITLE
Reinstate indexing after auth flow on page load

### DIFF
--- a/support-frontend/app/controllers/AuthCodeFlowController.scala
+++ b/support-frontend/app/controllers/AuthCodeFlowController.scala
@@ -110,7 +110,10 @@ class AuthCodeFlowController(cc: ControllerComponents, authService: AsyncAuthent
           replaceParam(origin, referrerParamName, paramValue)
         }
         .getOrElse(origin)
-      cleansed(Redirect(url)).flashing(FlashKey.authTried -> "true")
+      cleansed(Redirect(url))
+        .flashing(FlashKey.authTried -> "true")
+        // Reinstate indexing in the target page
+        .withHeaders("X-Robots-Tag" -> "index,follow")
     }
 
     (code, codeVerifier, sessionState, error, errorDescription) match {


### PR DESCRIPTION
On pages where an auth flow takes place on page load, the response from Gateway has a response header `X-Robots-Tag: noindex,nofollow`, which might be giving Google a hint not to index content at the end of the redirect chain.

This is an attempt to see if we can give an opposing hint in the final redirect to the content.

The test will be if the page can now be indexed.

Alternatively, bots could be being sent in a loop.  But let's see if this works first.
