### PR TITLE
Update Zod from 3.21.4 to v3.22.2

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -115,7 +115,7 @@
     "snarkdown": "^2.0.0",
     "utility-types": "^3.10.0",
     "uuid": "^9.0.0",
-    "zod": "^3.21.4"
+    "zod": "^3.22.2"
   },
   "devDependencies": {
     "@axe-core/react": "^4.2.1",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -16193,7 +16193,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod@^3.21.4:
-  version "3.21.4"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
-  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==
+zod@^3.22.2:
+  version "3.22.2"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.2.tgz#3add8c682b7077c05ac6f979fea6998b573e157b"
+  integrity sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Updating Zod to latest

[**Trello Card**](https://trello.com/c/hWJEIRrJ/1580-investigate-email-validation-issue-with-specific-address)

## Why are you doing this?
The regex used to validate emails on the currently installed version would erroneously throw errors on certain addresses, notably where the domains have subdomains. This was updated by this [PR](https://github.com/colinhacks/zod/commit/36fef58410f4b2c9e79edabae2fc567a4aee13a7).

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots
| Before | After |
| --- |  --- |
| ![image](https://github.com/guardian/support-frontend/assets/99400613/f2a274c6-9860-4dc0-a96a-24b5ff003c61) | <img width="558" alt="image" src="https://github.com/guardian/support-frontend/assets/99400613/0236ce01-8883-4817-b135-95bb69361075"> |

