### PR TITLE
Home Delivery Tab: add new copy for national delivery

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.tsx
@@ -59,20 +59,30 @@ export const accordionContainer = css`
 const accordionTrackingId = 'Paper_HomeDelivery-tab_Delivery-accordion';
 export function ContentDeliveryFaqBlock({
 	setTabAction,
+	isNationalDeliveryAbTestVariant,
 }: {
 	setTabAction: (paperFulfilmentOption: PaperFulfilmentOptions) => void;
+	isNationalDeliveryAbTestVariant: boolean;
 }): JSX.Element {
 	return (
 		<FlexContainer cssOverrides={flexContainerOverride}>
 			<div css={faqsContainer}>
-				<p css={paragraph}>
-					If you live in Greater London, you can use the Guardian’s home
-					delivery service. If not, you can use our{' '}
-					<LinkTo tab={Collection} setTabAction={setTabAction}>
-						subscription cards
-					</LinkTo>
-					.
-				</p>
+				{isNationalDeliveryAbTestVariant ? (
+					<p css={paragraph}>
+						Use the Guardian’s home delivery service to get our newspaper direct
+						to your door.
+					</p>
+				) : (
+					<p css={paragraph}>
+						If you live in Greater London, you can use the Guardian’s home
+						delivery service. If not, you can use our{' '}
+						<LinkTo tab={Collection} setTabAction={setTabAction}>
+							subscription cards
+						</LinkTo>
+						.
+					</p>
+				)}
+
 				<p css={paragraph}>
 					Select your subscription below and checkout. You&apos;ll receive your
 					first newspaper as quickly as five days from subscribing.

--- a/support-frontend/assets/pages/paper-subscription-landing/components/tabs.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/tabs.tsx
@@ -55,7 +55,12 @@ function PaperTabs({
 				text: tabs[fulfilmentMethod].name,
 				href: tabs[fulfilmentMethod].href,
 				selected: fulfilmentMethod === selectedTab,
-				content: <TabContent setTabAction={setTabAction} />,
+				content: (
+					<TabContent
+						setTabAction={setTabAction}
+						isNationalDeliveryAbTestVariant={isNationalDeliveryAbTestVariant}
+					/>
+				),
 			};
 		},
 	);


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Adding new copy for Home Delivery once national delivery is available. Removes the reference to 'Greater London'.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com/c/kn5XlAzN/60-support-frontend-update-copy)

## Why are you doing this?

The copy on support frontend needs to be amended to reflect where we deliver. Currently it says Greater London.The copy on support frontend needs to be amended to reflect where we deliver. Currently it says Greater London.

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [ ] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

Before / `ab-nationalDelivery=control`
![image](https://github.com/guardian/support-frontend/assets/114918544/bf3f2258-3fb2-40f4-ba48-cdf683b8dc2d)

After / `ab-nationalDelivery=variant`
![image](https://github.com/guardian/support-frontend/assets/114918544/7a584e57-668c-470d-b99e-d633aa4b5e85)

