### PR TITLE
National Delivery - Add Saturday/Sunday Only paper validation

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/address/validation.test.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/validation.test.ts
@@ -1,4 +1,5 @@
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { AddressFields } from './state';
 import {
 	applyBillingAddressRules,
@@ -6,6 +7,7 @@ import {
 	isHomeDeliveryAvailable,
 	isHomeDeliveryInM25,
 	isPostcodeOptional,
+	isSaturdayOrSundayDeliveryAvailable,
 	isStateNullable,
 } from './validation';
 
@@ -192,6 +194,7 @@ describe('applyDeliveryAddressRules', () => {
 			'HomeDelivery',
 			fields,
 			{ isLoading: false },
+			'Everyday',
 			{},
 		);
 
@@ -336,6 +339,72 @@ describe('isHomeDeliveryAvailable', () => {
 		const result = isHomeDeliveryInM25(
 			fulfilmentOption,
 			postcode,
+			homeDeliveryPostcodes,
+		);
+
+		expect(result).toBeTruthy();
+	});
+});
+
+describe('isSaturdayOrSundayDeliveryAvailable', () => {
+	it('returns true if postcode inside area', () => {
+		const fulfilmentOption = 'HomeDelivery';
+		const productOption = 'Sunday';
+		const postcode = 'SE23 2AB';
+		const homeDeliveryPostcodes = ['SE23'];
+
+		const result = isSaturdayOrSundayDeliveryAvailable(
+			fulfilmentOption,
+			postcode,
+			productOption,
+			homeDeliveryPostcodes,
+		);
+
+		expect(result).toBeTruthy();
+	});
+
+	it('returns false if postcode outside area', () => {
+		const fulfilmentOption = 'HomeDelivery';
+		const productOption = 'Sunday';
+		const postcode = 'DE 2AB';
+		const homeDeliveryPostcodes = ['SE23'];
+
+		const result = isSaturdayOrSundayDeliveryAvailable(
+			fulfilmentOption,
+			postcode,
+			productOption,
+			homeDeliveryPostcodes,
+		);
+
+		expect(result).toBeFalsy();
+	});
+
+	it('returns true if not Sunday or Saturday product', () => {
+		const fulfilmentOption = 'HomeDelivery';
+		const productOption = 'Everyday';
+		const postcode = 'DE 2AB';
+		const homeDeliveryPostcodes = ['SE23'];
+
+		const result = isSaturdayOrSundayDeliveryAvailable(
+			fulfilmentOption,
+			postcode,
+			productOption,
+			homeDeliveryPostcodes,
+		);
+
+		expect(result).toBeTruthy();
+	});
+
+	it('returns true if not HomeDelivery fulfilment option', () => {
+		const fulfilmentOption: FulfilmentOptions = 'Collection';
+		const productOption = 'Sunday';
+		const postcode = 'DE 2AB';
+		const homeDeliveryPostcodes = ['SE23'];
+
+		const result = isSaturdayOrSundayDeliveryAvailable(
+			fulfilmentOption,
+			postcode,
+			productOption,
 			homeDeliveryPostcodes,
 		);
 

--- a/support-frontend/assets/helpers/redux/checkout/address/validation.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/validation.ts
@@ -171,12 +171,13 @@ function getDeliveryOnlyRules(
 		},
 		{
 			rule:
-				abParticipations.nationalDelivery === 'variant' &&
-				isSaturdayOrSundayDeliveryAvailable(
-					fulfilmentOption,
-					fields.postCode,
-					productOption,
-				),
+				abParticipations.nationalDelivery === 'variant'
+					? isSaturdayOrSundayDeliveryAvailable(
+							fulfilmentOption,
+							fields.postCode,
+							productOption,
+					  )
+					: true,
 			error: formError(
 				'postCode',
 				'Saturday or Sunday delivery is available for Greater London only',

--- a/support-frontend/assets/helpers/redux/checkout/address/validation.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/validation.ts
@@ -180,7 +180,7 @@ function getDeliveryOnlyRules(
 					: true,
 			error: formError(
 				'postCode',
-				'Saturday or Sunday delivery is available for Greater London only',
+				'Saturday or Sunday delivery is available for Greater London only. Go back and select Weekend delivery or choose a Digital Voucher.',
 			),
 		},
 	];

--- a/support-frontend/assets/helpers/redux/checkout/address/validation.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/validation.ts
@@ -220,6 +220,7 @@ export const isSaturdayOrSundayDeliveryAvailable = (
 	productOption: ProductOptions,
 	allowedPrefixes: string[] = M25_POSTCODE_PREFIXES,
 ): boolean => {
+	// For financial reasons Saturday or Sunday only papers are not available for delivery outside M25
 	if (productOption === 'Saturday' || productOption === 'Sunday') {
 		if (fulfilmentOption === 'HomeDelivery' && postcode !== null) {
 			return postcodeIsWithinDeliveryArea(postcode, allowedPrefixes);

--- a/support-frontend/assets/helpers/subscriptionsForms/formValidation.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formValidation.ts
@@ -98,6 +98,7 @@ function withDeliveryValidation(state: SubscriptionsState): AnyErrorType[] {
 		getFulfilmentOption(state),
 		state.page.checkoutForm.deliveryAddress.fields,
 		state.page.checkoutForm.addressMeta.deliveryAgent,
+		state.page.checkoutForm.product.productOption,
 		state.common.abParticipations,
 	);
 	const deliveryAddressErrorsList = getErrorList({

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
@@ -23,12 +23,15 @@ interface DeliveryAgentsSelectProps {
 		'addressMeta/setDeliveryAgent'
 	>;
 	formErrors: Array<FormError<string>>;
+	deliveryAddressErrors: Array<FormError<string>>;
 }
 
 export function DeliveryAgentsSelect(
 	props: DeliveryAgentsSelectProps,
 ): JSX.Element | null {
-	if (props.deliveryAgentsResponse?.type === 'Covered') {
+	const postcodeError = firstError('postCode', props.deliveryAddressErrors);
+
+	if (props.deliveryAgentsResponse?.type === 'Covered' && !postcodeError) {
 		if (props.deliveryAgentsResponse.agents?.length === 1) {
 			const singleDeliveryProvider = props.deliveryAgentsResponse.agents[0];
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -115,8 +115,9 @@ function mapStateToProps(state: SubscriptionsState) {
 		formErrors: state.page.checkout.formErrors,
 		submissionError: state.page.checkout.submissionError,
 		productPrices: state.page.checkoutForm.product.productPrices,
-		billingAddressErrors: state.page.checkoutForm.deliveryAddress.fields.errors,
-		deliveryAddressErrors: state.page.checkoutForm.billingAddress.fields.errors,
+		billingAddressErrors: state.page.checkoutForm.billingAddress.fields.errors,
+		deliveryAddressErrors:
+			state.page.checkoutForm.deliveryAddress.fields.errors,
 		isTestUser: state.page.user.isTestUser,
 		country: state.common.internationalisation.countryId,
 		billingCountry: state.page.checkoutForm.billingAddress.fields.country,
@@ -375,6 +376,7 @@ function PaperCheckoutForm(props: PropTypes) {
 								deliveryAgentsResponse={props.deliveryAgentsResponse}
 								setDeliveryAgent={props.setDeliveryAgent}
 								formErrors={props.formErrors}
+								deliveryAddressErrors={props.deliveryAddressErrors}
 							/>
 						)}
 						{isHomeDelivery ? (


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Adding a validation to prevent taking out a Saturday or Sunday only delivery product with a postcode outside the M25.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com/c/FdANOd6O/69-support-frontend-error-message-on-postcode-validation-sat-sunday-delivery)

## Why are you doing this?

For financial reasons the Guardian cannot offer Sat/Sun deliveries outside Greater London.

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [ ] No


## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

![image](https://github.com/guardian/support-frontend/assets/114918544/7941b075-e4ad-4bc8-aa2e-1f01ac2142b9)
