### PR TITLE
refactor: check signedInCookieName is empty to processRequestWithoutUser

### DIFF
--- a/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala
+++ b/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala
@@ -52,6 +52,10 @@ class UserFromAuthCookiesOrAuthServerActionBuilder(
   override def invokeBlock[A](request: Request[A], block: OptionalAuthRequest[A] => Future[Result]): Future[Result] =
     if (request.cookies.get(config.signedOutCookieName).isDefined) {
       processRequestWithoutUser(config)(request, block)
+    } else if (
+      request.cookies.get(config.idTokenCookieName).isEmpty || request.cookies.get(config.accessTokenCookieName).isEmpty
+    ) {
+      processRequestWithoutUser(config)(request, block)
     } else {
       val result = tryToProcessRequest(config, oktaAuthService)(request, block)
       result.left


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We're looking at changing the auth check flow from:
- If you have recently sign out (`GU_SO` cookie is set)
- Assume there is no user to auth and thus continue with no user i.e. `processRequestWithoutUser`

to:
- If you have not signed in (`GU_U` is missing)
- Assume there is no user to auth and thus continue with no user i.e. `processRequestWithoutUser`

I _think_ it is safe to assume that if there is no `GU_U` cookie the auth flow will always return no user.

~Another options would be to do this check on the cookies used in [`tryToProcessRequest`](https://github.com/guardian/support-frontend/blob/main/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala#L113-L118), [`GU_ACCESS_TOKEN` and `GU_ID_TOKEN`](https://github.com/guardian/support-frontend/blob/main/support-frontend/conf/application.conf#L16-L17).~ 👈 is not an option as those cookies are only set once you've been through the redirection auth dance.

At risk of destroying a [Chesterton's fence](https://en.wikipedia.org/wiki/Wikipedia:Chesterton%27s_fence), this PR is incomplete but rather a discussion point as to whether this would still make sense in regards to the intention of this functionality as, [given the tests](https://github.com/guardian/support-frontend/blob/main/support-frontend/test/actions/UserFromAuthCookiesOrAuthServerActionBuilderTest.scala), it has been explicitly.

<!-- [**Trello Card**](https://trello.com) -->

## Why are you doing this?
The reason for this is that, if a person or bot (Google bot in this instance) is not signed in they go through a redirect path of:

- https://support.theguardian.com/uk/contribute
- https://support.theguardian.com/oauth/authorize
- https://profile.theguardian.com/oauth2/{id}/v1/authorize?state={state}
- https://support.theguardian.com/oauth/callback?state={state}
- https://support.theguardian.com/uk/contribute

The issue is that https://profile.theguardian.com has the `X-Robots-Tag:noindex,nofollow` header set which means that Google defines this as `Not indexable" and we get no search traffic to the page.

Not redirecting non-signed in users should rectify this.

## Is this an AB test?
- [ ] Yes
- [x] No

