### PR TITLE
National Delivery: Mark Saturday and Sunday home delivery options as “only available within Greater London”

### DIFF
--- a/support-frontend/assets/components/product/productOption.tsx
+++ b/support-frontend/assets/components/product/productOption.tsx
@@ -107,7 +107,7 @@ function ProductOption(props: Product): JSX.Element {
 			<div css={productOptionVerticalLine}>
 				<p css={[productOptionOfferCopy, productOptionUnderline]}>
 					{props.offerCopy}
-					{!props.offerCopy && props.unavailableOutsideLondon && (
+					{props.unavailableOutsideLondon && (
 						<InfoSummary
 							cssOverrides={css`
 								border: 0;

--- a/support-frontend/assets/components/product/productOption.tsx
+++ b/support-frontend/assets/components/product/productOption.tsx
@@ -5,6 +5,7 @@ import {
 	buttonThemeReaderRevenue,
 	LinkButton,
 } from '@guardian/source-react-components';
+import { InfoSummary } from '@guardian/source-react-components-development-kitchen';
 import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 import { useHasBeenSeen } from 'helpers/customHooks/useHasBeenSeen';
@@ -40,6 +41,7 @@ export type Product = {
 	cssOverrides?: SerializedStyles;
 	billingPeriod?: BillingPeriod;
 	isSpecialOffer?: boolean;
+	unavailableOutsideLondon?: boolean;
 };
 
 function ProductOption(props: Product): JSX.Element {
@@ -105,6 +107,15 @@ function ProductOption(props: Product): JSX.Element {
 			<div css={productOptionVerticalLine}>
 				<p css={[productOptionOfferCopy, productOptionUnderline]}>
 					{props.offerCopy}
+					{!props.offerCopy && props.unavailableOutsideLondon && (
+						<InfoSummary
+							cssOverrides={css`
+								border: 0;
+							`}
+							message=""
+							context="Only available inside Greater London."
+						/>
+					)}
 				</p>
 			</div>
 			<div css={priceCopyGridPlacement}>

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
@@ -177,6 +177,7 @@ export function PaperPrices({
 						onClick={product.onClick}
 						onView={product.onView}
 						label={product.label}
+						unavailableOutsideLondon={product.unavailableOutsideLondon}
 					/>
 				))}
 			</FlexContainer>

--- a/support-frontend/assets/pages/paper-subscription-landing/components/paperProductPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/paperProductPrices.tsx
@@ -1,5 +1,9 @@
 import type { ReactNode } from 'react';
-import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import type { Product } from 'components/product/productOption';
+import type {
+	FulfilmentOptions,
+	PaperFulfilmentOptions,
+} from 'helpers/productPrice/fulfilmentOptions';
 import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
 import { ActivePaperProductTypes } from 'helpers/productPrice/productOptions';
 import type {
@@ -62,6 +66,13 @@ const getOfferText = (price: ProductPrice, promo?: Promotion) => {
 
 	return '';
 };
+
+const getUnavailableOutsideLondon = (
+	fulfilmentOption: FulfilmentOptions,
+	productOption: PaperProductOptions,
+) =>
+	fulfilmentOption === 'HomeDelivery' &&
+	(productOption === 'Saturday' || productOption === 'Sunday');
 
 // ---- Plans ----- //
 const copy: Record<
@@ -139,7 +150,8 @@ const copy: Record<
 const getPlans = (
 	fulfilmentOption: PaperFulfilmentOptions,
 	productPrices: ProductPrices,
-) =>
+	isNationalDeliveryAbTestVariant: boolean,
+): Product[] =>
 	ActivePaperProductTypes.map((productOption) => {
 		const priceAfterPromosApplied = finalPrice(
 			productPrices,
@@ -176,6 +188,9 @@ const getPlans = (
 			),
 			offerCopy: getOfferText(priceAfterPromosApplied, promotion),
 			label: labelText,
+			unavailableOutsideLondon:
+				isNationalDeliveryAbTestVariant &&
+				getUnavailableOutsideLondon(fulfilmentOption, productOption),
 		};
 	});
 
@@ -198,7 +213,11 @@ function PaperProductPrices({
 		return null;
 	}
 
-	const products = getPlans(tab, productPrices);
+	const products = getPlans(
+		tab,
+		productPrices,
+		isNationalDeliveryAbTestVariant,
+	);
 	return (
 		<PaperPrices
 			activeTab={tab}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Adds copy to note Saturday/Sunday only home deliveries are not available outside of Greater London, for financial reasons. This change is behind the `nationalDelivery` ab test.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com/c/FVXTYV03/72-mark-saturday-and-sunday-delivery-options-as-only-available-within-greater-london-or-similar-wording)

## Why are you doing this?

We will not be offering the Saturday(-only) and Sunday(-only) delivery options for the new National Delivery product, as they’re not financially viable. There is a validation on the checkout so this note should hopefully prevent people from hitting that.

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [x] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

Before
![image](https://github.com/guardian/support-frontend/assets/114918544/3d1212c9-7d7f-448f-b442-7c54a342e3f2)
![image](https://github.com/guardian/support-frontend/assets/114918544/c094151f-19a9-41c7-85c5-dd51cbea37e1)


After 
![image](https://github.com/guardian/support-frontend/assets/114918544/edc24186-7830-46ae-ab00-06f2f8d19c7a)
![image](https://github.com/guardian/support-frontend/assets/114918544/d2439ffb-b06d-4b02-9130-0bad895210c6)

