### PR TITLE
Give post-deployment availability test access to cookies

### DIFF
--- a/support-frontend/test/selenium/util/Dependencies.scala
+++ b/support-frontend/test/selenium/util/Dependencies.scala
@@ -1,17 +1,35 @@
 package selenium.util
 
-import okhttp3.OkHttpClient
 import okhttp3.Request.Builder
+import okhttp3.{Cookie, CookieJar, HttpUrl, OkHttpClient}
+
+import scala.collection.mutable
 
 object Dependencies {
 
-  private val client = new OkHttpClient()
+  private val client = {
+
+    // Keep cookies so that auth flow works
+    val cookieJar = new CookieJar {
+      val cookieStore = new mutable.HashMap[String, java.util.List[Cookie]]()
+
+      override def saveFromResponse(url: HttpUrl, cookies: java.util.List[Cookie]): Unit =
+        cookieStore.put(url.host(), cookies)
+
+      override def loadForRequest(url: HttpUrl): java.util.List[Cookie] =
+        cookieStore.getOrElse(url.host(), new java.util.ArrayList[Cookie]())
+    }
+
+    new OkHttpClient()
+      .newBuilder()
+      .cookieJar(cookieJar)
+      .build()
+  }
 
   trait Availability {
     val url: String
     def isAvailable: Boolean = {
-      // Cookie is to avoid a chain of auth redirects as this check is purely to ensure site is up
-      val request = new Builder().url(url).addHeader("Cookie", "GU_SO=true").build()
+      val request = new Builder().url(url).build()
       client.newCall(request).execute.isSuccessful
     }
   }


### PR DESCRIPTION
I had thought that the reason the availability test that runs before the Selenium tests was failing was something to do with the interaction with bots.  But it's actually because the OkHttp client doesn't store cookies by default.  So I've fixed that but it hasn't helped to understand the Google indexing problem.