### PR TITLE
Attempt 2 to reinstate indexing after auth flow on page load

### DIFF
--- a/support-frontend/app/controllers/AuthCodeFlowController.scala
+++ b/support-frontend/app/controllers/AuthCodeFlowController.scala
@@ -113,7 +113,7 @@ class AuthCodeFlowController(cc: ControllerComponents, authService: AsyncAuthent
       cleansed(Redirect(url))
         .flashing(FlashKey.authTried -> "true")
         // Reinstate indexing in the target page
-        .withHeaders("X-Robots-Tag" -> "index,follow")
+        .withHeaders("X-Robots-Tag" -> "all")
     }
 
     (code, codeVerifier, sessionState, error, errorDescription) match {


### PR DESCRIPTION
This is the second attempt to get indexing working after the auth flow on checkout pages.
Reading the [documentation](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#xrobotstag) on the `X-Robots-Tag` header, I realise that I may have given it invalid values on the first attempt.  I've now corrected that.

> all: There are no restrictions for indexing or serving. This rule is the default value

The first attempt was at #5312.
