### PR TITLE
Add alarm to deadletter queue for bigquery-acquisitions-publisher

### DIFF
--- a/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
+++ b/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
@@ -4,6 +4,7 @@ exports[`The BigqueryAcquisitionsPublisher stack matches the snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [
+      "GuAlarm",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuLambdaErrorPercentageAlarm",
@@ -20,6 +21,25 @@ exports[`The BigqueryAcquisitionsPublisher stack matches the snapshot 1`] = `
   "Resources": {
     "DeadLetterQueueAlarm48D9D867": {
       "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":contributions-dev",
+              ],
+            ],
+          },
+        ],
         "AlarmDescription": {
           "Fn::Join": [
             "",

--- a/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
+++ b/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
@@ -18,6 +18,44 @@ exports[`The BigqueryAcquisitionsPublisher stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "DeadLetterQueueAlarm48D9D867": {
+      "Properties": {
+        "AlarmDescription": {
+          "Fn::Join": [
+            "",
+            [
+              "Alarm for dead letter ",
+              {
+                "Fn::GetAtt": [
+                  "deadlettersbigqueryacquisitionspublisherQueue2B5FA5C1",
+                  "QueueName",
+                ],
+              },
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "deadlettersbigqueryacquisitionspublisherQueue2B5FA5C1",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Threshold": 1,
+        "TreatMissingData": "ignore",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "EventBusToSQSRule72D08395": {
       "Properties": {
         "Description": "Send all events to SQS",

--- a/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
+++ b/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
@@ -4,10 +4,10 @@ exports[`The BigqueryAcquisitionsPublisher stack matches the snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [
-      "GuAlarm",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuLambdaErrorPercentageAlarm",
+      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -40,20 +40,11 @@ exports[`The BigqueryAcquisitionsPublisher stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": {
-          "Fn::Join": [
-            "",
-            [
-              "Alarm for dead letter ",
-              {
-                "Fn::GetAtt": [
-                  "deadlettersbigqueryacquisitionspublisherQueue2B5FA5C1",
-                  "QueueName",
-                ],
-              },
-            ],
-          ],
-        },
+        "AlarmDescription": "There is one or more event in the dead-letters-bigquery-acquisitions-publisher-PROD dead letter queue. Check the logs for details of the exception and then use the dead letter queue redrive functionality to replay the failed event if appropriate. If the redrive functionality is not used then purge the queue instead or the alarm will remain in an alarm state and not send this email again in future.
+The main queue is at https://eu-west-1.console.aws.amazon.com/sqs/v2/home?region=eu-west-1#/queues/https%3A%2F%2Fsqs.eu-west-1.amazonaws.com%2F865473395570%2Fbigquery-acquisitions-publisher-queue-PROD
+The dead letter queue is at https://eu-west-1.console.aws.amazon.com/sqs/v2/home?region=eu-west-1#/queues/https%3A%2F%2Fsqs.eu-west-1.amazonaws.com%2F865473395570%2Fdead-letters-bigquery-acquisitions-publisher-PROD
+Logs are at https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fbigquery-acquisitions-publisher-PROD",
+        "AlarmName": "The PROD big-query-acquisitions-publisher lambda has failed",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {

--- a/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
+++ b/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
@@ -263,6 +263,9 @@ exports[`The BigqueryAcquisitionsPublisher stack matches the snapshot 1`] = `
         "FunctionName": {
           "Ref": "bigqueryacquisitionspublisherLambdaD7F059E6",
         },
+        "FunctionResponseTypes": [
+          "ReportBatchItemFailures",
+        ],
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },

--- a/cdk/lib/bigquery-acquisitions-publisher.ts
+++ b/cdk/lib/bigquery-acquisitions-publisher.ts
@@ -1,10 +1,10 @@
+import { GuAlarm } from "@guardian/cdk/lib/constructs/cloudwatch";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack } from "@guardian/cdk/lib/constructs/core";
 import { GuLambdaFunction } from "@guardian/cdk/lib/constructs/lambda";
 import type { App } from "aws-cdk-lib";
 import { Duration } from "aws-cdk-lib";
 import {
-  Alarm,
   ComparisonOperator,
   TreatMissingData,
 } from "aws-cdk-lib/aws-cloudwatch";
@@ -55,13 +55,16 @@ export class BigqueryAcquisitionsPublisher extends GuStack {
       },
     });
 
-    new Alarm(this, "DeadLetterQueueAlarm", {
+    new GuAlarm(this, "DeadLetterQueueAlarm", {
+      app: appName,
       alarmDescription: `Alarm for dead letter ${deadLetterQueue.queueName}`,
       metric: deadLetterQueue.metricApproximateNumberOfMessagesVisible(),
       threshold: 1,
       evaluationPeriods: 1,
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       treatMissingData: TreatMissingData.IGNORE,
+      snsTopicName: "contributions-dev",
+      actionsEnabled: this.stage === "PROD",
     });
 
     // Rule which passes events on to SQS

--- a/cdk/lib/bigquery-acquisitions-publisher.ts
+++ b/cdk/lib/bigquery-acquisitions-publisher.ts
@@ -74,8 +74,6 @@ export class BigqueryAcquisitionsPublisher extends GuStack {
       targets: [new SqsQueue(queue)],
     });
 
-    const eventSource = new SqsEventSource(queue);
-
     // Create a custom role because the name needs to be short, otherwise the request to Google Cloud fails
     const role = new Role(this, "bigquery-to-s3-role", {
       roleName: `bq-acq-${this.stage}`,
@@ -110,6 +108,11 @@ export class BigqueryAcquisitionsPublisher extends GuStack {
               "Check the logs for details https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fbigquery-acquisitions-publisher-PROD",
           }
         : undefined;
+
+    // SQS to Lambda event source mapping
+    const eventSource = new SqsEventSource(queue, {
+      reportBatchItemFailures: true,
+    });
 
     new GuLambdaFunction(this, `${appName}Lambda`, {
       app: appName,

--- a/support-lambdas/bigquery-acquisitions-publisher/src/main/scala/com/gu/bigqueryAcquisitionsPublisher/Lambda.scala
+++ b/support-lambdas/bigquery-acquisitions-publisher/src/main/scala/com/gu/bigqueryAcquisitionsPublisher/Lambda.scala
@@ -33,7 +33,8 @@ object Lambda extends LazyLogging {
         bigQuery.shutdown()
 
         new SQSBatchResponse(
-          failedMessageIds.map(messageId => new BatchItemFailure(messageId)).asJava,
+          List(new BatchItemFailure(messages.head.getMessageId)).asJava,
+            // failedMessageIds.map(messageId => new BatchItemFailure(messageId)).asJava,
         )
 
       case Left(error) =>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
#4923 introduced a new SQS queue and lambda which handles writing acquisition events to BigQuery, while it had an alarm for unhandled runtime failures, any handled runtime failures were being returned to the queue via an `SQSBatchResponse`. The idea was that the queue would then pass the failed event to the dead letter queue where it could be investigated however there were two issues with this:
- the event source mapping between the queue and the lambda was not set up to report batch failures so these would have been lost.
- there was no alarm on the dead letter queue so events could be building up on there and we would not know

This PR fixes both of those issues.

As I have said in the description of the alarm, it is important from now on that when events arrive in the dead letter queue they are either sent back to the main queue using redrive functionality (after fixing whatever caused the failure) OR purged from the dead letter queue, otherwise the alarm will remain in an alarm state and will not send the alarm email again in future.