### PR TITLE
Ignore auth cookies if user isn't signed in

### DIFF
--- a/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala
+++ b/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala
@@ -1,8 +1,13 @@
 package actions
 
 import actions.AsyncAuthenticatedBuilder.OptionalAuthRequest
+import actions.UserFromAuthCookiesActionBuilder.{
+  UserClaims,
+  responseWithNoUser,
+  shouldValidateUser,
+  validateUserRemotely,
+}
 import actions.UserFromAuthCookiesActionBuilder.UserClaims.toUser
-import actions.UserFromAuthCookiesActionBuilder._
 import com.gu.identity.auth._
 import com.gu.identity.model.{PrivateFields, User}
 import config.Identity
@@ -29,7 +34,7 @@ class UserFromAuthCookiesActionBuilder(
     with Logging {
 
   override def invokeBlock[A](request: Request[A], block: OptionalAuthRequest[A] => Future[Result]): Future[Result] =
-    processRequest(config, oktaAuthService)(request, block, _ => processRequestWithoutUser(config)(request, block))
+    shouldValidateUser(config, oktaAuthService)(request, block, _ => responseWithNoUser(config)(request, block))
 }
 
 /** Tries to authenticate the user from ID and access token cookies. If there are no cookies, queries the auth server to
@@ -45,40 +50,30 @@ class UserFromAuthCookiesOrAuthServerActionBuilder(
     with Logging {
 
   override def invokeBlock[A](request: Request[A], block: OptionalAuthRequest[A] => Future[Result]): Future[Result] = {
-    processRequest(config, oktaAuthService)(
+    shouldValidateUser(config, oktaAuthService)(
       request,
       block,
       failure => {
         logger.info(s"Request ${request.id} doesn't have valid token cookies: ${failure.message}")
-        if (request.flash.get(authTried).isDefined) {
+        val alreadyAttempted = request.flash.get(authTried).isDefined
+        if (alreadyAttempted) {
           // Already tried to authenticate this request so just pass it through without a user
-          processRequestWithoutUser(config)(request, block)
+          responseWithNoUser(config)(request, block)
         } else {
-          // Haven't tried to authenticate this request yet so redirect to auth
-          isAuthServerUp().flatMap {
-            case true =>
-              val session = {
-                val withoutReferrer = request.session + (originUrl -> request.uri)
-                request.headers
-                  .get(REFERER)
-                  .map(referrer => withoutReferrer + (referringUrl -> referrer))
-                  .getOrElse(withoutReferrer)
-              }
-              Future.successful(Redirect(routes.AuthCodeFlowController.authorize()).withSession(session))
-            case false =>
-              // If auth server is down, just pass request through without a user
-              logger.warn(s"Auth server is down, can't authenticate request ${request.id}")
-              processRequestWithoutUser(config)(request, block)
-          }
+          // Haven't tried to authenticate this request yet so redirect to auth server
+          validateUserRemotely(config, isAuthServerUp)(request, block)
         }
       },
     )
   }
 }
 
-object UserFromAuthCookiesActionBuilder {
+object UserFromAuthCookiesActionBuilder extends Logging {
 
-  def processRequest[A](config: Identity, oktaAuthService: OktaAuthService[DefaultAccessClaims, UserClaims])(
+  /** Provides an authenticated [[User]] to the given block if authentication is possible. Otherwise, processes the
+    * given block without a user.
+    */
+  def shouldValidateUser[A](config: Identity, oktaAuthService: OktaAuthService[DefaultAccessClaims, UserClaims])(
       request: Request[A],
       block: OptionalAuthRequest[A] => Future[Result],
       handleFailure: ValidationError => Future[Result],
@@ -86,16 +81,65 @@ object UserFromAuthCookiesActionBuilder {
     def isCookiePresent(name: String) = request.cookies.get(name).isDefined
     val isSignedOut = isCookiePresent(config.signedOutCookieName)
     val isSignedIn = isCookiePresent(config.signedInCookieName)
+    // If user is signed out or there are no cookies, just pass request through without a user
     if (isSignedOut || !isSignedIn) {
-      processRequestWithoutUser(config)(request, block)
+      responseWithNoUser(config)(request, block)
     } else {
-      val result = tryToProcessRequest(config, oktaAuthService)(request, block)
+      val result = validateUserLocally(config, oktaAuthService)(request).map(responseWithUser(request, block))
       result.left.map(handleFailure).merge
     }
   }
 
-  /** Processes a request where the [[OptionalAuthRequest]] doesn't have a user. */
-  def processRequestWithoutUser[A](
+  /** Validates auth tokens cached in cookies to find a user.
+    */
+  private def validateUserLocally[A](
+      config: Identity,
+      oktaAuthService: OktaAuthService[DefaultAccessClaims, UserClaims],
+  )(request: Request[A]): Either[ValidationError, User] = {
+    val accessScopes = config.oauthScopes.trim.split("\\s+").map(scope => ClientAccessScope(scope)).toList
+    for {
+      idTokenCookie <- request.cookies
+        .get(config.idTokenCookieName)
+        .toRight(GenericValidationError("No id token cookie"))
+      accessTokenCookie <- request.cookies
+        .get(config.accessTokenCookieName)
+        .toRight(GenericValidationError("No access token cookie"))
+      userClaims <- oktaAuthService.validateIdTokenLocally(IdToken(idTokenCookie.value), nonce = None)
+      _ <- oktaAuthService.validateAccessTokenLocally(AccessToken(accessTokenCookie.value), accessScopes)
+    } yield toUser(userClaims)
+  }
+
+  /** Redirects to auth server to validate user.
+    */
+  def validateUserRemotely[A](config: Identity, isAuthServerUp: () => Future[Boolean])(
+      request: Request[A],
+      block: OptionalAuthRequest[A] => Future[Result],
+  )(implicit ctx: ExecutionContext): Future[Result] = {
+    isAuthServerUp().flatMap {
+      case true =>
+        val session = {
+          val withoutReferrer = request.session + (originUrl -> request.uri)
+          request.headers
+            .get(REFERER)
+            .map(referrer => withoutReferrer + (referringUrl -> referrer))
+            .getOrElse(withoutReferrer)
+        }
+        Future.successful(Redirect(routes.AuthCodeFlowController.authorize()).withSession(session))
+      case false =>
+        // If auth server is down, just pass request through without a user
+        logger.warn(s"Auth server is down, can't authenticate request ${request.id}")
+        responseWithNoUser(config)(request, block)
+    }
+  }
+
+  /** Processes a request that has an authenticated user. */
+  private def responseWithUser[A](request: Request[A], block: OptionalAuthRequest[A] => Future[Result])(
+      user: User,
+  ): Future[Result] =
+    block(new AuthenticatedRequest(Some(user), request))
+
+  /** Processes a request that has no authenticated user. */
+  def responseWithNoUser[A](
       config: Identity,
   )(request: Request[A], block: OptionalAuthRequest[A] => Future[Result])(implicit
       ctx: ExecutionContext,
@@ -108,26 +152,6 @@ object UserFromAuthCookiesActionBuilder {
         toDiscardingCookie(config.accessTokenCookieName),
       ),
     )
-  }
-
-  /** Tries to process a request with the given block. If the request doesn't have valid token cookies, returns a
-    * [[ValidationError]].
-    */
-  private def tryToProcessRequest[A](
-      config: Identity,
-      oktaAuthService: OktaAuthService[DefaultAccessClaims, UserClaims],
-  )(request: Request[A], block: OptionalAuthRequest[A] => Future[Result]): Either[ValidationError, Future[Result]] = {
-    val accessScopes = config.oauthScopes.trim.split("\\s+").map(scope => ClientAccessScope(scope)).toList
-    for {
-      idTokenCookie <- request.cookies
-        .get(config.idTokenCookieName)
-        .toRight(GenericValidationError("No id token cookie"))
-      accessTokenCookie <- request.cookies
-        .get(config.accessTokenCookieName)
-        .toRight(GenericValidationError("No access token cookie"))
-      userClaims <- oktaAuthService.validateIdTokenLocally(IdToken(idTokenCookie.value), nonce = None)
-      _ <- oktaAuthService.validateAccessTokenLocally(AccessToken(accessTokenCookie.value), accessScopes)
-    } yield block(new AuthenticatedRequest(Some(toUser(userClaims)), request))
   }
 
   case class UserClaims(

--- a/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala
+++ b/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala
@@ -85,8 +85,10 @@ object UserFromAuthCookiesActionBuilder extends Logging {
     if (isSignedOut || !isSignedIn) {
       responseWithNoUser(config)(request, block)
     } else {
-      val result = validateUserLocally(config, oktaAuthService)(request).map(responseWithUser(request, block))
-      result.left.map(handleFailure).merge
+      validateUserLocally(config, oktaAuthService)(request).fold(
+        handleFailure,
+        responseWithUser(request, block),
+      )
     }
   }
 

--- a/support-frontend/app/config/Identity.scala
+++ b/support-frontend/app/config/Identity.scala
@@ -16,6 +16,9 @@ class Identity(config: Config) {
 
   lazy val useStub = config.getOptionalBoolean("useStub").getOrElse(false)
 
+  // This cookie indicates that user is signed in
+  lazy val signedInCookieName = config.getString("signed.in.cookie.name")
+
   // This cookie indicates that user has recently signed out
   lazy val signedOutCookieName = config.getString("signed.out.cookie.name")
 

--- a/support-frontend/app/controllers/AuthCodeFlowController.scala
+++ b/support-frontend/app/controllers/AuthCodeFlowController.scala
@@ -112,8 +112,6 @@ class AuthCodeFlowController(cc: ControllerComponents, authService: AsyncAuthent
         .getOrElse(origin)
       cleansed(Redirect(url))
         .flashing(FlashKey.authTried -> "true")
-        // Reinstate indexing in the target page
-        .withHeaders("X-Robots-Tag" -> "all")
     }
 
     (code, codeVerifier, sessionState, error, errorDescription) match {

--- a/support-frontend/conf/application.conf
+++ b/support-frontend/conf/application.conf
@@ -12,6 +12,7 @@ play.filters.csrf.cookie {
 play.assets.cache."/public/compiled-assets/" = "public, max-age=31536000"
 
 identity {
+  signed.in.cookie.name = "GU_U"
   signed.out.cookie.name = "GU_SO"
   id.token.cookie.name = "GU_ID_TOKEN"
   access.token.cookie.name = "GU_ACCESS_TOKEN"


### PR DESCRIPTION
## What are you doing in this PR?
Previously, the `MaybeAuthenticatedAction` was attempting to fetch auth tokens unless the user was signed out.
Now we also check that the user isn't ***signed in*** as well, by checking for the presence of the `GU_U` cookie, which is only dropped for signed-in users.

## Why are you doing this?
The reason for this is that, if a person or bot (Google bot in this instance) is not signed in they go through a redirect path of:

- https://support.theguardian.com/uk/contribute
- https://support.theguardian.com/oauth/authorize
- https://profile.theguardian.com/oauth2/{id}/v1/authorize?state={state}
- https://support.theguardian.com/oauth/callback?state={state}
- https://support.theguardian.com/uk/contribute

The issue is that https://profile.theguardian.com has the `X-Robots-Tag:noindex,nofollow` header set which means that Google defines this as `Not indexable" and we get no search traffic to the page.

Not redirecting non-signed in users should rectify this.

## Is this an AB test?
- [ ] Yes
- [x] No

Thanks to @jamesgorrie for the idea and most of the PR description.

Tested in Code and all seems to work.  Page https://support.code.dev-theguardian.com/uk/contribute is indexable by https://search.google.com/test/rich-results.
