### PR TITLE
fix: include @guardian/source packages in babel

### DIFF
--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -117,7 +117,7 @@ module.exports = (cssFilename, jsFilename, minimizeCss) => ({
 				test: /\.([jt]sx?|mjs)$/,
 				exclude: {
 					and: [/node_modules/],
-					not: [/@guardian\/consent-management-platform/, /@guardian\/libs/],
+					not: [/@guardian\/consent-management-platform/, /@guardian\/libs/, /@guardian\/source/],
 				},
 				use: [
 					{


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Including `@guardian/source` packages in the babel transpilation.

Source [suggest that you use certain babel plugins to have their components work](https://github.com/guardian/csnx/blob/main/libs/%40guardian/source-foundations/src/accessibility/focus-style-manager.ts#L9C14-L9C52)[^1]. This change ensures we're passing the components through those plugins.


## Why are you doing this?
To get support and 💰 from people using < Safari 13.

We should analyse the data post-fix to see try assess what the impact of this was. And maybe a way to test for large scale breaks like this

## Screenshots

<img width="1247" alt="Screenshot 2023-10-12 at 12 22 16" src="https://github.com/guardian/support-frontend/assets/31692/07e6d747-298c-46ec-8bf3-4bca5ebfe4b0">

<img width="775" alt="Screenshot 2023-10-12 at 12 21 02" src="https://github.com/guardian/support-frontend/assets/31692/2ba9e996-0978-4c6e-8a1b-f0ea71ed73f7">

We are aware that this doesn't look ideal, but we have tested the functionality and will follow up visual changes once we have assessed the effort required and impact it might be having.

[^1]: I think this components doc is out of date as it works without that plugin.

## Is this an AB test?
- No
