### PR TITLE
fix: add pull-request: write permission to compressed-size action

### DIFF
--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -2,6 +2,9 @@ name: Compressed Size
 
 on: [pull_request]
 
+permissions:
+  pull-requests: write
+
 jobs:
   compressed_size:
     if: github.repository_owner == 'guardian'


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Adds the `pull-request: write` permissions to the compressed-size action.

I had noticed [this error](https://github.com/guardian/support-frontend/actions/runs/6494978751/job/17638995600#step:6:930) as I was hoping to have the report on #5339.

## Why are you doing this?

A clearer understanding of how my changes are affecting the bundle size.
