### PR TITLE
Revert "fix: include @guardian/source packages in babel"

### DIFF
--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -117,7 +117,7 @@ module.exports = (cssFilename, jsFilename, minimizeCss) => ({
 				test: /\.([jt]sx?|mjs)$/,
 				exclude: {
 					and: [/node_modules/],
-					not: [/@guardian\/consent-management-platform/, /@guardian\/libs/, /@guardian\/source/],
+					not: [/@guardian\/consent-management-platform/, /@guardian\/libs/],
 				},
 				use: [
 					{


### PR DESCRIPTION
Reverts guardian/support-frontend#5339

Breaks the layout of the frontpage.
![Screenshot 2023-10-13 at 10 32 52](https://github.com/guardian/support-frontend/assets/31692/e51307a0-4376-46a3-be8a-fdb93aef5f30)

