### PR TITLE
fix: transpile @guardian/source-foundations for Safari < 14 support

### DIFF
--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -117,7 +117,14 @@ module.exports = (cssFilename, jsFilename, minimizeCss) => ({
 				test: /\.([jt]sx?|mjs)$/,
 				exclude: {
 					and: [/node_modules/],
-					not: [/@guardian\/consent-management-platform/, /@guardian\/libs/],
+					not: [
+            /@guardian\/consent-management-platform/,
+            /@guardian\/libs/,
+            // we need to include this here to support Safari < v14 which doens't support private class fields
+            // used here: https://github.com/guardian/csnx/blob/e3678d2fffb206ec560891db8ff0ce8c47b05328/libs/%40guardian/source-foundations/src/accessibility/focus-style-manager.ts#L9
+            // see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields
+            /@guardian\/source-foundations/
+          ],
 				},
 				use: [
 					{


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Redux of https://github.com/guardian/support-frontend/pull/5339.

Transpiles `@guardian/source-foundations` `node_module` to support in Safari < v14.

The previous PR introduced a bug which seems to occur when you include `@guardian/source-react-components` to the transpilation (validated locally).

I would like to further investigate:
* Why does that transpilation create that bug?
* [Why didn't Chromatic pick up on the changes](https://www.chromatic.com/build?appId=62e115310aef0868687b2322&number=4215)?

But thought a fix first would be good.

[**Trello Card**](https://trello.com/c/PUYJmq9U/1607-safari-13-js-breaks)

## screenshots

**Chrome - modern OSX** 
![Screenshot 2023-10-13 at 15 22 50](https://github.com/guardian/support-frontend/assets/31692/05142e87-f954-4d1b-8f10-5c41b4082b7c)

**Safari 13.1**
![Screenshot 2023-10-13 at 15 26 17](https://github.com/guardian/support-frontend/assets/31692/b301c994-9584-44af-adbb-06cdbde3e73f)



