### PR TITLE
feat: add fields (postalCode, state, email) to AcquisitionDataRow

### DIFF
--- a/support-lambdas/acquisitions-firehose-transformer/src/test/scala/com/gu/acquisitionFirehoseTransformer/LambdaSpec.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/test/scala/com/gu/acquisitionFirehoseTransformer/LambdaSpec.scala
@@ -88,6 +88,9 @@ class LambdaSpec extends AnyFlatSpec with Matchers {
       paymentId = None,
       queryParameters = Nil,
       platform = None,
+      postalCode = Some("postalCode"),
+      state = Some("state"),
+      email = Some("email")
     )
 
     val record = new KinesisFirehoseEvent.Record()

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
@@ -2,7 +2,6 @@ package com.gu.support.acquisitions.models
 
 import com.gu.i18n.{Country, Currency}
 import com.gu.support.acquisitions.{AbTest, QueryParameter}
-import com.gu.support.catalog.{FulfilmentOptions, ProductOptions}
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec.deriveCodec
 import com.gu.support.encoding.CustomCodecs._
@@ -42,6 +41,9 @@ case class AcquisitionDataRow(
     paymentId: Option[String],
     queryParameters: List[QueryParameter],
     platform: Option[String],
+    postalCode: Option[String],
+    state: Option[String],
+    email: Option[String],
 )
 
 object AcquisitionDataRow {

--- a/support-payment-api/src/main/scala/model/acquisition/AcquisitionDataRowBuilder.scala
+++ b/support-payment-api/src/main/scala/model/acquisition/AcquisitionDataRowBuilder.scala
@@ -60,6 +60,9 @@ object AcquisitionDataRowBuilder {
       paymentId = Some(contributionData.paymentId),
       queryParameters = acquisitionData.queryParameters.map(_.toList).getOrElse(Nil),
       platform = acquisitionData.platform,
+      postalCode = contributionData.postalCode,
+      state = contributionData.countrySubdivisionCode,
+      email = Some(contributionData.email),
     )
   }
 
@@ -96,6 +99,9 @@ object AcquisitionDataRowBuilder {
       paymentId = Some(contributionData.paymentId),
       queryParameters = acquisitionData.flatMap(_.queryParameters.map(_.toList)).getOrElse(Nil),
       platform = acquisitionData.flatMap(_.platform),
+      postalCode = contributionData.postalCode,
+      state = contributionData.countrySubdivisionCode,
+      email = Some(contributionData.email),
     )
   }
 
@@ -134,6 +140,9 @@ object AcquisitionDataRowBuilder {
       paymentId = Some(contributionData.paymentId),
       queryParameters = acquisitionData.queryParameters.map(_.toList).getOrElse(Nil),
       platform = acquisitionData.platform,
+      postalCode = contributionData.postalCode,
+      state = contributionData.countrySubdivisionCode,
+      email = Some(contributionData.email),
     )
   }
 

--- a/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
@@ -89,6 +89,9 @@ object AcquisitionDataRowBuilder {
       paymentId = None,
       queryParameters = state.acquisitionData.map(getQueryParameters).getOrElse(Nil),
       platform = None,
+      postalCode = commonState.user.billingAddress.postCode,
+      state = commonState.user.billingAddress.state,
+      email = Some(commonState.user.primaryEmailAddress),
     )
   }
 

--- a/support-workers/src/test/scala/com/gu/acquisitions/BigQuerySpec.scala
+++ b/support-workers/src/test/scala/com/gu/acquisitions/BigQuerySpec.scala
@@ -87,6 +87,9 @@ class BigQuerySpec extends AsyncFlatSpec with Matchers with LazyLogging {
       Some("paymentId1234"),
       List(QueryParameter("foo", "bar")),
       None,
+      Some("postalCode"),
+      Some("state"),
+      Some("email")
     )
 
     service.sendAcquisition(dataRow).value.map(_ shouldBe Right(()))


### PR DESCRIPTION
## What are you doing in this PR?

I add the optional fields `postalCode`, `state` and `email` to the `AcquisitionDataRow` case class.

These new fields are sent from:
- `payment-api` producer
- `support-workers` producer

[**Trello Card**](https://trello.com/c/c6yBnLcu/366-single-contribution-record-add-fields-to-event-body-send-by-payment-api-and-support-workers-apps)

## Why are you doing this?

The single contribution record, I need to create in Salesforce, requires those fields if they are available.

This is the case class:
```scala
case class SalesforceSingleContributionRecord(
  Amount__c: Double,
  Contribution_ID__c: String,
  Country_Code__c: String,
  Country_Subdivision_Code__c: String, // Not available in the event yet
  Currency__c: String,
  Email__c: String, // Not available in the event yet
  Identity_ID__c: String,
  Payment_Date__c: String,
  Payment_ID__c: String,
  Payment_Provider__c: String,
  Payment_Status__c: String,
  Postal_Code__c: String // Not available in the event yet
)
```

## Risks

Acquisition bus consumers to confirm this change does not break their schema / implementation.
