### PR TITLE
Add dynamic checkout nudge

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -53,7 +53,7 @@ export function CheckoutBenefitsListContainer({
 	);
 	const selectedAmount = useContributionsSelector(getUserSelectedAmount);
 	const minimumContributionAmount = useContributionsSelector(
-		getMinimumContributionAmount,
+		getMinimumContributionAmount(),
 	);
 
 	const currency = currencies[currencyId];

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
@@ -104,9 +104,10 @@ export type CheckoutNudgeProps = {
 	nudgeSubtitle: string;
 	nudgeParagraph: string;
 	nudgeLinkCopy: string;
+	nudgeLinkHref?: string;
 	countryGroupId: CountryGroupId;
 	onNudgeClose: () => void;
-	onNudgeClick: () => void;
+	onNudgeClick?: () => void;
 };
 
 export function CheckoutNudge({
@@ -116,6 +117,7 @@ export function CheckoutNudge({
 	nudgeSubtitle,
 	nudgeParagraph,
 	nudgeLinkCopy,
+	nudgeLinkHref,
 	countryGroupId,
 	onNudgeClose,
 	onNudgeClick,
@@ -134,7 +136,7 @@ export function CheckoutNudge({
 				</h2>
 				<p css={para}>{nudgeParagraph}</p>
 				<div css={link}>
-					<a onClick={onNudgeClick} css={alink}>
+					<a href={nudgeLinkHref} onClick={onNudgeClick} css={alink}>
 						{nudgeLinkCopy}
 					</a>
 				</div>

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
@@ -107,7 +107,7 @@ export type CheckoutNudgeProps = {
 	nudgeLinkHref?: string;
 	countryGroupId: CountryGroupId;
 	onNudgeClose: () => void;
-	onNudgeClick?: () => void;
+	onNudgeClick: (event: React.MouseEvent<HTMLAnchorElement>) => void;
 };
 
 export function CheckoutNudge({

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -63,13 +63,15 @@ export function CheckoutNudgeContainer({
 	const min = useContributionsSelector(getMinimumContributionAmount('ANNUAL'));
 	const max = useContributionsSelector(getMaximumContributionAmount('ANNUAL'));
 
+	const otherAmount = otherAmounts[frequency].amount?.length
+		? otherAmounts[frequency].amount
+		: '0';
+
 	const annualAmount =
-		selectedAmount === 'other'
-			? otherAmounts[frequency].amount ?? '0'
-			: selectedAmount;
+		selectedAmount === 'other' ? otherAmount : selectedAmount;
 
 	const clampedAmount = Math.min(
-		Math.max(Number.parseInt(annualAmount), min),
+		Math.max(Number.parseInt(annualAmount ?? '0'), min),
 		max,
 	);
 

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -63,9 +63,15 @@ export function CheckoutNudgeContainer({
 	const min = useContributionsSelector(getMinimumContributionAmount('ANNUAL'));
 	const max = useContributionsSelector(getMaximumContributionAmount('ANNUAL'));
 
-	const otherAmount = otherAmounts[frequency].amount?.length
-		? otherAmounts[frequency].amount
-		: '0';
+	const otherAmount =
+		otherAmounts[frequency].amount?.length &&
+		// Regex pattern matches valid currency value;
+		// 1234 or 1234.56
+		/^\d*(\.?\d{2})?$/g.test(
+			`${parseInt(otherAmounts[frequency].amount ?? '')}`,
+		)
+			? otherAmounts[frequency].amount
+			: '0';
 
 	const annualAmount =
 		selectedAmount === 'other' ? otherAmount : selectedAmount;

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -81,11 +81,13 @@ export function CheckoutNudgeContainer({
 		max,
 	);
 
-	let title, subtitle;
+	let title, subtitle, paragraph;
 
 	if (dynamic) {
-		title = 'Make it annual';
+		title = 'Make it an annual gift';
 		subtitle = `change to ${currencyGlyph}${clampedAmount} per year`;
+		paragraph =
+			'Choose to support us annually, and you’ll make a bigger impact with your year-end gift. Help protect our open, independent journalism long term.';
 	} else {
 		const minAmount = getConfigMinAmount(countryGroupId, 'ANNUAL');
 		const weeklyMinAmount =
@@ -102,10 +104,9 @@ export function CheckoutNudgeContainer({
 		subtitle = `with ${
 			currencyGlyph + minAmount.toString()
 		} (${minWeeklyAmount} per week)`;
+		paragraph =
+			'Funding Guardian journalism every year is great value on a weekly basis. Make a bigger impact today, and protect our independence long term. Please consider annual support.';
 	}
-
-	const paragraph =
-		'Funding Guardian journalism every year is great value on a weekly basis. Make a bigger impact today, and protect our independence long term. Please consider annual support.';
 
 	function onNudgeClose() {
 		setDisplayNudge(false);

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -16,6 +16,7 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
+import { trackComponentClick } from 'helpers/tracking/behaviour';
 import type { CheckoutNudgeProps } from './checkoutNudge';
 
 type CheckoutNudgeContainerProps = {
@@ -102,7 +103,15 @@ export function CheckoutNudgeContainer({
 		setDisplayNudge(false);
 	}
 
-	function onNudgeClick() {
+	function onNudgeClick(event: React.MouseEvent<HTMLAnchorElement>) {
+		event.preventDefault();
+		trackComponentClick('contribution-annual-nudge');
+
+		if (dynamic) {
+			window.location.href = event.currentTarget.href;
+			return;
+		}
+
 		dispatch(setProductType('ANNUAL'));
 	}
 
@@ -118,6 +127,6 @@ export function CheckoutNudgeContainer({
 			: undefined,
 		countryGroupId: countryGroupId,
 		onNudgeClose,
-		onNudgeClick: !dynamic ? onNudgeClick : undefined,
+		onNudgeClick,
 	});
 }

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -43,7 +43,7 @@ export function PriceCardsContainer({
 	const { selectedAmounts, otherAmounts } = useContributionsSelector(
 		(state) => state.page.checkoutForm.product,
 	);
-	const minAmount = useContributionsSelector(getMinimumContributionAmount);
+	const minAmount = useContributionsSelector(getMinimumContributionAmount());
 	const {
 		amounts: frequencyAmounts,
 		defaultAmount,

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -1,11 +1,12 @@
 import type { OtherAmountProps } from 'components/otherAmount/otherAmount';
-import type { ContributionType, SelectedAmounts } from 'helpers/contributions';
+import type { ContributionType } from 'helpers/contributions';
 import {
 	setOtherAmount,
 	setOtherAmountBeforeAmendment,
 	setSelectedAmount,
 	setSelectedAmountBeforeAmendment,
 } from 'helpers/redux/checkout/product/actions';
+import { getSelectedAmount } from 'helpers/redux/checkout/product/selectors/productType';
 import { getMinimumContributionAmount } from 'helpers/redux/commonState/selectors';
 import { getOtherAmountErrors } from 'helpers/redux/selectors/formValidation/otherAmountValidation';
 import {
@@ -28,14 +29,6 @@ const contributionTypeToPaymentInterval: Partial<
 	MONTHLY: 'month',
 	ANNUAL: 'year',
 };
-
-function getSelectedAmount(
-	selectedAmounts: SelectedAmounts,
-	contributionType: ContributionType,
-	defaultAmount: number,
-) {
-	return selectedAmounts[contributionType] || defaultAmount;
-}
 
 export function PriceCardsContainer({
 	frequency,

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -75,6 +75,18 @@ export const tests: Tests = {
 		referrerControlled: false,
 		seed: 0,
 	},
+	makeItAnnualNudge: {
+		variants: [{ id: 'control' }, { id: 'variant' }],
+		isActive: false,
+		audiences: {
+			UnitedStates: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		referrerControlled: false,
+		seed: 0,
+	},
 	canMakePaymentsWithActiveCard: {
 		variants: [
 			{

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -76,7 +76,14 @@ export const tests: Tests = {
 		seed: 0,
 	},
 	makeItAnnualNudge: {
-		variants: [{ id: 'control' }, { id: 'variant' }],
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
 		isActive: false,
 		audiences: {
 			UnitedStates: {

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -100,8 +100,8 @@ export function addProductSideEffects(
 			if (isContribution(productType)) {
 				if (selectedAmounts[productType] === 'other') {
 					const customAmount = otherAmounts[productType].amount ?? '';
-					const minAmount = getMinimumContributionAmount(state);
-					const maxAmount = getMaximumContributionAmount(state);
+					const minAmount = getMinimumContributionAmount(productType)(state);
+					const maxAmount = getMaximumContributionAmount(productType)(state);
 
 					if (amountIsNotInRange(customAmount, minAmount, maxAmount)) {
 						const currency = currencies[currencyId];

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/productType.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/productType.ts
@@ -1,4 +1,4 @@
-import type { ContributionType } from 'helpers/contributions';
+import type { ContributionType, SelectedAmounts } from 'helpers/contributions';
 import { contributionTypes } from 'helpers/contributions';
 import type { SubscriptionProduct } from 'helpers/productPrice/subscriptions';
 import {
@@ -60,4 +60,12 @@ export function getSubscriptionType(
 		return productType;
 	}
 	return getSubscriptionTypeFromURL();
+}
+
+export function getSelectedAmount(
+	selectedAmounts: SelectedAmounts,
+	contributionType: ContributionType,
+	defaultAmount: number,
+): number | string {
+	return selectedAmounts[contributionType] || defaultAmount;
 }

--- a/support-frontend/assets/helpers/redux/commonState/selectors.ts
+++ b/support-frontend/assets/helpers/redux/commonState/selectors.ts
@@ -12,24 +12,27 @@ export function getDefaultContributionType(
 }
 
 export function getMinimumContributionAmount(
-	state: ContributionsState,
-): number {
-	const { countryGroupId } = state.common.internationalisation;
-	const contributionType = getContributionType(state);
-	const { min } = config[countryGroupId][contributionType];
+	contributionType?: ContributionType,
+) {
+	return (state: ContributionsState): number => {
+		const { countryGroupId } = state.common.internationalisation;
+		const { min } =
+			config[countryGroupId][contributionType ?? getContributionType(state)];
 
-	return min;
+		return min;
+	};
 }
 
 export function getMaximumContributionAmount(
-	state: ContributionsState,
-): number {
-	const { countryGroupId } = state.common.internationalisation;
-	const contributionType = getContributionType(state);
+	contributionType?: ContributionType,
+) {
+	return (state: ContributionsState): number => {
+		const { countryGroupId } = state.common.internationalisation;
+		const { max } =
+			config[countryGroupId][contributionType ?? getContributionType(state)];
 
-	const { max } = config[countryGroupId][contributionType];
-
-	return max;
+		return max;
+	};
 }
 
 export function isUserInAbVariant(abTestName: string, variantName: string) {

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -109,6 +109,8 @@ export function AmountAndBenefits({
 
 							<CheckoutNudgeContainer
 								renderNudge={(nudgeProps) => <CheckoutNudge {...nudgeProps} />}
+								dynamic={true}
+								frequency={tabId}
 							/>
 						</BoxContents>
 					)}

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -109,7 +109,6 @@ export function AmountAndBenefits({
 
 							<CheckoutNudgeContainer
 								renderNudge={(nudgeProps) => <CheckoutNudge {...nudgeProps} />}
-								dynamic={true}
 								frequency={tabId}
 							/>
 						</BoxContents>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Adding dynamic text to the checkout nudge component that displays the amount currently selected on single contributions

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com/c/cf4kT5iL/1590-test-make-it-annual-nudge-development)


<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [x] Yes
- [ ] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots
https://github.com/guardian/support-frontend/assets/2510683/0e057e23-e979-4dd3-9f6d-3a39c336cb9b



