### PR TITLE
Add an AV calculation for the National Delivery product

### DIFF
--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/calculator/AnnualisedValueTwoCalculator.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/calculator/AnnualisedValueTwoCalculator.scala
@@ -13,6 +13,9 @@ import com.gu.support.acquisitions.models.PrintProduct.{
   HomeDeliverySundayPlus,
   HomeDeliveryWeekend,
   HomeDeliveryWeekendPlus,
+  NationalDeliveryEveryday,
+  NationalDeliverySixday,
+  NationalDeliveryWeekend,
   VoucherEveryday,
   VoucherEverydayPlus,
   VoucherSaturday,
@@ -25,6 +28,7 @@ import com.gu.support.acquisitions.models.PrintProduct.{
   VoucherWeekendPlus,
 }
 import com.gu.support.acquisitions.models.{AcquisitionProduct, PaymentFrequency}
+import com.gu.support.catalog.NationalDelivery
 
 object AnnualisedValueTwoCalculator {
 
@@ -84,7 +88,7 @@ object AnnualisedValueTwoCalculator {
       case (Annually, USD) => Right(68.18)
       case (Annually, AUD) => Right(98.1855)
       case (Annually, _) => Right(40.28)
-      case (_) => Left("Error calculating AV for membership supporter")
+      case _ => Left("Error calculating AV for membership supporter")
     }
 
   def getMembershipPartnerAV(a: AcquisitionModel): Either[String, Double] =
@@ -141,6 +145,9 @@ object AnnualisedValueTwoCalculator {
           case (HomeDeliverySixdayPlus, _) => Right(345.54)
           case (HomeDeliveryEveryday, _) => Right(320.04)
           case (HomeDeliveryEverydayPlus, _) => Right(346.65)
+          case (NationalDeliveryEveryday, _) => Right(320.04)
+          case (NationalDeliverySixday, _) => Right(298.53)
+          case (NationalDeliveryWeekend, _) => Right(129.01)
           case _ => Left(s"No pricing information for ${x.product.value}")
         }
       })


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
As part of the work to create the new National Delivery product we need to provide an Annualised Value (AV) calculation for each configuration of the product (every day, six day and weekend).

This AV calculation is only used by the kinesis data stream which drives tickers and the Epic super mode, the calculation which is available in the data lake is specified in the [data-platform-models repo](https://github.com/guardian/data-platform-models/blob/498533bfe08ac005f95b961d87817130fb922c50/dbt/macros/annualised_value/annualised_value.sql#L4)