### PR TITLE
National Delivery - Delivery Details Update

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.tsx
@@ -94,19 +94,24 @@ export function ContentDeliveryFaqBlock({
 								trackingId={accordionTrackingId}
 								label="Delivery details"
 							>
-								<p>
-									Your newspaper will arrive before 8am from Monday to Saturday
-									and before 8.30am on Sunday.
-								</p>
+								{isNationalDeliveryAbTestVariant ? (
+									<p>Your newspaper will arrive before 9am.</p>
+								) : (
+									<p>
+										Your newspaper will arrive before 8am from Monday to
+										Saturday and before 8.30am on Sunday.
+									</p>
+								)}
 								<p>
 									We can’t deliver to individual flats, or apartments within
 									blocks because we need access to your post box to deliver your
 									newspaper.
 								</p>
 								<p>
-									You can pause your subscription for up to 36 days a year. So
-									if you’re going away anywhere, you won’t have to pay for the
-									newspapers that you miss.
+									You can pause your subscription for up to{' '}
+									{isNationalDeliveryAbTestVariant ? '5 weeks' : '36 days'} a
+									year. So if you’re going away anywhere, you won’t have to pay
+									for the newspapers that you miss.
 								</p>
 							</TabAccordionRow>,
 						]}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Update the delivery details in the Home Delivery tab on paper checkout. Bring this in line with the new Ts & Cs. This change is behind the national delivery AB test.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com/c/fnq4DuIK/120-delivery-details-copy-tweaks)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [ ] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots
Before
![image](https://github.com/guardian/support-frontend/assets/114918544/e5df4745-feb8-4e6b-acdb-900a0f4e0018)

After
![image](https://github.com/guardian/support-frontend/assets/114918544/0550d9f5-12a1-4eb0-8f35-3ba1c37ba495)

