### PR TITLE
chore(deps): upgrade @guardian/source-react-components from 14.0.2 => 16.0.1

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -90,7 +90,7 @@
     "@guardian/libs": "14.0.0",
     "@guardian/pasteup": "1.0.0-alpha.7",
     "@guardian/source-foundations": "^11.0.0",
-    "@guardian/source-react-components": "^14.0.2",
+    "@guardian/source-react-components": "^16.0.1",
     "@guardian/source-react-components-development-kitchen": "^12.0.1",
     "@reduxjs/toolkit": "^1.9.4",
     "@sentry/browser": "^7.72.0",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -2311,10 +2311,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-12.0.1.tgz#b4b42eebb3ccfd954eaf4f7733d0b2a88792cfef"
   integrity sha512-oUIbCWigdxycg8yd615MUN5UWvqOqUlNVGDQREeRsTMyKbJqRZDEuCU8JL1UQrvNFnKM1nzIRZh6GdDuxKw0dA==
 
-"@guardian/source-react-components@^14.0.2":
-  version "14.0.2"
-  resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-14.0.2.tgz#00656908aadf8b2d2b01328f5c01753271693fbe"
-  integrity sha512-rWAyOwyCwdNhJdjOMZzw5hgDGtxC6xO+0fo6+r2k8ZhAgYAR+7YkSS26QF68SRLU3CN4YsJ2pDZAmJiJrBPAnw==
+"@guardian/source-react-components@^16.0.1":
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-16.0.1.tgz#24d4c4081e6a293a101b3217b598fccf151b04bd"
+  integrity sha512-M/zrs+G5NqykicECNf803B9815tVkPfazwmYsGfrDdKGptBmLhcofGlpC/MGdKiJ9lTlOQBieUyZ2y6i2mBJyQ==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
## What are you doing in this PR?
Bumping our dependency @guardian/source-react-components from 14.0.2 => 16.0.1.

[Release notes](https://github.com/guardian/csnx/releases/tag/%40guardian%2Fsource-react-components%4016.0.1).

- https://github.com/guardian/csnx/commit/1b32aeb45ad3ca490f8ce155f1ee0b2dd62ec02c: Update @babel/core
