### PR TITLE
Read the defaultContributionType and displayContributionType from RRCP Amounts config in Support Checkout

### DIFF
--- a/support-frontend/assets/components/paymentFrequencyTabs/paymentFrequencyTabsContainer.tsx
+++ b/support-frontend/assets/components/paymentFrequencyTabs/paymentFrequencyTabsContainer.tsx
@@ -19,9 +19,14 @@ export function PaymentFrequencyTabsContainer({
 	render,
 }: PaymentFrequencyTabsContainerProps): JSX.Element {
 	const dispatch = useContributionsDispatch();
-	const { contributionTypes } = useContributionsSelector(
-		(state) => state.common.settings,
+	// const { contributionTypes } = useContributionsSelector(
+	// 	(state) => state.common.settings,
+	// );
+
+	const { displayContributionType } = useContributionsSelector(
+		(state) => state.common.amounts,
 	);
+
 	const { countryGroupId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
@@ -35,14 +40,13 @@ export function PaymentFrequencyTabsContainer({
 		dispatch(setProductType(contributionType));
 	}
 
-	const tabs = contributionTypes[countryGroupId].map(({ contributionType }) => {
+	const tabs = displayContributionType.map((contributionType) => {
 		return {
 			id: contributionType,
 			labelText: toHumanReadableContributionType(contributionType),
 			selected: contributionType === productType,
 		};
 	});
-
 	return render({
 		ariaLabel,
 		tabs,

--- a/support-frontend/assets/components/paymentFrequencyTabs/paymentFrequencyTabsContainer.tsx
+++ b/support-frontend/assets/components/paymentFrequencyTabs/paymentFrequencyTabsContainer.tsx
@@ -19,14 +19,10 @@ export function PaymentFrequencyTabsContainer({
 	render,
 }: PaymentFrequencyTabsContainerProps): JSX.Element {
 	const dispatch = useContributionsDispatch();
-	// const { contributionTypes } = useContributionsSelector(
-	// 	(state) => state.common.settings,
-	// );
 
 	const { displayContributionType } = useContributionsSelector(
 		(state) => state.common.amounts,
 	);
-
 	const { countryGroupId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
@@ -39,7 +35,6 @@ export function PaymentFrequencyTabsContainer({
 
 		dispatch(setProductType(contributionType));
 	}
-
 	const tabs = displayContributionType.map((contributionType) => {
 		return {
 			id: contributionType,

--- a/support-frontend/assets/helpers/redux/commonState/reducer.ts
+++ b/support-frontend/assets/helpers/redux/commonState/reducer.ts
@@ -48,7 +48,6 @@ export const commonSlice = createSlice({
 				abParticipations,
 				settings,
 				amounts,
-				defaultAmounts,
 			} = action.payload;
 			return {
 				...state,
@@ -59,7 +58,6 @@ export const commonSlice = createSlice({
 				abParticipations,
 				settings,
 				amounts,
-				defaultAmounts,
 			};
 		},
 		setCountryInternationalisation(state, action: PayloadAction<IsoCountry>) {

--- a/support-frontend/assets/helpers/redux/commonState/selectors.ts
+++ b/support-frontend/assets/helpers/redux/commonState/selectors.ts
@@ -1,22 +1,13 @@
 import type { ContributionType } from 'helpers/contributions';
 import { config } from 'helpers/contributions';
-import { getValidContributionTypesFromUrlOrElse } from 'helpers/forms/checkouts';
 import { getContributionType } from '../checkout/product/selectors/productType';
 import type { ContributionsState } from '../contributionsStore';
 
 export function getDefaultContributionType(
 	state: ContributionsState,
 ): ContributionType {
-	const { countryGroupId } = state.common.internationalisation;
-	const contributionTypes = getValidContributionTypesFromUrlOrElse(
-		state.common.settings.contributionTypes,
-	);
-	const contribTypesForLocale = contributionTypes[countryGroupId];
-	const defaultContributionType =
-		contribTypesForLocale.find((contribType) => contribType.isDefault) ??
-		contribTypesForLocale[0];
-
-	return defaultContributionType.contributionType;
+	const { defaultContributionType } = state.common.amounts;
+	return defaultContributionType;
 }
 
 export function getMinimumContributionAmount(

--- a/support-frontend/assets/helpers/redux/commonState/state.ts
+++ b/support-frontend/assets/helpers/redux/commonState/state.ts
@@ -30,7 +30,6 @@ export type CommonState = {
 	abParticipations: Participations;
 	settings: Settings;
 	amounts: SelectedAmountsVariant;
-	defaultAmounts: SelectedAmountsVariant;
 	internationalisation: Internationalisation;
 	existingPaymentMethods?: ExistingPaymentMethod[];
 };
@@ -43,7 +42,6 @@ export type CommonStateSetupData = {
 	abParticipations: Participations;
 	settings: Settings;
 	amounts: SelectedAmountsVariant;
-	defaultAmounts: SelectedAmountsVariant;
 };
 
 const countryGroupId = detectCountryGroup();
@@ -55,7 +53,6 @@ export const initialCommonState: CommonState = {
 	abParticipations: {},
 	settings: getSettings(),
 	amounts: getFallbackAmounts(countryGroupId),
-	defaultAmounts: getFallbackAmounts(countryGroupId),
 	internationalisation: {
 		currencyId: detectCurrency(countryGroupId),
 		countryGroupId,

--- a/support-frontend/assets/helpers/redux/utils/setup.ts
+++ b/support-frontend/assets/helpers/redux/utils/setup.ts
@@ -51,7 +51,6 @@ function buildInitialState(
 		abParticipations,
 		settings,
 		amounts,
-		defaultAmounts: amounts,
 	};
 }
 

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/setUpRedux.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/setUpRedux.ts
@@ -134,19 +134,6 @@ function selectInitialAmounts(
 	}
 }
 
-// Override the settings from the server if contributionTypes are defined in url params or campaign settings
-// function getContributionTypes(state: ContributionsState): ContributionTypes {
-// 	// const campaignSettings = getCampaignSettings();
-//   //
-// 	// if (campaignSettings?.contributionTypes) {
-// 	// 	return campaignSettings.contributionTypes;
-// 	// }
-//   //
-// 	// return getValidContributionTypesFromUrlOrElse(
-// 	// 	state.common.settings.contributionTypes,
-// 	// );
-// }
-
 function selectInitialContributionTypeAndPaymentMethod(
 	state: ContributionsState,
 	dispatch: ContributionsDispatch,
@@ -171,9 +158,6 @@ function selectInitialContributionTypeAndPaymentMethod(
 export function setUpRedux(store: ContributionsStore): void {
 	const dispatch = store.dispatch;
 	const state = store.getState();
-	// TODO - move these settings out of the redux store, as they only change once, upon initialisation
-	// const contributionTypes = getContributionTypes(state);
-	// dispatch(setContributionTypes(contributionTypes));
 
 	setUpUserState(dispatch);
 	void dispatch(getRecurringContributorStatus());
@@ -187,7 +171,6 @@ export function setUpRedux(store: ContributionsStore): void {
 	const contributionType = selectInitialContributionTypeAndPaymentMethod(
 		state,
 		dispatch,
-		// contributionTypes,
 	);
 	selectInitialAmounts(state, dispatch, contributionType);
 

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/setUpRedux.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/setUpRedux.ts
@@ -1,15 +1,10 @@
 // ----- Imports ----- //
-import { getCampaignSettings } from 'helpers/campaigns/campaigns';
-import type {
-	ContributionType,
-	ContributionTypes,
-} from 'helpers/contributions';
+import type { ContributionType } from 'helpers/contributions';
 import {
 	getAmountFromUrl,
 	getContributionTypeFromSession,
 	getContributionTypeFromUrl,
 	getPaymentMethodFromSession,
-	getValidContributionTypesFromUrlOrElse,
 	getValidPaymentMethods,
 } from 'helpers/forms/checkouts';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
@@ -29,7 +24,6 @@ import {
 	setOtherAmount,
 	setProductType,
 } from 'helpers/redux/checkout/product/actions';
-import { setContributionTypes } from 'helpers/redux/commonState/actions';
 import type {
 	ContributionsDispatch,
 	ContributionsState,
@@ -65,28 +59,20 @@ function getInitialPaymentMethod(
 }
 
 function getInitialContributionType(
-	countryGroupId: CountryGroupId,
-	contributionTypes: ContributionTypes,
+	state: ContributionsState,
 ): ContributionType {
+	const { defaultContributionType, displayContributionType } =
+		state.common.amounts;
+
 	const contributionType =
 		getContributionTypeFromUrl() ?? getContributionTypeFromSession();
 
-	// make sure we don't select a contribution type which isn't on the page
-	if (
-		contributionType &&
-		contributionTypes[countryGroupId].find(
-			(ct) => ct.contributionType === contributionType,
-		)
-	) {
+	// // make sure we don't select a contribution type which isn't on the page
+	if (contributionType && displayContributionType.includes(contributionType)) {
 		return contributionType;
 	}
 
-	const defaultContributionType = contributionTypes[countryGroupId].find(
-		(ct) => ct.isDefault,
-	);
-	return defaultContributionType
-		? defaultContributionType.contributionType
-		: contributionTypes[countryGroupId][0].contributionType;
+	return defaultContributionType;
 }
 
 function selectInitialAmounts(
@@ -149,30 +135,27 @@ function selectInitialAmounts(
 }
 
 // Override the settings from the server if contributionTypes are defined in url params or campaign settings
-function getContributionTypes(state: ContributionsState): ContributionTypes {
-	const campaignSettings = getCampaignSettings();
-
-	if (campaignSettings?.contributionTypes) {
-		return campaignSettings.contributionTypes;
-	}
-
-	return getValidContributionTypesFromUrlOrElse(
-		state.common.settings.contributionTypes,
-	);
-}
+// function getContributionTypes(state: ContributionsState): ContributionTypes {
+// 	// const campaignSettings = getCampaignSettings();
+//   //
+// 	// if (campaignSettings?.contributionTypes) {
+// 	// 	return campaignSettings.contributionTypes;
+// 	// }
+//   //
+// 	// return getValidContributionTypesFromUrlOrElse(
+// 	// 	state.common.settings.contributionTypes,
+// 	// );
+// }
 
 function selectInitialContributionTypeAndPaymentMethod(
 	state: ContributionsState,
 	dispatch: ContributionsDispatch,
-	contributionTypes: ContributionTypes,
 ): ContributionType {
 	const { countryId } = state.common.internationalisation;
 	const { switches } = state.common.settings;
 	const { countryGroupId } = state.common.internationalisation;
-	const contributionType = getInitialContributionType(
-		countryGroupId,
-		contributionTypes,
-	);
+
+	const contributionType = getInitialContributionType(state);
 	const paymentMethod = getInitialPaymentMethod(
 		contributionType,
 		countryId,
@@ -189,8 +172,8 @@ export function setUpRedux(store: ContributionsStore): void {
 	const dispatch = store.dispatch;
 	const state = store.getState();
 	// TODO - move these settings out of the redux store, as they only change once, upon initialisation
-	const contributionTypes = getContributionTypes(state);
-	dispatch(setContributionTypes(contributionTypes));
+	// const contributionTypes = getContributionTypes(state);
+	// dispatch(setContributionTypes(contributionTypes));
 
 	setUpUserState(dispatch);
 	void dispatch(getRecurringContributorStatus());
@@ -204,7 +187,7 @@ export function setUpRedux(store: ContributionsStore): void {
 	const contributionType = selectInitialContributionTypeAndPaymentMethod(
 		state,
 		dispatch,
-		contributionTypes,
+		// contributionTypes,
 	);
 	selectInitialAmounts(state, dispatch, contributionType);
 

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/setUpRedux.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/setUpRedux.ts
@@ -67,7 +67,7 @@ function getInitialContributionType(
 	const contributionType =
 		getContributionTypeFromUrl() ?? getContributionTypeFromSession();
 
-	// // make sure we don't select a contribution type which isn't on the page
+	// make sure we don't select a contribution type which isn't on the page
 	if (contributionType && displayContributionType.includes(contributionType)) {
 		return contributionType;
 	}

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -44,7 +44,6 @@ const isInTwoStepTest =
 	abParticipations.twoStepCheckoutWithNudgeBelow &&
 	abParticipations.twoStepCheckoutWithNudgeBelow !== 'control';
 
-console.log(abParticipations);
 const showCheckoutTopUpToggle =
 	abParticipations.twoStepCheckoutWithNudgeBelow === 'variant_b';
 


### PR DESCRIPTION
## What are you doing in this PR?

Support checkout: Read the `defaultContributionType` and `displayContributionType` from RRCP Amounts config

[**Trello Card**](https://trello.com/c/EY0v3UWy/1565-default-to-annual-remove-monthly-support-checkout-read-the-defaultcontributiontype-and-displaycontributiontype-from-rrcp-amounts)

## Why are you doing this?

Currently the payment frequency tabs and the default tab on the Support Checkout are rendered based on the values in  `common.settings.contributionTypes` from Redux state.

However, the amounts cards rendered on the support checkout for each tab are defined in amounts test config set in RRCP, this config is written to S3 as JSON, and then read by support-frontend and made available in the client on `window.guardian.settings.amounts`.

`window.guardian.settings.amounts` is an array of amounts tests. Each test can have one or more variants. Each variant has a `defaultContributionType` and `displayContributionType` property. Both of these properties can be configured in the RRCP:

- `defaultContributionType` defines the default tab a user assigned to the test should see, this can be "ONE_OFF" | "MONTHLY" | "ANNUAL"
- `displayContributionType` defines what tabs a user should see in an array of Contribution Types

In https://github.com/guardian/support-frontend/pull/5027 logic was added to select the correct amounts test/variant to render and add it to `common.settings.amounts` in Redux state.

To date we’ve not been reading `defaultContributionType` or `displayContributionType` from `common.settings.amounts` in Redux state.

However with this Pull Request we achieve our goal of doing so in the fastest and most straightforward manner.

**Notes:**

While  testing locally, to make changes to the defaultContributionType and displayContributionType  you can update the  Amazon S3 / Buckets /support-admin-console / DEV / configured-amounts-v3.json file .

Users can click on choice cards in the Epic/Banner. The choices they make are passed as query string params selected-contribution-type ("ONE_OFF", "MONTHLY", "ANNUAL") and selected-amount. If present in the URL selected-contribution-type should override the  defaultContributionType.

## Navigating through the PR

This PR touches 7 files, as follows:

**support-frontend/assets/components/paymentFrequencyTabs/paymentFrequencyTabsContainer.tsx**
Changes to display tabs in Supporter checkout based on the `displayContributionType`  from `common.settings.amounts` in Redux state.

**support-frontend/assets/helpers/redux/commonState/selectors.ts**
Changes to get the default tab selected from `defaultContributionType` from `common.settings.amounts` in Redux state.

**support-frontend/assets/pages/supporter-plus-landing/setup/setUpRedux.ts**
Necessary changes to look for initial contribution type and amount if passed as query string params `selected-contribution-type` ("ONE_OFF", "MONTHLY", "ANNUAL") and `selected-amount`, or set in session storage. 

If a selected contribution type is present as a query string param or in session storage then we cross check the value is valid by confirming it exists in `common.settings.amounts.displayContributionType`. If it's invalid we fallback to the value passed from `common.settings.amounts.defaultContributionType` in Redux state.

We've also removed the check for contribution Types from campaign settings  as this is no longer used. 

**support-frontend/assets/helpers/redux/commonState/reducer.ts.**  and 
**support-frontend/assets/helpers/redux/commonState/state.ts** and 
**support-frontend/assets/helpers/redux/utils/setup.ts**
Removing common.defaultAmounts from reducer which we concluded is not used anywhere in the code

**support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx**
Remove an unnecessary console.log statement

## Tasks for later

> The ideal solution for this is to remove the contributionTypes from `window.guardian` and Redux state, this will require client and server side changes. This is also complicated as we have Kindle checkout which references the contributionType and shares similar code as the supporter checkout. So our next step would be to remove the contributionTypes entirely after removing the Kindle (Digital-sub) code in a separate PR.

> Also we found a lot of Code related to Campaign settings that is not used anymore while working on this. We need to remove them as well in a separate PR.





## Is this an AB test?
- [ ] Yes
- [x ] No


## Screenshots

