### PR TITLE
Stop National Delivery Integration test from running (take 2)

### DIFF
--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -5,7 +5,6 @@ import com.gu.i18n.Country.UK
 import com.gu.i18n.Currency.GBP
 import com.gu.salesforce.Fixtures.{emailAddress, idId}
 import com.gu.salesforce.Salesforce.SalesforceContactRecords
-import com.gu.support.acquisitions.{AbTest, AcquisitionData, OphanIds, ReferrerAcquisitionData}
 import com.gu.support.catalog.{Domestic, Everyday, HomeDelivery, NationalDelivery, RestOfWorld}
 import com.gu.support.paperround.AgentId
 import com.gu.support.promotions.PromoCode
@@ -23,6 +22,7 @@ import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.{
   SupporterPlusState,
 }
 import com.gu.support.zuora.api.StripeGatewayDefault
+import com.gu.zuora.Fixtures.deliveryAgentId
 import io.circe.parser
 import io.circe.syntax._
 import org.joda.time.{DateTimeZone, LocalDate}
@@ -139,6 +139,33 @@ object JsonFixtures {
       deliveryInstructions = Some("Leave with neighbour"),
     )
 
+  val userJsonWithDeliveryAddressOutsideLondon =
+    User(
+      idId,
+      emailAddress,
+      None,
+      "test-user",
+      "from support-frontend integration tests",
+      billingAddress = Address(
+        Some("4 Hackins Hey"),
+        None,
+        Some("Liverpool"),
+        None,
+        Some("L2 2AW"),
+        Country.UK,
+      ),
+      deliveryAddress = Some(
+        Address(
+          Some("4 Hackins Hey"),
+          None,
+          Some("Liverpool"),
+          None,
+          Some("L2 2AW"),
+          Country.UK,
+        ),
+      ),
+      deliveryInstructions = Some("Leave with neighbour - support-frontend"),
+    )
   def requestIdJson: String = s""""requestId": "${UUID.randomUUID()}\""""
   val validBaid = "B-23637766K5365543J"
   val payPalEmail = "test@paypal.com"
@@ -390,7 +417,7 @@ object JsonFixtures {
           {
             $requestIdJson,
             ${userJson()},
-            "product": ${weeklyJson},
+            "product": $weeklyJson,
             "analyticsInfo": {
               "paymentProvider": "PayPal",
               "isGiftPurchase": true
@@ -458,7 +485,7 @@ object JsonFixtures {
       UUID.randomUUID(),
       user(),
       Contribution(amount, GBP, billingPeriod),
-      AnalyticsInfo(false, Stripe),
+      AnalyticsInfo(isGiftPurchase = false, Stripe),
       None,
       None,
       None,
@@ -471,7 +498,7 @@ object JsonFixtures {
       currency: Currency,
       billingPeriod: BillingPeriod,
       country: Country = UK,
-  ) =
+  ): String =
     CreateZuoraSubscriptionState(
       SupporterPlusState(
         SupporterPlus(amount, currency, billingPeriod),
@@ -481,7 +508,7 @@ object JsonFixtures {
       UUID.randomUUID(),
       user("9999998", country),
       SupporterPlus(amount, currency, Monthly),
-      AnalyticsInfo(false, Stripe),
+      AnalyticsInfo(isGiftPurchase = false, Stripe),
       None,
       None,
       None,
@@ -501,7 +528,7 @@ object JsonFixtures {
       UUID.randomUUID(),
       user(),
       DigitalPack(GBP, Annual),
-      AnalyticsInfo(false, Stripe),
+      AnalyticsInfo(isGiftPurchase = false, Stripe),
       None,
       None,
       None,
@@ -528,7 +555,7 @@ object JsonFixtures {
       requestId,
       user(),
       DigitalPack(GBP, Annual),
-      AnalyticsInfo(false, Stripe),
+      AnalyticsInfo(isGiftPurchase = false, Stripe),
       None,
       None,
       None,
@@ -555,7 +582,7 @@ object JsonFixtures {
       UUID.randomUUID(),
       user(),
       DigitalPack(GBP, Annual),
-      AnalyticsInfo(false, Stripe),
+      AnalyticsInfo(isGiftPurchase = false, Stripe),
       None,
       None,
       None,
@@ -576,7 +603,7 @@ object JsonFixtures {
       UUID.randomUUID(),
       userJsonWithDeliveryAddress,
       Paper(GBP, Monthly, HomeDelivery, Everyday, None),
-      AnalyticsInfo(false, Stripe),
+      AnalyticsInfo(isGiftPurchase = false, Stripe),
       None,
       None,
       None,
@@ -585,10 +612,10 @@ object JsonFixtures {
     ).asJson.spaces2
 
   val createEverydayNationalDeliveryPaperSubscriptionJson = {
-    val paper = Paper(GBP, Monthly, NationalDelivery, Everyday, Some(AgentId(-43)))
+    val paper = Paper(GBP, Monthly, NationalDelivery, Everyday, Some(AgentId(deliveryAgentId)))
     CreateZuoraSubscriptionState(
       PaperState(
-        userJsonWithDeliveryAddress,
+        userJsonWithDeliveryAddressOutsideLondon,
         paper,
         stripePaymentMethodObj,
         LocalDate.now(DateTimeZone.UTC),
@@ -596,9 +623,9 @@ object JsonFixtures {
         salesforceContact,
       ),
       UUID.randomUUID(),
-      userJsonWithDeliveryAddress,
+      userJsonWithDeliveryAddressOutsideLondon,
       paper,
-      AnalyticsInfo(false, Stripe),
+      AnalyticsInfo(isGiftPurchase = false, Stripe),
       None,
       None,
       None,
@@ -624,7 +651,7 @@ object JsonFixtures {
       UUID.randomUUID(),
       userJsonWithDeliveryAddress,
       GuardianWeekly(GBP, billingPeriod, RestOfWorld),
-      AnalyticsInfo(false, Stripe),
+      AnalyticsInfo(isGiftPurchase = false, Stripe),
       Some(LocalDate.now(DateTimeZone.UTC).plusDays(10)),
       maybePromoCode,
       None,
@@ -653,7 +680,7 @@ object JsonFixtures {
       UUID.randomUUID(),
       userJsonWithDeliveryAddress,
       GuardianWeekly(GBP, Quarterly, RestOfWorld),
-      AnalyticsInfo(false, Stripe),
+      AnalyticsInfo(isGiftPurchase = false, Stripe),
       Some(LocalDate.now(DateTimeZone.UTC).plusDays(10)),
       None,
       None,
@@ -951,7 +978,7 @@ object JsonFixtures {
       UUID.randomUUID(),
       user(),
       DigitalPack(GBP, Annual),
-      AnalyticsInfo(false, Stripe),
+      AnalyticsInfo(isGiftPurchase = false, Stripe),
       None,
       Some("DJRHYMDS8"),
       None,

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -102,6 +102,7 @@ class CreateZuoraSubscriptionSpec extends AsyncLambdaSpec with MockServicesCreat
   }
 
   // ignored while we test with PaperRound to avoid possible data quality issues
+  // it can be added back in when the initial testing period is over
   ignore should "create an everyday national-delivery paper subscription" in {
     createZuoraHelper
       .createSubscription(createEverydayNationalDeliveryPaperSubscriptionJson)

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -4,8 +4,9 @@ import com.gu.config.Configuration
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.Currency.{EUR, GBP}
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
+import com.gu.services.ServiceProvider
 import com.gu.support.acquisitions.{AbTest, AcquisitionData, OphanIds, ReferrerAcquisitionData}
-import com.gu.support.catalog.{CatalogService, Everyday, S3CatalogProvider, NationalDelivery}
+import com.gu.support.catalog.{CatalogService, Everyday, NationalDelivery, S3CatalogProvider}
 import com.gu.support.config.{Stages, TouchPointEnvironments}
 import com.gu.support.promotions.{DefaultPromotions, PromotionService}
 import com.gu.support.redemption.CodeAlreadyUsed
@@ -100,7 +101,8 @@ class CreateZuoraSubscriptionSpec extends AsyncLambdaSpec with MockServicesCreat
       })
   }
 
-  it should "create an everyday national-delivery paper subscription" in {
+  // ignored while we test with PaperRound to avoid possible data quality issues
+  ignore should "create an everyday national-delivery paper subscription" in {
     createZuoraHelper
       .createSubscription(createEverydayNationalDeliveryPaperSubscriptionJson)
       .map(_ should matchPattern {
@@ -210,7 +212,7 @@ class CreateZuoraSubscriptionHelper(implicit executionContext: ExecutionContext)
     mockZuora
   }
 
-  def mockServiceProvider(giftCodeGenerator: GiftCodeGeneratorService) = mockServices[Any](
+  def mockServiceProvider(giftCodeGenerator: GiftCodeGeneratorService): ServiceProvider = mockServices[Any](
     (s => s.zuoraService, mockZuoraService),
     (s => s.zuoraGiftService, realZuoraGiftService),
     (s => s.promotionService, realPromotionService),

--- a/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -24,6 +24,7 @@ object Fixtures {
   val secondTokenId = "cus_AaynKIp19IIGDz"
   val cardNumber = "4242"
   val payPalBaid = "B-23637766K5365543J"
+  val deliveryAgentId = 2532
 
   val date = new LocalDate(2017, 5, 4)
 
@@ -44,7 +45,7 @@ object Fixtures {
   val contactDetails = ContactDetails("Test-FirstName", "Test-LastName", Some("test@thegulocal.com"), Country.UK)
   val differentContactDetails = ContactDetails(
     "Test-FirstName",
-    "Test-LastName",
+    "from support-frontend integration tests",
     Some("test@thegulocal.com"),
     Country.UK,
     Some("123 easy street"),
@@ -52,7 +53,19 @@ object Fixtures {
     Some("london"),
     Some("n1 9gu"),
     None,
-    Some("Leave with neighbour"),
+    Some("Leave with neighbour - support-frontend"),
+  )
+  val differentContactDetailsOutsideLondon = ContactDetails(
+    "Test-FirstName",
+    "from support-frontend integration tests",
+    Some("test@thegulocal.com"),
+    Country.UK,
+    Some("4 Hackins Hey"),
+    None,
+    Some("Liverpool"),
+    Some("L2 2AW"),
+    None,
+    Some("Leave with neighbour - support-frontend"),
   )
   val creditCardPaymentMethod = CreditCardReferenceTransaction(
     tokenId,
@@ -113,6 +126,7 @@ object Fixtures {
     ),
     Subscription(date, date, date, "id123"),
   )
+
   val everydayNationalDeliveryPaperSubscriptionData = SubscriptionData(
     List(
       RatePlanData(
@@ -121,7 +135,7 @@ object Fixtures {
         Nil,
       ),
     ),
-    Subscription(date, date, date, "id123", deliveryAgent = Some(AgentId(1821))),
+    Subscription(date, date, date, "id123", deliveryAgent = Some(AgentId(deliveryAgentId))),
   )
 
   def creditCardSubscriptionRequest(currency: Currency = GBP): SubscribeRequest =
@@ -172,7 +186,7 @@ object Fixtures {
         SubscribeItem(
           account(paymentGateway = DirectDebitGateway),
           contactDetails,
-          Some(differentContactDetails),
+          Some(differentContactDetailsOutsideLondon),
           Some(directDebitPaymentMethod),
           everydayNationalDeliveryPaperSubscriptionData,
           SubscribeOptions(),

--- a/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
@@ -159,6 +159,7 @@ class ZuoraITSpec extends AsyncFlatSpec with Matchers {
   it should "work for a paper subscription" in doRequest(Right(directDebitSubscriptionRequestPaper))
 
   // ignored for now to avoid overwhelming PaperRound with test data
+  // it can be added back in when the initial testing period is over
   ignore should "work for a national delivery paper subscription" in doRequest(
     Right(directDebitSubscriptionRequestNationalDelivery),
   )


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

#5357 Stopped one integration test which creates national delivery subs from running however there was another one still going. This PR sets that test to `ignored` as well but it also changes the test fixture data related to national delivery subs so that it is valid (at the current time) so that when we do reinstate those tests they shouldn't break the paperround processor
