### PR TITLE
feat: add noindex to digital subscription (Kindle) pages

### DIFF
--- a/support-frontend/app/controllers/DigitalSubscriptionController.scala
+++ b/support-frontend/app/controllers/DigitalSubscriptionController.scala
@@ -85,7 +85,7 @@ class DigitalSubscriptionController(
             payPalConfigProvider.get(true),
             v2recaptchaConfigPublicKey,
             orderIsAGift,
-            robots = Some("noindex"),
+            noindex = true,
           ),
         )
       }

--- a/support-frontend/app/controllers/DigitalSubscriptionController.scala
+++ b/support-frontend/app/controllers/DigitalSubscriptionController.scala
@@ -85,6 +85,7 @@ class DigitalSubscriptionController(
             payPalConfigProvider.get(true),
             v2recaptchaConfigPublicKey,
             orderIsAGift,
+            robots = Some("noindex"),
           ),
         )
       }

--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -14,6 +14,7 @@
   csrf: Option[String] = None,
   shareImageUrl: Option[String] = None,
   shareUrl: Option[String] = None,
+  robots: Option[String] = None,
   serversideTests: Map[String,Participation] = Map()
 )(body: Html = Html(""))(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
@@ -55,6 +56,10 @@
 
     @canonicalLink.map { definedCanonicalLink =>
       <link rel="canonical" href="@definedCanonicalLink" />
+    }
+
+    @robots.map { robots =>
+      <meta name="robots" content="noindex" />
     }
 
     @for((lang, link) <- hrefLangLinks){

--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -14,7 +14,7 @@
   csrf: Option[String] = None,
   shareImageUrl: Option[String] = None,
   shareUrl: Option[String] = None,
-  robots: Option[String] = None,
+  noindex: Boolean = false,
   serversideTests: Map[String,Participation] = Map()
 )(body: Html = Html(""))(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
@@ -58,7 +58,7 @@
       <link rel="canonical" href="@definedCanonicalLink" />
     }
 
-    @robots.map { robots =>
+    @if(noindex) {
       <meta name="robots" content="noindex" />
     }
 

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -30,9 +30,10 @@
   v2recaptchaConfigPublicKey: String,
   orderIsAGift: Boolean = false,
   homeDeliveryPostcodes: Option[List[String]] = None,
+  robots: Option[String] = None
 )(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: AllSettings)
 
-  @main(title = title, mainJsBundle = Left(RefPath(js)), mainElement = mainElement, mainStyleBundle = Left(RefPath(css)), csrf = csrf) {
+  @main(title = title, mainJsBundle = Left(RefPath(js)), mainElement = mainElement, mainStyleBundle = Left(RefPath(css)), csrf = csrf, robots = robots) {
     <script type="text/javascript">
       window.guardian = window.guardian || {};
 

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -30,10 +30,10 @@
   v2recaptchaConfigPublicKey: String,
   orderIsAGift: Boolean = false,
   homeDeliveryPostcodes: Option[List[String]] = None,
-  robots: Option[String] = None
+  noindex: Boolean = false
 )(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: AllSettings)
 
-  @main(title = title, mainJsBundle = Left(RefPath(js)), mainElement = mainElement, mainStyleBundle = Left(RefPath(css)), csrf = csrf, robots = robots) {
+  @main(title = title, mainJsBundle = Left(RefPath(js)), mainElement = mainElement, mainStyleBundle = Left(RefPath(css)), csrf = csrf, noindex = noindex) {
     <script type="text/javascript">
       window.guardian = window.guardian || {};
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We're stopping search engines indexing the `/{country}/kindle` as a test to see if that's where we're getting trickle of subs from.

We do this by adding the [`<meta name="robots" value="noindex" />`](https://developers.google.com/search/docs/crawling-indexing/block-indexing#meta-tag) tag.

All other routes that use `DigitalSubscriptionController.digital` are redirected in Fastly (no link as it's not in CVS) so unaffected by this.

## `view-source:https://support.thegulocal.com/uk/kindle`
<img width="1045" alt="Screenshot 2023-10-24 at 11 42 15" src="https://github.com/guardian/support-frontend/assets/31692/32bddaeb-5ee9-47f3-ad21-fd12ac9ea5a5">

## `view-source:https://support.thegulocal.com/uk/contribute`
<img width="989" alt="Screenshot 2023-10-24 at 11 42 30" src="https://github.com/guardian/support-frontend/assets/31692/e39001c3-8f86-4c19-9dad-44eb9b1d2835">
