### PR TITLE
Set up new US campaign ticker

### DIFF
--- a/support-frontend/assets/components/ticker/ticker.tsx
+++ b/support-frontend/assets/components/ticker/ticker.tsx
@@ -1,3 +1,8 @@
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import {
+	fromCountryGroupId,
+	glyph,
+} from 'helpers/internationalisation/currency';
 import {
 	tickerHeadline,
 	tickerLabel,
@@ -15,7 +20,7 @@ export type TickerProps = {
 	end: number;
 	countType: TickerCountType;
 	endType: TickerEndType;
-	currencySymbol: string;
+	countryGroupId: CountryGroupId;
 	headline: string;
 };
 
@@ -23,7 +28,17 @@ type TickerLabelProps = {
 	total: number;
 	goal: number;
 	countType: TickerCountType;
-	currencySymbol: string;
+	countryGroupId: CountryGroupId;
+};
+
+const localesByCountryGroup: Record<CountryGroupId, string> = {
+	UnitedStates: 'en-US',
+	Canada: 'en-US',
+	International: 'en-US',
+	GBPCountries: 'en-GB',
+	EURCountries: 'en-GB',
+	AUDCountries: 'en-GB',
+	NZDCountries: 'en-GB',
 };
 
 function progressBarTranslation(total: number, end: number) {
@@ -31,8 +46,8 @@ function progressBarTranslation(total: number, end: number) {
 	return percentage > 0 ? 0 : percentage;
 }
 
-function localiseAmount(amount: number) {
-	return amount.toLocaleString('en-US');
+function localiseAmount(amount: number, countryGroupId: CountryGroupId) {
+	return amount.toLocaleString(localesByCountryGroup[countryGroupId]);
 }
 
 function TickerLabel(props: TickerLabelProps) {
@@ -41,22 +56,24 @@ function TickerLabel(props: TickerLabelProps) {
 			<div css={tickerLabelContainer}>
 				<p css={tickerLabel}>
 					<span css={tickerLabelTotal}>
-						{localiseAmount(props.total)} supporters
+						{localiseAmount(props.total, props.countryGroupId)} supporters
 					</span>{' '}
-					of {localiseAmount(props.goal)} goal
+					of {localiseAmount(props.goal, props.countryGroupId)} goal
 				</p>
 			</div>
 		);
 	}
+
+	const currencySymbol = glyph(fromCountryGroupId(props.countryGroupId));
 	return (
 		<div css={tickerLabelContainer}>
 			<p css={tickerLabel}>
 				<span css={tickerLabelTotal}>
-					{props.currencySymbol}
-					{localiseAmount(props.total)}
+					{currencySymbol}
+					{localiseAmount(props.total, props.countryGroupId)}
 				</span>{' '}
-				of {props.currencySymbol}
-				{localiseAmount(props.goal)} goal
+				of {currencySymbol}
+				{localiseAmount(props.goal, props.countryGroupId)} goal
 			</p>
 		</div>
 	);
@@ -83,7 +100,7 @@ export function Ticker(props: TickerProps): JSX.Element {
 			</div>
 			<TickerLabel
 				countType={props.countType}
-				currencySymbol={props.currencySymbol}
+				countryGroupId={props.countryGroupId}
 				total={props.total}
 				goal={props.goal}
 			/>

--- a/support-frontend/assets/components/ticker/ticker.tsx
+++ b/support-frontend/assets/components/ticker/ticker.tsx
@@ -2,6 +2,7 @@ import './contributionTicker.scss';
 import {
 	tickerCount,
 	tickerGoal,
+	tickerGoalPosition,
 	tickerLabel,
 	tickerLabelContainer,
 	tickerMarker,
@@ -31,9 +32,13 @@ export type TickerMainLabelProps = {
 	copy: TickerCopy;
 };
 
-function percentageToTranslate(total: number, end: number) {
+function progressBarTranslation(total: number, end: number) {
 	const percentage = (total / end) * 100 - 100;
 	return percentage > 0 ? 0 : percentage;
+}
+
+function markerTranslation(goal: number, end: number) {
+	return (goal / end) * 100 - 100;
 }
 
 function TickerMainLabel({
@@ -73,13 +78,14 @@ function TickerMainLabel({
 }
 
 export function Ticker(props: TickerProps): JSX.Element {
-	const progressBarTransform = `translate3d(${percentageToTranslate(
+	const markerPosition = markerTranslation(props.goal, props.end);
+
+	const progressBarTransform = `translate3d(${progressBarTranslation(
 		props.total,
 		props.end,
 	)}%, 0, 0)`;
-	const markerTransform = `translate3d(${
-		(props.goal / props.end) * 100 - 100
-	}%, -2px, 0)`;
+	const markerTransform = `translate3d(${markerPosition}%, -2px, 0)`;
+	const markerLabelTransform = `translate3d(${markerPosition}%, 0, 0)`;
 
 	const goalReached = props.total >= props.goal;
 
@@ -87,17 +93,24 @@ export function Ticker(props: TickerProps): JSX.Element {
 		<div>
 			<div css={tickerLabelContainer}>
 				<TickerMainLabel {...props} goalReached={goalReached} />
-				<div css={[tickerLabel, tickerGoal]}>
-					<div css={tickerCount}>
-						{props.countType === 'money' ? props.currencySymbol : ''}
-						{Math.floor(props.goal).toLocaleString()}
-					</div>
-					<div>
-						{props.endType === 'unlimited' && goalReached ? (
-							props.copy.countLabel
-						) : (
-							<>&nbsp;goal</>
-						)}
+				<div
+					css={tickerGoalPosition}
+					style={{
+						transform: markerLabelTransform,
+					}}
+				>
+					<div css={[tickerLabel, tickerGoal]}>
+						<div css={tickerCount}>
+							{props.countType === 'money' ? props.currencySymbol : ''}
+							{Math.floor(props.goal).toLocaleString()}
+						</div>
+						<div>
+							{props.endType === 'unlimited' && goalReached ? (
+								props.copy.countLabel
+							) : (
+								<>&nbsp;goal</>
+							)}
+						</div>
 					</div>
 				</div>
 			</div>

--- a/support-frontend/assets/components/ticker/ticker.tsx
+++ b/support-frontend/assets/components/ticker/ticker.tsx
@@ -1,19 +1,13 @@
-import { css } from '@emotion/react';
-import { visuallyHidden } from '@guardian/source-foundations';
-import './contributionTicker.scss';
 import {
-	tickerCount,
-	tickerGoal,
-	tickerGoalPosition,
+	tickerHeadline,
 	tickerLabel,
 	tickerLabelContainer,
-	tickerMarker,
+	tickerLabelTotal,
 	tickerProgressBar,
 	tickerProgressBarBackground,
 	tickerProgressBarFill,
-	tickerStatus,
 } from './tickerStyles';
-import type { TickerCopy, TickerCountType, TickerEndType } from './types';
+import type { TickerCountType, TickerEndType } from './types';
 
 export type TickerProps = {
 	total: number;
@@ -22,16 +16,14 @@ export type TickerProps = {
 	countType: TickerCountType;
 	endType: TickerEndType;
 	currencySymbol: string;
-	copy: TickerCopy;
+	headline: string;
 };
 
-export type TickerMainLabelProps = {
-	goalReached: boolean;
+type TickerLabelProps = {
 	total: number;
+	goal: number;
 	countType: TickerCountType;
-	endType: TickerEndType;
 	currencySymbol: string;
-	copy: TickerCopy;
 };
 
 function progressBarTranslation(total: number, end: number) {
@@ -39,90 +31,40 @@ function progressBarTranslation(total: number, end: number) {
 	return percentage > 0 ? 0 : percentage;
 }
 
-function markerTranslation(goal: number, end: number) {
-	return (goal / end) * 100 - 100;
-}
-
-function TickerMainLabel({
-	goalReached,
-	total,
-	countType,
-	endType,
-	currencySymbol,
-	copy,
-}: TickerMainLabelProps) {
-	if (!goalReached) {
+function TickerLabel(props: TickerLabelProps) {
+	if (props.countType === 'people') {
 		return (
-			<div css={[tickerLabel, tickerStatus]}>
-				<div css={tickerCount}>
-					{countType === 'money' ? currencySymbol : ''}
-					{Math.floor(total).toLocaleString()}&nbsp;
-				</div>
-				<div>{copy.countLabel}</div>
+			<div css={tickerLabelContainer}>
+				<p css={tickerLabel}>
+					<span css={tickerLabelTotal}>{props.total} supporters</span> of{' '}
+					{props.goal} goal
+				</p>
 			</div>
 		);
 	}
-
-	if (endType === 'unlimited') {
-		return (
-			<div css={[tickerLabel, tickerStatus]}>
-				<div css={tickerCount}>{copy.goalReachedPrimary}&nbsp;</div>
-				<div>{copy.goalReachedSecondary}</div>
-			</div>
-		);
-	}
-
 	return (
-		<div css={[tickerLabel, tickerStatus]}>
-			<div css={tickerCount}>{copy.goalReachedPrimary}&nbsp;</div>
+		<div css={tickerLabelContainer}>
+			<p css={tickerLabel}>
+				<span css={tickerLabelTotal}>
+					{props.currencySymbol}
+					{props.total}
+				</span>{' '}
+				of {props.currencySymbol}
+				{props.goal} goal
+			</p>
 		</div>
 	);
 }
 
 export function Ticker(props: TickerProps): JSX.Element {
-	const markerPosition = markerTranslation(props.goal, props.end);
-
 	const progressBarTransform = `translate3d(${progressBarTranslation(
 		props.total,
 		props.end,
 	)}%, 0, 0)`;
-	const markerTransform = `translate3d(${markerPosition}%, -2px, 0)`;
-	const markerLabelTransform = `translate3d(${markerPosition}%, 0, 0)`;
-
-	const goalReached = props.total >= props.goal;
 
 	return (
 		<div>
-			<h2
-				css={css`
-					${visuallyHidden}
-				`}
-			>
-				Current campaign progress
-			</h2>
-			<div css={tickerLabelContainer}>
-				<TickerMainLabel {...props} goalReached={goalReached} />
-				<div
-					css={tickerGoalPosition}
-					style={{
-						transform: markerLabelTransform,
-					}}
-				>
-					<div css={[tickerLabel, tickerGoal]}>
-						<div css={tickerCount}>
-							{props.countType === 'money' ? props.currencySymbol : ''}
-							{Math.floor(props.goal).toLocaleString()}
-						</div>
-						<div>
-							{props.endType === 'unlimited' && goalReached ? (
-								props.copy.countLabel
-							) : (
-								<>&nbsp;goal</>
-							)}
-						</div>
-					</div>
-				</div>
-			</div>
+			<h2 css={tickerHeadline}>{props.headline}</h2>
 			<div css={tickerProgressBar}>
 				<div css={tickerProgressBarBackground}>
 					<div
@@ -132,13 +74,13 @@ export function Ticker(props: TickerProps): JSX.Element {
 						}}
 					/>
 				</div>
-				<div
-					css={tickerMarker}
-					style={{
-						transform: markerTransform,
-					}}
-				/>
 			</div>
+			<TickerLabel
+				countType={props.countType}
+				currencySymbol={props.currencySymbol}
+				total={props.total}
+				goal={props.goal}
+			/>
 		</div>
 	);
 }

--- a/support-frontend/assets/components/ticker/ticker.tsx
+++ b/support-frontend/assets/components/ticker/ticker.tsx
@@ -1,0 +1,133 @@
+import './contributionTicker.scss';
+import {
+	tickerCount,
+	tickerGoal,
+	tickerLabel,
+	tickerProgressBar,
+	tickerProgressBarBackground,
+	tickerProgressBarFill,
+	tickerStatus,
+} from './tickerStyles';
+
+type TickerEndType = 'unlimited' | 'hardstop';
+
+type TickerCountType = 'money' | 'people';
+
+type TickerCopy = {
+	countLabel: string;
+	goalReachedPrimary: string;
+	goalReachedSecondary: string;
+};
+
+export type TickerProps = {
+	total: number;
+	goal: number;
+	end: number;
+	countType: TickerCountType;
+	endType: TickerEndType;
+	currencySymbol: string;
+	copy: TickerCopy;
+};
+
+export type TickerBodyProps = {
+	goalReached: boolean;
+	total: number;
+	countType: TickerCountType;
+	endType: TickerEndType;
+	currencySymbol: string;
+	copy: TickerCopy;
+};
+
+function percentageToTranslate(total: number, end: number) {
+	const percentage = (total / end) * 100 - 100;
+	return percentage > 0 ? 0 : percentage;
+}
+
+function TickerBody({
+	goalReached,
+	total,
+	countType,
+	endType,
+	currencySymbol,
+	copy,
+}: TickerBodyProps) {
+	if (!goalReached) {
+		return (
+			<div css={[tickerLabel, tickerStatus]}>
+				<div css={tickerCount}>
+					{countType === 'money' ? currencySymbol : ''}
+					{Math.floor(total).toLocaleString()}&nbsp;
+				</div>
+				<div className="contributions-landing-ticker__count-label contributions-landing-ticker__label">
+					{copy.countLabel}
+				</div>
+			</div>
+		);
+	}
+
+	if (endType === 'unlimited') {
+		return (
+			<div css={[tickerLabel, tickerStatus]}>
+				<div css={tickerCount}>{copy.goalReachedPrimary}&nbsp;</div>
+				<div className="contributions-landing-ticker__count-label contributions-landing-ticker__label">
+					{copy.goalReachedSecondary}
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div css={[tickerLabel, tickerStatus]}>
+			<div css={tickerCount}>{copy.goalReachedPrimary}&nbsp;</div>
+		</div>
+	);
+}
+
+export function Ticker(props: TickerProps): JSX.Element {
+	const progressBarAnimation = `translate3d(${percentageToTranslate(
+		props.total,
+		props.end,
+	)}%, 0, 0)`;
+	const markerAnimation = `translate3d(${
+		(props.goal / props.end) * 100 - 100
+	}%, 0, 0)`;
+
+	const goalReached = props.total >= props.goal;
+
+	return (
+		<div>
+			<div className="contributions-landing-ticker__values">
+				<TickerBody {...props} goalReached={goalReached} />
+				<div css={[tickerLabel, tickerGoal]}>
+					<div css={tickerCount}>
+						{props.countType === 'money' ? props.currencySymbol : ''}
+						{Math.floor(props.goal).toLocaleString()}
+					</div>
+					<div className="contributions-landing-ticker__count-label contributions-landing-ticker__label">
+						{props.endType === 'unlimited' && goalReached ? (
+							props.copy.countLabel
+						) : (
+							<>&nbsp;goal</>
+						)}
+					</div>
+				</div>
+			</div>
+			<div css={tickerProgressBar}>
+				<div css={tickerProgressBarBackground}>
+					<div
+						css={tickerProgressBarFill}
+						style={{
+							transform: progressBarAnimation,
+						}}
+					/>
+				</div>
+				<div
+					className="contributions-landing-ticker__marker"
+					style={{
+						transform: markerAnimation,
+					}}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/support-frontend/assets/components/ticker/ticker.tsx
+++ b/support-frontend/assets/components/ticker/ticker.tsx
@@ -1,3 +1,5 @@
+import { css } from '@emotion/react';
+import { visuallyHidden } from '@guardian/source-foundations';
 import './contributionTicker.scss';
 import {
 	tickerCount,
@@ -91,6 +93,13 @@ export function Ticker(props: TickerProps): JSX.Element {
 
 	return (
 		<div>
+			<h2
+				css={css`
+					${visuallyHidden}
+				`}
+			>
+				Current campaign progress
+			</h2>
 			<div css={tickerLabelContainer}>
 				<TickerMainLabel {...props} goalReached={goalReached} />
 				<div

--- a/support-frontend/assets/components/ticker/ticker.tsx
+++ b/support-frontend/assets/components/ticker/ticker.tsx
@@ -31,13 +31,19 @@ function progressBarTranslation(total: number, end: number) {
 	return percentage > 0 ? 0 : percentage;
 }
 
+function localiseAmount(amount: number) {
+	return amount.toLocaleString('en-US');
+}
+
 function TickerLabel(props: TickerLabelProps) {
 	if (props.countType === 'people') {
 		return (
 			<div css={tickerLabelContainer}>
 				<p css={tickerLabel}>
-					<span css={tickerLabelTotal}>{props.total} supporters</span> of{' '}
-					{props.goal} goal
+					<span css={tickerLabelTotal}>
+						{localiseAmount(props.total)} supporters
+					</span>{' '}
+					of {localiseAmount(props.goal)} goal
 				</p>
 			</div>
 		);
@@ -47,10 +53,10 @@ function TickerLabel(props: TickerLabelProps) {
 			<p css={tickerLabel}>
 				<span css={tickerLabelTotal}>
 					{props.currencySymbol}
-					{props.total}
+					{localiseAmount(props.total)}
 				</span>{' '}
 				of {props.currencySymbol}
-				{props.goal} goal
+				{localiseAmount(props.goal)} goal
 			</p>
 		</div>
 	);

--- a/support-frontend/assets/components/ticker/ticker.tsx
+++ b/support-frontend/assets/components/ticker/ticker.tsx
@@ -3,21 +3,14 @@ import {
 	tickerCount,
 	tickerGoal,
 	tickerLabel,
+	tickerLabelContainer,
+	tickerMarker,
 	tickerProgressBar,
 	tickerProgressBarBackground,
 	tickerProgressBarFill,
 	tickerStatus,
 } from './tickerStyles';
-
-type TickerEndType = 'unlimited' | 'hardstop';
-
-type TickerCountType = 'money' | 'people';
-
-type TickerCopy = {
-	countLabel: string;
-	goalReachedPrimary: string;
-	goalReachedSecondary: string;
-};
+import type { TickerCopy, TickerCountType, TickerEndType } from './types';
 
 export type TickerProps = {
 	total: number;
@@ -29,7 +22,7 @@ export type TickerProps = {
 	copy: TickerCopy;
 };
 
-export type TickerBodyProps = {
+export type TickerMainLabelProps = {
 	goalReached: boolean;
 	total: number;
 	countType: TickerCountType;
@@ -43,14 +36,14 @@ function percentageToTranslate(total: number, end: number) {
 	return percentage > 0 ? 0 : percentage;
 }
 
-function TickerBody({
+function TickerMainLabel({
 	goalReached,
 	total,
 	countType,
 	endType,
 	currencySymbol,
 	copy,
-}: TickerBodyProps) {
+}: TickerMainLabelProps) {
 	if (!goalReached) {
 		return (
 			<div css={[tickerLabel, tickerStatus]}>
@@ -58,9 +51,7 @@ function TickerBody({
 					{countType === 'money' ? currencySymbol : ''}
 					{Math.floor(total).toLocaleString()}&nbsp;
 				</div>
-				<div className="contributions-landing-ticker__count-label contributions-landing-ticker__label">
-					{copy.countLabel}
-				</div>
+				<div>{copy.countLabel}</div>
 			</div>
 		);
 	}
@@ -69,9 +60,7 @@ function TickerBody({
 		return (
 			<div css={[tickerLabel, tickerStatus]}>
 				<div css={tickerCount}>{copy.goalReachedPrimary}&nbsp;</div>
-				<div className="contributions-landing-ticker__count-label contributions-landing-ticker__label">
-					{copy.goalReachedSecondary}
-				</div>
+				<div>{copy.goalReachedSecondary}</div>
 			</div>
 		);
 	}
@@ -84,26 +73,26 @@ function TickerBody({
 }
 
 export function Ticker(props: TickerProps): JSX.Element {
-	const progressBarAnimation = `translate3d(${percentageToTranslate(
+	const progressBarTransform = `translate3d(${percentageToTranslate(
 		props.total,
 		props.end,
 	)}%, 0, 0)`;
-	const markerAnimation = `translate3d(${
+	const markerTransform = `translate3d(${
 		(props.goal / props.end) * 100 - 100
-	}%, 0, 0)`;
+	}%, -2px, 0)`;
 
 	const goalReached = props.total >= props.goal;
 
 	return (
 		<div>
-			<div className="contributions-landing-ticker__values">
-				<TickerBody {...props} goalReached={goalReached} />
+			<div css={tickerLabelContainer}>
+				<TickerMainLabel {...props} goalReached={goalReached} />
 				<div css={[tickerLabel, tickerGoal]}>
 					<div css={tickerCount}>
 						{props.countType === 'money' ? props.currencySymbol : ''}
 						{Math.floor(props.goal).toLocaleString()}
 					</div>
-					<div className="contributions-landing-ticker__count-label contributions-landing-ticker__label">
+					<div>
 						{props.endType === 'unlimited' && goalReached ? (
 							props.copy.countLabel
 						) : (
@@ -117,14 +106,14 @@ export function Ticker(props: TickerProps): JSX.Element {
 					<div
 						css={tickerProgressBarFill}
 						style={{
-							transform: progressBarAnimation,
+							transform: progressBarTransform,
 						}}
 					/>
 				</div>
 				<div
-					className="contributions-landing-ticker__marker"
+					css={tickerMarker}
 					style={{
-						transform: markerAnimation,
+						transform: markerTransform,
 					}}
 				/>
 			</div>

--- a/support-frontend/assets/components/ticker/tickerContainer.tsx
+++ b/support-frontend/assets/components/ticker/tickerContainer.tsx
@@ -1,12 +1,7 @@
 import { useEffect, useState } from 'react';
 import { fetchJson } from 'helpers/async/fetch';
 import type { TickerProps } from './ticker';
-import type {
-	TickerConfigData,
-	TickerCopy,
-	TickerCountType,
-	TickerEndType,
-} from './types';
+import type { TickerConfigData, TickerCountType, TickerEndType } from './types';
 
 function getInitialTickerValues(
 	tickerCountType: TickerCountType,
@@ -25,14 +20,14 @@ function getInitialTickerValues(
 }
 
 function getDefaultTickerEnd(_total: number, goal: number) {
-	return goal + goal * 0.15;
+	return goal;
 }
 
 type TickerContainerProps = {
 	countType: TickerCountType;
 	endType: TickerEndType;
 	currencySymbol: string;
-	copy: TickerCopy;
+	headline: string;
 	calculateEnd?: (total: number, goal: number) => number;
 	render: (props: TickerProps) => JSX.Element;
 };
@@ -42,7 +37,7 @@ export function TickerContainer({
 	countType,
 	endType,
 	currencySymbol,
-	copy,
+	headline,
 	calculateEnd = getDefaultTickerEnd,
 }: TickerContainerProps): JSX.Element {
 	const [tickerConfig, setTickerConfig] = useState<TickerConfigData>({
@@ -62,7 +57,7 @@ export function TickerContainer({
 		countType,
 		endType,
 		currencySymbol,
-		copy,
+		headline,
 		end,
 	});
 }

--- a/support-frontend/assets/components/ticker/tickerContainer.tsx
+++ b/support-frontend/assets/components/ticker/tickerContainer.tsx
@@ -5,6 +5,7 @@ import { isCodeOrProd } from 'helpers/urls/url';
 import type { TickerProps } from './ticker';
 import type { TickerConfigData, TickerCountType, TickerEndType } from './types';
 
+// In dev we use a dummy route for ticker data; in CODE and PROD this needs to point to the specific ticker ID
 function getTickerUrl(tickerCountType: TickerCountType, tickerId: string) {
 	if (isCodeOrProd()) {
 		return `/ticker/${tickerId}.json`;

--- a/support-frontend/assets/components/ticker/tickerContainer.tsx
+++ b/support-frontend/assets/components/ticker/tickerContainer.tsx
@@ -19,8 +19,9 @@ function getInitialTickerValues(
 	});
 }
 
-function getDefaultTickerEnd(_total: number, goal: number) {
-	return goal;
+function getDefaultTickerEnd(total: number, goal: number) {
+	if (goal > total) return goal;
+	return total;
 }
 
 type TickerContainerProps = {

--- a/support-frontend/assets/components/ticker/tickerContainer.tsx
+++ b/support-frontend/assets/components/ticker/tickerContainer.tsx
@@ -24,37 +24,50 @@ function getInitialTickerValues(
 	});
 }
 
+function getTickerEndAmount(
+	endType: TickerEndType,
+	tickerConfig: TickerConfigData,
+) {
+	const goalReached = tickerConfig.total > tickerConfig.goal;
+	if (endType === 'unlimited' && goalReached) {
+		return tickerConfig.total + tickerConfig.total * 0.15;
+	}
+	return tickerConfig.goal;
+}
+
 type TickerContainerProps = {
-	tickerCountType: TickerCountType;
-	tickerEndType: TickerEndType;
+	countType: TickerCountType;
+	endType: TickerEndType;
 	currencySymbol: string;
 	copy: TickerCopy;
 	render: (props: TickerProps) => JSX.Element;
 };
 
-export function TickerContainer(props: TickerContainerProps): JSX.Element {
+export function TickerContainer({
+	render,
+	countType,
+	endType,
+	currencySymbol,
+	copy,
+}: TickerContainerProps): JSX.Element {
 	const [tickerConfig, setTickerConfig] = useState<TickerConfigData>({
 		total: 0,
 		goal: 0,
 	});
 
-	const end =
-		props.tickerEndType === 'unlimited' &&
-		tickerConfig.total > tickerConfig.goal
-			? tickerConfig.total + tickerConfig.total * 0.15
-			: tickerConfig.goal;
+	const end = getTickerEndAmount(endType, tickerConfig);
 
 	useEffect(() => {
-		void getInitialTickerValues(props.tickerCountType).then(setTickerConfig);
+		void getInitialTickerValues(countType).then(setTickerConfig);
 	}, []);
 
-	return props.render({
+	return render({
 		total: tickerConfig.total,
 		goal: tickerConfig.goal,
-		countType: props.tickerCountType,
-		endType: props.tickerEndType,
-		currencySymbol: props.currencySymbol,
-		copy: props.copy,
+		countType,
+		endType,
+		currencySymbol,
+		copy,
 		end,
 	});
 }

--- a/support-frontend/assets/components/ticker/tickerContainer.tsx
+++ b/support-frontend/assets/components/ticker/tickerContainer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { fetchJson } from 'helpers/async/fetch';
+import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import type { TickerProps } from './ticker';
 import type { TickerConfigData, TickerCountType, TickerEndType } from './types';
 
@@ -27,7 +28,6 @@ function getDefaultTickerEnd(total: number, goal: number) {
 type TickerContainerProps = {
 	countType: TickerCountType;
 	endType: TickerEndType;
-	currencySymbol: string;
 	headline: string;
 	calculateEnd?: (total: number, goal: number) => number;
 	render: (props: TickerProps) => JSX.Element;
@@ -37,10 +37,12 @@ export function TickerContainer({
 	render,
 	countType,
 	endType,
-	currencySymbol,
 	headline,
 	calculateEnd = getDefaultTickerEnd,
 }: TickerContainerProps): JSX.Element {
+	const { countryGroupId } = useContributionsSelector(
+		(state) => state.common.internationalisation,
+	);
 	const [tickerConfig, setTickerConfig] = useState<TickerConfigData>({
 		total: 0,
 		goal: 0,
@@ -57,7 +59,7 @@ export function TickerContainer({
 		goal: tickerConfig.goal,
 		countType,
 		endType,
-		currencySymbol,
+		countryGroupId,
 		headline,
 		end,
 	});

--- a/support-frontend/assets/components/ticker/tickerContainer.tsx
+++ b/support-frontend/assets/components/ticker/tickerContainer.tsx
@@ -24,15 +24,8 @@ function getInitialTickerValues(
 	});
 }
 
-function getTickerEndAmount(
-	endType: TickerEndType,
-	tickerConfig: TickerConfigData,
-) {
-	const goalReached = tickerConfig.total > tickerConfig.goal;
-	if (endType === 'unlimited' && goalReached) {
-		return tickerConfig.total + tickerConfig.total * 0.15;
-	}
-	return tickerConfig.goal;
+function getDefaultTickerEnd(_total: number, goal: number) {
+	return goal + goal * 0.15;
 }
 
 type TickerContainerProps = {
@@ -40,6 +33,7 @@ type TickerContainerProps = {
 	endType: TickerEndType;
 	currencySymbol: string;
 	copy: TickerCopy;
+	calculateEnd?: (total: number, goal: number) => number;
 	render: (props: TickerProps) => JSX.Element;
 };
 
@@ -49,13 +43,14 @@ export function TickerContainer({
 	endType,
 	currencySymbol,
 	copy,
+	calculateEnd = getDefaultTickerEnd,
 }: TickerContainerProps): JSX.Element {
 	const [tickerConfig, setTickerConfig] = useState<TickerConfigData>({
 		total: 0,
 		goal: 0,
 	});
 
-	const end = getTickerEndAmount(endType, tickerConfig);
+	const end = calculateEnd(tickerConfig.total, tickerConfig.goal);
 
 	useEffect(() => {
 		void getInitialTickerValues(countType).then(setTickerConfig);

--- a/support-frontend/assets/components/ticker/tickerContainer.tsx
+++ b/support-frontend/assets/components/ticker/tickerContainer.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { fetchJson } from 'helpers/async/fetch';
+import type { TickerProps } from './ticker';
+import type {
+	TickerConfigData,
+	TickerCopy,
+	TickerCountType,
+	TickerEndType,
+} from './types';
+
+function getInitialTickerValues(
+	tickerCountType: TickerCountType,
+): Promise<TickerConfigData> {
+	return fetchJson<TickerConfigData>(
+		tickerCountType === 'money' ? '/ticker.json' : '/supporters-ticker.json',
+		{},
+	).then((data: TickerConfigData) => {
+		const total = Math.floor(data.total);
+		const goal = Math.floor(data.goal);
+		return {
+			total,
+			goal,
+		};
+	});
+}
+
+type TickerContainerProps = {
+	tickerCountType: TickerCountType;
+	tickerEndType: TickerEndType;
+	currencySymbol: string;
+	copy: TickerCopy;
+	render: (props: TickerProps) => JSX.Element;
+};
+
+export function TickerContainer(props: TickerContainerProps): JSX.Element {
+	const [tickerConfig, setTickerConfig] = useState<TickerConfigData>({
+		total: 0,
+		goal: 0,
+	});
+
+	const end =
+		props.tickerEndType === 'unlimited' &&
+		tickerConfig.total > tickerConfig.goal
+			? tickerConfig.total + tickerConfig.total * 0.15
+			: tickerConfig.goal;
+
+	useEffect(() => {
+		void getInitialTickerValues(props.tickerCountType).then(setTickerConfig);
+	}, []);
+
+	return props.render({
+		total: tickerConfig.total,
+		goal: tickerConfig.goal,
+		countType: props.tickerCountType,
+		endType: props.tickerEndType,
+		currencySymbol: props.currencySymbol,
+		copy: props.copy,
+		end,
+	});
+}

--- a/support-frontend/assets/components/ticker/tickerStyles.ts
+++ b/support-frontend/assets/components/ticker/tickerStyles.ts
@@ -29,6 +29,7 @@ export const tickerCount = css`
 `;
 
 export const tickerLabelContainer = css`
+	position: relative;
 	display: flex;
 	justify-content: space-between;
 	margin-bottom: ${space[1]}px;
@@ -37,11 +38,20 @@ export const tickerLabelContainer = css`
 export const tickerLabel = css`
 	display: flex;
 	flex-wrap: wrap;
-	flex-grow: 1;
+	max-width: 40%;
 `;
 
 export const tickerGoal = css`
 	justify-content: flex-end;
+	margin-right: -10%;
+`;
+
+export const tickerGoalPosition = css`
+	display: flex;
+	justify-content: flex-end;
+	position: absolute;
+	right: 0;
+	width: 100%;
 `;
 
 export const tickerStatus = css`

--- a/support-frontend/assets/components/ticker/tickerStyles.ts
+++ b/support-frontend/assets/components/ticker/tickerStyles.ts
@@ -1,0 +1,43 @@
+import { css } from '@emotion/react';
+import { palette, space } from '@guardian/source-foundations';
+
+export const tickerProgressBar = css`
+	position: relative;
+`;
+
+export const tickerProgressBarBackground = css`
+	width: calc(100%);
+	height: ${space[3]}px;
+	overflow: hidden;
+	background-color: #d9d9d9;
+	position: absolute;
+`;
+
+export const tickerProgressBarFill = css`
+	background-color: ${palette.neutral[0]};
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	transform: translateX(-100%);
+	transition: transform 3s cubic-bezier(0.25, 0.55, 0.2, 0.85);
+`;
+
+export const tickerCount = css`
+	font-weight: bold;
+`;
+
+export const tickerLabel = css`
+	display: flex;
+	flex-wrap: wrap;
+	flex-grow: 1;
+`;
+
+export const tickerGoal = css`
+	justify-content: flex-end;
+`;
+
+export const tickerStatus = css`
+	justify-content: flex-start;
+`;

--- a/support-frontend/assets/components/ticker/tickerStyles.ts
+++ b/support-frontend/assets/components/ticker/tickerStyles.ts
@@ -10,13 +10,13 @@ export const tickerProgressBarBackground = css`
 	width: calc(100%);
 	height: ${space[3]}px;
 	overflow: hidden;
-	background-color: #d9d9d9;
+	background-color: rgba(5, 41, 98, 0.35);
 	position: absolute;
 	border-radius: ${space[2]}px;
 `;
 
 export const tickerProgressBarFill = css`
-	background-color: ${palette.neutral[0]};
+	background-color: ${palette.brand[400]};
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -24,6 +24,7 @@ export const tickerProgressBarFill = css`
 	bottom: 0;
 	transform: translateX(-100%);
 	transition: transform 3s cubic-bezier(0.25, 0.55, 0.2, 0.85);
+	border-radius: ${space[2]}px;
 `;
 
 export const tickerHeadline = css`
@@ -43,4 +44,5 @@ export const tickerLabel = css`
 
 export const tickerLabelTotal = css`
 	font-weight: 700;
+	color: ${palette.brand[400]};
 `;

--- a/support-frontend/assets/components/ticker/tickerStyles.ts
+++ b/support-frontend/assets/components/ticker/tickerStyles.ts
@@ -1,8 +1,9 @@
 import { css } from '@emotion/react';
-import { palette, space } from '@guardian/source-foundations';
+import { palette, space, textSans } from '@guardian/source-foundations';
 
 export const tickerProgressBar = css`
 	position: relative;
+	height: ${space[3]}px;
 `;
 
 export const tickerProgressBarBackground = css`
@@ -11,6 +12,7 @@ export const tickerProgressBarBackground = css`
 	overflow: hidden;
 	background-color: #d9d9d9;
 	position: absolute;
+	border-radius: ${space[2]}px;
 `;
 
 export const tickerProgressBarFill = css`
@@ -24,43 +26,21 @@ export const tickerProgressBarFill = css`
 	transition: transform 3s cubic-bezier(0.25, 0.55, 0.2, 0.85);
 `;
 
-export const tickerCount = css`
-	font-weight: bold;
+export const tickerHeadline = css`
+	${textSans.medium({ fontWeight: 'bold' })}
+	margin-bottom: ${space[2]}px;
 `;
 
 export const tickerLabelContainer = css`
 	position: relative;
 	display: flex;
-	justify-content: space-between;
-	margin-bottom: ${space[1]}px;
+	margin-top: ${space[1]}px;
 `;
 
 export const tickerLabel = css`
-	display: flex;
-	flex-wrap: wrap;
-	max-width: 40%;
+	${textSans.medium()}
 `;
 
-export const tickerGoal = css`
-	justify-content: flex-end;
-	margin-right: -10%;
-`;
-
-export const tickerGoalPosition = css`
-	display: flex;
-	justify-content: flex-end;
-	position: absolute;
-	right: 0;
-	width: 100%;
-`;
-
-export const tickerStatus = css`
-	justify-content: flex-start;
-`;
-
-export const tickerMarker = css`
-	border-right: 2px solid ${palette.neutral[7]};
-	content: ' ';
-	display: block;
-	height: ${space[4]}px;
+export const tickerLabelTotal = css`
+	font-weight: 700;
 `;

--- a/support-frontend/assets/components/ticker/tickerStyles.ts
+++ b/support-frontend/assets/components/ticker/tickerStyles.ts
@@ -28,6 +28,12 @@ export const tickerCount = css`
 	font-weight: bold;
 `;
 
+export const tickerLabelContainer = css`
+	display: flex;
+	justify-content: space-between;
+	margin-bottom: ${space[1]}px;
+`;
+
 export const tickerLabel = css`
 	display: flex;
 	flex-wrap: wrap;
@@ -40,4 +46,11 @@ export const tickerGoal = css`
 
 export const tickerStatus = css`
 	justify-content: flex-start;
+`;
+
+export const tickerMarker = css`
+	border-right: 2px solid ${palette.neutral[7]};
+	content: ' ';
+	display: block;
+	height: ${space[4]}px;
 `;

--- a/support-frontend/assets/components/ticker/types.ts
+++ b/support-frontend/assets/components/ticker/types.ts
@@ -1,3 +1,5 @@
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+
 export type TickerCountType = 'money' | 'people';
 
 export type TickerEndType = 'unlimited' | 'hardstop';
@@ -11,4 +13,12 @@ export type TickerCopy = {
 export type TickerConfigData = {
 	total: number;
 	goal: number;
+};
+
+export type TickerSettings = {
+	countType: TickerCountType;
+	endType: TickerEndType;
+	countryGroup: CountryGroupId;
+	currencySymbol: string;
+	headline: string;
 };

--- a/support-frontend/assets/components/ticker/types.ts
+++ b/support-frontend/assets/components/ticker/types.ts
@@ -1,5 +1,3 @@
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-
 export type TickerCountType = 'money' | 'people';
 
 export type TickerEndType = 'unlimited' | 'hardstop';
@@ -18,7 +16,5 @@ export type TickerConfigData = {
 export type TickerSettings = {
 	countType: TickerCountType;
 	endType: TickerEndType;
-	countryGroup: CountryGroupId;
-	currencySymbol: string;
 	headline: string;
 };

--- a/support-frontend/assets/components/ticker/types.ts
+++ b/support-frontend/assets/components/ticker/types.ts
@@ -1,0 +1,14 @@
+export type TickerCountType = 'money' | 'people';
+
+export type TickerEndType = 'unlimited' | 'hardstop';
+
+export type TickerCopy = {
+	countLabel: string;
+	goalReachedPrimary: string;
+	goalReachedSecondary: string;
+};
+
+export type TickerConfigData = {
+	total: number;
+	goal: number;
+};

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -155,4 +155,24 @@ export const tests: Tests = {
 		referrerControlled: false,
 		seed: 0,
 	},
+	usCampaignTicker: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		isActive: false,
+		audiences: {
+			UnitedStates: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+		referrerControlled: false,
+		seed: 4,
+	},
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -155,24 +155,4 @@ export const tests: Tests = {
 		referrerControlled: false,
 		seed: 0,
 	},
-	usCampaignTicker: {
-		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'variant',
-			},
-		],
-		isActive: false,
-		audiences: {
-			UnitedStates: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
-		referrerControlled: false,
-		seed: 4,
-	},
 };

--- a/support-frontend/assets/helpers/async/fetch.ts
+++ b/support-frontend/assets/helpers/async/fetch.ts
@@ -3,12 +3,12 @@ import type { CsrfState } from 'helpers/redux/checkout/csrf/state';
 type Credentials = 'omit' | 'same-origin' | 'include';
 
 /** Sends a request to an API and converts the response into a JSON object */
-async function fetchJson(
+async function fetchJson<T extends Record<string, unknown>>(
 	endpoint: RequestInfo,
 	settings: RequestInit,
-): Promise<Record<string, unknown>> {
+): Promise<T> {
 	const resp = await fetch(endpoint, settings);
-	return (await resp.json()) as Record<string, unknown>;
+	return (await resp.json()) as T;
 }
 
 type GetRequestHeaders = {

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -1,4 +1,4 @@
-import type { TickerSettings } from 'components/ticker/contributionTicker';
+import type { TickerSettings } from 'components/ticker/types';
 import type { ContributionTypes } from 'helpers/contributions';
 
 type CampaignCopy = {
@@ -35,14 +35,9 @@ export const campaign: CampaignSettings = {
 	campaignCode: 'Us_eoy_2023',
 	copy: usEoy2021Copy,
 	tickerSettings: {
-		tickerCountType: 'money',
-		tickerEndType: 'unlimited',
-		currencySymbol: '$',
-		copy: {
-			countLabel: 'contributed',
-			goalReachedPrimary: "We've met our goal - thank you",
-			goalReachedSecondary: 'but you can still contribute',
-		},
+		countType: 'money',
+		endType: 'unlimited',
+		headline: 'End of year campaign',
 	},
 };
 

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -18,7 +18,7 @@ export type CampaignSettings = {
 	contributionTypes?: ContributionTypes;
 	backgroundImage?: string;
 	extraComponent?: JSX.Element;
-	tickerSettings?: TickerSettings;
+	tickerSettings: TickerSettings;
 	goalReachedCopy?: JSX.Element;
 	// If set, the form will be replaced with this if goal reached
 };
@@ -40,8 +40,8 @@ export const campaign: CampaignSettings = {
 		currencySymbol: '$',
 		copy: {
 			countLabel: 'contributed',
-			goalReachedPrimary: "We've hit our goal!",
-			goalReachedSecondary: 'but you can still support us',
+			goalReachedPrimary: "We've met our goal - thank you",
+			goalReachedSecondary: 'but you can still contribute',
 		},
 	},
 };

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -32,7 +32,7 @@ const usEoy2021Copy = (): CampaignCopy => ({
 });
 
 export const campaign: CampaignSettings = {
-	campaignCode: 'Us_eoy_2021',
+	campaignCode: 'Us_eoy_2023',
 	copy: usEoy2021Copy,
 	tickerSettings: {
 		tickerCountType: 'money',

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -365,10 +365,10 @@ function checkRegularStatus(
 						MAX_POLLS,
 						POLLING_INTERVAL,
 						() =>
-							fetchJson(
+							fetchJson<StatusResponse>(
 								statusResponse.trackingUri,
 								getRequestOptions('same-origin', csrf),
-							) as Promise<StatusResponse>,
+							),
 						(json2: StatusResponse) => json2.status === 'pending',
 					)
 						.then(handleCompletion)

--- a/support-frontend/assets/helpers/redux/checkout/payment/payPal/thunks.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/payPal/thunks.ts
@@ -45,15 +45,18 @@ export const setUpPayPalPayment = createAsyncThunk<
 			requireShippingAddress: false,
 		};
 
-		const payPalResponse = (await fetchJson(routes.payPalSetupPayment, {
-			credentials: 'include',
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				'Csrf-Token': csrfToken,
+		const payPalResponse = await fetchJson<{ token?: string }>(
+			routes.payPalSetupPayment,
+			{
+				credentials: 'include',
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Csrf-Token': csrfToken,
+				},
+				body: JSON.stringify(requestBody),
 			},
-			body: JSON.stringify(requestBody),
-		})) as { token?: string };
+		);
 
 		if (payPalResponse.token) {
 			resolve(payPalResponse.token);

--- a/support-frontend/assets/helpers/redux/checkout/personalDetails/thunks.ts
+++ b/support-frontend/assets/helpers/redux/checkout/personalDetails/thunks.ts
@@ -19,10 +19,10 @@ export const getUserTypeFromIdentity = createAsyncThunk<
 	async function getUserType(email, thunkApi) {
 		const { csrf } = thunkApi.getState().page.checkoutForm;
 
-		const resp = (await fetchJson(
+		const resp = await fetchJson<UserTypeResponse>(
 			`${routes.getUserType}?maybeEmail=${encodeURIComponent(email)}`,
 			getRequestOptions('same-origin', csrf),
-		)) as UserTypeResponse;
+		);
 
 		if (typeof resp.userType !== 'string') {
 			throw new Error('userType string was not present in response');

--- a/support-frontend/assets/helpers/redux/user/thunks.ts
+++ b/support-frontend/assets/helpers/redux/user/thunks.ts
@@ -23,7 +23,7 @@ export const getRecurringContributorStatus = createAsyncThunk<
 		// No point in making the call if we don't have an access token as we know it's going to fail
 		if (authWithOkta && !accessToken) return {};
 
-		const attributes = (await fetchJson(
+		const attributes = await fetchJson<UserAttributes>(
 			`${window.guardian.mdapiUrl}/user-attributes/me`,
 			{
 				mode: 'cors',
@@ -31,7 +31,7 @@ export const getRecurringContributorStatus = createAsyncThunk<
 				// Okta authorization uses the Authorization header rather than a cookie
 				headers: oktaAuthHeader(authWithOkta, accessToken!),
 			},
-		)) as UserAttributes;
+		);
 
 		return attributes.contentAccess ?? {};
 	},

--- a/support-frontend/assets/pages/subscriptions-redemption/api.ts
+++ b/support-frontend/assets/pages/subscriptions-redemption/api.ts
@@ -48,7 +48,7 @@ function validate(userCode: string): Promise<ValidationResult> {
 		isTestUser ? '?isTestUser=true' : ''
 	}`;
 
-	return fetchJson(validationUrl, {}) as Promise<ValidationResult>;
+	return fetchJson<ValidationResult>(validationUrl, {});
 }
 
 function dispatchError(dispatch: RedemptionDispatch, error: Option<string>) {

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -63,14 +63,12 @@ export function AmountAndBenefits({
 									`}
 								>
 									<TickerContainer
-										countType="money"
-										endType="unlimited"
-										currencySymbol="$"
-										copy={{
-											countLabel: '',
-											goalReachedPrimary: '',
-											goalReachedSecondary: '',
-										}}
+										countType={campaignSettings.tickerSettings.tickerCountType}
+										endType={campaignSettings.tickerSettings.tickerEndType}
+										currencySymbol={
+											campaignSettings.tickerSettings.currencySymbol
+										}
+										copy={campaignSettings.tickerSettings.copy}
 										render={(tickerProps) => <Ticker {...tickerProps} />}
 									/>
 								</div>

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -59,16 +59,13 @@ export function AmountAndBenefits({
 								<div
 									css={css`
 										margin-top: -${space[2]}px;
-										margin-bottom: ${space[4]}px;
+										margin-bottom: ${space[3]}px;
 									`}
 								>
 									<TickerContainer
-										countType={campaignSettings.tickerSettings.tickerCountType}
-										endType={campaignSettings.tickerSettings.tickerEndType}
-										currencySymbol={
-											campaignSettings.tickerSettings.currencySymbol
-										}
-										headline="Test ticker headline"
+										countType={campaignSettings.tickerSettings.countType}
+										endType={campaignSettings.tickerSettings.endType}
+										headline={campaignSettings.tickerSettings.headline}
 										render={(tickerProps) => <Ticker {...tickerProps} />}
 									/>
 								</div>

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -10,9 +10,12 @@ import { PaymentFrequencyTabsContainer } from 'components/paymentFrequencyTabs/p
 import { PaymentFrequencyTabs } from 'components/paymentFrequencyTabs/paymentFrequenncyTabs';
 import { PriceCards } from 'components/priceCards/priceCards';
 import { PriceCardsContainer } from 'components/priceCards/priceCardsContainer';
+import { Ticker } from 'components/ticker/ticker';
+import { TickerContainer } from 'components/ticker/tickerContainer';
 import Tooltip from 'components/tooltip/Tooltip';
 import { TooltipContainer } from 'components/tooltip/TooltipContainer';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { useContributionsSelector } from 'helpers/redux/storeHooks';
 
 export function AmountAndBenefits({
 	countryGroupId,
@@ -27,6 +30,9 @@ export function AmountAndBenefits({
 	addBackgroundToBenefitsList?: boolean;
 	isCompactBenefitsList?: boolean;
 }): JSX.Element {
+	const { usCampaignTicker } = useContributionsSelector(
+		(state) => state.common.abParticipations,
+	);
 	return (
 		<PaymentFrequencyTabsContainer
 			render={(tabProps) => (
@@ -39,6 +45,19 @@ export function AmountAndBenefits({
 									<CheckoutErrorSummary errorList={errorList} />
 								)}
 							/>
+							{usCampaignTicker === 'variant' && (
+								<TickerContainer
+									countType="money"
+									endType="unlimited"
+									currencySymbol="$"
+									copy={{
+										countLabel: '',
+										goalReachedPrimary: '',
+										goalReachedSecondary: '',
+									}}
+									render={(tickerProps) => <Ticker {...tickerProps} />}
+								/>
+							)}
 							<PriceCardsContainer
 								frequency={tabId}
 								renderPriceCards={({

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -63,6 +63,7 @@ export function AmountAndBenefits({
 									`}
 								>
 									<TickerContainer
+										tickerId="US"
 										countType={campaignSettings.tickerSettings.countType}
 										endType={campaignSettings.tickerSettings.endType}
 										headline={campaignSettings.tickerSettings.headline}

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -1,3 +1,5 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/source-foundations';
 import { CheckoutBenefitsList } from 'components/checkoutBenefits/checkoutBenefitsList';
 import { CheckoutBenefitsListContainer } from 'components/checkoutBenefits/checkoutBenefitsListContainer';
 import { BoxContents } from 'components/checkoutBox/checkoutBox';
@@ -14,6 +16,7 @@ import { Ticker } from 'components/ticker/ticker';
 import { TickerContainer } from 'components/ticker/tickerContainer';
 import Tooltip from 'components/tooltip/Tooltip';
 import { TooltipContainer } from 'components/tooltip/TooltipContainer';
+import { getCampaignSettings } from 'helpers/campaigns/campaigns';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 
@@ -30,9 +33,16 @@ export function AmountAndBenefits({
 	addBackgroundToBenefitsList?: boolean;
 	isCompactBenefitsList?: boolean;
 }): JSX.Element {
-	const { usCampaignTicker } = useContributionsSelector(
-		(state) => state.common.abParticipations,
+	const { abParticipations, internationalisation } = useContributionsSelector(
+		(state) => state.common,
 	);
+	const campaignSettings = getCampaignSettings('Us_eoy_2023');
+
+	const showUSCampaignTicker =
+		abParticipations.usCampaignTicker === 'variant' &&
+		internationalisation.countryGroupId === 'UnitedStates' &&
+		campaignSettings;
+
 	return (
 		<PaymentFrequencyTabsContainer
 			render={(tabProps) => (
@@ -45,18 +55,25 @@ export function AmountAndBenefits({
 									<CheckoutErrorSummary errorList={errorList} />
 								)}
 							/>
-							{usCampaignTicker === 'variant' && (
-								<TickerContainer
-									countType="money"
-									endType="unlimited"
-									currencySymbol="$"
-									copy={{
-										countLabel: '',
-										goalReachedPrimary: '',
-										goalReachedSecondary: '',
-									}}
-									render={(tickerProps) => <Ticker {...tickerProps} />}
-								/>
+							{showUSCampaignTicker && (
+								<div
+									css={css`
+										margin-top: -${space[2]}px;
+										margin-bottom: ${space[4]}px;
+									`}
+								>
+									<TickerContainer
+										countType="money"
+										endType="unlimited"
+										currencySymbol="$"
+										copy={{
+											countLabel: '',
+											goalReachedPrimary: '',
+											goalReachedSecondary: '',
+										}}
+										render={(tickerProps) => <Ticker {...tickerProps} />}
+									/>
+								</div>
 							)}
 							<PriceCardsContainer
 								frequency={tabId}

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -33,15 +33,13 @@ export function AmountAndBenefits({
 	addBackgroundToBenefitsList?: boolean;
 	isCompactBenefitsList?: boolean;
 }): JSX.Element {
-	const { abParticipations, internationalisation } = useContributionsSelector(
+	const { internationalisation } = useContributionsSelector(
 		(state) => state.common,
 	);
 	const campaignSettings = getCampaignSettings('Us_eoy_2023');
 
 	const showUSCampaignTicker =
-		abParticipations.usCampaignTicker === 'variant' &&
-		internationalisation.countryGroupId === 'UnitedStates' &&
-		campaignSettings;
+		internationalisation.countryGroupId === 'UnitedStates' && campaignSettings;
 
 	return (
 		<PaymentFrequencyTabsContainer

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -68,7 +68,7 @@ export function AmountAndBenefits({
 										currencySymbol={
 											campaignSettings.tickerSettings.currencySymbol
 										}
-										copy={campaignSettings.tickerSettings.copy}
+										headline="Test ticker headline"
 										render={(tickerProps) => <Ticker {...tickerProps} />}
 									/>
 								</div>

--- a/support-frontend/stories/checkouts/Ticker.stories.tsx
+++ b/support-frontend/stories/checkouts/Ticker.stories.tsx
@@ -45,11 +45,7 @@ PeopleTicker.args = {
 	countType: 'people',
 	endType: 'unlimited',
 	currencySymbol: '£',
-	copy: {
-		countLabel: 'supporters in Australia',
-		goalReachedPrimary: "We've hit our goal!",
-		goalReachedSecondary: 'but you can still support us',
-	},
+	headline: 'End of year campaign',
 };
 
 export const MoneyTicker = Template.bind({});
@@ -61,9 +57,5 @@ MoneyTicker.args = {
 	countType: 'money',
 	endType: 'hardstop',
 	currencySymbol: '$',
-	copy: {
-		countLabel: 'contributed',
-		goalReachedPrimary: "We've hit our goal!",
-		goalReachedSecondary: 'but you can still support us',
-	},
+	headline: 'End of year campaign',
 };

--- a/support-frontend/stories/checkouts/Ticker.stories.tsx
+++ b/support-frontend/stories/checkouts/Ticker.stories.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import type { TickerProps } from 'components/ticker/ticker';
+import { Ticker } from 'components/ticker/ticker';
+import { withCenterAlignment } from '../../.storybook/decorators/withCenterAlignment';
+
+export default {
+	title: 'Checkouts/Ticker',
+	component: Ticker,
+	argTypes: {
+		appearance: {
+			control: {
+				type: 'radio',
+				options: ['light', 'dark'],
+			},
+		},
+		onGoalReached: { action: 'goal reached' },
+	},
+	decorators: [
+		(Story: React.FC): JSX.Element => (
+			<div
+				style={{
+					width: '100%',
+					maxWidth: '500px',
+				}}
+			>
+				<Story />
+			</div>
+		),
+		withCenterAlignment,
+	],
+};
+
+function Template(args: TickerProps) {
+	return <Ticker {...args} />;
+}
+
+Template.args = {} as TickerProps;
+
+export const PeopleTicker = Template.bind({});
+
+PeopleTicker.args = {
+	total: 200000,
+	goal: 200000,
+	end: 250000,
+	countType: 'people',
+	endType: 'unlimited',
+	currencySymbol: '£',
+	copy: {
+		countLabel: 'supporters in Australia',
+		goalReachedPrimary: "We've hit our goal!",
+		goalReachedSecondary: 'but you can still support us',
+	},
+};
+
+export const MoneyTicker = Template.bind({});
+
+MoneyTicker.args = {
+	total: 50000,
+	goal: 200000,
+	end: 250000,
+	countType: 'money',
+	endType: 'hardstop',
+	currencySymbol: '$',
+	copy: {
+		countLabel: 'contributed',
+		goalReachedPrimary: "We've hit our goal!",
+		goalReachedSecondary: 'but you can still support us',
+	},
+};

--- a/support-frontend/stories/checkouts/Ticker.stories.tsx
+++ b/support-frontend/stories/checkouts/Ticker.stories.tsx
@@ -44,7 +44,7 @@ PeopleTicker.args = {
 	end: 250000,
 	countType: 'people',
 	endType: 'unlimited',
-	currencySymbol: '£',
+	countryGroupId: 'AUDCountries',
 	headline: 'End of year campaign',
 };
 
@@ -56,6 +56,6 @@ MoneyTicker.args = {
 	end: 230000,
 	countType: 'money',
 	endType: 'hardstop',
-	currencySymbol: '$',
+	countryGroupId: 'UnitedStates',
 	headline: 'End of year campaign',
 };

--- a/support-frontend/stories/checkouts/Ticker.stories.tsx
+++ b/support-frontend/stories/checkouts/Ticker.stories.tsx
@@ -57,7 +57,7 @@ export const MoneyTicker = Template.bind({});
 MoneyTicker.args = {
 	total: 50000,
 	goal: 200000,
-	end: 250000,
+	end: 230000,
 	countType: 'money',
 	endType: 'hardstop',
 	currencySymbol: '$',


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds a new and updated ticker component for the 2023 EOY US campaign and adds it to the checkout, behind the existing campaign switch.

[**Trello Card**](https://trello.com/c/XgWlzhwj)

## Why are you doing this?

There is a desire to revive the old campaign tickers used in previous years to track contributions during specific periods. The existing ticker component uses some difficult-to-maintain SCSS styles, is tightly coupled to the data fetching mechanism, is an older style class component, and is not especially screen reader accessible; the new component addresses these issues.

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

