### PR TITLE
Change Single to One-Time on checkout tabs (support frontend)

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -176,7 +176,7 @@ export type ContributionsOrderSummaryProps = {
 };
 
 const supportTypes = {
-	ONE_OFF: 'Single',
+	ONE_OFF: 'One-Time',
 	MONTHLY: 'Monthly',
 	ANNUAL: 'Annual',
 };

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -102,10 +102,10 @@ function getValidContributionTypesFromUrlOrElse(
 
 function toHumanReadableContributionType(
 	contributionType: ContributionType,
-): 'Single' | 'Monthly' | 'Annual' {
+): 'One-time' | 'Monthly' | 'Annual' {
 	switch (contributionType) {
 		case 'ONE_OFF':
-			return 'Single';
+			return 'One-time';
 
 		case 'MONTHLY':
 			return 'Monthly';


### PR DESCRIPTION
## What are you doing in this PR?

We need to change the wording for One-off contributions from Single to "One-time" in the checkout tab.


[**Trello Card**](https://trello.com/c/0ABxipb3/1619-changing-single-to-one-time-on-checkout-tabs-support-frontend)

## Why are you doing this?

Following UXR, We would like to test changing the word “single” on the checkout to “One-time”.

This would not be a test, this would be global.

## Is this an AB test?
- [ ] Yes
- [x ] No

## Screenshots

##  Before Change
<img width="1728" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/0a96b34b-c63f-4ba4-bf2c-0daed8dab59b">

<img width="1728" alt="Screenshot 2023-10-24 at 17 06 20" src="https://github.com/guardian/support-frontend/assets/73653255/4e8d7901-5a0f-4cdd-8d82-30b56b688c95">


## After Change 

<img width="1728" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/6c15afb7-be96-40fa-911a-0c15e8a40125">

<img width="1728" alt="Screenshot 2023-10-24 at 17 07 45" src="https://github.com/guardian/support-frontend/assets/73653255/3406566f-c068-415f-8cd7-68aae7ec5cf5">


