### PR TITLE
E2E tests: 2 step checkout

### DIFF
--- a/support-e2e/playwright.local.config.ts
+++ b/support-e2e/playwright.local.config.ts
@@ -1,13 +1,13 @@
-import { defineConfig } from '@playwright/test';
-import { baseObject } from './playwright.base.config';
+import { defineConfig } from "@playwright/test";
+import { baseObject } from "./playwright.base.config";
 
 export default defineConfig({
-	...baseObject,
-	use: {
-		/* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-		actionTimeout: 0,
-		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-		trace: 'on-first-retry',
-		baseURL: 'https://support.thegulocal.com',
-	},
+  ...baseObject,
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+    baseURL: "https://support.theguardian.com",
+  },
 });

--- a/support-e2e/playwright.local.config.ts
+++ b/support-e2e/playwright.local.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
     actionTimeout: 0,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
-    baseURL: "https://support.theguardian.com",
+    baseURL: "https://support.thegulocal.com",
   },
 });

--- a/support-e2e/tests/monthlyContribution.test.ts
+++ b/support-e2e/tests/monthlyContribution.test.ts
@@ -15,7 +15,7 @@ test.beforeEach(async ({ page, context, baseURL }) => {
 test.describe("Sign up for a Recurring Contribution (New Contributions Flow)", () => {
   test("Monthly contribution sign-up with Stripe - GBP", async ({ page }) => {
     await page.getByRole("tab").getByText("Monthly").click();
-    await page.getByText("Continue to checkout").click();
+    await page.getByRole("button", { name: "Continue to checkout" }).click();
 
     await page.getByLabel("Email address").type(email);
     await page.getByLabel("First name").type(firstName);

--- a/support-e2e/tests/monthlyContribution.test.ts
+++ b/support-e2e/tests/monthlyContribution.test.ts
@@ -4,11 +4,11 @@ import { email, firstName, lastName } from "./utils/users";
 
 test.beforeEach(async ({ page, context, baseURL }) => {
   const baseUrlWithFallback = baseURL ?? "https://support.theguardian.com";
-  const pageUrl = `${baseUrlWithFallback}/uk/contribute`;
+  const pageUrl = `${baseUrlWithFallback}/uk/contribute#ab-twoStepCheckoutWithNudgeBelow=variant_a`;
 
   const domain = new URL(pageUrl).hostname;
   await setTestCookies(context, firstName, domain);
-  await page.goto(pageUrl, {waitUntil: "networkidle"});
+  await page.goto(pageUrl, { waitUntil: "networkidle" });
 });
 
 test.describe("Sign up for a Recurring Contribution (New Contributions Flow)", () => {
@@ -23,7 +23,9 @@ test.describe("Sign up for a Recurring Contribution (New Contributions Flow)", (
     await page.locator("#qa-credit-card").click();
 
     await expect(
-      await page.frameLocator('[title="reCAPTCHA"]').locator('#recaptcha-anchor-label')
+      await page
+        .frameLocator('[title="reCAPTCHA"]')
+        .locator("#recaptcha-anchor-label"),
     ).toBeVisible();
 
     const cardNumber = page
@@ -40,19 +42,19 @@ test.describe("Sign up for a Recurring Contribution (New Contributions Flow)", (
     await cvc.fill("123");
 
     const recaptchaIframe = page.frameLocator('[title="reCAPTCHA"]');
-    const recaptchaCheckbox = recaptchaIframe.locator('.recaptcha-checkbox');
+    const recaptchaCheckbox = recaptchaIframe.locator(".recaptcha-checkbox");
     await expect(recaptchaCheckbox).toBeEnabled();
 
     await recaptchaCheckbox.click();
     await expect(
-      recaptchaIframe.locator("#recaptcha-accessible-status")
+      recaptchaIframe.locator("#recaptcha-accessible-status"),
     ).toContainText("You are verified");
 
     const contributeButton =
       "#qa-contributions-landing-submit-contribution-button";
 
     await expect(page.locator(contributeButton)).toContainText(
-      /Pay £([0-9]+) per month/
+      /Pay £([0-9]+) per month/,
     );
 
     await page.locator(contributeButton).click();

--- a/support-e2e/tests/monthlyContribution.test.ts
+++ b/support-e2e/tests/monthlyContribution.test.ts
@@ -4,6 +4,7 @@ import { email, firstName, lastName } from "./utils/users";
 
 test.beforeEach(async ({ page, context, baseURL }) => {
   const baseUrlWithFallback = baseURL ?? "https://support.theguardian.com";
+  // We should remove the forcing into the ab test once this has been made live
   const pageUrl = `${baseUrlWithFallback}/uk/contribute#ab-twoStepCheckoutWithNudgeBelow=variant_a`;
 
   const domain = new URL(pageUrl).hostname;


### PR DESCRIPTION
## What are you doing in this PR?
- forces the e2e tests to be running on the `ab-twoStepCheckoutWithNudgeBelow=variant_a`
- refactors a few of the [locators](https://playwright.dev/docs/locators#locate-by-text) to follow [Playwright's advice of "prioritizing user-facing attributes and explicit contracts such as page.getByRole()"](https://playwright.dev/docs/locators#locating-elements)

[**Trello Card**](https://trello.com/c/1F4DgCyB/1621-put-2-step-variant-live-to-100-of-audience)

## Why are you doing this?
This is because we're swapping to the 2 step checkout as default, but will allow us to work on the tests in parallel while doing so.