### PR TITLE
fix: ignore **/target for VS Code when using metals

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "typescript.format.enable": false, // disable default VS code TS formatting in favour of ESLint
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true,
-    "source.fixAll.prettier": true,
+    "source.fixAll.prettier": true
   },
   "eslint.workingDirectories": ["support-frontend"],
   "eslint.validate": ["typescript", "typescriptreact"],
@@ -11,4 +11,7 @@
     "react-dom": "preact-compat",
     "ophan": "ophan-tracker-js/build/ophan.support"
   },
+  "files.watcherExclude": {
+    "**/target": true
+  }
 }


### PR DESCRIPTION
## What are you doing in this PR?
Ignores the `target` directories for when we're using [Metals](https://scalameta.org/metals/) for Scala.

This is a default set by Metals so anyone using it will have this automatically appended.
