### PR TITLE
Temporary disabled AB test to test canMakePaymentsWithActiveCard

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -75,4 +75,15 @@ export const tests: Tests = {
 		referrerControlled: false,
 		seed: 0,
 	},
+	canMakePaymentsWithActiveCard: {
+		variants: [
+			{
+				id: 'control',
+			},
+		],
+		isActive: false,
+		audiences: {},
+		referrerControlled: false,
+		seed: 1,
+	},
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -35,6 +35,42 @@ const countryIds = Object.values(countryGroups).map(
 	(group) => group.supportInternationalisationId,
 );
 
+const {
+	common: { abParticipations },
+} = store.getState();
+
+/**
+ * Temporary check behind disabled AB test to validate whether
+ * window.ApplePaySession.canMakePaymentsWithActiveCard works
+ * on support.theguardian.com
+ */
+
+const checkCanMakePaymentsWithActiveCard =
+	abParticipations.canMakePaymentsWithActiveCard &&
+	abParticipations.canMakePaymentsWithActiveCard == 'control';
+
+if (checkCanMakePaymentsWithActiveCard) {
+	const merchantIdentifier = 'merchant.uk.co.guardian.contributions';
+
+	const canMakePaymentsWithActiveCard = (): Promise<boolean> => {
+		return new Promise((resolve) => {
+			if (window.ApplePaySession) {
+				void window.ApplePaySession.canMakePaymentsWithActiveCard(
+					merchantIdentifier,
+				).then((result) => {
+					resolve(result);
+				});
+			} else {
+				resolve(false);
+			}
+		});
+	};
+
+	void canMakePaymentsWithActiveCard().then((result) => {
+		console.log(`canMakePaymentsWithActiveCard? ${result.toString()}`);
+	});
+}
+
 // ----- ScrollToTop on Navigate: https://v5.reactrouter.com/web/guides/scroll-restoration ---- //
 
 function ScrollToTop() {

--- a/support-frontend/window.d.ts
+++ b/support-frontend/window.d.ts
@@ -37,6 +37,9 @@ declare global {
 	};
 
 	interface Window {
+		ApplePaySession?: {
+			canMakePaymentsWithActiveCard: (merchantId: string) => Promise<boolean>;
+		};
 		guardian: {
 			amazonPayClientId: {
 				default: string;


### PR DESCRIPTION
## What are you doing in this PR?

Proposal: Release a disabled AB test canMakePaymentsWithActiveCard to PROD. Force myself in to the AB test to see whether the `window.ApplePaySession.canMakePaymentsWithActiveCard` resolves with `true` on `support.theguardian.com`. I've tested on CODE and it resolved as `false`. Once my test is complete I'll revert this change.
