### PR TITLE
Update the one-Time to one-time in ContributionsOrderSummary

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -130,7 +130,7 @@ export type ContributionsOrderSummaryProps = {
 };
 
 const supportTypes = {
-	ONE_OFF: 'One-Time',
+	ONE_OFF: 'One-time',
 	MONTHLY: 'Monthly',
 	ANNUAL: 'Annual',
 };


### PR DESCRIPTION

## What are you doing in this PR?

This is to update wording form One-Time to One-time in ContributionsOrderSummary "Your Support" to keep it consistent with the choice cards

## Is this an AB test?
- [ ] Yes
- [x ] No


## Screenshots

## Before change

<img width="1323" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/d6c5c336-1d6a-442f-9ac2-b2c4cb80e351">


## After change

<img width="1323" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/98e19492-08c4-49cd-942e-80ea7710b8f0">


