### PR TITLE
Fix Other amount field hidden when returning to Page 1

### DIFF
--- a/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsContainer.tsx
+++ b/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsContainer.tsx
@@ -34,6 +34,7 @@ export function CheckoutTopUpAmountsContainer({
 
 	const isWithinThreshold =
 		contributionType !== 'ONE_OFF' &&
+		amountBeforeAmendments != 'other' &&
 		amountBeforeAmendments >=
 			benefitsThresholdsByCountryGroup[countryGroupId][contributionType] &&
 		amountBeforeAmendments <=

--- a/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsContainer.tsx
+++ b/support-frontend/assets/components/checkoutTopUpAmounts/checkoutTopUpAmountsContainer.tsx
@@ -34,7 +34,6 @@ export function CheckoutTopUpAmountsContainer({
 
 	const isWithinThreshold =
 		contributionType !== 'ONE_OFF' &&
-		amountBeforeAmendments != 'other' &&
 		amountBeforeAmendments >=
 			benefitsThresholdsByCountryGroup[countryGroupId][contributionType] &&
 		amountBeforeAmendments <=

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/selectedAmount.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/selectedAmount.ts
@@ -17,17 +17,15 @@ export function getUserSelectedAmount(state: ContributionsState): number {
 
 export function getUserSelectedAmountBeforeAmendment(
 	state: ContributionsState,
-): number {
+): number|string {
 	const contributionType = getContributionType(state);
-	const { selectedAmountsBeforeAmendment, otherAmountsBeforeAmendment } =
+	const { selectedAmountsBeforeAmendment } =
 		state.page.checkoutForm.product;
 	const priceCardAmountSelected =
 		selectedAmountsBeforeAmendment[contributionType];
 
 	if (priceCardAmountSelected === 'other') {
-		const customAmount = otherAmountsBeforeAmendment[contributionType];
-		// TODO: what do we do when this is NaN? Do we handle elsewhere?
-		return Number.parseFloat(customAmount.amount ?? '');
+    return 'other';
 	}
 
 	return priceCardAmountSelected;

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/selectedAmount.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/selectedAmount.ts
@@ -17,15 +17,14 @@ export function getUserSelectedAmount(state: ContributionsState): number {
 
 export function getUserSelectedAmountBeforeAmendment(
 	state: ContributionsState,
-): number|string {
+): number | string {
 	const contributionType = getContributionType(state);
-	const { selectedAmountsBeforeAmendment } =
-		state.page.checkoutForm.product;
+	const { selectedAmountsBeforeAmendment } = state.page.checkoutForm.product;
 	const priceCardAmountSelected =
 		selectedAmountsBeforeAmendment[contributionType];
 
 	if (priceCardAmountSelected === 'other') {
-    return 'other';
+		return 'other';
 	}
 
 	return priceCardAmountSelected;

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/selectedAmount.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/selectedAmount.ts
@@ -15,16 +15,28 @@ export function getUserSelectedAmount(state: ContributionsState): number {
 	return priceCardAmountSelected;
 }
 
+export function getUserSelectedOtherAmount(state: ContributionsState): number|string {
+  const contributionType = getContributionType(state);
+  const { selectedAmounts} = state.page.checkoutForm.product;
+  const priceCardAmountSelected = selectedAmounts[contributionType];
+
+  return priceCardAmountSelected;
+}
+
+
 export function getUserSelectedAmountBeforeAmendment(
 	state: ContributionsState,
-): number | string {
+): number {
 	const contributionType = getContributionType(state);
-	const { selectedAmountsBeforeAmendment } = state.page.checkoutForm.product;
+	const { selectedAmountsBeforeAmendment, otherAmountsBeforeAmendment } =
+		state.page.checkoutForm.product;
 	const priceCardAmountSelected =
 		selectedAmountsBeforeAmendment[contributionType];
 
 	if (priceCardAmountSelected === 'other') {
-		return 'other';
+		const customAmount = otherAmountsBeforeAmendment[contributionType];
+		// TODO: what do we do when this is NaN? Do we handle elsewhere?
+		return Number.parseFloat(customAmount.amount ?? '');
 	}
 
 	return priceCardAmountSelected;

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/selectedAmount.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/selectedAmount.ts
@@ -15,14 +15,15 @@ export function getUserSelectedAmount(state: ContributionsState): number {
 	return priceCardAmountSelected;
 }
 
-export function getUserSelectedOtherAmount(state: ContributionsState): number|string {
-  const contributionType = getContributionType(state);
-  const { selectedAmounts} = state.page.checkoutForm.product;
-  const priceCardAmountSelected = selectedAmounts[contributionType];
+export function getUserSelectedOtherAmount(
+	state: ContributionsState,
+): number | string {
+	const contributionType = getContributionType(state);
+	const { selectedAmounts } = state.page.checkoutForm.product;
+	const priceCardAmountSelected = selectedAmounts[contributionType];
 
-  return priceCardAmountSelected;
+	return priceCardAmountSelected;
 }
-
 
 export function getUserSelectedAmountBeforeAmendment(
 	state: ContributionsState,

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/secondStepCheckout.tsx
@@ -18,8 +18,8 @@ import { resetValidation } from 'helpers/redux/checkout/checkoutActions';
 import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import {
-	getUserSelectedAmount,
-	getUserSelectedAmountBeforeAmendment,
+  getUserSelectedAmount,
+  getUserSelectedAmountBeforeAmendment, getUserSelectedOtherAmount,
 } from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import {
 	useContributionsDispatch,
@@ -61,7 +61,7 @@ export function SupporterPlusCheckout({
 	const amountBeforeAmendments = useContributionsSelector(
 		getUserSelectedAmountBeforeAmendment,
 	);
-
+  const otherAmount = useContributionsSelector(getUserSelectedOtherAmount);
 	const amountIsAboveThreshold = shouldShowSupporterPlusMessaging(
 		contributionType,
 		selectedAmounts,
@@ -76,10 +76,11 @@ export function SupporterPlusCheckout({
 			priority="tertiary"
 			size="xsmall"
 			onClick={() => {
-				dispatch(
+        const amountToBePassed = otherAmount==='other'? 'other':amountBeforeAmendments;
+        dispatch(
 					setSelectedAmount({
 						contributionType: contributionType,
-						amount: `${amountBeforeAmendments}`,
+						amount: `${amountToBePassed}`,
 					}),
 				);
 				dispatch(resetValidation());

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/secondStepCheckout.tsx
@@ -18,8 +18,9 @@ import { resetValidation } from 'helpers/redux/checkout/checkoutActions';
 import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import {
-  getUserSelectedAmount,
-  getUserSelectedAmountBeforeAmendment, getUserSelectedOtherAmount,
+	getUserSelectedAmount,
+	getUserSelectedAmountBeforeAmendment,
+	getUserSelectedOtherAmount,
 } from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import {
 	useContributionsDispatch,
@@ -61,7 +62,7 @@ export function SupporterPlusCheckout({
 	const amountBeforeAmendments = useContributionsSelector(
 		getUserSelectedAmountBeforeAmendment,
 	);
-  const otherAmount = useContributionsSelector(getUserSelectedOtherAmount);
+	const otherAmount = useContributionsSelector(getUserSelectedOtherAmount);
 	const amountIsAboveThreshold = shouldShowSupporterPlusMessaging(
 		contributionType,
 		selectedAmounts,
@@ -76,8 +77,9 @@ export function SupporterPlusCheckout({
 			priority="tertiary"
 			size="xsmall"
 			onClick={() => {
-        const amountToBePassed = otherAmount==='other'? 'other':amountBeforeAmendments;
-        dispatch(
+				const amountToBePassed =
+					otherAmount === 'other' ? 'other' : amountBeforeAmendments;
+				dispatch(
 					setSelectedAmount({
 						contributionType: contributionType,
 						amount: `${amountToBePassed}`,


### PR DESCRIPTION
## What are you doing in this PR?

Fix issue where other amount field hidden when returning to Page 1 from Page 2, having previously been visible.


[**Trello Card**](https://trello.com/c/kArMJ9aw/1643-2-step-checkout-other-amount-field-hidden-when-returning-to-page-1)

## Why are you doing this?

On Page 1 of the 2-step checkout (any tab) click the “Choose your amount” CTA and enter a value in the other amount field and proceed to Page 2.
On Page 2 click the “Change” CTA in the order summary component.
When you return to Page 1 the “Choose your amount” CTA is not highlighted and the other amount field is hidden.
This is not desired behaviour. We would like the “Choose your amount” CTA to be highlighted and the other amount field visible, with the previously entered amount in it.


## Is this an AB test?
- [ ] Yes
- [x ] No

## Screenshots

## Before Change(Click on "Change" CTA, on page 2 of two-step checkout Other Amounts and associated amounts field is not highlighted)
<img width="1027" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/bd9f02ea-4646-4187-940c-1e298629f605">
<img width="1027" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/f4b7c836-ea22-4f35-a026-df9f3a4e829e">


## After Change(Click on "Change" CTA, on page 2 of two-step checkout Other Amounts and associated amounts field is  highlighted)

<img width="1027" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/29984acf-2c0f-4ced-902e-c24ee73ea22d">
<img width="1027" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/74ebb2b2-0263-4b20-9af3-def8937bbfc4">


