### PR TITLE
Revert "Temporary disabled AB test to test canMakePaymentsWithActiveCard"

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -94,15 +94,4 @@ export const tests: Tests = {
 		referrerControlled: false,
 		seed: 0,
 	},
-	canMakePaymentsWithActiveCard: {
-		variants: [
-			{
-				id: 'control',
-			},
-		],
-		isActive: false,
-		audiences: {},
-		referrerControlled: false,
-		seed: 1,
-	},
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -35,42 +35,6 @@ const countryIds = Object.values(countryGroups).map(
 	(group) => group.supportInternationalisationId,
 );
 
-const {
-	common: { abParticipations },
-} = store.getState();
-
-/**
- * Temporary check behind disabled AB test to validate whether
- * window.ApplePaySession.canMakePaymentsWithActiveCard works
- * on support.theguardian.com
- */
-
-const checkCanMakePaymentsWithActiveCard =
-	abParticipations.canMakePaymentsWithActiveCard &&
-	abParticipations.canMakePaymentsWithActiveCard == 'control';
-
-if (checkCanMakePaymentsWithActiveCard) {
-	const merchantIdentifier = 'merchant.uk.co.guardian.contributions';
-
-	const canMakePaymentsWithActiveCard = (): Promise<boolean> => {
-		return new Promise((resolve) => {
-			if (window.ApplePaySession) {
-				void window.ApplePaySession.canMakePaymentsWithActiveCard(
-					merchantIdentifier,
-				).then((result) => {
-					resolve(result);
-				});
-			} else {
-				resolve(false);
-			}
-		});
-	};
-
-	void canMakePaymentsWithActiveCard().then((result) => {
-		console.log(`canMakePaymentsWithActiveCard? ${result.toString()}`);
-	});
-}
-
 // ----- ScrollToTop on Navigate: https://v5.reactrouter.com/web/guides/scroll-restoration ---- //
 
 function ScrollToTop() {

--- a/support-frontend/window.d.ts
+++ b/support-frontend/window.d.ts
@@ -37,9 +37,6 @@ declare global {
 	};
 
 	interface Window {
-		ApplePaySession?: {
-			canMakePaymentsWithActiveCard: (merchantId: string) => Promise<boolean>;
-		};
 		guardian: {
 			amazonPayClientId: {
 				default: string;


### PR DESCRIPTION
Reverts guardian/support-frontend#5380

I've run the test and concluded `support.theguardian.com` is not set-up to use `canMakePaymentsWithActiveCard`.

Tested on `PROD` using an iPhone with Apple Pay enabled, `canMakePaymentsWithActiveCard` resolved with `false`.