### PR TITLE
Round selected amount in benefits container to 2 decimal places

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -65,7 +65,7 @@ export function CheckoutBenefitsListContainer({
 	);
 	const userSelectedAmountWithCurrency = simpleFormatAmount(
 		currency,
-		selectedAmount,
+		selectedAmount.toFixed(2),
 	);
 
 	const higherTier = thresholdPrice <= selectedAmount;


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Rounding the amount in the benefits container to two fixed decimal places

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com)

## Why are you doing this?
Currently, if the user enters an invalid amount (i.e. with more than 2 decimal places) in the *choose amount* field, it will be shown in the benefits list below. 

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [x] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots
| Before | After |
| --- | --- |
| <img width="511" alt="image" src="https://github.com/guardian/support-frontend/assets/99400613/0314538d-9e00-47bb-b1ec-5d85dbbf49e6"> | <img width="520" alt="image" src="https://github.com/guardian/support-frontend/assets/99400613/20a80f1f-a177-4734-a6f8-bbae8ccf3ef4"> |


