### PR TITLE
National Delivery - Add Provider Summary and Delivery Method

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
@@ -42,38 +42,37 @@ export function DeliveryAgentsSelect(
 		}
 
 		return (
-			<>
-				<RadioGroup
-					label="Select delivery provider"
-					id="delivery-provider"
-					css={marginBottom}
-					error={firstError('deliveryProvider', props.formErrors)}
-				>
-					<>
-						{props.deliveryAgentsResponse.agents?.map((agent) => (
-							<div
-								css={css`
-									border-bottom: 1px solid ${palette.neutral[86]};
-								`}
-							>
-								<Radio
-									value={agent.agentId}
-									checked={props.chosenDeliveryAgent === agent.agentId}
-									onChange={() => props.setDeliveryAgent(agent.agentId)}
-									label={
-										<>
-											{agent.agentName}{' '}
-											<GreenLabel deliveryMethod={agent.deliveryMethod} />
-										</>
-									}
-								/>
-								<DeliveryProviderSummary summary={agent.summary} />
-								<GreenDeliverySummary deliveryMethod={agent.deliveryMethod} />
-							</div>
-						))}
-					</>
-				</RadioGroup>
-			</>
+			<RadioGroup
+				label="Select delivery provider"
+				id="delivery-provider"
+				css={marginBottom}
+				error={firstError('deliveryProvider', props.formErrors)}
+			>
+				<>
+					{props.deliveryAgentsResponse.agents?.map((agent) => (
+						<div
+							css={css`
+								border-bottom: 1px solid ${palette.neutral[86]};
+							`}
+							key={agent.agentId}
+						>
+							<Radio
+								value={agent.agentId}
+								checked={props.chosenDeliveryAgent === agent.agentId}
+								onChange={() => props.setDeliveryAgent(agent.agentId)}
+								label={
+									<>
+										{agent.agentName}{' '}
+										<GreenLabel deliveryMethod={agent.deliveryMethod} />
+									</>
+								}
+							/>
+							<DeliveryProviderSummary summary={agent.summary} />
+							<GreenDeliverySummary deliveryMethod={agent.deliveryMethod} />
+						</div>
+					))}
+				</>
+			</RadioGroup>
 		);
 	}
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
@@ -1,12 +1,12 @@
 import { css } from '@emotion/react';
-import { space } from '@guardian/source-foundations';
-import {
-	Option as OptionForSelect,
-	Select,
-} from '@guardian/source-react-components';
-import { InfoSummary } from '@guardian/source-react-components-development-kitchen';
+import { isOneOf } from '@guardian/libs';
+import { palette, space, textSans } from '@guardian/source-foundations';
+import { Label, Radio, RadioGroup } from '@guardian/source-react-components';
 import type { ActionCreatorWithOptionalPayload } from '@reduxjs/toolkit';
-import type { DeliveryAgentsResponse } from 'helpers/redux/checkout/addressMeta/state';
+import type {
+	DeliveryAgentOption,
+	DeliveryAgentsResponse,
+} from 'helpers/redux/checkout/addressMeta/state';
 import type { FormError } from 'helpers/subscriptionsForms/validation';
 import { firstError } from 'helpers/subscriptionsForms/validation';
 
@@ -17,6 +17,7 @@ const marginBottom = css`
 const singleDeliveryProviderCss = css(marginBottom, `border: 0;`);
 
 interface DeliveryAgentsSelectProps {
+	chosenDeliveryAgent?: number;
 	deliveryAgentsResponse?: DeliveryAgentsResponse;
 	setDeliveryAgent: ActionCreatorWithOptionalPayload<
 		number | undefined,
@@ -33,41 +34,146 @@ export function DeliveryAgentsSelect(
 
 	if (props.deliveryAgentsResponse?.type === 'Covered' && !postcodeError) {
 		if (props.deliveryAgentsResponse.agents?.length === 1) {
-			const singleDeliveryProvider = props.deliveryAgentsResponse.agents[0];
-
 			return (
-				<InfoSummary
-					css={singleDeliveryProviderCss}
-					context={
-						<>
-							<i>{singleDeliveryProvider.agentName}</i> will deliver your
-							newspaper.
-						</>
-					}
-					message=""
+				<SingleDeliveryProvider
+					singleDeliveryProvider={props.deliveryAgentsResponse.agents[0]}
 				/>
 			);
 		}
 
 		return (
-			<Select
-				label="Select delivery provider"
-				id="delivery-provider"
-				css={marginBottom}
-				onChange={(e) => props.setDeliveryAgent(parseInt(e.target.value))}
-				error={firstError('deliveryProvider', props.formErrors)}
-			>
-				<OptionForSelect value="">Click to select</OptionForSelect>
-				<>
-					{props.deliveryAgentsResponse.agents?.map((agent) => (
-						<OptionForSelect value={agent.agentId}>
-							{agent.agentName}
-						</OptionForSelect>
-					))}
-				</>
-			</Select>
+			<>
+				<RadioGroup
+					label="Select delivery provider"
+					id="delivery-provider"
+					css={marginBottom}
+					error={firstError('deliveryProvider', props.formErrors)}
+				>
+					<>
+						{props.deliveryAgentsResponse.agents?.map((agent) => (
+							<div
+								css={css`
+									border-bottom: 1px solid ${palette.neutral[86]};
+								`}
+							>
+								<Radio
+									value={agent.agentId}
+									checked={props.chosenDeliveryAgent === agent.agentId}
+									onChange={() => props.setDeliveryAgent(agent.agentId)}
+									label={
+										<>
+											{agent.agentName}{' '}
+											<GreenLabel deliveryMethod={agent.deliveryMethod} />
+										</>
+									}
+								/>
+								<DeliveryProviderSummary summary={agent.summary} />
+								<GreenDeliverySummary deliveryMethod={agent.deliveryMethod} />
+							</div>
+						))}
+					</>
+				</RadioGroup>
+			</>
 		);
 	}
 
 	return null;
+}
+
+function SingleDeliveryProvider({
+	singleDeliveryProvider,
+}: {
+	singleDeliveryProvider: DeliveryAgentOption;
+}) {
+	return (
+		<div css={singleDeliveryProviderCss}>
+			<Label text="Delivery provider">
+				<div
+					css={css`
+						${textSans.medium()};
+						margin-bottom: ${space[1]}px;
+					`}
+				>
+					{' '}
+					{singleDeliveryProvider.agentName}{' '}
+					<GreenLabel deliveryMethod={singleDeliveryProvider.deliveryMethod} />
+				</div>
+				<DeliveryProviderSummary summary={singleDeliveryProvider.summary} />
+				<GreenDeliverySummary
+					deliveryMethod={singleDeliveryProvider.deliveryMethod}
+				/>
+			</Label>
+		</div>
+	);
+}
+
+function GreenLabel({ deliveryMethod }: { deliveryMethod: string }) {
+	if (!isGreenOption(deliveryMethod)) {
+		return null;
+	}
+
+	return (
+		<span
+			css={css`
+				color: ${palette.success[400]};
+				${textSans.small({ fontStyle: 'italic' })};
+			`}
+		>
+			{deliveryMethod}
+		</span>
+	);
+}
+
+function DeliveryProviderSummary({ summary }: { summary: string }) {
+	if (!summary) {
+		return null;
+	}
+
+	return (
+		<p
+			css={css`
+				${textSans.small()};
+				margin-bottom: ${space[2]}px;
+			`}
+		>
+			{summary}
+		</p>
+	);
+}
+
+function GreenDeliverySummary({ deliveryMethod }: { deliveryMethod: string }) {
+	if (!isGreenOption(deliveryMethod)) {
+		return null;
+	}
+
+	return (
+		<p
+			css={css`
+				color: ${palette.success[400]};
+				${textSans.small({ fontStyle: 'italic' })};
+				margin-bottom: ${space[2]}px;
+			`}
+		>
+			{getGreenSummary(deliveryMethod)}
+		</p>
+	);
+}
+
+function isGreenOption(
+	deliveryMethod: string,
+): deliveryMethod is 'Green delivery' | 'Green options' {
+	const greenDeliveryMethods = ['Green delivery', 'Green options'] as const;
+
+	const isGreenDeliveryMethods = isOneOf(greenDeliveryMethods);
+
+	return isGreenDeliveryMethods(deliveryMethod);
+}
+
+function getGreenSummary(deliveryMethod: 'Green delivery' | 'Green options') {
+	switch (deliveryMethod) {
+		case 'Green delivery':
+			return 'This provider will deliver your newspaper via foot, bicycle, or electric vehicle.';
+		case 'Green options':
+			return 'This provider may deliver your newspaper via foot, bicycle, electric vehicle or petrol/diesel vehicle.';
+	}
 }

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -131,6 +131,8 @@ function mapStateToProps(state: SubscriptionsState) {
 		participations: state.common.abParticipations,
 		deliveryAgentsResponse:
 			state.page.checkoutForm.addressMeta.deliveryAgent.response,
+		chosenDeliveryAgent:
+			state.page.checkoutForm.addressMeta.deliveryAgent.chosenAgent,
 	};
 }
 
@@ -374,6 +376,7 @@ function PaperCheckoutForm(props: PropTypes) {
 						{isNationalDeliveryAbTest && isHomeDelivery && (
 							<DeliveryAgentsSelect
 								deliveryAgentsResponse={props.deliveryAgentsResponse}
+								chosenDeliveryAgent={props.chosenDeliveryAgent}
 								setDeliveryAgent={props.setDeliveryAgent}
 								formErrors={props.formErrors}
 								deliveryAddressErrors={props.deliveryAddressErrors}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR refactors the delivery provider selection for newspaper home delivery outside London. From a dropdown to a radio group. This allows us to show information about the delivery method and a summary of each provider. 

The summary and delivery method are provided by the PaperRound API. There are three possibilities for delivery method: "Green delivery", "Green options" (both show messages) or anything else (display nothing).

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[Figma](https://www.figma.com/file/IlRRbyvX3mxkytgQMnZgpR/Paper-Round-M25-(Minor-Updates)?type=design&node-id=286-815&mode=design&t=mG9X35HybOMlei9K-0)
[**Trello Card**](https://trello.com/c/VTW1j7Z3/123-delivery-options-dropdown-to-display-radio-buttons-with-green-options)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [x] No


## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

Single option
Before
![image](https://github.com/guardian/support-frontend/assets/114918544/14c9d52d-d140-457f-b577-44ef4636e1de)

After
![image](https://github.com/guardian/support-frontend/assets/114918544/ae9afc4c-b668-4b1c-968d-d5b97e6e0466)

Multiple options
Before
![image](https://github.com/guardian/support-frontend/assets/114918544/6628237f-da90-45f3-bf1e-42cf6838f863)

After
![image](https://github.com/guardian/support-frontend/assets/114918544/d6b22f3d-6573-447c-97dd-a043091717bb)

