### PR TITLE
Update google-cloud-bigquery to 2.34.0 to fix org.json:json snyk vulnerability issue 

### DIFF
--- a/support-modules/acquisition-events/build.sbt
+++ b/support-modules/acquisition-events/build.sbt
@@ -5,7 +5,7 @@ name := "module-acquisition-events"
 description := "Module for sending acquisition events"
 
 libraryDependencies ++= Seq(
-  "com.google.cloud" % "google-cloud-bigquery" % "2.31.2",
+  "com.google.cloud" % "google-cloud-bigquery" % "2.34.0",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "com.amazonaws" % "aws-java-sdk-eventbridge" % awsClientVersion,


### PR DESCRIPTION

## What are you doing in this PR?

Update google-cloud-bigquery to 2.34.0  from 2.31.2 to fix org.json:json snyk vulnerability issue 

[**Trello Card**](https://trello.com/c/CO9Rba4g/1652-high-severity-snyk-vulnerability-support-frontendorgjsonjson)

## Why are you doing this?

org.json:json came up as a high severity vulnerability and this is a transitive dependency of com.google.cloud:google-cloud-bigquery and com.amazon.pay:amazon-pay-java-sdk@3.6.2

Updating com.amazon.pay:amazon-pay-java-sdk@3.6.2 to the latest version(3.7.1)  still has this as a vulnerability.So updating google-cloud-bigquery alone.
