### PR TITLE
Hide decimals when they're unnecessary in benefits list

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -65,7 +65,7 @@ export function CheckoutBenefitsListContainer({
 	);
 	const userSelectedAmountWithCurrency = simpleFormatAmount(
 		currency,
-		selectedAmount.toFixed(2),
+		+parseFloat(selectedAmount.toFixed(2)),
 	);
 
 	const higherTier = thresholdPrice <= selectedAmount;


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Hotfixing an issue caused by a [previous PR](https://github.com/guardian/support-frontend/pull/5393) where amounts displayed in the benfits container are rounded to two decimal places.


## Why are you doing this?
The previous PR had the unintended effect of converting whole numbers to floats with two decimal places. So **£95** became **£95.00** which is unnecessary.

## Is this an AB test?
- [ ] Yes
- [x] No



## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots
| Before | After |
| ------- | ---- |
| <img width="518" alt="image" src="https://github.com/guardian/support-frontend/assets/99400613/5ab3fa67-122c-4f61-8cff-03518c65b6ae"> | <img width="515" alt="image" src="https://github.com/guardian/support-frontend/assets/99400613/aaba8a4f-8d98-44a2-a0db-2028334dd133"> |



