### PR TITLE
fix: make subHeading on left bar of contributions checkout 17px

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/checkoutScaffold.tsx
@@ -60,7 +60,7 @@ const darkBackgroundContainerMobile = css`
 `;
 
 const subHeading = css`
-	font-weight: normal;
+	${textSans.medium()};
 	padding-right: ${space[2]}px;
 `;
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Resizes the text on the left to match the designs as per request from the designers.

This was spotted as part of the US EOY 2023 work.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

| Before | After |
|--------|-------|
| ![before][before] | ![before][after] | 

[before]: https://github.com/guardian/support-frontend/assets/31692/7fec79a3-9b9f-44ec-bfdf-2a6369c014a4


[after]: https://github.com/guardian/support-frontend/assets/31692/dfb6d00a-647c-4afc-8434-81d2590942cf




