### PR TITLE
update the single contribution dynamic (ab variant) annual nudge copy

### DIFF
--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -93,10 +93,10 @@ export function CheckoutNudgeContainer({
 	let title, subtitle, paragraph;
 
 	if (dynamic) {
-		title = 'Make it an annual gift';
+		title = 'Make it annual';
 		subtitle = `change to ${clampedAmountToCurrenyStr} per year`;
 		paragraph =
-			'Choose to support us annually, and you’ll make a bigger impact with your year-end gift. Help protect our open, independent journalism long term.';
+			'Regular, reliable funding from readers is vital for our future. Help protect our open, independent journalism long term.';
 	} else {
 		const minAmount = getConfigMinAmount(countryGroupId, 'ANNUAL');
 		const weeklyMinAmount =


### PR DESCRIPTION
## What are you doing in this PR?
Copy change for single contributions, specifically the nudge to contribute annually. (This copy change is for the variant in the ab test)

## Screenshots
Before            |  After
:-------------------------:|:-------------------------:
![](https://github.com/guardian/support-frontend/assets/2510683/7f63434f-6bf3-4d20-b267-b68e1889e28b)  |  ![](https://github.com/guardian/support-frontend/assets/2510683/d7aef7d5-eaf8-414a-9a60-82fb8aef3822)


