### PR TITLE
AN and AMP sources should only use regional amounts tests

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -268,7 +268,11 @@ function getAmountsTestParticipations(
 			t.targeting.countries.includes(country),
 	);
 	let targetTest;
-	if (targetTestArray.length) {
+	const source = getSourceFromAcquisitionData() ?? '';
+	if (
+		!['APPLE_NEWS', 'GOOGLE_AMP'].includes(source) &&
+		targetTestArray.length
+	) {
 		targetTestArray.sort((a, b) => a.order - b.order);
 		targetTest = targetTestArray[0];
 	}
@@ -321,6 +325,25 @@ function getTestFromAcquisitionData(): AcquisitionABTest[] | undefined {
 		return acquisitionData.abTest
 			? [acquisitionData.abTest]
 			: acquisitionData.abTests;
+	} catch {
+		console.error('Cannot parse acquisition data from query string');
+		return undefined;
+	}
+}
+
+export function getSourceFromAcquisitionData(): string | undefined {
+	const acquisitionDataParam = getQueryParameter('acquisitionData');
+
+	if (!acquisitionDataParam) {
+		return undefined;
+	}
+
+	try {
+		const acquisitionData = JSON.parse(acquisitionDataParam) as {
+			source?: string;
+		};
+
+		return acquisitionData.source;
 	} catch {
 		console.error('Cannot parse acquisition data from query string');
 		return undefined;

--- a/support-frontend/assets/helpers/abTests/helpers.ts
+++ b/support-frontend/assets/helpers/abTests/helpers.ts
@@ -1,4 +1,5 @@
 import type { Participations } from 'helpers/abTests/abtest';
+import { getSourceFromAcquisitionData } from 'helpers/abTests/abtest';
 import type {
 	AmountsTest,
 	SelectedAmountsVariant,
@@ -341,7 +342,11 @@ export function getAmounts(
 		);
 	}
 	let targetTest;
-	if (targetTestArray.length) {
+	const source = getSourceFromAcquisitionData() ?? '';
+	if (
+		!['APPLE_NEWS', 'GOOGLE_AMP'].includes(source) &&
+		targetTestArray.length
+	) {
 		targetTestArray.sort((a, b) => a.order - b.order);
 		targetTest = targetTestArray[0];
 	}


### PR DESCRIPTION
## What are you doing in this PR?
Adds a check to determine the source of an incoming user (`GOOGLE_AMP, APPLE_NEWS`) and enforces the requirement to show these users the appropriate regional data in the amounts card.

[**Trello Card**](https://trello.com/c/JtwmCKxH)

## Why are you doing this?
Epics shown on Google AMP and Apple News articles will always include `single`, `monthly` and `annual` payment options. We need to ensure that the amounts card shown on the landing page similarly includes all payment options as part of a seamless user journey.

## Is this an AB test?
- [ ] Yes
- [x] No

## Accessibility test checklist
Not required - will not affect visual output

## Screenshots
Not required - will not affect visual output

