### PR TITLE
Add postcode validation for home delivery

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/address/validation.test.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/validation.test.ts
@@ -9,6 +9,7 @@ import {
 	isPostcodeOptional,
 	isSaturdayOrSundayDeliveryAvailable,
 	isStateNullable,
+	isValidPostcodeForHomeDelivery,
 } from './validation';
 
 describe('applyBillingAddressRules', () => {
@@ -233,6 +234,44 @@ describe('isStateNullable', () => {
 		expect(isStateNullable('HK')).toBeTruthy();
 	});
 });
+
+describe('isValidPostcodeForHomeDelivery', () => {
+	it('returns true when not a home delivery', () => {
+		const fulfilmentOption = 'Collection';
+		const postcode = 'DA11 7NP';
+
+		const result = isValidPostcodeForHomeDelivery(
+			fulfilmentOption,
+			postcode,
+		);
+
+		expect(result).toBeTruthy();
+	})
+
+	it('returns true when valid UK postcode', () => {
+		const fulfilmentOption = 'HomeDelivery';
+		const postcode = 'DA11 7NP';
+
+		const result = isValidPostcodeForHomeDelivery(
+			fulfilmentOption,
+			postcode,
+		);
+
+		expect(result).toBeTruthy();
+	})
+
+	it('returns false when invalid UK postcode', () => {
+		const fulfilmentOption = 'HomeDelivery';
+		const postcode = 'DA11 7NP ';
+
+		const result = isValidPostcodeForHomeDelivery(
+			fulfilmentOption,
+			postcode,
+		);
+
+		expect(result).toBeFalsy();
+	})
+})
 
 describe('isHomeDeliveryInM25 ', () => {
 	it('returns true when the order is a home delivery and the postcode is within the M25', () => {

--- a/support-frontend/assets/helpers/redux/checkout/address/validation.test.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/validation.test.ts
@@ -240,38 +240,29 @@ describe('isValidPostcodeForHomeDelivery', () => {
 		const fulfilmentOption = 'Collection';
 		const postcode = 'DA11 7NP';
 
-		const result = isValidPostcodeForHomeDelivery(
-			fulfilmentOption,
-			postcode,
-		);
+		const result = isValidPostcodeForHomeDelivery(fulfilmentOption, postcode);
 
 		expect(result).toBeTruthy();
-	})
+	});
 
 	it('returns true when valid UK postcode', () => {
 		const fulfilmentOption = 'HomeDelivery';
 		const postcode = 'DA11 7NP';
 
-		const result = isValidPostcodeForHomeDelivery(
-			fulfilmentOption,
-			postcode,
-		);
+		const result = isValidPostcodeForHomeDelivery(fulfilmentOption, postcode);
 
 		expect(result).toBeTruthy();
-	})
+	});
 
 	it('returns false when invalid UK postcode', () => {
 		const fulfilmentOption = 'HomeDelivery';
 		const postcode = 'DA11 7NP ';
 
-		const result = isValidPostcodeForHomeDelivery(
-			fulfilmentOption,
-			postcode,
-		);
+		const result = isValidPostcodeForHomeDelivery(fulfilmentOption, postcode);
 
 		expect(result).toBeFalsy();
-	})
-})
+	});
+});
 
 describe('isHomeDeliveryInM25 ', () => {
 	it('returns true when the order is a home delivery and the postcode is within the M25', () => {

--- a/support-frontend/assets/helpers/redux/checkout/address/validation.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/validation.ts
@@ -3,6 +3,7 @@ import {
 	M25_POSTCODE_PREFIXES,
 	postcodeIsWithinDeliveryArea,
 } from 'helpers/forms/deliveryCheck';
+import { isValidPostcode } from 'helpers/forms/formValidation';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
@@ -156,6 +157,13 @@ function getDeliveryOnlyRules(
 ): Array<Rule<AddressFormFieldError>> {
 	return [
 		{
+			rule: isValidPostcodeForHomeDelivery(fulfilmentOption, fields.postCode),
+			error: formError(
+				'postCode',
+				'Please enter a valid postcode.',
+			),
+		},
+		{
 			rule:
 				abParticipations.nationalDelivery === 'variant'
 					? isHomeDeliveryAvailable(
@@ -187,6 +195,16 @@ function getDeliveryOnlyRules(
 }
 
 // ---- Helpers --- //
+
+export function isValidPostcodeForHomeDelivery(fulfilmentOption: FulfilmentOptions | null,
+	postcode: string,
+){
+	if (fulfilmentOption === 'HomeDelivery') {
+		return isValidPostcode(postcode);
+	}
+
+	return true;
+}
 
 export const isHomeDeliveryInM25 = (
 	fulfilmentOption: Option<FulfilmentOptions>,

--- a/support-frontend/assets/helpers/redux/checkout/address/validation.ts
+++ b/support-frontend/assets/helpers/redux/checkout/address/validation.ts
@@ -158,10 +158,7 @@ function getDeliveryOnlyRules(
 	return [
 		{
 			rule: isValidPostcodeForHomeDelivery(fulfilmentOption, fields.postCode),
-			error: formError(
-				'postCode',
-				'Please enter a valid postcode.',
-			),
+			error: formError('postCode', 'Please enter a valid postcode.'),
 		},
 		{
 			rule:
@@ -196,9 +193,10 @@ function getDeliveryOnlyRules(
 
 // ---- Helpers --- //
 
-export function isValidPostcodeForHomeDelivery(fulfilmentOption: FulfilmentOptions | null,
+export function isValidPostcodeForHomeDelivery(
+	fulfilmentOption: FulfilmentOptions | null,
 	postcode: string,
-){
+) {
 	if (fulfilmentOption === 'HomeDelivery') {
 		return isValidPostcode(postcode);
 	}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR adds a validation for UK postcodes in the home delivery checkout. If it is a home delivery subscription we should validate that it is a valid UK postcode.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com/c/zXpiY8uV/130-postcode-input-during-paperround-call-causes-failure)

## Why are you doing this?

There was a race condition in the checkout for national delivery subscriptions - 
- Enter a postcode, and then change it before the call to get the delivery agents finishes so that it’s no longer a valid postcode (e.g. by adding a space at the end)

- Now when you submit the form the postcode validation won’t complain, because if you’ve chosen a delivery agent it assumes the postcode is correct

- The server side validation would fail, because the postcode and the delivery agent do not match.

This PR fixes this behaviour by validating the postcode on the client.

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [x] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

