### PR TITLE
 Fix Support Checkout TY Page - Reminders Component  showing up after  setting a reminder

### DIFF
--- a/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
@@ -131,7 +131,7 @@ export const getThankYouModuleData = (
 			bodyCopy: (
 				<SupportReminderBodyCopy supportReminderState={supportReminder} />
 			),
-			ctas:supportReminder.hasBeenCompleted? null:(
+			ctas: supportReminder.hasBeenCompleted ? null : (
 				<SupportReminderCTAandPrivacy
 					email={email}
 					supportReminderState={supportReminder}

--- a/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
@@ -131,7 +131,7 @@ export const getThankYouModuleData = (
 			bodyCopy: (
 				<SupportReminderBodyCopy supportReminderState={supportReminder} />
 			),
-			ctas: (
+			ctas:supportReminder.hasBeenCompleted? null:(
 				<SupportReminderCTAandPrivacy
 					email={email}
 					supportReminderState={supportReminder}


### PR DESCRIPTION
## What are you doing in this PR?

Hiding the “Set my reminder CTA”  on Support checkout once a reminder has been set up

[**Trello Card**](https://trello.com/c/2UvnYN8i/1658-support-checkout-ty-page-reminders-component-submitted-state)

## Why are you doing this?

We show a reminders component on the Support Checkout TY Page, for Single Contributions only. We should hide the “Set my reminder CTA” once the reminder has been successfully set-up. Currently it remains visible and active.

## Is this an AB test?
- [ ] Yes
- [ x] No



## Screenshots

<img width="400" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/39ba807d-3c2b-471b-8650-500e620872ce">

## Before Change if we set a reminder 

<img width="400" alt="Screenshot 2023-11-07 at 17 11 00" src="https://github.com/guardian/support-frontend/assets/73653255/7b571de6-9da1-46ab-83fb-1e1ecbb88b92">


## After Change if we set a reminder 

<img width="400" alt="Screenshot 2023-11-07 at 17 12 09" src="https://github.com/guardian/support-frontend/assets/73653255/24937338-85d0-4fa6-8929-e12c2b269936">





