### PR TITLE
fix: use switches_v2 for settingsSource local file path

### DIFF
--- a/support-frontend/conf/DEV.public.conf
+++ b/support-frontend/conf/DEV.public.conf
@@ -45,7 +45,7 @@ settingsSource {
   s3.bucket="support-admin-console"
 
   # To use local admin settings create this file (delete it to load from S3):
-  switches.local.path="~/.gu/support-admin-console/switches_v2.json"
+  switches_v2.local.path="~/.gu/support-admin-console/switches_v2.json"
 
   amounts.local.path="~/.gu/support-admin-console/amounts.json"
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Fixing the switches path to `switches_v2` as the [config path is derived](https://github.com/guardian/support-frontend/blob/cf3ee485ff2aa42581326d9240979d05bb998184/support-frontend/app/admin/settings/Settings.scala#L88-L96) from the [filename](https://github.com/guardian/support-frontend/blob/cf3ee485ff2aa42581326d9240979d05bb998184/support-frontend/app/admin/settings/Settings.scala#L63).
