### PR TITLE
fix: change Okta if to avoid non-null assertions

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/thunks.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/existingPaymentMethods/thunks.ts
@@ -33,8 +33,8 @@ export const getExistingPaymentMethods = createAsyncThunk<
 			const authWithOkta = isSwitchOn('featureSwitches.authenticateWithOkta');
 			const accessToken = cookie.get('GU_ACCESS_TOKEN');
 
-			// No point in making the call if we don't have an access token as we know it's going to fail
-			if (authWithOkta && !accessToken) return [];
+			// Exit early if Okta isn't enabled or we're missing the access token
+			if (!authWithOkta || !accessToken) return [];
 
 			const existingPaymentMethods = await fetchJson(
 				`${mdapiUrl}/user-attributes/me/existing-payment-options?currencyFilter=${currencyId}`,
@@ -42,7 +42,7 @@ export const getExistingPaymentMethods = createAsyncThunk<
 					mode: 'cors',
 					credentials: 'include',
 					// Okta authorization uses the Authorization header rather than a cookie
-					headers: oktaAuthHeader(authWithOkta, accessToken!),
+					headers: oktaAuthHeader(authWithOkta, accessToken),
 				},
 			);
 			if (isValidPaymentList(existingPaymentMethods)) {

--- a/support-frontend/assets/helpers/redux/user/thunks.ts
+++ b/support-frontend/assets/helpers/redux/user/thunks.ts
@@ -20,8 +20,8 @@ export const getRecurringContributorStatus = createAsyncThunk<
 		const authWithOkta = isSwitchOn('featureSwitches.authenticateWithOkta');
 		const accessToken = cookie.get('GU_ACCESS_TOKEN');
 
-		// No point in making the call if we don't have an access token as we know it's going to fail
-		if (authWithOkta && !accessToken) return {};
+		// Exit early if Okta isn't enabled or we're missing the access token
+		if (!authWithOkta || !accessToken) return {};
 
 		const attributes = await fetchJson<UserAttributes>(
 			`${window.guardian.mdapiUrl}/user-attributes/me`,
@@ -29,7 +29,7 @@ export const getRecurringContributorStatus = createAsyncThunk<
 				mode: 'cors',
 				credentials: 'include',
 				// Okta authorization uses the Authorization header rather than a cookie
-				headers: oktaAuthHeader(authWithOkta, accessToken!),
+				headers: oktaAuthHeader(authWithOkta, accessToken),
 			},
 		);
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Changing the logic ever so slightly to avoid non-null assertions, mainly because they keep coming up in PR reviews which was bothering me slightly (and you should avoid them).

If we have the current types
```ts
authWithOka = true | false
accessToken = string | undefined
```

We could feasibly, but not practically, land up with
```ts
if (false && !undefined) return []
// which equates to
if (false && false) return []
```

Which would then continue with `accessToken = undefined`. In the new case if either are false, we exit early.

Mainly though, we don't get these errors any more:
![Screenshot 2023-11-08 at 08 51 11](https://github.com/guardian/support-frontend/assets/31692/f3b11446-d620-4d0c-8ba2-098634c4099c)
