### PR TITLE
feat: allow enabling of campaigns via URL hash

### DIFF
--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -80,6 +80,8 @@ export function getCampaignCode(campaignCode?: string): string | null {
 
 export function isCampaignEnabled(campaignCode: string): boolean {
 	return (
+		window.location.hash ===
+			`#settings.switches.campaignSwitches.${campaignCode}=On` ||
 		window.guardian.settings.switches.campaignSwitches[campaignCode] === 'On'
 	);
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We allow yourself to put yourself into a campaign via the hash `#settings.switches.campaignSwitches.${campaignCode}=On`.

This will allow us to share these links with other colleagues outside of engineering who don't have access to editing the [local switch configuration](https://github.com/guardian/support-frontend/blob/main/support-frontend/conf/DEV.public.conf#L48). 

e.g. `https://support.theguardian.com/us/support#settings.switches.campaignSwitches.usEoy2023=On` should enable [the `usEoy2023` campaign](https://github.com/guardian/support-frontend/pull/5414). 

With this config
```JSONC
  "campaignSwitches": {
    "description": "Campaign switches",
    "switches": {
      // ...
      "usEoy2023": {
        "description": "EOY US 2023",
        "state": "Off"
      }
    }
  }
```

We would see this:
![Screenshot 2023-11-08 at 09 16 34](https://github.com/guardian/support-frontend/assets/31692/b71f9c08-79dc-40f1-a965-046f40b303bf)

But can enable the campaign and see this:
![Screenshot 2023-11-08 at 09 16 08](https://github.com/guardian/support-frontend/assets/31692/286882a0-7002-43b5-ba4f-c87824219fb5)

## Thoughts

**Why use the full `settings.switches.campaignSwitches` value but not abstract it?**
To make this work with all settings might not be desirable for security reasons, and also you'd have to do a whole bunch of string splitting and object lookup work, which would be way more complicated that a string match. Using the whole key however sets a pattern that we could easily implement in other places, and makes it relatively discoverable as to what is being changed.

**Where's your tests?**
To test this I would like to be able to test it as an integration test (actually in a browser and validate against the global setting) to ensure we don't break this for our users. But we don't have an easy way to do this that isn't `playwright` that only runs on merging to `main`. Any unit tests feels like I would be testing JS string templates. 

**And your docs?**
If people are happy with this I will add it to the wiki.