### PR TITLE
fix: change US EOY content and do correct line breaks on heading

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/landingPageHeading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/landingPageHeading.tsx
@@ -29,7 +29,7 @@ const headingStyles = css`
 	}
 `;
 
-type Props = { heading?: string };
+type Props = { heading?: string | JSX.Element };
 export function LandingPageHeading({
 	heading = 'Support&nbsp;fearless, independent journalism',
 }: Props): JSX.Element {

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/checkoutScaffold.tsx
@@ -130,7 +130,16 @@ export function SupporterPlusCheckoutScaffold({
 		isUsEoy2023CampaignEnabled && countryGroupId === 'UnitedStates';
 
 	const heading = showUsEoy2023Content ? (
-		<LandingPageHeading heading="Make a year-end gift to the Guardian" />
+		<LandingPageHeading
+			heading={
+				<>
+					Make a<br />
+					year-end gift
+					<br />
+					to the Guardian
+				</>
+			}
+		/>
 	) : (
 		<LandingPageHeading heading="Support&nbsp;fearless, independent journalism" />
 	);
@@ -195,9 +204,9 @@ export function SupporterPlusCheckoutScaffold({
 				{!isPaymentPage &&
 					(showUsEoy2023Content ? (
 						<p css={subHeading}>
-							We rely on funding from readers, not from a billionaire owner.
-							Join the more than 250,000 readers in the US whose regular support
-							helps to sustain our journalism long term.
+							We rely on funding from readers, not shareholders or a billionaire
+							owner. Join the more than 250,000 readers in the US whose regular
+							support helps to sustain our journalism.
 						</p>
 					) : (
 						<p css={subHeading}>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
- Adding line breaks to the heading for US EOY 2023 campaign
- Changing the copy

It would be good to have a think about how we might support this amount of copy control if it were configurable.

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/) (mostly to revalidate that `<br />` which has no affect, which it doesn't)

## Screenshots

| before | after |
| --- | --- |
| ![Before][before] | ![After][after] |

[before]: https://github.com/guardian/support-frontend/assets/31692/b60e8cac-9b17-4258-84fc-e77ec2f8fae7
 
[after]: https://github.com/guardian/support-frontend/assets/31692/aeba7190-c4f2-4aca-b8ec-c6f3dc794e2d


