### PR TITLE
Make delivery provider Green label case insensitive

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
@@ -16,6 +16,9 @@ const marginBottom = css`
 
 const singleDeliveryProviderCss = css(marginBottom, `border: 0;`);
 
+const greenDeliveryMethods = ['green delivery', 'green options'] as const;
+type GreenDeliveryMethod = typeof greenDeliveryMethods[number];
+
 interface DeliveryAgentsSelectProps {
 	chosenDeliveryAgent?: number;
 	deliveryAgentsResponse?: DeliveryAgentsResponse;
@@ -160,19 +163,17 @@ function GreenDeliverySummary({ deliveryMethod }: { deliveryMethod: string }) {
 
 function isGreenOption(
 	deliveryMethod: string,
-): deliveryMethod is 'Green delivery' | 'Green options' {
-	const greenDeliveryMethods = ['Green delivery', 'Green options'] as const;
+): deliveryMethod is GreenDeliveryMethod {
+	const isGreenDeliveryMethod = isOneOf(greenDeliveryMethods);
 
-	const isGreenDeliveryMethods = isOneOf(greenDeliveryMethods);
-
-	return isGreenDeliveryMethods(deliveryMethod);
+	return isGreenDeliveryMethod(deliveryMethod.toLowerCase());
 }
 
-function getGreenSummary(deliveryMethod: 'Green delivery' | 'Green options') {
+function getGreenSummary(deliveryMethod: GreenDeliveryMethod) {
 	switch (deliveryMethod) {
-		case 'Green delivery':
+		case 'green delivery':
 			return 'This provider will deliver your newspaper via foot, bicycle, or electric vehicle.';
-		case 'Green options':
+		case 'green options':
 			return 'This provider may deliver your newspaper via foot, bicycle, electric vehicle or petrol/diesel vehicle.';
 	}
 }

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
@@ -110,6 +110,8 @@ function SingleDeliveryProvider({
 }
 
 function GreenLabel({ deliveryMethod }: { deliveryMethod: string }) {
+	deliveryMethod = deliveryMethod.toLowerCase();
+
 	if (!isGreenOption(deliveryMethod)) {
 		return null;
 	}
@@ -144,6 +146,8 @@ function DeliveryProviderSummary({ summary }: { summary: string }) {
 }
 
 function GreenDeliverySummary({ deliveryMethod }: { deliveryMethod: string }) {
+	deliveryMethod = deliveryMethod.toLowerCase();
+
 	if (!isGreenOption(deliveryMethod)) {
 		return null;
 	}
@@ -166,7 +170,7 @@ function isGreenOption(
 ): deliveryMethod is GreenDeliveryMethod {
 	const isGreenDeliveryMethod = isOneOf(greenDeliveryMethods);
 
-	return isGreenDeliveryMethod(deliveryMethod.toLowerCase());
+	return isGreenDeliveryMethod(deliveryMethod);
 }
 
 function getGreenSummary(deliveryMethod: GreenDeliveryMethod) {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Making the green label for delivery providers outside London (ie the "Green options" in the image below) match case insensitive. 
![image](https://github.com/guardian/support-frontend/assets/114918544/80df8735-3cee-4bdf-a0a6-0b0cced1ee2a)

We show something if the delivery provider response's `deliveryMethod` matches 'Green options' or 'Green delivery'.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com)

## Why are you doing this?

I noticed in production the API was returning "Green Delivery" instead of "Green delivery".

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [x] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

