### PR TITLE
fix: remove `nbsp;` in `LandingPageHeadline`

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/landingPageHeading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/landingPageHeading.tsx
@@ -31,7 +31,7 @@ const headingStyles = css`
 
 type Props = { heading?: string | JSX.Element };
 export function LandingPageHeading({
-	heading = 'Support&nbsp;fearless, independent journalism',
+	heading = 'Support fearless, independent journalism',
 }: Props): JSX.Element {
 	return <h1 css={headingStyles}>{heading}</h1>;
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/checkoutScaffold.tsx
@@ -141,7 +141,7 @@ export function SupporterPlusCheckoutScaffold({
 			}
 		/>
 	) : (
-		<LandingPageHeading heading="Support&nbsp;fearless, independent journalism" />
+		<LandingPageHeading heading="Support fearless, independent journalism" />
 	);
 
 	useEffect(() => {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Removes the `nbsp;` in the LandingPageHeadline as it seems to render incorrectly on the https://support.theguardian.com/uk/kindle ppage.

It also seems to be unnecessary as it would never break between those words give the left column is a fixed width or hidden. I imagine this was here for a previous version of the UI.

I haven't quite got to the bottom of why this is the case, but thought it worth getting a hotfix in.

## Screenshots

### `uk/contribute`

#### Desktop (before)
![Screenshot 2023-11-08 at 13 27 42](https://github.com/guardian/support-frontend/assets/31692/d48e67d1-4f57-4f26-99dc-3e28717d9e3e)

#### Desktop (after)

![Screenshot 2023-11-08 at 13 22 10](https://github.com/guardian/support-frontend/assets/31692/35502343-95da-4806-99b7-56b903e8050e)

#### Mobile (after)
![Screenshot 2023-11-08 at 13 22 05](https://github.com/guardian/support-frontend/assets/31692/41505543-e3dd-4de6-99da-b06d270504f2)

---

### `uk/contribute`

#### Desktop 
![Screenshot 2023-11-08 at 13 25 41](https://github.com/guardian/support-frontend/assets/31692/6d0607f6-2ec9-4d57-a34f-3164899d0b3d)

#### Mobile
![Screenshot 2023-11-08 at 13 21 56](https://github.com/guardian/support-frontend/assets/31692/9945b50e-29d1-4561-9333-972d3bb76c0f)
