### PR TITLE
fix: green label should preserve case from api response

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
@@ -110,9 +110,7 @@ function SingleDeliveryProvider({
 }
 
 function GreenLabel({ deliveryMethod }: { deliveryMethod: string }) {
-	deliveryMethod = deliveryMethod.toLowerCase();
-
-	if (!isGreenOption(deliveryMethod)) {
+	if (!isGreenOption(deliveryMethod.toLowerCase())) {
 		return null;
 	}
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Minor fix from #5428, preserving the case from the api response in the label

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [ ] Yes
- [ ] No

<!--
Delete this section if it's not an AB test
-->
If this is an AB test, PR reviewers should open and check the Optimize test.
[**Optimize Link**](https://optimize.google.com/optimize/home)

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

Before
![image](https://github.com/guardian/support-frontend/assets/114918544/8d515bb5-39d2-4ec6-917d-9793aeb83640)
After
![image](https://github.com/guardian/support-frontend/assets/114918544/b3a85d02-53b1-47d6-9532-7d0376acf8e0)
