### PR TITLE
Send Acquisition Data-Quantum Metric

### DIFF
--- a/support-frontend/assets/helpers/page/analyticsAndConsent.ts
+++ b/support-frontend/assets/helpers/page/analyticsAndConsent.ts
@@ -11,8 +11,8 @@ import {
 	trackAbTests,
 } from 'helpers/tracking/ophan';
 import {
-  init as initQuantumMetric,
-  sendEventAcquisitionDataFromQueryParamEvent
+	init as initQuantumMetric,
+	sendEventAcquisitionDataFromQueryParamEvent,
 } from 'helpers/tracking/quantumMetric';
 import { isPostDeployUser } from 'helpers/user/user';
 import { init as initLogger } from 'helpers/utilities/logger';
@@ -25,7 +25,7 @@ function analyticsInitialisation(
 	participations: Participations,
 	acquisitionData: ReferrerAcquisitionData,
 ): void {
-  sendEventAcquisitionDataFromQueryParamEvent(acquisitionData);
+	sendEventAcquisitionDataFromQueryParamEvent(acquisitionData);
 	setReferrerDataInLocalStorage(acquisitionData);
 	void googleTagManager.init();
 	ophan.init();

--- a/support-frontend/assets/helpers/page/analyticsAndConsent.ts
+++ b/support-frontend/assets/helpers/page/analyticsAndConsent.ts
@@ -10,7 +10,10 @@ import {
 	setReferrerDataInLocalStorage,
 	trackAbTests,
 } from 'helpers/tracking/ophan';
-import { init as initQuantumMetric } from 'helpers/tracking/quantumMetric';
+import {
+  init as initQuantumMetric,
+  sendEventAcquisitionDataFromQueryParamEvent
+} from 'helpers/tracking/quantumMetric';
 import { isPostDeployUser } from 'helpers/user/user';
 import { init as initLogger } from 'helpers/utilities/logger';
 import 'helpers/internationalisation/country';
@@ -22,6 +25,7 @@ function analyticsInitialisation(
 	participations: Participations,
 	acquisitionData: ReferrerAcquisitionData,
 ): void {
+  sendEventAcquisitionDataFromQueryParamEvent(acquisitionData);
 	setReferrerDataInLocalStorage(acquisitionData);
 	void googleTagManager.init();
 	ophan.init();

--- a/support-frontend/assets/helpers/page/analyticsAndConsent.ts
+++ b/support-frontend/assets/helpers/page/analyticsAndConsent.ts
@@ -10,10 +10,7 @@ import {
 	setReferrerDataInLocalStorage,
 	trackAbTests,
 } from 'helpers/tracking/ophan';
-import {
-	init as initQuantumMetric,
-	sendEventAcquisitionDataFromQueryParamEvent,
-} from 'helpers/tracking/quantumMetric';
+import { init as initQuantumMetric } from 'helpers/tracking/quantumMetric';
 import { isPostDeployUser } from 'helpers/user/user';
 import { init as initLogger } from 'helpers/utilities/logger';
 import 'helpers/internationalisation/country';
@@ -25,11 +22,10 @@ function analyticsInitialisation(
 	participations: Participations,
 	acquisitionData: ReferrerAcquisitionData,
 ): void {
-	sendEventAcquisitionDataFromQueryParamEvent(acquisitionData);
 	setReferrerDataInLocalStorage(acquisitionData);
 	void googleTagManager.init();
 	ophan.init();
-	initQuantumMetric(participations);
+	initQuantumMetric(participations, acquisitionData);
 	trackAbTests(participations);
 	// Sentry logging.
 	initLogger().catch((err) => {

--- a/support-frontend/assets/helpers/tracking/acquisitions.ts
+++ b/support-frontend/assets/helpers/tracking/acquisitions.ts
@@ -186,6 +186,7 @@ function buildReferrerAcquisitionData(
 			: acquisitionData.abTests) as AcquisitionABTest[] | undefined,
 		queryParameters: queryParameters.length > 0 ? queryParameters : [],
 		labels: acquisitionData.labels as string[] | undefined,
+		isRemote: acquisitionData.isRemote as boolean | undefined,
 	};
 }
 

--- a/support-frontend/assets/helpers/tracking/acquisitions.ts
+++ b/support-frontend/assets/helpers/tracking/acquisitions.ts
@@ -45,6 +45,7 @@ export type ReferrerAcquisitionData = {
 	// as we want to include query parameters in the acquisition event to e.g. facilitate off-platform tracking
 	queryParameters?: AcquisitionQueryParameters;
 	labels?: string[];
+	isRemote?: boolean;
 };
 
 export type PaymentAPIAcquisitionData = {

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -8,7 +8,7 @@ import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import type { SubscriptionProduct } from 'helpers/productPrice/subscriptions';
 import { logException } from 'helpers/utilities/logger';
-import  type { ReferrerAcquisitionData } from "./acquisitions";
+import type { ReferrerAcquisitionData } from './acquisitions';
 import {
 	canRunQuantumMetric,
 	getContributionAnnualValue,
@@ -16,20 +16,18 @@ import {
 	waitForQuantumMetricAPi,
 } from './quantumMetricHelpers';
 
-
 // ---- Types ---- //
 
 type SendEventTestParticipationId = 30;
 
 enum SendEventAcquisitionDataFromQueryParam {
-  Source = 94,
-  ComponentId = 95,
-  ComponentType = 96,
-  CampaignCode = 97,
-  ReferrerUrl = 99,
-  IsRemote = 100,
+	Source = 94,
+	ComponentId = 95,
+	ComponentType = 96,
+	CampaignCode = 97,
+	ReferrerUrl = 99,
+	IsRemote = 100,
 }
-
 
 enum SendEventSubscriptionCheckoutStart {
 	DigiSub = 75,
@@ -69,7 +67,7 @@ type SendEventId =
 	| SendEventContributionAmountUpdate
 	| SendEventContributionCheckoutConversion
 	| SendEventContributionPaymentMethodUpdate
-  | SendEventAcquisitionDataFromQueryParam;
+	| SendEventAcquisitionDataFromQueryParam;
 
 // ---- sendEvent logic ---- //
 
@@ -117,7 +115,6 @@ function sendEvent(
 		: cartValueEventIds.includes(id)
 		? 64
 		: 0;
-
 	if (window.QuantumMetricAPI?.isOn()) {
 		window.QuantumMetricAPI.sendEvent(id, qmCartValueEventId, value);
 	}
@@ -142,30 +139,53 @@ function sendEventWhenReadyTrigger(sendEventWhenReady: () => void): void {
 }
 
 function sendEventAcquisitionDataFromQueryParamEvent(
-  acquisitionData :ReferrerAcquisitionData,
+	acquisitionData: ReferrerAcquisitionData,
 ): void {
-  void ifQmPermitted(() => {
-    const sendEventWhenReady = () => {
-     if (window.QuantumMetricAPI?.isOn()) {
-       const source = acquisitionData.source;
-       const componentId = acquisitionData.componentId;
-       const componentType = acquisitionData.componentType;
-       const campaignCode = acquisitionData.campaignCode;
-       const referrerUrl = acquisitionData.referrerUrl;
-       const isRemote = true;
+	void ifQmPermitted(() => {
+		const sendEventWhenReady = () => {
+			if (window.QuantumMetricAPI?.isOn()) {
+				const source = acquisitionData.source ?? '';
+				const componentId = acquisitionData.componentId ?? '';
+				const componentType = acquisitionData.componentType ?? '';
+				const campaignCode = acquisitionData.campaignCode ?? '';
+				const referrerUrl = acquisitionData.referrerUrl ?? '';
+				const isRemote = acquisitionData.isRemote ?? '';
 
+				sendEvent(
+					SendEventAcquisitionDataFromQueryParam.Source,
+					false,
+					source.toString(),
+				);
+				sendEvent(
+					SendEventAcquisitionDataFromQueryParam.ComponentId,
+					false,
+					componentId.toString(),
+				);
+				sendEvent(
+					SendEventAcquisitionDataFromQueryParam.ComponentType,
+					false,
+					componentType.toString(),
+				);
+				sendEvent(
+					SendEventAcquisitionDataFromQueryParam.CampaignCode,
+					false,
+					campaignCode.toString(),
+				);
+				sendEvent(
+					SendEventAcquisitionDataFromQueryParam.ReferrerUrl,
+					false,
+					referrerUrl.toString(),
+				);
+				sendEvent(
+					SendEventAcquisitionDataFromQueryParam.IsRemote,
+					false,
+					isRemote.toString(),
+				);
+			}
+		};
 
-       sendEvent(SendEventAcquisitionDataFromQueryParam.Source, false, source?.toString());
-       sendEvent(SendEventAcquisitionDataFromQueryParam.ComponentId, false, componentId?.toString());
-       sendEvent(SendEventAcquisitionDataFromQueryParam.ComponentType, false, componentType?.toString());
-       sendEvent(SendEventAcquisitionDataFromQueryParam.CampaignCode, false, campaignCode ?.toString());
-       sendEvent(SendEventAcquisitionDataFromQueryParam.ReferrerUrl, false, referrerUrl.toString());
-       sendEvent(SendEventAcquisitionDataFromQueryParam.IsRemote, false, isRemote.toString());
-      }
-    };
-
-    sendEventWhenReadyTrigger(sendEventWhenReady);
-  });
+		sendEventWhenReadyTrigger(sendEventWhenReady);
+	});
 }
 
 function sendEventSubscriptionCheckoutEvent(
@@ -428,5 +448,5 @@ export {
 	sendEventContributionCartValue,
 	sendEventContributionPaymentMethod,
 	sendEventConversionPaymentMethod,
-  sendEventAcquisitionDataFromQueryParamEvent,
+	sendEventAcquisitionDataFromQueryParamEvent,
 };

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -143,57 +143,26 @@ function sendEventAcquisitionDataFromQueryParamEvent(
 ): void {
 	void ifQmPermitted(() => {
 		const sendEventWhenReady = () => {
-			const source = acquisitionData.source;
-			const componentId = acquisitionData.componentId;
-			const componentType = acquisitionData.componentType;
-			const campaignCode = acquisitionData.campaignCode;
-			const referrerUrl = acquisitionData.referrerUrl;
-			const isRemote = acquisitionData.isRemote;
-
-			if (window.QuantumMetricAPI?.isOn()) {
-				if (source) {
+			type ReferrerAcquisitionDataKeysToLogType = Record<string, number>;
+			const acquisitionDataKeysToLog: ReferrerAcquisitionDataKeysToLogType = {
+				source: SendEventAcquisitionDataFromQueryParam.Source,
+				componentId: SendEventAcquisitionDataFromQueryParam.ComponentId,
+				componentType: SendEventAcquisitionDataFromQueryParam.ComponentType,
+				campaignCode: SendEventAcquisitionDataFromQueryParam.CampaignCode,
+				referrerUrl: SendEventAcquisitionDataFromQueryParam.ReferrerUrl,
+				isRemote: SendEventAcquisitionDataFromQueryParam.IsRemote,
+			};
+			Object.keys(acquisitionDataKeysToLog).forEach((key) => {
+				const acquisitionDataValueToLog =
+					acquisitionData[key as keyof ReferrerAcquisitionData]?.toString();
+				if (acquisitionDataValueToLog) {
 					sendEvent(
-						SendEventAcquisitionDataFromQueryParam.Source,
+						acquisitionDataKeysToLog[key],
 						false,
-						source.toString(),
+						acquisitionDataValueToLog.toString(),
 					);
 				}
-				if (componentId) {
-					sendEvent(
-						SendEventAcquisitionDataFromQueryParam.ComponentId,
-						false,
-						componentId.toString(),
-					);
-				}
-				if (componentType) {
-					sendEvent(
-						SendEventAcquisitionDataFromQueryParam.ComponentType,
-						false,
-						componentType.toString(),
-					);
-				}
-				if (campaignCode) {
-					sendEvent(
-						SendEventAcquisitionDataFromQueryParam.CampaignCode,
-						false,
-						campaignCode.toString(),
-					);
-				}
-				if (referrerUrl) {
-					sendEvent(
-						SendEventAcquisitionDataFromQueryParam.ReferrerUrl,
-						false,
-						referrerUrl.toString(),
-					);
-				}
-				if (isRemote) {
-					sendEvent(
-						SendEventAcquisitionDataFromQueryParam.IsRemote,
-						false,
-						isRemote.toString(),
-					);
-				}
-			}
+			});
 		};
 
 		sendEventWhenReadyTrigger(sendEventWhenReady);
@@ -440,7 +409,10 @@ function addQM() {
 	});
 }
 
-function init(participations: Participations): void {
+function init(
+	participations: Participations,
+	acquisitionData: ReferrerAcquisitionData,
+): void {
 	void ifQmPermitted(() => {
 		void addQM().then(() => {
 			/**
@@ -448,6 +420,7 @@ function init(participations: Participations): void {
 			 * send user AB test participations via the sendEvent function.
 			 */
 			sendEventABTestParticipations(participations);
+			sendEventAcquisitionDataFromQueryParamEvent(acquisitionData);
 		});
 	});
 }

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -143,44 +143,56 @@ function sendEventAcquisitionDataFromQueryParamEvent(
 ): void {
 	void ifQmPermitted(() => {
 		const sendEventWhenReady = () => {
-			if (window.QuantumMetricAPI?.isOn()) {
-				const source = acquisitionData.source ?? '';
-				const componentId = acquisitionData.componentId ?? '';
-				const componentType = acquisitionData.componentType ?? '';
-				const campaignCode = acquisitionData.campaignCode ?? '';
-				const referrerUrl = acquisitionData.referrerUrl ?? '';
-				const isRemote = acquisitionData.isRemote ?? '';
+			const source = acquisitionData.source;
+			const componentId = acquisitionData.componentId;
+			const componentType = acquisitionData.componentType;
+			const campaignCode = acquisitionData.campaignCode;
+			const referrerUrl = acquisitionData.referrerUrl;
+			const isRemote = acquisitionData.isRemote;
 
-				sendEvent(
-					SendEventAcquisitionDataFromQueryParam.Source,
-					false,
-					source.toString(),
-				);
-				sendEvent(
-					SendEventAcquisitionDataFromQueryParam.ComponentId,
-					false,
-					componentId.toString(),
-				);
-				sendEvent(
-					SendEventAcquisitionDataFromQueryParam.ComponentType,
-					false,
-					componentType.toString(),
-				);
-				sendEvent(
-					SendEventAcquisitionDataFromQueryParam.CampaignCode,
-					false,
-					campaignCode.toString(),
-				);
-				sendEvent(
-					SendEventAcquisitionDataFromQueryParam.ReferrerUrl,
-					false,
-					referrerUrl.toString(),
-				);
-				sendEvent(
-					SendEventAcquisitionDataFromQueryParam.IsRemote,
-					false,
-					isRemote.toString(),
-				);
+			if (window.QuantumMetricAPI?.isOn()) {
+				if (source) {
+					sendEvent(
+						SendEventAcquisitionDataFromQueryParam.Source,
+						false,
+						source.toString(),
+					);
+				}
+				if (componentId) {
+					sendEvent(
+						SendEventAcquisitionDataFromQueryParam.ComponentId,
+						false,
+						componentId.toString(),
+					);
+				}
+				if (componentType) {
+					sendEvent(
+						SendEventAcquisitionDataFromQueryParam.ComponentType,
+						false,
+						componentType.toString(),
+					);
+				}
+				if (campaignCode) {
+					sendEvent(
+						SendEventAcquisitionDataFromQueryParam.CampaignCode,
+						false,
+						campaignCode.toString(),
+					);
+				}
+				if (referrerUrl) {
+					sendEvent(
+						SendEventAcquisitionDataFromQueryParam.ReferrerUrl,
+						false,
+						referrerUrl.toString(),
+					);
+				}
+				if (isRemote) {
+					sendEvent(
+						SendEventAcquisitionDataFromQueryParam.IsRemote,
+						false,
+						isRemote.toString(),
+					);
+				}
 			}
 		};
 

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -8,6 +8,7 @@ import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import type { SubscriptionProduct } from 'helpers/productPrice/subscriptions';
 import { logException } from 'helpers/utilities/logger';
+import  type { ReferrerAcquisitionData } from "./acquisitions";
 import {
 	canRunQuantumMetric,
 	getContributionAnnualValue,
@@ -15,9 +16,20 @@ import {
 	waitForQuantumMetricAPi,
 } from './quantumMetricHelpers';
 
+
 // ---- Types ---- //
 
 type SendEventTestParticipationId = 30;
+
+enum SendEventAcquisitionDataFromQueryParam {
+  Source = 94,
+  ComponentId = 95,
+  ComponentType = 96,
+  CampaignCode = 97,
+  ReferrerUrl = 99,
+  IsRemote = 100,
+}
+
 
 enum SendEventSubscriptionCheckoutStart {
 	DigiSub = 75,
@@ -56,7 +68,8 @@ type SendEventId =
 	| SendEventSubscriptionCheckoutConversion
 	| SendEventContributionAmountUpdate
 	| SendEventContributionCheckoutConversion
-	| SendEventContributionPaymentMethodUpdate;
+	| SendEventContributionPaymentMethodUpdate
+  | SendEventAcquisitionDataFromQueryParam;
 
 // ---- sendEvent logic ---- //
 
@@ -126,6 +139,33 @@ function sendEventWhenReadyTrigger(sendEventWhenReady: () => void): void {
 			sendEventWhenReady();
 		});
 	}
+}
+
+function sendEventAcquisitionDataFromQueryParamEvent(
+  acquisitionData :ReferrerAcquisitionData,
+): void {
+  void ifQmPermitted(() => {
+    const sendEventWhenReady = () => {
+     if (window.QuantumMetricAPI?.isOn()) {
+       const source = acquisitionData.source;
+       const componentId = acquisitionData.componentId;
+       const componentType = acquisitionData.componentType;
+       const campaignCode = acquisitionData.campaignCode;
+       const referrerUrl = acquisitionData.referrerUrl;
+       const isRemote = true;
+
+
+       sendEvent(SendEventAcquisitionDataFromQueryParam.Source, false, source?.toString());
+       sendEvent(SendEventAcquisitionDataFromQueryParam.ComponentId, false, componentId?.toString());
+       sendEvent(SendEventAcquisitionDataFromQueryParam.ComponentType, false, componentType?.toString());
+       sendEvent(SendEventAcquisitionDataFromQueryParam.CampaignCode, false, campaignCode ?.toString());
+       sendEvent(SendEventAcquisitionDataFromQueryParam.ReferrerUrl, false, referrerUrl.toString());
+       sendEvent(SendEventAcquisitionDataFromQueryParam.IsRemote, false, isRemote.toString());
+      }
+    };
+
+    sendEventWhenReadyTrigger(sendEventWhenReady);
+  });
 }
 
 function sendEventSubscriptionCheckoutEvent(
@@ -388,4 +428,5 @@ export {
 	sendEventContributionCartValue,
 	sendEventContributionPaymentMethod,
 	sendEventConversionPaymentMethod,
+  sendEventAcquisitionDataFromQueryParamEvent,
 };


### PR DESCRIPTION
## What are you doing in this PR?

Send Acquisition Data to Quantum Metric

[**Trello Card**](https://trello.com/c/ES1hCYiJ/1663-quantum-metric-send-acquisition-data)

## Why are you doing this?
QM have suggested passing info from the acquisitionData query param via the sendEvent function call so we can partition results based on the various bits of information in this query param. 

acquisitionData Source
Captures the acquisitionData source as defined within the URL query string parameters.
QuantumMetricAPI.sendEvent(94, 0, "Insert Source here");

acquisitionData ComponentId
Captures the ComponentId from the acquisitionData query string parameter.
QuantumMetricAPI.sendEvent(95, 0, "Insert ComponentId here");

acquisitionData ComponentType
Captures the ComponentType from the acquisitionData query string parameters.
QuantumMetricAPI.sendEvent(96, 0, "Insert ComponentType here");

acquisitionData CampaignCode
Captures the CampaignCode from the acquisitionData query string params.
QuantumMetricAPI.sendEvent(97, 0, "Insert CampaignCode here");

acquisitionData ReferrerUrl
Captures the ReferrerUrl from the acquisitionData query string params.
QuantumMetricAPI.sendEvent(99, 0, "Insert ReferrerUrl here");

acquisitionData isRemote
Captures the isRemote from the acquisitionData query string params.
QuantumMetricAPI.sendEvent(100, 0, "Insert isRemote here");

## Is this an AB test?
- [ ] Yes
- [x ] No


## Screenshots

Example URL w/ acquisitionData: [https://support.theguardian.com/uk/contribute?selected-contribution-type=ONE_OFF&selected-amount=60&REFPVID=ln8z9octg1errtw2b1xp&INTCMP=2023-09-20_SUPPORTER_BANNER_V3_SALE&acquisitionData={"source"%3A"GUARDIAN_WEB"%2C"componentId"%3A"2023-09-20_SUPPORTER_BANNER_V3_SALE"%2C"componentType"%3A"ACQUISITIONS_ENGAGEMENT_BANNER"%2C"campaignCode"%3A"2023-09-20_SUPPORTER_BANNER_V3_SALE"%2C"abTests"%3A[{"name"%3A"2023-09-20_SUPPORTER_BANNER"%2C"variant"%3A"V3_SALE"}%2C{"name"%3A"SUPPORTER_AMOUNTS_EVERGREEN__GB_REGION"%2C"variant"%3A"CONTROL"%2C"testType"%3A"AMOUNTS_TEST"}]%2C"referrerPageviewId"%3A"ln8z9octg1errtw2b1xp"%2C"referrerUrl"%3A"https%3A%2F%2Fwww.theguardian.com%2Fenvironment%2F2023%2Foct%2F02%2Fbusiness-chiefs-who-criticised-labour-in-2015-turn-on-rishi-sunak-green-u-turn-net-zero-policies"%2C"isRemote"%3Atrue}&numArticles=2](https://support.theguardian.com/uk/contribute?selected-contribution-type=ONE_OFF&selected-amount=60&REFPVID=ln8z9octg1errtw2b1xp&INTCMP=2023-09-20_SUPPORTER_BANNER_V3_SALE&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%222023-09-20_SUPPORTER_BANNER_V3_SALE%22%2C%22componentType%22%3A%22ACQUISITIONS_ENGAGEMENT_BANNER%22%2C%22campaignCode%22%3A%222023-09-20_SUPPORTER_BANNER_V3_SALE%22%2C%22abTests%22%3A%5B%7B%22name%22%3A%222023-09-20_SUPPORTER_BANNER%22%2C%22variant%22%3A%22V3_SALE%22%7D%2C%7B%22name%22%3A%22SUPPORTER_AMOUNTS_EVERGREEN__GB_REGION%22%2C%22variant%22%3A%22CONTROL%22%2C%22testType%22%3A%22AMOUNTS_TEST%22%7D%5D%2C%22referrerPageviewId%22%3A%22ln8z9octg1errtw2b1xp%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Fwww.theguardian.com%2Fenvironment%2F2023%2Foct%2F02%2Fbusiness-chiefs-who-criticised-labour-in-2015-turn-on-rishi-sunak-green-u-turn-net-zero-policies%22%2C%22isRemote%22%3Atrue%7D&numArticles=2)



<img width="790" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/682f6de2-ddda-4620-b333-92a5ceefbfc4">



NOTE: Even if the url has isRemote, somehow , it was not captured in the QM(It was mentioned in [support-dot com-components](https://github.com/guardian/support-dotcom-components/blob/ba0c5bacee7687ccec7a7837877794169cd7c942/packages/shared/src/lib/tracking.ts#L65) that isRemote  is a Temp param to indicate served by remote service, but this was not found in support-frontend earlier)
