### PR TITLE
 Update Digital checkout to handle no promo code

### DIFF
--- a/support-frontend/assets/pages/digital-subscriber-checkout/components/billingPeriodSelector.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/components/billingPeriodSelector.tsx
@@ -95,7 +95,8 @@ export function BillingPeriodSelector(): JSX.Element {
 	);
 	const promotions = useContributionsSelector(getSubscriptionPromotions);
 
-	return <BoxContents>
+	return (
+		<BoxContents>
 			<div css={headingContainer}>
 				<h2 css={heading}>Digital subscription</h2>
 				<p css={subheading}>Subscribe below to unlock the following benefits</p>
@@ -104,9 +105,9 @@ export function BillingPeriodSelector(): JSX.Element {
 				<ChoiceCardGroup name="billingPeriod">
 					<div css={choiceCardWrapper}>
 						<p css={offerText}>
-              {promotions.monthlyPrice?.discount?.amount
-                ? `${promotions.monthlyPrice.discount.amount}% off regular monthly price`
-                : ''}
+							{promotions.monthlyPrice?.discount?.amount
+								? `${promotions.monthlyPrice.discount.amount}% off regular monthly price`
+								: ''}
 						</p>
 						<ChoiceCard
 							id="monthly"
@@ -115,11 +116,13 @@ export function BillingPeriodSelector(): JSX.Element {
 							checked={billingPeriod === 'Monthly'}
 							onChange={() => dispatch(setBillingPeriod('Monthly'))}
 						/>
-            {promotions.monthlyPrice?.discount?.amount &&( <p css={offerDetails}>
-              {monthlyPrice} per month for the first{' '}
-              {promotions.monthlyPrice.discount.durationMonths} months. Then{' '}
-              {basePrices.monthlyPrice} per month.
-            </p>)}
+						{promotions.monthlyPrice?.discount?.amount && (
+							<p css={offerDetails}>
+								{monthlyPrice} per month for the first{' '}
+								{promotions.monthlyPrice.discount.durationMonths} months. Then{' '}
+								{basePrices.monthlyPrice} per month.
+							</p>
+						)}
 					</div>
 					<Hide from="tablet">
 						<Divider size="full" spaceAbove="tight" cssOverrides={divider} />
@@ -127,8 +130,8 @@ export function BillingPeriodSelector(): JSX.Element {
 					<div css={choiceCardWrapper}>
 						<p css={offerText}>
 							{promotions.annualPrice?.discount?.amount
-              ? `${promotions.annualPrice.discount.amount}% off regular regular annual`
-              : ''}
+								? `${promotions.annualPrice.discount.amount}% off regular regular annual`
+								: ''}
 						</p>
 						<ChoiceCard
 							id="annual"
@@ -137,16 +140,21 @@ export function BillingPeriodSelector(): JSX.Element {
 							checked={billingPeriod === 'Annual'}
 							onChange={() => dispatch(setBillingPeriod('Annual'))}
 						/>
-            {promotions.annualPrice?.discount?.amount && (  <p css={offerDetails}>
-              {annualPrice} for{' '}
-              {promotions.annualPrice.numberOfDiscountedPeriods} year. Then{' '}
-              {basePrices.annualPrice} per year.
-            </p>)}
+						{promotions.annualPrice?.discount?.amount && (
+							<p css={offerDetails}>
+								{annualPrice} for{' '}
+								{promotions.annualPrice.numberOfDiscountedPeriods} year. Then{' '}
+								{basePrices.annualPrice} per year.
+							</p>
+						)}
 					</div>
 				</ChoiceCardGroup>
 			</div>
 			<KindleSubscriptionBenefitsListContainer
-				renderBenefitsList={(benefitsListProps) => <CheckoutBenefitsList {...benefitsListProps} />}
+				renderBenefitsList={(benefitsListProps) => (
+					<CheckoutBenefitsList {...benefitsListProps} />
+				)}
 			/>
-		</BoxContents>;
+		</BoxContents>
+	);
 }

--- a/support-frontend/assets/pages/digital-subscriber-checkout/components/billingPeriodSelector.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/components/billingPeriodSelector.tsx
@@ -95,8 +95,7 @@ export function BillingPeriodSelector(): JSX.Element {
 	);
 	const promotions = useContributionsSelector(getSubscriptionPromotions);
 
-	return (
-		<BoxContents>
+	return <BoxContents>
 			<div css={headingContainer}>
 				<h2 css={heading}>Digital subscription</h2>
 				<p css={subheading}>Subscribe below to unlock the following benefits</p>
@@ -105,8 +104,9 @@ export function BillingPeriodSelector(): JSX.Element {
 				<ChoiceCardGroup name="billingPeriod">
 					<div css={choiceCardWrapper}>
 						<p css={offerText}>
-							{promotions.monthlyPrice?.discount?.amount}% off regular monthly{' '}
-							price
+              {promotions.monthlyPrice?.discount?.amount
+                ? `${promotions.monthlyPrice.discount.amount}% off regular monthly price`
+                : ''}
 						</p>
 						<ChoiceCard
 							id="monthly"
@@ -115,19 +115,20 @@ export function BillingPeriodSelector(): JSX.Element {
 							checked={billingPeriod === 'Monthly'}
 							onChange={() => dispatch(setBillingPeriod('Monthly'))}
 						/>
-						<p css={offerDetails}>
-							{monthlyPrice} per month for the first{' '}
-							{promotions.monthlyPrice?.discount?.durationMonths} months. Then{' '}
-							{basePrices.monthlyPrice} per month.
-						</p>
+            {promotions.monthlyPrice?.discount?.amount &&( <p css={offerDetails}>
+              {monthlyPrice} per month for the first{' '}
+              {promotions.monthlyPrice.discount.durationMonths} months. Then{' '}
+              {basePrices.monthlyPrice} per month.
+            </p>)}
 					</div>
 					<Hide from="tablet">
 						<Divider size="full" spaceAbove="tight" cssOverrides={divider} />
 					</Hide>
 					<div css={choiceCardWrapper}>
 						<p css={offerText}>
-							{promotions.annualPrice?.discount?.amount}% off regular annual{' '}
-							price
+							{promotions.annualPrice?.discount?.amount
+              ? `${promotions.annualPrice.discount.amount}% off regular regular annual`
+              : ''}
 						</p>
 						<ChoiceCard
 							id="annual"
@@ -136,19 +137,16 @@ export function BillingPeriodSelector(): JSX.Element {
 							checked={billingPeriod === 'Annual'}
 							onChange={() => dispatch(setBillingPeriod('Annual'))}
 						/>
-						<p css={offerDetails}>
-							{annualPrice} for{' '}
-							{promotions.annualPrice?.numberOfDiscountedPeriods} year. Then{' '}
-							{basePrices.annualPrice} per year.
-						</p>
+            {promotions.annualPrice?.discount?.amount && (  <p css={offerDetails}>
+              {annualPrice} for{' '}
+              {promotions.annualPrice.numberOfDiscountedPeriods} year. Then{' '}
+              {basePrices.annualPrice} per year.
+            </p>)}
 					</div>
 				</ChoiceCardGroup>
 			</div>
 			<KindleSubscriptionBenefitsListContainer
-				renderBenefitsList={(benefitsListProps) => (
-					<CheckoutBenefitsList {...benefitsListProps} />
-				)}
+				renderBenefitsList={(benefitsListProps) => <CheckoutBenefitsList {...benefitsListProps} />}
 			/>
-		</BoxContents>
-	);
+		</BoxContents>;
 }

--- a/support-frontend/assets/pages/digital-subscriber-checkout/components/billingPeriodSelector.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/components/billingPeriodSelector.tsx
@@ -130,7 +130,7 @@ export function BillingPeriodSelector(): JSX.Element {
 					<div css={choiceCardWrapper}>
 						<p css={offerText}>
 							{promotions.annualPrice?.discount?.amount
-								? `${promotions.annualPrice.discount.amount}% off regular regular annual`
+								? `${promotions.annualPrice.discount.amount}% off regular annual price`
 								: ''}
 						</p>
 						<ChoiceCard


### PR DESCRIPTION
## What are you doing in this PR?

Update Digital checkout to handle no promo code

[**Trello Card**](https://trello.com/c/n5Rk3bwE/1670-editions-update-digital-checkout-to-handle-no-promo-code)

## Why are you doing this?

Currently the “Kindle” Checkout applies a promotion to the pricing cards if a promoCode query string is applied in the URL, eg. https://support.theguardian.com/uk/kindle?promoCode=DLESNCWON.

When we have a valid promoCode in the URL the promotion is available in the promotions array at window.guardian.productPrices.[REGION].NoFulfilmentOptions.NoProductOptions[FREQUENCY].promotions

When no promoCode is applied the checkout currently still renders the “% off regular monthly price” regardless of whether there’s a promo applied or not. We should hide this if no promo is applied, we also don’t want to show the “£9.74 per month for the first 12 months. Then £14.99 per month.” beneath the card.

## Is this an AB test?
- [x ] Yes
- [] No


## Screenshots

## Before Change

### Without Promocode
<img width="514" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/832b14f8-f13a-49d0-95fa-50ed61baa9aa"> 
### With PromoCode
<img width="514" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/43cadccf-d4b7-4ea0-9765-e11fa1771b74">


## After Change

### Without Promocode
<img width="514" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/a9cb02a2-e0cd-407d-a512-70d4875899c0">

### With PromoCode
<img width="514" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/d5f9ce82-49ca-4b93-aec8-acf054726ee1">

