### PR TITLE
Scroll back to the top of the page when transitioning to the print thank you page

### DIFF
--- a/support-frontend/assets/helpers/customHooks/useScrollToTop.ts
+++ b/support-frontend/assets/helpers/customHooks/useScrollToTop.ts
@@ -1,0 +1,9 @@
+import { useEffect } from 'react';
+
+export function useScrollToTop(): void {
+	useEffect(() => {
+		requestAnimationFrame(() => {
+			window.scrollTo(0, 0);
+		});
+	}, []);
+}

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.tsx
@@ -8,6 +8,7 @@ import Content from 'components/content/contentSimple';
 import HeadingBlock from 'components/headingBlock/headingBlock';
 import { HeroWrapper } from 'components/productPage/productPageHero/productPageHero';
 import moduleStyles from 'components/subscriptionCheckouts/thankYou/thankYou.module.scss';
+import { useScrollToTop } from 'helpers/customHooks/useScrollToTop';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import {
@@ -15,7 +16,6 @@ import {
 	HomeDelivery,
 } from 'helpers/productPrice/fulfilmentOptions';
 import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
-import 'helpers/internationalisation/countryGroup';
 import type { SubscriptionsState } from 'helpers/redux/subscriptionsStore';
 import { getFormFields } from 'helpers/subscriptionsForms/formFields';
 import { myAccountUrl } from 'helpers/urls/externalLinks';
@@ -160,6 +160,9 @@ function ThankYouContent({
 	const packageName = `${cleanProductOption} ${
 		!hasAddedDigitalSubscription ? 'package ' : ''
 	}`;
+
+	useScrollToTop();
+
 	return (
 		<div className="thank-you-stage">
 			<HeroWrapper appearance="custom" className={styles.hero}>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
@@ -10,6 +10,7 @@ import { HeroWrapper } from 'components/productPage/productPageHero/productPageH
 import { SubscriptionsSurvey } from 'components/subscriptionCheckouts/subscriptionsSurvey/SubscriptionsSurvey';
 import moduleStyles from 'components/subscriptionCheckouts/thankYou/thankYou.module.scss';
 import Text, { LargeParagraph, SansParagraph } from 'components/text/text';
+import { useScrollToTop } from 'helpers/customHooks/useScrollToTop';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
 import type { SubscriptionsState } from 'helpers/redux/subscriptionsStore';
@@ -158,6 +159,9 @@ function ThankYouContent({
 					national post services.
 				</span>,
 		  ];
+
+	useScrollToTop();
+
 	return (
 		<div className="thank-you-stage">
 			<HeroWrapper


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This returns the user's scroll position to the top when they reach the thank you page for both newspaper and Guardian Weekly checkouts.

[**Trello Card**](https://trello.com/c/AMe5EYem)

## Why are you doing this?

This is to resolve an issue flagged up during manual testing for the newspaper national delivery rollout. We have the same issue on Guardian Weekly so I implemented it there too just for consistency's sake

