### PR TITLE
Enable nightly backups for SupporterProductData tables

### DIFF
--- a/supporter-product-data/cloudformation/dynamo-tables.yaml
+++ b/supporter-product-data/cloudformation/dynamo-tables.yaml
@@ -40,6 +40,9 @@ Resources:
       TimeToLiveSpecification:
         AttributeName: "expiryDate"
         Enabled: true
+      Tags:
+        - Key: devx-backup-enabled
+          Value: true
 
   WriteCapacityScalableTarget:
     Condition: CreateProdResources
@@ -126,6 +129,9 @@ Resources:
       TimeToLiveSpecification:
         AttributeName: "expiryDate"
         Enabled: true
+      Tags:
+        - Key: devx-backup-enabled
+          Value: true
 Outputs:
   ProvisionedTableOutput:
     Condition: CreateProdResources


### PR DESCRIPTION
## What are you doing in this PR?

This PR allows us to start backing up these DynamoDB tables using https://github.com/guardian/aws-backup. For more details on this project see [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit) and this [audit](https://docs.google.com/spreadsheets/d/1gNh_yQ3GVo_dVAemgZfRZM_MaQxep6_x-hzrhvVBGHY/edit#gid=1523470588) that @guardian/devx-reliability have been working on with Heads of Engineering.

## Why are you doing this?

We will be able to recover (most) data stored in this table in the unlikely event that it is deleted. 

## Deployment

As far as I can tell, this CloudFormation stack is deployed manually[^1].

If people are happy with this change in principle, I will:

- [x] Manually update the `CODE` stack via the console (to check that this works)
- [ ] Merge the PR
- [ ] Manually update the `PROD` stack via the console

[^1]: It looks like [some of this infrastructure is deployed via Riff-Raff](https://github.com/guardian/support-frontend/blob/8329681e585714f3334c3ffaac6effca9027b4a0/supporter-product-data/riff-raff.yaml#L11), but not [these tables](https://github.com/guardian/support-frontend/blob/main/supporter-product-data/cloudformation/dynamo-tables.yaml). 