### PR TITLE
Don’t use top-level .message field

### DIFF
--- a/support-frontend/app/controllers/PaperRound.scala
+++ b/support-frontend/app/controllers/PaperRound.scala
@@ -36,7 +36,7 @@ class PaperRound(
           case MP => NotFound(toJson(UnknownPostcode))
           case IP => BadRequest(toJson(ProblemWithInput))
           case IE =>
-            val errorMessage = s"${result.message}: ${result.data.message}"
+            val errorMessage = s"${result.data.message}"
             SafeLogger.error(scrub"Got internal error from PaperRound: $errorMessage")
             InternalServerError(toJson(PaperRoundError(errorMessage)))
         }

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -576,7 +576,7 @@ class PaperValidationTest extends AsyncFlatSpec with Matchers {
   import TestData.validPaperRequest
 
   case class TestPaperRound(agentMap: Map[String, List[BigInt]]) extends PaperRoundAPI {
-    def toResponse(coverage: PostcodeCoverage) = CoverageEndpoint.Response(200, "", coverage)
+    def toResponse(coverage: PostcodeCoverage) = CoverageEndpoint.Response(200, coverage)
     def toAgentsCoverage(agentId: AgentId) = CoverageEndpoint.AgentsCoverage(agentId, "", "", 0, "", AgentId(0), "")
     def coverage(body: CoverageEndpoint.RequestBody): Future[CoverageEndpoint.Response] =
       Future {

--- a/support-models/src/main/scala/com/gu/support/paperround/PaperRound.scala
+++ b/support-models/src/main/scala/com/gu/support/paperround/PaperRound.scala
@@ -108,7 +108,7 @@ object ChargeBandsEndpoint {
 object CoverageEndpoint {
   case class RequestBody(postcode: String)
 
-  case class Response(statusCode: Integer, message: String, data: PostcodeCoverage)
+  case class Response(statusCode: Integer, data: PostcodeCoverage)
 
   case class PostcodeCoverage(agents: List[AgentsCoverage], message: String, status: CoverageStatus)
   case class AgentsCoverage(


### PR DESCRIPTION
PaperRound appear to have removed this field from their responses, resulting in a decoding failure when the support-frontend backend tried to parse the response from their /coverage endpoint.

Removing the field from our code should prevent the decoding failure.