### PR TITLE
AgentsEndpoint.Response: Remove message field

### DIFF
--- a/support-models/src/main/scala/com/gu/support/paperround/PaperRound.scala
+++ b/support-models/src/main/scala/com/gu/support/paperround/PaperRound.scala
@@ -23,7 +23,7 @@ object AgentId {
 }
 
 object AgentsEndpoint {
-  case class Response(statusCode: Integer, message: String, data: AgentsList)
+  case class Response(statusCode: Integer, data: AgentsList)
 
   case class AgentsList(agents: List[AgentDetails])
   case class AgentDetails(


### PR DESCRIPTION
This field has been removed by PaperRound from the API, presumably because they didn’t intend for us to rely on it. We weren’t actually _using_ the field, so we shouldn’t have been parsing it in the first place!

At the moment this is breaking the sending of thank you emails from support-workers, so this commit should fix that by no longer parsing it.