### PR TITLE
Re-position the campaign ticker and amend headline ready for release

### DIFF
--- a/support-frontend/assets/components/ticker/tickerStyles.ts
+++ b/support-frontend/assets/components/ticker/tickerStyles.ts
@@ -1,5 +1,11 @@
 import { css } from '@emotion/react';
-import { palette, space, textSans } from '@guardian/source-foundations';
+import {
+	from,
+	palette,
+	space,
+	textSans,
+	visuallyHidden,
+} from '@guardian/source-foundations';
 
 export const tickerProgressBar = css`
 	position: relative;
@@ -30,6 +36,10 @@ export const tickerProgressBarFill = css`
 export const tickerHeadline = css`
 	${textSans.medium({ fontWeight: 'bold' })}
 	margin-bottom: ${space[2]}px;
+
+	${from.desktop} {
+		${visuallyHidden}
+	}
 `;
 
 export const tickerLabelContainer = css`

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -37,7 +37,7 @@ export const campaign: CampaignSettings = {
 	tickerSettings: {
 		countType: 'money',
 		endType: 'unlimited',
-		headline: 'End of year campaign',
+		headline: 'Help us reach our end-of-year goal',
 	},
 };
 

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -53,22 +53,6 @@ export function AmountAndBenefits({
 									<CheckoutErrorSummary errorList={errorList} />
 								)}
 							/>
-							{showUSCampaignTicker && (
-								<div
-									css={css`
-										margin-top: -${space[2]}px;
-										margin-bottom: ${space[3]}px;
-									`}
-								>
-									<TickerContainer
-										tickerId="US"
-										countType={campaignSettings.tickerSettings.countType}
-										endType={campaignSettings.tickerSettings.endType}
-										headline={campaignSettings.tickerSettings.headline}
-										render={(tickerProps) => <Ticker {...tickerProps} />}
-									/>
-								</div>
-							)}
 							<PriceCardsContainer
 								frequency={tabId}
 								renderPriceCards={({
@@ -105,6 +89,22 @@ export function AmountAndBenefits({
 									</>
 								)}
 							/>
+							{showUSCampaignTicker && (
+								<div
+									css={css`
+										margin-top: -${space[2]}px;
+										margin-bottom: ${space[3]}px;
+									`}
+								>
+									<TickerContainer
+										tickerId="US"
+										countType={campaignSettings.tickerSettings.countType}
+										endType={campaignSettings.tickerSettings.endType}
+										headline={campaignSettings.tickerSettings.headline}
+										render={(tickerProps) => <Ticker {...tickerProps} />}
+									/>
+								</div>
+							)}
 							<CheckoutBenefitsListContainer
 								renderBenefitsList={(benefitsListProps) => (
 									<CheckoutBenefitsList

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { space } from '@guardian/source-foundations';
+import { from, space } from '@guardian/source-foundations';
 import { CheckoutBenefitsList } from 'components/checkoutBenefits/checkoutBenefitsList';
 import { CheckoutBenefitsListContainer } from 'components/checkoutBenefits/checkoutBenefitsListContainer';
 import { BoxContents } from 'components/checkoutBox/checkoutBox';
@@ -19,6 +19,15 @@ import { TooltipContainer } from 'components/tooltip/TooltipContainer';
 import { getCampaignSettings } from 'helpers/campaigns/campaigns';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
+
+const tickerSpacing = css`
+	margin-top: ${space[2]}px;
+	margin-bottom: ${space[5]}px;
+
+	${from.desktop} {
+		margin-bottom: 32px;
+	}
+`;
 
 export function AmountAndBenefits({
 	countryGroupId,
@@ -90,12 +99,7 @@ export function AmountAndBenefits({
 								)}
 							/>
 							{showUSCampaignTicker && (
-								<div
-									css={css`
-										margin-top: -${space[2]}px;
-										margin-bottom: ${space[3]}px;
-									`}
-								>
+								<div css={tickerSpacing}>
 									<TickerContainer
 										tickerId="US"
 										countType={campaignSettings.tickerSettings.countType}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This repositions the campaign ticker below the price cards and adds the desired headline ready for the campaign's release. The headline is visually hidden at the desktop breakpoint and above, but will still be read by screen readers.

[**Trello Card**](https://trello.com/c/vNQgmtE5)

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

### Mobile
![Screenshot 2023-11-15 at 11 26 37](https://github.com/guardian/support-frontend/assets/29146931/96667e07-3c37-4df1-8e6d-7e3f618e87d7)

### Desktop
![Screenshot 2023-11-15 at 11-26-44 Support the Guardian](https://github.com/guardian/support-frontend/assets/29146931/e40eeb2d-b09d-4d43-b2aa-0aa3ecc48086)
