### PR TITLE
fix typo: snippets/deploy-fastly-snippet => ./deploy-fastly-snippets

### DIFF
--- a/.github/workflows/deploy-fastly-snippets.yaml
+++ b/.github/workflows/deploy-fastly-snippets.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: 18
       - name: Fastly snippet - Redirects table
-        run: node .github/workflows/scripts/deploy-fastly-snippets.js
+        run: node .github/workflows/deploy-fastly-snippets.js
         env:
           FASTLY_SERVICE_SNIPPET_FILE: ./support-frontend/conf/redirects-table.vcl
           FASTLY_SERVICE_SNIPPET_NAME: support-frontend - Redirects table


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Removes the `snippets` directory in filepath.

Sorry for the repeat here, I have run `cat .github/workflows/deploy-fastly-snippets.js` to validate this one.

And even a screenshot to prove it:
![Screenshot 2023-11-15 at 13 14 22](https://github.com/guardian/support-frontend/assets/31692/8759aaf3-2bd3-4e55-a8f0-1847fb7432b6)

