### PR TITLE
fix: support kindle thankyou route

### DIFF
--- a/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionRouter.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionRouter.tsx
@@ -56,9 +56,9 @@ const router = () => {
 		<BrowserRouter>
 			<Provider store={store}>
 				<Routes>
+					{/* We're supporting both routes for now until we make `/kindle` obsolete */}
 					{countryIds.map((countryId) => (
 						<>
-							{/* We're supporting both routes for now until we make `/kindle` obsolete */}
 							<Route path={`/${countryId}/kindle`} element={landingPage} />
 							<Route
 								path={`/${countryId}/subscribe/digital`}
@@ -67,10 +67,16 @@ const router = () => {
 						</>
 					))}
 					{countryIds.map((countryId) => (
-						<Route
-							path={`/${countryId}/thankyou`}
-							element={<DigitalSubscriptionThankYou />}
-						/>
+						<>
+							<Route
+								path={`/${countryId}/kindle/thankyou`}
+								element={<DigitalSubscriptionThankYou />}
+							/>
+							<Route
+								path={`/${countryId}/thankyou`}
+								element={<DigitalSubscriptionThankYou />}
+							/>
+						</>
 					))}
 				</Routes>
 			</Provider>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Supporting the `/{countryId}/kindle/thankyou` route.

This bug was introduced here: https://github.com/guardian/support-frontend/pull/5433

## Why are you doing this?
So we don't see a blank page when someone pays for a digital subscription.

Thanks @GHaberis for spotting and reporting.

## Screenshosts
<img width="830" alt="Screenshot 2023-11-15 at 15 46 56" src="https://github.com/guardian/support-frontend/assets/31692/90a06116-7a76-4025-9cdb-a689b637c99e">
