### PR TITLE
Deactivate us make it annual nudge

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -70,7 +70,7 @@ export const tests: Tests = {
 				id: 'variant',
 			},
 		],
-		isActive: true,
+		isActive: false,
 		audiences: {
 			UnitedStates: {
 				offset: 0,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Deactivating the make it annual nudge for US market

## Why are you doing this?
The A/B test for make it annual nudge in the US performed poorly

<!--
Remember, PRs are documentation for future contributors.
-->

## Is this an AB test?
- [x] Yes
- [ ] No



## Accessibility test checklist
 - [ ] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [ ] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [ ] [Colour contrast passed](https://www.whocanuse.com/)

## Screenshots

