### PR TITLE
Opt-out of nightly backups for SupporterProductData tables

### DIFF
--- a/supporter-product-data/cloudformation/dynamo-tables.yaml
+++ b/supporter-product-data/cloudformation/dynamo-tables.yaml
@@ -40,6 +40,10 @@ Resources:
       TimeToLiveSpecification:
         AttributeName: "expiryDate"
         Enabled: true
+      # This table is used as a cache (which can be easily repopulated), so there is no need to back it up
+      Tags:
+        - Key: devx-backup-enabled
+          Value: false
 
   WriteCapacityScalableTarget:
     Condition: CreateProdResources
@@ -126,6 +130,10 @@ Resources:
       TimeToLiveSpecification:
         AttributeName: "expiryDate"
         Enabled: true
+      # This table is used as a cache (which can be easily repopulated), so there is no need to back it up
+      Tags:
+        - Key: devx-backup-enabled
+          Value: false
 Outputs:
   ProvisionedTableOutput:
     Condition: CreateProdResources


### PR DESCRIPTION
## What are you doing in this PR?

This PR is a replacement for https://github.com/guardian/support-frontend/pull/5443. It adds a CloudFormation tag which is used for tracking/auditing purposes only.

## Why are you doing this?

There is no need to backup these tables - see https://github.com/guardian/support-frontend/pull/5443#issuecomment-1818858689. Although [opting-out isn't strictly necessary, it will make future DynamoDB audits easier](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit#heading=h.ikcdq5hb5oj5).

## Deployment

As far as I can tell, this CloudFormation stack is deployed manually[^1].

To deploy this, I will:

- [ ] Manually update the `CODE` stack via the console (to check that this works)
- [ ] Merge the PR
- [ ] Manually update the `PROD` stack via the console

[^1]: It looks like [some of this infrastructure is deployed via Riff-Raff](https://github.com/guardian/support-frontend/blob/8329681e585714f3334c3ffaac6effca9027b4a0/supporter-product-data/riff-raff.yaml#L11), but not [these tables](https://github.com/guardian/support-frontend/blob/main/supporter-product-data/cloudformation/dynamo-tables.yaml). 


