### PR TITLE
Add alarm for failures getting delivery agents

### DIFF
--- a/cdk/lib/__snapshots__/frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/frontend.test.ts.snap
@@ -41,6 +41,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
       "GuAlarm",
       "GuAlarm",
       "GuAlarm",
+      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -345,6 +346,46 @@ exports[`The Frontend stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "GetDeliveryAgentsFailure4BEED0AC": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":conversion-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Impact - support-frontend failed to get delivery agents from PaperRound. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
+        "AlarmName": "URGENT 9-5 - PROD support-frontend GetDeliveryAgentsFailure",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "GetDeliveryAgentsFailure",
+        "Namespace": "support-frontend",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "GetDistributablePolicyFrontendA36D2A61": {
       "Properties": {

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -316,5 +316,28 @@ export class Frontend extends GuStack {
       treatMissingData: TreatMissingData.NOT_BREACHING,
       snsTopicName: "conversion-dev",
     });
+
+    new GuAlarm(this, "GetDeliveryAgentsFailure", {
+      app,
+      alarmName: alarmName("support-frontend GetDeliveryAgentsFailure"),
+      alarmDescription: alarmDescription(
+        "support-frontend failed to get delivery agents from PaperRound"
+      ),
+      actionsEnabled: shouldEnableAlarms,
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      metric: new Metric({
+        metricName: "GetDeliveryAgentsFailure",
+        namespace: "support-frontend",
+        dimensionsMap: {
+          Stage: this.stage,
+        },
+        statistic: "Sum",
+        period: Duration.seconds(60),
+      }),
+      treatMissingData: TreatMissingData.NOT_BREACHING,
+      snsTopicName: "conversion-dev",
+    });
   }
 }

--- a/support-frontend/app/controllers/PaperRound.scala
+++ b/support-frontend/app/controllers/PaperRound.scala
@@ -1,9 +1,13 @@
 package controllers
 
 import actions.CustomActionBuilders
+import com.gu.aws.AwsCloudWatchMetricPut
+import com.gu.aws.AwsCloudWatchMetricPut.{client => cloudwatchClient}
+import com.gu.aws.AwsCloudWatchMetricSetup.{getDeliveryAgentsSuccess, getDeliveryAgentsFailure}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
 import com.gu.rest.{CodeBody, WebServiceHelperError}
+import com.gu.support.config.Stage
 import com.gu.support.paperround.{AgentId, CoverageEndpoint, PaperRound, PaperRoundService, PaperRoundServiceProvider}
 import com.gu.support.paperround.CoverageEndpoint._
 import io.circe._
@@ -21,6 +25,7 @@ class PaperRound(
     serviceProvider: PaperRoundServiceProvider,
     actionRefiners: CustomActionBuilders,
     testUserService: TestUserService,
+    stage: Stage,
 ) extends AbstractController(components)
     with Circe {
   import actionRefiners._
@@ -30,23 +35,32 @@ class PaperRound(
       .forUser(testUserService.isTestUser(request))
       .coverage(CoverageEndpoint.RequestBody(postcode = postcode))
       .map { result =>
-        result.data.status match {
-          case CO => Ok(toJson(Covered(result.data.agents.map(fromAgentsCoverage(_)))))
-          case NC => Ok(toJson(NotCovered))
-          case MP => NotFound(toJson(UnknownPostcode))
-          case IP => BadRequest(toJson(ProblemWithInput))
-          case IE =>
-            val errorMessage = s"${result.data.message}"
-            SafeLogger.error(scrub"Got internal error from PaperRound: $errorMessage")
-            InternalServerError(toJson(PaperRoundError(errorMessage)))
+        {
+          val response = result.data.status match {
+            case CO => Ok(toJson(Covered(result.data.agents.map(fromAgentsCoverage(_)))))
+            case NC => Ok(toJson(NotCovered))
+            case MP => NotFound(toJson(UnknownPostcode))
+            case IP => BadRequest(toJson(ProblemWithInput))
+            case IE =>
+              val errorMessage = s"${result.data.message}"
+              SafeLogger.error(scrub"Got internal error from PaperRound: $errorMessage")
+              InternalServerError(toJson(PaperRoundError(errorMessage)))
+          }
+          result.data.status match {
+            case IE => AwsCloudWatchMetricPut(cloudwatchClient)(getDeliveryAgentsFailure(stage))
+            case _ => AwsCloudWatchMetricPut(cloudwatchClient)(getDeliveryAgentsSuccess(stage))
+          }
+          response
         }
       } recover {
       case PaperRound.Error(statusCode, message, errorCode) =>
         val responseBody = s"$errorCode – Got $statusCode reponse with message $message"
         SafeLogger.error(scrub"Error calling PaperRound, returning $responseBody")
+        AwsCloudWatchMetricPut(cloudwatchClient)(getDeliveryAgentsFailure(stage))
         InternalServerError(responseBody)
       case error =>
         SafeLogger.error(scrub"Failed to get agents from PaperRound due to: $error")
+        AwsCloudWatchMetricPut(cloudwatchClient)(getDeliveryAgentsFailure(stage))
         InternalServerError(s"Unknown error: $error")
     }
   }

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -235,6 +235,7 @@ trait Controllers {
     paperRoundServiceProvider,
     actionRefiners,
     testUsers,
+    appConfig.stage,
   )
 
   lazy val promotionsController = new Promotions(

--- a/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
+++ b/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
@@ -79,6 +79,22 @@ object AwsCloudWatchMetricSetup {
       ),
     )
 
+  def getDeliveryAgentsFailure(stage: Stage): MetricRequest =
+    getMetricRequest(
+      MetricName("GetDeliveryAgentsFailure"),
+      Map(
+        MetricDimensionName("Stage") -> MetricDimensionValue(stage.toString),
+      ),
+    )
+
+  def getDeliveryAgentsSuccess(stage: Stage): MetricRequest =
+    getMetricRequest(
+      MetricName("GetDeliveryAgentsSuccess"),
+      Map(
+        MetricDimensionName("Stage") -> MetricDimensionValue(stage.toString),
+      ),
+    )
+
   private def getMetricRequest(
       name: MetricName,
       dimensions: Map[MetricDimensionName, MetricDimensionValue],


### PR DESCRIPTION
- Add a metric for successes and one for failures
- Add an alarm on the failure metric
- Include an alarm in CODE so we get a heads up if it breaks in CODE first (as it did recently)
  
## Background

For national delivery, the support-frontend server has an endpoint that looks up postcode coverage with PaperRound by calling their API. If an error is encountered while doing this lookup, there’s currently no alert: a 500 is returned to the client, but that’s it (the 500 may cause an alert if it’s a big enough proportion of all requests, but it probably won’t be).

Adding a metric (and associated alarm) for failed calls to this endpoint will help us catch problems more quickly.

- Trello Card: https://trello.com/c/RUsF7U7e/479-add-metric-for-errors-checking-a-postcodes-coverage-with-paperround

## Testing

- I ran this locally and confirmed that the metrics show up [in cloudwatch](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metricsV2?graph=~(view~'timeSeries~stacked~false~metrics~(~(~'support-frontend~'GetDeliveryAgentsSuccess~'Stage~'DEV)~(~'.~'GetDeliveryAgentsFailure~'.~'.))~region~'eu-west-1~start~'2023-11-21T12*3a50*3a00.000Z~end~'2023-11-21T13*3a05*3a00.000Z)&query=~'*7bsupport-frontend*2cStage*7d*20GetDelivery*20GetDelivery)
- I have not (yet) deployed this to CODE and verified that the alarm fires on failure: this would be good to do if I have time