### PR TITLE
Add client-side validation to prevent form submission if captcha hasn’t been selected with Direct Debit

### DIFF
--- a/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
@@ -18,7 +18,6 @@ export function getStripeFormErrors(
 	const recaptchaErrors = getRecaptchaError(state);
 
 	if (!showErrors) return {};
-
 	return { ...errors, robot_checkbox: recaptchaErrors };
 }
 
@@ -39,15 +38,17 @@ export function getAmazonPayFormErrors(
 
 function getDirectDebitFormErrors(state: ContributionsState): ErrorCollection {
 	const { errors, formError } = state.page.checkoutForm.payment.directDebit;
-	if (formError) {
+  const recaptchaErrors = getRecaptchaError(state);
+
+  if (formError) {
 		return {
-			...errors,
+			...errors,robot_checkbox: recaptchaErrors,
 			directDebitDetails: [formError],
 		};
 	}
 
 	return {
-		...errors,
+		...errors,robot_checkbox: recaptchaErrors
 	};
 }
 

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
@@ -38,17 +38,19 @@ export function getAmazonPayFormErrors(
 
 function getDirectDebitFormErrors(state: ContributionsState): ErrorCollection {
 	const { errors, formError } = state.page.checkoutForm.payment.directDebit;
-  const recaptchaErrors = getRecaptchaError(state);
+	const recaptchaErrors = getRecaptchaError(state);
 
-  if (formError) {
+	if (formError) {
 		return {
-			...errors,robot_checkbox: recaptchaErrors,
+			...errors,
+			robot_checkbox: recaptchaErrors,
 			directDebitDetails: [formError],
 		};
 	}
 
 	return {
-		...errors,robot_checkbox: recaptchaErrors
+		...errors,
+		robot_checkbox: recaptchaErrors,
 	};
 }
 


### PR DESCRIPTION
## What are you doing in this PR?

Add client-side validation  to prevent form submission if captcha hasn’t been selected with Direct Debit

[**Trello Card**](https://trello.com/c/VmdWC8sR/1425-look-into-captcha-validation-failures-not-preventing-support-workers-execution)

## Why are you doing this?

If the  getRecaptchaError  is not included in the  getDirectDebitFormErrors , it allows the form submission even if there is no recaptcha  selected  in Direct debit form when all the direct debit details/ fields are correct.
## Is this an AB test?
- [ ] Yes
- [x ] No


## Screenshots
###  (Before change)-Even if the recaptcha in the Direct debit section was not selected, the user was allowed to submit the form and the support workers successfully executed the request.

<img width="500" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/ae4a6f69-d45d-4377-803e-acc1eac38de8">

The user was shown -"Please check the 'I'm not a robot' " checkbox error message

## Screenshots 
###  (After change)- The user won't be allowed to submit the form

<img width="500" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/cea958ae-c2c1-4dad-8f5f-a1db981b0889">
