### PR TITLE
Add EOY campaign ticker for Australia to the S+ checkout

### DIFF
--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -8,6 +8,8 @@ type CampaignCopy = {
 
 export type CampaignSettings = {
 	campaignCode: string;
+	campaignPath: string;
+	tickerId: string;
 	copy?: (goalReached: boolean) => CampaignCopy;
 	formMessage?: JSX.Element;
 	termsAndConditions?: (
@@ -23,36 +25,36 @@ export type CampaignSettings = {
 	// If set, the form will be replaced with this if goal reached
 };
 
-const currentCampaignPath: string | null = 'us/contribute';
-
-const usEoy2021Copy = (): CampaignCopy => ({
-	headerCopy: "Join us in the fight for America's future",
-	contributeCopy:
-		'Quality, independent journalism that is freely accessible to all has never been more crucial. We’re raising $1.25m to fund our reporting in 2022. If you can, support the Guardian today.',
-});
-
-export const campaign: CampaignSettings = {
-	campaignCode: 'Us_eoy_2023',
-	copy: usEoy2021Copy,
-	tickerSettings: {
-		countType: 'money',
-		endType: 'unlimited',
-		headline: 'Help us reach our end-of-year goal',
+export const activeCampaigns: Record<string, CampaignSettings> = {
+	usEoy2023: {
+		campaignCode: 'usEoy2023',
+		campaignPath: 'us/contribute',
+		tickerId: 'US',
+		tickerSettings: {
+			countType: 'money',
+			endType: 'unlimited',
+			headline: 'Help us reach our end-of-year goal',
+		},
+	},
+	ausTicker2023: {
+		campaignCode: 'ausTicker2023',
+		campaignPath: 'au/contribute',
+		tickerId: 'AUS',
+		tickerSettings: {
+			countType: 'money',
+			endType: 'unlimited',
+			headline: 'Help us reach our end-of-year goal',
+		},
 	},
 };
 
-function campaignEnabledForUser(
-	campaignCode: string | null | undefined,
-): boolean {
+function campaignEnabledForUser(campaignCode?: string): boolean {
 	const { campaignSwitches } = window.guardian.settings.switches;
-	if (
-		currentCampaignPath &&
-		campaignSwitches.enableContributionsCampaign === 'On'
-	) {
-		return (
-			campaignSwitches.forceContributionsCampaign === 'On' ||
-			window.location.pathname.endsWith(`/${currentCampaignPath}`) ||
-			campaign.campaignCode === campaignCode
+
+	if (campaignCode && campaignSwitches.enableContributionsCampaign === 'On') {
+		const matchingCampaign = activeCampaigns[campaignCode];
+		return window.location.pathname.endsWith(
+			`/${matchingCampaign.campaignPath}`,
 		);
 	}
 
@@ -62,14 +64,15 @@ function campaignEnabledForUser(
 export function getCampaignSettings(
 	campaignCode?: string,
 ): CampaignSettings | null {
-	if (campaignEnabledForUser(campaignCode)) {
-		return campaign;
+	if (campaignCode && campaignEnabledForUser(campaignCode)) {
+		return activeCampaigns[campaignCode];
 	}
 
 	return null;
 }
+
 export function getCampaignCode(campaignCode?: string): string | null {
-	const campaignSettings = getCampaignSettings(campaignCode);
+	const campaignSettings = getCampaignSettings(campaignCode ?? '');
 
 	if (campaignSettings) {
 		return campaignSettings.campaignCode;

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -49,9 +49,7 @@ export const activeCampaigns: Record<string, CampaignSettings> = {
 };
 
 function campaignEnabledForUser(campaignCode?: string): boolean {
-	const { campaignSwitches } = window.guardian.settings.switches;
-
-	if (campaignCode && campaignSwitches.enableContributionsCampaign === 'On') {
+	if (campaignCode && isCampaignEnabled(campaignCode)) {
 		const matchingCampaign = activeCampaigns[campaignCode];
 		return window.location.pathname.endsWith(
 			`/${matchingCampaign.campaignPath}`,
@@ -82,9 +80,10 @@ export function getCampaignCode(campaignCode?: string): string | null {
 }
 
 export function isCampaignEnabled(campaignCode: string): boolean {
+	const { campaignSwitches } = window.guardian.settings.switches;
 	return (
 		window.location.hash ===
 			`#settings.switches.campaignSwitches.${campaignCode}=On` ||
-		window.guardian.settings.switches.campaignSwitches[campaignCode] === 'On'
+		campaignSwitches[campaignCode] === 'On'
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -54,7 +54,7 @@ export function AmountAndBenefits({
 
 	const campaignSettings = getCampaignSettings(campaignCode);
 
-	const showCampaignTicker = campaignSettings;
+	const showCampaignTicker = !!campaignSettings;
 
 	return (
 		<PaymentFrequencyTabsContainer

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -17,7 +17,6 @@ import { TickerContainer } from 'components/ticker/tickerContainer';
 import Tooltip from 'components/tooltip/Tooltip';
 import { TooltipContainer } from 'components/tooltip/TooltipContainer';
 import { getCampaignSettings } from 'helpers/campaigns/campaigns';
-import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 
@@ -54,11 +53,8 @@ export function AmountAndBenefits({
 	const campaignCode = tickerCampaigns[internationalisation.countryGroupId];
 
 	const campaignSettings = getCampaignSettings(campaignCode);
-	const campaignEnabled =
-		campaignCode &&
-		isSwitchOn(`settings.switches.campaignSwitches.${campaignCode}`);
 
-	const showCampaignTicker = campaignEnabled && campaignSettings;
+	const showCampaignTicker = campaignSettings;
 
 	return (
 		<PaymentFrequencyTabsContainer

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -17,6 +17,7 @@ import { TickerContainer } from 'components/ticker/tickerContainer';
 import Tooltip from 'components/tooltip/Tooltip';
 import { TooltipContainer } from 'components/tooltip/TooltipContainer';
 import { getCampaignSettings } from 'helpers/campaigns/campaigns';
+import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 
@@ -28,6 +29,11 @@ const tickerSpacing = css`
 		margin-bottom: 32px;
 	}
 `;
+
+const tickerCampaigns: Partial<Record<CountryGroupId, string>> = {
+	UnitedStates: 'usEoy2023',
+	AUDCountries: 'ausTicker2023',
+};
 
 export function AmountAndBenefits({
 	countryGroupId,
@@ -45,10 +51,14 @@ export function AmountAndBenefits({
 	const { internationalisation } = useContributionsSelector(
 		(state) => state.common,
 	);
-	const campaignSettings = getCampaignSettings('Us_eoy_2023');
+	const campaignCode = tickerCampaigns[internationalisation.countryGroupId];
 
-	const showUSCampaignTicker =
-		internationalisation.countryGroupId === 'UnitedStates' && campaignSettings;
+	const campaignSettings = getCampaignSettings(campaignCode);
+	const campaignEnabled =
+		campaignCode &&
+		isSwitchOn(`settings.switches.campaignSwitches.${campaignCode}`);
+
+	const showCampaignTicker = campaignEnabled && campaignSettings;
 
 	return (
 		<PaymentFrequencyTabsContainer
@@ -98,10 +108,10 @@ export function AmountAndBenefits({
 									</>
 								)}
 							/>
-							{showUSCampaignTicker && (
+							{showCampaignTicker && (
 								<div css={tickerSpacing}>
 									<TickerContainer
-										tickerId="US"
+										tickerId={campaignSettings.tickerId}
 										countType={campaignSettings.tickerSettings.countType}
 										endType={campaignSettings.tickerSettings.endType}
 										headline={campaignSettings.tickerSettings.headline}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This enables the ticker to show up on the Australia checkout for their end-of-year campaign. It also updates our campaign module to enable multiple campaigns to be run simultaneously

[**Trello Card**](https://trello.com/c/oGJcu4sv)

## Screenshots

### Desktop
![Screenshot 2023-11-24 at 13-15-38 Support the Guardian](https://github.com/guardian/support-frontend/assets/29146931/55bf2436-8c52-4b91-8732-41831fdd1dc9)

### Mobile
![Screenshot 2023-11-24 at 13 20 55](https://github.com/guardian/support-frontend/assets/29146931/ebbb2ce5-c683-4f33-a229-2da258088e4c)
