### PR TITLE
Use FooterLinks from source-react-components-development-kitchen on Support checkout

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/checkoutScaffold.tsx
@@ -98,11 +98,11 @@ const links = [
 		text: 'Privacy policy',
 		isExternal: true,
 	},
-  {
+	{
 		text: 'Privacy settings',
-    onClick: () => {
-      cmp.showPrivacyManager();
-    }
+		onClick: () => {
+			cmp.showPrivacyManager();
+		},
 	},
 	{
 		href: 'https://www.theguardian.com/help/contact-us',
@@ -114,7 +114,7 @@ const links = [
 		text: 'Help centre',
 		isExternal: true,
 	},
-]
+];
 
 export function SupporterPlusCheckoutScaffold({
 	children,

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepTest/checkoutScaffold.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { cmp } from '@guardian/consent-management-platform';
 import {
 	from,
 	palette,
@@ -7,12 +8,15 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import { Column, Columns, Hide } from '@guardian/source-react-components';
+import {
+	FooterLinks,
+	FooterWithContents,
+} from '@guardian/source-react-components-development-kitchen';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CheckoutHeading } from 'components/checkoutHeading/checkoutHeading';
 import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
-import Footer from 'components/footerCompliant/Footer';
 import GridImage from 'components/gridImage/gridImage';
 import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countrySwitcherContainer';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
@@ -87,6 +91,30 @@ const leftColImageUnitedStates = css`
 		display: block;
 	}
 `;
+
+const links = [
+	{
+		href: 'https://www.theguardian.com/info/privacy',
+		text: 'Privacy policy',
+		isExternal: true,
+	},
+  {
+		text: 'Privacy settings',
+    onClick: () => {
+      cmp.showPrivacyManager();
+    }
+	},
+	{
+		href: 'https://www.theguardian.com/help/contact-us',
+		text: 'Contact us',
+		isExternal: true,
+	},
+	{
+		href: 'https://www.theguardian.com/help',
+		text: 'Help centre',
+		isExternal: true,
+	},
+]
 
 export function SupporterPlusCheckoutScaffold({
 	children,
@@ -164,7 +192,11 @@ export function SupporterPlusCheckoutScaffold({
 					{!isPaymentPage && <Nav {...countrySwitcherProps} />}
 				</>
 			}
-			footer={<Footer />}
+			footer={
+				<FooterWithContents>
+					<FooterLinks links={links}></FooterLinks>
+				</FooterWithContents>
+			}
 		>
 			<CheckoutHeading
 				heading={!isPaymentPage && heading}

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -91,7 +91,7 @@
     "@guardian/pasteup": "1.0.0-alpha.7",
     "@guardian/source-foundations": "^13.0.0",
     "@guardian/source-react-components": "^16.0.1",
-    "@guardian/source-react-components-development-kitchen": "^14.0.2",
+    "@guardian/source-react-components-development-kitchen": "^14.1.0",
     "@reduxjs/toolkit": "^1.9.4",
     "@sentry/browser": "^7.72.0",
     "@stripe/react-stripe-js": "^1.8.1",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -2258,10 +2258,10 @@
   dependencies:
     mini-svg-data-uri "1.4.4"
 
-"@guardian/source-react-components-development-kitchen@^14.0.2":
-  version "14.0.2"
-  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-14.0.2.tgz#c8bab2cf21717b5c857dad075bca8a12112c0b13"
-  integrity sha512-F5nDwRuekC9ZUSEy+FdXMnke/q/rYi4Mple2t1rv6d61oHsOnnGxReQtfPYyVnYv5zGYo8phlOtLGstSQg3DRQ==
+"@guardian/source-react-components-development-kitchen@^14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-14.1.0.tgz#d07fdc1338a3da0dd4de5de85239574fcd3e6adb"
+  integrity sha512-S71Jskvubyyqkdby7TTZwOpIMJFsXcXwD663ddZtyo1rbpyl9Bo6RlilpCCv3G/G8EU+g4QA40lUqQTVATOBMA==
 
 "@guardian/source-react-components@^16.0.1":
   version "16.0.1"


### PR DESCRIPTION
## What are you doing in this PR?

This PR undoes a temporary fix that was made to introduce a "Privacy settings" link to the Support checkout's footer, when clicked this launches the CMP: https://github.com/guardian/support-frontend/pull/5442. This change was necessary as the `FooterLinks` component from `source-react-components-development-kitchen` wasn't flexible enough to support links other than anchor tags linking through to pages.

The `FooterLinks` component from `source-react-components-development-kitchen` has now been updated to support buttons with onClick handlers, which means we revert to using it again, making the most of this new feature: https://github.com/guardian/csnx/pull/940.