### PR TITLE
fix: rename workflow input from delete-fastly-snippets => delete-snippets

### DIFF
--- a/.github/workflows/deploy-fastly-snippets.yaml
+++ b/.github/workflows/deploy-fastly-snippets.yaml
@@ -22,7 +22,7 @@ jobs:
     env:
       FASTLY_SERVICE_ID: ${{ secrets.FASTLY_SERVICE_ID }}
       FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}
-      DELETE_SNIPPETS: ${{ github.event.inputs.delete-fastly-snippets }}
+      DELETE_SNIPPETS: ${{ github.event.inputs.delete-snippets }}
       LOCK_AND_ACTIVATE_SERVICE: ${{ github.event.inputs.lock-and-activate-service }}
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## What are you doing in this PR?
Fixing typo in the reading of the `delete-snippets` `input`. I thought we had tested this. A little unsure of how to test this going forward...
