### PR TITLE
Changes to redirect users in VAT impacted countries

### DIFF
--- a/.github/workflows/deploy-fastly-snippets.js
+++ b/.github/workflows/deploy-fastly-snippets.js
@@ -60,6 +60,16 @@ const snippets = [
     name: "support-frontend - gu_geo_country cookie deliver",
     type: "deliver",
   },
+  {
+    file: "./support-frontend/conf/fastly-snippets/vat-compliance-redirects-recv.vcl",
+    name: "support-frontend - VAT compliance redirect",
+    type: "recv",
+  },
+  {
+    file: "./support-frontend/conf/fastly-snippets/vat-compliance-redirects-error.vcl",
+    name: "support-frontend - VAT compliance redirect error",
+    type: "error",
+  },
 ];
 
 /**

--- a/support-frontend/conf/fastly-snippets/vat-compliance-redirects-error.vcl
+++ b/support-frontend/conf/fastly-snippets/vat-compliance-redirects-error.vcl
@@ -1,0 +1,7 @@
+# type: error
+if (obj.status == 619) {
+   set obj.status = 301;
+   set obj.response = "Moved Permanently";
+   set req.http.Location = "https://support.theguardian.com/contribute";
+   return (deliver);
+}

--- a/support-frontend/conf/fastly-snippets/vat-compliance-redirects-recv.vcl
+++ b/support-frontend/conf/fastly-snippets/vat-compliance-redirects-recv.vcl
@@ -40,7 +40,7 @@
   client.geo.country_code == "NE"
 )
 {
-  if (req.url ~ "^\/[a-z]{2}/subscribe/digital" && req.url == "/subscribe/digital"   ){
+  if (req.url ~ "^\/[a-z]{2}/subscribe/digital" || req.url == "/subscribe/digital"   ){
        error 619;
     }
 }

--- a/support-frontend/conf/fastly-snippets/vat-compliance-redirects-recv.vcl
+++ b/support-frontend/conf/fastly-snippets/vat-compliance-redirects-recv.vcl
@@ -1,0 +1,46 @@
+# type: recv
+   if (
+  client.geo.country_code == "RS"||
+  client.geo.country_code == "EG"||
+  client.geo.country_code == "PK"||
+  client.geo.country_code == "MU"||
+  client.geo.country_code == "BH"||
+  client.geo.country_code == "MA"||
+  client.geo.country_code == "MC"||
+  client.geo.country_code == "OM"||
+  client.geo.country_code == "GE"||
+  client.geo.country_code == "NC"||
+  client.geo.country_code == "TZ"||
+  client.geo.country_code == "ZM"||
+  client.geo.country_code == "AL"||
+  client.geo.country_code == "BD"||
+  client.geo.country_code == "KZ"||
+  client.geo.country_code == "CW"||
+  client.geo.country_code == "DO"||
+  client.geo.country_code == "GP"||
+  client.geo.country_code == "MQ"||
+  client.geo.country_code == "PF"||
+  client.geo.country_code == "TN"||
+  client.geo.country_code == "BQ"||
+  client.geo.country_code == "AX"||
+  client.geo.country_code == "SN"||
+  client.geo.country_code == "AM"||
+  client.geo.country_code == "CM"||
+  client.geo.country_code == "AO"||
+  client.geo.country_code == "KG"||
+  client.geo.country_code == "MR"||
+  client.geo.country_code == "GA"||
+  client.geo.country_code == "UZ"||
+  client.geo.country_code == "MD"||
+  client.geo.country_code == "DZ"||
+  client.geo.country_code == "TJ"||
+  client.geo.country_code == "LS"||
+  client.geo.country_code == "CG"||
+  client.geo.country_code == "TG"||
+  client.geo.country_code == "NE"
+)
+{
+  if (req.url ~ "^\/[a-z]{2}/subscribe/digital" && req.url == "/subscribe/digital"   ){
+       error 619;
+    }
+}


### PR DESCRIPTION
## What are you doing in this PR?

Any users landing on the subscription checkout route should be redirected them to the S+ checkout, where they will be allocated in the VAT compliant amounts test.

[**Trello Card**](https://trello.com/c/lzATPJUo/1698-editions-prevent-users-in-vat-impacted-countries-from-purchasing-digi-subs)

## Why are you doing this?
This is to prevent users in VAT impacted countries from purchasing Digital Subscriptions

## Is this an AB test?
- [ ] Yes
- [X ] No


