### PR TITLE
Enable makeItAnnualNudgeGlobal for USA

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -122,6 +122,6 @@ export const tests: Tests = {
 		omitCountries: countriesAffectedByVATStatus,
 		referrerControlled: false,
 		seed: 0,
-		targetPage: pageUrlRegexes.contributions.notUsLandingPage,
+		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 	},
 };


### PR DESCRIPTION
## What are you doing in this PR?

The `targetPage` for `makeItAnnualNudgeGlobal` was blocking the users in the US from entering the test, this fixes that. 