### PR TITLE
Black Friday Appeal Subscriptions Landing Closing Date

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsLandingContent.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsLandingContent.tsx
@@ -23,7 +23,7 @@ function SubscriptionsLandingContent({
 		participations,
 	);
 
-	const blackFridayPeriod = new Date(2023, 11, 30);
+	const blackFridayPeriod = new Date(2023, 11, 1);
 	const isBlackFriday = new Date() < blackFridayPeriod;
 
 	const validBlackFridayProduct = (


### PR DESCRIPTION
## What are you doing in this PR?

Date correction offer to appear on Sub Landing Page until 30/11/2023

This matches promocode GWBLACKFRIDAY

[**Linked BlackFriday PR**](https://github.com/guardian/support-frontend/pull/5417) 

[**Trello Card**](https://trello.com/c/vqW6PQYb/1651-black-friday-gw-landing-page-changes)

## Screenshots

![image](https://github.com/guardian/support-frontend/assets/76729591/ec21149e-d52c-4130-b0d6-ff54d5d2acdd)


## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)
 - [x] [Navigable with keyboard](https://www.accessibility-developer-guide.com/knowledge/keyboard-only/browsing-websites/)
 - [x] [Colour contrast passed](https://www.whocanuse.com/)



