### PR TITLE
feat: add actions/stale to marke PRs and issues as stale after 30 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,16 @@
+name: 'Close stale PRs'
+on:
+  schedule:
+    # 10:00, Tuesday - Thursday
+    # Avoids alerting people outside of working hours
+    - cron: '0 10 * * 2-4'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: 30
+          stale-issue-message: 'This issue has been open and inactive for 30 days and marked as stale. It will close in 7 days if there is no further activity.'
+          stale-pr-message: 'This PR has been open and inactive for 30 days and marked as stale. It will close in 7 days if there is no further activity.'


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Adds the [stale action](https://github.com/actions/stale) to the repo.

## Why are you doing this?
While we don't have a massive issue with tonnes of unclosed issues and PRs I was going to go asking folk if we can close some of the older ones to reduce noise and remembered - there's an action for this.

This will hopefully allow us to glance at the PRs number and be happy knowing that's how many things are in review.

We could then use something like [PR Announcer](https://github.com/guardian/actions-prnouncer) too.

