### PR TITLE
Redirect on obj.http.Location for VAT compliance redirects

### DIFF
--- a/support-frontend/conf/fastly-snippets/vat-compliance-redirects-error.vcl
+++ b/support-frontend/conf/fastly-snippets/vat-compliance-redirects-error.vcl
@@ -1,7 +1,6 @@
 # type: error
 if (obj.status == 619) {
    set obj.status = 301;
-   set obj.response = "Moved Permanently";
-   set req.http.Location = "https://support.theguardian.com/contribute";
+   set obj.http.Location = "https://support.theguardian.com/contribute";
    return (deliver);
 }

--- a/support-frontend/conf/fastly-snippets/vat-compliance-redirects-recv.vcl
+++ b/support-frontend/conf/fastly-snippets/vat-compliance-redirects-recv.vcl
@@ -1,46 +1,46 @@
 # type: recv
-   if (
-  client.geo.country_code == "RS"||
-  client.geo.country_code == "EG"||
-  client.geo.country_code == "PK"||
-  client.geo.country_code == "MU"||
-  client.geo.country_code == "BH"||
-  client.geo.country_code == "MA"||
-  client.geo.country_code == "MC"||
-  client.geo.country_code == "OM"||
-  client.geo.country_code == "GE"||
-  client.geo.country_code == "NC"||
-  client.geo.country_code == "TZ"||
-  client.geo.country_code == "ZM"||
-  client.geo.country_code == "AL"||
-  client.geo.country_code == "BD"||
-  client.geo.country_code == "KZ"||
-  client.geo.country_code == "CW"||
-  client.geo.country_code == "DO"||
-  client.geo.country_code == "GP"||
-  client.geo.country_code == "MQ"||
-  client.geo.country_code == "PF"||
-  client.geo.country_code == "TN"||
-  client.geo.country_code == "BQ"||
-  client.geo.country_code == "AX"||
-  client.geo.country_code == "SN"||
-  client.geo.country_code == "AM"||
-  client.geo.country_code == "CM"||
-  client.geo.country_code == "AO"||
-  client.geo.country_code == "KG"||
-  client.geo.country_code == "MR"||
-  client.geo.country_code == "GA"||
-  client.geo.country_code == "UZ"||
-  client.geo.country_code == "MD"||
-  client.geo.country_code == "DZ"||
-  client.geo.country_code == "TJ"||
-  client.geo.country_code == "LS"||
-  client.geo.country_code == "CG"||
-  client.geo.country_code == "TG"||
+# fiddle: https://fiddle.fastly.dev/fiddle/6db36311
+if (
+  client.geo.country_code == "RS" ||
+  client.geo.country_code == "EG" ||
+  client.geo.country_code == "PK" ||
+  client.geo.country_code == "MU" ||
+  client.geo.country_code == "BH" ||
+  client.geo.country_code == "MA" ||
+  client.geo.country_code == "MC" ||
+  client.geo.country_code == "OM" ||
+  client.geo.country_code == "GE" ||
+  client.geo.country_code == "NC" ||
+  client.geo.country_code == "TZ" ||
+  client.geo.country_code == "ZM" ||
+  client.geo.country_code == "AL" ||
+  client.geo.country_code == "BD" ||
+  client.geo.country_code == "KZ" ||
+  client.geo.country_code == "CW" ||
+  client.geo.country_code == "DO" ||
+  client.geo.country_code == "GP" ||
+  client.geo.country_code == "MQ" ||
+  client.geo.country_code == "PF" ||
+  client.geo.country_code == "TN" ||
+  client.geo.country_code == "BQ" ||
+  client.geo.country_code == "AX" ||
+  client.geo.country_code == "SN" ||
+  client.geo.country_code == "AM" ||
+  client.geo.country_code == "CM" ||
+  client.geo.country_code == "AO" ||
+  client.geo.country_code == "KG" ||
+  client.geo.country_code == "MR" ||
+  client.geo.country_code == "GA" ||
+  client.geo.country_code == "UZ" ||
+  client.geo.country_code == "MD" ||
+  client.geo.country_code == "DZ" ||
+  client.geo.country_code == "TJ" ||
+  client.geo.country_code == "LS" ||
+  client.geo.country_code == "CG" ||
+  client.geo.country_code == "TG" ||
   client.geo.country_code == "NE"
-)
-{
-  if (req.url ~ "^\/[a-z]{2}/subscribe/digital" || req.url == "/subscribe/digital"   ){
-       error 619;
-    }
+) {
+  if (req.url ~ "^\/[a-z]{2}/subscribe/digital" || req.url == "/subscribe/digital"){
+    error 619;
+  }
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Using `obj.http.Location` to send the `Location` header as per the examples

[Here's a fiddle to prove it](https://fiddle.fastly.dev/fiddle/6db36311) for now until we have more robust testing.
