### PR TITLE
fix: Add `default: true` to delete-snippets on deploy-fastly-snippets action

### DIFF
--- a/.github/workflows/deploy-fastly-snippets.yaml
+++ b/.github/workflows/deploy-fastly-snippets.yaml
@@ -10,9 +10,11 @@ on:
         type: boolean
         description: Delete all Fastly snippets before deploying
         required: true
+        default: true
       lock-and-activate-service:
         type: boolean
         description: Lock and activate the service version after snippets are deployed
+        required: true
         default: true
 jobs:
   deploy_fastly_snippets:


### PR DESCRIPTION
## What are you doing in this PR?
Ensures that both inputs are required and default to true.

These default to true as that is the expected behaviour, with the option to opt-out for testing.
