### PR TITLE
fix case typo in import statement

### DIFF
--- a/support-e2e/tests/gwCheckout.test.ts
+++ b/support-e2e/tests/gwCheckout.test.ts
@@ -4,7 +4,7 @@ import { email, firstName, lastName } from "./utils/users";
 import { checkRecaptcha } from "./utils/recaptcha";
 import { fillInCardDetails } from "./utils/cardDetails";
 import { fillInDirectDebitDetails } from "./utils/directDebitDetails";
-import { fillInPayPalDetails } from "./utils/PayPal";
+import { fillInPayPalDetails } from "./utils/payPal";
 import { setupPage } from "./utils/page";
 
 type PaymentType = "Credit/Debit card" | "Direct debit" | "PayPal";


### PR DESCRIPTION
## What are you doing in this PR?
Fix case typo in import statement in GW e2e test

## Screenshots
Before            |  After
:-------------------------:|:-------------------------:
![](https://github.com/guardian/support-frontend/assets/2510683/7380ad0a-d2bd-4658-8e90-11f610d5784f)  |  ![](https://github.com/guardian/support-frontend/assets/2510683/7741f07f-788f-4295-810c-c8032cba25fc)
