### PR TITLE
Replace /kindle route with /subscribe/digitaledition

### DIFF
--- a/support-frontend/app/controllers/DigitalSubscriptionController.scala
+++ b/support-frontend/app/controllers/DigitalSubscriptionController.scala
@@ -46,7 +46,7 @@ class DigitalSubscriptionController(
     if (orderIsAGift) "subscribe/digital/gift" else "subscribe/digital",
   )
 
-  def kindleGeoRedirectWithPromoCode(): Action[AnyContent] = geoRedirect("kindle?promoCode=DLESNCWON")
+  def digitalEditionGeoRedirect(): Action[AnyContent] = geoRedirect("subscribe/digitaledition")
 
   def digital(countryCode: String, orderIsAGift: Boolean): Action[AnyContent] = {
     MaybeAuthenticatedAction { implicit request =>

--- a/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionRouter.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionRouter.tsx
@@ -63,7 +63,6 @@ const router = () => {
 								element={landingPage}
 							/>
 							<Route
-								// path={`/${countryId}/thankyou`}
 								path={`/${countryId}/subscribe/digitaledition/thankyou`}
 								element={<DigitalSubscriptionThankYou />}
 							/>

--- a/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionRouter.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionRouter.tsx
@@ -62,11 +62,11 @@ const router = () => {
 								path={`/${countryId}/subscribe/digitaledition`}
 								element={landingPage}
 							/>
-              <Route
-                // path={`/${countryId}/thankyou`}
-                path={`/${countryId}/subscribe/digitaledition/thankyou`}
-                element={<DigitalSubscriptionThankYou />}
-              />
+							<Route
+								// path={`/${countryId}/thankyou`}
+								path={`/${countryId}/subscribe/digitaledition/thankyou`}
+								element={<DigitalSubscriptionThankYou />}
+							/>
 						</>
 					))}
 				</Routes>

--- a/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionRouter.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionRouter.tsx
@@ -56,26 +56,17 @@ const router = () => {
 		<BrowserRouter>
 			<Provider store={store}>
 				<Routes>
-					{/* We're supporting both routes for now until we make `/kindle` obsolete */}
 					{countryIds.map((countryId) => (
 						<>
-							<Route path={`/${countryId}/kindle`} element={landingPage} />
 							<Route
-								path={`/${countryId}/subscribe/digital`}
+								path={`/${countryId}/subscribe/digitaledition`}
 								element={landingPage}
 							/>
-						</>
-					))}
-					{countryIds.map((countryId) => (
-						<>
-							<Route
-								path={`/${countryId}/kindle/thankyou`}
-								element={<DigitalSubscriptionThankYou />}
-							/>
-							<Route
-								path={`/${countryId}/thankyou`}
-								element={<DigitalSubscriptionThankYou />}
-							/>
+              <Route
+                // path={`/${countryId}/thankyou`}
+                path={`/${countryId}/subscribe/digitaledition/thankyou`}
+                element={<DigitalSubscriptionThankYou />}
+              />
 						</>
 					))}
 				</Routes>

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -99,8 +99,8 @@ GET  /subscribe/digital                                            controllers.D
 GET  /subscribe/digital/gift                                       controllers.DigitalSubscriptionController.digitalGeoRedirect(orderIsAGift: Boolean = true)
 GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe/digital          controllers.DigitalSubscriptionController.digital(country: String, orderIsAGift: Boolean = false)
 GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe/digital/gift     controllers.DigitalSubscriptionController.digital(country: String, orderIsAGift: Boolean = true)
-GET  /kindle                                                       controllers.DigitalSubscriptionController.kindleGeoRedirectWithPromoCode()
-GET  /$country<(uk|us|au|eu|int|nz|ca)>/kindle                     controllers.DigitalSubscriptionController.digital(country: String, orderIsAGift: Boolean = false)
+GET  /subscribe/digitaledition                                     controllers.DigitalSubscriptionController.digitalEditionGeoRedirect()
+GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe/digitaledition   controllers.DigitalSubscriptionController.digital(country: String, orderIsAGift: Boolean = false)
 
 # redirect from old checkout urls
 GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe/digital/checkout       controllers.Application.permanentRedirectWithCountry(country, location="/subscribe/digital/checkout")


### PR DESCRIPTION
## What are you doing in this PR?

Replace the `/kindle` route with a new route `/subscribe/digitaledition` as requested by stakeholders. This route loads the Digital Subscription checkout.

[**Trello Card**](https://trello.com/c/wLKDl31x/1715-editions-enable-subscribe-digital-route-in-prod-remove-noindex-restriction)