### PR TITLE
Swap `kindle` for `digitaledition` on country selector

### DIFF
--- a/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionLandingPage.tsx
@@ -125,7 +125,7 @@ export function SupporterPlusLandingPage({
 			International,
 		],
 		selectedCountryGroup: countryGroupId,
-		subPath: '/kindle',
+		subPath: '/subscribe/digitaledition',
 	};
 	const heading = (
 		<LandingPageHeading heading="Under no one’s thumb but yours" />


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Making sure the country selector points to the `digitalsubscription` route. This is a hangover from some refactoring.


**Before**
<img width="974" alt="Screenshot 2023-12-06 at 09 28 36" src="https://github.com/guardian/support-frontend/assets/31692/610a0418-82cf-40f1-b897-b68aeaa8a2a2">

**After**
<img width="821" alt="Screenshot 2023-12-06 at 09 28 12" src="https://github.com/guardian/support-frontend/assets/31692/bed44f92-26a7-4373-b974-350c714f790f">