### PR TITLE
Remove referrences to the "Kindle" checkout

### DIFF
--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -319,7 +319,7 @@ object DigitalPackValidation {
     def isValidPaidSub(paymentFields: PaymentFields) =
       SimpleCheckoutFormValidation.passes(createSupportWorkersRequest) and
         hasStateIfRequired(country, state) and
-        // Lines removed to facilitate purchase of digi subs via the S+ checkout for migrating Kindle customers
+        // Lines removed to facilitate purchase of digi subs via the S+ checkout
         // hasAddressLine1AndCity(billingAddress) and
         // hasPostcodeIfRequired(country, postCode) and
         // hasValidPostcodeLength(postCode, "Billing") and

--- a/support-frontend/assets/components/paymentButton/digitalSubscriberPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/digitalSubscriberPaymentButtonContainer.tsx
@@ -22,7 +22,7 @@ function getButtonText(
 	}`;
 }
 
-export function KindleSubscriberPaymentButtonContainer({
+export function DigitalSubscriberPaymentButtonContainer({
 	onClick,
 	createButtonText = getButtonText,
 }: DefaultPaymentContainerProps): JSX.Element {

--- a/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionLandingPage.tsx
@@ -19,7 +19,7 @@ import { Container } from 'components/layout/container';
 import { LoadingOverlay } from 'components/loadingOverlay/loadingOverlay';
 import Nav from 'components/nav/nav';
 import { PageScaffold } from 'components/page/pageScaffold';
-import { KindleSubscriberPaymentButtonContainer } from 'components/paymentButton/kindleSubscriberPaymentButtonContainer';
+import { DigitalSubscriberPaymentButtonContainer } from 'components/paymentButton/digitalSubscriberPaymentButtonContainer';
 import { PaymentButtonController } from 'components/paymentButton/paymentButtonController';
 import { PaymentMethodSelector } from 'components/paymentMethodSelector/paymentMethodSelector';
 import PaymentMethodSelectorContainer from 'components/paymentMethodSelector/PaymentMethodSelectorContainer';
@@ -210,7 +210,7 @@ export function SupporterPlusLandingPage({
 										)}
 									/>
 									<PaymentButtonController
-										defaultContainer={KindleSubscriberPaymentButtonContainer}
+										defaultContainer={DigitalSubscriberPaymentButtonContainer}
 										paymentButtons={getPaymentMethodButtons(
 											contributionType,
 											switches,

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -147,7 +147,7 @@ function getBillingCountryAndState(state: ContributionsState): {
 	};
 }
 
-// This exists *only* to support the purchase of digi subs for migrating Kindle subscribers
+// This exists *only* to support the purchase of digi subs
 function getPromoCode(state: ContributionsState) {
 	const promotion = getSubscriptionPromotionForBillingPeriod(state);
 	if (promotion) {

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -162,7 +162,7 @@ function getProductFields(
 	state: ContributionsState,
 	amount: number,
 ): RegularPaymentRequest['product'] {
-	// This exists *only* to support the purchase of digi subs for migrating Kindle subscribers
+	// This exists *only* to support the purchase of digi subs
 	if (state.page.checkoutForm.product.productType === 'DigitalPack') {
 		return {
 			productType: 'DigitalPack',


### PR DESCRIPTION
## What are you doing in this PR?

Small bits of tidy up following the deprecation of the "Kindle" route, and the repurposing of the associated checkout for putting Digital Subscriptions (for the Edition) back on market.

