### PR TITLE
Upgrade java 8 => java 11 for support-lambdas and Update  ch.qos.logback:logback-classic to 1.4.13

### DIFF
--- a/.github/workflows/support-lambdas-build.yml
+++ b/.github/workflows/support-lambdas-build.yml
@@ -47,11 +47,11 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: actions/setup-java@v3
         with:
-          java-version: "8"
-          distribution: "adopt"
+          java-version: "11"
+          distribution: "corretto"
       - uses: actions/cache@v3
         with:
           path: |

--- a/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
+++ b/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
@@ -149,7 +149,7 @@ Logs are at https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-w
             "Arn",
           ],
         },
-        "Runtime": "java8.al2",
+        "Runtime": "java11",
         "Tags": [
           {
             "Key": "App",

--- a/cdk/lib/bigquery-acquisitions-publisher.ts
+++ b/cdk/lib/bigquery-acquisitions-publisher.ts
@@ -112,7 +112,7 @@ export class BigqueryAcquisitionsPublisher extends GuStack {
 
     new GuLambdaFunction(this, `${appName}Lambda`, {
       app: appName,
-      runtime: Runtime.JAVA_8_CORRETTO,
+      runtime: Runtime.JAVA_11,
       fileName: `${appName}.jar`,
       functionName,
       handler: "com.gu.bigqueryAcquisitionsPublisher.Lambda::handler",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
 
 addSbtPlugin(
-  "com.typesafe.play" % "sbt-plugin" % "2.8.19",
+  "com.typesafe.play" % "sbt-plugin" % "2.8.21",
 ) // when updating major version, also update play-circe version
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")

--- a/stripe-patrons-data/build.sbt
+++ b/stripe-patrons-data/build.sbt
@@ -9,7 +9,7 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.4.11",
+  "ch.qos.logback" % "logback-classic" % "1.4.12",
   "software.amazon.awssdk" % "dynamodb" % awsClientVersion2,
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",

--- a/stripe-patrons-data/build.sbt
+++ b/stripe-patrons-data/build.sbt
@@ -9,7 +9,7 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.4.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.13",
   "software.amazon.awssdk" % "dynamodb" % awsClientVersion2,
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",

--- a/support-lambdas/acquisition-events-api/build.sbt
+++ b/support-lambdas/acquisition-events-api/build.sbt
@@ -8,7 +8,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.3",
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
-  "ch.qos.logback" % "logback-classic" % "1.1.11",
+  "ch.qos.logback" % "logback-classic" % "1.4.12",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-lambdas/acquisition-events-api/build.sbt
+++ b/support-lambdas/acquisition-events-api/build.sbt
@@ -8,7 +8,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.3",
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
-  "ch.qos.logback" % "logback-classic" % "1.4.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.13",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-lambdas/acquisitions-firehose-transformer/build.sbt
+++ b/support-lambdas/acquisitions-firehose-transformer/build.sbt
@@ -5,7 +5,7 @@ description := "A Firehose transformation lambda for serialising the acquisition
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.3",
-  "ch.qos.logback" % "logback-classic" % "1.4.12",
+  "ch.qos.logback" % "logback-classic" % "1.3.14",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-lambdas/acquisitions-firehose-transformer/build.sbt
+++ b/support-lambdas/acquisitions-firehose-transformer/build.sbt
@@ -5,7 +5,7 @@ description := "A Firehose transformation lambda for serialising the acquisition
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.3",
-  "ch.qos.logback" % "logback-classic" % "1.3.14",
+  "ch.qos.logback" % "logback-classic" % "1.1.11",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-lambdas/acquisitions-firehose-transformer/build.sbt
+++ b/support-lambdas/acquisitions-firehose-transformer/build.sbt
@@ -5,7 +5,7 @@ description := "A Firehose transformation lambda for serialising the acquisition
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.3",
-  "ch.qos.logback" % "logback-classic" % "1.4.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.13",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-lambdas/acquisitions-firehose-transformer/build.sbt
+++ b/support-lambdas/acquisitions-firehose-transformer/build.sbt
@@ -5,7 +5,7 @@ description := "A Firehose transformation lambda for serialising the acquisition
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.3",
-  "ch.qos.logback" % "logback-classic" % "1.1.11",
+  "ch.qos.logback" % "logback-classic" % "1.4.12",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-lambdas/acquisitions-firehose-transformer/cfn.yaml
+++ b/support-lambdas/acquisitions-firehose-transformer/cfn.yaml
@@ -31,7 +31,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${App}-${Stage}
       Description: A Firehose transformation lambda for serialising the acquisitions event stream to csv
-      Runtime: java8.al2
+      Runtime: java11
       Handler: com.gu.acquisitionFirehoseTransformer.Lambda::handler
       MemorySize: 512
       Timeout: 300

--- a/support-lambdas/bigquery-acquisitions-publisher/build.sbt
+++ b/support-lambdas/bigquery-acquisitions-publisher/build.sbt
@@ -8,7 +8,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.1",
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
-  "ch.qos.logback" % "logback-classic" % "1.4.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.13",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion

--- a/support-lambdas/bigquery-acquisitions-publisher/build.sbt
+++ b/support-lambdas/bigquery-acquisitions-publisher/build.sbt
@@ -8,7 +8,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.1",
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
-  "ch.qos.logback" % "logback-classic" % "1.1.11",
+  "ch.qos.logback" % "logback-classic" % "1.4.12",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion

--- a/support-lambdas/it-test-runner/build.sbt
+++ b/support-lambdas/it-test-runner/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
-  "ch.qos.logback" % "logback-classic" % "1.2.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.12",
   "io.symphonia" % "lambda-logging" % "1.0.3",
   "org.scalatest" %% "scalatest" % "3.2.16", // not a "Test" dependency, it's an actual one
 )

--- a/support-lambdas/it-test-runner/build.sbt
+++ b/support-lambdas/it-test-runner/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
-  "ch.qos.logback" % "logback-classic" % "1.4.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.13",
   "io.symphonia" % "lambda-logging" % "1.0.3",
   "org.scalatest" %% "scalatest" % "3.2.16", // not a "Test" dependency, it's an actual one
 )

--- a/support-lambdas/stripe-intent/build.sbt
+++ b/support-lambdas/stripe-intent/build.sbt
@@ -32,5 +32,5 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
-  "ch.qos.logback" % "logback-classic" % "1.4.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.13",
 )

--- a/support-lambdas/stripe-intent/build.sbt
+++ b/support-lambdas/stripe-intent/build.sbt
@@ -32,5 +32,5 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
-  "ch.qos.logback" % "logback-classic" % "1.2.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.12",
 )

--- a/support-lambdas/stripe-intent/cfn.yaml
+++ b/support-lambdas/stripe-intent/cfn.yaml
@@ -37,7 +37,7 @@ Resources:
         Bucket: support-workers-dist
         Key: !Sub support/${Stage}/stripe-intent/stripe-intent.jar
       MemorySize: 2048
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 300
       Environment:
         Variables:

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -11,7 +11,7 @@ scalacOptions ++= Seq(
 addCompilerPlugin("org.typelevel" % "kind-projector_2.13.4" % "0.13.2")
 
 libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.4.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.13",
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -11,7 +11,7 @@ scalacOptions ++= Seq(
 addCompilerPlugin("org.typelevel" % "kind-projector_2.13.4" % "0.13.2")
 
 libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.2.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.12",
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -8,9 +8,9 @@ scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-release:8", "-
 libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "2.2.3",
   "org.typelevel" %% "cats-core" % catsVersion,
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
-  "ch.qos.logback" % "logback-classic" % "1.2.12",
-  "io.symphonia" % "lambda-logging" % "1.0.1",
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
+  "ch.qos.logback" % "logback-classic" % "1.4.7",
+  "io.symphonia" % "lambda-logging" % "1.0.3",
   "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
   "io.lemonlabs" %% "scala-uri" % scalaUriVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % "0.14.3",
   "io.circe" %% "circe-parser" % circeVersion,
-  "io.sentry" % "sentry-logback" % "1.7.30",
+  "io.sentry" % "sentry-logback" % "6.19.0",
   "com.google.code.findbugs" % "jsr305" % "3.0.2",
   "com.gocardless" % "gocardless-pro" % "2.10.0",
 )

--- a/supporter-product-data/build.sbt
+++ b/supporter-product-data/build.sbt
@@ -5,7 +5,7 @@ import sbt.Keys.libraryDependencies
 version := "0.1-SNAPSHOT"
 
 libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.4.13",
+  "ch.qos.logback" % "logback-classic" % "1.4.12",
   "software.amazon.awssdk" % "dynamodb" % awsClientVersion2,
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,

--- a/supporter-product-data/build.sbt
+++ b/supporter-product-data/build.sbt
@@ -5,7 +5,7 @@ import sbt.Keys.libraryDependencies
 version := "0.1-SNAPSHOT"
 
 libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.4.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.13",
   "software.amazon.awssdk" % "dynamodb" % awsClientVersion2,
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,

--- a/supporter-product-data/build.sbt
+++ b/supporter-product-data/build.sbt
@@ -5,7 +5,7 @@ import sbt.Keys.libraryDependencies
 version := "0.1-SNAPSHOT"
 
 libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.2.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.12",
   "software.amazon.awssdk" % "dynamodb" % awsClientVersion2,
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,


### PR DESCRIPTION
## What are you doing in this PR?
This PR is to upgrade java version for support-lambdas from 8 to 11 and update  ch.qos.logback:logback-classic to 1.4.13

[**Trello Card**](https://trello.com/c/dmkZYn1T/1720-high-snyk-vulnerability-in-support-frontend-denial-of-service-dos-affecting-chqoslogbacklogback-classic-package-versions-1412)

## Why are you doing this?


This was flagged as a HIGH SNYK vulnerability in support-frontend:  Denial of Service (DoS) Affecting ch.qos.logback:logback-classic package, versions 1.4.13

<img width="1164" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/b3db696e-5a14-437b-a4b8-dd8a88e469a3">


Notes:

In order to make the  update of logback-classic to 1.4.13, support lambdas must be in Java 11 as the 1.4.x series requires Java 11 at build time and at runtime. [Refer.](https://github.com/qos-ch/logback)

Have made the  update logback-classic to 1.4.13  in
1. acquisition-events-api
2. bigquery-acquisitions-publisher
3. it-test-runner
4. payment-api
5. stripe-intent
6. supporter-product-data
7. stripe-patrons-data
8. acquisitions-firehose-transformer



This change does not include
1. com.gu.identity:identity-auth-play_2.13@4.12 because even if we update this to the latest version (4.15), the vulnerability cannot be removed 
2. com.gu.identity:identity-crypto_2.13@4.12 because even if we update this to the latest version (4.15), the vulnerability cannot be removed 
3. com.typesafe.play:play-logback_2.13@2.8.19  because even if we update this to the latest version (2.9.0), the vulnerability cannot be removed 
4. io.symphonia:lambda-logging@1.0.1 because even if we update this to the latest version (1.0.3), the vulnerability cannot be removed 

Issues

01. Update logback-classic to 1.4.7  in support-workers as it caused test failures and issues like below when upgraded to 1.4.13
   java.lang.NoClassDefFoundError: Could not initialize class com.gu.support.workers.JsonFixtures$
   java.lang.NoClassDefFoundError: Could not initialize class com.gu.config.Configuration$
  java.lang.AbstractMethodError: Receiver class io.symphonia.lambda.logging.DefaultLogbackConfigurator does not define or inherit an implementation of the resolved method 'abstract ch.qos.logback.classic.spi.Configurator$ExecutionStatus configure(ch.qos.logback.classic.LoggerContext)' of interface ch.qos.logback.classic.spi.Configurator.



JAVA 8 to 11 changes:

Have updated java versions from 8 to 11 in 
support-lambdas-build.yml
bigquery-acquisitions-publisher
acquisitions-firehose-transformer
stripe-intent
