### PR TITLE
Install and configure circular dependency plugin

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -99,6 +99,7 @@
     "@types/dompurify": "^3.0.2",
     "@types/seedrandom": "^3.0.7",
     "@types/uuid": "^9.0.2",
+    "circular-dependency-plugin": "^5.2.2",
     "classnames": "^2.2.6",
     "dompurify": "^3.0.3",
     "emotion-theming": "^11.0.0",

--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -10,6 +10,7 @@ const { getClassName } = require('./scripts/css');
 const entryPoints = require('./webpack.entryPoints');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
+const CircularDependencyPlugin = require('circular-dependency-plugin');
 
 const cssLoaders = [
 	{
@@ -83,6 +84,10 @@ module.exports = (cssFilename, jsFilename, minimizeCss) => ({
 		}),
 		...(minimizeCss ? [new CssMinimizerPlugin()] : []),
 		new CleanUpStatsPlugin(),
+		new CircularDependencyPlugin({
+			// exclude detection of files based on a RegExp
+			exclude: /a\.js|node_modules/,
+		}),
 	],
 
 	context: path.resolve(__dirname, 'assets'),
@@ -118,13 +123,13 @@ module.exports = (cssFilename, jsFilename, minimizeCss) => ({
 				exclude: {
 					and: [/node_modules/],
 					not: [
-            /@guardian\/consent-management-platform/,
-            /@guardian\/libs/,
-            // we need to include this here to support Safari < v14 which doens't support private class fields
-            // used here: https://github.com/guardian/csnx/blob/e3678d2fffb206ec560891db8ff0ce8c47b05328/libs/%40guardian/source-foundations/src/accessibility/focus-style-manager.ts#L9
-            // see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields
-            /@guardian\/source-foundations/
-          ],
+						/@guardian\/consent-management-platform/,
+						/@guardian\/libs/,
+						// we need to include this here to support Safari < v14 which doens't support private class fields
+						// used here: https://github.com/guardian/csnx/blob/e3678d2fffb206ec560891db8ff0ce8c47b05328/libs/%40guardian/source-foundations/src/accessibility/focus-style-manager.ts#L9
+						// see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields
+						/@guardian\/source-foundations/,
+					],
 				},
 				use: [
 					{

--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -86,7 +86,7 @@ module.exports = (cssFilename, jsFilename, minimizeCss) => ({
 		new CleanUpStatsPlugin(),
 		new CircularDependencyPlugin({
 			// exclude detection of files based on a RegExp
-			exclude: /a\.js|node_modules/,
+			exclude: /node_modules/,
 		}),
 	],
 

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -6791,6 +6791,11 @@ ci-info@^3.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
   integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
 
+circular-dependency-plugin@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/circular-dependency-plugin/-/circular-dependency-plugin-5.2.2.tgz#39e836079db1d3cf2f988dc48c5188a44058b600"
+  integrity sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==
+
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Installing and configuring the circular-dependency-plugin for webpack

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/hnt5M6GX/1719-fix-cyclical-file-dependencies)

## Why are you doing this?
This is a really helpful plugin that finds and highlights circular dependencies and outputs them in the terminal log. We have a larger task to remove those, and this is foundational to that challenge. 

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run the dev server, you should see extra output in the terminal that highlights all circular dependencies

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
This should only affect the webpack dev server, it might slow build down a little but we can always remove it later when the problematic dependencies have been removed as ESLint will ensure that no new ones are created in future.


## Screenshots
<img width="1506" alt="image" src="https://github.com/guardian/support-frontend/assets/99400613/ee5acbff-6a8d-4d59-a967-22518777d70c">
