### PR TITLE
playwright selector, assertion and config fixes

### DIFF
--- a/support-e2e/package.json
+++ b/support-e2e/package.json
@@ -7,8 +7,8 @@
 		"pw-prod-test": "playwright test --ui --config=playwright.prod.config.ts"
 	},
 	"dependencies": {
-		"@playwright/test": "1.36.0",
-		"browserstack-local": "^1.5.1",
+		"@playwright/test": "1.40.1",
+		"browserstack-local": "^1.5.5",
     "uuid": "^9.0.0"
 	},
 	"devDependencies": {

--- a/support-e2e/tests/recurringContributions.test.ts
+++ b/support-e2e/tests/recurringContributions.test.ts
@@ -41,7 +41,7 @@ test.describe("Sign up for a Recurring Contribution (Two-Step checkout)", () => 
       await page.getByRole("button", { name: "Continue to checkout" }).click();
       await setTestUserDetails(page, testFirstName, testLastName, testEmail);
       if (testDetails.country === "US") {
-        await page.getByLabel("State").fill("NY");
+        await page.getByLabel("State").selectOption({ label: "New York" })
         await page.getByLabel("ZIP code").fill("90210");
       }
       await page.getByRole("radio", { name: testDetails.paymentType }).check();
@@ -71,7 +71,7 @@ test.describe("Sign up for a Recurring Contribution (Two-Step checkout)", () => 
         testDetails.paymentType === "Direct debit"
       ) {
         await checkRecaptcha(page);
-        await page.getByText(/Pay (£|\$)([0-9]+) per (month|year)/).click();
+        await page.getByText(/(Pay|Support us with) (£|\$)([0-9]+) per (month|year)/).click();
       }
       await expect(page).toHaveURL(
         `/${testDetails.country?.toLowerCase() || "uk"}/thankyou`,

--- a/support-e2e/yarn.lock
+++ b/support-e2e/yarn.lock
@@ -2,22 +2,12 @@
 # yarn lockfile v1
 
 
-"@playwright/test@1.36.0":
-  version "1.36.0"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.36.0.tgz#df2c0b09bbd27016adf1892b0c3502c4ce88d307"
-  integrity sha512-yN+fvMYtiyLFDCQos+lWzoX4XW3DNuaxjBu68G0lkgLgC6BP+m/iTxJQoSicz/x2G5EsrqlZTqTIP9sTgLQerg==
+"@playwright/test@1.40.1":
+  version "1.40.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.40.1.tgz#9e66322d97b1d74b9f8718bacab15080f24cde65"
+  integrity sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==
   dependencies:
-    "@types/node" "*"
-    playwright-core "1.36.0"
-  optionalDependencies:
-    fsevents "2.3.2"
-
-"@types/node@*":
-  version "20.8.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.4.tgz#0e9ebb2ff29d5c3302fc84477d066fa7c6b441aa"
-  integrity sha512-ZVPnqU58giiCjSxjVUESDtdPk4QR5WQhhINbc9UBrKLU68MX5BF6kbQzTrkwbolyr0X8ChBpXfavr5mZFKZQ5A==
-  dependencies:
-    undici-types "~5.25.1"
+    playwright "1.40.1"
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -39,7 +29,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-browserstack-local@^1.5.1:
+browserstack-local@^1.5.5:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/browserstack-local/-/browserstack-local-1.5.5.tgz#f36b625f3b8bfd053f673d85fd1082f2d0759693"
   integrity sha512-jKne7yosrMcptj3hqxp36TP9k0ZW2sCqhyurX24rUL4G3eT7OLgv+CSQN8iq5dtkv5IK+g+v8fWvsiC/S9KxMg==
@@ -174,10 +164,19 @@ pause-stream@0.0.11:
   dependencies:
     through "~2.3"
 
-playwright-core@1.36.0:
-  version "1.36.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.36.0.tgz#35d1ed5f364a31e58bc8f06688ab02d538b96eb6"
-  integrity sha512-7RTr8P6YJPAqB+8j5ATGHqD6LvLLM39sYVNsslh78g8QeLcBs5750c6+msjrHUwwGt+kEbczBj1XB22WMwn+WA==
+playwright-core@1.40.1:
+  version "1.40.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.40.1.tgz#442d15e86866a87d90d07af528e0afabe4c75c05"
+  integrity sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==
+
+playwright@1.40.1:
+  version "1.40.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.40.1.tgz#a11bf8dca15be5a194851dbbf3df235b9f53d7ae"
+  integrity sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==
+  dependencies:
+    playwright-core "1.40.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 prettier@^3.0.3:
   version "3.0.3"
@@ -223,11 +222,6 @@ through@2, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
-
-undici-types@~5.25.1:
-  version "5.25.3"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.25.3.tgz#e044115914c85f0bcbb229f346ab739f064998c3"
-  integrity sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==
 
 uuid@^9.0.0:
   version "9.0.1"


### PR DESCRIPTION
## What are you doing in this PR?
Update version of playwright and browserstack dependancy to be happy not passing through 'allowDownloads' property to the test config when running the tests via browserstack. 

Change select element selection in test from 'fill' to 'selectOption'. 

Update assertion for 1st page of recurring contribution checkout to look for either 'pay  per X' OR 'Support us with  per X' instead of just the 'pay' string