### PR TITLE
Big query publisher deadletter retention

### DIFF
--- a/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
+++ b/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
@@ -542,6 +542,7 @@ Logs are at https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-w
     "deadlettersbigqueryacquisitionspublisherQueue2B5FA5C1": {
       "DeletionPolicy": "Delete",
       "Properties": {
+        "MessageRetentionPeriod": 1209600,
         "QueueName": "dead-letters-bigquery-acquisitions-publisher-PROD",
         "Tags": [
           {

--- a/cdk/lib/bigquery-acquisitions-publisher.ts
+++ b/cdk/lib/bigquery-acquisitions-publisher.ts
@@ -45,6 +45,7 @@ export class BigqueryAcquisitionsPublisher extends GuStack {
 
     const deadLetterQueue = new Queue(this, `dead-letters-${appName}Queue`, {
       queueName: deadLetterQueueName,
+      retentionPeriod: Duration.days(14),
     });
 
     const queue = new Queue(this, `${appName}Queue`, {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Currently the retention period on the BigQueryAcquisitionsPublisher dead letter queue is the default 4 days. This doesn't give much time to investigate and redrive any failures so this PR increases it to the maximum 14 days.