### PR TITLE
Fix CFN template for supporter-product-data

### DIFF
--- a/supporter-product-data/cloudformation/dynamo-tables.yaml
+++ b/supporter-product-data/cloudformation/dynamo-tables.yaml
@@ -136,6 +136,6 @@ Outputs:
   OnDemandTableOutput:
     Condition: CreateCodeResources
     Description: This Dynamo table is used to store rate plan information about supporters
-    Value: !GetAtt [ DevOrUatTable, "Arn" ]
+    Value: !GetAtt [ CodeTable, "Arn" ]
     Export:
       Name: !Sub ${AWS::StackName}-SupporterProductDataTable


### PR DESCRIPTION
## What are you doing in this PR?

The `supporter-product-data-tables-CODE` CloudFormation stack cannot currently be updated due to the following error:

`Template error: instance of Fn::GetAtt references undefined resource DevOrUatTable`

I think this is due to a small omission from https://github.com/guardian/support-frontend/pull/4938, so this PR is just tidying up.

## Deployment

I don't think the Dynamo CFN changes in https://github.com/guardian/support-frontend/pull/4938 have ever been applied. This means that (manually) deploying this change will also deploy the changes in https://github.com/guardian/support-frontend/pull/4938/files#diff-99f29580ec61fd20b364bd7ae277583f1e36b8c6e192942a19f0b12e7db32495. 

~⚠️ Because the [logical id](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html#resources-section-structure-syntax) is changing we will be deleting the old table (`DevOrUatTable`) and creating a new empty one (`CodeTable`). All data that is currently in the `DevOrUatTable` will be lost ⚠️~ 

~I think there's a way to backup the data and then restore to the new table (although there will still be some downtime), so let me know if this data loss is going to be a problem and we can look into this in more detail.~

**Update**: I had to apply this update in 2 steps (and use a restore to retain the `CODE` data), but it has been applied now so CFN updates for these 2 stacks should be unblocked again. This PR just brings `main` back in line with what has actually been deployed.





