### PR TITLE
Remove cyclical dependency from product type

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -3,9 +3,11 @@ import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import { currencies } from 'helpers/internationalisation/currency';
 import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
 import { shouldHideBenefitsList } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
-import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import {
+	getContributionType,
+	getMinimumContributionAmount,
+} from 'helpers/redux/checkout/product/selectors/productType';
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
-import { getMinimumContributionAmount } from 'helpers/redux/commonState/selectors';
 import {
 	useContributionsDispatch,
 	useContributionsSelector,

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudgeContainer.tsx
@@ -6,13 +6,11 @@ import { detect, glyph } from 'helpers/internationalisation/currency';
 import { setProductType } from 'helpers/redux/checkout/product/actions';
 import {
 	getContributionType,
-	getSelectedAmount,
-} from 'helpers/redux/checkout/product/selectors/productType';
-import {
 	getMaximumContributionAmount,
 	getMinimumContributionAmount,
-	isUserInAbVariant,
-} from 'helpers/redux/commonState/selectors';
+	getSelectedAmount,
+} from 'helpers/redux/checkout/product/selectors/productType';
+import { isUserInAbVariant } from 'helpers/redux/commonState/selectors';
 import {
 	useContributionsDispatch,
 	useContributionsSelector,

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -6,8 +6,10 @@ import {
 	setSelectedAmount,
 	setSelectedAmountBeforeAmendment,
 } from 'helpers/redux/checkout/product/actions';
-import { getSelectedAmount } from 'helpers/redux/checkout/product/selectors/productType';
-import { getMinimumContributionAmount } from 'helpers/redux/commonState/selectors';
+import {
+	getMinimumContributionAmount,
+	getSelectedAmount,
+} from 'helpers/redux/checkout/product/selectors/productType';
 import { getOtherAmountErrors } from 'helpers/redux/selectors/formValidation/otherAmountValidation';
 import {
 	useContributionsDispatch,

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -1,10 +1,6 @@
 import { isAnyOf } from '@reduxjs/toolkit';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import { currencies } from 'helpers/internationalisation/currency';
-import {
-	getMaximumContributionAmount,
-	getMinimumContributionAmount,
-} from 'helpers/redux/commonState/selectors';
 import type { ContributionsStartListening } from 'helpers/redux/contributionsStore';
 import * as storage from 'helpers/storage/storage';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
@@ -18,7 +14,11 @@ import {
 	validateOtherAmount,
 } from './actions';
 import { getContributionCartValueData } from './selectors/cartValue';
-import { isContribution } from './selectors/productType';
+import {
+	getMaximumContributionAmount,
+	getMinimumContributionAmount,
+	isContribution,
+} from './selectors/productType';
 
 const shouldSendEventContributionCartValue = isAnyOf(
 	setAllAmounts,

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/productType.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/productType.ts
@@ -1,5 +1,5 @@
 import type { ContributionType, SelectedAmounts } from 'helpers/contributions';
-import { contributionTypes } from 'helpers/contributions';
+import { config, contributionTypes } from 'helpers/contributions';
 import type { SubscriptionProduct } from 'helpers/productPrice/subscriptions';
 import {
 	DigitalPack,
@@ -7,7 +7,6 @@ import {
 	Paper,
 	PaperAndDigital,
 } from 'helpers/productPrice/subscriptions';
-// eslint-disable-next-line import/no-cycle -- these are quite tricky to unpick so we should come back to this
 import { getDefaultContributionType } from 'helpers/redux/commonState/selectors';
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import type { SubscriptionsState } from 'helpers/redux/subscriptionsStore';
@@ -68,4 +67,28 @@ export function getSelectedAmount(
 	defaultAmount: number,
 ): number | string {
 	return selectedAmounts[contributionType] || defaultAmount;
+}
+
+export function getMinimumContributionAmount(
+	contributionType?: ContributionType,
+) {
+	return (state: ContributionsState): number => {
+		const { countryGroupId } = state.common.internationalisation;
+		const { min } =
+			config[countryGroupId][contributionType ?? getContributionType(state)];
+
+		return min;
+	};
+}
+
+export function getMaximumContributionAmount(
+	contributionType?: ContributionType,
+) {
+	return (state: ContributionsState): number => {
+		const { countryGroupId } = state.common.internationalisation;
+		const { max } =
+			config[countryGroupId][contributionType ?? getContributionType(state)];
+
+		return max;
+	};
 }

--- a/support-frontend/assets/helpers/redux/commonState/selectors.ts
+++ b/support-frontend/assets/helpers/redux/commonState/selectors.ts
@@ -1,7 +1,4 @@
 import type { ContributionType } from 'helpers/contributions';
-import { config } from 'helpers/contributions';
-// eslint-disable-next-line import/no-cycle -- these are quite tricky to unpick so we should come back to this
-import { getContributionType } from '../checkout/product/selectors/productType';
 import type { ContributionsState } from '../contributionsStore';
 
 export function getDefaultContributionType(
@@ -9,30 +6,6 @@ export function getDefaultContributionType(
 ): ContributionType {
 	const { defaultContributionType } = state.common.amounts;
 	return defaultContributionType;
-}
-
-export function getMinimumContributionAmount(
-	contributionType?: ContributionType,
-) {
-	return (state: ContributionsState): number => {
-		const { countryGroupId } = state.common.internationalisation;
-		const { min } =
-			config[countryGroupId][contributionType ?? getContributionType(state)];
-
-		return min;
-	};
-}
-
-export function getMaximumContributionAmount(
-	contributionType?: ContributionType,
-) {
-	return (state: ContributionsState): number => {
-		const { countryGroupId } = state.common.internationalisation;
-		const { max } =
-			config[countryGroupId][contributionType ?? getContributionType(state)];
-
-		return max;
-	};
 }
 
 export function isUserInAbVariant(abTestName: string, variantName: string) {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Removing cyclical dependency between `productType` and `selectors`

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/hnt5M6GX/1719-fix-cyclical-file-dependencies)

## Why are you doing this?
