### PR TITLE
fix: downgrade it-test-running logback-classic dep to 1.4.7

### DIFF
--- a/support-lambdas/it-test-runner/build.sbt
+++ b/support-lambdas/it-test-runner/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
-  "ch.qos.logback" % "logback-classic" % "1.4.13",
+  "ch.qos.logback" % "logback-classic" % "1.4.7",
   "io.symphonia" % "lambda-logging" % "1.0.3",
   "org.scalatest" %% "scalatest" % "3.2.16", // not a "Test" dependency, it's an actual one
 )


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Based on https://github.com/guardian/support-frontend/pull/5507, we think that we have a dependency issue where
* `support-workers` is dependent on `it-test-runner` when running in CI
* `it-test-runner` is on `logback-classic` `1.4.13` 
* `support-workers` doesn't work on `logback-classic` `1.4.13`

We are unsure of how to test this locally, but would like to get the tests green before working on a longer term fix and exploring how we could test this more thoroughly locally.
