### PR TITLE
Fix isLive flag use for regional amounts tests

### DIFF
--- a/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
@@ -432,7 +432,7 @@ describe('getAmountsTestVariant', () => {
 		}
 		return {
 			testName,
-			liveTestName: testName,
+			liveTestName: `${testName}_LIVE`,
 			isLive: withVariant,
 			targeting,
 			order: 0,
@@ -513,8 +513,8 @@ describe('getAmountsTestVariant', () => {
 			acquisitionAbTests,
 		);
 
-		expect(result.amountsParticipation).toEqual({ [testName]: 'V1' });
-		expect(result.selectedAmountsVariant.testName).toEqual(testName);
+		expect(result.amountsParticipation).toEqual({ [`${testName}_LIVE`]: 'V1' });
+		expect(result.selectedAmountsVariant.testName).toEqual(`${testName}_LIVE`);
 	});
 
 	it('targets amounts test based on region, and returns a participation because there is a variant', () => {
@@ -555,8 +555,8 @@ describe('getAmountsTestVariant', () => {
 			acquisitionAbTests,
 		);
 
-		expect(result.amountsParticipation).toEqual({ GBP_TEST: 'V1' });
-		expect(result.selectedAmountsVariant.testName).toEqual('GBP_TEST');
+		expect(result.amountsParticipation).toEqual({ GBP_TEST_LIVE: 'V1' });
+		expect(result.selectedAmountsVariant.testName).toEqual('GBP_TEST_LIVE');
 	});
 
 	it('targets amounts test based on region, and returns no participation because there is no variant', () => {
@@ -601,6 +601,37 @@ describe('getAmountsTestVariant', () => {
 		expect(result.selectedAmountsVariant.testName).toEqual('GBP_TEST');
 	});
 
+	it('targets amounts test based on region, and returns no participation because test is not live', () => {
+		const acquisitionAbTests: AcquisitionABTest[] = [];
+		const test = buildAmountsTest(
+			'GBP_TEST',
+			{
+				targetingType: 'Region',
+				region: 'GBPCountries',
+			},
+			true,
+		);
+		const tests = [
+			{
+				...test,
+				isLive: false, // test has a variant, but is not live
+			},
+		];
+
+		const result = getAmountsTestVariant(
+			country,
+			countryGroupId,
+			buildSettings(tests),
+			path,
+			mvt,
+			acquisitionAbTests,
+		);
+
+		expect(result.amountsParticipation).toBeUndefined();
+		expect(result.selectedAmountsVariant.testName).toEqual('GBP_TEST');
+		expect(result.selectedAmountsVariant.variantName).toEqual('CONTROL');
+	});
+
 	it('targets amounts test based on country, and returns a participation because there is a variant', () => {
 		const acquisitionAbTests: AcquisitionABTest[] = [];
 		const tests = [
@@ -631,8 +662,8 @@ describe('getAmountsTestVariant', () => {
 			acquisitionAbTests,
 		);
 
-		expect(result.amountsParticipation).toEqual({ COUNTRY_TEST: 'V1' });
-		expect(result.selectedAmountsVariant.testName).toEqual('COUNTRY_TEST');
+		expect(result.amountsParticipation).toEqual({ COUNTRY_TEST_LIVE: 'V1' });
+		expect(result.selectedAmountsVariant.testName).toEqual('COUNTRY_TEST_LIVE');
 	});
 });
 

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -6,7 +6,11 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import * as cookie from 'helpers/storage/cookie';
 import { getQueryParameter } from 'helpers/urls/url';
-import type { AmountsTest, SelectedAmountsVariant } from '../contributions';
+import type {
+	AmountsTest,
+	AmountsVariant,
+	SelectedAmountsVariant,
+} from '../contributions';
 import { tests } from './abtestDefinitions';
 import { getFallbackAmounts } from './helpers';
 
@@ -317,9 +321,21 @@ export function getAmountsTestVariant(
 		};
 	}
 
+	const selectVariant = (
+		isLive: boolean,
+		variants: AmountsVariant[],
+	): AmountsVariant => {
+		if (isLive && variants.length > 1) {
+			const assignmentIndex = randomNumber(mvt, seed) % variants.length;
+			return variants[assignmentIndex];
+		}
+		// For regional AmountsTests, if the test is not live then we use the control
+		return variants[0];
+	};
+
 	const currentTestName = isLive && liveTestName ? liveTestName : testName;
-	const assignmentIndex = randomNumber(mvt, seed) % variants.length;
-	const variant = variants[assignmentIndex];
+	const variant = selectVariant(isLive, variants);
+
 	const amountsParticipation = buildParticipation(
 		targetedTest,
 		currentTestName,


### PR DESCRIPTION
Regional amounts test configurations are still used even if `isLive: false`. This is because there is always a regional amounts configuration, and the control should be used if the AB test is not live.
Currently, if `isLive: false`, the checkout page may still show the variants.
This PR fixes this by ensuring only the control is used in this case.