### PR TITLE
fix: upgrade logback-classic to 1.3.14 in aquisition-firehose-transformer

### DIFF
--- a/support-lambdas/acquisitions-firehose-transformer/README.md
+++ b/support-lambdas/acquisitions-firehose-transformer/README.md
@@ -2,7 +2,7 @@
 This project contains a lambda which acts as a [transformer](https://docs.aws.amazon.com/firehose/latest/dev/data-transformation.html)
 for the `acquisitions-firehose-{STAGE}` Kinesis Data Firehose.
 
-The source of the this Data Firehose is the `acquisitions-stream-{STAGE}` Kinesis data stream and the destination is an S3 bucket.
+The source of this Data Firehose is the `acquisitions-stream-{STAGE}` Kinesis data stream and the destination is an S3 bucket.
 
 The data is then used to drive the epic super mode and tickers.
 

--- a/support-lambdas/acquisitions-firehose-transformer/build.sbt
+++ b/support-lambdas/acquisitions-firehose-transformer/build.sbt
@@ -5,7 +5,7 @@ description := "A Firehose transformation lambda for serialising the acquisition
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.3",
-  "ch.qos.logback" % "logback-classic" % "1.1.11",
+  "ch.qos.logback" % "logback-classic" % "1.3.14",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,


### PR DESCRIPTION
## What are you doing in this PR?
Part of: https://github.com/guardian/support-frontend/issues/5532

Upgrades `logback-classic` to 1.3.14. We are sticking to 1.13 rather than 1.14 as 1.14 requires Java 11, and we would like to decouple the Java 8 => Java 11 upgrade.

[You can read about `logback-classis`'s support here](https://github.com/qos-ch/logback?tab=readme-ov-file#java-ee-and-jakarta-ee-versions).

Tested locally on Java 8 via `testOnly com.gu.acquisitionFirehoseTransformer.LambdaSpec`