### PR TITLE
Stripe intent logback classic upgrade

### DIFF
--- a/support-lambdas/it-test-runner/build.sbt
+++ b/support-lambdas/it-test-runner/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
-  "ch.qos.logback" % "logback-classic" % "1.2.12",
+  "ch.qos.logback" % "logback-classic" % "1.3.14",
   "io.symphonia" % "lambda-logging" % "1.0.3",
   "org.scalatest" %% "scalatest" % "3.2.16", // not a "Test" dependency, it's an actual one
 )

--- a/support-lambdas/stripe-intent/build.sbt
+++ b/support-lambdas/stripe-intent/build.sbt
@@ -32,5 +32,5 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
-  "ch.qos.logback" % "logback-classic" % "1.2.12",
+  "ch.qos.logback" % "logback-classic" % "1.3.14",
 )


### PR DESCRIPTION
## What are you doing in this PR?
Part of: https://github.com/guardian/support-frontend/issues/5532

Upgrades `logback-classic` to 1.3.14. We are sticking to 1.13 rather than 1.14 as 1.14 requires Java 11, and we would like to decouple the Java 8 => Java 11 upgrade.

[You can read about `logback-classis`'s support here](https://github.com/qos-ch/logback?tab=readme-ov-file#java-ee-and-jakarta-ee-versions).

This was tested running:
```bash
 testOnly com.gu.stripeIntent.HandlerSpec

 # And after remove the @IntegrationTest
 testOnly com.gu.stripeIntent.HandlerITSpec
```