### PR TITLE
fix: upgrade logback-classic to 1.3.14 in aquisition-events-api

### DIFF
--- a/support-lambdas/acquisition-events-api/build.sbt
+++ b/support-lambdas/acquisition-events-api/build.sbt
@@ -8,7 +8,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.3",
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
-  "ch.qos.logback" % "logback-classic" % "1.1.11",
+  "ch.qos.logback" % "logback-classic" % "1.3.14",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,


### PR DESCRIPTION
## What are you doing in this PR?
Part of: https://github.com/guardian/support-frontend/issues/5532

Upgrades `logback-classic` to 1.3.14. We are sticking to 1.13 rather than 1.14 as 1.14 requires Java 11, and we would like to decouple the Java 8 => Java 11 upgrade.

[You can read about `logback-classis`'s support here](https://github.com/qos-ch/logback?tab=readme-ov-file#java-ee-and-jakarta-ee-versions).

This was tested running:
```bash
 testOnly com.gu.stripeIntent.HandlerSpec

 # And after remove the @IntegrationTest
 testOnly com.gu.stripeIntent.HandlerITSpec
```

The readme suggests running against a `LambdaSpec`, but there is no such thing.