### PR TITLE
Editions : TsAndCs Manage My Account Url amended

### DIFF
--- a/support-frontend/assets/pages/digital-subscriber-checkout/components/paymentTsAndCs.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/components/paymentTsAndCs.tsx
@@ -24,8 +24,7 @@ export function PaymentTsAndCs(): JSX.Element {
 			you cancel. You can cancel at any time before your next renewal date.
 			Cancellation will take effect at the end of your current subscription
 			month. To cancel, go to{' '}
-			<a href="https://profile.theguardian.com/">Manage My Account</a> or see
-			our{' '}
+			<a href="http://manage.theguardian.com/">Manage My Account</a> or see our{' '}
 			<a href="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions">
 				Terms
 			</a>


### PR DESCRIPTION
## What are you doing in this PR?

Digital Edition TsAndCs, change 'Manage My Account' from profile to manage. Profile won't send you through to manage unless you came from there.

|before|after|
|--------|---------|
|http://profile.theguardian.com/|http://manage.theguardian.com/|
