### PR TITLE
Build preRender DigitalSubscriptionLandingPage and simplify preRender SupporterPlusLandingPage

### DIFF
--- a/support-frontend/app/controllers/DigitalSubscriptionController.scala
+++ b/support-frontend/app/controllers/DigitalSubscriptionController.scala
@@ -60,7 +60,6 @@ class DigitalSubscriptionController(
         } else {
           "Support the Guardian | The Guardian Digital Subscription"
         }
-        val id = EmptyDiv("digital-subscription-checkout-page-" + countryCode)
         val js = "digitalSubscriptionLandingPage.js"
         val css = "digitalSubscriptionLandingPage.css"
         val csrf = CSRF.getToken.value
@@ -72,10 +71,14 @@ class DigitalSubscriptionController(
         val maybePromotionCopy = {
           landingCopyProvider.promotionCopy(promoCodes ++ defaultPromos, DigitalPack, "uk", orderIsAGift)
         }
+        val mainElement = assets.getSsrCacheContentsAsHtml(
+          divId = s"digital-subscription-landing-$countryCode",
+          file = "digital-subscription-landing.html",
+        )
         Ok(
           views.html.subscriptionCheckout(
             title,
-            id,
+            mainElement,
             js,
             css,
             Some(csrf),

--- a/support-frontend/app/controllers/DigitalSubscriptionFormController.scala
+++ b/support-frontend/app/controllers/DigitalSubscriptionFormController.scala
@@ -51,7 +51,7 @@ class DigitalSubscriptionFormController(
     } else {
       "Support the Guardian | The Guardian Digital Subscription"
     }
-    val id = EmptyDiv("digital-subscription-landing")
+    val id = EmptyDiv("digital-subscription-checkout-page")
     val js = "digitalSubscriptionCheckoutPage.js"
     val css = "digitalSubscriptionCheckoutPage.css"
     val csrf = CSRF.getToken.value
@@ -83,10 +83,7 @@ class DigitalSubscriptionFormController(
   def displayThankYouExisting(): Action[AnyContent] = CachedAction() { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = "Support the Guardian | The Guardian Digital Subscription"
-    val mainElement = assets.getSsrCacheContentsAsHtml(
-      divId = s"digital-subscription-landing",
-      file = "digital-subscription-landing.html",
-    )
+    val mainElement = EmptyDiv("digital-subscription-checkout-page")
     val js = Left(RefPath("digitalSubscriptionCheckoutPageThankYouExisting.js"))
     val css = Left(RefPath("digitalSubscriptionCheckoutPageThankYouExisting.css"))
 

--- a/support-frontend/app/controllers/DigitalSubscriptionFormController.scala
+++ b/support-frontend/app/controllers/DigitalSubscriptionFormController.scala
@@ -51,7 +51,7 @@ class DigitalSubscriptionFormController(
     } else {
       "Support the Guardian | The Guardian Digital Subscription"
     }
-    val id = EmptyDiv("digital-subscription-checkout-page")
+    val id = EmptyDiv("digital-subscription-landing")
     val js = "digitalSubscriptionCheckoutPage.js"
     val css = "digitalSubscriptionCheckoutPage.css"
     val csrf = CSRF.getToken.value
@@ -83,7 +83,10 @@ class DigitalSubscriptionFormController(
   def displayThankYouExisting(): Action[AnyContent] = CachedAction() { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = "Support the Guardian | The Guardian Digital Subscription"
-    val mainElement = EmptyDiv("digital-subscription-checkout-page")
+    val mainElement = assets.getSsrCacheContentsAsHtml(
+      divId = s"digital-subscription-landing",
+      file = "digital-subscription-landing.html",
+    )
     val js = Left(RefPath("digitalSubscriptionCheckoutPageThankYouExisting.js"))
     val css = Left(RefPath("digitalSubscriptionCheckoutPageThankYouExisting.css"))
 

--- a/support-frontend/assets/components/checkoutHeading/checkoutHeading.tsx
+++ b/support-frontend/assets/components/checkoutHeading/checkoutHeading.tsx
@@ -27,7 +27,7 @@ const headingContentContainer = css`
 `;
 
 export interface CheckoutHeadingProps extends CSSOverridable {
-	heading: React.ReactNode;
+	heading?: React.ReactNode;
 	children?: React.ReactNode;
 	image?: React.ReactNode;
 	withTopborder?: true;

--- a/support-frontend/assets/helpers/rendering/ssrPages.ts
+++ b/support-frontend/assets/helpers/rendering/ssrPages.ts
@@ -1,9 +1,14 @@
 import { renderToString } from 'react-dom/server';
+import { digitalSubscriptionLandingPage } from 'pages/digital-subscriber-checkout/preRenderDigitalSubscriptionLandingPage';
 import { supporterPlusLanding } from 'pages/supporter-plus-landing/preRenderSupporterPlusLandingPage';
 
 export const pages = [
 	{
 		filename: 'supporter-plus-landing.html',
 		html: renderToString(supporterPlusLanding),
+	},
+	{
+		filename: 'digital-subscription-landing.html',
+		html: renderToString(digitalSubscriptionLandingPage),
 	},
 ];

--- a/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionLandingPage.tsx
@@ -94,7 +94,7 @@ const leftColImageEditions = css`
 	}
 `;
 
-export function SupporterPlusLandingPage({
+export function DigitalSubscriptionLandingPage({
 	thankYouRoute,
 }: {
 	thankYouRoute: string;
@@ -139,7 +139,7 @@ export function SupporterPlusLandingPage({
 
 	return (
 		<PageScaffold
-			id="supporter-plus-landing"
+			id="digital-subscription-landing"
 			header={
 				<>
 					<Header>

--- a/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionRouter.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionRouter.tsx
@@ -8,7 +8,7 @@ import { setUpTrackingAndConsents } from 'helpers/page/page';
 import { isDetailsSupported, polyfillDetails } from 'helpers/polyfills/details';
 import { initReduxForContributions } from 'helpers/redux/contributionsStore';
 import { renderPage } from 'helpers/rendering/render';
-import { SupporterPlusLandingPage } from 'pages/digital-subscriber-checkout/digitalSubscriptionLandingPage';
+import { DigitalSubscriptionLandingPage } from 'pages/digital-subscriber-checkout/digitalSubscriptionLandingPage';
 import { DigitalSubscriptionThankYou } from 'pages/digital-subscriber-thank-you/digitalSubscriptionThankYou';
 import { setUpRedux } from './setup/setUpRedux';
 
@@ -37,7 +37,7 @@ window.guardian.settings = {
 
 setUpRedux(store);
 
-const reactElementId = `digital-subscription-checkout-page-${countryGroups[countryGroupId].supportInternationalisationId}`;
+const reactElementId = `digital-subscription-landing-${countryGroups[countryGroupId].supportInternationalisationId}`;
 const thankYouRoute = 'thankyou';
 const countryIds = Object.values(countryGroups).map(
 	(group) => group.supportInternationalisationId,
@@ -47,7 +47,7 @@ const countryIds = Object.values(countryGroups).map(
 
 const router = () => {
 	const landingPage = (
-		<SupporterPlusLandingPage thankYouRoute={thankYouRoute} />
+		<DigitalSubscriptionLandingPage thankYouRoute={thankYouRoute} />
 	);
 
 	return (

--- a/support-frontend/assets/pages/digital-subscriber-checkout/preRenderDigitalSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/preRenderDigitalSubscriptionLandingPage.tsx
@@ -1,0 +1,114 @@
+import { css } from '@emotion/react';
+import { from, neutral, space, textSans } from '@guardian/source-foundations';
+import { Column, Columns, Hide } from '@guardian/source-react-components';
+import {
+	FooterLinks,
+	FooterWithContents,
+} from '@guardian/source-react-components-development-kitchen';
+import { Box } from 'components/checkoutBox/checkoutBox';
+import { CheckoutHeading } from 'components/checkoutHeading/checkoutHeading';
+import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countrySwitcherContainer';
+import { Header } from 'components/headers/simpleHeader/simpleHeader';
+import { Container } from 'components/layout/container';
+import Nav from 'components/nav/nav';
+import { PageScaffold } from 'components/page/pageScaffold';
+import {
+	AUDCountries,
+	Canada,
+	EURCountries,
+	GBPCountries,
+	International,
+	NZDCountries,
+	UnitedStates,
+} from 'helpers/internationalisation/countryGroup';
+import { PrerenderGlobalStyles } from 'helpers/rendering/prerenderGlobalStyles';
+import { LandingPageHeading } from 'pages/supporter-plus-landing/components/landingPageHeading';
+
+const checkoutContainer = css`
+	position: relative;
+	color: ${neutral[7]};
+	${textSans.medium()};
+
+	padding-top: ${space[3]}px;
+	padding-bottom: ${space[9]}px;
+
+	${from.tablet} {
+		padding-bottom: ${space[12]}px;
+	}
+
+	${from.desktop} {
+		padding-top: ${space[6]}px;
+	}
+`;
+
+const emptyBox = css`
+	height: 500px;
+`;
+
+const countrySwitcherProps: CountryGroupSwitcherProps = {
+	countryGroupIds: [
+		GBPCountries,
+		UnitedStates,
+		AUDCountries,
+		EURCountries,
+		NZDCountries,
+		Canada,
+		International,
+	],
+	selectedCountryGroup: GBPCountries,
+	subPath: '/subscribe/digitaledition',
+};
+
+function PreRenderDigitalSubscriptionLandingPage(): JSX.Element {
+	const heading = (
+		<LandingPageHeading heading="Under no one’s thumb but yours" />
+	);
+
+	return (
+		<PageScaffold
+			id="digital-subscription-landing"
+			header={
+				<>
+					<Header>
+						<Hide from="desktop">
+							<CountrySwitcherContainer>
+								<CountryGroupSwitcher {...countrySwitcherProps} />
+							</CountrySwitcherContainer>
+						</Hide>
+					</Header>
+					<Nav {...countrySwitcherProps} />
+				</>
+			}
+			footer={
+				<FooterWithContents>
+					<FooterLinks></FooterLinks>
+				</FooterWithContents>
+			}
+		>
+			<PrerenderGlobalStyles />
+			<CheckoutHeading heading={heading}>
+				<p></p>
+			</CheckoutHeading>
+			<Container sideBorders backgroundColor={neutral[97]}>
+				<Columns cssOverrides={checkoutContainer} collapseUntil="tablet">
+					<Column span={[0, 2, 5]}></Column>
+					<Column span={[1, 8, 7]}>
+						<Hide from="desktop">{heading}</Hide>
+						<Box>
+							<div css={emptyBox}></div>
+						</Box>
+						<Box>
+							<div css={emptyBox}></div>
+						</Box>
+					</Column>
+				</Columns>
+			</Container>
+		</PageScaffold>
+	);
+}
+
+export const digitalSubscriptionLandingPage = (
+	<PreRenderDigitalSubscriptionLandingPage />
+);

--- a/support-frontend/assets/pages/supporter-plus-landing/components/landingPageHeading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/landingPageHeading.tsx
@@ -15,8 +15,6 @@ const headingStyles = css`
 `;
 
 type Props = { heading?: string | JSX.Element };
-export function LandingPageHeading({
-	heading = 'Support fearless, independent journalism',
-}: Props): JSX.Element {
+export function LandingPageHeading({ heading = '' }: Props): JSX.Element {
 	return <h1 css={headingStyles}>{heading}</h1>;
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/components/landingPageHeading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/landingPageHeading.tsx
@@ -14,7 +14,11 @@ const headingStyles = css`
 	}
 `;
 
-type Props = { heading?: string | JSX.Element };
-export function LandingPageHeading({ heading = '' }: Props): JSX.Element {
+interface LandingHeadingProps {
+	heading: string | JSX.Element;
+}
+export function LandingPageHeading({
+	heading,
+}: LandingHeadingProps): JSX.Element {
 	return <h1 css={headingStyles}>{heading}</h1>;
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/components/landingPageHeading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/landingPageHeading.tsx
@@ -1,31 +1,16 @@
 import { css } from '@emotion/react';
-import {
-	from,
-	headline,
-	neutral,
-	space,
-	until,
-} from '@guardian/source-foundations';
+import { from, headline, neutral, space } from '@guardian/source-foundations';
 
 const headingStyles = css`
+	display: none;
+
 	color: ${neutral[100]};
-	display: inline-block;
-	${headline.medium({ fontWeight: 'bold' })}
-	font-size: 28px;
-	max-width: 400px;
+	max-width: 480px;
+	${headline.large({ fontWeight: 'bold' })}
+	margin-bottom: ${space[3]}px;
 
-	${from.tablet} {
-		font-size: 34px;
-		max-width: 480px;
-	}
-
-	${until.desktop} {
-		margin: 0 auto;
-		margin-bottom: ${space[5]}px;
-	}
 	${from.desktop} {
-		${headline.large({ fontWeight: 'bold' })}
-		margin-bottom: ${space[3]}px;
+		display: inline-block;
 	}
 `;
 

--- a/support-frontend/assets/pages/supporter-plus-landing/preRenderSupporterPlusLandingPage.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/preRenderSupporterPlusLandingPage.tsx
@@ -30,7 +30,6 @@ import {
 	UnitedStates,
 } from 'helpers/internationalisation/countryGroup';
 import { PrerenderGlobalStyles } from 'helpers/rendering/prerenderGlobalStyles';
-import { LandingPageHeading } from './components/landingPageHeading';
 
 const checkoutContainer = css`
 	position: relative;
@@ -72,8 +71,6 @@ const countrySwitcherProps: CountryGroupSwitcherProps = {
 };
 
 function PreRenderSupporterPlusLandingPage(): JSX.Element {
-	const heading = <LandingPageHeading />;
-
 	return (
 		<PageScaffold
 			id="supporter-plus-landing"
@@ -96,15 +93,13 @@ function PreRenderSupporterPlusLandingPage(): JSX.Element {
 			}
 		>
 			<PrerenderGlobalStyles />
-			<CheckoutHeading heading={heading}>
+			<CheckoutHeading>
 				<p></p>
 			</CheckoutHeading>
 			<Container sideBorders cssOverrides={darkBackgroundContainerMobile}>
 				<Columns cssOverrides={checkoutContainer} collapseUntil="tablet">
 					<Column span={[0, 2, 5]}></Column>
-					<Column span={[1, 8, 7]}>
-						<Hide from="desktop">{heading}</Hide>
-					</Column>
+					<Column span={[1, 8, 7]}></Column>
 				</Columns>
 			</Container>
 		</PageScaffold>

--- a/support-frontend/assets/pages/supporter-plus-landing/preRenderSupporterPlusLandingPage.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/preRenderSupporterPlusLandingPage.tsx
@@ -1,5 +1,12 @@
 import { css } from '@emotion/react';
-import { from, neutral, space, textSans } from '@guardian/source-foundations';
+import {
+	from,
+	neutral,
+	palette,
+	space,
+	textSans,
+	until,
+} from '@guardian/source-foundations';
 import { Column, Columns, Hide } from '@guardian/source-react-components';
 import {
 	FooterLinks,
@@ -39,6 +46,14 @@ const checkoutContainer = css`
 
 	${from.desktop} {
 		padding-top: ${space[6]}px;
+	}
+`;
+
+const darkBackgroundContainerMobile = css`
+	background-color: ${palette.neutral[97]};
+	${until.tablet} {
+		background-color: ${palette.brand[400]};
+		border-bottom: 1px solid ${palette.brand[600]};
 	}
 `;
 
@@ -84,7 +99,7 @@ function PreRenderSupporterPlusLandingPage(): JSX.Element {
 			<CheckoutHeading heading={heading}>
 				<p></p>
 			</CheckoutHeading>
-			<Container sideBorders backgroundColor={neutral[97]}>
+			<Container sideBorders cssOverrides={darkBackgroundContainerMobile}>
 				<Columns cssOverrides={checkoutContainer} collapseUntil="tablet">
 					<Column span={[0, 2, 5]}></Column>
 					<Column span={[1, 8, 7]}>

--- a/support-frontend/assets/pages/supporter-plus-landing/preRenderSupporterPlusLandingPage.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/preRenderSupporterPlusLandingPage.tsx
@@ -5,7 +5,6 @@ import {
 	FooterLinks,
 	FooterWithContents,
 } from '@guardian/source-react-components-development-kitchen';
-import { Box } from 'components/checkoutBox/checkoutBox';
 import { CheckoutHeading } from 'components/checkoutHeading/checkoutHeading';
 import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
@@ -41,10 +40,6 @@ const checkoutContainer = css`
 	${from.desktop} {
 		padding-top: ${space[6]}px;
 	}
-`;
-
-const emptyBox = css`
-	height: 500px;
 `;
 
 const countrySwitcherProps: CountryGroupSwitcherProps = {
@@ -94,12 +89,6 @@ function PreRenderSupporterPlusLandingPage(): JSX.Element {
 					<Column span={[0, 2, 5]}></Column>
 					<Column span={[1, 8, 7]}>
 						<Hide from="desktop">{heading}</Hide>
-						<Box>
-							<div css={emptyBox}></div>
-						</Box>
-						<Box>
-							<div css={emptyBox}></div>
-						</Box>
 					</Column>
 				</Columns>
 			</Container>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
@@ -44,11 +44,16 @@ const checkoutContainer = (isPaymentPage?: boolean) => css`
 	position: relative;
 	color: ${palette.neutral[7]};
 	${textSans.medium()};
+
 	padding-top: ${space[isPaymentPage ? 2 : 6]}px;
 	padding-bottom: ${space[9]}px;
+
 	${from.tablet} {
-		padding-top: 40px;
 		padding-bottom: ${space[12]}px;
+	}
+
+	${from.desktop} {
+		padding-top: ${space[6]}px;
 	}
 `;
 

--- a/support-frontend/stories/checkoutLayout/CheckoutHeading.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutHeading.stories.tsx
@@ -45,7 +45,9 @@ Template.decorators = [] as unknown[];
 export const Heading = Template.bind({});
 
 Heading.args = {
-	heading: <LandingPageHeading />,
+	heading: (
+		<LandingPageHeading heading="Support fearless, independent journalism" />
+	),
 	children: (
 		<p style={{ marginRight: '48px' }}>
 			Help protect the Guardian&apos;s independence so we can keep delivering


### PR DESCRIPTION
## What are you doing in this PR?

CORRECTION REQUESTED 13/1/23 GeorgeH : 

Simplified Process, pre-render only basic page to  encompass all future checkout variants without modifcitsion
- Create (separate) preDigitalSubscriptionLandingPage
- Modify preSupporterPlusLandingPage 
1.  Remove LeftHand side text
2.  Remove Both White Stacked Containers

[**archived un-released PR**](https://github.com/guardian/support-frontend/pull/5512)

## Why are you doing this?

So users on slower devices (eg. Mobile devices not on WiFi) don’t just get a blank screen when they first land on the checkout.