### PR TITLE
Three tier checkout basic setup

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -13,6 +13,8 @@ export const pageUrlRegexes = {
 		notUsLandingPage: '/uk|au|eu|int|nz|ca/contribute(/.*)?$',
 		auLandingPage: '/au/contribute(/.*)?$',
 		usLandingPage: '/us/contribute(/.*)?$',
+		allLandingPagesExecptSupportPlus:
+			'\bcontribute\b(?!.*acquisitionData.*abTest.*supporterPlusOnly.*variant.*variant)',
 	},
 	subscriptions: {
 		subsDigiSubPages: '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)',
@@ -123,5 +125,23 @@ export const tests: Tests = {
 		referrerControlled: false,
 		seed: 0,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+	},
+	threeTierCheckout: {
+		variants: [
+			{
+				id: 'variant',
+			},
+		],
+		isActive: false,
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		omitCountries: countriesAffectedByVATStatus,
+		referrerControlled: false,
+		seed: 0,
+		targetPage: pageUrlRegexes.contributions.allLandingPagesExecptSupportPlus,
 	},
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -15,6 +15,7 @@ import { SupporterPlusThankYou } from 'pages/supporter-plus-thank-you/supporterP
 import { setUpRedux } from './setup/setUpRedux';
 import { SupporterPlusInitialLandingPage } from './twoStepPages/firstStepLanding';
 import { SupporterPlusCheckout } from './twoStepPages/secondStepCheckout';
+import {ThreeTierLandingPage} from './twoStepPages/threeTierFirstStepLanding';
 
 if (!isDetailsSupported) {
 	polyfillDetails();
@@ -50,7 +51,14 @@ function ScrollToTop() {
 // ----- Render ----- //
 
 const router = () => {
-	const firstStepLandingPage = (
+	const {
+		common: { abParticipations },
+	} = store.getState();
+	const isInThreeTierCheckoutTest =
+		abParticipations.threeTierCheckout === 'variant';
+	const firstStepLandingPage = isInThreeTierCheckoutTest ? (
+		<ThreeTierLandingPage thankYouRoute={thankYouRoute} />
+	) : (
 		<SupporterPlusInitialLandingPage thankYouRoute={thankYouRoute} />
 	);
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierFirstStepLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierFirstStepLanding.tsx
@@ -1,0 +1,163 @@
+import { css, ThemeProvider } from '@emotion/react';
+import { cmp } from '@guardian/consent-management-platform';
+import { from, palette, space, until } from '@guardian/source-foundations';
+import {
+	Button,
+	buttonThemeReaderRevenueBrand,
+	Container,
+} from '@guardian/source-react-components';
+import {
+	FooterLinks,
+	FooterWithContents,
+} from '@guardian/source-react-components-development-kitchen';
+import { useEffect } from 'preact/hooks';
+import { useNavigate } from 'react-router';
+import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countrySwitcherContainer';
+import { Header } from 'components/headers/simpleHeader/simpleHeader';
+import { PageScaffold } from 'components/page/pageScaffold';
+import { useOtherAmountValidation } from 'helpers/customHooks/useFormValidation';
+import {
+	AUDCountries,
+	Canada,
+	EURCountries,
+	GBPCountries,
+	International,
+	NZDCountries,
+	UnitedStates,
+} from 'helpers/internationalisation/countryGroup';
+import { resetValidation } from 'helpers/redux/checkout/checkoutActions';
+import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
+import { navigateWithPageView } from 'helpers/tracking/ophan';
+
+const checkoutBtnStyleOverrides = css`
+	width: 100%;
+	justify-content: center;
+`;
+
+const darkBackgroundContainerMobile = css`
+	display: flex;
+	background: linear-gradient(
+		to bottom,
+		${palette.brand[400]} 441px,
+		${palette.neutral[97]} 441px,
+		${palette.neutral[97]} 100%
+	);
+	${until.tablet} {
+		background-color: ${palette.brand[400]};
+		border-bottom: 1px solid ${palette.brand[600]};
+	}
+	min-height: 480px;
+	${from.desktop} {
+		min-height: 440px;
+	}
+	padding-top: ${space[6]}px;
+`;
+
+const links = [
+	{
+		href: 'https://www.theguardian.com/info/privacy',
+		text: 'Privacy policy',
+		isExternal: true,
+	},
+	{
+		text: 'Privacy settings',
+		onClick: () => {
+			cmp.showPrivacyManager();
+		},
+	},
+	{
+		href: 'https://www.theguardian.com/help/contact-us',
+		text: 'Contact us',
+		isExternal: true,
+	},
+	{
+		href: 'https://www.theguardian.com/help',
+		text: 'Help centre',
+		isExternal: true,
+	},
+];
+
+export function ThreeTierLandingPage(): JSX.Element {
+	const dispatch = useContributionsDispatch();
+	const navigate = useNavigate();
+	const contributionType = useContributionsSelector(getContributionType);
+	const amount = useContributionsSelector(getUserSelectedAmount);
+
+	const { abParticipations } = useContributionsSelector(
+		(state) => state.common,
+	);
+
+	const { countryGroupId } = useContributionsSelector(
+		(state) => state.common.internationalisation,
+	);
+
+	const countrySwitcherProps: CountryGroupSwitcherProps = {
+		countryGroupIds: [
+			GBPCountries,
+			UnitedStates,
+			AUDCountries,
+			EURCountries,
+			NZDCountries,
+			Canada,
+			International,
+		],
+		selectedCountryGroup: countryGroupId,
+		subPath: '/contribute',
+	};
+
+	const proceedToNextStep = useOtherAmountValidation(() => {
+		const destination = `checkout?selected-amount=${amount}&selected-contribution-type=${contributionType.toLowerCase()}`;
+		navigateWithPageView(navigate, destination, abParticipations);
+	}, false);
+
+	useEffect(() => {
+		dispatch(resetValidation());
+	}, []);
+
+	return (
+		<PageScaffold
+			id="supporter-plus-landing"
+			header={
+				<>
+					<Header>
+						<CountrySwitcherContainer>
+							<CountryGroupSwitcher {...countrySwitcherProps} />
+						</CountrySwitcherContainer>
+					</Header>
+				</>
+			}
+			footer={
+				<FooterWithContents>
+					<FooterLinks links={links}></FooterLinks>
+				</FooterWithContents>
+			}
+		>
+			<Container
+				sideBorders
+				topBorder
+				borderColor="rgba(170, 170, 180, 0.5)"
+				cssOverrides={darkBackgroundContainerMobile}
+			>
+				<h1>Support fearless, independent journalism</h1>
+				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
+					<Button
+						iconSide="left"
+						priority="primary"
+						size="default"
+						cssOverrides={checkoutBtnStyleOverrides}
+						onClick={proceedToNextStep}
+					>
+						Support with XX
+					</Button>
+				</ThemeProvider>
+			</Container>
+		</PageScaffold>
+	);
+}


### PR DESCRIPTION
## What are you doing in this PR?

This pr sets up a new ab test called `threeTierCheckout` (the test is not active in this pr).

The branching logic for displaying either the `ThreeTierLandingPage` or the existing `SupporterPlusInitialLandingPage` pages/components has been added to the client side router.

The `ThreeTierLandingPage` currently consists of the basic client side page scaffold without any of the inner content (this will come in a later pr).

## Screenshots
<img width="814" alt="threetierscaffold" src="https://github.com/guardian/support-frontend/assets/2510683/f95cd3e6-edb0-4650-ba7a-ce3c444a4037">

