### PR TITLE
E2E paypal and browserstack fixes

### DIFF
--- a/support-e2e/browserstack.config.ts
+++ b/support-e2e/browserstack.config.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
-import { exec } from 'child_process';
+import { execSync } from 'child_process';
 import BrowserStackLocal from 'browserstack-local';
+import { Page } from '@playwright/test';
 
 interface BrowserDetails {
 	browser: string;
@@ -10,7 +11,7 @@ interface BrowserDetails {
   name: string;
 }
 
-const clientPlaywrightVersion = exec('npx playwright --version')
+const clientPlaywrightVersion = execSync('npx playwright --version')
 	.toString()
 	.trim()
 	.split(' ')[1] as string;
@@ -19,8 +20,8 @@ const browserStackProperties = {
 	'browserstack.username': process.env.BROWSERSTACK_USERNAME ?? '',
 	'browserstack.accessKey': process.env.BROWSERSTACK_ACCESS_KEY ?? '',
 	'browserstack.local': false,
+	'browserstack.geoLocation': 'GB',
 	'client.playwrightVersion': clientPlaywrightVersion,
-	build: 'playwright-build',
 }
 
 export const bsLocal = new BrowserStackLocal.Local();
@@ -32,10 +33,29 @@ export const BS_LOCAL_ARGS = {
 export const getCdpEndpoint = (
 	browserDetails: BrowserDetails,
 ) => {
-  const caps = {...browserStackProperties, ...browserDetails}
+  const latestCommitID = execSync("git rev-parse --short HEAD").toString().trim();
+  const niceDateStringNow = new Intl.DateTimeFormat('en-GB', {
+    dateStyle: 'full',
+    timeStyle: 'long',
+  }).format(new Date());
+  const caps = {
+    ...browserStackProperties,
+    ...browserDetails,
+    build: `playwright-build-${latestCommitID}`,
+    name: `playwright E2E test - ${niceDateStringNow}`
+  };
 	const cdpUrl = `wss://cdp.browserstack.com/playwright?caps=${encodeURIComponent(
 		JSON.stringify(caps),
 	)}`;
 	console.log(`--> ${cdpUrl}`);
 	return cdpUrl;
 };
+
+export const markTest = (page:Page, status:string, reason:string) => {
+    return page.evaluate(
+        _ => {},
+        `browserstack_executor: ${JSON.stringify({
+            action: 'setSessionStatus',
+            arguments: { status, reason }
+        })}`);
+}

--- a/support-e2e/browserstack.config.ts
+++ b/support-e2e/browserstack.config.ts
@@ -1,7 +1,6 @@
 import 'dotenv/config';
 import { execSync } from 'child_process';
 import BrowserStackLocal from 'browserstack-local';
-import { Page } from '@playwright/test';
 
 interface BrowserDetails {
 	browser: string;
@@ -33,15 +32,20 @@ export const BS_LOCAL_ARGS = {
 export const getCdpEndpoint = (
 	browserDetails: BrowserDetails,
 ) => {
-  const latestCommitID = execSync("git rev-parse --short HEAD").toString().trim();
+  const latestCommitID = execSync(`git rev-parse --short ${process.env.GITHUB_SHA ?? "HEAD"}`).toString().trim();
   const niceDateStringNow = new Intl.DateTimeFormat('en-GB', {
-    dateStyle: 'full',
-    timeStyle: 'long',
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    second: "numeric",
+    timeZone: "Europe/London",
   }).format(new Date());
   const caps = {
     ...browserStackProperties,
     ...browserDetails,
-    build: `playwright-build-${latestCommitID}`,
+    build: `playwright-build-${latestCommitID}-${niceDateStringNow}`,
     name: `playwright E2E test - ${niceDateStringNow}`
   };
 	const cdpUrl = `wss://cdp.browserstack.com/playwright?caps=${encodeURIComponent(
@@ -51,11 +55,4 @@ export const getCdpEndpoint = (
 	return cdpUrl;
 };
 
-export const markTest = (page:Page, status:string, reason:string) => {
-    return page.evaluate(
-        _ => {},
-        `browserstack_executor: ${JSON.stringify({
-            action: 'setSessionStatus',
-            arguments: { status, reason }
-        })}`);
-}
+

--- a/support-e2e/package.json
+++ b/support-e2e/package.json
@@ -2,7 +2,7 @@
 	"name": "support-e2e",
 	"version": "0.0.0",
 	"scripts": {
-		"pw-browserstack-test": "playwright test --config=playwright.browserstack.config.ts",
+		"pw-browserstack-test": "RUNNING_IN_BROWSERSTACK=true playwright test --config=playwright.browserstack.config.ts",
 		"pw-local-test": "playwright test --ui --config=playwright.local.config.ts",
 		"pw-prod-test": "playwright test --ui --config=playwright.prod.config.ts"
 	},

--- a/support-e2e/playwright.browserstack.config.ts
+++ b/support-e2e/playwright.browserstack.config.ts
@@ -20,7 +20,8 @@ export default defineConfig({
 							browser_version: 'latest',
 							os: 'Windows',
 							os_version: '11',
-              name: 'testing the browserstack with new node',
+              'browserstack.debug': 'true',
+              'browserstack.networkLogs': 'true'
 						},
 
 					),

--- a/support-e2e/tests/gwCheckout.test.ts
+++ b/support-e2e/tests/gwCheckout.test.ts
@@ -6,6 +6,7 @@ import { fillInCardDetails } from "./utils/cardDetails";
 import { fillInDirectDebitDetails } from "./utils/directDebitDetails";
 import { fillInPayPalDetails } from "./utils/paypal";
 import { setupPage } from "./utils/page";
+import { afterEachTasks } from "./utils/afterEachTest";
 
 type PaymentType = "Credit/Debit card" | "Direct debit" | "PayPal";
 
@@ -72,6 +73,8 @@ const testsDetailsGifted: TestDetailsGifted[] = [
     paymentType: "PayPal",
   },
 ];
+
+afterEachTasks(test);
 
 test.describe("Sign up for a Guardian Weekly subscription", () => {
   testsDetails.forEach((testDetails) => {
@@ -146,9 +149,6 @@ test.describe("Sign up for a Guardian Weekly subscription", () => {
         page.getByRole("heading", { name: successMsgRegex })
       ).toBeVisible();
 
-      context.pages().forEach(async (page) => {
-        await page.close();
-      });
     });
   });
 });
@@ -239,9 +239,6 @@ test.describe("Gifted subscriptions", () => {
         page.getByRole("heading", { name: successMsgRegex })
       ).toBeVisible();
 
-      context.pages().forEach(async (page) => {
-        await page.close();
-      });
     });
   });
 });

--- a/support-e2e/tests/landingPages.test.ts
+++ b/support-e2e/tests/landingPages.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "@playwright/test";
+import { afterEachTasks } from "./utils/afterEachTest";
 import { setTestCookies } from "./utils/cookies";
 import { firstName } from "./utils/users";
+
+afterEachTasks(test);
 
 test.describe("Paper product page", () => {
   test("Basic loading-when a user goes to the Newspapar Subscriptions page,it should display the page", async ({
@@ -15,7 +18,6 @@ test.describe("Paper product page", () => {
     await page.goto(pageUrl);
     await page.locator("id=qa-paper-subscriptions").isVisible();
     await expect(page).toHaveURL(/\/uk\/subscribe\/paper/);
-    await page.close();
   });
 });
 
@@ -33,7 +35,6 @@ test.describe("Weekly product page", () => {
 
     await page.locator("id=qa-guardian-weekly").isVisible();
     await expect(page).toHaveURL(/\/uk\/subscribe\/weekly/);
-    await page.close();
   });
 });
 
@@ -51,7 +52,6 @@ test.describe("Weekly gift product page", () => {
 
     await page.locator("id=qa-guardian-weekly-gift").isVisible();
     await expect(page).toHaveURL(/\/uk\/subscribe\/weekly\/gift/);
-    await page.close();
   });
 });
 
@@ -69,6 +69,5 @@ test.describe("Subscriptions landing page", () => {
 
     await page.locator("id=qa-subscriptions-landing-page").isVisible();
     await expect(page).toHaveURL(/\/uk\/subscribe/);
-    await page.close();
   });
 });

--- a/support-e2e/tests/newspaperCheckout.test.ts
+++ b/support-e2e/tests/newspaperCheckout.test.ts
@@ -6,6 +6,7 @@ import { fillInCardDetails } from "./utils/cardDetails";
 import { fillInDirectDebitDetails } from "./utils/directDebitDetails";
 import { fillInPayPalDetails } from "./utils/paypal";
 import { setupPage } from "./utils/page";
+import { afterEachTasks } from "./utils/afterEachTest";
 
 interface TestDetails {
   frequency: "Every day" | "Weekend" | "Six day" | "Saturday" | "Sunday";
@@ -58,6 +59,8 @@ const testsDetails: TestDetails[] = [
     paymentType: "Direct debit",
   },
 ];
+
+afterEachTasks(test);
 
 test.describe("Sign up newspaper subscription", () => {
   testsDetails.forEach((testDetails) => {
@@ -125,9 +128,6 @@ test.describe("Sign up newspaper subscription", () => {
         page.getByRole("heading", { name: successMsgRegex })
       ).toBeVisible();
 
-      context.pages().forEach(async (page) => {
-        await page.close();
-      });
     });
   });
 });

--- a/support-e2e/tests/oneOffContributions.test.ts
+++ b/support-e2e/tests/oneOffContributions.test.ts
@@ -4,6 +4,7 @@ import { checkRecaptcha } from "./utils/recaptcha";
 import { fillInCardDetails } from "./utils/cardDetails";
 import { fillInPayPalDetails } from "./utils/paypal";
 import { setupPage } from "./utils/page";
+import { afterEachTasks } from "./utils/afterEachTest";
 
 interface TestDetails {
   paymentType: "Credit/Debit card" | "PayPal";
@@ -14,6 +15,8 @@ const testsDetails: TestDetails[] = [
   { paymentType: "Credit/Debit card", customAmount: "22.55" },
   { paymentType: "PayPal" },
 ];
+
+afterEachTasks(test);
 
 test.describe("Sign up for a one-off contribution", () => {
   testsDetails.forEach((testDetails) => {
@@ -48,9 +51,6 @@ test.describe("Sign up for a one-off contribution", () => {
           break;
       }
       await expect(page).toHaveURL(/\/uk\/thankyou/);
-      context.pages().forEach(async (page) => {
-        await page.close();
-      });
     });
   });
 });

--- a/support-e2e/tests/recurringContributions.test.ts
+++ b/support-e2e/tests/recurringContributions.test.ts
@@ -6,6 +6,7 @@ import { fillInCardDetails } from "./utils/cardDetails";
 import { fillInDirectDebitDetails } from "./utils/directDebitDetails";
 import { fillInPayPalDetails } from "./utils/paypal";
 import { setupPage } from "./utils/page";
+import { afterEachTasks } from "./utils/afterEachTest";
 
 interface TestDetails {
   paymentType: "Credit/Debit card" | "Direct debit" | "PayPal";
@@ -21,6 +22,8 @@ const testsDetails: TestDetails[] = [
   { paymentType: "Direct debit", frequency: "Annual" },
   { paymentType: "PayPal", frequency: "Monthly" },
 ];
+
+afterEachTasks(test);
 
 test.describe("Sign up for a Recurring Contribution (Two-Step checkout)", () => {
   testsDetails.forEach((testDetails) => {
@@ -77,7 +80,6 @@ test.describe("Sign up for a Recurring Contribution (Two-Step checkout)", () => 
         `/${testDetails.country?.toLowerCase() || "uk"}/thankyou`,
         { timeout: 600000 }
       );
-      await page.close();
     });
   });
 });

--- a/support-e2e/tests/utils/afterEachTest.ts
+++ b/support-e2e/tests/utils/afterEachTest.ts
@@ -1,0 +1,25 @@
+import {
+  PlaywrightTestArgs,
+  PlaywrightTestOptions,
+  PlaywrightWorkerArgs,
+  PlaywrightWorkerOptions,
+  TestType
+} from "@playwright/test";
+
+export const afterEachTasks = (test:TestType<PlaywrightTestArgs & PlaywrightTestOptions, PlaywrightWorkerArgs & PlaywrightWorkerOptions>) => {
+    test.afterEach(async ({page, context}, testInfo) => {
+     if (process.env.RUNNING_IN_BROWSERSTACK) {
+       if (testInfo.status) {
+        await page.evaluate(
+          _ => {},
+          `browserstack_executor: ${JSON.stringify({
+              action: 'setSessionStatus',
+              arguments: { status: testInfo.status }
+          })}`)
+       }
+     }
+     context.pages().forEach(async (page) => {
+       await page.close();
+     });
+    });
+}

--- a/support-e2e/tests/utils/paypal.ts
+++ b/support-e2e/tests/utils/paypal.ts
@@ -2,22 +2,17 @@ import "dotenv/config";
 import { Page } from "@playwright/test";
 
 export const fillInPayPalDetails = async (page: Page) => {
-  const englishLink = page.getByRole("link", { name: "English" });
-  if (await englishLink.isVisible()) {
-    englishLink.click();
-  }
-  await page.getByPlaceholder("Email or mobile number").fill("doc@gu.co.uk");
-  const nextButton = page.getByRole("button", { name: "Next" });
+  await page.locator("#email").fill("sb-k6ax328721376@personal.example.com");
+  const nextButton = page.locator("#btnNext");
   if (await nextButton.isVisible()) {
-    nextButton.click();
+    await nextButton.click();
   }
-  await page
-    .getByPlaceholder("Password")
+  await page.locator("#password")
     .fill(`${process.env.PAYPAL_TEST_PASSWORD}`);
-  const loginButton = page.getByRole("button", { name: "Log in" });
+  const loginButton = page.locator("#btnLogin");
   if (await loginButton.isVisible()) {
-    loginButton.click();
+    await loginButton.click();
   }
-  await page.getByRole("button", { name: /(Continue to Review Order|Agree \& Pay Now)/ }).click();
+  await page.locator("#payment-submit-btn").click();
 };
 


### PR DESCRIPTION
## What are you doing in this PR?

This pr fixes the problem where browserstack was not reporting the status of the tests that were just run.

The paypal form filling in function has been changed to use id selectors instead of labels to address an issue where the paypal form was displaying in dutch, although this issue idsprobably also mitigated by selecting the geo location in the browserstack test config (also in this pr).

The paypal test user credentials have been updated so that these tests do not use a shared account that may be locked out if someone enters the wrong password too many times.

The browserstack automate runs are now labelled with the latest commit id and the date/time so that each run is unique and more discoverable.

## Screenshots
<img width="1182" alt="Screenshot 2023-12-14 at 16 59 09" src="https://github.com/guardian/support-frontend/assets/2510683/851db693-6433-4ad1-9deb-9cee5bc6f02c">

