### PR TITLE
fix: upgrade logback-classic to 1.4.14 in strip-patrons-data

### DIFF
--- a/stripe-patrons-data/build.sbt
+++ b/stripe-patrons-data/build.sbt
@@ -9,7 +9,7 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.4.11",
+  "ch.qos.logback" % "logback-classic" % "1.4.14",
   "software.amazon.awssdk" % "dynamodb" % awsClientVersion2,
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",


### PR DESCRIPTION
## What are you doing in this PR?
Part of: https://github.com/guardian/support-frontend/issues/5532

Upgrades `logback-classic` to 1.4.14.

This was tested running the standard strip-patrons-data suite.