### PR TITLE
Revert "fix: upgrade logback-classic to 1.3.14 in it-test-runner"

### DIFF
--- a/support-lambdas/it-test-runner/build.sbt
+++ b/support-lambdas/it-test-runner/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
-  "ch.qos.logback" % "logback-classic" % "1.3.14",
+  "ch.qos.logback" % "logback-classic" % "1.2.12",
   "io.symphonia" % "lambda-logging" % "1.0.3",
   "org.scalatest" %% "scalatest" % "3.2.16", // not a "Test" dependency, it's an actual one
 )


### PR DESCRIPTION
Reverts guardian/support-frontend#5535

I can see the `A needed class was not found. This could be due to an error in your runpath. Missing class: Could not initialize class com.gu.config.Configuration` when running these manually.