### PR TITLE
Remove circular dependencies plugin

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -99,7 +99,6 @@
     "@types/dompurify": "^3.0.2",
     "@types/seedrandom": "^3.0.7",
     "@types/uuid": "^9.0.2",
-    "circular-dependency-plugin": "^5.2.2",
     "classnames": "^2.2.6",
     "dompurify": "^3.0.3",
     "emotion-theming": "^11.0.0",

--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -10,7 +10,6 @@ const { getClassName } = require('./scripts/css');
 const entryPoints = require('./webpack.entryPoints');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
-const CircularDependencyPlugin = require('circular-dependency-plugin');
 
 const cssLoaders = [
 	{
@@ -84,10 +83,6 @@ module.exports = (cssFilename, jsFilename, minimizeCss) => ({
 		}),
 		...(minimizeCss ? [new CssMinimizerPlugin()] : []),
 		new CleanUpStatsPlugin(),
-		new CircularDependencyPlugin({
-			// exclude detection of files based on a RegExp
-			exclude: /node_modules/,
-		}),
 	],
 
 	context: path.resolve(__dirname, 'assets'),


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Removing the circular dependencies plugin from webpack.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/hnt5M6GX/1719-fix-cyclical-file-dependencies)

## Why are you doing this?
In theory, we no longer need this plugin and might as well remove it to speed up the local build process. It was helpful to highlight the circular dependencies we had that were able to slip past eslint by ignoring rules, but they are now fixed and we should not be merging any PRs that ignore rules in the future which will prevent this from happening again and therefore make this plugin redundant. 

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
This is a change to the build process, but should only affect the local dev server builds. If the build passes on PROD and locally, it should be fine.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
