### PR TITLE
fix: upgrade logback-classic to 1.3.14 in it-test-runner

### DIFF
--- a/.github/workflows/support-lambdas-build.yml
+++ b/.github/workflows/support-lambdas-build.yml
@@ -47,11 +47,11 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: actions/setup-java@v3
         with:
-          java-version: "8"
-          distribution: "adopt"
+          java-version: "11"
+          distribution: "corretto"
       - uses: actions/cache@v3
         with:
           path: |

--- a/support-lambdas/it-test-runner/build.sbt
+++ b/support-lambdas/it-test-runner/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
-  "ch.qos.logback" % "logback-classic" % "1.2.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.14",
   "io.symphonia" % "lambda-logging" % "1.0.3",
   "org.scalatest" %% "scalatest" % "3.2.16", // not a "Test" dependency, it's an actual one
 )

--- a/support-models/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -3,7 +3,6 @@ package com.gu.support.workers
 import com.gu.i18n.Currency
 import com.gu.i18n.Currency.GBP
 
-//noinspection TypeAnnotation
 object Fixtures {
   val idId = "12345"
   val email = "test@thegulocal.com"

--- a/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
@@ -10,7 +10,6 @@ import com.gu.support.workers.{
 }
 import org.joda.time.LocalDate
 
-//noinspection TypeAnnotation
 object Fixtures {
   val accountNumber = "A00071408"
   val promoCode = "TEST_CODE"

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "2.2.3",
   "org.typelevel" %% "cats-core" % catsVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
-  "ch.qos.logback" % "logback-classic" % "1.2.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.14",
   "io.symphonia" % "lambda-logging" % "1.0.1",
   "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
   "io.lemonlabs" %% "scala-uri" % scalaUriVersion,

--- a/support-workers/src/main/scala/com/gu/monitoring/PiiFilter.scala
+++ b/support-workers/src/main/scala/com/gu/monitoring/PiiFilter.scala
@@ -3,10 +3,17 @@ package com.gu.monitoring
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.filter.Filter
 import ch.qos.logback.core.spi.FilterReply
+import org.slf4j.Marker
+
+import scala.jdk.CollectionConverters._
 
 class PiiFilter extends Filter[ILoggingEvent] {
-  override def decide(event: ILoggingEvent): FilterReply =
-    if (event.getMarker.contains(SafeLogger.sanitizedLogMessage))
+  override def decide(event: ILoggingEvent): FilterReply = {
+    val sanitizedMarkerExists = event.getMarkerList.asScala.toList
+      .collectFirst(marker => marker.contains(SafeLogger.sanitizedLogMessage))
+      .nonEmpty
+    if (sanitizedMarkerExists)
       FilterReply.ACCEPT
     else FilterReply.DENY
+  }
 }

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -30,7 +30,6 @@ import org.joda.time.{DateTimeZone, LocalDate}
 import java.io.ByteArrayInputStream
 import java.util.UUID
 
-//noinspection TypeAnnotation
 object JsonFixtures {
 
   def wrapFixture(string: String): ByteArrayInputStream =

--- a/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -13,7 +13,6 @@ import com.gu.support.workers._
 import com.gu.support.zuora.api._
 import org.joda.time.LocalDate
 
-//noinspection TypeAnnotation
 object Fixtures {
   val accountNumber = "A00084679"
 


### PR DESCRIPTION
## What are you doing in this PR?
Part of: https://github.com/guardian/support-frontend/issues/5532

Upgrades `logback-classic` to 1.4.14.

This was tested on CODE.