### PR TITLE
chore(deps): use java11 on all support workers and it-test-runner

### DIFF
--- a/.github/workflows/support-lambdas-build.yml
+++ b/.github/workflows/support-lambdas-build.yml
@@ -47,11 +47,11 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: actions/setup-java@v3
         with:
-          java-version: "8"
-          distribution: "adopt"
+          java-version: "11"
+          distribution: "corretto"
       - uses: actions/cache@v3
         with:
           path: |

--- a/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
+++ b/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
@@ -149,7 +149,7 @@ Logs are at https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-w
             "Arn",
           ],
         },
-        "Runtime": "java8.al2",
+        "Runtime": "java11",
         "Tags": [
           {
             "Key": "App",

--- a/cdk/lib/bigquery-acquisitions-publisher.ts
+++ b/cdk/lib/bigquery-acquisitions-publisher.ts
@@ -113,7 +113,7 @@ export class BigqueryAcquisitionsPublisher extends GuStack {
 
     new GuLambdaFunction(this, `${appName}Lambda`, {
       app: appName,
-      runtime: Runtime.JAVA_8_CORRETTO,
+      runtime: Runtime.JAVA_11,
       fileName: `${appName}.jar`,
       functionName,
       handler: "com.gu.bigqueryAcquisitionsPublisher.Lambda::handler",

--- a/support-lambdas/acquisitions-firehose-transformer/cfn.yaml
+++ b/support-lambdas/acquisitions-firehose-transformer/cfn.yaml
@@ -31,7 +31,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${App}-${Stage}
       Description: A Firehose transformation lambda for serialising the acquisitions event stream to csv
-      Runtime: java8.al2
+      Runtime: java11
       Handler: com.gu.acquisitionFirehoseTransformer.Lambda::handler
       MemorySize: 512
       Timeout: 300

--- a/support-lambdas/it-test-runner/build.sbt
+++ b/support-lambdas/it-test-runner/build.sbt
@@ -3,7 +3,7 @@ import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport.riffRaffManifestProj
 import sbt.Keys.libraryDependencies
 
 version := "0.1-SNAPSHOT"
-scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-release:8", "-Xfatal-warnings")
+scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xfatal-warnings")
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",

--- a/support-lambdas/stripe-intent/cfn.yaml
+++ b/support-lambdas/stripe-intent/cfn.yaml
@@ -37,7 +37,7 @@ Resources:
         Bucket: support-workers-dist
         Key: !Sub support/${Stage}/stripe-intent/stripe-intent.jar
       MemorySize: 2048
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 300
       Environment:
         Variables:

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -3,7 +3,7 @@ import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport.riffRaffManifestProj
 import sbt.Keys.libraryDependencies
 
 version := "0.1-SNAPSHOT"
-scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-release:8", "-Xfatal-warnings")
+scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xfatal-warnings")
 
 libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "2.2.3",


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
Part of: https://github.com/guardian/support-frontend/issues/5532

## What are you doing in this PR?
Upgrading all `support-lambdas` and `support-workers` to be on the same version of Java (Java11). There is an implicit coupling where `support-workers` calls `support-lambdas`. This should hopefully remove any conflict errors we're seeing because of that. 

Whilst trying to upgrade to `logback-classic@1.4.1` there are too many moving parts to try work out what is causing the issues. This should hopefully remove one of those variables.
