### PR TITLE
Track AbTests participations  on both Page 1 and Page 2 of two-step checkout (Ophan)

### DIFF
--- a/support-frontend/assets/helpers/page/page.ts
+++ b/support-frontend/assets/helpers/page/page.ts
@@ -1,31 +1,18 @@
 // ----- Imports ----- //
 import type { Participations } from 'helpers/abTests/abtest';
-import * as abTest from 'helpers/abTests/abtest';
-import {getAmountsTestVariant} from "helpers/abTests/abtest";
-import { Country, CountryGroup } from 'helpers/internationalisation';
+import { Country } from 'helpers/internationalisation';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
 	analyticsInitialisation,
 	consentInitialisation,
 } from 'helpers/page/analyticsAndConsent';
 import { getReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
-import {getSettings} from "../globalsAndSwitches/globals";
 
-function setUpTrackingAndConsents(): void {
-  const settings = getSettings();
+function setUpTrackingAndConsents(participations: Participations = {}): void {
 	const countryId: IsoCountry = Country.detect();
-	const countryGroupId: CountryGroupId = CountryGroup.detect();
-	const participations: Participations = abTest.init(countryId, countryGroupId);
-  const {  amountsParticipation } =
-    getAmountsTestVariant(countryId, countryGroupId, settings);
-  const participationsWithAmountsTest = {
-    ...participations,
-    ...amountsParticipation,
-  };
 	const acquisitionData = getReferrerAcquisitionData();
 	void consentInitialisation(countryId);
-	analyticsInitialisation(participationsWithAmountsTest, acquisitionData);
+	analyticsInitialisation(participations, acquisitionData);
 }
 
 // ----- Exports ----- //

--- a/support-frontend/assets/helpers/page/page.ts
+++ b/support-frontend/assets/helpers/page/page.ts
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 import type { Participations } from 'helpers/abTests/abtest';
 import * as abTest from 'helpers/abTests/abtest';
-import {getAmountsTestVariant} from "helpers/abTests/abtest";
+import { getAmountsTestVariant } from 'helpers/abTests/abtest';
 import { Country, CountryGroup } from 'helpers/internationalisation';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -10,19 +10,22 @@ import {
 	consentInitialisation,
 } from 'helpers/page/analyticsAndConsent';
 import { getReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
-import {getSettings} from "../globalsAndSwitches/globals";
+import { getSettings } from '../globalsAndSwitches/globals';
 
 function setUpTrackingAndConsents(): void {
-  const settings = getSettings();
+	const settings = getSettings();
 	const countryId: IsoCountry = Country.detect();
 	const countryGroupId: CountryGroupId = CountryGroup.detect();
 	const participations: Participations = abTest.init(countryId, countryGroupId);
-  const {  amountsParticipation } =
-    getAmountsTestVariant(countryId, countryGroupId, settings);
-  const participationsWithAmountsTest = {
-    ...participations,
-    ...amountsParticipation,
-  };
+	const { amountsParticipation } = getAmountsTestVariant(
+		countryId,
+		countryGroupId,
+		settings,
+	);
+	const participationsWithAmountsTest = {
+		...participations,
+		...amountsParticipation,
+	};
 	const acquisitionData = getReferrerAcquisitionData();
 	void consentInitialisation(countryId);
 	analyticsInitialisation(participationsWithAmountsTest, acquisitionData);

--- a/support-frontend/assets/helpers/page/page.ts
+++ b/support-frontend/assets/helpers/page/page.ts
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 import type { Participations } from 'helpers/abTests/abtest';
 import * as abTest from 'helpers/abTests/abtest';
+import {getAmountsTestVariant} from "helpers/abTests/abtest";
 import { Country, CountryGroup } from 'helpers/internationalisation';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -9,14 +10,22 @@ import {
 	consentInitialisation,
 } from 'helpers/page/analyticsAndConsent';
 import { getReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import {getSettings} from "../globalsAndSwitches/globals";
 
 function setUpTrackingAndConsents(): void {
+  const settings = getSettings();
 	const countryId: IsoCountry = Country.detect();
 	const countryGroupId: CountryGroupId = CountryGroup.detect();
 	const participations: Participations = abTest.init(countryId, countryGroupId);
+  const {  amountsParticipation } =
+    getAmountsTestVariant(countryId, countryGroupId, settings);
+  const participationsWithAmountsTest = {
+    ...participations,
+    ...amountsParticipation,
+  };
 	const acquisitionData = getReferrerAcquisitionData();
 	void consentInitialisation(countryId);
-	analyticsInitialisation(participations, acquisitionData);
+	analyticsInitialisation(participationsWithAmountsTest, acquisitionData);
 }
 
 // ----- Exports ----- //

--- a/support-frontend/assets/helpers/page/page.ts
+++ b/support-frontend/assets/helpers/page/page.ts
@@ -1,18 +1,31 @@
 // ----- Imports ----- //
 import type { Participations } from 'helpers/abTests/abtest';
-import { Country } from 'helpers/internationalisation';
+import * as abTest from 'helpers/abTests/abtest';
+import {getAmountsTestVariant} from "helpers/abTests/abtest";
+import { Country, CountryGroup } from 'helpers/internationalisation';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
 	analyticsInitialisation,
 	consentInitialisation,
 } from 'helpers/page/analyticsAndConsent';
 import { getReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import {getSettings} from "../globalsAndSwitches/globals";
 
-function setUpTrackingAndConsents(participations: Participations = {}): void {
+function setUpTrackingAndConsents(): void {
+  const settings = getSettings();
 	const countryId: IsoCountry = Country.detect();
+	const countryGroupId: CountryGroupId = CountryGroup.detect();
+	const participations: Participations = abTest.init(countryId, countryGroupId);
+  const {  amountsParticipation } =
+    getAmountsTestVariant(countryId, countryGroupId, settings);
+  const participationsWithAmountsTest = {
+    ...participations,
+    ...amountsParticipation,
+  };
 	const acquisitionData = getReferrerAcquisitionData();
 	void consentInitialisation(countryId);
-	analyticsInitialisation(participations, acquisitionData);
+	analyticsInitialisation(participationsWithAmountsTest, acquisitionData);
 }
 
 // ----- Exports ----- //

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -19,12 +19,14 @@ if (!isDetailsSupported) {
 	polyfillDetails();
 }
 
+setUpTrackingAndConsents();
+
 // ----- Redux Store ----- //
 
 const countryGroupId: CountryGroupId = CountryGroup.detect();
 const store = initReduxForContributions();
+
 setUpRedux(store);
-setUpTrackingAndConsents(store.getState().common.abParticipations);
 
 const reactElementId = `supporter-plus-landing-page-${countryGroups[countryGroupId].supportInternationalisationId}`;
 const thankYouRoute = `/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou`;

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -19,14 +19,12 @@ if (!isDetailsSupported) {
 	polyfillDetails();
 }
 
-setUpTrackingAndConsents();
-
 // ----- Redux Store ----- //
 
 const countryGroupId: CountryGroupId = CountryGroup.detect();
 const store = initReduxForContributions();
-
 setUpRedux(store);
+setUpTrackingAndConsents(store.getState().common.abParticipations);
 
 const reactElementId = `supporter-plus-landing-page-${countryGroups[countryGroupId].supportInternationalisationId}`;
 const thankYouRoute = `/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou`;

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -57,6 +57,9 @@ export function SupporterPlusCheckout({
 	const { selectedAmounts, otherAmounts } = useContributionsSelector(
 		(state) => state.page.checkoutForm.product,
 	);
+  const { abParticipations } = useContributionsSelector(
+    (state) => state.common,
+  );
 	const contributionType = useContributionsSelector(getContributionType);
 	const amount = useContributionsSelector(getUserSelectedAmount);
 	const amountBeforeAmendments = useContributionsSelector(
@@ -87,7 +90,7 @@ export function SupporterPlusCheckout({
 				);
 				dispatch(resetValidation());
 				const destination = `/${countryGroups[countryGroupId].supportInternationalisationId}/contribute`;
-				navigateWithPageView(navigate, destination);
+				navigateWithPageView(navigate, destination , abParticipations);
 			}}
 		>
 			Change

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -57,9 +57,9 @@ export function SupporterPlusCheckout({
 	const { selectedAmounts, otherAmounts } = useContributionsSelector(
 		(state) => state.page.checkoutForm.product,
 	);
-  const { abParticipations } = useContributionsSelector(
-    (state) => state.common,
-  );
+	const { abParticipations } = useContributionsSelector(
+		(state) => state.common,
+	);
 	const contributionType = useContributionsSelector(getContributionType);
 	const amount = useContributionsSelector(getUserSelectedAmount);
 	const amountBeforeAmendments = useContributionsSelector(
@@ -90,7 +90,7 @@ export function SupporterPlusCheckout({
 				);
 				dispatch(resetValidation());
 				const destination = `/${countryGroups[countryGroupId].supportInternationalisationId}/contribute`;
-				navigateWithPageView(navigate, destination , abParticipations);
+				navigateWithPageView(navigate, destination, abParticipations);
 			}}
 		>
 			Change

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -57,9 +57,9 @@ export function SupporterPlusCheckout({
 	const { selectedAmounts, otherAmounts } = useContributionsSelector(
 		(state) => state.page.checkoutForm.product,
 	);
-	const { abParticipations } = useContributionsSelector(
-		(state) => state.common,
-	);
+  const { abParticipations } = useContributionsSelector(
+    (state) => state.common,
+  );
 	const contributionType = useContributionsSelector(getContributionType);
 	const amount = useContributionsSelector(getUserSelectedAmount);
 	const amountBeforeAmendments = useContributionsSelector(
@@ -90,7 +90,7 @@ export function SupporterPlusCheckout({
 				);
 				dispatch(resetValidation());
 				const destination = `/${countryGroups[countryGroupId].supportInternationalisationId}/contribute`;
-				navigateWithPageView(navigate, destination, abParticipations);
+				navigateWithPageView(navigate, destination , abParticipations);
 			}}
 		>
 			Change

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -6771,11 +6771,6 @@ ci-info@^3.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
   integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
 
-circular-dependency-plugin@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/circular-dependency-plugin/-/circular-dependency-plugin-5.2.2.tgz#39e836079db1d3cf2f988dc48c5188a44058b600"
-  integrity sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==
-
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"


### PR DESCRIPTION
## What are you doing in this PR?

Fixes issue where Ophan is being sent an empty ab test participations object (via `trackAbTests`) on Page 1 of the 2 step checkout, but not Page 2. 

[**Trello Card**](https://trello.com/c/M7Rg18K0/1742-trackabtests-participations-on-both-page-1-and-page-2-of-2-step-checkout)

## Why are you doing this?

trackAbTests for Ophan was provided with an empty ab participations on Page 1 of two-step checkout
This issue happened as the  Amounts Tests were not included in the ab participations sent to Ophan on Page 1.

Also the ab participations were not sent to Ophan on click of the "Change" button on second page and navigation to page 1.This PR includes a fix for that too
