### PR TITLE
fix: use discount price on Guardian Weekly Gift checkout

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
@@ -461,7 +461,7 @@ function WeeklyCheckoutFormGifting(props: PropTypes): JSX.Element {
 						errorHeading={submissionErrorHeading}
 					/>
 					<Total
-						price={props.price.price}
+						price={props.discountedPrice.price}
 						currency={props.currencyId}
 						promotions={props.price.promotions}
 					/>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
@@ -44,7 +44,10 @@ import { NoProductOptions } from 'helpers/productPrice/productOptions';
 import { GuardianWeekly } from 'helpers/productPrice/subscriptions';
 import { setBillingCountry } from 'helpers/redux/checkout/address/actions';
 import { getUserTypeFromIdentity } from 'helpers/redux/checkout/personalDetails/thunks';
-import { selectPriceForProduct } from 'helpers/redux/checkout/product/selectors/productPrice';
+import {
+	selectDiscountedPrice,
+	selectPriceForProduct,
+} from 'helpers/redux/checkout/product/selectors/productPrice';
 import type {
 	SubscriptionsDispatch,
 	SubscriptionsState,
@@ -103,6 +106,7 @@ function mapStateToProps(state: SubscriptionsState) {
 			state.common.internationalisation.defaultCurrency,
 		payPalHasLoaded: state.page.checkoutForm.payment.payPal.hasLoaded,
 		price: selectPriceForProduct(state),
+		discountedPrice: selectDiscountedPrice(state),
 	};
 }
 
@@ -442,7 +446,7 @@ function WeeklyCheckoutFormGifting(props: PropTypes): JSX.Element {
 							validateForm={props.validateForm}
 							isTestUser={props.isTestUser}
 							setupRecurringPayPalPayment={props.setupRecurringPayPalPayment}
-							amount={props.price.price}
+							amount={props.discountedPrice.price}
 							billingPeriod={props.billingPeriod}
 							// @ts-expect-error TODO: Fixing the types around validation errors will affect every checkout, too much to tackle now
 							allErrors={[


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Uses the discountPrice as per the [`paperCheckout`](https://github.com/guardian/support-frontend/blob/44a30fdbcf9cfee3503d36e547ea703574e1d637/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx#L552) and the [`weeklyCheckout`](https://github.com/guardian/support-frontend/blob/44a30fdbcf9cfee3503d36e547ea703574e1d637/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx#L414).

✨ Bonus fix ✨: Fix the total at the bottom of the page


[**Trello Card**](https://trello.com/c/UHPzZKGZ/1745-guardian-weekly-gifting-checkout-incorrect-price-displayed-on-paypal-summary-when-promo-code-applied)

## Why are you doing this?
So people get discounts. And discounts mean prizes.

## The original price was £165
<img width="579" alt="Screenshot 2023-12-19 at 15 36 28" src="https://github.com/guardian/support-frontend/assets/31692/3d1ccd50-eeb9-4c2f-9c8b-5f0f585bedf7">

<img width="537" alt="Screenshot 2023-12-19 at 15 38 08" src="https://github.com/guardian/support-frontend/assets/31692/fc3c4450-62b0-4155-b7dd-6e0e7e410560">

## Update to the total
<img width="395" alt="Screenshot 2023-12-19 at 15 48 12" src="https://github.com/guardian/support-frontend/assets/31692/f1beeeab-ce62-4297-883d-3c2dd3794f32">

