### PR TITLE
fix: update blurb for digital edition on subscription page

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
@@ -69,7 +69,7 @@ const digital = (
 	title: 'The Guardian Digital Edition',
 	subtitle: getDisplayPrice(countryGroupId, priceCopy.price),
 	description:
-		'Keep informed on the day’s top stories with the Guardian digital edition. Read the headlines, along with your favourite political commentators, lifestyle columnists, sport pundits and more – in a daily, digestible read, across all your devices.',
+		'Enjoy the Guardian and Observer newspaper, reimagined for mobile and tablet',
 	buttons: [
 		{
 			ctaButtonText: 'Find out more',


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Shrinking the blurb for the Digital Edition on the subscription page.

[**Trello Card**](https://trello.com/c/asnZwEzU/1743-update-the-editions-copy-on-the-subscribe-container)

## Why are you doing this?
To save readers precious time.

## Screenshots
<img width="1575" alt="Screenshot 2023-12-19 at 15 56 51" src="https://github.com/guardian/support-frontend/assets/31692/e4bd9023-4418-4a6d-81f2-93c8ad41a8f9">
