### PR TITLE
Remove `paper/delivery` url

### DIFF
--- a/support-frontend/app/controllers/CanonicalLinks.scala
+++ b/support-frontend/app/controllers/CanonicalLinks.scala
@@ -4,10 +4,6 @@ trait CanonicalLinks {
 
   val supportUrl: String
 
-  def buildCanonicalPaperSubscriptionLink(withDelivery: Boolean = false): String =
-    if (withDelivery) s"${supportUrl}/uk/subscribe/paper/delivery"
-    else s"${supportUrl}/uk/subscribe/paper"
-
   def buildCanonicalDigitalSubscriptionLink(countryCode: String, orderIsAGift: Boolean): String =
     if (orderIsAGift) s"${supportUrl}/${countryCode}/subscribe/digital/gift"
     else s"${supportUrl}/${countryCode}/subscribe/digital"

--- a/support-frontend/app/controllers/PaperSubscriptionController.scala
+++ b/support-frontend/app/controllers/PaperSubscriptionController.scala
@@ -35,13 +35,9 @@ class PaperSubscriptionController(
 
   implicit val a: AssetsResolver = assets
 
-  def paperMethodRedirect(withDelivery: Boolean = false): Action[AnyContent] = Action { implicit request =>
-    Redirect(buildCanonicalPaperSubscriptionLink(withDelivery), request.queryString, status = FOUND)
-  }
-
   def paper(): Action[AnyContent] = CachedAction() { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
-    val canonicalLink = Some(buildCanonicalPaperSubscriptionLink())
+    val canonicalLink = Some(s"${supportUrl}/uk/subscribe/paper")
     val defaultPromos = priceSummaryServiceProvider.forUser(isTestUser = false).getDefaultPromoCodes(Paper)
     val queryPromos = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil)
 

--- a/support-frontend/assets/helpers/urls/routes.ts
+++ b/support-frontend/assets/helpers/urls/routes.ts
@@ -1,5 +1,8 @@
 // ----- Routes ----- //
-import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import {
+	type FulfilmentOptions,
+	HomeDelivery,
+} from 'helpers/productPrice/fulfilmentOptions';
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
 import type { Option } from 'helpers/types/option';
 import type { CountryGroupId } from '../internationalisation/countryGroup';
@@ -58,11 +61,7 @@ function paperSubsUrl(
 	withDelivery = false,
 	promoCode?: Option<string>,
 ): string {
-	const baseURL = [
-		getOrigin(),
-		'uk/subscribe/paper',
-		...(withDelivery ? ['delivery'] : []),
-	].join('/');
+	const baseURL = [getOrigin(), 'uk/subscribe/paper'].join('/');
 	const queryParams = [
 		...getAllQueryParams(),
 		...(promoCode ? [['promoCode', promoCode]] : []),
@@ -71,8 +70,10 @@ function paperSubsUrl(
 		.map((keyValuePair) => keyValuePair.join('='))
 		.join('&');
 
+	const hash = withDelivery ? `#${HomeDelivery}` : '';
+
 	if (queryParamsString) {
-		return `${baseURL}?${queryParamsString}`;
+		return `${baseURL}?${queryParamsString}${hash}`;
 	}
 
 	return baseURL;

--- a/support-frontend/assets/helpers/urls/routes.ts
+++ b/support-frontend/assets/helpers/urls/routes.ts
@@ -1,8 +1,6 @@
 // ----- Routes ----- //
-import {
-	type FulfilmentOptions,
-	HomeDelivery,
-} from 'helpers/productPrice/fulfilmentOptions';
+import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import { type FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
 import type { Option } from 'helpers/types/option';
 import type { CountryGroupId } from '../internationalisation/countryGroup';
@@ -32,9 +30,9 @@ const routes: Record<string, string> = {
 	digitalSubscriptionLanding: '/subscribe/digitaledition',
 	digitalSubscriptionLandingGift: '/subscribe/digital/gift',
 	paperSubscriptionLanding: '/subscribe/paper',
-	paperSubscriptionProductChoices: '/subscribe/paper#subscribe',
+	paperSubscriptionProductChoices: '/subscribe/paper#HomeDelivery',
 	paperSubscriptionDeliveryProductChoices:
-		'/subscribe/paper/delivery#subscribe',
+		'/subscribe/paper/delivery#HomeDelivery',
 	guardianWeeklySubscriptionLanding: '/subscribe/weekly',
 	guardianWeeklySubscriptionLandingGift: '/subscribe/weekly/gift',
 	guardianWeeklyStudent:
@@ -58,7 +56,7 @@ function postcodeLookupUrl(postcode: string): string {
 }
 
 function paperSubsUrl(
-	withDelivery = false,
+	paperFulfulmentOption?: PaperFulfilmentOptions,
 	promoCode?: Option<string>,
 ): string {
 	const baseURL = [getOrigin(), 'uk/subscribe/paper'].join('/');
@@ -70,7 +68,7 @@ function paperSubsUrl(
 		.map((keyValuePair) => keyValuePair.join('='))
 		.join('&');
 
-	const hash = withDelivery ? `#${HomeDelivery}` : '';
+	const hash = paperFulfulmentOption ? `#${paperFulfulmentOption}` : '';
 
 	if (queryParamsString) {
 		return `${baseURL}?${queryParamsString}${hash}`;

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -295,9 +295,9 @@ function PaperCheckoutForm(props: PropTypes) {
 			startDate={formattedStartDate}
 			includesDigiSub={includesDigiSub}
 			changeSubscription={`${paperSubsUrl(
-				false,
+				Collection,
 				getQueryParameter('promoCode'),
-			)}#subscribe`}
+			)}`}
 		/>
 	);
 
@@ -316,9 +316,9 @@ function PaperCheckoutForm(props: PropTypes) {
 			digiSubPrice={expandedPricingText}
 			includesDigiSub={includesDigiSub}
 			changeSubscription={`${paperSubsUrl(
-				true,
+				HomeDelivery,
 				getQueryParameter('promoCode'),
-			)}#subscribe`}
+			)}`}
 			startDate={formattedStartDate}
 		/>
 	);

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/linkTo.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/linkTo.tsx
@@ -38,13 +38,13 @@ function LinkTo({
 	setTabAction: (arg0: PaperFulfilmentOptions) => void;
 	tab: PaperFulfilmentOptions;
 	children: ReactNode;
-	activeTab?: PaperFulfilmentOptions | null;
+	activeTab?: PaperFulfilmentOptions;
 	isPricesTabLink?: boolean;
 }): JSX.Element {
 	return (
 		<Link
 			css={isPricesTabLink ? linkStyles(tab, activeTab) : linkColor}
-			href={paperSubsUrl(tab === 'HomeDelivery')}
+			href={paperSubsUrl(activeTab)}
 			aria-current={tab === activeTab}
 			onClick={(ev) => {
 				ev.preventDefault();

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
@@ -97,7 +97,7 @@ export function PaperPrices({
 	}You can cancel your subscription at any time`;
 
 	return (
-		<section css={pricesSection} id="subscribe">
+		<section css={pricesSection}>
 			<h2 css={pricesHeadline}>Pick your subscription package below</h2>
 			<div css={pricesTabs}>
 				<LinkTo

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.tsx
@@ -152,7 +152,7 @@ export function PaperHero({
 								priority="tertiary"
 								iconSide="right"
 								icon={<SvgArrowDownStraight />}
-								href="#subscribe"
+								href="#HomeDelivery"
 							>
 								See pricing options
 							</LinkButton>

--- a/support-frontend/assets/pages/paper-subscription-landing/components/paperTabs.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/paperTabs.tsx
@@ -2,7 +2,10 @@
 import { Outset } from 'components/content/content';
 import Tabs from 'components/tabs/tabs';
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import { paperSubsUrl } from 'helpers/urls/routes';
+import {
+	Collection,
+	HomeDelivery,
+} from 'helpers/productPrice/fulfilmentOptions';
 import { ContentDeliveryFaqBlock } from './content/deliveryTab';
 import { SubsCardFaqBlock } from './content/subsCardTab';
 // ----- Tabs ----- //
@@ -14,12 +17,12 @@ type TabOptions = {
 export const tabs: Record<PaperFulfilmentOptions, TabOptions> = {
 	HomeDelivery: {
 		name: 'Home Delivery',
-		href: paperSubsUrl(true),
+		href: `#${HomeDelivery}`,
 		content: ContentDeliveryFaqBlock,
 	},
 	Collection: {
 		name: 'Subscription Card',
-		href: paperSubsUrl(false),
+		href: `#${Collection}`,
 		content: SubsCardFaqBlock,
 	},
 };

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
@@ -19,10 +19,9 @@ import {
 import { getPromotionCopy } from 'helpers/productPrice/promotions';
 import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
 import { renderPage } from 'helpers/rendering/render';
-import { paperSubsUrl } from 'helpers/urls/routes';
 import { PaperHero } from './components/hero/hero';
 import PaperProductPrices from './components/paperProductPrices';
-import Tabs from './components/tabs';
+import PaperTabs from './components/paperTabs';
 import type { PaperLandingPropTypes } from './paperSubscriptionLandingProps';
 import { paperLandingProps } from './paperSubscriptionLandingProps';
 import 'stylesheets/skeleton/skeleton.scss';
@@ -51,22 +50,9 @@ function PaperLandingPage({
 }: PaperLandingPropTypes) {
 	const sanitisedPromoCopy = getPromotionCopy(promotionCopy);
 
-	const [shouldRedirectToHomeDelivery, setShouldRedirectToHomeDelivery] =
-		useState<boolean>(true);
+	const fulfilment =
+		window.location.hash === `#${Collection}` ? Collection : HomeDelivery;
 
-	if (
-		shouldRedirectToHomeDelivery &&
-		!window.location.pathname.includes('delivery')
-	) {
-		window.history.replaceState({}, '', paperSubsUrl(true));
-		setShouldRedirectToHomeDelivery(false);
-	}
-
-	const fulfilment: PaperFulfilmentOptions =
-		window.location.pathname.includes('delivery') ||
-		shouldRedirectToHomeDelivery
-			? HomeDelivery
-			: Collection;
 	const [selectedTab, setSelectedTab] =
 		useState<PaperFulfilmentOptions>(fulfilment);
 
@@ -82,7 +68,8 @@ function PaperLandingPage({
 			product: 'Paper',
 			componentType: 'ACQUISITIONS_BUTTON',
 		})();
-		window.history.replaceState({}, '', paperSubsUrl(newTab === HomeDelivery));
+
+		window.history.replaceState({}, '', `#${newTab}`);
 	}
 
 	return (
@@ -99,7 +86,7 @@ function PaperLandingPage({
 				<CentredContainer>
 					<Block>
 						<div css={tabsTabletSpacing}>
-							<Tabs
+							<PaperTabs
 								selectedTab={selectedTab}
 								setTabAction={handleSetTabAction}
 							/>

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
@@ -135,7 +135,7 @@ const paper = (
 	buttons: [
 		{
 			ctaButtonText: 'Find out more',
-			link: paperSubsUrl(false),
+			link: paperSubsUrl(),
 			analyticsTracking: sendTrackingEventsOnClick({
 				id: 'paper_cta',
 				product: Paper,

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
@@ -95,7 +95,7 @@ const termsConditionsLink =
 
 function Prices({ orderIsAGift, products }: PropTypes): JSX.Element {
 	return (
-		<section css={pricesSection} id="subscribe">
+		<section css={pricesSection}>
 			<h2 css={pricesHeadline}>Subscribe to the Guardian Weekly today</h2>
 			<p css={pricesSubHeadline}>
 				{orderIsAGift ? 'Select a gift period' : "Choose how you'd like to pay"}

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
@@ -199,7 +199,7 @@ export function WeeklyHero({
 								iconSide="right"
 								icon={<SvgArrowDownStraight />}
 								cssOverrides={linkButtonColour}
-								href="#subscribe"
+								href="#HomeDelivery"
 							>
 								See pricing options
 							</LinkButton>

--- a/support-frontend/conf/fastly-snippets/redirects-table.vcl
+++ b/support-frontend/conf/fastly-snippets/redirects-table.vcl
@@ -49,4 +49,10 @@ table support_frontend_redirects {
   "/int/subscribe": "/int/subscribe/weekly",
   "/nz/subscribe": "/nz/subscribe/weekly",
   "/ca/subscribe": "/ca/subscribe/weekly",
+
+  # paper
+  "/paper": "/uk/subscribe/paper",
+  "/subscribe/paper": "/uk/subscribe/paper",
+  # This was a legacy URL to differentiate between tabs on the page
+  "/uk/subscribe/paper/delivery": "/uk/subscribe/paper",
 }

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -117,11 +117,7 @@ GET  /subscribe/weekly/checkout/gift                               controllers.W
 GET  /$country<(uk|us|au|int|nz|ca|eu)>/subscribe/weekly           controllers.WeeklySubscriptionController.weekly(country: String, orderIsAGift: Boolean = false)
 GET  /$country<(uk|us|au|int|nz|ca|eu)>/subscribe/weekly/gift      controllers.WeeklySubscriptionController.weekly(country: String, orderIsAGift: Boolean = true)
 
-GET  /paper                                                        controllers.PaperSubscriptionController.paperMethodRedirect(withDelivery: Boolean = false)
-GET  /subscribe/paper                                              controllers.PaperSubscriptionController.paperMethodRedirect(withDelivery: Boolean = false)
-GET  /subscribe/paper/delivery                                     controllers.PaperSubscriptionController.paperMethodRedirect(withDelivery: Boolean = true)
 GET  /uk/subscribe/paper                                           controllers.PaperSubscriptionController.paper()
-GET  /uk/subscribe/paper/delivery                                  controllers.PaperSubscriptionController.paper()
 GET  /subscribe/paper/checkout                                     controllers.PaperSubscriptionFormController.displayForm()
 
 # redemptions


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
- Removes the use of using a fully qualified route `paper/delivery` to control a fragment of the page in favour of using the url fragment/hash to do so
- Moves redirection for the paper route to Fastly

## Why are you doing this?

Using a URL to control a fragment of the page felt like the wrong tool for the job. This code also created some interesting logic between the history manipulation on the client and routing on the server where you couldn't hit `/paper` directly without redirecting to `/paper/delivery`.

It hopefully simplifies this part of the code too by using JS to deal with the fragment/hash and the server / fastly to deal with routing.

This code was introduced [here](https://github.com/guardian/support-frontend/pull/5436/files#diff-262aa4c1d3a23544743205a3065e7217fcc8f4638bf30c751a12469bd00e2f58R59). It made sense at the time, but hopefully this helps reduce out route fragmentation.

### SEO

I have gone with the `/paper` over `/paper/delivery` as `/paper/delivery` doesn't even feature in our Search Console. [Nor does it show up on Google SERPs](https://www.google.com/search?q=https%3A%2F%2Fsupport.theguardian.com%2Fuk%2Fsubscribe%2Fpaper%2Fdelivery).

# Screen-recording

https://github.com/guardian/support-frontend/assets/31692/f39f0c73-605a-4328-a8e9-91df509d8fab


