### PR TITLE
Update headline copy and ticker headline visibility

### DIFF
--- a/support-frontend/assets/components/ticker/ticker.tsx
+++ b/support-frontend/assets/components/ticker/ticker.tsx
@@ -87,7 +87,9 @@ export function Ticker(props: TickerProps): JSX.Element {
 
 	return (
 		<div>
-			<h2 css={tickerHeadline}>{props.headline}</h2>
+			{props.headline.length > 0 && (
+				<h2 css={tickerHeadline}>{props.headline}</h2>
+			)}
 			<div css={tickerProgressBar}>
 				<div css={tickerProgressBarBackground}>
 					<div

--- a/support-frontend/assets/components/ticker/ticker.tsx
+++ b/support-frontend/assets/components/ticker/ticker.tsx
@@ -87,9 +87,7 @@ export function Ticker(props: TickerProps): JSX.Element {
 
 	return (
 		<div>
-			{props.headline.length > 0 && (
-				<h2 css={tickerHeadline}>{props.headline}</h2>
-			)}
+			<h2 css={tickerHeadline}>{props.headline}</h2>
 			<div css={tickerProgressBar}>
 				<div css={tickerProgressBarBackground}>
 					<div

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -33,7 +33,7 @@ export const activeCampaigns: Record<string, CampaignSettings> = {
 		tickerSettings: {
 			countType: 'money',
 			endType: 'unlimited',
-			headline: '',
+			headline: 'Help us reach our goal',
 		},
 	},
 	ausTicker2023: {

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -33,7 +33,7 @@ export const activeCampaigns: Record<string, CampaignSettings> = {
 		tickerSettings: {
 			countType: 'money',
 			endType: 'unlimited',
-			headline: 'Help us reach our end-of-year goal',
+			headline: '',
 		},
 	},
 	ausTicker2023: {

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
@@ -74,6 +74,7 @@ const darkBackgroundContainerMobile = css`
 const subHeadingUnitedStates = css`
 	${textSans.medium()};
 	padding-right: ${space[2]}px;
+	margin-bottom: 54px;
 `;
 
 const subHeading = css`
@@ -179,16 +180,7 @@ export function SupporterPlusCheckoutScaffold({
 		isUsEoy2023CampaignEnabled && countryGroupId === 'UnitedStates';
 
 	const headingUSEoy2023 = (
-		<LandingPageHeading
-			heading={
-				<>
-					Make a<br />
-					year-end gift
-					<br />
-					to the Guardian
-				</>
-			}
-		/>
+		<LandingPageHeading heading={<>Support the Guardian</>} />
 	);
 
 	useEffect(() => {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Updating the checkout headline copy displayed as part of the US end of year campaign and hiding the text above the ticker

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/hgJRjICX/1748-update-headline-copy-for-us-eoy-campaign)

## Why are you doing this?
With the year ended, the copy **Make a year-end gift to the Guardian** won't make sense, so it needs to be updated to something that will. Same goes for the text above the ticker that appears on mobile. 

## Screenshots
| Before | After |
| --- | --- |
| <img width="408" alt="image" src="https://github.com/guardian/support-frontend/assets/99400613/72f16bb0-6eae-4326-bcf2-6c8f7951513a"> <img width="512" alt="image" src="https://github.com/guardian/support-frontend/assets/99400613/e82f1ae8-77dd-448f-82e6-a1c1fe21154a">  | <img width="408" alt="image" src="https://github.com/guardian/support-frontend/assets/99400613/b9f2b811-adee-4353-9305-7c04c5a2758c"> <img width="513" alt="image" src="https://github.com/guardian/support-frontend/assets/99400613/67b0d0a1-58a6-4f43-a9a5-adff24d2c2ed"> |




