### PR TITLE
Small refactor of abTest module interface

### DIFF
--- a/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
@@ -14,12 +14,13 @@ import {
 	UnitedStates,
 } from '../../internationalisation/countryGroup';
 import {
+	_,
 	init as abInit,
 	getAmountsTestVariant,
-	targetPageMatches,
 } from '../abtest';
 import type { Audience, Participations, Test, Variant } from '../abtest';
 
+const { targetPageMatches } = _;
 const { subsDigiSubPages, digiSub } = pageUrlRegexes.subscriptions;
 const { nonGiftLandingNotAusNotUS, nonGiftLandingAndCheckoutWithGuest } =
 	digiSub;

--- a/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
@@ -13,11 +13,7 @@ import {
 	GBPCountries,
 	UnitedStates,
 } from '../../internationalisation/countryGroup';
-import {
-	_,
-	init as abInit,
-	getAmountsTestVariant,
-} from '../abtest';
+import { _, init as abInit, getAmountsTestVariant } from '../abtest';
 import type { Audience, Participations, Test, Variant } from '../abtest';
 
 const { targetPageMatches } = _;

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -79,7 +79,7 @@ export type Tests = Record<string, Test>;
 
 // ----- Init ----- //
 
-export function init(
+function init(
 	country: IsoCountry,
 	countryGroupId: CountryGroupId,
 	abTests: Tests = tests,
@@ -209,7 +209,7 @@ interface GetAmountsTestVariantResult {
 	selectedAmountsVariant: SelectedAmountsVariant; // Always return an AmountsVariant, even if it's a fallback
 	amountsParticipation?: Participations; // Optional because we only add participation if we want to track an amounts test that has multiple variants
 }
-export function getAmountsTestVariant(
+function getAmountsTestVariant(
 	country: IsoCountry,
 	countryGroupId: CountryGroupId,
 	settings: Settings,
@@ -219,8 +219,9 @@ export function getAmountsTestVariant(
 		[],
 ): GetAmountsTestVariantResult {
 	const { amounts } = settings;
-	if (!amounts) {
-		return {
+
+  if (!amounts) {
+    return {
 			selectedAmountsVariant: getFallbackAmounts(countryGroupId),
 		};
 	}
@@ -230,11 +231,12 @@ export function getAmountsTestVariant(
 		testName: string,
 		variantName: string,
 	): Participations | undefined => {
-		// Check if we actually want to track this test
+    // Check if we actually want to track this test
 		const pathMatches = targetPageMatches(
 			path,
 			'/??/contribute|thankyou(/.*)?$',
 		);
+
 		if (pathMatches && test.variants.length > 1 && test.isLive) {
 			return {
 				[testName]: variantName,
@@ -341,7 +343,8 @@ export function getAmountsTestVariant(
 		currentTestName,
 		variant.variantName,
 	);
-	return {
+
+  return {
 		selectedAmountsVariant: {
 			...variant,
 			testName: currentTestName,
@@ -372,7 +375,7 @@ function getTestFromAcquisitionData(): AcquisitionABTest[] | undefined {
 	}
 }
 
-export function getSourceFromAcquisitionData(): string | undefined {
+function getSourceFromAcquisitionData(): string | undefined {
 	const acquisitionDataParam = getQueryParameter('acquisitionData');
 
 	if (!acquisitionDataParam) {
@@ -528,7 +531,7 @@ function assigned(variantIndex: number): VariantAssignment {
 	return { type: 'ASSIGNED', variantIndex };
 }
 
-export function targetPageMatches(
+function targetPageMatches(
 	locationPath: string,
 	targetPage: (string | null | undefined) | RegExp,
 ): boolean {
@@ -537,4 +540,14 @@ export function targetPageMatches(
 	}
 
 	return locationPath.match(targetPage) != null;
+}
+
+export {
+  init,
+  getAmountsTestVariant,
+}
+
+// Exported for testing only
+export const _ = {
+  targetPageMatches
 }

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -220,8 +220,8 @@ function getAmountsTestVariant(
 ): GetAmountsTestVariantResult {
 	const { amounts } = settings;
 
-  if (!amounts) {
-    return {
+	if (!amounts) {
+		return {
 			selectedAmountsVariant: getFallbackAmounts(countryGroupId),
 		};
 	}
@@ -231,7 +231,7 @@ function getAmountsTestVariant(
 		testName: string,
 		variantName: string,
 	): Participations | undefined => {
-    // Check if we actually want to track this test
+		// Check if we actually want to track this test
 		const pathMatches = targetPageMatches(
 			path,
 			'/??/contribute|thankyou(/.*)?$',
@@ -344,7 +344,7 @@ function getAmountsTestVariant(
 		variant.variantName,
 	);
 
-  return {
+	return {
 		selectedAmountsVariant: {
 			...variant,
 			testName: currentTestName,
@@ -542,12 +542,9 @@ function targetPageMatches(
 	return locationPath.match(targetPage) != null;
 }
 
-export {
-  init,
-  getAmountsTestVariant,
-}
+export { init, getAmountsTestVariant };
 
 // Exported for testing only
 export const _ = {
-  targetPageMatches
-}
+	targetPageMatches,
+};

--- a/support-frontend/assets/helpers/page/page.ts
+++ b/support-frontend/assets/helpers/page/page.ts
@@ -22,7 +22,7 @@ function setUpTrackingAndConsents(): void {
 		countryGroupId,
 		settings,
 	);
-  const participationsWithAmountsTest = {
+	const participationsWithAmountsTest = {
 		...participations,
 		...amountsParticipation,
 	};

--- a/support-frontend/assets/helpers/page/page.ts
+++ b/support-frontend/assets/helpers/page/page.ts
@@ -22,7 +22,7 @@ function setUpTrackingAndConsents(): void {
 		countryGroupId,
 		settings,
 	);
-	const participationsWithAmountsTest = {
+  const participationsWithAmountsTest = {
 		...participations,
 		...amountsParticipation,
 	};


### PR DESCRIPTION
## What are you doing in this PR?

I've been documenting our [client-side AB tests](https://github.com/guardian/support-frontend/wiki/Client-side-AB-Testing) set-up on the support site. In doing so I noticed a few exports that weren't actually imported anywhere, or were only imported to test, so I made the following small changes:

1) Removed the export `getSourceFromAcquisitionData`, this function is only referenced within the module.
2) Moved the `targetPageMatches` export to an `_` export which is naming convention to highlight it's only exported for testing purposes.
3) Grouped the remaining named exports `init` and `getAmountsTestVariant` at the end of the module. I find grouping the exports like this at the end of the module easier when trying to get a quick overview of a modules interface. 

Interested in feedback on points 2 and 3 as I don't believe we have agreed conventions on these approaches, but consistency through convention could be beneficial.
