### PR TITLE
VSCODE format .ts/.tsx on save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .metals
 metals.sbt
 .bloop
+.vscode/settings.json
 
 node_modules
 npm-debug.log

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,20 @@
 {
   "typescript.format.enable": false, // disable default VS code TS formatting in favour of ESLint
-  "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+  "[typescript]": { // for .ts files
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": true
+    },
+  },
+  "[typescriptreact]": { // for .tsx files
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": true
+    },
   },
   "eslint.workingDirectories": ["support-frontend"],
-  "eslint.validate": ["typescript", "typescriptreact"],
   "jumpToAliasFile.alias": {
     "react": "preact-compat",
     "react-dom": "preact-compat",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,9 @@
 {
   "typescript.format.enable": false, // disable default VS code TS formatting in favour of ESLint
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit",
-    "source.fixAll.prettier": "explicit"
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.workingDirectories": ["support-frontend"],
   "eslint.validate": ["typescript", "typescriptreact"],

--- a/.vscode/settings.json.recommended
+++ b/.vscode/settings.json.recommended
@@ -14,6 +14,13 @@
       "source.fixAll.eslint": true
     },
   },
+  "[javascript]": { // for .js files
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": true
+    },
+  },
   "eslint.workingDirectories": ["support-frontend"],
   "jumpToAliasFile.alias": {
     "react": "preact-compat",

--- a/support-frontend/.prettierrc.js
+++ b/support-frontend/.prettierrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  ...require('@guardian/prettier')
+	...require('@guardian/prettier')
 };

--- a/support-frontend/.prettierrc.js
+++ b/support-frontend/.prettierrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	...require('@guardian/prettier')
+	...require('@guardian/prettier'),
 };


### PR DESCRIPTION
## What are you doing in this PR?

I've noticed VSCODE hasn't been applying Prettier formatting on save, despite the workspace settings in .`vscode/settings.json` containng a rule `"source.fixAll.prettier": "explicit"`, the purpose of which was to format using our Prettier settings on save, having looked at it this doesn't do anything.

I've looked at various examples online and have landed on an updated configuration that now:

- Applies Prettier fixes to all `.ts` and `.tsx` files on save, I've tested and confirmed it's using our Prettier settings in `support-frontend/.prettierrc.js` when formatting on save.
- Applies ESLint updates to all `.ts` and `.tsx` files on save.
- Doesn't attempt to format non `.ts` and `.tsx` files on save.