### PR TITLE
Checkout TsAndCs FinePrint bottom spacing adjust

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/finePrint.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/finePrint.tsx
@@ -1,3 +1,4 @@
+import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { neutral, textSans, until } from '@guardian/source-foundations';
 
@@ -17,13 +18,17 @@ type FinePrintSize = 'xsmall' | 'xxsmall';
 type FinePrintProps = {
 	mobileTheme: FinePrintTheme;
 	size?: FinePrintSize;
+	cssOverrides?: SerializedStyles;
 	children: React.ReactNode;
 };
 
 export function FinePrint({
 	mobileTheme,
 	size = 'xxsmall',
+	cssOverrides,
 	children,
 }: FinePrintProps): JSX.Element {
-	return <div css={textStyles(mobileTheme, size)}>{children}</div>;
+	return (
+		<div css={[textStyles(mobileTheme, size), cssOverrides]}>{children}</div>
+	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/components/guardianTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/guardianTsAndCs.tsx
@@ -1,5 +1,14 @@
+import { css } from '@emotion/react';
+import { from, space } from '@guardian/source-foundations';
 import type { FinePrintTheme } from './finePrint';
 import { FinePrint } from './finePrint';
+
+const guardianTsAndCsStyles = css`
+	margin-bottom: ${space[6]}px;
+	${from.tablet} {
+		margin-bottom: 64px;
+	}
+`;
 
 export function GuardianTsAndCs({
 	mobileTheme = 'dark',
@@ -7,7 +16,7 @@ export function GuardianTsAndCs({
 	mobileTheme?: FinePrintTheme;
 }): JSX.Element {
 	return (
-		<FinePrint mobileTheme={mobileTheme}>
+		<FinePrint mobileTheme={mobileTheme} cssOverrides={guardianTsAndCsStyles}>
 			<p>
 				The ultimate owner of the Guardian is The Scott Trust Limited, whose
 				role it is to secure the editorial and financial independence of the


### PR DESCRIPTION
## What are you doing in this PR?

Spacing appears to have been lost from TsAndC’s fineprint text at bottom of checkout. 

Adjustments required ->
"<Tablet : 24px"
">=Tablet: 64px"

[**Trello Card**](https://trello.com/c/vjM36Wmb/452-checkout-scaffold-tax-donation-bottom-of-page-spacing-adjust)

## Screenshots

|mobile|tablet+|
|--------|---------|
|![unnamed (7)](https://github.com/guardian/support-frontend/assets/76729591/f3f490f3-3156-4c25-914c-8a2bf1f6168c)|![unnamed (8)](https://github.com/guardian/support-frontend/assets/76729591/14226ecd-8ebd-47b3-8ddc-350729a025d4)|
