### PR TITLE
refactor: remove polyfill callback code

### DIFF
--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -74,7 +74,7 @@
 
     @inline(inlineCss: StyleContent) = {
       <style>
-      @inlineCss.value
+        @inlineCss.value
       </style>
     }
 
@@ -103,16 +103,16 @@
     <link rel="apple-touch-icon-precomposed" href="@assets("images/favicons/57x57.png")">
 
     <script type="application/ld+json">
-		{
-			"@@context": "http://schema.org",
-			"@@type": "Organization",
-			"name": "Support the Guardian",
-			"url": "https://support.theguardian.com",
-			"logo": "https://support.theguardian.com@assets("images/favicons/152x152.png")"
-		}
-	</script>
+      {
+        "@@context": "http://schema.org",
+        "@@type": "Organization",
+        "name": "Support the Guardian",
+        "url": "https://support.theguardian.com",
+        "logo": "https://support.theguardian.com@assets("images/favicons/152x152.png")"
+      }
+	  </script>
 
-    </head>
+  </head>
   <body class="header-tweaks">
     <noscript>
       <div style="text-align: center;
@@ -141,18 +141,7 @@
 
     @mainElement.fold(emptyDiv, withContent)
 
-    <script>
-      function guardianPolyfilled() {
-        window.guardian.polyfillScriptLoaded = true;
-      }
-    </script>
-
-    <script src="https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch,NodeList.prototype.forEach,ResizeObserver&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1"></script>
-
-    <script>
-      window.guardian = window.guardian || {};
-      window.guardian.polyfillVersion = 'v3';
-    </script>
+    <script src="https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch,NodeList.prototype.forEach,ResizeObserver&flags=gated&unknown=polyfill&cacheClear=1"></script>
 
     <script type="text/javascript">
       window.guardian = window.guardian || {};

--- a/support-frontend/window.d.ts
+++ b/support-frontend/window.d.ts
@@ -61,8 +61,6 @@ declare global {
 				default: string;
 				test: string;
 			};
-			polyfillScriptLoaded?: boolean;
-			polyfillVersion?: string;
 			productPrices: ProductPrices;
 			recaptchaEnabled?: boolean;
 			serversideTests?: Participations | null;


### PR DESCRIPTION
## What are you doing in this PR?
Removing references to the polyfill callback code. I can't see anywhere we are using it and more code = more complexity.

The only thing I can think of is we might have used it for debugging, but I haven't seen this anywhere.

## Why are you doing this?
Less code = less complexity = more fun + more productivity.

Things like this also make it harder to refactor as I need to assess if it should come along for the ride or if we can remove it. This should make it easier for the next person to make changes.
