### PR TITLE
refactor: remove id from pagescaffold

### DIFF
--- a/support-frontend/assets/components/page/pageScaffold.tsx
+++ b/support-frontend/assets/components/page/pageScaffold.tsx
@@ -27,7 +27,6 @@ const container = css`
 `;
 
 export type PageScaffoldProps = {
-	id: string;
 	header?: ReactNode;
 	footer?: ReactNode;
 	children: ReactNode;
@@ -35,21 +34,25 @@ export type PageScaffoldProps = {
 
 FocusStyleManager.onlyShowFocusOnTabs();
 
-export function PageScaffold(props: PageScaffoldProps): JSX.Element {
+export function PageScaffold({
+	header,
+	footer,
+	children,
+}: PageScaffoldProps): JSX.Element {
 	useScrollToAnchor();
 
 	return (
-		<div id={props.id} css={container}>
+		<div css={container}>
 			<Global styles={[reset, guardianFonts]} />
 			<SkipLink id="maincontent" label="Skip to main content" />
 			<SkipLink id="navigation" label="Skip to navigation" />
 			<CsrBanner />
 			<TestUserBanner />
-			{props.header}
+			{header}
 			<main role="main" id="maincontent">
-				{props.children}
+				{children}
 			</main>
-			{props.footer}
+			{footer}
 		</div>
 	);
 }

--- a/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionLandingPage.tsx
@@ -139,7 +139,6 @@ export function DigitalSubscriptionLandingPage({
 
 	return (
 		<PageScaffold
-			id="digital-subscription-landing"
 			header={
 				<>
 					<Header>

--- a/support-frontend/assets/pages/digital-subscriber-checkout/preRenderDigitalSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/preRenderDigitalSubscriptionLandingPage.tsx
@@ -68,7 +68,6 @@ function PreRenderDigitalSubscriptionLandingPage(): JSX.Element {
 
 	return (
 		<PageScaffold
-			id="digital-subscription-landing"
 			header={
 				<>
 					<Header>

--- a/support-frontend/assets/pages/digital-subscriber-thank-you/digitalSubscriptionThankYou.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-thank-you/digitalSubscriptionThankYou.tsx
@@ -75,7 +75,6 @@ export function DigitalSubscriptionThankYou(): JSX.Element {
 
 	return (
 		<PageScaffold
-			id="supporter-plus-thank-you"
 			header={<Header />}
 			footer={
 				<FooterWithContents>

--- a/support-frontend/assets/pages/supporter-plus-landing/preRenderSupporterPlusLandingPage.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/preRenderSupporterPlusLandingPage.tsx
@@ -73,7 +73,6 @@ const countrySwitcherProps: CountryGroupSwitcherProps = {
 function PreRenderSupporterPlusLandingPage(): JSX.Element {
 	return (
 		<PageScaffold
-			id="supporter-plus-landing"
 			header={
 				<>
 					<Header>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
@@ -199,7 +199,6 @@ export function SupporterPlusCheckoutScaffold({
 
 	return (
 		<PageScaffold
-			id="supporter-plus-landing"
 			header={
 				<>
 					<Header>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -136,7 +136,6 @@ export function ThreeTierLanding(): JSX.Element {
 
 	return (
 		<PageScaffold
-			id="supporter-plus-landing-three-tier"
 			header={
 				<>
 					<Header>

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -223,7 +223,6 @@ export function SupporterPlusThankYou(): JSX.Element {
 
 	return (
 		<PageScaffold
-			id="supporter-plus-thank-you"
 			header={<Header />}
 			footer={
 				<FooterWithContents>

--- a/support-frontend/stories/core/PageScaffold.stories.tsx
+++ b/support-frontend/stories/core/PageScaffold.stories.tsx
@@ -18,7 +18,7 @@ export default {
 function Template(args: PageScaffoldProps) {
 	return (
 		<MemoryRouter>
-			<PageScaffold id={args.id}>{args.children}</PageScaffold>
+			<PageScaffold>{args.children}</PageScaffold>
 		</MemoryRouter>
 	);
 }


### PR DESCRIPTION
## What are you doing in this PR?
Removes the `id` from `PageScaffold` as it's unused.

## Why are you doing this?
Extra code = extra overhead when trying to refactor making things harder to change, and thus sometimes they don't get changed.
