### PR TITLE
3-tier first page, checkout inner content components

### DIFF
--- a/support-frontend/assets/components/checkmarkList/checkmarkList.tsx
+++ b/support-frontend/assets/components/checkmarkList/checkmarkList.tsx
@@ -57,6 +57,7 @@ export type CheckmarkListProps = {
 	checkListData: CheckListData[];
 	style?: CheckmarkListStyle;
 	iconColor?: string;
+	cssOverrides?: SerializedStyles;
 };
 
 function ChecklistItemIcon({
@@ -83,9 +84,10 @@ export function CheckmarkList({
 	checkListData,
 	style = 'standard',
 	iconColor = style === 'compact' ? palette.success[400] : palette.brand[500],
+	cssOverrides,
 }: CheckmarkListProps): JSX.Element {
 	return (
-		<table css={tableCss(style)}>
+		<table css={[tableCss(style), cssOverrides]}>
 			{checkListData.map((item) => (
 				<tr>
 					<td

--- a/support-frontend/assets/components/paymentFrequencyButtons/paymentFrequencyButtons.tsx
+++ b/support-frontend/assets/components/paymentFrequencyButtons/paymentFrequencyButtons.tsx
@@ -1,0 +1,76 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import { from, palette, space, textSans } from '@guardian/source-foundations';
+import { useState } from 'react';
+
+interface PaymentFrequencyButtonObj {
+	label: string;
+	isPreSelected?: boolean;
+}
+
+interface PaymentFrequencyButtonsProps {
+	paymentFrequencies: PaymentFrequencyButtonObj[];
+	buttonClickHandler: (buttonIndex: number) => void;
+	additionalStyles?: SerializedStyles;
+}
+
+const container = (numberOfChildren: number) => css`
+	display: grid;
+	width: 100%;
+	grid-template-columns: repeat(${numberOfChildren}, 1fr);
+	gap: 1px;
+	${from.tablet} {
+		width: fit-content;
+	}
+`;
+
+const button = (isSelected: boolean) => css`
+	background-color: ${isSelected ? palette.neutral[100] : '#A2B2CB'};
+	transition: background-color 0.3s;
+	${textSans.medium({
+		fontWeight: 'bold',
+	})}
+	border: 0;
+	padding: ${space[3]}px ${space[9]}px;
+	color: ${palette.brand[400]};
+	:hover {
+		background-color: ${isSelected ? palette.neutral[100] : '#DAE0EA'};
+	}
+	cursor: pointer;
+	:first-child {
+		border-radius: ${space[3]}px 0 0 ${space[3]}px;
+	}
+	:last-child {
+		border-radius: 0 ${space[3]}px ${space[3]}px 0;
+	}
+`;
+
+export function PaymentFrequencyButtons({
+	paymentFrequencies,
+	buttonClickHandler,
+	additionalStyles,
+}: PaymentFrequencyButtonsProps): JSX.Element {
+	const [selectedButton, setSelectedButton] = useState(
+		Math.max(
+			paymentFrequencies.findIndex(
+				(paymentFrequency) => paymentFrequency.isPreSelected,
+			),
+			0,
+		),
+	);
+	return (
+		<div css={[container(paymentFrequencies.length), additionalStyles]}>
+			{paymentFrequencies.map((paymentFrequency, buttonIndex) => (
+				<button
+					css={button(buttonIndex === selectedButton)}
+					onClick={() => {
+						setSelectedButton(buttonIndex);
+						buttonClickHandler(buttonIndex);
+					}}
+				>
+					{paymentFrequency.label}
+				</button>
+			))}
+		</div>
+	);
+}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
@@ -1,0 +1,80 @@
+import { css } from '@emotion/react';
+import {
+	between,
+	from,
+	headline,
+	palette,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
+import { Button } from '@guardian/source-react-components';
+
+const container = css`
+	text-align: center;
+`;
+
+const heading = css`
+	color: ${palette.neutral[7]};
+	${headline.xsmall({
+		fontWeight: 'bold',
+	})}
+	${between.tablet.and.desktop} {
+		margin: 0 auto;
+		max-width: 340px;
+	}
+	${from.desktop} {
+		font-size: 2.125rem;
+	}
+`;
+
+const standFirst = css`
+	color: ${palette.neutral[10]};
+	${textSans.medium()};
+	line-height: 1.35;
+	${from.tablet} {
+		margin: 0 auto;
+		max-width: 340px;
+	}
+	${from.desktop} {
+		max-width: 422px;
+	}
+`;
+
+const btnStyleOverrides = css`
+	width: 100%;
+	justify-content: center;
+	margin-top: ${space[6]}px;
+	${from.tablet} {
+		max-width: 340px;
+	}
+	${from.desktop} {
+		max-width: 275px;
+	}
+`;
+
+interface SupportOnceProps {
+	btnClickHandler: () => void;
+}
+
+export function SupportOnce({
+	btnClickHandler,
+}: SupportOnceProps): JSX.Element {
+	return (
+		<div css={container}>
+			<h2 css={heading}>Support us just once</h2>
+			<p css={standFirst}>
+				We welcome support of any size, any time, whether you choose to give £1
+				or much more.
+			</p>
+			<Button
+				iconSide="left"
+				priority="primary"
+				size="default"
+				cssOverrides={btnStyleOverrides}
+				onClick={() => btnClickHandler()}
+			>
+				Support now
+			</Button>
+		</div>
+	);
+}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -1,0 +1,140 @@
+import { css, ThemeProvider } from '@emotion/react';
+import {
+	from,
+	palette,
+	space,
+	textSans,
+	until,
+} from '@guardian/source-foundations';
+import {
+	Button,
+	buttonThemeReaderRevenueBrand,
+} from '@guardian/source-react-components';
+import { CheckmarkList } from 'components/checkmarkList/checkmarkList';
+import type { RegularContributionType } from 'helpers/contributions';
+import { ThreeTierLozenge } from './threeTierLozenge';
+
+interface ThreeTierCardProps {
+	cardTitle: string;
+	currentPrice: string;
+	previousPrice?: string;
+	priceSuffix?: string;
+	isRecommended?: true;
+	benefits: Array<{ copy: string; tooltip?: string }>;
+	benefitsPrefix?: string | JSX.Element;
+	currency: string;
+	paymentFrequency: RegularContributionType;
+	cardCtaClickHandler: (price: string) => void;
+}
+
+const container = (isRecommended?: boolean) => css`
+	position: ${isRecommended ? 'relative' : 'static'};
+	background-color: ${isRecommended ? '#F1FBFF' : palette.neutral[100]};
+	border-radius: ${space[3]}px;
+	padding: 32px ${space[3]}px ${space[6]}px ${space[3]}px;
+	${until.desktop} {
+		order: ${isRecommended ? 0 : 1};
+		padding-top: ${space[6]}px;
+	}
+`;
+
+const title = css`
+	${textSans.small({ fontWeight: 'bold' })};
+	color: #606060;
+`;
+
+const price = (hasPriceSuffix: boolean) => css`
+	${textSans.xlarge({ fontWeight: 'bold' })};
+	position: relative;
+	margin-bottom: ${hasPriceSuffix ? '0' : `${space[4]}px`};
+	${from.desktop} {
+		margin-bottom: ${space[6]}px;
+	}
+`;
+
+const priceSuffixCss = css`
+	display: block;
+	font-size: ${space[3]}px;
+	font-weight: 400;
+	color: #606060;
+	margin-bottom: ${space[4]}px;
+	${from.desktop} {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		width: 100%;
+		text-align: center;
+		margin-bottom: 0;
+	}
+`;
+
+const previousPriceStrikeThrough = css`
+	font-weight: 400;
+	text-decoration: line-through;
+`;
+
+const btnStyleOverrides = css`
+	width: 100%;
+	justify-content: center;
+	margin-bottom: ${space[6]}px;
+`;
+
+const checkmarkList = css`
+	width: 100%;
+	text-align: left;
+	${from.desktop} {
+		width: 90%;
+	}
+`;
+
+export function ThreeTierCard({
+	cardTitle,
+	currentPrice,
+	previousPrice,
+	priceSuffix,
+	isRecommended,
+	benefits,
+	benefitsPrefix,
+	currency,
+	paymentFrequency,
+	cardCtaClickHandler,
+}: ThreeTierCardProps): JSX.Element {
+	const frequencyCopyMap = {
+		MONTHLY: 'month',
+		ANNUAL: 'year',
+	};
+	const previousPriceCopy = previousPrice && `${currency}${previousPrice}`;
+	const currentPriceCopy = `${currency}${currentPrice}/${frequencyCopyMap[paymentFrequency]}`;
+	return (
+		<div css={container(isRecommended)}>
+			{isRecommended && <ThreeTierLozenge title="Recommended" />}
+			<h3 css={title}>{cardTitle}</h3>
+			<h2 css={price(!!priceSuffix)}>
+				<span css={previousPriceStrikeThrough}>{previousPriceCopy}</span>
+				{previousPriceCopy && ' '}
+				{currentPriceCopy}
+				{priceSuffix && <span css={priceSuffixCss}>{priceSuffix}</span>}
+			</h2>
+			<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
+				<Button
+					iconSide="left"
+					priority="primary"
+					size="default"
+					cssOverrides={btnStyleOverrides}
+					onClick={() => cardCtaClickHandler(currentPrice)}
+				>
+					Support now
+				</Button>
+			</ThemeProvider>
+			{benefitsPrefix}
+			<CheckmarkList
+				checkListData={benefits.map((benefit) => {
+					return { text: <span>{benefit.copy}</span>, isChecked: true };
+				})}
+				style={'compact'}
+				iconColor={palette.brand[500]}
+				cssOverrides={checkmarkList}
+			/>
+		</div>
+	);
+}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
@@ -1,0 +1,59 @@
+import { css } from '@emotion/react';
+import { between, from, space } from '@guardian/source-foundations';
+import type { RegularContributionType } from 'helpers/contributions';
+import { ThreeTierCard } from './threeTierCard';
+
+interface ThreeTierCardsProps {
+	cardsContent: Array<{
+		cardTitle: string;
+		currentPrice: string;
+		previousPrice?: string;
+		priceSuffix?: string;
+		isRecommended?: true;
+		benefits: Array<{ copy: string; tooltip?: string }>;
+		benefitsPrefix?: string | JSX.Element;
+	}>;
+	currency: string;
+	paymentFrequency: RegularContributionType;
+	cardsCtaClickHandler: (price: string) => void;
+}
+
+const container = (cardCount: number) => css`
+	display: flex;
+	flex-direction: column;
+	gap: ${space[3]}px;
+	> * {
+		flex-basis: ${100 / cardCount}%;
+	}
+	${between.tablet.and.desktop} {
+		margin: 0 auto;
+		max-width: 340px;
+	}
+	${from.desktop} {
+		gap: ${space[5]}px;
+		flex-direction: row;
+	}
+`;
+
+export function ThreeTierCards({
+	cardsContent,
+	currency,
+	paymentFrequency,
+	cardsCtaClickHandler,
+}: ThreeTierCardsProps): JSX.Element {
+	return (
+		<div css={container(cardsContent.length)}>
+			{cardsContent.map((cardContent, cardIndex) => {
+				return (
+					<ThreeTierCard
+						key={`threeTierCard${cardIndex}`}
+						{...cardContent}
+						currency={currency}
+						paymentFrequency={paymentFrequency}
+						cardCtaClickHandler={cardsCtaClickHandler}
+					/>
+				);
+			})}
+		</div>
+	);
+}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierLozenge.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierLozenge.tsx
@@ -1,0 +1,24 @@
+import { css } from '@emotion/react';
+import { palette, space, textSans } from '@guardian/source-foundations';
+
+interface ThreeTierLozengeProps {
+	title: string;
+}
+
+const container = css`
+	position: absolute;
+	top: 0;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	padding: ${space[1]}px ${space[4]}px;
+	border-radius: ${space[1]}px;
+	background-color: ${palette.brand[500]};
+	color: ${palette.neutral[100]};
+	${textSans.small({ fontWeight: 'bold' })};
+`;
+
+export function ThreeTierLozenge({
+	title,
+}: ThreeTierLozengeProps): JSX.Element {
+	return <div css={container}>{title}</div>;
+}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -1,23 +1,26 @@
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import { cmp } from '@guardian/consent-management-platform';
-import { from, palette, space } from '@guardian/source-foundations';
 import {
-	Button,
-	buttonThemeReaderRevenueBrand,
-	Container,
-} from '@guardian/source-react-components';
+	from,
+	headline,
+	palette,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
+import { Container } from '@guardian/source-react-components';
 import {
 	FooterLinks,
 	FooterWithContents,
 } from '@guardian/source-react-components-development-kitchen';
 import { useEffect } from 'preact/hooks';
-import { useNavigate } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countrySwitcherContainer';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
-import { useOtherAmountValidation } from 'helpers/customHooks/useFormValidation';
+import { PaymentFrequencyButtons } from 'components/paymentFrequencyButtons/paymentFrequencyButtons';
+import type { RegularContributionType } from 'helpers/contributions';
 import {
 	AUDCountries,
 	Canada,
@@ -28,28 +31,35 @@ import {
 	UnitedStates,
 } from 'helpers/internationalisation/countryGroup';
 import { resetValidation } from 'helpers/redux/checkout/checkoutActions';
+import {
+	setProductType,
+	setSelectedAmount,
+} from 'helpers/redux/checkout/product/actions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
-import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
 import { navigateWithPageView } from 'helpers/tracking/ophan';
-
-const checkoutBtnStyleOverrides = css`
-	width: 100%;
-	justify-content: center;
-`;
+import { SupportOnce } from '../components/supportOnce';
+import { ThreeTierCards } from '../components/threeTierCards';
 
 const recurringContainer = css`
 	background-color: ${palette.brand[400]};
 	border-bottom: 1px solid ${palette.brand[600]};
-
-	${from.tablet} {
-		border-bottom: none;
-	}
 	> div {
 		padding: ${space[2]}px 10px ${space[4]}px;
+	}
+	${from.mobileLandscape} {
+		> div {
+			padding: ${space[2]}px ${space[5]}px ${space[4]}px;
+		}
+	}
+	${from.tablet} {
+		border-bottom: none;
+		> div {
+			padding: ${space[2]}px 10px ${space[4]}px;
+		}
 	}
 	${from.desktop} {
 		> div {
@@ -60,14 +70,98 @@ const recurringContainer = css`
 
 const oneTimeContainer = css`
 	display: flex;
-	background-color: ${palette.brand[800]};
+	background-color: ${palette.neutral[97]};
 	> div {
 		padding: ${space[6]}px 10px 72px;
 	}
 	${from.desktop} {
 		> div {
-			padding-top: 32px;
+			padding-bottom: ${space[24]}px;
 		}
+	}
+`;
+
+const innerContentContainer = css`
+	max-width: 940px;
+	margin: 0 auto;
+	text-align: center;
+`;
+
+const heading = css`
+	text-align: left;
+	color: ${palette.neutral[100]};
+	margin-top: ${space[4]}px;
+	${headline.xsmall({
+		fontWeight: 'bold',
+	})}
+	${from.tablet} {
+		text-align: center;
+	}
+	${from.desktop} {
+		font-size: 2.625rem;
+	}
+`;
+
+const standFirst = css`
+	text-align: left;
+	color: ${palette.neutral[100]};
+	margin: 0 0 ${space[4]}px;
+	${textSans.medium()};
+	line-height: 1.35;
+	strong {
+		font-weight: bold;
+	}
+	${from.tablet} {
+		text-align: center;
+		width: 65%;
+		margin: 0 auto;
+	}
+	${from.desktop} {
+		margin: ${space[4]}px auto ${space[6]}px;
+	}
+`;
+
+const benefitsPrefixCss = css`
+	${textSans.small()};
+	color: ${palette.neutral[7]};
+	text-align: left;
+	strong {
+		font-weight: bold;
+	}
+`;
+
+const paymentFrequencyButtonsCss = css`
+	margin: ${space[4]}px auto 32px;
+	${from.desktop} {
+		margin: ${space[6]}px auto ${space[12]}px;
+	}
+`;
+
+const benefitsPrefixPlus = css`
+	${textSans.small()};
+	color: ${palette.neutral[7]};
+	display: flex;
+	align-items: center;
+	margin: ${space[3]}px 0;
+	:before {
+		content: '';
+		height: 1px;
+		background-color: ${palette.neutral[86]};
+		flex-grow: 2;
+		margin-right: ${space[2]}px;
+	}
+	:after {
+		content: '';
+		height: 1px;
+		background-color: ${palette.neutral[86]};
+		flex-grow: 2;
+		margin-left: ${space[2]}px;
+	}
+`;
+
+const tabletLineBreak = css`
+	${from.desktop} {
+		display: none;
 	}
 `;
 
@@ -98,9 +192,6 @@ const links = [
 export function ThreeTierLanding(): JSX.Element {
 	const dispatch = useContributionsDispatch();
 	const navigate = useNavigate();
-	const contributionType = useContributionsSelector(getContributionType);
-	const amount = useContributionsSelector(getUserSelectedAmount);
-
 	const { abParticipations } = useContributionsSelector(
 		(state) => state.common,
 	);
@@ -123,14 +214,49 @@ export function ThreeTierLanding(): JSX.Element {
 		subPath: '/contribute',
 	};
 
-	const proceedToNextStep = useOtherAmountValidation(() => {
-		const destination = `checkout?selected-amount=${amount}&selected-contribution-type=${contributionType.toLowerCase()}`;
-		navigateWithPageView(navigate, destination, abParticipations);
-	}, false);
+	const productType = useContributionsSelector(getContributionType);
 
 	useEffect(() => {
 		dispatch(resetValidation());
+		if (productType === 'ONE_OFF') {
+			dispatch(setProductType('MONTHLY'));
+			/*
+			 * Resets the product type to be a recurring type so
+			 * that the cards show monthly or annual values. This
+			 * happens if a user comes back to this page from the
+			 * one off contribution checkout
+			 */
+		}
 	}, []);
+
+	const paymentFrequencies: RegularContributionType[] = ['MONTHLY', 'ANNUAL'];
+	const paymentFrequencyMap = {
+		MONTHLY: 'Monthly',
+		ANNUAL: 'Annual',
+	};
+
+	const handlePaymentFrequencyBtnClick = (buttonIndex: number) => {
+		dispatch(setProductType(paymentFrequencies[buttonIndex]));
+	};
+
+	const handleCardCtaClick = (price: string) => {
+		dispatch(
+			setSelectedAmount({
+				contributionType: productType,
+				amount: price,
+			}),
+		);
+		navigateWithPageView(navigate, 'checkout', abParticipations);
+	};
+
+	const handleSupportOnceBtnClick = () => {
+		dispatch(setProductType('ONE_OFF'));
+		navigateWithPageView(
+			navigate,
+			'checkout?showChoiceCards=true',
+			abParticipations,
+		);
+	};
 
 	return (
 		<PageScaffold
@@ -156,25 +282,88 @@ export function ThreeTierLanding(): JSX.Element {
 				borderColor="rgba(170, 170, 180, 0.5)"
 				cssOverrides={recurringContainer}
 			>
-				<h1>Support fearless, independent journalism</h1>
-				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-					<Button
-						iconSide="left"
-						priority="primary"
-						size="default"
-						cssOverrides={checkoutBtnStyleOverrides}
-						onClick={proceedToNextStep}
-					>
-						Support with XX
-					</Button>
-				</ThemeProvider>
+				<div css={innerContentContainer}>
+					<h1 css={heading}>
+						Support fearless, <br css={tabletLineBreak} />
+						independent journalism
+					</h1>
+					<p css={standFirst}>
+						Here comes body copy about the support option below.{' '}
+						<strong>Cancel anytime.</strong>
+					</p>
+					<PaymentFrequencyButtons
+						paymentFrequencies={paymentFrequencies.map(
+							(paymentFrequency, index) => ({
+								label: paymentFrequencyMap[paymentFrequency],
+								isPreSelected: paymentFrequencies[index] === productType,
+							}),
+						)}
+						buttonClickHandler={handlePaymentFrequencyBtnClick}
+						additionalStyles={paymentFrequencyButtonsCss}
+					/>
+					<ThreeTierCards
+						cardsContent={[
+							{
+								cardTitle: 'Support',
+								currentPrice: productType === 'MONTHLY' ? '4' : '400',
+								benefits: [
+									{
+										copy: 'Regular supporter newsletter from inside our newsroom',
+									},
+									{ copy: 'See far fewer asks for support' },
+								],
+							},
+							{
+								cardTitle: 'All access digital',
+								currentPrice: productType === 'MONTHLY' ? '10' : '1000',
+								isRecommended: true,
+								benefits: [
+									{
+										copy: 'Guardian news app with personalised recommendations and offline reading',
+									},
+									{ copy: 'Ad-free reading on all your digital devices' },
+									{
+										copy: 'Regular supporter newsletter from inside our newsroom',
+									},
+									{ copy: 'See far fewer asks for support' },
+								],
+							},
+							{
+								cardTitle: 'Digital + print',
+								previousPrice: productType === 'MONTHLY' ? '25' : '2500',
+								currentPrice: productType === 'MONTHLY' ? '16' : '1600',
+								priceSuffix:
+									productType === 'MONTHLY'
+										? '£16 for the first 12 months, then £25'
+										: '£1600 for the first 12 months, then £2500',
+								benefits: [
+									{
+										copy: 'Guardian Weekly magazine delivered to your door, offering a digestible view of world news.',
+										tooltip: 'tooltip text',
+									},
+								],
+								benefitsPrefix: (
+									<div css={benefitsPrefixCss}>
+										<span>
+											All features of <strong>All access digital</strong>
+										</span>
+										<span css={benefitsPrefixPlus}>plus</span>
+									</div>
+								),
+							},
+						]}
+						currency="£"
+						paymentFrequency={productType as RegularContributionType}
+						cardsCtaClickHandler={handleCardCtaClick}
+					/>
+				</div>
 			</Container>
 			<Container
 				sideBorders
 				borderColor="rgba(170, 170, 180, 0.5)"
 				cssOverrides={oneTimeContainer}
 			>
-				<p>one time placeholder</p>
+				<SupportOnce btnClickHandler={handleSupportOnceBtnClick} />
 			</Container>
 		</PageScaffold>
 	);


### PR DESCRIPTION
## What are you doing in this PR?

Build the new components needed for the three tier first page checkout. the main ones being the three column cards and the tabs above. The test will propose 3 tiers with fixed prices and an option to support just once with variable prices.

The tiers will be the following:
tier 1: our current recurring contribution product at a fixe price
tier 2: our current Supporter+ product at a fixed price
tier 3: GW + Supporter plus bundled together at a fixed price

Checkout can be viewed at the following url behind (currently disabled) ab-Test named `threeTierCheckout` ->
https://support.thegulocal.com/uk/contribute#ab-threeTierCheckout=variant

|mobile-mobileMedium|MobileLandscape|Tablet|Desktop-LeftCol-Wide|
|--------|---------|---------|---------|
|<img width="122" alt="image" src="https://github.com/guardian/support-frontend/assets/76729591/e8501e6c-3ed4-4539-8367-bbb865f7764f">|<img width="180" alt="image" src="https://github.com/guardian/support-frontend/assets/76729591/dcb60809-bbb0-455b-add6-3651bd9b8b26">|<img width="289" alt="image" src="https://github.com/guardian/support-frontend/assets/76729591/8a18403d-53cd-4e01-82c6-71c8b4ead471">|<img width="413" alt="image" src="https://github.com/guardian/support-frontend/assets/76729591/651ff8ff-ffbc-4ad9-9d80-c1149093dd11">|

[**Trello Card**](https://trello.com/c/f2GYh9Lp/443-3-tier-first-page-checkout-inner-content-components)

## Why are you doing this?

At the level of the product proposition, the aim is to clarify the choice architecture of our proposition by providing 3 clearly defined routes to support. We believe that a Digital/Print bundled tier will offer a new higher value level of support while anchoring people to our core Supporter+ product.

## How to test & measure success?

[**Figma**](https://www.figma.com/file/xqUMHA7rP4XDtxsOHcZy3U/testing-tiers?type=design&node-id=858%3A70938&mode=dev)

We believe a Digital/Print bundled tier will offer a new higher value level while anchoring people to our core Supporter+ product. This new tier will also create an upsell path for existing supporters and drive up overall ARPU.

## Have we considered potential risks?

- Data model of tier card data (separate ticket created here [**Trello Card**](https://trello.com/c/JeJDgWST/445-3-tier-start-work-on-modelling-our-products-to-support-the-checkout))
- Choice Cards introduced into second page for one-time contributions (separate ticket created here  [**Trello Card**](https://trello.com/c/w05gRUmc/444-3-tier-second-page-checkout-logic-incl-choice-cards))

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)