### PR TITLE
AppLoader renaming for consistency

### DIFF
--- a/support-frontend/app/wiring/ActionBuilders.scala
+++ b/support-frontend/app/wiring/ActionBuilders.scala
@@ -7,7 +7,7 @@ import play.filters.HttpFiltersComponents
 trait ActionBuilders {
   self: Services with BuiltInComponentsFromContext with ApplicationConfiguration with HttpFiltersComponents =>
 
-  implicit lazy val actionRefiners = new CustomActionBuilders(
+  implicit lazy val actionBuilders = new CustomActionBuilders(
     asyncAuthenticationService = asyncAuthenticationService,
     userFromAuthCookiesOrAuthServerActionBuilder = userFromAuthCookiesOrAuthServerActionBuilder,
     userFromAuthCookiesActionBuilder = userFromAuthCookiesActionBuilder,

--- a/support-frontend/app/wiring/AppComponents.scala
+++ b/support-frontend/app/wiring/AppComponents.scala
@@ -5,6 +5,7 @@ import controllers.AssetsComponents
 import filters.{CacheHeadersCheck, RelaxReferrerPolicyFromRedirectFilter, SetCookiesCheck}
 import lib.{CustomHttpErrorHandler, ErrorController}
 import monitoring.{SentryLogging, StateMachineMonitor}
+import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.EssentialFilter
@@ -14,8 +15,9 @@ import play.filters.cors.{CORSComponents, CORSConfig}
 import play.filters.csp.CSPComponents
 import play.filters.gzip.GzipFilter
 
-trait AppComponents
-    extends PlayComponents
+class AppComponents(context: Context)
+    extends BuiltInComponentsFromContext(context)
+    with PlayComponents
     with AhcWSComponents
     with AssetsComponents
     with Controllers
@@ -27,7 +29,6 @@ trait AppComponents
     with CORSComponents
     with CSPComponents
     with HttpFiltersComponents {
-  self: BuiltInComponentsFromContext =>
 
   private lazy val customHandler: CustomHttpErrorHandler = new CustomHttpErrorHandler(
     environment,

--- a/support-frontend/app/wiring/AppComponents.scala
+++ b/support-frontend/app/wiring/AppComponents.scala
@@ -40,7 +40,7 @@ class AppComponents(context: Context)
     appConfig.stage,
   )
   override lazy val httpErrorHandler = customHandler
-  override lazy val errorController = new ErrorController(actionRefiners, customHandler)
+  override lazy val errorController = new ErrorController(actionBuilders, customHandler)
 
   final override lazy val corsConfig: CORSConfig = CORSConfig().withOriginsAllowed(_ == appConfig.supportUrl)
 

--- a/support-frontend/app/wiring/AppLoader.scala
+++ b/support-frontend/app/wiring/AppLoader.scala
@@ -60,7 +60,7 @@ class AppLoader extends ApplicationLoader with StrictLogging {
       )
 
     try {
-      (new BuiltInComponentsFromContext(contextWithConfig.get) with AppComponents).application
+      new AppComponents(contextWithConfig.get).application
     } catch {
       case err: Throwable =>
         logger.error("Could not start application", err)

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -18,12 +18,12 @@ trait Controllers {
     with GoogleAuth =>
 
   lazy val assetController = new controllers.Assets(httpErrorHandler, assetsMetadata)
-  lazy val faviconController = new controllers.Favicon(actionRefiners, appConfig.stage)(fileMimeTypes, implicitly)
+  lazy val faviconController = new controllers.Favicon(actionBuilders, appConfig.stage)(fileMimeTypes, implicitly)
   def errorController: ErrorController
   lazy val elementForStage = CSSElementForStage(assetsResolver.getFileContentsAsHtml, appConfig.stage) _
 
   lazy val applicationController = new Application(
-    actionRefiners,
+    actionBuilders,
     assetsResolver,
     testUsers,
     controllerComponents,
@@ -41,17 +41,17 @@ trait Controllers {
   )
 
   lazy val diagnosticsController = new DiagnosticsController(
-    actionRefiners,
+    actionBuilders,
   )
 
   lazy val articleShareController = new ArticleShare(
-    actionRefiners,
+    actionBuilders,
     controllerComponents,
     capiService,
   )
 
   lazy val subscriptionsController = new SubscriptionsController(
-    actionRefiners,
+    actionBuilders,
     priceSummaryServiceProvider,
     assetsResolver,
     controllerComponents,
@@ -61,7 +61,7 @@ trait Controllers {
   )
 
   lazy val redemptionController = new RedemptionController(
-    actionRefiners,
+    actionBuilders,
     assetsResolver,
     allSettingsProvider,
     testUsers,
@@ -78,7 +78,7 @@ trait Controllers {
     priceSummaryServiceProvider,
     landingCopyProvider,
     assetsResolver,
-    actionRefiners,
+    actionBuilders,
     testUsers,
     appConfig.regularStripeConfigProvider,
     appConfig.regularPayPalConfigProvider,
@@ -92,7 +92,7 @@ trait Controllers {
     priceSummaryServiceProvider,
     landingCopyProvider,
     assetsResolver,
-    actionRefiners,
+    actionBuilders,
     controllerComponents,
     stringsConfig,
     allSettingsProvider,
@@ -103,7 +103,7 @@ trait Controllers {
     priceSummaryServiceProvider,
     landingCopyProvider,
     assetsResolver,
-    actionRefiners,
+    actionBuilders,
     controllerComponents,
     stringsConfig,
     allSettingsProvider,
@@ -113,7 +113,7 @@ trait Controllers {
   lazy val digitalPackFormController = new DigitalSubscriptionFormController(
     priceSummaryServiceProvider,
     assetsResolver,
-    actionRefiners,
+    actionBuilders,
     testUsers,
     appConfig.regularStripeConfigProvider,
     appConfig.regularPayPalConfigProvider,
@@ -125,7 +125,7 @@ trait Controllers {
   lazy val paperFormController = new PaperSubscriptionFormController(
     priceSummaryServiceProvider,
     assetsResolver,
-    actionRefiners,
+    actionBuilders,
     testUsers,
     appConfig.regularStripeConfigProvider,
     appConfig.regularPayPalConfigProvider,
@@ -137,7 +137,7 @@ trait Controllers {
   lazy val weeklyFormController = new WeeklySubscriptionFormController(
     priceSummaryServiceProvider,
     assetsResolver,
-    actionRefiners,
+    actionBuilders,
     testUsers,
     appConfig.regularStripeConfigProvider,
     appConfig.regularPayPalConfigProvider,
@@ -148,7 +148,7 @@ trait Controllers {
 
   lazy val createSubscriptionController = new CreateSubscriptionController(
     supportWorkersClient,
-    actionRefiners,
+    actionBuilders,
     identityService,
     recaptchaService = recaptchaService,
     recaptchaConfigProvider = appConfig.recaptchaConfigProvider,
@@ -162,12 +162,12 @@ trait Controllers {
   lazy val supportWorkersStatusController = new SupportWorkersStatus(
     supportWorkersClient,
     controllerComponents,
-    actionRefiners,
+    actionBuilders,
   )
 
   lazy val stripeController = new StripeController(
     components = controllerComponents,
-    actionRefiners = actionRefiners,
+    actionRefiners = actionBuilders,
     recaptchaService = recaptchaService,
     stripeService = stripeService,
     recaptchaConfigProvider = appConfig.recaptchaConfigProvider,
@@ -177,7 +177,7 @@ trait Controllers {
   )
 
   lazy val payPalRegularController = new PayPalRegular(
-    actionRefiners,
+    actionBuilders,
     assetsResolver,
     payPalNvpServiceProvider,
     testUsers,
@@ -186,7 +186,7 @@ trait Controllers {
   )
 
   lazy val payPalOneOffController = new PayPalOneOff(
-    actionRefiners,
+    actionBuilders,
     assetsResolver,
     testUsers,
     controllerComponents,
@@ -206,20 +206,20 @@ trait Controllers {
     new AuthCodeFlowController(controllerComponents, asyncAuthenticationService, appConfig.identity)
 
   lazy val siteMapController = new SiteMap(
-    actionRefiners,
+    actionBuilders,
     controllerComponents,
   )
 
   lazy val identityController = new IdentityController(
     identityService,
     controllerComponents,
-    actionRefiners,
+    actionBuilders,
     appConfig.identity.webappUrl,
     () => AwsCloudWatchMetricPut(AwsCloudWatchMetricPut.client)(setupWarningRequest(appConfig.stage)),
   )
 
   lazy val directDebitController = new DirectDebit(
-    actionRefiners,
+    actionBuilders,
     controllerComponents,
     goCardlessServiceProvider,
     testUsers,
@@ -228,13 +228,13 @@ trait Controllers {
   lazy val getAddressController = new GetAddress(
     controllerComponents,
     getAddressIOService,
-    actionRefiners,
+    actionBuilders,
   )
 
   lazy val paperRoundController = new PaperRound(
     controllerComponents,
     paperRoundServiceProvider,
-    actionRefiners,
+    actionBuilders,
     testUsers,
     appConfig.stage,
   )
@@ -243,7 +243,7 @@ trait Controllers {
     promotionServiceProvider,
     priceSummaryServiceProvider,
     assetsResolver,
-    actionRefiners,
+    actionBuilders,
     testUsers,
     controllerComponents,
     allSettingsProvider,
@@ -252,7 +252,7 @@ trait Controllers {
 
   lazy val pricesController = new PricesController(
     priceSummaryServiceProvider,
-    actionRefiners,
+    actionBuilders,
     controllerComponents,
   )
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
- Extend `BuiltInComponentsFromContext` from `AppLoader`. This brings us closer inline with [the official](https://www.playframework.com/documentation/2.9.x/ScalaCompileTimeDependencyInjection#Application-entry-point) docs which helps for future travellers, especially those unfamiliar with Play. This seems to be [a more common way (80 examples)](https://github.com/search?q=org%3Aguardian+%22class+AppComponents%22&type=code) vs [how it's done here (23 examples)](https://github.com/search?q=org%3Aguardian+%22trait+AppComponents%22&type=code) across the org.
- Rename `actinRefiners` => `actionBuilders`. This is just one last loose end from [this commit](https://github.com/guardian/support-frontend/pull/120/commits/8693a10c6ce0880937051285d5bde68ddcf51fe4).

## Why are you doing this?
A little but of consistency and clarity for future folks and myself when I have to revisit this code.

Both commits should be no-ops.

