### PR TITLE
Update the list of guardian weekly benefits

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.tsx
@@ -4,16 +4,24 @@ import BenefitsHeading from './benefitsHeading';
 
 const coreBenefits = [
 	{
-		content: `Every issue delivered with up to 35% off the cover price`,
+		content:
+			'The Guardian Weekly magazine delivered every week to your door, wherever you live in the world',
 	},
 	{
-		content: "Access to the magazine's digital archive",
+		content:
+			'64 pages of carefully curated news, features and opinion from the Guardian',
 	},
 	{
-		content: 'A weekly email newsletter from the editor',
+		content: 'A selection of puzzles, crosswords and a weekly recipe',
 	},
 	{
-		content: "The very best of the Guardian's puzzles",
+		content: 'Access to a digital version of the magazine',
+	},
+	{
+		content: `Become part of our global community of supporters who collectively power the Guardian's fiercely independent journalism`,
+	},
+	{
+		content: 'A weekly newsletter from the editor',
 	},
 ];
 
@@ -25,7 +33,7 @@ function Benefits(): JSX.Element {
 					id: 'benefits',
 					content: (
 						<>
-							<BenefitsHeading text="As a subscriber you’ll enjoy" />
+							<BenefitsHeading text="What do you get with a Guardian Weekly subscription?" />
 							<List items={coreBenefits} />
 						</>
 					),


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Update the list of benefits on the Guardian Weekly landing page.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/LxnWxC09/60-change-gw-benefits-on-landing-page)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Go to `/subscribe/weekly`

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots

Desktop before

![image](https://github.com/guardian/support-frontend/assets/114918544/24962589-7df9-4d33-a7f3-74eb29a15548)

Desktop after

![image](https://github.com/guardian/support-frontend/assets/114918544/d1c402cf-1f87-49c8-9b7b-80162a257ca4)

Mobile before

![image](https://github.com/guardian/support-frontend/assets/114918544/88e58474-9ecb-442d-adff-06b4f18246c7)

Mobile after

![image](https://github.com/guardian/support-frontend/assets/114918544/634b9930-eea3-433d-ba83-61ff1bea94dc)

