### PR TITLE
Support lambdas/workers upgrade to logback 1.4.14

### DIFF
--- a/support-lambdas/acquisition-events-api/build.sbt
+++ b/support-lambdas/acquisition-events-api/build.sbt
@@ -8,7 +8,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.3",
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
-  "ch.qos.logback" % "logback-classic" % "1.1.11",
+  "ch.qos.logback" % "logback-classic" % "1.4.13",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-lambdas/acquisitions-firehose-transformer/build.sbt
+++ b/support-lambdas/acquisitions-firehose-transformer/build.sbt
@@ -5,7 +5,7 @@ description := "A Firehose transformation lambda for serialising the acquisition
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.3",
-  "ch.qos.logback" % "logback-classic" % "1.1.11",
+  "ch.qos.logback" % "logback-classic" % "1.4.13",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-lambdas/acquisitions-firehose-transformer/build.sbt
+++ b/support-lambdas/acquisitions-firehose-transformer/build.sbt
@@ -5,7 +5,7 @@ description := "A Firehose transformation lambda for serialising the acquisition
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.3",
-  "ch.qos.logback" % "logback-classic" % "1.4.13",
+  "ch.qos.logback" % "logback-classic" % "1.4.14",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-lambdas/bigquery-acquisitions-publisher/build.sbt
+++ b/support-lambdas/bigquery-acquisitions-publisher/build.sbt
@@ -8,7 +8,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.1",
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
-  "ch.qos.logback" % "logback-classic" % "1.4.13",
+  "ch.qos.logback" % "logback-classic" % "1.4.14",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-lambdas/bigquery-acquisitions-publisher/build.sbt
+++ b/support-lambdas/bigquery-acquisitions-publisher/build.sbt
@@ -8,7 +8,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.1",
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
-  "ch.qos.logback" % "logback-classic" % "1.1.11",
+  "ch.qos.logback" % "logback-classic" % "1.4.13",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-lambdas/it-test-runner/build.sbt
+++ b/support-lambdas/it-test-runner/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
-  "ch.qos.logback" % "logback-classic" % "1.4.13",
+  "ch.qos.logback" % "logback-classic" % "1.4.14",
   "org.scalatest" %% "scalatest" % "3.2.16", // not a "Test" dependency, it's an actual one
 )
 

--- a/support-lambdas/it-test-runner/build.sbt
+++ b/support-lambdas/it-test-runner/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
-  "ch.qos.logback" % "logback-classic" % "1.2.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.13",
   "org.scalatest" %% "scalatest" % "3.2.16", // not a "Test" dependency, it's an actual one
 )
 

--- a/support-lambdas/stripe-intent/build.sbt
+++ b/support-lambdas/stripe-intent/build.sbt
@@ -32,5 +32,5 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
-  "ch.qos.logback" % "logback-classic" % "1.4.13",
+  "ch.qos.logback" % "logback-classic" % "1.4.14",
 )

--- a/support-lambdas/stripe-intent/build.sbt
+++ b/support-lambdas/stripe-intent/build.sbt
@@ -32,5 +32,5 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
-  "ch.qos.logback" % "logback-classic" % "1.2.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.13",
 )

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "2.2.3",
   "org.typelevel" %% "cats-core" % catsVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
-  "ch.qos.logback" % "logback-classic" % "1.2.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.13",
   "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
   "io.lemonlabs" %% "scala-uri" % scalaUriVersion,
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "2.2.3",
   "org.typelevel" %% "cats-core" % catsVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
-  "ch.qos.logback" % "logback-classic" % "1.4.13",
+  "ch.qos.logback" % "logback-classic" % "1.4.14",
   "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
   "io.lemonlabs" %% "scala-uri" % scalaUriVersion,
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",

--- a/support-workers/src/main/scala/com/gu/monitoring/PiiFilter.scala
+++ b/support-workers/src/main/scala/com/gu/monitoring/PiiFilter.scala
@@ -3,10 +3,11 @@ package com.gu.monitoring
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.filter.Filter
 import ch.qos.logback.core.spi.FilterReply
+import scala.jdk.CollectionConverters._
 
 class PiiFilter extends Filter[ILoggingEvent] {
   override def decide(event: ILoggingEvent): FilterReply =
-    if (event.getMarker.contains(SafeLogger.sanitizedLogMessage))
+    if (event.getMarkerList.asScala.toList.exists(marker => marker.contains(SafeLogger.sanitizedLogMessage)))
       FilterReply.ACCEPT
     else FilterReply.DENY
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Upgrades `logback-classic` => 1.14.14 in `support-workers` and `support-lambdas`.

[**Trello Card**](https://trello.com/c/Xmv2JyRL/457-update-logback-dependency-across-the-support-frontend-repo)

## Why are you doing this?
Security

## How to test
We will deploy to `CODE` and ensure that everything is running as planned.

`support-workers` and `it-test-runner` were deployed to `CODE`, then the lambda run. We had the message: `RUN COMPLETED - sending metric: RunCompleted(Ordinal(1, 854),Some(66833),Some(Summary(234,0,7,0,0,60,0,0)),None,None,None,ScalaTest-main,1704894969526)`.

This previously failed. Looks like we're good to go!

