### PR TITLE
Identity | Change logic of `GU_SO` cookie use

### DIFF
--- a/support-frontend/test/actions/UserFromAuthCookiesOrAuthServerActionBuilderTest.scala
+++ b/support-frontend/test/actions/UserFromAuthCookiesOrAuthServerActionBuilderTest.scala
@@ -29,7 +29,7 @@ class UserFromAuthCookiesOrAuthServerActionBuilderTest extends AnyWordSpec with 
   private val accessToken = AccessToken("accessToken")
   private val idToken = IdToken("idToken")
   private val idClaims =
-    UserClaims(primaryEmailAddress = "email", identityId = "id", firstName = None, lastName = None)
+    UserClaims(primaryEmailAddress = "email", identityId = "id", firstName = None, lastName = None, iat = None)
   private val accessClaims = DefaultAccessClaims(primaryEmailAddress = "email", identityId = "id", username = None)
   private val accessScopes = "scope1 scope2 scope3"
   private val accessScopeList =
@@ -392,6 +392,7 @@ class UserFromAuthCookiesOrAuthServerActionBuilderTest extends AnyWordSpec with 
             identityId = "idid",
             firstName = None,
             lastName = None,
+            iat = None,
           ),
         )
       }
@@ -406,6 +407,7 @@ class UserFromAuthCookiesOrAuthServerActionBuilderTest extends AnyWordSpec with 
               "username" -> "un",
               "first_name" -> "fn",
               "last_name" -> "sn",
+              "iat" -> 123456.asInstanceOf[AnyRef],
             ),
           ),
         ) mustBe Right(
@@ -414,6 +416,7 @@ class UserFromAuthCookiesOrAuthServerActionBuilderTest extends AnyWordSpec with 
             identityId = "idid",
             firstName = Some("fn"),
             lastName = Some("sn"),
+            iat = Some(123456),
           ),
         )
       }


### PR DESCRIPTION
## Why are you doing this?

We discovered an issue in the way that the GU_SO cookie works, meaning that a user could sign out, then immediately sign in again as a new user, but the tokens for the old user had not been cleared yet, so the new user would see the old users data.

The problem and solution have been outlined in detail within this PR https://github.com/guardian/gateway/pull/2529

And the documentation was updated in this PR https://github.com/guardian/gateway/pull/2530

Essentially the fix is to read the `GU_SO` cookie and get the timestamp for when a user signs out, and compare it to the `iat` claim of the ID token. This leads to one of three scenarios:
1. If the `GU_SO` value is > `iat` then the user has signed out recently, so the tokens are invalid, get new tokens if needed
2. If the `GU_SO` value is < `iat` then the user has not signed out recently, so the tokens are valid, continue
3. If the `GU_SO` cookie is missing then the user has not signed out recently, so the tokens are valid, continue

## What are you doing in this PR?

This PR updates the logic in `UserFromAuthCookiesActionBuilder` to use this new logic regarding the `GU_SO` cookie to fix this issue. We've also documented in line as to why this is required.