### PR TITLE
fix: remove use /paper over /paper/delivery route for e2e tests

### DIFF
--- a/support-e2e/tests/newspaperCheckout.test.ts
+++ b/support-e2e/tests/newspaperCheckout.test.ts
@@ -77,7 +77,7 @@ test.describe("Sign up newspaper subscription", () => {
       const page = await context.newPage();
       const testFirstName = firstName();
       const testEmail = email();
-      setupPage(page, context, baseURL, "/uk/subscribe/paper/delivery");
+      setupPage(page, context, baseURL, "/uk/subscribe/paper");
       await page
         .locator(`a[aria-label='${testDetails.frequency}- Subscribe']`)
         .click();


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Using the `/paper` over the [removed `/paper/delivery` route](https://github.com/guardian/support-frontend/pull/5572) for our e2e tests.

This is a no-op in terms of the test, as home delivery was the default option for the page.

<img width="270" alt="Screenshot 2024-01-15 at 11 18 50" src="https://github.com/guardian/support-frontend/assets/31692/bda36f82-e9e1-46e6-a990-f2a7100b9472">