### PR TITLE
chore: update frontend java version 8 => 11

### DIFF
--- a/support-frontend/conf/riff-raff.yaml
+++ b/support-frontend/conf/riff-raff.yaml
@@ -21,7 +21,7 @@ deployments:
         PROD: Frontend-PROD.template.json
       amiParameter: AMIFrontend
       amiTags:
-        Recipe: jammy-membership-java8
+        Recipe: jammy-membership-java11
         AmigoStage: PROD
       amiEncrypted: true
   frontend:


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Upgrades the last Java8 service to Java11!

Most of us have been running `support-frontend` on Java11 locally, so this has been dogfooded pretty well.

This will be tested on `CODE`.
