### PR TITLE
fix: run threeTierCheckout test on contribution or  weekly pages with relevant URL param

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -81,6 +81,34 @@ export const tests: Tests = {
 		omitCountries: countriesAffectedByVATStatus,
 		referrerControlled: false,
 		seed: 0,
-		targetPage: pageUrlRegexes.contributions.allLandingPagesExecptSupportPlus,
+
+		/**
+		 * This runs on
+		 * - /{countryGroupId}/contribute
+		 * - /{countryGroupId}/contribute/checkout
+		 * - /{countryGroupId}/thankyou
+		 * - /subscribe/weekly/checkout?isThirdTier=true
+		 *
+		 * And does not run on
+		 * - /subscribe/weekly/checkout
+		 */
+		canRun: () => {
+			// Contribution pages
+			const isContribution =
+				window.location.pathname.match(
+					/\/uk|us|au|eu|int|nz|ca\/contribute(\/.*)?$/,
+				) !== null;
+			const isThankYou =
+				window.location.pathname.match(/\/uk|us|au|eu|int|nz|ca\/thankyou/) !==
+				null;
+
+			// Weekly pages
+			const urlParams = new URLSearchParams(window.location.search);
+			const isThirdTier = urlParams.get('isThirdTier') === 'true';
+			const isWeeklyCheckout =
+				window.location.pathname === '/subscribe/weekly/checkout';
+
+			return isContribution || isThankYou || (isWeeklyCheckout && isThirdTier);
+		},
 	},
 };


### PR DESCRIPTION
# What does this do?

Updates the `canRun` function of the `threeTierCheckout` to run on contribution pages and the weekly checkout with the `isThirdTier=true` URL parameter.

# Why are you doing this?

Adding the new `isThirdTier=true` URL param allows us to

- Let the Weekly checkout know it should include the Support+ subscription
- Include a person in the test with this parameter
- Gives us a signal to pass the upstream `/create` endpoint & step functions that it should include the Subscriber+ contribution

