### PR TITLE
fix: Handle error where salesforce API response status is 200 but Success is false

### DIFF
--- a/support-models/src/main/scala/com/gu/salesforce/Salesforce.scala
+++ b/support-models/src/main/scala/com/gu/salesforce/Salesforce.scala
@@ -126,36 +126,35 @@ object Salesforce {
       MailingCountry: Option[String],
   ) extends UpsertData
 
-  trait SalesforceResponse {
-    val Success: Boolean
-  }
-
+  case class SalesforceContactResponse(
+      Success: Boolean,
+      ErrorString: Option[String],
+      ContactRecord: Option[SalesforceContactRecord],
+  )
   object SalesforceContactResponse {
     implicit val codec: Codec[SalesforceContactResponse] = deriveCodec
   }
 
-  object SalesforceContactRecords {
-    implicit val codec: Codec[SalesforceContactRecords] = deriveCodec
-  }
-
-  case class SalesforceContactResponse(
+  case class SalesforceContactSuccess(
       Success: Boolean,
       ErrorString: Option[String],
       ContactRecord: SalesforceContactRecord,
-  ) extends SalesforceResponse
-
-  case class SalesforceContactError(
-      Success: Boolean,
-      ErrorString: Option[String],
   )
+
+  object SalesforceContactSuccess {
+    implicit val codec: Codec[SalesforceContactSuccess] = deriveCodec
+  }
 
   case class SalesforceContactRecords(buyer: SalesforceContactRecord, giftRecipient: Option[SalesforceContactRecord]) {
     def recipient: SalesforceContactRecord = giftRecipient.getOrElse(buyer)
   }
+  object SalesforceContactRecords {
+    implicit val codec: Codec[SalesforceContactRecords] = deriveCodec
+  }
 
   case class SalesforceContactRecordsResponse(
-      buyer: SalesforceContactResponse,
-      giftRecipient: Option[SalesforceContactResponse],
+      buyer: SalesforceContactSuccess,
+      giftRecipient: Option[SalesforceContactSuccess],
   ) {
     def successful: Boolean = buyer.Success && giftRecipient.forall(_.Success)
 

--- a/support-workers/src/test/scala/com/gu/salesforce/SalesforceServiceSpec.scala
+++ b/support-workers/src/test/scala/com/gu/salesforce/SalesforceServiceSpec.scala
@@ -1,0 +1,53 @@
+package com.gu.salesforce
+
+import com.gu.okhttp.RequestRunners.FutureHttpClient
+import com.gu.salesforce.Fixtures.uk
+import com.gu.salesforce.Salesforce.{NewContact, SalesforceContactResponse, SalesforceErrorResponse}
+import io.circe.Json
+import org.mockito.MockitoSugar.{doReturn, spy, when}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar._
+import io.circe.syntax._
+import org.mockito.ArgumentMatchersSugar.any
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class SalesforceServiceSpec extends AnyFlatSpec with Matchers {
+  "SalesforceServiceSpec" should "throw appropriately throw an INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE SalesforceErrorResponse" in {
+    implicit val executionContext: ExecutionContext = ExecutionContext.global
+    val config = mock[SalesforceConfig]
+    when(config.url).thenReturn("https://test.salesforce.com")
+    val client = mock[FutureHttpClient]
+    val service = new SalesforceService(config = config, client = client)
+    val errorString =
+      "Failed Upsert of new Contact: Upsert failed. First exception on row 0; first error: INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE, Updates can’t be made during maintenance. Try again when maintenance is complete: []"
+
+    val maintenanceResponse = service.parseResponseToResult(
+      SalesforceContactResponse(
+        Success = false,
+        ErrorString = Some(
+          errorString,
+        ),
+        ContactRecord = None,
+      ),
+    )
+    // The joy of untyped Future failures
+    maintenanceResponse.leftSide.value.get.failed.get shouldBe SalesforceErrorResponse(
+      message = errorString,
+      errorCode = "INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE",
+    )
+
+    val genericResponse = service.parseResponseToResult(
+      SalesforceContactResponse(
+        Success = false,
+        ErrorString = Some("Things have gone awry"),
+        ContactRecord = None,
+      ),
+    )
+    genericResponse.leftSide.value.get.failed.get shouldBe SalesforceErrorResponse(
+      message = "Things have gone awry",
+      errorCode = "UNKNOWN_ERROR",
+    )
+  }
+}

--- a/support-workers/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
+++ b/support-workers/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
@@ -4,15 +4,25 @@ import com.gu.config.Configuration
 import com.gu.i18n.{Country, Title}
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.salesforce.Fixtures._
-import com.gu.salesforce.Salesforce.{Authentication, DeliveryContact, NewContact, SalesforceContactResponse}
+import com.gu.salesforce.Salesforce.{
+  Authentication,
+  DeliveryContact,
+  NewContact,
+  SalesforceContactSuccess,
+  SalesforceErrorResponse,
+}
 import com.gu.support.workers
 import com.gu.support.workers.{Address, GiftRecipient}
 import com.gu.test.tags.annotations.IntegrationTest
 import com.typesafe.scalalogging.LazyLogging
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.time.{Millis, Seconds, Span}
 
 import scala.concurrent.duration._
+import scala.util.{Failure, Success}
 
 @IntegrationTest
 class SalesforceSpec extends AsyncFlatSpec with Matchers with LazyLogging {
@@ -62,7 +72,7 @@ class SalesforceSpec extends AsyncFlatSpec with Matchers with LazyLogging {
     val service =
       new SalesforceService(Configuration.load().salesforceConfigProvider.get(), configurableFutureRunner(10.seconds))
 
-    service.upsert(customer).map { response: SalesforceContactResponse =>
+    service.upsert(customer).map { response: SalesforceContactSuccess =>
       response.Success shouldBe true
       response.ContactRecord.Id shouldBe salesforceId
       response.ContactRecord.AccountId shouldBe salesforceAccountId
@@ -85,7 +95,7 @@ class SalesforceSpec extends AsyncFlatSpec with Matchers with LazyLogging {
       Phone = Some(telephoneNumber),
     )
 
-    service.upsert(upsertData).map { response: SalesforceContactResponse =>
+    service.upsert(upsertData).map { response: SalesforceContactSuccess =>
       response.Success shouldBe true
       response.ContactRecord.Id shouldBe salesforceId
       response.ContactRecord.AccountId shouldBe salesforceAccountId
@@ -110,7 +120,7 @@ class SalesforceSpec extends AsyncFlatSpec with Matchers with LazyLogging {
       MailingCountry = Some(uk),
     )
 
-    service.upsert(upsertData).map { response: SalesforceContactResponse =>
+    service.upsert(upsertData).map { response: SalesforceContactSuccess =>
       response.Success shouldBe true
       response.ContactRecord.AccountId shouldBe salesforceAccountId
     }

--- a/support-workers/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
@@ -102,24 +102,4 @@ class SalesforceErrorsSpec extends AsyncLambdaSpec with Matchers {
       err shouldBe a[SalesforceErrorResponse]
     }
   }
-
-  "SalesforceService" should "throw a SalesforceErrorResponse with errorCode INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE if in maintenance" in {
-    val service =
-      new SalesforceService(Configuration.load().salesforceConfigProvider.get(), configurableFutureRunner(10.seconds))
-    val message =
-      "Failed Upsert of new Contact: Upsert failed. First exception on row 0; first error: INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE, Updates can’t be made during maintenance. Try again when maintenance is complete: []"
-
-    /** This is some logic that has been baked into the CODE API for testing.
-      *
-      * see: https://github.com/guardian/support-frontend/pull/5612#issuecomment-1898191628
-      */
-    val upsert = service.upsert(upsertData.copy(Email = "readonly@readonly.com"))
-    upsert.failed.map { err =>
-      err shouldBe a[SalesforceErrorResponse]
-      err shouldBe SalesforceErrorResponse(
-        errorCode = "INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE",
-        message = message,
-      )
-    }
-  }
 }

--- a/support-workers/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
@@ -16,6 +16,7 @@ import com.gu.salesforce.{AuthService, SalesforceConfig, SalesforceService}
 import com.gu.support.workers.AsyncLambdaSpec
 import com.gu.test.tags.annotations.IntegrationTest
 import okhttp3.Request
+import org.mockito.ArgumentMatchersSugar.any
 import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
@@ -97,8 +98,28 @@ class SalesforceErrorsSpec extends AsyncLambdaSpec with Matchers {
     )
 
     val upsert = service.upsert(invalidUpsertData)
-    upsert.failed.map { ex =>
-      ex shouldBe a[SalesforceErrorResponse]
+    upsert.failed.map { err =>
+      err shouldBe a[SalesforceErrorResponse]
+    }
+  }
+
+  "SalesforceService" should "throw a SalesforceErrorResponse with errorCode INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE if in maintenance" in {
+    val service =
+      new SalesforceService(Configuration.load().salesforceConfigProvider.get(), configurableFutureRunner(10.seconds))
+    val message =
+      "Failed Upsert of new Contact: Upsert failed. First exception on row 0; first error: INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE, Updates can’t be made during maintenance. Try again when maintenance is complete: []"
+
+    /** This is some logic that has been baked into the CODE API for testing.
+      *
+      * see: https://github.com/guardian/support-frontend/pull/5612#issuecomment-1898191628
+      */
+    val upsert = service.upsert(upsertData.copy(Email = "readonly@readonly.com"))
+    upsert.failed.map { err =>
+      err shouldBe a[SalesforceErrorResponse]
+      err shouldBe SalesforceErrorResponse(
+        errorCode = "INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE",
+        message = message,
+      )
     }
   }
 }


### PR DESCRIPTION
The Salesforce API returns a http status of 200 even if the request fails, but with the `Success` property on the response set to `false`.

e.g.
```JSON
{
    "Success": false,
    "ErrorString": "Failed Upsert of new Contact: Upsert failed. First exception on row 0; first error: CANNOT_INSERT_UPDATE_ACTIVATE_ENTITY, ContactTrigger: execution of AfterInsert\n\ncaused by: line 78, column 9: Dependent class is invalid and needs recompilation:\n Class testUtilities : Dependent class is invalid and needs recompilation:\n Class KnowledgePublishToHelpCentreService : DML operation Update not allowed on Knowledge__kav: []",
    "ContactRecord": null
}
```

This fix handles that case and returns the `SalesforceErrorResponse` to the lambda / client to ensure it's handled correctly i.e. retried.


[**Trello Card**](https://trello.com/c/hcVE76TJ/453-fix-salesforce-retries-in-support-workers-impacts-recurring-contribution)

## How to test

There is an integration test using invalid user data to ensure the right error is thrown. I haven't quite thought of a way to test against the use case we are hoping to have covered by this i.e. a Salesforce outage.

## How can we measure success?
We don't lose any contact information when there is a Salesforce API outage.

## Have we considered potential risks?
The testing isn't against the actual usecase.
