### PR TITLE
Deprecated jdk8 cask installer removed from BrewFile

### DIFF
--- a/support-frontend/Brewfile
+++ b/support-frontend/Brewfile
@@ -1,4 +1,3 @@
-cask "AdoptOpenJDK/openjdk/adoptopenjdk8"
 tap "guardian/devtools"
 brew "guardian/devtools/dev-nginx"
 cask "gu-scala"


### PR DESCRIPTION
## What are you doing in this PR?

Cleanup Brewfile to remove deprecated JDK8 cask installer.

Deprecation Notice -> [**here**](https://github.com/AdoptOpenJDK/homebrew-openjdk)
