### PR TITLE
Add extra email validation regex

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/personalDetails/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/personalDetails/state.ts
@@ -17,6 +17,7 @@ export type UserTypeFromIdentityResponse =
 export const emailRules = zuoraCompatibleString(
 	z
 		.string()
+		.regex(/^[\w.-]+@[\w.-]+.\w{2,4}$/, 'Please enter a valid email address.')
 		.email('Please enter a valid email address.')
 		.min(1, 'Please enter an email address.')
 		.max(maxLengths.email, 'Email address is too long'),

--- a/support-frontend/assets/helpers/redux/checkout/personalDetails/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/personalDetails/state.ts
@@ -17,7 +17,7 @@ export type UserTypeFromIdentityResponse =
 export const emailRules = zuoraCompatibleString(
 	z
 		.string()
-		.regex(/^[\w.-]+@[\w.-]+.\w{2,4}$/, 'Please enter a valid email address.')
+		.regex(/^[^,]+$/, 'Please enter a valid email address.')
 		.email('Please enter a valid email address.')
 		.min(1, 'Please enter an email address.')
 		.max(maxLengths.email, 'Email address is too long'),


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Addig an extra regex check to the email validation on the checkout.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/0FPWDHrv/115-add-client-side-validation-to-prevent-email-addresses-including-commas-on-all-checkouts)

## Why are you doing this?
Currently, the checkout will allow commas, presumably as some email fields allow a comma separated list, which we do not. This PR adds an extra regex check that validates a single email address without commas. The question of whether the previously used validation check (`.emal()`) still has value is one I wanted to ask as part of reviewing. We could consider it redundant, or an extra security layer. 

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
Manually enter valid/invalid emails into the checkout form 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
We should have no more alarms related to email addresses with commas in them.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->



