### PR TITLE
Add user selected lozenge to the three tier cards

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -17,7 +17,9 @@ import { ThreeTierLozenge } from './threeTierLozenge';
 
 interface ThreeTierCardProps {
 	title: string;
-	isRecommended?: true;
+	isRecommended: boolean;
+	isRecommendedSubdued: boolean;
+	isUserSelected: boolean;
 	benefits: TierBenefits;
 	planCost: TierPlanCosts;
 	currency: string;
@@ -25,16 +27,30 @@ interface ThreeTierCardProps {
 	cardCtaClickHandler: (price: number) => void;
 }
 
-const container = (isRecommended?: boolean) => css`
-	position: ${isRecommended ? 'relative' : 'static'};
-	background-color: ${isRecommended ? '#F1FBFF' : palette.neutral[100]};
-	border-radius: ${space[3]}px;
-	padding: 32px ${space[3]}px ${space[6]}px ${space[3]}px;
-	${until.desktop} {
-		order: ${isRecommended ? 0 : 1};
-		padding-top: ${space[6]}px;
+const container = (
+	isRecommended: boolean,
+	isUserSelected: boolean,
+	subdueHighlight: boolean,
+) => {
+	const hasLozenge = isRecommended || isUserSelected;
+	let cardOrder = 2;
+	if (hasLozenge) {
+		cardOrder = subdueHighlight ? 1 : 0;
 	}
-`;
+	return css`
+		position: ${hasLozenge ? 'relative' : 'static'};
+		background-color: ${hasLozenge && !subdueHighlight
+			? '#F1FBFF'
+			: palette.neutral[100]};
+		border-radius: ${space[3]}px;
+		padding: 32px ${space[3]}px ${space[6]}px ${space[3]}px;
+		${until.desktop} {
+			order: ${cardOrder};
+			padding-top: ${space[6]}px;
+			margin-top: ${isRecommended && subdueHighlight ? '15px' : '0'};
+		}
+	`;
+};
 
 const titleCss = css`
 	${textSans.small({ fontWeight: 'bold' })};
@@ -136,6 +152,8 @@ export function ThreeTierCard({
 	title,
 	planCost,
 	isRecommended,
+	isRecommendedSubdued,
+	isUserSelected,
 	benefits,
 	currency,
 	paymentFrequency,
@@ -147,8 +165,11 @@ export function ThreeTierCard({
 	const currentPriceCopy = `${currency}${currentPrice}/${frequencyCopyMap[paymentFrequency]}`;
 
 	return (
-		<div css={container(isRecommended)}>
-			{isRecommended && <ThreeTierLozenge title="Recommended" />}
+		<div css={container(isRecommended, isUserSelected, isRecommendedSubdued)}>
+			{isUserSelected && <ThreeTierLozenge title="Your selection" />}
+			{isRecommended && !isUserSelected && (
+				<ThreeTierLozenge subdue={isRecommendedSubdued} title="Recommended" />
+			)}
 			<h3 css={titleCss}>{title}</h3>
 			<h2 css={price(!!planCost.discount)}>
 				<span css={previousPriceStrikeThrough}>{previousPriceCopy}</span>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
@@ -7,7 +7,8 @@ import { ThreeTierCard } from './threeTierCard';
 interface ThreeTierCardsProps {
 	cardsContent: Array<{
 		title: string;
-		isRecommended?: true;
+		isRecommended: boolean;
+		isUserSelected: boolean;
 		benefits: TierBenefits;
 		planCost: TierPlanCosts;
 	}>;
@@ -39,6 +40,10 @@ export function ThreeTierCards({
 	paymentFrequency,
 	cardsCtaClickHandler,
 }: ThreeTierCardsProps): JSX.Element {
+	const haveRecommendedAndSelectedCards =
+		cardsContent.filter((card) => card.isRecommended || card.isUserSelected)
+			.length > 1;
+
 	return (
 		<div css={container(cardsContent.length)}>
 			{cardsContent.map((cardContent, cardIndex) => {
@@ -46,6 +51,7 @@ export function ThreeTierCards({
 					<ThreeTierCard
 						key={`threeTierCard${cardIndex}`}
 						{...cardContent}
+						isRecommendedSubdued={haveRecommendedAndSelectedCards}
 						currency={currency}
 						paymentFrequency={paymentFrequency}
 						cardCtaClickHandler={cardsCtaClickHandler}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierLozenge.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierLozenge.tsx
@@ -3,22 +3,25 @@ import { palette, space, textSans } from '@guardian/source-foundations';
 
 interface ThreeTierLozengeProps {
 	title: string;
+	subdue?: boolean;
 }
 
-const container = css`
+const container = (isSubdued?: boolean) => css`
 	position: absolute;
 	top: 0;
 	left: 50%;
 	transform: translate(-50%, -50%);
 	padding: ${space[1]}px ${space[4]}px;
 	border-radius: ${space[1]}px;
-	background-color: ${palette.brand[500]};
-	color: ${palette.neutral[100]};
+	background-color: ${isSubdued ? palette.neutral[100] : palette.brand[500]};
+	color: ${isSubdued ? '#606060' : palette.neutral[100]};
+	border: 1px solid ${isSubdued ? palette.neutral[60] : palette.brand[500]};
 	${textSans.small({ fontWeight: 'bold' })};
 `;
 
 export function ThreeTierLozenge({
 	title,
+	subdue,
 }: ThreeTierLozengeProps): JSX.Element {
-	return <div css={container}>{title}</div>;
+	return <div css={container(subdue)}>{title}</div>;
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -209,6 +209,9 @@ export function ThreeTierLanding(): JSX.Element {
 
 	const productType = useContributionsSelector(getContributionType);
 
+	const urlParams = new URLSearchParams(window.location.search);
+	const urlSelectedAmount = urlParams.get('selected-amount');
+
 	useEffect(() => {
 		dispatch(resetValidation());
 		if (productType === 'ONE_OFF') {
@@ -251,6 +254,22 @@ export function ThreeTierLanding(): JSX.Element {
 		productType === 'ONE_OFF'
 			? 'monthly'
 			: (productType.toLowerCase() as 'monthly' | 'annual');
+
+	const isCardUserSelected = (
+		cardPrice: number,
+		cardPriceDiscount?: number,
+	): boolean => {
+		const cardPriceToCompare = cardPriceDiscount ?? cardPrice;
+		const hasUrlSelectedAmount = !isNaN(Number(urlSelectedAmount));
+
+		if (!hasUrlSelectedAmount) {
+			return false;
+		}
+		return (
+			Object.prototype.hasOwnProperty.call(paymentFrequencyMap, productType) &&
+			Number(urlSelectedAmount) === cardPriceToCompare
+		);
+	};
 
 	return (
 		<PageScaffold
@@ -299,7 +318,15 @@ export function ThreeTierLanding(): JSX.Element {
 							{
 								title: tierCards.tier1.title,
 								benefits: tierCards.tier1.benefits,
-								isRecommended: tierCards.tier1.isRecommended,
+								isRecommended: !!tierCards.tier1.isRecommended,
+								isUserSelected: isCardUserSelected(
+									tierCards.tier1.plans[regularProductTypeKey].charges[
+										countryGroupId
+									].price,
+									tierCards.tier1.plans[regularProductTypeKey].charges[
+										countryGroupId
+									].discount?.price,
+								),
 								planCost:
 									tierCards.tier1.plans[regularProductTypeKey].charges[
 										countryGroupId
@@ -308,7 +335,15 @@ export function ThreeTierLanding(): JSX.Element {
 							{
 								title: tierCards.tier2.title,
 								benefits: tierCards.tier2.benefits,
-								isRecommended: tierCards.tier2.isRecommended,
+								isRecommended: !!tierCards.tier2.isRecommended,
+								isUserSelected: isCardUserSelected(
+									tierCards.tier2.plans[regularProductTypeKey].charges[
+										countryGroupId
+									].price,
+									tierCards.tier2.plans[regularProductTypeKey].charges[
+										countryGroupId
+									].discount?.price,
+								),
 								planCost:
 									tierCards.tier2.plans[regularProductTypeKey].charges[
 										countryGroupId
@@ -317,7 +352,15 @@ export function ThreeTierLanding(): JSX.Element {
 							{
 								title: tierCards.tier3.title,
 								benefits: tierCards.tier3.benefits,
-								isRecommended: tierCards.tier3.isRecommended,
+								isRecommended: !!tierCards.tier3.isRecommended,
+								isUserSelected: isCardUserSelected(
+									tierCards.tier3.plans[regularProductTypeKey].charges[
+										countryGroupId
+									].price,
+									tierCards.tier3.plans[regularProductTypeKey].charges[
+										countryGroupId
+									].discount?.price,
+								),
 								planCost:
 									tierCards.tier3.plans[regularProductTypeKey].charges[
 										countryGroupId


### PR DESCRIPTION
## What are you doing in this PR?
If a user comes to the three tier landing page from a banner or an epic and they have pre selected an amount then we should highlight the corresponding card.

The mechanism with which the user preselects a card is via the `selected-amount` url parameter.

## Screenshots
<img width="1323" alt="Screenshot 2024-01-19 at 16 02 22" src="https://github.com/guardian/support-frontend/assets/2510683/1cc3c118-d606-4665-a3d5-17d81f2147c5">

<img width="275" alt="Screenshot 2024-01-19 at 16 04 40" src="https://github.com/guardian/support-frontend/assets/2510683/808ff81a-7437-44a7-a0fe-e17bb319c277">


on mobile breakpoints where the cards stack, the user selected card will take precedence, then the recommended card, then the standard card(s)
