### PR TITLE
Add signedIn/Out logging to http error handler

### DIFF
--- a/support-frontend/app/lib/CustomHttpErrorHandler.scala
+++ b/support-frontend/app/lib/CustomHttpErrorHandler.scala
@@ -80,8 +80,10 @@ class CustomHttpErrorHandler(
       case _ => "unknown line number, please check the logs"
     }
     val sanitizedExceptionDetails = s"Caused by: ${usefulException.cause} in $lineInfo"
+    val signedIn = request.cookies.get("GU_U").isDefined
+    val signedOut = request.cookies.get("GU_SO").isDefined
     val requestDetails =
-      s"(${request.method}) [${request.path}]" // Use path, not uri, as query strings often contain things like ?api-key=my_secret
+      s"(${request.method}) [signedIn: $signedIn, signedOut: $signedOut] [${request.path}]" // Use path, not uri, as query strings often contain things like ?api-key=my_secret
 
     // We are deliberately bypassing the SafeLogger here, because we need to use standard string interpolation to make this exception handling useful.
     logger.error(


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Adds a little bit of logging to help debug some `5xx` errors we've seen coming through from `support-frontend`'s [CustomHttpErrorHandler](https://github.com/guardian/support-frontend/blob/main/support-frontend/app/lib/CustomHttpErrorHandler.scala#L87-L90).

We have an hypothesis that it could be from [this PR](https://github.com/guardian/support-frontend/pull/5596) - this should help analyse that hypothesis. 

[**Trello Card**](https://trello.com/c/Lsv2gWRn/526-5xx-error-increase-from-the-15-16-january-on-support-frontend)

