### PR TITLE
Switch PreparePaymentMethodForReuse lambda to use standard getAccount

### DIFF
--- a/support-models/src/main/scala/com/gu/support/zuora/api/response/Responses.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/response/Responses.scala
@@ -65,6 +65,8 @@ object BasicInfo {
 case class BasicInfo(
     id: String,
     name: String,
+    IdentityId__c: Option[String],
+    sfContactId__c: Option[String],
     accountNumber: String,
     notes: Option[String],
     status: String,
@@ -74,27 +76,17 @@ case class BasicInfo(
     communicationProfileId: Option[String],
 )
 
+object BillingAndPayment {
+  implicit val codec: Codec[BillingAndPayment] = deriveCodec
+}
+case class BillingAndPayment(defaultPaymentMethodId: Option[String], paymentGateway: PaymentGateway)
+
 object GetAccountResponse {
   implicit val codec: Codec[GetAccountResponse] = deriveCodec
 }
 
-case class GetAccountResponse(success: Boolean, basicInfo: BasicInfo) extends ZuoraResponse
-
-//this response cannot extend ZuoraResponse because this endpoint doesn't return a 'success' boolean field
-case class GetObjectAccountResponse(
-    IdentityId__c: Option[String],
-    sfContactId__c: Option[String],
-    CrmId: Option[String],
-    DefaultPaymentMethodId: Option[String],
-    AutoPay: Boolean,
-    Balance: Double,
-    Currency: String,
-    PaymentGateway: PaymentGateway,
-)
-
-object GetObjectAccountResponse {
-  implicit val codec: Codec[GetObjectAccountResponse] = deriveCodec
-}
+case class GetAccountResponse(success: Boolean, basicInfo: BasicInfo, billingAndPayment: BillingAndPayment)
+    extends ZuoraResponse
 
 sealed trait GetPaymentMethodResponse {
   def `type`: String

--- a/support-services/src/main/scala/com/gu/zuora/ZuoraService.scala
+++ b/support-services/src/main/scala/com/gu/zuora/ZuoraService.scala
@@ -57,9 +57,6 @@ class ZuoraService(val config: ZuoraConfig, client: FutureHttpClient, baseUrl: O
     )
   }
 
-  def getObjectAccount(accountId: String): Future[GetObjectAccountResponse] =
-    get[GetObjectAccountResponse](s"object/account/$accountId", authHeaders)
-
   override def getSubscriptions(accountNumber: ZuoraAccountNumber): Future[List[DomainSubscription]] =
     get[SubscriptionsResponse](s"subscriptions/accounts/${accountNumber.value}", authHeaders).map {
       subscriptionsResponse =>

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/PreparePaymentMethodForReuse.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/PreparePaymentMethodForReuse.scala
@@ -36,14 +36,17 @@ class PreparePaymentMethodForReuse(servicesProvider: ServiceProvider = ServicePr
     val zuoraService = services.zuoraService
     val accountId = state.paymentFields.billingAccountId
     for {
-      account <- zuoraService.getObjectAccount(accountId).withEventualLogging(s"getObjectAccount($accountId)")
-      accountIdentityId <- getOrFailWithMessage(account.IdentityId__c, s"Zuora account $accountId has no identityId")
+      account <- zuoraService.getAccount(accountId).withEventualLogging(s"getObjectAccount($accountId)")
+      accountIdentityId <- getOrFailWithMessage(
+        account.basicInfo.IdentityId__c,
+        s"Zuora account $accountId has no identityId",
+      )
       _ <- ifFalseReturnError(
         accountIdentityId == state.user.id,
         s"Zuora account $accountId identity id: $accountIdentityId does not match ${state.user.id}",
       )
       paymentId <- getOrFailWithMessage(
-        account.DefaultPaymentMethodId,
+        account.billingAndPayment.defaultPaymentMethodId,
         s"Zuora account $accountId has no default payment method",
       )
       getPaymentMethodResponse <- zuoraService
@@ -53,10 +56,16 @@ class PreparePaymentMethodForReuse(servicesProvider: ServiceProvider = ServicePr
         getPaymentMethodResponse.paymentMethodStatus == "Active",
         s"Zuora account $accountId has a non active default payment method",
       )
-      sfContactId <- getOrFailWithMessage(account.sfContactId__c, s"Zuora account $accountId has no sfContact")
-      crmId <- getOrFailWithMessage(account.CrmId, s"Zuora account $accountId has not CrmId")
-      paymentMethod <- toPaymentMethod(getPaymentMethodResponse, services.goCardlessService, account.PaymentGateway)
-      sfContact = SalesforceContactRecord(sfContactId, crmId)
+      sfContactId <- getOrFailWithMessage(
+        account.basicInfo.sfContactId__c,
+        s"Zuora account $accountId has no sfContact",
+      )
+      paymentMethod <- toPaymentMethod(
+        getPaymentMethodResponse,
+        services.goCardlessService,
+        account.billingAndPayment.paymentGateway,
+      )
+      sfContact = SalesforceContactRecord(sfContactId, account.basicInfo.crmId)
       (productState, productType) <- Future.fromTry(state.product match {
         case c: Contribution =>
           Success(

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/PreparePaymentMethodForReuseSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/PreparePaymentMethodForReuseSpec.scala
@@ -64,9 +64,9 @@ class PreparePaymentMethodForReuseSpec extends AsyncLambdaSpec with MockServices
     // Need to return None from the Zuora service `getRecurringSubscription`
     // method or the subscribe step gets skipped
     // if these methods weren't coupled into one class then we could pass them separately and avoid reflection
-    when(mockZuora.getObjectAccount(any[String]))
+    when(mockZuora.getAccount(any[String]))
       .thenAnswer((invocation: InvocationOnMock) =>
-        realZuoraService.getObjectAccount(invocation.getArguments.head.asInstanceOf[String]),
+        realZuoraService.getAccount(invocation.getArguments.head.asInstanceOf[String]),
       )
     when(mockZuora.getPaymentMethod(any[String]))
       .thenAnswer((invocation: InvocationOnMock) =>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
The `PreparePaymentMethodForReuse lambda was fetching account information using a Zuora api call which required the guid id of the account rather than the more usual account number. This was a problem for the three tier work currently taking place as we do not have this id readily available.

This PR changes the lambda to use the more commonly used api call which accepts either an account id or an account number and also adds a few fields to the response of that call which were not being mapped previously.
