### PR TITLE
feat: add threeTierCreateSupporterPlusSubscription to form and state

### DIFF
--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -61,6 +61,10 @@ case class CreateSupportWorkersRequest(
     telephoneNumber: Option[String],
     deliveryInstructions: Option[String],
     debugInfo: Option[String],
+    /** We do not generally set default values, but because this is a test it is a way of avoiding having to edit loads
+      * of places in the code base
+      */
+    threeTierCreateSupporterPlusSubscription: Option[Boolean] = None,
 )
 
 object SupportWorkersClient {
@@ -163,6 +167,7 @@ class SupportWorkersClient(
             ophanIds = request.body.ophanIds,
             referrerAcquisitionData = referrerAcquisitionDataWithGAFields(request),
             supportAbTests = request.body.supportAbTests,
+            threeTierCreateSupporterPlusSubscription = request.body.threeTierCreateSupporterPlusSubscription,
           ),
         ),
         promoCode = request.body.promoCode,

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -169,6 +169,7 @@ export type RegularPaymentRequest = {
 	csrUsername?: string;
 	salesforceCaseId?: string;
 	recaptchaToken?: string;
+	threeTierCreateSupporterPlusSubscription?: boolean;
 	debugInfo: string;
 };
 export type StripePaymentIntentAuthorisation = {

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -57,7 +57,7 @@ import { successfulSubscriptionConversion } from 'helpers/tracking/googleTagMana
 import { sendEventSubscriptionCheckoutConversion } from 'helpers/tracking/quantumMetric';
 import type { Option } from 'helpers/types/option';
 import { routes } from 'helpers/urls/routes';
-import { getQueryParameter, isProd } from 'helpers/urls/url';
+import { getQueryParameter } from 'helpers/urls/url';
 import { trackCheckoutSubmitAttempt } from '../tracking/behaviour';
 
 type Addresses = {
@@ -181,7 +181,7 @@ function buildRegularPaymentRequest(
 	const giftRecipient = getGiftRecipient(state.page.checkoutForm.gifting);
 	// We will need to remove this !isProd check before we go live
 	const threeTierCreateSupporterPlusSubscription =
-		!isProd() &&
+		state.common.abParticipations.threeTierCheckout === 'variant' &&
 		getQueryParameter('threeTierCreateSupporterPlusSubscription') === 'true';
 
 	return {

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -57,6 +57,7 @@ import { successfulSubscriptionConversion } from 'helpers/tracking/googleTagMana
 import { sendEventSubscriptionCheckoutConversion } from 'helpers/tracking/quantumMetric';
 import type { Option } from 'helpers/types/option';
 import { routes } from 'helpers/urls/routes';
+import { getQueryParameter, isProd } from 'helpers/urls/url';
 import { trackCheckoutSubmitAttempt } from '../tracking/behaviour';
 
 type Addresses = {
@@ -178,6 +179,10 @@ function buildRegularPaymentRequest(
 	const recaptchaToken = state.page.checkoutForm.recaptcha.token;
 	const promoCode = getPromoCode(promotions);
 	const giftRecipient = getGiftRecipient(state.page.checkoutForm.gifting);
+	// We will need to remove this !isProd check before we go live
+	const threeTierCreateSupporterPlusSubscription =
+		!isProd() &&
+		getQueryParameter('threeTierCreateSupporterPlusSubscription') === 'true';
 
 	return {
 		title,
@@ -200,6 +205,7 @@ function buildRegularPaymentRequest(
 		deliveryInstructions,
 		csrUsername,
 		salesforceCaseId,
+		threeTierCreateSupporterPlusSubscription,
 		debugInfo: actionHistory,
 	};
 }

--- a/support-models/src/main/scala/com/gu/support/acquisitions/AcquisitionData.scala
+++ b/support-models/src/main/scala/com/gu/support/acquisitions/AcquisitionData.scala
@@ -63,6 +63,7 @@ case class AcquisitionData(
     ophanIds: OphanIds,
     referrerAcquisitionData: ReferrerAcquisitionData,
     supportAbTests: Set[AbTest],
+    threeTierCreateSupporterPlusSubscription: Option[Boolean] = None,
 )
 
 object AcquisitionData {


### PR DESCRIPTION
## What are you doing in this PR?

Allows the `threeTierCreateSupporterPlusSubscription` option to be passed from the client => `support-workers`.

This allows us to branch logically off of this `Boolean` to create a Supporter+ subscription for people ordering weekly via this route.

I have chosen the `AcquisitionData` model to attach this to as it percolates all the way through the step functions requiring fewer changes to the code. It also sort-of fits there.

[**Trello Card**](https://trello.com/c/zh96UwvO/486-create-support-subscription-for-supporter-buying-weekly-from-the-third-tier-in-3-tier-test)

## How to test

Run support-workers with this property to see if it gets passed down the state machine.