### PR TITLE
US Emotional Messaging Around Benefits List - Amount Change

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -56,7 +56,7 @@ function getEmotionalBenefit(
 		if (selectedAmount >= 35) {
 			message =
 				'make a greater impact on the future of independent journalism and ';
-		} else if (selectedAmount >= 20) {
+		} else if (selectedAmount >= 13) {
 			message = 'deepen your commitment to the Guardian’s independence and ';
 		}
 	} else if (contributionType === 'ANNUAL') {


### PR DESCRIPTION
## What are you doing in this PR?

AMOUNT CORRECTION TO ORIGINAL PR  [**HERE**](https://github.com/guardian/support-frontend/pull/5630) MONTHLY FROM (incorrect) $20 => (correct) $13

The US+ Global DRR is keen to pre test more emotional language on benefits on the current checkout, to support 3 tier LP testing. This is a copy test on the current checkout. If successful, this copy could be amended to 3 tier LP.

## Screenshots

[**Trello Card**](https://trello.com/c/cSdCWciH/441-pre-testing-emotional-messaging-on-current-checkout-us-only)

## How to test

https://support.thegulocal.com/us/contribute#ab-emotionalBenefits=variant