### PR TITLE
US Emotional Messaging Around Benefits List - Enable abTest

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -77,10 +77,10 @@ export const tests: Tests = {
 		audiences: {
 			UnitedStates: {
 				offset: 0,
-				size: 0,
+				size: 1,
 			},
 		},
-		isActive: false,
+		isActive: true,
 		referrerControlled: true,
 		seed: 5,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,


### PR DESCRIPTION
## What are you doing in this PR?

Enables `ab-emotionalBenefits` test for these PR's

- [US Emotional Messaging Around Benefits List](https://github.com/guardian/support-frontend/pull/5618)
- [Equal Or Greater Than Amount Switching](https://github.com/guardian/support-frontend/pull/5630)
- [Amount Change](https://github.com/guardian/support-frontend/pull/5632)

The US+ Global DRR is keen to pre test more emotional language on benefits on the current checkout, to support 3 tier LP testing. This is a copy test on the current checkout. If successful, this copy could be amended to 3 tier LP.

## Screenshots

[**Trello Card**](https://trello.com/c/cSdCWciH/441-pre-testing-emotional-messaging-on-current-checkout-us-only)

## How to test

https://support.thegulocal.com/us/contribute#ab-emotionalBenefits=variant