### PR TITLE
US Emotional Messaging Around Benefits List - Copy Change

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -51,7 +51,7 @@ function getEmotionalBenefit(
 	selectedAmount: number,
 	contributionType: ContributionType,
 ) {
-	let message = `support access to independent journalism for all those who want and need it, `;
+	let message = `support access to independent journalism for all those who want and need it, and `;
 	if (contributionType === 'MONTHLY') {
 		if (selectedAmount >= 35) {
 			message =

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -81,7 +81,7 @@ export const tests: Tests = {
 			},
 		},
 		isActive: true,
-		referrerControlled: true,
+		referrerControlled: false,
 		seed: 5,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 	},


### PR DESCRIPTION
## What are you doing in this PR?

LOWER BAND COPY CORRECTION TO ORIGINAL PR  [**HERE**](https://github.com/guardian/support-frontend/pull/5630) MONTHLY 

REFERRER CONTROL = FALSE (enables test to work without test name having to be in URL)

FROM (incorrect) 
`For $5 per month, support access to independent journalism for all those who want and need it, you'll unlock`
 TO (correct)
`For $5 per month, support access to independent journalism for all those who want and need it, and you'll unlock`

The US+ Global DRR is keen to pre test more emotional language on benefits on the current checkout, to support 3 tier LP testing. This is a copy test on the current checkout. If successful, this copy could be amended to 3 tier LP.

[**Trello Card**](https://trello.com/c/cSdCWciH/441-pre-testing-emotional-messaging-on-current-checkout-us-only)

## How to test

https://support.thegulocal.com/us/contribute#ab-emotionalBenefits=variant