### PR TITLE
feat: add promoCode to SupporterPlusState

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/states/PreparePaymentMethodForReuseState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/PreparePaymentMethodForReuseState.scala
@@ -4,6 +4,7 @@ import com.gu.support.acquisitions.AcquisitionData
 
 import java.util.UUID
 import com.gu.support.encoding.Codec.deriveCodec
+import com.gu.support.promotions.PromoCode
 import com.gu.support.redemptions.RedemptionData
 import com.gu.support.workers.{User, _}
 
@@ -15,6 +16,7 @@ case class PreparePaymentMethodForReuseState(
     user: User,
     giftRecipient: Option[GiftRecipient],
     acquisitionData: Option[AcquisitionData],
+    promoCode: Option[PromoCode],
 ) extends MinimalFailureHandlerState
 
 import com.gu.support.encoding.Codec

--- a/support-models/src/test/scala/com/gu/support/workers/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/SerialisationSpec.scala
@@ -139,5 +139,6 @@ object StatesTestData {
     analyticsInfo = AnalyticsInfo(false, StripeApplePay),
     paymentFields = ExistingPaymentFields("existingBillingAcId"),
     acquisitionData = None,
+    promoCode = None,
   )
 }

--- a/support-workers/cloud-formation/src/templates/state-machine.yaml
+++ b/support-workers/cloud-formation/src/templates/state-machine.yaml
@@ -88,10 +88,10 @@ States:
     Choices:
       - Next: ThreeTierUnpackSendThankYouEmailState
         And:
-#          - Variable: $.state.acquisitionData.threeTierCreateSupporterPlusSubscription
-#            IsPresent: true
-#          - Variable: $.state.acquisitionData.threeTierCreateSupporterPlusSubscription
-#            BooleanEquals: true
+          - Variable: $.state.acquisitionData.threeTierCreateSupporterPlusSubscription
+            IsPresent: true
+          - Variable: $.state.acquisitionData.threeTierCreateSupporterPlusSubscription
+            BooleanEquals: true
           - Variable: $.state.sendThankYouEmailState.product.productType
             IsPresent: true
           - Variable: $.state.sendThankYouEmailState.product.productType

--- a/support-workers/cloud-formation/src/templates/state-machine.yaml
+++ b/support-workers/cloud-formation/src/templates/state-machine.yaml
@@ -88,10 +88,10 @@ States:
     Choices:
       - Next: ThreeTierUnpackSendThankYouEmailState
         And:
-          - Variable: $.state.acquisitionData.threeTierCreateSupporterPlusSubscription
-            IsPresent: true
-          - Variable: $.state.acquisitionData.threeTierCreateSupporterPlusSubscription
-            BooleanEquals: true
+#          - Variable: $.state.acquisitionData.threeTierCreateSupporterPlusSubscription
+#            IsPresent: true
+#          - Variable: $.state.acquisitionData.threeTierCreateSupporterPlusSubscription
+#            BooleanEquals: true
           - Variable: $.state.sendThankYouEmailState.product.productType
             IsPresent: true
           - Variable: $.state.sendThankYouEmailState.product.productType
@@ -142,18 +142,18 @@ States:
       {{> supporterPlusProductChoice currency="AUD" amount=160 billingPeriod="Annual" }}
 
   # These steps are called from the `supporterPlusProductChoice` choices above
-  {{> supporterPlusProduct currency="GBP" amount=10 billingPeriod="Monthly" }}
-  {{> supporterPlusProduct currency="EUR" amount=10 billingPeriod="Monthly" }}
-  {{> supporterPlusProduct currency="USD" amount=13 billingPeriod="Monthly" }}
-  {{> supporterPlusProduct currency="CAD" amount=13 billingPeriod="Monthly" }}
-  {{> supporterPlusProduct currency="NZD" amount=17 billingPeriod="Monthly" }}
-  {{> supporterPlusProduct currency="AUD" amount=20 billingPeriod="Monthly" }}
-  {{> supporterPlusProduct currency="GBP" amount=95 billingPeriod="Annual" }}
-  {{> supporterPlusProduct currency="EUR" amount=95 billingPeriod="Annual" }}
-  {{> supporterPlusProduct currency="USD" amount=120 billingPeriod="Annual" }}
-  {{> supporterPlusProduct currency="CAD" amount=120 billingPeriod="Annual" }}
-  {{> supporterPlusProduct currency="NZD" amount=160 billingPeriod="Annual" }}
-  {{> supporterPlusProduct currency="AUD" amount=160 billingPeriod="Annual" }}
+  {{> supporterPlusProduct currency="GBP" amount=10 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_UK_MONTHLY" }}
+  {{> supporterPlusProduct currency="EUR" amount=10 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_EU_MONTHLY" }}
+  {{> supporterPlusProduct currency="USD" amount=13 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_US_MONTHLY" }}
+  {{> supporterPlusProduct currency="CAD" amount=13 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_CA_MONTHLY" }}
+  {{> supporterPlusProduct currency="NZD" amount=17 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_NZ_MONTHLY" }}
+  {{> supporterPlusProduct currency="AUD" amount=20 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_AU_MONTHLY" }}
+  {{> supporterPlusProduct currency="GBP" amount=95 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_UK_ANNUAL" }}
+  {{> supporterPlusProduct currency="EUR" amount=95 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_EU_ANNUAL" }}
+  {{> supporterPlusProduct currency="USD" amount=120 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_US_ANNUAL" }}
+  {{> supporterPlusProduct currency="CAD" amount=120 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_CA_ANNUAL" }}
+  {{> supporterPlusProduct currency="NZD" amount=160 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_NZ_ANNUAL" }}
+  {{> supporterPlusProduct currency="AUD" amount=160 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_AU_ANNUAL" }}
 
   Done:
     Type: Pass

--- a/support-workers/cloud-formation/src/templates/state-machine.yaml
+++ b/support-workers/cloud-formation/src/templates/state-machine.yaml
@@ -155,6 +155,20 @@ States:
   {{> supporterPlusProduct currency="NZD" amount=160 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_NZ_ANNUAL" }}
   {{> supporterPlusProduct currency="AUD" amount=160 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_AU_ANNUAL" }}
 
+  ThreeTierPreparePaymentMethodForReuse:
+    Type: Task
+    Resource: "${PreparePaymentMethodForReuseLambda.Arn}"
+    Next: ThreeTierCreateZuoraSubscription
+    {{> retry}}
+    {{> catch}}
+
+  ThreeTierCreateZuoraSubscription:
+    Type: Task
+    Resource: "${CreateZuoraSubscriptionLambda.Arn}"
+    Next: ParallelTasks
+    {{> retry}}
+    {{> catch}}
+
   Done:
     Type: Pass
     End: True

--- a/support-workers/cloud-formation/src/templates/supporterPlusProduct.yaml
+++ b/support-workers/cloud-formation/src/templates/supporterPlusProduct.yaml
@@ -13,4 +13,4 @@ ThreeTierSupporterPlus{{billingPeriod}}{{currency}}PromoCode:
   Type: Pass
   Result: {{promoCode}}
   ResultPath: $.state.promoCode
-  Next: PreparePaymentMethodForReuse
+  Next: ThreeTierPreparePaymentMethodForReuse

--- a/support-workers/cloud-formation/src/templates/supporterPlusProduct.yaml
+++ b/support-workers/cloud-formation/src/templates/supporterPlusProduct.yaml
@@ -7,4 +7,10 @@ ThreeTierSupporterPlus{{billingPeriod}}{{currency}}:
     billingPeriod: {{billingPeriod}}
     productType: SupporterPlus
   ResultPath: $.state.product
+  Next: ThreeTierSupporterPlus{{billingPeriod}}{{currency}}PromoCode
+
+ThreeTierSupporterPlus{{billingPeriod}}{{currency}}PromoCode:
+  Type: Pass
+  Result: {{promoCode}}
+  ResultPath: $.state.promoCode
   Next: PreparePaymentMethodForReuse

--- a/support-workers/scripts/project/build.properties
+++ b/support-workers/scripts/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.7

--- a/support-workers/scripts/update-code-cloudformation.sh
+++ b/support-workers/scripts/update-code-cloudformation.sh
@@ -2,14 +2,23 @@
 
 ./build-cloudformation.sh
 
-aws --region eu-west-1 cloudformation validate-template --template-body file://../cloud-formation/target/cfn.yaml --profile membership
+aws --region eu-west-1 --profile membership \
+  s3 cp ../cloud-formation/target/cfn.yaml s3://support-workers-dist/support/CODE/cloudformation/
+
+aws --region eu-west-1 --profile membership \
+  cloudformation validate-template --template-url https://s3.amazonaws.com/support-workers-dist/support/CODE/cloudformation/cfn.yaml
+  # --template-body file://../cloud-formation/target/cfn.yaml
 
 aws --region eu-west-1 --profile membership \
   cloudformation update-stack \
   --capabilities CAPABILITY_IAM  \
   --stack-name support-CODE-workers \
-  --template-body file://../cloud-formation/target/cfn.yaml \
-  --parameters  ParameterKey=Stage,ParameterValue=CODE ParameterKey=OphanRole,UsePreviousValue=true ParameterKey=KinesisStreamArn,UsePreviousValue=true
+  --parameters  ParameterKey=Stage,ParameterValue=CODE ParameterKey=OphanRole,UsePreviousValue=true ParameterKey=KinesisStreamArn,UsePreviousValue=true \
+  --template-url https://s3.amazonaws.com/support-workers-dist/support/CODE/cloudformation/cfn.yaml
+  # --template-body file://../cloud-formation/target/cfn.yaml
+
+aws --region eu-west-1 --profile membership \
+  s3 rm s3://support-workers-dist/support/CODE/cloudformation/cfn.yaml
 
 if [[ $? == 0 ]]; then
   echo -e "\nStack update has been started, check progress in the AWS console.";

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/PreparePaymentMethodForReuse.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/PreparePaymentMethodForReuse.scala
@@ -98,15 +98,15 @@ class PreparePaymentMethodForReuse(servicesProvider: ServiceProvider = ServicePr
       })
     } yield HandlerResult(
       CreateZuoraSubscriptionState(
-        productState,
-        state.requestId,
-        state.user,
-        productType,
-        state.analyticsInfo,
-        None,
-        None,
-        None,
-        None,
+        productSpecificState = productState,
+        requestId = state.requestId,
+        user = state.user,
+        product = productType,
+        analyticsInfo = state.analyticsInfo,
+        firstDeliveryDate = None,
+        promoCode = state.promoCode,
+        csrUsername = None,
+        salesforceCaseId = None,
         acquisitionData = state.acquisitionData,
       ),
       requestInfo

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/ZuoraSubscriptionCreatorSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/ZuoraSubscriptionCreatorSpec.scala
@@ -1,0 +1,93 @@
+package com.gu.zuora
+
+import com.gu.support.zuora.api.{Account, RatePlan, RatePlanData, SubscribeItem}
+import com.gu.support.zuora.domain.DomainSubscription
+import org.mockito.MockitoSugar.{times, verify, when}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar.mock
+import com.gu.support.zuora.api.response.{ZuoraAccountNumber, ZuoraSubscriptionNumber, RatePlan => ZuoraRatePlan}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import org.mockito.Mockito.{mock => mockitoMock}
+
+import scala.concurrent.Future
+
+class ZuoraSubscriptionCreatorSpec extends AnyFlatSpec with Matchers {
+
+  /** These tests validate that the zuoraService.subscribe() should be skipped if there is an existing
+    * domainSubscription and that subscription has matching rate plans
+    */
+  "subscribeIfApplicable" should "subscribe with no domainSubscription" in {
+    val zuoraService = mock[ZuoraSubscribeService]
+    val subscribeItem = mockitoMock(classOf[SubscribeItem], Mockito.RETURNS_DEEP_STUBS)
+    val maybeDomainSubscription = None
+    when(zuoraService.subscribe(any())).thenReturn(Future.successful(Nil))
+
+    ZuoraSubscriptionCreator.subscribeIfApplicable(
+      zuoraService = zuoraService,
+      subscribeItem = subscribeItem,
+      maybeDomainSubscription = maybeDomainSubscription,
+    )
+
+    verify(zuoraService, times(1)).subscribe(any())
+  }
+
+  "subscribeIfApplicable" should "subscribe with a domainSubscription and non-matching rate plans" in {
+    val zuoraService = mock[ZuoraSubscribeService]
+    val subscribeItem = mockitoMock(classOf[SubscribeItem], Mockito.RETURNS_DEEP_STUBS)
+    val domainSubscription = mock[DomainSubscription]
+    val maybeDomainSubscription = Option(domainSubscription)
+    val ratePlanData = List(
+      RatePlanData(RatePlan("id1"), Nil, Nil),
+      RatePlanData(RatePlan("id2"), Nil, Nil),
+      RatePlanData(RatePlan("id3"), Nil, Nil),
+    )
+    val zuoraRatePlans = List(
+      ZuoraRatePlan("id1", "id1", "id1", Nil),
+      ZuoraRatePlan("id2", "id2", "id2", Nil),
+      // Here's the difference, `id4`
+      ZuoraRatePlan("id3", "id3", "id4", Nil),
+    )
+
+    when(subscribeItem.subscriptionData.ratePlanData).thenReturn(ratePlanData)
+    when(domainSubscription.ratePlans).thenReturn(zuoraRatePlans)
+    when(zuoraService.subscribe(any())).thenReturn(Future.successful(Nil))
+
+    ZuoraSubscriptionCreator.subscribeIfApplicable(
+      zuoraService = zuoraService,
+      subscribeItem = subscribeItem,
+      maybeDomainSubscription = maybeDomainSubscription,
+    )
+
+    verify(zuoraService, times(1)).subscribe(any())
+  }
+
+  "subscribeIfApplicable" should "skip with a domainSubscription but matching rate plans" in {
+    val zuoraService = mock[ZuoraSubscribeService]
+    val subscribeItem = mockitoMock(classOf[SubscribeItem], Mockito.RETURNS_DEEP_STUBS)
+    val domainSubscription = mock[DomainSubscription]
+    val maybeDomainSubscription = Option(domainSubscription)
+    val ratePlanData = List(
+      RatePlanData(RatePlan("id1"), Nil, Nil),
+      RatePlanData(RatePlan("id2"), Nil, Nil),
+      RatePlanData(RatePlan("id3"), Nil, Nil),
+    )
+    val zuoraRatePlans = List(
+      ZuoraRatePlan("id1", "id1", "id1", Nil),
+      ZuoraRatePlan("id2", "id2", "id2", Nil),
+      ZuoraRatePlan("id3", "id3", "id3", Nil),
+    )
+
+    when(subscribeItem.subscriptionData.ratePlanData).thenReturn(ratePlanData)
+    when(domainSubscription.ratePlans).thenReturn(zuoraRatePlans)
+
+    ZuoraSubscriptionCreator.subscribeIfApplicable(
+      zuoraService = zuoraService,
+      subscribeItem = subscribeItem,
+      maybeDomainSubscription = maybeDomainSubscription,
+    )
+
+    verify(zuoraService, times(0)).subscribe(any())
+  }
+}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
- Adds `promoCode` `promoCode` to `PreparePaymentMethodForReuse` for Supporter+ bolt-on which then propagates through the system.
- Tightens the check to see if a payment is a duplicate by comparing the rate plans as well as the `requestId` as we were assuming the Supporter+ bolt on was a duplicate thus not being created.
- Adds a test for `subscribeIfApplicable`

The logic was quite hard to fathom in writing the tests for `ZuoraSubscriptionCreator`, which made me feel it could use with a little tidy, but that might be for another PR.

[**Trello Card**](https://trello.com/c/zFv8FO72/540-add-three-tier-promotion-codes)