### PR TITLE
Revert "chore: update frontend java version 8 => 11"

### DIFF
--- a/support-frontend/conf/riff-raff.yaml
+++ b/support-frontend/conf/riff-raff.yaml
@@ -21,7 +21,7 @@ deployments:
         PROD: Frontend-PROD.template.json
       amiParameter: AMIFrontend
       amiTags:
-        Recipe: jammy-membership-java11
+        Recipe: jammy-membership-java8
         AmigoStage: PROD
       amiEncrypted: true
   frontend:


### PR DESCRIPTION
Reverts guardian/support-frontend#5608

This has stopped deployment because it's still requiring the old package.  This reverts to unblock so that a new PR can be tried in CODE first.

See a similar fix here:
https://github.com/guardian/members-data-api/pull/1037#discussion_r1400412892
Also see parameter changes possibly needed here:
https://github.com/guardian/members-data-api/pull/1037#discussion_r1400396814

Feel free to merge this PR if I'm not around, once it's approved.