### PR TITLE
Fix E2E failure alerting

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -5,7 +5,7 @@ on:
     types: [labeled] # Only run when a PR is labeled with the 'Seen-on-PROD' label set by prout
 
 concurrency:
-  group: 'playwright-${{ github.head_ref }}'
+  group: "playwright-${{ github.head_ref }}"
   cancel-in-progress: true
 
 jobs:
@@ -14,11 +14,11 @@ jobs:
     name: Playwright
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    env :
-      BROWSERSTACK_USERNAME : ${{ secrets.BROWSERSTACK_USERNAME }}
-      BROWSERSTACK_ACCESS_KEY : ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-      GOOGLE_CHAT_WEB_HOOK : ${{ secrets.GOOGLE_CHAT_WEB_HOOK }}
-      PAYPAL_TEST_PASSWORD : ${{secrets.PAYPAL_TEST_PASSWORD}}
+    env:
+      BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+      BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+      GOOGLE_CHAT_WEB_HOOK: ${{ secrets.GOOGLE_CHAT_WEB_HOOK }}
+      PAYPAL_TEST_PASSWORD: ${{ secrets.PAYPAL_TEST_PASSWORD }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -41,5 +41,4 @@ jobs:
         run: |
           echo "Tests have failed - calling webhook"
           failedWorkflowRun="https://github.com/guardian/support-frontend/actions/runs/$GITHUB_RUN_ID"
-          curl -X POST -H 'Content-Type: application/json' '$GOOGLE_CHAT_WEB_HOOK' -d '{"text": "❌ The Playwright post deployment tests for support frontend have failed! <users/all> \n \n 👉 <'"$failedWorkflowRun"'|Workflow run> \n 🤖 <https://automate.browserstack.com/dashboard/v2/builds/31f35a1d9bccc9d45360aa7bfd651fcd9e1499d0|Browser stack test results> \n \n 📖 <https://github.com/guardian/support-frontend/wiki/Post-deployment-test-runbook|Check the runbook for a step by step guide>"}'
-
+          curl -X POST -H "Content-Type: application/json" "$GOOGLE_CHAT_WEB_HOOK" -d '{"text": "🚨 The Playwright post deployment tests for support frontend have failed! <users/all> \n \n 👉 <'"$failedWorkflowRun"'|Workflow run> \n 🤖 <https://automate.browserstack.com/dashboard/v2/builds/31f35a1d9bccc9d45360aa7bfd651fcd9e1499d0|Browser stack test results> \n \n 📖 <https://github.com/guardian/support-frontend/wiki/Post-deployment-test-runbook|Check the runbook for a step by step guide>"}'


### PR DESCRIPTION
Fixes https://github.com/guardian/support-frontend/issues/5653

[Trello](https://trello.com/c/npqIGlkP/568-post-to-sr-dev-google-chat-when-e2e-tests-fail)

Our E2E tests were failing and the alarm in the chat channel was not being triggered. 

There is a few linting fixes here, but the main issue is that we were using `'$GOOGLE_CHAT_WEB_HOOK'` instead of `"$GOOGLE_CHAT_WEB_HOOK"`. [Double quotes are used for string interpolation in bash, single quotes do not do this](https://www.baeldung.com/linux/bash-double-quotes#variable-interpolation).

As a note these errors take ~15 minutes to run, and ~30 minutes to fail. I wonder if we could split them out into "Integral" vs "Subsidiary" or similar.