### PR TITLE
Add excludeIfInReferrerControlledTest to AB test model

### DIFF
--- a/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
@@ -101,43 +101,43 @@ describe('init', () => {
 		expect(participations).toEqual(expectedParticipations);
 	});
 
-  it('excludes a test with excludeIfInReferrerControlledTest set if another test has referrerControlled set', () => {
-    const tests = {
-      t1: buildTest({
-        variants: [
-          buildVariant({ id: 'control' }),
-          buildVariant({ id: 'variant' }),
-        ],
-        referrerControlled: false,
-        excludeIfInReferrerControlledTest: true,
-      }),
-      t2: buildTest({
-        variants: [
-          buildVariant({ id: 'control' }),
-          buildVariant({ id: 'variant' }),
-        ],
-        referrerControlled: true,
-      }),
-    };
+	it('excludes a test with excludeIfInReferrerControlledTest set if another test has referrerControlled set', () => {
+		const tests = {
+			t1: buildTest({
+				variants: [
+					buildVariant({ id: 'control' }),
+					buildVariant({ id: 'variant' }),
+				],
+				referrerControlled: false,
+				excludeIfInReferrerControlledTest: true,
+			}),
+			t2: buildTest({
+				variants: [
+					buildVariant({ id: 'control' }),
+					buildVariant({ id: 'variant' }),
+				],
+				referrerControlled: true,
+			}),
+		};
 
-    const acquisitionAbTests = [
-      buildAcquisitionAbTest({ name: 't2', variant: 'variant' }),
-    ];
+		const acquisitionAbTests = [
+			buildAcquisitionAbTest({ name: 't2', variant: 'variant' }),
+		];
 
-    const participations: Participations = abInit(
-      country,
-      countryGroupId,
-      tests,
-      mvt,
-      acquisitionAbTests,
-    );
+		const participations: Participations = abInit(
+			country,
+			countryGroupId,
+			tests,
+			mvt,
+			acquisitionAbTests,
+		);
 
-    const expectedParticipations: Participations = {
-      t2: 'variant',
-    };
+		const expectedParticipations: Participations = {
+			t2: 'variant',
+		};
 
-    expect(participations).toEqual(expectedParticipations);
-  });
+		expect(participations).toEqual(expectedParticipations);
+	});
 
 	it('uses the variant assignment in the acquisitionData for referrerControlled tests belonging to a campaign', () => {
 		const campaignPrefix = 't';
@@ -722,7 +722,7 @@ function buildTest({
 	audiences = { ALL: buildAudience({}) },
 	isActive = true,
 	seed = 0,
-  excludeIfInReferrerControlledTest = false,
+	excludeIfInReferrerControlledTest = false,
 }: Partial<Test>): Test {
 	return {
 		variants,
@@ -730,7 +730,7 @@ function buildTest({
 		isActive,
 		referrerControlled,
 		seed,
-    excludeIfInReferrerControlledTest,
+		excludeIfInReferrerControlledTest,
 	};
 }
 

--- a/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
@@ -101,6 +101,44 @@ describe('init', () => {
 		expect(participations).toEqual(expectedParticipations);
 	});
 
+  it('excludes a test with excludeIfInReferrerControlledTest set if another test has referrerControlled set', () => {
+    const tests = {
+      t1: buildTest({
+        variants: [
+          buildVariant({ id: 'control' }),
+          buildVariant({ id: 'variant' }),
+        ],
+        referrerControlled: false,
+        excludeIfInReferrerControlledTest: true,
+      }),
+      t2: buildTest({
+        variants: [
+          buildVariant({ id: 'control' }),
+          buildVariant({ id: 'variant' }),
+        ],
+        referrerControlled: true,
+      }),
+    };
+
+    const acquisitionAbTests = [
+      buildAcquisitionAbTest({ name: 't2', variant: 'variant' }),
+    ];
+
+    const participations: Participations = abInit(
+      country,
+      countryGroupId,
+      tests,
+      mvt,
+      acquisitionAbTests,
+    );
+
+    const expectedParticipations: Participations = {
+      t2: 'variant',
+    };
+
+    expect(participations).toEqual(expectedParticipations);
+  });
+
 	it('uses the variant assignment in the acquisitionData for referrerControlled tests belonging to a campaign', () => {
 		const campaignPrefix = 't';
 
@@ -684,6 +722,7 @@ function buildTest({
 	audiences = { ALL: buildAudience({}) },
 	isActive = true,
 	seed = 0,
+  excludeIfInReferrerControlledTest = false,
 }: Partial<Test>): Test {
 	return {
 		variants,
@@ -691,6 +730,7 @@ function buildTest({
 		isActive,
 		referrerControlled,
 		seed,
+    excludeIfInReferrerControlledTest,
 	};
 }
 

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -179,10 +179,7 @@ function getParticipations(
 
 	// If referrerControlled is set for any test, exclude tests that have excludeIfInReferrerControlledTest set
 	const inReferrerControlledTest = Object.keys(participations).some(
-		(testName) => {
-			const test = abTests[testName];
-			return test.referrerControlled;
-		},
+		(testId) => abTests[testId].referrerControlled,
 	);
 	if (inReferrerControlledTest) {
 		Object.keys(participations).forEach((testId) => {

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -68,8 +68,8 @@ export type Test = {
 	// In particular this allows 3rd party tests to be identified and tracked in support-frontend
 	// without too much "magic" involving the shared mvtId.
 	referrerControlled: boolean;
-  // If another test participation is referrerControlled, exclude this test
-  excludeIfInReferrerControlledTest?: boolean;
+	// If another test participation is referrerControlled, exclude this test
+	excludeIfInReferrerControlledTest?: boolean;
 	seed: number;
 	// An optional regex that will be tested against the path of the current page
 	// before activating this test eg. '/(uk|us|au|ca|nz)/subscribe$'
@@ -177,18 +177,20 @@ function getParticipations(
 		participations[testId] = test.variants[variantAssignment.variantIndex].id;
 	});
 
-  // If referrerControlled is set for any test, exclude tests that have excludeIfInReferrerControlledTest set
-  const inReferrerControlledTest = Object.keys(participations).some(testName => {
-    const test = abTests[testName];
-    return test.referrerControlled;
-  });
-  if (inReferrerControlledTest) {
-    Object.keys(participations).forEach(testId => {
-      if (abTests[testId].excludeIfInReferrerControlledTest) {
-        delete participations[testId];
-      }
-    });
-  }
+	// If referrerControlled is set for any test, exclude tests that have excludeIfInReferrerControlledTest set
+	const inReferrerControlledTest = Object.keys(participations).some(
+		(testName) => {
+			const test = abTests[testName];
+			return test.referrerControlled;
+		},
+	);
+	if (inReferrerControlledTest) {
+		Object.keys(participations).forEach((testId) => {
+			if (abTests[testId].excludeIfInReferrerControlledTest) {
+				delete participations[testId];
+			}
+		});
+	}
 
 	return participations;
 }

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -68,6 +68,8 @@ export type Test = {
 	// In particular this allows 3rd party tests to be identified and tracked in support-frontend
 	// without too much "magic" involving the shared mvtId.
 	referrerControlled: boolean;
+  // If another test participation is referrerControlled, exclude this test
+  excludeIfInReferrerControlledTest?: boolean;
 	seed: number;
 	// An optional regex that will be tested against the path of the current page
 	// before activating this test eg. '/(uk|us|au|ca|nz)/subscribe$'
@@ -174,6 +176,20 @@ function getParticipations(
 
 		participations[testId] = test.variants[variantAssignment.variantIndex].id;
 	});
+
+  // If referrerControlled is set for any test, exclude tests that have excludeIfInReferrerControlledTest set
+  const inReferrerControlledTest = Object.keys(participations).some(testName => {
+    const test = abTests[testName];
+    return test.referrerControlled;
+  });
+  if (inReferrerControlledTest) {
+    Object.keys(participations).forEach(testId => {
+      if (abTests[testId].excludeIfInReferrerControlledTest) {
+        delete participations[testId];
+      }
+    });
+  }
+
 	return participations;
 }
 

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -103,7 +103,7 @@ export const tests: Tests = {
 		},
 		omitCountries: countriesAffectedByVATStatus,
 		referrerControlled: false,
-    excludeIfInReferrerControlledTest: true,
+		excludeIfInReferrerControlledTest: true,
 		seed: 0,
 
 		/**

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -103,6 +103,7 @@ export const tests: Tests = {
 		},
 		omitCountries: countriesAffectedByVATStatus,
 		referrerControlled: false,
+    excludeIfInReferrerControlledTest: true,
 		seed: 0,
 
 		/**

--- a/support-frontend/assets/helpers/redux/commonState/reducer.ts
+++ b/support-frontend/assets/helpers/redux/commonState/reducer.ts
@@ -4,7 +4,6 @@ import type { ContributionTypes } from 'helpers/contributions';
 import { CountryGroup } from 'helpers/internationalisation';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { fromCountryGroupId } from 'helpers/internationalisation/currency';
-import type { Participations } from '../../abTests/abtest';
 import type { CommonStateSetupData, Internationalisation } from './state';
 import { initialCommonState } from './state';
 
@@ -22,24 +21,11 @@ function getInternationalisationFromCountry(
 	};
 }
 
-function getABTestNames(abParticipations: Participations) {
-	const isUserInSupporterPlusABTest = 'supporterPlusOnly' in abParticipations;
-
-	const abTestType = isUserInSupporterPlusABTest
-		? { supporterPlusOnly: abParticipations.supporterPlusOnly }
-		: abParticipations;
-
-	return abTestType;
-}
-
 export const commonSlice = createSlice({
 	name: 'common',
 	initialState: initialCommonState,
 	reducers: {
 		setInitialCommonState(state, action: PayloadAction<CommonStateSetupData>) {
-			action.payload.abParticipations = getABTestNames(
-				action.payload.abParticipations,
-			);
 			const {
 				campaign,
 				referrerAcquisitionData,


### PR DESCRIPTION
Currently there's some special logic in the reducer to prevent any other other AB test participations if the url specifies that the user should be in the `supporterPlusOnly` AB test.
[Example](https://support.theguardian.com/uk/contribute?acquisitionData={%20%22abTest%22:{%20%22name%22:%20%22supporterPlusOnly%22,%20%22variant%22:%20%22variant%22%20}%20})

We'd like to use this type of logic again for an upcoming feature. But really we want to avoid interfering with the `threeTierCheckout` test - if the user is in a referrer-controlled AB test then we do not want them to go into the `threeTierCheckout`.

This PR adds a new field to the AB test model: `excludeIfInReferrerControlledTest`.
If a test participation has `referrerControlled: true`, we exclude any other test which has `excludeIfInReferrerControlledTest: true`.
This means AB tests like `supporterPlusOnly` can override the `threeTierCheckout` test