### PR TITLE
Three Tier - Query string parameters to all links - Tier Type Correction

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -17,10 +17,8 @@ import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
 import type { TierBenefits, TierPlanCosts } from '../setup/threeTierConfig';
 import { ThreeTierLozenge } from './threeTierLozenge';
 
-export type Tier = 1 | 2 | 3;
-
 interface ThreeTierCardProps {
-	cardTier: Tier;
+	cardTier: 1 | 2 | 3;
 	title: string;
 	isRecommended: boolean;
 	isRecommendedSubdued: boolean;
@@ -29,7 +27,7 @@ interface ThreeTierCardProps {
 	planCost: TierPlanCosts;
 	currency: string;
 	paymentFrequency: RegularContributionType;
-	cardCtaClickHandler: (price: number, cardTier: Tier) => void;
+	cardCtaClickHandler: (price: number, cardTier: 1 | 2 | 3) => void;
 	externalBtnLink?: string;
 }
 

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import { between, from, space } from '@guardian/source-foundations';
 import type { RegularContributionType } from 'helpers/contributions';
 import type { TierBenefits, TierPlanCosts } from '../setup/threeTierConfig';
-import type { Tier } from './threeTierCard';
 import { ThreeTierCard } from './threeTierCard';
 
 interface ThreeTierCardsProps {
@@ -16,7 +15,7 @@ interface ThreeTierCardsProps {
 	}>;
 	currency: string;
 	paymentFrequency: RegularContributionType;
-	cardsCtaClickHandler: (price: number, cardTier: Tier) => void;
+	cardsCtaClickHandler: (price: number, cardTier: 1 | 2 | 3) => void;
 }
 
 const container = (cardCount: number) => css`
@@ -36,7 +35,7 @@ const container = (cardCount: number) => css`
 	}
 `;
 
-const cardIndexToTier = (index: number): Tier => {
+const cardIndexToTier = (index: number): 1 | 2 | 3 => {
 	switch (index) {
 		case 1:
 			return 2;

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -43,7 +43,6 @@ import {
 } from 'helpers/redux/storeHooks';
 import { navigateWithPageView } from 'helpers/tracking/ophan';
 import { SupportOnce } from '../components/supportOnce';
-import type { Tier } from '../components/threeTierCard';
 import { ThreeTierCards } from '../components/threeTierCards';
 import { tierCards } from '../setup/threeTierConfig';
 
@@ -242,7 +241,7 @@ export function ThreeTierLanding(): JSX.Element {
 		dispatch(setProductType(paymentFrequencies[buttonIndex]));
 	};
 
-	const handleCardCtaClick = (price: number, cardTier: Tier) => {
+	const handleCardCtaClick = (price: number, cardTier: 1 | 2 | 3) => {
 		dispatch(
 			setSelectedAmount({
 				contributionType,
@@ -281,7 +280,7 @@ export function ThreeTierLanding(): JSX.Element {
 		);
 	};
 
-	const getCardContentBaseObject = (cardTier: Tier) => {
+	const getCardContentBaseObject = (cardTier: 1 | 2 | 3) => {
 		const tierPlanCountryCharges =
 			tierCards[`tier${cardTier}`].plans[contributionTypeKey].charges[
 				countryGroupId
@@ -298,7 +297,7 @@ export function ThreeTierLanding(): JSX.Element {
 		};
 	};
 
-	const generateTierCheckoutLink = (cardTier: Tier) => {
+	const generateTierCheckoutLink = (cardTier: 1 | 2 | 3) => {
 		const tierPlanCountryCharges =
 			tierCards[`tier${cardTier}`].plans[contributionTypeKey].charges[
 				countryGroupId


### PR DESCRIPTION
## What are you doing in this PR?

TIER TYPE SIMPLIFICATION TO ORIGINAL PR  [**HERE**](https://github.com/guardian/support-frontend/pull/5656)
- Removal of Tier type. Created type errors (suspected naming issue with `Tier`)
- Rather than rename, decided to define as 1, 2 or 3 only.

[**Trello Card**](https://trello.com/c/MjmPGSGt/557-add-query-string-parameters-to-three-tier-links)
