### PR TITLE
Three tier aria labels added using  paymentFrequency

### DIFF
--- a/support-frontend/assets/components/paymentFrequencyButtons/paymentFrequencyButtons.tsx
+++ b/support-frontend/assets/components/paymentFrequencyButtons/paymentFrequencyButtons.tsx
@@ -2,9 +2,11 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { from, palette, space, textSans } from '@guardian/source-foundations';
 import { useState } from 'react';
+import type { RegularContributionType } from 'helpers/contributions';
 
 interface PaymentFrequencyButtonObj {
 	label: string;
+	paymentFrequency: RegularContributionType;
 	isPreSelected?: boolean;
 }
 
@@ -59,10 +61,18 @@ export function PaymentFrequencyButtons({
 		),
 	);
 	return (
-		<div css={[container(paymentFrequencies.length), additionalStyles]}>
+		<div
+			css={[container(paymentFrequencies.length), additionalStyles]}
+			role="tablist"
+			aria-label="Payment frequency options"
+		>
 			{paymentFrequencies.map((paymentFrequency, buttonIndex) => (
 				<button
 					css={button(buttonIndex === selectedButton)}
+					role="tab"
+					id={paymentFrequency.paymentFrequency}
+					aria-controls={`${paymentFrequency.paymentFrequency}-tab`}
+					aria-selected={buttonIndex === selectedButton}
 					onClick={() => {
 						setSelectedButton(buttonIndex);
 						buttonClickHandler(buttonIndex);

--- a/support-frontend/assets/components/paymentFrequencyButtons/paymentFrequencyButtons.tsx
+++ b/support-frontend/assets/components/paymentFrequencyButtons/paymentFrequencyButtons.tsx
@@ -5,8 +5,8 @@ import { useState } from 'react';
 import type { RegularContributionType } from 'helpers/contributions';
 
 interface PaymentFrequencyButtonObj {
-	label: string;
-	paymentFrequency: RegularContributionType;
+	paymentFrequencyLabel: string;
+	paymentFrequencyId: RegularContributionType;
 	isPreSelected?: boolean;
 }
 
@@ -70,15 +70,15 @@ export function PaymentFrequencyButtons({
 				<button
 					css={button(buttonIndex === selectedButton)}
 					role="tab"
-					id={paymentFrequency.paymentFrequency}
-					aria-controls={`${paymentFrequency.paymentFrequency}-tab`}
+					id={paymentFrequency.paymentFrequencyId}
+					aria-controls={`${paymentFrequency.paymentFrequencyId}-tab`}
 					aria-selected={buttonIndex === selectedButton}
 					onClick={() => {
 						setSelectedButton(buttonIndex);
 						buttonClickHandler(buttonIndex);
 					}}
 				>
-					{paymentFrequency.label}
+					{paymentFrequency.paymentFrequencyLabel}
 				</button>
 			))}
 		</div>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
@@ -58,7 +58,12 @@ export function ThreeTierCards({
 			.length > 1;
 
 	return (
-		<div css={container(cardsContent.length)}>
+		<div
+			css={container(cardsContent.length)}
+			role="tabpanel"
+			id={`${paymentFrequency}-tab`}
+			aria-labelledby={`${paymentFrequency}`}
+		>
 			{cardsContent.map((cardContent, cardIndex) => {
 				return (
 					<ThreeTierCard

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -366,8 +366,8 @@ export function ThreeTierLanding(): JSX.Element {
 					<PaymentFrequencyButtons
 						paymentFrequencies={paymentFrequencies.map(
 							(paymentFrequency, index) => ({
-								label: paymentFrequencyMap[paymentFrequency],
-								paymentFrequency,
+								paymentFrequencyLabel: paymentFrequencyMap[paymentFrequency],
+								paymentFrequencyId: paymentFrequency,
 								isPreSelected: paymentFrequencies[index] === contributionType,
 							}),
 						)}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -367,6 +367,7 @@ export function ThreeTierLanding(): JSX.Element {
 						paymentFrequencies={paymentFrequencies.map(
 							(paymentFrequency, index) => ({
 								label: paymentFrequencyMap[paymentFrequency],
+								paymentFrequency,
 								isPreSelected: paymentFrequencies[index] === contributionType,
 							}),
 						)}


### PR DESCRIPTION
## What are you doing in this PR?

Accessibility improvement to 3-tier landing page : parity with existing landing page & helps QM track interactions with the Toggle.

[**Trello Card**](https://trello.com/c/9RUcZd0S/578-add-aria-attributes-to-3-tier-frequency-toggles)

## How to test


## Accessibility test checklist
-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)

