### PR TITLE
feat: add verbose logging to pricesummaryesrvice

### DIFF
--- a/support-frontend/app/services/pricing/PriceSummaryService.scala
+++ b/support-frontend/app/services/pricing/PriceSummaryService.scala
@@ -1,6 +1,7 @@
 package services.pricing
 
-import com.gu.i18n.{CountryGroup, Currency}
+import com.gu.i18n.{Country, CountryGroup, Currency}
+import com.gu.monitoring.SafeLogger
 import com.gu.support.catalog._
 import services.pricing.PriceSummaryService.{getDiscountedPrice, getNumberOfDiscountedPeriods}
 import com.gu.support.promotions._
@@ -24,6 +25,10 @@ class PriceSummaryService(
       promoCodes: List[PromoCode],
       readerType: ReaderType = Direct,
   ): ProductPrices = {
+    SafeLogger.info(
+      s"getPrices for catalogue: ${catalogService.environment}, promotionService: ${promotionService.environment}",
+    )
+
     val defaultPromos = getDefaultPromoCodes(product)
     val promotions = promotionService.findPromotions(promoCodes ++ defaultPromos)
     product
@@ -72,6 +77,25 @@ class PriceSummaryService(
       price: Price,
       saving: Option[Int],
   ) = {
+    val country = countryGroup.defaultCountry.orElse(countryGroup.countries.headOption).getOrElse(Country.UK)
+    SafeLogger.info(s"Validating promotions. Country: $country, productRatePlan: ${productRatePlan.id}")
+
+    SafeLogger.info("Promotions to validate")
+    SafeLogger.info(promotions.map(promo => promo.promoCode).mkString(", "))
+
+    val (invalidPromotions, validPromotions) = promotions
+      .map(promo =>
+        promotionService
+          .validatePromotion(promo, country, productRatePlan.id, isRenewal = false),
+      )
+      .partitionMap(identity)
+
+    SafeLogger.info("Invalid promotions")
+    SafeLogger.info(invalidPromotions.map(promoError => promoError.msg).mkString(", "))
+
+    SafeLogger.info("Valid promotions")
+    SafeLogger.info(validPromotions.map(promoError => promoError.promoCode).mkString(", "))
+
     val promotionSummaries: List[PromotionSummary] = for {
       promotion <- promotions
       country <- countryGroup.defaultCountry.orElse(countryGroup.countries.headOption)

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
@@ -16,6 +16,9 @@ class PromotionService(config: PromotionsConfig, maybeCollection: Option[Promoti
   // This is a small hack to allow us to start using promotions to handle 6 for 6 without having to build the tooling
   private def allWith6For6 = promotionCollection.all.toList :+ Promotions.SixForSixPromotion
 
+  def environment = if (config.tables.promotions.contains("PROD")) { "PROD" }
+  else { "CODE" }
+
   def findPromotion(promoCode: PromoCode): Either[PromoError, PromotionWithCode] =
     allWith6For6
       .filter(_.promoCodes.exists(_ == promoCode))


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Adding some logging to the `PriceSummaryService` to try and work out why we promoCodes on `PROD` as a test user intermittently work.

A working theory is that we aren't comparing the right data between the `promotionsService` and `catalogueService`.


[Trello card](https://trello.com/c/PtZJsS3h/582-get-promocodes-working-on-prod-for-test-users).