### PR TITLE
Promo cache respects stage

### DIFF
--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionCache.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionCache.scala
@@ -11,6 +11,7 @@ case class PromotionCacheResponse(fetched: DateTime, promotions: Iterable[Promot
 }
 
 class PromotionCache {
+  // this val contains the mutable cache contents
   val promotionsRef = Ref[Option[PromotionCacheResponse]](None)
 
   def get: Option[Iterable[Promotion]] = promotionsRef.single().filter(_.isFresh).map(_.promotions)

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionCollection.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionCollection.scala
@@ -19,11 +19,12 @@ class CachedDynamoPromotionCollection(config: PromotionsTablesConfig)
     extends DynamoPromotionCollection(config)
     with PromotionCollection {
 
-  override def all: Iterator[Promotion] = PromotionCache.get.getOrElse(fetchAndCache).toIterator
+  val cache = new PromotionCache
+  override def all: Iterator[Promotion] = cache.get.getOrElse(fetchAndCache).toIterator
 
   private def fetchAndCache = {
     val promotions = super.all.toList
-    PromotionCache.set(promotions)
+    cache.set(promotions)
     promotions
   }
 }

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionCacheSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionCacheSpec.scala
@@ -7,12 +7,14 @@ import org.scalatest.matchers.should.Matchers
 class PromotionCacheSpec extends AsyncFlatSpec with Matchers {
 
   "PromotionCache" should "return cached promotions when they are fresh" in {
-    PromotionCache.set(Nil)
-    PromotionCache.get shouldBe Some(Nil)
+    val cache = new PromotionCache
+    cache.set(Nil)
+    cache.get shouldBe Some(Nil)
   }
 
   it should "return None if they are stale" in {
-    PromotionCache.set(Nil, DateTime.now().minusSeconds(61))
-    PromotionCache.get shouldBe None
+    val cache = new PromotionCache
+    cache.set(Nil, DateTime.now().minusSeconds(61))
+    cache.get shouldBe None
   }
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Currently the `PromomotionCache` is a singleton, meaning that any service using it will use the same cache, irrespective of which table it came from.

This means that if
- we fill the cache with `PROD` data
- Become a test user
- Try to read CODE data

We will actually get `PROD` data until we need to refresh the cache. 

```mermaid

flowchart TB
    PriceSummaryService
    PriceSummaryService --> codeService
    PriceSummaryService --> prodService
    
    subgraph PROD
        prodService --> ProdPromotionService
        ProdPromotionService --> ProdCachedDynamoPromotionCollection["new CachedDynamoPromotionCollection"]
        
    end


    subgraph CODE
        codeService --> CodePromotionService
        CodePromotionService --> CodeCachedDynamoPromotionCollection["new CachedDynamoPromotionCollection"]
    end
        
    ProdCachedDynamoPromotionCollection <-- read CODE data --> PromotionCache 
    CodeCachedDynamoPromotionCollection -- write CODE data --> PromotionCache
    
    PromotionCache
```

[**Trello Card**](https://trello.com/c/PtZJsS3h/582-get-promocodes-working-on-prod-for-test-users)

## Testing

I've omitted testing as I couldn't think of anyway to test this that was any more clear than the implementation.
