### PR TITLE
Three tier copy update revision

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
@@ -69,7 +69,7 @@ export function SupportOnce({
 			<p css={standFirst}>
 				We welcome support of any size, any time - whether you choose to
 				give&nbsp;
-				{currency}1 or much more.
+				{currency}1 or more.
 			</p>
 			<Button
 				iconSide="left"

--- a/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
@@ -31,7 +31,9 @@ const standFirst = css`
 	color: ${palette.neutral[10]};
 	${textSans.medium()};
 	line-height: 1.35;
+	padding-top: ${space[1]}px;
 	${from.tablet} {
+		padding-top: ${space[2]}px;
 		margin: 0 auto;
 		max-width: 340px;
 	}
@@ -53,18 +55,21 @@ const btnStyleOverrides = css`
 `;
 
 interface SupportOnceProps {
+	currency: string;
 	btnClickHandler: () => void;
 }
 
 export function SupportOnce({
+	currency,
 	btnClickHandler,
 }: SupportOnceProps): JSX.Element {
 	return (
 		<div css={container}>
 			<h2 css={heading}>Support us just once</h2>
 			<p css={standFirst}>
-				We welcome support of any size, any time, whether you choose to give £1
-				or much more.
+				We welcome support of any size, any time - whether you choose to
+				give&nbsp;
+				{currency}1 or much more.
 			</p>
 			<Button
 				iconSide="left"

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -187,7 +187,7 @@ export function ThreeTierCard({
 			<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
 				{externalBtnLink ? (
 					<LinkButton href={externalBtnLink} cssOverrides={btnStyleOverrides}>
-						Support now
+						Subscribe
 					</LinkButton>
 				) : (
 					<Button
@@ -197,7 +197,7 @@ export function ThreeTierCard({
 						cssOverrides={btnStyleOverrides}
 						onClick={() => cardCtaClickHandler(currentPrice, cardTier)}
 					>
-						Support now
+						Subscribe
 					</Button>
 				)}
 			</ThemeProvider>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -137,10 +137,10 @@ const benefitsPrefixPlus = css`
 `;
 
 const discountSummaryCopy = (currency: string, planCost: TierPlanCosts) => {
-	// EXAMPLE: £16 for the first 12 months, then £25/month
+	// EXAMPLE: £16 for 12 months, then £25/month
 	if (planCost.discount) {
 		const durationValue = planCost.discount.duration.value;
-		return `${currency}${planCost.discount.price} for the first ${
+		return `${currency}${planCost.discount.price} for ${
 			durationValue > 1 ? durationValue : ''
 		} ${recurringContributionPeriodMap[planCost.discount.duration.period]}${
 			durationValue > 1 ? 's' : ''

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierDisclaimer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierDisclaimer.tsx
@@ -42,7 +42,7 @@ export function ThreeTierDisclaimer({
 					</p>
 					<p>
 						Offer only available to new subscribers who do not have an existing
-						subscription with the Guardian
+						subscription with the Guardian.
 					</p>
 				</div>
 			)}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -413,7 +413,10 @@ export function ThreeTierLanding(): JSX.Element {
 				borderColor="rgba(170, 170, 180, 0.5)"
 				cssOverrides={oneTimeContainer(countryGroupId === UnitedStates)}
 			>
-				<SupportOnce btnClickHandler={handleSupportOnceBtnClick} />
+				<SupportOnce
+					currency={currencies[currencyId].glyph}
+					btnClickHandler={handleSupportOnceBtnClick}
+				/>
 				{countryGroupId === UnitedStates && (
 					<div css={suppportAnotherWayContainer}>
 						<h4>Support another way</h4>


### PR DESCRIPTION
## What are you doing in this PR?

3-tier landing and checkout page - copy updates
- Subscribe recurring buttons
- Dicount summary copy change
- Support Once, dash in copy, currency symbol pull through, spacing above paragraph (4px <desktop, 8px >desktop)
- Disclaimer full stop copy update

Tier Card's
![image](https://github.com/guardian/support-frontend/assets/76729591/7618e0f6-e987-47e7-8971-c1382c307329)

[**Trello Card**](https://trello.com/c/AJZ1yIDO/548-3-tier-landing-and-checkout-page-copy-updates-additional-tooltip)

Checkout can be viewed at the following url behind (currently disabled) ab-Test named `threeTierCheckout` ->
https://support.thegulocal.com/uk/contribute#ab-threeTierCheckout=variant