### PR TITLE
contributionOrderSummary three tier product name displayed

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -124,6 +124,7 @@ export type ContributionsOrderSummaryProps = {
 	onAccordionClick?: (opening: boolean) => void;
 	headerButton?: React.ReactNode;
 	tsAndCs?: React.ReactNode;
+	threeTierProductName?: string;
 	showTopUpAmounts?: boolean;
 	topUpToggleChecked?: boolean;
 	topUpToggleOnChange?: () => void;
@@ -155,6 +156,7 @@ export function ContributionsOrderSummary({
 	onAccordionClick,
 	headerButton,
 	tsAndCs,
+	threeTierProductName,
 }: ContributionsOrderSummaryProps): JSX.Element {
 	const [showDetails, setShowDetails] = useState(false);
 
@@ -172,13 +174,18 @@ export function ContributionsOrderSummary({
 	return (
 		<div css={componentStyles}>
 			<div css={[summaryRow, rowSpacing, headingRow]}>
-				<h2 css={heading}>Your support</h2>
+				<h2 css={heading}>
+					{threeTierProductName ? 'Your subscription' : 'Your support'}
+				</h2>
 				{headerButton}
 			</div>
 			<hr css={hrCss} />
 			<div css={detailsSection}>
 				<div css={summaryRow}>
-					<p>{supportTypes[contributionType]} support</p>
+					<p>
+						{threeTierProductName ??
+							`${supportTypes[contributionType]} support`}
+					</p>
 					{showAccordion && (
 						<Button
 							priority="subdued"

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
@@ -9,6 +9,7 @@ import { trackComponentClick } from 'helpers/tracking/behaviour';
 import type { ContributionsOrderSummaryProps } from './contributionsOrderSummary';
 
 type ContributionsOrderSummaryContainerProps = {
+	inThreeTier: boolean;
 	renderOrderSummary: (props: ContributionsOrderSummaryProps) => JSX.Element;
 };
 
@@ -39,6 +40,7 @@ function getTermsConditions(
 }
 
 export function ContributionsOrderSummaryContainer({
+	inThreeTier,
 	renderOrderSummary,
 }: ContributionsOrderSummaryContainerProps): JSX.Element {
 	const contributionType = useContributionsSelector(getContributionType);
@@ -64,12 +66,23 @@ export function ContributionsOrderSummaryContainer({
 		);
 	}
 
+	const threeTierProductName = (): string | undefined => {
+		if (inThreeTier) {
+			if (isSupporterPlus) {
+				return 'All-access digital';
+			} else {
+				return 'Support';
+			}
+		}
+	};
+
 	return renderOrderSummary({
 		contributionType,
 		total: selectedAmount,
 		currency: currency,
 		checkListData: checklist,
 		onAccordionClick,
+		threeTierProductName: threeTierProductName(),
 		tsAndCs: getTermsConditions(contributionType, isSupporterPlus),
 	});
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -112,6 +112,7 @@ export function SupporterPlusCheckout({
 						<ContributionsPriceCards />
 					) : (
 						<ContributionsOrderSummaryContainer
+							inThreeTier={isInThreeTierCheckoutTest}
 							renderOrderSummary={(orderSummaryProps) => (
 								<ContributionsOrderSummary
 									{...orderSummaryProps}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
