### PR TITLE
Bump AWS sdk (v1)

### DIFF
--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -1,7 +1,7 @@
 object LibraryVersions {
   val circeVersion = "0.14.6"
 
-  val awsClientVersion = "1.12.578"
+  val awsClientVersion = "1.12.654"
   val awsClientVersion2 = "2.21.12"
 
   val catsVersion = "2.10.0"


### PR DESCRIPTION
Our AWS dependencies are pulling in a vulnerable version of `ion-java` - https://security.snyk.io/vuln/SNYK-JAVA-SOFTWAREAMAZONION-6153869
The latest version of the AWS sdk does not depend on `ion-java` at all.

All apps tested in CODE