### PR TITLE
refactor: use EitherValues on UpdateSupporterProductDataSpec

### DIFF
--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/UpdateSupporterProductDataSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/UpdateSupporterProductDataSpec.scala
@@ -11,6 +11,7 @@ import com.gu.support.workers.lambdas.UpdateSupporterProductDataSpec.{
 import com.gu.support.workers.states.SendThankYouEmailState
 import com.gu.supporterdata.model.ContributionAmount
 import io.circe.parser._
+import org.scalatest.EitherValues
 import org.scalatest.Inside.inside
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
@@ -18,40 +19,30 @@ import org.scalatest.OptionValues._
 
 import scala.io.Source
 
-class UpdateSupporterProductDataSpec extends AnyFlatSpec {
+class UpdateSupporterProductDataSpec extends AnyFlatSpec with EitherValues {
 
   "UpdateSupporterProductData" should "not insert an item into Dynamo for a digisub gift purchase" in {
-    val maybeState = decode[SendThankYouEmailState](digitalSusbcriptionGiftPurchaseState)
-    inside(maybeState) { case Right(state) =>
-      val supporterRatePlanItem =
-        UpdateSupporterProductData.getSupporterRatePlanItemFromState(state, serviceWithFixtures)
-      inside(supporterRatePlanItem) { case Right(value) =>
-        value shouldBe None
-      }
-    }
+    val state = decode[SendThankYouEmailState](digitalSusbcriptionGiftPurchaseState).value
+    val supporterRatePlanItem =
+      UpdateSupporterProductData.getSupporterRatePlanItemFromState(state, serviceWithFixtures).value
+
+    supporterRatePlanItem shouldBe None
   }
 
   "UpdateSupporterProductData" should "return a valid SupporterRatePlanItem for a digisub gift redemption" in {
-    val maybeState = decode[SendThankYouEmailState](digitalSubscriptionGiftRedemptionState)
-    inside(maybeState) { case Right(state) =>
-      val supporterRatePlanItem =
-        UpdateSupporterProductData.getSupporterRatePlanItemFromState(state, serviceWithFixtures)
-      inside(supporterRatePlanItem) { case Right(item) =>
-        item.value.identityId shouldBe "102803446"
-      }
-    }
+    val state = decode[SendThankYouEmailState](digitalSubscriptionGiftRedemptionState).value
+    val supporterRatePlanItem =
+      UpdateSupporterProductData.getSupporterRatePlanItemFromState(state, serviceWithFixtures).value
+
+    supporterRatePlanItem.value.identityId shouldBe "102803446"
   }
 
   "UpdateSupporterProductData" should "return a valid SupporterRatePlanItem for a Supporter Plus purchase" in {
-    val maybeState = decode[SendThankYouEmailState](supporterPlusState)
-    inside(maybeState) { case Right(state) =>
-      val supporterRatePlanItem =
-        UpdateSupporterProductData.getSupporterRatePlanItemFromState(state, serviceWithFixtures)
-      inside(supporterRatePlanItem) { case Right(item) =>
-        item.value.identityId shouldBe "200092951"
-        item.value.contributionAmount shouldBe Some(ContributionAmount(12, "GBP"))
-      }
-    }
+    val state = decode[SendThankYouEmailState](supporterPlusState).value
+    val supporterRatePlanItem =
+      UpdateSupporterProductData.getSupporterRatePlanItemFromState(state, serviceWithFixtures).value
+    supporterRatePlanItem.value.identityId shouldBe "200092951"
+    supporterRatePlanItem.value.contributionAmount shouldBe Some(ContributionAmount(12, "GBP"))
   }
 }
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Using `EitherValues` to make the test read easier.

This was based on [a conversation](https://github.com/guardian/support-frontend/pull/5673#discussion_r1484120789) with @johnduffell which I thought an example would be best to describe what I was getting at.

