### PR TITLE
Three tier copy changes

### DIFF
--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -60,6 +60,12 @@ export function DefaultPaymentButtonContainer({
 		(state) => state.common.internationalisation,
 	);
 
+	const { abParticipations } = useContributionsSelector(
+		(state) => state.common,
+	);
+	const isInThreeTierCheckoutTest =
+		abParticipations.threeTierCheckout === 'variant';
+
 	const testId = 'qa-contributions-landing-submit-contribution-button';
 
 	const amountIsAboveThreshold = shouldShowSupporterPlusMessaging(
@@ -73,7 +79,7 @@ export function DefaultPaymentButtonContainer({
 		? 'Pay now'
 		: createButtonText(
 				amountWithCurrency,
-				amountIsAboveThreshold,
+				amountIsAboveThreshold || isInThreeTierCheckoutTest,
 				contributionTypeToPaymentInterval[contributionType],
 		  );
 

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -150,11 +150,11 @@ const discountSummaryCopy = (currency: string, planCost: TierPlanCosts) => {
 				? 1
 				: planCost.discount.duration.value;
 
-		return `${currency}${planCost.discount.price} for the first ${
-			duration > 1 ? duration : ''
-		} ${recurringContributionPeriodMap[period]}${
-			duration > 1 ? 's' : ''
-		}, then ${currency}${planCost.price}/${
+		return `${currency}${planCost.discount.price}/${
+			recurringContributionPeriodMap[planCost.discount.duration.period]
+		} for the first ${duration > 1 ? duration : ''} ${
+			recurringContributionPeriodMap[period]
+		}${duration > 1 ? 's' : ''}, then ${currency}${planCost.price}/${
 			recurringContributionPeriodMap[planCost.discount.duration.period]
 		}`;
 	}


### PR DESCRIPTION
## What are you doing in this PR?

- Change copy to `£16/month for the first year, then £25/month*` to discount summary on tier card3

|before|after|
|----|----|
|![image](https://github.com/guardian/support-frontend/assets/76729591/f94f1b58-3b39-43aa-97f0-cce56ef5a89e)|![image](https://github.com/guardian/support-frontend/assets/76729591/8577bdf1-071b-4774-b39e-be906aab146d)|

- Tier1 (Support product) checkout button should read `Pay £4 per month` (Three-tier ONLY)

|before|after|
|----|----|
|![image](https://github.com/guardian/support-frontend/assets/76729591/e8f3d8f6-5301-4a55-ac89-0628158ae190)|![image](https://github.com/guardian/support-frontend/assets/76729591/f5b69a98-7256-4a5c-9255-aa19fc473dd9)|

## Why are you doing this?

Final copy amendments to first test of 3-tier