### PR TITLE
Add PROD catalogue S3 Access to IT tests

### DIFF
--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -67,6 +67,7 @@ Resources:
               Resource:
                - arn:aws:s3:::support-workers-private/CODE/support-workers.private.conf
                - arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-CODE/catalog.json
+               - arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-PROD/catalog.json
         - Statement:
             - Effect: Allow
               Action: dynamodb:Scan

--- a/support-services/src/main/scala/com/gu/support/catalog/CatalogJsonProvider.scala
+++ b/support-services/src/main/scala/com/gu/support/catalog/CatalogJsonProvider.scala
@@ -15,7 +15,7 @@ trait CatalogJsonProvider {
 class S3CatalogProvider(environment: TouchPointEnvironment) extends CatalogJsonProvider with LazyLogging {
   override def get: Option[Json] = {
     val bucket = s"s3://gu-zuora-catalog/PROD/Zuora-${environment}"
-    logger.info(s"Attempting to load catalog from s3://$bucket/catalog.json")
+    logger.info(s"Attempting to load catalog from $bucket/catalog.json")
     val catalog = new AmazonS3URI(bucket + "/catalog.json")
     fetchJson(AwsS3Client, catalog)
   }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Adds permissions to allow IT tests to access PROD catalog in S3.

We have widened the amount of tests we're are running because we've added [this line](https://github.com/guardian/support-frontend/pull/5673/files#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91R161).

We'd like to follow this up by working out if we should be running this in other places, and potentially refactor the CatalogService to return an error rather than just [None when there is a loading fail](https://github.com/guardian/support-frontend/blob/main/support-services/src/main/scala/com/gu/support/catalog/CatalogService.scala#L66-L71).
