### PR TITLE
Pd userclaims iat 5xx

### DIFF
--- a/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala
+++ b/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala
@@ -209,7 +209,7 @@ object UserFromAuthCookiesActionBuilder extends Logging {
             iat = unparsedClaims.rawClaims.get("iat").map {
               case iat: java.lang.Integer => iat.toLong
               case iat: java.lang.Long => iat.toLong
-            }
+            },
           ),
         )
     }

--- a/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala
+++ b/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala
@@ -206,7 +206,10 @@ object UserFromAuthCookiesActionBuilder extends Logging {
             identityId = defaultClaims.identityId,
             firstName = unparsedClaims.getOptional("first_name"),
             lastName = unparsedClaims.getOptional("last_name"),
-            iat = unparsedClaims.getOptional[Long]("iat"),
+            iat = unparsedClaims.rawClaims.get("iat").map {
+              case iat: java.lang.Integer => iat.toLong
+              case iat: java.lang.Long => iat.toLong
+            }
           ),
         )
     }


### PR DESCRIPTION
re -> ALARM: "URGENT 9-5 - PROD support-frontend is returning 5XX errors" in EU (Ireland)

This was caused when:
- A user signs in
- A user then signs out
- And then signs again

That means `GU_U`, `GU_ID_TOKEN`, `GU_ACCESS_TOKEN` **and** `GU_SO` cookies are set, which means [this code](https://github.com/guardian/support-frontend/blob/main/support-frontend/app/actions/UserFromAuthCookiesActionBuilder.scala#L119-L130) is reached that then tries to convert a `java.lang.Integer` => `Scala.Long`.

Caused by UserClaim iat returning from identity as a `java.lang.Integer`, this is now explicitly converted to a `scala.Long`. 

`asInstanceOf` below is an example error thrown->
``` SCALA
val javaInt: java.lang.Integer = 123
javaInt.asInstanceOf[Long]

// ...Caused by: java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.Long
```


https://github.com/guardian/identity/blob/9cbd286754ea20cd8e1cff307776da987806ba9b/identity-auth-core/src/main/scala/com/gu/identity/auth/AccessClaims.scala#L24

