### PR TITLE
Correct the ids used for discounts in CODE

### DIFF
--- a/support-config/src/main/resources/touchpoint.CODE.conf
+++ b/support-config/src/main/resources/touchpoint.CODE.conf
@@ -65,8 +65,8 @@ touchpoint.backend.environments {
     }
     promotions {
       discount {
-        productRatePlanId="2c92c0f852f2ebb20152f9269f067819"
-        productRatePlanChargeId="2c92c0f952f30dc30152f92b2ee62707"
+        productRatePlanId="2c92c0f85721ff7c01572942235b6d7a"
+        productRatePlanChargeId="2c92c0f957220b5d0157299c97a60bbd"
       }
       tables {
         promotions = "MembershipSub-Promotions-CODE"

--- a/support-config/src/test/scala/com/gu/support/config/PromotionsConfigSpec.scala
+++ b/support-config/src/test/scala/com/gu/support/config/PromotionsConfigSpec.scala
@@ -8,11 +8,11 @@ class PromotionsConfigSpec extends AsyncFlatSpec with Matchers {
   "PromotionsTablesConfigProvider" should "load successfully" in {
     val devConfig = new PromotionsConfigProvider(ConfigFactory.load(), Stages.DEV).get()
     devConfig.tables.promotions shouldBe "MembershipSub-Promotions-CODE"
-    devConfig.discount.productRatePlanChargeId shouldBe "2c92c0f952f30dc30152f92b2ee62707"
+    devConfig.discount.productRatePlanChargeId shouldBe "2c92c0f957220b5d0157299c97a60bbd"
 
     val codeConfig = new PromotionsConfigProvider(ConfigFactory.load(), Stages.CODE).get()
     codeConfig.tables.promotions shouldBe "MembershipSub-Promotions-CODE"
-    codeConfig.discount.productRatePlanChargeId shouldBe "2c92c0f952f30dc30152f92b2ee62707"
+    codeConfig.discount.productRatePlanChargeId shouldBe "2c92c0f957220b5d0157299c97a60bbd"
 
     val prodConfig = new PromotionsConfigProvider(ConfigFactory.load(), Stages.PROD).get()
     prodConfig.tables.promotions shouldBe "MembershipSub-Promotions-PROD"


### PR DESCRIPTION
When we create acquisition discounts in support-workers, we do so by adding a specific discount product rate plan to the new subscription and overriding the amount of the discount. The product rate plan we use as the template for this in production is in the `Discounts` product and is called `Percentage`, however we haven't been using the equivalent product rate plan from the code environment even though it does exist. 

This PR updates the ids used by support-workers in the CODE environment to match the ones in PROD for the sake of consistency.
