### PR TITLE
Three tier - Send low, middle And one-off cart values to Quantum Metric.

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -37,7 +37,10 @@ export function addProductSideEffects(
 			const { contributionAmount, contributionType, contributionCurrency } =
 				getContributionCartValueData(listenerApi.getState());
 
-			if (contributionAmount) {
+			const { abParticipations } = listenerApi.getState().common;
+			const inThreeTierVariant =
+				abParticipations.threeTierCheckout === 'variant';
+			if (contributionAmount && !inThreeTierVariant) {
 				sendEventContributionCartValue(
 					contributionAmount.toString(),
 					contributionType,

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -44,7 +44,7 @@ export function addProductSideEffects(
 			const { abParticipations } = listenerApi.getState().common;
 			const inThreeTierVariant =
 				abParticipations.threeTierCheckout === 'variant';
-			const isMonthlyOrAnnual = ['MONTHLY', 'ANUUAL'].includes(
+			const isMonthlyOrAnnual = ['MONTHLY', 'ANNUAL'].includes(
 				contributionType,
 			);
 			if (inThreeTierVariant && isMonthlyOrAnnual) {

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -37,16 +37,24 @@ export function addProductSideEffects(
 			const { contributionAmount, contributionType, contributionCurrency } =
 				getContributionCartValueData(listenerApi.getState());
 
+			if (!contributionAmount) {
+				return;
+			}
+
 			const { abParticipations } = listenerApi.getState().common;
 			const inThreeTierVariant =
 				abParticipations.threeTierCheckout === 'variant';
-			if (contributionAmount && !inThreeTierVariant) {
-				sendEventContributionCartValue(
-					contributionAmount.toString(),
-					contributionType,
-					contributionCurrency,
-				);
+			const isMonthlyOrAnnual = ['MONTHLY', 'ANUUAL'].includes(
+				contributionType,
+			);
+			if (inThreeTierVariant && isMonthlyOrAnnual) {
+				return;
 			}
+			sendEventContributionCartValue(
+				contributionAmount.toString(),
+				contributionType,
+				contributionCurrency,
+			);
 		},
 	});
 

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -12,7 +12,14 @@ import {
 	LinkButton,
 } from '@guardian/source-react-components';
 import { CheckmarkList } from 'components/checkmarkList/checkmarkList';
-import type { RegularContributionType } from 'helpers/contributions';
+import type {
+	ContributionType,
+	RegularContributionType,
+} from 'helpers/contributions';
+import {
+	currencies,
+	type IsoCurrency,
+} from 'helpers/internationalisation/currency';
 import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
 import type { TierBenefits, TierPlanCosts } from '../setup/threeTierConfig';
 import { ThreeTierLozenge } from './threeTierLozenge';
@@ -25,9 +32,14 @@ interface ThreeTierCardProps {
 	isUserSelected: boolean;
 	benefits: TierBenefits;
 	planCost: TierPlanCosts;
-	currency: string;
+	currencyId: IsoCurrency;
 	paymentFrequency: RegularContributionType;
-	cardCtaClickHandler: (price: number, cardTier: 1 | 2 | 3) => void;
+	cardCtaClickHandler: (
+		price: number,
+		cardTier: 1 | 2 | 3,
+		contributionType: ContributionType,
+		contributionCurrency: IsoCurrency,
+	) => void;
 	externalBtnLink?: string;
 }
 
@@ -168,11 +180,12 @@ export function ThreeTierCard({
 	isRecommendedSubdued,
 	isUserSelected,
 	benefits,
-	currency,
+	currencyId,
 	paymentFrequency,
 	cardCtaClickHandler,
 	externalBtnLink,
 }: ThreeTierCardProps): JSX.Element {
+	const currency = currencies[currencyId].glyph;
 	const currentPrice = planCost.discount?.price ?? planCost.price;
 	const previousPriceCopy =
 		!!planCost.discount && `${currency}${planCost.price}`;
@@ -205,7 +218,14 @@ export function ThreeTierCard({
 						priority="primary"
 						size="default"
 						cssOverrides={btnStyleOverrides}
-						onClick={() => cardCtaClickHandler(currentPrice, cardTier)}
+						onClick={() =>
+							cardCtaClickHandler(
+								currentPrice,
+								cardTier,
+								paymentFrequency,
+								currencyId,
+							)
+						}
 					>
 						Subscribe
 					</Button>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
@@ -1,6 +1,10 @@
 import { css } from '@emotion/react';
 import { between, from, space } from '@guardian/source-foundations';
-import type { RegularContributionType } from 'helpers/contributions';
+import type {
+	ContributionType,
+	RegularContributionType,
+} from 'helpers/contributions';
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { TierBenefits, TierPlanCosts } from '../setup/threeTierConfig';
 import { ThreeTierCard } from './threeTierCard';
 
@@ -13,9 +17,14 @@ interface ThreeTierCardsProps {
 		planCost: TierPlanCosts;
 		externalBtnLink?: string;
 	}>;
-	currency: string;
+	currencyId: IsoCurrency;
 	paymentFrequency: RegularContributionType;
-	cardsCtaClickHandler: (price: number, cardTier: 1 | 2 | 3) => void;
+	cardsCtaClickHandler: (
+		price: number,
+		cardTier: 1 | 2 | 3,
+		contributionType: ContributionType,
+		contributionCurrency: IsoCurrency,
+	) => void;
 }
 
 const container = (cardCount: number) => css`
@@ -49,7 +58,7 @@ const cardIndexToTier = (index: number): 1 | 2 | 3 => {
 
 export function ThreeTierCards({
 	cardsContent,
-	currency,
+	currencyId,
 	paymentFrequency,
 	cardsCtaClickHandler,
 }: ThreeTierCardsProps): JSX.Element {
@@ -71,7 +80,7 @@ export function ThreeTierCards({
 						key={`threeTierCard${cardIndex}`}
 						{...cardContent}
 						isRecommendedSubdued={haveRecommendedAndSelectedCards}
-						currency={currency}
+						currencyId={currencyId}
 						paymentFrequency={paymentFrequency}
 						cardCtaClickHandler={cardsCtaClickHandler}
 					/>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -20,7 +20,10 @@ import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countr
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
 import { PaymentFrequencyButtons } from 'components/paymentFrequencyButtons/paymentFrequencyButtons';
-import type { RegularContributionType } from 'helpers/contributions';
+import type {
+	ContributionType,
+	RegularContributionType,
+} from 'helpers/contributions';
 import {
 	AUDCountries,
 	Canada,
@@ -30,6 +33,7 @@ import {
 	NZDCountries,
 	UnitedStates,
 } from 'helpers/internationalisation/countryGroup';
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { currencies } from 'helpers/internationalisation/currency';
 import { resetValidation } from 'helpers/redux/checkout/checkoutActions';
 import {
@@ -42,6 +46,7 @@ import {
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
 import { navigateWithPageView } from 'helpers/tracking/ophan';
+import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
 import { SupportOnce } from '../components/supportOnce';
 import { ThreeTierCards } from '../components/threeTierCards';
 import { ThreeTierDisclaimer } from '../components/threeTierDisclaimer';
@@ -255,7 +260,12 @@ export function ThreeTierLanding(): JSX.Element {
 		dispatch(setProductType(paymentFrequencies[buttonIndex]));
 	};
 
-	const handleCardCtaClick = (price: number, cardTier: 1 | 2 | 3) => {
+	const handleCardCtaClick = (
+		price: number,
+		cardTier: 1 | 2 | 3,
+		contributionType: ContributionType,
+		contributionCurrency: IsoCurrency,
+	) => {
 		dispatch(
 			setSelectedAmount({
 				contributionType,
@@ -266,6 +276,11 @@ export function ThreeTierLanding(): JSX.Element {
 			navigate,
 			generateTierCheckoutLink(cardTier),
 			abParticipations,
+		);
+		sendEventContributionCartValue(
+			price.toString(),
+			contributionType,
+			contributionCurrency,
 		);
 	};
 
@@ -402,7 +417,7 @@ export function ThreeTierLanding(): JSX.Element {
 								externalBtnLink: generateTierCheckoutLink(3),
 							},
 						]}
-						currency={currencies[currencyId].glyph}
+						currencyId={currencyId}
 						paymentFrequency={contributionType}
 						cardsCtaClickHandler={handleCardCtaClick}
 					/>


### PR DESCRIPTION
## What are you doing in this PR?

**Objective:** Send Low, Middle And One-Off "Cart Value" to Quantum Metric.

On the existing checkout we use [Redux Toolkit's Listener Middlewear](https://redux-toolkit.js.org/api/createListenerMiddleware) to execute "side effects" when certain pieces of the Redux Store are updated. For example we Trigger tracking calls to Quantum Metric when the Contribution Amount or Frequency changes to indicate a change in "Cart Value".

**Low & Middle Tier**
- Stop reporting cart value to QM as a side effect of Redux state changing if a user is in the `threeTierCheckout` AB test `variant`, as the values stored in Redux on initial page load do not match the 3-tier landing page (we use hardcoded values on this page).
- Introduce a  CTA click handler on the 3-tier landing page to report cart value to QM instead.

**One-Off**
- Continue to use Redux side effect for reporting cart value (page2 one-off card click do update redux state)

**Top Tier**
- To be defined further in a seperate PR.

[**Trello Card**](https://trello.com/c/fshH8Spw/527-3-tier-tracking-review-and-implement)

Checkout can be viewed at the following url behind (currently disabled) ab-Test named threeTierCheckout ->
https://support.thegulocal.com/uk/contribute#ab-threeTierCheckout=variant