### PR TITLE
fix: use three tier total on mobile checkout when applicable

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -482,10 +482,21 @@ function WeeklyCheckoutForm(props: PropTypes) {
 						errorReason={props.submissionError}
 						errorHeading={submissionErrorHeading}
 					/>
-					<Total
-						price={props.discountedPrice.price}
-						currency={props.currencyId}
-					/>
+					{inThreeTierTestVariant ? (
+						<Total
+							price={
+								digitalPlusPrintPotentialDiscount?.price ??
+								standardDigitalPlusPrintPrice
+							}
+							currency={props.currencyId}
+						/>
+					) : (
+						<Total
+							price={props.discountedPrice.price}
+							currency={props.currencyId}
+						/>
+					)}
+
 					{inThreeTierTestVariant ? (
 						<ThreeTierTerms
 							paymentMethod={props.paymentMethod}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Uses the three tier pricing in the mobile total when in the test.

## Why are you doing this?

To make the prices accurate as to what someone will be paying.

## Screenshots

| before | after |
|---|---|
| ![Screenshot 2024-02-13 at 08 37 59](https://github.com/guardian/support-frontend/assets/31692/80e552a4-dfd5-441f-96a6-ac338b1c73d4) | ![Screenshot 2024-02-13 at 08 33 36](https://github.com/guardian/support-frontend/assets/31692/58989759-aa1f-4c60-9c46-5a5815f0cecc) |

