### PR TITLE
Three tier - Send top tier cart values to Quantum Metric, click and conversion

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -271,7 +271,7 @@ function onPaymentAuthorised(
 
 			/**
 			 * Rewrite the price (cart value) to report to QM
-			 * for users inThreeTierTestVariant as the original props.price
+			 * for users inThreeTierTestVariant as the original productPrice
 			 * object doesn't account for the addition of S+ and associated promotions.
 			 */
 			const priceForQuantumMetric: ProductPrice = inThreeTierTestVariant

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -23,6 +23,7 @@ import {
 } from 'helpers/productPrice/fulfilmentOptions';
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
+import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import {
 	getCurrency,
 	getProductPrice,
@@ -57,6 +58,7 @@ import { successfulSubscriptionConversion } from 'helpers/tracking/googleTagMana
 import { sendEventSubscriptionCheckoutConversion } from 'helpers/tracking/quantumMetric';
 import type { Option } from 'helpers/types/option';
 import { routes } from 'helpers/urls/routes';
+import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import { trackCheckoutSubmitAttempt } from '../tracking/behaviour';
 
 type Addresses = {
@@ -249,11 +251,42 @@ function onPaymentAuthorised(
 			}
 			// track conversion with GTM
 			successfulSubscriptionConversion();
+
+			const tierBillingPeriodName =
+				billingPeriod === 'Monthly' ? 'monthly' : 'annual';
+			const { countryGroupId } = state.common.internationalisation;
+
+			const { abParticipations } = state.common;
+			const inThreeTierTestVariant =
+				abParticipations.threeTierCheckout === 'variant';
+			const standardDigitalPlusPrintPrice =
+				tierCards.tier3.plans[tierBillingPeriodName].charges[countryGroupId]
+					.price;
+			const digitalPlusPrintPotentialDiscount =
+				tierCards.tier3.plans[tierBillingPeriodName].charges[countryGroupId]
+					.discount;
+			const discountedDigitalPlusPrintPrice =
+				digitalPlusPrintPotentialDiscount?.price ??
+				standardDigitalPlusPrintPrice;
+
+			/**
+			 * Rewrite the price (cart value) to report to QM
+			 * for users inThreeTierTestVariant as the original props.price
+			 * object doesn't account for the addition of S+ and associated promotions.
+			 */
+			const priceForQuantumMetric: ProductPrice = inThreeTierTestVariant
+				? {
+						...productPrice,
+						promotions: [],
+						price: discountedDigitalPlusPrintPrice,
+				  }
+				: productPrice;
+
 			// track conversion with QM
 			sendEventSubscriptionCheckoutConversion(
 				productType,
 				!!orderIsAGift,
-				productPrice,
+				priceForQuantumMetric,
 				billingPeriod,
 			);
 		} else if (result.error) {

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -115,7 +115,6 @@ function sendEvent(
 		: cartValueEventIds.includes(id)
 		? 64
 		: 0;
-	console.log('QM', id, qmCartValueEventId, value);
 	if (window.QuantumMetricAPI?.isOn()) {
 		window.QuantumMetricAPI.sendEvent(id, qmCartValueEventId, value);
 	}

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -115,6 +115,7 @@ function sendEvent(
 		: cartValueEventIds.includes(id)
 		? 64
 		: 0;
+	console.log('QM', id, qmCartValueEventId, value);
 	if (window.QuantumMetricAPI?.isOn()) {
 		window.QuantumMetricAPI.sendEvent(id, qmCartValueEventId, value);
 	}

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -168,7 +168,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 		sendEventSubscriptionCheckoutStart(
 			props.product,
 			false,
-			props.price,
+			inThreeTierTestVariant ? 16 : props.price,
 			props.billingPeriod,
 		);
 		inThreeTierTestVariant &&

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -47,6 +47,7 @@ import {
 import { gwDeliverableCountries } from 'helpers/internationalisation/gwDeliverableCountries';
 import { weeklyBillingPeriods } from 'helpers/productPrice/billingPeriods';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
+import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import { GuardianWeekly } from 'helpers/productPrice/subscriptions';
 import { setBillingCountry } from 'helpers/redux/checkout/address/actions';
 import { getUserTypeFromIdentity } from 'helpers/redux/checkout/personalDetails/thunks';
@@ -165,10 +166,23 @@ function WeeklyCheckoutForm(props: PropTypes) {
 	useCsrCustomerData(props.setCsrCustomerData);
 
 	useEffect(() => {
+		/**
+		 * Rewrite the price (cart value) to report to QM
+		 * for users inThreeTierTestVariant as the original props.price
+		 * object doesn't account for the addition of S+ and associated promotions.
+		 */
+		const priceForQuantumMetric: ProductPrice = inThreeTierTestVariant
+			? {
+					...props.price,
+					promotions: [],
+					price: discountedDigitalPlusPrintPrice,
+			  }
+			: props.price;
+
 		sendEventSubscriptionCheckoutStart(
 			props.product,
 			false,
-			inThreeTierTestVariant ? 16 : props.price,
+			priceForQuantumMetric,
 			props.billingPeriod,
 		);
 		inThreeTierTestVariant &&
@@ -203,6 +217,8 @@ function WeeklyCheckoutForm(props: PropTypes) {
 	const digitalPlusPrintPotentialDiscount =
 		tierCards.tier3.plans[tierBillingPeriodName].charges[props.countryGroupId]
 			.discount;
+	const discountedDigitalPlusPrintPrice =
+		digitalPlusPrintPotentialDiscount?.price ?? standardDigitalPlusPrintPrice;
 
 	const publicationStartDays = days.filter((day) => {
 		const invalidPublicationDates = ['-12-24', '-12-25', '-12-30'];


### PR DESCRIPTION
## What are you doing in this PR?

**Objective:** Send Top Tier "Cart Value" to Quantum Metric.

**Top Tier**
- On GW weekly checkout page load,  report cart value to QM.
- When GW weekly checkout converted, report conversion with cart value to QM.

**Limitation:** ProductPrice for top tier currently does not support combined products (ie S+ & GW in this case), as this is an ThreeTier abTest currently total discounted price will be reported and promotion removed. This will need to be revisited  should we go ahead with more combined-products.

[**Trello Card**](https://trello.com/c/fshH8Spw/527-3-tier-tracking-review-and-implement)

Checkout can be viewed at the following url behind (currently disabled) ab-Test named threeTierCheckout ->
https://support.thegulocal.com/uk/contribute#ab-threeTierCheckout=variant