### PR TITLE
make sure JVM always generates stack traces

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -81,6 +81,7 @@ Universal / javaOptions ++= Seq(
   "-J-XX:+PrintGCDetails",
   "-J-XX:+PrintGCDateStamps",
   s"-J-Xloggc:/var/log/${packageName.value}/gc.log",
+  "-XX:-OmitStackTraceInFastThrow",
 )
 
 addCommandAlias(


### PR DESCRIPTION
Following on from
https://github.com/guardian/support-frontend/pull/5682

Most of the time the stack traces was missing and we could only see "ClassCastExecption: null". This made it quite hard to understand what was going on.

It turns out this is an optimisation if an error is frequently generated, the JVM uses a generic instance without any useful information, in order to improve performance.  It can be turned off with `-XX:-OmitStackTraceInFastThrow,`

https://yoshihisaonoue.wordpress.com/2021/02/07/jvm-option-xx-omitstacktraceinfastthrow/

Tested on CODE - the instances come up healthy and the checkout displays correctly.