### PR TITLE
Three tier - top tier and onetime click ophan events

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -43,6 +43,7 @@ interface ThreeTierCardProps {
 	linkCtaClickHandler: (
 		price: number,
 		contributionType: ContributionType,
+		contributionCurrency: IsoCurrency,
 	) => void;
 	externalBtnLink?: string;
 }
@@ -218,7 +219,7 @@ export function ThreeTierCard({
 						href={externalBtnLink}
 						cssOverrides={btnStyleOverrides}
 						onClick={() => {
-							linkCtaClickHandler(currentPrice, paymentFrequency);
+							linkCtaClickHandler(currentPrice, paymentFrequency, currencyId);
 						}}
 					>
 						Subscribe

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -34,11 +34,15 @@ interface ThreeTierCardProps {
 	planCost: TierPlanCosts;
 	currencyId: IsoCurrency;
 	paymentFrequency: RegularContributionType;
-	cardCtaClickHandler: (
+	buttonCtaClickHandler: (
 		price: number,
 		cardTier: 1 | 2 | 3,
 		contributionType: ContributionType,
 		contributionCurrency: IsoCurrency,
+	) => void;
+	linkCtaClickHandler: (
+		price: number,
+		contributionType: ContributionType,
 	) => void;
 	externalBtnLink?: string;
 }
@@ -182,7 +186,8 @@ export function ThreeTierCard({
 	benefits,
 	currencyId,
 	paymentFrequency,
-	cardCtaClickHandler,
+	buttonCtaClickHandler,
+	linkCtaClickHandler,
 	externalBtnLink,
 }: ThreeTierCardProps): JSX.Element {
 	const currency = currencies[currencyId].glyph;
@@ -209,7 +214,13 @@ export function ThreeTierCard({
 			</h2>
 			<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
 				{externalBtnLink ? (
-					<LinkButton href={externalBtnLink} cssOverrides={btnStyleOverrides}>
+					<LinkButton
+						href={externalBtnLink}
+						cssOverrides={btnStyleOverrides}
+						onClick={() => {
+							linkCtaClickHandler(currentPrice, paymentFrequency);
+						}}
+					>
 						Subscribe
 					</LinkButton>
 				) : (
@@ -219,7 +230,7 @@ export function ThreeTierCard({
 						size="default"
 						cssOverrides={btnStyleOverrides}
 						onClick={() =>
-							cardCtaClickHandler(
+							buttonCtaClickHandler(
 								currentPrice,
 								cardTier,
 								paymentFrequency,

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
@@ -19,11 +19,15 @@ interface ThreeTierCardsProps {
 	}>;
 	currencyId: IsoCurrency;
 	paymentFrequency: RegularContributionType;
-	cardsCtaClickHandler: (
+	buttonCtaClickHandler: (
 		price: number,
 		cardTier: 1 | 2 | 3,
 		contributionType: ContributionType,
 		contributionCurrency: IsoCurrency,
+	) => void;
+	linkCtaClickHandler: (
+		price: number,
+		contributionType: ContributionType,
 	) => void;
 }
 
@@ -60,7 +64,8 @@ export function ThreeTierCards({
 	cardsContent,
 	currencyId,
 	paymentFrequency,
-	cardsCtaClickHandler,
+	buttonCtaClickHandler,
+	linkCtaClickHandler,
 }: ThreeTierCardsProps): JSX.Element {
 	const haveRecommendedAndSelectedCards =
 		cardsContent.filter((card) => card.isRecommended || card.isUserSelected)
@@ -82,7 +87,8 @@ export function ThreeTierCards({
 						isRecommendedSubdued={haveRecommendedAndSelectedCards}
 						currencyId={currencyId}
 						paymentFrequency={paymentFrequency}
-						cardCtaClickHandler={cardsCtaClickHandler}
+						buttonCtaClickHandler={buttonCtaClickHandler}
+						linkCtaClickHandler={linkCtaClickHandler}
 					/>
 				);
 			})}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
@@ -28,6 +28,7 @@ interface ThreeTierCardsProps {
 	linkCtaClickHandler: (
 		price: number,
 		contributionType: ContributionType,
+		contributionCurrency: IsoCurrency,
 	) => void;
 }
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -45,6 +45,7 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
+import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { navigateWithPageView } from 'helpers/tracking/ophan';
 import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
 import { SupportOnce } from '../components/supportOnce';
@@ -260,7 +261,7 @@ export function ThreeTierLanding(): JSX.Element {
 		dispatch(setProductType(paymentFrequencies[buttonIndex]));
 	};
 
-	const handleCardCtaClick = (
+	const handleButtonCtaClick = (
 		price: number,
 		cardTier: 1 | 2 | 3,
 		contributionType: ContributionType,
@@ -281,6 +282,20 @@ export function ThreeTierLanding(): JSX.Element {
 			price.toString(),
 			contributionType,
 			contributionCurrency,
+		);
+	};
+
+	const handleLinkCtaClick = (
+		price: number,
+		contributionType: ContributionType,
+	) => {
+		/**
+		 * Lower & middle tier track component click fired via redux side effects.
+		 * Top tier accessed via network request to GuardianWeekly landing page
+		 * therefore tracking required
+		 **/
+		trackComponentClick(
+			`npf-contribution-amount-toggle-${countryGroupId}-${contributionType}-${price}`,
 		);
 	};
 
@@ -419,7 +434,8 @@ export function ThreeTierLanding(): JSX.Element {
 						]}
 						currencyId={currencyId}
 						paymentFrequency={contributionType}
-						cardsCtaClickHandler={handleCardCtaClick}
+						buttonCtaClickHandler={handleButtonCtaClick}
+						linkCtaClickHandler={handleLinkCtaClick}
 					/>
 				</div>
 			</Container>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -306,6 +306,9 @@ export function ThreeTierLanding(): JSX.Element {
 			generateOneOffCheckoutLink(),
 			abParticipations,
 		);
+		trackComponentClick(
+			`npf-contribution-amount-toggle-${countryGroupId}-ONE_OFF`,
+		);
 	};
 
 	const isCardUserSelected = (

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -288,7 +288,13 @@ export function ThreeTierLanding(): JSX.Element {
 	const handleLinkCtaClick = (
 		price: number,
 		contributionType: ContributionType,
+		contributionCurrency: IsoCurrency,
 	) => {
+		sendEventContributionCartValue(
+			price.toString(),
+			contributionType,
+			contributionCurrency,
+		);
 		/**
 		 * Lower & middle tier track component click fired via redux side effects.
 		 * Top tier accessed via network request to GuardianWeekly landing page


### PR DESCRIPTION
## What are you doing in this PR?

- **Objective:** Send Top Tier and One-Time click events

TopTier Button Click needs a manual Ophan click event→ 
`{"component":{"componentType":"ACQUISITIONS_OTHER","id":"npf-contribution-amount-toggle-GBPCountries-MONTHLY-10"},"action":"CLICK"}`

OneTime Button Click needs a manual Ophan click event→ 
`{"component":{"componentType":"ACQUISITIONS_OTHER","id":"npf-contribution-type-toggle-GBPCountries-ONE_OFF"},"action":"CLICK"}`

- This PR also fires a Top Tier click to Quantum Metric.

[**Trello Card**](https://trello.com/c/fshH8Spw/527-3-tier-tracking-review-and-implement)

Checkout can be viewed at the following url behind (currently disabled) ab-Test named threeTierCheckout ->
https://support.thegulocal.com/uk/contribute#ab-threeTierCheckout=variant







