### PR TITLE
use JRE11 instead of 8 in preparation for play 3

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -49,8 +49,6 @@ Compile / packageDoc / publishArtifact := false
 
 enablePlugins(SystemdPlugin)
 
-debianPackageDependencies := Seq("openjdk-8-jre-headless")
-
 packageSummary := "Support Frontend Play App"
 packageDescription := """Frontend for the new supporter platform"""
 maintainer := "Membership <membership.dev@theguardian.com>"
@@ -79,7 +77,6 @@ Universal / javaOptions ++= Seq(
   "-Dpidfile.path=/dev/null",
   "-J-XX:MaxMetaspaceSize=256m",
   "-J-XX:+PrintGCDetails",
-  "-J-XX:+PrintGCDateStamps",
   s"-J-Xloggc:/var/log/${packageName.value}/gc.log",
 )
 

--- a/support-frontend/conf/riff-raff.yaml
+++ b/support-frontend/conf/riff-raff.yaml
@@ -21,7 +21,7 @@ deployments:
         PROD: Frontend-PROD.template.json
       amiParameter: AMIFrontend
       amiTags:
-        Recipe: jammy-membership-java8
+        Recipe: jammy-membership-java11
         AmigoStage: PROD
       amiEncrypted: true
   frontend:


### PR DESCRIPTION
Another go at https://github.com/guardian/support-frontend/pull/5645 loosely based on https://github.com/guardian/members-data-api/pull/1037

This is needed before we can bump to play 3, not to mention being good practice.

 tested ok in CODE!