### PR TITLE
3-Tier: Remove PayPal as a payment method from the GW checkout

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -207,6 +207,21 @@ function WeeklyCheckoutForm(props: PropTypes) {
 		props.billingCountry,
 	);
 
+	/**
+	 * PayPal is not supported as a payment method for users
+	 * inThreeTierTestVariant, so remove it from paymentMethods
+	 * array.
+	 **/
+	if (inThreeTierTestVariant) {
+		const paypalIndex = paymentMethods.findIndex(
+			(subscriptionPaymentMethod) => subscriptionPaymentMethod === 'PayPal',
+		);
+
+		if (paypalIndex !== -1) {
+			paymentMethods.splice(paypalIndex);
+		}
+	}
+
 	const tierBillingPeriod = props.billingPeriod === 'Annual' ? 'year' : 'month';
 	const tierBillingPeriodName =
 		props.billingPeriod === 'Annual' ? 'annual' : 'monthly';


### PR DESCRIPTION
## What are you doing in this PR?

Testing the 3-tier checkout flow picked up some issues on the Guardian Weekly checkout (used by the Top Tier) when attempting to pay with PayPal. The conclusion was this is too complex to fix ahead of the test go live, so we'll remove PayPal as an available payment method for users in the test on this checkout.