### PR TITLE
Fix threeTierCheckout canRun function page targetting

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -135,14 +135,11 @@ export const tests: Tests = {
 		 * - /subscribe/weekly/checkout
 		 */
 		canRun: () => {
-			// Contribution pages
-			const isContribution =
+			// Contribute pages
+			const isContributionLandingPageOrThankyou =
 				window.location.pathname.match(
-					/\/uk|us|au|eu|int|nz|ca\/contribute(\/.*)?$/,
+					pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 				) !== null;
-			const isThankYou =
-				window.location.pathname.match(/\/uk|us|au|eu|int|nz|ca\/thankyou/) !==
-				null;
 
 			// Weekly pages
 			const urlParams = new URLSearchParams(window.location.search);
@@ -151,7 +148,9 @@ export const tests: Tests = {
 			const isWeeklyCheckout =
 				window.location.pathname === '/subscribe/weekly/checkout';
 
-			return isContribution || isThankYou || (isWeeklyCheckout && isThirdTier);
+			return (
+				isContributionLandingPageOrThankyou || (isWeeklyCheckout && isThirdTier)
+			);
 		},
 	},
 };


### PR DESCRIPTION
## What are you doing in this PR?

The `canRun` function for `threeTierCheckout` AB test interrogates `window.location.pathname` and looks for a match using RegEx to confirm whether the test should run on a given URL.

The `isContribution` and `isThankYou` where unexpectedly returning matches on page paths such as:

- /uk/subscribe
- /uk/subscribe/weekly
- /uk/subscribe/weekly/gift
- /uk/subscribe/paper
- /uk/subscribe/digitaledition 

I've swapped the `isContribution` and `isThankYou` and checks and consolidated to a single variable `isContributionLandingPageOrThankyou` and am reusing the RegEx from `pageUrlRegexes.contributions.allLandingPagesAndThankyouPages`, which is what we'd typically use to target pages.

This returns a match on :

- {uk|us|au|eu|int|nz|ca}/contribute (Contribute Page 1)
- {uk|us|au|eu|int|nz|ca}/contribute/checkout (Contribute Page 2)
- {uk|us|au|eu|int|nz|ca}/thankyou (Contribute TY page)

And returns null on :

- /{uk|us|au|eu|int|nz|ca}/subscribe
- /{uk|us|au|eu|int|nz|ca}/subscribe/weekly
- /{uk|us|au|eu|int|nz|ca}/subscribe/weekly/gift
- /{uk|us|au|eu|int|nz|ca}/subscribe/paper
- /{uk|us|au|eu|int|nz|ca}/subscribe/digitaledition 
 

