### PR TITLE
add `/month` to the 3 tier disclaimer

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierDisclaimer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierDisclaimer.tsx
@@ -18,8 +18,8 @@ const discountSummaryCopy = (currency: string, planCost: TierPlanCosts) => {
 	// EXAMPLE: £16/month for the first 12 months, then £25/month
 	if (planCost.discount) {
 		const duration = planCost.discount.duration.value;
-    const period = planCost.discount.duration.period;
-    return `${currency}${planCost.discount.price}/${
+		const period = planCost.discount.duration.period;
+		return `${currency}${planCost.discount.price}/${
 			recurringContributionPeriodMap[planCost.discount.duration.period]
 		} for the first ${duration > 1 ? duration : ''} ${
 			recurringContributionPeriodMap[period]

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierDisclaimer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierDisclaimer.tsx
@@ -15,14 +15,15 @@ const container = css`
 `;
 
 const discountSummaryCopy = (currency: string, planCost: TierPlanCosts) => {
-	// EXAMPLE: £16 for the first 12 months, then £25/month
+	// EXAMPLE: £16/month for the first 12 months, then £25/month
 	if (planCost.discount) {
-		const durationValue = planCost.discount.duration.value;
-		return `${currency}${planCost.discount.price} for the first ${
-			durationValue > 1 ? durationValue : ''
-		} ${recurringContributionPeriodMap[planCost.discount.duration.period]}${
-			durationValue > 1 ? 's' : ''
-		}, then ${currency}${planCost.price}/${
+		const duration = planCost.discount.duration.value;
+    const period = planCost.discount.duration.period;
+    return `${currency}${planCost.discount.price}/${
+			recurringContributionPeriodMap[planCost.discount.duration.period]
+		} for the first ${duration > 1 ? duration : ''} ${
+			recurringContributionPeriodMap[period]
+		}${duration > 1 ? 's' : ''}, then ${currency}${planCost.price}/${
 			recurringContributionPeriodMap[planCost.discount.duration.period]
 		}`;
 	}


### PR DESCRIPTION
This PR updates the 3 tier disclaimer to include /month, otherwise it sounds like the monthly cost covers the whole year
![image](https://github.com/guardian/support-frontend/assets/7304387/c7d232ee-ca44-499f-8afb-dfbc05367fdb)

I copied the block from
https://github.com/guardian/support-frontend/blob/ca20f7f7c77d807795086571d9a4f777b7d3bd53/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx#L170-L176
because it looked a bit neater and the overall logic looks the same as what this should be