### PR TITLE
fix: use modern TLS protocols and ciphers

### DIFF
--- a/support-frontend/nginx/support.conf
+++ b/support-frontend/nginx/support.conf
@@ -6,6 +6,8 @@ server {
     ssl_certificate_key support.thegulocal.com.key;
 
     ssl_prefer_server_ciphers on;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
 
     # Proxy the Websocket connection to the Webpack server - see https://stackoverflow.com/a/40549432/438886
     location /ws {
@@ -43,6 +45,8 @@ server {
     ssl_certificate_key support-ui.thegulocal.com.key;
 
     ssl_prefer_server_ciphers on;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
 
     location / {
         proxy_pass http://localhost:9001/; ## storybook


### PR DESCRIPTION
## What does this change?

Uses `TLSv1.2` and `TLSv1.3` for local development. We were getting a `ERR_SSL_VERSION_OR_CIPHER_MISMATCH` error locally and this fixes that.

We have seen strange behaviour where the TLS protocol version in this config was affected by the [promo tool's config](https://github.com/guardian/memsub-promotions/pull/281) - so we've updated that too, but will dig into that unexpected behaviour.