### PR TITLE
WIP: refactor pricing summary to reduce the need for comment

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierDisclaimer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierDisclaimer.tsx
@@ -15,17 +15,13 @@ const container = css`
 `;
 
 const discountSummaryCopy = (currency: string, planCost: TierPlanCosts) => {
-	// EXAMPLE: £16/month for the first 12 months, then £25/month
 	if (planCost.discount) {
-		const duration = planCost.discount.duration.value;
-		const period = planCost.discount.duration.period;
-		return `${currency}${planCost.discount.price}/${
-			recurringContributionPeriodMap[planCost.discount.duration.period]
-		} for the first ${duration > 1 ? duration : ''} ${
-			recurringContributionPeriodMap[period]
-		}${duration > 1 ? 's' : ''}, then ${currency}${planCost.price}/${
-			recurringContributionPeriodMap[planCost.discount.duration.period]
-		}`;
+		const discountDuration = planCost.discount.duration.value;
+		const period = recurringContributionPeriodMap[planCost.discount.duration.period];
+		const discountRate = `${currency}${planCost.discount.price}/${period}`
+		const introductoryPeriod = `${discountDuration > 1 ? discountDuration : ''} ${period}${discountDuration > 1 ? 's' : ''}`
+		const usualPrice = `${currency}${planCost.price}/${period}`
+		return `${discountRate} for the first ${introductoryPeriod}, then ${usualPrice}`;
 	}
 };
 


### PR DESCRIPTION
(Once we have confirmation from legal about the correct T&C we can fix this function to either say `first 12 months` or `first year`, and any other tweaks or changes)
(we can also make the threTierCard, topTierCheckoutPage, disclaimer all use the same function, meaning that if it's right one place it'll be right everywhere - apart from the thank you email)