### PR TITLE
fix: Check 3-tier redirect on navigation rather instantiation

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -51,6 +51,33 @@ function ScrollToTop() {
 	return null;
 }
 
+type ThreeTierRedirectProps = {
+	children: React.ReactNode;
+	countryId: string;
+};
+function ThreeTierRedirectOneOffToCheckout({
+	children,
+	countryId,
+}: ThreeTierRedirectProps) {
+	const urlParams = new URLSearchParams(window.location.search);
+	const urlSelectedContributionType = urlParams.get(
+		'selected-contribution-type',
+	);
+	const urlParamsString = urlParams.toString();
+	const oneOff = urlSelectedContributionType === 'ONE_OFF';
+
+	return oneOff ? (
+		<Navigate
+			to={`/${countryId}/contribute/checkout${`${
+				urlParamsString ? `?${urlParamsString}` : ''
+			}${window.location.hash}`}`}
+			replace
+		/>
+	) : (
+		<>{children}</>
+	);
+}
+
 // ----- Render ----- //
 
 const router = () => {
@@ -59,23 +86,6 @@ const router = () => {
 	} = store.getState();
 	const isInThreeTierCheckoutTest =
 		abParticipations.threeTierCheckout === 'variant';
-	const firstStepLandingPage = isInThreeTierCheckoutTest ? (
-		<ThreeTierLanding />
-	) : (
-		<SupporterPlusInitialLandingPage thankYouRoute={thankYouRoute} />
-	);
-	const urlParams = new URLSearchParams(window.location.search);
-	const urlSelectedContributionType = urlParams.get(
-		'selected-contribution-type',
-	);
-
-	const isThreeTierAndOneOffUrlParam =
-		isInThreeTierCheckoutTest && urlSelectedContributionType === 'ONE_OFF';
-
-	const getExistingUrlParamsAndHash = () => {
-		const urlParams = new URLSearchParams(window.location.search).toString();
-		return `${urlParams ? `?${urlParams}` : ''}${window.location.hash}`;
-	};
 
 	return (
 		<BrowserRouter>
@@ -92,13 +102,14 @@ const router = () => {
 									 * contribution type (set in the url) and find yourself in the three tier
 									 * variant we should redirect you to the /contribute/checkout route
 									 */
-									isThreeTierAndOneOffUrlParam ? (
-										<Navigate
-											to={`/${countryId}/contribute/checkout${getExistingUrlParamsAndHash()}`}
-											replace
-										/>
+									isInThreeTierCheckoutTest ? (
+										<ThreeTierRedirectOneOffToCheckout countryId={countryId}>
+											<ThreeTierLanding />
+										</ThreeTierRedirectOneOffToCheckout>
 									) : (
-										firstStepLandingPage
+										<SupporterPlusInitialLandingPage
+											thankYouRoute={thankYouRoute}
+										/>
 									)
 								}
 							/>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This checks the `selected-contribution-type` URL parameter on every navigation rather than the instantiation of the router.

[**Trello Card**](https://trello.com/c/VAB8wUhc/615-back-button-in-amounts-container-doesnt-work-for-users-in-3-tier-variant-landing-directly-on-one-time-checkout-via-banner-epic?filter=label:3-tier)

## Why are you doing this?

Currently we set the value of `isThreeTierAndOneOffUrlParam: boolean` on instantiation of the router i.e. on a person's first landing.

This would be set to true if:
* They are in the three tier test
* `selected-contribution-type === 'ONE_OFF'`

So if you land on the page - https://support.theguardian.com/uk/contribute/checkout?selected-contribution-type=ONE_OFF&selected-amount=30#ab-threeTierCheckout=variant

That value will be set to `true` for that navigation session.
If you navigate to `/uk/contribute` that value is still `true` and will redirect you again.

This PR reads the value of the URL param on each navigation to fix that.

## How to test

* Navigate to https://support.theguardian.com/uk/contribute/checkout?selected-contribution-type=ONE_OFF&selected-amount=30#ab-threeTierCheckout=variant
* Hit the `Back` button

To test that we are still doing the initial redirect you can visit:
https://support.theguardian.com/uk/contribute?selected-contribution-type=ONE_OFF&selected-amount=30#ab-threeTierCheckout=variant


https://github.com/guardian/support-frontend/assets/31692/5e356c25-89da-431e-9b75-6d4b44821e9c

