### PR TITLE
always run UI tests even for scala steward PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,7 +3,6 @@ on:
   push:
 jobs:
   upload-storybook:
-    if: ${{ github.actor != 'gu-scala-steward-public-repos[bot]' }}
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
"UI tests" are a required workflow

Previously we didn't run them for scala version bump prs, but that makes them unmergable as they are waiting for a status that wil never come.

![image](https://github.com/guardian/support-frontend/assets/7304387/a6e6ab2c-e56e-4bdb-97b6-309a7beddeac)


As we have [`turbsnap`](https://www.chromatic.com/docs/github-actions/#enable-turbosnap) [enabled](https://github.com/guardian/support-frontend/blob/main/.github/workflows/chromatic.yml#L36) - I would opt for removing the Scala Steward check on the PR template.

TL;DR of turbosnap is that it won't run if it doesn't pick up on any changes via package.json or the component tree. It's very good.

This PR removes the line that skips them as per this pr https://github.com/guardian/support-frontend/pull/4547
