### PR TITLE
fix: use fulfilmentOptions as discriminator in 3-tier step functions

### DIFF
--- a/support-workers/cloud-formation/src/templates/state-machine.yaml
+++ b/support-workers/cloud-formation/src/templates/state-machine.yaml
@@ -131,17 +131,15 @@ States:
     Choices:
       {{> supporterPlusProductChoice currency="GBP" billingPeriod="Monthly" }}
       {{> supporterPlusProductChoice currency="EUR" billingPeriod="Monthly" }}
-      # Order is important - we need US before INT so that condition is caught first
-      {{> supporterPlusProductChoice currency="USD" billingPeriod="Monthly" isUS="true" }}
-      {{> supporterPlusProductChoice currency="USD" billingPeriod="Monthly" }}
+      {{> supporterPlusProductChoice currency="USD" billingPeriod="Monthly" fulfilmentOptions="RestOfWorld" }}
+      {{> supporterPlusProductChoice currency="USD" billingPeriod="Monthly" fulfilmentOptions="Domestic" }}
       {{> supporterPlusProductChoice currency="CAD" billingPeriod="Monthly" }}
       {{> supporterPlusProductChoice currency="NZD" billingPeriod="Monthly" }}
       {{> supporterPlusProductChoice currency="AUD" billingPeriod="Monthly" }}
       {{> supporterPlusProductChoice currency="GBP" billingPeriod="Annual" }}
       {{> supporterPlusProductChoice currency="EUR" billingPeriod="Annual" }}
-      # Order is important - we need US before INT so that condition is caught first
-      {{> supporterPlusProductChoice currency="USD" billingPeriod="Annual" isUS="true" }}
-      {{> supporterPlusProductChoice currency="USD" billingPeriod="Annual" }}
+      {{> supporterPlusProductChoice currency="USD" billingPeriod="Annual" fulfilmentOptions="RestOfWorld" }}
+      {{> supporterPlusProductChoice currency="USD" billingPeriod="Annual" fulfilmentOptions="Domestic" }}
       {{> supporterPlusProductChoice currency="CAD" billingPeriod="Annual" }}
       {{> supporterPlusProductChoice currency="NZD" billingPeriod="Annual" }}
       {{> supporterPlusProductChoice currency="AUD" billingPeriod="Annual" }}
@@ -149,17 +147,15 @@ States:
   # These steps are called from the `supporterPlusProductChoice` choices above
   {{> supporterPlusProduct currency="GBP" amount=10 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_UK_MONTHLY" }}
   {{> supporterPlusProduct currency="EUR" amount=10 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_EU_MONTHLY" }}
-  # Order is important - we need US before INT so that condition is caught first
-  {{> supporterPlusProduct currency="USD" amount=13 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_US_MONTHLY" isUS="true" }}
-  {{> supporterPlusProduct currency="USD" amount=13 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_INT_MONTHLY" }}
+  {{> supporterPlusProduct currency="USD" amount=13 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_INT_MONTHLY" fulfilmentOptions="RestOfWorld" }}
+  {{> supporterPlusProduct currency="USD" amount=13 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_US_MONTHLY" fulfilmentOptions="Domestic" }}
   {{> supporterPlusProduct currency="CAD" amount=13 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_CA_MONTHLY" }}
   {{> supporterPlusProduct currency="NZD" amount=17 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_NZ_MONTHLY" }}
   {{> supporterPlusProduct currency="AUD" amount=17 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_AU_MONTHLY" }}
   {{> supporterPlusProduct currency="GBP" amount=95 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_UK_ANNUAL" }}
   {{> supporterPlusProduct currency="EUR" amount=95 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_EU_ANNUAL" }}
-  # Order is important - we need US before INT so that condition is caught first
-  {{> supporterPlusProduct currency="USD" amount=120 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_US_ANNUAL" isUS="true" }}
-  {{> supporterPlusProduct currency="USD" amount=120 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_INT_ANNUAL" }}
+  {{> supporterPlusProduct currency="USD" amount=120 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_INT_ANNUAL" fulfilmentOptions="RestOfWorld" }}
+  {{> supporterPlusProduct currency="USD" amount=120 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_US_ANNUAL" fulfilmentOptions="Domestic" }}
   {{> supporterPlusProduct currency="CAD" amount=120 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_CA_ANNUAL" }}
   {{> supporterPlusProduct currency="NZD" amount=160 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_NZ_ANNUAL" }}
   {{> supporterPlusProduct currency="AUD" amount=160 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_AU_ANNUAL" }}

--- a/support-workers/cloud-formation/src/templates/supporterPlusProduct.yaml
+++ b/support-workers/cloud-formation/src/templates/supporterPlusProduct.yaml
@@ -1,5 +1,5 @@
 # This step ID is called from and should match ./supporterPlusProductChoice.yaml
-ThreeTierSupporterPlus{{billingPeriod}}{{currency}}{{#if isUS}}US{{/if}}:
+ThreeTierSupporterPlus{{billingPeriod}}{{currency}}{{fulfilmentOptions}}:
   Type: Pass
   Result:
     amount: {{amount}}
@@ -7,9 +7,9 @@ ThreeTierSupporterPlus{{billingPeriod}}{{currency}}{{#if isUS}}US{{/if}}:
     billingPeriod: {{billingPeriod}}
     productType: SupporterPlus
   ResultPath: $.state.product
-  Next: ThreeTierSupporterPlus{{billingPeriod}}{{currency}}{{#if isUS}}US{{/if}}PromoCode
+  Next: ThreeTierSupporterPlus{{billingPeriod}}{{currency}}{{fulfilmentOptions}}PromoCode
 
-ThreeTierSupporterPlus{{billingPeriod}}{{currency}}{{#if isUS}}US{{/if}}PromoCode:
+ThreeTierSupporterPlus{{billingPeriod}}{{currency}}{{fulfilmentOptions}}PromoCode:
   Type: Pass
   Result: {{promoCode}}
   ResultPath: $.state.promoCode

--- a/support-workers/cloud-formation/src/templates/supporterPlusProductChoice.yaml
+++ b/support-workers/cloud-formation/src/templates/supporterPlusProductChoice.yaml
@@ -1,11 +1,11 @@
 # This step ID is generated and should match in ./supporterPlusProduct.yaml
-- Next: ThreeTierSupporterPlus{{billingPeriod}}{{currency}}{{#if isUS}}US{{/if}}
+- Next: ThreeTierSupporterPlus{{billingPeriod}}{{currency}}{{fulfilmentOptions}}
   And:
   - Variable: $.state.product.currency
     StringEquals: {{currency}}
   - Variable: $.state.product.billingPeriod
     StringEquals: {{billingPeriod}}
-  {{#if isUS}}
-  - Variable: $.state.user.billingAddress.country
-    StringEquals: US
+  {{#if fulfilmentOptions}}
+  - Variable: $.state.product.fulfilmentOptions
+    StringEquals: {{fulfilmentOptions}}
   {{/if}}

--- a/support-workers/cloud-formation/src/templates/three-tier-state-machine.yaml
+++ b/support-workers/cloud-formation/src/templates/three-tier-state-machine.yaml
@@ -55,17 +55,15 @@ States:
     Choices:
       {{> supporterPlusProductChoice currency="GBP" billingPeriod="Monthly" }}
       {{> supporterPlusProductChoice currency="EUR" billingPeriod="Monthly" }}
-      # Order is important - we need US before INT so that condition is caught first
-      {{> supporterPlusProductChoice currency="USD" billingPeriod="Monthly" isUS="true" }}
-      {{> supporterPlusProductChoice currency="USD" billingPeriod="Monthly" }}
+      {{> supporterPlusProductChoice currency="USD" billingPeriod="Monthly" fulfilmentOptions="RestOfWorld" }}
+      {{> supporterPlusProductChoice currency="USD" billingPeriod="Monthly" fulfilmentOptions="Domestic" }}
       {{> supporterPlusProductChoice currency="CAD" billingPeriod="Monthly" }}
       {{> supporterPlusProductChoice currency="NZD" billingPeriod="Monthly" }}
       {{> supporterPlusProductChoice currency="AUD" billingPeriod="Monthly" }}
       {{> supporterPlusProductChoice currency="GBP" billingPeriod="Annual" }}
       {{> supporterPlusProductChoice currency="EUR" billingPeriod="Annual" }}
-      # Order is important - we need US before INT so that condition is caught first
-      {{> supporterPlusProductChoice currency="USD" billingPeriod="Annual" isUS="true" }}
-      {{> supporterPlusProductChoice currency="USD" billingPeriod="Annual" }}
+      {{> supporterPlusProductChoice currency="USD" billingPeriod="Annual" fulfilmentOptions="RestOfWorld" }}
+      {{> supporterPlusProductChoice currency="USD" billingPeriod="Annual" fulfilmentOptions="Domestic" }}
       {{> supporterPlusProductChoice currency="CAD" billingPeriod="Annual" }}
       {{> supporterPlusProductChoice currency="NZD" billingPeriod="Annual" }}
       {{> supporterPlusProductChoice currency="AUD" billingPeriod="Annual" }}
@@ -73,17 +71,15 @@ States:
   # These steps are called from the `supporterPlusProductChoice` choices above
   {{> supporterPlusProduct currency="GBP" amount=10 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_UK_MONTHLY" }}
   {{> supporterPlusProduct currency="EUR" amount=10 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_EU_MONTHLY" }}
-  # Order is important - we need US before INT so that condition is caught first
-  {{> supporterPlusProduct currency="USD" amount=13 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_US_MONTHLY" isUS="true" }}
-  {{> supporterPlusProduct currency="USD" amount=13 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_INT_MONTHLY" }}
+  {{> supporterPlusProduct currency="USD" amount=13 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_INT_MONTHLY" fulfilmentOptions="RestOfWorld" }}
+  {{> supporterPlusProduct currency="USD" amount=13 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_US_MONTHLY" fulfilmentOptions="Domestic" }}
   {{> supporterPlusProduct currency="CAD" amount=13 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_CA_MONTHLY" }}
   {{> supporterPlusProduct currency="NZD" amount=17 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_NZ_MONTHLY" }}
   {{> supporterPlusProduct currency="AUD" amount=17 billingPeriod="Monthly" promoCode="3TIER_SUPPORTERPLUS_AU_MONTHLY" }}
   {{> supporterPlusProduct currency="GBP" amount=95 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_UK_ANNUAL" }}
   {{> supporterPlusProduct currency="EUR" amount=95 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_EU_ANNUAL" }}
-  # Order is important - we need US before INT so that condition is caught first
-  {{> supporterPlusProduct currency="USD" amount=120 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_US_ANNUAL" isUS="true" }}
-  {{> supporterPlusProduct currency="USD" amount=120 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_INT_ANNUAL" }}
+  {{> supporterPlusProduct currency="USD" amount=120 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_INT_ANNUAL" fulfilmentOptions="RestOfWorld" }}
+  {{> supporterPlusProduct currency="USD" amount=120 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_US_ANNUAL" fulfilmentOptions="Domestic" }}
   {{> supporterPlusProduct currency="CAD" amount=120 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_CA_ANNUAL" }}
   {{> supporterPlusProduct currency="NZD" amount=160 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_NZ_ANNUAL" }}
   {{> supporterPlusProduct currency="AUD" amount=160 billingPeriod="Annual" promoCode="3TIER_SUPPORTERPLUS_AU_ANNUAL" }}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

As per @rupertbates' suggestion - uses the `fulfilmentOptions` to discern between `US` and `INT`. I've not used it elsewhere as those should always be domestic from my understanding which them makes it more explicit as to why we're using it.

**Aus**
![Screenshot 2024-02-20 at 11 41 06](https://github.com/guardian/support-frontend/assets/31692/4a1cce61-0663-47fc-9581-532107806ed1)

**Germany**
![Screenshot 2024-02-20 at 11 41 40](https://github.com/guardian/support-frontend/assets/31692/057d26f8-6ba4-43ce-a8c3-2ff503a3a55c)

**UK**
![Screenshot 2024-02-20 at 11 41 59](https://github.com/guardian/support-frontend/assets/31692/89782060-79cd-4c07-806f-394b5a43a455)

**India**
![Screenshot 2024-02-20 at 11 42 23](https://github.com/guardian/support-frontend/assets/31692/75415b87-5847-492e-a9c9-e1a091dd7594)

**US**
![Screenshot 2024-02-20 at 11 42 45](https://github.com/guardian/support-frontend/assets/31692/c5648630-e4fa-4fef-8c16-d44f9efdd348)

