### PR TITLE
Support v3 of the Lynx tool

### DIFF
--- a/support-frontend/assets/helpers/tracking/acquisitions.ts
+++ b/support-frontend/assets/helpers/tracking/acquisitions.ts
@@ -269,29 +269,35 @@ function getReferrerAcquisitionDataFromSessionStorage():
 		: null;
 }
 
-function getAcquisitionDataFromUtmParams(): | Record<string, unknown>
-  | null
-  | undefined {
+function getAcquisitionDataFromUtmParams():
+	| Record<string, unknown>
+	| null
+	| undefined {
+	// Same order of fields as https://reader-revenue-lynx.s3.eu-west-1.amazonaws.com/v3.html
+	const utmParamNames = [
+		'utm_campaign',
+		'utm_content',
+		'utm_term',
+		'utm_source',
+		'utm_medium',
+	];
+	const utmParameters = Object.fromEntries(
+		utmParamNames.map((paramName) => [paramName, getQueryParameter(paramName)]),
+	);
 
-  // Same order of fields as https://reader-revenue-lynx.s3.eu-west-1.amazonaws.com/v3.html
-  const utmParamNames = ['utm_campaign', 'utm_content', 'utm_term', 'utm_source', 'utm_medium'];
-  const utmParameters = Object.fromEntries(
-    utmParamNames.map(paramName => [paramName, getQueryParameter(paramName)])
-  );
-
-  // All must be present in the URL for them to be accepted
-  if (utmParamNames.every(paramName => utmParameters[paramName].length > 0)) {
-    return {
-      campaignCode: utmParameters.utm_campaign,
-      abTest: {
-        name: utmParameters.utm_content,
-        variant: utmParameters.utm_term
-      },
-      source: utmParameters.utm_source,
-      componentType: utmParameters.utm_medium,
-      queryParameters: toAcquisitionQueryParameters(getAllQueryParams()),
-    };
-  }
+	// All must be present in the URL for them to be accepted
+	if (utmParamNames.every((paramName) => utmParameters[paramName].length > 0)) {
+		return {
+			campaignCode: utmParameters.utm_campaign,
+			abTest: {
+				name: utmParameters.utm_content,
+				variant: utmParameters.utm_term,
+			},
+			source: utmParameters.utm_source,
+			componentType: utmParameters.utm_medium,
+			queryParameters: toAcquisitionQueryParameters(getAllQueryParams()),
+		};
+	}
 }
 
 // Reads the acquisition data from the &acquistionData param containing a serialised JSON string.
@@ -328,7 +334,7 @@ function getReferrerAcquisitionData(): ReferrerAcquisitionData {
 	// Read acquisitonData from the various query params, or from sessionStorage, in the following precedence
 	const candidateAcquisitionData =
 		getAcquisitionDataFromAcquisitionDataParam() ??
-    getAcquisitionDataFromUtmParams() ??
+		getAcquisitionDataFromUtmParams() ??
 		getAcquisitionDataFromPPCParams() ??
 		getReferrerAcquisitionDataFromSessionStorage();
 

--- a/support-frontend/assets/helpers/tracking/acquisitions.ts
+++ b/support-frontend/assets/helpers/tracking/acquisitions.ts
@@ -270,7 +270,7 @@ function getReferrerAcquisitionDataFromSessionStorage():
 }
 
 function getAcquisitionDataFromUtmParams():
-	| Record<string, unknown>
+	| Record<string, string | AcquisitionABTest | AcquisitionQueryParameters>
 	| null
 	| undefined {
 	// Same order of fields as https://reader-revenue-lynx.s3.eu-west-1.amazonaws.com/v3.html

--- a/support-frontend/assets/helpers/tracking/acquisitions.ts
+++ b/support-frontend/assets/helpers/tracking/acquisitions.ts
@@ -269,6 +269,31 @@ function getReferrerAcquisitionDataFromSessionStorage():
 		: null;
 }
 
+function getAcquisitionDataFromUtmParams(): | Record<string, unknown>
+  | null
+  | undefined {
+
+  // Same order of fields as https://reader-revenue-lynx.s3.eu-west-1.amazonaws.com/v3.html
+  const utmParamNames = ['utm_campaign', 'utm_content', 'utm_term', 'utm_source', 'utm_medium'];
+  const utmParameters = Object.fromEntries(
+    utmParamNames.map(paramName => [paramName, getQueryParameter(paramName)])
+  );
+
+  // All must be present in the URL for them to be accepted
+  if (utmParamNames.every(paramName => utmParameters[paramName].length > 0)) {
+    return {
+      campaignCode: utmParameters.utm_campaign,
+      abTest: {
+        name: utmParameters.utm_content,
+        variant: utmParameters.utm_term
+      },
+      source: utmParameters.utm_source,
+      componentType: utmParameters.utm_medium,
+      queryParameters: toAcquisitionQueryParameters(getAllQueryParams()),
+    };
+  }
+}
+
 // Reads the acquisition data from the &acquistionData param containing a serialised JSON string.
 function getAcquisitionDataFromAcquisitionDataParam():
 	| Record<string, unknown>
@@ -303,6 +328,7 @@ function getReferrerAcquisitionData(): ReferrerAcquisitionData {
 	// Read acquisitonData from the various query params, or from sessionStorage, in the following precedence
 	const candidateAcquisitionData =
 		getAcquisitionDataFromAcquisitionDataParam() ??
+    getAcquisitionDataFromUtmParams() ??
 		getAcquisitionDataFromPPCParams() ??
 		getReferrerAcquisitionDataFromSessionStorage();
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Change to also generate acquisitionData from 5 utm_* parameters iff they are all present. This is to support v3 of the lynx tool.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/wxnDQWVD)

## Why are you doing this?
Improving the lives of the Marketing and D&I teams in evaluating the effectiveness of marketing across our estate in BigQuery. See https://docs.google.com/document/d/1e3U3LK8OOa-mWrSvFwhyHFG7jL5r4K6NFKSmI9VSB8w/edit

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
1. Generate a CODE environment URL using the new v2 link builder: https://reader-revenue-lynx.s3.eu-west-1.amazonaws.com/v2.html. Visit URL in an Incognito window.
-  Check that the acquisitionData session storage is as expected
2. Generate a CODE environment URL using the new v3 link builder: https://reader-revenue-lynx.s3.eu-west-1.amazonaws.com/v3.html. Visit URL in an Incognito window.
-  Check that the acquisitionData session storage is identical to the two times before (except for the recording of what the query string is).
3. Override the SOURCE value in the `&acquisitionData=...` parameter and confirm it takes precedence over the `utm_` data.
-  Check that the acquisitionData session storage contains an updated source and that the rest are identical to the two times before (except for the recording of what the query string is).
4. Remove `acquisitionData=...` parameter from the URL, keeping the `utm_*` ones. Visit URL in a new Incognito window.
-  Check that the acquisitionData session storage is identical to the first two times before (except for the recording of what the query string is).

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

1. v1 and v2 tools can be turned off.
2. v3 tool can be configured not to add `acquisitionData=...` to the URL

## Have we considered potential risks?
Marketing know to fall back to using v2.html

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist
N/A

## Screenshots
N/A