### PR TITLE
refactor: decouple orderSummary from contributionType

### DIFF
--- a/support-frontend/assets/components/checkList/checkList.tsx
+++ b/support-frontend/assets/components/checkList/checkList.tsx
@@ -4,7 +4,7 @@ import { from, palette, space, textSans } from '@guardian/source-foundations';
 import { SvgCrossRound, SvgTickRound } from '@guardian/source-react-components';
 import Tooltip from 'components/tooltip/Tooltip';
 
-const checkListIconCss = (style: CheckmarkListStyle) => css`
+const checkListIconCss = (style: CheckListStyle) => css`
 	vertical-align: top;
 	padding-right: ${style === 'compact' ? '4px' : '10px'};
 	line-height: 0;
@@ -39,7 +39,7 @@ const toolTipCss = css`
 		}
 	}
 `;
-const tableCss = (style: CheckmarkListStyle) => css`
+const tableCss = (style: CheckListStyle) => css`
 	${style === 'standard'
 		? textSans.medium({ lineHeight: 'tight' })
 		: textSans.small()}
@@ -64,11 +64,11 @@ export type CheckListData = {
 	toolTip?: string;
 };
 
-type CheckmarkListStyle = 'standard' | 'compact';
+type CheckListStyle = 'standard' | 'compact';
 
-export type CheckmarkListProps = {
+export type CheckListProps = {
 	checkListData: CheckListData[];
-	style?: CheckmarkListStyle;
+	style?: CheckListStyle;
 	iconColor?: string;
 	cssOverrides?: SerializedStyles;
 };
@@ -78,7 +78,7 @@ function ChecklistItemIcon({
 	style,
 }: {
 	checked: boolean;
-	style: CheckmarkListStyle;
+	style: CheckListStyle;
 }): JSX.Element {
 	return checked ? (
 		<SvgTickRound
@@ -93,12 +93,12 @@ function ChecklistItemIcon({
 	);
 }
 
-export function CheckmarkList({
+export function CheckList({
 	checkListData,
 	style = 'standard',
 	iconColor = style === 'compact' ? palette.success[400] : palette.brand[500],
 	cssOverrides,
-}: CheckmarkListProps): JSX.Element {
+}: CheckListProps): JSX.Element {
 	return (
 		<table css={[tableCss(style), cssOverrides]}>
 			{checkListData.map((item) => (

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
@@ -9,8 +9,8 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
-import { CheckmarkList } from 'components/checkmarkList/checkmarkList';
-import type { CheckListData } from 'components/checkmarkList/checkmarkList';
+import { CheckList } from 'components/checkList/checkList';
+import type { CheckListData } from 'components/checkList/checkList';
 
 const containerCss = css`
 	${textSans.medium({ lineHeight: 'tight' })};
@@ -112,7 +112,7 @@ export function CheckoutBenefitsList({
 				<span>{titleCopy}</span>
 			</h2>
 			<hr css={hrCss(`${space[4]}px 0`)} />
-			<CheckmarkList
+			<CheckList
 				checkListData={checkListData}
 				style={isCompactList ? 'compact' : 'standard'}
 				iconColor={palette.brand[500]}

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
@@ -60,7 +60,7 @@ export function ContributionsOrderSummaryContainer({
 					higherTier: isSupporterPlus,
 			  });
 
-	function onAccordionClick(isOpen: boolean) {
+	function onCheckListToggle(isOpen: boolean) {
 		trackComponentClick(
 			`contribution-order-summary-${isOpen ? 'opened' : 'closed'}`,
 		);
@@ -76,12 +76,28 @@ export function ContributionsOrderSummaryContainer({
 		}
 	};
 
+	let description;
+	let paymentFrequency;
+	if (contributionType === 'ONE_OFF') {
+		description = 'One-time support';
+	} else if (contributionType === 'MONTHLY') {
+		description = 'Monthly support';
+		paymentFrequency = 'month';
+	} else {
+		// The if (contributionType === 'ANNUAL') condition would be here
+		// but typescript errors on it being unnecessary due to it always being truthy
+		description = 'Annual support';
+		paymentFrequency = 'year';
+	}
+
 	return renderOrderSummary({
-		contributionType,
+		description,
 		total: selectedAmount,
 		currency: currency,
+		paymentFrequency,
+		enableCheckList: contributionType !== 'ONE_OFF',
 		checkListData: checklist,
-		onAccordionClick,
+		onCheckListToggle,
 		threeTierProductName: threeTierProductName(),
 		tsAndCs: getTermsConditions(contributionType, isSupporterPlus),
 	});

--- a/support-frontend/assets/pages/digital-subscriber-checkout/components/subscriptionBenefitsListData.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/components/subscriptionBenefitsListData.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import type { CheckListData } from 'components/checkmarkList/checkmarkList';
+import type { CheckListData } from 'components/checkList/checkList';
 
 const boldText = css`
 	font-weight: bold;

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -11,7 +11,7 @@ import {
 	buttonThemeReaderRevenueBrand,
 	LinkButton,
 } from '@guardian/source-react-components';
-import { CheckmarkList } from 'components/checkmarkList/checkmarkList';
+import { CheckList } from 'components/checkList/checkList';
 import type {
 	ContributionType,
 	RegularContributionType,
@@ -258,7 +258,7 @@ export function ThreeTierCard({
 					<span css={benefitsPrefixPlus}>plus</span>
 				</div>
 			)}
-			<CheckmarkList
+			<CheckList
 				checkListData={benefits.list.map((benefit) => {
 					return {
 						text: benefit.copy,

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/limitedPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/limitedPriceCards.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
 import { textSans } from '@guardian/source-foundations';
 import { useEffect } from 'react';
-import type { CheckListData } from 'components/checkmarkList/checkmarkList';
-import { CheckmarkList } from 'components/checkmarkList/checkmarkList';
+import type { CheckListData } from 'components/checkList/checkList';
+import { CheckList } from 'components/checkList/checkList';
 import { BoxContents } from 'components/checkoutBox/checkoutBox';
 import { CheckoutErrorSummary } from 'components/errorSummary/errorSummary';
 import { CheckoutErrorSummaryContainer } from 'components/errorSummary/errorSummaryContainer';
@@ -150,7 +150,7 @@ export function LimitedPriceCards(): JSX.Element {
 								<div>
 									<h3 css={accordionHeading}>Exclusive extras include:</h3>
 									<div css={listSpacing}>
-										<CheckmarkList
+										<CheckList
 											checkListData={testCheckListData()}
 											style="compact"
 										/>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
@@ -4,7 +4,7 @@ import { from, palette } from '@guardian/source-foundations';
 import type { ConnectedProps } from 'react-redux';
 import { connect } from 'react-redux';
 import Asyncronously from 'components/asyncronously/asyncronously';
-import { CheckmarkList } from 'components/checkmarkList/checkmarkList';
+import { CheckList } from 'components/checkList/checkList';
 import Content from 'components/content/content';
 import GridPicture from 'components/gridPicture/gridPicture';
 import HeadingBlock from 'components/headingBlock/headingBlock';
@@ -257,7 +257,7 @@ function ThankYouContent({
 						<Text title="What is included in my subscription?">
 							Your subscription includes:
 							<br />
-							<CheckmarkList
+							<CheckList
 								checkListData={benefitsTier3and2.map((benefit) => {
 									return { text: <span>{benefit.copy}</span>, isChecked: true };
 								})}

--- a/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
@@ -10,7 +10,7 @@ import { withSourceReset } from '../../.storybook/decorators/withSourceReset';
 export default {
 	title: 'Checkouts/Contributions Order Summary',
 	component: ContributionsOrderSummary,
-	argTypes: { onAccordionClick: { action: 'accordion clicked' } },
+	argTypes: { onCheckListToggle: { action: 'accordion clicked' } },
 	decorators: [
 		(Story: React.FC): JSX.Element => (
 			<Columns
@@ -42,7 +42,9 @@ Template.args = {} as ContributionsOrderSummaryProps;
 export const Default = Template.bind({});
 
 Default.args = {
-	contributionType: 'MONTHLY',
+	description: 'Monthly support',
+	paymentFrequency: 'month',
+	enableCheckList: true,
 	total: 10,
 	currency: {
 		glyph: '£',
@@ -70,7 +72,8 @@ Default.args = {
 export const SingleContribution = Template.bind({});
 
 SingleContribution.args = {
-	contributionType: 'ONE_OFF',
+	description: 'One-off contribution',
+	enableCheckList: false,
 	total: 25,
 	currency: {
 		glyph: '$',

--- a/support-frontend/stories/content/CheckmarkList.stories.tsx
+++ b/support-frontend/stories/content/CheckmarkList.stories.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { Column, Columns } from '@guardian/source-react-components';
-import type { CheckmarkListProps } from 'components/checkmarkList/checkmarkList';
-import { CheckmarkList } from 'components/checkmarkList/checkmarkList';
+import type { CheckListProps } from 'components/checkList/checkList';
+import { CheckList } from 'components/checkList/checkList';
 import { checkListData } from 'components/checkoutBenefits/checkoutBenefitsListData';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { withCenterAlignment } from '../../.storybook/decorators/withCenterAlignment';
@@ -9,7 +9,7 @@ import { withSourceReset } from '../../.storybook/decorators/withSourceReset';
 
 export default {
 	title: 'Content/Checkmark List',
-	component: CheckmarkList,
+	component: CheckList,
 	decorators: [
 		(Story: React.FC): JSX.Element => (
 			<Columns
@@ -32,11 +32,11 @@ export default {
 	],
 };
 
-function Template(args: CheckmarkListProps) {
-	return <CheckmarkList {...args} />;
+function Template(args: CheckListProps) {
+	return <CheckList {...args} />;
 }
 
-Template.args = {} as CheckmarkListProps;
+Template.args = {} as CheckListProps;
 
 export const Default = Template.bind({});
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
- Renames `CheckmarkList` and `Accordion` => `CheckList` as they are all the same thing. ✨ consistency!
- Removes `contributionType` from `ContributionsOrderSummary` (with the aim of it becoming _the_ `OrderSummary` 🧹 
- Add `description` and `paymentFrequency` to `ContributionsOrderSummary`


[**Trello Card**](https://trello.com/c/ZY1dQDdY/619-generic-checkout-mvp-using-catalog-data)

## Why are you doing this?
In the aim of making these components useful for all products ([the generic checkout](https://github.com/guardian/support-frontend/pull/5704/files#r1497743253)) we can no longer rely on `contributionType` as it varies more widely across products. 

I have decided to go for the most vague of types, `string`, for `description` and `paymentFrequency` which would give us the greatest flexibility in the checkout. We might want to tighten the types once we know what they are for all products, but would suggest we also keep an eye on being flexible for testing and new product and payment types.


## How to test

This should be a no-op

## Screenshots

| One-time | Monthly | Annual |
|---|---|---|
| ![Screenshot 2024-02-21 at 21 29 47](https://github.com/guardian/support-frontend/assets/31692/d9cf6d84-6fe6-4806-bd3d-dbeaeec86bff) | ![Screenshot 2024-02-21 at 21 30 03](https://github.com/guardian/support-frontend/assets/31692/818c9f85-5858-46d6-9086-9934af5728d0) | ![Screenshot 2024-02-21 at 21 30 16](https://github.com/guardian/support-frontend/assets/31692/285c3c48-466f-4ddc-9b64-25188f9ab156) |

Part of #5722 


