### PR TITLE
refactor: decouple PersonalDetails from contributionType

### DIFF
--- a/support-frontend/assets/components/personalDetails/personalDetails.tsx
+++ b/support-frontend/assets/components/personalDetails/personalDetails.tsx
@@ -7,7 +7,6 @@ import {
 	visuallyHidden,
 } from '@guardian/source-foundations';
 import { TextInput } from '@guardian/source-react-components';
-import type { ContributionType } from 'helpers/contributions';
 import { emailRegexPattern } from 'helpers/forms/formValidation';
 import type { PersonalDetailsState } from 'helpers/redux/checkout/personalDetails/state';
 
@@ -42,13 +41,13 @@ export type PersonalDetailsProps = {
 	email: string;
 	firstName: string;
 	lastName: string;
-	contributionType: ContributionType;
 	isSignedIn: boolean;
 	onEmailChange: (email: string) => void;
 	onFirstNameChange: (firstName: string) => void;
 	onLastNameChange: (lastName: string) => void;
 	signOutLink: React.ReactNode;
 	contributionState: React.ReactNode;
+	hideNameFields?: boolean;
 	contributionZipcode?: React.ReactNode;
 	overrideHeadingCopy?: string;
 	hideDetailsHeading?: true;
@@ -59,7 +58,6 @@ export function PersonalDetails({
 	email,
 	firstName,
 	lastName,
-	contributionType,
 	isSignedIn,
 	onEmailChange,
 	onFirstNameChange,
@@ -67,6 +65,7 @@ export function PersonalDetails({
 	errors,
 	signOutLink,
 	contributionState,
+	hideNameFields,
 	contributionZipcode,
 	hideDetailsHeading,
 	overrideHeadingCopy,
@@ -93,7 +92,7 @@ export function PersonalDetails({
 
 			{signOutLink}
 
-			{contributionType !== 'ONE_OFF' ? (
+			{!hideNameFields && (
 				<>
 					<div>
 						<TextInput
@@ -122,7 +121,7 @@ export function PersonalDetails({
 						/>
 					</div>
 				</>
-			) : null}
+			)}
 
 			{contributionState}
 

--- a/support-frontend/assets/components/personalDetails/personalDetailsContainer.tsx
+++ b/support-frontend/assets/components/personalDetails/personalDetailsContainer.tsx
@@ -31,6 +31,8 @@ export function PersonalDetailsContainer({
 	);
 
 	const contributionType = useContributionsSelector(getContributionType);
+	const hideNameFields = contributionType === 'ONE_OFF';
+
 	const { state, postCode, errorObject } = useContributionsSelector(
 		(state) => state.page.checkoutForm.billingAddress.fields,
 	);
@@ -67,7 +69,6 @@ export function PersonalDetailsContainer({
 		email,
 		firstName,
 		lastName,
-		contributionType,
 		isSignedIn,
 		onEmailChange,
 		onFirstNameChange,
@@ -95,5 +96,6 @@ export function PersonalDetailsContainer({
 				/>
 			</div>
 		) : undefined,
+		hideNameFields,
 	});
 }

--- a/support-frontend/stories/checkoutLayout/PersonalDetails.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/PersonalDetails.stories.tsx
@@ -54,7 +54,6 @@ SingleContribSignedIn.args = {
 	email: '',
 	firstName: '',
 	lastName: '',
-	contributionType: 'ONE_OFF',
 	isSignedIn: false,
 	signOutLink: <Signout isSignedIn={true} />,
 	contributionState: (
@@ -65,6 +64,7 @@ SingleContribSignedIn.args = {
 			countryId={'GB'}
 		/>
 	),
+	hideNameFields: true,
 	hideDetailsHeading: true,
 };
 
@@ -74,7 +74,6 @@ SingleContribSignedOut.args = {
 	email: '',
 	firstName: '',
 	lastName: '',
-	contributionType: 'ONE_OFF',
 	isSignedIn: false,
 	signOutLink: <Signout isSignedIn={false} />,
 	contributionState: (
@@ -85,6 +84,7 @@ SingleContribSignedOut.args = {
 			countryId={'GB'}
 		/>
 	),
+	hideNameFields: true,
 	hideDetailsHeading: true,
 };
 
@@ -94,7 +94,6 @@ SingleContribSignedOutWithVisibleHeader.args = {
 	email: '',
 	firstName: '',
 	lastName: '',
-	contributionType: 'ONE_OFF',
 	isSignedIn: false,
 	signOutLink: <Signout isSignedIn={false} />,
 	contributionState: (
@@ -105,6 +104,7 @@ SingleContribSignedOutWithVisibleHeader.args = {
 			countryId={'GB'}
 		/>
 	),
+	hideNameFields: true,
 };
 
 export const MultiContribSignedIn = Template.bind({});
@@ -113,7 +113,6 @@ MultiContribSignedIn.args = {
 	email: '',
 	firstName: '',
 	lastName: '',
-	contributionType: 'MONTHLY',
 	isSignedIn: false,
 	signOutLink: <Signout isSignedIn={true} />,
 	contributionState: (
@@ -133,7 +132,6 @@ MultiContribSignedOut.args = {
 	email: '',
 	firstName: '',
 	lastName: '',
-	contributionType: 'MONTHLY',
 	isSignedIn: false,
 	signOutLink: <Signout isSignedIn={false} />,
 	contributionState: (
@@ -153,7 +151,6 @@ MultiContribUSSignedIn.args = {
 	email: '',
 	firstName: '',
 	lastName: '',
-	contributionType: 'MONTHLY',
 	isSignedIn: false,
 	signOutLink: <Signout isSignedIn={true} />,
 	contributionState: (
@@ -173,7 +170,6 @@ MultiContribUSSignedOut.args = {
 	email: '',
 	firstName: '',
 	lastName: '',
-	contributionType: 'MONTHLY',
 	isSignedIn: false,
 	signOutLink: <Signout isSignedIn={false} />,
 	contributionState: (
@@ -193,7 +189,6 @@ WithErrors.args = {
 	email: '',
 	firstName: '',
 	lastName: '',
-	contributionType: 'MONTHLY',
 	isSignedIn: false,
 	errors: {
 		firstName: ['Please enter your first name'],


### PR DESCRIPTION
## What are you doing in this PR?
- Removes `contributionType` in place of `hideNameFields` to determine whether to hide name fields.

[**Trello Card**](https://trello.com/c/ZY1dQDdY/619-generic-checkout-mvp-using-catalog-data)

## Why are you doing this?
In the aim of making these components useful for all products in the [the generic checkout](https://github.com/guardian/support-frontend/pull/5704/files#r1497743253) we can no longer rely on `contributionType` as it varies more widely across products.

## How to test

Should be a no-op

## Screenshots

| Annual | One-off |
|------|-----------|
| <img width="641" alt="Screenshot 2024-02-22 at 08 41 03" src="https://github.com/guardian/support-frontend/assets/31692/e02e221d-83d8-4017-a800-d7e88fe8ba7f"> | <img width="626" alt="Screenshot 2024-02-22 at 08 41 33" src="https://github.com/guardian/support-frontend/assets/31692/94db4dcd-9637-4dae-90d3-485e2b2e6f46"> |



Part of #5722 
