### PR TITLE
Three tier, replace threeTierCheckout with threeTierCheckoutV2, control and variant only

### DIFF
--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -5,7 +5,7 @@ import { getContributionType } from 'helpers/redux/checkout/product/selectors/pr
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { shouldShowSupporterPlusMessaging } from 'helpers/supporterPlus/showMessaging';
-import { inThreeTierVariants } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import { DefaultPaymentButton } from './defaultPaymentButton';
 
 const contributionTypeToPaymentInterval: Partial<
@@ -61,7 +61,7 @@ export function DefaultPaymentButtonContainer({
 		(state) => state.common.internationalisation,
 	);
 
-	const inThreeTierVariant = inThreeTierVariants(
+	const inThreeTierVariant = inThreeTierV2Variant(
 		useContributionsSelector((state) => state.common).abParticipations,
 	);
 

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -15,8 +15,8 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
-import { inThreeTierV2VariantB } from 'pages/supporter-plus-landing/setup/threeTierABTest';
-import { tierCardsVariantB } from 'pages/supporter-plus-landing/setup/threeTierConfig';
+import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import type { PriceCardPaymentInterval } from './priceCard';
 import type { PriceCardsProps } from './priceCards';
 
@@ -49,18 +49,17 @@ export function PriceCardsContainer({
 	);
 	const minAmount = useContributionsSelector(getMinimumContributionAmount());
 
-	const inThreeTierVariantB = inThreeTierV2VariantB(
+	const inThreeTierVariant = inThreeTierV2Variant(
 		useContributionsSelector((state) => state.common.abParticipations),
 	);
 	const tierBillingPeriod =
 		paymentFrequency === 'ANNUAL' ? 'annual' : 'monthly';
-	const tierCardData =
-		tierCardsVariantB.tier1.plans[tierBillingPeriod].priceCards;
+	const tierCardData = tierCards.tier1.plans[tierBillingPeriod].priceCards;
 	const {
 		amounts: frequencyAmounts,
 		defaultAmount,
 		hideChooseYourAmount,
-	} = inThreeTierVariantB && tierCardData
+	} = inThreeTierVariant && tierCardData
 		? tierCardData[countryGroupId]
 		: amountsCardData[paymentFrequency];
 

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -103,56 +103,6 @@ export const tests: Tests = {
 		seed: 5,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 	},
-	threeTierCheckout: {
-		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'variant',
-			},
-		],
-		isActive: false,
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		omitCountries: countriesAffectedByVATStatus,
-		referrerControlled: false,
-		excludeIfInReferrerControlledTest: true,
-		seed: 0,
-
-		/**
-		 * This runs on
-		 * - /{countryGroupId}/contribute
-		 * - /{countryGroupId}/contribute/checkout
-		 * - /{countryGroupId}/thankyou
-		 * - /subscribe/weekly/checkout?threeTierCreateSupporterPlusSubscription=true
-		 *
-		 * And does not run on
-		 * - /subscribe/weekly/checkout
-		 */
-		canRun: () => {
-			// Contribute pages
-			const isContributionLandingPageOrThankyou =
-				window.location.pathname.match(
-					pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
-				) !== null;
-
-			// Weekly pages
-			const urlParams = new URLSearchParams(window.location.search);
-			const isThirdTier =
-				urlParams.get('threeTierCreateSupporterPlusSubscription') === 'true';
-			const isWeeklyCheckout =
-				window.location.pathname === '/subscribe/weekly/checkout';
-
-			return (
-				isContributionLandingPageOrThankyou || (isWeeklyCheckout && isThirdTier)
-			);
-		},
-	},
 	threeTierCheckoutV2: {
 		variants: [
 			{

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -159,10 +159,7 @@ export const tests: Tests = {
 				id: 'control',
 			},
 			{
-				id: 'variantA',
-			},
-			{
-				id: 'variantB',
+				id: 'variant',
 			},
 		],
 		isActive: false,

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -5,7 +5,7 @@ import type { ContributionsStartListening } from 'helpers/redux/contributionsSto
 import * as storage from 'helpers/storage/storage';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
-import { inThreeTierVariants } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import { validateForm } from '../checkoutActions';
 import {
 	setAllAmounts,
@@ -42,7 +42,7 @@ export function addProductSideEffects(
 				return;
 			}
 
-			const inThreeTierVariant = inThreeTierVariants(
+			const inThreeTierVariant = inThreeTierV2Variant(
 				listenerApi.getState().common.abParticipations,
 			);
 			const isMonthlyOrAnnual = ['MONTHLY', 'ANNUAL'].includes(

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -58,8 +58,8 @@ import { successfulSubscriptionConversion } from 'helpers/tracking/googleTagMana
 import { sendEventSubscriptionCheckoutConversion } from 'helpers/tracking/quantumMetric';
 import type { Option } from 'helpers/types/option';
 import { routes } from 'helpers/urls/routes';
-import { inThreeTierVariants } from 'pages/supporter-plus-landing/setup/threeTierABTest';
-import { tierCardsVariantB as tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
+import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { tierCards as tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import { trackCheckoutSubmitAttempt } from '../tracking/behaviour';
 
 type Addresses = {
@@ -204,7 +204,7 @@ function buildRegularPaymentRequest(
 		csrUsername,
 		salesforceCaseId,
 		debugInfo: actionHistory,
-		threeTierCreateSupporterPlusSubscription: inThreeTierVariants(
+		threeTierCreateSupporterPlusSubscription: inThreeTierV2Variant(
 			state.common.abParticipations,
 		),
 	};
@@ -258,7 +258,7 @@ function onPaymentAuthorised(
 				billingPeriod === 'Monthly' ? 'monthly' : 'annual';
 			const { countryGroupId } = state.common.internationalisation;
 
-			const inThreeTierVariant = inThreeTierVariants(
+			const inThreeTierVariant = inThreeTierV2Variant(
 				state.common.abParticipations,
 			);
 			const standardDigitalPlusPrintPrice =

--- a/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
@@ -13,7 +13,7 @@ import {
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
 import { navigateWithPageView } from 'helpers/tracking/ophan';
-import { inThreeTierV2VariantB } from '../setup/threeTierABTest';
+import { inThreeTierV2Variant } from '../setup/threeTierABTest';
 
 const titleAndButtonContainer = css`
 	display: flex;
@@ -57,7 +57,7 @@ export function ContributionsPriceCards({
 	);
 	const navigate = useNavigate();
 
-	const inThreeTierVariantB = inThreeTierV2VariantB(
+	const inThreeTierVariant = inThreeTierV2Variant(
 		useContributionsSelector((state) => state.common).abParticipations,
 	);
 
@@ -123,7 +123,7 @@ export function ContributionsPriceCards({
 								errors={errors}
 							/>
 						}
-						amountIntervalSeperator={inThreeTierVariantB ? '/' : undefined}
+						amountIntervalSeperator={inThreeTierVariant ? '/' : undefined}
 					/>
 				)}
 			/>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -20,9 +20,7 @@ import {
 	currencies,
 	type IsoCurrency,
 } from 'helpers/internationalisation/currency';
-import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
-import { inThreeTierV2VariantB } from '../setup/threeTierABTest';
 import type { TierBenefits, TierPlanCosts } from '../setup/threeTierConfig';
 import { ThreeTierLozenge } from './threeTierLozenge';
 
@@ -193,15 +191,12 @@ export function ThreeTierCard({
 	linkCtaClickHandler,
 	externalBtnLink,
 }: ThreeTierCardProps): JSX.Element {
-	const inThreeTierVariantB = inThreeTierV2VariantB(
-		useContributionsSelector((state) => state.common).abParticipations,
-	);
 	const currency = currencies[currencyId].glyph;
 	const currentPrice = planCost.discount?.price ?? planCost.price;
 	const previousPriceCopy =
 		!!planCost.discount && `${currency}${planCost.price}`;
 	const currentPriceCopy = `${
-		inThreeTierVariantB && cardTier === 1 ? 'From ' : ''
+		cardTier === 1 ? 'From ' : ''
 	}${currency}${currentPrice}/${
 		recurringContributionPeriodMap[paymentFrequency]
 	}`;

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
@@ -1,15 +1,6 @@
 import type { Participations } from 'helpers/abTests/abtest';
 
-export const inThreeTierVariants = (
-	abParticipations: Participations,
-): boolean => {
-	return (
-		abParticipations.threeTierCheckout === 'variant' ||
-		abParticipations.threeTierCheckoutV2 === 'variant'
-	);
-};
-
-export const inThreeTierV2VariantB = (
+export const inThreeTierV2Variant = (
 	abParticipations: Participations,
 ): boolean => {
 	return abParticipations.threeTierCheckoutV2 === 'variant';

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
@@ -5,13 +5,12 @@ export const inThreeTierVariants = (
 ): boolean => {
 	return (
 		abParticipations.threeTierCheckout === 'variant' ||
-		abParticipations.threeTierCheckoutV2 === 'variantA' ||
-		abParticipations.threeTierCheckoutV2 === 'variantB'
+		abParticipations.threeTierCheckoutV2 === 'variant'
 	);
 };
 
 export const inThreeTierV2VariantB = (
 	abParticipations: Participations,
 ): boolean => {
-	return abParticipations.threeTierCheckoutV2 === 'variantB';
+	return abParticipations.threeTierCheckoutV2 === 'variant';
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierConfig.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierConfig.ts
@@ -43,48 +43,7 @@ interface TierCards {
 	tier3: TierCard;
 }
 
-const tier1VariantA: TierCard = {
-	title: 'Support',
-	benefits: {
-		list: [
-			{
-				copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
-			},
-		],
-	},
-	plans: {
-		monthly: {
-			label: 'Monthly',
-			charges: {
-				GBPCountries: {
-					price: 4,
-				},
-				EURCountries: { price: 4 },
-				International: { price: 5 },
-				UnitedStates: { price: 5 },
-				Canada: { price: 5 },
-				NZDCountries: { price: 10 },
-				AUDCountries: { price: 10 },
-			},
-		},
-		annual: {
-			label: 'Annual',
-			charges: {
-				GBPCountries: {
-					price: 50,
-				},
-				EURCountries: { price: 50 },
-				International: { price: 60 },
-				UnitedStates: { price: 60 },
-				Canada: { price: 60 },
-				NZDCountries: { price: 80 },
-				AUDCountries: { price: 80 },
-			},
-		},
-	},
-};
-
-const tier1VariantB: TierCard = {
+const tier1: TierCard = {
 	title: 'Support',
 	benefits: {
 		list: [
@@ -409,14 +368,9 @@ const tier3: TierCard = {
 		},
 	},
 };
-export const tierCardsVariantA: TierCards = {
-	tier1: tier1VariantA,
-	tier2,
-	tier3,
-};
 
-export const tierCardsVariantB: TierCards = {
-	tier1: tier1VariantB,
+export const tierCards: TierCards = {
+	tier1,
 	tier2,
 	tier3,
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -17,7 +17,7 @@ import { initReduxForContributions } from 'helpers/redux/contributionsStore';
 import { renderPage } from 'helpers/rendering/render';
 import { SupporterPlusThankYou } from 'pages/supporter-plus-thank-you/supporterPlusThankYou';
 import { setUpRedux } from './setup/setUpRedux';
-import { inThreeTierVariants } from './setup/threeTierABTest';
+import { inThreeTierV2Variant } from './setup/threeTierABTest';
 import { SupporterPlusInitialLandingPage } from './twoStepPages/firstStepLanding';
 import { SupporterPlusCheckout } from './twoStepPages/secondStepCheckout';
 import { ThreeTierLanding } from './twoStepPages/threeTierLanding';
@@ -79,7 +79,7 @@ function ThreeTierRedirectOneOffToCheckout({
 	);
 }
 
-export const inThreeTierVariant = inThreeTierVariants(
+export const inThreeTierVariant = inThreeTierV2Variant(
 	store.getState().common.abParticipations,
 );
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -36,10 +36,7 @@ import { ContributionsPriceCards } from '../components/contributionsPriceCards';
 import { PaymentFailureMessage } from '../components/paymentFailure';
 import { PaymentTsAndCs } from '../components/paymentTsAndCs';
 import { getPaymentMethodButtons } from '../paymentButtons';
-import {
-	inThreeTierV2VariantB,
-	inThreeTierVariants,
-} from '../setup/threeTierABTest';
+import { inThreeTierV2Variant } from '../setup/threeTierABTest';
 import { SupporterPlusCheckoutScaffold } from './checkoutScaffold';
 
 const shorterBoxMargin = css`
@@ -82,12 +79,11 @@ export function SupporterPlusCheckout({
 	const { abParticipations } = useContributionsSelector(
 		(state) => state.common,
 	);
-	const inThreeTierVariant = inThreeTierVariants(abParticipations);
-	const inThreeTierVariantB = inThreeTierV2VariantB(abParticipations);
+	const inThreeTierVariant = inThreeTierV2Variant(abParticipations);
 
 	const showPriceCards =
 		(inThreeTierVariant && contributionType === 'ONE_OFF') ||
-		(inThreeTierVariantB && !amountIsAboveThreshold);
+		(inThreeTierVariant && !amountIsAboveThreshold);
 
 	const changeButton = (
 		<Button
@@ -103,7 +99,7 @@ export function SupporterPlusCheckout({
 					}),
 				);
 				// 3-tier Other amount over S+ threshold will not re-display unless reset
-				if (inThreeTierVariantB && amountIsAboveThreshold) {
+				if (inThreeTierVariant && amountIsAboveThreshold) {
 					dispatch(
 						setOtherAmount({
 							contributionType: contributionType,

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -51,8 +51,7 @@ import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
 import { SupportOnce } from '../components/supportOnce';
 import { ThreeTierCards } from '../components/threeTierCards';
 import { ThreeTierDisclaimer } from '../components/threeTierDisclaimer';
-import { inThreeTierV2VariantB } from '../setup/threeTierABTest';
-import { tierCardsVariantA, tierCardsVariantB } from '../setup/threeTierConfig';
+import { tierCards } from '../setup/threeTierConfig';
 
 const recurringContainer = css`
 	background-color: ${palette.brand[400]};
@@ -209,8 +208,6 @@ export function ThreeTierLanding(): JSX.Element {
 	const { abParticipations } = useContributionsSelector(
 		(state) => state.common,
 	);
-	const inThreeTierVariantB = inThreeTierV2VariantB(abParticipations);
-	const tierCards = inThreeTierVariantB ? tierCardsVariantB : tierCardsVariantA;
 
 	const { countryGroupId, currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
@@ -24,8 +24,8 @@ import {
 	manageSubsUrl,
 } from 'helpers/urls/externalLinks';
 import { formatUserDate } from 'helpers/utilities/dateConversions';
-import { inThreeTierVariants } from 'pages/supporter-plus-landing/setup/threeTierABTest';
-import { tierCardsVariantB as tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
+import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 
 const styles = moduleStyles as {
 	heroGuardianWeeklyNonGifting: string;
@@ -166,7 +166,7 @@ function ThankYouContent({
 	product,
 	participations,
 }: PropTypes) {
-	const inThreeTierVariant = inThreeTierVariants(participations);
+	const inThreeTierVariant = inThreeTierV2Variant(participations);
 
 	const whatHappensNextItems = orderIsGift
 		? [

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -83,8 +83,8 @@ import {
 	formatUserDate,
 } from 'helpers/utilities/dateConversions';
 import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
-import { inThreeTierVariants } from 'pages/supporter-plus-landing/setup/threeTierABTest';
-import { tierCardsVariantB as tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
+import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import { getWeeklyDays } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
 
 // ----- Styles ----- //
@@ -199,7 +199,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 		props.setBillingCountry(props.deliveryCountry);
 	};
 
-	const inThreeTierVariant = inThreeTierVariants(props.participations);
+	const inThreeTierVariant = inThreeTierV2Variant(props.participations);
 
 	const paymentMethods = supportedPaymentMethods(
 		props.currencyId,


### PR DESCRIPTION
Checkout can be viewed at the following url behind (currently disabled) ab-Test named threeTierCheckout ->

FROM
1. https://support.thegulocal.com/uk/contribute#ab-threeTierCheckout=control
2. https://support.thegulocal.com/uk/contribute#ab-threeTierCheckoutV2=variantA
3. https://support.thegulocal.com/uk/contribute#ab-threeTierCheckoutV2=variantB

TO
1. https://support.thegulocal.com/uk/contribute#ab-threeTierCheckoutV2=control
3. https://support.thegulocal.com/uk/contribute#ab-threeTierCheckoutV2=variant
 
- Remove abTest threeTierCheckout
- Remove (FROM/2)