### PR TITLE
Disable supporter-product-data alarm in early hours

### DIFF
--- a/supporter-product-data/cloudformation/cfn.yaml
+++ b/supporter-product-data/cloudformation/cfn.yaml
@@ -450,16 +450,25 @@ Resources:
       AlarmDescription: >
         The supporter-product-data step function failed, check for failed executions here:
         https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/statemachines/view/arn:aws:states:eu-west-1:865473395570:stateMachine:supporter-product-data-PROD
-      MetricName: ExecutionsFailed
-      Namespace: AWS/States
-      Dimensions:
-        - Name: StateMachineArn
-          Value: !Ref SupporterProductData
+      Metrics:
+        - Id: errors
+          # Do not alarm between 00:00 and 06:00 because Zuora is very slow and we often have failures during these hours
+          Expression: "IF(HOUR(m1) > 5, m1)"
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/States
+              MetricName: ExecutionsFailed
+              Dimensions:
+                - Name: StateMachineArn
+                  Value: !Ref SupporterProductData
+            Stat: Sum
+            Period: 60
+            Unit: Count
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
-      Period: 60
       EvaluationPeriods: 60
-      Statistic: Sum
       TreatMissingData: notBreaching
     DependsOn: SupporterProductData
 


### PR DESCRIPTION
Sometimes during the night zuora becomes very slow and the state machine fails.
I previously tried [increasing the tolerance](https://github.com/guardian/support-frontend/pull/5726) to 40mins, but it's not enough.

Instead, this PR changes the alarm to only trigger after 6am. We expect the state machine to fail until that time.