### PR TITLE
update to play 3 in order to reduce security vulns

### DIFF
--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -64,11 +64,12 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
-      - name: Setup Java 8
-        uses: actions/setup-java@v3
+      - name: Setup Java 11
+        uses: actions/setup-java@v4
         with:
-          java-version: "8"
-          distribution: "adopt"
+          distribution: 'corretto'
+          java-version: '11'
+          cache: 'sbt'
 
       - uses: actions/cache@v4
         with:

--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -9,7 +9,7 @@ object LibraryVersions {
   val jacksonDatabindVersion = "2.15.2"
   val okhttpVersion = "3.14.9"
   val scalaUriVersion = "4.0.3"
-  val playCirceVersion = "2814.2"
+  val playCirceVersion = "3014.1"
   val stripeVersion = "21.15.0" // Supports API version 2019-05-16
   val oktaJwtVerifierVersion = "0.5.7"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.4
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
 
 addSbtPlugin(
-  "com.typesafe.play" % "sbt-plugin" % "2.8.19",
+  "org.playframework" % "sbt-plugin" % "3.0.1",
 ) // when updating major version, also update play-circe version
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")

--- a/support-frontend/app/actions/CustomActionBuilders.scala
+++ b/support-frontend/app/actions/CustomActionBuilders.scala
@@ -2,8 +2,8 @@ package actions
 
 import actions.AsyncAuthenticatedBuilder.OptionalAuthRequest
 import admin.settings.FeatureSwitches
-import akka.stream.scaladsl.Flow
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.util.ByteString
 import com.gu.aws.{AwsCloudWatchMetricPut, AwsCloudWatchMetricSetup}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger.Sanitizer

--- a/support-frontend/app/admin/settings/SettingsProvider.scala
+++ b/support-frontend/app/admin/settings/SettingsProvider.scala
@@ -3,7 +3,7 @@ package admin.settings
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicReference
 import admin.settings.SettingsProvider._
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import cats.data.EitherT
 import cats.instances.future._
 import com.gu.aws.AwsS3Client

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -3,7 +3,7 @@ package controllers
 import actions.AsyncAuthenticatedBuilder.OptionalAuthRequest
 import actions.CustomActionBuilders
 import admin.settings.{AllSettings, AllSettingsProvider, Switches}
-import akka.actor.{ActorSystem, Scheduler}
+import org.apache.pekko.actor.{ActorSystem, Scheduler}
 import cats.data.EitherT
 import cats.implicits._
 import com.gu.monitoring.SafeLogger

--- a/support-frontend/app/filters/CacheHeadersCheck.scala
+++ b/support-frontend/app/filters/CacheHeadersCheck.scala
@@ -1,7 +1,7 @@
 package filters
 
 import scala.concurrent.{ExecutionContext, Future}
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import play.api.mvc._
 import play.api.http.Status.{MOVED_PERMANENTLY, NOT_FOUND, OK}
 

--- a/support-frontend/app/filters/RelaxReferrerPolicyFromRedirectFilter.scala
+++ b/support-frontend/app/filters/RelaxReferrerPolicyFromRedirectFilter.scala
@@ -1,5 +1,5 @@
 package filters
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import play.api.mvc.{Filter, RequestHeader, Result}
 import play.filters.headers.SecurityHeadersFilter
 

--- a/support-frontend/app/filters/SetCookiesCheck.scala
+++ b/support-frontend/app/filters/SetCookiesCheck.scala
@@ -1,7 +1,7 @@
 package filters
 
 import scala.concurrent.{ExecutionContext, Future}
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import play.api.mvc._
 import play.api.http.Status.{MOVED_PERMANENTLY, NOT_FOUND, OK}
 import play.api.mvc.request.RequestAttrKey

--- a/support-frontend/app/models/identity/requests/CreateGuestAccountRequestBody.scala
+++ b/support-frontend/app/models/identity/requests/CreateGuestAccountRequestBody.scala
@@ -1,6 +1,6 @@
 package models.identity.requests
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import com.gu.identity.model.{PrivateFields, PublicFields}
 import play.api.libs.json.{Json, Writes}
 import play.api.libs.ws.{BodyWritable, InMemoryBody}

--- a/support-frontend/app/monitoring/StateMachineMonitor.scala
+++ b/support-frontend/app/monitoring/StateMachineMonitor.scala
@@ -1,6 +1,6 @@
 package monitoring
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import services.stepfunctions.SupportWorkersClient
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}

--- a/support-frontend/app/services/HttpIdentityService.scala
+++ b/support-frontend/app/services/HttpIdentityService.scala
@@ -1,6 +1,6 @@
 package services
 
-import akka.actor.Scheduler
+import org.apache.pekko.actor.Scheduler
 import cats.data.EitherT
 import cats.implicits._
 import com.google.common.net.InetAddresses

--- a/support-frontend/app/services/pricing/DefaultPromotionService.scala
+++ b/support-frontend/app/services/pricing/DefaultPromotionService.scala
@@ -6,7 +6,7 @@ import com.gu.support.config.{Stage, TouchPointEnvironments}
 import io.circe._
 import io.circe.parser._
 import io.circe.generic.auto._
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.gu.aws.AwsCloudWatchMetricPut.{client => cloudwatchClient}
 import com.gu.aws.AwsCloudWatchMetricSetup.defaultPromotionsLoadingFailure
 import com.gu.support.catalog.{DigitalPack, GuardianWeekly, Paper, Product}

--- a/support-frontend/app/services/stepfunctions/Client.scala
+++ b/support-frontend/app/services/stepfunctions/Client.scala
@@ -2,7 +2,7 @@ package services.stepfunctions
 
 import services.aws.AwsAsync
 import StateMachineContainer.{Response, convertErrors}
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import cats.data.EitherT
 import cats.implicits._
 import com.amazonaws.regions.Regions

--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -1,6 +1,6 @@
 package services.stepfunctions
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import cats.data.EitherT
 import cats.implicits._
 import com.amazonaws.services.stepfunctions.model.StateExitedEventDetails

--- a/support-frontend/app/wiring/PlayComponents.scala
+++ b/support-frontend/app/wiring/PlayComponents.scala
@@ -1,6 +1,6 @@
 package wiring
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import play.api.{ApplicationLoader, BuiltInComponents, BuiltInComponentsFromContext}
 
 import scala.concurrent.ExecutionContext

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "identity-test-users" % "0.8",
   "com.google.guava" % "guava" % "32.1.1-jre",
   "io.lemonlabs" %% "scala-uri" % scalaUriVersion,
-  "com.gu.play-googleauth" %% "play-v28" % "2.2.7",
+  "com.gu.play-googleauth" %% "play-v30" % "3.0.6",
   "io.github.bonigarcia" % "webdrivermanager" % "5.5.3" % "test",
   "org.scalatestplus" %% "scalatestplus-mockito" % "1.0.0-M2" % Test,
   "com.squareup.okhttp3" % "okhttp" % "4.11.0",
@@ -42,6 +42,10 @@ libraryDependencies ++= Seq(
   ws,
 )
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
+
+ThisBuild / libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+)
 
 Compile / doc / sources := Seq.empty
 

--- a/support-frontend/test/controllers/ApplicationTest.scala
+++ b/support-frontend/test/controllers/ApplicationTest.scala
@@ -2,7 +2,7 @@ package controllers
 
 import actions.{CustomActionBuilders, UserFromAuthCookiesActionBuilder, UserFromAuthCookiesOrAuthServerActionBuilder}
 import admin.settings.{AllSettingsProvider, FeatureSwitches, On}
-import akka.util.Timeout
+import org.apache.pekko.util.Timeout
 import assets.AssetsResolver
 import com.gu.support.config._
 import config.{RecaptchaConfigProvider, StringsConfig}

--- a/support-frontend/test/controllers/SiteMapTest.scala
+++ b/support-frontend/test/controllers/SiteMapTest.scala
@@ -2,7 +2,7 @@ package controllers
 
 import actions.{CustomActionBuilders, UserFromAuthCookiesActionBuilder, UserFromAuthCookiesOrAuthServerActionBuilder}
 import admin.settings.{FeatureSwitches, On}
-import akka.util.Timeout
+import org.apache.pekko.util.Timeout
 import com.gu.support.config.Stages
 import fixtures.TestCSRFComponents
 import org.scalatest.matchers.must.Matchers

--- a/support-frontend/test/services/pricing/PriceSummaryServiceIntegrationSpec.scala
+++ b/support-frontend/test/services/pricing/PriceSummaryServiceIntegrationSpec.scala
@@ -1,6 +1,6 @@
 package services.pricing
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.gu.aws.AwsS3Client
 import com.gu.i18n.CountryGroup.{UK, US}
 import com.gu.support.catalog._

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -44,13 +44,12 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
   "com.google.guava" % "guava" % "25.1-jre", // -- added explicitly - snyk report avoid logback vulnerability
   "com.paypal.sdk" % "rest-api-sdk" % "1.14.0" exclude ("org.apache.logging.log4j", "log4j-slf4j-impl"),
-  akkaHttpServer, // or use nettyServer for Netty
+  pekkoHttpServer, // or use nettyServer for Netty
   logback, // add Play logging support
   jdbc,
   ws,
   "com.lihaoyi" %% "pprint" % "0.8.1",
   "com.github.blemale" %% "scaffeine" % "3.1.0",
-  "org.scala-lang.modules" %% "scala-xml" % "1.3.1",
 
   /** This is to satisfy `amazon-pay-java-sdk` dependencies as jaxb has been removed from Java 8 => Java 11.
     *

--- a/support-payment-api/src/main/scala/MyApplicationLoader.scala
+++ b/support-payment-api/src/main/scala/MyApplicationLoader.scala
@@ -1,5 +1,5 @@
 import _root_.controllers._
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import aws.AWSClientBuilder
 import backend._
 import com.amazon.pay.impl.ipn.NotificationFactory

--- a/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
+++ b/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
@@ -1,6 +1,6 @@
 package backend
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import cats.data.EitherT
 import cats.implicits._
 import com.amazon.pay.response.ipn.model.{Notification, NotificationType, RefundNotification}

--- a/support-payment-api/src/main/scala/backend/PaypalBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaypalBackend.scala
@@ -1,6 +1,6 @@
 package backend
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import cats.data.EitherT
 import cats.instances.future._
 import cats.syntax.apply._

--- a/support-payment-api/src/main/scala/backend/StripeBackend.scala
+++ b/support-payment-api/src/main/scala/backend/StripeBackend.scala
@@ -1,6 +1,6 @@
 package backend
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import cats.data.EitherT
 import cats.instances.future._
 import cats.syntax.apply._

--- a/support-payment-api/src/main/scala/controllers/ActionOps.scala
+++ b/support-payment-api/src/main/scala/controllers/ActionOps.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.streams.Accumulator
 import play.api.mvc._

--- a/support-payment-api/src/main/scala/controllers/JsonUtils.scala
+++ b/support-payment-api/src/main/scala/controllers/JsonUtils.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import com.typesafe.scalalogging.StrictLogging
 import io.circe.generic.semiauto.deriveDecoder
 import io.circe.syntax._

--- a/support-payment-api/src/main/scala/model/AppThreadPool.scala
+++ b/support-payment-api/src/main/scala/model/AppThreadPool.scala
@@ -1,6 +1,6 @@
 package model
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import cats.data.Validated
 import cats.syntax.apply._
 import cats.syntax.validated._

--- a/support-payment-api/src/main/scala/services/IdentityClient.scala
+++ b/support-payment-api/src/main/scala/services/IdentityClient.scala
@@ -1,6 +1,6 @@
 package services
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import cats.data.EitherT
 import cats.instances.future._
 import cats.syntax.applicativeError._

--- a/support-payment-api/src/main/scala/services/SwitchService.scala
+++ b/support-payment-api/src/main/scala/services/SwitchService.scala
@@ -1,6 +1,6 @@
 package services
 
-import akka.actor.{ActorSystem, Cancellable}
+import org.apache.pekko.actor.{ActorSystem, Cancellable}
 import cats.data.EitherT
 import com.amazonaws.services.s3.AmazonS3
 import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}

--- a/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
@@ -1,6 +1,6 @@
 package backend
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import backend.BackendError.SoftOptInsServiceError
 import cats.data.EitherT
 import cats.implicits._

--- a/support-payment-api/src/test/scala/controllers/AmazonPayControllerSpec.scala
+++ b/support-payment-api/src/test/scala/controllers/AmazonPayControllerSpec.scala
@@ -1,7 +1,7 @@
 package controllers
 
-import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, Materializer}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.{ActorMaterializer, Materializer}
 import backend._
 import cats.data.EitherT
 import cats.instances.all._

--- a/support-payment-api/src/test/scala/controllers/GoCardlessControllerSpec.scala
+++ b/support-payment-api/src/test/scala/controllers/GoCardlessControllerSpec.scala
@@ -1,7 +1,7 @@
 package controllers
 
-import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, Materializer}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.{ActorMaterializer, Materializer}
 import backend.{GoCardlessBackend, PaypalBackend, StripeBackend}
 import cats.data.EitherT
 import cats.implicits._

--- a/support-payment-api/src/test/scala/controllers/PaypalControllerSpec.scala
+++ b/support-payment-api/src/test/scala/controllers/PaypalControllerSpec.scala
@@ -1,7 +1,7 @@
 package controllers
 
-import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, Materializer}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.{ActorMaterializer, Materializer}
 import backend._
 import cats.data.EitherT
 import cats.implicits._

--- a/support-payment-api/src/test/scala/controllers/StripeControllerSpec.scala
+++ b/support-payment-api/src/test/scala/controllers/StripeControllerSpec.scala
@@ -1,7 +1,7 @@
 package controllers
 
-import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, Materializer}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.{ActorMaterializer, Materializer}
 import backend._
 import cats.data.EitherT
 import cats.implicits._

--- a/support-payment-api/src/test/scala/services/SwitchServiceSpec.scala
+++ b/support-payment-api/src/test/scala/services/SwitchServiceSpec.scala
@@ -1,6 +1,6 @@
 package services
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import aws.AWSClientBuilder
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/support-payment-api/src/test/scala/services/WSClientProvider.scala
+++ b/support-payment-api/src/test/scala/services/WSClientProvider.scala
@@ -1,7 +1,7 @@
 package services
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.ActorMaterializer
 import org.scalatest.{BeforeAndAfterAll, Suite}
 import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.AhcWSClient


### PR DESCRIPTION
This will update play in both support frontend and payment api to 3 (from 2.8)

It mainly involves changing the word "akka" to "org.apache.pekko"!

This is needed to get a better version of logback that isn't vulnerable, but it's also a good thing in general.

I noticed that identity-auth-play depends on play 2.8 but it doesn't seem to cause an issue, perhaps because they have different package names.