### PR TITLE
Fix supporter-product-data alarm

### DIFF
--- a/supporter-product-data/cloudformation/cfn.yaml
+++ b/supporter-product-data/cloudformation/cfn.yaml
@@ -421,7 +421,6 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
       EvaluationPeriods: 1
-      Statistic: Sum
     DependsOn: SupporterProductData
 
   UnprocessedSupporterProductDataRecordAlarm:


### PR DESCRIPTION
This field is now defined under the `Metrics` block, and cloudformation complains