### PR TITLE
Suppress support-workers alarm if test user

### DIFF
--- a/support-workers/cloud-formation/src/templates/state-machine.yaml
+++ b/support-workers/cloud-formation/src/templates/state-machine.yaml
@@ -187,6 +187,10 @@ States:
   SucceedOrFailChoice:
     Type: Choice
     Choices:
+        # Do not trigger an alarm if the user is a test user
+      - Variable: "$.requestInfo.testUser"
+        BooleanEquals: true
+        Next: CheckoutFailure
       - Variable: "$.requestInfo.failed"
         BooleanEquals: true
         Next: FailState


### PR DESCRIPTION
If the state machine fails but `testUser: true`, move to the `CheckoutFailure` state, which does not trigger an alarm