### PR TITLE
now play is updated, we can bump logback safely

### DIFF
--- a/support-lambdas/acquisition-events-api/build.sbt
+++ b/support-lambdas/acquisition-events-api/build.sbt
@@ -8,7 +8,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.4",
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
-  "ch.qos.logback" % "logback-classic" % "1.4.13",
+  "ch.qos.logback" % "logback-classic" % "1.4.14",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -11,7 +11,7 @@ scalacOptions ++= Seq(
 addCompilerPlugin("org.typelevel" % "kind-projector_2.13.4" % "0.13.2")
 
 libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.2.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.14",
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,

--- a/supporter-product-data/build.sbt
+++ b/supporter-product-data/build.sbt
@@ -5,7 +5,7 @@ import sbt.Keys.libraryDependencies
 version := "0.1-SNAPSHOT"
 
 libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.2.12",
+  "ch.qos.logback" % "logback-classic" % "1.4.14",
   "software.amazon.awssdk" % "dynamodb" % awsClientVersion2,
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,


### PR DESCRIPTION
following on from https://github.com/guardian/support-frontend/pull/5737
We had to bump logback to 1.3 or 1.4 latest, but play didn't start with either of those.
Having bumped play to 3.0 in the above PR, we can update the explicit version across the board.
All tests pass and support-frontend still can start (and log stuff)