### PR TITLE
Generic checkout: add personal details

### DIFF
--- a/support-frontend/assets/components/paymentButton/defaultPaymentButton.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButton.tsx
@@ -16,16 +16,23 @@ export type DefaultPaymentButtonProps = {
 	buttonText: string;
 	onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
 	disabled?: boolean;
+	type?: HTMLButtonElement['type'];
 };
 
 export function DefaultPaymentButton({
 	id,
 	buttonText,
 	onClick,
+	type,
 }: DefaultPaymentButtonProps): JSX.Element {
 	return (
 		<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-			<Button id={id} cssOverrides={buttonOverrides} onClick={onClick}>
+			<Button
+				id={id}
+				cssOverrides={buttonOverrides}
+				onClick={onClick}
+				type={type}
+			>
 				{buttonText}
 			</Button>
 		</ThemeProvider>

--- a/support-frontend/assets/components/personalDetails/personalDetails.tsx
+++ b/support-frontend/assets/components/personalDetails/personalDetails.tsx
@@ -87,6 +87,7 @@ export function PersonalDetails({
 					pattern={emailRegexPattern}
 					error={errors?.email?.[0]}
 					disabled={isSignedIn}
+					name="email"
 				/>
 			</div>
 
@@ -104,6 +105,7 @@ export function PersonalDetails({
 							autoCapitalize="words"
 							onChange={(e) => onFirstNameChange(e.target.value)}
 							error={errors?.firstName?.[0]}
+							name="firstName"
 							required
 						/>
 					</div>
@@ -117,6 +119,7 @@ export function PersonalDetails({
 							autoCapitalize="words"
 							onChange={(e) => onLastNameChange(e.target.value)}
 							error={errors?.lastName?.[0]}
+							name="lastName"
 							required
 						/>
 					</div>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Adds personal fields to the generic checkout.

There's been a few choices made, mostly around trying not to use redux state for things where there are native HTML alternative (hopefully reducing complexity).

- Introduce the `form` element to be able to hook into native HTML form handling, and work with documented standard APIs
  - [client side form validation](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation)
  - [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest_API/Using_FormData_Objects)
- Start to create the shape of the request we would like to send over to `create` endpoint based on the Zuora model. This currently sends the `product`, `ratePlan` and `currency`, which should allow us to look up the cost from there e.g. <img width="502" alt="Screenshot 2024-02-27 at 12 12 03" src="https://github.com/guardian/support-frontend/assets/31692/90b96e89-c105-4ce6-9cc7-984f5fcd0b25">

I've added some context specific comments in the code below.

[**Trello Card**](https://trello.com/c/rurWegCp/628-add-personal-details-to-generic-checkout)

Part of #5722 

Next steps: [Add payment fields to the checkout](https://trello.com/c/qHy6BAvz/645-add-payment-fields-to-generic-checkout)

## Screenshots

### Form validation
<img width="695" alt="Screenshot 2024-02-27 at 12 12 16" src="https://github.com/guardian/support-frontend/assets/31692/07759857-0201-46d6-9419-8d620c977f02">

<img width="703" alt="Screenshot 2024-02-27 at 12 12 41" src="https://github.com/guardian/support-frontend/assets/31692/2e966d5d-a27c-4fae-9ff6-e6b254fb0834">
