### PR TITLE
use new nonDiscountedAmount field

### DIFF
--- a/support-workers/cloud-formation/src/templates/supporterPlusProduct.yaml
+++ b/support-workers/cloud-formation/src/templates/supporterPlusProduct.yaml
@@ -2,7 +2,7 @@
 ThreeTierSupporterPlus{{billingPeriod}}{{currency}}{{fulfilmentOptions}}:
   Type: Pass
   Result:
-    amount: {{amount}}
+    nonDiscountedAmount: {{amount}}
     currency: {{currency}}
     billingPeriod: {{billingPeriod}}
     productType: SupporterPlus


### PR DESCRIPTION
Further to 
https://github.com/guardian/support-frontend/pull/5684

The state machine synthesises the json during the top tier process (because this is currently a temporary situation)

Unfortunately I forgot about this, so anyone buying the top tier would only get the GW and not the S+ part.