### PR TITLE
3-tier: all one-off price card amounts should now be fed from RRCP, test2 bug-fix

### DIFF
--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -59,7 +59,7 @@ export function PriceCardsContainer({
 		amounts: frequencyAmounts,
 		defaultAmount,
 		hideChooseYourAmount,
-	} = inThreeTierVariant && tierCardData
+	} = inThreeTierVariant && tierCardData && paymentFrequency !== 'ONE_OFF'
 		? tierCardData[countryGroupId]
 		: amountsCardData[paymentFrequency];
 


### PR DESCRIPTION
## What are you doing in this PR?

Bug-fix so one-off price card amounts in the 3-tier variant should be fed from RRCP here ->
![image](https://github.com/guardian/support-frontend/assets/76729591/e15faab5-3d6c-4e22-916e-d9a454c29dc4)

- Bug introduced in Test2 PR ( https://github.com/guardian/support-frontend/pull/5709 }
- Test1 unaffected

|From|To|
|------|------|
|![image](https://github.com/guardian/support-frontend/assets/76729591/f31a5275-01f3-4ada-9b3f-c19ccccbbdf0)|![image](https://github.com/guardian/support-frontend/assets/76729591/87682c19-1d0e-46d5-8dea-6745d2de35ae)|

