### PR TITLE
3-tier: replace current contribute landing page with three tier test1 as Control, three tier test2 as Variant

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
@@ -9,7 +9,6 @@ import { trackComponentClick } from 'helpers/tracking/behaviour';
 import type { ContributionsOrderSummaryProps } from './contributionsOrderSummary';
 
 type ContributionsOrderSummaryContainerProps = {
-	inThreeTier: boolean;
 	renderOrderSummary: (props: ContributionsOrderSummaryProps) => JSX.Element;
 };
 
@@ -40,7 +39,6 @@ function getTermsConditions(
 }
 
 export function ContributionsOrderSummaryContainer({
-	inThreeTier,
 	renderOrderSummary,
 }: ContributionsOrderSummaryContainerProps): JSX.Element {
 	const contributionType = useContributionsSelector(getContributionType);
@@ -67,12 +65,10 @@ export function ContributionsOrderSummaryContainer({
 	}
 
 	const threeTierProductName = (): string | undefined => {
-		if (inThreeTier) {
-			if (isSupporterPlus) {
-				return 'All-access digital';
-			} else {
-				return 'Support';
-			}
+		if (isSupporterPlus) {
+			return 'All-access digital';
+		} else {
+			return 'Support';
 		}
 	};
 

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -5,7 +5,7 @@ import { getContributionType } from 'helpers/redux/checkout/product/selectors/pr
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { shouldShowSupporterPlusMessaging } from 'helpers/supporterPlus/showMessaging';
-import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import { DefaultPaymentButton } from './defaultPaymentButton';
 
 const contributionTypeToPaymentInterval: Partial<
@@ -61,7 +61,7 @@ export function DefaultPaymentButtonContainer({
 		(state) => state.common.internationalisation,
 	);
 
-	const inThreeTierVariant = inThreeTierV2Variant(
+	const inThreeTierVariant = inThreeTierV3(
 		useContributionsSelector((state) => state.common).abParticipations,
 	);
 

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -61,7 +61,7 @@ export function DefaultPaymentButtonContainer({
 		(state) => state.common.internationalisation,
 	);
 
-	const inThreeTierVariant = inThreeTierV3(
+	const inThreeTier = inThreeTierV3(
 		useContributionsSelector((state) => state.common).abParticipations,
 	);
 
@@ -78,7 +78,7 @@ export function DefaultPaymentButtonContainer({
 		? 'Pay now'
 		: createButtonText(
 				amountWithCurrency,
-				amountIsAboveThreshold || inThreeTierVariant,
+				amountIsAboveThreshold || inThreeTier,
 				contributionTypeToPaymentInterval[contributionType],
 		  );
 

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -16,7 +16,10 @@ import {
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
 import { inThreeTierV3Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
-import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
+import {
+	tierCardsControl,
+	tierCardsVariant,
+} from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import type { PriceCardPaymentInterval } from './priceCard';
 import type { PriceCardsProps } from './priceCards';
 
@@ -54,6 +57,8 @@ export function PriceCardsContainer({
 	);
 	const tierBillingPeriod =
 		paymentFrequency === 'ANNUAL' ? 'annual' : 'monthly';
+
+	const tierCards = inThreeTierVariant ? tierCardsVariant : tierCardsControl;
 	const tierCardData = tierCards.tier1.plans[tierBillingPeriod].priceCards;
 	const {
 		amounts: frequencyAmounts,

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -15,7 +15,7 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
-import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { inThreeTierV3Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import type { PriceCardPaymentInterval } from './priceCard';
 import type { PriceCardsProps } from './priceCards';
@@ -49,7 +49,7 @@ export function PriceCardsContainer({
 	);
 	const minAmount = useContributionsSelector(getMinimumContributionAmount());
 
-	const inThreeTierVariant = inThreeTierV2Variant(
+	const inThreeTierVariant = inThreeTierV3Variant(
 		useContributionsSelector((state) => state.common.abParticipations),
 	);
 	const tierBillingPeriod =

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -103,56 +103,6 @@ export const tests: Tests = {
 		seed: 5,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 	},
-	threeTierCheckoutV2: {
-		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'variant',
-			},
-		],
-		isActive: false,
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		omitCountries: countriesAffectedByVATStatus,
-		referrerControlled: false,
-		excludeIfInReferrerControlledTest: true,
-		seed: 0,
-
-		/**
-		 * This runs on
-		 * - /{countryGroupId}/contribute
-		 * - /{countryGroupId}/contribute/checkout
-		 * - /{countryGroupId}/thankyou
-		 * - /subscribe/weekly/checkout?threeTierCreateSupporterPlusSubscription=true
-		 *
-		 * And does not run on
-		 * - /subscribe/weekly/checkout
-		 */
-		canRun: () => {
-			// Contribute pages
-			const isContributionLandingPageOrThankyou =
-				window.location.pathname.match(
-					pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
-				) !== null;
-
-			// Weekly pages
-			const urlParams = new URLSearchParams(window.location.search);
-			const isThirdTier =
-				urlParams.get('threeTierCreateSupporterPlusSubscription') === 'true';
-			const isWeeklyCheckout =
-				window.location.pathname === '/subscribe/weekly/checkout';
-
-			return (
-				isContributionLandingPageOrThankyou || (isWeeklyCheckout && isThirdTier)
-			);
-		},
-	},
 	threeTierCheckoutV3: {
 		variants: [
 			{

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -112,7 +112,57 @@ export const tests: Tests = {
 				id: 'variant',
 			},
 		],
-		isActive: true,
+		isActive: false,
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		omitCountries: countriesAffectedByVATStatus,
+		referrerControlled: false,
+		excludeIfInReferrerControlledTest: true,
+		seed: 0,
+
+		/**
+		 * This runs on
+		 * - /{countryGroupId}/contribute
+		 * - /{countryGroupId}/contribute/checkout
+		 * - /{countryGroupId}/thankyou
+		 * - /subscribe/weekly/checkout?threeTierCreateSupporterPlusSubscription=true
+		 *
+		 * And does not run on
+		 * - /subscribe/weekly/checkout
+		 */
+		canRun: () => {
+			// Contribute pages
+			const isContributionLandingPageOrThankyou =
+				window.location.pathname.match(
+					pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+				) !== null;
+
+			// Weekly pages
+			const urlParams = new URLSearchParams(window.location.search);
+			const isThirdTier =
+				urlParams.get('threeTierCreateSupporterPlusSubscription') === 'true';
+			const isWeeklyCheckout =
+				window.location.pathname === '/subscribe/weekly/checkout';
+
+			return (
+				isContributionLandingPageOrThankyou || (isWeeklyCheckout && isThirdTier)
+			);
+		},
+	},
+	threeTierCheckoutV3: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		isActive: false,
 		audiences: {
 			ALL: {
 				offset: 0,

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -5,7 +5,7 @@ import type { ContributionsStartListening } from 'helpers/redux/contributionsSto
 import * as storage from 'helpers/storage/storage';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
-import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import { validateForm } from '../checkoutActions';
 import {
 	setAllAmounts,
@@ -42,7 +42,7 @@ export function addProductSideEffects(
 				return;
 			}
 
-			const inThreeTierVariant = inThreeTierV2Variant(
+			const inThreeTierVariant = inThreeTierV3(
 				listenerApi.getState().common.abParticipations,
 			);
 			const isMonthlyOrAnnual = ['MONTHLY', 'ANNUAL'].includes(

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -42,13 +42,13 @@ export function addProductSideEffects(
 				return;
 			}
 
-			const inThreeTierVariant = inThreeTierV3(
+			const inThreeTier = inThreeTierV3(
 				listenerApi.getState().common.abParticipations,
 			);
 			const isMonthlyOrAnnual = ['MONTHLY', 'ANNUAL'].includes(
 				contributionType,
 			);
-			if (inThreeTierVariant && isMonthlyOrAnnual) {
+			if (inThreeTier && isMonthlyOrAnnual) {
 				return;
 			}
 			sendEventContributionCartValue(

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -289,8 +289,8 @@ function onPaymentAuthorised(
 				productType,
 			);
 
-			const inThreeTierVariant = inThreeTierV3(state.common.abParticipations);
-			if (inThreeTierVariant) {
+			const inThreeTier = inThreeTierV3(state.common.abParticipations);
+			if (inThreeTier) {
 				const tierBillingPeriodName =
 					billingPeriod.toLowerCase() as keyof TierPlans;
 				const contributionType = billingPeriod.toUpperCase() as

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -64,7 +64,7 @@ import type { Option } from 'helpers/types/option';
 import { routes } from 'helpers/urls/routes';
 import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import type { TierPlans } from 'pages/supporter-plus-landing/setup/threeTierConfig';
-import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
+import { tierCardsControl as tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import { trackCheckoutSubmitAttempt } from '../tracking/behaviour';
 
 type Addresses = {

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -62,7 +62,7 @@ import {
 import { sendEventSubscriptionCheckoutConversion } from 'helpers/tracking/quantumMetric';
 import type { Option } from 'helpers/types/option';
 import { routes } from 'helpers/urls/routes';
-import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import type { TierPlans } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import { trackCheckoutSubmitAttempt } from '../tracking/behaviour';
@@ -225,7 +225,7 @@ function buildRegularPaymentRequest(
 		csrUsername,
 		salesforceCaseId,
 		debugInfo: actionHistory,
-		threeTierCreateSupporterPlusSubscription: inThreeTierV2Variant(
+		threeTierCreateSupporterPlusSubscription: inThreeTierV3(
 			state.common.abParticipations,
 		),
 	};
@@ -289,9 +289,7 @@ function onPaymentAuthorised(
 				productType,
 			);
 
-			const inThreeTierVariant = inThreeTierV2Variant(
-				state.common.abParticipations,
-			);
+			const inThreeTierVariant = inThreeTierV3(state.common.abParticipations);
 			if (inThreeTierVariant) {
 				const tierBillingPeriodName =
 					billingPeriod.toLowerCase() as keyof TierPlans;

--- a/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
@@ -13,7 +13,6 @@ import {
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
 import { navigateWithPageView } from 'helpers/tracking/ophan';
-import { inThreeTierV2Variant } from '../setup/threeTierABTest';
 
 const titleAndButtonContainer = css`
 	display: flex;
@@ -42,7 +41,6 @@ const standFirst = css`
 
 interface ContributionsPriceCardsProps {
 	paymentFrequency: ContributionType;
-	inThreeTierVariant?: boolean;
 }
 
 export function ContributionsPriceCards({
@@ -56,10 +54,6 @@ export function ContributionsPriceCards({
 		(state) => state.common.internationalisation,
 	);
 	const navigate = useNavigate();
-
-	const inThreeTierVariant = inThreeTierV2Variant(
-		useContributionsSelector((state) => state.common).abParticipations,
-	);
 
 	const backButton = (
 		<Button
@@ -123,7 +117,7 @@ export function ContributionsPriceCards({
 								errors={errors}
 							/>
 						}
-						amountIntervalSeperator={inThreeTierVariant ? '/' : undefined}
+						amountIntervalSeperator={'/'}
 					/>
 				)}
 			/>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -20,7 +20,9 @@ import {
 	currencies,
 	type IsoCurrency,
 } from 'helpers/internationalisation/currency';
+import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
+import { inThreeTierV3Variant } from '../setup/threeTierABTest';
 import type { TierBenefits, TierPlanCosts } from '../setup/threeTierConfig';
 import { ThreeTierLozenge } from './threeTierLozenge';
 
@@ -191,12 +193,15 @@ export function ThreeTierCard({
 	linkCtaClickHandler,
 	externalBtnLink,
 }: ThreeTierCardProps): JSX.Element {
+	const inThreeTierVariant = inThreeTierV3Variant(
+		useContributionsSelector((state) => state.common).abParticipations,
+	);
 	const currency = currencies[currencyId].glyph;
 	const currentPrice = planCost.discount?.price ?? planCost.price;
 	const previousPriceCopy =
 		!!planCost.discount && `${currency}${planCost.price}`;
 	const currentPriceCopy = `${
-		cardTier === 1 ? 'From ' : ''
+		inThreeTierVariant && cardTier === 1 ? 'From ' : ''
 	}${currency}${currentPrice}/${
 		recurringContributionPeriodMap[paymentFrequency]
 	}`;

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
@@ -3,5 +3,14 @@ import type { Participations } from 'helpers/abTests/abtest';
 export const inThreeTierV2Variant = (
 	abParticipations: Participations,
 ): boolean => {
-	return abParticipations.threeTierCheckoutV2 === 'variant';
+	return (
+		abParticipations.threeTierCheckoutV2 === 'variant' ||
+		inThreeTierV3Variant(abParticipations)
+	);
+};
+
+export const inThreeTierV3Variant = (
+	abParticipations: Participations,
+): boolean => {
+	return abParticipations.threeTierCheckoutV3 === 'variant';
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
@@ -4,9 +4,15 @@ export const inThreeTierV2Variant = (
 	abParticipations: Participations,
 ): boolean => {
 	return (
-		abParticipations.threeTierCheckoutV2 === 'variant' ||
+		inThreeTierV3Control(abParticipations) ||
 		inThreeTierV3Variant(abParticipations)
 	);
+};
+
+export const inThreeTierV3Control = (
+	abParticipations: Participations,
+): boolean => {
+	return abParticipations.threeTierCheckoutV3 === 'control';
 };
 
 export const inThreeTierV3Variant = (

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
@@ -1,17 +1,13 @@
 import type { Participations } from 'helpers/abTests/abtest';
 
-export const inThreeTierV2Variant = (
-	abParticipations: Participations,
-): boolean => {
+export const inThreeTierV3 = (abParticipations: Participations): boolean => {
 	return (
 		inThreeTierV3Control(abParticipations) ||
 		inThreeTierV3Variant(abParticipations)
 	);
 };
 
-export const inThreeTierV3Control = (
-	abParticipations: Participations,
-): boolean => {
+const inThreeTierV3Control = (abParticipations: Participations): boolean => {
 	return abParticipations.threeTierCheckoutV3 === 'control';
 };
 

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierConfig.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierConfig.ts
@@ -43,7 +43,48 @@ interface TierCards {
 	tier3: TierCard;
 }
 
-const tier1: TierCard = {
+const tier1Control: TierCard = {
+	title: 'Support',
+	benefits: {
+		list: [
+			{
+				copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+			},
+		],
+	},
+	plans: {
+		monthly: {
+			label: 'Monthly',
+			charges: {
+				GBPCountries: {
+					price: 4,
+				},
+				EURCountries: { price: 4 },
+				International: { price: 5 },
+				UnitedStates: { price: 5 },
+				Canada: { price: 5 },
+				NZDCountries: { price: 10 },
+				AUDCountries: { price: 10 },
+			},
+		},
+		annual: {
+			label: 'Annual',
+			charges: {
+				GBPCountries: {
+					price: 50,
+				},
+				EURCountries: { price: 50 },
+				International: { price: 60 },
+				UnitedStates: { price: 60 },
+				Canada: { price: 60 },
+				NZDCountries: { price: 80 },
+				AUDCountries: { price: 80 },
+			},
+		},
+	},
+};
+
+const tier1Variant: TierCard = {
 	title: 'Support',
 	benefits: {
 		list: [
@@ -369,8 +410,14 @@ const tier3: TierCard = {
 	},
 };
 
-export const tierCards: TierCards = {
-	tier1,
+export const tierCardsControl: TierCards = {
+	tier1: tier1Control,
+	tier2,
+	tier3,
+};
+
+export const tierCardsVariant: TierCards = {
+	tier1: tier1Variant,
 	tier2,
 	tier3,
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -17,8 +17,6 @@ import { initReduxForContributions } from 'helpers/redux/contributionsStore';
 import { renderPage } from 'helpers/rendering/render';
 import { SupporterPlusThankYou } from 'pages/supporter-plus-thank-you/supporterPlusThankYou';
 import { setUpRedux } from './setup/setUpRedux';
-import { inThreeTierV2Variant } from './setup/threeTierABTest';
-import { SupporterPlusInitialLandingPage } from './twoStepPages/firstStepLanding';
 import { SupporterPlusCheckout } from './twoStepPages/secondStepCheckout';
 import { ThreeTierLanding } from './twoStepPages/threeTierLanding';
 
@@ -79,10 +77,6 @@ function ThreeTierRedirectOneOffToCheckout({
 	);
 }
 
-export const inThreeTierVariant = inThreeTierV2Variant(
-	store.getState().common.abParticipations,
-);
-
 // ----- Render ----- //
 
 const router = () => {
@@ -101,15 +95,9 @@ const router = () => {
 									 * contribution type (set in the url) and find yourself in the three tier
 									 * variant we should redirect you to the /contribute/checkout route
 									 */
-									inThreeTierVariant ? (
-										<ThreeTierRedirectOneOffToCheckout countryId={countryId}>
-											<ThreeTierLanding />
-										</ThreeTierRedirectOneOffToCheckout>
-									) : (
-										<SupporterPlusInitialLandingPage
-											thankYouRoute={thankYouRoute}
-										/>
-									)
+									<ThreeTierRedirectOneOffToCheckout countryId={countryId}>
+										<ThreeTierLanding />
+									</ThreeTierRedirectOneOffToCheckout>
 								}
 							/>
 							<Route

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -36,7 +36,10 @@ import { ContributionsPriceCards } from '../components/contributionsPriceCards';
 import { PaymentFailureMessage } from '../components/paymentFailure';
 import { PaymentTsAndCs } from '../components/paymentTsAndCs';
 import { getPaymentMethodButtons } from '../paymentButtons';
-import { inThreeTierV2Variant } from '../setup/threeTierABTest';
+import {
+	inThreeTierV2Variant,
+	inThreeTierV3Variant,
+} from '../setup/threeTierABTest';
 import { SupporterPlusCheckoutScaffold } from './checkoutScaffold';
 
 const shorterBoxMargin = css`
@@ -80,10 +83,20 @@ export function SupporterPlusCheckout({
 		(state) => state.common,
 	);
 	const inThreeTierVariant = inThreeTierV2Variant(abParticipations);
+	const inThreeTierVariantV3 = inThreeTierV3Variant(abParticipations);
 
-	const showPriceCards =
-		(inThreeTierVariant && contributionType === 'ONE_OFF') ||
-		(inThreeTierVariant && !amountIsAboveThreshold);
+	const showPriceCardsOneOff =
+		inThreeTierVariant && contributionType === 'ONE_OFF';
+	const showPriceCardsTier1 = inThreeTierVariantV3 && !amountIsAboveThreshold;
+	const showPriceCards = showPriceCardsOneOff || showPriceCardsTier1;
+	console.log('TEST showPriceCardsOneOff', showPriceCardsOneOff);
+	console.log(
+		'TEST showPriceCardsTier1 inThreeTierVariantV3 !amountIsAboveThreshold',
+		showPriceCardsTier1,
+		inThreeTierVariantV3,
+		!amountIsAboveThreshold,
+	);
+	console.log('TEST showPriceCards ', showPriceCards);
 
 	const changeButton = (
 		<Button

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -36,10 +36,7 @@ import { ContributionsPriceCards } from '../components/contributionsPriceCards';
 import { PaymentFailureMessage } from '../components/paymentFailure';
 import { PaymentTsAndCs } from '../components/paymentTsAndCs';
 import { getPaymentMethodButtons } from '../paymentButtons';
-import {
-	inThreeTierV2Variant,
-	inThreeTierV3Variant,
-} from '../setup/threeTierABTest';
+import { inThreeTierV3Variant } from '../setup/threeTierABTest';
 import { SupporterPlusCheckoutScaffold } from './checkoutScaffold';
 
 const shorterBoxMargin = css`
@@ -82,21 +79,10 @@ export function SupporterPlusCheckout({
 	const { abParticipations } = useContributionsSelector(
 		(state) => state.common,
 	);
-	const inThreeTierVariant = inThreeTierV2Variant(abParticipations);
-	const inThreeTierVariantV3 = inThreeTierV3Variant(abParticipations);
+	const inThreeTierVariant = inThreeTierV3Variant(abParticipations);
 
-	const showPriceCardsOneOff =
-		inThreeTierVariant && contributionType === 'ONE_OFF';
-	const showPriceCardsTier1 = inThreeTierVariantV3 && !amountIsAboveThreshold;
-	const showPriceCards = showPriceCardsOneOff || showPriceCardsTier1;
-	console.log('TEST showPriceCardsOneOff', showPriceCardsOneOff);
-	console.log(
-		'TEST showPriceCardsTier1 inThreeTierVariantV3 !amountIsAboveThreshold',
-		showPriceCardsTier1,
-		inThreeTierVariantV3,
-		!amountIsAboveThreshold,
-	);
-	console.log('TEST showPriceCards ', showPriceCards);
+	const showPriceCardsTier1 = inThreeTierVariant && !amountIsAboveThreshold;
+	const showPriceCards = contributionType === 'ONE_OFF' || showPriceCardsTier1;
 
 	const changeButton = (
 		<Button
@@ -137,7 +123,6 @@ export function SupporterPlusCheckout({
 						<ContributionsPriceCards paymentFrequency={contributionType} />
 					) : (
 						<ContributionsOrderSummaryContainer
-							inThreeTier={inThreeTierVariant}
 							renderOrderSummary={(orderSummaryProps) => (
 								<ContributionsOrderSummary
 									{...orderSummaryProps}
@@ -189,9 +174,7 @@ export function SupporterPlusCheckout({
 						currency={currencyId}
 						amount={amount}
 						amountIsAboveThreshold={amountIsAboveThreshold}
-						productNameAboveThreshold={
-							inThreeTierVariant ? 'All-access digital' : 'Supporter Plus'
-						}
+						productNameAboveThreshold={'All-access digital'}
 					/>
 				</BoxContents>
 			</Box>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -51,7 +51,8 @@ import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
 import { SupportOnce } from '../components/supportOnce';
 import { ThreeTierCards } from '../components/threeTierCards';
 import { ThreeTierDisclaimer } from '../components/threeTierDisclaimer';
-import { tierCards } from '../setup/threeTierConfig';
+import { inThreeTierV3Variant } from '../setup/threeTierABTest';
+import { tierCardsControl, tierCardsVariant } from '../setup/threeTierConfig';
 
 const recurringContainer = css`
 	background-color: ${palette.brand[400]};
@@ -208,6 +209,8 @@ export function ThreeTierLanding(): JSX.Element {
 	const { abParticipations } = useContributionsSelector(
 		(state) => state.common,
 	);
+	const inThreeTierVariant = inThreeTierV3Variant(abParticipations);
+	const tierCards = inThreeTierVariant ? tierCardsVariant : tierCardsControl;
 
 	const { countryGroupId, currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
@@ -25,7 +25,7 @@ import {
 } from 'helpers/urls/externalLinks';
 import { formatUserDate } from 'helpers/utilities/dateConversions';
 import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
-import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
+import { tierCardsControl as tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 
 const styles = moduleStyles as {
 	heroGuardianWeeklyNonGifting: string;

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
@@ -166,7 +166,7 @@ function ThankYouContent({
 	product,
 	participations,
 }: PropTypes) {
-	const inThreeTierVariant = inThreeTierV3(participations);
+	const inThreeTier = inThreeTierV3(participations);
 
 	const whatHappensNextItems = orderIsGift
 		? [
@@ -217,7 +217,7 @@ function ThankYouContent({
 	);
 
 	const thankyouSupportHeader = `Thank you for supporting our journalism${
-		!inThreeTierVariant ? '!' : ''
+		!inThreeTier ? '!' : ''
 	}`;
 
 	useScrollToTop();
@@ -235,16 +235,11 @@ function ThankYouContent({
 					overheadingClass="--thankyou"
 					overheading={thankyouSupportHeader}
 				>
-					{getHeading(
-						billingPeriod,
-						isPending,
-						orderIsGift,
-						inThreeTierVariant,
-					)}
+					{getHeading(billingPeriod, isPending, orderIsGift, inThreeTier)}
 				</HeadingBlock>
 			</HeroWrapper>
 
-			{inThreeTierVariant ? (
+			{inThreeTier ? (
 				<>
 					<Content>
 						{isPending && (
@@ -322,8 +317,8 @@ function ThankYouContent({
 					</SansParagraph>
 				</Text>
 			</Content>
-			{!inThreeTierVariant && <SubscriptionsSurvey product={product} />}
-			{!inThreeTierVariant && (
+			{!inThreeTier && <SubscriptionsSurvey product={product} />}
+			{!inThreeTier && (
 				<Content>
 					<Asyncronously
 						loader={

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
@@ -24,7 +24,7 @@ import {
 	manageSubsUrl,
 } from 'helpers/urls/externalLinks';
 import { formatUserDate } from 'helpers/utilities/dateConversions';
-import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 
 const styles = moduleStyles as {
@@ -166,7 +166,7 @@ function ThankYouContent({
 	product,
 	participations,
 }: PropTypes) {
-	const inThreeTierVariant = inThreeTierV2Variant(participations);
+	const inThreeTierVariant = inThreeTierV3(participations);
 
 	const whatHappensNextItems = orderIsGift
 		? [

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -172,7 +172,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 		 * for users inThreeTierTestVariant as the original props.price
 		 * object doesn't account for the addition of S+ and associated promotions.
 		 */
-		const priceForQuantumMetric: ProductPrice = inThreeTierVariant
+		const priceForQuantumMetric: ProductPrice = inThreeTier
 			? {
 					...props.price,
 					promotions: [],
@@ -186,7 +186,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 			priceForQuantumMetric,
 			props.billingPeriod,
 		);
-		inThreeTierVariant && props.setPaymentMethod({ paymentMethod: 'Stripe' });
+		inThreeTier && props.setPaymentMethod({ paymentMethod: 'Stripe' });
 	}, []);
 
 	const submissionErrorHeading =
@@ -199,7 +199,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 		props.setBillingCountry(props.deliveryCountry);
 	};
 
-	const inThreeTierVariant = inThreeTierV3(props.participations);
+	const inThreeTier = inThreeTierV3(props.participations);
 
 	const paymentMethods = supportedPaymentMethods(
 		props.currencyId,
@@ -211,7 +211,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 	 * inThreeTierTestVariant, so remove it from paymentMethods
 	 * array.
 	 **/
-	if (inThreeTierVariant) {
+	if (inThreeTier) {
 		const paypalIndex = paymentMethods.findIndex(
 			(subscriptionPaymentMethod) => subscriptionPaymentMethod === 'PayPal',
 		);
@@ -255,10 +255,10 @@ function WeeklyCheckoutForm(props: PropTypes) {
 	return (
 		<Content>
 			<Layout
-				asideNoBorders={inThreeTierVariant}
+				asideNoBorders={inThreeTier}
 				aside={
 					<>
-						{inThreeTierVariant ? (
+						{inThreeTier ? (
 							<DigitalPlusPrintSummary
 								total={standardDigitalPlusPrintPrice}
 								currencySymbol={currencies[props.price.currency].glyph}
@@ -367,7 +367,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 							<BillingAddress countries={billableCountries} />
 						</FormSection>
 					) : null}
-					{!inThreeTierVariant && (
+					{!inThreeTier && (
 						<FormSection title="Please select the first publication you’d like to receive">
 							<Rows>
 								<RadioGroup
@@ -406,7 +406,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 							</Rows>
 						</FormSection>
 					)}
-					{!inThreeTierVariant && (
+					{!inThreeTier && (
 						<BillingPeriodSelector
 							fulfilmentOption={props.fulfilmentOption}
 							onChange={(billingPeriod) =>
@@ -460,7 +460,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 							name={`${props.firstName} ${props.lastName}`}
 							validateForm={props.validateForm}
 							buttonText={
-								inThreeTierVariant
+								inThreeTier
 									? `Pay ${currencies[props.price.currency].glyph}${
 											digitalPlusPrintPotentialDiscount?.price ??
 											standardDigitalPlusPrintPrice
@@ -512,7 +512,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 						errorReason={props.submissionError}
 						errorHeading={submissionErrorHeading}
 					/>
-					{inThreeTierVariant ? (
+					{inThreeTier ? (
 						<Total
 							price={
 								digitalPlusPrintPotentialDiscount?.price ??
@@ -527,7 +527,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 						/>
 					)}
 
-					{inThreeTierVariant ? (
+					{inThreeTier ? (
 						<ThreeTierTerms
 							paymentMethod={props.paymentMethod}
 							paymentFrequency={tierBillingPeriod}

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -84,7 +84,7 @@ import {
 } from 'helpers/utilities/dateConversions';
 import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
 import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
-import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
+import { tierCardsControl as tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import { getWeeklyDays } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
 
 // ----- Styles ----- //

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -83,7 +83,7 @@ import {
 	formatUserDate,
 } from 'helpers/utilities/dateConversions';
 import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
-import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import { getWeeklyDays } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
 
@@ -199,7 +199,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 		props.setBillingCountry(props.deliveryCountry);
 	};
 
-	const inThreeTierVariant = inThreeTierV2Variant(props.participations);
+	const inThreeTierVariant = inThreeTierV3(props.participations);
 
 	const paymentMethods = supportedPaymentMethods(
 		props.currencyId,


### PR DESCRIPTION
## What are you doing in this PR?

Current contribute landing page will move over to ThreeTier Test1 landing page, variant will be ThreeTier Test2 landing page. 
Tier1 Card copy change ('From') between Variant and Control
Tier1 Card PriceCopy changes between Variant and Control (to be supplied)

Summary ABTest Changes->
- `ab-threeTierCheckoutV3=control` will now be Test1 (original `ab-threeTierCheckout=variant`)
-  `ab-threeTierCheckoutV3=variant` will be Test2 `ab-threeTierCheckoutV2=variant`

|Control|Variant|
|-----|-----|
|![image](https://github.com/guardian/support-frontend/assets/76729591/6daeee06-a9c2-42df-9f04-5f2592ebfc2f)![image](https://github.com/guardian/support-frontend/assets/76729591/342b939d-bd42-492d-a2d4-f8d16f5936f8)|![image](https://github.com/guardian/support-frontend/assets/76729591/75077b83-2d8b-4402-aace-3c230267a83b)![image](https://github.com/guardian/support-frontend/assets/76729591/3c4156df-fb55-44f7-830d-a747ea80f80f)|

FROM
https://support.thegulocal.com/uk/contribute#ab-threeTierCheckoutV2=control
https://support.thegulocal.com/uk/contribute#ab-threeTierCheckoutV2=variant

TO
https://support.thegulocal.com/uk/contribute#ab-threeTierCheckoutV3=control
https://support.thegulocal.com/uk/contribute#ab-threeTierCheckoutV3=variant

[**Trello Card**](https://trello.com/c/HCtVdGam/651-3-tier-test3)
