### PR TITLE
fix: use amount not nonDiscountedAmount

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/Products.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/Products.scala
@@ -31,11 +31,11 @@ case class Contribution(
 }
 
 case class SupporterPlus(
-    nonDiscountedAmount: BigDecimal,
+    amount: BigDecimal,
     currency: Currency,
     billingPeriod: BillingPeriod,
 ) extends ProductType {
-  override def describe: String = s"$billingPeriod-SupporterPlus-$currency-$nonDiscountedAmount"
+  override def describe: String = s"$billingPeriod-SupporterPlus-$currency-$amount"
 }
 
 case class DigitalPack(

--- a/support-workers/cloud-formation/src/templates/supporterPlusProduct.yaml
+++ b/support-workers/cloud-formation/src/templates/supporterPlusProduct.yaml
@@ -2,7 +2,7 @@
 ThreeTierSupporterPlus{{billingPeriod}}{{currency}}{{fulfilmentOptions}}:
   Type: Pass
   Result:
-    nonDiscountedAmount: {{amount}}
+    amount: {{amount}}
     currency: {{currency}}
     billingPeriod: {{billingPeriod}}
     productType: SupporterPlus

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/SupporterPlusSubcriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/SupporterPlusSubcriptionBuilder.scala
@@ -34,7 +34,7 @@ class SupporterPlusSubcriptionBuilder(
       else config.v2.annualContributionChargeId
     val todaysDate = dateGenerator.today
 
-    val contributionAmount = state.product.nonDiscountedAmount - getBaseProductPrice(productRatePlanId, state.product.currency)
+    val contributionAmount = state.product.amount - getBaseProductPrice(productRatePlanId, state.product.currency)
     val subscriptionData = subscribeItemBuilder.buildProductSubscription(
       productRatePlanId = productRatePlanId,
       ratePlanCharges = List(

--- a/support-workers/src/test/scala/com/gu/support/workers/DigitalSubscriptionGiftRedemptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/DigitalSubscriptionGiftRedemptionSpec.scala
@@ -64,7 +64,8 @@ class DigitalSubscriptionGiftRedemptionSpec extends AnyFlatSpec with Serialisati
       .getSubscriptionState(expiredResponse, Some("456"))
       .clientCode shouldBe CodeExpired.clientCode
 
-    val nonExpiredDate = LocalDate.now().minusYears(1)
+    // The plusDays(1) if for feb 29 but we should fix this as it masks a bug in prod
+    val nonExpiredDate = LocalDate.now().minusYears(1).plusDays(1)
     val nonExpiredResponse = SubscriptionRedemptionQueryResponse(
       List(
         SubscriptionRedemptionFields(

--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/UpdateSupporterProductDataSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/UpdateSupporterProductDataSpec.scala
@@ -71,7 +71,7 @@ object UpdateSupporterProductDataSpec {
             "deliveryInstructions": null
           },
           "product": {
-            "nonDiscountedAmount": 12,
+            "amount": 12,
             "currency": "GBP",
             "billingPeriod": "Monthly",
             "productType": "SupporterPlus"


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Use `amount` non `nonDiscountedAmount` as we try to decode the JSON from the that's sent from the client that uses `amount`.
