### PR TITLE
3-tier: replace current contribute landing page with ThreeTier test1 as variantFixed, three tier test2 as variantVariable

### DIFF
--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -5,7 +5,7 @@ import { getContributionType } from 'helpers/redux/checkout/product/selectors/pr
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { shouldShowSupporterPlusMessaging } from 'helpers/supporterPlus/showMessaging';
-import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import { DefaultPaymentButton } from './defaultPaymentButton';
 
 const contributionTypeToPaymentInterval: Partial<
@@ -61,7 +61,7 @@ export function DefaultPaymentButtonContainer({
 		(state) => state.common.internationalisation,
 	);
 
-	const inThreeTierVariant = inThreeTierV2Variant(
+	const inThreeTierVariant = inThreeTierV3(
 		useContributionsSelector((state) => state.common).abParticipations,
 	);
 

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -5,7 +5,7 @@ import { getContributionType } from 'helpers/redux/checkout/product/selectors/pr
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { shouldShowSupporterPlusMessaging } from 'helpers/supporterPlus/showMessaging';
-import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { showThreeTierCheckout } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import { DefaultPaymentButton } from './defaultPaymentButton';
 
 const contributionTypeToPaymentInterval: Partial<
@@ -61,7 +61,7 @@ export function DefaultPaymentButtonContainer({
 		(state) => state.common.internationalisation,
 	);
 
-	const inThreeTier = inThreeTierV3(
+	const inThreeTier = showThreeTierCheckout(
 		useContributionsSelector((state) => state.common).abParticipations,
 	);
 

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -61,10 +61,6 @@ export function DefaultPaymentButtonContainer({
 		(state) => state.common.internationalisation,
 	);
 
-	const inThreeTier = showThreeTierCheckout(
-		useContributionsSelector((state) => state.common).abParticipations,
-	);
-
 	const testId = 'qa-contributions-landing-submit-contribution-button';
 
 	const amountIsAboveThreshold = shouldShowSupporterPlusMessaging(
@@ -78,7 +74,10 @@ export function DefaultPaymentButtonContainer({
 		? 'Pay now'
 		: createButtonText(
 				amountWithCurrency,
-				amountIsAboveThreshold || inThreeTier,
+				amountIsAboveThreshold ||
+					showThreeTierCheckout(
+						useContributionsSelector((state) => state.common).abParticipations,
+					),
 				contributionTypeToPaymentInterval[contributionType],
 		  );
 

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -61,7 +61,7 @@ export function DefaultPaymentButtonContainer({
 		(state) => state.common.internationalisation,
 	);
 
-	const inThreeTierVariant = inThreeTierV3(
+	const inThreeTier = inThreeTierV3(
 		useContributionsSelector((state) => state.common).abParticipations,
 	);
 
@@ -78,7 +78,7 @@ export function DefaultPaymentButtonContainer({
 		? 'Pay now'
 		: createButtonText(
 				amountWithCurrency,
-				amountIsAboveThreshold || inThreeTierVariant,
+				amountIsAboveThreshold || inThreeTier,
 				contributionTypeToPaymentInterval[contributionType],
 		  );
 

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -15,7 +15,7 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
-import { inThreeTierV3VariantVariable } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { inThreeTierV3Variable } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import {
 	tierCardsFixed,
 	tierCardsVariable,
@@ -52,7 +52,7 @@ export function PriceCardsContainer({
 	);
 	const minAmount = useContributionsSelector(getMinimumContributionAmount());
 
-	const inThreeTierVariant = inThreeTierV3VariantVariable(
+	const inThreeTierVariant = inThreeTierV3Variable(
 		useContributionsSelector((state) => state.common.abParticipations),
 	);
 	const tierBillingPeriod =

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -15,7 +15,7 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
-import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import type { PriceCardPaymentInterval } from './priceCard';
 import type { PriceCardsProps } from './priceCards';
@@ -49,7 +49,7 @@ export function PriceCardsContainer({
 	);
 	const minAmount = useContributionsSelector(getMinimumContributionAmount());
 
-	const inThreeTierVariant = inThreeTierV2Variant(
+	const inThreeTierVariant = inThreeTierV3(
 		useContributionsSelector((state) => state.common.abParticipations),
 	);
 	const tierBillingPeriod =

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -15,7 +15,7 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
-import { inThreeTierV3Variable } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { showThreeTierVariablePrice } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import {
 	tierCardsFixed,
 	tierCardsVariable,
@@ -52,7 +52,7 @@ export function PriceCardsContainer({
 	);
 	const minAmount = useContributionsSelector(getMinimumContributionAmount());
 
-	const inThreeTierVariant = inThreeTierV3Variable(
+	const inThreeTierVariant = showThreeTierVariablePrice(
 		useContributionsSelector((state) => state.common.abParticipations),
 	);
 	const tierBillingPeriod =

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -15,8 +15,11 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
-import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
-import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
+import { inThreeTierV3VariantVariable } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import {
+	tierCardsFixed,
+	tierCardsVariable,
+} from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import type { PriceCardPaymentInterval } from './priceCard';
 import type { PriceCardsProps } from './priceCards';
 
@@ -49,11 +52,12 @@ export function PriceCardsContainer({
 	);
 	const minAmount = useContributionsSelector(getMinimumContributionAmount());
 
-	const inThreeTierVariant = inThreeTierV3(
+	const inThreeTierVariant = inThreeTierV3VariantVariable(
 		useContributionsSelector((state) => state.common.abParticipations),
 	);
 	const tierBillingPeriod =
 		paymentFrequency === 'ANNUAL' ? 'annual' : 'monthly';
+	const tierCards = inThreeTierVariant ? tierCardsVariable : tierCardsFixed;
 	const tierCardData = tierCards.tier1.plans[tierBillingPeriod].priceCards;
 	const {
 		amounts: frequencyAmounts,

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -52,18 +52,22 @@ export function PriceCardsContainer({
 	);
 	const minAmount = useContributionsSelector(getMinimumContributionAmount());
 
-	const inThreeTierVariant = showThreeTierVariablePrice(
+	const inThreeTierVariantVariable = showThreeTierVariablePrice(
 		useContributionsSelector((state) => state.common.abParticipations),
 	);
 	const tierBillingPeriod =
 		paymentFrequency === 'ANNUAL' ? 'annual' : 'monthly';
-	const tierCards = inThreeTierVariant ? tierCardsVariable : tierCardsFixed;
+	const tierCards = inThreeTierVariantVariable
+		? tierCardsVariable
+		: tierCardsFixed;
 	const tierCardData = tierCards.tier1.plans[tierBillingPeriod].priceCards;
 	const {
 		amounts: frequencyAmounts,
 		defaultAmount,
 		hideChooseYourAmount,
-	} = inThreeTierVariant && tierCardData && paymentFrequency !== 'ONE_OFF'
+	} = inThreeTierVariantVariable &&
+	tierCardData &&
+	paymentFrequency !== 'ONE_OFF'
 		? tierCardData[countryGroupId]
 		: amountsCardData[paymentFrequency];
 

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -103,13 +103,13 @@ export const tests: Tests = {
 		seed: 5,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 	},
-	threeTierCheckoutV2: {
+	threeTierCheckoutV3: {
 		variants: [
 			{
-				id: 'control',
+				id: 'variantFixed',
 			},
 			{
-				id: 'variant',
+				id: 'variantVariable',
 			},
 		],
 		isActive: false,

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -5,7 +5,7 @@ import type { ContributionsStartListening } from 'helpers/redux/contributionsSto
 import * as storage from 'helpers/storage/storage';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
-import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import { validateForm } from '../checkoutActions';
 import {
 	setAllAmounts,
@@ -42,7 +42,7 @@ export function addProductSideEffects(
 				return;
 			}
 
-			const inThreeTierVariant = inThreeTierV2Variant(
+			const inThreeTierVariant = inThreeTierV3(
 				listenerApi.getState().common.abParticipations,
 			);
 			const isMonthlyOrAnnual = ['MONTHLY', 'ANNUAL'].includes(

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -42,13 +42,13 @@ export function addProductSideEffects(
 				return;
 			}
 
-			const inThreeTierVariant = inThreeTierV3(
+			const inThreeTier = inThreeTierV3(
 				listenerApi.getState().common.abParticipations,
 			);
 			const isMonthlyOrAnnual = ['MONTHLY', 'ANNUAL'].includes(
 				contributionType,
 			);
-			if (inThreeTierVariant && isMonthlyOrAnnual) {
+			if (inThreeTier && isMonthlyOrAnnual) {
 				return;
 			}
 			sendEventContributionCartValue(

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -5,7 +5,7 @@ import type { ContributionsStartListening } from 'helpers/redux/contributionsSto
 import * as storage from 'helpers/storage/storage';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
-import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { showThreeTierCheckout } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import { validateForm } from '../checkoutActions';
 import {
 	setAllAmounts,
@@ -42,7 +42,7 @@ export function addProductSideEffects(
 				return;
 			}
 
-			const inThreeTier = inThreeTierV3(
+			const inThreeTier = showThreeTierCheckout(
 				listenerApi.getState().common.abParticipations,
 			);
 			const isMonthlyOrAnnual = ['MONTHLY', 'ANNUAL'].includes(

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -42,13 +42,13 @@ export function addProductSideEffects(
 				return;
 			}
 
-			const inThreeTier = showThreeTierCheckout(
-				listenerApi.getState().common.abParticipations,
-			);
 			const isMonthlyOrAnnual = ['MONTHLY', 'ANNUAL'].includes(
 				contributionType,
 			);
-			if (inThreeTier && isMonthlyOrAnnual) {
+			if (
+				showThreeTierCheckout(listenerApi.getState().common.abParticipations) &&
+				isMonthlyOrAnnual
+			) {
 				return;
 			}
 			sendEventContributionCartValue(

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -62,7 +62,7 @@ import {
 import { sendEventSubscriptionCheckoutConversion } from 'helpers/tracking/quantumMetric';
 import type { Option } from 'helpers/types/option';
 import { routes } from 'helpers/urls/routes';
-import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { showThreeTierCheckout } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import type { TierPlans } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import { tierCardsFixed as tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import { trackCheckoutSubmitAttempt } from '../tracking/behaviour';
@@ -225,7 +225,7 @@ function buildRegularPaymentRequest(
 		csrUsername,
 		salesforceCaseId,
 		debugInfo: actionHistory,
-		threeTierCreateSupporterPlusSubscription: inThreeTierV3(
+		threeTierCreateSupporterPlusSubscription: showThreeTierCheckout(
 			state.common.abParticipations,
 		),
 	};
@@ -289,7 +289,7 @@ function onPaymentAuthorised(
 				productType,
 			);
 
-			const inThreeTier = inThreeTierV3(state.common.abParticipations);
+			const inThreeTier = showThreeTierCheckout(state.common.abParticipations);
 			if (inThreeTier) {
 				const tierBillingPeriodName =
 					billingPeriod.toLowerCase() as keyof TierPlans;

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -185,6 +185,7 @@ function buildRegularPaymentRequest(
 	state: SubscriptionsState,
 	paymentAuthorisation: PaymentAuthorisation,
 	addresses: Addresses,
+	inThreeTier: boolean,
 	promotions?: Promotion[],
 	currencyId?: Option<IsoCurrency>,
 ): RegularPaymentRequest {
@@ -225,9 +226,7 @@ function buildRegularPaymentRequest(
 		csrUsername,
 		salesforceCaseId,
 		debugInfo: actionHistory,
-		threeTierCreateSupporterPlusSubscription: showThreeTierCheckout(
-			state.common.abParticipations,
-		),
+		threeTierCreateSupporterPlusSubscription: inThreeTier,
 	};
 }
 
@@ -244,7 +243,7 @@ function onPaymentAuthorised(
 		productOption,
 		productPrices,
 	} = state.page.checkoutForm.product;
-
+	const inThreeTier = showThreeTierCheckout(state.common.abParticipations);
 	const productType = getSubscriptionType(state);
 	const { paymentMethod } = state.page.checkoutForm.payment;
 	const { csrf } = state.page.checkoutForm;
@@ -262,6 +261,7 @@ function onPaymentAuthorised(
 		state,
 		paymentAuthorisation,
 		addresses,
+		inThreeTier,
 		productPrice.promotions,
 		currency,
 	);
@@ -288,8 +288,6 @@ function onPaymentAuthorised(
 				billingPeriod,
 				productType,
 			);
-
-			const inThreeTier = showThreeTierCheckout(state.common.abParticipations);
 			if (inThreeTier) {
 				const tierBillingPeriodName =
 					billingPeriod.toLowerCase() as keyof TierPlans;

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -289,8 +289,8 @@ function onPaymentAuthorised(
 				productType,
 			);
 
-			const inThreeTierVariant = inThreeTierV3(state.common.abParticipations);
-			if (inThreeTierVariant) {
+			const inThreeTier = inThreeTierV3(state.common.abParticipations);
+			if (inThreeTier) {
 				const tierBillingPeriodName =
 					billingPeriod.toLowerCase() as keyof TierPlans;
 				const contributionType = billingPeriod.toUpperCase() as

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -64,7 +64,7 @@ import type { Option } from 'helpers/types/option';
 import { routes } from 'helpers/urls/routes';
 import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import type { TierPlans } from 'pages/supporter-plus-landing/setup/threeTierConfig';
-import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
+import { tierCardsFixed as tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import { trackCheckoutSubmitAttempt } from '../tracking/behaviour';
 
 type Addresses = {

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -62,7 +62,7 @@ import {
 import { sendEventSubscriptionCheckoutConversion } from 'helpers/tracking/quantumMetric';
 import type { Option } from 'helpers/types/option';
 import { routes } from 'helpers/urls/routes';
-import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import type { TierPlans } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import { trackCheckoutSubmitAttempt } from '../tracking/behaviour';
@@ -225,7 +225,7 @@ function buildRegularPaymentRequest(
 		csrUsername,
 		salesforceCaseId,
 		debugInfo: actionHistory,
-		threeTierCreateSupporterPlusSubscription: inThreeTierV2Variant(
+		threeTierCreateSupporterPlusSubscription: inThreeTierV3(
 			state.common.abParticipations,
 		),
 	};
@@ -289,9 +289,7 @@ function onPaymentAuthorised(
 				productType,
 			);
 
-			const inThreeTierVariant = inThreeTierV2Variant(
-				state.common.abParticipations,
-			);
+			const inThreeTierVariant = inThreeTierV3(state.common.abParticipations);
 			if (inThreeTierVariant) {
 				const tierBillingPeriodName =
 					billingPeriod.toLowerCase() as keyof TierPlans;

--- a/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
@@ -13,7 +13,7 @@ import {
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
 import { navigateWithPageView } from 'helpers/tracking/ophan';
-import { inThreeTierV3 } from '../setup/threeTierABTest';
+import { inThreeTierV3Variable } from '../setup/threeTierABTest';
 
 const titleAndButtonContainer = css`
 	display: flex;
@@ -57,7 +57,7 @@ export function ContributionsPriceCards({
 	);
 	const navigate = useNavigate();
 
-	const inThreeTierVariant = inThreeTierV3(
+	const inThreeTierVariant = inThreeTierV3Variable(
 		useContributionsSelector((state) => state.common).abParticipations,
 	);
 

--- a/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
@@ -42,7 +42,6 @@ const standFirst = css`
 
 interface ContributionsPriceCardsProps {
 	paymentFrequency: ContributionType;
-	inThreeTierVariant?: boolean;
 }
 
 export function ContributionsPriceCards({
@@ -57,7 +56,7 @@ export function ContributionsPriceCards({
 	);
 	const navigate = useNavigate();
 
-	const inThreeTierVariant = showThreeTierVariablePrice(
+	const inThreeTierVariantVariable = showThreeTierVariablePrice(
 		useContributionsSelector((state) => state.common).abParticipations,
 	);
 
@@ -123,7 +122,9 @@ export function ContributionsPriceCards({
 								errors={errors}
 							/>
 						}
-						amountIntervalSeperator={inThreeTierVariant ? '/' : undefined}
+						amountIntervalSeperator={
+							inThreeTierVariantVariable ? '/' : undefined
+						}
 					/>
 				)}
 			/>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
@@ -13,7 +13,7 @@ import {
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
 import { navigateWithPageView } from 'helpers/tracking/ophan';
-import { inThreeTierV3Variable } from '../setup/threeTierABTest';
+import { showThreeTierVariablePrice } from '../setup/threeTierABTest';
 
 const titleAndButtonContainer = css`
 	display: flex;
@@ -57,7 +57,7 @@ export function ContributionsPriceCards({
 	);
 	const navigate = useNavigate();
 
-	const inThreeTierVariant = inThreeTierV3Variable(
+	const inThreeTierVariant = showThreeTierVariablePrice(
 		useContributionsSelector((state) => state.common).abParticipations,
 	);
 

--- a/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
@@ -13,7 +13,7 @@ import {
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
 import { navigateWithPageView } from 'helpers/tracking/ophan';
-import { inThreeTierV2Variant } from '../setup/threeTierABTest';
+import { inThreeTierV3 } from '../setup/threeTierABTest';
 
 const titleAndButtonContainer = css`
 	display: flex;
@@ -57,7 +57,7 @@ export function ContributionsPriceCards({
 	);
 	const navigate = useNavigate();
 
-	const inThreeTierVariant = inThreeTierV2Variant(
+	const inThreeTierVariant = inThreeTierV3(
 		useContributionsSelector((state) => state.common).abParticipations,
 	);
 

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -20,7 +20,9 @@ import {
 	currencies,
 	type IsoCurrency,
 } from 'helpers/internationalisation/currency';
+import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
+import { inThreeTierV3VariantVariable } from '../setup/threeTierABTest';
 import type { TierBenefits, TierPlanCosts } from '../setup/threeTierConfig';
 import { ThreeTierLozenge } from './threeTierLozenge';
 
@@ -191,12 +193,15 @@ export function ThreeTierCard({
 	linkCtaClickHandler,
 	externalBtnLink,
 }: ThreeTierCardProps): JSX.Element {
+	const inThreeTierVariant = inThreeTierV3VariantVariable(
+		useContributionsSelector((state) => state.common).abParticipations,
+	);
 	const currency = currencies[currencyId].glyph;
 	const currentPrice = planCost.discount?.price ?? planCost.price;
 	const previousPriceCopy =
 		!!planCost.discount && `${currency}${planCost.price}`;
 	const currentPriceCopy = `${
-		cardTier === 1 ? 'From ' : ''
+		inThreeTierVariant && cardTier === 1 ? 'From ' : ''
 	}${currency}${currentPrice}/${
 		recurringContributionPeriodMap[paymentFrequency]
 	}`;

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -22,7 +22,7 @@ import {
 } from 'helpers/internationalisation/currency';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
-import { inThreeTierV3VariantVariable } from '../setup/threeTierABTest';
+import { inThreeTierV3Variable } from '../setup/threeTierABTest';
 import type { TierBenefits, TierPlanCosts } from '../setup/threeTierConfig';
 import { ThreeTierLozenge } from './threeTierLozenge';
 
@@ -193,7 +193,7 @@ export function ThreeTierCard({
 	linkCtaClickHandler,
 	externalBtnLink,
 }: ThreeTierCardProps): JSX.Element {
-	const inThreeTierVariant = inThreeTierV3VariantVariable(
+	const inThreeTierVariant = inThreeTierV3Variable(
 		useContributionsSelector((state) => state.common).abParticipations,
 	);
 	const currency = currencies[currencyId].glyph;

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -193,7 +193,7 @@ export function ThreeTierCard({
 	linkCtaClickHandler,
 	externalBtnLink,
 }: ThreeTierCardProps): JSX.Element {
-	const inThreeTierVariant = showThreeTierVariablePrice(
+	const inThreeTierVariantVariable = showThreeTierVariablePrice(
 		useContributionsSelector((state) => state.common).abParticipations,
 	);
 	const currency = currencies[currencyId].glyph;
@@ -201,7 +201,7 @@ export function ThreeTierCard({
 	const previousPriceCopy =
 		!!planCost.discount && `${currency}${planCost.price}`;
 	const currentPriceCopy = `${
-		inThreeTierVariant && cardTier === 1 ? 'From ' : ''
+		inThreeTierVariantVariable && cardTier === 1 ? 'From ' : ''
 	}${currency}${currentPrice}/${
 		recurringContributionPeriodMap[paymentFrequency]
 	}`;

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -22,7 +22,7 @@ import {
 } from 'helpers/internationalisation/currency';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
-import { inThreeTierV3Variable } from '../setup/threeTierABTest';
+import { showThreeTierVariablePrice } from '../setup/threeTierABTest';
 import type { TierBenefits, TierPlanCosts } from '../setup/threeTierConfig';
 import { ThreeTierLozenge } from './threeTierLozenge';
 
@@ -193,7 +193,7 @@ export function ThreeTierCard({
 	linkCtaClickHandler,
 	externalBtnLink,
 }: ThreeTierCardProps): JSX.Element {
-	const inThreeTierVariant = inThreeTierV3Variable(
+	const inThreeTierVariant = showThreeTierVariablePrice(
 		useContributionsSelector((state) => state.common).abParticipations,
 	);
 	const currency = currencies[currencyId].glyph;

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
@@ -1,6 +1,8 @@
 import type { Participations } from 'helpers/abTests/abtest';
 
-export const inThreeTierV3 = (abParticipations: Participations): boolean => {
+export const showThreeTierCheckout = (
+	abParticipations: Participations,
+): boolean => {
 	return (
 		inThreeTierV3Fixed(abParticipations) ||
 		inThreeTierV3Variable(abParticipations)

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
@@ -4,16 +4,16 @@ export const showThreeTierCheckout = (
 	abParticipations: Participations,
 ): boolean => {
 	return (
-		inThreeTierV3Fixed(abParticipations) ||
-		inThreeTierV3Variable(abParticipations)
+		showThreeTierFixedPrice(abParticipations) ||
+		showThreeTierVariablePrice(abParticipations)
 	);
 };
 
-const inThreeTierV3Fixed = (abParticipations: Participations): boolean => {
+const showThreeTierFixedPrice = (abParticipations: Participations): boolean => {
 	return abParticipations.threeTierCheckoutV3 === 'variantFixed';
 };
 
-export const inThreeTierV3Variable = (
+export const showThreeTierVariablePrice = (
 	abParticipations: Participations,
 ): boolean => {
 	return abParticipations.threeTierCheckoutV3 === 'variantVariable';

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
@@ -1,7 +1,20 @@
 import type { Participations } from 'helpers/abTests/abtest';
 
-export const inThreeTierV2Variant = (
+export const inThreeTierV3 = (abParticipations: Participations): boolean => {
+	return (
+		inThreeTierV3VariantFixed(abParticipations) ||
+		inThreeTierV3VariantVariable(abParticipations)
+	);
+};
+
+const inThreeTierV3VariantFixed = (
 	abParticipations: Participations,
 ): boolean => {
-	return abParticipations.threeTierCheckoutV2 === 'variant';
+	return abParticipations.threeTierCheckoutV3 === 'variantFixed';
+};
+
+export const inThreeTierV3VariantVariable = (
+	abParticipations: Participations,
+): boolean => {
+	return abParticipations.threeTierCheckoutV3 === 'variantVariable';
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierABTest.ts
@@ -2,18 +2,16 @@ import type { Participations } from 'helpers/abTests/abtest';
 
 export const inThreeTierV3 = (abParticipations: Participations): boolean => {
 	return (
-		inThreeTierV3VariantFixed(abParticipations) ||
-		inThreeTierV3VariantVariable(abParticipations)
+		inThreeTierV3Fixed(abParticipations) ||
+		inThreeTierV3Variable(abParticipations)
 	);
 };
 
-const inThreeTierV3VariantFixed = (
-	abParticipations: Participations,
-): boolean => {
+const inThreeTierV3Fixed = (abParticipations: Participations): boolean => {
 	return abParticipations.threeTierCheckoutV3 === 'variantFixed';
 };
 
-export const inThreeTierV3VariantVariable = (
+export const inThreeTierV3Variable = (
 	abParticipations: Participations,
 ): boolean => {
 	return abParticipations.threeTierCheckoutV3 === 'variantVariable';

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierConfig.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierConfig.ts
@@ -43,7 +43,7 @@ interface TierCards {
 	tier3: TierCard;
 }
 
-const tier1Control: TierCard = {
+const tier1Fixed: TierCard = {
 	title: 'Support',
 	benefits: {
 		list: [
@@ -84,7 +84,7 @@ const tier1Control: TierCard = {
 	},
 };
 
-const tier1Variant: TierCard = {
+const tier1Variable: TierCard = {
 	title: 'Support',
 	benefits: {
 		list: [
@@ -411,13 +411,13 @@ const tier3: TierCard = {
 };
 
 export const tierCardsFixed: TierCards = {
-	tier1: tier1Control,
+	tier1: tier1Fixed,
 	tier2,
 	tier3,
 };
 
 export const tierCardsVariable: TierCards = {
-	tier1: tier1Variant,
+	tier1: tier1Variable,
 	tier2,
 	tier3,
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierConfig.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierConfig.ts
@@ -43,7 +43,48 @@ interface TierCards {
 	tier3: TierCard;
 }
 
-const tier1: TierCard = {
+const tier1Control: TierCard = {
+	title: 'Support',
+	benefits: {
+		list: [
+			{
+				copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+			},
+		],
+	},
+	plans: {
+		monthly: {
+			label: 'Monthly',
+			charges: {
+				GBPCountries: {
+					price: 4,
+				},
+				EURCountries: { price: 4 },
+				International: { price: 5 },
+				UnitedStates: { price: 5 },
+				Canada: { price: 5 },
+				NZDCountries: { price: 10 },
+				AUDCountries: { price: 10 },
+			},
+		},
+		annual: {
+			label: 'Annual',
+			charges: {
+				GBPCountries: {
+					price: 50,
+				},
+				EURCountries: { price: 50 },
+				International: { price: 60 },
+				UnitedStates: { price: 60 },
+				Canada: { price: 60 },
+				NZDCountries: { price: 80 },
+				AUDCountries: { price: 80 },
+			},
+		},
+	},
+};
+
+const tier1Variant: TierCard = {
 	title: 'Support',
 	benefits: {
 		list: [
@@ -369,8 +410,14 @@ const tier3: TierCard = {
 	},
 };
 
-export const tierCards: TierCards = {
-	tier1,
+export const tierCardsFixed: TierCards = {
+	tier1: tier1Control,
+	tier2,
+	tier3,
+};
+
+export const tierCardsVariable: TierCards = {
+	tier1: tier1Variant,
 	tier2,
 	tier3,
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -17,7 +17,7 @@ import { initReduxForContributions } from 'helpers/redux/contributionsStore';
 import { renderPage } from 'helpers/rendering/render';
 import { SupporterPlusThankYou } from 'pages/supporter-plus-thank-you/supporterPlusThankYou';
 import { setUpRedux } from './setup/setUpRedux';
-import { inThreeTierV2Variant } from './setup/threeTierABTest';
+import { inThreeTierV3 } from './setup/threeTierABTest';
 import { SupporterPlusInitialLandingPage } from './twoStepPages/firstStepLanding';
 import { SupporterPlusCheckout } from './twoStepPages/secondStepCheckout';
 import { ThreeTierLanding } from './twoStepPages/threeTierLanding';
@@ -79,7 +79,7 @@ function ThreeTierRedirectOneOffToCheckout({
 	);
 }
 
-export const inThreeTierVariant = inThreeTierV2Variant(
+export const inThreeTierVariant = inThreeTierV3(
 	store.getState().common.abParticipations,
 );
 

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -79,7 +79,7 @@ function ThreeTierRedirectOneOffToCheckout({
 	);
 }
 
-export const inThreeTierVariant = inThreeTierV3(
+export const inThreeTier = inThreeTierV3(
 	store.getState().common.abParticipations,
 );
 
@@ -101,7 +101,7 @@ const router = () => {
 									 * contribution type (set in the url) and find yourself in the three tier
 									 * variant we should redirect you to the /contribute/checkout route
 									 */
-									inThreeTierVariant ? (
+									inThreeTier ? (
 										<ThreeTierRedirectOneOffToCheckout countryId={countryId}>
 											<ThreeTierLanding />
 										</ThreeTierRedirectOneOffToCheckout>

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -17,7 +17,7 @@ import { initReduxForContributions } from 'helpers/redux/contributionsStore';
 import { renderPage } from 'helpers/rendering/render';
 import { SupporterPlusThankYou } from 'pages/supporter-plus-thank-you/supporterPlusThankYou';
 import { setUpRedux } from './setup/setUpRedux';
-import { inThreeTierV3 } from './setup/threeTierABTest';
+import { showThreeTierCheckout } from './setup/threeTierABTest';
 import { SupporterPlusInitialLandingPage } from './twoStepPages/firstStepLanding';
 import { SupporterPlusCheckout } from './twoStepPages/secondStepCheckout';
 import { ThreeTierLanding } from './twoStepPages/threeTierLanding';
@@ -79,7 +79,7 @@ function ThreeTierRedirectOneOffToCheckout({
 	);
 }
 
-export const inThreeTier = inThreeTierV3(
+export const inThreeTier = showThreeTierCheckout(
 	store.getState().common.abParticipations,
 );
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -36,7 +36,10 @@ import { ContributionsPriceCards } from '../components/contributionsPriceCards';
 import { PaymentFailureMessage } from '../components/paymentFailure';
 import { PaymentTsAndCs } from '../components/paymentTsAndCs';
 import { getPaymentMethodButtons } from '../paymentButtons';
-import { inThreeTierV3, inThreeTierV3Variable } from '../setup/threeTierABTest';
+import {
+	inThreeTierV3Variable,
+	showThreeTierCheckout,
+} from '../setup/threeTierABTest';
 import { SupporterPlusCheckoutScaffold } from './checkoutScaffold';
 
 const shorterBoxMargin = css`
@@ -79,7 +82,7 @@ export function SupporterPlusCheckout({
 	const { abParticipations } = useContributionsSelector(
 		(state) => state.common,
 	);
-	const inThreeTier = inThreeTierV3(abParticipations);
+	const inThreeTier = showThreeTierCheckout(abParticipations);
 	const inThreeTierVariant = inThreeTierV3Variable(abParticipations);
 
 	const showPriceCards =

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -36,10 +36,7 @@ import { ContributionsPriceCards } from '../components/contributionsPriceCards';
 import { PaymentFailureMessage } from '../components/paymentFailure';
 import { PaymentTsAndCs } from '../components/paymentTsAndCs';
 import { getPaymentMethodButtons } from '../paymentButtons';
-import {
-	inThreeTierV3,
-	inThreeTierV3VariantVariable,
-} from '../setup/threeTierABTest';
+import { inThreeTierV3, inThreeTierV3Variable } from '../setup/threeTierABTest';
 import { SupporterPlusCheckoutScaffold } from './checkoutScaffold';
 
 const shorterBoxMargin = css`
@@ -83,7 +80,7 @@ export function SupporterPlusCheckout({
 		(state) => state.common,
 	);
 	const inThreeTier = inThreeTierV3(abParticipations);
-	const inThreeTierVariant = inThreeTierV3VariantVariable(abParticipations);
+	const inThreeTierVariant = inThreeTierV3Variable(abParticipations);
 
 	const showPriceCards =
 		(inThreeTier && contributionType === 'ONE_OFF') ||

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -36,7 +36,10 @@ import { ContributionsPriceCards } from '../components/contributionsPriceCards';
 import { PaymentFailureMessage } from '../components/paymentFailure';
 import { PaymentTsAndCs } from '../components/paymentTsAndCs';
 import { getPaymentMethodButtons } from '../paymentButtons';
-import { inThreeTierV3 } from '../setup/threeTierABTest';
+import {
+	inThreeTierV3,
+	inThreeTierV3VariantVariable,
+} from '../setup/threeTierABTest';
 import { SupporterPlusCheckoutScaffold } from './checkoutScaffold';
 
 const shorterBoxMargin = css`
@@ -79,10 +82,11 @@ export function SupporterPlusCheckout({
 	const { abParticipations } = useContributionsSelector(
 		(state) => state.common,
 	);
-	const inThreeTierVariant = inThreeTierV3(abParticipations);
+	const inThreeTier = inThreeTierV3(abParticipations);
+	const inThreeTierVariant = inThreeTierV3VariantVariable(abParticipations);
 
 	const showPriceCards =
-		(inThreeTierVariant && contributionType === 'ONE_OFF') ||
+		(inThreeTier && contributionType === 'ONE_OFF') ||
 		(inThreeTierVariant && !amountIsAboveThreshold);
 
 	const changeButton = (
@@ -124,7 +128,7 @@ export function SupporterPlusCheckout({
 						<ContributionsPriceCards paymentFrequency={contributionType} />
 					) : (
 						<ContributionsOrderSummaryContainer
-							inThreeTier={inThreeTierVariant}
+							inThreeTier={inThreeTier}
 							renderOrderSummary={(orderSummaryProps) => (
 								<ContributionsOrderSummary
 									{...orderSummaryProps}
@@ -177,7 +181,7 @@ export function SupporterPlusCheckout({
 						amount={amount}
 						amountIsAboveThreshold={amountIsAboveThreshold}
 						productNameAboveThreshold={
-							inThreeTierVariant ? 'All-access digital' : 'Supporter Plus'
+							inThreeTier ? 'All-access digital' : 'Supporter Plus'
 						}
 					/>
 				</BoxContents>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -83,11 +83,12 @@ export function SupporterPlusCheckout({
 		(state) => state.common,
 	);
 	const inThreeTier = showThreeTierCheckout(abParticipations);
-	const inThreeTierVariant = showThreeTierVariablePrice(abParticipations);
+	const inThreeTierVariantVariable =
+		showThreeTierVariablePrice(abParticipations);
 
 	const showPriceCards =
 		(inThreeTier && contributionType === 'ONE_OFF') ||
-		(inThreeTierVariant && !amountIsAboveThreshold);
+		(inThreeTierVariantVariable && !amountIsAboveThreshold);
 
 	const changeButton = (
 		<Button
@@ -103,7 +104,7 @@ export function SupporterPlusCheckout({
 					}),
 				);
 				// 3-tier Other amount over S+ threshold will not re-display unless reset
-				if (inThreeTierVariant && amountIsAboveThreshold) {
+				if (inThreeTierVariantVariable && amountIsAboveThreshold) {
 					dispatch(
 						setOtherAmount({
 							contributionType: contributionType,

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -37,8 +37,8 @@ import { PaymentFailureMessage } from '../components/paymentFailure';
 import { PaymentTsAndCs } from '../components/paymentTsAndCs';
 import { getPaymentMethodButtons } from '../paymentButtons';
 import {
-	inThreeTierV3Variable,
 	showThreeTierCheckout,
+	showThreeTierVariablePrice,
 } from '../setup/threeTierABTest';
 import { SupporterPlusCheckoutScaffold } from './checkoutScaffold';
 
@@ -83,7 +83,7 @@ export function SupporterPlusCheckout({
 		(state) => state.common,
 	);
 	const inThreeTier = showThreeTierCheckout(abParticipations);
-	const inThreeTierVariant = inThreeTierV3Variable(abParticipations);
+	const inThreeTierVariant = showThreeTierVariablePrice(abParticipations);
 
 	const showPriceCards =
 		(inThreeTier && contributionType === 'ONE_OFF') ||

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -36,7 +36,7 @@ import { ContributionsPriceCards } from '../components/contributionsPriceCards';
 import { PaymentFailureMessage } from '../components/paymentFailure';
 import { PaymentTsAndCs } from '../components/paymentTsAndCs';
 import { getPaymentMethodButtons } from '../paymentButtons';
-import { inThreeTierV2Variant } from '../setup/threeTierABTest';
+import { inThreeTierV3 } from '../setup/threeTierABTest';
 import { SupporterPlusCheckoutScaffold } from './checkoutScaffold';
 
 const shorterBoxMargin = css`
@@ -79,7 +79,7 @@ export function SupporterPlusCheckout({
 	const { abParticipations } = useContributionsSelector(
 		(state) => state.common,
 	);
-	const inThreeTierVariant = inThreeTierV2Variant(abParticipations);
+	const inThreeTierVariant = inThreeTierV3(abParticipations);
 
 	const showPriceCards =
 		(inThreeTierVariant && contributionType === 'ONE_OFF') ||

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -51,7 +51,7 @@ import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
 import { SupportOnce } from '../components/supportOnce';
 import { ThreeTierCards } from '../components/threeTierCards';
 import { ThreeTierDisclaimer } from '../components/threeTierDisclaimer';
-import { inThreeTierV3VariantVariable } from '../setup/threeTierABTest';
+import { inThreeTierV3Variable } from '../setup/threeTierABTest';
 import { tierCardsFixed, tierCardsVariable } from '../setup/threeTierConfig';
 
 const recurringContainer = css`
@@ -209,7 +209,7 @@ export function ThreeTierLanding(): JSX.Element {
 	const { abParticipations } = useContributionsSelector(
 		(state) => state.common,
 	);
-	const inThreeTierVariant = inThreeTierV3VariantVariable(abParticipations);
+	const inThreeTierVariant = inThreeTierV3Variable(abParticipations);
 	const tierCards = inThreeTierVariant ? tierCardsVariable : tierCardsFixed;
 	const { countryGroupId, currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -51,7 +51,7 @@ import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
 import { SupportOnce } from '../components/supportOnce';
 import { ThreeTierCards } from '../components/threeTierCards';
 import { ThreeTierDisclaimer } from '../components/threeTierDisclaimer';
-import { inThreeTierV3Variable } from '../setup/threeTierABTest';
+import { showThreeTierVariablePrice } from '../setup/threeTierABTest';
 import { tierCardsFixed, tierCardsVariable } from '../setup/threeTierConfig';
 
 const recurringContainer = css`
@@ -209,7 +209,7 @@ export function ThreeTierLanding(): JSX.Element {
 	const { abParticipations } = useContributionsSelector(
 		(state) => state.common,
 	);
-	const inThreeTierVariant = inThreeTierV3Variable(abParticipations);
+	const inThreeTierVariant = showThreeTierVariablePrice(abParticipations);
 	const tierCards = inThreeTierVariant ? tierCardsVariable : tierCardsFixed;
 	const { countryGroupId, currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -209,8 +209,11 @@ export function ThreeTierLanding(): JSX.Element {
 	const { abParticipations } = useContributionsSelector(
 		(state) => state.common,
 	);
-	const inThreeTierVariant = showThreeTierVariablePrice(abParticipations);
-	const tierCards = inThreeTierVariant ? tierCardsVariable : tierCardsFixed;
+	const inThreeTierVariantVariable =
+		showThreeTierVariablePrice(abParticipations);
+	const tierCards = inThreeTierVariantVariable
+		? tierCardsVariable
+		: tierCardsFixed;
 	const { countryGroupId, currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -51,7 +51,8 @@ import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
 import { SupportOnce } from '../components/supportOnce';
 import { ThreeTierCards } from '../components/threeTierCards';
 import { ThreeTierDisclaimer } from '../components/threeTierDisclaimer';
-import { tierCards } from '../setup/threeTierConfig';
+import { inThreeTierV3VariantVariable } from '../setup/threeTierABTest';
+import { tierCardsFixed, tierCardsVariable } from '../setup/threeTierConfig';
 
 const recurringContainer = css`
 	background-color: ${palette.brand[400]};
@@ -208,7 +209,8 @@ export function ThreeTierLanding(): JSX.Element {
 	const { abParticipations } = useContributionsSelector(
 		(state) => state.common,
 	);
-
+	const inThreeTierVariant = inThreeTierV3VariantVariable(abParticipations);
+	const tierCards = inThreeTierVariant ? tierCardsVariable : tierCardsFixed;
 	const { countryGroupId, currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
@@ -166,7 +166,7 @@ function ThankYouContent({
 	product,
 	participations,
 }: PropTypes) {
-	const inThreeTierVariant = inThreeTierV3(participations);
+	const inThreeTier = inThreeTierV3(participations);
 
 	const whatHappensNextItems = orderIsGift
 		? [
@@ -217,7 +217,7 @@ function ThankYouContent({
 	);
 
 	const thankyouSupportHeader = `Thank you for supporting our journalism${
-		!inThreeTierVariant ? '!' : ''
+		!inThreeTier ? '!' : ''
 	}`;
 
 	useScrollToTop();
@@ -235,16 +235,11 @@ function ThankYouContent({
 					overheadingClass="--thankyou"
 					overheading={thankyouSupportHeader}
 				>
-					{getHeading(
-						billingPeriod,
-						isPending,
-						orderIsGift,
-						inThreeTierVariant,
-					)}
+					{getHeading(billingPeriod, isPending, orderIsGift, inThreeTier)}
 				</HeadingBlock>
 			</HeroWrapper>
 
-			{inThreeTierVariant ? (
+			{inThreeTier ? (
 				<>
 					<Content>
 						{isPending && (
@@ -322,8 +317,8 @@ function ThankYouContent({
 					</SansParagraph>
 				</Text>
 			</Content>
-			{!inThreeTierVariant && <SubscriptionsSurvey product={product} />}
-			{!inThreeTierVariant && (
+			{!inThreeTier && <SubscriptionsSurvey product={product} />}
+			{!inThreeTier && (
 				<Content>
 					<Asyncronously
 						loader={

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
@@ -24,7 +24,7 @@ import {
 	manageSubsUrl,
 } from 'helpers/urls/externalLinks';
 import { formatUserDate } from 'helpers/utilities/dateConversions';
-import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 
 const styles = moduleStyles as {
@@ -166,7 +166,7 @@ function ThankYouContent({
 	product,
 	participations,
 }: PropTypes) {
-	const inThreeTierVariant = inThreeTierV2Variant(participations);
+	const inThreeTierVariant = inThreeTierV3(participations);
 
 	const whatHappensNextItems = orderIsGift
 		? [

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
@@ -24,7 +24,7 @@ import {
 	manageSubsUrl,
 } from 'helpers/urls/externalLinks';
 import { formatUserDate } from 'helpers/utilities/dateConversions';
-import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { showThreeTierCheckout } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import { tierCardsFixed as tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 
 const styles = moduleStyles as {
@@ -166,7 +166,7 @@ function ThankYouContent({
 	product,
 	participations,
 }: PropTypes) {
-	const inThreeTier = inThreeTierV3(participations);
+	const inThreeTier = showThreeTierCheckout(participations);
 
 	const whatHappensNextItems = orderIsGift
 		? [

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
@@ -25,7 +25,7 @@ import {
 } from 'helpers/urls/externalLinks';
 import { formatUserDate } from 'helpers/utilities/dateConversions';
 import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
-import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
+import { tierCardsFixed as tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 
 const styles = moduleStyles as {
 	heroGuardianWeeklyNonGifting: string;

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -84,7 +84,7 @@ import {
 } from 'helpers/utilities/dateConversions';
 import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
 import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
-import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
+import { tierCardsFixed as tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import { getWeeklyDays } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
 
 // ----- Styles ----- //

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -172,7 +172,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 		 * for users inThreeTierTestVariant as the original props.price
 		 * object doesn't account for the addition of S+ and associated promotions.
 		 */
-		const priceForQuantumMetric: ProductPrice = inThreeTierVariant
+		const priceForQuantumMetric: ProductPrice = inThreeTier
 			? {
 					...props.price,
 					promotions: [],
@@ -186,7 +186,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 			priceForQuantumMetric,
 			props.billingPeriod,
 		);
-		inThreeTierVariant && props.setPaymentMethod({ paymentMethod: 'Stripe' });
+		inThreeTier && props.setPaymentMethod({ paymentMethod: 'Stripe' });
 	}, []);
 
 	const submissionErrorHeading =
@@ -199,7 +199,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 		props.setBillingCountry(props.deliveryCountry);
 	};
 
-	const inThreeTierVariant = inThreeTierV3(props.participations);
+	const inThreeTier = inThreeTierV3(props.participations);
 
 	const paymentMethods = supportedPaymentMethods(
 		props.currencyId,
@@ -211,7 +211,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 	 * inThreeTierTestVariant, so remove it from paymentMethods
 	 * array.
 	 **/
-	if (inThreeTierVariant) {
+	if (inThreeTier) {
 		const paypalIndex = paymentMethods.findIndex(
 			(subscriptionPaymentMethod) => subscriptionPaymentMethod === 'PayPal',
 		);
@@ -255,10 +255,10 @@ function WeeklyCheckoutForm(props: PropTypes) {
 	return (
 		<Content>
 			<Layout
-				asideNoBorders={inThreeTierVariant}
+				asideNoBorders={inThreeTier}
 				aside={
 					<>
-						{inThreeTierVariant ? (
+						{inThreeTier ? (
 							<DigitalPlusPrintSummary
 								total={standardDigitalPlusPrintPrice}
 								currencySymbol={currencies[props.price.currency].glyph}
@@ -367,7 +367,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 							<BillingAddress countries={billableCountries} />
 						</FormSection>
 					) : null}
-					{!inThreeTierVariant && (
+					{!inThreeTier && (
 						<FormSection title="Please select the first publication you’d like to receive">
 							<Rows>
 								<RadioGroup
@@ -406,7 +406,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 							</Rows>
 						</FormSection>
 					)}
-					{!inThreeTierVariant && (
+					{!inThreeTier && (
 						<BillingPeriodSelector
 							fulfilmentOption={props.fulfilmentOption}
 							onChange={(billingPeriod) =>
@@ -460,7 +460,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 							name={`${props.firstName} ${props.lastName}`}
 							validateForm={props.validateForm}
 							buttonText={
-								inThreeTierVariant
+								inThreeTier
 									? `Pay ${currencies[props.price.currency].glyph}${
 											digitalPlusPrintPotentialDiscount?.price ??
 											standardDigitalPlusPrintPrice
@@ -512,7 +512,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 						errorReason={props.submissionError}
 						errorHeading={submissionErrorHeading}
 					/>
-					{inThreeTierVariant ? (
+					{inThreeTier ? (
 						<Total
 							price={
 								digitalPlusPrintPotentialDiscount?.price ??
@@ -527,7 +527,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 						/>
 					)}
 
-					{inThreeTierVariant ? (
+					{inThreeTier ? (
 						<ThreeTierTerms
 							paymentMethod={props.paymentMethod}
 							paymentFrequency={tierBillingPeriod}

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -83,7 +83,7 @@ import {
 	formatUserDate,
 } from 'helpers/utilities/dateConversions';
 import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
-import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { showThreeTierCheckout } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import { tierCardsFixed as tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import { getWeeklyDays } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
 
@@ -199,7 +199,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 		props.setBillingCountry(props.deliveryCountry);
 	};
 
-	const inThreeTier = inThreeTierV3(props.participations);
+	const inThreeTier = showThreeTierCheckout(props.participations);
 
 	const paymentMethods = supportedPaymentMethods(
 		props.currencyId,

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -83,7 +83,7 @@ import {
 	formatUserDate,
 } from 'helpers/utilities/dateConversions';
 import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
-import { inThreeTierV2Variant } from 'pages/supporter-plus-landing/setup/threeTierABTest';
+import { inThreeTierV3 } from 'pages/supporter-plus-landing/setup/threeTierABTest';
 import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 import { getWeeklyDays } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
 
@@ -199,7 +199,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 		props.setBillingCountry(props.deliveryCountry);
 	};
 
-	const inThreeTierVariant = inThreeTierV2Variant(props.participations);
+	const inThreeTierVariant = inThreeTierV3(props.participations);
 
 	const paymentMethods = supportedPaymentMethods(
 		props.currencyId,


### PR DESCRIPTION
## What are you doing in this PR?

For vat compliant countries ->  
Users will be split 50/50 between 2 cohorts:

1. `variantFixed` will display ThreeTier Test1 landing page
2. `variantVariable` will be ThreeTier Test2 landing page

For non-vat compliant countires ->  
Through omission from `threeTierCheckoutV3` users will see the original contribute landing page with VAT compliant pricing (eg. below S+ threshold).

Tier1 Card copy change ('From') between Variant and Control

Tier1 Card price (& priceCard) changes between Variant and Control (as previously supplied)

Summary ABTest Changes->
- `ab-threeTierCheckoutV3=variantFixed` will now be Test1 (original `ab-threeTierCheckout=variant`)
-  `ab-threeTierCheckoutV3=variantVariable` will be Test2 (`ab-threeTierCheckoutV2=variant`)

|VariantFixed|VariantVariable|
|-----|-----|
|![image](https://github.com/guardian/support-frontend/assets/76729591/6daeee06-a9c2-42df-9f04-5f2592ebfc2f)![image](https://github.com/guardian/support-frontend/assets/76729591/342b939d-bd42-492d-a2d4-f8d16f5936f8)|![image](https://github.com/guardian/support-frontend/assets/76729591/75077b83-2d8b-4402-aace-3c230267a83b)![image](https://github.com/guardian/support-frontend/assets/76729591/3c4156df-fb55-44f7-830d-a747ea80f80f)|

FROM
https://support.thegulocal.com/uk/contribute#ab-threeTierCheckoutV2=control
https://support.thegulocal.com/uk/contribute#ab-threeTierCheckoutV2=variant

TO
https://support.thegulocal.com/uk/contribute#ab-threeTierCheckoutV3=variantFixed
https://support.thegulocal.com/uk/contribute#ab-threeTierCheckoutV3=variantVariable

[**Trello Card**](https://trello.com/c/HCtVdGam/651-3-tier-test3)
