### PR TITLE
feat: add payment config to checkout

### DIFF
--- a/support-frontend/app/views/checkout.scala.html
+++ b/support-frontend/app/views/checkout.scala.html
@@ -1,0 +1,34 @@
+@import admin.ServersideAbTest.Participation
+@import assets.StyleContent
+@import assets.RefPath
+@import assets.AssetsResolver
+@import admin.settings.AllSettings
+@import views.EmptyDiv
+@(
+  geoData: GeoData,
+  serversideTests: Map[String,Participation],
+  paymentMethodConfigs: PaymentMethodConfigs,
+  v2recaptchaConfigPublicKey: String,
+)(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
+
+@main(
+  title = "Support the Guardian | Checkout",
+  mainElement = EmptyDiv("checkout"),
+  mainJsBundle = Left(RefPath("[countryGroupId]/checkout.js")),
+  mainStyleBundle = Right(StyleContent(Html(""))),
+  description = Some("Help us deliver the independent journalism the world needs. Support the Guardian by making a contribution."),
+  canonicalLink = Some("https://support.theguardian.com/checkout"),
+  serversideTests = serversideTests,
+  hrefLangLinks = Map(),
+  csrf = None,
+  shareImageUrl = None,
+  shareUrl = None,
+  noindex = true
+){
+  @windowGuardianPaymentConfig(
+    geoData = geoData,
+    paymentMethodConfigs = paymentMethodConfigs,
+    v2recaptchaConfigPublicKey = v2recaptchaConfigPublicKey,
+    settings = settings,
+  )
+}

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -7,7 +7,7 @@
 @import helper.CSRF
 @import views.{Preload, SSRContent, ReactDiv}
 @import models.GeoData
-@import controllers.ContributionsPaymentMethodConfigs
+@import controllers.PaymentMethodConfigs
 
 @(
   title: String,
@@ -16,7 +16,7 @@
   js: Either[RefPath, StyleContent],
   css: Either[RefPath, StyleContent],
   description: Option[String],
-  paymentMethodConfigs: ContributionsPaymentMethodConfigs,
+  paymentMethodConfigs: PaymentMethodConfigs,
   paymentApiUrl: String,
   paymentApiPayPalEndpoint: String,
   membersDataApiUrl: String,
@@ -31,86 +31,32 @@
 
 @main(title = title, mainJsBundle = js, description = description, mainElement = mainElement, mainStyleBundle = css, shareImageUrl = Some(shareImageUrl), shareUrl = Some(shareUrl), serversideTests = serversideTests) {
   <script type="text/javascript">
-  window.guardian = window.guardian || {};
-  @idUser.map { user =>
-    window.guardian.user = {
-      id: "@user.id",
-      email: "@user.primaryEmailAddress",
-      @user.publicFields.displayName.map { displayName =>
-        displayName: "@displayName",
-      }
-      @for(firstName <- user.privateFields.firstName; lastName <- user.privateFields.secondName) {
-        firstName: "@firstName",
-        lastName: "@lastName",
-      }
-      @for(address4 <- user.privateFields.address4) {
-        address4: "@address4",
-      }
-      @for(country <- user.privateFields.country) {
-        country: "@country",
-      }
-    };
-  }
-
-  window.guardian.geoip = {
-    countryGroup: "@geoData.countryGroup.map(_.id).mkString",
-    countryCode: "@geoData.country.map(_.alpha2).mkString",
-    stateCode: "@geoData.validatedStateCodeForCountry.mkString"
-  };
-
-  window.guardian.stripeKeyDefaultCurrencies = {
-    ONE_OFF: {
-      default: "@paymentMethodConfigs.oneOffDefaultStripeConfig.defaultAccount.publicKey",
-      test: "@paymentMethodConfigs.oneOffTestStripeConfig.defaultAccount.publicKey"
-    },
-    REGULAR: {
-      default: "@paymentMethodConfigs.regularDefaultStripeConfig.defaultAccount.publicKey",
-      test: "@paymentMethodConfigs.regularTestStripeConfig.defaultAccount.publicKey"
+    window.guardian = window.guardian || {};
+    @idUser.map { user =>
+      window.guardian.user = {
+        id: "@user.id",
+        email: "@user.primaryEmailAddress",
+        @user.publicFields.displayName.map { displayName =>
+          displayName: "@displayName",
+        }
+        @for(firstName <- user.privateFields.firstName; lastName <- user.privateFields.secondName) {
+          firstName: "@firstName",
+          lastName: "@lastName",
+        }
+        @for(address4 <- user.privateFields.address4) {
+          address4: "@address4",
+        }
+        @for(country <- user.privateFields.country) {
+          country: "@country",
+        }
+      };
     }
-  };
-  window.guardian.stripeKeyAustralia = {
-    ONE_OFF: {
-      default: "@paymentMethodConfigs.oneOffDefaultStripeConfig.forCountry(Some(Country.Australia)).publicKey",
-      test: "@paymentMethodConfigs.oneOffTestStripeConfig.forCountry(Some(Country.Australia)).publicKey"
-    },
-    REGULAR: {
-      default: "@paymentMethodConfigs.regularDefaultStripeConfig.forCountry(Some(Country.Australia)).publicKey",
-      test: "@paymentMethodConfigs.regularTestStripeConfig.forCountry(Some(Country.Australia)).publicKey"
-    }
-  };
-  window.guardian.stripeKeyUnitedStates = {
-    @if(settings.switches.featureSwitches.usStripeAccountForSingle.isOn) {
-        ONE_OFF: {
-            default: "@paymentMethodConfigs.oneOffDefaultStripeConfig.forCountry(Some(Country.US)).publicKey",
-            test: "@paymentMethodConfigs.oneOffTestStripeConfig.forCountry(Some(Country.US)).publicKey"
-        },
-    } else {
-      ONE_OFF: window.guardian.stripeKeyDefaultCurrencies.ONE_OFF,
-    }
-    REGULAR: window.guardian.stripeKeyDefaultCurrencies.REGULAR
-  };
-  window.guardian.payPalEnvironment = {
-    default: "@paymentMethodConfigs.regularDefaultPayPalConfig.payPalEnvironment",
-    test: "@paymentMethodConfigs.regularTestPayPalConfig.payPalEnvironment"
-  };
-  window.guardian.amazonPaySellerId = {
-    default: "@paymentMethodConfigs.defaultAmazonPayConfig.sellerId",
-    test: "@paymentMethodConfigs.testAmazonPayConfig.sellerId"
-  };
-  window.guardian.amazonPayClientId = {
-    default: "@paymentMethodConfigs.defaultAmazonPayConfig.clientId",
-    test: "@paymentMethodConfigs.testAmazonPayConfig.clientId",
-  };
-  window.guardian.paymentApiUrl = "@paymentApiUrl";
-  window.guardian.paymentApiPayPalEndpoint = "@paymentApiPayPalEndpoint";
-  window.guardian.mdapiUrl = "@membersDataApiUrl";
-  window.guardian.csrf = { token: "@CSRF.getToken.value" };
-
-  @guestAccountCreationToken.map { guestAccountCreationToken =>
-    window.guardian.guestAccountCreationToken = "@guestAccountCreationToken";
-  }
-
-  window.guardian.recaptchaEnabled = @settings.switches.recaptchaSwitches.enableRecaptchaFrontend.isOn
-  window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey"
   </script>
+
+  @windowGuardianPaymentConfig(
+    geoData = geoData,
+    paymentMethodConfigs = paymentMethodConfigs,
+    v2recaptchaConfigPublicKey = v2recaptchaConfigPublicKey,
+    settings = settings,
+  )
 }

--- a/support-frontend/app/views/windowGuardianPaymentConfig.scala.html
+++ b/support-frontend/app/views/windowGuardianPaymentConfig.scala.html
@@ -1,0 +1,67 @@
+@import com.gu.i18n.Country
+@import admin.settings.AllSettings
+@import views.html.helper.CSRF
+
+@(geoData: GeoData, paymentMethodConfigs: PaymentMethodConfigs, v2recaptchaConfigPublicKey: String, settings: AllSettings)(implicit request: RequestHeader)
+
+<script type="text/javascript">
+  window.guardian.geoip = {
+    countryGroup: "@geoData.countryGroup.map(_.id).mkString",
+    countryCode: "@geoData.country.map(_.alpha2).mkString",
+    stateCode: "@geoData.validatedStateCodeForCountry.mkString"
+  };
+
+  window.guardian.stripeKeyDefaultCurrencies = {
+    ONE_OFF: {
+      default: "@paymentMethodConfigs.oneOffDefaultStripeConfig.defaultAccount.publicKey",
+      test: "@paymentMethodConfigs.oneOffTestStripeConfig.defaultAccount.publicKey"
+    },
+    REGULAR: {
+      default: "@paymentMethodConfigs.regularDefaultStripeConfig.defaultAccount.publicKey",
+      test: "@paymentMethodConfigs.regularTestStripeConfig.defaultAccount.publicKey"
+    }
+  };
+
+  window.guardian.stripeKeyAustralia = {
+    ONE_OFF: {
+      default: "@paymentMethodConfigs.oneOffDefaultStripeConfig.forCountry(Some(Country.Australia)).publicKey",
+      test: "@paymentMethodConfigs.oneOffTestStripeConfig.forCountry(Some(Country.Australia)).publicKey"
+    },
+    REGULAR: {
+      default: "@paymentMethodConfigs.regularDefaultStripeConfig.forCountry(Some(Country.Australia)).publicKey",
+      test: "@paymentMethodConfigs.regularTestStripeConfig.forCountry(Some(Country.Australia)).publicKey"
+    }
+  };
+
+  window.guardian.stripeKeyUnitedStates = {
+    @if(settings.switches.featureSwitches.usStripeAccountForSingle.isOn) {
+    ONE_OFF: {
+      default: "@paymentMethodConfigs.oneOffDefaultStripeConfig.forCountry(Some(Country.US)).publicKey",
+      test: "@paymentMethodConfigs.oneOffTestStripeConfig.forCountry(Some(Country.US)).publicKey"
+    },
+    } else {
+    ONE_OFF: window.guardian.stripeKeyDefaultCurrencies.ONE_OFF,
+    }
+    REGULAR: window.guardian.stripeKeyDefaultCurrencies.REGULAR
+  };
+
+  window.guardian.payPalEnvironment = {
+    default: "@paymentMethodConfigs.regularDefaultPayPalConfig.payPalEnvironment",
+    test: "@paymentMethodConfigs.regularTestPayPalConfig.payPalEnvironment"
+  };
+
+  window.guardian.amazonPaySellerId = {
+    default: "@paymentMethodConfigs.defaultAmazonPayConfig.sellerId",
+    test: "@paymentMethodConfigs.testAmazonPayConfig.sellerId"
+  };
+
+  window.guardian.amazonPayClientId = {
+    default: "@paymentMethodConfigs.defaultAmazonPayConfig.clientId",
+    test: "@paymentMethodConfigs.testAmazonPayConfig.clientId",
+  };
+
+  window.guardian.recaptchaEnabled = @settings.switches.recaptchaSwitches.enableRecaptchaFrontend.isOn
+  window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey";
+
+  window.guardian.csrf = { token: "@CSRF.getToken.value" };
+</script>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

- Copy payment config from `contributions.html.scala` `windowGuardianPaymentConfig.scala.html` that contains the `window.guardian` JS config needed for payments
- Reference this in `contributions.html.scala`
- Create new `checkout.scala.html` page with `@windowGuardianPaymentConfig`

This should be a no-op on existing pages, and make payment config available on the new checkout page.

Part of #5722 