### PR TITLE
feat: add productPrices to window.guardian

### DIFF
--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -8,7 +8,9 @@
 @import views.{Preload, SSRContent, ReactDiv}
 @import models.GeoData
 @import controllers.PaymentMethodConfigs
-
+@import com.gu.support.encoding.CustomCodecs._
+@import services.pricing.ProductPrices
+@import views.ViewHelpers.outputJson
 @(
   title: String,
   id: String,
@@ -26,7 +28,8 @@
   shareImageUrl: String,
   shareUrl: String,
   v2recaptchaConfigPublicKey: String,
-  serversideTests: Map[String, Participation] = Map()
+  serversideTests: Map[String, Participation] = Map(),
+  productPrices: ProductPrices,
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
 @main(title = title, mainJsBundle = js, description = description, mainElement = mainElement, mainStyleBundle = css, shareImageUrl = Some(shareImageUrl), shareUrl = Some(shareUrl), serversideTests = serversideTests) {
@@ -51,6 +54,8 @@
         }
       };
     }
+
+    window.guardian.productPrices = @Html(outputJson(productPrices))
   </script>
 
   @windowGuardianPaymentConfig(

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -38,6 +38,7 @@ trait Controllers {
     allSettingsProvider,
     appConfig.stage,
     implicitWs,
+    priceSummaryServiceProvider,
     appConfig.supportUrl,
   )
 

--- a/support-frontend/test/controllers/ApplicationTest.scala
+++ b/support-frontend/test/controllers/ApplicationTest.scala
@@ -14,6 +14,7 @@ import play.api.libs.ws.WSClient
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsString, header, stubControllerComponents}
 import services._
+import services.pricing.PriceSummaryServiceProvider
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -54,6 +55,7 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
         mock[AllSettingsProvider],
         mock[Stage],
         mock[WSClient],
+        mock[PriceSummaryServiceProvider],
         "support.thegulocal.com",
       )(mock[ExecutionContext]).healthcheck.apply(FakeRequest())
       contentAsString(result) mustBe "healthy"
@@ -76,6 +78,7 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
         mock[AllSettingsProvider],
         mock[Stage],
         mock[WSClient],
+        mock[PriceSummaryServiceProvider],
         "support.thegulocal.com",
       )(mock[ExecutionContext]).healthcheck.apply(FakeRequest())
       header("Cache-Control", result) mustBe Some("no-cache, private")


### PR DESCRIPTION
This puts the productPrices, including promoCodes on the to the window.guardian.productPrices field, which we will then be able to access in the React app to use promoCodes for Supporter Plus in the UI.


[**Trello Card**](https://trello.com/c/5t4LIRvo/564-promos-on-supporterplus-part-2-attach-active-promotions-to-supporterplus-thresholds-model-on-windowguardian)

## Why are you doing this?

To allow people to use promoCodes for Supporter Plus

## Screenshots
This shows an active `promoCode` in the productPrices with `promoCode` set in the URL. 

<img width="728" alt="Screenshot 2024-03-04 at 13 06 36" src="https://github.com/guardian/support-frontend/assets/31692/e54ee179-694f-4247-b1f6-1559013ab3ba">
