### PR TITLE
fix: add missing payment config to window.guardian

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -261,9 +261,12 @@ class Application(
 
   def checkout(countryGroupId: String): Action[AnyContent] = MaybeAuthenticatedAction { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
+
     val geoData = request.geoData
     val serversideTests = generateParticipations(Nil)
     val isTestUser = testUsers.isTestUser(request)
+    // This will be present if the token has been flashed into the session by the PayPal redirect endpoint
+    val guestAccountCreationToken = request.flash.get("guestAccountCreationToken")
 
     Ok(
       views.html.checkout(
@@ -280,6 +283,10 @@ class Application(
         ),
         v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(isTestUser).v2PublicKey,
         serversideTests = serversideTests,
+        paymentApiUrl = paymentAPIService.paymentAPIUrl,
+        paymentApiPayPalEndpoint = paymentAPIService.payPalCreatePaymentEndpoint,
+        membersDataApiUrl = membersDataApiUrl,
+        guestAccountCreationToken = guestAccountCreationToken,
       ),
     ).withSettingsSurrogateKey
   }

--- a/support-frontend/app/views/checkout.scala.html
+++ b/support-frontend/app/views/checkout.scala.html
@@ -8,6 +8,10 @@
   geoData: GeoData,
   serversideTests: Map[String,Participation],
   paymentMethodConfigs: PaymentMethodConfigs,
+  paymentApiUrl: String,
+  paymentApiPayPalEndpoint: String,
+  membersDataApiUrl: String,
+  guestAccountCreationToken: Option[String],
   v2recaptchaConfigPublicKey: String,
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
@@ -30,5 +34,9 @@
     paymentMethodConfigs = paymentMethodConfigs,
     v2recaptchaConfigPublicKey = v2recaptchaConfigPublicKey,
     settings = settings,
+    paymentApiUrl = paymentApiUrl,
+    paymentApiPayPalEndpoint = paymentApiPayPalEndpoint,
+    membersDataApiUrl = membersDataApiUrl,
+    guestAccountCreationToken = guestAccountCreationToken,
   )
 }

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -58,5 +58,9 @@
     paymentMethodConfigs = paymentMethodConfigs,
     v2recaptchaConfigPublicKey = v2recaptchaConfigPublicKey,
     settings = settings,
+    paymentApiUrl = paymentApiUrl,
+    paymentApiPayPalEndpoint = paymentApiPayPalEndpoint,
+    membersDataApiUrl = membersDataApiUrl,
+    guestAccountCreationToken = guestAccountCreationToken,
   )
 }

--- a/support-frontend/app/views/windowGuardianPaymentConfig.scala.html
+++ b/support-frontend/app/views/windowGuardianPaymentConfig.scala.html
@@ -2,7 +2,16 @@
 @import admin.settings.AllSettings
 @import views.html.helper.CSRF
 
-@(geoData: GeoData, paymentMethodConfigs: PaymentMethodConfigs, v2recaptchaConfigPublicKey: String, settings: AllSettings)(implicit request: RequestHeader)
+@(
+  geoData: GeoData,
+  paymentMethodConfigs: PaymentMethodConfigs,
+  paymentApiUrl: String,
+  paymentApiPayPalEndpoint: String,
+  membersDataApiUrl: String,
+  v2recaptchaConfigPublicKey: String,
+  guestAccountCreationToken: Option[String],
+  settings: AllSettings
+)(implicit request: RequestHeader)
 
 <script type="text/javascript">
   window.guardian.geoip = {
@@ -60,8 +69,15 @@
     test: "@paymentMethodConfigs.testAmazonPayConfig.clientId",
   };
 
+  window.guardian.paymentApiUrl = "@paymentApiUrl";
+  window.guardian.paymentApiPayPalEndpoint = "@paymentApiPayPalEndpoint";
+  window.guardian.mdapiUrl = "@membersDataApiUrl";
+  window.guardian.csrf = { token: "@CSRF.getToken.value" };
+
+  @guestAccountCreationToken.map { guestAccountCreationToken =>
+    window.guardian.guestAccountCreationToken = "@guestAccountCreationToken";
+  }
+
   window.guardian.recaptchaEnabled = @settings.switches.recaptchaSwitches.enableRecaptchaFrontend.isOn
   window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey";
-
-  window.guardian.csrf = { token: "@CSRF.getToken.value" };
 </script>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Adds the missing fields that were erroneously removed in https://github.com/guardian/support-frontend/pull/5759.

As a second PR I will try get some testing in that validates between server and [client](https://github.com/guardian/support-frontend/blob/main/support-frontend/window.d.ts) to make this a little more safe.

## Testing

This was tested locally and on `CODE` across single and recurring contributions.