### PR TITLE
use currency before country to determine stripe account to use

### DIFF
--- a/support-frontend/assets/components/stripe/contributionsStripe.tsx
+++ b/support-frontend/assets/components/stripe/contributionsStripe.tsx
@@ -24,8 +24,8 @@ export function ContributionsStripe({
 	children,
 	contributionTypeOverride,
 }: ContributionsStripeProps): JSX.Element {
-	const country = useContributionsSelector(
-		(state) => state.common.internationalisation.countryId,
+	const { countryId, currencyId } = useContributionsSelector(
+		(state) => state.common.internationalisation,
 	);
 	const contributionType =
 		contributionTypeOverride ?? useContributionsSelector(getContributionType);
@@ -38,7 +38,12 @@ export function ContributionsStripe({
 
 	useEffect(() => {
 		const stripeAccount = stripeAccountForContributionType[contributionType];
-		const publicKey = getStripeKey(stripeAccount, country, isTestUser);
+		const publicKey = getStripeKey(
+			stripeAccount,
+			countryId,
+			currencyId,
+			isTestUser,
+		);
 
 		dispatch(setStripeAccountName(stripeAccount));
 		dispatch(setStripePublicKey(publicKey));

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.test.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.test.tsx
@@ -56,6 +56,7 @@ describe('Stripe Form', () => {
 		validateForm = jest.fn();
 		props = {
 			country: 'GB',
+			currency: 'GBP',
 			isTestUser: true,
 			allErrors: [],
 			submitForm,

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.tsx
@@ -7,10 +7,12 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CsrfState } from 'helpers/redux/checkout/csrf/state';
 import type { FormField } from 'helpers/subscriptionsForms/formFields';
 import type { FormError } from 'helpers/subscriptionsForms/validation';
+import type { IsoCurrency } from '../../../helpers/internationalisation/currency';
 
 // Types
 export type PropTypes = {
 	country: IsoCountry;
+	currency: IsoCurrency;
 	isTestUser: boolean;
 	allErrors: Array<FormError<FormField>>;
 	submitForm: () => void;
@@ -23,7 +25,12 @@ function StripeProviderForCountry(props: PropTypes): JSX.Element {
 	const [stripeObject, setStripeObject] = useState<stripeJs.Stripe | null>(
 		null,
 	);
-	const stripeKey = getStripeKey('REGULAR', props.country, props.isTestUser);
+	const stripeKey = getStripeKey(
+		'REGULAR',
+		props.country,
+		props.currency,
+		props.isTestUser,
+	);
 	useEffect(() => {
 		if (stripeObject === null) {
 			void stripeJs.loadStripe(stripeKey).then(setStripeObject);

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -507,6 +507,7 @@ function PaperCheckoutForm(props: PropTypes) {
 					>
 						<StripeProviderForCountry
 							country={props.country}
+							currency={props.currencyId}
 							isTestUser={props.isTestUser}
 							submitForm={props.submitForm}
 							allErrors={

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -115,6 +115,7 @@ const buildStripeChargeDataFromAuthorisation = (
 	publicKey: getStripeKey(
 		stripeAccountForContributionType[getContributionType(state)],
 		state.common.internationalisation.countryId,
+		state.common.internationalisation.currencyId,
 		state.page.user.isTestUser,
 	),
 	recaptchaToken: state.page.checkoutForm.recaptcha.token,

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -449,6 +449,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
 					>
 						<StripeProviderForCountry
 							country={props.deliveryCountry}
+							currency={props.currencyId}
 							isTestUser={props.isTestUser}
 							submitForm={props.submitForm}
 							// @ts-expect-error TODO: fix when we can fix error states for all checkouts

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
@@ -404,6 +404,7 @@ function WeeklyCheckoutFormGifting(props: PropTypes): JSX.Element {
 					>
 						<StripeProviderForCountry
 							country={props.deliveryCountry}
+							currency={props.currencyId}
 							isTestUser={props.isTestUser}
 							submitForm={props.submitForm}
 							// @ts-expect-error TODO: Fixing the types around validation errors will affect every checkout, too much to tackle now


### PR DESCRIPTION
A reader was having trouble doing a recurring contribution.
It turns out the client side uses the AU stripe account if country=AU, and the server side does the same if currency=AUD.

On the client side a country code is taken from the geolocation cookie [1] and if it's within the country group (e.g. "KI" is within AUDCountries from "/**au**/contribute") then it will use that as the country.  The currency to offer is also taken from the country group.

This means that readers in AUD countries other than AU, would use the ROW stripe account on the client side and the AUS stripe account on the server side.

Since the idea of having an AUS stripe account is to reduce the chance of international transaction fees, the transactions will still go through even if we get it wrong.  Generally we think the currency is a good proxy for whether the bank is an AUS based one.

This PR makes it check the currency rather than the country.  For the US stripe account, it checks the country also, to maintain the old behaviour for single contributions.  This is so specific US only cards can be accepted.

Single contributions has code to POST the stripe public key, and then look it up, rather than making the same decision on client and server side separately.  We aim to follow the same pattern in recurring in the next PR.

Tested locally against CODE support-workers as follows:
billing country: GB, delivery country: AU,  AUD  GuardianWeekly
billing country: AU, delivery country: GB,  GBP  GuardianWeekly
billing country: GB,  GBP  SupporterPlus
billing country: AU,  AUD  SupporterPlus
billing country: KI,  AUD  Contribution


[1] https://github.com/guardian/support-frontend/blob/5c86d13562fa74900241b0612a152e0225389e6c/support-frontend/assets/helpers/internationalisation/classes/country.ts#L234