### PR TITLE
Skip thank you email on e2e test email address

### DIFF
--- a/support-e2e/tests/utils/users.ts
+++ b/support-e2e/tests/utils/users.ts
@@ -13,4 +13,10 @@ function generateString(length:number) {
 
 export const firstName = () => `${generateString(5)}TestF`;
 export const lastName = () => `${generateString(5)}TestL`;
-export const email = () => `test${uuidv4()}@theguardian.com`;
+/**
+ * This email is skipped when sending thank you emails from Braze in `support-workers`.
+ * If you change this here, you need to change it there too.
+ *
+ * see: support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+ */
+export const email = () => `test.e2e.supporter.revenue+${uuidv4()}@theguardian.com`;

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -57,11 +57,11 @@ object JsonFixtures {
       ),
       deliveryInstructions = Some("Leave with neighbour"),
     )
-  def userJson(id: String = idId): String =
+  def userJson(id: String = idId, primaryEmailAddress: String = emailAddress): String =
     s"""
       "user":{
           "id": "$id",
-          "primaryEmailAddress": "$emailAddress",
+          "primaryEmailAddress": "$primaryEmailAddress",
           "firstName": "test",
           "lastName": "user",
           "country": "GB",
@@ -813,6 +813,30 @@ object JsonFixtures {
           },
           "acquisitionData": $acquisitionData
         }"""
+  val sendAcquisitionEventJsonWithE2ETestUser =
+    s"""{
+          $requestIdJson,
+          "analyticsInfo": {
+            "paymentProvider": "Stripe",
+            "isGiftPurchase": false
+          },
+          "sendThankYouEmailState": {
+            "productType": "Contribution",
+            ${userJson(primaryEmailAddress =
+        "test.e2e.supporter.revenue+2b45f234-3969-49bf-b0fa-70c361737e76@theguardian.com",
+      )},
+            "salesForceContact": {
+                "Id": "0036E00000VlOPDQA3",
+                "AccountId": "0016E00000f17pYQAQ"
+            },
+            "product": ${contribution(currency = GBP)},
+            "paymentMethod": $stripePaymentMethod,
+            "accountNumber": "accountnumber123",
+            "subscriptionNumber": "subno123"
+          },
+          "acquisitionData": $acquisitionData
+        }"""
+
   val sendAcquisitionEventPrintJson =
     s"""
     {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Stops E2E email addresses triggering thank you from from Braze.

[**Trello Card**](https://trello.com/c/S5wJ92zV/685-skip-e2e-thank-you-emails-sending)

## Why are you doing this?
Currently we [generate email address via uuidv4](https://github.com/guardian/support-frontend/commit/c6e124bb2c65bb9a5a6fd499cd427105e7806a0f) in our playwright e2e tests.

This has created a situation where Braze is trying to send emails to non-existant email addresses and they are bouncing.

This is compounded by the fact that the `SendThankYouEmail` sends emails via the `PROD` Braze account, even for test users as the [Lambda SQS queue is set on instantiation](https://github.com/guardian/support-frontend/blob/main/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala#L25) where we have no context as to whether the user is test as that's stored in state.

Either way - the @guardian/value team are concerned that having these emails blasted out and bouncing from `CODE` or `PROD` might have a negative impact on our email reputation from email clients, so this just skips adding the email to queue all together.

## How to test

I've added and extended the integration test for the lambda, although I _think_ this doesn't run in CI. @johnduffell do you know?

## How can we measure success?

Fewer bouncing emails sent with no debugging ability lost.

## Have we considered potential risks?

The check of `startsWith` or `endsWith` could potentially block valid emails, although I really don't think this is the case.

I have also used an email that is to a specific email address, so we could move to another option discussed of setting that up as an email group and just blasting emails there.

We are also not sure if this is an issue for identity.

## Screenshots

<img width="382" alt="Screenshot 2024-03-12 at 10 29 15" src="https://github.com/guardian/support-frontend/assets/31692/ccaec6c2-f975-40be-abb3-36436319a33c">

