### PR TITLE
Stop showing top-tier TY page to standard GW checkouts

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.tsx
@@ -24,7 +24,6 @@ import {
 	manageSubsUrl,
 } from 'helpers/urls/externalLinks';
 import { formatUserDate } from 'helpers/utilities/dateConversions';
-import { threeTierCheckoutEnabled } from 'pages/supporter-plus-landing/setup/threeTierChecks';
 import { tierCards } from 'pages/supporter-plus-landing/setup/threeTierConfig';
 
 const styles = moduleStyles as {
@@ -36,8 +35,6 @@ const styles = moduleStyles as {
 function mapStateToProps(state: SubscriptionsState) {
 	return {
 		...getFormFields(state),
-		participations: state.common.abParticipations,
-		countryId: state.common.internationalisation.countryId,
 	};
 }
 
@@ -165,10 +162,10 @@ function ThankYouContent({
 	isPending,
 	orderIsGift,
 	product,
-	participations,
-	countryId,
 }: PropTypes) {
-	const inThreeTier = threeTierCheckoutEnabled(participations, countryId);
+	const urlParams = new URLSearchParams(window.location.search);
+	const inThreeTier =
+		urlParams.get('threeTierCreateSupporterPlusSubscription') === 'true';
 
 	const whatHappensNextItems = orderIsGift
 		? [


### PR DESCRIPTION
## What are you doing in this PR?

`threeTierCheckoutEnabled` was returning `true` 

Instead of using this on GW checkout pages we can use the presence of the `threeTierCreateSupporterPlusSubscription` query string param as indication they're on the top-tier checkout as we no longer use the participation in a 3-tier AB test. 