### PR TITLE
fix: prefix names with test info in e2e

### DIFF
--- a/support-e2e/tests/utils/users.ts
+++ b/support-e2e/tests/utils/users.ts
@@ -1,16 +1,19 @@
-import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuidv4 } from "uuid";
 
-const characters ='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+const characters =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
-function generateString(length:number) {
-    let result = '';
-    const charactersLength = characters.length;
-    for ( let i = 0; i < length; i++ ) {
-        result += characters.charAt(Math.floor(Math.random() * charactersLength));
-    }
-    return result;
+function generateString(length: number) {
+  let result = "";
+  const charactersLength = characters.length;
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+  }
+  return result;
 }
 
-export const firstName = () => `${generateString(5)}TestF`;
-export const lastName = () => `${generateString(5)}TestL`;
+export const firstName = () =>
+  `test.support.frontend.e2e.firstName+${generateString(5)}`;
+export const lastName = () =>
+  `test.support.frontend.e2e.lastName+${generateString(5)}`;
 export const email = () => `test${uuidv4()}@theguardian.com`;


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
[As per @johnduffell's good suggestion](https://github.com/guardian/support-frontend/pull/5779/files#r1521347342), let's prefix the names to help for ordering and search.

I've tried to keep the data in the name that might allow people to identify where this test user came from.

Related to #5779 
