### PR TITLE
Fix threeTierCheckoutEnabled conditional check on GW checkouts

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierChecks.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierChecks.ts
@@ -6,6 +6,14 @@ export const threeTierCheckoutEnabled = (
 	abParticipations: Participations,
 	countryId: IsoCountry,
 ): boolean => {
+	const isWeeklyCheckout =
+		window.location.pathname === '/subscribe/weekly/checkout';
+
+	if (isWeeklyCheckout) {
+		const urlParams = new URLSearchParams(window.location.search);
+		return urlParams.get('threeTierCreateSupporterPlusSubscription') === 'true';
+	}
+
 	const displayPatronsCheckout = !!abParticipations.patronsOneOffOnly;
 	const displaySupportPlusOnlyCheckout = !!abParticipations.supporterPlusOnly;
 


### PR DESCRIPTION
## What are you doing in this PR?

We call `threeTierCheckoutEnabled` from [submit.ts](https://github.com/guardian/support-frontend/blob/main/support-frontend/assets/helpers/subscriptionsForms/submit.ts#L246 ) when building the payload to send to the `/create` endpoint. This logic is shared between the `/contribute` checkout and the `/subscribe` checkouts.

However in the standard GW checkout `threeTierCheckoutEnabled` was returning `true` (as the checks in `threeTierCheckoutEnabled` were only relevant to the `/contribute`  checkout, the consequence was we were setting `threeTierCreateSupporterPlusSubscription: true` in the payload for standard non 3-tier checkouts.

To resolve this I've made `threeTierCheckoutEnabled` work so it'll only return true for users on the GW checkout when the `threeTierCreateSupporterPlusSubscription` is present.