### PR TITLE
Update threeTierCheckoutEnabled to also identify GW Gift checkout as …

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierChecks.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierChecks.ts
@@ -6,8 +6,9 @@ export const threeTierCheckoutEnabled = (
 	abParticipations: Participations,
 	countryId: IsoCountry,
 ): boolean => {
-	const isWeeklyCheckout =
-		window.location.pathname === '/subscribe/weekly/checkout';
+	const isWeeklyCheckout = window.location.pathname.startsWith(
+		'/subscribe/weekly/checkout',
+	);
 
 	if (isWeeklyCheckout) {
 		const urlParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## What are you doing in this PR?

Edit the `threeTierCheckoutEnabled` logic introduced here: https://github.com/guardian/support-frontend/pull/5783 so we also identify Guardian Weekly Gift checkouts when defining `isWeeklyCheckout`.

**Non-GW-gift window.location.pathname:** '/subscribe/weekly/checkout'
**Gift-GW window.location.pathname:** '/subscribe/weekly/checkout/gift'