### PR TITLE
Add test + variant names to the output of the acquisitions lambda

### DIFF
--- a/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/AcquisitionToJson.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/AcquisitionToJson.scala
@@ -1,7 +1,7 @@
 package com.gu.acquisitionFirehoseTransformer
 
 import com.gu.support.acquisitions.models.AcquisitionDataRow
-
+import com.gu.support.acquisitions.AbTest
 import io.circe.Json
 import io.circe.generic.auto._
 import io.circe.syntax._
@@ -26,6 +26,7 @@ object AcquisitionToJson {
       paymentProvider: String,
       referrerUrl: String,
       labels: List[String],
+      abTests: List[AbTest],
   )
 
   def apply(
@@ -48,6 +49,7 @@ object AcquisitionToJson {
       acquisition.paymentProvider.map(_.value).getOrElse(""),
       acquisition.referrerUrl.getOrElse(""),
       acquisition.labels,
+      acquisition.abTests,
     ).asJson
   }
 }

--- a/support-lambdas/acquisitions-firehose-transformer/src/test/scala/com/gu/acquisitionFirehoseTransformer/LambdaSpec.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/test/scala/com/gu/acquisitionFirehoseTransformer/LambdaSpec.scala
@@ -4,6 +4,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 
 import com.gu.support.acquisitions.models._
+import com.gu.support.acquisitions.AbTest
 import com.amazonaws.services.lambda.runtime.events.KinesisFirehoseEvent
 
 import io.circe.syntax._
@@ -37,10 +38,10 @@ class LambdaSpec extends AnyFlatSpec with Matchers {
     val jsons = records.toList.map { record => new String(record.getData().array()) }
 
     jsons(0) should be(
-      """{"paymentFrequency":"MONTHLY","countryCode":"GB","amount":10.0,"annualisedValue":100.18037999999999,"annualisedValueGBP":120.21645599999998,"currency":"USD","timestamp":"2018-12-13 14:15:04","campaignCode":"MY_CAMPAIGN_CODE","componentId":"MY_COMPONENT_ID","product":"RECURRING_CONTRIBUTION","paymentProvider":"STRIPE","referrerUrl":"referrer-url","labels":[]}""" + '\n',
+      """{"paymentFrequency":"MONTHLY","countryCode":"GB","amount":10.0,"annualisedValue":100.18037999999999,"annualisedValueGBP":120.21645599999998,"currency":"USD","timestamp":"2018-12-13 14:15:04","campaignCode":"MY_CAMPAIGN_CODE","componentId":"MY_COMPONENT_ID","product":"RECURRING_CONTRIBUTION","paymentProvider":"STRIPE","referrerUrl":"referrer-url","labels":[],"abTests":[{"name":"name","variant":"variant"}]}""" + '\n',
     )
     jsons(1) should be(
-      """{"paymentFrequency":"MONTHLY","countryCode":"GB","amount":20.0,"annualisedValue":200.36075999999997,"annualisedValueGBP":240.43291199999996,"currency":"USD","timestamp":"2018-12-13 14:15:04","campaignCode":"MY_CAMPAIGN_CODE","componentId":"MY_COMPONENT_ID","product":"RECURRING_CONTRIBUTION","paymentProvider":"STRIPE","referrerUrl":"referrer-url","labels":[]}""" + '\n',
+      """{"paymentFrequency":"MONTHLY","countryCode":"GB","amount":20.0,"annualisedValue":200.36075999999997,"annualisedValueGBP":240.43291199999996,"currency":"USD","timestamp":"2018-12-13 14:15:04","campaignCode":"MY_CAMPAIGN_CODE","componentId":"MY_COMPONENT_ID","product":"RECURRING_CONTRIBUTION","paymentProvider":"STRIPE","referrerUrl":"referrer-url","labels":[],"abTests":[{"name":"name","variant":"variant"}]}""" + '\n',
     )
   }
 
@@ -70,7 +71,7 @@ class LambdaSpec extends AnyFlatSpec with Matchers {
       campaignCode = Some("MY_CAMPAIGN_CODE"),
       source = None,
       referrerUrl = Some("referrer-url"),
-      abTests = Nil,
+      abTests = List(AbTest("name", "variant")),
       paymentFrequency = PaymentFrequency.Monthly,
       paymentProvider = Some(PaymentProvider.Stripe),
       printOptions = None,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Add test + variant names to the output of the acquisitions lambda

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

To support the multi-armed bandit prototype [(point 2b)](https://docs.google.com/document/d/1jV6DkkLLH90PetO1Os7c6pi8WEiCx2t9BUIraqIEAHU/edit)

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Deploy to `CODE`, we should start getting the data in S3

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
