### PR TITLE
Change prefix format so email addresses generated by e2e tests pass validation

### DIFF
--- a/support-e2e/tests/utils/users.ts
+++ b/support-e2e/tests/utils/users.ts
@@ -12,10 +12,8 @@ function generateString(length: number) {
   return result;
 }
 
-export const firstName = () =>
-  `test.support.frontend.e2e.firstName+${generateString(5)}`;
-export const lastName = () =>
-  `test.support.frontend.e2e.lastName+${generateString(5)}`;
+export const firstName = () => `e2e.firstName+${generateString(5)}`;
+export const lastName = () => `e2e.lastName+${generateString(5)}`;
 /**
  * This email needs to end with @thegulocal.com.
  *
@@ -25,5 +23,4 @@ export const lastName = () =>
  *
  * @see https://github.com/guardian/membership-workflow/blob/99e2b90305f93bf35ce230f6b6c17e0c4533facb/app/model/BrazeCampaignTriggerPayload.scala#L28
  **/
-export const email = () =>
-  `test.support.frontend.e2e+${uuidv4()}@thegulocal.com`;
+export const email = () => `e2e.email+${uuidv4()}@thegulocal.com`;


### PR DESCRIPTION
## What are you doing in this PR?

We made change in https://github.com/guardian/support-frontend/pull/5779 that meant we started generating email addresses that are greater than 80 characters long for the GW Gift tests as these tests prepend 'giftee-' to the email address generated by the `email()` function. 

80 characters is the maximum email address length accepted by SalesForce, so the e2e tests are failing the GW Gift tests as the `CreateSalesforceContact` step in the `Support-Workers-Prod` step functions is now failing Salesforce's validation.