### PR TITLE
update support-workers to java21 runtime

### DIFF
--- a/support-workers/cloud-formation/src/templates/lambda.yaml
+++ b/support-workers/cloud-formation/src/templates/lambda.yaml
@@ -10,5 +10,5 @@
     Code:
       S3Bucket: support-workers-dist
       S3Key: !Sub support/${Stage}/support-workers/support-workers.jar
-    Runtime: "java11"
+    Runtime: "java21"
     Timeout: "60"


### PR DESCRIPTION
This PR bumps support workers to java 21.  This is supposed to give us performance improvements.
https://aws.amazon.com/blogs/compute/java-17-runtime-now-available-on-aws-lambda/
https://aws.amazon.com/about-aws/whats-new/2023/11/aws-lambda-support-java-21/

We are using scala 2.13.12 which is compatible with JRE21
https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html

I have tested in CODE and looking at one lambda (create payment method) you can clearly see the performance improvement for the cold start
<img width="597" alt="image" src="https://github.com/guardian/support-frontend/assets/7304387/370a6b03-2ed4-4453-93b2-30c4f9780bc5">



This is replicated for the whole state machine execution, although it is diluted by the different paths it can take through the state machine.
<img width="485" alt="image" src="https://github.com/guardian/support-frontend/assets/7304387/090eb733-2e62-408f-b0b6-db9399b5fa2e">

