### PR TITLE
update support-workers to arm64 architecture

### DIFF
--- a/support-workers/cloud-formation/src/templates/lambda.yaml
+++ b/support-workers/cloud-formation/src/templates/lambda.yaml
@@ -12,3 +12,5 @@
       S3Key: !Sub support/${Stage}/support-workers/support-workers.jar
     Runtime: "java21"
     Timeout: "60"
+    Architectures:
+      - arm64


### PR DESCRIPTION
following on from https://github.com/guardian/support-frontend/pull/5792
this PR updates support workers to arm64 architecture.

This is not necessarily faster than x86, but it costs slightly less.  Since we have been using arm64 on our instances, it seems safe to swtich on our lambdas.

Tested in CODE and the latency cold start was slower for an individual lambda:
<img width="446" alt="image" src="https://github.com/guardian/support-frontend/assets/7304387/b1c2bd1e-e01f-4a23-9299-8fc7cbb19113">


but only slightly slower overall for the state machine, suggesting it might share something?
<img width="558" alt="image" src="https://github.com/guardian/support-frontend/assets/7304387/a2ec289d-c13d-4761-9aa5-6f1f70fdd473">

I am in two minds whether to ship it - it would save us a tiny amount of money as arm is cheaper, also most of our production runs are warmed up so there's no cold start.  Given that we don't really do any processing when warm - most of the time is spent waiting for SF/Zuora/etc in actual runs, I doubt we will notice any benefit for warm runs.

Any thoughts?  Go or no go?