### PR TITLE
Update subscription landing page e2e tests to verify presence of expected HTML element

### DIFF
--- a/support-e2e/tests/landingPages.test.ts
+++ b/support-e2e/tests/landingPages.test.ts
@@ -16,7 +16,10 @@ test.describe("Paper product page", () => {
     const domain = new URL(pageUrl).hostname;
     await setTestCookies(context, firstName(), domain);
     await page.goto(pageUrl);
-    await page.locator("id=qa-paper-subscriptions").isVisible();
+    const pageRendered = await page
+      .locator("id=qa-paper-subscriptions")
+      .isVisible();
+    expect(pageRendered).toBeTruthy();
     await expect(page).toHaveURL(/\/uk\/subscribe\/paper/);
   });
 });
@@ -32,8 +35,10 @@ test.describe("Weekly product page", () => {
     const domain = new URL(pageUrl).hostname;
     await setTestCookies(context, firstName(), domain);
     await page.goto(pageUrl);
-
-    await page.locator("id=qa-guardian-weekly").isVisible();
+    const pageRendered = await page
+      .locator("id=qa-guardian-weekly")
+      .isVisible();
+    expect(pageRendered).toBeTruthy();
     await expect(page).toHaveURL(/\/uk\/subscribe\/weekly/);
   });
 });
@@ -49,8 +54,10 @@ test.describe("Weekly gift product page", () => {
     const domain = new URL(pageUrl).hostname;
     await setTestCookies(context, firstName(), domain);
     await page.goto(pageUrl);
-
-    await page.locator("id=qa-guardian-weekly-gift").isVisible();
+    const pageRendered = await page
+      .locator("id=qa-guardian-weekly-gift")
+      .isVisible();
+    expect(pageRendered).toBeTruthy();
     await expect(page).toHaveURL(/\/uk\/subscribe\/weekly\/gift/);
   });
 });
@@ -66,8 +73,10 @@ test.describe("Subscriptions landing page", () => {
     const domain = new URL(pageUrl).hostname;
     await setTestCookies(context, firstName(), domain);
     await page.goto(pageUrl);
-
-    await page.locator("id=qa-subscriptions-landing-page").isVisible();
+    const pageRendered = await page
+      .locator("id=qa-subscriptions-landing-page")
+      .isVisible();
+    expect(pageRendered).toBeTruthy();
     await expect(page).toHaveURL(/\/uk\/subscribe/);
   });
 });


### PR DESCRIPTION
## What are you doing in this PR?

It doesn't look like the e2e tests in `landingPages.test.ts` were actually testing anything.  This line in the tests `await page.locator("id=qa-paper-subscriptions").isVisible();`, would eventually resolve with `true` (element present) or `false` (element not present) however we didn't do anything with the return value of `isVisible`, so for example I could update the test to look for an element that doesn't exist `await page.locator("id=hello-world").isVisible();` and the test would still pass. The only expectation was to confirm the URL matched what we'd specified it is in the test.