### PR TITLE
Reduce retry count in Playwright config

### DIFF
--- a/support-e2e/.prettierrc.js
+++ b/support-e2e/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+	...require('@guardian/prettier'),
+};

--- a/support-e2e/package.json
+++ b/support-e2e/package.json
@@ -13,6 +13,7 @@
 	},
 	"devDependencies": {
 		"dotenv": "^16.3.1",
-		"prettier": "^3.0.3"
+		"prettier": "^3.0.3",
+    "@guardian/prettier": "^8.0.0"
 	}
 }

--- a/support-e2e/playwright.base.config.ts
+++ b/support-e2e/playwright.base.config.ts
@@ -1,37 +1,37 @@
-import { devices } from "@playwright/test";
-import type { PlaywrightTestConfig } from "@playwright/test";
+import { devices } from '@playwright/test';
+import type { PlaywrightTestConfig } from '@playwright/test';
 
 export const baseObject: PlaywrightTestConfig = {
-  testDir: "tests",
-  testMatch: "**/*.test.ts",
+	testDir: 'tests',
+	testMatch: '**/*.test.ts',
 
-  /* Maximum time one test can run for. */
-  timeout: 120 * 1000,
-  expect: {
-    timeout: 90000,
-  },
-  fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
-  retries: 1,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  reporter: "html",
-  use: {
-    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-    actionTimeout: 0,
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: "on-first-retry",
-    baseURL: "https://support.theguardian.com",
-  },
+	/* Maximum time one test can run for. */
+	timeout: 120 * 1000,
+	expect: {
+		timeout: 90000,
+	},
+	fullyParallel: true,
+	/* Fail the build on CI if you accidentally left test.only in the source code. */
+	forbidOnly: !!process.env.CI,
+	retries: 1,
+	/* Opt out of parallel tests on CI. */
+	workers: process.env.CI ? 1 : undefined,
+	reporter: 'html',
+	use: {
+		/* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+		actionTimeout: 0,
+		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+		trace: 'on-first-retry',
+		baseURL: 'https://support.theguardian.com',
+	},
 
-  projects: [
-    {
-      name: "chromium",
-      use: {
-        ...devices["Desktop Chrome"],
-        viewport: { width: 1280, height: 720 },
-      },
-    },
-  ],
+	projects: [
+		{
+			name: 'chromium',
+			use: {
+				...devices['Desktop Chrome'],
+				viewport: { width: 1280, height: 720 },
+			},
+		},
+	],
 };

--- a/support-e2e/playwright.base.config.ts
+++ b/support-e2e/playwright.base.config.ts
@@ -1,37 +1,37 @@
-import { devices } from '@playwright/test';
-import type { PlaywrightTestConfig } from '@playwright/test';
+import { devices } from "@playwright/test";
+import type { PlaywrightTestConfig } from "@playwright/test";
 
 export const baseObject: PlaywrightTestConfig = {
-	testDir: 'tests',
-	testMatch: '**/*.test.ts',
+  testDir: "tests",
+  testMatch: "**/*.test.ts",
 
-	/* Maximum time one test can run for. */
-	timeout: 120 * 1000,
-	expect: {
-		timeout: 90000,
-	},
-	fullyParallel: true,
-	/* Fail the build on CI if you accidentally left test.only in the source code. */
-	forbidOnly: !!process.env.CI,
-	retries: 3,
-	/* Opt out of parallel tests on CI. */
-	workers: process.env.CI ? 1 : undefined,
-	reporter: 'html',
-	use: {
-		/* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-		actionTimeout: 0,
-		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-		trace: 'on-first-retry',
-		baseURL: 'https://support.theguardian.com',
-	},
+  /* Maximum time one test can run for. */
+  timeout: 120 * 1000,
+  expect: {
+    timeout: 90000,
+  },
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  retries: 1,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+    baseURL: "https://support.theguardian.com",
+  },
 
-	projects: [
-		{
-			name: 'chromium',
-			use: {
-				...devices['Desktop Chrome'],
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
         viewport: { width: 1280, height: 720 },
-			},
-		},
-	],
+      },
+    },
+  ],
 };

--- a/support-e2e/yarn.lock
+++ b/support-e2e/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@guardian/prettier@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-8.0.0.tgz#d621f01ad5ae7fa8579a966045ed0e3748beaede"
+  integrity sha512-Q2z9jDTf+38hXpfXSq4whbvfh5CpkB+z7DbL6AvO3O0+Kl6/FOCQLyFJe3YWT1WnnZPf/iF3VvVr/zjtRcBkuA==
+
 "@playwright/test@1.40.1":
   version "1.40.1"
   resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.40.1.tgz#9e66322d97b1d74b9f8718bacab15080f24cde65"


### PR DESCRIPTION
## What are you doing in this PR?

We have set up our Playwright config to retry a failing test up to 3 times. This means if the tests fai the time taken to test & retry 3 times exceeds Github Action’s maximum execution time of 30 minutes, the consequence of this is the Action won't post about the failed test to Google Chat, which is the most visible way to notify engineers to learn the e2e Action has failed.

I therefore propose in the PR to reduce the retry count from 3 to 1. 

PRO: The Action is more likely to complete within 30 mins, if it fails we learn about a failed test quickly via the Action posting to Google Chat.

CON: We may fail tests on transient issues which may have been resolved after multiple retries? I think it's worth testing with a lower retry count and seeing if this is an issue.

