### PR TITLE
Update student discount percent

### DIFF
--- a/support-frontend/assets/components/product/giftNonGiftCta.tsx
+++ b/support-frontend/assets/components/product/giftNonGiftCta.tsx
@@ -46,7 +46,7 @@ function GiftOrPersonalOrStudent({
 						: 'Gift subscriptions'}
 				</h2>
 				{isStudent ? (
-					<p>{product}s get 70% off a Guardian Weekly subscription.</p>
+					<p>{product}s get 50% off a Guardian Weekly subscription.</p>
 				) : (
 					!orderIsAGift && <p>A {product} subscription makes a great gift.</p>
 				)}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Updating the copy for student discounts to accurately reflect the student beans %

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/h2WCOpNo/285-change-gw-student-deal-copy-to-50)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots

![image](https://github.com/guardian/support-frontend/assets/114918544/5a20b5e1-235a-49c0-b0ce-30b26694c1c3)
