### PR TITLE
make support-frontend use java 21

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -77,13 +77,17 @@ def getFiles(rootFile: File, deployName: String): Seq[(File, String)] = {
   getFiles0(rootFile)
 }
 
-Universal / javaOptions ++= Seq(
-  "-Dpidfile.path=/dev/null",
-  "-J-XX:MaxMetaspaceSize=256m",
-  "-J-XX:+PrintGCDetails",
-  s"-J-Xloggc:/var/log/${packageName.value}/gc.log",
+val jvmParameters = Def.setting(Seq(
+  "-XX:MaxMetaspaceSize=256m",
+  s"-Xlog:gc*:/var/log/${packageName.value}/gc.log", // https://docs.azul.com/prime/Unified-GC-Logging#enabling-unified-gc-logging
   "-XX:-OmitStackTraceInFastThrow",
+))
+val playParameters = Seq(
+  "-Dpidfile.path=/dev/null", // https://www.playframework.com/documentation/3.0.x/ProductionConfiguration#Changing-the-path-of-RUNNING_PID
 )
+// -J tells the packager to pass it through to the JVM
+// https://www.scala-sbt.org/sbt-native-packager/archetypes/java_app/customize.html#via-build-sbt
+Universal / javaOptions ++= playParameters ++ jvmParameters.value.map(param => "-J" + param)
 
 addCommandAlias(
   "devrun",

--- a/support-frontend/conf/riff-raff.yaml
+++ b/support-frontend/conf/riff-raff.yaml
@@ -21,7 +21,7 @@ deployments:
         PROD: Frontend-PROD.template.json
       amiParameter: AMIFrontend
       amiTags:
-        Recipe: jammy-membership-java11
+        Recipe: jammy-membership-java21
         AmigoStage: PROD
       amiEncrypted: true
   frontend:


### PR DESCRIPTION
Since updating support-workers to java 21, the cold start time has improved a lot.

This PR updates support-frontend to java 21 by using the new AMI that I created and baked
https://amigo.gutools.co.uk/recipes/jammy-membership-java21

This is as per the new recommendation in https://docs.google.com/document/d/1ZR-YnaXCT5_gLVmTCeGs0mWd3KPaAozPjQK8uUzHZ9w/edit

Tested in CODE and working to buy a middle tier (supporter plus)