### PR TITLE
make payment-api use java 21

### DIFF
--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -50,18 +50,12 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
-      - name: Setup Java 11
+      - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: "11"
+          java-version: "21"
           distribution: "corretto"
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.ivy2/cache
-            ~/.sbt
-            ~/.coursier
-          key: sbt
+          cache: sbt
 
       - name: Build and upload to RiffRaff
         run: |

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val release = Seq[ReleaseStep](
 inThisBuild(
   Seq(
     organization := "com.gu",
-    scalaVersion := "2.13.12",
+    scalaVersion := "2.13.13",
     // https://www.scala-sbt.org/1.x/docs/Cached-Resolution.html
     updateOptions := updateOptions.value.withCachedResolution(true),
     resolvers ++= Resolver.sonatypeOssRepos("releases"), // libraries that haven't yet synced to maven central

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val release = Seq[ReleaseStep](
 inThisBuild(
   Seq(
     organization := "com.gu",
-    scalaVersion := "2.13.13",
+    scalaVersion := "2.13.12",
     // https://www.scala-sbt.org/1.x/docs/Cached-Resolution.html
     updateOptions := updateOptions.value.withCachedResolution(true),
     resolvers ++= Resolver.sonatypeOssRepos("releases"), // libraries that haven't yet synced to maven central

--- a/support-internationalisation/build.sbt
+++ b/support-internationalisation/build.sbt
@@ -2,8 +2,8 @@ import sbtrelease.ReleaseStateTransformations._
 
 name := "support-internationalisation"
 
-scalaVersion := "3.3.3" // beware >= 3.1.3 has an incompatibility with <= 2.13.8 which causes compile issue `Unsupported Scala 3 generic tuple type scala.Tuple in bounds of type MirroredElemTypes; found in  scala.deriving.Mirror.<refinement>.`
-crossScalaVersions := Seq("2.13.8", "3.3.3")
+scalaVersion := "3.3.3"
+crossScalaVersions := Seq("2.13.13", "3.3.3")
 
 description := "Scala library to provide internationalisation classes to Guardian Membership/Subscriptions/support projects."
 

--- a/support-internationalisation/build.sbt
+++ b/support-internationalisation/build.sbt
@@ -2,8 +2,8 @@ import sbtrelease.ReleaseStateTransformations._
 
 name := "support-internationalisation"
 
-scalaVersion := "3.2.2" // beware >= 3.1.3 has an incompatibility with <= 2.13.8 which causes compile issue `Unsupported Scala 3 generic tuple type scala.Tuple in bounds of type MirroredElemTypes; found in  scala.deriving.Mirror.<refinement>.`
-crossScalaVersions := Seq("2.13.8", "3.2.2")
+scalaVersion := "3.3.3" // beware >= 3.1.3 has an incompatibility with <= 2.13.8 which causes compile issue `Unsupported Scala 3 generic tuple type scala.Tuple in bounds of type MirroredElemTypes; found in  scala.deriving.Mirror.<refinement>.`
+crossScalaVersions := Seq("2.13.8", "3.3.3")
 
 description := "Scala library to provide internationalisation classes to Guardian Membership/Subscriptions/support projects."
 

--- a/support-payment-api/project/build.properties
+++ b/support-payment-api/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.1.0

--- a/support-payment-api/project/plugins.sbt
+++ b/support-payment-api/project/plugins.sbt
@@ -1,8 +1,0 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.4")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.8.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-
-libraryDependencies += "org.vafer" % "jdeb" % "1.10" artifacts (Artifact("jdeb", "jar", "jar"))

--- a/support-payment-api/src/main/resources/riff-raff.yaml
+++ b/support-payment-api/src/main/resources/riff-raff.yaml
@@ -10,7 +10,7 @@ deployments:
     parameters:
       amiParameter: AMIPaymentapi
       amiTags:
-        Recipe: jammy-membership-java11
+        Recipe: jammy-membership-java21
         AmigoStage: PROD
       amiEncrypted: true
       templateStagePaths:


### PR DESCRIPTION
This PR follows on from updating support-frontend to java 21 https://github.com/guardian/support-frontend/pull/5801

This one updates payment api similarly, also updates the JDK used to compile to java 21

Note there is a bug in 2.13.13 so I didn't update the main scala version, but it will be fixed in 2.13.14 https://github.com/scala/bug/issues/12955

Payment API deploys ok in CODE and I could do a single contribution