### PR TITLE
Three tier: S+ promoCode non-visual optimisations PT2

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -83,6 +83,11 @@ const buttonOverrides = css`
 	}
 `;
 
+const originalPriceStrikeThrough = css`
+	font-weight: 400;
+	text-decoration: line-through;
+`;
+
 const iconCss = (flip: boolean) => css`
 	svg {
 		max-width: ${space[4]}px;
@@ -118,6 +123,7 @@ const termsAndConditions = css`
 export type ContributionsOrderSummaryProps = {
 	description: string;
 	total: number;
+	totalOriginal?: number;
 	currency: Currency;
 	enableCheckList: boolean;
 	checkListData: CheckListData[];
@@ -135,6 +141,7 @@ export type ContributionsOrderSummaryProps = {
 export function ContributionsOrderSummary({
 	description,
 	total,
+	totalOriginal,
 	currency,
 	paymentFrequency,
 	checkListData,
@@ -156,6 +163,10 @@ export function ContributionsOrderSummary({
 	);
 
 	const formattedTotal = simpleFormatAmount(currency, total);
+	const formattedTotalOriginal = simpleFormatAmount(
+		currency,
+		totalOriginal ?? '',
+	);
 
 	return (
 		<div css={componentStyles}>
@@ -195,6 +206,11 @@ export function ContributionsOrderSummary({
 			<div css={[summaryRow, rowSpacing, boldText, totalRow(!!tsAndCs)]}>
 				<p>Total</p>
 				<p>
+					{totalOriginal && (
+						<span css={originalPriceStrikeThrough}>
+							{formattedTotalOriginal}
+						</span>
+					)}{' '}
 					{paymentFrequency
 						? `${formattedTotal}/${paymentFrequency}`
 						: formattedTotal}

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
@@ -1,6 +1,20 @@
 import { checkListData } from 'components/checkoutBenefits/checkoutBenefitsListData';
 import type { ContributionType } from 'helpers/contributions';
+import type { IsoCountry } from 'helpers/internationalisation/country';
 import { currencies } from 'helpers/internationalisation/currency';
+import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
+import {
+	type FulfilmentOptions,
+	NoFulfilmentOptions,
+} from 'helpers/productPrice/fulfilmentOptions';
+import {
+	NoProductOptions,
+	type ProductOptions,
+} from 'helpers/productPrice/productOptions';
+import {
+	getCountryGroup,
+	type ProductPrices,
+} from 'helpers/productPrice/productPrices';
 import { isSupporterPlusFromState } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
@@ -45,10 +59,38 @@ export function ContributionsOrderSummaryContainer({
 }: ContributionsOrderSummaryContainerProps): JSX.Element {
 	const contributionType = useContributionsSelector(getContributionType);
 
-	const { currencyId } = useContributionsSelector(
+	const { countryId, currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
-	const selectedAmount = useContributionsSelector(getUserSelectedAmount);
+	const { productType } = useContributionsSelector(
+		(state) => state.page.checkoutForm.product,
+	);
+	const billingPeriod = (productType[0] +
+		productType.slice(1).toLowerCase()) as BillingPeriod;
+	const currentPrice = useContributionsSelector(getUserSelectedAmount);
+	const originalPrice = useContributionsSelector((state) =>
+		getOriginalPrice(
+			state.page.checkoutForm.product.productPrices,
+			countryId,
+			billingPeriod,
+		),
+	);
+
+	function getOriginalPrice(
+		productPrices: ProductPrices,
+		country: IsoCountry,
+		billingPeriod: BillingPeriod,
+		fulfilmentOption: FulfilmentOptions = NoFulfilmentOptions,
+		productOption: ProductOptions = NoProductOptions,
+	): number | undefined {
+		const countryGroup = getCountryGroup(country);
+		const originalPrice =
+			productPrices[countryGroup.name]?.[fulfilmentOption]?.[productOption]?.[
+				billingPeriod
+			]?.[countryGroup.currency]?.price ?? 0;
+		return originalPrice > currentPrice ? originalPrice : undefined;
+	}
+
 	const isSupporterPlus = useContributionsSelector(isSupporterPlusFromState);
 
 	const currency = currencies[currencyId];
@@ -92,7 +134,8 @@ export function ContributionsOrderSummaryContainer({
 
 	return renderOrderSummary({
 		description,
-		total: selectedAmount,
+		total: currentPrice,
+		totalOriginal: isSupporterPlus ? originalPrice : undefined,
 		currency: currency,
 		paymentFrequency,
 		enableCheckList: contributionType !== 'ONE_OFF',

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
@@ -53,6 +53,22 @@ function getTermsConditions(
 	);
 }
 
+function getOriginalPrice(
+	productPrices: ProductPrices,
+	currentPrice: number,
+	country: IsoCountry,
+	billingPeriod: BillingPeriod,
+	fulfilmentOption: FulfilmentOptions = NoFulfilmentOptions,
+	productOption: ProductOptions = NoProductOptions,
+): number | undefined {
+	const countryGroup = getCountryGroup(country);
+	const originalPrice =
+		productPrices[countryGroup.name]?.[fulfilmentOption]?.[productOption]?.[
+			billingPeriod
+		]?.[countryGroup.currency]?.price ?? 0;
+	return originalPrice > currentPrice ? originalPrice : undefined;
+}
+
 export function ContributionsOrderSummaryContainer({
 	inThreeTier,
 	renderOrderSummary,
@@ -71,25 +87,11 @@ export function ContributionsOrderSummaryContainer({
 	const originalPrice = useContributionsSelector((state) =>
 		getOriginalPrice(
 			state.page.checkoutForm.product.productPrices,
+			currentPrice,
 			countryId,
 			billingPeriod,
 		),
 	);
-
-	function getOriginalPrice(
-		productPrices: ProductPrices,
-		country: IsoCountry,
-		billingPeriod: BillingPeriod,
-		fulfilmentOption: FulfilmentOptions = NoFulfilmentOptions,
-		productOption: ProductOptions = NoProductOptions,
-	): number | undefined {
-		const countryGroup = getCountryGroup(country);
-		const originalPrice =
-			productPrices[countryGroup.name]?.[fulfilmentOption]?.[productOption]?.[
-				billingPeriod
-			]?.[countryGroup.currency]?.price ?? 0;
-		return originalPrice > currentPrice ? originalPrice : undefined;
-	}
 
 	const isSupporterPlus = useContributionsSelector(isSupporterPlusFromState);
 

--- a/support-frontend/assets/helpers/productPrice/promotions.tsx
+++ b/support-frontend/assets/helpers/productPrice/promotions.tsx
@@ -107,15 +107,24 @@ function getPromotion(
 	fulfilmentOption: FulfilmentOptions = NoFulfilmentOptions,
 	productOption: ProductOptions = NoProductOptions,
 ): Promotion | undefined {
-	return getAppliedPromo(
-		getProductPrice(
-			productPrices,
-			country,
-			billingPeriod,
-			fulfilmentOption,
-			productOption,
-		).promotions,
-	);
+	/*
+  getProductPrice can raise an Error if not available (ie Storybook)
+  this try/catch wrapper ensures its returned as undefined as specified,
+  getProductPrice (used throughout) safer to remain un-changed
+  */
+	try {
+		return getAppliedPromo(
+			getProductPrice(
+				productPrices,
+				country,
+				billingPeriod,
+				fulfilmentOption,
+				productOption,
+			).promotions,
+		);
+	} catch (error) {
+		return undefined;
+	}
 }
 
 function getSanitisedHtml(markdownString: string): string {

--- a/support-frontend/assets/helpers/redux/checkout/product/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/reducer.ts
@@ -67,7 +67,7 @@ export const productSlice = createSlice({
 		},
 		setSelectedAmount(state, action: PayloadAction<AmountChange>) {
 			const { contributionType, amount } = action.payload;
-			const newAmount = amount === 'other' ? amount : Number.parseInt(amount);
+			const newAmount = amount === 'other' ? amount : Number.parseFloat(amount);
 			state.selectedAmounts[contributionType] = newAmount;
 		},
 		setOtherAmount(state, action: PayloadAction<AmountChange>) {
@@ -80,7 +80,7 @@ export const productSlice = createSlice({
 			action: PayloadAction<AmountChange>,
 		) {
 			const { contributionType, amount } = action.payload;
-			const newAmount = amount === 'other' ? amount : Number.parseInt(amount);
+			const newAmount = amount === 'other' ? amount : Number.parseFloat(amount);
 			state.selectedAmountsBeforeAmendment[contributionType] = newAmount;
 		},
 		setOtherAmountBeforeAmendment(state, action: PayloadAction<AmountChange>) {

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/isSupporterPlus.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/isSupporterPlus.ts
@@ -1,7 +1,8 @@
-import type {
-	ContributionType,
-	OtherAmounts,
-	SelectedAmounts,
+import {
+	type ContributionType,
+	getAmount,
+	type OtherAmounts,
+	type SelectedAmounts,
 } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
@@ -19,15 +20,14 @@ export function isSupporterPlus(
 		return false;
 	}
 
-	const benefitsThreshold = getThresholdPrice(countryGroupId, contributionType);
-	const selectedAmount = selectedAmounts[contributionType];
+	const thresholdPrice = getThresholdPrice(countryGroupId, contributionType);
+	const selectedAmount = getAmount(
+		selectedAmounts,
+		otherAmounts,
+		contributionType,
+	);
 
-	if (selectedAmount === 'other') {
-		const otherAmount = otherAmounts[contributionType].amount;
-		return otherAmount ? parseInt(otherAmount) >= benefitsThreshold : false;
-	}
-
-	return selectedAmount >= benefitsThreshold;
+	return selectedAmount >= thresholdPrice;
 }
 
 export function isSupporterPlusFromState(state: ContributionsState): boolean {

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/isSupporterPlus.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/isSupporterPlus.ts
@@ -3,7 +3,6 @@ import type {
 	OtherAmounts,
 	SelectedAmounts,
 } from 'helpers/contributions';
-import { getAmount } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
@@ -33,24 +32,12 @@ export function isSupporterPlus(
 
 export function isSupporterPlusFromState(state: ContributionsState): boolean {
 	const contributionType = getContributionType(state);
-
-	if (isOneOff(contributionType)) {
-		return false;
-	}
-
-	const thresholdPrice = getThresholdPrice(
-		state.common.internationalisation.countryGroupId,
+	return isSupporterPlus(
 		contributionType,
-	);
-	const amount = getAmount(
 		state.page.checkoutForm.product.selectedAmounts,
 		state.page.checkoutForm.product.otherAmounts,
-		contributionType,
+		state.common.internationalisation.countryGroupId,
 	);
-
-	const amountIsHighEnough = !!(thresholdPrice && amount >= thresholdPrice);
-
-	return amountIsHighEnough;
 }
 
 export function hideBenefitsListFromState(state: ContributionsState): boolean {

--- a/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
@@ -1,6 +1,9 @@
 import { css } from '@emotion/react';
 import { neutral, textSans } from '@guardian/source-foundations';
-import type { ContributionType } from 'helpers/contributions';
+import type {
+	ContributionType,
+	RegularContributionType,
+} from 'helpers/contributions';
 import { formatAmount } from 'helpers/forms/checkouts';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
@@ -148,15 +151,11 @@ export function PaymentTsAndCs({
 		);
 	};
 
-	const thresholdDescription = (contributionType: ContributionType) => {
-		const supporterPlusThresholds = lowerBenefitsThresholds[countryGroupId];
-		const threshold: number =
-			contributionType === 'MONTHLY'
-				? supporterPlusThresholds['MONTHLY']
-				: supporterPlusThresholds['ANNUAL'];
-		return `${currencyGlyph}${threshold} per ${frequencySingular(
-			contributionType,
-		)}`;
+	const thresholdAmounts = lowerBenefitsThresholds[countryGroupId];
+	const thresholdDescription = (contributionType: RegularContributionType) => {
+		return `${currencyGlyph}${
+			thresholdAmounts[contributionType]
+		} per ${frequencySingular(contributionType)}`;
 	};
 
 	const copyAboveThreshold = (
@@ -169,8 +168,9 @@ export function PaymentTsAndCs({
 					If you pay at least {thresholdDescription('MONTHLY')} or{' '}
 					{thresholdDescription('ANNUAL')}, you will receive the{' '}
 					{productNameAboveThreshold} benefits on a subscription basis. If you
-					pay more than {thresholdDescription(contributionType)}, these
-					additional amounts will be separate{' '}
+					pay more than{' '}
+					{thresholdDescription(contributionType as RegularContributionType)},
+					these additional amounts will be separate{' '}
 					{frequencyPlural(contributionType)} voluntary financial contributions
 					to the Guardian. The {productNameAboveThreshold} subscription and any
 					contributions will auto-renew each{' '}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -54,6 +54,7 @@ import {
 	ThreeTierDisclaimer,
 	ToteTsAndCs,
 } from '../components/threeTierDisclaimer';
+import type { TierPlans } from '../setup/threeTierConfig';
 import {
 	tierCards as tierCardsNoTote,
 	tierCardsTote,
@@ -240,8 +241,7 @@ export function ThreeTierLanding(): JSX.Element {
 		useContributionsSelector(getContributionType);
 	const contributionType =
 		contributionTypeFromState === 'ANNUAL' ? 'ANNUAL' : 'MONTHLY';
-	const contributionTypeKey =
-		contributionTypeFromState === 'ANNUAL' ? 'annual' : 'monthly';
+	const tierPlanPeriod = contributionType.toLowerCase() as keyof TierPlans;
 
 	const urlParams = new URLSearchParams(window.location.search);
 	const urlSelectedAmount = urlParams.get('selected-amount');
@@ -348,7 +348,7 @@ export function ThreeTierLanding(): JSX.Element {
 	) => {
 		const tierPlanCountryCharges =
 			tierCards[`tier${cardTier}`].plans[
-				contributionTypeKeyOverride ?? contributionTypeKey
+				contributionTypeKeyOverride ?? tierPlanPeriod
 			].charges[countryGroupId];
 		return {
 			title: tierCards[`tier${cardTier}`].title,
@@ -364,13 +364,12 @@ export function ThreeTierLanding(): JSX.Element {
 
 	const generateTierCheckoutLink = (cardTier: 1 | 2 | 3) => {
 		const tierPlanCountryCharges =
-			tierCards[`tier${cardTier}`].plans[contributionTypeKey].charges[
+			tierCards[`tier${cardTier}`].plans[tierPlanPeriod].charges[
 				countryGroupId
 			];
 		const promoCode = tierPlanCountryCharges.promoCode;
-		const price = tierPlanCountryCharges.discount
-			? tierPlanCountryCharges.discount.price
-			: tierPlanCountryCharges.price;
+		const price =
+			tierPlanCountryCharges.discount?.price ?? tierPlanCountryCharges.price;
 
 		const url = cardTier === 3 ? `/subscribe/weekly/checkout?` : `checkout?`;
 		const urlParams = new URLSearchParams();
@@ -383,7 +382,7 @@ export function ThreeTierLanding(): JSX.Element {
 			urlParams.set('period', paymentFrequencyMap[contributionType]);
 		} else {
 			urlParams.set('selected-amount', price.toString());
-			urlParams.set('selected-contribution-type', contributionTypeKey);
+			urlParams.set('selected-contribution-type', tierPlanPeriod);
 		}
 
 		return `${url}${urlParams.toString()}${window.location.hash}`;


### PR DESCRIPTION
## What are you doing in this PR?

PT2 : Code changes required to prepare for the PromoCode PR, 

No visual changes are made in this PR

- Improved isSupporterPlus, Ts&Cs, TierPlan function optimisations/naming
- contributionOrderSummary total can (optionally) display crossed out originalPrice
- contributionOrderSummaryContainer can (optionally) retrieve and pass onto contributionOrderSummary the originalPrice (alongside CurrentPrice)
- redux S+ amounts can be stored as fractional numbers (likely to be generated by promoCodes in future)
- getProductPrice try-catch wrapper to ensures errors returned are undefined as getPromotion function specifies (future storybook support without PromoCodes)

[Trello Card](https://trello.com/c/5t4LIRvo/564-promos-on-supporterplus-part-2-attach-active-promotions-to-supporterplus-thresholds-model-on-windowguardian)
