### PR TITLE
Hide the country group dropdown if user is in a country from VAT group

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
@@ -28,6 +28,7 @@ import { PageScaffold } from 'components/page/pageScaffold';
 import { SecureTransactionIndicator } from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import HeadlineImageDesktop from 'components/svgs/headlineImageDesktop';
 import HeadlineImageMobile from 'components/svgs/headlineImageMobile';
+import { countriesAffectedByVATStatus } from 'helpers/internationalisation/country';
 import {
 	AUDCountries,
 	Canada,
@@ -135,7 +136,7 @@ export function SupporterPlusCheckoutScaffold({
 	thankYouRoute: string;
 	isPaymentPage?: true;
 }): JSX.Element {
-	const { countryGroupId } = useContributionsSelector(
+	const { countryGroupId, countryId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
 
@@ -170,6 +171,9 @@ export function SupporterPlusCheckoutScaffold({
 	}, [paymentComplete]);
 
 	const displayPatronsCheckout = !!abParticipations.patronsOneOffOnly;
+
+	const countryIsAffectedByVATStatus =
+		countriesAffectedByVATStatus.includes(countryId);
 
 	function SubHeading() {
 		if (displayPatronsCheckout) {
@@ -209,7 +213,7 @@ export function SupporterPlusCheckoutScaffold({
 			header={
 				<>
 					<Header>
-						{!isPaymentPage && (
+						{!countryIsAffectedByVATStatus && !isPaymentPage && (
 							<Hide from="desktop">
 								<CountrySwitcherContainer>
 									<CountryGroupSwitcher {...countrySwitcherProps} />
@@ -217,7 +221,9 @@ export function SupporterPlusCheckoutScaffold({
 							</Hide>
 						)}
 					</Header>
-					{!isPaymentPage && <Nav {...countrySwitcherProps} />}
+					{!countryIsAffectedByVATStatus && !isPaymentPage && (
+						<Nav {...countrySwitcherProps} />
+					)}
 				</>
 			}
 			footer={


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Don't show the `CountryGroupSwitcher` on the checkout if the user is in a country from the `countriesAffectedByVATStatus` list.

## Why are you doing this?
There is a list of countries in which we only offer contributions (not incurring VAT). This is done by using a amounts test target at these specific countries, and only allowing amounts under supporter+ threshold.
Changing the country/currency via the dropdown in the header allowed to bypass this and so this PR removes it when the user is in one of these countries.

## How to test
Navigate to the checkout from one of the affected countries. You can force the country by adding the query string parameter `country` and a 2 letter country code (make sure the region matches the country) e.g. /uk/contribute?country=GB for UK or /int/contribute?country=TW for Taiwan. (browserstack can also be used to test this)

## Screenshots
| Before (PROD) | After (CODE) |
| --- | --- |
| Desktop ![Before desktop](https://github.com/guardian/support-frontend/assets/99180049/9a05af6d-42ea-425b-974e-1a0eb4543ff7) | Desktop ![After desktop](https://github.com/guardian/support-frontend/assets/99180049/45dd9fa1-6447-44fa-962b-8ea5fe62a9aa) |
| Mobile ![Before mobile](https://github.com/guardian/support-frontend/assets/99180049/a10d53ec-513d-49ef-aff5-7cdc63b3052c) | Mobile ![After mobile](https://github.com/guardian/support-frontend/assets/99180049/23864aba-0a8d-4d7b-bf33-5a24b985fcdf) |


