### PR TITLE
threeTierCreateSupporterPlusSubscription should be false in payload for Paper and Digital Edition subs

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierChecks.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierChecks.ts
@@ -6,6 +6,17 @@ export const threeTierCheckoutEnabled = (
 	abParticipations: Participations,
 	countryId: IsoCountry,
 ): boolean => {
+	const isPaperCheckout = window.location.pathname.startsWith(
+		'/subscribe/paper/checkout',
+	);
+	const isDigitalEditionCheckout = window.location.pathname.startsWith(
+		'/subscribe/digitaledition/checkout',
+	);
+
+	if (isPaperCheckout || isDigitalEditionCheckout) {
+		return false;
+	}
+
 	const isWeeklyCheckout = window.location.pathname.startsWith(
 		'/subscribe/weekly/checkout',
 	);

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierChecks.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierChecks.ts
@@ -9,8 +9,14 @@ export const threeTierCheckoutEnabled = (
 	const isPaperCheckout = window.location.pathname.startsWith(
 		'/subscribe/paper/checkout',
 	);
-	const isDigitalEditionCheckout = window.location.pathname.startsWith(
-		'/subscribe/digitaledition/checkout',
+	/**
+	 * Unlike Paper and Guardian Weekly the
+	 * Digital Edition path includes region eg: uk/subscribe/digitaledition
+	 * so we just check for presence of /subscribe/digitaledition substring in
+	 * window.location.path here instead of using startsWith.
+	 */
+	const isDigitalEditionCheckout = window.location.pathname.includes(
+		'/subscribe/digitaledition',
 	);
 
 	if (isPaperCheckout || isDigitalEditionCheckout) {


### PR DESCRIPTION
## What are you doing in this PR?

`threeTierCheckoutEnabled()` is called via https://github.com/guardian/support-frontend/blob/main/support-frontend/assets/helpers/subscriptionsForms/submit.ts#L246 when building the payload for ALL recurring subscriptions, including Paper and Digital Edition. 

Currently `threeTierCheckoutEnabled()` returns `true` on the Paper and Digital Edition checkout, meaning we pass `threeTierCreateSupporterPlusSubscription` as `true` in the payload to the `/create` endpoint, I've tested and luckily the step functions don't go down the path of creating an SupporterPlus sub for users who are purchasing Paper OR Digital Edition! But  `threeTierCheckoutEnabled()` should really return `false` for  Paper and Digital Edition checkouts.