### PR TITLE
Fix "see pricing options" CTA - Guardian Weekly

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
@@ -95,7 +95,7 @@ const termsConditionsLink =
 
 function Prices({ orderIsAGift, products }: PropTypes): JSX.Element {
 	return (
-		<section css={pricesSection}>
+		<section css={pricesSection} id="subscribe">
 			<h2 css={pricesHeadline}>Subscribe to the Guardian Weekly today</h2>
 			<p css={pricesSubHeadline}>
 				{orderIsAGift ? 'Select a gift period' : "Choose how you'd like to pay"}

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
@@ -199,7 +199,7 @@ export function WeeklyHero({
 								iconSide="right"
 								icon={<SvgArrowDownStraight />}
 								cssOverrides={linkButtonColour}
-								href="#HomeDelivery"
+								href="#subscribe"
 							>
 								See pricing options
 							</LinkButton>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Fix the "See Pricing Options" CTA on the weekly subscription page. Add back ID to scroll to in the page.
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/EqiISinB/287-guardian-weekly-landing-page-fix-cta)

## Why are you doing this?

The button previously did nothing (introduced in #5572). It should scroll to the pricing section. This was flagged up by a designer.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Go to `uk/subscribe/weekly` and click "See pricing options". Page scrolls down automatically.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
<img width="853" alt="image" src="https://github.com/guardian/support-frontend/assets/114918544/409b3ebf-a842-4636-b82f-a02a78dd2740">
