### PR TITLE
improve logging of which class logging came from and remove excessive logging

### DIFF
--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/conf/PatronsIdentityConfig.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/conf/PatronsIdentityConfig.scala
@@ -8,7 +8,7 @@ case class PatronsIdentityConfig(apiUrl: String, apiClientToken: String)
 
 object PatronsIdentityConfig extends ConfigService {
   def fromParameterStoreSync(stage: Stage) = {
-    SafeLogger.info(s"Loading Identity config")
+    logger.info(s"Loading Identity config")
     val params = ParameterStoreService(stage).getParametersByPathSync("identity-config")
     PatronsIdentityConfig(
       findParameterOrThrow("api-url", params),

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/conf/PatronsStripeConfig.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/conf/PatronsStripeConfig.scala
@@ -17,7 +17,7 @@ object PatronsStripeConfig extends ConfigService {
   private val stripeConfigPath = "stripe-config"
 
   def fromParameterStoreSync(stage: Stage): PatronsStripeConfig = {
-    SafeLogger.info(s"Loading Stripe config")
+    logger.info(s"Loading Stripe config")
     val params = ParameterStoreService(stage).getParametersByPathSync(stripeConfigPath)
     PatronsStripeConfig(
       findParameterOrThrow("api-key", params),

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/lambdas/PatronSignUpEventLambda.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/lambdas/PatronSignUpEventLambda.scala
@@ -43,7 +43,7 @@ import scala.util.{Failure, Success, Try}
 class PatronSignUpEventLambda extends StrictLogging {
   val runner = configurableFutureRunner(60.seconds)
 
-  implicit val stage = StageConstructors.fromEnvironment
+  implicit val stage: Stage = StageConstructors.fromEnvironment
   private val stripeConfig = PatronsStripeConfig.fromParameterStoreSync(stage)
   private val identityConfig = PatronsIdentityConfig.fromParameterStoreSync(stage)
 
@@ -103,7 +103,7 @@ class PatronSignUpEventLambda extends StrictLogging {
     logger.info("Attempting to verify event payload")
     EitherT.fromEither(for {
       payload <- Option(event.getBody).toRight(InvalidRequestError("Missing body"))
-      _ = SafeLogger.info(s"payload is ${payload.replace("\n", "")}")
+      _ = logger.info(s"payload is ${payload.replace("\n", "")}")
       sigHeader <- event.getHeaders.asScala.get("Stripe-Signature").toRight(InvalidRequestError("Missing sig header"))
       _ <- Try(
         Webhook.Signature.verifyHeader(payload, sigHeader, signingSecret, 300),

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/services/PatronsIdentityService.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/services/PatronsIdentityService.scala
@@ -1,8 +1,6 @@
 package com.gu.patrons.services
 
 import cats.data.OptionT
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger.Sanitizer
 import com.gu.okhttp.RequestRunners.FutureHttpClient
 import com.gu.patrons.conf.PatronsIdentityConfig
 import com.gu.patrons.model.identity._
@@ -23,7 +21,7 @@ class PatronsIdentityService(val config: PatronsIdentityConfig, client: FutureHt
       email: String,
       firstName: Option[String],
   )(implicit ec: ExecutionContext): Future[String] = {
-    SafeLogger.info(s"Attempting to find identity id for user $email")
+    logger.info(s"Attempting to find identity id for user $email")
     OptionT(getUserIdFromEmail(email))
       .getOrElseF(createUserIdFromEmailUser(email, firstName))
   }
@@ -36,11 +34,11 @@ class PatronsIdentityService(val config: PatronsIdentityConfig, client: FutureHt
       Map("X-GU-ID-Client-Access-Token" -> s"Bearer ${config.apiClientToken}"),
       Map("emailAddress" -> email),
     ).map { response =>
-      SafeLogger.info(s"Found identity id ${response.user.id} for email $email")
+      logger.info(s"Found identity id ${response.user.id} for email $email")
       Some(response.user.id)
     }.recover {
       case err: IdentityErrorResponse if err.errors.headOption.map(_.message).contains("Not found") =>
-        SafeLogger.info(s"Email address $email not found in Identity")
+        logger.info(s"Email address $email not found in Identity")
         None
     }
 
@@ -48,7 +46,7 @@ class PatronsIdentityService(val config: PatronsIdentityConfig, client: FutureHt
       email: String,
       firstName: Option[String],
   )(implicit ec: ExecutionContext) = {
-    SafeLogger.info(s"Attempting to create guest identity account for user $email")
+    logger.info(s"Attempting to create guest identity account for user $email")
     val body = CreateGuestAccountRequestBody(
       email,
       PrivateFields(
@@ -62,10 +60,10 @@ class PatronsIdentityService(val config: PatronsIdentityConfig, client: FutureHt
       Map("X-GU-ID-Client-Access-Token" -> s"Bearer ${config.apiClientToken}"),
       Map("accountVerificationEmail" -> "true"),
     ).map { response =>
-      SafeLogger.info(s"Created account with identity id ${response.guestRegistrationRequest.userId} for email $email")
+      logger.info(s"Created account with identity id ${response.guestRegistrationRequest.userId} for email $email")
       response.guestRegistrationRequest.userId
     }.recover { err =>
-      SafeLogger.error(
+      logger.error(
         scrub"Received an error from Identity while trying to create guest identity account for $email",
         err,
       )

--- a/stripe-patrons-data/src/test/scala/com/gu/patrons/services/StripeSubscriptionsProcessorSpec.scala
+++ b/stripe-patrons-data/src/test/scala/com/gu/patrons/services/StripeSubscriptionsProcessorSpec.scala
@@ -1,10 +1,9 @@
 package com.gu.patrons.services
 
-import com.gu.monitoring.SafeLogger
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.patrons.conf.{PatronsIdentityConfig, PatronsStripeConfig}
-import com.gu.patrons.model.{StripeSubscription, ExpandedStripeCustomer}
-import com.gu.supporterdata.model.Stage.{CODE, PROD}
+import com.gu.patrons.model.{ExpandedStripeCustomer, StripeSubscription}
+import com.gu.supporterdata.model.Stage.CODE
 import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -33,7 +32,7 @@ class StripeSubscriptionsProcessorSpec extends AsyncFlatSpec with Matchers {
       identityService
         .getUserIdFromEmail(subscription.customer.email)
         .map(maybeIdentityId =>
-          SafeLogger.info(s"${subscription.customer.email} - ${maybeIdentityId.getOrElse("No Identity account")}"),
+          info(s"${subscription.customer.email} - ${maybeIdentityId.getOrElse("No Identity account")}"),
         )
   }
 

--- a/support-config/src/main/scala/com/gu/support/config/StripeConfig.scala
+++ b/support-config/src/main/scala/com/gu/support/config/StripeConfig.scala
@@ -2,7 +2,7 @@ package com.gu.support.config
 
 import com.gu.i18n.{Country, Currency}
 import com.gu.i18n.Currency.AUD
-import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.{SafeLogger, SafeLogging}
 import com.typesafe.config.Config
 
 case class StripeConfig(
@@ -10,29 +10,29 @@ case class StripeConfig(
     australiaAccount: StripeAccountConfig,
     unitedStatesAccount: StripeAccountConfig,
     version: Option[String],
-) {
+) extends SafeLogging {
 
   // Still needed for SupportWorkers (recurring products) which don't support a US Stripe account yet.
   def forCurrency(maybeCurrency: Option[Currency]): StripeAccountConfig =
     maybeCurrency match {
       case Some(AUD) =>
-        SafeLogger.debug(s"StripeConfig: getting AU stripe account for AUD")
+        logger.debug(s"StripeConfig: getting AU stripe account for AUD")
         australiaAccount
       case _ =>
-        SafeLogger.debug(s"StripeConfig: getting default stripe account for ${maybeCurrency.map(_.iso).mkString}")
+        logger.debug(s"StripeConfig: getting default stripe account for ${maybeCurrency.map(_.iso).mkString}")
         defaultAccount
     }
 
   def forCountry(maybeCountry: Option[Country]): StripeAccountConfig =
     maybeCountry match {
       case Some(Country.Australia) =>
-        SafeLogger.debug(s"StripeConfig: getting AU stripe account for Australia")
+        logger.debug(s"StripeConfig: getting AU stripe account for Australia")
         australiaAccount
       case Some(Country.US) =>
-        SafeLogger.debug(s"StripeConfig: getting US stripe account for United States")
+        logger.debug(s"StripeConfig: getting US stripe account for United States")
         unitedStatesAccount
       case _ =>
-        SafeLogger.debug(s"StripeConfig: getting default stripe account for ${maybeCountry.map(_.name).mkString}")
+        logger.debug(s"StripeConfig: getting default stripe account for ${maybeCountry.map(_.name).mkString}")
         defaultAccount
     }
 }

--- a/support-frontend/app/actions/CustomActionBuilders.scala
+++ b/support-frontend/app/actions/CustomActionBuilders.scala
@@ -2,13 +2,12 @@ package actions
 
 import actions.AsyncAuthenticatedBuilder.OptionalAuthRequest
 import admin.settings.FeatureSwitches
-import org.apache.pekko.stream.scaladsl.Flow
-import org.apache.pekko.util.ByteString
 import com.gu.aws.{AwsCloudWatchMetricPut, AwsCloudWatchMetricSetup}
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger.Sanitizer
+import com.gu.monitoring.SafeLogging
 import com.gu.support.config.Stage
 import models.identity.responses.IdentityErrorResponse._
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.util.ByteString
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.filters.csrf._
@@ -60,7 +59,7 @@ class CustomActionBuilders(
         new AsyncAuthenticatedBuilder(asyncAuthenticationService.tryAuthenticateUser, cc.parsers.defaultBodyParser)
     )
 
-  case class LoggingAndAlarmOnFailure[A](chainedAction: Action[A]) extends EssentialAction {
+  case class LoggingAndAlarmOnFailure[A](chainedAction: Action[A]) extends EssentialAction with SafeLogging {
 
     private def pushAlarmMetric = {
       val cloudwatchEvent = AwsCloudWatchMetricSetup.serverSideCreateFailure(stage)
@@ -75,14 +74,14 @@ class CustomActionBuilders(
           invalidEmailAddressCode,
         )
       ) {
-        SafeLogger.error(scrub"pushing alarm metric - non 2xx response ${result.toString()}")
+        logger.error(scrub"pushing alarm metric - non 2xx response ${result.toString()}")
         pushAlarmMetric
       }
 
     def apply(requestHeader: RequestHeader): Accumulator[ByteString, Result] = {
       val accumulator = chainedAction.apply(requestHeader)
       val loggedAccumulator = accumulator.through(Flow.fromFunction { (byteString: ByteString) =>
-        SafeLogger.info("incoming POST: " + byteString.utf8String)
+        logger.info("incoming POST: " + byteString.utf8String)
         byteString
       })
       loggedAccumulator
@@ -91,7 +90,7 @@ class CustomActionBuilders(
           result
         }
         .recoverWith({ case throwable: Throwable =>
-          SafeLogger.error(scrub"pushing alarm metric - 5xx response caused by ${throwable}")
+          logger.error(scrub"pushing alarm metric - 5xx response caused by ${throwable}")
           pushAlarmMetric
           Future.failed(throwable)
         })

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -8,24 +8,22 @@ import cats.data.EitherT
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup._
 import com.gu.identity.model.{User => IdUser}
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
+import com.gu.monitoring.SafeLogging
 import com.gu.support.catalog.SupporterPlus
 import com.gu.support.config._
 import com.typesafe.scalalogging.StrictLogging
 import config.{RecaptchaConfigProvider, StringsConfig}
 import lib.RedirectWithEncodedQueryString
 import models.GeoData
-import play.api.mvc._
-import services.{PaymentAPIService, TestUserService}
-import utils.FastlyGEOIP._
 import play.api.libs.circe.Circe
 import play.api.libs.ws.WSClient
+import play.api.mvc._
+import services.pricing.PriceSummaryServiceProvider
+import services.{PaymentAPIService, TestUserService}
+import utils.FastlyGEOIP._
+import views.EmptyDiv
 
 import scala.concurrent.{ExecutionContext, Future}
-import play.twirl.api.Html
-import services.pricing.PriceSummaryServiceProvider
-import views.EmptyDiv
 
 case class PaymentMethodConfigs(
     oneOffDefaultStripeConfig: StripeConfig,
@@ -312,7 +310,7 @@ class Application(
   }
 }
 
-object CSSElementForStage {
+object CSSElementForStage extends SafeLogging {
 
   def apply(getFileContentsAsHtml: RefPath => Option[StyleContent], stage: Stage)(
       cssPath: RefPath,
@@ -321,7 +319,7 @@ object CSSElementForStage {
       Left(cssPath)
     } else {
       getFileContentsAsHtml(cssPath).fold[Either[RefPath, StyleContent]] {
-        SafeLogger.error(
+        logger.error(
           scrub"Inline CSS failed to load for $cssPath",
         ) // in future add email perf alert instead (cloudwatch alarm perhaps)
         Left(cssPath)

--- a/support-frontend/app/controllers/GetAddress.scala
+++ b/support-frontend/app/controllers/GetAddress.scala
@@ -1,14 +1,11 @@
 package controllers
 
 import actions.CustomActionBuilders
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
-import com.gu.rest.{CodeBody, WebServiceHelperError}
-import com.gu.support.getaddressio.GetAddressIOService
+import com.gu.monitoring.SafeLogging
+import com.gu.support.getaddressio.{FindAddressResultError, GetAddressIOService}
 import io.circe.syntax._
 import play.api.libs.circe.Circe
 import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
-import com.gu.support.getaddressio.FindAddressResultError
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -18,7 +15,8 @@ class GetAddress(
     getAddressService: GetAddressIOService,
     actionRefiners: CustomActionBuilders,
 ) extends AbstractController(components)
-    with Circe {
+    with Circe
+    with SafeLogging {
   import actionRefiners._
 
   def findAddress(postCode: String): Action[AnyContent] = NoCacheAction().async { implicit request =>
@@ -33,7 +31,7 @@ class GetAddress(
         case _: FindAddressResultError =>
           BadRequest // The postcode was invalid
         case error =>
-          SafeLogger.error(scrub"Failed to complete postcode lookup via getAddress.io due to: $error")
+          logger.error(scrub"Failed to complete postcode lookup via getAddress.io due to: $error")
           InternalServerError
       }
     }

--- a/support-frontend/app/controllers/PayPalRegular.scala
+++ b/support-frontend/app/controllers/PayPalRegular.scala
@@ -3,10 +3,9 @@ package controllers
 import actions.AsyncAuthenticatedBuilder.OptionalAuthRequest
 import actions.CustomActionBuilders
 import admin.settings.{AllSettings, AllSettingsProvider, SettingsSurrogateKeySyntax}
-import assets.{AssetsResolver, RefPath, StyleContent}
+import assets.{AssetsResolver, RefPath}
+import com.gu.monitoring.SafeLogging
 import io.circe.syntax._
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
 import play.api.libs.circe.Circe
 import play.api.mvc._
 import services.paypal.PayPalBillingDetails.codec
@@ -26,7 +25,8 @@ class PayPalRegular(
 )(implicit val ec: ExecutionContext)
     extends AbstractController(components)
     with Circe
-    with SettingsSurrogateKeySyntax {
+    with SettingsSurrogateKeySyntax
+    with SafeLogging {
 
   import actionBuilders._
 
@@ -82,7 +82,7 @@ class PayPalRegular(
   // redirected and needs to come back.
   def returnUrl: Action[AnyContent] = PrivateAction { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
-    SafeLogger.error(scrub"User hit the PayPal returnUrl.")
+    logger.error(scrub"User hit the PayPal returnUrl.")
     Ok(
       views.html.main(
         "Support the Guardian | PayPal Error",
@@ -96,7 +96,7 @@ class PayPalRegular(
   // The endpoint corresponding to the PayPal cancel url, hit if the user is
   // redirected and the payment fails.
   def cancelUrl: Action[AnyContent] = PrivateAction { implicit request =>
-    SafeLogger.error(scrub"User hit the PayPal cancelUrl, something went wrong.")
+    logger.error(scrub"User hit the PayPal cancelUrl, something went wrong.")
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     Ok(
       views.html.main(

--- a/support-frontend/app/controllers/PricesController.scala
+++ b/support-frontend/app/controllers/PricesController.scala
@@ -84,7 +84,7 @@ object PricesController {
     )
 
   import io.circe.generic.auto._
-  implicit val pricesEncoder: Encoder[Prices] = Encoder[Prices]
+  implicit val pricesEncoder = Encoder[Prices]
 }
 
 class PricesController(

--- a/support-frontend/app/controllers/PricesController.scala
+++ b/support-frontend/app/controllers/PricesController.scala
@@ -84,7 +84,7 @@ object PricesController {
     )
 
   import io.circe.generic.auto._
-  implicit val pricesEncoder = Encoder[Prices]
+  implicit val pricesEncoder: Encoder[Prices] = Encoder[Prices]
 }
 
 class PricesController(

--- a/support-frontend/app/controllers/RedemptionController.scala
+++ b/support-frontend/app/controllers/RedemptionController.scala
@@ -6,8 +6,7 @@ import admin.settings.{AllSettings, AllSettingsProvider}
 import assets.AssetsResolver
 import cats.data.EitherT
 import cats.implicits._
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
+import com.gu.monitoring.SafeLogging
 import com.gu.support.redemption._
 import com.gu.support.redemption.gifting.GiftCodeValidator
 import com.gu.support.redemptions.RedemptionCode
@@ -37,7 +36,8 @@ class RedemptionController(
 )(implicit
     val ec: ExecutionContext,
 ) extends AbstractController(components)
-    with Circe {
+    with Circe
+    with SafeLogging {
 
   import actionRefiners._
 
@@ -83,7 +83,7 @@ class RedemptionController(
   def displayError(redemptionCode: RawRedemptionCode, error: String, isTestUser: Boolean)(implicit
       request: OptionalAuthRequest[Any],
   ): Result = {
-    SafeLogger.error(
+    logger.error(
       scrub"An error occurred while trying to process redemption code - ${redemptionCode}. Error was - ${error}",
     )
     Ok(
@@ -110,7 +110,7 @@ class RedemptionController(
       val codeValidator =
         new CodeValidator(zuoraLookupServiceProvider.forUser(testUser))
       codeValidator.validate(redemptionCode).value.map { validationResult =>
-        SafeLogger.info(s"Validating code ${redemptionCode}: ${validationResult}")
+        logger.info(s"Validating code ${redemptionCode}: ${validationResult}")
         Ok(
           RedemptionValidationResult(
             valid = validationResult.isRight,

--- a/support-frontend/app/controllers/SupportWorkersStatus.scala
+++ b/support-frontend/app/controllers/SupportWorkersStatus.scala
@@ -2,10 +2,9 @@ package controllers
 
 import actions.CustomActionBuilders
 import cats.instances.future._
+import com.gu.monitoring.SafeLogging
 import io.circe.syntax._
 import lib.PlayImplicits._
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
 import play.api.libs.circe.Circe
 import play.api.mvc._
 import services.stepfunctions.SupportWorkersClient
@@ -18,14 +17,15 @@ class SupportWorkersStatus(
     actionRefiners: CustomActionBuilders,
 )(implicit val exec: ExecutionContext)
     extends AbstractController(components)
-    with Circe {
+    with Circe
+    with SafeLogging {
   import actionRefiners._
   def status(jobId: String): Action[AnyContent] = MaybeAuthenticatedActionOnFormSubmission.async { implicit request =>
     client
       .status(jobId, request.uuid)
       .fold(
         { error =>
-          SafeLogger.error(scrub"Failed to get status of step function execution for job ${jobId} due to $error")
+          logger.error(scrub"Failed to get status of step function execution for job ${jobId} due to $error")
           InternalServerError
         },
         response => Ok(response.asJson),

--- a/support-frontend/app/lib/CustomHttpErrorHandler.scala
+++ b/support-frontend/app/lib/CustomHttpErrorHandler.scala
@@ -27,7 +27,6 @@ class CustomHttpErrorHandler(
     router: => Option[Router],
     val assets: AssetsResolver,
     settingsProvider: AllSettingsProvider,
-    stage: Stage,
 )(implicit val ec: ExecutionContext)
     extends DefaultHttpErrorHandler(env, config, sourceMapper, router)
     with LazyLogging

--- a/support-frontend/app/monitoring/SentryLogging.scala
+++ b/support-frontend/app/monitoring/SentryLogging.scala
@@ -1,27 +1,23 @@
 package monitoring
 
+import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.filter.ThresholdFilter
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
+import com.gu.monitoring.SafeLogging
 import config.Configuration
 import io.sentry.Sentry
 import io.sentry.logback.SentryAppender
-
-import scala.jdk.CollectionConverters._
-import scala.util.{Failure, Success, Try}
-import SentryFilters._
-import ch.qos.logback.classic.Logger
+import monitoring.SentryFilters._
 import org.slf4j.Logger.ROOT_LOGGER_NAME
 import org.slf4j.LoggerFactory
 
-import scala.collection.MapView
+import scala.util.{Failure, Success, Try}
 
-object SentryLogging {
+object SentryLogging extends SafeLogging {
   def init(config: Configuration): Unit = {
     config.sentryDsn match {
-      case None => SafeLogger.warn("No Sentry logging configured (OK for dev)")
+      case None => logger.warn("No Sentry logging configured (OK for dev)")
       case Some(sentryDSN) =>
-        SafeLogger.info(s"Initialising Sentry logging")
+        logger.info(s"Initialising Sentry logging")
         Try {
           Sentry.init(sentryDSN)
           val sentryAppender = new SentryAppender {
@@ -37,9 +33,9 @@ object SentryLogging {
 
           LoggerFactory.getLogger(ROOT_LOGGER_NAME).asInstanceOf[Logger].addAppender(sentryAppender)
         } match {
-          case Success(_) => SafeLogger.debug("Sentry logging configured.")
+          case Success(_) => logger.debug("Sentry logging configured.")
           case Failure(e) =>
-            SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
+            logger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
         }
     }
   }

--- a/support-frontend/app/monitoring/StateMachineMonitor.scala
+++ b/support-frontend/app/monitoring/StateMachineMonitor.scala
@@ -1,13 +1,13 @@
 package monitoring
 
+import com.gu.monitoring.SafeLogging
 import org.apache.pekko.actor.ActorSystem
 import services.stepfunctions.SupportWorkersClient
+
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
 
-class StateMachineMonitor(client: SupportWorkersClient, actorSystem: ActorSystem) {
+class StateMachineMonitor(client: SupportWorkersClient, actorSystem: ActorSystem) extends SafeLogging {
 
   val cloudwatchMetricsPattern = "regular-contributions-state-machine-unavailable"
 
@@ -15,11 +15,11 @@ class StateMachineMonitor(client: SupportWorkersClient, actorSystem: ActorSystem
     implicit val ec = actorSystem.dispatcher
     actorSystem.scheduler.schedule(5.seconds, 60.seconds) {
       client.healthy().onComplete {
-        case Success(true) => SafeLogger.debug("Regular contributions state machine is healthy")
+        case Success(true) => logger.debug("Regular contributions state machine is healthy")
         case Success(false) =>
-          SafeLogger.error(scrub"Regular contributions state machine is not available [$cloudwatchMetricsPattern]")
+          logger.error(scrub"Regular contributions state machine is not available [$cloudwatchMetricsPattern]")
         case Failure(exception) =>
-          SafeLogger.error(
+          logger.error(
             scrub"Exception while fetching regular contributions state machine status [$cloudwatchMetricsPattern]",
             exception,
           )

--- a/support-frontend/app/services/AuthenticationService.scala
+++ b/support-frontend/app/services/AuthenticationService.scala
@@ -5,8 +5,7 @@ import com.gu.identity.auth.{IdapiAuthConfig, IdentityClient}
 import com.gu.identity.model.User
 import com.gu.identity.play.IdapiPlayAuthService
 import com.gu.identity.play.IdapiPlayAuthService.UserCredentialsMissingError
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
+import com.gu.monitoring.SafeLogging
 import config.Identity
 import org.http4s.Uri
 import play.api.http.ContentTypes.FORM
@@ -18,7 +17,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class AsyncAuthenticationService(identityPlayAuthService: IdapiPlayAuthService, ws: WSClient, config: Identity)(implicit
     ec: ExecutionContext,
-) {
+) extends SafeLogging {
 
   def tryAuthenticateUser(requestHeader: RequestHeader): Future[Option[User]] =
     identityPlayAuthService
@@ -38,7 +37,7 @@ class AsyncAuthenticationService(identityPlayAuthService: IdapiPlayAuthService, 
           None
         case err =>
           // something else went wrong - we should alert on this
-          SafeLogger.error(scrub"unable to authorize user", err)
+          logger.error(scrub"unable to authorize user", err)
           None
       }
 

--- a/support-frontend/app/services/GoCardlessFrontendService.scala
+++ b/support-frontend/app/services/GoCardlessFrontendService.scala
@@ -4,8 +4,7 @@ import com.gocardless.GoCardlessClient
 import com.gocardless.GoCardlessClient.Environment
 import com.gocardless.errors.GoCardlessApiException
 import com.gocardless.resources.BankDetailsLookup.AvailableDebitScheme
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
+import com.gu.monitoring.SafeLogging
 import com.gu.support.config.GoCardlessConfig
 import com.gu.support.gocardless.GoCardlessService
 import models.CheckBankAccountDetails
@@ -13,7 +12,7 @@ import models.CheckBankAccountDetails
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class GoCardlessFrontendService(config: GoCardlessConfig) extends GoCardlessService(config) {
+class GoCardlessFrontendService(config: GoCardlessConfig) extends GoCardlessService(config) with SafeLogging {
 
   lazy val client = GoCardlessClient.create(config.apiToken, Environment.valueOf(config.environment))
 
@@ -34,7 +33,7 @@ class GoCardlessFrontendService(config: GoCardlessConfig) extends GoCardlessServ
       bdl.getAvailableDebitSchemes.contains(AvailableDebitScheme.BACS)
     } recover { case e: GoCardlessApiException =>
       if (e.getCode == 429) {
-        SafeLogger.error(scrub"Bypassing preliminary bank account check - GoCardless rate limit has been exceeded")
+        logger.error(scrub"Bypassing preliminary bank account check - GoCardless rate limit has been exceeded")
         true
       } else {
         false

--- a/support-frontend/app/services/HttpIdentityService.scala
+++ b/support-frontend/app/services/HttpIdentityService.scala
@@ -1,12 +1,10 @@
 package services
 
-import org.apache.pekko.actor.Scheduler
 import cats.data.EitherT
 import cats.implicits._
 import com.google.common.net.InetAddresses
 import com.gu.identity.model.PrivateFields
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
+import com.gu.monitoring.SafeLogging
 import com.gu.retry.EitherTRetry.retry
 import config.Identity
 import io.circe.Encoder
@@ -14,6 +12,7 @@ import io.circe.generic.semiauto.deriveEncoder
 import models.identity.requests.CreateGuestAccountRequestBody
 import models.identity.responses.IdentityErrorResponse.{GuestEndpoint, IdentityError, OtherIdentityError, UserEndpoint}
 import models.identity.responses.{GuestRegistrationResponse, IdentityErrorResponse, UserResponse}
+import org.apache.pekko.actor.Scheduler
 import play.api.libs.json.{JsPath, Json, JsonValidationError, Reads}
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 import play.api.mvc.RequestHeader
@@ -72,7 +71,7 @@ object IdentityService {
     new IdentityService(apiUrl = config.apiUrl, apiClientToken = config.apiClientToken)
 }
 
-class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient: WSClient) {
+class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient: WSClient) extends SafeLogging {
 
   import IdentityServiceEnrichers._
 
@@ -86,11 +85,11 @@ class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient:
     val payload = Json.obj("email" -> email, "set-consents" -> Json.arr("supporter"))
     request(s"consent-email").post(payload).map { response =>
       val validResponse = response.status >= 200 && response.status < 300
-      if (validResponse) SafeLogger.info("Successful response from Identity Consent API")
-      else SafeLogger.error(scrub"Failure response from Identity Consent API: ${response.toString}")
+      if (validResponse) logger.info("Successful response from Identity Consent API")
+      else logger.error(scrub"Failure response from Identity Consent API: ${response.toString}")
       validResponse
     } recover { case e: Exception =>
-      SafeLogger.error(scrub"Failed to update the user's marketing preferences $e")
+      logger.error(scrub"Failed to update the user's marketing preferences $e")
       false
     }
   }

--- a/support-frontend/app/services/PayPalNvpService.scala
+++ b/support-frontend/app/services/PayPalNvpService.scala
@@ -1,8 +1,6 @@
 package services
 
-import cats.data.OptionT
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
+import com.gu.monitoring.SafeLogging
 import com.gu.support.config.PayPalConfig
 import com.gu.support.touchpoint.TouchpointService
 import io.lemonlabs.uri.QueryString
@@ -14,7 +12,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.Try
 
-class PayPalNvpService(apiConfig: PayPalConfig, wsClient: WSClient) extends TouchpointService {
+class PayPalNvpService(apiConfig: PayPalConfig, wsClient: WSClient) extends TouchpointService with SafeLogging {
 
   val defaultNVPParams = Map(
     "USER" -> apiConfig.user,
@@ -28,11 +26,11 @@ class PayPalNvpService(apiConfig: PayPalConfig, wsClient: WSClient) extends Touc
     val msg = s"NVPResponse: $response"
 
     retrieveNVPParam(response, "ACK") match {
-      case Some("Success") => SafeLogger.info("Successful PayPal NVP request")
-      case Some("SuccessWithWarning") => SafeLogger.warn(s"Response (with warning) from PayPal was: $msg")
-      case Some("Failure") => SafeLogger.error(scrub"Failure response from PayPal was: $msg")
-      case Some("FailureWithWarning") => SafeLogger.error(scrub"Response from PayPal was: $msg")
-      case _ => SafeLogger.warn("No ACK parameter was present in the response")
+      case Some("Success") => logger.info("Successful PayPal NVP request")
+      case Some("SuccessWithWarning") => logger.warn(s"Response (with warning) from PayPal was: $msg")
+      case Some("Failure") => logger.error(scrub"Failure response from PayPal was: $msg")
+      case Some("FailureWithWarning") => logger.error(scrub"Response from PayPal was: $msg")
+      case _ => logger.warn("No ACK parameter was present in the response")
     }
 
   }
@@ -62,7 +60,7 @@ class PayPalNvpService(apiConfig: PayPalConfig, wsClient: WSClient) extends Touc
   private def retrieveNVPParam(response: QueryString, paramName: String) =
     response.paramMap.getOrElse(paramName, Nil).headOption match {
       case None =>
-        SafeLogger.warn(s"Parameter $paramName was missing from the NVP response - $response")
+        logger.warn(s"Parameter $paramName was missing from the NVP response - $response")
         None
       case Some(value) => Some(value)
     }

--- a/support-frontend/app/services/PaymentAPIService.scala
+++ b/support-frontend/app/services/PaymentAPIService.scala
@@ -1,15 +1,14 @@
 package services
 
 import cats.data.EitherT
-import com.gu.monitoring.SafeLogger._
+import cats.implicits._
+import com.gu.monitoring.SafeLogging
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import io.circe.parser.decode
 import play.api.libs.json._
 import play.api.libs.ws.{WSClient, WSResponse}
 import services.ExecutePaymentBody._
-import io.circe.Decoder
-import io.circe.parser.decode
-import com.gu.monitoring.SafeLogger
-import cats.implicits._
-import io.circe.generic.semiauto.deriveDecoder
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -48,7 +47,8 @@ object ExecutePaymentBody {
   implicit val jf: OFormat[ExecutePaymentBody] = Json.format[ExecutePaymentBody]
 }
 
-class PaymentAPIService(wsClient: WSClient, val paymentAPIUrl: String)(implicit ec: ExecutionContext) {
+class PaymentAPIService(wsClient: WSClient, val paymentAPIUrl: String)(implicit ec: ExecutionContext)
+    extends SafeLogging {
 
   private val paypalCreatePaymentPath = "/contribute/one-off/paypal/create-payment"
   private val paypalExecutePaymentPath = "/contribute/one-off/paypal/execute-payment"
@@ -86,9 +86,9 @@ class PaymentAPIService(wsClient: WSClient, val paymentAPIUrl: String)(implicit 
 
   def logErrorResponse(error: PayPalError): Unit = {
     if (error.errorName.contains("INSTRUMENT_DECLINED")) {
-      SafeLogger.info("Paypal payment failed with 'INSTRUMENT_DECLINED' response.")
+      logger.info("Paypal payment failed with 'INSTRUMENT_DECLINED' response.")
     } else {
-      SafeLogger.error(scrub"Paypal payment failed due to ${error.errorName} error. Full message: ${error.message}")
+      logger.error(scrub"Paypal payment failed due to ${error.errorName} error. Full message: ${error.message}")
     }
   }
 

--- a/support-frontend/app/services/pricing/PriceSummaryService.scala
+++ b/support-frontend/app/services/pricing/PriceSummaryService.scala
@@ -77,25 +77,7 @@ class PriceSummaryService(
       productRatePlan: ProductRatePlan[Product],
       price: Price,
       saving: Option[Int],
-  ) = {
-    val country = countryGroup.defaultCountry.orElse(countryGroup.countries.headOption).getOrElse(Country.UK)
-    logger.info(s"Validating promotions. Country: $country, productRatePlan: ${productRatePlan.id}")
-
-    logger.info("Promotions to validate")
-    logger.info(promotions.map(promo => promo.promoCode).mkString(", "))
-
-    val (invalidPromotions, validPromotions) = promotions
-      .map(promo =>
-        promotionService
-          .validatePromotion(promo, country, productRatePlan.id, isRenewal = false),
-      )
-      .partitionMap(identity)
-
-    logger.info("Invalid promotions")
-    logger.info(invalidPromotions.map(promoError => promoError.msg).mkString(", "))
-
-    logger.info("Valid promotions")
-    logger.info(validPromotions.map(promoError => promoError.promoCode).mkString(", "))
+  ): (Currency, PriceSummary) = {
 
     val promotionSummaries: List[PromotionSummary] = for {
       promotion <- promotions

--- a/support-frontend/app/services/pricing/PriceSummaryService.scala
+++ b/support-frontend/app/services/pricing/PriceSummaryService.scala
@@ -26,10 +26,6 @@ class PriceSummaryService(
       promoCodes: List[PromoCode],
       readerType: ReaderType = Direct,
   ): ProductPrices = {
-    logger.info(
-      s"getPrices for catalogue: ${catalogService.environment}, promotionService: ${promotionService.environment}",
-    )
-
     val defaultPromos = getDefaultPromoCodes(product)
     val promotions = promotionService.findPromotions(promoCodes ++ defaultPromos)
     product

--- a/support-frontend/app/services/pricing/PriceSummaryService.scala
+++ b/support-frontend/app/services/pricing/PriceSummaryService.scala
@@ -1,7 +1,7 @@
 package services.pricing
 
 import com.gu.i18n.{Country, CountryGroup, Currency}
-import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogging
 import com.gu.support.catalog._
 import services.pricing.PriceSummaryService.{getDiscountedPrice, getNumberOfDiscountedPeriods}
 import com.gu.support.promotions._
@@ -17,7 +17,8 @@ class PriceSummaryService(
     promotionService: PromotionService,
     defaultPromotionService: DefaultPromotionService,
     catalogService: CatalogService,
-) extends TouchpointService {
+) extends TouchpointService
+    with SafeLogging {
   private type GroupedPriceList = Map[(FulfilmentOptions, ProductOptions, BillingPeriod), Map[Currency, PriceSummary]]
 
   def getPrices[T <: Product](
@@ -25,7 +26,7 @@ class PriceSummaryService(
       promoCodes: List[PromoCode],
       readerType: ReaderType = Direct,
   ): ProductPrices = {
-    SafeLogger.info(
+    logger.info(
       s"getPrices for catalogue: ${catalogService.environment}, promotionService: ${promotionService.environment}",
     )
 
@@ -78,10 +79,10 @@ class PriceSummaryService(
       saving: Option[Int],
   ) = {
     val country = countryGroup.defaultCountry.orElse(countryGroup.countries.headOption).getOrElse(Country.UK)
-    SafeLogger.info(s"Validating promotions. Country: $country, productRatePlan: ${productRatePlan.id}")
+    logger.info(s"Validating promotions. Country: $country, productRatePlan: ${productRatePlan.id}")
 
-    SafeLogger.info("Promotions to validate")
-    SafeLogger.info(promotions.map(promo => promo.promoCode).mkString(", "))
+    logger.info("Promotions to validate")
+    logger.info(promotions.map(promo => promo.promoCode).mkString(", "))
 
     val (invalidPromotions, validPromotions) = promotions
       .map(promo =>
@@ -90,11 +91,11 @@ class PriceSummaryService(
       )
       .partitionMap(identity)
 
-    SafeLogger.info("Invalid promotions")
-    SafeLogger.info(invalidPromotions.map(promoError => promoError.msg).mkString(", "))
+    logger.info("Invalid promotions")
+    logger.info(invalidPromotions.map(promoError => promoError.msg).mkString(", "))
 
-    SafeLogger.info("Valid promotions")
-    SafeLogger.info(validPromotions.map(promoError => promoError.promoCode).mkString(", "))
+    logger.info("Valid promotions")
+    logger.info(validPromotions.map(promoError => promoError.promoCode).mkString(", "))
 
     val promotionSummaries: List[PromotionSummary] = for {
       promotion <- promotions

--- a/support-frontend/app/services/stepfunctions/Client.scala
+++ b/support-frontend/app/services/stepfunctions/Client.scala
@@ -1,21 +1,18 @@
 package services.stepfunctions
 
-import services.aws.AwsAsync
-import StateMachineContainer.{Response, convertErrors}
-import org.apache.pekko.actor.ActorSystem
 import cats.data.EitherT
 import cats.implicits._
 import com.amazonaws.regions.Regions
-import services.aws.CredentialsProvider
 import com.amazonaws.services.stepfunctions.model.{ExecutionStatus => _, _}
 import com.amazonaws.services.stepfunctions.{AWSStepFunctionsAsync, AWSStepFunctionsAsyncClientBuilder}
+import com.gu.monitoring.SafeLogging
 import io.circe.Encoder
-import cats.implicits._
-import com.gu.monitoring.SafeLogger
+import org.apache.pekko.actor.ActorSystem
+import services.aws.{AwsAsync, CredentialsProvider}
+import services.stepfunctions.StateMachineContainer.{Response, convertErrors}
 import services.stepfunctions.StateMachineErrors.Fail
 
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 
 object Client {
@@ -32,14 +29,14 @@ object Client {
   }
 }
 
-class Client(client: AWSStepFunctionsAsync, arn: StateMachineArn) {
+class Client(client: AWSStepFunctionsAsync, arn: StateMachineArn) extends SafeLogging {
 
   private def startExecution(arn: String, input: String)(implicit
       ec: ExecutionContext,
   ): Response[StartExecutionResult] = convertErrors {
     AwsAsync(client.startExecutionAsync, new StartExecutionRequest().withStateMachineArn(arn).withInput(input))
       .transform { theTry =>
-        SafeLogger.info(s"state machine result: $theTry")
+        logger.info(s"state machine result: $theTry")
         theTry
       }
   }

--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -1,20 +1,19 @@
 package services.stepfunctions
 
-import org.apache.pekko.actor.ActorSystem
 import cats.data.EitherT
 import cats.implicits._
 import com.amazonaws.services.stepfunctions.model.StateExitedEventDetails
 import com.gu.i18n.Title
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
+import com.gu.monitoring.SafeLogging
 import com.gu.support.acquisitions.{AbTest, AcquisitionData, OphanIds, ReferrerAcquisitionData}
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec._
 import com.gu.support.promotions.PromoCode
 import com.gu.support.redemptions.RedemptionData
 import com.gu.support.workers.CheckoutFailureReasons.CheckoutFailureReason
-import com.gu.support.workers.states.{AnalyticsInfo, CheckoutFailureState, CreatePaymentMethodState}
 import com.gu.support.workers._
+import com.gu.support.workers.states.{AnalyticsInfo, CheckoutFailureState, CreatePaymentMethodState}
+import org.apache.pekko.actor.ActorSystem
 import io.circe.{Decoder, Encoder}
 import org.joda.time.LocalDate
 import play.api.mvc.{Call, Request}
@@ -22,7 +21,7 @@ import services.stepfunctions.CreateSupportWorkersRequest.GiftRecipientRequest
 import services.stepfunctions.SupportWorkersClient._
 
 import java.util.UUID
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.util.{Failure, Success, Try}
 
 object CreateSupportWorkersRequest {
@@ -97,9 +96,10 @@ class SupportWorkersClient(
     stateWrapper: StateWrapper,
     supportUrl: String,
     statusCall: String => Call,
-)(implicit system: ActorSystem) {
-  private implicit val sw = stateWrapper
-  private implicit val ec = system.dispatcher
+)(implicit system: ActorSystem)
+    extends SafeLogging {
+  private implicit val sw: StateWrapper = stateWrapper
+  private implicit val ec: ExecutionContextExecutor = system.dispatcher
   private val underlying = Client(arn)
 
   private def referrerAcquisitionDataWithGAFields(
@@ -183,18 +183,18 @@ class SupportWorkersClient(
         .triggerExecution(createPaymentMethodState, user.isTestUser, isExistingAccount)
         .bimap(
           { error =>
-            SafeLogger.error(scrub"[$requestId] Failed to trigger Step Function execution for ${user.id} - $error")
+            logger.error(scrub"[$requestId] Failed to trigger Step Function execution for ${user.id} - $error")
             StateMachineFailure.toString
           },
           { success =>
-            SafeLogger.info(s"[$requestId] Successfully triggered Step Function execution for ${user.id} ($success)")
+            logger.info(s"[$requestId] Successfully triggered Step Function execution for ${user.id} ($success)")
             underlying.jobIdFromArn(success.arn).map { jobId =>
               StatusResponse(
                 status = Status.Pending,
                 trackingUri = supportUrl + statusCall(jobId).url,
               )
             } getOrElse {
-              SafeLogger.error(
+              logger.error(
                 scrub"[$requestId] Failed to parse ${success.arn} to a jobId after triggering Step Function execution for ${user.id} $request",
               )
               StatusResponse(
@@ -213,7 +213,7 @@ class SupportWorkersClient(
   def status(jobId: String, requestId: UUID): EitherT[Future, SupportWorkersError, StatusResponse] = {
 
     def respondToClient(statusResponse: StatusResponse): StatusResponse = {
-      SafeLogger.info(
+      logger.info(
         s"[$requestId] Client is polling for status - the current status for execution $jobId is: ${statusResponse}",
       )
       statusResponse
@@ -223,7 +223,7 @@ class SupportWorkersClient(
       .history(jobId)
       .bimap(
         { error =>
-          SafeLogger.error(scrub"[$requestId] failed to get status of step function execution $jobId: $error")
+          logger.error(scrub"[$requestId] failed to get status of step function execution $jobId: $error")
           StateMachineFailure: SupportWorkersError
         },
         { events =>
@@ -240,7 +240,7 @@ class SupportWorkersClient(
 
 }
 
-object StepFunctionExecutionStatus {
+object StepFunctionExecutionStatus extends SafeLogging {
 
   def checkoutStatus(
       detailedHistory: List[Try[StateExitedEventDetails]],
@@ -263,12 +263,12 @@ object StepFunctionExecutionStatus {
       stateWrapper: StateWrapper,
       eventDetails: StateExitedEventDetails,
   ): Option[CheckoutFailureReason] = {
-    SafeLogger.info(s"Event details are: $eventDetails")
+    logger.info(s"Event details are: $eventDetails")
     stateWrapper.unWrap[CheckoutFailureState](eventDetails.getOutput) match {
       case Success(checkoutFailureState) =>
         Some(checkoutFailureState.checkoutFailureReason)
       case Failure(error) =>
-        SafeLogger.error(scrub"Failed to determine checkout failure reason due to $error")
+        logger.error(scrub"Failed to determine checkout failure reason due to $error")
         None
     }
 

--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -3,32 +3,19 @@ package utils
 import admin.settings.{RecurringPaymentMethodSwitches, SubscriptionsPaymentMethodSwitches, Switches}
 import com.gu.i18n.Currency.GBP
 import com.gu.i18n.{Country, CountryGroup, Currency}
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
+import com.gu.monitoring.SafeLogging
 import com.gu.support.abtests.BenefitsTest.isValidBenefitsTestPurchase
-import com.gu.support.acquisitions.AbTest
-import com.gu.support.catalog.{
-  Collection,
-  Domestic,
-  FulfilmentOptions,
-  NationalDelivery,
-  HomeDelivery,
-  NoFulfilmentOptions,
-  RestOfWorld,
-}
-import com.gu.support.paperround.PaperRoundAPI
+import com.gu.support.catalog.{Contribution, DigitalPack, GuardianWeekly, Paper, SupporterPlus, _}
 import com.gu.support.paperround.CoverageEndpoint.{CO, RequestBody}
+import com.gu.support.paperround.{AgentId, PaperRoundAPI}
 import com.gu.support.redemptions.RedemptionData
 import com.gu.support.workers._
 import com.gu.support.zuora.api.ReaderType
-import java.nio.charset.Charset
 import services.stepfunctions.CreateSupportWorkersRequest
 import services.stepfunctions.CreateSupportWorkersRequest.GiftRecipientRequest
 import utils.CheckoutValidationRules._
 
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext
-import com.gu.support.paperround.AgentId
+import scala.concurrent.{ExecutionContext, Future}
 
 object CheckoutValidationRules {
 
@@ -375,7 +362,7 @@ object GuardianWeeklyValidation {
 
 }
 
-object PaperValidation {
+object PaperValidation extends SafeLogging {
 
   import AddressAndCurrencyValidationRules._
 
@@ -436,7 +423,7 @@ object PaperValidation {
           response.data.status match {
             case CO if response.data.agents.map(_.agentId).contains(agent) => Valid
             case _ =>
-              SafeLogger.error(
+              logger.error(
                 scrub"User’s postcode $postcode wasn’t covered by their chosen delivery agent $agent: PaperRound response was $response",
               )
               Invalid(

--- a/support-frontend/app/wiring/ActionBuilders.scala
+++ b/support-frontend/app/wiring/ActionBuilders.scala
@@ -7,7 +7,7 @@ import play.filters.HttpFiltersComponents
 trait ActionBuilders {
   self: Services with BuiltInComponentsFromContext with ApplicationConfiguration with HttpFiltersComponents =>
 
-  implicit lazy val actionBuilders = new CustomActionBuilders(
+  implicit lazy val actionBuilders: CustomActionBuilders = new CustomActionBuilders(
     asyncAuthenticationService = asyncAuthenticationService,
     userFromAuthCookiesOrAuthServerActionBuilder = userFromAuthCookiesOrAuthServerActionBuilder,
     userFromAuthCookiesActionBuilder = userFromAuthCookiesActionBuilder,

--- a/support-frontend/app/wiring/AppComponents.scala
+++ b/support-frontend/app/wiring/AppComponents.scala
@@ -37,7 +37,6 @@ class AppComponents(context: Context)
     Some(router),
     assetsResolver,
     allSettingsProvider,
-    appConfig.stage,
   )
   override lazy val httpErrorHandler = customHandler
   override lazy val errorController = new ErrorController(actionBuilders, customHandler)

--- a/support-frontend/app/wiring/Services.scala
+++ b/support-frontend/app/wiring/Services.scala
@@ -12,6 +12,7 @@ import com.gu.support.paperround.PaperRoundServiceProvider
 import com.gu.support.promotions.PromotionServiceProvider
 import com.gu.zuora.ZuoraGiftLookupServiceProvider
 import play.api.BuiltInComponentsFromContext
+import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.AhcWSComponents
 import services._
 import services.paypal.PayPalNvpServiceProvider
@@ -21,7 +22,7 @@ import services.stepfunctions.{StateWrapper, SupportWorkersClient}
 trait Services {
   self: BuiltInComponentsFromContext with AhcWSComponents with PlayComponents with ApplicationConfiguration =>
 
-  implicit val implicitWs = wsClient
+  implicit val implicitWs: WSClient = wsClient
   implicit private val s3Client: AwsS3Client = AwsS3Client
 
   lazy val payPalNvpServiceProvider = new PayPalNvpServiceProvider(appConfig.regularPayPalConfigProvider, wsClient)

--- a/support-lambdas/stripe-intent/src/main/scala/com/gu/handler/JsonLambda.scala
+++ b/support-lambdas/stripe-intent/src/main/scala/com/gu/handler/JsonLambda.scala
@@ -1,14 +1,11 @@
 package com.gu.handler
 
-import java.io.{InputStream, OutputStream}
-
 import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
 import io.circe.Decoder
 import io.circe.parser.decode
 import io.circe.syntax._
 
+import java.io.{InputStream, OutputStream}
 import scala.concurrent.duration.{Duration, MILLISECONDS}
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.io.Source
@@ -42,7 +39,7 @@ abstract class JsonLambda[Request: Decoder, Environment](implicit executionConte
       t
     }
     ioStreamAttempt.recover { case t =>
-      SafeLogger.error(scrub"Lambda failed with exception", t)
+      logger.error(scrub"Lambda failed with exception", t)
       throw t
     }
   }

--- a/support-lambdas/stripe-intent/src/main/scala/com/gu/handler/LogImplicit.scala
+++ b/support-lambdas/stripe-intent/src/main/scala/com/gu/handler/LogImplicit.scala
@@ -1,17 +1,17 @@
 package com.gu.handler
 
-import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.{SafeLogger, SafeLogging}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait LogImplicit {
+trait LogImplicit extends SafeLogging {
 
   implicit class LogImplicit2[A](value: Future[A]) {
 
     // this is just a handy method to add logging to the end of any value
     def withLogging(message: String)(implicit executionContext: ExecutionContext): Future[A] = {
       value.transform { res =>
-        SafeLogger.info(s"$message: $res")
+        logger.info(s"$message: $res")
         res
       }
     }

--- a/support-lambdas/stripe-intent/src/main/scala/com/gu/handler/impure/S3Loader.scala
+++ b/support-lambdas/stripe-intent/src/main/scala/com/gu/handler/impure/S3Loader.scala
@@ -8,7 +8,7 @@ import com.amazonaws.auth.{
 }
 import com.amazonaws.services.s3.AmazonS3URI
 import com.gu.aws.AwsS3Client
-import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogging
 import com.typesafe.config.{Config, ConfigFactory}
 
 object Aws {
@@ -23,9 +23,9 @@ object Aws {
 
 }
 
-object S3Loader {
+object S3Loader extends SafeLogging {
   def load(uri: AmazonS3URI): Config = {
-    SafeLogger.info(s"Loading config from S3 from $uri")
+    logger.info(s"Loading config from S3 from $uri")
     AwsS3Client
       .fetchAsString(uri)
       .map(

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/bigquery/BigQueryService.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/bigquery/BigQueryService.scala
@@ -1,24 +1,16 @@
 package com.gu.support.acquisitions
 
 import cats.data.EitherT
-import com.google.api.core.ApiFutureCallback
-import com.google.api.core.ApiFutures
+import com.google.api.core.{ApiFutureCallback, ApiFutures}
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.auth.Credentials
 import com.google.auth.oauth2.GoogleCredentials
-import com.google.cloud.bigquery.storage.v1.{
-  AppendRowsResponse,
-  BigQueryWriteClient,
-  BigQueryWriteSettings,
-  JsonStreamWriter,
-  TableName,
-}
 import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializtionError
+import com.google.cloud.bigquery.storage.v1._
 import com.gu.aws.AwsCloudWatchMetricPut
 import com.gu.aws.AwsCloudWatchMetricPut.{client => cloudwatchClient}
 import com.gu.aws.AwsCloudWatchMetricSetup.writeAcquisitionDataToBigQueryFailure
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger.Sanitizer
+import com.gu.monitoring.SafeLogging
 import com.gu.support.acquisitions.AcquisitionEventTable.{datasetName, tableName}
 import com.gu.support.acquisitions.models.AcquisitionDataRow
 import com.gu.support.config.Stage
@@ -26,10 +18,10 @@ import org.json.{JSONArray, JSONObject}
 
 import java.io.ByteArrayInputStream
 import java.util.concurrent.Executors
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.{Future, Promise}
 import scala.jdk.CollectionConverters._
 
-class BigQueryService(stage: Stage, credentials: Credentials) {
+class BigQueryService(stage: Stage, credentials: Credentials) extends SafeLogging {
   private val projectId = s"datatech-platform-${stage.toString.toLowerCase}"
 
   lazy val bigQueryWriteSettings =
@@ -60,7 +52,7 @@ class BigQueryService(stage: Stage, credentials: Credentials) {
       acquisitionDataRow: AcquisitionDataRow,
   ): Future[Either[String, Unit]] = {
     val rowContent: JSONObject = AcquisitionDataRowMapper.mapToTableRow(acquisitionDataRow)
-    SafeLogger.info(s"Attempting to append row ($rowContent) created from ($acquisitionDataRow)")
+    logger.info(s"Attempting to append row ($rowContent) created from ($acquisitionDataRow)")
     val promise = Promise[Either[String, Unit]]()
     try {
       val responseFuture = streamWriter.append(new JSONArray(List(rowContent).asJava))
@@ -74,7 +66,7 @@ class BigQueryService(stage: Stage, credentials: Credentials) {
       case e: AppendSerializtionError =>
         val errorMessage =
           e.getRowIndexToErrorMessage.asScala.map { case (i, message) => s"$i: $message" }.mkString(", ")
-        SafeLogger.error(scrub"There was an exception appending to $tableName: $errorMessage", e)
+        logger.error(scrub"There was an exception appending to $tableName: $errorMessage", e)
         promise.success(Left(s"Error appending to table $tableName: $errorMessage"))
     }
     promise.future
@@ -90,11 +82,12 @@ object BigQueryService {
     )
 
   case class AppendCompleteCallback(stage: Stage, promise: Promise[Either[String, Unit]])
-      extends ApiFutureCallback[AppendRowsResponse] {
+      extends ApiFutureCallback[AppendRowsResponse]
+      with SafeLogging {
     val executor = Executors.newSingleThreadExecutor()
 
     def onSuccess(response: AppendRowsResponse): Unit = {
-      SafeLogger.info(s"Rows successfully inserted into table $tableName")
+      logger.info(s"Rows successfully inserted into table $tableName")
       promise.success(Right(()))
       executor.shutdown()
     }
@@ -104,7 +97,7 @@ object BigQueryService {
           e.getRowIndexToErrorMessage.asScala.map { case (i, message) => s"$i: $message" }.mkString(", ")
         case _ => ""
       }
-      SafeLogger.error(scrub"There was an exception inserting a row into $tableName: $detail", throwable)
+      logger.error(scrub"There was an exception inserting a row into $tableName: $detail", throwable)
       AwsCloudWatchMetricPut(cloudwatchClient)(writeAcquisitionDataToBigQueryFailure(stage))
       promise.success(
         Left(s"There was an exception inserting a row into $tableName: ${throwable.getMessage}; $detail"),

--- a/support-modules/rest/src/main/scala/com.gu.okhttp/package.scala
+++ b/support-modules/rest/src/main/scala/com.gu.okhttp/package.scala
@@ -1,15 +1,14 @@
 package com.gu
 
 import java.io.IOException
-
-import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.{SafeLogger, SafeLogging}
 import okhttp3._
 
 import scala.concurrent.{Future, Promise}
 
 package object okhttp {
 
-  implicit class RichOkHttpClient(client: OkHttpClient) {
+  implicit class RichOkHttpClient(client: OkHttpClient) extends SafeLogging {
 
     def execute(request: Request): Future[Response] = {
       val p = Promise[Response]()
@@ -19,7 +18,7 @@ package object okhttp {
         .enqueue(new Callback {
           override def onFailure(call: Call, e: IOException) {
             val sanitizedUrl = s"${request.url().uri().getHost}${request.url().uri().getPath}" // don't log query string
-            SafeLogger.warn(s"okhttp request failure: ${request.method()} $sanitizedUrl", e)
+            logger.warn(s"okhttp request failure: ${request.method()} $sanitizedUrl", e)
             p.failure(e)
           }
 

--- a/support-payment-api/src/main/scala/services/PaypalService.scala
+++ b/support-payment-api/src/main/scala/services/PaypalService.scala
@@ -2,7 +2,6 @@ package services
 
 import cats.data.EitherT
 import cats.implicits._
-import com.gu.monitoring.SafeLogger
 import com.paypal.api.payments._
 import com.paypal.base.Constants
 import com.paypal.base.rest.APIContext

--- a/support-services/src/main/scala/com/gu/support/getaddressio/GetAddressIOService.scala
+++ b/support-services/src/main/scala/com/gu/support/getaddressio/GetAddressIOService.scala
@@ -1,6 +1,7 @@
 package com.gu.support.getaddressio
 
 import com.gu.i18n.{Country, PostalCode}
+import com.gu.monitoring.SafeLogging
 import com.gu.okhttp.RequestRunners
 import com.gu.okhttp.RequestRunners.FutureHttpClient
 import com.gu.rest.WebServiceHelper
@@ -28,8 +29,7 @@ object FindAddressResultError {
 
 class GetAddressIOService(config: GetAddressIOConfig, client: FutureHttpClient)(implicit
     executionContext: ExecutionContext,
-) extends WebServiceHelper[FindAddressResultError]
-    with LazyLogging {
+) extends WebServiceHelper[FindAddressResultError] {
 
   override val wsUrl: String = config.apiUrl
   override val httpClient: FutureHttpClient = client

--- a/support-services/src/main/scala/com/gu/zuora/ZuoraGiftService.scala
+++ b/support-services/src/main/scala/com/gu/zuora/ZuoraGiftService.scala
@@ -60,7 +60,7 @@ class ZuoraGiftService(val config: ZuoraConfig, stage: Stage, client: FutureHttp
       putJson[ZuoraSuccessOrFailureResponse](s"subscriptions/${subscriptionId}", requestData.asJson, authHeaders)
     response.transform {
       case Success(successfulResponse) if successfulResponse.success =>
-        SafeLogger.info(
+        logger.info(
           s"Successfully updated gifteeIdentityId on Digital Subscription gift for user $gifteeIdentityId",
         )
         Success(successfulResponse)

--- a/support-workers/src/main/scala/com/gu/config/Configuration.scala
+++ b/support-workers/src/main/scala/com/gu/config/Configuration.scala
@@ -1,14 +1,14 @@
 package com.gu.config
 
 import com.gu.config.loaders.PrivateConfigLoader
-import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogging
 import com.gu.salesforce.SalesforceConfigProvider
 import com.gu.support.config._
 import com.typesafe.config.{Config, ConfigFactory}
 
 import scala.util.Try
 
-object Configuration {
+object Configuration extends SafeLogging {
 
   def load(): Configuration = new Configuration(loadConfig)
 
@@ -26,7 +26,7 @@ object Configuration {
     )
     .getOrElse(Stages.DEV)
 
-  SafeLogger.info(s"Load from S3: $loadFromS3, Stage: $stage")
+  logger.info(s"Load from S3: $loadFromS3, Stage: $stage")
 
   // this is static so it persists between lambda executions, but lazy so it doesn't cause a fatal error at class loading time
   private lazy val loadConfig = PrivateConfigLoader

--- a/support-workers/src/main/scala/com/gu/config/loaders/S3Loader.scala
+++ b/support-workers/src/main/scala/com/gu/config/loaders/S3Loader.scala
@@ -2,14 +2,14 @@ package com.gu.config.loaders
 
 import com.amazonaws.services.s3.AmazonS3URI
 import com.gu.aws.AwsS3Client
-import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.{SafeLogger, SafeLogging}
 import com.gu.support.config.Stage
 import com.typesafe.config.{Config, ConfigFactory}
 
-class S3Loader extends PrivateConfigLoader {
+class S3Loader extends PrivateConfigLoader with SafeLogging {
   override def load(stage: Stage, public: Config): Config = {
     val uri: AmazonS3URI = new AmazonS3URI(public.getString(s"config.private.s3.$stage"))
-    SafeLogger.info(s"Loading config from S3 for stage: $stage from $uri")
+    logger.info(s"Loading config from S3 for stage: $stage from $uri")
     AwsS3Client
       .fetchAsString(uri)
       .map(

--- a/support-workers/src/main/scala/com/gu/emailservices/EmailService.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/EmailService.scala
@@ -4,12 +4,11 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder
 import com.amazonaws.services.sqs.model.{SendMessageRequest, SendMessageResult}
 import com.gu.aws.{AwsAsync, CredentialsProvider}
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
+import com.gu.monitoring.SafeLogging
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class EmailService(emailQueueName: String)(implicit val executionContext: ExecutionContext) {
+class EmailService(emailQueueName: String)(implicit val executionContext: ExecutionContext) extends SafeLogging {
 
   private val sqsClient = AmazonSQSAsyncClientBuilder.standard
     .withCredentials(CredentialsProvider)
@@ -19,17 +18,17 @@ class EmailService(emailQueueName: String)(implicit val executionContext: Execut
   private val queueUrl = sqsClient.getQueueUrl(emailQueueName).getQueueUrl
 
   def send(fields: EmailFields): Future[SendMessageResult] = {
-    SafeLogger.info(s"Sending message to SQS queue $queueUrl")
+    logger.info(s"Sending message to SQS queue $queueUrl")
     val payload = fields.payload
-    SafeLogger.info(s"message content is: $payload")
+    logger.info(s"message content is: $payload")
     val messageResult = AwsAsync(sqsClient.sendMessageAsync, new SendMessageRequest(queueUrl, payload))
     messageResult
       .recover { case throwable =>
-        SafeLogger.error(scrub"Failed to send message due to $queueUrl due to:", throwable)
+        logger.error(scrub"Failed to send message due to $queueUrl due to:", throwable)
         throw throwable
       }
       .map { result =>
-        SafeLogger.info(s"Successfully sent message to $queueUrl: $result")
+        logger.info(s"Successfully sent message to $queueUrl: $result")
         result
       }
   }

--- a/support-workers/src/main/scala/com/gu/helpers/Timing.scala
+++ b/support-workers/src/main/scala/com/gu/helpers/Timing.scala
@@ -1,19 +1,19 @@
 package com.gu.helpers
 
-import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogging
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object Timing {
+object Timing extends SafeLogging {
 
   def record[T](service: String, metricName: String)(block: => Future[T])(implicit ec: ExecutionContext): Future[T] = {
     val fullName = s"$service $metricName"
-    SafeLogger.debug(s"$fullName started...")
+    logger.debug(s"$fullName started...")
     val startTime = System.currentTimeMillis()
 
     def recordEnd[A](name: String)(a: A): A = {
       val duration = System.currentTimeMillis() - startTime
-      SafeLogger.debug(s"$name completed in $duration ms")
+      logger.debug(s"$name completed in $duration ms")
 
       a
     }

--- a/support-workers/src/main/scala/com/gu/paypal/PayPalService.scala
+++ b/support-workers/src/main/scala/com/gu/paypal/PayPalService.scala
@@ -1,9 +1,7 @@
 package com.gu.paypal
 
-import java.util.NoSuchElementException
-
 import com.gu.config.Configuration
-import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogging
 import com.gu.okhttp.RequestRunners.FutureHttpClient
 import com.gu.support.config.{PayPalConfig, Stages}
 import io.lemonlabs.uri.QueryString
@@ -14,7 +12,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.Try
 
-class PayPalService(apiConfig: PayPalConfig, client: FutureHttpClient) {
+class PayPalService(apiConfig: PayPalConfig, client: FutureHttpClient) extends SafeLogging {
 
   val config = apiConfig
   // The parameters sent with every NVP request.
@@ -31,10 +29,10 @@ class PayPalService(apiConfig: PayPalConfig, client: FutureHttpClient) {
     def msg(status: String) = s"PayPal: $status (NVPResponse: $response)"
 
     retrieveNVPParam(response, "ACK") match {
-      case "Success" => SafeLogger.info("Successful PayPal NVP request")
-      case "SuccessWithWarning" => SafeLogger.warn(msg("Warning"))
-      case "Failure" => SafeLogger.warn(msg("Error"))
-      case "FailureWithWarning" => SafeLogger.warn(msg("Error With Warning"))
+      case "Success" => logger.info("Successful PayPal NVP request")
+      case "SuccessWithWarning" => logger.warn(msg("Warning"))
+      case "Failure" => logger.warn(msg("Error"))
+      case "FailureWithWarning" => logger.warn(msg("Error With Warning"))
     }
 
   }
@@ -47,7 +45,7 @@ class PayPalService(apiConfig: PayPalConfig, client: FutureHttpClient) {
       throw PayPalError(response.code(), responseBody)
 
     if (Configuration.stage == Stages.DEV)
-      SafeLogger.info("NVP response body = " + responseBody)
+      logger.info("NVP response body = " + responseBody)
 
     val parsedResponse = parseQuery(responseBody)
 

--- a/support-workers/src/main/scala/com/gu/stepfunctions/StepFunctionsService.scala
+++ b/support-workers/src/main/scala/com/gu/stepfunctions/StepFunctionsService.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.stepfunctions.AWSStepFunctionsAsyncClientBuilder
 import com.amazonaws.services.stepfunctions.model.{DescribeExecutionResult, ExecutionListItem, StateMachineListItem}
 import com.gu.aws.CredentialsProvider
 import com.gu.config.Configuration.stage
-import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.{SafeLogger, SafeLogging}
 import com.gu.support.config.Stages
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.workers.User
@@ -17,7 +17,7 @@ import io.circe.generic.auto._
 import scala.jdk.CollectionConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
-class StepFunctionsService {
+class StepFunctionsService extends SafeLogging {
   private val prefix =
     if (stage == Stages.DEV)
       s"MonthlyContributions${Stages.CODE.toString}-" // There is no DEV state machine
@@ -44,7 +44,7 @@ class StepFunctionsService {
   private def findUserDataInStateMachine(userId: String, arn: String, nextToken: Option[String] = None)(implicit
       ec: ExecutionContext,
   ): Future[Option[User]] = {
-    SafeLogger.info(s"Searching for user in statemachine $arn, nextToken: ${nextToken.getOrElse("")}")
+    logger.info(s"Searching for user in statemachine $arn, nextToken: ${nextToken.getOrElse("")}")
 
     for {
       response <- client.listExecutions(arn, nextToken)

--- a/support-workers/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
@@ -1,7 +1,6 @@
 package com.gu.support.workers.exceptions
 
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
+import com.gu.monitoring.SafeLogging
 import com.gu.paypal.PayPalError
 import com.gu.rest.{WebServiceClientError, WebServiceHelperError}
 import com.gu.salesforce.Salesforce.SalesforceErrorResponse
@@ -18,10 +17,10 @@ import javax.net.ssl.SSLException
 /** Maps exceptions from the application to either fatal or non fatal exceptions based on whether we think retrying them
   * has a chance of succeeding see support-workers/docs/error-handling.md
   */
-object ErrorHandler {
+object ErrorHandler extends SafeLogging {
   def handleException(throwable: Throwable): Nothing = {
     val retryException = toRetryException(throwable)
-    SafeLogger.error(scrub"${retryException.getMessage}", retryException)
+    logger.error(scrub"${retryException.getMessage}", retryException)
     throw retryException
   }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -28,7 +28,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       context: Context,
       services: Services,
   ): FutureHandlerResult = {
-    SafeLogger.debug(s"CreatePaymentMethod state: $state")
+    logger.debug(s"CreatePaymentMethod state: $state")
 
     state.paymentFields fold (
       paymentFields =>
@@ -180,10 +180,10 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       userAgent: String,
   ): Future[SepaPaymentMethod] = {
     if (ipAddress.length() > 15) {
-      SafeLogger.warn(s"IPv6 Address: ${ipAddress} is longer than 15 characters")
+      logger.warn(s"IPv6 Address: ${ipAddress} is longer than 15 characters")
     }
     if (userAgent.length() > 255) {
-      SafeLogger.warn(s"User Agent: ${userAgent} will be truncated to 255 characters")
+      logger.warn(s"User Agent: ${userAgent} will be truncated to 255 characters")
     }
     Future.successful(
       SepaPaymentMethod(

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -40,14 +40,14 @@ class CreateSalesforceContact
       context: Context,
       services: Services,
   ): Future[HandlerResult[CreateZuoraSubscriptionState]] = {
-    SafeLogger.debug(s"CreateSalesforceContact state: $state")
+    logger.debug(s"CreateSalesforceContact state: $state")
 
     services.salesforceService.createContactRecords(state.user, state.giftRecipient).flatMap { response =>
       if (response.successful) {
         Future.successful(HandlerResult(new NextState(state).build(response.contactRecords), requestInfo))
       } else {
         val errorMessage = response.errorMessage.getOrElse("No error message returned")
-        SafeLogger.warn(s"Error creating Salesforce contact:\n$errorMessage")
+        logger.warn(s"Error creating Salesforce contact:\n$errorMessage")
         Future.failed(new SalesforceException(errorMessage))
       }
     }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -29,7 +29,7 @@ class FailureHandler(emailService: EmailService) extends Handler[FailureHandlerS
       requestInfo: RequestInfo,
       context: Context,
   ): FutureHandlerResult = {
-    SafeLogger.info(
+    logger.info(
       s"FAILED product: ${state.product.describe}\n " +
         s"test_user: ${state.user.isTestUser}\n" +
         s"error: $error\n",
@@ -49,12 +49,12 @@ class FailureHandler(emailService: EmailService) extends Handler[FailureHandlerS
       case _: GuardianWeekly =>
         FailedEmailFields.guardianWeekly(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
     }
-    SafeLogger.info(s"Sending a failure email. Email fields: $emailFields")
+    logger.info(s"Sending a failure email. Email fields: $emailFields")
     emailService.send(emailFields)
   }
 
   private def handleError(state: FailureHandlerState, error: Option[ExecutionError], requestInfo: RequestInfo) = {
-    SafeLogger.info(s"Attempting to handle error $error")
+    logger.info(s"Attempting to handle error $error")
     val pattern =
       "No such token: (.*); a similar object exists in test mode, but a live mode key was used to make this request.".r
     error.flatMap(extractUnderlyingError) match {
@@ -95,7 +95,7 @@ class FailureHandler(emailService: EmailService) extends Handler[FailureHandlerS
       checkoutFailureReason: CheckoutFailureReason,
       requestInfo: RequestInfo,
   ) = {
-    SafeLogger.info(s"Returning CheckoutFailure state...")
+    logger.info(s"Returning CheckoutFailure state...")
     HandlerResult(CheckoutFailureState(state.user, checkoutFailureReason), requestInfo)
   }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -5,8 +5,6 @@ import com.gu.acquisitions.AcquisitionDataRowBuilder
 import com.gu.aws.AwsCloudWatchMetricPut
 import com.gu.aws.AwsCloudWatchMetricSetup.paymentSuccessRequest
 import com.gu.config.Configuration
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger.Sanitizer
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.catalog.{Contribution => _, DigitalPack => _, Paper => _}
 import com.gu.support.workers._
@@ -29,7 +27,7 @@ class SendAcquisitionEvent(serviceProvider: ServiceProvider = ServiceProvider)
       services: Services,
   ): FutureHandlerResult = {
 
-    SafeLogger.info(s"Sending acquisition event to BigQuery: ${state.toString}")
+    logger.info(s"Sending acquisition event to BigQuery: ${state.toString}")
 
     state.sendThankYouEmailState match {
       case _: SendThankYouEmailDigitalSubscriptionGiftRedemptionState =>
@@ -43,7 +41,7 @@ class SendAcquisitionEvent(serviceProvider: ServiceProvider = ServiceProvider)
 
   private def sendAcquisitionEvent(state: SendAcquisitionEventState, requestInfo: RequestInfo, services: Services) = {
     sendPaymentSuccessMetric(state).toEither.left
-      .foreach(SafeLogger.error(scrub"failed to send PaymentSuccess metric", _))
+      .foreach(logger.error(scrub"failed to send PaymentSuccess metric", _))
 
     val acquisition = AcquisitionDataRowBuilder.buildFromState(state, requestInfo)
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
@@ -46,16 +46,16 @@ class UpdateSupporterProductData(serviceProvider: ServiceProvider)
       catalogService: CatalogService,
       supporterDataDynamoService: SupporterDataDynamoService,
   ) = {
-    SafeLogger.info(s"Attempting to update user ${state.user.id}")
+    logger.info(s"Attempting to update user ${state.user.id}")
     getSupporterRatePlanItemFromState(state, catalogService) match {
       case Right(Some(supporterRatePlanItem)) =>
-        SafeLogger.info(s"Attempting to write supporterRatePlanItem $supporterRatePlanItem")
+        logger.info(s"Attempting to write supporterRatePlanItem $supporterRatePlanItem")
         supporterDataDynamoService.writeItem(supporterRatePlanItem).map { _ =>
-          SafeLogger.info(s"Successfully updated supporterRatePlanItem for user ${state.user.id}")
+          logger.info(s"Successfully updated supporterRatePlanItem for user ${state.user.id}")
           ()
         }
       case Right(None) =>
-        SafeLogger.info(
+        logger.info(
           s"Skipping write to SupporterProductData dynamo table because product is ${state.product.describe}",
         )
         Future.successful(())

--- a/support-workers/src/main/scala/com/gu/zuora/ZuoraSubscriptionCreator.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/ZuoraSubscriptionCreator.scala
@@ -2,10 +2,10 @@ package com.gu.zuora
 
 import com.gu.WithLoggingSugar._
 import com.gu.helpers.DateGenerator
-import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogging
 import com.gu.support.workers._
 import com.gu.support.zuora.api.response.{ZuoraAccountNumber, ZuoraSubscriptionNumber}
-import com.gu.support.zuora.api.{SubscribeItem, _}
+import com.gu.support.zuora.api._
 import com.gu.support.zuora.domain.DomainSubscription
 import com.gu.zuora.ZuoraSubscriptionCreator.checkSingleResponse
 
@@ -42,7 +42,7 @@ class ZuoraSubscriptionCreator(
 
 }
 
-object ZuoraSubscriptionCreator {
+object ZuoraSubscriptionCreator extends SafeLogging {
 
   def subscriptionRatePlansMatchDomainSubscriptionRatePlans(
       subscribeItemRatePlans: List[RatePlanData],
@@ -65,7 +65,7 @@ object ZuoraSubscriptionCreator {
             subscribeItem.subscriptionData.ratePlanData,
             domainSubscription.ratePlans,
           ) =>
-        SafeLogger.info("Skipping subscribe for user because a subscription has already been created for this request")
+        logger.info("Skipping subscribe for user because a subscription has already been created for this request")
         Future.successful((domainSubscription.accountNumber, domainSubscription.subscriptionNumber))
       case _ =>
         checkSingleResponse(zuoraService.subscribe(SubscribeRequest(List(subscribeItem)))).map { response =>

--- a/support-workers/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
@@ -26,7 +26,7 @@ class EndToEndSpec extends AsyncLambdaSpec with MockContext {
 
   def runSignupWithCurrency(currency: Currency): Future[Assertion] = {
     val json = createStripeSourcePaymentMethodContributionJson(currency = currency)
-    SafeLogger.info(json)
+    info(json)
     val output = Future
       .successful(wrapFixture(json))
       .chain(new CreatePaymentMethod())
@@ -82,9 +82,9 @@ class EndToEndSpec extends AsyncLambdaSpec with MockContext {
 
     def last(handler: Handler[_, _]): Future[ByteArrayOutputStream] = stream flatMap { stream =>
       val output = new ByteArrayOutputStream()
-      SafeLogger.info(s"calling handler: ${handler.getClass}")
+      info(s"calling handler: ${handler.getClass}")
       handler.handleRequestFuture(stream, output, context).map { _ =>
-        SafeLogger.info(s"finished handler: ${handler.getClass}")
+        info(s"finished handler: ${handler.getClass}")
         output
       }
     }

--- a/support-workers/src/test/scala/com/gu/support/workers/WrapperSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/WrapperSpec.scala
@@ -20,7 +20,7 @@ class WrapperSpec extends AnyFlatSpec with Matchers {
 
   it should "be able to handle a JsonWrapper with messages" in {
     val result = Encoding.in[CreateSalesforceContactState](JsonFixtures.wrapperWithMessages.asInputStream)
-    SafeLogger.info(s"$result")
+    info(s"$result")
     result.isSuccess should be(true)
   }
 }

--- a/support-workers/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
@@ -28,7 +28,7 @@ class SalesforceErrorsSpec extends AsyncLambdaSpec with Matchers {
     val invalidConfig = SalesforceConfig("", "https://test.salesforce.com", "", "", "", "", "")
     val authService = new AuthService(invalidConfig)
     recoverToSucceededIf[SalesforceAuthenticationErrorResponse] {
-      authService.authorize.map(auth => SafeLogger.info(s"Got an auth: $auth"))
+      authService.authorize.map(auth => info(s"Got an auth: $auth"))
     }
   }
 
@@ -57,7 +57,7 @@ class SalesforceErrorsSpec extends AsyncLambdaSpec with Matchers {
     val service = new SalesforceService(invalidConfig, configurableFutureRunner(10.seconds))
 
     recoverToSucceededIf[SalesforceAuthenticationErrorResponse] {
-      service.upsert(upsertData).map(response => SafeLogger.info(s"Got a response: $response"))
+      service.upsert(upsertData).map(response => info(s"Got a response: $response"))
     }
   }
 
@@ -69,10 +69,10 @@ class SalesforceErrorsSpec extends AsyncLambdaSpec with Matchers {
           req.url(s"${auth.instance_url}/$upsertEndpoint") // We still need to set the base url
       }
 
-    service.upsert(upsertData).map(response => SafeLogger.info(s"Got a response: $response"))
+    service.upsert(upsertData).map(response => info(s"Got a response: $response"))
 
     recoverToExceptionIf[SalesforceErrorResponse] {
-      service.upsert(upsertData).map(response => SafeLogger.info(s"Got a response: $response"))
+      service.upsert(upsertData).map(response => info(s"Got a response: $response"))
     }.map(_.message shouldBe "Session expired or invalid")
   }
 

--- a/support-workers/src/test/scala/com/gu/support/workers/errors/ZuoraErrorsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/errors/ZuoraErrorsSpec.scala
@@ -33,7 +33,7 @@ class ZuoraErrorsITSpec
       new ZuoraService(Configuration.load().zuoraConfigProvider.get(), configurableFutureRunner(30.seconds))
     recoverToSucceededIf[ZuoraErrorResponse] {
       zuoraService.subscribe(invalidSubscriptionRequest).map { response =>
-        SafeLogger.info(s"response: $response")
+        info(s"response: $response")
       }
     }
   }
@@ -43,7 +43,7 @@ class ZuoraErrorsITSpec
       new ZuoraService(Configuration.load().zuoraConfigProvider.get(), configurableFutureRunner(30.seconds))
     recoverToSucceededIf[ZuoraErrorResponse] {
       zuoraService.subscribe(incorrectPaymentMethod).map { response =>
-        SafeLogger.info(s"response: $response")
+        info(s"response: $response")
       }
     }
   }

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/DigitalSubscriptionGiftRedemptionIntegrationSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/DigitalSubscriptionGiftRedemptionIntegrationSpec.scala
@@ -24,7 +24,7 @@ class DigitalSubscriptionGiftRedemptionIntegrationSpec extends AsyncLambdaSpec w
 
     val requestId = UUID.randomUUID()
     val giftCode = new GiftCodeGeneratorService().generateCode(Annual)
-    SafeLogger.info(s"Gift code non existent = $giftCode")
+    info(s"Gift code non existent = $giftCode")
     val nonExistentCode = giftCode.value // We haven't created a sub with this
 
     recoverToExceptionIf[RuntimeException](
@@ -38,7 +38,7 @@ class DigitalSubscriptionGiftRedemptionIntegrationSpec extends AsyncLambdaSpec w
     val createSubRequestId = UUID.randomUUID()
     val redeemSubRequestId = UUID.randomUUID()
     val giftCode = new GiftCodeGeneratorService().generateCode(Annual)
-    SafeLogger.info(s"Gift code to create = $giftCode")
+    info(s"Gift code to create = $giftCode")
     val mockCodeGenerator = mock[GiftCodeGeneratorService]
     when(mockCodeGenerator.generateCode(any[BillingPeriod])).thenReturn(giftCode)
 

--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
@@ -53,10 +53,10 @@ class FailureHandlerITSpec extends AsyncLambdaSpec with MockContext {
       val requestInfo = outState.get._3
       val checkoutFailureState = outState.get._1
 
-      SafeLogger.info(requestInfo.messages.head)
-
-      requestInfo.failed should be(false)
-      checkoutFailureState.checkoutFailureReason should be(PaymentMethodUnacceptable)
+      withClue(requestInfo.messages.head) {
+        requestInfo.failed should be(false)
+        checkoutFailureState.checkoutFailureReason should be(PaymentMethodUnacceptable)
+      }
     }
 
   }
@@ -71,10 +71,10 @@ class FailureHandlerITSpec extends AsyncLambdaSpec with MockContext {
       val requestInfo = outState.get._3
       val checkoutFailureState = outState.get._1
 
-      SafeLogger.info(requestInfo.messages.head)
-
-      requestInfo.failed should be(false)
-      checkoutFailureState.checkoutFailureReason should be(PaymentMethodUnacceptable)
+      withClue(requestInfo.messages.head) {
+        requestInfo.failed should be(false)
+        checkoutFailureState.checkoutFailureReason should be(PaymentMethodUnacceptable)
+      }
     }
 
   }
@@ -89,10 +89,10 @@ class FailureHandlerITSpec extends AsyncLambdaSpec with MockContext {
       val requestInfo = outState.get._3
       val checkoutFailureState = outState.get._1
 
-      SafeLogger.warn(requestInfo.messages.head)
-
-      requestInfo.failed should be(false)
-      checkoutFailureState.checkoutFailureReason should be(PaymentMethodUnacceptable)
+      withClue(requestInfo.messages.head) {
+        requestInfo.failed should be(false)
+        checkoutFailureState.checkoutFailureReason should be(PaymentMethodUnacceptable)
+      }
     }
 
   }
@@ -107,10 +107,10 @@ class FailureHandlerITSpec extends AsyncLambdaSpec with MockContext {
       val requestInfo = outState.get._3
       val checkoutFailureState = outState.get._1
 
-      SafeLogger.info(requestInfo.messages.head)
-
-      requestInfo.failed should be(false)
-      checkoutFailureState.checkoutFailureReason should be(AccountMismatch)
+      withClue(requestInfo.messages.head) {
+        requestInfo.failed should be(false)
+        checkoutFailureState.checkoutFailureReason should be(AccountMismatch)
+      }
     }
   }
 
@@ -132,9 +132,9 @@ class FailureHandlerITSpec extends AsyncLambdaSpec with MockContext {
       val outState = Encoding.in[CheckoutFailureState](outStream.toInputStream)
       val requestInfo = outState.get._3
 
-      SafeLogger.warn(requestInfo.messages.head)
-
-      requestInfo.failed should be(false)
+      withClue(requestInfo.messages.head) {
+        requestInfo.failed should be(false)
+      }
     }
   }
 

--- a/supporter-product-data/src/main/scala/com/gu/lambdas/Handler.scala
+++ b/supporter-product-data/src/main/scala/com/gu/lambdas/Handler.scala
@@ -1,8 +1,7 @@
 package com.gu.lambdas
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
-import com.gu.monitoring.SafeLogger
-import com.typesafe.scalalogging.StrictLogging
+import com.gu.monitoring.SafeLogging
 import io.circe.parser.decode
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
@@ -17,7 +16,8 @@ abstract class Handler[IN, OUT](implicit
     decoder: Decoder[IN],
     encoder: Encoder[OUT],
     ec: ExecutionContext,
-) extends RequestStreamHandler {
+) extends RequestStreamHandler
+    with SafeLogging {
 
   override def handleRequest(is: InputStream, os: OutputStream, context: Context): Unit =
     Await.result(
@@ -40,11 +40,11 @@ abstract class Handler[IN, OUT](implicit
 
 }
 
-object StreamHandler {
+object StreamHandler extends SafeLogging {
   def fromStream[T](is: InputStream)(implicit decoder: Decoder[T]): Try[T] = {
     val triedT = Try {
       val body = Source.fromInputStream(is).mkString
-      SafeLogger.info(s"Lambda input: $body")
+      logger.info(s"Lambda input: $body")
       body
     }.flatMap(decode[T](_).toTry)
     is.close()

--- a/supporter-product-data/src/main/scala/com/gu/services/SqsService.scala
+++ b/supporter-product-data/src/main/scala/com/gu/services/SqsService.scala
@@ -2,25 +2,20 @@ package com.gu.services
 
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder
-import com.amazonaws.services.sqs.model.{
-  SendMessageBatchRequest,
-  SendMessageBatchRequestEntry,
-  SendMessageRequest,
-  SendMessageResult,
-}
-import com.gu.aws.{AwsAsync, CredentialsProvider}
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
+import com.amazonaws.services.sqs.model.{SendMessageBatchRequest, SendMessageBatchRequestEntry}
+import com.gu.aws.CredentialsProvider
+import com.gu.monitoring.SafeLogging
 import com.gu.supporterdata.model.{ContributionAmount, Stage, SupporterRatePlanItem}
 import io.circe.Encoder
 import io.circe.generic.semiauto.deriveEncoder
 import io.circe.syntax.EncoderOps
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
-class SqsService(queueName: String, alarmService: AlarmService)(implicit val executionContext: ExecutionContext) {
+class SqsService(queueName: String, alarmService: AlarmService)(implicit val executionContext: ExecutionContext)
+    extends SafeLogging {
   implicit val encoder: Encoder[SupporterRatePlanItem] = deriveEncoder
   implicit val contributionAmountEncoder: Encoder[ContributionAmount] = deriveEncoder
   private val sqsClient = AmazonSQSAsyncClientBuilder.standard
@@ -31,7 +26,7 @@ class SqsService(queueName: String, alarmService: AlarmService)(implicit val exe
   private val queueUrl = sqsClient.getQueueUrl(queueName).getQueueUrl
 
   def sendBatch(supporterRatePlanItems: List[(SupporterRatePlanItem, Int)]) = {
-    SafeLogger.info(s"Sending message batch with ${supporterRatePlanItems.length} items to SQS queue $queueUrl")
+    logger.info(s"Sending message batch with ${supporterRatePlanItems.length} items to SQS queue $queueUrl")
 
     val batchRequestEntries = supporterRatePlanItems.map { case (item, index) =>
       new SendMessageBatchRequestEntry(index.toString, item.asJson.noSpaces)
@@ -46,14 +41,14 @@ class SqsService(queueName: String, alarmService: AlarmService)(implicit val exe
         if (failures.nonEmpty) {
           failures.foreach { error =>
             val failedItem = supporterRatePlanItems(error.getId.toInt)
-            SafeLogger.error(
+            logger.error(
               scrub"Error writing to the queue\nFor item with body: ${failedItem.asJson}\nError message: ${error.getMessage}",
             )
           }
           alarmService.triggerSQSWriteAlarm
         }
       case Failure(exception) =>
-        SafeLogger.error(
+        logger.error(
           scrub"Error writing to the queue\nAn exception was thrown by SQS when writing this list of items: ${supporterRatePlanItems.asJson.spaces2}",
           exception,
         )
@@ -63,11 +58,11 @@ class SqsService(queueName: String, alarmService: AlarmService)(implicit val exe
   }
 }
 
-object SqsService {
+object SqsService extends SafeLogging {
   import scala.concurrent.ExecutionContext.Implicits.global
   def apply(stage: Stage) = {
     val queueName = s"supporter-product-data-${stage.value}"
-    SafeLogger.info(s"Creating SqsService for SQS queue $queueName")
+    logger.info(s"Creating SqsService for SQS queue $queueName")
     new SqsService(queueName, new AlarmService(stage))
   }
 }


### PR DESCRIPTION
I have noticed that all our logging appears as "SafeLogger" rather than the class it was logged from.

Also I noticed there's some really verbose logging which makes it hard to find anything in the logs based on timestamp (intorduced in https://github.com/guardian/support-frontend/pull/5664 )

This PR changes all logging to use a trait (first commit), and removes the above logging (second commit)

Before it has all these lines and they're hard to find in the codebase:
![image](https://github.com/guardian/support-frontend/assets/7304387/9c06d71d-7b71-4394-9ab7-8565d63885e1)

now they look better
![image](https://github.com/guardian/support-frontend/assets/7304387/343bc717-ad5c-41ed-97c9-4fdbdf23ac06)


and locally in intellij
![image](https://github.com/guardian/support-frontend/assets/7304387/458ef49c-d9a6-4fab-8a1b-12ab1272e3fc)


Tested in CODE and checked out an every day newspaper successfully