### PR TITLE
add new test for prices encoder

### DIFF
--- a/support-frontend/test/controllers/PricesControllerSerialisationTest.scala
+++ b/support-frontend/test/controllers/PricesControllerSerialisationTest.scala
@@ -1,0 +1,55 @@
+package controllers
+
+import com.gu.i18n.Currency
+import com.gu.support.promotions.{
+  DiscountBenefit,
+  FreeTrialBenefit,
+  IntroductoryPeriodType,
+  IntroductoryPriceBenefit,
+  Issue,
+}
+import controllers.PricesController.{CountryGroupPriceData, Prices, ProductPriceData, RatePlanPriceData}
+import org.joda.time.Days
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import services.pricing.{PriceSummary, PromotionSummary}
+
+import scala.concurrent.duration.DurationInt
+import io.circe.syntax._
+
+class PricesControllerSerialisationTest extends AnyFlatSpec with Matchers {
+
+  it should "serialise a sample prices payload" in {
+    val promotionSummary = PromotionSummary(
+      "promo",
+      "desc",
+      "proCode",
+      Some(BigDecimal(1.1)),
+      Some(3),
+      None,
+      Some(FreeTrialBenefit(Days.SEVEN)),
+      None,
+      Some(IntroductoryPriceBenefit(0.5, 3, Issue)),
+      None,
+    )
+    val priceSummary = PriceSummary(BigDecimal(1.2), Some(50), Currency.GBP, false, List(promotionSummary))
+    val ratePlanPriceData = RatePlanPriceData("pr", "cur", Some(priceSummary))
+    val productPriceData = ProductPriceData(ratePlanPriceData, ratePlanPriceData)
+    val countryGroupPriceData = CountryGroupPriceData(Some(productPriceData), Some(productPriceData))
+    val prices =
+      Prices(
+        countryGroupPriceData,
+        countryGroupPriceData,
+        countryGroupPriceData,
+        countryGroupPriceData,
+        countryGroupPriceData,
+        countryGroupPriceData,
+        countryGroupPriceData,
+      )
+    val actual = prices.asJson.spaces2
+    withClue(actual) {
+      actual.length should be >= 24200 // 24259
+    }
+  }
+
+}


### PR DESCRIPTION
following on from 
https://github.com/guardian/support-frontend/pull/5818#issuecomment-2007240542
@mchv pointed out a test might find the NPE issue.

This is useful to have, because this endpoint https://support.theguardian.com/prices is used by dotcom, and wouldn't be tested routinely in CODE.  The existing testing is on the data, rather than the serialisation.  The first we would know of it would be a high 5xx rate alarm.

I wrote this test against main before the above PR and it passed.  I added the type annotation and it failed
```
[info] PricesControllerSerialisationTest:
[info] - should serialise a sample prices payload *** FAILED ***
[info]   java.lang.NullPointerException: Cannot invoke "io.circe.Encoder.apply(Object)" because "encoder" is null
[info]   at io.circe.syntax.package$EncoderOps$.asJson$extension(package.scala:24)
[info]   at controllers.PricesControllerSerialisationTest.$anonfun$new$1(PricesControllerSerialisationTest.scala:49)
```

I updated main locally and it passed again.