### PR TITLE
fix browserstack link

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -37,6 +37,7 @@ jobs:
         working-directory: ./support-e2e
 
       - name: Set outputs
+        if: ${{ failure() }}
         id: vars
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
browserstack link wasn't populated here https://github.com/guardian/support-frontend/actions/runs/8346808348/job/22844962434

`browserStackSearch="https://automate.browserstack.com/dashboard/v2/search?query=playwright-build-&type=builds"`
should have the commit ID in there too

This PR adds it back in so the var is set on failure, rather than skipped