### PR TITLE
print out supporter-workers input and output state in a much nicer way

### DIFF
--- a/support-workers/src/main/resources/logback.xml
+++ b/support-workers/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <configuration>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="STDOUT" class="com.gu.support.workers.lambdas.LambdaAppender">
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
             <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
                 <marker>SENTRY</marker>

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/Handler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/Handler.scala
@@ -1,8 +1,9 @@
 package com.gu.support.workers.lambdas
 
-import java.io.{InputStream, OutputStream}
+import ch.qos.logback.core.OutputStreamAppender
 
-import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
+import java.io.{InputStream, OutputStream}
+import com.amazonaws.services.lambda.runtime.{Context, LambdaRuntime, RequestStreamHandler}
 import com.gu.monitoring.SafeLogging
 import com.gu.support.workers.exceptions.ErrorHandler
 import com.gu.support.workers.{ExecutionError, RequestInfo}
@@ -12,6 +13,28 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.control.NonFatal
 
+/** this appender makes sure that multi line messages stay together in cloudwatch
+  */
+class LambdaAppender[E] extends OutputStreamAppender[E] {
+  override def start(): Unit = {
+    println("Starting appender " + this.getClass.getName)
+    setOutputStream(new OutputStream() {
+
+      override def write(b: Int): Unit =
+        LambdaRuntime.getLogger.log(Array(b.toByte))
+
+      override def write(b: Array[Byte]): Unit =
+        LambdaRuntime.getLogger.log(b)
+
+      override def write(b: Array[Byte], off: Int, len: Int): Unit =
+        LambdaRuntime.getLogger.log(b.slice(off, off + len))
+
+      override def flush(): Unit =
+        System.out.flush()
+    })
+    super.start()
+  }
+}
 abstract class Handler[IN, OUT](implicit
     decoder: Decoder[IN],
     encoder: Encoder[OUT],
@@ -36,12 +59,17 @@ abstract class Handler[IN, OUT](implicit
     }
 
   def handleRequestFuture(is: InputStream, os: OutputStream, context: Context): Future[Unit] = {
+    def log[T](message: String, a: T): Unit = {
+      val prettyData = pprint.apply(a).plainText.replaceAll("\\n", "\n\t")
+      logger.info(message + ":\n\t" + prettyData)
+    }
+
     val eventualUnit: Future[Unit] = for {
       inputData <- Future.fromTry(in(is))
-      _ = logger.info(s"START  ${this.getClass} with $inputData")
+      _ = log(s"START  ${this.getClass} with", inputData)
       (input, error, requestInfo) = inputData
       result <- handlerFuture(input, error, requestInfo, context)
-      _ = logger.info(s"FINISH ${this.getClass} with $result")
+      _ = log(s"FINISH ${this.getClass} with", result)
       _ <- Future.fromTry(out(result, os))
     } yield ()
     eventualUnit.recover { case t =>

--- a/support-workers/src/test/resources/logback.xml
+++ b/support-workers/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <configuration>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="STDOUT" class="com.gu.support.workers.lambdas.LambdaAppender">
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
             <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
                 <marker>SENTRY</marker>


### PR DESCRIPTION
It's quite hard to pick out individual fields in the state when looking at support-workers logs.

This PR updates it so that it's nicely formatted.

I had to pull in a new library pprint https://com-lihaoyi.github.io/PPrint/

Also I had to write a custom logback appender which uses the AWS functionality that doesn't split up multi line log statements https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html#:~:text=The%20logger%20class%20supports%20multiline%20logs.

before (this is in CODE)

<img width="1380" alt="image" src="https://github.com/guardian/support-frontend/assets/7304387/ed2bc5bc-f1fc-42e1-a478-e346fdc2a930">


After (split into two screenshots due to length)
<img width="1160" alt="image" src="https://github.com/guardian/support-frontend/assets/7304387/b9b9d1ff-5d00-4dcc-8011-3d14b98c46bc">
<img width="1194" alt="image" src="https://github.com/guardian/support-frontend/assets/7304387/97553f2a-e7fc-4ef9-bd23-eaf0f5f182f7">
