### PR TITLE
use useful name for support workers executions

### DIFF
--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -180,7 +180,7 @@ class SupportWorkersClient(
       )
       isExistingAccount = createPaymentMethodState.paymentFields.left.exists(_.isInstanceOf[ExistingPaymentFields])
       name =
-        (if (user.isTestUser) "TEST-" else "") +
+        (if (user.isTestUser) "TestUser-" else "") +
           createPaymentMethodState.product.describe + "-" +
           createPaymentMethodState.paymentFields.fold(_.describe, _.getClass.getSimpleName)
       executionResult <- underlying

--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -179,8 +179,12 @@ class SupportWorkersClient(
           request.headers.get("X-Forwarded-For").flatMap(_.split(',').headOption).getOrElse(request.remoteAddress),
       )
       isExistingAccount = createPaymentMethodState.paymentFields.left.exists(_.isInstanceOf[ExistingPaymentFields])
+      name =
+        (if (user.isTestUser) "TEST-" else "") +
+          createPaymentMethodState.product.describe + "-" +
+          createPaymentMethodState.paymentFields.fold(_.describe, _.getClass.getSimpleName)
       executionResult <- underlying
-        .triggerExecution(createPaymentMethodState, user.isTestUser, isExistingAccount)
+        .triggerExecution(createPaymentMethodState, user.isTestUser, isExistingAccount, name)
         .bimap(
           { error =>
             logger.error(scrub"[$requestId] Failed to trigger Step Function execution for ${user.id} - $error")

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
@@ -7,7 +7,9 @@ import com.gu.support.encoding.Codec.deriveCodec
 import io.circe.syntax._
 import io.circe.{Encoder, _}
 
-sealed trait PaymentFields
+sealed trait PaymentFields {
+  def describe: String = getClass.getSimpleName.replaceAll("PaymentFields", "")
+}
 
 case class PayPalPaymentFields(baid: String) extends PaymentFields
 
@@ -15,7 +17,10 @@ case class StripePaymentFields(
     paymentMethod: PaymentMethodId,
     stripePaymentType: Option[StripePaymentType],
     stripePublicKey: Option[StripePublicKey], // this is only optional until all checkouts are updated
-) extends PaymentFields
+) extends PaymentFields {
+  override def describe: String =
+    stripePaymentType.map(_.getClass.getSimpleName.replaceAll("\\$", "")).getOrElse("Stripe")
+}
 
 object StripePublicKey {
 


### PR DESCRIPTION
So far the support workers executions are just a wall of UUIDs
![image](https://github.com/guardian/support-frontend/assets/7304387/a5317503-e75a-46be-95a1-eca5f51a7f89)

This PR makes them more useful
![image](https://github.com/guardian/support-frontend/assets/7304387/a5857eae-75db-44f6-b8e5-811179b0593e)

The format is
```
TEST-Monthly-GuardianWeekly-Domestic-GBP-DirectDebit-1409401929736666
^^^^ ^^^^^^^^product description^^^^^^^^ ^^^^^^^^^^^ ^^^^^nanosecond rolling time (292 year rollaround)
||||                                     pay_meth
present only if test user
```