### PR TITLE
Add ProductCatalogService

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -19,7 +19,7 @@ import play.api.libs.circe.Circe
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.pricing.PriceSummaryServiceProvider
-import services.{PaymentAPIService, TestUserService}
+import services.{CachedProductCatalogService, CachedProductCatalogServiceProvider, PaymentAPIService, TestUserService}
 import utils.FastlyGEOIP._
 import views.EmptyDiv
 
@@ -39,7 +39,7 @@ case class PaymentMethodConfigs(
 class Application(
     actionRefiners: CustomActionBuilders,
     val assets: AssetsResolver,
-    testUsers: TestUserService,
+    testUserService: TestUserService,
     components: ControllerComponents,
     oneOffStripeConfigProvider: StripePublicConfigProvider,
     regularStripeConfigProvider: StripePublicConfigProvider,
@@ -53,6 +53,7 @@ class Application(
     stage: Stage,
     wsClient: WSClient,
     priceSummaryServiceProvider: PriceSummaryServiceProvider,
+    cachedProductCatalogServiceProvider: CachedProductCatalogServiceProvider,
     val supportUrl: String,
 )(implicit val ec: ExecutionContext)
     extends AbstractController(components)
@@ -186,7 +187,7 @@ class Application(
     )
 
     val serversideTests = generateParticipations(Nil)
-    val testMode = testUsers.isTestUser(request)
+    val testMode = testUserService.isTestUser(request)
 
     val queryPromos =
       request.queryString
@@ -273,7 +274,7 @@ class Application(
 
     val geoData = request.geoData
     val serversideTests = generateParticipations(Nil)
-    val isTestUser = testUsers.isTestUser(request)
+    val isTestUser = testUserService.isTestUser(request)
     // This will be present if the token has been flashed into the session by the PayPal redirect endpoint
     val guestAccountCreationToken = request.flash.get("guestAccountCreationToken")
 
@@ -300,13 +301,12 @@ class Application(
     ).withSettingsSurrogateKey
   }
 
-  def products() = Action.async { implicit request =>
-    wsClient
-      .url(
-        "https://raw.githubusercontent.com/guardian/support-service-lambdas/0b031ea5821c95a7f7c59e45951d2d1f0bebed9d/modules/product/src/prodCatalogMapping.json",
-      )
-      .get()
-      .map(response => Ok(response.body).withHeaders("Cache-Control" -> "max-age=30"))
+  @deprecated("We will remove this once we get the data to the client not via HTTP")
+  def products() = Action { implicit request =>
+    val isTestUser = testUserService.isTestUser(request)
+    val cachedProductCatalogService = cachedProductCatalogServiceProvider.forUser(isTestUser)
+
+    Ok(cachedProductCatalogService.get().toJson).withHeaders("Cache-Control" -> "no-cache, private")
   }
 }
 

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -302,11 +302,11 @@ class Application(
   }
 
   @deprecated("We will remove this once we get the data to the client not via HTTP")
-  def products() = Action { implicit request =>
+  def products() = NoCacheAction() { implicit request =>
     val isTestUser = testUserService.isTestUser(request)
     val cachedProductCatalogService = cachedProductCatalogServiceProvider.forUser(isTestUser)
 
-    Ok(cachedProductCatalogService.get().toJson).withHeaders("Cache-Control" -> "no-cache, private")
+    Ok(cachedProductCatalogService.get().toJson)
   }
 }
 

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -301,7 +301,7 @@ class Application(
     ).withSettingsSurrogateKey
   }
 
-  @deprecated("We will remove this once we get the data to the client not via HTTP")
+  @deprecated("We will remove this once the data is embedded in the page")
   def products() = NoCacheAction() { implicit request =>
     val isTestUser = testUserService.isTestUser(request)
     val cachedProductCatalogService = cachedProductCatalogServiceProvider.forUser(isTestUser)

--- a/support-frontend/app/services/ProductCatalogService.scala
+++ b/support-frontend/app/services/ProductCatalogService.scala
@@ -1,0 +1,58 @@
+package services
+
+import com.gu.okhttp.RequestRunners.FutureHttpClient
+import com.gu.rest.WebServiceHelper
+import io.circe.{Decoder, Json, JsonObject}
+import io.circe.generic.semiauto.deriveDecoder
+import org.apache.pekko.actor.ActorSystem
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ExecutionContext, Future}
+
+case class ProductCatalogServiceError(message: String) extends Throwable
+object ProductCatalogServiceError {
+  implicit val decoder: Decoder[ProductCatalogServiceError] = deriveDecoder
+}
+
+trait ProductCatalogService extends WebServiceHelper[ProductCatalogServiceError] {
+  val client: FutureHttpClient
+  override val wsUrl: String
+  override val httpClient: FutureHttpClient = client
+
+  def get(): Future[JsonObject] = {
+    get[JsonObject](endpoint = "product-catalog.json")
+  }
+}
+
+class ProdProductCatalogService(val client: FutureHttpClient) extends ProductCatalogService {
+  val wsUrl: String = "https://product-catalog.guardianapis.com"
+}
+
+class CodeProductCatalogService(val client: FutureHttpClient) extends ProductCatalogService {
+  val wsUrl: String = "https://product-catalog.code.dev-guardianapis.com"
+}
+
+class CachedProductCatalogService(system: ActorSystem, productCatalogService: ProductCatalogService)(implicit
+    ec: ExecutionContext,
+) {
+  private val json = new AtomicReference[JsonObject](JsonObject())
+  private def update() = {
+    productCatalogService.get().map(json.set)
+  }
+  def get(): JsonObject = json.get()
+
+  system.scheduler.scheduleWithFixedDelay(0.minutes, 10.minutes) { () =>
+    {
+      update()
+    }
+  }
+}
+
+class CachedProductCatalogServiceProvider(
+    codeCachedProductCatalogService: CachedProductCatalogService,
+    prodCachedProductCatalogService: CachedProductCatalogService,
+) {
+  def forUser(isTestUser: Boolean) =
+    if (isTestUser) codeCachedProductCatalogService else prodCachedProductCatalogService
+}

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -39,6 +39,7 @@ trait Controllers {
     appConfig.stage,
     implicitWs,
     priceSummaryServiceProvider,
+    cachedProductCatalogServiceProvider,
     appConfig.supportUrl,
   )
 

--- a/support-frontend/app/wiring/Services.scala
+++ b/support-frontend/app/wiring/Services.scala
@@ -92,4 +92,18 @@ trait Services {
 
   lazy val zuoraGiftLookupServiceProvider: ZuoraGiftLookupServiceProvider =
     new ZuoraGiftLookupServiceProvider(appConfig.zuoraConfigProvider, appConfig.stage)
+
+  lazy val prodProductCatalogService: ProdProductCatalogService = new ProdProductCatalogService(
+    RequestRunners.futureRunner,
+  )
+  lazy val codeProductCatalogService: CodeProductCatalogService = new CodeProductCatalogService(
+    RequestRunners.futureRunner,
+  )
+
+  lazy val cachedProductCatalogServiceProvider: CachedProductCatalogServiceProvider =
+    new CachedProductCatalogServiceProvider(
+      codeCachedProductCatalogService = new CachedProductCatalogService(actorSystem, codeProductCatalogService),
+      prodCachedProductCatalogService = new CachedProductCatalogService(actorSystem, prodProductCatalogService),
+    )
+
 }

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -149,9 +149,7 @@ const ProductSchema = object({
 	),
 });
 
-const ProductsSchema = object({
-	products: record(ProductSchema),
-});
+const ProductsSchema = record(ProductSchema);
 type Products = Output<typeof ProductsSchema>;
 
 function describeProduct(product: string, ratePlan: string) {
@@ -296,7 +294,7 @@ export function Checkout() {
 		return <div>Not enough query parameters</div>;
 	}
 
-	const currentProduct = products?.products[query.product];
+	const currentProduct = products?.[query.product];
 	const currentRatePlan = currentProduct?.ratePlans[query.ratePlan];
 	const currentPrice = currentRatePlan?.pricing[currentCurrencyKey] ?? 0;
 

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -135,22 +135,23 @@ const query = {
 	ratePlan: searchParams.get('ratePlan'),
 };
 
-const ProductSchema = object({
-	ratePlans: record(
-		object({
-			id: string(),
-			pricing: record(number()),
-			charges: record(
-				object({
-					id: string(),
-				}),
-			),
-		}),
-	),
-});
+const ProductCatalogSchema = record(
+	object({
+		ratePlans: record(
+			object({
+				id: string(),
+				pricing: record(number()),
+				charges: record(
+					object({
+						id: string(),
+					}),
+				),
+			}),
+		),
+	}),
+);
 
-const ProductsSchema = record(ProductSchema);
-type Products = Output<typeof ProductsSchema>;
+type ProductCatalog = Output<typeof ProductCatalogSchema>;
 
 function describeProduct(product: string, ratePlan: string) {
 	let description = `${product} - ${ratePlan}`;
@@ -279,14 +280,14 @@ const stripePublicKey = getStripeKey(
 );
 
 export function Checkout() {
-	const [products, setProducts] = useState<Products>();
+	const [productCatalog, setProductCatalog] = useState<ProductCatalog>();
 
 	useEffect(() => {
 		void fetch('/api/products')
 			.then((resp) => resp.json())
 			.then((data) => {
-				const vData = parse(ProductsSchema, data);
-				setProducts(vData);
+				const vData = parse(ProductCatalogSchema, data);
+				setProductCatalog(vData);
 			});
 	}, []);
 
@@ -294,7 +295,7 @@ export function Checkout() {
 		return <div>Not enough query parameters</div>;
 	}
 
-	const currentProduct = products?.[query.product];
+	const currentProduct = productCatalog?.[query.product];
 	const currentRatePlan = currentProduct?.ratePlans[query.ratePlan];
 	const currentPrice = currentRatePlan?.pricing[currentCurrencyKey] ?? 0;
 

--- a/support-frontend/test/controllers/ApplicationTest.scala
+++ b/support-frontend/test/controllers/ApplicationTest.scala
@@ -56,6 +56,7 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
         mock[Stage],
         mock[WSClient],
         mock[PriceSummaryServiceProvider],
+        mock[CachedProductCatalogServiceProvider],
         "support.thegulocal.com",
       )(mock[ExecutionContext]).healthcheck.apply(FakeRequest())
       contentAsString(result) mustBe "healthy"
@@ -79,6 +80,7 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
         mock[Stage],
         mock[WSClient],
         mock[PriceSummaryServiceProvider],
+        mock[CachedProductCatalogServiceProvider],
         "support.thegulocal.com",
       )(mock[ExecutionContext]).healthcheck.apply(FakeRequest())
       header("Cache-Control", result) mustBe Some("no-cache, private")

--- a/support-frontend/test/services/ProductCatalogServiceSpec.scala
+++ b/support-frontend/test/services/ProductCatalogServiceSpec.scala
@@ -1,0 +1,31 @@
+package services
+
+import com.gu.okhttp.RequestRunners
+import com.gu.test.tags.annotations.IntegrationTest
+import io.circe.JsonObject
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** this test is more for debugging as it is actually just a front for an S3 object. It is good to know that the API is
+  * up and operational.
+  */
+@IntegrationTest
+class ProductCatalogServiceSpec extends AsyncFlatSpec with Matchers {
+  val prodService =
+    new ProdProductCatalogService(RequestRunners.futureRunner)
+
+  val codeService =
+    new CodeProductCatalogService(RequestRunners.futureRunner)
+
+  "ProdProductCatalogServiceSpec" should "get" in {
+    prodService.get().map { result =>
+      result.isEmpty shouldBe false
+    }
+  }
+
+  "CodeProductCatalogServiceSpec" should "get" in {
+    codeService.get().map { result =>
+      result.isEmpty shouldBe false
+    }
+  }
+}


### PR DESCRIPTION
## What are you doing in this PR?
- Adds the ProductCatalogService from the [product-catalog API](https://product-catalog.guardianapis.com/product-catalog.json) (which is generated by https://github.com/guardian/support-service-lambdas/tree/main/handlers/generate-product-catalog )
- Adds the `CachedProductCatalogServiceProvider` to prevent having an HTTP call on each request for data that doesn't been to be mega-fresh
- Adds an integration test to help with debugging


Currently I am just using it for the endpoint that the generic checkout (#5722) uses, but I'll be making it available on the `window.guardian` object, negating the need to make an async call from the client for it.


[**Trello Card**](https://trello.com/c/IfPDMdrT/709-create-product-catalog-service-to-make-to-enable-making-it-available-on-windowguardian)

## How to test

This is available at `/api/products` (although this will be made obsolete once it's on the `window.guardian`).


## Screenshots
<img width="1042" alt="Screenshot 2024-03-20 at 15 26 44" src="https://github.com/guardian/support-frontend/assets/31692/7cf9ec94-6d58-4e82-9d7b-a63b89ba990d">


