### PR TITLE
Three tier: S+ price excluding promotion passed to Zuora

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
@@ -86,9 +86,13 @@ export function ContributionsOrderSummaryContainer({
 		);
 	}
 
-	const threeTierProductName = (): string | undefined => {
+	const threeTierProductName = (
+		contributionType: ContributionType,
+	): string | undefined => {
 		if (inThreeTier) {
-			if (isSupporterPlus) {
+			if (contributionType === 'ONE_OFF') {
+				return 'One-time support';
+			} else if (isSupporterPlus) {
 				return 'All-access digital';
 			} else {
 				return 'Support';
@@ -96,30 +100,24 @@ export function ContributionsOrderSummaryContainer({
 		}
 	};
 
-	let description;
-	let paymentFrequency;
-	if (contributionType === 'ONE_OFF') {
-		description = 'One-time support';
-	} else if (contributionType === 'MONTHLY') {
-		description = 'Monthly support';
-		paymentFrequency = 'month';
-	} else {
-		// The if (contributionType === 'ANNUAL') condition would be here
-		// but typescript errors on it being unnecessary due to it always being truthy
-		description = 'Annual support';
-		paymentFrequency = 'year';
-	}
+	const description = threeTierProductName(contributionType) ?? '';
+	const paymentFrequency =
+		contributionType === 'MONTHLY'
+			? 'month'
+			: contributionType === 'ANNUAL'
+			? 'year'
+			: '';
 
 	return renderOrderSummary({
 		description,
 		total: promoPrice,
 		totalExcludingPromo: isSupporterPlus && isPromoApplied ? price : undefined,
-		currency: currency,
+		currency,
 		paymentFrequency,
 		enableCheckList: contributionType !== 'ONE_OFF',
 		checkListData: checklist,
 		onCheckListToggle,
-		threeTierProductName: threeTierProductName(),
+		threeTierProductName: threeTierProductName(contributionType),
 		tsAndCs: getTermsConditions(contributionType, isSupporterPlus),
 	});
 }

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
@@ -1,24 +1,15 @@
 import { checkListData } from 'components/checkoutBenefits/checkoutBenefitsListData';
-import type { ContributionType } from 'helpers/contributions';
-import type { IsoCountry } from 'helpers/internationalisation/country';
+import {
+	type ContributionType,
+	getAmount,
+	type RegularContributionType,
+} from 'helpers/contributions';
 import { currencies } from 'helpers/internationalisation/currency';
-import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
-import {
-	type FulfilmentOptions,
-	NoFulfilmentOptions,
-} from 'helpers/productPrice/fulfilmentOptions';
-import {
-	NoProductOptions,
-	type ProductOptions,
-} from 'helpers/productPrice/productOptions';
-import {
-	getCountryGroup,
-	type ProductPrices,
-} from 'helpers/productPrice/productPrices';
 import { isSupporterPlusFromState } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import { getLowerBenefitsThreshold } from 'helpers/supporterPlus/benefitsThreshold';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import type { ContributionsOrderSummaryProps } from './contributionsOrderSummary';
 
@@ -53,49 +44,34 @@ function getTermsConditions(
 	);
 }
 
-function getProductPrice(
-	productPrices: ProductPrices,
-	productPriceWithPromo: number,
-	country: IsoCountry,
-	billingPeriod: BillingPeriod,
-	fulfilmentOption: FulfilmentOptions = NoFulfilmentOptions,
-	productOption: ProductOptions = NoProductOptions,
-): number | undefined {
-	const countryGroup = getCountryGroup(country);
-	const productPrice =
-		productPrices[countryGroup.name]?.[fulfilmentOption]?.[productOption]?.[
-			billingPeriod
-		]?.[countryGroup.currency]?.price ?? 0;
-	return productPrice > productPriceWithPromo ? productPrice : undefined;
-}
-
 export function ContributionsOrderSummaryContainer({
 	inThreeTier,
 	renderOrderSummary,
 }: ContributionsOrderSummaryContainerProps): JSX.Element {
 	const contributionType = useContributionsSelector(getContributionType);
 
-	const { countryId, currencyId } = useContributionsSelector(
+	const { currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
-	const { productType } = useContributionsSelector(
-		(state) => state.page.checkoutForm.product,
-	);
-	const billingPeriod = (productType[0] +
-		productType.slice(1).toLowerCase()) as BillingPeriod;
-	const productPriceWithPromo = useContributionsSelector(getUserSelectedAmount);
-	const productPrice = useContributionsSelector((state) =>
-		getProductPrice(
-			state.page.checkoutForm.product.productPrices,
-			productPriceWithPromo,
-			countryId,
-			billingPeriod,
-		),
-	);
+	const currency = currencies[currencyId];
 
 	const isSupporterPlus = useContributionsSelector(isSupporterPlusFromState);
-
-	const currency = currencies[currencyId];
+	const promoPrice = useContributionsSelector((state) =>
+		isSupporterPlus
+			? getLowerBenefitsThreshold(
+					state,
+					contributionType as RegularContributionType,
+			  )
+			: getUserSelectedAmount(state),
+	);
+	const price = useContributionsSelector((state) =>
+		getAmount(
+			state.page.checkoutForm.product.selectedAmounts,
+			state.page.checkoutForm.product.otherAmounts,
+			contributionType,
+		),
+	);
+	const isPromoApplied = price > promoPrice;
 
 	const checklist =
 		contributionType === 'ONE_OFF'
@@ -136,8 +112,8 @@ export function ContributionsOrderSummaryContainer({
 
 	return renderOrderSummary({
 		description,
-		total: productPriceWithPromo,
-		totalExcludingPromo: isSupporterPlus ? productPrice : undefined,
+		total: promoPrice,
+		totalExcludingPromo: isSupporterPlus && isPromoApplied ? price : undefined,
 		currency: currency,
 		paymentFrequency,
 		enableCheckList: contributionType !== 'ONE_OFF',

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -1,10 +1,14 @@
-import type { ContributionType } from 'helpers/contributions';
+import type {
+	ContributionType,
+	RegularContributionType,
+} from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import { currencies } from 'helpers/internationalisation/currency';
 import { isSupporterPlusFromState } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import { getLowerBenefitsThreshold } from 'helpers/supporterPlus/benefitsThreshold';
 import { threeTierCheckoutEnabled } from 'pages/supporter-plus-landing/setup/threeTierChecks';
 import { DefaultPaymentButton } from './defaultPaymentButton';
 
@@ -48,8 +52,16 @@ export function DefaultPaymentButtonContainer({
 	const { currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
-	const selectedAmount = useContributionsSelector(getUserSelectedAmount);
 	const contributionType = useContributionsSelector(getContributionType);
+	const isSupporterPlus = useContributionsSelector(isSupporterPlusFromState);
+	const selectedAmount = useContributionsSelector((state) =>
+		isSupporterPlus
+			? getLowerBenefitsThreshold(
+					state,
+					contributionType as RegularContributionType,
+			  )
+			: getUserSelectedAmount(state),
+	);
 
 	const currency = currencies[currencyId];
 	const amountWithCurrency = simpleFormatAmount(currency, selectedAmount);

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -80,7 +80,7 @@ const titleCss = css`
 	color: #606060;
 `;
 
-const price = (hasDiscountSummary: boolean) => css`
+const priceCss = (hasDiscountSummary: boolean) => css`
 	${textSans.xlarge({ fontWeight: 'bold' })};
 	position: relative;
 	margin-bottom: ${hasDiscountSummary ? '0' : `${space[4]}px`};
@@ -198,10 +198,10 @@ export function ThreeTierCard({
 	externalBtnLink,
 }: ThreeTierCardProps): JSX.Element {
 	const currency = currencies[currencyId].glyph;
-	const currentPrice = planCost.discount?.price ?? planCost.price;
-	const previousPriceCopy =
-		!!planCost.discount && `${currency}${planCost.price}`;
-	const currentPriceCopy = `${currency}${currentPrice}/${recurringContributionPeriodMap[paymentFrequency]}`;
+	const price = planCost.price;
+	const priceCopy = !!planCost.discount && `${currency}${price}`;
+	const promoPrice = planCost.discount?.price ?? planCost.price;
+	const promoPriceCopy = `${currency}${promoPrice}/${recurringContributionPeriodMap[paymentFrequency]}`;
 	const quantumMetricButtonRef = `tier-${cardTier}-button`;
 	return (
 		<div css={container(isRecommended, isUserSelected, isRecommendedSubdued)}>
@@ -210,10 +210,10 @@ export function ThreeTierCard({
 				<ThreeTierLozenge subdue={isRecommendedSubdued} title="Recommended" />
 			)}
 			<h3 css={titleCss}>{title}</h3>
-			<h2 css={price(!!planCost.discount)}>
-				<span css={previousPriceStrikeThrough}>{previousPriceCopy}</span>
-				{previousPriceCopy && ' '}
-				{currentPriceCopy}
+			<h2 css={priceCss(!!planCost.discount)}>
+				<span css={previousPriceStrikeThrough}>{priceCopy}</span>
+				{priceCopy && ' '}
+				{promoPriceCopy}
 				{!!planCost.discount && (
 					<span css={discountSummaryCss}>
 						{discountSummaryCopy(currency, planCost, promoCount)}
@@ -226,7 +226,7 @@ export function ThreeTierCard({
 						href={externalBtnLink}
 						cssOverrides={btnStyleOverrides}
 						onClick={() => {
-							linkCtaClickHandler(currentPrice, paymentFrequency, currencyId);
+							linkCtaClickHandler(price, paymentFrequency, currencyId);
 						}}
 						data-qm-trackable={quantumMetricButtonRef}
 					>
@@ -240,7 +240,7 @@ export function ThreeTierCard({
 						cssOverrides={btnStyleOverrides}
 						onClick={() =>
 							buttonCtaClickHandler(
-								currentPrice,
+								price,
 								cardTier,
 								paymentFrequency,
 								currencyId,

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -415,12 +415,6 @@ export function ThreeTierLanding(): JSX.Element {
 			cardTier !== 1
 				? promo?.promoCode ?? tierPlanCountryCharges.promoCode
 				: undefined;
-		const promoDiscountPriceTierMid =
-			cardTier === 2 ? promo?.discountedPrice : undefined;
-		const price =
-			promoDiscountPriceTierMid ??
-			tierPlanCountryCharges.discount?.price ??
-			tierPlanCountryCharges.price;
 
 		const url = cardTier === 3 ? `/subscribe/weekly/checkout?` : `checkout?`;
 		const urlParams = new URLSearchParams();
@@ -432,7 +426,7 @@ export function ThreeTierLanding(): JSX.Element {
 			urlParams.set('threeTierCreateSupporterPlusSubscription', 'true');
 			urlParams.set('period', paymentFrequencyMap[contributionType]);
 		} else {
-			urlParams.set('selected-amount', price.toString());
+			urlParams.set('selected-amount', tierPlanCountryCharges.price.toString());
 			urlParams.set('selected-contribution-type', tierPlanPeriod);
 		}
 


### PR DESCRIPTION
## What are you doing in this PR?

Definition:-
- `promoPrices` : price including any promotional discount
- `prices` : price excluding any promotional discount 

Currently, on the 3-Tier landing, the paramURL generated (& associated redux) when you press 'Subscribe' on Tier2 with a promoCode exists is `?selected-amount=promoPrices`.  Zuora will apply the PromoCode discount to this already discounted amount.

1. Therefore we need to the price excluding promotional discount in the Url (ie FROM:`?selected-amount=promoPrices` TO:`?selected-amount=prices`)
2. Redux location `page.checkoutForm.product.selectedAmounts` set to price excluding promotional discount .
3. The discounted `promoPrices` must still be displayed in the checkoutSummary.
4. The discounted `promoPrices` must still be displayed in the paymentButtonController.

[**Trello Card**](https://trello.com/c/3qBusWVB/710-3-tier-promcode-zuora-checkout-corrections)