### PR TITLE
truncate execution names that are over 80 character

### DIFF
--- a/support-frontend/app/services/stepfunctions/Client.scala
+++ b/support-frontend/app/services/stepfunctions/Client.scala
@@ -54,12 +54,11 @@ class Client(client: AWSStepFunctionsAsync, arn: StateMachineArn) extends SafeLo
   private def startExecution(arn: String, input: String, name: String)(implicit
       ec: ExecutionContext,
   ): Response[StartExecutionResult] = convertErrors {
-    val validName: String = Client.generateExecutionName(name)
     val startExecutionRequest =
       new StartExecutionRequest()
         .withStateMachineArn(arn)
         .withInput(input)
-        .withName(validName)
+        .withName(Client.generateExecutionName(name))
     AwsAsync(client.startExecutionAsync, startExecutionRequest)
       .transform { theTry =>
         logger.info(s"state machine result: $theTry")

--- a/support-frontend/app/services/stepfunctions/Client.scala
+++ b/support-frontend/app/services/stepfunctions/Client.scala
@@ -34,11 +34,17 @@ class Client(client: AWSStepFunctionsAsync, arn: StateMachineArn) extends SafeLo
   private def startExecution(arn: String, input: String, name: String)(implicit
       ec: ExecutionContext,
   ): Response[StartExecutionResult] = convertErrors {
+    val proposedName = name + "-" + System.nanoTime().toString
+    val validName =
+      if (proposedName.length <= 80)
+        proposedName
+      else
+        (System.nanoTime().toString + "-" + name).take(78) + "--"
     val startExecutionRequest =
       new StartExecutionRequest()
         .withStateMachineArn(arn)
         .withInput(input)
-        .withName(name + "-" + System.nanoTime().toString)
+        .withName(validName)
     AwsAsync(client.startExecutionAsync, startExecutionRequest)
       .transform { theTry =>
         logger.info(s"state machine result: $theTry")

--- a/support-frontend/test/services/stepfunctions/SupportWorkersClientTest.scala
+++ b/support-frontend/test/services/stepfunctions/SupportWorkersClientTest.scala
@@ -60,4 +60,28 @@ class SupportWorkersClientTest extends AnyFlatSpec with Matchers with MockitoSug
     actual shouldBe StatusResults.failure(CheckoutFailureReasons.Unknown)
   }
 
+  "generateExecutionName" should "generate a valid name" in {
+    def doTest(len: Int, value: Long, truncated: Boolean) = {
+      import Client.generateExecutionName
+      val actual = generateExecutionName(("123456789-" * 10).take(len), value)
+      info(s"string: <$actual>")
+      withClue(s"string: <$actual>") {
+        actual.length should be(80)
+        actual should fullyMatch regex ("[0-9a-zA-Z_-]+")
+        if (truncated)
+          actual.takeRight(2) should be("--")
+        else
+          actual.last should not be (('-'))
+      }
+    }
+    doTest(68, Long.MinValue, truncated = false)
+    doTest(69, Long.MinValue, truncated = true)
+    doTest(68, Long.MaxValue, truncated = false)
+    doTest(69, Long.MaxValue, truncated = true)
+    doTest(68, 0L, truncated = false)
+    doTest(69, 0L, truncated = true)
+    doTest(68, System.nanoTime(), truncated = false)
+    doTest(69, System.nanoTime(), truncated = true)
+  }
+
 }

--- a/support-frontend/test/services/stepfunctions/SupportWorkersClientTest.scala
+++ b/support-frontend/test/services/stepfunctions/SupportWorkersClientTest.scala
@@ -64,7 +64,6 @@ class SupportWorkersClientTest extends AnyFlatSpec with Matchers with MockitoSug
     def doTest(len: Int, value: Long, truncated: Boolean) = {
       import Client.generateExecutionName
       val actual = generateExecutionName(("123456789-" * 10).take(len), value)
-      info(s"string: <$actual>")
       withClue(s"string: <$actual>") {
         actual.length should be(80)
         actual should fullyMatch regex ("[0-9a-zA-Z_-]+")


### PR DESCRIPTION
Following on from https://github.com/guardian/support-frontend/pull/5823

It turns out that in extreme cases the execution name can be over 80 chars
`TestUser-Quarterly-GuardianWeekly-RestOfWorld-USD-StripeCheckout-1425327897029666`
is 81 characters, meaning that checkout is impossible.

This PR truncates it if necessary (and makes sure the unique number is in the non truncated section)
<img width="906" alt="image" src="https://github.com/guardian/support-frontend/assets/7304387/df2997cd-c5f0-4660-a3ac-723e4fd6f39c">

EDIT
I have updated this PR to use a the densest possible encoding of a long (see below), so the truncation problem has gone away probably.  However it could still happen unexpectedly in future, so I have added some tests.
![image](https://github.com/guardian/support-frontend/assets/7304387/5a918400-b524-4c82-b217-38dc09ec924d)

example IDs as generated by the new test
```
12345678901234567890123456789012345678901234567890123456789012345678901234567890
================================================================================
123456789-123456789-123456789-123456789-123456789-123456789-12345678-gAAAAAAAAAA
123456789-123456789-123456789-123456789-123456789-123456789-123456-gAAAAAAAAAA--
123456789-123456789-123456789-123456789-123456789-123456789-12345678-f_________8
123456789-123456789-123456789-123456789-123456789-123456789-123456-f_________8--
123456789-123456789-123456789-123456789-123456789-123456789-12345678-AAAAAAAAAAA
123456789-123456789-123456789-123456789-123456789-123456789-123456-AAAAAAAAAAA--
123456789-123456789-123456789-123456789-123456789-123456789-12345678-AAV3NZMnDh8
123456789-123456789-123456789-123456789-123456789-123456789-123456-AAV3NZMn8vY--
```
