### PR TITLE
tote bag: Thankyou page copy for US supporterPlus

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/subheading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/subheading.tsx
@@ -114,4 +114,21 @@ function Subheading({
 	);
 }
 
+export function ToteHeading(): JSX.Element {
+	return (
+		<>
+			<div
+				css={css`
+					font-weight: bold;
+				`}
+			>
+				Remember to claim your tote bag
+			</div>
+			To claim your tote, sign in to{' '}
+			<a href="https://manage.theguardian.com">your account</a> and complete
+			your ‘Correspondence address’ located on the ‘Settings’ page.
+		</>
+	);
+}
+
 export default Subheading;

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/subheading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/subheading.tsx
@@ -124,9 +124,11 @@ export function ToteHeading(): JSX.Element {
 			>
 				Remember to claim your tote bag
 			</div>
-			To claim your tote, sign in to{' '}
-			<a href="https://manage.theguardian.com">your account</a> and complete
-			your ‘Correspondence address’ located on the ‘Settings’ page.
+			<span>
+				To claim your tote, sign in to{' '}
+				<a href="https://manage.theguardian.com">your account</a> and complete
+				your ‘Correspondence address’ located on the ‘Settings’ page.
+			</span>
 		</>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader.tsx
@@ -5,7 +5,7 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { UserTypeFromIdentityResponse } from 'helpers/redux/checkout/personalDetails/state';
 import DirectDebitMessage from './directDebitMessage';
 import Heading from './heading';
-import Subheading from './subheading';
+import Subheading, { ToteHeading } from './subheading';
 
 export const header = css`
 	background: white;
@@ -44,6 +44,7 @@ type ThankYouHeaderProps = {
 	amountIsAboveThreshold: boolean;
 	isSignedIn: boolean;
 	userTypeFromIdentityResponse: UserTypeFromIdentityResponse;
+	showTote?: boolean;
 };
 
 function ThankYouHeader({
@@ -56,6 +57,7 @@ function ThankYouHeader({
 	amountIsAboveThreshold,
 	isSignedIn,
 	userTypeFromIdentityResponse,
+	showTote,
 }: ThankYouHeaderProps): JSX.Element {
 	return (
 		<header css={header}>
@@ -77,6 +79,11 @@ function ThankYouHeader({
 					userTypeFromIdentityResponse={userTypeFromIdentityResponse}
 				/>
 			</p>
+			{showTote && (
+				<p css={headerSupportingText}>
+					<ToteHeading />
+				</p>
+			)}
 		</header>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -15,7 +15,10 @@ import type { ContributionType } from 'helpers/contributions';
 import { getAmount } from 'helpers/contributions';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import { DirectDebit, PayPal } from 'helpers/forms/paymentMethods';
-import { countryGroups } from 'helpers/internationalisation/countryGroup';
+import {
+	countryGroups,
+	UnitedStates,
+} from 'helpers/internationalisation/countryGroup';
 import { isSupporterPlusFromState } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
@@ -218,6 +221,10 @@ export function SupporterPlusThankYou(): JSX.Element {
 	const firstColumn = thankYouModules.slice(0, numberOfModulesInFirstColumn);
 	const secondColumn = thankYouModules.slice(numberOfModulesInFirstColumn);
 
+	const showTote =
+		countryGroupId === UnitedStates &&
+		useContributionsSelector(isSupporterPlusFromState);
+
 	return (
 		<PageScaffold
 			header={<Header />}
@@ -240,6 +247,7 @@ export function SupporterPlusThankYou(): JSX.Element {
 							amountIsAboveThreshold={amountIsAboveThreshold}
 							isSignedIn={isSignedIn}
 							userTypeFromIdentityResponse={userTypeFromIdentityResponse}
+							showTote={showTote}
 						/>
 					</div>
 


### PR DESCRIPTION
## What are you doing in this PR?

Th following note added to the US SupporterPlus Thankyou page->

`Remember to claim your tote bag`
`To claim your tote, sign in to your account and complete your ‘Correspondence address’ located on the ‘Settings’ page.`

![image](https://github.com/guardian/support-frontend/assets/76729591/edf189f4-d59a-44d4-bf56-a33ba8dd2883)

[**Trello Card**](https://trello.com/c/llPMl6Jh/711-s-thank-you-page-the-us-tote-copy-add-dev-effort)