### PR TITLE
feat: promotion text on thank you page

### DIFF
--- a/support-frontend/assets/pages/digital-subscriber-thank-you/components/thankYouHeader.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-thank-you/components/thankYouHeader.tsx
@@ -1,11 +1,20 @@
+import { css } from '@emotion/react';
+import { from, titlepiece } from '@guardian/source-foundations';
 import DirectDebitMessage from 'pages/supporter-plus-thank-you/components/thankYouHeader/directDebitMessage';
 import {
 	header,
 	headerSupportingText,
-	headerTitleText,
 } from 'pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader';
 import Heading from './heading';
 import Subheading from './subheading';
+
+const headerTitleText = css`
+	${titlepiece.small()};
+	font-size: 24px;
+	${from.tablet} {
+		font-size: 40px;
+	}
+`;
 
 type ThankYouHeaderProps = {
 	name: string | null;

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -38,7 +38,12 @@ const store = initReduxForContributions();
 
 setUpRedux(store);
 
-const thankYouRoute = `/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou`;
+const urlParams = new URLSearchParams(window.location.search);
+const promoCode = urlParams.get('promoCode');
+const thankYouRouteParams = promoCode
+	? `?${new URLSearchParams({ promoCode }).toString()}`
+	: '';
+const thankYouRoute = `/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou${thankYouRouteParams}`;
 const countryIds = Object.values(countryGroups).map(
 	(group) => group.supportInternationalisationId,
 );

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { from, space, titlepiece } from '@guardian/source-foundations';
 import type { ContributionType } from 'helpers/contributions';
 import { formatAmount } from 'helpers/forms/checkouts';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
@@ -6,43 +7,74 @@ import {
 	currencies,
 	spokenCurrencies,
 } from 'helpers/internationalisation/currency';
+import type { Promotion } from 'helpers/productPrice/promotions';
 
-const MAX_DISPLAY_NAME_LENGTH = 10;
-
-export const amountText = css`
-	background-color: #ffe500;
-	padding: 0 5px;
-`;
-
-interface HeadingProps {
-	name: string | null;
-	isOneOffPayPal: boolean;
-	amount: number | undefined;
-	currency: IsoCurrency;
-	contributionType: ContributionType;
-}
-
-function Heading({
-	name,
-	isOneOffPayPal,
-	amount,
-	currency,
-	contributionType,
-}: HeadingProps): JSX.Element {
-	const maybeNameAndTrailingSpace: string =
-		name && name.length < MAX_DISPLAY_NAME_LENGTH ? `${name} ` : '';
-
-	// Do not show special header to paypal/one-off as we don't have the relevant info after the redirect
-	if (isOneOffPayPal || !amount) {
+type MonthlyProps = {
+	amount: number;
+	isoCurrency: IsoCurrency;
+	promotion?: Promotion;
+	name?: string;
+};
+function Monthly({ isoCurrency, amount, promotion, name }: MonthlyProps) {
+	if (
+		/**
+		 * This is a check to see if the promo exists,
+		 * it's a little odd due to the type having
+		 * every prop optional.
+		 *
+		 * We could/should do some parsing pre-render to avoid this.
+		 * */
+		promotion?.discountedPrice &&
+		promotion.discount?.durationMonths
+	) {
 		return (
-			<div>
-				Thank you {maybeNameAndTrailingSpace}for your valuable contribution
-			</div>
+			<>
+				<h1 css={headerTitleText}>
+					Thank you {name}for supporting us with{' '}
+					<YellowAmount
+						amount={promotion.discountedPrice}
+						currency={isoCurrency}
+					/>
+					{`/month`}
+					<sup>*</sup>
+				</h1>
+				<p
+					css={css`
+						margin-top: ${space[2]}px;
+					`}
+				>
+					<sup>*</sup> for {promotion.discount.durationMonths} months, then{' '}
+					{formatAmount(
+						currencies[isoCurrency],
+						spokenCurrencies[isoCurrency],
+						amount,
+						false,
+					)}
+					{`/month`} afterwards unless you cancel.{' '}
+				</p>
+			</>
 		);
 	}
 
-	const currencyAndAmount = (
-		<span css={amountText}>
+	return (
+		<div>
+			Thank you {name}for supporting us with{' '}
+			<YellowAmount currency={isoCurrency} amount={amount} /> each month ❤️
+		</div>
+	);
+}
+
+const yellowAmountText = css`
+	background-color: #ffe500;
+	padding: 0 5px;
+`;
+type YellowAmountProps = {
+	amount: number;
+	currency: IsoCurrency;
+};
+function YellowAmount({ amount, currency }: YellowAmountProps) {
+	return (
+		<span css={yellowAmountText}>
 			{formatAmount(
 				currencies[currency],
 				spokenCurrencies[currency],
@@ -51,34 +83,75 @@ function Heading({
 			)}
 		</span>
 	);
+}
+
+const headerTitleText = css`
+	${titlepiece.small()};
+	font-size: 24px;
+	${from.tablet} {
+		font-size: 40px;
+	}
+`;
+type HeadingProps = {
+	name: string | null;
+	isOneOffPayPal: boolean;
+	amount: number | undefined;
+	currency: IsoCurrency;
+	contributionType: ContributionType;
+	promotion?: Promotion;
+};
+function Heading({
+	name,
+	isOneOffPayPal,
+	amount,
+	currency,
+	contributionType,
+	promotion,
+}: HeadingProps): JSX.Element {
+	const maybeNameAndTrailingSpace: string =
+		name && name.length < 10 ? `${name} ` : '';
+
+	// Do not show special header to paypal/one-off as we don't have the relevant info after the redirect
+	if (isOneOffPayPal || !amount) {
+		return (
+			<h1 css={headerTitleText}>
+				Thank you {maybeNameAndTrailingSpace}for your valuable contribution
+			</h1>
+		);
+	}
 
 	switch (contributionType) {
 		case 'ONE_OFF':
 			return (
-				<div>Thank you for supporting us today with {currencyAndAmount} ❤️</div>
+				<h1 css={headerTitleText}>
+					Thank you for supporting us today with{' '}
+					<YellowAmount currency={currency} amount={amount} /> ❤️
+				</h1>
 			);
 
 		case 'MONTHLY':
 			return (
-				<div>
-					Thank you {maybeNameAndTrailingSpace}for supporting us with{' '}
-					{currencyAndAmount} each month ❤️
-				</div>
+				<Monthly
+					amount={amount}
+					isoCurrency={currency}
+					promotion={promotion}
+					name={maybeNameAndTrailingSpace}
+				/>
 			);
 
 		case 'ANNUAL':
 			return (
-				<div>
+				<h1 css={headerTitleText}>
 					Thank you {maybeNameAndTrailingSpace}for supporting us with{' '}
-					{currencyAndAmount} each year ❤️
-				</div>
+					<YellowAmount currency={currency} amount={amount} /> each year ❤️
+				</h1>
 			);
 
 		default:
 			return (
-				<div>
+				<h1 css={headerTitleText}>
 					Thank you {maybeNameAndTrailingSpace}for your valuable contribution
-				</div>
+				</h1>
 			);
 	}
 }

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
@@ -57,10 +57,10 @@ function Monthly({ isoCurrency, amount, promotion, name }: MonthlyProps) {
 	}
 
 	return (
-		<div>
+		<h1 css={headerTitleText}>
 			Thank you {name}for supporting us with{' '}
 			<YellowAmount currency={isoCurrency} amount={amount} /> each month ❤️
-		</div>
+		</h1>
 	);
 }
 

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/react';
-import { body, from, space, titlepiece } from '@guardian/source-foundations';
+import { body, from, space } from '@guardian/source-foundations';
 import type { ContributionType } from 'helpers/contributions';
-import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import { type IsoCurrency } from 'helpers/internationalisation/currency';
+import type { Promotion } from 'helpers/productPrice/promotions';
 import type { UserTypeFromIdentityResponse } from 'helpers/redux/checkout/personalDetails/state';
 import DirectDebitMessage from './directDebitMessage';
 import Heading from './heading';
@@ -14,14 +15,6 @@ export const header = css`
 
 	${from.tablet} {
 		background: none;
-	}
-`;
-
-export const headerTitleText = css`
-	${titlepiece.small()};
-	font-size: 24px;
-	${from.tablet} {
-		font-size: 40px;
 	}
 `;
 
@@ -44,6 +37,7 @@ type ThankYouHeaderProps = {
 	amountIsAboveThreshold: boolean;
 	isSignedIn: boolean;
 	userTypeFromIdentityResponse: UserTypeFromIdentityResponse;
+	promotion?: Promotion;
 	showTote?: boolean;
 };
 
@@ -58,18 +52,19 @@ function ThankYouHeader({
 	isSignedIn,
 	userTypeFromIdentityResponse,
 	showTote,
+	promotion,
 }: ThankYouHeaderProps): JSX.Element {
 	return (
 		<header css={header}>
-			<h1 css={headerTitleText}>
-				<Heading
-					name={name}
-					isOneOffPayPal={isOneOffPayPal}
-					amount={amount}
-					currency={currency}
-					contributionType={contributionType}
-				/>
-			</h1>
+			<Heading
+				name={name}
+				isOneOffPayPal={isOneOffPayPal}
+				amount={amount}
+				promotion={promotion}
+				currency={currency}
+				contributionType={contributionType}
+			/>
+
 			<p css={headerSupportingText}>
 				{showDirectDebitMessage && <DirectDebitMessage />}
 				<Subheading

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -19,6 +19,7 @@ import {
 	countryGroups,
 	UnitedStates,
 } from 'helpers/internationalisation/countryGroup';
+import { getPromotion } from 'helpers/productPrice/promotions';
 import { isSupporterPlusFromState } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
@@ -119,9 +120,14 @@ export function SupporterPlusThankYou(): JSX.Element {
 	const paymentMethod = useContributionsSelector(
 		(state) => state.page.checkoutForm.payment.paymentMethod.name,
 	);
-	const { selectedAmounts, otherAmounts } = useContributionsSelector(
-		(state) => state.page.checkoutForm.product,
-	);
+	const {
+		selectedAmounts,
+		otherAmounts,
+		billingPeriod,
+		fulfilmentOption,
+		productOption,
+		productPrices,
+	} = useContributionsSelector((state) => state.page.checkoutForm.product);
 	const { isSignedIn } = useContributionsSelector((state) => state.page.user);
 	const contributionType = useContributionsSelector(getContributionType);
 	const isNewAccount = userTypeFromIdentityResponse === 'new';
@@ -134,6 +140,14 @@ export function SupporterPlusThankYou(): JSX.Element {
 	const isAmountLargeDonation = amount
 		? isLargeDonation(amount, contributionType, paymentMethod)
 		: false;
+
+	const promotion = getPromotion(
+		productPrices,
+		countryId,
+		billingPeriod,
+		fulfilmentOption,
+		productOption,
+	);
 
 	useEffect(() => {
 		if (amount) {
@@ -248,6 +262,7 @@ export function SupporterPlusThankYou(): JSX.Element {
 							isSignedIn={isSignedIn}
 							userTypeFromIdentityResponse={userTypeFromIdentityResponse}
 							showTote={showTote}
+							promotion={promotion}
 						/>
 					</div>
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Passes the promotion down from state into the thank you page heading.

I'm not sure we want it to look like this, but it will get us to stage 1. I wonder if a <sup>*</sup> style footnote might work better? e.g.

---

### Thank you James for supporting us with **_£5_** every month<sup>*</sup> ❤️

<sup>*</sup> For 6 months, then £10 every month.

---

☝️ has been done, I'll work with design to make sure it's all good.

## 👀 Screenshots 👀 
![Screenshot 2024-03-22 at 16 33 31](https://github.com/guardian/support-frontend/assets/31692/97c7e9bb-6058-4cde-a35d-031397c68f38)
![Screenshot 2024-03-22 at 16 33 45](https://github.com/guardian/support-frontend/assets/31692/24611034-0e2e-49c4-9837-6629c9cc8b5c)
