### PR TITLE
feat: add new google-site-verification-token

### DIFF
--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -24,6 +24,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="google-site-verification" content="nFrhJ3suC2OpKRasEkZyH1KZKpSZc-ofno_uunJgfvg" />
+    <meta name="google-site-verification" content="FFhKkEy2YuhK7-0VkmjVakdszyuPQiNWJHrtgUgPh54" />
 
     @csrf.map { token =>
       <script type="text/javascript">


### PR DESCRIPTION
Adds a new `google-site-verification` token. This is for the [Google Search Console](https://search.google.com/search-console/about).

My understanding [from the docs is that you can have multiple of the same verification methods](https://support.google.com/webmasters/answer/9008080?hl=en#:~:text=Using%20multiple%20verification%20methods). 

I didn't want to replace the existing one as [the PR updating it](https://github.com/guardian/support-frontend/pull/792) doesn't describe which service it is for - so this should avoid breaking that.


