### PR TITLE
fix: use testMode for product prices on contributions

### DIFF
--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -111,7 +111,7 @@ test.describe('Subscribe/Contribute via the Tiered checkout)', () => {
 
 test.describe('Subscribe (S+) incl PromoCode via the Tiered checkout', () => {
 	testDetailsPromo.forEach((testDetails) => {
-		test.skip(`${testDetails.frequency} (S+) Subscription incl PromoCode at Tier-2 with Credit/Debit card - UK`, async ({
+		test(`${testDetails.frequency} (S+) Subscription incl PromoCode at Tier-2 with Credit/Debit card - UK`, async ({
 			context,
 			baseURL,
 		}) => {

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -194,7 +194,7 @@ class Application(
         .getOrElse("promoCode", Nil)
         .toList
 
-    val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(SupporterPlus, queryPromos)
+    val productPrices = priceSummaryServiceProvider.forUser(testMode).getPrices(SupporterPlus, queryPromos)
 
     views.html.contributions(
       title = "Support the Guardian",


### PR DESCRIPTION
Uses `testMode` when fetching prices and injecting them on the client. This should only affect the `/contribution` route on `PROD`.

This was noticed as we are using `PROD` promotions even when a test user.
