### PR TITLE
fix(tests): add promoCode to thank you URL assertion

### DIFF
--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -150,7 +150,10 @@ test.describe('Subscribe (S+) incl PromoCode via the Tiered checkout', () => {
 				'Pay £([0-9]+|(([0-9]+).([0-9]+))) per (year|month)',
 			);
 			await page.getByText(paymentButtonRegex).click();
-			await expect(page).toHaveURL(`/uk/thankyou`, { timeout: 600000 });
+			await expect(page).toHaveURL(
+				`/uk/thankyou?promoCode=PLAYWRIGHT_TEST_SPLUS`,
+				{ timeout: 600000 },
+			);
 		});
 	});
 });


### PR DESCRIPTION
After [enabling the tests again](https://github.com/guardian/support-frontend/pull/5843) - I had forgotten to account for the fact that [we now pass the `promoCode` to the thank you page](https://github.com/guardian/support-frontend/pull/5837/files#diff-fd63b7bdddd1f8c8a686a6ba94bee4323ebd6d88ea919d35cdcf7dbecd9a6db5R41-R46).

This fixes that.