### PR TITLE
fix: update thank you promotion messaging

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
@@ -9,6 +9,14 @@ import {
 } from 'helpers/internationalisation/currency';
 import type { Promotion } from 'helpers/productPrice/promotions';
 
+const supCss = css`
+	font-size: 60%;
+	vertical-align: 9px;
+	${from.tablet} {
+		font-size: 60%;
+		vertical-align: 14px;
+	}
+`;
 type MonthlyProps = {
 	amount: number;
 	isoCurrency: IsoCurrency;
@@ -36,21 +44,28 @@ function Monthly({ isoCurrency, amount, promotion, name }: MonthlyProps) {
 						currency={isoCurrency}
 					/>
 					{`/month`}
-					<sup>*</sup>
+					<sup css={supCss}>*</sup>
 				</h1>
 				<p
 					css={css`
 						margin-top: ${space[2]}px;
 					`}
 				>
-					<sup>*</sup> for {promotion.discount.durationMonths} months, then{' '}
+					<sup>*</sup> You'll pay{' '}
 					{formatAmount(
 						currencies[isoCurrency],
 						spokenCurrencies[isoCurrency],
 						amount,
 						false,
 					)}
-					{`/month`} afterwards unless you cancel.{' '}
+					/month for the first {promotion.discount.durationMonths} months, then{' '}
+					{formatAmount(
+						currencies[isoCurrency],
+						spokenCurrencies[isoCurrency],
+						amount,
+						false,
+					)}
+					/month afterwards unless you cancel.
 				</p>
 			</>
 		);


### PR DESCRIPTION
Updates the thank you messaging for discounted prices.

Also makes the `*` a little smaller.

<img width="752" alt="Screenshot 2024-03-25 at 15 36 35" src="https://github.com/guardian/support-frontend/assets/31692/78fe6782-50ca-4af7-937a-2bbc41f74227">
<img width="343" alt="Screenshot 2024-03-25 at 15 40 11" src="https://github.com/guardian/support-frontend/assets/31692/d2ce5adc-b8ec-4e23-ae76-196f77deca46">
