### PR TITLE
Update tiered e2e promo tests to use Annual and Monthly `promoCodes`

### DIFF
--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -28,9 +28,19 @@ const testsDetails: TestDetails[] = [
 	},
 ];
 
-const testDetailsPromo: TestDetails[] = [
-	{ tier: 2, frequency: 'Monthly' },
-	{ tier: 2, frequency: 'Annual' },
+const testDetailsPromo = [
+	{
+		tier: 2,
+		frequency: 'Monthly',
+		promoCode: 'PLAYWRIGHT_TEST_SPLUS_MONTHLY',
+		expectedPromoText: '£8/month for the first 3 months, then £10/month',
+	},
+	{
+		tier: 2,
+		frequency: 'Annual',
+		promoCode: 'PLAYWRIGHT_TEST_SPLUS_ANNUAL',
+		expectedPromoText: '£76/year for the first year, then £95/year',
+	},
 ];
 
 afterEachTasks(test);
@@ -111,7 +121,7 @@ test.describe('Subscribe/Contribute via the Tiered checkout)', () => {
 
 test.describe('Subscribe (S+) incl PromoCode via the Tiered checkout', () => {
 	testDetailsPromo.forEach((testDetails) => {
-		test(`${testDetails.frequency} (S+) Subscription incl PromoCode at Tier-2 with Credit/Debit card - UK`, async ({
+		test(`${testDetails.frequency} (S+) Subscription incl PromoCode at Tier-${testDetails.tier} with Credit/Debit card - UK`, async ({
 			context,
 			baseURL,
 		}) => {
@@ -123,19 +133,11 @@ test.describe('Subscribe (S+) incl PromoCode via the Tiered checkout', () => {
 				page,
 				context,
 				baseURL,
-				`/uk/contribute?promoCode=PLAYWRIGHT_TEST_SPLUS`,
+				`/uk/contribute?promoCode=${testDetails.promoCode}`,
 			);
 			await page.getByRole('tab').getByText(testDetails.frequency).click();
 			await expect(
-				page
-					.getByText(
-						` ${
-							testDetails.frequency === `Monthly`
-								? `month for the first 3 months`
-								: `year for the first year`
-						}, then`,
-					)
-					.first(),
+				page.getByText(testDetails.expectedPromoText).first(),
 			).toBeVisible();
 			await page
 				.locator(
@@ -151,7 +153,7 @@ test.describe('Subscribe (S+) incl PromoCode via the Tiered checkout', () => {
 			);
 			await page.getByText(paymentButtonRegex).click();
 			await expect(page).toHaveURL(
-				`/uk/thankyou?promoCode=PLAYWRIGHT_TEST_SPLUS`,
+				`/uk/thankyou?promoCode=${testDetails.promoCode}`,
 				{ timeout: 600000 },
 			);
 		});


### PR DESCRIPTION
We have to use two different `promoCodes` for annual vs monthly as we want them to have different durations.

This does that, makes the `promoCode` configurable, and makes the expected text configrable.

<img width="407" alt="Screenshot 2024-03-25 at 17 18 37" src="https://github.com/guardian/support-frontend/assets/31692/10e6eebd-59b4-4189-ae6d-5ae0d219e77f">
