### PR TITLE
Feature switch additional benefits add (currently tote bag)

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -87,18 +87,15 @@ export const tests: Tests = {
 			{
 				id: 'control',
 			},
-			{
-				id: 'variant',
-			},
 		],
 		audiences: {
-			ALL: {
+			US: {
 				offset: 0,
 				size: 0,
 			},
 		},
 		isActive: false,
-		referrerControlled: true,
+		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 3,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 	},

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -91,10 +91,10 @@ export const tests: Tests = {
 		audiences: {
 			US: {
 				offset: 0,
-				size: 0,
+				size: 1,
 			},
 		},
-		isActive: false,
+		isActive: true,
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 3,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -82,4 +82,24 @@ export const tests: Tests = {
 		seed: 2,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 	},
+	additionalBenefits: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 0,
+			},
+		},
+		isActive: false,
+		referrerControlled: true,
+		seed: 3,
+		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+	},
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierChecks.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierChecks.ts
@@ -1,7 +1,6 @@
 import type { Participations } from 'helpers/abTests/abtest';
 import { countriesAffectedByVATStatus } from 'helpers/internationalisation/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 export const threeTierCheckoutEnabled = (
 	abParticipations: Participations,
@@ -41,12 +40,4 @@ export const threeTierCheckoutEnabled = (
 		displaySupportPlusOnlyCheckout ||
 		countriesAffectedByVATStatus.includes(countryId)
 	);
-};
-
-export const additionalBenefitsEnabled = (
-	abParticipations: Participations,
-	countryGroupId: CountryGroupId,
-): boolean => {
-	const displayAdditionalBenefits = !!abParticipations.additionalBenefits;
-	return countryGroupId === 'UnitedStates' && displayAdditionalBenefits;
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierChecks.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierChecks.ts
@@ -1,6 +1,7 @@
 import type { Participations } from 'helpers/abTests/abtest';
 import { countriesAffectedByVATStatus } from 'helpers/internationalisation/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 export const threeTierCheckoutEnabled = (
 	abParticipations: Participations,
@@ -40,4 +41,12 @@ export const threeTierCheckoutEnabled = (
 		displaySupportPlusOnlyCheckout ||
 		countriesAffectedByVATStatus.includes(countryId)
 	);
+};
+
+export const additionalBenefitsEnabled = (
+	abParticipations: Participations,
+	countryGroupId: CountryGroupId,
+): boolean => {
+	const displayAdditionalBenefits = !!abParticipations.additionalBenefits;
+	return countryGroupId === 'UnitedStates' && displayAdditionalBenefits;
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -222,8 +222,9 @@ export function ThreeTierLanding(): JSX.Element {
 		(state) => state.common.internationalisation,
 	);
 
-	const tierCards =
-		countryGroupId === UnitedStates ? tierCardsTote : tierCardsNoTote;
+	const tierCards = abParticipations.additionalBenefits
+		? tierCardsTote
+		: tierCardsNoTote;
 
 	const countrySwitcherProps: CountryGroupSwitcherProps = {
 		countryGroupIds: [
@@ -551,7 +552,7 @@ export function ThreeTierLanding(): JSX.Element {
 					]}
 					currency={currencies[currencyId].glyph}
 				></ThreeTierTsAndCs>
-				{countryGroupId === UnitedStates && (
+				{!!abParticipations.additionalBenefits && (
 					<ToteTsAndCs
 						currency={currencies[currencyId].glyph}
 						toteCostMonthly={

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -15,10 +15,7 @@ import type { ContributionType } from 'helpers/contributions';
 import { getAmount } from 'helpers/contributions';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import { DirectDebit, PayPal } from 'helpers/forms/paymentMethods';
-import {
-	countryGroups,
-	UnitedStates,
-} from 'helpers/internationalisation/countryGroup';
+import { countryGroups } from 'helpers/internationalisation/countryGroup';
 import { getPromotion } from 'helpers/productPrice/promotions';
 import { isSupporterPlusFromState } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
@@ -105,6 +102,9 @@ export function SupporterPlusThankYou(): JSX.Element {
 	const campaignSettings = useMemo<CampaignSettings | null>(
 		() => getCampaignSettings(campaignCode),
 		[],
+	);
+	const { abParticipations } = useContributionsSelector(
+		(state) => state.common,
 	);
 	const { countryId, countryGroupId, currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
@@ -236,7 +236,7 @@ export function SupporterPlusThankYou(): JSX.Element {
 	const secondColumn = thankYouModules.slice(numberOfModulesInFirstColumn);
 
 	const showTote =
-		countryGroupId === UnitedStates &&
+		!!abParticipations.additionalBenefits &&
 		useContributionsSelector(isSupporterPlusFromState);
 
 	return (


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

AB Test to show the Tote benefits, Ts&Cs and thankyou page. 

This is `enabled` & displayed to 100% audience to match production. 

A further PR this afternoon will reset the state to `disabled` at the end of the tote-bag offer.

[**Trello Card**](https://trello.com/c/H6GwdNkQ/723-remove-tote-copy-from-the-us-landing-and-ty-pages-tue-26th)

## Screenshots

|ab-additionalBenefits=control|original|
|-----|-----|
|![image](https://github.com/guardian/support-frontend/assets/76729591/d59ef7e9-dc66-4514-94f4-52ad4c600876)|![image](https://github.com/guardian/support-frontend/assets/76729591/9a3fb720-93bd-48e7-99c4-d3e07077318e)|

