### PR TITLE
Read thank you page amount from session storage

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -134,9 +134,9 @@ export function SupporterPlusThankYou(): JSX.Element {
 	const isOneOffPayPal =
 		paymentMethod === PayPal && contributionType === 'ONE_OFF';
 	const isOneOff = contributionType === 'ONE_OFF';
-	const amount = isOneOffPayPal
-		? getAmountFromSessionStorage()
-		: getAmount(selectedAmounts, otherAmounts, contributionType);
+	const amount =
+		getAmountFromSessionStorage() ??
+		getAmount(selectedAmounts, otherAmounts, contributionType);
 	const isAmountLargeDonation = amount
 		? isLargeDonation(amount, contributionType, paymentMethod)
 		: false;


### PR DESCRIPTION
Reads the amount paid in the checkout from session storage.

This is currently read from redux state outside of the `isOneOffPayPal` condition, which resets once you refresh the page.

We had a discussion as to whether this state should be stored in the `URLParams` going forward, and are a little undecided as it might expose information users aren't happy with, so thought this the quickest fix for now.

## Tested

- run playwright tests
- tested 1 off payment
- tested recurring payment
- tested S+ payment
- tested S+ promo payment