### PR TITLE
fix: update e2e promo tests to use multi-stage text checks

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -33,7 +33,7 @@ jobs:
         working-directory: ./support-e2e
 
       - name: Run Playwright
-        run: yarn pw-browserstack-test
+        run: yarn test-browserstack
         working-directory: ./support-e2e
 
       - name: Set outputs

--- a/support-e2e/README.md
+++ b/support-e2e/README.md
@@ -8,9 +8,9 @@ You can view the action [here](../.github/workflows/playwright.yaml).
 
 Scripts to run the tests are present in the [package.json](package.json) file. Allowing you to also run the tests locally. Three ways of running the tests have been setup:
 
-- `pw-browserstack-test` Runs the tests via BrowserStack Automate against the production site (https://support.theguardian.com/).
-- `pw-local-test` Runs the tests via the Playwright ui against a local running version of the site (https://support.thegulocal.com/).
-- `pw-prod-test` Runs the tests via the Playwright ui against the production site (https://support.theguardian.com/).
+- `test-browserstack` Runs the tests via BrowserStack Automate against the production site (https://support.theguardian.com/).
+- `local-test` Runs the tests via the Playwright ui against a local running version of the site (https://support.thegulocal.com/).
+- `prod-test` Runs the tests via the Playwright ui against the production site (https://support.theguardian.com/).
 
 It should also be possible to run the tests via BrowserStack Automate against a local running version of the site if you have local testing setup in your BrowserStack account and amend/create a new test configuration file.
 

--- a/support-e2e/package.json
+++ b/support-e2e/package.json
@@ -2,11 +2,11 @@
 	"name": "support-e2e",
 	"version": "0.0.0",
 	"scripts": {
-		"prettier:check": "prettier --check ./",
-		"prettier:fix": "prettier --write ./",
-		"pw-browserstack-test": "RUNNING_IN_BROWSERSTACK=true playwright test --config=playwright.browserstack.config.ts",
-		"pw-local-test": "playwright test --ui --config=playwright.local.config.ts",
-		"pw-prod-test": "playwright test --ui --config=playwright.prod.config.ts"
+		"prettier-check": "prettier --check ./",
+		"prettier-fix": "prettier --write ./",
+		"test-browserstack": "RUNNING_IN_BROWSERSTACK=true playwright test --config=playwright.browserstack.config.ts",
+		"test-local": "playwright test --ui --config=playwright.local.config.ts",
+		"test-prod": "playwright test --ui --config=playwright.prod.config.ts"
 	},
 	"dependencies": {
 		"@playwright/test": "1.40.1",

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
@@ -55,7 +55,7 @@ function Monthly({ isoCurrency, amount, promotion, name }: MonthlyProps) {
 					{formatAmount(
 						currencies[isoCurrency],
 						spokenCurrencies[isoCurrency],
-						amount,
+						promotion.discountedPrice,
 						false,
 					)}
 					/month for the first {promotion.discount.durationMonths} months, then{' '}
@@ -75,6 +75,73 @@ function Monthly({ isoCurrency, amount, promotion, name }: MonthlyProps) {
 		<h1 css={headerTitleText}>
 			Thank you {name}for supporting us with{' '}
 			<YellowAmount currency={isoCurrency} amount={amount} /> each month ❤️
+		</h1>
+	);
+}
+
+type AnnualProps = {
+	amount: number;
+	isoCurrency: IsoCurrency;
+	promotion?: Promotion;
+	name?: string;
+};
+function Annual({ isoCurrency, amount, promotion, name }: AnnualProps) {
+	if (
+		/**
+		 * This is a check to see if the promo exists,
+		 * it's a little odd due to the type having
+		 * every prop optional.
+		 *
+		 * We could/should do some parsing pre-render to avoid this.
+		 * */
+		promotion?.discountedPrice &&
+		promotion.discount?.durationMonths
+	) {
+		return (
+			<>
+				<h1 css={headerTitleText}>
+					Thank you {name}for supporting us with{' '}
+					<YellowAmount
+						amount={promotion.discountedPrice}
+						currency={isoCurrency}
+					/>
+					{`/year`}
+					<sup css={supCss}>*</sup>
+				</h1>
+				<p
+					css={css`
+						margin-top: ${space[2]}px;
+					`}
+				>
+					<sup>*</sup> You'll pay{' '}
+					{formatAmount(
+						currencies[isoCurrency],
+						spokenCurrencies[isoCurrency],
+						promotion.discountedPrice,
+						false,
+					)}
+					{/**
+					 * We'll assume that yearly promotions are always 12 months.
+					 * if not this will look weird, but we can work out what we would
+					 * like to do if that becomes a usecase
+					 **/}
+					/year for the first year, then{' '}
+					{formatAmount(
+						currencies[isoCurrency],
+						spokenCurrencies[isoCurrency],
+						amount,
+						false,
+					)}
+					/year afterwards unless you cancel.
+				</p>
+			</>
+		);
+	}
+
+	return (
+		<h1 css={headerTitleText}>
+			Thank you {name}for supporting us with{' '}
+			<YellowAmount currency={isoCurrency} amount={amount} /> each year ❤️
 		</h1>
 	);
 }
@@ -156,10 +223,12 @@ function Heading({
 
 		case 'ANNUAL':
 			return (
-				<h1 css={headerTitleText}>
-					Thank you {maybeNameAndTrailingSpace}for supporting us with{' '}
-					<YellowAmount currency={currency} amount={amount} /> each year ❤️
-				</h1>
+				<Annual
+					amount={amount}
+					isoCurrency={currency}
+					promotion={promotion}
+					name={maybeNameAndTrailingSpace}
+				/>
 			);
 
 		default:


### PR DESCRIPTION
Adds checks at the multiple stages of buying a product with a promo.

- Asserts the promo text on the tier card
- Asserts the total text on the checkout
- Asserts the "Buy" button text
- Asserts the promo text on the thank you page

This has picked up a bug that I was using the full amount for the promo text on the thank you page. Nice ✨ .

Lastly we add the annual promo example and header.

The script names for the e2e tests now follow `test-{env}` as it was a tiny bit fiddly to remember what it was.

[Trello card](https://trello.com/c/6EA1c4B7/705-3-tier-promotion-playwright-test-improve)

## Screenshots
<img width="409" alt="Screenshot 2024-03-26 at 14 41 03" src="https://github.com/guardian/support-frontend/assets/31692/6c3c13c9-6a30-4184-91b4-0a5d6f956e7b">
