### PR TITLE
run scala builds on non main PRs

### DIFF
--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -1,10 +1,8 @@
 name: Build payment-api
 
 on:
-  workflow_dispatch:
   pull_request:
-    branches:
-      - main
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/stripe-patrons-data.yml
+++ b/.github/workflows/stripe-patrons-data.yml
@@ -2,12 +2,10 @@ name: Build stripe-patrons-data
 
 on:
   pull_request:
-    branches:
-      - main
+  workflow_dispatch:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   support_frontend_build:

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -2,8 +2,7 @@ name: Build support-frontend
 
 on:
   pull_request:
-    branches:
-      - main
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/support-lambdas-build.yml
+++ b/.github/workflows/support-lambdas-build.yml
@@ -2,8 +2,7 @@ name: Build support-lambdas
 
 on:
   pull_request:
-    branches:
-      - main
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/support-workers-build.yml
+++ b/.github/workflows/support-workers-build.yml
@@ -2,8 +2,7 @@ name: Build support-workers
 
 on:
   pull_request:
-    branches:
-      - main
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/supporter-product-data.yml
+++ b/.github/workflows/supporter-product-data.yml
@@ -2,8 +2,7 @@ name: Build supporter-product-data
 
 on:
   pull_request:
-    branches:
-      - main
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Sometimes I do one PR and while it's waiting for review, I add another PR off the first one.

This means I am not blocked if the work depends on each other, but the second PR doesn't look like it includes the first PR, making it easier to review.

I noticed that if I do that, it doesn't run the builds on the second one, so I can't test in CODE.


This PR makes the Scala builds run on all PRs, and it also allows them to be manually run from the GH UI.