### PR TITLE
SupporterPlus Checkout Disclaimer Ts&Cs change  to second sentence

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
@@ -148,12 +148,11 @@ export function PaymentTsAndCs({
 						promotion,
 					)}
 					, you will receive the {productNameAboveThreshold} benefits on a
-					subscription basis. If you pay more than{' '}
-					{supporterPlusLegal(countryGroupId, contributionType, ' per ')}, these
-					additional amounts will be separate{' '}
-					{frequencyPlural(contributionType)} voluntary financial contributions
-					to the Guardian. The {productNameAboveThreshold} subscription and any
-					contributions will auto-renew each{' '}
+					subscription basis. If you increase your payments per{' '}
+					{frequencySingular(contributionType)}, these additional amounts will
+					be separate {frequencyPlural(contributionType)} voluntary financial
+					contributions to the Guardian. The {productNameAboveThreshold}{' '}
+					subscription and any contributions will auto-renew each{' '}
 					{frequencySingular(contributionType)}. You will be charged the
 					subscription and contribution amounts using your chosen payment method
 					at each renewal unless you cancel. You can cancel your subscription or


### PR DESCRIPTION
SupporterPlus Disclaimer Ts&Cs Change  to second sentence only.

FROM->
`If you pay more than {ccy}{S+Threshold} per {month/year} , these additional amounts will be separate {monthly/annual} voluntary financial contributions to the Guardian.`

TO->
`If you increase your payments per {month/year} , these additional amounts will be separate {monthly/annual} voluntary financial contributions to the Guardian`

|before|after|
|-----|-----|
|![image](https://github.com/guardian/support-frontend/assets/76729591/c211f71d-e23f-4577-ab68-ae77e23f66d3)|![image](https://github.com/guardian/support-frontend/assets/76729591/019b3688-add2-447b-a2a0-e6c98aefed2a)|
