### PR TITLE
fix: use h2 for heading and h3 for price

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -201,13 +201,15 @@ export function ThreeTierCard({
 	const promoPriceCopy = `${currency}${promoPrice}/${recurringContributionPeriodMap[paymentFrequency]}`;
 	const quantumMetricButtonRef = `tier-${cardTier}-button`;
 	return (
-		<div css={container(isRecommended, isUserSelected, isRecommendedSubdued)}>
+		<section
+			css={container(isRecommended, isUserSelected, isRecommendedSubdued)}
+		>
 			{isUserSelected && <ThreeTierLozenge title="Your selection" />}
 			{isRecommended && !isUserSelected && (
 				<ThreeTierLozenge subdue={isRecommendedSubdued} title="Recommended" />
 			)}
 			<h2 css={titleCss}>{title}</h2>
-			<h3 css={priceCss(!!planCost.discount)}>
+			<p css={priceCss(!!planCost.discount)}>
 				<span css={previousPriceStrikeThrough}>{priceCopy}</span>
 				{priceCopy && ' '}
 				{promoPriceCopy}
@@ -216,7 +218,7 @@ export function ThreeTierCard({
 						{discountSummaryCopy(currency, planCost, promoCount)}
 					</span>
 				)}
-			</h3>
+			</p>
 			<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
 				{externalBtnLink ? (
 					<LinkButton
@@ -277,6 +279,6 @@ export function ThreeTierCard({
 				iconColor={palette.brand[500]}
 				cssOverrides={checkmarkList}
 			/>
-		</div>
+		</section>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -206,8 +206,8 @@ export function ThreeTierCard({
 			{isRecommended && !isUserSelected && (
 				<ThreeTierLozenge subdue={isRecommendedSubdued} title="Recommended" />
 			)}
-			<h3 css={titleCss}>{title}</h3>
-			<h2 css={priceCss(!!planCost.discount)}>
+			<h2 css={titleCss}>{title}</h2>
+			<h3 css={priceCss(!!planCost.discount)}>
 				<span css={previousPriceStrikeThrough}>{priceCopy}</span>
 				{priceCopy && ' '}
 				{promoPriceCopy}
@@ -216,7 +216,7 @@ export function ThreeTierCard({
 						{discountSummaryCopy(currency, planCost, promoCount)}
 					</span>
 				)}
-			</h2>
+			</h3>
 			<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
 				{externalBtnLink ? (
 					<LinkButton


### PR DESCRIPTION
The [axe plugin we're using](https://github.com/dequelabs/axe-core-npm) was reporting that [we had the headers in the wrong order](https://dequeuniversity.com/rules/axe/4.4/heading-order?application=axeAPI).

After re-assessing the markup, I have opted to use sections for each product and an H2 for it's name, and remove the heading for the price, which didn't seem to make semantic sense.

**Before**

https://github.com/guardian/support-frontend/assets/31692/df9eeed0-6985-49c9-b2f2-81beeb3dff1d

**After**

https://github.com/guardian/support-frontend/assets/31692/848e7377-6b6b-4d23-937c-26e813e18518




