### PR TITLE
fix payment success metric

### DIFF
--- a/support-modules/aws/src/main/scala/com/gu/aws/AwsCloudWatchMetricPut.scala
+++ b/support-modules/aws/src/main/scala/com/gu/aws/AwsCloudWatchMetricPut.scala
@@ -59,7 +59,7 @@ object AwsCloudWatchMetricPut extends LazyLogging {
 
     val attempt = Try(client.putMetricData(putMetricDataRequest))
     attempt match {
-      case Failure(exception) => logger.warn("metric send failed with " + exception.toString)
+      case Failure(exception) => logger.error("metric send failed with " + exception.toString)
       case Success(value) => logger.info("metric sent successfully: " + value)
     }
     attempt.map(_ => ())

--- a/support-services/src/test/scala/com/gu/aws/AwsCloudWatchMetricPutSpec.scala
+++ b/support-services/src/test/scala/com/gu/aws/AwsCloudWatchMetricPutSpec.scala
@@ -1,6 +1,9 @@
 package com.gu.aws
 
+import com.gu.aws.AwsCloudWatchMetricSetup.paymentSuccessRequest
+import com.gu.i18n.Currency.GBP
 import com.gu.support.config.Stages
+import com.gu.support.workers.{DirectDebit, Monthly, SupporterPlus}
 import com.gu.test.tags.annotations.IntegrationTest
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -8,8 +11,15 @@ import org.scalatest.matchers.should.Matchers
 @IntegrationTest
 class AwsCloudWatchMetricPutSpec extends AsyncFlatSpec with Matchers {
 
-  "serverSideCreateFailure" should "be logged to CloudWatch" in {
-    AwsCloudWatchMetricPut(AwsCloudWatchMetricPut.client)(AwsCloudWatchMetricSetup.serverSideCreateFailure(Stages.CODE))
+  "payment success request" should "be logged to CloudWatch" in {
+    val cloudwatchEvent =
+      paymentSuccessRequest(
+        Stages.CODE,
+        true,
+        DirectDebit,
+        SupporterPlus(amount = 10, currency = GBP, billingPeriod = Monthly),
+      )
+    AwsCloudWatchMetricPut(AwsCloudWatchMetricPut.client)(cloudwatchEvent)
       .fold(
         err => fail(err),
         _ => succeed,


### PR DESCRIPTION
I shipped a PR yesterday to update some of the AWS clients to v2, including cloudwatch.
https://github.com/guardian/support-frontend/pull/5833

This involved a rewrite to use the new API.  Unfortunately the `dimensions` method in the new SDK overwrites the set of dimensions, whereas in the old SDK the similar method it added to them.

This means that when I ported over the old code, I made it go through each dimension, replacing them all with that one,r ather than adding them all.  This meant that they all ended up only under the Stage=PROD dimension, rather than the right PaymentProvider and Product as well.
<img width="844" alt="image" src="https://github.com/guardian/support-frontend/assets/7304387/a6b46dac-5ed7-4182-80f5-06cd790031d3">


To exacerbate that initial error, the test I was using to check it was only sending one dimension, so it worked fine (I ran it locally and just inspected the AWS console).  In CODE testing I didn't look at the PaymentSuccess metric in cloudwatch so I missed that it went to the wrong place.

This PR fixes the PaymentSuccess metric in support-workers, and updates the test to send a multi metric as part of the test.