### PR TITLE
test: temporarily inactivate PayPal e2e tests

### DIFF
--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -19,7 +19,12 @@ const testsDetails: TestDetails[] = [
 	{ paymentType: 'Credit/Debit card', tier: 1, frequency: 'Monthly' },
 	{ paymentType: 'Credit/Debit card', tier: 2, frequency: 'Annual' },
 	{ paymentType: 'Direct debit', tier: 2, frequency: 'Monthly' },
-	{ paymentType: 'PayPal', tier: 2, frequency: 'Monthly' },
+	/**
+	 * PayPal is currently throwing a "to many login attempts" error, so we're
+	 * going to inactivate this test until we have a solution for it to avoid
+	 * alert numbness.
+	 */
+	// { paymentType: 'PayPal', tier: 2, frequency: 'Monthly' },
 	{
 		paymentType: 'Credit/Debit card',
 		tier: 1,


### PR DESCRIPTION
Temporarily inactivate `PayPal` e2e tests as we are getting "To many login attempts" errors which are throwing false positives and creating 👻 fear 🧟‍♂️  where there shouldn't be.