### PR TITLE
fix IT tests

### DIFF
--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
@@ -117,8 +117,6 @@ class FailureHandlerITSpec extends AsyncLambdaSpec with MockContext {
 
     val testFields = FailedEmailFields.digitalPack("test@thegulocal.com", IdentityUserId("30001643"))
 
-    when(emailService.send(any[EmailFields])).thenReturn(Future.successful(()))
-
     val failureHandler = new FailureHandler(emailService)
 
     val outStream = new ByteArrayOutputStream()


### PR DESCRIPTION
After the PR to update to AWS v2 in https://github.com/guardian/support-frontend/pull/5850 , I noticed one of the IT tests are failing due to a simplified return type.

```
'send' is a *void method* and it *cannot* be stubbed with a *return value*!
Voids are usually stubbed with Throwables:
    doThrow(exception).when(mock).someVoidMethod();
If you need to set the void method to do nothing you can use:
    doNothing().when(mock).someVoidMethod();
For more information, check out the javadocs for Mockito.doNothing().
```

This PR fixes it.