### PR TITLE
Send promo code information in the acquisition event for supporter plus

### DIFF
--- a/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
@@ -123,7 +123,8 @@ object AcquisitionDataRowBuilder {
 
   private def productTypeAndAmount(product: ProductType): (AcquisitionProduct, Option[BigDecimal]) = product match {
     case c: Contribution => (AcquisitionProduct.RecurringContribution, Some(c.amount.toDouble))
-    case s: SupporterPlus => (AcquisitionProduct.SupporterPlus, None) // we don't send S+ amount because it may be discounted
+    case s: SupporterPlus =>
+      (AcquisitionProduct.SupporterPlus, None) // we don't send S+ amount because it may be discounted
     case _: DigitalPack => (AcquisitionProduct.DigitalSubscription, None)
     case _: Paper => (AcquisitionProduct.Paper, None)
     case _: GuardianWeekly => (AcquisitionProduct.GuardianWeekly, None)
@@ -198,7 +199,7 @@ object AcquisitionDataRowBuilder {
       case s: SendThankYouEmailSupporterPlusState =>
         AcquisitionTypeDetails(
           Some(s.paymentMethod),
-          None,
+          s.promoCode,
           Direct,
           Purchase,
           Some(s.accountNumber),


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We now support promotions on the supporter plus product, however we are not currently sending promo code information to BigQuery with the acquisition event. This PR fixes that.