### PR TITLE
test: inactivate all PayPal tests

### DIFF
--- a/support-e2e/tests/gwCheckout.test.ts
+++ b/support-e2e/tests/gwCheckout.test.ts
@@ -29,10 +29,17 @@ const testsDetails: TestDetails[] = [
 		frequency: 'Monthly',
 		paymentType: 'Direct debit',
 	},
-	{
-		frequency: 'Monthly',
-		paymentType: 'PayPal',
-	},
+	/**
+	 * PayPal is currently throwing a "to many login attempts" error, so we're
+	 * going to inactivate this test until we have a solution for it to avoid
+	 * alert numbness.
+	 *
+	 * TODO - re-enable this test when PayPal is fixed
+	 */
+	// {
+	// 	frequency: 'Monthly',
+	// 	paymentType: 'PayPal',
+	// },
 	{
 		frequency: 'Quarterly',
 		paymentType: 'Credit/Debit card',

--- a/support-e2e/tests/newspaperCheckout.test.ts
+++ b/support-e2e/tests/newspaperCheckout.test.ts
@@ -22,10 +22,17 @@ const testsDetails: TestDetails[] = [
 		frequency: 'Every day',
 		paymentType: 'Direct debit',
 	},
-	{
-		frequency: 'Every day',
-		paymentType: 'Paypal',
-	},
+	/**
+	 * PayPal is currently throwing a "to many login attempts" error, so we're
+	 * going to inactivate this test until we have a solution for it to avoid
+	 * alert numbness.
+	 *
+	 * TODO - re-enable this test when PayPal is fixed
+	 */
+	// {
+	// 	frequency: 'Every day',
+	// 	paymentType: 'Paypal',
+	// },
 	{
 		frequency: 'Weekend',
 		paymentType: 'Credit/Debit card',

--- a/support-e2e/tests/oneOffContributions.test.ts
+++ b/support-e2e/tests/oneOffContributions.test.ts
@@ -13,6 +13,13 @@ interface TestDetails {
 
 const testsDetails: TestDetails[] = [
 	{ paymentType: 'Credit/Debit card', customAmount: '22.55' },
+	/**
+	 * PayPal is currently throwing a "to many login attempts" error, so we're
+	 * going to inactivate this test until we have a solution for it to avoid
+	 * alert numbness.
+	 *
+	 * TODO - re-enable this test when PayPal is fixed
+	 */
 	{ paymentType: 'PayPal' },
 ];
 

--- a/support-e2e/tests/oneOffContributions.test.ts
+++ b/support-e2e/tests/oneOffContributions.test.ts
@@ -20,7 +20,7 @@ const testsDetails: TestDetails[] = [
 	 *
 	 * TODO - re-enable this test when PayPal is fixed
 	 */
-	{ paymentType: 'PayPal' },
+	// { paymentType: 'PayPal' },
 ];
 
 afterEachTasks(test);

--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -23,6 +23,8 @@ const testsDetails: TestDetails[] = [
 	 * PayPal is currently throwing a "to many login attempts" error, so we're
 	 * going to inactivate this test until we have a solution for it to avoid
 	 * alert numbness.
+	 *
+	 * TODO - re-enable this test when PayPal is fixed
 	 */
 	// { paymentType: 'PayPal', tier: 2, frequency: 'Monthly' },
 	{


### PR DESCRIPTION
Related to #5860 

Inactivates all PayPal E2E tests while we work out how to not be hit with the "To many login attempts" error.