### PR TITLE
Playwright timeouts

### DIFF
--- a/support-e2e/playwright.base.config.ts
+++ b/support-e2e/playwright.base.config.ts
@@ -12,9 +12,6 @@ export const baseObject: PlaywrightTestConfig = {
 	 * {@link https://github.com/guardian/support-frontend/blob/62727c38f160e2effe83cbe990319ca05e12a777/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts#L248-L249}
 	 * */
 	timeout: 40 * 1000,
-	expect: {
-		timeout: 90000,
-	},
 	fullyParallel: true,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
 	forbidOnly: !!process.env.CI,

--- a/support-e2e/playwright.base.config.ts
+++ b/support-e2e/playwright.base.config.ts
@@ -17,8 +17,6 @@ export const baseObject: PlaywrightTestConfig = {
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
 	forbidOnly: !!process.env.CI,
 	retries: 1,
-	/* Opt out of parallel tests on CI. */
-	workers: process.env.CI ? 1 : undefined,
 	reporter: 'html',
 	use: {
 		/* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/support-e2e/playwright.base.config.ts
+++ b/support-e2e/playwright.base.config.ts
@@ -8,10 +8,11 @@ export const baseObject: PlaywrightTestConfig = {
 	/**
 	 * Maximum time one test can run for.
 	 *
-	 * This is set to 40 seconds due to the thank you page timeout being 30 seconds allowing for
-	 * {@link https://github.com/guardian/support-frontend/blob/62727c38f160e2effe83cbe990319ca05e12a777/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts#L248-L249}
+	 * This is set to 60 seconds due to the thank you page timeout being 30 seconds for checking on support-workers.
+	 * This value is `(supportWorkersTimeout + defaultPlaywrightTimeout) * millisecondsInSecond`
+	 * @see `POLLING_INTERVAL` and `MAX_POLLS` in {@link file://./../../support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts}
 	 * */
-	timeout: 40 * 1000,
+	timeout: (30 + 30) * 1000,
 	fullyParallel: true,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
 	forbidOnly: !!process.env.CI,

--- a/support-e2e/playwright.base.config.ts
+++ b/support-e2e/playwright.base.config.ts
@@ -5,8 +5,13 @@ export const baseObject: PlaywrightTestConfig = {
 	testDir: 'tests',
 	testMatch: '**/*.test.ts',
 
-	/* Maximum time one test can run for. */
-	timeout: 120 * 1000,
+	/**
+	 * Maximum time one test can run for.
+	 *
+	 * This is set to 40 seconds due to the thank you page timeout being 30 seconds allowing for
+	 * {@link https://github.com/guardian/support-frontend/blob/62727c38f160e2effe83cbe990319ca05e12a777/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts#L248-L249}
+	 * */
+	timeout: 40 * 1000,
 	expect: {
 		timeout: 90000,
 	},

--- a/support-e2e/tests/gwCheckout.test.ts
+++ b/support-e2e/tests/gwCheckout.test.ts
@@ -5,7 +5,7 @@ import { checkRecaptcha } from './utils/recaptcha';
 import { fillInCardDetails } from './utils/cardDetails';
 import { fillInDirectDebitDetails } from './utils/directDebitDetails';
 import { fillInPayPalDetails } from './utils/paypal';
-import { setupPage } from './utils/page';
+import { THANK_YOU_PAGE_EXPECT_TIMEOUT, setupPage } from './utils/page';
 import { afterEachTasks } from './utils/afterEachTest';
 
 type PaymentType = 'Credit/Debit card' | 'Direct debit' | 'PayPal';
@@ -75,7 +75,7 @@ const testsDetailsGifted: TestDetailsGifted[] = [
 		frequency: '12 months',
 		paymentType: 'Direct debit',
 	},
-  /**
+	/**
 	 * PayPal is currently throwing a "to many login attempts" error, so we're
 	 * going to inactivate this test until we have a solution for it to avoid
 	 * alert numbness.
@@ -96,6 +96,7 @@ test.describe('Sign up for a Guardian Weekly subscription', () => {
 			context,
 			baseURL,
 		}) => {
+			// Landing
 			const page = await context.newPage();
 			const testFirstName = firstName();
 			const testEmail = email();
@@ -103,6 +104,8 @@ test.describe('Sign up for a Guardian Weekly subscription', () => {
 			await page
 				.locator(`a[aria-label='${testDetails.frequency}- Subscribe now']`)
 				.click();
+
+			// Checkout
 			await page.getByLabel('title').selectOption('Ms');
 			await page.getByLabel('First name').fill(testFirstName);
 			await page.getByLabel('Last name').fill(lastName());
@@ -163,7 +166,7 @@ test.describe('Sign up for a Guardian Weekly subscription', () => {
 
 			await expect(
 				page.getByRole('heading', { name: successMsgRegex }),
-			).toBeVisible();
+			).toBeVisible({ timeout: THANK_YOU_PAGE_EXPECT_TIMEOUT });
 		});
 	});
 });
@@ -175,6 +178,7 @@ test.describe('Gifted subscriptions', () => {
 			context,
 			baseURL,
 		}) => {
+			// Landing
 			const testFirstName = firstName();
 			const testLastName = lastName();
 			const testEmail = email();
@@ -182,6 +186,8 @@ test.describe('Gifted subscriptions', () => {
 			await page
 				.locator(`a[aria-label='${testDetails.frequency}- Subscribe now']`)
 				.click();
+
+			// Checkout
 			const gifteeDetails = await page
 				.getByText("Gift recipient's details", { exact: true })
 				.locator('..');
@@ -252,9 +258,10 @@ test.describe('Gifted subscriptions', () => {
 				`${processingSubscriptionMessage}|${subscribedMessage}`,
 			);
 
+			// Thank you
 			await expect(
 				page.getByRole('heading', { name: successMsgRegex }),
-			).toBeVisible();
+			).toBeVisible({ timeout: THANK_YOU_PAGE_EXPECT_TIMEOUT });
 		});
 	});
 });

--- a/support-e2e/tests/newspaperCheckout.test.ts
+++ b/support-e2e/tests/newspaperCheckout.test.ts
@@ -5,7 +5,7 @@ import { checkRecaptcha } from './utils/recaptcha';
 import { fillInCardDetails } from './utils/cardDetails';
 import { fillInDirectDebitDetails } from './utils/directDebitDetails';
 import { fillInPayPalDetails } from './utils/paypal';
-import { setupPage } from './utils/page';
+import { THANK_YOU_PAGE_EXPECT_TIMEOUT, setupPage } from './utils/page';
 import { afterEachTasks } from './utils/afterEachTest';
 
 interface TestDetails {
@@ -81,6 +81,7 @@ test.describe('Sign up newspaper subscription', () => {
 			) {
 				test.skip();
 			}
+			// Landing
 			const page = await context.newPage();
 			const testFirstName = firstName();
 			const testEmail = email();
@@ -88,6 +89,8 @@ test.describe('Sign up newspaper subscription', () => {
 			await page
 				.locator(`a[aria-label='${testDetails.frequency}- Subscribe']`)
 				.click();
+
+			// Checkout
 			await page.getByLabel('title').selectOption('Ms');
 			await page.fill('label:has-text("First name")', testFirstName);
 			await page.fill('label:has-text("Last name")', lastName());
@@ -133,9 +136,10 @@ test.describe('Sign up newspaper subscription', () => {
 				`${processingSubscriptionMessage}|${subscribedMessage}`,
 			);
 
+			// Thank you
 			await expect(
 				page.getByRole('heading', { name: successMsgRegex }),
-			).toBeVisible();
+			).toBeVisible({ timeout: THANK_YOU_PAGE_EXPECT_TIMEOUT });
 		});
 	});
 });

--- a/support-e2e/tests/oneOffContributions.test.ts
+++ b/support-e2e/tests/oneOffContributions.test.ts
@@ -3,7 +3,7 @@ import { email } from './utils/users';
 import { checkRecaptcha } from './utils/recaptcha';
 import { fillInCardDetails } from './utils/cardDetails';
 import { fillInPayPalDetails } from './utils/paypal';
-import { setupPage } from './utils/page';
+import { THANK_YOU_PAGE_EXPECT_TIMEOUT, setupPage } from './utils/page';
 import { afterEachTasks } from './utils/afterEachTest';
 
 interface TestDetails {
@@ -35,9 +35,12 @@ test.describe('Sign up for a one-off contribution', () => {
 			context,
 			baseURL,
 		}) => {
+			// Landing
 			const page = await context.newPage();
 			await setupPage(page, context, baseURL, '/uk/contribute');
 			await page.getByRole('button', { name: 'Support now' }).click();
+
+			// Checkout
 			await expect(page).toHaveURL(/\/uk\/contribute\/checkout/);
 			if (testDetails.customAmount) {
 				await page.locator("label[for='amount-other']").click();
@@ -57,7 +60,11 @@ test.describe('Sign up for a one-off contribution', () => {
 					fillInPayPalDetails(page);
 					break;
 			}
-			await expect(page).toHaveURL(/\/uk\/thankyou/);
+
+			// Thank you
+			await expect(page).toHaveURL(/\/uk\/thankyou/, {
+				timeout: THANK_YOU_PAGE_EXPECT_TIMEOUT,
+			});
 		});
 	});
 });

--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -5,7 +5,7 @@ import { checkRecaptcha } from './utils/recaptcha';
 import { fillInCardDetails } from './utils/cardDetails';
 import { fillInDirectDebitDetails } from './utils/directDebitDetails';
 import { fillInPayPalDetails } from './utils/paypal';
-import { setupPage } from './utils/page';
+import { THANK_YOU_PAGE_EXPECT_TIMEOUT, setupPage } from './utils/page';
 import { afterEachTasks } from './utils/afterEachTest';
 
 interface TestDetails {
@@ -128,7 +128,7 @@ test.describe('Subscribe/Contribute via the Tiered checkout)', () => {
 			}
 			await expect(page).toHaveURL(
 				`/${testDetails.country?.toLowerCase() || 'uk'}/thankyou`,
-				{ timeout: 600000 },
+				{ timeout: THANK_YOU_PAGE_EXPECT_TIMEOUT },
 			);
 		});
 	});
@@ -174,10 +174,9 @@ test.describe('Subscribe (S+) incl PromoCode via the Tiered checkout', () => {
 			// Thank you
 			await expect(
 				page.getByText(testDetails.expectedThankYouText).first(),
-			).toBeVisible();
+			).toBeVisible({ timeout: THANK_YOU_PAGE_EXPECT_TIMEOUT });
 			await expect(page).toHaveURL(
 				`/uk/thankyou?promoCode=${testDetails.promoCode}`,
-				{ timeout: 600000 },
 			);
 		});
 	});

--- a/support-e2e/tests/utils/page.ts
+++ b/support-e2e/tests/utils/page.ts
@@ -17,3 +17,9 @@ export const setupPage = async (
 	await setTestCookies(context, 'SupportPostDeployTestF', domain);
 	await page.goto(pageUrl);
 };
+
+/**
+ * This is set to 35 seconds due to the 30 second timeout we have on the thank you screen displaying.
+ * @see `POLLING_INTERVAL` and `MAX_POLLS` in {@link file://./../../support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts}
+ **/
+export const THANK_YOU_PAGE_EXPECT_TIMEOUT = 35 * 1000;


### PR DESCRIPTION
- Reduces the timeout on out Playwright tests to avoid uncaught states that do not fail on locking up for a maximum of 2 minutes each, which we've seen accumulate into ~30 minutes in bad circumstanes.
- Sets the `expect.timeout` to the default 5 seconds, but sets a higher value in areas we know will take longer e.g. the thank you page.
- Sets the [`workers`](https://playwright.dev/docs/test-parallel#limit-workers) default of 5, which seems to increase the speed at which the test scenarios are run. @rBangay - was there a specific reason to have limited this?
  ## 5 workers
  <img width="924" alt="Screenshot 2024-04-02 at 20 43 45" src="https://github.com/guardian/support-frontend/assets/31692/dadec39d-8fd6-45ae-b596-7bf462c4ef95">

  ## 1 worker
  <img width="923" alt="Screenshot 2024-04-02 at 20 44 02" src="https://github.com/guardian/support-frontend/assets/31692/f6950d4e-2572-40fa-82d3-e78f6acbe56d">





These changes should create a situation in which we see failures quicker, but also hopefully raise issues where things should happen quick, but doesn't e.g. clicking through to checkout takes 20 seconds for an introduced bug.
