### PR TITLE
feat: use RRCP amounts for recurring tier

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -366,6 +366,13 @@ export function ThreeTierLanding(): JSX.Element {
 				contributionTypeKeyOverride ?? tierPlanPeriod
 			].charges[countryGroupId];
 
+		if (cardTier === 1) {
+			tierPlanCountryCharges = {
+				...tierPlanCountryCharges,
+				price: recurringAmount,
+			};
+		}
+
 		if (cardTier === 2 && promotion) {
 			tierPlanCountryCharges = {
 				...tierPlanCountryCharges,
@@ -408,6 +415,14 @@ export function ThreeTierLanding(): JSX.Element {
 			planCost: cardContent.planCost,
 		};
 	};
+
+	const { amounts } = useContributionsSelector((state) => state.common);
+	const monthlyRecurringAmount = amounts.amountsCardData.MONTHLY.amounts[0];
+	const annualRecurringAmount = amounts.amountsCardData.ANNUAL.amounts[0];
+	const recurringAmount =
+		contributionType === 'MONTHLY'
+			? monthlyRecurringAmount
+			: annualRecurringAmount;
 
 	const generateTierCheckoutLink = (cardTier: 1 | 2 | 3, promo?: Promotion) => {
 		const tierPlanCountryCharges =


### PR DESCRIPTION
Following this diagram, this implements the red bounding boxes, namely, **the lowest amounts** in **`Monthly` and `Annual`** being reflected in **Recurring contribution tier (Tier-1)**. 

<img width="1140" alt="Screenshot 2024-04-02 at 22 17 12" src="https://github.com/guardian/support-frontend/assets/31692/8f9732a8-ca52-43aa-861e-b3e439f74463">

## Screenshots
### RRCP
<img width="1034" alt="Screenshot 2024-04-02 at 22 15 17" src="https://github.com/guardian/support-frontend/assets/31692/110b581f-ee84-454b-8496-fd833ab5566b">

### Monthly
<img width="989" alt="Screenshot 2024-04-02 at 22 13 36" src="https://github.com/guardian/support-frontend/assets/31692/014e88d2-14a4-4525-bfec-409f33eb88e6">

### Annual
<img width="989" alt="Screenshot 2024-04-02 at 22 13 39" src="https://github.com/guardian/support-frontend/assets/31692/86c4b741-affd-4525-a3fd-43ab3a2e5f38">

