### PR TITLE
Move `describeProduct` to it's own module

### DIFF
--- a/support-frontend/assets/helpers/productCatalogue.ts
+++ b/support-frontend/assets/helpers/productCatalogue.ts
@@ -1,0 +1,112 @@
+import { newspaperCountries } from 'helpers/internationalisation/country';
+import { gwDeliverableCountries } from 'helpers/internationalisation/gwDeliverableCountries';
+
+export function describeProduct(product: string, ratePlan: string) {
+	let description = `${product} - ${ratePlan}`;
+	let frequency = '';
+	let showAddressFields = false;
+	let addressCountries = {};
+	let benefits: string[] = [];
+	let benefitsDescription = '';
+
+	/**
+	 * This is not actually a product from our catalog,
+	 * but a faux product we invesrted for the three tier test
+	 **/
+	if (product === 'GuardianWeeklyAndSupporterPlus') {
+		description = 'Digital + print';
+		benefits = [
+			'Guardian Weekly print magazine delivered to your door every week',
+		];
+		benefitsDescription = 'The rewards from All-access digital';
+	}
+
+	if (product === 'Contribution') {
+		description = 'Support';
+		benefits = [
+			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+		];
+	}
+
+	if (product === 'SupporterPlus') {
+		description = 'All-access digital';
+
+		benefits = [
+			'Unlimited access to the Guardian app',
+			'Ad-free reading on all your devices',
+			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+			'Far fewer asks for support',
+		];
+	}
+
+	if (product === 'HomeDelivery') {
+		frequency = 'month';
+		description = `${ratePlan} paper`;
+
+		showAddressFields = true;
+		addressCountries = newspaperCountries;
+
+		if (ratePlan === 'Sixday') {
+			description = 'Six day paper';
+		}
+		if (ratePlan === 'Everyday') {
+			description = 'Every day paper';
+		}
+		if (ratePlan === 'Weekend') {
+			description = 'Weekend paper';
+		}
+		if (ratePlan === 'Saturday') {
+			description = 'Saturday paper';
+		}
+		if (ratePlan === 'Sunday') {
+			description = 'Sunday paper';
+		}
+	}
+
+	if (product === 'NationalDelivery') {
+		showAddressFields = true;
+		addressCountries = newspaperCountries;
+	}
+
+	if (
+		product === 'GuardianWeeklyDomestic' ||
+		product === 'GuardianWeeklyRestOfWorld'
+	) {
+		showAddressFields = true;
+		addressCountries = gwDeliverableCountries;
+
+		if (ratePlan === 'OneYearGift') {
+			frequency = 'year';
+			description = 'The Guardian Weekly Gift Subscription';
+		}
+		if (ratePlan === 'Annual') {
+			frequency = 'year';
+			description = 'The Guardian Weekly';
+		}
+		if (ratePlan === 'Quarterly') {
+			frequency = 'quarter';
+			description = 'The Guardian Weekly';
+		}
+		if (ratePlan === 'Monthly') {
+			frequency = 'month';
+			description = 'The Guardian Weekly';
+		}
+		if (ratePlan === 'ThreeMonthGift') {
+			frequency = 'quarter';
+			description = 'The Guardian Weekly Gift Subscription';
+		}
+		if (ratePlan === 'SixWeekly') {
+			frequency = 'month';
+			description = 'The Guardian Weekly';
+		}
+	}
+
+	return {
+		description,
+		frequency,
+		showAddressFields,
+		addressCountries,
+		benefits,
+		benefitsDescription,
+	};
+}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -54,14 +54,11 @@ import {
 import { getStripeKey } from 'helpers/forms/stripe';
 import { validateWindowGuardian } from 'helpers/globalsAndSwitches/window';
 import CountryHelper from 'helpers/internationalisation/classes/country';
-import {
-	type IsoCountry,
-	newspaperCountries,
-} from 'helpers/internationalisation/country';
+import { type IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { Currency } from 'helpers/internationalisation/currency';
 import { currencies } from 'helpers/internationalisation/currency';
-import { gwDeliverableCountries } from 'helpers/internationalisation/gwDeliverableCountries';
+import { describeProduct } from 'helpers/productCatalogue';
 import { renderPage } from 'helpers/rendering/render';
 import { get } from 'helpers/storage/cookie';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
@@ -129,77 +126,6 @@ const query = {
 	product: searchParams.get('product'),
 	ratePlan: searchParams.get('ratePlan'),
 };
-
-function describeProduct(product: string, ratePlan: string) {
-	let description = `${product} - ${ratePlan}`;
-	let frequency = '';
-	let showAddressFields = false;
-	let addressCountries = {};
-
-	if (product === 'HomeDelivery') {
-		frequency = 'month';
-		description = `${ratePlan} paper`;
-
-		showAddressFields = true;
-		addressCountries = newspaperCountries;
-
-		if (ratePlan === 'Sixday') {
-			description = 'Six day paper';
-		}
-		if (ratePlan === 'Everyday') {
-			description = 'Every day paper';
-		}
-		if (ratePlan === 'Weekend') {
-			description = 'Weekend paper';
-		}
-		if (ratePlan === 'Saturday') {
-			description = 'Saturday paper';
-		}
-		if (ratePlan === 'Sunday') {
-			description = 'Sunday paper';
-		}
-	}
-
-	if (product === 'NationalDelivery') {
-		showAddressFields = true;
-		addressCountries = newspaperCountries;
-	}
-
-	if (
-		product === 'GuardianWeeklyDomestic' ||
-		product === 'GuardianWeeklyRestOfWorld'
-	) {
-		showAddressFields = true;
-		addressCountries = gwDeliverableCountries;
-
-		if (ratePlan === 'OneYearGift') {
-			frequency = 'year';
-			description = 'The Guardian Weekly Gift Subscription';
-		}
-		if (ratePlan === 'Annual') {
-			frequency = 'year';
-			description = 'The Guardian Weekly';
-		}
-		if (ratePlan === 'Quarterly') {
-			frequency = 'quarter';
-			description = 'The Guardian Weekly';
-		}
-		if (ratePlan === 'Monthly') {
-			frequency = 'month';
-			description = 'The Guardian Weekly';
-		}
-		if (ratePlan === 'ThreeMonthGift') {
-			frequency = 'quarter';
-			description = 'The Guardian Weekly Gift Subscription';
-		}
-		if (ratePlan === 'SixWeekly') {
-			frequency = 'month';
-			description = 'The Guardian Weekly';
-		}
-	}
-
-	return { description, frequency, showAddressFields, addressCountries };
-}
 
 /** Page styles - styles used specifically for the checkout page */
 const darkBackgroundContainerMobile = css`


### PR DESCRIPTION
This moves `describeProduct` to it's own module to be shared with `ThreeTierLanding`, and adds `benefits` and `benefitsDescription` to ensure we can render `ThreeTierLanding`.

We have also added a `GuardianWeeklyAndSupporterPlus` product which is a hack we'll need while we work out how we deal with bundles.

This is to help being [`ProductCatalog` into the `ThreeTierLanding`](https://github.com/guardian/support-frontend/issues/5882)

