### PR TITLE
fix: only show promotion is supporter plus on thank you page

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/isSupporterPlus.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/isSupporterPlus.ts
@@ -15,6 +15,7 @@ export function isSupporterPlusFromState(state: ContributionsState): boolean {
 		state.page.checkoutForm.product.otherAmounts,
 		contributionType,
 	);
+	console.info('isSupporterPlusFromState', thresholdPrice, selectedAmount);
 	return selectedAmount >= thresholdPrice;
 }
 

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/isSupporterPlus.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/isSupporterPlus.ts
@@ -15,7 +15,7 @@ export function isSupporterPlusFromState(state: ContributionsState): boolean {
 		state.page.checkoutForm.product.otherAmounts,
 		contributionType,
 	);
-	console.info('isSupporterPlusFromState', thresholdPrice, selectedAmount);
+
 	return selectedAmount >= thresholdPrice;
 }
 

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -150,7 +150,10 @@ export function SupporterPlusThankYou(): JSX.Element {
 	 *
 	 * We should clear this up when refactoring
 	 */
-	const isSupporterPlus = thresholdPrice ? amount >= thresholdPrice : false;
+	const isSupporterPlus =
+		contributionType !== 'ONE_OFF' && thresholdPrice
+			? amount >= thresholdPrice
+			: false;
 
 	/**
 	 * We only support SupporterPlus for now.


### PR DESCRIPTION
This is a hotfix and probably not **_the_** sustainable way to do this.

We will be looking at how data is passed to the thank you page in future which should help with this.

This only applies the promotion if it is `SupporterPlus`. I haven't found the route to how someone got to the checkout with a contribution amount and a `promoCode` e.g. https://support.theguardian.com/uk/contribute/checkout?selected-amount=4&selected-contribution-type=monthly&promoCode=50SPRING2024

The `promoCode` isn't reflected in the UI at that point:
<img width="606" alt="Screenshot 2024-04-03 at 12 39 45" src="https://github.com/guardian/support-frontend/assets/31692/12cbd9f4-8745-412b-915c-562c6edb419c">

But when the `promoCode` is in the thank-you page URL, it borks:
https://support.theguardian.com/uk/thankyou?promoCode=50SPRING2024

I think this is because we read amount from `localStorage` _OR_ state. Hopefully we can get around this by removing this condition. 

But for now this fixes a known bug seen in `PROD` (reported by triage unit)

[**Trello Card**](https://trello.com/c/nYPxPdsy/746-severity-2-medium-bug-report-55-system-impacted-guardian-checkout-supporttheguardiancom)

## Screenshots

### Before
<img width="1173" alt="Screenshot 2024-04-03 at 12 49 48" src="https://github.com/guardian/support-frontend/assets/31692/6972131c-15e8-473d-9a1b-84103072a97f">

### After
<img width="1173" alt="Screenshot 2024-04-03 at 12 49 48" src="https://github.com/guardian/support-frontend/assets/31692/b33ce9ee-419f-4a7a-8a3b-fd4e335f9d55">
