### PR TITLE
Revert "Playwright timeouts"

### DIFF
--- a/support-e2e/playwright.base.config.ts
+++ b/support-e2e/playwright.base.config.ts
@@ -5,18 +5,17 @@ export const baseObject: PlaywrightTestConfig = {
 	testDir: 'tests',
 	testMatch: '**/*.test.ts',
 
-	/**
-	 * Maximum time one test can run for.
-	 *
-	 * This is set to 60 seconds due to the thank you page timeout being 30 seconds for checking on support-workers.
-	 * This value is `(supportWorkersTimeout + defaultPlaywrightTimeout) * millisecondsInSecond`
-	 * @see `POLLING_INTERVAL` and `MAX_POLLS` in {@link file://./../../support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts}
-	 * */
-	timeout: (30 + 30) * 1000,
+	/* Maximum time one test can run for. */
+	timeout: 120 * 1000,
+	expect: {
+		timeout: 90000,
+	},
 	fullyParallel: true,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
 	forbidOnly: !!process.env.CI,
 	retries: 1,
+	/* Opt out of parallel tests on CI. */
+	workers: process.env.CI ? 1 : undefined,
 	reporter: 'html',
 	use: {
 		/* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/support-e2e/tests/gwCheckout.test.ts
+++ b/support-e2e/tests/gwCheckout.test.ts
@@ -5,7 +5,7 @@ import { checkRecaptcha } from './utils/recaptcha';
 import { fillInCardDetails } from './utils/cardDetails';
 import { fillInDirectDebitDetails } from './utils/directDebitDetails';
 import { fillInPayPalDetails } from './utils/paypal';
-import { THANK_YOU_PAGE_EXPECT_TIMEOUT, setupPage } from './utils/page';
+import { setupPage } from './utils/page';
 import { afterEachTasks } from './utils/afterEachTest';
 
 type PaymentType = 'Credit/Debit card' | 'Direct debit' | 'PayPal';
@@ -75,7 +75,7 @@ const testsDetailsGifted: TestDetailsGifted[] = [
 		frequency: '12 months',
 		paymentType: 'Direct debit',
 	},
-	/**
+  /**
 	 * PayPal is currently throwing a "to many login attempts" error, so we're
 	 * going to inactivate this test until we have a solution for it to avoid
 	 * alert numbness.
@@ -96,7 +96,6 @@ test.describe('Sign up for a Guardian Weekly subscription', () => {
 			context,
 			baseURL,
 		}) => {
-			// Landing
 			const page = await context.newPage();
 			const testFirstName = firstName();
 			const testEmail = email();
@@ -104,8 +103,6 @@ test.describe('Sign up for a Guardian Weekly subscription', () => {
 			await page
 				.locator(`a[aria-label='${testDetails.frequency}- Subscribe now']`)
 				.click();
-
-			// Checkout
 			await page.getByLabel('title').selectOption('Ms');
 			await page.getByLabel('First name').fill(testFirstName);
 			await page.getByLabel('Last name').fill(lastName());
@@ -166,7 +163,7 @@ test.describe('Sign up for a Guardian Weekly subscription', () => {
 
 			await expect(
 				page.getByRole('heading', { name: successMsgRegex }),
-			).toBeVisible({ timeout: THANK_YOU_PAGE_EXPECT_TIMEOUT });
+			).toBeVisible();
 		});
 	});
 });
@@ -178,7 +175,6 @@ test.describe('Gifted subscriptions', () => {
 			context,
 			baseURL,
 		}) => {
-			// Landing
 			const testFirstName = firstName();
 			const testLastName = lastName();
 			const testEmail = email();
@@ -186,8 +182,6 @@ test.describe('Gifted subscriptions', () => {
 			await page
 				.locator(`a[aria-label='${testDetails.frequency}- Subscribe now']`)
 				.click();
-
-			// Checkout
 			const gifteeDetails = await page
 				.getByText("Gift recipient's details", { exact: true })
 				.locator('..');
@@ -258,10 +252,9 @@ test.describe('Gifted subscriptions', () => {
 				`${processingSubscriptionMessage}|${subscribedMessage}`,
 			);
 
-			// Thank you
 			await expect(
 				page.getByRole('heading', { name: successMsgRegex }),
-			).toBeVisible({ timeout: THANK_YOU_PAGE_EXPECT_TIMEOUT });
+			).toBeVisible();
 		});
 	});
 });

--- a/support-e2e/tests/newspaperCheckout.test.ts
+++ b/support-e2e/tests/newspaperCheckout.test.ts
@@ -5,7 +5,7 @@ import { checkRecaptcha } from './utils/recaptcha';
 import { fillInCardDetails } from './utils/cardDetails';
 import { fillInDirectDebitDetails } from './utils/directDebitDetails';
 import { fillInPayPalDetails } from './utils/paypal';
-import { THANK_YOU_PAGE_EXPECT_TIMEOUT, setupPage } from './utils/page';
+import { setupPage } from './utils/page';
 import { afterEachTasks } from './utils/afterEachTest';
 
 interface TestDetails {
@@ -81,7 +81,6 @@ test.describe('Sign up newspaper subscription', () => {
 			) {
 				test.skip();
 			}
-			// Landing
 			const page = await context.newPage();
 			const testFirstName = firstName();
 			const testEmail = email();
@@ -89,8 +88,6 @@ test.describe('Sign up newspaper subscription', () => {
 			await page
 				.locator(`a[aria-label='${testDetails.frequency}- Subscribe']`)
 				.click();
-
-			// Checkout
 			await page.getByLabel('title').selectOption('Ms');
 			await page.fill('label:has-text("First name")', testFirstName);
 			await page.fill('label:has-text("Last name")', lastName());
@@ -136,10 +133,9 @@ test.describe('Sign up newspaper subscription', () => {
 				`${processingSubscriptionMessage}|${subscribedMessage}`,
 			);
 
-			// Thank you
 			await expect(
 				page.getByRole('heading', { name: successMsgRegex }),
-			).toBeVisible({ timeout: THANK_YOU_PAGE_EXPECT_TIMEOUT });
+			).toBeVisible();
 		});
 	});
 });

--- a/support-e2e/tests/oneOffContributions.test.ts
+++ b/support-e2e/tests/oneOffContributions.test.ts
@@ -3,7 +3,7 @@ import { email } from './utils/users';
 import { checkRecaptcha } from './utils/recaptcha';
 import { fillInCardDetails } from './utils/cardDetails';
 import { fillInPayPalDetails } from './utils/paypal';
-import { THANK_YOU_PAGE_EXPECT_TIMEOUT, setupPage } from './utils/page';
+import { setupPage } from './utils/page';
 import { afterEachTasks } from './utils/afterEachTest';
 
 interface TestDetails {
@@ -35,12 +35,9 @@ test.describe('Sign up for a one-off contribution', () => {
 			context,
 			baseURL,
 		}) => {
-			// Landing
 			const page = await context.newPage();
 			await setupPage(page, context, baseURL, '/uk/contribute');
 			await page.getByRole('button', { name: 'Support now' }).click();
-
-			// Checkout
 			await expect(page).toHaveURL(/\/uk\/contribute\/checkout/);
 			if (testDetails.customAmount) {
 				await page.locator("label[for='amount-other']").click();
@@ -60,11 +57,7 @@ test.describe('Sign up for a one-off contribution', () => {
 					fillInPayPalDetails(page);
 					break;
 			}
-
-			// Thank you
-			await expect(page).toHaveURL(/\/uk\/thankyou/, {
-				timeout: THANK_YOU_PAGE_EXPECT_TIMEOUT,
-			});
+			await expect(page).toHaveURL(/\/uk\/thankyou/);
 		});
 	});
 });

--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -5,7 +5,7 @@ import { checkRecaptcha } from './utils/recaptcha';
 import { fillInCardDetails } from './utils/cardDetails';
 import { fillInDirectDebitDetails } from './utils/directDebitDetails';
 import { fillInPayPalDetails } from './utils/paypal';
-import { THANK_YOU_PAGE_EXPECT_TIMEOUT, setupPage } from './utils/page';
+import { setupPage } from './utils/page';
 import { afterEachTasks } from './utils/afterEachTest';
 
 interface TestDetails {
@@ -128,7 +128,7 @@ test.describe('Subscribe/Contribute via the Tiered checkout)', () => {
 			}
 			await expect(page).toHaveURL(
 				`/${testDetails.country?.toLowerCase() || 'uk'}/thankyou`,
-				{ timeout: THANK_YOU_PAGE_EXPECT_TIMEOUT },
+				{ timeout: 600000 },
 			);
 		});
 	});
@@ -174,9 +174,10 @@ test.describe('Subscribe (S+) incl PromoCode via the Tiered checkout', () => {
 			// Thank you
 			await expect(
 				page.getByText(testDetails.expectedThankYouText).first(),
-			).toBeVisible({ timeout: THANK_YOU_PAGE_EXPECT_TIMEOUT });
+			).toBeVisible();
 			await expect(page).toHaveURL(
 				`/uk/thankyou?promoCode=${testDetails.promoCode}`,
+				{ timeout: 600000 },
 			);
 		});
 	});

--- a/support-e2e/tests/utils/page.ts
+++ b/support-e2e/tests/utils/page.ts
@@ -17,9 +17,3 @@ export const setupPage = async (
 	await setTestCookies(context, 'SupportPostDeployTestF', domain);
 	await page.goto(pageUrl);
 };
-
-/**
- * This is set to 35 seconds due to the 30 second timeout we have on the thank you screen displaying.
- * @see `POLLING_INTERVAL` and `MAX_POLLS` in {@link file://./../../support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts}
- **/
-export const THANK_YOU_PAGE_EXPECT_TIMEOUT = 35 * 1000;


### PR DESCRIPTION
Reverts guardian/support-frontend#5876

I'm reverting these for now because even though testing from local seemed to work a treat, now they're running from CI there's a tonne of errors being thrown.

I'm not sure what the cause of these are, but I'd like to get the tests back up and running while I debug.