### PR TITLE
feat: read tier card values from product catalog

### DIFF
--- a/support-frontend/assets/helpers/productCatalogue.ts
+++ b/support-frontend/assets/helpers/productCatalogue.ts
@@ -1,0 +1,70 @@
+import { newspaperCountries } from 'helpers/internationalisation/country';
+import { gwDeliverableCountries } from 'helpers/internationalisation/gwDeliverableCountries';
+
+export const productCatalogDescription = {
+	GuardianWeeklyAndSupporterPlus: {
+		label: 'Digital + print',
+		benefitsSummary: 'The rewards from All-access digital',
+		benefits: [
+			{
+				text: 'Guardian Weekly print magazine delivered to your door every week',
+			},
+		],
+	},
+	DigitalSubscription: {
+		label: 'The Guardian Digital Edition',
+		benefits: [
+			{
+				text: 'The Editions app. Enjoy the Guardian and Observer newspaper, reimagined for mobile and tablet',
+			},
+			{ text: 'Full access to our news app. Read our reporting on the go' },
+			{ text: 'Ad-free reading. Avoid ads on all your devices' },
+			{
+				text: 'Free 14 day trial. Enjoy a free trial of your subscription, before you pay',
+			},
+		],
+	},
+	NationalDelivery: {
+		label: 'National Delivery',
+		delivery: true,
+		addressCountries: newspaperCountries,
+	},
+	SupporterPlus: {
+		label: 'All-access digital',
+		benefits: [
+			{ text: 'Unlimited access to the Guardian app' },
+			{ text: 'Ad-free reading on all your devices' },
+			{
+				text: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+			},
+			{ text: 'Far fewer asks for support' },
+		],
+	},
+	GuardianWeeklyRestOfWorld: {
+		label: 'The Guardian Weekly',
+		delivery: true,
+		addressCountries: gwDeliverableCountries,
+	},
+	GuardianWeeklyDomestic: {
+		label: 'The Guardian Weekly',
+		delivery: true,
+		addressCountries: gwDeliverableCountries,
+	},
+	SubscriptionCard: {
+		label: 'Newspaper subscription',
+		delivery: true,
+	},
+	Contribution: {
+		label: 'Support',
+		benefits: [
+			{
+				text: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+			},
+		],
+	},
+	HomeDelivery: {
+		label: 'Home Delivery',
+		delivery: true,
+		addressCountries: newspaperCountries,
+	},
+};

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -54,10 +54,8 @@ import {
 import { getStripeKey } from 'helpers/forms/stripe';
 import { validateWindowGuardian } from 'helpers/globalsAndSwitches/window';
 import CountryHelper from 'helpers/internationalisation/classes/country';
-import {
-	type IsoCountry,
-	newspaperCountries,
-} from 'helpers/internationalisation/country';
+import type { IsoCountry } from 'helpers/internationalisation/country';
+import { newspaperCountries } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { Currency } from 'helpers/internationalisation/currency';
 import { currencies } from 'helpers/internationalisation/currency';

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
@@ -8,7 +8,7 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { TierBenefits, TierPlanCosts } from '../setup/threeTierConfig';
 import { ThreeTierCard } from './threeTierCard';
 
-interface ThreeTierCardsProps {
+type ThreeTierCardsProps = {
 	cardsContent: Array<{
 		title: string;
 		isRecommended: boolean;
@@ -30,7 +30,7 @@ interface ThreeTierCardsProps {
 		contributionType: ContributionType,
 		contributionCurrency: IsoCurrency,
 	) => void;
-}
+};
 
 const container = (cardCount: number) => css`
 	display: flex;


### PR DESCRIPTION
## What are you doing in this PR?
- Reads values from the [product catalog](https://product-catalog.guardianapis.com/product-catalog.json) to populate prices in Tier 1 and Tier 2 (`Contribution` and `SupportPlus`)
- Retains the pricing override for `Contribution` from RRCP
- Retains the promoCode application for `SupporterPlus`
- Adds the concept of a `productCatalogDescription` which mirrors the `product-catalog` keys with extra info for rendering. We'd hope to use this data across the site to refine some consistency we have lost e.g. on thank you pages
- Transforms `product-catalog` data into `TierCardData`. As a secondary step I would like to just pass the catalog data to the card to avoid proliferating our types.


### productCatalogDescription
This might be a good experiment to try work out what values we might want as editable from RRCP. For not this should make it easy enough to apply A/B tests by alternating this data on a test key.


[**Trello Card**](https://trello.com)

## Screenshots
