### PR TITLE
[RB] - update post support survey links for AU and ROW

### DIFF
--- a/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
@@ -53,10 +53,26 @@ export const getThankYouModuleData = (
 	csrf: CsrfState,
 	email: string,
 	isOneOff: boolean,
+	amountIsAboveThreshold: boolean,
 	campaignCode?: string,
 ): Record<ThankYouModuleType, ThankYouModuleData> => {
 	const { feedbackSurveyHasBeenCompleted, supportReminder } =
 		useContributionsSelector((state) => state.page.checkoutForm.thankYou);
+
+	const getFeedbackSurveyLink = (countryId: IsoCountry) => {
+		const surveyBasePath = 'https://guardiannewsandmedia.formstack.com/forms/';
+		if (countryId === 'AU') {
+			return `${surveyBasePath}guardian_australia_message`;
+		}
+		if (isOneOff) {
+			return `${surveyBasePath}guardian_supporter_single`;
+		}
+		return `${surveyBasePath}${
+			amountIsAboveThreshold
+				? 'guardian_supporter_above'
+				: 'guardian_supporter_below'
+		}`;
+	};
 
 	const thankYouModuleData: Record<ThankYouModuleType, ThankYouModuleData> = {
 		appDownload: {
@@ -87,11 +103,7 @@ export const getThankYouModuleData = (
 				/>
 			),
 			ctas: feedbackSurveyHasBeenCompleted ? null : (
-				<FeedbackCTA
-					feedbackSurveyLink={`https://guardiannewsandmedia.formstack.com/forms/eoy_ny_23_24_${
-						isOneOff ? 'onetime' : 'recurring'
-					}`}
-				/>
+				<FeedbackCTA feedbackSurveyLink={getFeedbackSurveyLink(countryId)} />
 			),
 			trackComponentLoadId: OPHAN_COMPONENT_ID_SURVEY,
 		},

--- a/support-frontend/assets/pages/digital-subscriber-thank-you/digitalSubscriptionThankYou.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-thank-you/digitalSubscriptionThankYou.tsx
@@ -10,6 +10,7 @@ import { getThankYouModuleData } from 'components/thankYou/thankYouModuleData';
 import type { CampaignSettings } from 'helpers/campaigns/campaigns';
 import { getCampaignSettings } from 'helpers/campaigns/campaigns';
 import { DirectDebit } from 'helpers/forms/paymentMethods';
+import { isSupporterPlusFromState } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { OPHAN_COMPONENT_ID_RETURN_TO_GUARDIAN } from 'helpers/thankYouPages/utils/ophan';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
@@ -42,6 +43,10 @@ export function DigitalSubscriptionThankYou(): JSX.Element {
 	const paymentMethod = useContributionsSelector(
 		(state) => state.page.checkoutForm.payment.paymentMethod.name,
 	);
+
+	const amountIsAboveThreshold = useContributionsSelector(
+		isSupporterPlusFromState,
+	);
 	const { isSignedIn } = useContributionsSelector((state) => state.page.user);
 	const isNewAccount = userTypeFromIdentityResponse === 'new';
 	const thankYouModuleData = getThankYouModuleData(
@@ -50,6 +55,7 @@ export function DigitalSubscriptionThankYou(): JSX.Element {
 		csrf,
 		email,
 		false,
+		amountIsAboveThreshold,
 		campaignSettings?.campaignCode,
 	);
 

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -216,12 +216,15 @@ export function SupporterPlusThankYou(): JSX.Element {
 		}
 	}, []);
 
+	const amountIsAboveThreshold = !!(thresholdPrice && amount >= thresholdPrice);
+
 	const thankYouModuleData = getThankYouModuleData(
 		countryId,
 		countryGroupId,
 		csrf,
 		email,
 		isOneOff,
+		amountIsAboveThreshold,
 		campaignSettings?.campaignCode,
 	);
 


### PR DESCRIPTION
## What are you doing in this PR?

Updating the survey link for the post checkout journey, with a specific link for Australia and the same 3 links for the rest of the world dependant on whether you are making a one off contribution, recurring below the supporter plus treshold and recurring above the supporter plus threshold.