### PR TITLE
Use type `number` for amounts

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -170,7 +170,7 @@ export function ContributionsOrderSummary({
 	const formattedTotal = simpleFormatAmount(currency, total);
 	const formattedTotalExcludingPromo = simpleFormatAmount(
 		currency,
-		totalExcludingPromo ?? '',
+		totalExcludingPromo ?? 0,
 	);
 
 	return (

--- a/support-frontend/assets/components/otherAmount/otherAmount.tsx
+++ b/support-frontend/assets/components/otherAmount/otherAmount.tsx
@@ -9,7 +9,7 @@ const topSpacing = css`
 `;
 
 export type OtherAmountProps = {
-	selectedAmount: string;
+	selectedAmount: number | 'other';
 	otherAmount: string;
 	currency: IsoCurrency;
 	minAmount: number;

--- a/support-frontend/assets/components/priceCards/priceCard.tsx
+++ b/support-frontend/assets/components/priceCards/priceCard.tsx
@@ -3,7 +3,7 @@ import { ChoiceCard } from '@guardian/source-react-components';
 export type PriceCardPaymentInterval = 'month' | 'year';
 
 export type PriceCardProps = {
-	amount: string;
+	amount: number | 'other';
 	amountWithCurrency: string;
 	isSelected: boolean;
 	onClick: (amount: string) => void;
@@ -45,9 +45,9 @@ export function PriceCard({
 			id={`amount-${amount}`}
 			key={`amount-${amount}`}
 			name="amount"
-			onChange={() => onClick(amount)}
+			onChange={() => onClick(amount.toString())}
 			checked={isSelected}
-			value={amount}
+			value={amount.toString()}
 			label={labelText}
 		/>
 	);

--- a/support-frontend/assets/components/priceCards/priceCards.tsx
+++ b/support-frontend/assets/components/priceCards/priceCards.tsx
@@ -61,8 +61,8 @@ function getChoiceCardGroupStyles(lastButtonFullWidth: boolean) {
 }
 
 export type PriceCardsProps = {
-	amounts: string[];
-	selectedAmount: string;
+	amounts: number[];
+	selectedAmount: number | 'other';
 	currency: IsoCurrency;
 	onAmountChange: (newAmount: string) => void;
 	paymentInterval?: PriceCardPaymentInterval;

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -55,7 +55,7 @@ export function PriceCardsContainer({
 		selectedAmounts,
 		paymentFrequency,
 		defaultAmount,
-	).toString();
+	);
 	const otherAmountErrors = useContributionsSelector(getOtherAmountErrors);
 	const otherAmount = otherAmounts[paymentFrequency].amount ?? '';
 
@@ -91,7 +91,7 @@ export function PriceCardsContainer({
 
 	return renderPriceCards({
 		currency: currencyId,
-		amounts: frequencyAmounts.map((amount) => amount.toString()),
+		amounts: frequencyAmounts,
 		selectedAmount,
 		otherAmount,
 		paymentInterval: contributionTypeToPaymentInterval[paymentFrequency],

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
@@ -9,7 +9,8 @@ import {
 } from 'helpers/forms/paymentMethods';
 import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { getValidPaymentMethods } from '../forms/checkouts';
+import { currencies } from 'helpers/internationalisation/currency';
+import { getValidPaymentMethods, simpleFormatAmount } from '../forms/checkouts';
 
 jest.mock('helpers/globalsAndSwitches/globals', () => ({
 	__esModule: true,
@@ -61,6 +62,17 @@ describe('checkouts', () => {
 			expect(
 				getValidPaymentMethods(contributionType, countryId, countryGroupId),
 			).toEqual([Stripe]);
+		});
+	});
+
+	describe('simpleFormatAmount', () => {
+		it.each([
+			[currencies.GBP, 12, '£12'],
+			[currencies.NZD, 12.5, '$12.50'],
+			[currencies.CAD, 12.0005, '$12'],
+			[currencies.CAD, 12.015, '$12.02'],
+		])(`%i%i should format as %i`, (currency, amount, expected) => {
+			expect(simpleFormatAmount(currency, amount)).toBe(expected);
 		});
 	});
 });

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -228,12 +228,28 @@ function getPaymentDescription(
 	return '';
 }
 
-const simpleFormatAmount = (
-	currency: Currency,
-	amount: number | string,
-): string => {
+function round(amount: number) {
+	/**
+	 * This rounds a `number` to the second decimal.
+	 *
+	 * `Number.toFixed` returns a string which is not useful for calculations
+	 * and would need unnecessary type conversions
+	 */
+	return Math.round(amount * 1e2) / 1e2;
+}
+
+const simpleFormatAmount = (currency: Currency, amount: number): string => {
 	const glyph = currency.isPaddedGlyph ? ` ${currency.glyph} ` : currency.glyph;
-	const amountText = /^(\d+\.\d)$/.test(`${amount}`) ? `${amount}0` : amount;
+	/**
+	 * We need to round the amount before checking if it is an Int for the edge case of something like 12.0001
+	 * which would not be an int, but then format as 12.00, whereas we'd like 12.
+	 */
+	const roundedAmount = round(amount);
+	const isInt = roundedAmount % 1 === 0;
+	/** only add the percentile amount if it's not a round integer */
+	const amountText = isInt
+		? roundedAmount.toString()
+		: roundedAmount.toFixed(2);
 
 	const valueWithGlyph = currency.isSuffixGlyph
 		? `${amountText}${glyph}`

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/productType.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/productType.ts
@@ -65,7 +65,7 @@ export function getSelectedAmount(
 	selectedAmounts: SelectedAmounts,
 	contributionType: ContributionType,
 	defaultAmount: number,
-): number | string {
+) {
 	return selectedAmounts[contributionType] || defaultAmount;
 }
 

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/patronsPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/patronsPriceCards.tsx
@@ -13,14 +13,14 @@ import { PriceCards } from '../../../components/priceCards/priceCards';
 import type { CountryGroupId } from '../../../helpers/internationalisation/countryGroup';
 import { setProductType } from '../../../helpers/redux/checkout/product/actions';
 
-const REGIONAL_AMOUNTS: Record<CountryGroupId, string[]> = {
-	GBPCountries: ['300', '350', '500', '1000'],
-	UnitedStates: ['250', '350', '500', '1000'],
-	EURCountries: ['350', '400', '600', '1200'],
-	AUDCountries: ['500', '700', '1000', '2000'],
-	Canada: ['500', '600', '800', '1500'],
-	NZDCountries: ['500', '700', '1000', '2000'],
-	International: ['250', '350', '500', '1000'],
+const REGIONAL_AMOUNTS: Record<CountryGroupId, number[]> = {
+	GBPCountries: [300, 350, 500, 1000],
+	UnitedStates: [250, 350, 500, 1000],
+	EURCountries: [350, 400, 600, 1200],
+	AUDCountries: [500, 700, 1000, 2000],
+	Canada: [500, 600, 800, 1500],
+	NZDCountries: [500, 700, 1000, 2000],
+	International: [250, 350, 500, 1000],
 };
 
 export function PatronsPriceCards(): JSX.Element {

--- a/support-frontend/stories/checkouts/PriceCard.stories.tsx
+++ b/support-frontend/stories/checkouts/PriceCard.stories.tsx
@@ -22,7 +22,7 @@ Template.args = {} as Omit<PriceCardProps, 'onClick'>;
 export const WithFrequency = Template.bind({});
 
 WithFrequency.args = {
-	amount: '10',
+	amount: 10,
 	amountWithCurrency: '£10',
 	isSelected: true,
 	paymentInterval: 'month',
@@ -31,7 +31,7 @@ WithFrequency.args = {
 export const WithoutFrequency = Template.bind({});
 
 WithoutFrequency.args = {
-	amount: '30',
+	amount: 30,
 	amountWithCurrency: '$30',
 	isSelected: false,
 };

--- a/support-frontend/stories/checkouts/PriceCards.stories.tsx
+++ b/support-frontend/stories/checkouts/PriceCards.stories.tsx
@@ -61,16 +61,16 @@ Template.args = {} as Omit<PriceCardsProps, 'onAmountChange'>;
 export const SingleContribution = Template.bind({});
 
 SingleContribution.args = {
-	amounts: ['5', '12', '15', '20'],
-	selectedAmount: '12',
+	amounts: [5, 12, 15, 20],
+	selectedAmount: 12,
 	currency: 'GBP',
 };
 
 export const RecurringContribution = Template.bind({});
 
 RecurringContribution.args = {
-	amounts: ['5', '12', '15', '20'],
-	selectedAmount: '12',
+	amounts: [5, 12, 15, 20],
+	selectedAmount: 12,
 	currency: 'GBP',
 	paymentInterval: 'month',
 };
@@ -78,8 +78,8 @@ RecurringContribution.args = {
 export const OddAmountOfOptions = Template.bind({});
 
 OddAmountOfOptions.args = {
-	amounts: ['5', '12', '15', '20', '30'],
-	selectedAmount: '12',
+	amounts: [5, 12, 15, 20, 30],
+	selectedAmount: 12,
 	currency: 'GBP',
 	paymentInterval: 'year',
 };


### PR DESCRIPTION
Maintains the source data type of `number` for `amounts` rather than transforming to `string`.

This tightens the type making it easier to work with as a `number` when doing calculations, and then render to `string` at the rendering edge, rather than having to flip-flop between conversions dependant on context.

This was inspired by wanting to `round` in the `format` methods in a refactor I am doing and the `number | string` type created unnecessary checks.

[These are the examples of wanting rounding to happen at all instances](https://github.com/search?q=repo%3Aguardian%2Fsupport-frontend++promoPriceRounded&type=code).


## How to test

Compile, E2E and visual tests are passing.

## Screenshots

<img width="624" alt="Screenshot 2024-04-08 at 14 10 14" src="https://github.com/guardian/support-frontend/assets/31692/0c84a38a-a37d-4616-9752-672a919dd108">

