### PR TITLE
feat: add CMP E2E test

### DIFF
--- a/support-e2e/tests/consent-management.test.ts
+++ b/support-e2e/tests/consent-management.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+
+test('Should show a dismissable consent management banner', async ({
+	context,
+	baseURL,
+}) => {
+	const page = await context.newPage();
+	await page.goto(`${baseURL}`);
+
+	const consentManagementBanner = page.frameLocator(
+		'[title="The Guardian consent message"]',
+	);
+
+	await expect(
+		consentManagementBanner
+			// We use this role check as this text exists in the legal copy too
+			.getByRole('button')
+			.getByText('Manage or reject cookies'),
+	).toBeVisible({ timeout: 50000 });
+	await expect(
+		consentManagementBanner.getByText('Yes, I’m happy'),
+	).toBeVisible();
+	await consentManagementBanner.getByText('Yes, I’m happy').click();
+	await expect(
+		consentManagementBanner.getByText('Manage or reject cookies'),
+	).not.toBeVisible();
+	await expect(
+		consentManagementBanner.getByText('Yes, I’m happy'),
+	).not.toBeVisible();
+});


### PR DESCRIPTION
Adds a simple E22 test for our CMP integration.

Thought it might have given more confidence in [this PR](https://github.com/guardian/support-frontend/pull/5805) and other changes in the future.

## How to test

This is the test

## Screenshots

<img width="1777" alt="Screenshot 2024-04-08 at 15 45 36" src="https://github.com/guardian/support-frontend/assets/31692/76b17eaf-a433-41fc-8c8d-258673141dc7">
