### PR TITLE
Fix layout issue on VAT compliant checkout

### DIFF
--- a/support-frontend/assets/components/nav/nav.tsx
+++ b/support-frontend/assets/components/nav/nav.tsx
@@ -22,7 +22,7 @@ function Nav({
 	countryGroupIds,
 	selectedCountryGroup,
 	subPath,
-	countryIsAffectedByVATStatus,
+	countryIsAffectedByVATStatus = false,
 }: NavProps): JSX.Element {
 	return (
 		<Container

--- a/support-frontend/assets/components/nav/nav.tsx
+++ b/support-frontend/assets/components/nav/nav.tsx
@@ -15,12 +15,14 @@ interface NavProps {
 	countryGroupIds: CountryGroupId[];
 	selectedCountryGroup: CountryGroupId;
 	subPath: string;
+	countryIsAffectedByVATStatus: boolean;
 }
 
 function Nav({
 	countryGroupIds,
 	selectedCountryGroup,
 	subPath,
+	countryIsAffectedByVATStatus,
 }: NavProps): JSX.Element {
 	return (
 		<Container
@@ -34,15 +36,17 @@ function Nav({
 			<Hide until="desktop">
 				<Columns>
 					<Column span={5} />
-					<Column>
-						<div css={switcherContainer}>
-							<CountryGroupSwitcher
-								countryGroupIds={countryGroupIds}
-								selectedCountryGroup={selectedCountryGroup}
-								subPath={subPath}
-							/>
-						</div>
-					</Column>
+					{!countryIsAffectedByVATStatus && (
+						<Column>
+							<div css={switcherContainer} data-test="xxx">
+								<CountryGroupSwitcher
+									countryGroupIds={countryGroupIds}
+									selectedCountryGroup={selectedCountryGroup}
+									subPath={subPath}
+								/>
+							</div>
+						</Column>
+					)}
 				</Columns>
 			</Hide>
 		</Container>

--- a/support-frontend/assets/components/nav/nav.tsx
+++ b/support-frontend/assets/components/nav/nav.tsx
@@ -15,7 +15,7 @@ interface NavProps {
 	countryGroupIds: CountryGroupId[];
 	selectedCountryGroup: CountryGroupId;
 	subPath: string;
-	countryIsAffectedByVATStatus: boolean;
+	countryIsAffectedByVATStatus?: boolean;
 }
 
 function Nav({

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
@@ -221,8 +221,14 @@ export function SupporterPlusCheckoutScaffold({
 							</Hide>
 						)}
 					</Header>
-					{!countryIsAffectedByVATStatus && !isPaymentPage && (
+					{/* {!countryIsAffectedByVATStatus && !isPaymentPage && (
 						<Nav {...countrySwitcherProps} />
+					)} */}
+					{!isPaymentPage && (
+						<Nav
+							{...countrySwitcherProps}
+							countryIsAffectedByVATStatus={countryIsAffectedByVATStatus}
+						/>
 					)}
 				</>
 			}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
@@ -221,9 +221,6 @@ export function SupporterPlusCheckoutScaffold({
 							</Hide>
 						)}
 					</Header>
-					{/* {!countryIsAffectedByVATStatus && !isPaymentPage && (
-						<Nav {...countrySwitcherProps} />
-					)} */}
 					{!isPaymentPage && (
 						<Nav
 							{...countrySwitcherProps}


### PR DESCRIPTION
## What are you doing in this PR?

I noticed a small layout issue on the VAT Compliant checkout where the horizontal rule at the top of the page was missing. A change went in recently to hide the country drop down (https://github.com/guardian/support-frontend/pull/5808) on the VAT Compliant checkout however the conditional was wrapping the entire `<Nav>` element, the horizontal rule isn't visible when the `<Nav>` isn't rendered, I've moved the conditional to the country drop down element within the `<Nav>` element. 

**Before**
<img width="1487" alt="Screenshot 2024-04-09 at 17 10 10" src="https://github.com/guardian/support-frontend/assets/1590704/dd3cfba0-1189-4190-8503-9ea5841d360e">

**After**
<img width="1487" alt="Screenshot 2024-04-09 at 17 13 03" src="https://github.com/guardian/support-frontend/assets/1590704/d33e337c-bc68-43bf-8ae8-8c7419b80cf5">