### PR TITLE
use actions-riff-raff for support-workers

### DIFF
--- a/.github/workflows/support-workers-build.yml
+++ b/.github/workflows/support-workers-build.yml
@@ -60,14 +60,14 @@ jobs:
         run: |
           sbt "project support-workers" it:assembly
 
-      - name: Build and upload support-workers and it tests to RiffRaff
+      - name: Build support-workers assembly
         run: |
           sbt "project support-workers" test assembly
 
       - name: Upload to riff-raff
         uses: guardian/actions-riff-raff@v4
         with:
-          app: support:support-workers-mono
+          projectName: support:support-workers-mono
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           buildNumberOffset: 12000

--- a/.github/workflows/support-workers-build.yml
+++ b/.github/workflows/support-workers-build.yml
@@ -46,13 +46,6 @@ jobs:
         run: yarn run build-cfn
         working-directory: support-workers/cloud-formation/src
 
-      # Required by sbt riffRaffUpload
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
-
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
@@ -65,12 +58,56 @@ jobs:
       # - the support-workers build
       - name: Build integration test assembly
         run: |
-          export LAST_TEAMCITY_BUILD=12000
-          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
           sbt "project support-workers" it:assembly
 
       - name: Build and upload support-workers and it tests to RiffRaff
         run: |
-          export LAST_TEAMCITY_BUILD=12000
-          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt "project support-workers" riffRaffUpload
+          sbt "project support-workers" test assembly
+
+      - name: Upload to riff-raff
+        uses: guardian/actions-riff-raff@v4
+        with:
+          app: support:support-workers-mono
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          buildNumberOffset: 12000
+          config: |
+            stacks: [support]
+            regions: [eu-west-1]
+            allowedStages:
+              - CODE
+              - PROD
+            deployments:
+              cfn:
+                type: cloud-formation
+                app: workers
+                parameters:
+                  templatePath: cfn.yaml
+              support-workers:
+                type: aws-lambda
+                parameters:
+                  bucket: support-workers-dist
+                  functionNames:
+                    - "-CreatePaymentMethodLambda-"
+                    - "-CreateSalesforceContactLambda-"
+                    - "-CreateZuoraSubscriptionLambda-"
+                    - "-SendThankYouEmailLambda-"
+                    - "-UpdateSupporterProductDataLambda-"
+                    - "-FailureHandlerLambda-"
+                    - "-SendAcquisitionEventLambda-"
+                    - "-PreparePaymentMethodForReuseLambda-"
+                  fileName: support-workers.jar
+                dependencies: [cfn]
+              it-tests:
+                type: aws-s3
+                parameters:
+                  bucket: support-workers-dist
+                  cacheControl: private
+                  publicReadAcl: false
+          contentDirectories: |
+              cfn:
+                - support-workers/cloud-formation/target/cfn.yaml
+              support-workers:
+                - support-workers/target/scala-2.13/support-workers.jar
+              it-tests:
+                - support-workers/target/scala-2.13/support-workers-it.jar

--- a/.github/workflows/support-workers-build.yml
+++ b/.github/workflows/support-workers-build.yml
@@ -16,10 +16,10 @@ jobs:
         (github.repository_owner == 'guardian' ||
           github.event_name == 'push')
 
-    # Required by actions-assume-aws-role
     permissions:
       id-token: write
       contents: read
+      pull-requests: write
 
     name: support-workers build
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -146,7 +146,6 @@ lazy val `support-frontend` = (project in file("support-frontend"))
   )
 
 lazy val `support-workers` = (project in file("support-workers"))
-  .enablePlugins(RiffRaffArtifact)
   .disablePlugins(ReleasePlugin, SbtPgp, Sonatype)
   .configs(IntegrationTest)
   .settings(

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -1,5 +1,4 @@
 import LibraryVersions._
-import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport.riffRaffManifestProjectName
 import sbt.Keys.libraryDependencies
 
 version := "0.1-SNAPSHOT"
@@ -31,14 +30,6 @@ libraryDependencies ++= Seq(
   "com.lihaoyi" %% "pprint" % "0.8.1",
 )
 
-riffRaffPackageType := assembly.value
-riffRaffManifestProjectName := s"support:support-workers-mono"
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffArtifactResources += (file("support-workers/cloud-formation/target/cfn.yaml"), "cfn/cfn.yaml")
-riffRaffArtifactResources += (file(
-  "support-workers/target/scala-2.13/support-workers-it.jar",
-), "it-tests/support-workers-it.jar")
 assemblyJarName := s"${name.value}.jar"
 
 Project.inConfig(IntegrationTest)(baseAssemblySettings)


### PR DESCRIPTION
use https://github.com/guardian/actions-riff-raff for uploading support-workers

This means it's more secure (don't expose the riffraff key to the whole build.
Also we can use snapstart (possibly)

I compared the riffraff.yaml generated which is semantically the same, and the file names and sizes that appear in the artifact, and they are identical 
see https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=support%3Asupport-workers-mono&id=18823