### PR TITLE
fix: use discountedPrice not amount

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -171,8 +171,8 @@ export function ContributionsOrderSummary({
 	const formattedAmount = simpleFormatAmount(currency, amount);
 	/** We have to check deeper than just promotion as the other values are optional */
 	const formattedPromotionAmount =
-		promotion?.discount?.amount &&
-		simpleFormatAmount(currency, amount - promotion.discount.amount);
+		promotion?.discountedPrice &&
+		simpleFormatAmount(currency, amount - promotion.discountedPrice);
 
 	return (
 		<div css={componentStyles}>


### PR DESCRIPTION
`amount` refers the percentage, not the actual price, causing very strange rendering of the total.

| before | after |
|---|---|
| <img width="527" alt="Screenshot 2024-04-11 at 12 22 28" src="https://github.com/guardian/support-frontend/assets/31692/8a3e9deb-6a3d-42a1-b85a-5e138626c430"> | <img width="571" alt="Screenshot 2024-04-11 at 12 22 34" src="https://github.com/guardian/support-frontend/assets/31692/68a8a1a4-6c29-4749-ae07-c812641a1f19"> |