### PR TITLE
fix: remove promotion value from S+ check

### DIFF
--- a/support-frontend/assets/helpers/supporterPlus/benefitsThreshold.ts
+++ b/support-frontend/assets/helpers/supporterPlus/benefitsThreshold.ts
@@ -3,8 +3,6 @@ import type {
 	RegularContributionType,
 } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
-import { getPromotion } from 'helpers/productPrice/promotions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import { isRecurring } from './isContributionRecurring';
@@ -82,21 +80,10 @@ export function getLowerBenefitsThreshold(
 		regularContributionType ?? getContributionType(state);
 	const contributionTypeThreshold =
 		contributionType.toUpperCase() as keyof ThresholdAmounts;
-	const billingPeriod = (contributionType[0] +
-		contributionType.slice(1).toLowerCase()) as BillingPeriod;
 
-	const promotion = getPromotion(
-		state.page.checkoutForm.product.productPrices,
-		state.common.internationalisation.countryId,
-		billingPeriod,
-	);
-
-	return (
-		promotion?.discountedPrice ??
-		lowerBenefitsThresholds[state.common.internationalisation.countryGroupId][
-			contributionTypeThreshold
-		]
-	);
+	return lowerBenefitsThresholds[
+		state.common.internationalisation.countryGroupId
+	][contributionTypeThreshold];
 }
 export function getLowerBenefitsThresholds(
 	state: ContributionsState,

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -60,9 +60,7 @@ export function SupporterPlusCheckout({
 		getUserSelectedAmountBeforeAmendment,
 	);
 	const otherAmount = useContributionsSelector(getUserSelectedOtherAmount);
-	const amountIsAboveThreshold = useContributionsSelector(
-		isSupporterPlusFromState,
-	);
+	const isSupporterPlus = useContributionsSelector(isSupporterPlusFromState);
 
 	const navigate = useNavigate();
 	const { abParticipations } = useContributionsSelector(
@@ -94,13 +92,15 @@ export function SupporterPlusCheckout({
 		</Button>
 	);
 
-	const promotion = useContributionsSelector((state) =>
-		getPromotion(
-			state.page.checkoutForm.product.productPrices,
-			countryId,
-			state.page.checkoutForm.product.billingPeriod,
-		),
-	);
+	const promotion = isSupporterPlus
+		? useContributionsSelector((state) =>
+				getPromotion(
+					state.page.checkoutForm.product.productPrices,
+					countryId,
+					state.page.checkoutForm.product.billingPeriod,
+				),
+		  )
+		: undefined;
 	return (
 		<SupporterPlusCheckoutScaffold thankYouRoute={thankYouRoute} isPaymentPage>
 			<Box cssOverrides={shorterBoxMargin}>
@@ -160,7 +160,7 @@ export function SupporterPlusCheckout({
 						contributionType={contributionType}
 						currency={currencyId}
 						amount={amount}
-						amountIsAboveThreshold={amountIsAboveThreshold}
+						amountIsAboveThreshold={isSupporterPlus}
 						productNameAboveThreshold={
 							inThreeTier ? 'All-access digital' : 'Supporter Plus'
 						}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -92,6 +92,7 @@ export function SupporterPlusCheckout({
 		</Button>
 	);
 
+	/** Promotions on the checkout are for SupporterPlus only for now */
 	const promotion = isSupporterPlus
 		? useContributionsSelector((state) =>
 				getPromotion(


### PR DESCRIPTION
- Removes checking the promotion value in S+ threshold check.
- Remove application of promotion on non-SupporterPlus products (recurring and one-off)

This was a hangover for when we included the promotion deduction in the `selectedAmount`.

We need to look into why this wasn't caught by the e2e tests and there's a potential to refactor the [`getPromotion` code](https://github.com/guardian/support-frontend/blob/5eb34e324d78d563bb280229b7639683307ae2bb/support-frontend/assets/helpers/productPrice/promotions.tsx#L103) to account for this at the source.
 


