### PR TITLE
Prevent creation of a supporter plus sub with a negative contribution

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
@@ -34,6 +34,7 @@ object ErrorHandler extends SafeLogging {
       case e: BuildSubscribePromoError => new RetryNone(e.cause.msg, cause = e)
       case e: BuildSubscribeRedemptionError => new RetryNone(e.cause.clientCode, cause = e)
       case e: StateNotValidException => new RetryNone(e.message, cause = e)
+      case e: BadRequestException => new RetryNone(e.getMessage, cause = e)
       case wshe: WebServiceHelperError[_] if wshe.cause.isInstanceOf[DecodingFailure] =>
         // if we fail to parse SalesForce response or any JSON response, it means something failed
         // or we had malformed input, so we should not retry again.

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/SupporterPlusSubcriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/SupporterPlusSubcriptionBuilder.scala
@@ -7,7 +7,7 @@ import com.gu.support.config.{TouchPointEnvironment, ZuoraSupporterPlusConfig}
 import com.gu.support.promotions.{PromoError, PromotionService}
 import com.gu.support.workers.Monthly
 import com.gu.support.workers.ProductTypeRatePlans.supporterPlusRatePlan
-import com.gu.support.workers.exceptions.CatalogDataNotFoundException
+import com.gu.support.workers.exceptions.{BadRequestException, CatalogDataNotFoundException}
 import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.SupporterPlusState
 import com.gu.support.zuora.api.ReaderType.Direct
 import com.gu.support.zuora.api._
@@ -35,6 +35,11 @@ class SupporterPlusSubcriptionBuilder(
     val todaysDate = dateGenerator.today
 
     val contributionAmount = state.product.amount - getBaseProductPrice(productRatePlanId, state.product.currency)
+    if (contributionAmount < 0)
+      throw new BadRequestException(
+        s"The contribution amount of a supporter plus subscription cannot be less than zero, but here it would be $contributionAmount",
+      )
+
     val subscriptionData = subscribeItemBuilder.buildProductSubscription(
       productRatePlanId = productRatePlanId,
       ratePlanCharges = List(

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -1,8 +1,8 @@
 package com.gu.support.workers.integration
 
 import com.gu.config.Configuration
-import com.gu.i18n.CountryGroup
-import com.gu.i18n.Currency.{EUR, GBP}
+import com.gu.i18n.{Country, CountryGroup}
+import com.gu.i18n.Currency.{EUR, GBP, USD}
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.services.ServiceProvider
 import com.gu.support.acquisitions.{AbTest, AcquisitionData, OphanIds, ReferrerAcquisitionData}
@@ -70,6 +70,17 @@ class CreateZuoraSubscriptionSpec extends AsyncLambdaSpec with MockServicesCreat
       .createSubscription(createSupporterPlusZuoraSubscriptionJson(10, EUR, Monthly, austria))
       .map(_ should matchPattern { case _: SendThankYouEmailSupporterPlusState =>
       })
+  }
+
+  it should "not create a Supporter Plus subscription at less than the base price" in {
+    createZuoraHelper
+      .createSubscription(createSupporterPlusZuoraSubscriptionJson(10, USD, Monthly))
+      .failed
+      .map(ex =>
+        ex.getMessage should include(
+          "The contribution amount of a supporter plus subscription cannot be less than zero",
+        ),
+      )
   }
 
   it should "create a Digital Pack subscription" in {


### PR DESCRIPTION
We have recently had a bug [documented here](https://docs.google.com/document/d/15P66QvoEPdt3Nd_td5D6FQ2Fm-inrzO04H3GFOnUH2k/edit) which enabled the creation of supporter plus subscriptions with a negative contribution element.

This PR prevents that by failing if the contribution amount is less than zero.