### PR TITLE
Update subscription landing page e2e tests to verify presence of expected HTML element

### DIFF
--- a/support-e2e/tests/landingPages.test.ts
+++ b/support-e2e/tests/landingPages.test.ts
@@ -16,7 +16,8 @@ test.describe('Paper product page', () => {
 		const domain = new URL(pageUrl).hostname;
 		await setTestCookies(context, firstName(), domain);
 		await page.goto(pageUrl);
-		await page.locator('id=qa-paper-subscriptions').isVisible();
+
+		await expect(page.locator('id=qa-paper-subscriptions')).toBeVisible();
 		await expect(page).toHaveURL(/\/uk\/subscribe\/paper/);
 	});
 });
@@ -33,7 +34,7 @@ test.describe('Weekly product page', () => {
 		await setTestCookies(context, firstName(), domain);
 		await page.goto(pageUrl);
 
-		await page.locator('id=qa-guardian-weekly').isVisible();
+		await expect(page.locator('id=qa-guardian-weekly')).toBeVisible();
 		await expect(page).toHaveURL(/\/uk\/subscribe\/weekly/);
 	});
 });
@@ -50,7 +51,7 @@ test.describe('Weekly gift product page', () => {
 		await setTestCookies(context, firstName(), domain);
 		await page.goto(pageUrl);
 
-		await page.locator('id=qa-guardian-weekly-gift').isVisible();
+		await expect(page.locator('id=qa-guardian-weekly-gift')).toBeVisible();
 		await expect(page).toHaveURL(/\/uk\/subscribe\/weekly\/gift/);
 	});
 });
@@ -67,7 +68,9 @@ test.describe('Subscriptions landing page', () => {
 		await setTestCookies(context, firstName(), domain);
 		await page.goto(pageUrl);
 
-		await page.locator('id=qa-subscriptions-landing-page').isVisible();
+		await expect(
+			page.locator('id=qa-subscriptions-landing-page'),
+		).toBeVisible();
 		await expect(page).toHaveURL(/\/uk\/subscribe/);
 	});
 });


### PR DESCRIPTION
V2 of [this PR](https://github.com/guardian/support-frontend/pull/5798) as it's got some nasty conflicts that were harder to fix than replicating the PR.

## What are you doing in this PR?

It doesn't look like the e2e tests in `landingPages.test.ts` were actually testing anything.  This line in the tests `await page.locator("id=qa-paper-subscriptions").isVisible();`, would eventually resolve with `true` (element present) or `false` (element not present) however we didn't do anything with the return value of `isVisible`, so for example I could update the test to look for an element that doesn't exist `await page.locator("id=hello-world").isVisible();` and the test would still pass. The only expectation was to confirm the URL matched what we'd specified it is in the test.

Authored-by: GHaberis <george.haberis@guardian.co.uk>

