### PR TITLE
Three tier (US book) benefit offers visual tweaks

### DIFF
--- a/support-frontend/assets/components/offer/offer.tsx
+++ b/support-frontend/assets/components/offer/offer.tsx
@@ -17,7 +17,8 @@ export function OfferBook(): JSX.Element {
 	return (
 		<p>
 			<span style={{ fontWeight: 'bold' }}>
-				A free book as our gift to you<sup>**</sup>{' '}
+				A free book as our gift to you
+				<sup style={{ fontWeight: 'lighter', fontSize: '14px' }}>**</sup>{' '}
 			</span>
 			Choose from a selection curated by Guardian staff{' '}
 			<span css={tooltipOfferStyle}>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierTsAndCs.tsx
@@ -85,8 +85,10 @@ export function OfferTsAndCs({
 	return (
 		<div css={container}>
 			<p>
-				<sup>**</sup> Free books are only available for qualified new recurring
-				supporters (monthly: {currency}
+				{' '}
+				<sup style={{ fontWeight: 'lighter', fontSize: '14px' }}>**</sup> Free
+				books are only available for qualified new recurring supporters
+				(monthly: {currency}
 				{offerCostMonthly} or more; annual: {currency}
 				{offerCostAnnual} or more) on a first come, first served basis while
 				supplies last. Limit one per customer. Distribution to US and

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -243,7 +243,10 @@ const productCatalogDescInclOffers = {
 		label: productCatalogDescExclOffers.SupporterPlusWithGuardianWeekly.label,
 		benefitsSummary: ['The rewards from All-access digital'],
 		offersSummary: [
-			{ strong: true, copy: 'including a free book as our gift to you**' },
+			{
+				strong: true,
+				copy: `including a free book as our gift to${'\u00A0'}you**`,
+			},
 		],
 		benefits:
 			productCatalogDescExclOffers.SupporterPlusWithGuardianWeekly.benefits,


### PR DESCRIPTION
## What are you doing in this PR?

Minor visual tweaks requested by designers->
- book offer double asterix fontWeight:regular and fontSize:14px
- `to you**` should contain a non-breaking sace so both words wrap onto next line

[**Trello Card**](https://trello.com/c/iJV8lQJc/729-add-book-benefits-copy-to-the-us-landing-pages-and-ty-pages-15th-april-if-possible)

|TierCard2|TierCard3|
|-----|-----|
|![image](https://github.com/guardian/support-frontend/assets/76729591/a89118b7-6d8a-4bfe-a46b-7e74cbed3b28)|![image](https://github.com/guardian/support-frontend/assets/76729591/034816c7-929d-451a-84e9-41f3c5a66bb3)|
