### PR TITLE
Use productCatalogDescription on checkout

### DIFF
--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -1,3 +1,6 @@
+import { newspaperCountries } from './internationalisation/country';
+import { gwDeliverableCountries } from './internationalisation/gwDeliverableCountries';
+
 export const productCatalog = window.guardian.productCatalog;
 
 export type ProductDescription = {
@@ -6,6 +9,8 @@ export type ProductDescription = {
 	benefitsSummary?: Array<string | { strong: boolean; copy: string }>;
 	offers?: Array<{ copy: JSX.Element; tooltip?: string }>;
 	offersSummary?: Array<string | { strong: boolean; copy: string }>;
+	ratePlans: Record<string, { billingPeriod: 'Annual' | 'Month' | 'Quarter' }>;
+	deliverableTo?: Record<string, string>;
 };
 
 export const productCatalogDescription: Record<string, ProductDescription> = {
@@ -21,6 +26,21 @@ export const productCatalogDescription: Record<string, ProductDescription> = {
 				tooltip: `Guardian Weekly is a beautifully concise magazine featuring a handpicked selection of in-depth articles, global news, long reads, opinion and more. Delivered to you every week, wherever you are in the world.`,
 			},
 		],
+		ratePlans: {
+			MonthlyWithGuardianWeekly: {
+				billingPeriod: 'Month',
+			},
+			AnnualWithGuardianWeekly: {
+				billingPeriod: 'Annual',
+			},
+			MonthlyWithGuardianWeeklyInt: {
+				billingPeriod: 'Month',
+			},
+			AnnualWithGuardianWeeklyInt: {
+				billingPeriod: 'Annual',
+			},
+		},
+		deliverableTo: gwDeliverableCountries,
 	},
 	DigitalSubscription: {
 		label: 'The Guardian Digital Edition',
@@ -34,10 +54,36 @@ export const productCatalogDescription: Record<string, ProductDescription> = {
 				copy: 'Free 14 day trial. Enjoy a free trial of your subscription, before you pay',
 			},
 		],
+		ratePlans: {
+			Monthly: {
+				billingPeriod: 'Month',
+			},
+			Annual: {
+				billingPeriod: 'Annual',
+			},
+			ThreeMonthGift: {
+				billingPeriod: 'Month',
+			},
+			OneYearGift: {
+				billingPeriod: 'Annual',
+			},
+		},
 	},
 	NationalDelivery: {
 		label: 'National Delivery',
 		benefits: [],
+		ratePlans: {
+			Sixday: {
+				billingPeriod: 'Month',
+			},
+			Weekend: {
+				billingPeriod: 'Annual',
+			},
+			Everyday: {
+				billingPeriod: 'Month',
+			},
+		},
+		deliverableTo: newspaperCountries,
 	},
 	SupporterPlus: {
 		label: 'All-access digital',
@@ -55,18 +101,85 @@ export const productCatalogDescription: Record<string, ProductDescription> = {
 				tooltip: `You'll see far fewer financial support asks at the bottom of articles or in pop-up banners.`,
 			},
 		],
+		ratePlans: {
+			Monthly: {
+				billingPeriod: 'Month',
+			},
+			Annual: {
+				billingPeriod: 'Annual',
+			},
+		},
 	},
 	GuardianWeeklyRestOfWorld: {
 		label: 'The Guardian Weekly',
 		benefits: [],
+		ratePlans: {
+			Monthly: {
+				billingPeriod: 'Month',
+			},
+			OneYearGift: {
+				billingPeriod: 'Annual',
+			},
+			Annual: {
+				billingPeriod: 'Annual',
+			},
+			SixWeekly: {
+				billingPeriod: 'Month',
+			},
+			Quarterly: {
+				billingPeriod: 'Quarter',
+			},
+			ThreeMonthGift: {
+				billingPeriod: 'Month',
+			},
+		},
+		deliverableTo: gwDeliverableCountries,
 	},
 	GuardianWeeklyDomestic: {
 		label: 'The Guardian Weekly',
 		benefits: [],
+		ratePlans: {
+			Monthly: {
+				billingPeriod: 'Month',
+			},
+			OneYearGift: {
+				billingPeriod: 'Annual',
+			},
+			Annual: {
+				billingPeriod: 'Annual',
+			},
+			SixWeekly: {
+				billingPeriod: 'Month',
+			},
+			Quarterly: {
+				billingPeriod: 'Quarter',
+			},
+			ThreeMonthGift: {
+				billingPeriod: 'Month',
+			},
+		},
+		deliverableTo: gwDeliverableCountries,
 	},
 	SubscriptionCard: {
 		label: 'Newspaper subscription',
 		benefits: [],
+		ratePlans: {
+			Sixday: {
+				billingPeriod: 'Month',
+			},
+			Everyday: {
+				billingPeriod: 'Month',
+			},
+			Weekend: {
+				billingPeriod: 'Month',
+			},
+			Sunday: {
+				billingPeriod: 'Month',
+			},
+			Saturday: {
+				billingPeriod: 'Month',
+			},
+		},
 	},
 	Contribution: {
 		label: 'Support',
@@ -75,10 +188,36 @@ export const productCatalogDescription: Record<string, ProductDescription> = {
 				copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
 			},
 		],
+		ratePlans: {
+			Monthly: {
+				billingPeriod: 'Month',
+			},
+			Annual: {
+				billingPeriod: 'Annual',
+			},
+		},
 	},
 	HomeDelivery: {
 		label: 'Home Delivery',
 		benefits: [],
+		ratePlans: {
+			Everyday: {
+				billingPeriod: 'Month',
+			},
+			Sunday: {
+				billingPeriod: 'Month',
+			},
+			Sixday: {
+				billingPeriod: 'Month',
+			},
+			Weekend: {
+				billingPeriod: 'Month',
+			},
+			Saturday: {
+				billingPeriod: 'Month',
+			},
+		},
+		deliverableTo: newspaperCountries,
 	},
 };
 

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -55,11 +55,10 @@ import { getStripeKey } from 'helpers/forms/stripe';
 import { validateWindowGuardian } from 'helpers/globalsAndSwitches/window';
 import CountryHelper from 'helpers/internationalisation/classes/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import { newspaperCountries } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { Currency } from 'helpers/internationalisation/currency';
 import { currencies } from 'helpers/internationalisation/currency';
-import { gwDeliverableCountries } from 'helpers/internationalisation/gwDeliverableCountries';
+import { productCatalogDescription } from 'helpers/productCatalog';
 import { renderPage } from 'helpers/rendering/render';
 import { get } from 'helpers/storage/cookie';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
@@ -127,77 +126,6 @@ const query = {
 	product: searchParams.get('product'),
 	ratePlan: searchParams.get('ratePlan'),
 };
-
-function describeProduct(product: string, ratePlan: string) {
-	let description = `${product} - ${ratePlan}`;
-	let frequency = '';
-	let showAddressFields = false;
-	let addressCountries = {};
-
-	if (product === 'HomeDelivery') {
-		frequency = 'month';
-		description = `${ratePlan} paper`;
-
-		showAddressFields = true;
-		addressCountries = newspaperCountries;
-
-		if (ratePlan === 'Sixday') {
-			description = 'Six day paper';
-		}
-		if (ratePlan === 'Everyday') {
-			description = 'Every day paper';
-		}
-		if (ratePlan === 'Weekend') {
-			description = 'Weekend paper';
-		}
-		if (ratePlan === 'Saturday') {
-			description = 'Saturday paper';
-		}
-		if (ratePlan === 'Sunday') {
-			description = 'Sunday paper';
-		}
-	}
-
-	if (product === 'NationalDelivery') {
-		showAddressFields = true;
-		addressCountries = newspaperCountries;
-	}
-
-	if (
-		product === 'GuardianWeeklyDomestic' ||
-		product === 'GuardianWeeklyRestOfWorld'
-	) {
-		showAddressFields = true;
-		addressCountries = gwDeliverableCountries;
-
-		if (ratePlan === 'OneYearGift') {
-			frequency = 'year';
-			description = 'The Guardian Weekly Gift Subscription';
-		}
-		if (ratePlan === 'Annual') {
-			frequency = 'year';
-			description = 'The Guardian Weekly';
-		}
-		if (ratePlan === 'Quarterly') {
-			frequency = 'quarter';
-			description = 'The Guardian Weekly';
-		}
-		if (ratePlan === 'Monthly') {
-			frequency = 'month';
-			description = 'The Guardian Weekly';
-		}
-		if (ratePlan === 'ThreeMonthGift') {
-			frequency = 'quarter';
-			description = 'The Guardian Weekly Gift Subscription';
-		}
-		if (ratePlan === 'SixWeekly') {
-			frequency = 'month';
-			description = 'The Guardian Weekly';
-		}
-	}
-
-	return { description, frequency, showAddressFields, addressCountries };
-}
 
 /** Page styles - styles used specifically for the checkout page */
 const darkBackgroundContainerMobile = css`
@@ -271,7 +199,17 @@ export function Checkout() {
 	const currentRatePlan = currentProduct.ratePlans[query.ratePlan];
 	const currentPrice = currentRatePlan.pricing[currentCurrencyKey];
 
-	const product = describeProduct(query.product, query.ratePlan);
+	const productDescription = productCatalogDescription[query.product];
+	const ratePlanDescription = productDescription.ratePlans[query.ratePlan];
+	let paymentFrequency;
+	if (ratePlanDescription.billingPeriod === 'Annual') {
+		paymentFrequency = 'year';
+	} else if (ratePlanDescription.billingPeriod === 'Month') {
+		paymentFrequency = 'month';
+	} else {
+		paymentFrequency = 'quarter';
+	}
+
 	const showStateSelect =
 		query.product !== 'Contribution' &&
 		(countryId === 'US' || countryId === 'CA' || countryId === 'AU');
@@ -338,8 +276,8 @@ export function Checkout() {
 						<Box cssOverrides={shorterBoxMargin}>
 							<BoxContents>
 								<ContributionsOrderSummary
-									description={product.description}
-									paymentFrequency={product.frequency}
+									description={productDescription.label}
+									paymentFrequency={paymentFrequency}
 									amount={currentPrice}
 									currency={currentCurrency}
 									checkListData={[]}
@@ -377,7 +315,7 @@ export function Checkout() {
 									recaptchaToken: formData.get('recaptchaToken') as string,
 								};
 
-								const deliveryAddress = product.showAddressFields
+								const deliveryAddress = productDescription.deliverableTo
 									? {
 											lineOne: formData.get('delivery-lineOne') as string,
 											lineTwo: formData.get('delivery-lineTwo') as string,
@@ -391,7 +329,8 @@ export function Checkout() {
 									formData.get('billingAddressMatchesDelivery') === 'yes';
 
 								const billingAddress =
-									product.showAddressFields && !billingAddressMatchesDelivery
+									productDescription.deliverableTo &&
+									!billingAddressMatchesDelivery
 										? {
 												lineOne: formData.get('billing-lineOne') as string,
 												lineTwo: formData.get('billing-lineTwo') as string,
@@ -496,7 +435,7 @@ export function Checkout() {
 
 									<CheckoutDivider spacing="loose" />
 
-									{product.showAddressFields && (
+									{productDescription.deliverableTo && (
 										<>
 											<fieldset>
 												<h2 css={legend}>Where should we deliver to?</h2>
@@ -508,7 +447,7 @@ export function Checkout() {
 													country={countryId}
 													state={deliveryState}
 													postCode={deliveryPostcode}
-													countries={product.addressCountries}
+													countries={productDescription.deliverableTo}
 													errors={[]}
 													postcodeState={{
 														results: deliveryPostcodeStateResults,
@@ -599,7 +538,7 @@ export function Checkout() {
 														country={countryId}
 														state={billingState}
 														postCode={billingPostcode}
-														countries={product.addressCountries}
+														countries={productDescription.deliverableTo}
 														errors={[]}
 														postcodeState={{
 															results: billingPostcodeStateResults,

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -247,6 +247,8 @@ const productCatalogDescInclOffers: typeof productCatalogDescExclOffers = {
 		],
 		benefits:
 			productCatalogDescExclOffers.SupporterPlusWithGuardianWeekly.benefits,
+		ratePlans:
+			productCatalogDescExclOffers.SupporterPlusWithGuardianWeekly.ratePlans,
 	},
 	SupporterPlus: {
 		label: productCatalogDescExclOffers.SupporterPlus.label,
@@ -256,6 +258,7 @@ const productCatalogDescInclOffers: typeof productCatalogDescExclOffers = {
 				copy: <OfferBook></OfferBook>,
 			},
 		],
+		ratePlans: productCatalogDescExclOffers.SupporterPlus.ratePlans,
 	},
 };
 


### PR DESCRIPTION
Depends on https://github.com/guardian/support-frontend/pull/5910

Uses the `productCatalogDescription` on the checkout.


## Why are you doing this?
To make sure we have and use 1 way to describe the product catalog.
