### PR TITLE
Allow for 0 `discountPrice` (100% discount)

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -202,10 +202,6 @@ export function ThreeTierCard({
 }: ThreeTierCardProps): JSX.Element {
 	const currency = currencies[currencyId];
 	const period = recurringContributionPeriodMap[paymentFrequency];
-	const promotionPrice = promotion?.discountedPrice;
-	const formattedPromotionPrice =
-		promotionPrice && simpleFormatAmount(currency, promotionPrice);
-	const hasPromotion = !!formattedPromotionPrice;
 	const formattedPrice = simpleFormatAmount(currency, price);
 	const quantumMetricButtonRef = `tier-${cardTier}-button`;
 	const { label, benefits, benefitsSummary, offers, offersSummary } =
@@ -220,11 +216,14 @@ export function ThreeTierCard({
 				<ThreeTierLozenge subdue={isRecommendedSubdued} title="Recommended" />
 			)}
 			<h2 css={titleCss}>{label}</h2>
-			<p css={priceCss(hasPromotion)}>
-				{hasPromotion && (
+			<p css={priceCss(!!promotion)}>
+				{promotion && (
 					<>
 						<span css={previousPriceStrikeThrough}>{formattedPrice}</span>{' '}
-						{`${formattedPromotionPrice}/${period}`}
+						{`${simpleFormatAmount(
+							currency,
+							promotion.discountedPrice ?? price,
+						)}/${period}`}
 						<span css={discountSummaryCss}>
 							{discountSummaryCopy(
 								currency,
@@ -236,7 +235,7 @@ export function ThreeTierCard({
 						</span>
 					</>
 				)}
-				{!hasPromotion && `${formattedPrice}/${period}`}
+				{!promotion && `${formattedPrice}/${period}`}
 			</p>
 			<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
 				<LinkButton

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
@@ -24,25 +24,14 @@ type MonthlyProps = {
 	name?: string;
 };
 function Monthly({ isoCurrency, amount, promotion, name }: MonthlyProps) {
-	if (
-		/**
-		 * This is a check to see if the promo exists,
-		 * it's a little odd due to the type having
-		 * every prop optional.
-		 *
-		 * We could/should do some parsing pre-render to avoid this.
-		 * */
-		promotion?.discountedPrice &&
-		promotion.discount?.durationMonths
-	) {
+	if (promotion) {
+		const promotionPrice = promotion.discountedPrice ?? amount;
+		const promotionDuration = promotion.discount?.durationMonths ?? 0;
 		return (
 			<>
 				<h1 css={headerTitleText}>
 					Thank you {name}for supporting us with{' '}
-					<YellowAmount
-						amount={promotion.discountedPrice}
-						currency={isoCurrency}
-					/>
+					<YellowAmount amount={promotionPrice} currency={isoCurrency} />
 					{`/month`}
 					<sup css={supCss}>*</sup>
 				</h1>
@@ -55,10 +44,10 @@ function Monthly({ isoCurrency, amount, promotion, name }: MonthlyProps) {
 					{formatAmount(
 						currencies[isoCurrency],
 						spokenCurrencies[isoCurrency],
-						promotion.discountedPrice,
+						promotionPrice,
 						false,
 					)}
-					/month for the first {promotion.discount.durationMonths} months, then{' '}
+					/month for the first {promotionDuration} months, then{' '}
 					{formatAmount(
 						currencies[isoCurrency],
 						spokenCurrencies[isoCurrency],
@@ -86,25 +75,14 @@ type AnnualProps = {
 	name?: string;
 };
 function Annual({ isoCurrency, amount, promotion, name }: AnnualProps) {
-	if (
-		/**
-		 * This is a check to see if the promo exists,
-		 * it's a little odd due to the type having
-		 * every prop optional.
-		 *
-		 * We could/should do some parsing pre-render to avoid this.
-		 * */
-		promotion?.discountedPrice &&
-		promotion.discount?.durationMonths
-	) {
+	if (promotion) {
+		const promotionPrice = promotion.discountedPrice ?? amount;
+
 		return (
 			<>
 				<h1 css={headerTitleText}>
 					Thank you {name}for supporting us with{' '}
-					<YellowAmount
-						amount={promotion.discountedPrice}
-						currency={isoCurrency}
-					/>
+					<YellowAmount amount={promotionPrice} currency={isoCurrency} />
 					{`/year`}
 					<sup css={supCss}>*</sup>
 				</h1>
@@ -117,7 +95,7 @@ function Annual({ isoCurrency, amount, promotion, name }: AnnualProps) {
 					{formatAmount(
 						currencies[isoCurrency],
 						spokenCurrencies[isoCurrency],
-						promotion.discountedPrice,
+						promotionPrice,
 						false,
 					)}
 					{/**


### PR DESCRIPTION
We were applying the promotion based on `!!promotion.discountedPrice`. This would evaluate to `false` in the case that `discountPrice === 0`.

It is now the case that if the promotion exists, we will apply it. If the `discountPrice` is missing, we will fallback to full price, and if `numberOfDiscountedPeriods` is missing, we will fallback to `0`.

So without neither of those you might expect to see
> You'll pay £10/month for the first 0 months, then £10/month afterwards unless you cancel.

This is odd - but then again it's odd input. If we'd like to guard against this, I'd suggest we do it at the source.

## Show me  (with 100% discount)

### Landing
<img width="454" alt="Screenshot 2024-04-17 at 12 21 04" src="https://github.com/guardian/support-frontend/assets/31692/150ee250-e2fc-423b-85b5-0fb8fbc2025a">

### Checkout
<img width="449" alt="Screenshot 2024-04-17 at 12 21 09" src="https://github.com/guardian/support-frontend/assets/31692/91b5ced1-b1a0-43fa-8882-ba75d5285ad3">

### Thank you
<img width="441" alt="Screenshot 2024-04-17 at 12 22 21" src="https://github.com/guardian/support-frontend/assets/31692/56116930-b6bb-40e7-a68b-753ccef2a9dc">

