### PR TITLE
Fix `noUncheckedIndexedAccess` errors on thank you stories

### DIFF
--- a/support-frontend/stories/screens/supporterPlusThankYou/AusSupporterPlusThankYou.stories.tsx
+++ b/support-frontend/stories/screens/supporterPlusThankYou/AusSupporterPlusThankYou.stories.tsx
@@ -112,7 +112,7 @@ OneOffNotSignedIn.args = {
 OneOffNotSignedIn.decorators = [
 	(
 		Story: React.FC,
-		{ args }: Record<string, SupporterPlusThankYouArgs>,
+		{ args }: { args: SupporterPlusThankYouArgs },
 	): JSX.Element => {
 		const { paymentMethod, shouldShowLargeDonationMessage } = args;
 
@@ -158,7 +158,7 @@ OneOffSignedIn.args = {
 OneOffSignedIn.decorators = [
 	(
 		Story: React.FC,
-		{ args }: Record<string, SupporterPlusThankYouArgs>,
+		{ args }: { args: SupporterPlusThankYouArgs },
 	): JSX.Element => {
 		const { paymentMethod, shouldShowLargeDonationMessage } = args;
 
@@ -205,7 +205,7 @@ OneOffSignUp.args = {
 OneOffSignUp.decorators = [
 	(
 		Story: React.FC,
-		{ args }: Record<string, SupporterPlusThankYouArgs>,
+		{ args }: { args: SupporterPlusThankYouArgs },
 	): JSX.Element => {
 		const { paymentMethod, shouldShowLargeDonationMessage } = args;
 
@@ -256,7 +256,7 @@ RecurringNotSignedIn.args = {
 RecurringNotSignedIn.decorators = [
 	(
 		Story: React.FC,
-		{ args }: Record<string, SupporterPlusThankYouArgs>,
+		{ args }: { args: SupporterPlusThankYouArgs },
 	): JSX.Element => {
 		const {
 			contributionType,
@@ -317,7 +317,7 @@ RecurringSignedIn.args = {
 RecurringSignedIn.decorators = [
 	(
 		Story: React.FC,
-		{ args }: Record<string, SupporterPlusThankYouArgs>,
+		{ args }: { args: SupporterPlusThankYouArgs },
 	): JSX.Element => {
 		const {
 			contributionType,
@@ -379,7 +379,7 @@ RecurringSignUp.args = {
 RecurringSignUp.decorators = [
 	(
 		Story: React.FC,
-		{ args }: Record<string, SupporterPlusThankYouArgs>,
+		{ args }: { args: SupporterPlusThankYouArgs },
 	): JSX.Element => {
 		const {
 			contributionType,

--- a/support-frontend/stories/screens/supporterPlusThankYou/ROWSupporterPlusThankYou.stories.tsx
+++ b/support-frontend/stories/screens/supporterPlusThankYou/ROWSupporterPlusThankYou.stories.tsx
@@ -104,7 +104,7 @@ OneOffNotSignedIn.args = {
 OneOffNotSignedIn.decorators = [
 	(
 		Story: React.FC,
-		{ args }: Record<string, SupporterPlusThankYouArgs>,
+		{ args }: { args: SupporterPlusThankYouArgs },
 	): JSX.Element => {
 		const { paymentMethod, shouldShowLargeDonationMessage, countryGroup } =
 			args;
@@ -117,9 +117,11 @@ OneOffNotSignedIn.decorators = [
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
 		store.dispatch(setPaymentMethod({ paymentMethod }));
-		store.dispatch(
-			setCountryInternationalisation(countryGroups[countryGroup].countries[0]),
-		);
+
+		const country = countryGroups[countryGroup].countries[0];
+		if (country) {
+			store.dispatch(setCountryInternationalisation(country));
+		}
 
 		store.dispatch(
 			setSelectedAmount(
@@ -155,7 +157,7 @@ OneOffSignedIn.args = {
 OneOffSignedIn.decorators = [
 	(
 		Story: React.FC,
-		{ args }: Record<string, SupporterPlusThankYouArgs>,
+		{ args }: { args: SupporterPlusThankYouArgs },
 	): JSX.Element => {
 		const { paymentMethod, shouldShowLargeDonationMessage, countryGroup } =
 			args;
@@ -169,9 +171,10 @@ OneOffSignedIn.decorators = [
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
 		store.dispatch(setPaymentMethod({ paymentMethod }));
-		store.dispatch(
-			setCountryInternationalisation(countryGroups[countryGroup].countries[0]),
-		);
+		const country = countryGroups[countryGroup].countries[0];
+		if (country) {
+			store.dispatch(setCountryInternationalisation(country));
+		}
 
 		store.dispatch(
 			setSelectedAmount(
@@ -206,7 +209,7 @@ OneOffSignUp.args = {
 OneOffSignUp.decorators = [
 	(
 		Story: React.FC,
-		{ args }: Record<string, SupporterPlusThankYouArgs>,
+		{ args }: { args: SupporterPlusThankYouArgs },
 	): JSX.Element => {
 		const { paymentMethod, shouldShowLargeDonationMessage, countryGroup } =
 			args;
@@ -222,9 +225,10 @@ OneOffSignUp.decorators = [
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
 		store.dispatch(setPaymentMethod({ paymentMethod }));
-		store.dispatch(
-			setCountryInternationalisation(countryGroups[countryGroup].countries[0]),
-		);
+		const country = countryGroups[countryGroup].countries[0];
+		if (country) {
+			store.dispatch(setCountryInternationalisation(country));
+		}
 
 		store.dispatch(
 			setSelectedAmount(
@@ -261,7 +265,7 @@ RecurringNotSignedIn.args = {
 RecurringNotSignedIn.decorators = [
 	(
 		Story: React.FC,
-		{ args }: Record<string, SupporterPlusThankYouArgs>,
+		{ args }: { args: SupporterPlusThankYouArgs },
 	): JSX.Element => {
 		const {
 			contributionType,
@@ -282,9 +286,10 @@ RecurringNotSignedIn.decorators = [
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
 		store.dispatch(setPaymentMethod({ paymentMethod }));
-		store.dispatch(
-			setCountryInternationalisation(countryGroups[countryGroup].countries[0]),
-		);
+		const country = countryGroups[countryGroup].countries[0];
+		if (country) {
+			store.dispatch(setCountryInternationalisation(country));
+		}
 
 		const thresholdPrice =
 			lowerBenefitsThresholds[countryGroup][
@@ -326,7 +331,7 @@ RecurringSignedIn.args = {
 RecurringSignedIn.decorators = [
 	(
 		Story: React.FC,
-		{ args }: Record<string, SupporterPlusThankYouArgs>,
+		{ args }: { args: SupporterPlusThankYouArgs },
 	): JSX.Element => {
 		const {
 			contributionType,
@@ -348,9 +353,10 @@ RecurringSignedIn.decorators = [
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
 		store.dispatch(setPaymentMethod({ paymentMethod }));
-		store.dispatch(
-			setCountryInternationalisation(countryGroups[countryGroup].countries[0]),
-		);
+		const country = countryGroups[countryGroup].countries[0];
+		if (country) {
+			store.dispatch(setCountryInternationalisation(country));
+		}
 
 		const thresholdPrice =
 			lowerBenefitsThresholds[countryGroup][
@@ -392,7 +398,7 @@ RecurringSignUp.args = {
 RecurringSignUp.decorators = [
 	(
 		Story: React.FC,
-		{ args }: Record<string, SupporterPlusThankYouArgs>,
+		{ args }: { args: SupporterPlusThankYouArgs },
 	): JSX.Element => {
 		const {
 			contributionType,
@@ -415,9 +421,10 @@ RecurringSignUp.decorators = [
 		store.dispatch(setLastName('Bloggs'));
 		store.dispatch(setEmail('abcd@thegulocal.com'));
 		store.dispatch(setPaymentMethod({ paymentMethod }));
-		store.dispatch(
-			setCountryInternationalisation(countryGroups[countryGroup].countries[0]),
-		);
+		const country = countryGroups[countryGroup].countries[0];
+		if (country) {
+			store.dispatch(setCountryInternationalisation(country));
+		}
 
 		const thresholdPrice =
 			lowerBenefitsThresholds[countryGroup][


### PR DESCRIPTION
Part of https://github.com/guardian/support-frontend/issues/5829

- Fixes arg type for decorators
- Check `0` index on countries before dispatching a potentially `undefined` value
