### PR TITLE
fix: apply promotion on OrderSummary

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -169,10 +169,10 @@ export function ContributionsOrderSummary({
 	);
 
 	const formattedAmount = simpleFormatAmount(currency, amount);
-	/** We have to check deeper than just promotion as the other values are optional */
+
 	const formattedPromotionAmount =
-		promotion?.discountedPrice &&
-		simpleFormatAmount(currency, promotion.discountedPrice);
+		promotion &&
+		simpleFormatAmount(currency, promotion.discountedPrice ?? amount);
 
 	return (
 		<div css={componentStyles}>


### PR DESCRIPTION
Allows for `0` discount price on contribution checkout.

I thought this was part of https://github.com/guardian/support-frontend/pull/5926 - but I think I managed to rebase it out (as I had actually got a screenshot of it).

| before | after |
|---|---|
| <img width="593" alt="Screenshot 2024-04-17 at 14 51 39" src="https://github.com/guardian/support-frontend/assets/31692/ccceca1a-c789-4595-a72c-d6cdbc7f8cdc"> | <img width="449" alt="Screenshot 2024-04-17 at 12 21 09" src="https://github.com/guardian/support-frontend/assets/31692/a24d3c40-91d0-4fbb-b906-7df373cdc955"> |

