### PR TITLE
Add `productFields` in checkout `POST` data

### DIFF
--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -9,234 +9,220 @@ export type ProductDescription = {
 	benefitsSummary?: Array<string | { strong: boolean; copy: string }>;
 	offers?: Array<{ copy: JSX.Element; tooltip?: string }>;
 	offersSummary?: Array<string | { strong: boolean; copy: string }>;
-	ratePlans: Record<string, { billingPeriod: 'Annual' | 'Month' | 'Quarter' }>;
+	ratePlans: Record<
+		string,
+		{ billingPeriod: 'Annual' | 'Monthly' | 'Quarterly' }
+	>;
 	deliverableTo?: Record<string, string>;
 };
 
-const productIds = [
-	'SupporterPlusWithGuardianWeekly',
-	'DigitalSubscription',
-	'NationalDelivery',
-	'SupporterPlus',
-	'GuardianWeeklyRestOfWorld',
-	'GuardianWeeklyDomestic',
-	'SubscriptionCard',
-	'Contribution',
-	'HomeDelivery',
-] as const;
-type ProductId = (typeof productIds)[number];
-export function isProductId(value: string): value is ProductId {
-	return productIds.includes(value as ProductId);
-}
-
-export const productCatalogDescription: Record<ProductId, ProductDescription> =
-	{
-		SupporterPlusWithGuardianWeekly: {
-			label: 'Digital + print',
-			benefitsSummary: [
-				'The rewards from ',
-				{ strong: true, copy: 'All-access digital' },
-			],
-			benefits: [
-				{
-					copy: 'Guardian Weekly print magazine delivered to your door every week  ',
-					tooltip: `Guardian Weekly is a beautifully concise magazine featuring a handpicked selection of in-depth articles, global news, long reads, opinion and more. Delivered to you every week, wherever you are in the world.`,
-				},
-			],
-			ratePlans: {
-				MonthlyWithGuardianWeekly: {
-					billingPeriod: 'Month',
-				},
-				AnnualWithGuardianWeekly: {
-					billingPeriod: 'Annual',
-				},
-				MonthlyWithGuardianWeeklyInt: {
-					billingPeriod: 'Month',
-				},
-				AnnualWithGuardianWeeklyInt: {
-					billingPeriod: 'Annual',
-				},
+export const productCatalogDescription: Record<string, ProductDescription> = {
+	SupporterPlusWithGuardianWeekly: {
+		label: 'Digital + print',
+		benefitsSummary: [
+			'The rewards from ',
+			{ strong: true, copy: 'All-access digital' },
+		],
+		benefits: [
+			{
+				copy: 'Guardian Weekly print magazine delivered to your door every week  ',
+				tooltip: `Guardian Weekly is a beautifully concise magazine featuring a handpicked selection of in-depth articles, global news, long reads, opinion and more. Delivered to you every week, wherever you are in the world.`,
 			},
-			deliverableTo: gwDeliverableCountries,
-		},
-		DigitalSubscription: {
-			label: 'The Guardian Digital Edition',
-			benefits: [
-				{
-					copy: 'The Editions app. Enjoy the Guardian and Observer newspaper, reimagined for mobile and tablet',
-				},
-				{ copy: 'Full access to our news app. Read our reporting on the go' },
-				{ copy: 'Ad-free reading. Avoid ads on all your devices' },
-				{
-					copy: 'Free 14 day trial. Enjoy a free trial of your subscription, before you pay',
-				},
-			],
-			ratePlans: {
-				Monthly: {
-					billingPeriod: 'Month',
-				},
-				Annual: {
-					billingPeriod: 'Annual',
-				},
-				ThreeMonthGift: {
-					billingPeriod: 'Month',
-				},
-				OneYearGift: {
-					billingPeriod: 'Annual',
-				},
+		],
+		ratePlans: {
+			MonthlyWithGuardianWeekly: {
+				billingPeriod: 'Monthly',
+			},
+			AnnualWithGuardianWeekly: {
+				billingPeriod: 'Annual',
+			},
+			MonthlyWithGuardianWeeklyInt: {
+				billingPeriod: 'Monthly',
+			},
+			AnnualWithGuardianWeeklyInt: {
+				billingPeriod: 'Annual',
 			},
 		},
-		NationalDelivery: {
-			label: 'National Delivery',
-			benefits: [],
-			ratePlans: {
-				Sixday: {
-					billingPeriod: 'Month',
-				},
-				Weekend: {
-					billingPeriod: 'Annual',
-				},
-				Everyday: {
-					billingPeriod: 'Month',
-				},
+		deliverableTo: gwDeliverableCountries,
+	},
+	DigitalSubscription: {
+		label: 'The Guardian Digital Edition',
+		benefits: [
+			{
+				copy: 'The Editions app. Enjoy the Guardian and Observer newspaper, reimagined for mobile and tablet',
 			},
-			deliverableTo: newspaperCountries,
-		},
-		SupporterPlus: {
-			label: 'All-access digital',
-			benefits: [
-				{
-					copy: 'Unlimited access to the Guardian app',
-					tooltip: `Read beyond our 20 article-per-month limit, enjoy offline access and personalised recommendations, and access our full archive of journalism. Never miss a story with the Guardian News app – a beautiful, intuitive reading experience.`,
-				},
-				{ copy: 'Ad-free reading on all your devices' },
-				{
-					copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
-				},
-				{
-					copy: 'Far fewer asks for support',
-					tooltip: `You'll see far fewer financial support asks at the bottom of articles or in pop-up banners.`,
-				},
-			],
-			ratePlans: {
-				Monthly: {
-					billingPeriod: 'Month',
-				},
-				Annual: {
-					billingPeriod: 'Annual',
-				},
+			{ copy: 'Full access to our news app. Read our reporting on the go' },
+			{ copy: 'Ad-free reading. Avoid ads on all your devices' },
+			{
+				copy: 'Free 14 day trial. Enjoy a free trial of your subscription, before you pay',
+			},
+		],
+		ratePlans: {
+			Monthly: {
+				billingPeriod: 'Monthly',
+			},
+			Annual: {
+				billingPeriod: 'Annual',
+			},
+			ThreeMonthGift: {
+				billingPeriod: 'Monthly',
+			},
+			OneYearGift: {
+				billingPeriod: 'Annual',
 			},
 		},
-		GuardianWeeklyRestOfWorld: {
-			label: 'The Guardian Weekly',
-			benefits: [],
-			ratePlans: {
-				Monthly: {
-					billingPeriod: 'Month',
-				},
-				OneYearGift: {
-					billingPeriod: 'Annual',
-				},
-				Annual: {
-					billingPeriod: 'Annual',
-				},
-				SixWeekly: {
-					billingPeriod: 'Month',
-				},
-				Quarterly: {
-					billingPeriod: 'Quarter',
-				},
-				ThreeMonthGift: {
-					billingPeriod: 'Month',
-				},
+	},
+	NationalDelivery: {
+		label: 'National Delivery',
+		benefits: [],
+		ratePlans: {
+			Sixday: {
+				billingPeriod: 'Monthly',
 			},
-			deliverableTo: gwDeliverableCountries,
-		},
-		GuardianWeeklyDomestic: {
-			label: 'The Guardian Weekly',
-			benefits: [],
-			ratePlans: {
-				Monthly: {
-					billingPeriod: 'Month',
-				},
-				OneYearGift: {
-					billingPeriod: 'Annual',
-				},
-				Annual: {
-					billingPeriod: 'Annual',
-				},
-				SixWeekly: {
-					billingPeriod: 'Month',
-				},
-				Quarterly: {
-					billingPeriod: 'Quarter',
-				},
-				ThreeMonthGift: {
-					billingPeriod: 'Month',
-				},
+			Weekend: {
+				billingPeriod: 'Annual',
 			},
-			deliverableTo: gwDeliverableCountries,
-		},
-		SubscriptionCard: {
-			label: 'Newspaper subscription',
-			benefits: [],
-			ratePlans: {
-				Sixday: {
-					billingPeriod: 'Month',
-				},
-				Everyday: {
-					billingPeriod: 'Month',
-				},
-				Weekend: {
-					billingPeriod: 'Month',
-				},
-				Sunday: {
-					billingPeriod: 'Month',
-				},
-				Saturday: {
-					billingPeriod: 'Month',
-				},
+			Everyday: {
+				billingPeriod: 'Monthly',
 			},
 		},
-		Contribution: {
-			label: 'Support',
-			benefits: [
-				{
-					copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
-				},
-			],
-			ratePlans: {
-				Monthly: {
-					billingPeriod: 'Month',
-				},
-				Annual: {
-					billingPeriod: 'Annual',
-				},
+		deliverableTo: newspaperCountries,
+	},
+	SupporterPlus: {
+		label: 'All-access digital',
+		benefits: [
+			{
+				copy: 'Unlimited access to the Guardian app',
+				tooltip: `Read beyond our 20 article-per-month limit, enjoy offline access and personalised recommendations, and access our full archive of journalism. Never miss a story with the Guardian News app – a beautiful, intuitive reading experience.`,
+			},
+			{ copy: 'Ad-free reading on all your devices' },
+			{
+				copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+			},
+			{
+				copy: 'Far fewer asks for support',
+				tooltip: `You'll see far fewer financial support asks at the bottom of articles or in pop-up banners.`,
+			},
+		],
+		ratePlans: {
+			Monthly: {
+				billingPeriod: 'Monthly',
+			},
+			Annual: {
+				billingPeriod: 'Annual',
 			},
 		},
-		HomeDelivery: {
-			label: 'Home Delivery',
-			benefits: [],
-			ratePlans: {
-				Everyday: {
-					billingPeriod: 'Month',
-				},
-				Sunday: {
-					billingPeriod: 'Month',
-				},
-				Sixday: {
-					billingPeriod: 'Month',
-				},
-				Weekend: {
-					billingPeriod: 'Month',
-				},
-				Saturday: {
-					billingPeriod: 'Month',
-				},
+	},
+	GuardianWeeklyRestOfWorld: {
+		label: 'The Guardian Weekly',
+		benefits: [],
+		ratePlans: {
+			Monthly: {
+				billingPeriod: 'Monthly',
 			},
-			deliverableTo: newspaperCountries,
+			OneYearGift: {
+				billingPeriod: 'Annual',
+			},
+			Annual: {
+				billingPeriod: 'Annual',
+			},
+			SixWeekly: {
+				billingPeriod: 'Monthly',
+			},
+			Quarterly: {
+				billingPeriod: 'Quarterly',
+			},
+			ThreeMonthGift: {
+				billingPeriod: 'Monthly',
+			},
 		},
-	};
+		deliverableTo: gwDeliverableCountries,
+	},
+	GuardianWeeklyDomestic: {
+		label: 'The Guardian Weekly',
+		benefits: [],
+		ratePlans: {
+			Monthly: {
+				billingPeriod: 'Monthly',
+			},
+			OneYearGift: {
+				billingPeriod: 'Annual',
+			},
+			Annual: {
+				billingPeriod: 'Annual',
+			},
+			SixWeekly: {
+				billingPeriod: 'Monthly',
+			},
+			Quarterly: {
+				billingPeriod: 'Quarterly',
+			},
+			ThreeMonthGift: {
+				billingPeriod: 'Monthly',
+			},
+		},
+		deliverableTo: gwDeliverableCountries,
+	},
+	SubscriptionCard: {
+		label: 'Newspaper subscription',
+		benefits: [],
+		ratePlans: {
+			Sixday: {
+				billingPeriod: 'Monthly',
+			},
+			Everyday: {
+				billingPeriod: 'Monthly',
+			},
+			Weekend: {
+				billingPeriod: 'Monthly',
+			},
+			Sunday: {
+				billingPeriod: 'Monthly',
+			},
+			Saturday: {
+				billingPeriod: 'Monthly',
+			},
+		},
+	},
+	Contribution: {
+		label: 'Support',
+		benefits: [
+			{
+				copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+			},
+		],
+		ratePlans: {
+			Monthly: {
+				billingPeriod: 'Monthly',
+			},
+			Annual: {
+				billingPeriod: 'Annual',
+			},
+		},
+	},
+	HomeDelivery: {
+		label: 'Home Delivery',
+		benefits: [],
+		ratePlans: {
+			Everyday: {
+				billingPeriod: 'Monthly',
+			},
+			Sunday: {
+				billingPeriod: 'Monthly',
+			},
+			Sixday: {
+				billingPeriod: 'Monthly',
+			},
+			Weekend: {
+				billingPeriod: 'Monthly',
+			},
+			Saturday: {
+				billingPeriod: 'Monthly',
+			},
+		},
+		deliverableTo: newspaperCountries,
+	},
+};
 
 /** These `ratePlans` will eventually becomes part of the SupportPlus product in Zuora */
 export const supporterPlusWithGuardianWeekly = {

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -13,213 +13,230 @@ export type ProductDescription = {
 	deliverableTo?: Record<string, string>;
 };
 
-export const productCatalogDescription: Record<string, ProductDescription> = {
-	SupporterPlusWithGuardianWeekly: {
-		label: 'Digital + print',
-		benefitsSummary: [
-			'The rewards from ',
-			{ strong: true, copy: 'All-access digital' },
-		],
-		benefits: [
-			{
-				copy: 'Guardian Weekly print magazine delivered to your door every week  ',
-				tooltip: `Guardian Weekly is a beautifully concise magazine featuring a handpicked selection of in-depth articles, global news, long reads, opinion and more. Delivered to you every week, wherever you are in the world.`,
+const productIds = [
+	'SupporterPlusWithGuardianWeekly',
+	'DigitalSubscription',
+	'NationalDelivery',
+	'SupporterPlus',
+	'GuardianWeeklyRestOfWorld',
+	'GuardianWeeklyDomestic',
+	'SubscriptionCard',
+	'Contribution',
+	'HomeDelivery',
+] as const;
+type ProductId = (typeof productIds)[number];
+export function isProductId(value: string): value is ProductId {
+	return productIds.includes(value as ProductId);
+}
+
+export const productCatalogDescription: Record<ProductId, ProductDescription> =
+	{
+		SupporterPlusWithGuardianWeekly: {
+			label: 'Digital + print',
+			benefitsSummary: [
+				'The rewards from ',
+				{ strong: true, copy: 'All-access digital' },
+			],
+			benefits: [
+				{
+					copy: 'Guardian Weekly print magazine delivered to your door every week  ',
+					tooltip: `Guardian Weekly is a beautifully concise magazine featuring a handpicked selection of in-depth articles, global news, long reads, opinion and more. Delivered to you every week, wherever you are in the world.`,
+				},
+			],
+			ratePlans: {
+				MonthlyWithGuardianWeekly: {
+					billingPeriod: 'Month',
+				},
+				AnnualWithGuardianWeekly: {
+					billingPeriod: 'Annual',
+				},
+				MonthlyWithGuardianWeeklyInt: {
+					billingPeriod: 'Month',
+				},
+				AnnualWithGuardianWeeklyInt: {
+					billingPeriod: 'Annual',
+				},
 			},
-		],
-		ratePlans: {
-			MonthlyWithGuardianWeekly: {
-				billingPeriod: 'Month',
-			},
-			AnnualWithGuardianWeekly: {
-				billingPeriod: 'Annual',
-			},
-			MonthlyWithGuardianWeeklyInt: {
-				billingPeriod: 'Month',
-			},
-			AnnualWithGuardianWeeklyInt: {
-				billingPeriod: 'Annual',
+			deliverableTo: gwDeliverableCountries,
+		},
+		DigitalSubscription: {
+			label: 'The Guardian Digital Edition',
+			benefits: [
+				{
+					copy: 'The Editions app. Enjoy the Guardian and Observer newspaper, reimagined for mobile and tablet',
+				},
+				{ copy: 'Full access to our news app. Read our reporting on the go' },
+				{ copy: 'Ad-free reading. Avoid ads on all your devices' },
+				{
+					copy: 'Free 14 day trial. Enjoy a free trial of your subscription, before you pay',
+				},
+			],
+			ratePlans: {
+				Monthly: {
+					billingPeriod: 'Month',
+				},
+				Annual: {
+					billingPeriod: 'Annual',
+				},
+				ThreeMonthGift: {
+					billingPeriod: 'Month',
+				},
+				OneYearGift: {
+					billingPeriod: 'Annual',
+				},
 			},
 		},
-		deliverableTo: gwDeliverableCountries,
-	},
-	DigitalSubscription: {
-		label: 'The Guardian Digital Edition',
-		benefits: [
-			{
-				copy: 'The Editions app. Enjoy the Guardian and Observer newspaper, reimagined for mobile and tablet',
+		NationalDelivery: {
+			label: 'National Delivery',
+			benefits: [],
+			ratePlans: {
+				Sixday: {
+					billingPeriod: 'Month',
+				},
+				Weekend: {
+					billingPeriod: 'Annual',
+				},
+				Everyday: {
+					billingPeriod: 'Month',
+				},
 			},
-			{ copy: 'Full access to our news app. Read our reporting on the go' },
-			{ copy: 'Ad-free reading. Avoid ads on all your devices' },
-			{
-				copy: 'Free 14 day trial. Enjoy a free trial of your subscription, before you pay',
-			},
-		],
-		ratePlans: {
-			Monthly: {
-				billingPeriod: 'Month',
-			},
-			Annual: {
-				billingPeriod: 'Annual',
-			},
-			ThreeMonthGift: {
-				billingPeriod: 'Month',
-			},
-			OneYearGift: {
-				billingPeriod: 'Annual',
+			deliverableTo: newspaperCountries,
+		},
+		SupporterPlus: {
+			label: 'All-access digital',
+			benefits: [
+				{
+					copy: 'Unlimited access to the Guardian app',
+					tooltip: `Read beyond our 20 article-per-month limit, enjoy offline access and personalised recommendations, and access our full archive of journalism. Never miss a story with the Guardian News app – a beautiful, intuitive reading experience.`,
+				},
+				{ copy: 'Ad-free reading on all your devices' },
+				{
+					copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+				},
+				{
+					copy: 'Far fewer asks for support',
+					tooltip: `You'll see far fewer financial support asks at the bottom of articles or in pop-up banners.`,
+				},
+			],
+			ratePlans: {
+				Monthly: {
+					billingPeriod: 'Month',
+				},
+				Annual: {
+					billingPeriod: 'Annual',
+				},
 			},
 		},
-	},
-	NationalDelivery: {
-		label: 'National Delivery',
-		benefits: [],
-		ratePlans: {
-			Sixday: {
-				billingPeriod: 'Month',
+		GuardianWeeklyRestOfWorld: {
+			label: 'The Guardian Weekly',
+			benefits: [],
+			ratePlans: {
+				Monthly: {
+					billingPeriod: 'Month',
+				},
+				OneYearGift: {
+					billingPeriod: 'Annual',
+				},
+				Annual: {
+					billingPeriod: 'Annual',
+				},
+				SixWeekly: {
+					billingPeriod: 'Month',
+				},
+				Quarterly: {
+					billingPeriod: 'Quarter',
+				},
+				ThreeMonthGift: {
+					billingPeriod: 'Month',
+				},
 			},
-			Weekend: {
-				billingPeriod: 'Annual',
+			deliverableTo: gwDeliverableCountries,
+		},
+		GuardianWeeklyDomestic: {
+			label: 'The Guardian Weekly',
+			benefits: [],
+			ratePlans: {
+				Monthly: {
+					billingPeriod: 'Month',
+				},
+				OneYearGift: {
+					billingPeriod: 'Annual',
+				},
+				Annual: {
+					billingPeriod: 'Annual',
+				},
+				SixWeekly: {
+					billingPeriod: 'Month',
+				},
+				Quarterly: {
+					billingPeriod: 'Quarter',
+				},
+				ThreeMonthGift: {
+					billingPeriod: 'Month',
+				},
 			},
-			Everyday: {
-				billingPeriod: 'Month',
+			deliverableTo: gwDeliverableCountries,
+		},
+		SubscriptionCard: {
+			label: 'Newspaper subscription',
+			benefits: [],
+			ratePlans: {
+				Sixday: {
+					billingPeriod: 'Month',
+				},
+				Everyday: {
+					billingPeriod: 'Month',
+				},
+				Weekend: {
+					billingPeriod: 'Month',
+				},
+				Sunday: {
+					billingPeriod: 'Month',
+				},
+				Saturday: {
+					billingPeriod: 'Month',
+				},
 			},
 		},
-		deliverableTo: newspaperCountries,
-	},
-	SupporterPlus: {
-		label: 'All-access digital',
-		benefits: [
-			{
-				copy: 'Unlimited access to the Guardian app',
-				tooltip: `Read beyond our 20 article-per-month limit, enjoy offline access and personalised recommendations, and access our full archive of journalism. Never miss a story with the Guardian News app – a beautiful, intuitive reading experience.`,
-			},
-			{ copy: 'Ad-free reading on all your devices' },
-			{
-				copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
-			},
-			{
-				copy: 'Far fewer asks for support',
-				tooltip: `You'll see far fewer financial support asks at the bottom of articles or in pop-up banners.`,
-			},
-		],
-		ratePlans: {
-			Monthly: {
-				billingPeriod: 'Month',
-			},
-			Annual: {
-				billingPeriod: 'Annual',
+		Contribution: {
+			label: 'Support',
+			benefits: [
+				{
+					copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+				},
+			],
+			ratePlans: {
+				Monthly: {
+					billingPeriod: 'Month',
+				},
+				Annual: {
+					billingPeriod: 'Annual',
+				},
 			},
 		},
-	},
-	GuardianWeeklyRestOfWorld: {
-		label: 'The Guardian Weekly',
-		benefits: [],
-		ratePlans: {
-			Monthly: {
-				billingPeriod: 'Month',
+		HomeDelivery: {
+			label: 'Home Delivery',
+			benefits: [],
+			ratePlans: {
+				Everyday: {
+					billingPeriod: 'Month',
+				},
+				Sunday: {
+					billingPeriod: 'Month',
+				},
+				Sixday: {
+					billingPeriod: 'Month',
+				},
+				Weekend: {
+					billingPeriod: 'Month',
+				},
+				Saturday: {
+					billingPeriod: 'Month',
+				},
 			},
-			OneYearGift: {
-				billingPeriod: 'Annual',
-			},
-			Annual: {
-				billingPeriod: 'Annual',
-			},
-			SixWeekly: {
-				billingPeriod: 'Month',
-			},
-			Quarterly: {
-				billingPeriod: 'Quarter',
-			},
-			ThreeMonthGift: {
-				billingPeriod: 'Month',
-			},
+			deliverableTo: newspaperCountries,
 		},
-		deliverableTo: gwDeliverableCountries,
-	},
-	GuardianWeeklyDomestic: {
-		label: 'The Guardian Weekly',
-		benefits: [],
-		ratePlans: {
-			Monthly: {
-				billingPeriod: 'Month',
-			},
-			OneYearGift: {
-				billingPeriod: 'Annual',
-			},
-			Annual: {
-				billingPeriod: 'Annual',
-			},
-			SixWeekly: {
-				billingPeriod: 'Month',
-			},
-			Quarterly: {
-				billingPeriod: 'Quarter',
-			},
-			ThreeMonthGift: {
-				billingPeriod: 'Month',
-			},
-		},
-		deliverableTo: gwDeliverableCountries,
-	},
-	SubscriptionCard: {
-		label: 'Newspaper subscription',
-		benefits: [],
-		ratePlans: {
-			Sixday: {
-				billingPeriod: 'Month',
-			},
-			Everyday: {
-				billingPeriod: 'Month',
-			},
-			Weekend: {
-				billingPeriod: 'Month',
-			},
-			Sunday: {
-				billingPeriod: 'Month',
-			},
-			Saturday: {
-				billingPeriod: 'Month',
-			},
-		},
-	},
-	Contribution: {
-		label: 'Support',
-		benefits: [
-			{
-				copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
-			},
-		],
-		ratePlans: {
-			Monthly: {
-				billingPeriod: 'Month',
-			},
-			Annual: {
-				billingPeriod: 'Annual',
-			},
-		},
-	},
-	HomeDelivery: {
-		label: 'Home Delivery',
-		benefits: [],
-		ratePlans: {
-			Everyday: {
-				billingPeriod: 'Month',
-			},
-			Sunday: {
-				billingPeriod: 'Month',
-			},
-			Sixday: {
-				billingPeriod: 'Month',
-			},
-			Weekend: {
-				billingPeriod: 'Month',
-			},
-			Saturday: {
-				billingPeriod: 'Month',
-			},
-		},
-		deliverableTo: newspaperCountries,
-	},
-};
+	};
 
 /** These `ratePlans` will eventually becomes part of the SupportPlus product in Zuora */
 export const supporterPlusWithGuardianWeekly = {

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -59,7 +59,7 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { Currency } from 'helpers/internationalisation/currency';
 import { currencies } from 'helpers/internationalisation/currency';
-import { productCatalogDescription } from 'helpers/productCatalog';
+import { isProductId, productCatalogDescription } from 'helpers/productCatalog';
 import { renderPage } from 'helpers/rendering/render';
 import { get } from 'helpers/storage/cookie';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
@@ -188,18 +188,13 @@ export function Checkout() {
 		return <div>Not enough query parameters</div>;
 	}
 
-	/**
-	 * We do this check here as we have `noUncheckedIndexedAccess: false` set in our `tsconfig`
-	 * which means `productCatalog[query.product]` would never return undefined, but it could.
-	 */
-	if (!(query.product in productCatalog)) {
-		return <div>Product not found</div>;
-	}
-
 	const currentProduct = productCatalog[query.product];
 	const currentRatePlan = currentProduct.ratePlans[query.ratePlan];
 	const currentPrice = currentRatePlan.pricing[currentCurrencyKey];
 
+	if (!isProductId(query.product)) {
+		return <div>Product {query.product} not found</div>;
+	}
 	const productDescription = productCatalogDescription[query.product];
 	const ratePlanDescription = productDescription.ratePlans[query.ratePlan];
 	let paymentFrequency;


### PR DESCRIPTION
Adds the `productFields` needed to `POST` to the `/subscribe/create` endpoint.

Existing types from [`readerRevenueApis`](https://github.com/guardian/support-frontend/blob/main/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts) have been used to avoid replicating more than is needed.

I've hoisted a lot of the product config from the component as it's not needed.

There's a few renames, I'll try annotate them in the PR.