### PR TITLE
Restore ability to exclude countries subject to VAT compliant Amounts from client-side AB tests

### DIFF
--- a/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
@@ -711,7 +711,7 @@ function buildTest({
 	audiences = { ALL: buildAudience({}) },
 	isActive = true,
 	seed = 0,
-	excludeIfInReferrerControlledTest = false,
+	excludeCountriesSubjectToVatCompliantAmounts = false,
 }: Partial<Test>): Test {
 	return {
 		variants,
@@ -719,7 +719,7 @@ function buildTest({
 		isActive,
 		referrerControlled,
 		seed,
-		excludeIfInReferrerControlledTest,
+		excludeCountriesSubjectToVatCompliantAmounts,
 	};
 }
 

--- a/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
@@ -711,6 +711,7 @@ function buildTest({
 	audiences = { ALL: buildAudience({}) },
 	isActive = true,
 	seed = 0,
+	excludeIfInReferrerControlledTest = false,
 	excludeCountriesSubjectToVatCompliantAmounts = false,
 }: Partial<Test>): Test {
 	return {
@@ -719,6 +720,7 @@ function buildTest({
 		isActive,
 		referrerControlled,
 		seed,
+		excludeIfInReferrerControlledTest,
 		excludeCountriesSubjectToVatCompliantAmounts,
 	};
 }

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -78,30 +78,41 @@ export type Test = {
 	// before activating this test eg. '/(uk|us|au|ca|nz)/subscribe$'
 	targetPage?: string | RegExp;
 	omitCountries?: IsoCountry[];
+	excludeCountriesSubjectToVatCompliantAmounts: boolean;
 };
 
 export type Tests = Record<string, Test>;
 
 // ----- Init ----- //
 
-function init(
-	country: IsoCountry,
-	countryGroupId: CountryGroupId,
-	abTests: Tests = tests,
-	mvt: number = getMvtId(),
-	acquisitionDataTests: AcquisitionABTest[] = getTestFromAcquisitionData() ??
-		[],
-): Participations {
+type ABtestInitalizerData = {
+	countryId: IsoCountry;
+	countryGroupId: CountryGroupId;
+	selectedAmountsVariant?: SelectedAmountsVariant;
+	abTests?: Tests;
+	mvt?: number;
+	acquisitionDataTests?: AcquisitionABTest[];
+};
+
+function init({
+	countryId,
+	countryGroupId,
+	selectedAmountsVariant,
+	abTests = tests,
+	mvt = getMvtId(),
+	acquisitionDataTests = getTestFromAcquisitionData() ?? [],
+}: ABtestInitalizerData): Participations {
+	console.log('*** INIT ***');
 	const participations = getParticipations(
 		abTests,
 		mvt,
-		country,
+		countryId,
 		countryGroupId,
 		acquisitionDataTests,
+		selectedAmountsVariant,
 	);
 	const urlParticipations = getParticipationsFromUrl();
 	const serverSideParticipations = getServerSideParticipations();
-
 	return {
 		...participations,
 		...serverSideParticipations,
@@ -138,6 +149,7 @@ function getParticipations(
 	country: IsoCountry,
 	countryGroupId: CountryGroupId,
 	acquisitionDataTests?: AcquisitionABTest[],
+	selectedAmountsVariant?: SelectedAmountsVariant,
 ): Participations {
 	const participations: Participations = {};
 
@@ -155,6 +167,13 @@ function getParticipations(
 		}
 
 		if (!targetPageMatches(window.location.pathname, test.targetPage)) {
+			return;
+		}
+
+		if (
+			test.excludeCountriesSubjectToVatCompliantAmounts &&
+			selectedAmountsVariant?.testName === vatCompliantAmountsTestName
+		) {
 			return;
 		}
 
@@ -178,6 +197,7 @@ function getParticipations(
 		}
 
 		const testVariantId = test.variants[variantAssignment.variantIndex]?.id;
+
 		if (testVariantId) {
 			participations[testId] = testVariantId;
 		}

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -102,7 +102,6 @@ function init({
 	mvt = getMvtId(),
 	acquisitionDataTests = getTestFromAcquisitionData() ?? [],
 }: ABtestInitalizerData): Participations {
-	console.log('*** INIT ***');
 	const participations = getParticipations(
 		abTests,
 		mvt,

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -61,6 +61,7 @@ export const tests: Tests = {
 		referrerControlled: true,
 		seed: 1,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+		excludeCountriesSubjectToVatCompliantAmounts: true,
 	},
 	supporterPlusOnly: {
 		variants: [
@@ -81,6 +82,7 @@ export const tests: Tests = {
 		referrerControlled: true,
 		seed: 2,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+		excludeCountriesSubjectToVatCompliantAmounts: true,
 	},
 	usFreeBookOffer: {
 		variants: [
@@ -98,5 +100,6 @@ export const tests: Tests = {
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 3,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+		excludeCountriesSubjectToVatCompliantAmounts: true,
 	},
 };

--- a/support-frontend/assets/helpers/page/page.ts
+++ b/support-frontend/assets/helpers/page/page.ts
@@ -16,7 +16,11 @@ function setUpTrackingAndConsents(): void {
 	const settings = getSettings();
 	const countryId: IsoCountry = Country.detect();
 	const countryGroupId: CountryGroupId = CountryGroup.detect();
-	const participations: Participations = abTest.init(countryId, countryGroupId);
+	const abtestInitalizerData = {
+		countryId,
+		countryGroupId,
+	};
+	const participations: Participations = abTest.init(abtestInitalizerData);
 	const { amountsParticipation } = getAmountsTestVariant(
 		countryId,
 		countryGroupId,

--- a/support-frontend/assets/helpers/redux/utils/setup.ts
+++ b/support-frontend/assets/helpers/redux/utils/setup.ts
@@ -56,7 +56,13 @@ export function getInitialState(): CommonState {
 	const { selectedAmountsVariant, amountsParticipation } =
 		getAmountsTestVariant(countryId, countryGroupId, settings);
 
-	const participations: Participations = abTest.init(countryId, countryGroupId);
+	const abtestInitalizerData = {
+		countryId,
+		countryGroupId,
+		selectedAmountsVariant,
+	};
+
+	const participations: Participations = abTest.init(abtestInitalizerData);
 	const participationsWithAmountsTest = {
 		...participations,
 		...amountsParticipation,

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingProps.ts
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingProps.ts
@@ -21,8 +21,13 @@ export type PaperLandingPropTypes = {
 
 const countryGroupId = CountryGroup.detect();
 
+const abtestInitalizerData = {
+	countryId: Country.detect(),
+	countryGroupId,
+};
+
 export const paperLandingProps = (): PaperLandingPropTypes => ({
 	productPrices: getProductPrices(),
 	promotionCopy: getPromotionCopy(),
-	participations: initAbTests(Country.detect(), countryGroupId),
+	participations: initAbTests(abtestInitalizerData),
 });

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLandingProps.ts
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLandingProps.ts
@@ -20,9 +20,13 @@ export type SubscriptionsLandingPropTypes = {
 	referrerAcquisitions: ReferrerAcquisitionData;
 };
 const countryGroupId = CountryGroup.detect();
+const abtestInitalizerData = {
+	countryId: Country.detect(),
+	countryGroupId,
+};
 export const subscriptionsLandingProps = (): SubscriptionsLandingPropTypes => ({
 	countryGroupId,
-	participations: initAbTests(Country.detect(), countryGroupId),
+	participations: initAbTests(abtestInitalizerData),
 	pricingCopy: getGlobal('pricingCopy'),
 	referrerAcquisitions: getReferrerAcquisitionData(),
 });

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingProps.ts
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingProps.ts
@@ -33,6 +33,10 @@ export type WeeklyLPContentPropTypes = {
 };
 
 const countryGroupId = CountryGroup.detect();
+const abtestInitalizerData = {
+	countryId: Country.detect(),
+	countryGroupId,
+};
 
 export const weeklyLandingProps = (): WeeklyLandingPropTypes => ({
 	countryGroupId,
@@ -40,5 +44,5 @@ export const weeklyLandingProps = (): WeeklyLandingPropTypes => ({
 	productPrices: getProductPrices(),
 	promotionCopy: getPromotionCopy(),
 	orderIsAGift: getGlobal('orderIsAGift'),
-	participations: initAbTests(Country.detect(), countryGroupId),
+	participations: initAbTests(abtestInitalizerData),
 });


### PR DESCRIPTION
## What are you doing in this PR?

In https://github.com/guardian/support-frontend/pull/5925 I removed the array `countriesAffectedByVATStatus` from the codebase, and replaced any instances where it had been used (to identify whether a user's country was affected by VAT compliance) with a look-up that checked whether they were assigned to the `VAT_COMPLIANT` amounts instead.

`countriesAffectedByVATStatus` had previously been used in conjunction with the `omitCountries` property in our AB test definitions to make sure users viewing the VAT Compliant checkout weren't registered as participating in AB tests that didn't touch this checkout flow (eg. 3-tier tests). By removing `countriesAffectedByVATStatus`  I removed an easy way to achieve this omission.

This PR restores that by introducing a new prop to our AB test definitions `excludeCountriesSubjectToVatCompliantAmounts`, this is a required `boolean`. If it's `true` we will check whether a user has been assigned to the `VAT_COMPLIANT` amounts test and if so we will not assign a user to the AB test.


