### PR TITLE
Fix discounts not showing in email for annual products

### DIFF
--- a/support-workers/src/main/scala/com/gu/emailservices/SubscriptionEmailFieldHelpers.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/SubscriptionEmailFieldHelpers.scala
@@ -76,6 +76,9 @@ object SubscriptionEmailFieldHelpers {
       s"${priceWithCurrency(currency, initialPrice)} for the first ${billingPeriod.noun}"
     } else if (paymentsWithDifferentPrice.isEmpty) {
       s"${priceWithCurrency(currency, initialPrice)} every ${billingPeriod.noun}"
+    } else if (paymentsWithInitialPrice.length == 1) {
+      s"${priceWithCurrency(currency, initialPrice)} for the first ${billingPeriod.noun}, " +
+        s"then ${priceWithCurrency(currency, paymentsWithDifferentPrice.head.amount)} every ${billingPeriod.noun}"
     } else {
       val introductoryTimespan = {
         val firstIntroductoryPayment = paymentsWithInitialPrice.minBy(_.date)

--- a/support-workers/src/main/scala/com/gu/support/workers/PreviewPaymentSchedule.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/PreviewPaymentSchedule.scala
@@ -12,13 +12,12 @@ object PreviewPaymentSchedule {
 
   def preview(
       subscribeItem: SubscribeItem,
-      billingPeriod: BillingPeriod,
       zuoraService: ZuoraSubscribeService,
       singleResponseCheck: Future[List[PreviewSubscribeResponse]] => Future[PreviewSubscribeResponse],
   ): Future[PaymentSchedule] = {
-    val numberOfInvoicesToPreview: Int = 13
+    val numberOfMonthsToPreview: Int = 13 // 13 allows for annual subs to have a second invoice
     singleResponseCheck(
-      zuoraService.previewSubscribe(PreviewSubscribeRequest.fromSubscribe(subscribeItem, numberOfInvoicesToPreview)),
+      zuoraService.previewSubscribe(PreviewSubscribeRequest.fromSubscribe(subscribeItem, numberOfMonthsToPreview)),
     ).map(response => paymentSchedule(response.invoiceData.flatMap(_.invoiceItem)))
   }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/PreviewPaymentSchedule.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/PreviewPaymentSchedule.scala
@@ -16,18 +16,13 @@ object PreviewPaymentSchedule {
       zuoraService: ZuoraSubscribeService,
       singleResponseCheck: Future[List[PreviewSubscribeResponse]] => Future[PreviewSubscribeResponse],
   ): Future[PaymentSchedule] = {
-    val numberOfInvoicesToPreview: Int = billingPeriod match {
-      case Monthly => 13
-      case Quarterly => 5
-      case com.gu.support.workers.Annual => 2
-      case SixWeekly => 2
-    }
+    val numberOfInvoicesToPreview: Int = 13
     singleResponseCheck(
       zuoraService.previewSubscribe(PreviewSubscribeRequest.fromSubscribe(subscribeItem, numberOfInvoicesToPreview)),
     ).map(response => paymentSchedule(response.invoiceData.flatMap(_.invoiceItem)))
   }
 
-  def round(d: Double) = BigDecimal(d).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
+  private def round(d: Double) = BigDecimal(d).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
 
   def paymentSchedule(charges: List[Charge]): PaymentSchedule = {
     val dateChargeMap = charges.groupBy(_.serviceStartDate)

--- a/support-workers/src/main/scala/com/gu/zuora/ZuoraSubscriptionCreator.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/ZuoraSubscriptionCreator.scala
@@ -25,7 +25,7 @@ class ZuoraSubscriptionCreator(
       billingPeriod: BillingPeriod,
   ): Future[PaymentSchedule] =
     PreviewPaymentSchedule
-      .preview(subscribeItem, billingPeriod, zuoraService, checkSingleResponse)
+      .preview(subscribeItem, zuoraService, checkSingleResponse)
       .withEventualLogging("PreviewPaymentSchedule")
 
   def ensureSubscriptionCreated(subscribeItem: SubscribeItem): Future[(ZuoraAccountNumber, ZuoraSubscriptionNumber)] =

--- a/support-workers/src/test/scala/com/gu/emailservices/SubscriptionEmailFieldHelpersSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/SubscriptionEmailFieldHelpersSpec.scala
@@ -55,6 +55,14 @@ class SubscriptionEmailFieldHelpersSpec extends AnyFlatSpec with Matchers {
     assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Monthly, GBP, None) == expected)
   }
 
+  "describe" should "explain a payment schedule correctly for an annual subscription" in {
+    val firstDiscountedPayment = Payment(referenceDate, 59.76)
+    val firstFullPricePayment = Payment(referenceDate.plusYears(1), 95)
+    val schedule: List[Payment] = List(firstDiscountedPayment, firstFullPricePayment)
+    val expected = "£59.76 for the first year, then £95.00 every year"
+    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Annual, GBP, None) == expected)
+  }
+
   "describe" should "explain a payment schedule correctly if the first 2 quarters are discounted" in {
     val firstDiscountedPayment = Payment(referenceDate, 30.00)
     val firstFullPricePayment = Payment(referenceDate.plusMonths(6), 37.50)


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Fixes a bug whereby discounted annual subscriptions were not told the correct billing information in their thank you email. 

The billing summary in the thank you email is worked out by retrieving a preview of future invoices from Zuora and then using this to generate a description such as '£5.99 every month for 3 months, then £11.99 every month'.

The bug was caused by us only fetching one preview invoice (the one with the discounted price) so the code which works out the message thought the initial price was the regular price.

[**Trello Card**](https://trello.com/c/rj9SSTDl/721-annual-s-ty-email-price-does-not-contain-discount-info)
