### PR TITLE
Generic Checkout : abtest contribution setup

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -102,7 +102,7 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
-	contributionGenericCheckout: {
+	useGenericCheckout: {
 		variants: [
 			{
 				id: 'control',

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -102,4 +102,25 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
+	contributionGenericCheckout: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		isActive: false,
+		referrerControlled: false, // ab-test name not needed to be in paramURL
+		seed: 5,
+		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+		excludeCountriesSubjectToContributionsOnlyAmounts: true,
+	},
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -342,8 +342,7 @@ export function ThreeTierLanding(): JSX.Element {
 		),
 	);
 
-	const useGenericCheckout =
-		abParticipations.contributionGenericCheckout === 'variant';
+	const useGenericCheckout = abParticipations.useGenericCheckout === 'variant';
 	const showOffer =
 		!!abParticipations.usFreeBookOffer && countryGroupId === 'UnitedStates';
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -342,7 +342,8 @@ export function ThreeTierLanding(): JSX.Element {
 		),
 	);
 
-	const useGenericCheckout = !!abParticipations.contributionGenericCheckout;
+	const useGenericCheckout =
+		abParticipations.contributionGenericCheckout === 'variant';
 	const showOffer =
 		!!abParticipations.usFreeBookOffer && countryGroupId === 'UnitedStates';
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -401,19 +401,26 @@ export function ThreeTierLanding(): JSX.Element {
 				}),
 			);
 
-			/**
-			 * I am not sure why links and the react router can't both use a direct link?
-			 * i.e. `link` here is `contribute/checkout` which then doubles up when using the router
-			 * to `contribute/contribute/checkout` even though it is rendered as `contribute/checkout`.
-			 */
-			const linkWithoutContribute = link.split('/')[1];
-			navigateWithPageView(navigate, linkWithoutContribute, abParticipations);
-
 			sendEventContributionCartValue(
 				recurringAmount.toString(),
 				contributionType,
 				currencyId,
 			);
+
+			if (useGenericCheckout) {
+				/**
+				 * Generic Checkout is not defined in supporterPlusRouter
+				 */
+				window.location.href = link;
+			} else {
+				/**
+				 * I am not sure why links and the react router can't both use a direct link?
+				 * i.e. `link` here is `contribute/checkout` which then doubles up when using the router
+				 * to `contribute/contribute/checkout` even though it is rendered as `contribute/checkout`.
+				 */
+				const linkWithoutContribute = link.split('/')[1];
+				navigateWithPageView(navigate, linkWithoutContribute, abParticipations);
+			}
 			return false;
 		}
 	};

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -342,6 +342,7 @@ export function ThreeTierLanding(): JSX.Element {
 		),
 	);
 
+	const useGenericCheckout = !!abParticipations.contributionGenericCheckout;
 	const showOffer =
 		!!abParticipations.usFreeBookOffer && countryGroupId === 'UnitedStates';
 
@@ -438,6 +439,8 @@ export function ThreeTierLanding(): JSX.Element {
 
 	const selectedContributionType =
 		contributionType === 'ANNUAL' ? 'annual' : 'monthly';
+	const selectedContributionRatePlan =
+		contributionType === 'ANNUAL' ? 'Annual' : 'Monthly';
 
 	/**
 	 * Tier 1: Contributions
@@ -456,10 +459,17 @@ export function ThreeTierLanding(): JSX.Element {
 	});
 	const tier1Link = `contribute/checkout?${tier1UrlParams.toString()}`;
 
+	const tier1GenericCheckoutUrlParams = new URLSearchParams({
+		product: 'Contribution',
+		ratePlan: selectedContributionRatePlan,
+		amount: recurringAmount.toString(),
+	});
+	const tier1GenericCheckoutLink = `checkout?${tier1GenericCheckoutUrlParams.toString()}`;
+
 	const tier1Card = {
 		productDescription: productCatalogDescription.Contribution,
 		price: recurringAmount,
-		link: tier1Link,
+		link: useGenericCheckout ? tier1GenericCheckoutLink : tier1Link,
 		isUserSelected: isCardUserSelected(recurringAmount),
 		isRecommended: false,
 	};


### PR DESCRIPTION
## What are you doing in this PR?

- SetUp the generic checkout abtest
- Tier1 (Support) Card redirects to the generic checkout only when in the variant
- name = `contribtionGenericCheckout`

[**Trello Card**](https://trello.com/c/UskqYuJO/805-run-a-b-test-that-changes-the-link-on-the-third-tier-card-to-generic-checkout)

## How to test
https://support.thegulocal.com/uk/contribute#ab-contributionGenericCheckout=variant

From->
![image](https://github.com/guardian/support-frontend/assets/76729591/965adec2-ef5b-4148-898d-2327967255c8)

To->
![image](https://github.com/guardian/support-frontend/assets/76729591/d03d1139-c80e-4386-9302-c9802f4e1cc3)
