### PR TITLE
Don't use `productId = 'Contribution'` to infer `ONE_OFF`

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -185,16 +185,17 @@ const legend = css`
 `;
 
 const validPaymentMethods = [
-	query.product !== 'Contribution' && countryGroupId === 'EURCountries' && Sepa,
-	query.product !== 'Contribution' && countryId === 'GB' && DirectDebit,
+	countryGroupId === 'EURCountries' && Sepa,
+	countryId === 'GB' && DirectDebit,
+	// TODO - ONE_OFF support - ☝️ these will be inactivated for ONE_OFF payments
 	Stripe,
 	PayPal,
 	countryId === 'US' && AmazonPay,
 ].filter(isPaymentMethod);
 
-const stripeAccount = query.product !== 'Contribution' ? 'REGULAR' : 'ONE_OFF';
 const stripePublicKey = getStripeKey(
-	stripeAccount,
+	// TODO - ONE_OFF support - This will need to be ONE_OFF when we support it
+	'REGULAR',
 	countryId,
 	currencyKey,
 	isTestUser,
@@ -303,9 +304,9 @@ export function Checkout() {
 		);
 	}
 
+	// TODO - ONE_OFF support, this should be false when ONE_OFF
 	const showStateSelect =
-		query.product !== 'Contribution' &&
-		(countryId === 'US' || countryId === 'CA' || countryId === 'AU');
+		countryId === 'US' || countryId === 'CA' || countryId === 'AU';
 
 	const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | null>(
 		null,
@@ -415,6 +416,8 @@ export function Checkout() {
 			cardElement &&
 			stripeClientSecret
 		) {
+			// TODO - ONE_OFF support - we'l need to implement the ONE_OFF stripe payment.
+			// You can find this in file://./../../components/stripeCardForm/stripePaymentButton.tsx#oneOffPayment
 			const stripeIntentResult = await stripe.confirmCardSetup(
 				stripeClientSecret,
 				{
@@ -536,7 +539,8 @@ export function Checkout() {
 										firstName={firstName}
 										lastName={lastName}
 										isSignedIn={isSignedIn}
-										hideNameFields={query.product === 'Contribution'}
+										// TODO - ONE_OFF support, this should be true when ONE_OFF
+										hideNameFields={false}
 										onEmailChange={(email) => {
 											setEmail(email);
 										}}


### PR DESCRIPTION
I had mistakenly inferred the `productId = 'Contribution'` meant `ONE_OFF` payments. 

I've started dropping `TODO`s where we are going to have to think about supporting `ONE_OFF` as it's not actually in the catalog.

This means we now
* use the right stripe key
* show the state selector in relevant countries
* ask for personal details

## 👀 

<img width="672" alt="Screenshot 2024-04-22 at 17 04 39" src="https://github.com/guardian/support-frontend/assets/31692/c8919086-5218-40a1-b316-d5f2dd1bf73f">
