### PR TITLE
fix: add billing-address country to non-deliverable products

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -387,7 +387,7 @@ export function Checkout() {
 				city: formData.get('delivery-city') as string,
 				state: formData.get('delivery-state') as string,
 				postCode: formData.get('delivery-postcode') as string,
-				country: formData.get('country') as IsoCountry,
+				country: formData.get('delivery-country') as IsoCountry,
 			};
 
 			const billingAddressMatchesDelivery =
@@ -400,11 +400,13 @@ export function Checkout() {
 						city: formData.get('billing-city') as string,
 						state: formData.get('billing-state') as string,
 						postCode: formData.get('billing-postcode') as string,
-						country: formData.get('country') as IsoCountry,
+						country: formData.get('billing-country') as IsoCountry,
 				  }
 				: deliveryAddress;
 		} else {
-			billingAddress = { country: formData.get('country') as IsoCountry };
+			billingAddress = {
+				country: formData.get('billing-country') as IsoCountry,
+			};
 			deliveryAddress = undefined;
 		}
 
@@ -586,6 +588,17 @@ export function Checkout() {
 
 									<CheckoutDivider spacing="loose" />
 
+									{/**
+									 * We need the billing-country for all transactions, even non-deliverable ones
+									 * which we get from the GU_country cookie which comes from the Fastly geo client.
+									 */}
+									{!productDescription.deliverableTo && (
+										<input
+											type="hidden"
+											name="billing-country"
+											value={countryId}
+										/>
+									)}
 									{productDescription.deliverableTo && (
 										<>
 											<fieldset>


### PR DESCRIPTION
- Fixes the field name from where we fetch billing/delivery address
- Sets the billing-address for non-deliverable products

It's interesting that we set the `billingAddresss.country` from the [Fastly geo client](https://www.fastly.com/documentation/reference/vcl/variables/geolocation/) and don't allow a person to reset it.

This would mean the Billing Country could be wrong for people using VPNs etc - so maybe something to look into.
