### PR TITLE
Add Student Subscriptions to Australia

### DIFF
--- a/support-frontend/assets/helpers/urls/routes.ts
+++ b/support-frontend/assets/helpers/urls/routes.ts
@@ -35,8 +35,10 @@ const routes = {
 		'/subscribe/paper/delivery#HomeDelivery',
 	guardianWeeklySubscriptionLanding: '/subscribe/weekly',
 	guardianWeeklySubscriptionLandingGift: '/subscribe/weekly/gift',
-	guardianWeeklyStudent:
+	guardianWeeklyStudentUK:
 		'https://connect.studentbeans.com/v4/hosted/the-guardian-weekly/uk',
+  guardianWeeklyStudentAU:
+    'https://connect.studentbeans.com/v4/hosted/the-guardian-weekly/au',
 	postcodeLookup: '/postcode-lookup',
 	createSignInUrl: '/identity/signin-url',
 	stripeSetupIntentRecaptcha: '/stripe/create-setup-intent/recaptcha',

--- a/support-frontend/assets/helpers/urls/routes.ts
+++ b/support-frontend/assets/helpers/urls/routes.ts
@@ -37,8 +37,8 @@ const routes = {
 	guardianWeeklySubscriptionLandingGift: '/subscribe/weekly/gift',
 	guardianWeeklyStudentUK:
 		'https://connect.studentbeans.com/v4/hosted/the-guardian-weekly/uk',
-  guardianWeeklyStudentAU:
-    'https://connect.studentbeans.com/v4/hosted/the-guardian-weekly/au',
+	guardianWeeklyStudentAU:
+		'https://connect.studentbeans.com/v4/hosted/the-guardian-weekly/au',
 	postcodeLookup: '/postcode-lookup',
 	createSignInUrl: '/identity/signin-url',
 	stripeSetupIntentRecaptcha: '/stripe/create-setup-intent/recaptcha',

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -7,14 +7,15 @@ import headerWithCountrySwitcherContainer from 'components/headers/header/header
 import Block from 'components/page/block';
 import Page from 'components/page/page';
 import GiftNonGiftCta from 'components/product/giftNonGiftCta';
+import type { CountryGroupId} from 'helpers/internationalisation/countryGroup';
 import {
-	AUDCountries,
-	Canada,
-	EURCountries,
-	GBPCountries,
-	International,
-	NZDCountries,
-	UnitedStates,
+  AUDCountries,
+  Canada,
+  EURCountries,
+  GBPCountries,
+  International,
+  NZDCountries,
+  UnitedStates,
 } from 'helpers/internationalisation/countryGroup';
 import { setUpTrackingAndConsents } from 'helpers/page/page';
 import { getPromotionCopy } from 'helpers/productPrice/promotions';
@@ -96,10 +97,10 @@ function WeeklyLPContent({
 							href={giftNonGiftLink}
 							orderIsAGift={orderIsAGift}
 						/>
-						{countryGroupId === 'GBPCountries' && (
+						{(countryGroupId === 'GBPCountries'|| countryGroupId === 'AUDCountries')&& (
 							<GiftNonGiftCta
 								product="Student"
-								href={routes.guardianWeeklyStudent}
+								href={getStudentBeanLink(countryGroupId)}
 								orderIsAGift={orderIsAGift}
 								isStudent={true}
 							/>
@@ -109,6 +110,14 @@ function WeeklyLPContent({
 			</FullWidthContainer>
 		</Page>
 	);
+}
+
+
+function getStudentBeanLink(countryGroupId: CountryGroupId) {
+  if (countryGroupId === 'AUDCountries') {
+    return routes.guardianWeeklyStudentAU;
+  }
+    return routes.guardianWeeklyStudentUK;
 }
 
 // ----- Render ----- //

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -7,15 +7,15 @@ import headerWithCountrySwitcherContainer from 'components/headers/header/header
 import Block from 'components/page/block';
 import Page from 'components/page/page';
 import GiftNonGiftCta from 'components/product/giftNonGiftCta';
-import type { CountryGroupId} from 'helpers/internationalisation/countryGroup';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
-  AUDCountries,
-  Canada,
-  EURCountries,
-  GBPCountries,
-  International,
-  NZDCountries,
-  UnitedStates,
+	AUDCountries,
+	Canada,
+	EURCountries,
+	GBPCountries,
+	International,
+	NZDCountries,
+	UnitedStates,
 } from 'helpers/internationalisation/countryGroup';
 import { setUpTrackingAndConsents } from 'helpers/page/page';
 import { getPromotionCopy } from 'helpers/productPrice/promotions';
@@ -97,7 +97,8 @@ function WeeklyLPContent({
 							href={giftNonGiftLink}
 							orderIsAGift={orderIsAGift}
 						/>
-						{(countryGroupId === 'GBPCountries'|| countryGroupId === 'AUDCountries')&& (
+						{(countryGroupId === 'GBPCountries' ||
+							countryGroupId === 'AUDCountries') && (
 							<GiftNonGiftCta
 								product="Student"
 								href={getStudentBeanLink(countryGroupId)}
@@ -112,12 +113,11 @@ function WeeklyLPContent({
 	);
 }
 
-
 function getStudentBeanLink(countryGroupId: CountryGroupId) {
-  if (countryGroupId === 'AUDCountries') {
-    return routes.guardianWeeklyStudentAU;
-  }
-    return routes.guardianWeeklyStudentUK;
+	if (countryGroupId === 'AUDCountries') {
+		return routes.guardianWeeklyStudentAU;
+	}
+	return routes.guardianWeeklyStudentUK;
 }
 
 // ----- Render ----- //


### PR DESCRIPTION
**Co-authored by:** Andrew Howe-Ely and Lakshmi Pillai


## What are you doing in this PR?

Adding "Student dscounts" on to GW landing page for AUS 

[**Trello Card**](https://trello.com/c/40Out071/395-adding-student-dscounts-on-to-gw-landing-page-for-aus-s?filter=member:lakshmirpillai1)

## Why are you doing this?

Guardian Weekly’s student discount has been successful in the UK since launch last year. The Australia team have indicated they would like to launch it in their region as a test, with the aid of diversifying acquisition streams for GW. They see it as a first stepping point onto providing student discounts for Supporter+ etc.


## Screenshots

## Before Change

<img width="1241" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/41af6f45-6eb0-4c4e-b285-ddfadb322fc6">

## After Change
<img width="1241" alt="image" src="https://github.com/guardian/support-frontend/assets/73653255/3280ee6e-3455-4d7e-9653-b04e48516659">




