### PR TITLE
Generic Checkout : Order Summary Populated By ProductDescription.benefits

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -176,16 +176,16 @@ export function ContributionsOrderSummary({
 	const hasCheckList =
 		enableCheckList && (checkListData.length > 0 || !!productDescription);
 
-	const checkListDataFromBenefits = checkListFromBenefits(
-		productDescription?.benefits,
-	);
 	const checkList = hasCheckList && (
 		<CheckList
-			checkListData={checkListDataFromBenefits ?? checkListData}
+			checkListData={
+				checkListFromBenefits(productDescription?.benefits) ?? checkListData
+			}
 			style="compact"
 			iconColor={palette.brand[500]}
 		/>
 	);
+	const productName = productDescription?.label ?? description;
 
 	const formattedAmount = simpleFormatAmount(currency, amount);
 
@@ -204,7 +204,7 @@ export function ContributionsOrderSummary({
 			<hr css={hrCss} />
 			<div css={detailsSection}>
 				<div css={summaryRow}>
-					<p>{description}</p>
+					<p>{productName}</p>
 					{hasCheckList && (
 						<Button
 							priority="subdued"

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -16,6 +16,7 @@ import type { CheckListData } from 'components/checkList/checkList';
 import { CheckList } from 'components/checkList/checkList';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import type { Currency } from 'helpers/internationalisation/currency';
+import type { ProductDescription } from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
 
 const componentStyles = css`
@@ -122,6 +123,18 @@ const termsAndConditions = css`
 	}
 `;
 
+function checkListFromBenefits(
+	benefits: Array<{ copy: string; tooltip?: string }> | undefined,
+): CheckListData[] | undefined {
+	if (benefits) {
+		return benefits.map((benefit) => ({
+			isChecked: true,
+			text: benefit.copy,
+			strong: false,
+		}));
+	}
+}
+
 export type ContributionsOrderSummaryProps = {
 	description: string;
 	amount: number;
@@ -129,6 +142,7 @@ export type ContributionsOrderSummaryProps = {
 	currency: Currency;
 	enableCheckList: boolean;
 	checkListData: CheckListData[];
+	productDescription?: ProductDescription;
 	paymentFrequency?: string;
 	onCheckListToggle?: (opening: boolean) => void;
 	headerButton?: React.ReactNode;
@@ -137,7 +151,6 @@ export type ContributionsOrderSummaryProps = {
 	showTopUpAmounts?: boolean;
 	topUpToggleChecked?: boolean;
 	topUpToggleOnChange?: () => void;
-	productDescription?: { description: string; frequency: string };
 };
 
 const visuallyHiddenCss = css`
@@ -151,6 +164,7 @@ export function ContributionsOrderSummary({
 	currency,
 	paymentFrequency,
 	checkListData,
+	productDescription,
 	onCheckListToggle,
 	headerButton,
 	tsAndCs,
@@ -159,10 +173,15 @@ export function ContributionsOrderSummary({
 }: ContributionsOrderSummaryProps): JSX.Element {
 	const [showCheckList, setCheckList] = useState(false);
 
-	const hasCheckList = enableCheckList && checkListData.length > 0;
+	const hasCheckList =
+		enableCheckList && (checkListData.length > 0 || !!productDescription);
+
+	const checkListDataFromBenefits = checkListFromBenefits(
+		productDescription?.benefits,
+	);
 	const checkList = hasCheckList && (
 		<CheckList
-			checkListData={checkListData}
+			checkListData={checkListDataFromBenefits ?? checkListData}
 			style="compact"
 			iconColor={palette.brand[500]}
 		/>

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -16,7 +16,6 @@ import type { CheckListData } from 'components/checkList/checkList';
 import { CheckList } from 'components/checkList/checkList';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import type { Currency } from 'helpers/internationalisation/currency';
-import type { ProductDescription } from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
 
 const componentStyles = css`
@@ -123,18 +122,6 @@ const termsAndConditions = css`
 	}
 `;
 
-function checkListFromBenefits(
-	benefits: Array<{ copy: string; tooltip?: string }> | undefined,
-): CheckListData[] | undefined {
-	if (benefits) {
-		return benefits.map((benefit) => ({
-			isChecked: true,
-			text: benefit.copy,
-			strong: false,
-		}));
-	}
-}
-
 export type ContributionsOrderSummaryProps = {
 	description: string;
 	amount: number;
@@ -142,7 +129,6 @@ export type ContributionsOrderSummaryProps = {
 	currency: Currency;
 	enableCheckList: boolean;
 	checkListData: CheckListData[];
-	productDescription?: ProductDescription;
 	paymentFrequency?: string;
 	onCheckListToggle?: (opening: boolean) => void;
 	headerButton?: React.ReactNode;
@@ -151,6 +137,7 @@ export type ContributionsOrderSummaryProps = {
 	showTopUpAmounts?: boolean;
 	topUpToggleChecked?: boolean;
 	topUpToggleOnChange?: () => void;
+	productDescription?: { description: string; frequency: string };
 };
 
 const visuallyHiddenCss = css`
@@ -164,7 +151,6 @@ export function ContributionsOrderSummary({
 	currency,
 	paymentFrequency,
 	checkListData,
-	productDescription,
 	onCheckListToggle,
 	headerButton,
 	tsAndCs,
@@ -173,19 +159,14 @@ export function ContributionsOrderSummary({
 }: ContributionsOrderSummaryProps): JSX.Element {
 	const [showCheckList, setCheckList] = useState(false);
 
-	const hasCheckList =
-		enableCheckList && (checkListData.length > 0 || !!productDescription);
-
+	const hasCheckList = enableCheckList && checkListData.length > 0;
 	const checkList = hasCheckList && (
 		<CheckList
-			checkListData={
-				checkListFromBenefits(productDescription?.benefits) ?? checkListData
-			}
+			checkListData={checkListData}
 			style="compact"
 			iconColor={palette.brand[500]}
 		/>
 	);
-	const productName = productDescription?.label ?? description;
 
 	const formattedAmount = simpleFormatAmount(currency, amount);
 
@@ -204,7 +185,7 @@ export function ContributionsOrderSummary({
 			<hr css={hrCss} />
 			<div css={detailsSection}>
 				<div css={summaryRow}>
-					<p>{productName}</p>
+					<p>{description}</p>
 					{hasCheckList && (
 						<Button
 							priority="subdued"

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -584,8 +584,10 @@ export function Checkout() {
 									paymentFrequency={paymentFrequency}
 									amount={price}
 									currency={currency}
-									checkListData={[]}
-									productDescription={productDescription}
+									checkListData={productDescription.benefits.map((benefit) => ({
+										isChecked: true,
+										text: benefit.copy,
+									}))}
 									onCheckListToggle={(isOpen) => {
 										trackComponentClick(
 											`contribution-order-summary-${

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -538,6 +538,7 @@ export function Checkout() {
 									amount={price}
 									currency={currency}
 									checkListData={[]}
+									productDescription={productDescription}
 									onCheckListToggle={(isOpen) => {
 										trackComponentClick(
 											`contribution-order-summary-${


### PR DESCRIPTION
## What are you doing in this PR?
Generic order Summary Populated By ProductDescription.benefits & ProductionDescription.label.

Limitations (seperate PR if deemed necessary)->
1. Does not match current checkout summary text, matches ProductDescription benefits list in TierCards only.
2. No bold, styling not defined on ProductDescription benefits 
3. No disabled/enabled extra benefit summary lines, styling not defined on ProductDescription benefits 

|Contributions|S+|
|------|------|
|![image](https://github.com/guardian/support-frontend/assets/76729591/0aaf00d3-21b3-4b3d-993a-c7f274f58e5d)|![image](https://github.com/guardian/support-frontend/assets/76729591/fea100f2-8ede-401a-bbb0-ca24752b6565)|

[**Trello Card**](https://trello.com/c/UskqYuJO/805-run-a-b-test-that-changes-the-link-on-the-third-tier-card-to-generic-checkout)

## How to test
https://support.thegulocal.com/uk/contribute#ab-useGenericCheckout=variant