### PR TITLE
feat: add processingPayment to checkout

### DIFF
--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -235,7 +235,7 @@ export type PaymentResult = {
 	error?: ErrorReason;
 };
 
-type StatusResponse = {
+export type StatusResponse = {
 	status: Status;
 	trackingUri: string;
 	failureReason?: ErrorReason;


### PR DESCRIPTION
Part of #5722 

Adds rudimentary payment processing to the checkout form.

This functionality is analogous to the [`readerRevenueApis`](https://github.com/guardian/support-frontend/blob/main/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts#L329), but I feel a little simpler. 

[**Trello Card**](https://trello.com/c/AE1eUern/799-add-loading-state-to-checkout)

https://github.com/guardian/support-frontend/assets/31692/56758192-74ce-4355-bf2f-e203251c3621

