### PR TITLE
Run integration tests every 6 hours

### DIFF
--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -40,7 +40,7 @@ Resources:
         RerunTests:
           Type: Schedule
           Properties:
-            Schedule: 'rate(1 hour)'
+            Schedule: 'rate(6 hour)'
             Description: run the tests regularly so we know if they're broken
       EventInvokeConfig:
         MaximumRetryAttempts: 0

--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -40,7 +40,7 @@ Resources:
         RerunTests:
           Type: Schedule
           Properties:
-            Schedule: 'rate(6 hour)'
+            Schedule: 'rate(6 hours)'
             Description: run the tests regularly so we know if they're broken
       EventInvokeConfig:
         MaximumRetryAttempts: 0


### PR DESCRIPTION
Currently these run hourly.
There's a limit on salesforce records in the sandbox, and zuora will also be enforcing limits soon.
Reducing integration test runs will help reduce our usage