### PR TITLE
Use react router for landing => checkout => thank-you route

### DIFF
--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - name: Cache dependencies
@@ -36,6 +36,6 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           cwd: "./support-frontend"
-          pattern: "./public/compiled-assets/{javascripts,webpack}/*.js"
+          pattern: "./public/compiled-assets/{javascripts,webpack}/**/*.js"
           build-script: "build-github-action"
           minimum-change-threshold: 500

--- a/docs/adrs/2024-04-29-re-introducing-react-router.md
+++ b/docs/adrs/2024-04-29-re-introducing-react-router.md
@@ -1,0 +1,67 @@
+*Service:* support-frontend
+*Status:* accepted
+
+## Context
+
+We need to be able to access a thank you page for the [generic checkout](https://github.com/guardian/support-frontend/issues/5722) to route to after purchase.
+
+[Currently the generic checkout uses routing via Play framework][play-routes] [which][play-controller-render] [renders][play-html] a [`webpack.entryPoint`][webpack-entrypoint] for that [singular component][checkout-component].
+
+We currently have multiple ways of doing this. Both introduce complexity at different level. This ADR aims to choose one, hopefuly leading to deprecating the other, and help with decision making in the future.
+
+
+### Options
+
+#### Create a `/thank-you` play route
+
+This adds extra code and complexity at the `Request --> PlayApp --> PlayRoute` step.
+
+This is what we do with paper products by separating the `FormController` from the `LandingPageController`.
+e.g. [`PaperSubscriptionController` and `PaperSubscriptionFormController`](https://github.com/guardian/support-frontend/blob/b31dd3d73ad91313bac10e48a640d13d2656a264/support-frontend/conf/routes#L122-L123)
+
+##### Drawbacks
+- Maintains the need to context switch between Play and React when working on routing
+
+
+#### Use react-router
+
+This adds extra code and complexity at the `Request --> PlayApp --> PlayRoute --> PlayTemplate --> renderComponent` step.
+
+This is what we currently do with [`supporterPlusRouter`](https://github.com/guardian/support-frontend/blob/b31dd3d73ad91313bac10e48a640d13d2656a264/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx#L99-L142).
+
+##### Drawbacks
+- Potential for overloading the router and bloating the JS sent down the pipes. This could be mitigated via [code-splitting](https://v5.reactrouter.com/web/guides/code-splitting) or creating multiple routers.
+
+
+
+## Decision
+We are choosing to go with `react-router` as it feels like the complexity added is minimal and the need to switch between Scala/Play and React is minimised.
+
+This is inline with the goals for the checkout reducing complexity and decrease time-to-change.
+
+## Consequences
+
+- The bundle size increases
+- There more complexity in the request flow
+- But less complexity in changing routes in future
+
+[^1]: Current vs Proposed solution
+
+```mermaid
+flowchart TB
+    Request --> PaperLandingRoute["PaperRoute(/paper)"] --> PaperLandingController --> PaperLandingTemplate --> webpack.entryPoint.paperLanding --> renderPaperLanding
+    Request --> PaperCheckoutRoute["PlayRoute(/paper/checkout)"] --> PaperCheckoutController --> PaperCheckoutTemplate --> webpack.entryPoint.paperCheckout --> renderPaperCheckout
+    
+    RequestB --> ContributionLandingRoute["ContributionRoute(/contribution)"] --> ContributionController --> ContributionTemplate --> webpack.entryPoint.contributionRouter --> renderRouter
+    renderRouter --> /landing
+    renderRouter --> /checkout
+    renderRouter --> /thank-you
+``` 
+
+---
+
+[play-routes]: https://github.com/guardian/support-frontend/blob/b31dd3d73ad91313bac10e48a640d13d2656a264/support-frontend/conf/routes#L92-L93
+[play-controller-render]: https://github.com/guardian/support-frontend/blob/b31dd3d73ad91313bac10e48a640d13d2656a264/support-frontend/app/controllers/Application.scala#L285
+[play-html]: https://github.com/guardian/support-frontend/blob/b31dd3d73ad91313bac10e48a640d13d2656a264/support-frontend/app/views/checkout.scala.html#L24
+[webpack-entrypoint]: https://github.com/guardian/support-frontend/blob/b31dd3d73ad91313bac10e48a640d13d2656a264/support-frontend/webpack.entryPoints.js#L3
+[checkout-component]: https://github.com/guardian/support-frontend/blob/b31dd3d73ad91313bac10e48a640d13d2656a264/support-frontend/assets/pages/%5BcountryGroupId%5D/checkout.tsx#L620-L624

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -276,7 +276,7 @@ class Application(
     }
   }
 
-  def checkout(countryGroupId: String): Action[AnyContent] = MaybeAuthenticatedAction { implicit request =>
+  def router(countryGroupId: String): Action[AnyContent] = MaybeAuthenticatedAction { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
 
     val geoData = request.geoData
@@ -287,7 +287,7 @@ class Application(
     val productCatalog = cachedProductCatalogServiceProvider.forUser(isTestUser).get()
 
     Ok(
-      views.html.checkout(
+      views.html.router(
         geoData = geoData,
         paymentMethodConfigs = PaymentMethodConfigs(
           oneOffDefaultStripeConfig = oneOffStripeConfigProvider.get(false),

--- a/support-frontend/app/views/router.scala.html
+++ b/support-frontend/app/views/router.scala.html
@@ -21,7 +21,7 @@
 @main(
   title = "Support the Guardian | Checkout",
   mainElement = EmptyDiv("checkout"),
-  mainJsBundle = Left(RefPath("[countryGroupId]/checkout.js")),
+  mainJsBundle = Left(RefPath("[countryGroupId]/router.js")),
   mainStyleBundle = Right(StyleContent(Html(""))),
   description = Some("Help us deliver the independent journalism the world needs. Support the Guardian by making a contribution."),
   canonicalLink = Some("https://support.theguardian.com/checkout"),

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -25,7 +25,6 @@ import {
 	useStripe,
 } from '@stripe/react-stripe-js';
 import { useEffect, useRef, useState } from 'react';
-import { parse, picklist } from 'valibot'; // 1.54 kB
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { CheckoutHeading } from 'components/checkoutHeading/checkoutHeading';
 import DirectDebitForm from 'components/directDebit/directDebitForm/directDebitForm';
@@ -66,19 +65,17 @@ import { getStripeKey } from 'helpers/forms/stripe';
 import { validateWindowGuardian } from 'helpers/globalsAndSwitches/window';
 import CountryHelper from 'helpers/internationalisation/classes/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import type { Currency } from 'helpers/internationalisation/currency';
-import { currencies } from 'helpers/internationalisation/currency';
 import { productCatalogDescription } from 'helpers/productCatalog';
 import { NoFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
-import { renderPage } from 'helpers/rendering/render';
 import { get } from 'helpers/storage/cookie';
 import {
 	getOphanIds,
 	getReferrerAcquisitionData,
 } from 'helpers/tracking/acquisitions';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
+import type { GeoId } from 'pages/geoIdConfig';
+import { getGeoIdConfig } from 'pages/geoIdConfig';
 import { CheckoutDivider } from 'pages/supporter-plus-landing/components/checkoutDivider';
 import { GuardianTsAndCs } from 'pages/supporter-plus-landing/components/guardianTsAndCs';
 
@@ -88,73 +85,11 @@ validateWindowGuardian(window.guardian);
 const isTestUser = true as boolean;
 const csrf = window.guardian.csrf.token;
 
-/** Geo */
-const geoIds = ['uk', 'us', 'eu', 'au', 'nz', 'ca', 'int'] as const;
-const GeoIdSchema = picklist(geoIds);
-const geoId = parse(GeoIdSchema, window.location.pathname.split('/')[1]);
-
-let currency: Currency;
-let currencyKey: keyof typeof currencies;
-let countryGroupId: CountryGroupId;
-switch (geoId) {
-	case 'uk':
-		currency = currencies.GBP;
-		currencyKey = 'GBP';
-		countryGroupId = 'GBPCountries';
-		break;
-	case 'us':
-		currency = currencies.USD;
-		currencyKey = 'USD';
-		countryGroupId = 'UnitedStates';
-		break;
-	case 'au':
-		currency = currencies.AUD;
-		currencyKey = 'AUD';
-		countryGroupId = 'AUDCountries';
-		break;
-	case 'eu':
-		currency = currencies.EUR;
-		currencyKey = 'EUR';
-		countryGroupId = 'EURCountries';
-		break;
-	case 'nz':
-		currency = currencies.NZD;
-		currencyKey = 'NZD';
-		countryGroupId = 'NZDCountries';
-		break;
-	case 'ca':
-		currency = currencies.CAD;
-		currencyKey = 'CAD';
-		countryGroupId = 'Canada';
-		break;
-	case 'int':
-		currency = currencies.USD;
-		currencyKey = 'USD';
-		countryGroupId = 'International';
-		break;
-}
-
 const isSignedIn = !!get('GU_U');
 const countryId: IsoCountry =
 	CountryHelper.fromString(get('GU_country') ?? 'GB') ?? 'GB';
 
 const productCatalog = window.guardian.productCatalog;
-
-/** Page config - this is setup specifically for the checkout page */
-function isNumeric(str: string) {
-	return !isNaN(parseFloat(str));
-}
-
-const searchParams = new URLSearchParams(window.location.search);
-const searchParamsPrice = searchParams.get('price');
-const query = {
-	product: searchParams.get('product') ?? '',
-	ratePlan: searchParams.get('ratePlan') ?? '',
-	price:
-		searchParamsPrice && isNumeric(searchParamsPrice)
-			? parseFloat(searchParamsPrice)
-			: undefined,
-};
 
 /** Page styles - styles used specifically for the checkout page */
 const darkBackgroundContainerMobile = css`
@@ -195,146 +130,11 @@ const legend = css`
 	}
 `;
 
-const validPaymentMethods = [
-	countryGroupId === 'EURCountries' && Sepa,
-	countryId === 'GB' && DirectDebit,
-	// TODO - ONE_OFF support - ☝️ these will be inactivated for ONE_OFF payments
-	Stripe,
-	PayPal,
-	countryId === 'US' && AmazonPay,
-].filter(isPaymentMethod);
-
-const stripePublicKey = getStripeKey(
-	// TODO - ONE_OFF support - This will need to be ONE_OFF when we support it
-	'REGULAR',
-	countryId,
-	currencyKey,
-	isTestUser,
-);
-
-/**
- * Product config - we check that the querystring returns a product, ratePlan and price
- */
-const productId = query.product in productCatalog ? query.product : undefined;
-const product = productId ? productCatalog[query.product] : undefined;
-const ratePlan = product?.ratePlans[query.ratePlan];
-const price = query.price ?? ratePlan?.pricing[currencyKey];
-const supporterPlusRatePlanPrice =
-	productCatalog.SupporterPlus.ratePlans[query.ratePlan].pricing[currencyKey];
-
-/**
- * Is It a Contribution? URL queryPrice supplied?
- *    If queryPrice above ratePlanPrice, in a upgrade to S+ country, invalid amount
- */
-let isInvalidAmount = false;
-if (productId === 'Contribution' && query.price) {
-	const { selectedAmountsVariant } = getAmountsTestVariant(
-		countryId,
-		countryGroupId,
-		window.guardian.settings,
-	);
-	if (query.price < 1) {
-		isInvalidAmount = true;
-	}
-	if (!isContributionsOnlyCountry(selectedAmountsVariant)) {
-		if (query.price >= supporterPlusRatePlanPrice) {
-			isInvalidAmount = true;
-		}
-	}
-}
-
-/**
- * Is It a SupporterPlus? URL queryPrice supplied?
- *    If queryPrice below S+ ratePlanPrice, invalid amount
- */
-if (productId === 'SupporterPlus' && query.price) {
-	if (query.price < supporterPlusRatePlanPrice) {
-		isInvalidAmount = true;
-	}
-}
-
-const productDescription = productId
-	? productCatalogDescription[productId]
-	: undefined;
-const ratePlanDescription = productDescription?.ratePlans[query.ratePlan];
-
-/**
- * This is the data structure used by the `/subscribe/create` endpoint.
- *
- * This must match the types in `CreateSupportWorkersRequest#product`
- * and readerRevenueApis - `RegularPaymentRequest#product`.
- *
- * We might be able to defer this to the backend.
- */
-let productFields: RegularPaymentRequest['product'] | undefined;
-if (ratePlanDescription) {
-	if (productId === 'Contribution') {
-		productFields = {
-			productType: 'Contribution',
-			currency: currencyKey,
-			billingPeriod: ratePlanDescription.billingPeriod,
-			amount: query.price ?? 0,
-		};
-	} else if (productId === 'SupporterPlus') {
-		productFields = {
-			productType: 'SupporterPlus',
-			currency: currencyKey,
-			billingPeriod: ratePlanDescription.billingPeriod,
-			amount: query.price ?? 0,
-		};
-	} else if (productId === 'GuardianWeeklyDomestic') {
-		productFields = {
-			productType: 'GuardianWeekly',
-			currency: currencyKey,
-			fulfilmentOptions: 'Domestic',
-			billingPeriod: ratePlanDescription.billingPeriod,
-		};
-	} else if (productId === 'GuardianWeeklyRestOfWorld') {
-		productFields = {
-			productType: 'GuardianWeekly',
-			fulfilmentOptions: 'RestOfWorld',
-			currency: currencyKey,
-			billingPeriod: ratePlanDescription.billingPeriod,
-		};
-	} else if (productId === 'DigitalSubscription') {
-		productFields = {
-			productType: 'DigitalPack',
-			currency: currencyKey,
-			billingPeriod: ratePlanDescription.billingPeriod,
-			// TODO - this needs filling in properly, I am not sure where this value comes from
-			readerType: 'Direct',
-		};
-	} else if (
-		productId === 'NationalDelivery' ||
-		productId === 'SubscriptionCard' ||
-		productId === 'HomeDelivery'
-	) {
-		productFields = {
-			productType: 'Paper',
-			currency: currencyKey,
-			billingPeriod: ratePlanDescription.billingPeriod,
-			// TODO - this needs filling in properly
-			fulfilmentOptions: NoFulfilmentOptions,
-			productOptions: NoProductOptions,
-		};
-	}
-}
-
-/** These are just some values needed for rendering */
-let paymentFrequency: 'year' | 'month' | 'quarter';
-if (ratePlanDescription?.billingPeriod === 'Annual') {
-	paymentFrequency = 'year';
-} else if (ratePlanDescription?.billingPeriod === 'Monthly') {
-	paymentFrequency = 'month';
-} else {
-	paymentFrequency = 'quarter';
-}
-
-const processPayment = (statusResponse: StatusResponse) => {
+const processPayment = (statusResponse: StatusResponse, geoId: GeoId) => {
 	const { trackingUri, status, failureReason } = statusResponse;
 	const jobId = new URL(trackingUri).searchParams.get('jobId') ?? '';
 	if (status === 'success') {
-		window.location.href = `uk/thank-you?jobId=${jobId}`;
+		window.location.href = `/${geoId}/thank-you?jobId=${jobId}`;
 	} else if (status === 'failure') {
 		console.error(failureReason);
 	} else {
@@ -346,13 +146,104 @@ const processPayment = (statusResponse: StatusResponse) => {
 			})
 				.then((response) => response.json())
 				.then((json) => {
-					processPayment(json as StatusResponse);
+					void processPayment(json as StatusResponse, geoId);
 				});
 		}, 1000);
 	}
 };
 
-export function Checkout() {
+/** QueryString - this is setup specifically for the checkout page */
+function isNumeric(str: string) {
+	return !isNaN(parseFloat(str));
+}
+const searchParams = new URLSearchParams(window.location.search);
+const searchParamsPrice = searchParams.get('price');
+const query = {
+	product: searchParams.get('product') ?? '',
+	ratePlan: searchParams.get('ratePlan') ?? '',
+	price:
+		searchParamsPrice && isNumeric(searchParamsPrice)
+			? parseFloat(searchParamsPrice)
+			: undefined,
+};
+
+type Props = {
+	geoId: GeoId;
+};
+function CheckoutComponent({ geoId }: Props) {
+	const { currency, currencyKey, countryGroupId } = getGeoIdConfig(geoId);
+	const productId = query.product in productCatalog ? query.product : undefined;
+	const product = productId ? productCatalog[query.product] : undefined;
+	const ratePlan = product?.ratePlans[query.ratePlan];
+	const price = query.price ?? ratePlan?.pricing[currencyKey];
+
+	const productDescription = productId
+		? productCatalogDescription[productId]
+		: undefined;
+	const ratePlanDescription = productDescription?.ratePlans[query.ratePlan];
+
+	/**
+	 * This is the data structure used by the `/subscribe/create` endpoint.
+	 *
+	 * This must match the types in `CreateSupportWorkersRequest#product`
+	 * and readerRevenueApis - `RegularPaymentRequest#product`.
+	 *
+	 * We might be able to defer this to the backend.
+	 */
+	let productFields: RegularPaymentRequest['product'] | undefined;
+	if (ratePlanDescription) {
+		if (productId === 'Contribution') {
+			productFields = {
+				productType: 'Contribution',
+				currency: currencyKey,
+				billingPeriod: ratePlanDescription.billingPeriod,
+				amount: query.price ?? 0,
+			};
+		} else if (productId === 'SupporterPlus') {
+			productFields = {
+				productType: 'SupporterPlus',
+				currency: currencyKey,
+				billingPeriod: ratePlanDescription.billingPeriod,
+				amount: query.price ?? 0,
+			};
+		} else if (productId === 'GuardianWeeklyDomestic') {
+			productFields = {
+				productType: 'GuardianWeekly',
+				currency: currencyKey,
+				fulfilmentOptions: 'Domestic',
+				billingPeriod: ratePlanDescription.billingPeriod,
+			};
+		} else if (productId === 'GuardianWeeklyRestOfWorld') {
+			productFields = {
+				productType: 'GuardianWeekly',
+				fulfilmentOptions: 'RestOfWorld',
+				currency: currencyKey,
+				billingPeriod: ratePlanDescription.billingPeriod,
+			};
+		} else if (productId === 'DigitalSubscription') {
+			productFields = {
+				productType: 'DigitalPack',
+				currency: currencyKey,
+				billingPeriod: ratePlanDescription.billingPeriod,
+				// TODO - this needs filling in properly, I am not sure where this value comes from
+				readerType: 'Direct',
+			};
+		} else if (
+			productId === 'NationalDelivery' ||
+			productId === 'SubscriptionCard' ||
+			productId === 'HomeDelivery'
+		) {
+			productFields = {
+				productType: 'Paper',
+				currency: currencyKey,
+				billingPeriod: ratePlanDescription.billingPeriod,
+				// TODO - this needs filling in properly
+				fulfilmentOptions: NoFulfilmentOptions,
+				productOptions: NoProductOptions,
+			};
+		}
+	}
+
 	if (
 		/** These are all the things we need to parse the page */
 		!(
@@ -371,6 +262,46 @@ export function Checkout() {
 		);
 	}
 
+	/**
+	 * Is It a Contribution? URL queryPrice supplied?
+	 *    If queryPrice above ratePlanPrice, in a upgrade to S+ country, invalid amount
+	 */
+	let isInvalidAmount = false;
+	if (productId === 'Contribution' && query.price) {
+		const supporterPlusRatePlanPrice =
+			productCatalog.SupporterPlus.ratePlans[query.ratePlan].pricing[
+				currencyKey
+			];
+
+		const { selectedAmountsVariant } = getAmountsTestVariant(
+			countryId,
+			countryGroupId,
+			window.guardian.settings,
+		);
+		if (query.price < 1) {
+			isInvalidAmount = true;
+		}
+		if (!isContributionsOnlyCountry(selectedAmountsVariant)) {
+			if (query.price >= supporterPlusRatePlanPrice) {
+				isInvalidAmount = true;
+			}
+		}
+	}
+
+	/**
+	 * Is It a SupporterPlus? URL queryPrice supplied?
+	 *    If queryPrice below S+ ratePlanPrice, invalid amount
+	 */
+	if (productId === 'SupporterPlus' && query.price) {
+		const supporterPlusRatePlanPrice =
+			productCatalog.SupporterPlus.ratePlans[query.ratePlan].pricing[
+				currencyKey
+			];
+
+		if (query.price < supporterPlusRatePlanPrice) {
+			isInvalidAmount = true;
+		}
+	}
 	if (isInvalidAmount) {
 		return (
 			<div>
@@ -380,15 +311,29 @@ export function Checkout() {
 		);
 	}
 
+	const validPaymentMethods = [
+		countryGroupId === 'EURCountries' && Sepa,
+		countryId === 'GB' && DirectDebit,
+		// TODO - ONE_OFF support - ☝️ these will be inactivated for ONE_OFF payments
+		Stripe,
+		PayPal,
+		countryId === 'US' && AmazonPay,
+	].filter(isPaymentMethod);
+
 	// TODO - ONE_OFF support, this should be false when ONE_OFF
 	const showStateSelect =
 		countryId === 'US' || countryId === 'CA' || countryId === 'AU';
 
-	const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | null>(
-		null,
-	);
+	const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>();
 
 	/** Payment methods: Stripe */
+	const stripePublicKey = getStripeKey(
+		// TODO - ONE_OFF support - This will need to be ONE_OFF when we support it
+		'REGULAR',
+		countryId,
+		currencyKey,
+		isTestUser,
+	);
 	const stripe = useStripe();
 	const elements = useElements();
 	const cardElement = elements?.getElement(CardNumberElement);
@@ -588,7 +533,7 @@ export function Checkout() {
 				.then((response) => response.json())
 				.then((json) => json as StatusResponse);
 
-			processPayment(createSubscriptionResult);
+			processPayment(createSubscriptionResult, geoId);
 		} else {
 			setIsProcessingPayment(false);
 		}
@@ -617,7 +562,13 @@ export function Checkout() {
 							<BoxContents>
 								<ContributionsOrderSummary
 									description={productDescription.label}
-									paymentFrequency={paymentFrequency}
+									paymentFrequency={
+										ratePlanDescription.billingPeriod === 'Annual'
+											? 'year'
+											: ratePlanDescription.billingPeriod === 'Monthly'
+											? 'month'
+											: 'quarter'
+									}
 									amount={price}
 									currency={currency}
 									checkListData={[]}
@@ -1096,8 +1047,19 @@ export function Checkout() {
 	);
 }
 
-export default renderPage(
-	<StripeElements key={stripePublicKey} stripeKey={stripePublicKey}>
-		<Checkout />
-	</StripeElements>,
-);
+export function Checkout({ geoId }: Props) {
+	const { currencyKey } = getGeoIdConfig(geoId);
+	const stripePublicKey = getStripeKey(
+		// TODO - ONE_OFF support - This will need to be ONE_OFF when we support it
+		'REGULAR',
+		countryId,
+		currencyKey,
+		isTestUser,
+	);
+
+	return (
+		<StripeElements key={stripePublicKey} stripeKey={stripePublicKey}>
+			<CheckoutComponent geoId={geoId} />
+		</StripeElements>
+	);
+}

--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -4,18 +4,16 @@ import { geoIds } from 'pages/geoIdConfig';
 import { Checkout } from './checkout';
 
 const router = createBrowserRouter(
-	geoIds
-		.map((geoId) => [
-			{
-				path: `/${geoId}/checkout`,
-				element: <Checkout geoId={geoId} />,
-			},
-			{
-				path: `/${geoId}/thank-you`,
-				element: <div>Thanks!</div>,
-			},
-		])
-		.flat(),
+	geoIds.flatMap((geoId) => [
+		{
+			path: `/${geoId}/checkout`,
+			element: <Checkout geoId={geoId} />,
+		},
+		{
+			path: `/${geoId}/thank-you`,
+			element: <div>Thanks!</div>,
+		},
+	]),
 );
 
 function Router() {

--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -1,0 +1,25 @@
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { renderPage } from 'helpers/rendering/render';
+import { geoIds } from 'pages/geoIdConfig';
+import { Checkout } from './checkout';
+
+const router = createBrowserRouter(
+	geoIds
+		.map((geoId) => [
+			{
+				path: `/${geoId}/checkout`,
+				element: <Checkout geoId={geoId} />,
+			},
+			{
+				path: `/${geoId}/thank-you`,
+				element: <div>Thanks!</div>,
+			},
+		])
+		.flat(),
+);
+
+function Router() {
+	return <RouterProvider router={router} />;
+}
+
+export default renderPage(<Router />);

--- a/support-frontend/assets/pages/geoIdConfig.ts
+++ b/support-frontend/assets/pages/geoIdConfig.ts
@@ -1,0 +1,73 @@
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import type { Currency } from 'helpers/internationalisation/currency';
+import { currencies } from 'helpers/internationalisation/currency';
+
+type GeoIdConfig = {
+	currency: Currency;
+	currencyKey: keyof typeof currencies;
+	countryGroupId: CountryGroupId;
+};
+
+export const geoIds = ['uk', 'us', 'eu', 'au', 'nz', 'ca', 'int'] as const;
+export type GeoId = (typeof geoIds)[number];
+
+/**
+ * This method takes in the first URL segment (geoId) and returns static config
+ * that varies on that segment and returns config used on all pages.
+ *
+ * This config value is intentially sparse to avoid overloading it with data that is
+ * for a more specific use, in which case, you should try keep the data fetching closer
+ * to that usecase.
+ */
+export const getGeoIdConfig = (geoId: GeoId): GeoIdConfig => {
+	switch (geoId) {
+		case 'uk':
+			return {
+				currency: currencies.GBP,
+				currencyKey: 'GBP',
+				countryGroupId: 'GBPCountries',
+			};
+
+		case 'us':
+			return {
+				currency: currencies.USD,
+				currencyKey: 'USD',
+				countryGroupId: 'UnitedStates',
+			};
+
+		case 'au':
+			return {
+				currency: currencies.AUD,
+				currencyKey: 'AUD',
+				countryGroupId: 'AUDCountries',
+			};
+
+		case 'eu':
+			return {
+				currency: currencies.EUR,
+				currencyKey: 'EUR',
+				countryGroupId: 'EURCountries',
+			};
+
+		case 'nz':
+			return {
+				currency: currencies.NZD,
+				currencyKey: 'NZD',
+				countryGroupId: 'NZDCountries',
+			};
+
+		case 'ca':
+			return {
+				currency: currencies.CAD,
+				currencyKey: 'CAD',
+				countryGroupId: 'Canada',
+			};
+
+		case 'int':
+			return {
+				currency: currencies.USD,
+				currencyKey: 'USD',
+				countryGroupId: 'International',
+			};
+	}
+};

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -90,7 +90,8 @@ GET  /subscribe                                                    controllers.S
 GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe                  controllers.SubscriptionsController.landing(country: String)
 
 # ----- Checkout ----- #
-GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/checkout            controllers.Application.checkout(countryGroupId: String)
+GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/checkout            controllers.Application.router(countryGroupId: String)
+GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/thank-you           controllers.Application.router(countryGroupId: String)
 
 # This is just a fallback in case someone accidentally uses an unsupported country-specific
 # subscribe route. We just redirect to the subscriptions site and let its geolocation handle it.

--- a/support-frontend/webpack.entryPoints.js
+++ b/support-frontend/webpack.entryPoints.js
@@ -1,26 +1,36 @@
 module.exports = {
-  common: {
-    '[countryGroupId]/checkout': 'pages/[countryGroupId]/checkout.tsx',
-    favicons: 'images/favicons.ts',
-    subscriptionsLandingPage: 'pages/subscriptions-landing/subscriptionsLanding.tsx',
-    supporterPlusLandingPage: 'pages/supporter-plus-landing/supporterPlusRouter.tsx',
-    paperSubscriptionLandingPage: 'pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx',
-    paperSubscriptionCheckoutPage: 'pages/paper-subscription-checkout/paperSubscriptionCheckout.tsx',
-    weeklySubscriptionLandingPage: 'pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx',
-    weeklySubscriptionCheckoutPage: 'pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx',
-    subscriptionsRedemptionPage: 'pages/subscriptions-redemption/subscriptionsRedemption.tsx',
-    digitalSubscriptionLandingPage: 'pages/digital-subscriber-checkout/digitalSubscriptionRouter.tsx',
-    payPalErrorPage: 'pages/paypal-error/payPalError.tsx',
-    payPalErrorPageStyles: 'pages/paypal-error/payPalError.scss',
-    error404Page: 'pages/error/error404.tsx',
-    error500Page: 'pages/error/error500.tsx',
-    downForMaintenancePage: 'pages/error/maintenance.tsx',
-    unsupportedBrowserStyles: 'stylesheets/fallback-pages/unsupportedBrowser.scss',
-    contributionsRedirectStyles: 'stylesheets/fallback-pages/contributionsRedirect.scss',
-    promotionTerms: 'pages/promotion-terms/promotionTerms.tsx',
-    ausMomentMap: 'pages/aus-moment-map/ausMomentMap.tsx',
-  },
-  ssr: {
-    ssrPages: 'helpers/rendering/ssrPages.ts',
-  },
+	common: {
+		'[countryGroupId]/router': 'pages/[countryGroupId]/router.tsx',
+		favicons: 'images/favicons.ts',
+		subscriptionsLandingPage:
+			'pages/subscriptions-landing/subscriptionsLanding.tsx',
+		supporterPlusLandingPage:
+			'pages/supporter-plus-landing/supporterPlusRouter.tsx',
+		paperSubscriptionLandingPage:
+			'pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx',
+		paperSubscriptionCheckoutPage:
+			'pages/paper-subscription-checkout/paperSubscriptionCheckout.tsx',
+		weeklySubscriptionLandingPage:
+			'pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx',
+		weeklySubscriptionCheckoutPage:
+			'pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx',
+		subscriptionsRedemptionPage:
+			'pages/subscriptions-redemption/subscriptionsRedemption.tsx',
+		digitalSubscriptionLandingPage:
+			'pages/digital-subscriber-checkout/digitalSubscriptionRouter.tsx',
+		payPalErrorPage: 'pages/paypal-error/payPalError.tsx',
+		payPalErrorPageStyles: 'pages/paypal-error/payPalError.scss',
+		error404Page: 'pages/error/error404.tsx',
+		error500Page: 'pages/error/error500.tsx',
+		downForMaintenancePage: 'pages/error/maintenance.tsx',
+		unsupportedBrowserStyles:
+			'stylesheets/fallback-pages/unsupportedBrowser.scss',
+		contributionsRedirectStyles:
+			'stylesheets/fallback-pages/contributionsRedirect.scss',
+		promotionTerms: 'pages/promotion-terms/promotionTerms.tsx',
+		ausMomentMap: 'pages/aus-moment-map/ausMomentMap.tsx',
+	},
+	ssr: {
+		ssrPages: 'helpers/rendering/ssrPages.ts',
+	},
 };


### PR DESCRIPTION
- Uses `react-router` to encapsulate the `landing => checkout => thank-you` journey
- Adds the concept `GeoIdConfig` which is config that is variable on the `/{geoId}` segment of the URL
- Changes the `checkout` name for the route to `router` in the play app
- Copy/pastes the values dependant on the `geoId` in the checkout component into the component

I'm doing this because when setting up a whole new route for the thank you page from Play => rendering, the boilerplate was becoming immense and unwieldy. This replicates the pattern we had setup for `/{geoId}/contribution` from [Play](https://github.com/guardian/support-frontend/blob/main/support-frontend/conf/routes#L57-L69) => [Router](https://github.com/guardian/support-frontend/blob/main/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx).

This also avoids having to spin up another `webpack.entryPoint`. A 🚤 performance-point 🚀  here 
 - this does mean that the entire journey is built into 1 file, which could also start to get too large. This is how we currently do it, but it made me think that we should be tracking this against the current checkout flow to ensure we're making improvements. I'm tracking that in [the Epic](https://github.com/guardian/support-frontend/issues/5722).

Part of #5722

```[tasklist]
### Tasks
- [x] Add ADR if we like this
``` 