### PR TITLE
feat: add recursive file matching on compressed-size action

### DIFF
--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - name: Cache dependencies
@@ -36,6 +36,6 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           cwd: "./support-frontend"
-          pattern: "./public/compiled-assets/{javascripts,webpack}/*.js"
+          pattern: "./public/compiled-assets/{javascripts,webpack}/**/*.js"
           build-script: "build-github-action"
           minimum-change-threshold: 500


### PR DESCRIPTION
Adds recursive file checking for our `comrpessed-size-action`. I need this because [we have added a folder structure in the `webpack.entryPoints` which was missing the new `checkout`](https://github.com/guardian/support-frontend/blob/main/support-frontend/webpack.entryPoints.js#L3).

## Now supports this
<img width="378" alt="Screenshot 2024-04-26 at 12 27 41" src="https://github.com/guardian/support-frontend/assets/31692/4daa8b80-964b-4847-bc42-8e70a012adc1">
