### PR TITLE
Update integration test 'not running' alarm

### DIFF
--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -155,7 +155,7 @@ Resources:
                 - Name: Stage
                   Value: !Ref Stage
             Stat: Sum
-            Period: 900
+            Period: 3600 # 1 hour
             Unit: Count
         - Id: m2
           ReturnData: false
@@ -167,10 +167,10 @@ Resources:
                 - Name: Stage
                   Value: !Ref Stage
             Stat: Sum
-            Period: 900
+            Period: 3600 # 1 hour
             Unit: Count
       ComparisonOperator: LessThanThreshold
       Threshold: 100
-      EvaluationPeriods: 9
-      DatapointsToAlarm: 9
+      EvaluationPeriods: 7
+      DatapointsToAlarm: 7
       TreatMissingData: breaching


### PR DESCRIPTION
We recently changed these to run every 6 hours - https://github.com/guardian/support-frontend/pull/5959
This has triggered an alarm that checks if the metrics are being reported regularly.