### PR TITLE
feat: thank you page for generic checkout

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -79,7 +79,7 @@ import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
 import { CheckoutDivider } from 'pages/supporter-plus-landing/components/checkoutDivider';
 import { GuardianTsAndCs } from 'pages/supporter-plus-landing/components/guardianTsAndCs';
-import { setThankYouOrder } from './thank-you';
+import { setThankYouOrder, unsetThankYouOrder } from './thank-you';
 
 /** App config - this is config that should persist throughout the app */
 validateWindowGuardian(window.guardian);
@@ -183,6 +183,8 @@ type Props = {
 	geoId: GeoId;
 };
 function CheckoutComponent({ geoId }: Props) {
+	/** we unset any previous orders that have been made */
+	unsetThankYouOrder();
 	const { currency, currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 	const productId = query.product in productCatalog ? query.product : undefined;
 	const product = productId ? productCatalog[query.product] : undefined;

--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { renderPage } from 'helpers/rendering/render';
 import { geoIds } from 'pages/geoIdConfig';
 import { Checkout } from './checkout';
+import { ThankYou } from './thank-you';
 
 const router = createBrowserRouter(
 	geoIds.flatMap((geoId) => [
@@ -11,7 +12,7 @@ const router = createBrowserRouter(
 		},
 		{
 			path: `/${geoId}/thank-you`,
-			element: <div>Thanks!</div>,
+			element: <ThankYou geoId={geoId} />,
 		},
 	]),
 );

--- a/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
@@ -1,0 +1,121 @@
+import { css } from '@emotion/react';
+import { storage } from '@guardian/libs';
+import { from, space, sport } from '@guardian/source-foundations';
+import { Container } from '@guardian/source-react-components';
+import { FooterWithContents } from '@guardian/source-react-components-development-kitchen';
+import type { Input } from 'valibot';
+import { number, object, safeParse, string } from 'valibot';
+import { Header } from 'components/headers/simpleHeader/simpleHeader';
+import { PageScaffold } from 'components/page/pageScaffold';
+import { init as abTestInit } from 'helpers/abTests/abtest';
+import CountryHelper from 'helpers/internationalisation/classes/country';
+import { get } from 'helpers/storage/cookie';
+import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
+import ThankYouFooter from 'pages/supporter-plus-thank-you/components/thankYouFooter';
+import ThankYouHeader from 'pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader';
+
+export const checkoutContainer = css`
+	${from.tablet} {
+		background-color: ${sport[800]};
+	}
+`;
+
+export const headerContainer = css`
+	${from.desktop} {
+		width: 60%;
+	}
+	${from.leftCol} {
+		width: calc(50% - ${space[3]}px);
+	}
+`;
+
+/**
+ * The checkout page sets the order in sessionStorage
+ * And the thank-you page reads it.
+ */
+const OrderSchema = object({
+	firstName: string(),
+	price: number(),
+	product: string(),
+	ratePlan: string(),
+	paymentMethod: string(),
+});
+export function setThankYouOrder(order: Input<typeof OrderSchema>) {
+	storage.session.set('thankYouOrder', order);
+}
+
+type Props = {
+	geoId: GeoId;
+};
+export function ThankYou({ geoId }: Props) {
+	const countryId = CountryHelper.fromString(get('GU_country') ?? 'GB') ?? 'GB';
+	const isSignedIn = !!get('GU_U');
+	const { countryGroupId, currencyKey } = getGeoIdConfig(geoId);
+
+	const sessionStorageOrder = storage.session.get('thankYouOrder');
+	const parsedOrder = safeParse(
+		OrderSchema,
+		storage.session.get('thankYouOrder'),
+	);
+
+	if (!parsedOrder.success) {
+		return (
+			<div>Unable to read your order {JSON.stringify(sessionStorageOrder)}</div>
+		);
+	}
+
+	const order = parsedOrder.output;
+	// Soon we'll remove this be using billingPeriod from the API
+	const contributionType =
+		order.ratePlan === 'Monthly'
+			? 'MONTHLY'
+			: order.ratePlan === 'Annual'
+			? 'ANNUAL'
+			: order.product === 'Contribution'
+			? 'ONE_OFF'
+			: undefined;
+
+	if (!contributionType) {
+		return <div>Unable to find contribution type {contributionType}</div>;
+	}
+
+	const isOneOffPayPal =
+		order.paymentMethod === 'PayPal' && order.product === 'Contribution';
+
+	const abParticipations = abTestInit({ countryId, countryGroupId });
+	const showOffer =
+		!!abParticipations.usFreeBookOffer && order.product === 'SupporterPlus';
+
+	return (
+		<PageScaffold
+			header={<Header />}
+			footer={
+				<FooterWithContents>
+					<ThankYouFooter />
+				</FooterWithContents>
+			}
+		>
+			<div css={checkoutContainer}>
+				<Container>
+					<div css={headerContainer}>
+						<ThankYouHeader
+							isSignedIn={isSignedIn}
+							name={order.firstName}
+							amount={order.price}
+							contributionType={contributionType}
+							amountIsAboveThreshold={order.product === 'SupporterPlus'}
+							isOneOffPayPal={isOneOffPayPal}
+							showDirectDebitMessage={order.paymentMethod === 'DirectDebit'}
+							currency={currencyKey}
+							showOffer={showOffer}
+							// TODO - generic checkout support promotions
+							promotion={undefined}
+							// TODO - get this from the /identity/get-user-type endpoint
+							userTypeFromIdentityResponse={'guest'}
+						/>
+					</div>
+				</Container>
+			</div>
+		</PageScaffold>
+	);
+}

--- a/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
@@ -43,6 +43,9 @@ const OrderSchema = object({
 export function setThankYouOrder(order: Input<typeof OrderSchema>) {
 	storage.session.set('thankYouOrder', order);
 }
+export function unsetThankYouOrder() {
+	storage.session.remove('thankYouOrder');
+}
 
 type Props = {
 	geoId: GeoId;


### PR DESCRIPTION
Adds the thank you page to the generic checkout.

This uses a explicit object in session storage:
```JSON
{
  "value": {
    "firstName": "???",
    "price": 5,
    "product": "Contribution",
    "ratePlan": "Monthly",
    "paymentMethod": "Stripe"
  }
}
```

This will last **only** for the session, and will be deleted if you visit the checkout again (the only place that sets it).

## Screenshots
<img width="1620" alt="Screenshot 2024-05-01 at 15 12 48" src="https://github.com/guardian/support-frontend/assets/31692/6774344e-ae33-4089-bcfb-d14d91d81a04">
