### PR TITLE
fix: refine cmp e2e test to buttons and simpler text

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - name: Cache dependencies
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install
         run: yarn
-      - uses: chromaui/action@v11
+      - uses: chromaui/action@v11.3.0
         with:
           workingDir: support-frontend
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/support-e2e/tests/consent-management.test.ts
+++ b/support-e2e/tests/consent-management.test.ts
@@ -12,19 +12,16 @@ test('Should show a dismissable consent management banner', async ({
 	);
 
 	await expect(
-		consentManagementBanner
-			// We use this role check as this text exists in the legal copy too
-			.getByRole('button')
-			.getByText('No, thank you'),
+		consentManagementBanner.getByRole('button', { name: 'No' }),
 	).toBeVisible({ timeout: 50000 });
 	await expect(
-		consentManagementBanner.getByText('Yes, I’m happy'),
+		consentManagementBanner.getByRole('button', { name: 'Yes' }),
 	).toBeVisible();
-	await consentManagementBanner.getByText('Yes, I’m happy').click();
+	await consentManagementBanner.getByRole('button', { name: 'Yes' }).click();
 	await expect(
-		consentManagementBanner.getByText('No, thank you'),
+		consentManagementBanner.getByRole('button', { name: 'No' }),
 	).not.toBeVisible();
 	await expect(
-		consentManagementBanner.getByText('Yes, I’m happy'),
+		consentManagementBanner.getByRole('button', { name: 'Yes' }),
 	).not.toBeVisible();
 });


### PR DESCRIPTION
Refines the search for the "Yes/No" buttons to
* Be a button
* Have only "Yes" or "No" in

This is slightly reactive to the work going on in CMP - so if it happens again, we might have to re-think - but we should have a test that CMP is working so maybe the `isVisible` test is enough.

We've updated the chromatic action to use `v11.3.0` as [`v11.3.1`](https://github.com/chromaui/action/commit/d208304630e76d960a80b9db40a838eb8babcebe) seemed to have introduced a bug.

If we update to `v11.3.1` - we'll need to add the `storybookBaseDir: "support-frontend"` to the Chromatic action.
