### PR TITLE
Personal details form validation

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -688,6 +688,7 @@ function CheckoutComponent({ geoId }: Props) {
 												disabled={isSignedIn}
 												name="email"
 												required
+												maxLength={80}
 												error={emailError}
 												onInvalid={(event) => {
 													preventDefaultValidityMessage(event.currentTarget);
@@ -721,6 +722,7 @@ function CheckoutComponent({ geoId }: Props) {
 													onChange={(event) => setFirstName(event.target.value)}
 													name="firstName"
 													required
+													maxLength={40}
 													error={firstNameError}
 													onInvalid={(event) => {
 														preventDefaultValidityMessage(event.currentTarget);
@@ -752,6 +754,7 @@ function CheckoutComponent({ geoId }: Props) {
 													onChange={(event) => setLastName(event.target.value)}
 													name="lastName"
 													required
+													maxLength={40}
 													error={lastNameError}
 													onInvalid={(event) => {
 														preventDefaultValidityMessage(event.currentTarget);

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -197,6 +197,12 @@ const query = {
 			: undefined,
 };
 
+/** Form Validation */
+/**
+ * This uses a Unicode character class escape
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape
+ */
+const doesNotContainEmojiPattern = '^[^\\p{Emoji_Presentation}]+$';
 function preventDefaultValidityMessage(currentTarget: HTMLInputElement) {
 	/**
 	 * Prevents default message showing, but maintains the default validation methods occuring
@@ -724,6 +730,7 @@ function CheckoutComponent({ geoId }: Props) {
 													required
 													maxLength={40}
 													error={firstNameError}
+													pattern={doesNotContainEmojiPattern}
 													onInvalid={(event) => {
 														preventDefaultValidityMessage(event.currentTarget);
 														const validityState = event.currentTarget.validity;
@@ -756,6 +763,7 @@ function CheckoutComponent({ geoId }: Props) {
 													required
 													maxLength={40}
 													error={lastNameError}
+													pattern={doesNotContainEmojiPattern}
 													onInvalid={(event) => {
 														preventDefaultValidityMessage(event.currentTarget);
 														const validityState = event.currentTarget.validity;

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -6,6 +6,7 @@ import {
 	space,
 	textSans,
 	until,
+	visuallyHidden,
 } from '@guardian/source-foundations';
 import {
 	Column,
@@ -34,7 +35,6 @@ import { ContributionsOrderSummary } from 'components/orderSummary/contributions
 import { PageScaffold } from 'components/page/pageScaffold';
 import { DefaultPaymentButton } from 'components/paymentButton/defaultPaymentButton';
 import { PayPalButton } from 'components/payPalPaymentButton/payPalButton';
-import { PersonalDetails } from 'components/personalDetails/personalDetails';
 import { StateSelect } from 'components/personalDetails/stateSelect';
 import { Recaptcha } from 'components/recaptcha/recaptcha';
 import { SecureTransactionIndicator } from 'components/secureTransactionIndicator/secureTransactionIndicator';
@@ -47,6 +47,7 @@ import { findAddressesForPostcode } from 'components/subscriptionCheckouts/addre
 import { getAmountsTestVariant } from 'helpers/abTests/abtest';
 import { isContributionsOnlyCountry } from 'helpers/contributions';
 import type { ErrorReason } from 'helpers/forms/errorReasons';
+import { emailRegexPattern } from 'helpers/forms/formValidation';
 import { loadPayPalRecurring } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 import type {
 	RegularPaymentRequest,
@@ -131,6 +132,23 @@ const legend = css`
 	${from.tablet} {
 		font-size: 28px;
 	}
+`;
+
+const personalDetailsFieldGroupStyles = (hideDetailsHeading?: boolean) => css`
+	position: relative;
+	margin-top: ${hideDetailsHeading ? `${space[4]}px` : '0'};
+
+	& > *:not(:first-of-type) {
+		margin-top: ${space[3]}px;
+	}
+	${from.tablet} {
+		& > *:not(:first-of-type) {
+			margin-top: ${space[4]}px;
+		}
+	}
+`;
+const personalDetailsHeader = css`
+	${visuallyHidden};
 `;
 
 /**
@@ -640,55 +658,83 @@ function CheckoutComponent({ geoId }: Props) {
 						>
 							<Box cssOverrides={shorterBoxMargin}>
 								<BoxContents>
-									<PersonalDetails
-										email={email}
-										firstName={firstName}
-										lastName={lastName}
-										isSignedIn={isSignedIn}
-										// TODO - ONE_OFF support, this should be true when ONE_OFF
-										hideNameFields={false}
-										onEmailChange={(email) => {
-											setEmail(email);
-										}}
-										onFirstNameChange={(firstName) => {
-											setFirstName(firstName);
-										}}
-										onLastNameChange={(lastName) => {
-											setLastName(lastName);
-										}}
-										errors={{}}
-										signOutLink={<Signout isSignedIn={isSignedIn} />}
-										contributionState={
-											showStateSelect && (
-												<StateSelect
-													countryId={countryId}
-													state={'STATE'}
-													onStateChange={() => {
+									<div css={personalDetailsFieldGroupStyles(true)}>
+										<h2 css={personalDetailsHeader}>Your details</h2>
+										<div>
+											<TextInput
+												id="email"
+												data-qm-masking="blocklist"
+												label="Email address"
+												value={email}
+												type="email"
+												autoComplete="email"
+												onChange={(event) => setEmail(event.target.value)}
+												pattern={emailRegexPattern}
+												error={undefined}
+												disabled={isSignedIn}
+												name="email"
+											/>
+										</div>
+
+										<Signout isSignedIn={isSignedIn} />
+
+										<>
+											<div>
+												<TextInput
+													id="firstName"
+													data-qm-masking="blocklist"
+													label="First name"
+													value={firstName}
+													autoComplete="given-name"
+													autoCapitalize="words"
+													onChange={(event) => setFirstName(event.target.value)}
+													error={undefined}
+													name="firstName"
+													required
+												/>
+											</div>
+											<div>
+												<TextInput
+													id="lastName"
+													data-qm-masking="blocklist"
+													label="Last name"
+													value={lastName}
+													autoComplete="family-name"
+													autoCapitalize="words"
+													onChange={(event) => setLastName(event.target.value)}
+													error={undefined}
+													name="lastName"
+													required
+												/>
+											</div>
+										</>
+
+										{showStateSelect && (
+											<StateSelect
+												countryId={countryId}
+												state={'STATE'}
+												onStateChange={() => {
+													//  no-op
+												}}
+												error={undefined}
+											/>
+										)}
+
+										{countryId === 'US' && (
+											<div>
+												<TextInput
+													id="zipCode"
+													name="zip-code"
+													label="ZIP code"
+													value={''}
+													error={undefined}
+													onChange={() => {
 														//  no-op
 													}}
-													error={undefined}
 												/>
-											)
-										}
-										contributionZipcode={
-											countryId === 'US' ? (
-												<div>
-													<TextInput
-														id="zipCode"
-														name="zip-code"
-														label="ZIP code"
-														value={''}
-														error={undefined}
-														onChange={() => {
-															//  no-op
-														}}
-													/>
-												</div>
-											) : undefined
-										}
-										hideDetailsHeading={true}
-										overrideHeadingCopy="1. Your details"
-									/>
+											</div>
+										)}
+									</div>
 
 									<CheckoutDivider spacing="loose" />
 

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -47,7 +47,6 @@ import { findAddressesForPostcode } from 'components/subscriptionCheckouts/addre
 import { getAmountsTestVariant } from 'helpers/abTests/abtest';
 import { isContributionsOnlyCountry } from 'helpers/contributions';
 import type { ErrorReason } from 'helpers/forms/errorReasons';
-import { emailRegexPattern } from 'helpers/forms/formValidation';
 import { loadPayPalRecurring } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 import type {
 	RegularPaymentRequest,
@@ -197,6 +196,20 @@ const query = {
 			? parseFloat(searchParamsPrice)
 			: undefined,
 };
+
+function preventDefaultValidityMessage(currentTarget: HTMLInputElement) {
+	/**
+	 * Prevents default message showing, but maintains the default validation methods occuring
+	 * such as onInvalid.
+	 */
+	// 3. Reset the value from previous invalid events
+	currentTarget.setCustomValidity('');
+	// 1. Check the validity of the input
+	if (!currentTarget.validity.valid) {
+		// 2. setCustomValidity to " " which avoids the browser's default message
+		currentTarget.setCustomValidity(' ');
+	}
+}
 
 type Props = {
 	geoId: GeoId;
@@ -390,8 +403,11 @@ function CheckoutComponent({ geoId }: Props) {
 
 	/** Personal details */
 	const [firstName, setFirstName] = useState('');
+	const [firstNameError, setFirstNameError] = useState<string>();
 	const [lastName, setLastName] = useState('');
+	const [lastNameError, setLastNameError] = useState<string>();
 	const [email, setEmail] = useState('');
+	const [emailError, setEmailError] = useState<string>();
 
 	/** Delivery and billing addresses */
 	const [deliveryPostcode, setDeliveryPostcode] = useState('');
@@ -669,10 +685,25 @@ function CheckoutComponent({ geoId }: Props) {
 												type="email"
 												autoComplete="email"
 												onChange={(event) => setEmail(event.target.value)}
-												pattern={emailRegexPattern}
-												error={undefined}
 												disabled={isSignedIn}
 												name="email"
+												required
+												error={emailError}
+												onInvalid={(event) => {
+													preventDefaultValidityMessage(event.currentTarget);
+													const validityState = event.currentTarget.validity;
+													if (validityState.valid) {
+														setEmailError(undefined);
+													} else {
+														if (validityState.valueMissing) {
+															setEmailError('Please enter your email address.');
+														} else {
+															setEmailError(
+																'Please enter a valid email address.',
+															);
+														}
+													}
+												}}
 											/>
 										</div>
 
@@ -688,9 +719,26 @@ function CheckoutComponent({ geoId }: Props) {
 													autoComplete="given-name"
 													autoCapitalize="words"
 													onChange={(event) => setFirstName(event.target.value)}
-													error={undefined}
 													name="firstName"
 													required
+													error={firstNameError}
+													onInvalid={(event) => {
+														preventDefaultValidityMessage(event.currentTarget);
+														const validityState = event.currentTarget.validity;
+														if (validityState.valid) {
+															setFirstNameError(undefined);
+														} else {
+															if (validityState.valueMissing) {
+																setFirstNameError(
+																	'Please enter your first name.',
+																);
+															} else {
+																setFirstNameError(
+																	'Please enter a valid first name.',
+																);
+															}
+														}
+													}}
 												/>
 											</div>
 											<div>
@@ -702,9 +750,26 @@ function CheckoutComponent({ geoId }: Props) {
 													autoComplete="family-name"
 													autoCapitalize="words"
 													onChange={(event) => setLastName(event.target.value)}
-													error={undefined}
 													name="lastName"
 													required
+													error={lastNameError}
+													onInvalid={(event) => {
+														preventDefaultValidityMessage(event.currentTarget);
+														const validityState = event.currentTarget.validity;
+														if (validityState.valid) {
+															setLastNameError(undefined);
+														} else {
+															if (validityState.valueMissing) {
+																setLastNameError(
+																	'Please enter your last name.',
+																);
+															} else {
+																setLastNameError(
+																	'Please enter a valid last name.',
+																);
+															}
+														}
+													}}
 												/>
 											</div>
 										</>


### PR DESCRIPTION
Part of #5722 

* Removes the use of `PersonalDetails` component as the error API of that component was becoming difficult to integrate with. The abstraction isn't used anywhere that the checkout isn't going to make obsolete, so it's a little bit of code now, for less later.
* Adds validation using [browser APIs](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation). [The `ValidityState` is good to use in browsers we support](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState#browser_compatibility). I might try push this upstream to Source in a later PR once we've ironed some of this out.

It is probably easier to view this PR via [this commit](https://github.com/guardian/support-frontend/commit/fc8a1fc934bac0e44192b68124edfffa4832673c) and then [this commit](https://github.com/guardian/support-frontend/commit/fd1979a833f8f7ae34bdc43134598208c0bf8d1b).

## Show me the screenshots 

https://github.com/guardian/support-frontend/assets/31692/479a9604-a062-49f5-82a4-96eb334c6151


