### PR TITLE
fix: describe why it is OK to use non-null-assertion

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -395,9 +395,11 @@ function getAmountsTestVariant(
 	): AmountsVariant => {
 		if (isLive && variants.length > 1) {
 			const assignmentIndex = randomNumber(mvt, seed) % variants.length;
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the way this code is reached guarantees that assignmentIndex exists
 			return variants[assignmentIndex]!;
 		}
 		// For regional AmountsTests, if the test is not live then we use the control
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the way this code is reached guarantees that variants.length > 0
 		return variants[0]!;
 	};
 


### PR DESCRIPTION
Adds descriptions as to why we use the `non-null-assertions`.

This avoids this 👇 in PRs which always muddies the water.
<img width="1589" alt="Screenshot 2024-05-08 at 10 26 57" src="https://github.com/guardian/support-frontend/assets/31692/ac3de349-00fb-4ee9-9a42-b61c360d5d58">

[This was added in this PR](https://github.com/guardian/support-frontend/pull/5928/files) and should probably be refactored around with better typing rather than forced - but it's worked for ages as is.