### PR TITLE
fix: remove ;😀

### DIFF
--- a/support-frontend/stories/landingPage/ThreeTierCards.stories.tsx
+++ b/support-frontend/stories/landingPage/ThreeTierCards.stories.tsx
@@ -40,7 +40,7 @@ function Template(args: ThreeTierCardsProps) {
 	`;
 	return (
 		<div css={innerContentContainer}>
-			<ThreeTierCards {...args} />;
+			<ThreeTierCards {...args} />
 		</div>
 	);
 }


### PR DESCRIPTION
Removes a stray `;` I noticed in a chromatic review.
