### PR TITLE
Generic Checkout: Tier1 param url amount changed to price

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -490,7 +490,7 @@ export function ThreeTierLanding(): JSX.Element {
 	const tier1GenericCheckoutUrlParams = new URLSearchParams({
 		product: 'Contribution',
 		ratePlan: selectedContributionRatePlan,
-		amount: recurringAmount.toString(),
+		price: recurringAmount.toString(),
 	});
 	const tier1GenericCheckoutLink = `checkout?${tier1GenericCheckoutUrlParams.toString()}`;
 


### PR DESCRIPTION
## What are you doing in this PR?

- Check abTest `useGenericCheckout=variant` Tier1 routes to generic checkout
- Correct Tier ParamUrl contains `price` instead of `amount`

[**Trello Card**](https://trello.com/c/zFskeauG/835-a-b-test-setup)

|from|to (paramurl)|
|-----|-----|
|![image](https://github.com/guardian/support-frontend/assets/76729591/d7ff8ef0-8744-4859-ac90-2629928da63d)|![image](https://github.com/guardian/support-frontend/assets/76729591/aa137001-2966-4b97-93fd-540bd98ce341)|



## How to test

https://support.thegulocal.com/uk/contribute#ab-useGenericCheckout=variant
