### PR TITLE
fix: detect countryId which also sets the GU_Country cookie

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -89,8 +89,7 @@ const isTestUser = true as boolean;
 const csrf = window.guardian.csrf.token;
 
 const isSignedIn = !!get('GU_U');
-const countryId: IsoCountry =
-	CountryHelper.fromString(get('GU_country') ?? 'GB') ?? 'GB';
+const countryId: IsoCountry = CountryHelper.detect();
 
 const productCatalog = window.guardian.productCatalog;
 


### PR DESCRIPTION
[Uses `CountryHelper.detect()` reads and also sets the `GU_Country` cookie](https://github.com/guardian/support-frontend/blob/main/support-frontend/assets/helpers/internationalisation/classes/country.ts#L245-L283).

