### PR TITLE
Abandoned basket update cookie when one off amount changes

### DIFF
--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -72,6 +72,7 @@ export function PriceCardsContainer({
 				amount: newAmount,
 			}),
 		);
+		updateAbandonedBasketCookie(newAmount);
 	}
 
 	function onOtherAmountChange(newAmount: string) {

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -89,6 +89,7 @@ export function PriceCardsContainer({
 				amount: newAmount,
 			}),
 		);
+		updateAbandonedBasketCookie(newAmount);
 	}
 
 	return renderPriceCards({

--- a/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
+++ b/support-frontend/assets/components/priceCards/priceCardsContainer.tsx
@@ -15,6 +15,7 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
+import { updateAbandonedBasketCookie } from 'helpers/storage/abandonedBasketCookies';
 import type { PriceCardPaymentInterval } from './priceCard';
 import type { PriceCardsProps } from './priceCards';
 

--- a/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
+++ b/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
@@ -19,7 +19,7 @@ type AbandonedBasket = Input<typeof abandonedBasketSchema>;
 
 export function useAbandonedBasketCookie(
 	product: ProductCheckout,
-	amount: number | 'other',
+	amount: number,
 	billingPeriod: string,
 	region: string,
 ) {

--- a/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
+++ b/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
@@ -1,14 +1,6 @@
 import { useEffect } from 'react';
-import type {
-	Input} from 'valibot';
-import {
-	literal,
-	number,
-	object,
-	safeParse,
-	string,
-	union,
-} from 'valibot';
+import type { Input } from 'valibot';
+import { literal, number, object, safeParse, string, union } from 'valibot';
 import * as cookie from 'helpers/storage/cookie';
 import type { ProductCheckout } from 'helpers/tracking/behaviour';
 import { logException } from 'helpers/utilities/logger';

--- a/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
+++ b/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
@@ -43,7 +43,9 @@ export function updateAbandonedBasketCookie(newAmount: string) {
 
 	if (!abandonedBasketCookie) return;
 
-	const parsedCookie = abandonedBasketSchema.safeParse(abandonedBasketCookie);
+	const parsedCookie = abandonedBasketSchema.safeParse(
+		JSON.parse(abandonedBasketCookie),
+	);
 
 	if (parsedCookie.success) {
 		const newCookie = { ...parsedCookie.data, amount: newAmount };

--- a/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
+++ b/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
+import { z } from 'zod';
 import * as cookie from 'helpers/storage/cookie';
 import type { ProductCheckout } from 'helpers/tracking/behaviour';
-import { z } from Zod;
 import { logException } from 'helpers/utilities/logger';
 
 const COOKIE_EXPIRY_DAYS = 3;
@@ -14,7 +14,7 @@ const abandonedBasketSchema = z.object({
 	region: z.string(),
 });
 
-type AbandonedBasket = z.infer<typeof abandonedBasketSchema>;
+//type AbandonedBasket = z.infer<typeof abandonedBasketSchema>;
 
 export function useAbandonedBasketCookie(
 	product: ProductCheckout,
@@ -22,8 +22,6 @@ export function useAbandonedBasketCookie(
 	billingPeriod: string,
 	region: string,
 ) {
-
-
 	const abandonedBasket = {
 		product,
 		amount,
@@ -40,25 +38,25 @@ export function useAbandonedBasketCookie(
 	}, []);
 }
 
-export function updateAbandonedBasketCookie(newAmount: string){
-
+export function updateAbandonedBasketCookie(newAmount: string) {
 	const abandonedBasketCookie = cookie.get(ABANDONED_BASKET_COOKIE_NAME);
 
-	if(!abandonedBasketCookie) return;
+	if (!abandonedBasketCookie) return;
 
 	const parsedCookie = abandonedBasketSchema.safeParse(abandonedBasketCookie);
 
 	if (parsedCookie.success) {
+		const newCookie = { ...parsedCookie.data, amount: newAmount };
 
-		const newCookie = {... parsedCookie.data, amount: newAmount};
-		
 		cookie.set(
 			ABANDONED_BASKET_COOKIE_NAME,
-			JSON.stringify(newCookie.data),
+			JSON.stringify(newCookie),
 			COOKIE_EXPIRY_DAYS,
 		);
 	} else {
-		logException('Failed to parse abandoned basket cookie', parsedCookie.error);
-	  }
-
+		logException(
+			`Failed to parse abandoned basket cookie. Error:
+			${parsedCookie.error.toString()}`,
+		);
+	}
 }

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -42,7 +42,7 @@
       ".+\\.(js|jsx|ts|tsx)$": "./node_modules/babel-jest"
     },
     "transformIgnorePatterns": [
-      "/node_modules/(?!@guardian)",
+      "/node_modules/(?!@guardian|valibot)",
       "^.+\\.module\\.(css|sass|scss)$"
     ],
     "moduleFileExtensions": [


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Updating the cookie set on the second step of the checkout (#5972) with the updated amount when a user selects a different amount in the one-off contribution component.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/5NzPmZK0/438-abandoned-basket-update-cookie-when-one-off-amount-changes)

## Why are you doing this?

To keep the cookie as up to date as possible with the last thing a user selected on the checkout.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Go to `/contribute/checkout?selected-contribution-type=one_off` and see the `GU_CO_INCOMPLETE` cookie update the amount when choosing different amounts, including `other`

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Screenshots

![image](https://github.com/guardian/support-frontend/assets/114918544/02d75e1d-1dc4-4170-b649-faa003d3627a)

