### PR TITLE
feat: add user to router

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -306,6 +306,7 @@ class Application(
         membersDataApiUrl = membersDataApiUrl,
         guestAccountCreationToken = guestAccountCreationToken,
         productCatalog = productCatalog,
+        user = request.user,
       ),
     ).withSettingsSurrogateKey
   }

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -68,5 +68,7 @@
     membersDataApiUrl = membersDataApiUrl,
     guestAccountCreationToken = guestAccountCreationToken,
     productCatalog = productCatalog,
+    // We explicitly set None as we have this set above
+    user = None
   )
 }

--- a/support-frontend/app/views/router.scala.html
+++ b/support-frontend/app/views/router.scala.html
@@ -6,6 +6,7 @@
 @import views.EmptyDiv
 @import io.circe.JsonObject
 
+@import com.gu.identity.model.User
 @(
   geoData: GeoData,
   serversideTests: Map[String,Participation],
@@ -16,6 +17,7 @@
   guestAccountCreationToken: Option[String],
   v2recaptchaConfigPublicKey: String,
   productCatalog: JsonObject,
+  user: Option[User]
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
 @main(
@@ -30,7 +32,7 @@
   csrf = None,
   shareImageUrl = None,
   shareUrl = None,
-  noindex = true
+  noindex = true,
 ){
   @windowGuardianPaymentConfig(
     geoData = geoData,
@@ -42,5 +44,6 @@
     membersDataApiUrl = membersDataApiUrl,
     guestAccountCreationToken = guestAccountCreationToken,
     productCatalog = productCatalog,
+    user = user
   )
 }

--- a/support-frontend/app/views/windowGuardianPaymentConfig.scala.html
+++ b/support-frontend/app/views/windowGuardianPaymentConfig.scala.html
@@ -1,9 +1,9 @@
-@import com.gu.i18n.Country
 @import admin.settings.AllSettings
 @import views.html.helper.CSRF
 
 @import views.ViewHelpers.outputJson
 @import io.circe.JsonObject
+@import com.gu.identity.model.User
 @(
   geoData: GeoData,
   paymentMethodConfigs: PaymentMethodConfigs,
@@ -13,6 +13,7 @@
   v2recaptchaConfigPublicKey: String,
   guestAccountCreationToken: Option[String],
   productCatalog: JsonObject,
+  user: Option[User],
   settings: AllSettings
 )(implicit request: RequestHeader)
 
@@ -87,4 +88,17 @@
   window.guardian.checkoutPostcodeLookup = @settings.switches.subscriptionsSwitches.checkoutPostcodeLookup.isOn
 
   window.guardian.productCatalog = @Html(outputJson(productCatalog))
+
+  @user.map { user =>
+    window.guardian.user = {
+      id: "@user.id",
+      email: "@user.primaryEmailAddress",
+      @user.privateFields.firstName.map { firstName =>
+        firstName: "@firstName",
+      }
+      @user.privateFields.secondName.map { secondName =>
+        lastName: "@secondName",
+      }
+    };
+  }
 </script>


### PR DESCRIPTION
Adds the `user` to the checkout route.

- Adds a `user` object to `window.guardian` if a person is signed in
- Keeps this object as narrow as we need for https://github.com/guardian/support-frontend/pull/6000
- Doesn't use this for the `contributions` route to avoid bugs

<img width="715" alt="Screenshot 2024-05-14 at 14 06 27" src="https://github.com/guardian/support-frontend/assets/31692/4f4ab347-a168-4ead-aa12-4be33b55d0fd">
