### PR TITLE
Add legends and secure checkout SVG to checkout

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -129,6 +129,10 @@ const legend = css`
 	${from.tablet} {
 		font-size: 28px;
 	}
+
+	display: flex;
+	width: 100%;
+	justify-content: space-between;
 `;
 
 const fieldset = css`
@@ -992,11 +996,14 @@ function CheckoutComponent({ geoId }: Props) {
 										</>
 									)}
 									<fieldset>
-										<legend css={legend}>2. Payment method</legend>
-										<SecureTransactionIndicator
-											hideText={true}
-											cssOverrides={cssOverrides ?? css``}
-										/>
+										<legend css={legend}>
+											2. Payment method
+											<SecureTransactionIndicator
+												hideText={true}
+												cssOverrides={css``}
+											/>
+										</legend>
+
 										{validPaymentMethods.map((paymentMethod) => {
 											return (
 												<div>


### PR DESCRIPTION
Part of #5722 

- Uses and displays legends for Contribution checkout
- Adds Secure checkout SVG to payment details `fieldset`

I know that the `1.`, `2.`, `n.` won't work when we have delivery fields, I will reach out to Helene and see if there is a generic design solution to this.

[Worth avoiding whitedspace check in the diff](https://github.com/guardian/support-frontend/pull/6002/files?diff=unified&w=1).

| before | after |
|---|---|
| ![Screenshot 2024-05-14 at 15 44 26](https://github.com/guardian/support-frontend/assets/31692/b5c38be3-7fba-4cc2-8761-e00a02d907ae) | ![Screenshot 2024-05-14 at 15 44 11](https://github.com/guardian/support-frontend/assets/31692/caff5932-4e47-4715-a466-9a62826d4eab) |
 