### PR TITLE
Add styles to payment methods on generic checkout

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -15,6 +15,7 @@ import {
 	Radio,
 	RadioGroup,
 	TextInput,
+	textInputThemeDefault,
 } from '@guardian/source-react-components';
 import {
 	FooterLinks,
@@ -34,6 +35,7 @@ import { LoadingOverlay } from 'components/loadingOverlay/loadingOverlay';
 import { ContributionsOrderSummary } from 'components/orderSummary/contributionsOrderSummary';
 import { PageScaffold } from 'components/page/pageScaffold';
 import { DefaultPaymentButton } from 'components/paymentButton/defaultPaymentButton';
+import { paymentMethodData } from 'components/paymentMethodSelector/paymentMethodData';
 import { PayPalButton } from 'components/payPalPaymentButton/payPalButton';
 import { StateSelect } from 'components/personalDetails/stateSelect';
 import { Recaptcha } from 'components/recaptcha/recaptcha';
@@ -147,6 +149,39 @@ const personalDetailsFieldGroupStyles = (hideDetailsHeading?: boolean) => css`
 `;
 const personalDetailsHeader = css`
 	${visuallyHidden};
+`;
+
+const paymentMethodSelected = css`
+	box-shadow: inset 0 0 0 2px ${textInputThemeDefault.textInput.borderActive};
+	margin-top: ${space[2]}px;
+	border-radius: 4px;
+`;
+
+const paymentMethodNotSelected = css`
+	/* Using box shadows prevents layout shift when the rows are expanded */
+	box-shadow: inset 0 0 0 1px ${textInputThemeDefault.textInput.border};
+	margin-top: ${space[2]}px;
+	border-radius: 4px;
+`;
+
+const paymentMethodBody = css`
+	padding: ${space[5]}px ${space[3]}px ${space[6]}px;
+`;
+
+const paymentMethodRadioWithImage = css`
+	display: inline-flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 100%;
+	padding: ${space[2]}px ${space[3]}px;
+	font-weight: bold;
+`;
+const paymentMethodRadioWithImageSelected = css`
+	background-image: linear-gradient(
+		to top,
+		${palette.brand[500]} 2px,
+		transparent 2px
+	);
 `;
 
 /**
@@ -989,116 +1024,147 @@ function CheckoutComponent({ geoId }: Props) {
 										</>
 									)}
 
-									{validPaymentMethods.map((paymentMethod) => {
-										return (
-											<div>
-												<Radio
-													label={paymentMethod}
-													name="paymentMethod"
-													value={paymentMethod}
-													onChange={() => {
-														setPaymentMethod(paymentMethod);
-													}}
-												/>
-											</div>
-										);
-									})}
+									<RadioGroup>
+										{validPaymentMethods.map((validPaymentMethod) => {
+											const selected = paymentMethod === validPaymentMethod;
+											const { label, icon } =
+												paymentMethodData[validPaymentMethod];
+											return (
+												<div
+													css={
+														selected
+															? paymentMethodSelected
+															: paymentMethodNotSelected
+													}
+												>
+													<div
+														css={[
+															paymentMethodRadioWithImage,
+															selected
+																? paymentMethodRadioWithImageSelected
+																: undefined,
+														]}
+													>
+														<Radio
+															label={label}
+															name="paymentMethod"
+															value={validPaymentMethod}
+															onChange={() => {
+																setPaymentMethod(validPaymentMethod);
+															}}
+														/>
+														<div>{icon}</div>
+													</div>
+													{validPaymentMethod === 'Stripe' && selected && (
+														<div css={paymentMethodBody}>
+															<input
+																type="hidden"
+																name="recaptchaToken"
+																value={recaptchaToken}
+															/>
+															<StripeCardForm
+																onCardNumberChange={() => {
+																	// no-op
+																}}
+																onExpiryChange={() => {
+																	// no-op
+																}}
+																onCvcChange={() => {
+																	// no-op
+																}}
+																errors={{}}
+																recaptcha={
+																	<Recaptcha
+																		// We could change the parents type to Promise and uses await here, but that has
+																		// a lot of refactoring with not too much gain
+																		onRecaptchaCompleted={(token) => {
+																			setStripeClientSecretInProgress(true);
+																			setRecaptchaToken(token);
+																			void fetch(
+																				'/stripe/create-setup-intent/recaptcha',
+																				{
+																					method: 'POST',
+																					headers: {
+																						'Content-Type': 'application/json',
+																					},
+																					body: JSON.stringify({
+																						isTestUser,
+																						stripePublicKey,
+																						token,
+																					}),
+																				},
+																			)
+																				.then((resp) => resp.json())
+																				.then((json) => {
+																					setStripeClientSecret(
+																						(json as Record<string, string>)
+																							.client_secret,
+																					);
+																					setStripeClientSecretInProgress(
+																						false,
+																					);
+																				});
+																		}}
+																		onRecaptchaExpired={() => {
+																			// no-op
+																		}}
+																	/>
+																}
+															/>
+														</div>
+													)}
 
-									{paymentMethod === 'Stripe' && (
-										<>
-											<input
-												type="hidden"
-												name="recaptchaToken"
-												value={recaptchaToken}
-											/>
-											<StripeCardForm
-												onCardNumberChange={() => {
-													// no-op
-												}}
-												onExpiryChange={() => {
-													// no-op
-												}}
-												onCvcChange={() => {
-													// no-op
-												}}
-												errors={{}}
-												recaptcha={
-													<Recaptcha
-														// We could change the parents type to Promise and uses await here, but that has
-														// a lot of refactoring with not too much gain
-														onRecaptchaCompleted={(token) => {
-															setStripeClientSecretInProgress(true);
-															setRecaptchaToken(token);
-															void fetch(
-																'/stripe/create-setup-intent/recaptcha',
-																{
-																	method: 'POST',
-																	headers: {
-																		'Content-Type': 'application/json',
-																	},
-																	body: JSON.stringify({
-																		isTestUser,
-																		stripePublicKey,
-																		token,
-																	}),
-																},
-															)
-																.then((resp) => resp.json())
-																.then((json) => {
-																	setStripeClientSecret(
-																		(json as Record<string, string>)
-																			.client_secret,
-																	);
-																	setStripeClientSecretInProgress(false);
-																});
-														}}
-														onRecaptchaExpired={() => {
-															// no-op
-														}}
-													/>
-												}
-											/>
-										</>
-									)}
-
-									{paymentMethod === 'DirectDebit' && (
-										<DirectDebitForm
-											countryGroupId={countryGroupId}
-											accountHolderName={accountHolderName}
-											accountNumber={accountNumber}
-											accountHolderConfirmation={accountHolderConfirmation}
-											sortCode={sortCode}
-											recaptchaCompleted={false}
-											updateAccountHolderName={(name: string) => {
-												setAccountHolderName(name);
-											}}
-											updateAccountNumber={(number: string) => {
-												setAccountNumber(number);
-											}}
-											updateSortCode={(sortCode: string) => {
-												setSortCode(sortCode);
-											}}
-											updateAccountHolderConfirmation={(
-												confirmation: boolean,
-											) => {
-												setAccountHolderConfirmation(confirmation);
-											}}
-											recaptcha={
-												<Recaptcha
-													// We could change the parents type to Promise and uses await here, but that has
-													// a lot of refactoring with not too much gain
-													onRecaptchaCompleted={(token) => {
-														setRecaptchaToken(token);
-													}}
-													onRecaptchaExpired={() => {
-														// no-op
-													}}
-												/>
-											}
-											formError={''}
-											errors={{}}
-										/>
-									)}
+													{validPaymentMethod === 'DirectDebit' && selected && (
+														<div
+															css={css`
+																padding: ${space[5]}px ${space[3]}px
+																	${space[6]}px;
+															`}
+														>
+															<DirectDebitForm
+																countryGroupId={countryGroupId}
+																accountHolderName={accountHolderName}
+																accountNumber={accountNumber}
+																accountHolderConfirmation={
+																	accountHolderConfirmation
+																}
+																sortCode={sortCode}
+																recaptchaCompleted={false}
+																updateAccountHolderName={(name: string) => {
+																	setAccountHolderName(name);
+																}}
+																updateAccountNumber={(number: string) => {
+																	setAccountNumber(number);
+																}}
+																updateSortCode={(sortCode: string) => {
+																	setSortCode(sortCode);
+																}}
+																updateAccountHolderConfirmation={(
+																	confirmation: boolean,
+																) => {
+																	setAccountHolderConfirmation(confirmation);
+																}}
+																recaptcha={
+																	<Recaptcha
+																		// We could change the parents type to Promise and uses await here, but that has
+																		// a lot of refactoring with not too much gain
+																		onRecaptchaCompleted={(token) => {
+																			setRecaptchaToken(token);
+																		}}
+																		onRecaptchaExpired={() => {
+																			// no-op
+																		}}
+																	/>
+																}
+																formError={''}
+																errors={{}}
+															/>
+														</div>
+													)}
+												</div>
+											);
+										})}
+									</RadioGroup>
 								</BoxContents>
 							</Box>
 							<div


### PR DESCRIPTION
[Reviewing without whitespace is easier](https://github.com/guardian/support-frontend/pull/6003/files?w=1).

Part of #5722 

Adds the styles to the payment methods for the generic checkout.

I've avoided using [Source's `Accordion`](https://github.com/guardian/csnx/blob/main/libs/%40guardian/source-react-components/src/accordion/Accordion.tsx) as it provides none of the functionality and we override nearly all of the styles. I think this is because they are quite different use cases as you can [see in the design system](https://theguardian.design/2a1e5182b/p/38c5aa-accordion).

If we wanted to use this I imagine we would build an `AccordianSansStyles`, and then add themes. Maybe worth using the new design system process we have setup for this?

## Show me please

https://github.com/guardian/support-frontend/assets/31692/70635d78-6f23-4cc2-8376-4d36d269d487

