### PR TITLE
Generic Checkout : Playwright PaymentType Fix

### DIFF
--- a/support-e2e/tests/genericCheckout.test.ts
+++ b/support-e2e/tests/genericCheckout.test.ts
@@ -19,14 +19,14 @@ const testDetails = [
 	{
 		product: 'Contribution',
 		ratePlan: 'Monthly',
-		paymentType: 'DirectDebit',
+		paymentType: 'Direct debit',
 		price: 9,
 		country: 'UK',
 	},
 	{
 		product: 'Contribution',
 		ratePlan: 'Annual',
-		paymentType: 'Stripe',
+		paymentType: 'Credit/Debit card',
 		price: 90,
 		country: 'US',
 	},
@@ -40,7 +40,7 @@ const testDetails = [
 	{
 		product: 'SupporterPlus',
 		ratePlan: 'Annual',
-		paymentType: 'Stripe',
+		paymentType: 'Credit/Debit card',
 		price: 95,
 		country: 'EU',
 	},
@@ -82,7 +82,7 @@ test.describe('Generic Checkout', () => {
 			}
 			await page.getByRole('radio', { name: testDetails.paymentType }).check();
 			switch (testDetails.paymentType) {
-				case 'DirectDebit':
+				case 'Direct debit':
 					await fillInDirectDebitDetails(page, 'contribution');
 					await checkRecaptcha(page);
 					break;
@@ -100,15 +100,15 @@ test.describe('Generic Checkout', () => {
 					const popupPage = await popupPagePromise;
 					fillInPayPalDetails(popupPage);
 					break;
-				case 'Stripe':
+				case 'Credit/Debit card':
 				default:
 					await fillInCardDetails(page);
 					break;
 			}
 
 			if (
-				testDetails.paymentType === 'Stripe' ||
-				testDetails.paymentType === 'DirectDebit'
+				testDetails.paymentType === 'Credit/Debit card' ||
+				testDetails.paymentType === 'Direct debit'
 			) {
 				await checkRecaptcha(page);
 				await page.getByRole('button', { name: 'Pay now' }).click();

--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -96,7 +96,9 @@ test.describe('Subscribe/Contribute via the Tiered checkout)', () => {
 				const frequencyLabel =
 					testDetails.frequency === 'Annual' ? 'year' : 'month';
 				var paymentButtonRegex = new RegExp(
-					'(Pay|Support us with) (£|\\$)([0-9]+) per (' + frequencyLabel + ')',
+					'(Pay|Support us with) (£|\\$)([0-9]+|([0-9]+.[0-9]+)) per (' +
+						frequencyLabel +
+						')',
 				);
 				await page.getByText(paymentButtonRegex).click();
 			}


### PR DESCRIPTION
## What are you doing in this PR?

Change generic Checkout Playwright tests to incorporate paymentType name changes ->
DirectDebit => Direct debit
Stripe=> Credit/Debit card

![image](https://github.com/guardian/support-frontend/assets/76729591/fb7e434f-6338-4512-8520-63a3411a01d5)

Change payment button check to include non-rounded amounts ie
£100 => £94.92

![image](https://github.com/guardian/support-frontend/assets/76729591/5f19744b-ff8c-4ce9-b6fc-2f7600c75f12)



