### PR TITLE
feat: add logger.error to support-workers error handler

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/Handler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/Handler.scala
@@ -73,6 +73,7 @@ abstract class Handler[IN, OUT](implicit
       _ <- Future.fromTry(out(result, os))
     } yield ()
     eventualUnit.recover { case t =>
+      logger.error(scrub"${t.getMessage()}")
       ErrorHandler.handleException(t)
     }
   }


### PR DESCRIPTION
This is part of a test to play around with log filtering.

