### PR TITLE
Remove unused gu_contributions_reminder_signed_up cookie

### DIFF
--- a/support-frontend/app/controllers/DiagnosticsController.scala
+++ b/support-frontend/app/controllers/DiagnosticsController.scala
@@ -21,7 +21,6 @@ class DiagnosticsController(
     "gu.contributions.recurring.contrib-timestamp.Annual",
     "gu.contributions.contrib-timestamp",
     "gu_article_count_opt_out",
-    "gu_contributions_reminder_signed_up",
   )
 
   import actionRefiners._


### PR DESCRIPTION
## What are you doing in this PR?

This PR removes the gu_contributions_reminder_signed_up cookie from the Diagnostics as it is no longer set.

[**Trello Card**](https://trello.com/c/GN0qOTJw/103-remove-gucontributionsremindersignedup-cookie)

## Why are you doing this?

The cookie has already been removed and is no longer set anywhere as confirmed by a full search of The G organisation in GitHub.  We are therefore removing it from the Diagnostics endpoint.

co-authored-by @andrewHEguardian 
