### PR TITLE
Generic Checkout: Personal Detail Fields Validate via OnChange 

### DIFF
--- a/support-frontend/assets/components/personalDetails/personalDetailsContainer.tsx
+++ b/support-frontend/assets/components/personalDetails/personalDetailsContainer.tsx
@@ -82,7 +82,9 @@ export function PersonalDetailsContainer({
 			<StateSelect
 				countryId={countryId}
 				state={state}
-				onStateChange={onBillingStateChange}
+				onStateChange={(event) => {
+					onBillingStateChange(event.currentTarget.value);
+				}}
 				error={errorObject?.state?.[0]}
 			/>
 		),

--- a/support-frontend/assets/components/personalDetails/stateSelect.tsx
+++ b/support-frontend/assets/components/personalDetails/stateSelect.tsx
@@ -14,6 +14,7 @@ type StateSelectProps = {
 	countryId: IsoCountry;
 	state: string;
 	onStateChange: FormEventHandler<HTMLSelectElement>;
+	onBlur?: FormEventHandler<HTMLSelectElement>;
 	onInvalid?: FormEventHandler<HTMLSelectElement>;
 	error?: string;
 };
@@ -34,6 +35,7 @@ export function StateSelect({
 	countryId,
 	state,
 	onStateChange,
+	onBlur,
 	onInvalid,
 	error,
 }: StateSelectProps): JSX.Element | null {
@@ -49,6 +51,7 @@ export function StateSelect({
 				label={stateDescriptor}
 				value={state}
 				onChange={onStateChange}
+				onBlur={onBlur}
 				onInvalid={onInvalid}
 				error={error}
 				name={'billing-state'}

--- a/support-frontend/assets/components/personalDetails/stateSelect.tsx
+++ b/support-frontend/assets/components/personalDetails/stateSelect.tsx
@@ -13,7 +13,7 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 type StateSelectProps = {
 	countryId: IsoCountry;
 	state: string;
-	onStateChange: (newState: string) => void;
+	onStateChange: FormEventHandler<HTMLSelectElement>;
 	onInvalid?: FormEventHandler<HTMLSelectElement>;
 	error?: string;
 };
@@ -48,7 +48,7 @@ export function StateSelect({
 				id="state"
 				label={stateDescriptor}
 				value={state}
-				onChange={(e) => onStateChange(e.target.value)}
+				onChange={onStateChange}
 				onInvalid={onInvalid}
 				error={error}
 				name={'billing-state'}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -893,6 +893,8 @@ function CheckoutComponent({ geoId }: Props) {
 													name="billing-postcode"
 													onChange={(event) => {
 														setBillingPostcode(event.target.value);
+													}}
+													onBlur={(event) => {
 														event.target.checkValidity();
 													}}
 													maxLength={20}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -751,7 +751,9 @@ function CheckoutComponent({ geoId }: Props) {
 												type="email"
 												autoComplete="email"
 												onChange={(event) => {
-													setEmail(event.target.value);
+													setEmail(event.currentTarget.value);
+												}}
+												onBlur={(event) => {
 													event.target.checkValidity();
 												}}
 												disabled={isSignedIn}
@@ -790,6 +792,8 @@ function CheckoutComponent({ geoId }: Props) {
 													autoCapitalize="words"
 													onChange={(event) => {
 														setFirstName(event.target.value);
+													}}
+													onBlur={(event) => {
 														event.target.checkValidity();
 													}}
 													name="firstName"
@@ -826,6 +830,8 @@ function CheckoutComponent({ geoId }: Props) {
 													autoCapitalize="words"
 													onChange={(event) => {
 														setLastName(event.target.value);
+													}}
+													onBlur={(event) => {
 														event.target.checkValidity();
 													}}
 													name="lastName"

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -750,7 +750,10 @@ function CheckoutComponent({ geoId }: Props) {
 												value={email}
 												type="email"
 												autoComplete="email"
-												onChange={(event) => setEmail(event.target.value)}
+												onChange={(event) => {
+													setEmail(event.target.value);
+													event.target.checkValidity();
+												}}
 												disabled={isSignedIn}
 												name="email"
 												required
@@ -785,7 +788,10 @@ function CheckoutComponent({ geoId }: Props) {
 													value={firstName}
 													autoComplete="given-name"
 													autoCapitalize="words"
-													onChange={(event) => setFirstName(event.target.value)}
+													onChange={(event) => {
+														setFirstName(event.target.value);
+														event.target.checkValidity();
+													}}
 													name="firstName"
 													required
 													maxLength={40}
@@ -818,7 +824,10 @@ function CheckoutComponent({ geoId }: Props) {
 													value={lastName}
 													autoComplete="family-name"
 													autoCapitalize="words"
-													onChange={(event) => setLastName(event.target.value)}
+													onChange={(event) => {
+														setLastName(event.target.value);
+														event.target.checkValidity();
+													}}
 													name="lastName"
 													required
 													maxLength={40}
@@ -874,9 +883,10 @@ function CheckoutComponent({ geoId }: Props) {
 													id="zipCode"
 													label="ZIP code"
 													name="billing-postcode"
-													onChange={(event) =>
-														setBillingPostcode(event.target.value)
-													}
+													onChange={(event) => {
+														setBillingPostcode(event.target.value);
+														event.target.checkValidity();
+													}}
 													maxLength={20}
 													value={billingPostcode}
 													pattern={doesNotContainEmojiPattern}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -866,6 +866,8 @@ function CheckoutComponent({ geoId }: Props) {
 												state={billingState}
 												onStateChange={(event) => {
 													setBillingState(event.currentTarget.value);
+												}}
+												onBlur={(event) => {
 													event.currentTarget.checkValidity();
 												}}
 												onInvalid={(event) => {

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -849,7 +849,10 @@ function CheckoutComponent({ geoId }: Props) {
 											<StateSelect
 												countryId={countryId}
 												state={billingState}
-												onStateChange={setBillingState}
+												onStateChange={(event) => {
+													setBillingState(event.currentTarget.value);
+													event.currentTarget.checkValidity();
+												}}
 												onInvalid={(event) => {
 													preventDefaultValidityMessage(event.currentTarget);
 													const validityState = event.currentTarget.validity;


### PR DESCRIPTION
## What are you doing in this PR?

Ensure Personal Details fields validate after editing when loose focus (onChange/onStateChange).

[**Trello Card**](https://trello.com/c/ihabrisb/802-form-validation-for-generic-checkout-state-zipcode)

![image](https://github.com/guardian/support-frontend/assets/76729591/063446bd-f18b-4885-a70f-82b578a4dcae)
