### PR TITLE
Use `readonly` over `disabled` to ensure value is posted for email on checkout

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -756,7 +756,7 @@ function CheckoutComponent({ geoId }: Props) {
 												onBlur={(event) => {
 													event.target.checkValidity();
 												}}
-												disabled={isSignedIn}
+												readOnly={isSignedIn}
 												name="email"
 												required
 												maxLength={80}


### PR DESCRIPTION
Uses the [`readonly`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly) attribute for when a user is signed in.

The [`disabled` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled) excludes the value from the `FormData` which is where we populate this value from.

Thank you semantics!