### PR TITLE
Abandoned Basket Cookie: fix valibot parsing error message

### DIFF
--- a/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
+++ b/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
@@ -1,6 +1,14 @@
 import { useEffect } from 'react';
 import type { Input } from 'valibot';
-import { literal, number, object, safeParse, string, union } from 'valibot';
+import {
+	flatten,
+	literal,
+	number,
+	object,
+	safeParse,
+	string,
+	union,
+} from 'valibot';
 import * as cookie from 'helpers/storage/cookie';
 import type { ProductCheckout } from 'helpers/tracking/behaviour';
 import { logException } from 'helpers/utilities/logger';
@@ -68,7 +76,7 @@ export function updateAbandonedBasketCookie(amount: string) {
 	} else {
 		logException(
 			`Failed to parse abandoned basket cookie. Error:
-			${parsedCookie.issues.toString()}`,
+			${JSON.stringify(flatten(parsedCookie.issues))}`,
 		);
 	}
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Fix the error message logged when the abandoned basket cookie fails to parse.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

## Why are you doing this?

![image](https://github.com/guardian/support-frontend/assets/114918544/4cb7dd5e-20c4-4544-88ca-7c64ab391621)

There a lot of sentry exceptions for failed parsing of the cookie, but the error message wasn't formatted correctly so can't see the actual parsing error.

Once we see what the errors are we can fix the issue, and potentially don't want this logged as an exception 

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Running locally, go to one time checkout, manually edit the `GU_CO_INCOMPLETE` cookie to be invalid, and see error in console with readable error message.

![image](https://github.com/guardian/support-frontend/assets/114918544/505cd4bc-c007-4a6a-8c3c-2c9297547b49)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

