### PR TITLE
fix: add hack to ticket tailor iframe sizing

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -26,8 +26,23 @@ export function Events() {
 		>
 			<div css={checkoutContainer}>
 				<Container>
-					<div className="tt-widget">
-						<div className="tt-widget-fallback">
+					<div
+						className="tt-widget"
+						style={{
+							background: 'white',
+						}}
+					>
+						<iframe
+							src={`https://tickets.theguardian.live/checkout/new-session/id/${eventId}/chk/9fa2/?ref=support-theguardian-com&amp;widget=true&amp;minimal=true&amp;show_logo=false&amp;bg_fill=false`}
+							allow="payment"
+							style={{
+								height: '80vh',
+								width: '100%',
+								overflow: 'scroll',
+							}}
+						></iframe>
+						{/* We should reenstate this once we know while TT sort out some cross-domain problems */}
+						{/* <div className="tt-widget-fallback">
 							<p>
 								<a
 									href={`https://tickets.theguardian.live/checkout/new-session/id/${eventId}/chk/9fa2/?ref=support-theguardian-com`}
@@ -46,7 +61,7 @@ export function Events() {
 							data-inline-bg-fill="false"
 							data-inline-inherit-ref-from-url-param=""
 							data-inline-ref="support-theguardian-com"
-						></script>
+						></script> */}
 					</div>
 				</Container>
 			</div>

--- a/support-frontend/webpack.dev.js
+++ b/support-frontend/webpack.dev.js
@@ -16,10 +16,10 @@ module.exports = merge(common('[name].css', '[name].js', false), {
 		],
 		client: {
 			webSocketURL: 'https://support.thegulocal.com/ws',
-      overlay: false,
+			overlay: false,
 		},
 	},
 	resolve: {
-		fallback: { "crypto": false }
+		fallback: { crypto: false },
 	},
 });


### PR DESCRIPTION
Removes the TT widget JS and uses an iframe directly.

What we lose is the iframe resizing capability, but this is OK as it's currently not working. This is with TT and they are raising a case for it.

This is mainly to allow people to test the flow E2E.

Weirdly it did work ([you can see it in this PR](https://github.com/guardian/support-frontend/pull/5980)) - I am not sure what has changed.

## New slightly substandard version

https://github.com/guardian/support-frontend/assets/31692/e81910f7-1dd1-4bd1-aad2-7ded0861bbe7

