### PR TITLE
Revert "build(deps-dev): bump preact from 10.7.1 to 10.22.0 in /support-frontend"

### DIFF
--- a/support-frontend/assets/pages/aus-moment-map/components/map.tsx
+++ b/support-frontend/assets/pages/aus-moment-map/components/map.tsx
@@ -39,74 +39,74 @@ type MapProps = {
 	setSelectedTerritory: (arg0: string) => void;
 };
 
-type Ref = HTMLDivElement;
-
-export const Map = React.forwardRef<Ref, MapProps>((props, ref) => (
-	<div className="map" ref={ref}>
-		<div className="map-background" />
-		<div className="svg-wrapper">
-			<svg
-				className="svg-content"
-				viewBox="0 0 694 645"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<TerritorySvgContainer
-					onClick={() => props.setSelectedTerritory('ACT')}
-					isSelected={props.selectedTerritory === 'ACT'}
+export const Map = React.forwardRef(
+	(props: MapProps, ref: React.Ref<HTMLDivElement>) => (
+		<div className="map" ref={ref}>
+			<div className="map-background" />
+			<div className="svg-wrapper">
+				<svg
+					className="svg-content"
+					viewBox="0 0 694 645"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
 				>
-					<ActSvg />
-				</TerritorySvgContainer>
+					<TerritorySvgContainer
+						onClick={() => props.setSelectedTerritory('ACT')}
+						isSelected={props.selectedTerritory === 'ACT'}
+					>
+						<ActSvg />
+					</TerritorySvgContainer>
 
-				<TerritorySvgContainer
-					onClick={() => props.setSelectedTerritory('VIC')}
-					isSelected={props.selectedTerritory === 'VIC'}
-				>
-					<VictoriaSvg />
-				</TerritorySvgContainer>
+					<TerritorySvgContainer
+						onClick={() => props.setSelectedTerritory('VIC')}
+						isSelected={props.selectedTerritory === 'VIC'}
+					>
+						<VictoriaSvg />
+					</TerritorySvgContainer>
 
-				<TerritorySvgContainer
-					onClick={() => props.setSelectedTerritory('NSW')}
-					isSelected={props.selectedTerritory === 'NSW'}
-				>
-					<NewSouthWalesSvg />
-				</TerritorySvgContainer>
+					<TerritorySvgContainer
+						onClick={() => props.setSelectedTerritory('NSW')}
+						isSelected={props.selectedTerritory === 'NSW'}
+					>
+						<NewSouthWalesSvg />
+					</TerritorySvgContainer>
 
-				<TerritorySvgContainer
-					onClick={() => props.setSelectedTerritory('QLD')}
-					isSelected={props.selectedTerritory === 'QLD'}
-				>
-					<QueenslandSvg />
-				</TerritorySvgContainer>
+					<TerritorySvgContainer
+						onClick={() => props.setSelectedTerritory('QLD')}
+						isSelected={props.selectedTerritory === 'QLD'}
+					>
+						<QueenslandSvg />
+					</TerritorySvgContainer>
 
-				<TerritorySvgContainer
-					onClick={() => props.setSelectedTerritory('SA')}
-					isSelected={props.selectedTerritory === 'SA'}
-				>
-					<SouthAustraliaSvg />
-				</TerritorySvgContainer>
+					<TerritorySvgContainer
+						onClick={() => props.setSelectedTerritory('SA')}
+						isSelected={props.selectedTerritory === 'SA'}
+					>
+						<SouthAustraliaSvg />
+					</TerritorySvgContainer>
 
-				<TerritorySvgContainer
-					onClick={() => props.setSelectedTerritory('WA')}
-					isSelected={props.selectedTerritory === 'WA'}
-				>
-					<WesternAustraliaSvg />
-				</TerritorySvgContainer>
+					<TerritorySvgContainer
+						onClick={() => props.setSelectedTerritory('WA')}
+						isSelected={props.selectedTerritory === 'WA'}
+					>
+						<WesternAustraliaSvg />
+					</TerritorySvgContainer>
 
-				<TerritorySvgContainer
-					onClick={() => props.setSelectedTerritory('TAS')}
-					isSelected={props.selectedTerritory === 'TAS'}
-				>
-					<TasmaniaSvg />
-				</TerritorySvgContainer>
+					<TerritorySvgContainer
+						onClick={() => props.setSelectedTerritory('TAS')}
+						isSelected={props.selectedTerritory === 'TAS'}
+					>
+						<TasmaniaSvg />
+					</TerritorySvgContainer>
 
-				<TerritorySvgContainer
-					onClick={() => props.setSelectedTerritory('NT')}
-					isSelected={props.selectedTerritory === 'NT'}
-				>
-					<NorthernTerritorySvg />
-				</TerritorySvgContainer>
-			</svg>
+					<TerritorySvgContainer
+						onClick={() => props.setSelectedTerritory('NT')}
+						isSelected={props.selectedTerritory === 'NT'}
+					>
+						<NorthernTerritorySvg />
+					</TerritorySvgContainer>
+				</svg>
+			</div>
 		</div>
-	</div>
-));
+	),
+);

--- a/support-frontend/assets/pages/aus-moment-map/components/testimonialsContainer.tsx
+++ b/support-frontend/assets/pages/aus-moment-map/components/testimonialsContainer.tsx
@@ -321,10 +321,8 @@ type Props = {
 	setSelectedTerritory: (arg0: string) => void;
 };
 
-type Ref = HTMLDivElement;
-
-export const TestimonialsContainer = React.forwardRef<Ref, Props>(
-	(props, ref) => {
+export const TestimonialsContainer = React.forwardRef(
+	(props: Props, ref: React.Ref<HTMLDivElement>) => {
 		const { windowWidthIsLessThan } = useWindowWidth();
 
 		if ('testimonialsCollection' in props) {

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -189,7 +189,7 @@
     "postcss": "^8.4.38",
     "postcss-loader": "^7.3.0",
     "postcss-pxtorem": "^6.0.0",
-    "preact": "^10.22.0",
+    "preact": "^10.4.6",
     "preact-render-to-string": "^5.2.6",
     "prettier": "^2.8.8",
     "prettier-eslint": "^16.3.0",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -13646,10 +13646,10 @@ preact-render-to-string@^5.2.6:
   dependencies:
     pretty-format "^3.8.0"
 
-preact@^10.22.0:
-  version "10.22.0"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.22.0.tgz#a50f38006ae438d255e2631cbdaf7488e6dd4e16"
-  integrity sha512-RRurnSjJPj4rp5K6XoP45Ui33ncb7e4H7WiOHVpjbkvqvA3U+N8Z6Qbo0AE6leGYBV66n8EhEaFixvIu3SkxFw==
+preact@^10.4.6:
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.7.1.tgz#bdd2b2dce91a5842c3b9b34dfe050e5401068c9e"
+  integrity sha512-MufnRFz39aIhs9AMFisonjzTud1PK1bY+jcJLo6m2T9Uh8AqjD77w11eAAawmjUogoGOnipECq7e/1RClIKsxg==
 
 precinct@^8.1.0:
   version "8.3.1"


### PR DESCRIPTION
Reverts guardian/support-frontend#6015 something about updating preact from 10.7.1 to 10.22.0 introduced a noticeable flash of unstyled content, as seen below. Quickest thing we can do is revert and look into this.

https://github.com/guardian/support-frontend/assets/1590704/296af959-4ac7-4264-ba97-1d340a76e37c

[Trello](https://trello.com/c/p2ghoWMI/871-flash-of-unstyled-content-on-3-tier-checkout-pages)

