### PR TITLE
feat: migrate alarms for bigquery-acquisitions-publisher

### DIFF
--- a/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/acquisition-events-api.test.ts.snap
@@ -45,7 +45,7 @@ exports[`The Acquisition Events API stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":alarms-handler-topic-PROD",
+                ":alarms-handler-topic-CODE",
               ],
             ],
           },

--- a/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
+++ b/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
@@ -35,7 +35,7 @@ exports[`The BigqueryAcquisitionsPublisher stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":contributions-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -192,7 +192,7 @@ Logs are at https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-w
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":conversion-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },

--- a/cdk/lib/acquisition-events-api.ts
+++ b/cdk/lib/acquisition-events-api.ts
@@ -45,7 +45,7 @@ export class AcquisitionEventsApi extends GuStack {
       ),
       evaluationPeriods: 1,
       threshold: 1,
-      snsTopicName: 'alarms-handler-topic-PROD',
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
       actionsEnabled: this.stage === "PROD",
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       metric: new Metric({

--- a/cdk/lib/bigquery-acquisitions-publisher.ts
+++ b/cdk/lib/bigquery-acquisitions-publisher.ts
@@ -97,7 +97,7 @@ export class BigqueryAcquisitionsPublisher extends GuStack {
       this.stage == "PROD"
         ? {
             toleratedErrorPercentage: 0,
-            snsTopicName: "conversion-dev",
+            snsTopicName: `alarms-handler-topic-${this.stage}`,
             alarmName: "big-query-acquisition-publisher lambda has failed",
             alarmDescription:
               "Check the logs for details https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fbigquery-acquisitions-publisher-PROD",
@@ -139,7 +139,7 @@ export class BigqueryAcquisitionsPublisher extends GuStack {
       evaluationPeriods: 1,
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       treatMissingData: TreatMissingData.IGNORE,
-      snsTopicName: "contributions-dev",
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
       actionsEnabled: this.stage === "PROD",
     });
   }


### PR DESCRIPTION
## What are you doing in this PR?

- Migrate alarms for bigquery-acquisitions-publisher
- Refactor SNS topic for acquisition-events-api to not use hard-coded strings