### PR TITLE
refactor: remove experiments from settings

### DIFF
--- a/support-frontend/assets/__mocks__/settingsMock.ts
+++ b/support-frontend/assets/__mocks__/settingsMock.ts
@@ -42,7 +42,6 @@ export const mockSettings: Settings = {
 			enableRecaptchaBackend: 'On',
 			enableRecaptchaFrontend: 'On',
 		},
-		experiments: {},
 	},
 	amounts: [
 		{

--- a/support-frontend/assets/helpers/globalsAndSwitches/settings.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/settings.ts
@@ -21,16 +21,7 @@ type SwitchesKeys =
 	| 'campaignSwitches'
 	| 'recaptchaSwitches';
 
-export type Switches = Record<SwitchesKeys, SwitchObject> & {
-	experiments: Record<
-		string,
-		{
-			name: string;
-			description: string;
-			state: Status;
-		}
-	>;
-};
+export type Switches = Record<SwitchesKeys, SwitchObject>;
 
 export type Settings = {
 	switches: Switches;


### PR DESCRIPTION
The property is not set or used anywhere, so assuming it's legacy and removing it. 

This is part of an effort to get parsing between server & client a little tighter.