### PR TITLE
Remove unnecessary encoder

### DIFF
--- a/support-frontend/app/admin/ServersideAbTest.scala
+++ b/support-frontend/app/admin/ServersideAbTest.scala
@@ -25,7 +25,5 @@ object ServersideAbTest {
   }
 
   import io.circe.syntax._
-  implicit val encoder = Encoder[Map[String, Participation]]
-
   val asJsonString: Map[String, Participation] => String = _.asJson.noSpaces
 }


### PR DESCRIPTION
Having an encoder for `Map[K, V]` is not necessary as circe has these build in.

The reason for removing this is it is creating conflicts on the `implicits` when I import these types into parts of the code that have semi-automatic derivation creating two possible encoders which the compiler doesn't know which to pick.