### PR TITLE
Reinstate the ticket tailor widget

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -26,23 +26,8 @@ export function Events() {
 		>
 			<div css={checkoutContainer}>
 				<Container>
-					<div
-						className="tt-widget"
-						style={{
-							background: 'white',
-						}}
-					>
-						<iframe
-							src={`https://tickets.theguardian.live/checkout/new-session/id/${eventId}/chk/9fa2/?ref=support-theguardian-com&amp;widget=true&amp;minimal=true&amp;show_logo=false&amp;bg_fill=false`}
-							allow="payment"
-							style={{
-								height: '80vh',
-								width: '100%',
-								overflow: 'scroll',
-							}}
-						></iframe>
-						{/* We should reenstate this once we know while TT sort out some cross-domain problems */}
-						{/* <div className="tt-widget-fallback">
+					<div className="tt-widget">
+						<div className="tt-widget-fallback">
 							<p>
 								<a
 									href={`https://tickets.theguardian.live/checkout/new-session/id/${eventId}/chk/9fa2/?ref=support-theguardian-com`}
@@ -61,7 +46,7 @@ export function Events() {
 							data-inline-bg-fill="false"
 							data-inline-inherit-ref-from-url-param=""
 							data-inline-ref="support-theguardian-com"
-						></script> */}
+						></script>
 					</div>
 				</Container>
 			</div>


### PR DESCRIPTION
Ticket Tailor has fixed the issue with cross-origin iframe communication.

This re-instates the use of the widget over just having an iframe. 