### PR TITLE
Add Ts&Cs to price summary on checkout

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
@@ -16,7 +16,7 @@ type ContributionsOrderSummaryContainerProps = {
 	promotion?: Promotion;
 };
 
-function getTermsConditions(
+export function getTermsConditions(
 	countryGroupId: CountryGroupId,
 	contributionType: ContributionType,
 	isSupporterPlus: boolean,

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -32,6 +32,7 @@ import DirectDebitForm from 'components/directDebit/directDebitForm/directDebitF
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { LoadingOverlay } from 'components/loadingOverlay/loadingOverlay';
 import { ContributionsOrderSummary } from 'components/orderSummary/contributionsOrderSummary';
+import { getTermsConditions } from 'components/orderSummary/contributionsOrderSummaryContainer';
 import { PageScaffold } from 'components/page/pageScaffold';
 import { DefaultPaymentButton } from 'components/paymentButton/defaultPaymentButton';
 import { paymentMethodData } from 'components/paymentMethodSelector/paymentMethodData';
@@ -720,7 +721,15 @@ function CheckoutComponent({ geoId }: Props) {
 										);
 									}}
 									enableCheckList={true}
-									tsAndCs={null}
+									tsAndCs={getTermsConditions(
+										countryGroupId,
+										productFields.billingPeriod === 'Monthly'
+											? 'MONTHLY'
+											: productFields.billingPeriod === 'Annual'
+											? 'ANNUAL'
+											: 'ONE_OFF',
+										query.product === 'SupporterPlus',
+									)}
 								/>
 							</BoxContents>
 						</Box>


### PR DESCRIPTION
Adds the Ts & Cs to the summary on the checkout.

![Capture-2024-06-03-131800](https://github.com/guardian/support-frontend/assets/31692/63f1f565-0b55-48b0-82ef-93eb946507cf)
