### PR TITLE
Add ophan tracking to country select

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
@@ -77,7 +77,7 @@ function statesForCountry(country: Option<IsoCountry>): React.ReactNode {
 
 export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 	return (
-		<div>
+		<div data-component={`${scope}AddressFields`}>
 			<Select
 				css={marginBottom}
 				id={`${scope}-country`}
@@ -92,6 +92,7 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 				}}
 				error={firstError('country', props.errors)}
 				name={`${scope}-country`}
+				data-link-name={`${scope}CountrySelect : ${props.country}`}
 			>
 				<OptionForSelect value="">Select a country</OptionForSelect>
 				{sortedOptions(props.countries)}


### PR DESCRIPTION
This adds [`data-link-name` tracking](https://github.com/guardian/ophan/blob/a69e354d1bec4c0ba206a75fc62ea77a34f19a66/tracker-js/assets/click-path-capture.js#L31-L45) to the country `select`. I want to use this data to have an indication of how often we get the country wrong to help inform UX later on.

## Network request to Ophan
![Screenshot 2024-06-04 at 09 11 24](https://github.com/guardian/support-frontend/assets/31692/f7765376-dbb8-424f-8955-609cdcd88f20)


  