### PR TITLE
fix: use Your Subscription in checkout heading

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -59,7 +59,7 @@ const totalRow = (hasTsAncCs: boolean) => css`
 	}
 `;
 
-const heading = css`
+const headingCss = css`
 	${headline.xsmall({ fontWeight: 'bold' })}
 	${from.tablet} {
 		font-size: 28px;
@@ -133,7 +133,7 @@ export type ContributionsOrderSummaryProps = {
 	onCheckListToggle?: (opening: boolean) => void;
 	headerButton?: React.ReactNode;
 	tsAndCs?: React.ReactNode;
-	threeTierProductName?: string;
+	heading?: string;
 	showTopUpAmounts?: boolean;
 	topUpToggleChecked?: boolean;
 	topUpToggleOnChange?: () => void;
@@ -154,7 +154,7 @@ export function ContributionsOrderSummary({
 	onCheckListToggle,
 	headerButton,
 	tsAndCs,
-	threeTierProductName,
+	heading,
 	enableCheckList,
 }: ContributionsOrderSummaryProps): JSX.Element {
 	const [showCheckList, setCheckList] = useState(false);
@@ -177,9 +177,7 @@ export function ContributionsOrderSummary({
 	return (
 		<div css={componentStyles}>
 			<div css={[summaryRow, rowSpacing, headingRow]}>
-				<h2 css={heading}>
-					{threeTierProductName ? 'Your subscription' : 'Your support'}
-				</h2>
+				<h2 css={headingCss}>{heading ?? 'Your subscription'}</h2>
 				{headerButton}
 			</div>
 			<hr css={hrCss} />

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
@@ -11,7 +11,6 @@ import { trackComponentClick } from 'helpers/tracking/behaviour';
 import type { ContributionsOrderSummaryProps } from './contributionsOrderSummary';
 
 type ContributionsOrderSummaryContainerProps = {
-	inThreeTier: boolean;
 	renderOrderSummary: (props: ContributionsOrderSummaryProps) => JSX.Element;
 	promotion?: Promotion;
 };
@@ -61,7 +60,6 @@ export function getTermsConditions(
 }
 
 export function ContributionsOrderSummaryContainer({
-	inThreeTier,
 	renderOrderSummary,
 	promotion,
 }: ContributionsOrderSummaryContainerProps): JSX.Element {
@@ -92,21 +90,17 @@ export function ContributionsOrderSummaryContainer({
 		);
 	}
 
-	const threeTierProductName = (
-		contributionType: ContributionType,
-	): string | undefined => {
-		if (inThreeTier) {
-			if (contributionType === 'ONE_OFF') {
-				return 'One-time support';
-			} else if (isSupporterPlus) {
-				return 'All-access digital';
-			} else {
-				return 'Support';
-			}
-		}
-	};
+	let description;
+	let heading;
+	if (contributionType === 'ONE_OFF') {
+		heading = 'Your support';
+		description = 'One-time support';
+	} else if (isSupporterPlus) {
+		description = 'All-access digital';
+	} else {
+		description = 'Support';
+	}
 
-	const description = threeTierProductName(contributionType) ?? '';
 	const paymentFrequency =
 		contributionType === 'MONTHLY'
 			? 'month'
@@ -123,7 +117,7 @@ export function ContributionsOrderSummaryContainer({
 		enableCheckList: contributionType !== 'ONE_OFF',
 		checkListData: checklist,
 		onCheckListToggle,
-		threeTierProductName: threeTierProductName(contributionType),
+		heading,
 		tsAndCs: getTermsConditions(
 			countryGroupId,
 			contributionType,

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -120,7 +120,6 @@ export function SupporterPlusCheckout({
 						<ContributionsPriceCards paymentFrequency={contributionType} />
 					) : (
 						<ContributionsOrderSummaryContainer
-							inThreeTier={inThreeTier}
 							promotion={promotion}
 							renderOrderSummary={(orderSummaryProps) => (
 								<ContributionsOrderSummary


### PR DESCRIPTION
Uses "You subscription" as a heading for subscription products on checkout

| before | after |
|---|---|
| ![Screenshot 2024-06-04 at 10 29 24](https://github.com/guardian/support-frontend/assets/31692/d27885fa-078a-42e6-8fd8-f44c5f5ac0f3) | ![Screenshot 2024-06-04 at 10 29 34](https://github.com/guardian/support-frontend/assets/31692/178ebe5d-d126-4e13-b44e-a425b9666ee7) |
