### PR TITLE
Fix e2e tests: update the cta selector on the 3-tier landing page

### DIFF
--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -45,6 +45,8 @@ test.describe('Subscribe/Contribute via the Tiered checkout)', () => {
 			const testFirstName = firstName();
 			const testLastName = lastName();
 			const testEmail = email();
+			const ctaCopy = testDetails.country === 'US' ? 'Subscribe' : 'Support';
+
 			await setupPage(
 				page,
 				context,
@@ -53,7 +55,7 @@ test.describe('Subscribe/Contribute via the Tiered checkout)', () => {
 			);
 			await page.getByRole('tab').getByText(testDetails.frequency).click();
 			await page
-				.getByRole('link', { name: 'Subscribe' })
+				.getByRole('link', { name: ctaCopy })
 				.nth(testDetails.tier - 1)
 				.click();
 			await checkAbandonedBasketCookieExists(context);
@@ -146,6 +148,8 @@ test.describe('Supporter Plus promoCodes', () => {
 			const testFirstName = firstName();
 			const testLastName = lastName();
 			const testEmail = email();
+			const ctaCopy = 'Support';
+
 			await setupPage(
 				page,
 				context,
@@ -162,7 +166,7 @@ test.describe('Supporter Plus promoCodes', () => {
 				card.getByText(testDetails.expectedPromoText).first(),
 			).toBeVisible();
 			await page
-				.getByRole('link', { name: 'Subscribe' })
+				.getByRole('link', { name: ctaCopy })
 				.nth(testDetails.tier - 1)
 				.click();
 


### PR DESCRIPTION
## What are you doing in this PR?

We've updated the CTA copy on the 3-tier landing page, so the e2e test need updating so they can find it.