### PR TITLE
Abandoned Basket: Always set billingPeriod in uppercase in cookie

### DIFF
--- a/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
+++ b/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
@@ -34,7 +34,7 @@ export function useAbandonedBasketCookie(
 	const abandonedBasket = {
 		product,
 		amount: parseAmount(amount),
-		billingPeriod,
+		billingPeriod: billingPeriod.toUpperCase(),
 		region,
 	};
 	useEffect(() => {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

When setting the abandoned basket cookie always use an uppercase version of the billing period.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/laOsfKVH/476-abandoned-basket-set-cookie-with-billing-period-in-uppercase-always-support-frontend)

## Why are you doing this?

In the Guardian Weekly [checkout](https://github.com/guardian/support-frontend/blob/8ae6b184bcb6ec1605791a5bcb2fbf3789cdecf7/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx#L231) we set the billing period in lower case, however in the other contributions checkout and the [schema](https://github.com/guardian/support-dotcom-components/blob/82e89beb6d516025611cfddaaf39022598bfc07c/packages/shared/src/types/targeting/shared.ts#L40) we expect an uppercase value. 
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Go to Weekly checkout in 3 tier proposition and see cookie is set with `billingPeriod` in uppercase

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
