### PR TITLE
fix: make css RefPath optional

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -156,7 +156,7 @@ class Application(
         "Support the Guardian | Down for essential maintenance",
         views.EmptyDiv("down-for-maintenance-page"),
         RefPath("downForMaintenancePage.js"),
-        RefPath("downForMaintenancePage.css"),
+        Some(RefPath("downForMaintenancePage.css")),
       )()(assets, request, settingsProvider.getAllSettings()),
     ).withSettingsSurrogateKey
   }
@@ -173,9 +173,6 @@ class Application(
       campaignCode: Option[String],
       guestAccountCreationToken: Option[String],
   )(implicit request: RequestHeader, settings: AllSettings) = {
-
-    val css = RefPath("supporterPlusLandingPage.css")
-    val js = RefPath("supporterPlusLandingPage.js")
 
     val classes = "gu-content--contribution-form--placeholder" +
       campaignCode.map(code => s" gu-content--campaign-landing gu-content--$code").getOrElse("")
@@ -203,8 +200,8 @@ class Application(
       title = "Support the Guardian",
       id = s"contributions-landing-page-$countryCode",
       mainElement = mainElement,
-      js = js,
-      css = css,
+      js = RefPath("supporterPlusLandingPage.js"),
+      css = Some(RefPath("supporterPlusLandingPage.css")),
       description = stringsConfig.contributionsLandingDescription,
       paymentMethodConfigs = PaymentMethodConfigs(
         oneOffDefaultStripeConfig = oneOffStripeConfigProvider.get(false),
@@ -241,7 +238,7 @@ class Application(
         title = "Guardian Supporters Map",
         mainElement = EmptyDiv("aus-moment-map"),
         mainJsBundle = RefPath("ausMomentMap.js"),
-        mainStyleBundle = RefPath("ausMomentMap.css"),
+        mainStyleBundle = Some(RefPath("ausMomentMap.css")),
         description = stringsConfig.contributionsLandingDescription,
         canonicalLink = Some("https://support.theguardian.com/aus-map"),
         shareImageUrl = Some(

--- a/support-frontend/app/controllers/PaperSubscriptionController.scala
+++ b/support-frontend/app/controllers/PaperSubscriptionController.scala
@@ -46,7 +46,7 @@ class PaperSubscriptionController(
         title = "The Guardian Newspaper Subscription | Subscription Card and Home Delivery",
         mainElement = EmptyDiv("paper-subscription-landing-page"),
         mainJsBundle = RefPath("paperSubscriptionLandingPage.js"),
-        mainStyleBundle = RefPath("paperSubscriptionLandingPage.css"),
+        mainStyleBundle = Some(RefPath("paperSubscriptionLandingPage.css")),
         description = stringsConfig.paperLandingDescription,
         canonicalLink = canonicalLink,
         shareImageUrl = Some(

--- a/support-frontend/app/controllers/PayPalOneOff.scala
+++ b/support-frontend/app/controllers/PayPalOneOff.scala
@@ -40,7 +40,7 @@ class PayPalOneOff(
         "Support the Guardian | PayPal Error",
         EmptyDiv("paypal-error-page"),
         RefPath("payPalErrorPage.js"),
-        RefPath("payPalErrorPageStyles.css"),
+        Some(RefPath("payPalErrorPageStyles.css")),
       )(),
     ).withSettingsSurrogateKey
   }

--- a/support-frontend/app/controllers/PayPalRegular.scala
+++ b/support-frontend/app/controllers/PayPalRegular.scala
@@ -88,7 +88,7 @@ class PayPalRegular(
         "Support the Guardian | PayPal Error",
         EmptyDiv("paypal-error-page"),
         RefPath("payPalErrorPage.js"),
-        RefPath("payPalErrorPageStyles.css"),
+        Some(RefPath("payPalErrorPageStyles.css")),
       )(),
     ).withSettingsSurrogateKey
   }
@@ -103,7 +103,7 @@ class PayPalRegular(
         "Support the Guardian | PayPal Error",
         EmptyDiv("paypal-error-page"),
         RefPath("payPalErrorPage.js"),
-        RefPath("payPalErrorPageStyles.css"),
+        Some(RefPath("payPalErrorPageStyles.css")),
       )(),
     ).withSettingsSurrogateKey
   }

--- a/support-frontend/app/controllers/Promotions.scala
+++ b/support-frontend/app/controllers/Promotions.scala
@@ -59,7 +59,7 @@ class Promotions(
     val title = "Support the Guardian | Digital Pack Subscription"
     val mainElement = EmptyDiv("promotion-terms")
     val js = RefPath("promotionTerms.js")
-    val css = RefPath("promotionTerms.css")
+    val css = Some(RefPath("promotionTerms.css"))
     val promotionService = promotionServiceProvider.forUser(false)
     val maybePromotionTerms = PromotionTerms.fromPromoCode(promotionService, stage, promoCode)
 

--- a/support-frontend/app/controllers/SubscriptionsController.scala
+++ b/support-frontend/app/controllers/SubscriptionsController.scala
@@ -103,7 +103,7 @@ class SubscriptionsController(
         title,
         mainElement,
         RefPath(js),
-        RefPath("subscriptionsLandingPage.css"),
+        Some(RefPath("subscriptionsLandingPage.css")),
         description = stringsConfig.subscriptionsLandingDescription,
       ) {
         Html(s"""<script type="text/javascript">

--- a/support-frontend/app/controllers/WeeklySubscriptionController.scala
+++ b/support-frontend/app/controllers/WeeklySubscriptionController.scala
@@ -57,7 +57,7 @@ class WeeklySubscriptionController(
           else "The Guardian Weekly Subscriptions | The Guardian",
         mainElement = EmptyDiv("weekly-landing-page-" + countryCode),
         mainJsBundle = RefPath("weeklySubscriptionLandingPage.js"),
-        mainStyleBundle = RefPath("weeklySubscriptionLandingPage.css"),
+        mainStyleBundle = Some(RefPath("weeklySubscriptionLandingPage.css")),
         description = stringsConfig.weeklyLandingDescription,
         canonicalLink = canonicalLink,
         hrefLangLinks = getWeeklyHrefLangLinks(orderIsAGift),

--- a/support-frontend/app/lib/CustomHttpErrorHandler.scala
+++ b/support-frontend/app/lib/CustomHttpErrorHandler.scala
@@ -42,7 +42,7 @@ class CustomHttpErrorHandler(
           "Error 404",
           EmptyDiv("error-404-page"),
           RefPath("error404Page.js"),
-          RefPath("error404Page.css"),
+          Some(RefPath("error404Page.css")),
         )()(assets, request, settingsProvider.getAllSettings()),
       )
         .withHeaders(CacheControl.defaultCacheHeaders(30.seconds, 30.seconds): _*)
@@ -58,7 +58,7 @@ class CustomHttpErrorHandler(
           "Error 500",
           EmptyDiv("error-500-page"),
           RefPath("error500Page.js"),
-          RefPath("error500Page.css"),
+          Some(RefPath("error500Page.css")),
         )()(assets, request, settingsProvider.getAllSettings()),
       )
         .withHeaders(CacheControl.noCache)

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -15,7 +15,7 @@
   id: String,
   mainElement: ReactDiv,
   js: RefPath,
-  css: RefPath,
+  css: Option[RefPath],
   description: Option[String],
   paymentMethodConfigs: PaymentMethodConfigs,
   paymentApiUrl: String,

--- a/support-frontend/app/views/eventsRouter.scala.html
+++ b/support-frontend/app/views/eventsRouter.scala.html
@@ -9,7 +9,7 @@
   title = "Support the Guardian | Events",
   mainElement = EmptyDiv("events"),
   mainJsBundle = RefPath("[countryGroupId]/events/router.js"),
-  mainStyleBundle = RefPath(""),
+  mainStyleBundle = None,
   description = Some("Help us deliver the independent journalism the world needs. Support the Guardian by making a contribution."),
   canonicalLink = Some("https://support.theguardian.com/events"),
   hrefLangLinks = Map(),

--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -7,7 +7,7 @@
   title: String,
   mainElement: ReactDiv,
   mainJsBundle: RefPath,
-  mainStyleBundle: RefPath,
+  mainStyleBundle: Option[RefPath],
   description: Option[String] = None,
   canonicalLink: Option[String] = None,
   hrefLangLinks: Map[String, String] = Map(),
@@ -72,7 +72,9 @@
 
     <title>@title</title>
     <meta property="og:title" content="@title"/>
-    <link rel="stylesheet" href="@assets(mainStyleBundle)">
+    @for(bundle <- mainStyleBundle) {
+      <link rel="stylesheet" href="@assets(bundle)" />
+    }
 
     <link rel="shortcut icon" type="image/png" href="@routes.Favicon.get()">
     <link rel="apple-touch-icon" sizes="152x152" href="@assets("images/favicons/152x152.png")">

--- a/support-frontend/app/views/router.scala.html
+++ b/support-frontend/app/views/router.scala.html
@@ -24,7 +24,7 @@
   title = "Support the Guardian | Checkout",
   mainElement = EmptyDiv("checkout"),
   mainJsBundle = RefPath("[countryGroupId]/router.js"),
-  mainStyleBundle = RefPath(""),
+  mainStyleBundle = None,
   description = Some("Help us deliver the independent journalism the world needs. Support the Guardian by making a contribution."),
   canonicalLink = Some("https://support.theguardian.com/checkout"),
   serversideTests = serversideTests,

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -34,7 +34,7 @@
   homeDeliveryPostcodes: Option[List[String]] = None,
 )(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: AllSettings)
 
-  @main(title = title, mainJsBundle = RefPath(js), mainElement = mainElement, mainStyleBundle = RefPath(css), csrf = csrf) {
+  @main(title = title, mainJsBundle = RefPath(js), mainElement = mainElement, mainStyleBundle = Some(RefPath(css)), csrf = csrf) {
     <script type="text/javascript">
       window.guardian = window.guardian || {};
 

--- a/support-frontend/app/views/subscriptionRedemptionForm.scala.html
+++ b/support-frontend/app/views/subscriptionRedemptionForm.scala.html
@@ -26,7 +26,7 @@
   submitted: Boolean
 )(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: AllSettings)
 
-  @main(title = title, mainJsBundle = RefPath(js), mainElement = mainElement, mainStyleBundle = RefPath(css), csrf = csrf) {
+  @main(title = title, mainJsBundle = RefPath(js), mainElement = mainElement, mainStyleBundle = Some(RefPath(css)), csrf = csrf) {
     <script type="text/javascript">
       window.guardian = window.guardian || {};
       window.guardian.stage = @JsStringLiteral(stage);


### PR DESCRIPTION
Makes the CSS `RefPath` optional for pages that aren't using CSS (and shouldn't be as this is the CSS generated via SASS).

[Fixes this bug](https://support.theguardian.com/uk/checkout?product=SupporterPlus&ratePlan=Monthly) where the `RefPath` is not being found. This is a runtime error so wasn't picked up on hence I have attached the Playwright test results. 

### 100% tested
![Screenshot 2024-06-04 at 16 45 38](https://github.com/guardian/support-frontend/assets/31692/ef68fd3d-9441-4a22-8820-940815a2a0f2)
