### PR TITLE
Activate `useGenericCheckout` test without variant

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -108,9 +108,9 @@ export const tests: Tests = {
 			{
 				id: 'control',
 			},
-			{
-				id: 'variant',
-			},
+			// {
+			// 	id: 'variant',
+			// },
 		],
 		audiences: {
 			ALL: {
@@ -118,7 +118,7 @@ export const tests: Tests = {
 				size: 1,
 			},
 		},
-		isActive: false,
+		isActive: true,
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 5,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,


### PR DESCRIPTION
This activate the `useGenericCheckout` test and removes the variant which would push traffic to the new checkout.

The reason to do this is to start collecting data where `ab_test.name=useGenericCheckout` in some dashboards before we launch.