### PR TITLE
Prototype: Lazy Load 3-Tier Routes

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -1,5 +1,5 @@
 // ----- Imports ----- //
-import { useEffect, Suspense, lazy } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { Provider } from 'react-redux';
 import {
 	BrowserRouter,
@@ -9,8 +9,8 @@ import {
 	useLocation,
 } from 'react-router-dom';
 import { validateWindowGuardian } from 'helpers/globalsAndSwitches/window';
-// import { CountryGroup } from 'helpers/internationalisation';
-// import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { CountryGroup } from 'helpers/internationalisation';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
 import { setUpTrackingAndConsents } from 'helpers/page/page';
 import { isDetailsSupported, polyfillDetails } from 'helpers/polyfills/details';
@@ -33,17 +33,17 @@ setUpTrackingAndConsents();
 
 // ----- Redux Store ----- //
 
-// const countryGroupId: CountryGroupId = CountryGroup.detect();
+const countryGroupId: CountryGroupId = CountryGroup.detect();
 const store = initReduxForContributions();
 
 setUpRedux(store);
 
-// const urlParams = new URLSearchParams(window.location.search);
-// const promoCode = urlParams.get('promoCode');
-// const thankYouRouteParams = promoCode
-// 	? `?${new URLSearchParams({ promoCode }).toString()}`
-// 	: '';
-// const thankYouRoute = `/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou${thankYouRouteParams}`;
+const urlParams = new URLSearchParams(window.location.search);
+const promoCode = urlParams.get('promoCode');
+const thankYouRouteParams = promoCode
+	? `?${new URLSearchParams({ promoCode }).toString()}`
+	: '';
+const thankYouRoute = `/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou${thankYouRouteParams}`;
 const countryIds = Object.values(countryGroups).map(
 	(group) => group.supportInternationalisationId,
 );
@@ -122,7 +122,9 @@ const router = () => {
 								/>
 								<Route
 									path={`/${countryId}/contribute/checkout`}
-									element={<SupporterPlusCheckout />}
+									element={
+										<SupporterPlusCheckout thankYouRoute={thankYouRoute} />
+									}
 								/>
 								<Route
 									path={`/${countryId}/thankyou`}

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -20,7 +20,7 @@ import { renderPage } from 'helpers/rendering/render';
 import { setUpRedux } from './setup/setUpRedux';
 import { threeTierCheckoutEnabled } from './setup/threeTierChecks';
 // import { SupporterPlusInitialLandingPage } from './twoStepPages/firstStepLanding';
-import { SupporterPlusCheckout } from './twoStepPages/secondStepCheckout';
+// import { SupporterPlusCheckout } from './twoStepPages/secondStepCheckout';
 import { ThreeTierLanding } from './twoStepPages/threeTierLanding';
 
 validateWindowGuardian(window.guardian);
@@ -94,13 +94,16 @@ export const inThreeTier = threeTierCheckoutEnabled(
 	commonState.amounts,
 );
 
-// import { SupporterPlusCheckout } from './twoStepPages/secondStepCheckout';
-// import { ThreeTierLanding } from './twoStepPages/threeTierLanding';
-
 // Lazy load your components
+// const ThreeTierLanding = lazy(() => import('./twoStepPages/threeTierLanding'));
 const SupporterPlusCheckout = lazy(
 	() => import('./twoStepPages/secondStepCheckout'),
 );
+const SupporterPlusThankYou = lazy(
+	() => import('pages/supporter-plus-thank-you/supporterPlusThankYou'),
+);
+
+console.log('***');
 
 // ----- Render ----- //
 
@@ -109,7 +112,7 @@ const router = () => {
 		<BrowserRouter>
 			<ScrollToTop />
 			<Provider store={store}>
-				<Suspense fallback={<div>Loading...</div>}>
+				<Suspense fallback={<ThreeTierLanding />}>
 					<Routes>
 						{countryIds.map((countryId) => (
 							<>
@@ -121,44 +124,11 @@ const router = () => {
 									path={`/${countryId}/contribute/checkout`}
 									element={<SupporterPlusCheckout />}
 								/>
-								{/* <Route
-								path={`/${countryId}/contribute/checkout`}
-								element={
-									<SupporterPlusCheckout thankYouRoute={thankYouRoute} />
-								}
-							/> */}
+								<Route
+									path={`/${countryId}/thankyou`}
+									element={<SupporterPlusThankYou />}
+								/>
 							</>
-							// <>
-							// 	<Route
-							// 		path={`/${countryId}/contribute/:campaignCode?`}
-							// 		element={
-							// 			/*
-							// 			 * if you are coming to the /contribute route(s) and you also have a one off
-							// 			 * contribution type (set in the url) and find yourself in the three tier
-							// 			 * variant we should redirect you to the /contribute/checkout route
-							// 			 */
-							// 			inThreeTier ? (
-							// 				<ThreeTierRedirectOneOffToCheckout countryId={countryId}>
-							// 					<ThreeTierLanding />
-							// 				</ThreeTierRedirectOneOffToCheckout>
-							// 			) : (
-							// 				<SupporterPlusInitialLandingPage
-							// 					thankYouRoute={thankYouRoute}
-							// 				/>
-							// 			)
-							// 		}
-							// 	/>
-							// 	<Route
-							// 		path={`/${countryId}/contribute/checkout`}
-							// 		element={
-							// 			<SupporterPlusCheckout thankYouRoute={thankYouRoute} />
-							// 		}
-							// 	/>
-							// 	<Route
-							// 		path={`/${countryId}/thankyou`}
-							// 		element={<SupporterPlusThankYou />}
-							// 	/>
-							// </>
 						))}
 					</Routes>
 				</Suspense>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -46,7 +46,7 @@ const shorterBoxMargin = css`
 	}
 `;
 
-export default function SupporterPlusCheckout({
+export function SupporterPlusCheckout({
 	thankYouRoute,
 }: {
 	thankYouRoute: string;
@@ -181,3 +181,5 @@ export default function SupporterPlusCheckout({
 		</SupporterPlusCheckoutScaffold>
 	);
 }
+
+export default SupporterPlusCheckout;

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -1,183 +1,187 @@
-import { css } from '@emotion/react';
-import { space, until } from '@guardian/source/foundations';
-import { Button } from '@guardian/source/react-components';
-import { useNavigate } from 'react-router-dom';
-import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
-import { ContributionsOrderSummary } from 'components/orderSummary/contributionsOrderSummary';
-import { ContributionsOrderSummaryContainer } from 'components/orderSummary/contributionsOrderSummaryContainer';
-import { PaymentButtonController } from 'components/paymentButton/paymentButtonController';
-import { PaymentMethodSelector } from 'components/paymentMethodSelector/paymentMethodSelector';
-import PaymentMethodSelectorContainer from 'components/paymentMethodSelector/PaymentMethodSelectorContainer';
-import { PaymentRequestButtonContainer } from 'components/paymentRequestButton/paymentRequestButtonContainer';
-import { PersonalDetails } from 'components/personalDetails/personalDetails';
-import { PersonalDetailsContainer } from 'components/personalDetails/personalDetailsContainer';
-import { SavedCardButton } from 'components/savedCardButton/savedCardButton';
-import { ContributionsStripe } from 'components/stripe/contributionsStripe';
-import { countryGroups } from 'helpers/internationalisation/countryGroup';
-import { getPromotion } from 'helpers/productPrice/promotions';
-import { resetValidation } from 'helpers/redux/checkout/checkoutActions';
-import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
-import { isSupporterPlusFromState } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
-import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
-import {
-	getUserSelectedAmount,
-	getUserSelectedAmountBeforeAmendment,
-	getUserSelectedOtherAmount,
-} from 'helpers/redux/checkout/product/selectors/selectedAmount';
-import {
-	useContributionsDispatch,
-	useContributionsSelector,
-} from 'helpers/redux/storeHooks';
-import { useAbandonedBasketCookie } from 'helpers/storage/abandonedBasketCookies';
-import { navigateWithPageView } from 'helpers/tracking/ophan';
-import { CheckoutDivider } from '../components/checkoutDivider';
-import { ContributionsPriceCards } from '../components/contributionsPriceCards';
-import { PaymentFailureMessage } from '../components/paymentFailure';
-import { PaymentTsAndCs } from '../components/paymentTsAndCs';
-import { getPaymentMethodButtons } from '../paymentButtons';
-import { threeTierCheckoutEnabled } from '../setup/threeTierChecks';
-import { SupporterPlusCheckoutScaffold } from './checkoutScaffold';
+// import { css } from '@emotion/react';
+// import { space, until } from '@guardian/source/foundations';
+// import { Button } from '@guardian/source/react-components';
+// import { useNavigate } from 'react-router-dom';
+// import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
+// import { ContributionsOrderSummary } from 'components/orderSummary/contributionsOrderSummary';
+// import { ContributionsOrderSummaryContainer } from 'components/orderSummary/contributionsOrderSummaryContainer';
+// import { PaymentButtonController } from 'components/paymentButton/paymentButtonController';
+// import { PaymentMethodSelector } from 'components/paymentMethodSelector/paymentMethodSelector';
+// import PaymentMethodSelectorContainer from 'components/paymentMethodSelector/PaymentMethodSelectorContainer';
+// import { PaymentRequestButtonContainer } from 'components/paymentRequestButton/paymentRequestButtonContainer';
+// import { PersonalDetails } from 'components/personalDetails/personalDetails';
+// import { PersonalDetailsContainer } from 'components/personalDetails/personalDetailsContainer';
+// import { SavedCardButton } from 'components/savedCardButton/savedCardButton';
+// import { ContributionsStripe } from 'components/stripe/contributionsStripe';
+// import { countryGroups } from 'helpers/internationalisation/countryGroup';
+// import { getPromotion } from 'helpers/productPrice/promotions';
+// import { resetValidation } from 'helpers/redux/checkout/checkoutActions';
+// import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
+// import { isSupporterPlusFromState } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
+// import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+// import {
+// 	getUserSelectedAmount,
+// 	getUserSelectedAmountBeforeAmendment,
+// 	getUserSelectedOtherAmount,
+// } from 'helpers/redux/checkout/product/selectors/selectedAmount';
+// import {
+// 	useContributionsDispatch,
+// 	useContributionsSelector,
+// } from 'helpers/redux/storeHooks';
+// import { useAbandonedBasketCookie } from 'helpers/storage/abandonedBasketCookies';
+// import { navigateWithPageView } from 'helpers/tracking/ophan';
+// import { CheckoutDivider } from '../components/checkoutDivider';
+// import { ContributionsPriceCards } from '../components/contributionsPriceCards';
+// import { PaymentFailureMessage } from '../components/paymentFailure';
+// import { PaymentTsAndCs } from '../components/paymentTsAndCs';
+// import { getPaymentMethodButtons } from '../paymentButtons';
+// import { threeTierCheckoutEnabled } from '../setup/threeTierChecks';
+// import { SupporterPlusCheckoutScaffold } from './checkoutScaffold';
 
-const shorterBoxMargin = css`
-	:not(:last-child) {
-		${until.tablet} {
-			margin-bottom: ${space[2]}px;
-		}
-	}
-`;
+// const shorterBoxMargin = css`
+// 	:not(:last-child) {
+// 		${until.tablet} {
+// 			margin-bottom: ${space[2]}px;
+// 		}
+// 	}
+// `;
 
-export function SupporterPlusCheckout({
-	thankYouRoute,
-}: {
-	thankYouRoute: string;
-}): JSX.Element {
-	const dispatch = useContributionsDispatch();
-	const { countryGroupId, countryId, currencyId } = useContributionsSelector(
-		(state) => state.common.internationalisation,
-	);
-	const { supportInternationalisationId } = countryGroups[countryGroupId];
-	const contributionType = useContributionsSelector(getContributionType);
-	const amount = useContributionsSelector(getUserSelectedAmount);
-	const amountBeforeAmendments = useContributionsSelector(
-		getUserSelectedAmountBeforeAmendment,
-	);
-	const otherAmount = useContributionsSelector(getUserSelectedOtherAmount);
-	const isSupporterPlus = useContributionsSelector(isSupporterPlusFromState);
+// export function SupporterPlusCheckout({
+// 	thankYouRoute,
+// }: {
+// 	thankYouRoute: string;
+// }): JSX.Element {
+// 	const dispatch = useContributionsDispatch();
+// 	const { countryGroupId, countryId, currencyId } = useContributionsSelector(
+// 		(state) => state.common.internationalisation,
+// 	);
+// 	const { supportInternationalisationId } = countryGroups[countryGroupId];
+// 	const contributionType = useContributionsSelector(getContributionType);
+// 	const amount = useContributionsSelector(getUserSelectedAmount);
+// 	const amountBeforeAmendments = useContributionsSelector(
+// 		getUserSelectedAmountBeforeAmendment,
+// 	);
+// 	const otherAmount = useContributionsSelector(getUserSelectedOtherAmount);
+// 	const isSupporterPlus = useContributionsSelector(isSupporterPlusFromState);
 
-	const navigate = useNavigate();
-	const { abParticipations, amounts } = useContributionsSelector(
-		(state) => state.common,
-	);
+// 	const navigate = useNavigate();
+// 	const { abParticipations, amounts } = useContributionsSelector(
+// 		(state) => state.common,
+// 	);
 
-	const inThreeTier = threeTierCheckoutEnabled(abParticipations, amounts);
-	const showPriceCards = inThreeTier && contributionType === 'ONE_OFF';
-	const product = isSupporterPlus ? 'SupporterPlus' : 'Contribution';
+// 	const inThreeTier = threeTierCheckoutEnabled(abParticipations, amounts);
+// 	const showPriceCards = inThreeTier && contributionType === 'ONE_OFF';
+// 	const product = isSupporterPlus ? 'SupporterPlus' : 'Contribution';
 
-	useAbandonedBasketCookie(
-		product,
-		amount,
-		contributionType,
-		supportInternationalisationId,
-	);
+// 	useAbandonedBasketCookie(
+// 		product,
+// 		amount,
+// 		contributionType,
+// 		supportInternationalisationId,
+// 	);
 
-	const changeButton = (
-		<Button
-			priority="tertiary"
-			size="xsmall"
-			onClick={() => {
-				const amountToBePassed =
-					otherAmount === 'other' ? 'other' : amountBeforeAmendments;
-				dispatch(
-					setSelectedAmount({
-						contributionType: contributionType,
-						amount: `${amountToBePassed}`,
-					}),
-				);
-				dispatch(resetValidation());
-				const destination = `/${supportInternationalisationId}/contribute`;
-				navigateWithPageView(navigate, destination, abParticipations);
-			}}
-		>
-			Change
-		</Button>
-	);
+// 	const changeButton = (
+// 		<Button
+// 			priority="tertiary"
+// 			size="xsmall"
+// 			onClick={() => {
+// 				const amountToBePassed =
+// 					otherAmount === 'other' ? 'other' : amountBeforeAmendments;
+// 				dispatch(
+// 					setSelectedAmount({
+// 						contributionType: contributionType,
+// 						amount: `${amountToBePassed}`,
+// 					}),
+// 				);
+// 				dispatch(resetValidation());
+// 				const destination = `/${supportInternationalisationId}/contribute`;
+// 				navigateWithPageView(navigate, destination, abParticipations);
+// 			}}
+// 		>
+// 			Change
+// 		</Button>
+// 	);
 
-	/** Promotions on the checkout are for SupporterPlus only for now */
-	const promotion = isSupporterPlus
-		? useContributionsSelector((state) =>
-				getPromotion(
-					state.page.checkoutForm.product.productPrices,
-					countryId,
-					state.page.checkoutForm.product.billingPeriod,
-				),
-		  )
-		: undefined;
-	return (
-		<SupporterPlusCheckoutScaffold thankYouRoute={thankYouRoute} isPaymentPage>
-			<Box cssOverrides={shorterBoxMargin}>
-				<BoxContents>
-					{showPriceCards ? (
-						<ContributionsPriceCards paymentFrequency={contributionType} />
-					) : (
-						<ContributionsOrderSummaryContainer
-							promotion={promotion}
-							renderOrderSummary={(orderSummaryProps) => (
-								<ContributionsOrderSummary
-									{...orderSummaryProps}
-									headerButton={changeButton}
-								/>
-							)}
-						/>
-					)}
-				</BoxContents>
-			</Box>
-			<Box cssOverrides={shorterBoxMargin}>
-				<BoxContents>
-					{/* The same Stripe provider *must* enclose the Stripe card form and payment button(s). Also enclosing the PRB reduces re-renders. */}
-					<ContributionsStripe>
-						<PaymentRequestButtonContainer CustomButton={SavedCardButton} />
-						<PersonalDetailsContainer
-							renderPersonalDetails={(personalDetailsProps) => (
-								<PersonalDetails
-									{...personalDetailsProps}
-									overrideHeadingCopy="1. Your details"
-								/>
-							)}
-						/>
-						<CheckoutDivider spacing="loose" />
-						<PaymentMethodSelectorContainer
-							render={(paymentMethodSelectorProps) => (
-								<PaymentMethodSelector
-									{...paymentMethodSelectorProps}
-									overrideHeadingCopy="2. Payment method"
-								/>
-							)}
-						/>
-						<PaymentButtonController
-							cssOverrides={css`
-								margin-top: 30px;
-							`}
-							paymentButtons={getPaymentMethodButtons(
-								contributionType,
-								countryId,
-								countryGroupId,
-							)}
-						/>
-						<PaymentFailureMessage />
-					</ContributionsStripe>
-					<PaymentTsAndCs
-						countryGroupId={countryGroupId}
-						contributionType={contributionType}
-						currency={currencyId}
-						amount={amount}
-						amountIsAboveThreshold={isSupporterPlus}
-						productNameAboveThreshold={
-							inThreeTier ? 'All-access digital' : 'Supporter Plus'
-						}
-						promotion={promotion}
-					/>
-				</BoxContents>
-			</Box>
-		</SupporterPlusCheckoutScaffold>
-	);
+// 	/** Promotions on the checkout are for SupporterPlus only for now */
+// 	const promotion = isSupporterPlus
+// 		? useContributionsSelector((state) =>
+// 				getPromotion(
+// 					state.page.checkoutForm.product.productPrices,
+// 					countryId,
+// 					state.page.checkoutForm.product.billingPeriod,
+// 				),
+// 		  )
+// 		: undefined;
+// 	return (
+// 		<SupporterPlusCheckoutScaffold thankYouRoute={thankYouRoute} isPaymentPage>
+// 			<Box cssOverrides={shorterBoxMargin}>
+// 				<BoxContents>
+// 					{showPriceCards ? (
+// 						<ContributionsPriceCards paymentFrequency={contributionType} />
+// 					) : (
+// 						<ContributionsOrderSummaryContainer
+// 							promotion={promotion}
+// 							renderOrderSummary={(orderSummaryProps) => (
+// 								<ContributionsOrderSummary
+// 									{...orderSummaryProps}
+// 									headerButton={changeButton}
+// 								/>
+// 							)}
+// 						/>
+// 					)}
+// 				</BoxContents>
+// 			</Box>
+// 			<Box cssOverrides={shorterBoxMargin}>
+// 				<BoxContents>
+// 					{/* The same Stripe provider *must* enclose the Stripe card form and payment button(s). Also enclosing the PRB reduces re-renders. */}
+// 					<ContributionsStripe>
+// 						<PaymentRequestButtonContainer CustomButton={SavedCardButton} />
+// 						<PersonalDetailsContainer
+// 							renderPersonalDetails={(personalDetailsProps) => (
+// 								<PersonalDetails
+// 									{...personalDetailsProps}
+// 									overrideHeadingCopy="1. Your details"
+// 								/>
+// 							)}
+// 						/>
+// 						<CheckoutDivider spacing="loose" />
+// 						<PaymentMethodSelectorContainer
+// 							render={(paymentMethodSelectorProps) => (
+// 								<PaymentMethodSelector
+// 									{...paymentMethodSelectorProps}
+// 									overrideHeadingCopy="2. Payment method"
+// 								/>
+// 							)}
+// 						/>
+// 						<PaymentButtonController
+// 							cssOverrides={css`
+// 								margin-top: 30px;
+// 							`}
+// 							paymentButtons={getPaymentMethodButtons(
+// 								contributionType,
+// 								countryId,
+// 								countryGroupId,
+// 							)}
+// 						/>
+// 						<PaymentFailureMessage />
+// 					</ContributionsStripe>
+// 					<PaymentTsAndCs
+// 						countryGroupId={countryGroupId}
+// 						contributionType={contributionType}
+// 						currency={currencyId}
+// 						amount={amount}
+// 						amountIsAboveThreshold={isSupporterPlus}
+// 						productNameAboveThreshold={
+// 							inThreeTier ? 'All-access digital' : 'Supporter Plus'
+// 						}
+// 						promotion={promotion}
+// 					/>
+// 				</BoxContents>
+// 			</Box>
+// 		</SupporterPlusCheckoutScaffold>
+// 	);
+// }
+
+export default function SupporterPlusCheckout(): JSX.Element {
+	return <h1>Hello World</h1>;
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -1,187 +1,183 @@
-// import { css } from '@emotion/react';
-// import { space, until } from '@guardian/source/foundations';
-// import { Button } from '@guardian/source/react-components';
-// import { useNavigate } from 'react-router-dom';
-// import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
-// import { ContributionsOrderSummary } from 'components/orderSummary/contributionsOrderSummary';
-// import { ContributionsOrderSummaryContainer } from 'components/orderSummary/contributionsOrderSummaryContainer';
-// import { PaymentButtonController } from 'components/paymentButton/paymentButtonController';
-// import { PaymentMethodSelector } from 'components/paymentMethodSelector/paymentMethodSelector';
-// import PaymentMethodSelectorContainer from 'components/paymentMethodSelector/PaymentMethodSelectorContainer';
-// import { PaymentRequestButtonContainer } from 'components/paymentRequestButton/paymentRequestButtonContainer';
-// import { PersonalDetails } from 'components/personalDetails/personalDetails';
-// import { PersonalDetailsContainer } from 'components/personalDetails/personalDetailsContainer';
-// import { SavedCardButton } from 'components/savedCardButton/savedCardButton';
-// import { ContributionsStripe } from 'components/stripe/contributionsStripe';
-// import { countryGroups } from 'helpers/internationalisation/countryGroup';
-// import { getPromotion } from 'helpers/productPrice/promotions';
-// import { resetValidation } from 'helpers/redux/checkout/checkoutActions';
-// import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
-// import { isSupporterPlusFromState } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
-// import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
-// import {
-// 	getUserSelectedAmount,
-// 	getUserSelectedAmountBeforeAmendment,
-// 	getUserSelectedOtherAmount,
-// } from 'helpers/redux/checkout/product/selectors/selectedAmount';
-// import {
-// 	useContributionsDispatch,
-// 	useContributionsSelector,
-// } from 'helpers/redux/storeHooks';
-// import { useAbandonedBasketCookie } from 'helpers/storage/abandonedBasketCookies';
-// import { navigateWithPageView } from 'helpers/tracking/ophan';
-// import { CheckoutDivider } from '../components/checkoutDivider';
-// import { ContributionsPriceCards } from '../components/contributionsPriceCards';
-// import { PaymentFailureMessage } from '../components/paymentFailure';
-// import { PaymentTsAndCs } from '../components/paymentTsAndCs';
-// import { getPaymentMethodButtons } from '../paymentButtons';
-// import { threeTierCheckoutEnabled } from '../setup/threeTierChecks';
-// import { SupporterPlusCheckoutScaffold } from './checkoutScaffold';
+import { css } from '@emotion/react';
+import { space, until } from '@guardian/source/foundations';
+import { Button } from '@guardian/source/react-components';
+import { useNavigate } from 'react-router-dom';
+import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
+import { ContributionsOrderSummary } from 'components/orderSummary/contributionsOrderSummary';
+import { ContributionsOrderSummaryContainer } from 'components/orderSummary/contributionsOrderSummaryContainer';
+import { PaymentButtonController } from 'components/paymentButton/paymentButtonController';
+import { PaymentMethodSelector } from 'components/paymentMethodSelector/paymentMethodSelector';
+import PaymentMethodSelectorContainer from 'components/paymentMethodSelector/PaymentMethodSelectorContainer';
+import { PaymentRequestButtonContainer } from 'components/paymentRequestButton/paymentRequestButtonContainer';
+import { PersonalDetails } from 'components/personalDetails/personalDetails';
+import { PersonalDetailsContainer } from 'components/personalDetails/personalDetailsContainer';
+import { SavedCardButton } from 'components/savedCardButton/savedCardButton';
+import { ContributionsStripe } from 'components/stripe/contributionsStripe';
+import { countryGroups } from 'helpers/internationalisation/countryGroup';
+import { getPromotion } from 'helpers/productPrice/promotions';
+import { resetValidation } from 'helpers/redux/checkout/checkoutActions';
+import { setSelectedAmount } from 'helpers/redux/checkout/product/actions';
+import { isSupporterPlusFromState } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
+import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import {
+	getUserSelectedAmount,
+	getUserSelectedAmountBeforeAmendment,
+	getUserSelectedOtherAmount,
+} from 'helpers/redux/checkout/product/selectors/selectedAmount';
+import {
+	useContributionsDispatch,
+	useContributionsSelector,
+} from 'helpers/redux/storeHooks';
+import { useAbandonedBasketCookie } from 'helpers/storage/abandonedBasketCookies';
+import { navigateWithPageView } from 'helpers/tracking/ophan';
+import { CheckoutDivider } from '../components/checkoutDivider';
+import { ContributionsPriceCards } from '../components/contributionsPriceCards';
+import { PaymentFailureMessage } from '../components/paymentFailure';
+import { PaymentTsAndCs } from '../components/paymentTsAndCs';
+import { getPaymentMethodButtons } from '../paymentButtons';
+import { threeTierCheckoutEnabled } from '../setup/threeTierChecks';
+import { SupporterPlusCheckoutScaffold } from './checkoutScaffold';
 
-// const shorterBoxMargin = css`
-// 	:not(:last-child) {
-// 		${until.tablet} {
-// 			margin-bottom: ${space[2]}px;
-// 		}
-// 	}
-// `;
+const shorterBoxMargin = css`
+	:not(:last-child) {
+		${until.tablet} {
+			margin-bottom: ${space[2]}px;
+		}
+	}
+`;
 
-// export function SupporterPlusCheckout({
-// 	thankYouRoute,
-// }: {
-// 	thankYouRoute: string;
-// }): JSX.Element {
-// 	const dispatch = useContributionsDispatch();
-// 	const { countryGroupId, countryId, currencyId } = useContributionsSelector(
-// 		(state) => state.common.internationalisation,
-// 	);
-// 	const { supportInternationalisationId } = countryGroups[countryGroupId];
-// 	const contributionType = useContributionsSelector(getContributionType);
-// 	const amount = useContributionsSelector(getUserSelectedAmount);
-// 	const amountBeforeAmendments = useContributionsSelector(
-// 		getUserSelectedAmountBeforeAmendment,
-// 	);
-// 	const otherAmount = useContributionsSelector(getUserSelectedOtherAmount);
-// 	const isSupporterPlus = useContributionsSelector(isSupporterPlusFromState);
+export default function SupporterPlusCheckout({
+	thankYouRoute,
+}: {
+	thankYouRoute: string;
+}): JSX.Element {
+	const dispatch = useContributionsDispatch();
+	const { countryGroupId, countryId, currencyId } = useContributionsSelector(
+		(state) => state.common.internationalisation,
+	);
+	const { supportInternationalisationId } = countryGroups[countryGroupId];
+	const contributionType = useContributionsSelector(getContributionType);
+	const amount = useContributionsSelector(getUserSelectedAmount);
+	const amountBeforeAmendments = useContributionsSelector(
+		getUserSelectedAmountBeforeAmendment,
+	);
+	const otherAmount = useContributionsSelector(getUserSelectedOtherAmount);
+	const isSupporterPlus = useContributionsSelector(isSupporterPlusFromState);
 
-// 	const navigate = useNavigate();
-// 	const { abParticipations, amounts } = useContributionsSelector(
-// 		(state) => state.common,
-// 	);
+	const navigate = useNavigate();
+	const { abParticipations, amounts } = useContributionsSelector(
+		(state) => state.common,
+	);
 
-// 	const inThreeTier = threeTierCheckoutEnabled(abParticipations, amounts);
-// 	const showPriceCards = inThreeTier && contributionType === 'ONE_OFF';
-// 	const product = isSupporterPlus ? 'SupporterPlus' : 'Contribution';
+	const inThreeTier = threeTierCheckoutEnabled(abParticipations, amounts);
+	const showPriceCards = inThreeTier && contributionType === 'ONE_OFF';
+	const product = isSupporterPlus ? 'SupporterPlus' : 'Contribution';
 
-// 	useAbandonedBasketCookie(
-// 		product,
-// 		amount,
-// 		contributionType,
-// 		supportInternationalisationId,
-// 	);
+	useAbandonedBasketCookie(
+		product,
+		amount,
+		contributionType,
+		supportInternationalisationId,
+	);
 
-// 	const changeButton = (
-// 		<Button
-// 			priority="tertiary"
-// 			size="xsmall"
-// 			onClick={() => {
-// 				const amountToBePassed =
-// 					otherAmount === 'other' ? 'other' : amountBeforeAmendments;
-// 				dispatch(
-// 					setSelectedAmount({
-// 						contributionType: contributionType,
-// 						amount: `${amountToBePassed}`,
-// 					}),
-// 				);
-// 				dispatch(resetValidation());
-// 				const destination = `/${supportInternationalisationId}/contribute`;
-// 				navigateWithPageView(navigate, destination, abParticipations);
-// 			}}
-// 		>
-// 			Change
-// 		</Button>
-// 	);
+	const changeButton = (
+		<Button
+			priority="tertiary"
+			size="xsmall"
+			onClick={() => {
+				const amountToBePassed =
+					otherAmount === 'other' ? 'other' : amountBeforeAmendments;
+				dispatch(
+					setSelectedAmount({
+						contributionType: contributionType,
+						amount: `${amountToBePassed}`,
+					}),
+				);
+				dispatch(resetValidation());
+				const destination = `/${supportInternationalisationId}/contribute`;
+				navigateWithPageView(navigate, destination, abParticipations);
+			}}
+		>
+			Change
+		</Button>
+	);
 
-// 	/** Promotions on the checkout are for SupporterPlus only for now */
-// 	const promotion = isSupporterPlus
-// 		? useContributionsSelector((state) =>
-// 				getPromotion(
-// 					state.page.checkoutForm.product.productPrices,
-// 					countryId,
-// 					state.page.checkoutForm.product.billingPeriod,
-// 				),
-// 		  )
-// 		: undefined;
-// 	return (
-// 		<SupporterPlusCheckoutScaffold thankYouRoute={thankYouRoute} isPaymentPage>
-// 			<Box cssOverrides={shorterBoxMargin}>
-// 				<BoxContents>
-// 					{showPriceCards ? (
-// 						<ContributionsPriceCards paymentFrequency={contributionType} />
-// 					) : (
-// 						<ContributionsOrderSummaryContainer
-// 							promotion={promotion}
-// 							renderOrderSummary={(orderSummaryProps) => (
-// 								<ContributionsOrderSummary
-// 									{...orderSummaryProps}
-// 									headerButton={changeButton}
-// 								/>
-// 							)}
-// 						/>
-// 					)}
-// 				</BoxContents>
-// 			</Box>
-// 			<Box cssOverrides={shorterBoxMargin}>
-// 				<BoxContents>
-// 					{/* The same Stripe provider *must* enclose the Stripe card form and payment button(s). Also enclosing the PRB reduces re-renders. */}
-// 					<ContributionsStripe>
-// 						<PaymentRequestButtonContainer CustomButton={SavedCardButton} />
-// 						<PersonalDetailsContainer
-// 							renderPersonalDetails={(personalDetailsProps) => (
-// 								<PersonalDetails
-// 									{...personalDetailsProps}
-// 									overrideHeadingCopy="1. Your details"
-// 								/>
-// 							)}
-// 						/>
-// 						<CheckoutDivider spacing="loose" />
-// 						<PaymentMethodSelectorContainer
-// 							render={(paymentMethodSelectorProps) => (
-// 								<PaymentMethodSelector
-// 									{...paymentMethodSelectorProps}
-// 									overrideHeadingCopy="2. Payment method"
-// 								/>
-// 							)}
-// 						/>
-// 						<PaymentButtonController
-// 							cssOverrides={css`
-// 								margin-top: 30px;
-// 							`}
-// 							paymentButtons={getPaymentMethodButtons(
-// 								contributionType,
-// 								countryId,
-// 								countryGroupId,
-// 							)}
-// 						/>
-// 						<PaymentFailureMessage />
-// 					</ContributionsStripe>
-// 					<PaymentTsAndCs
-// 						countryGroupId={countryGroupId}
-// 						contributionType={contributionType}
-// 						currency={currencyId}
-// 						amount={amount}
-// 						amountIsAboveThreshold={isSupporterPlus}
-// 						productNameAboveThreshold={
-// 							inThreeTier ? 'All-access digital' : 'Supporter Plus'
-// 						}
-// 						promotion={promotion}
-// 					/>
-// 				</BoxContents>
-// 			</Box>
-// 		</SupporterPlusCheckoutScaffold>
-// 	);
-// }
-
-export default function SupporterPlusCheckout(): JSX.Element {
-	return <h1>Hello World</h1>;
+	/** Promotions on the checkout are for SupporterPlus only for now */
+	const promotion = isSupporterPlus
+		? useContributionsSelector((state) =>
+				getPromotion(
+					state.page.checkoutForm.product.productPrices,
+					countryId,
+					state.page.checkoutForm.product.billingPeriod,
+				),
+		  )
+		: undefined;
+	return (
+		<SupporterPlusCheckoutScaffold thankYouRoute={thankYouRoute} isPaymentPage>
+			<Box cssOverrides={shorterBoxMargin}>
+				<BoxContents>
+					{showPriceCards ? (
+						<ContributionsPriceCards paymentFrequency={contributionType} />
+					) : (
+						<ContributionsOrderSummaryContainer
+							promotion={promotion}
+							renderOrderSummary={(orderSummaryProps) => (
+								<ContributionsOrderSummary
+									{...orderSummaryProps}
+									headerButton={changeButton}
+								/>
+							)}
+						/>
+					)}
+				</BoxContents>
+			</Box>
+			<Box cssOverrides={shorterBoxMargin}>
+				<BoxContents>
+					{/* The same Stripe provider *must* enclose the Stripe card form and payment button(s). Also enclosing the PRB reduces re-renders. */}
+					<ContributionsStripe>
+						<PaymentRequestButtonContainer CustomButton={SavedCardButton} />
+						<PersonalDetailsContainer
+							renderPersonalDetails={(personalDetailsProps) => (
+								<PersonalDetails
+									{...personalDetailsProps}
+									overrideHeadingCopy="1. Your details"
+								/>
+							)}
+						/>
+						<CheckoutDivider spacing="loose" />
+						<PaymentMethodSelectorContainer
+							render={(paymentMethodSelectorProps) => (
+								<PaymentMethodSelector
+									{...paymentMethodSelectorProps}
+									overrideHeadingCopy="2. Payment method"
+								/>
+							)}
+						/>
+						<PaymentButtonController
+							cssOverrides={css`
+								margin-top: 30px;
+							`}
+							paymentButtons={getPaymentMethodButtons(
+								contributionType,
+								countryId,
+								countryGroupId,
+							)}
+						/>
+						<PaymentFailureMessage />
+					</ContributionsStripe>
+					<PaymentTsAndCs
+						countryGroupId={countryGroupId}
+						contributionType={contributionType}
+						currency={currencyId}
+						amount={amount}
+						amountIsAboveThreshold={isSupporterPlus}
+						productNameAboveThreshold={
+							inThreeTier ? 'All-access digital' : 'Supporter Plus'
+						}
+						promotion={promotion}
+					/>
+				</BoxContents>
+			</Box>
+		</SupporterPlusCheckoutScaffold>
+	);
 }

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -100,7 +100,7 @@ export type SupporterPlusThankYouProps = {
 	overideThresholdPrice?: number;
 };
 
-export default function SupporterPlusThankYou({
+export function SupporterPlusThankYou({
 	overideThresholdPrice,
 }: SupporterPlusThankYouProps): JSX.Element {
 	const campaignSettings = useMemo<CampaignSettings | null>(
@@ -323,3 +323,5 @@ export default function SupporterPlusThankYou({
 		</PageScaffold>
 	);
 }
+
+export default SupporterPlusThankYou;

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -100,7 +100,7 @@ export type SupporterPlusThankYouProps = {
 	overideThresholdPrice?: number;
 };
 
-export function SupporterPlusThankYou({
+export default function SupporterPlusThankYou({
 	overideThresholdPrice,
 }: SupporterPlusThankYouProps): JSX.Element {
 	const campaignSettings = useMemo<CampaignSettings | null>(

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -129,7 +129,7 @@
     "@babel/preset-typescript": "^7.23.3",
     "@emotion/babel-plugin": "^11.11.0",
     "@emotion/eslint-plugin": "^11.11.0",
-    "@guardian/browserslist-config": "^5.0.0",
+    "@guardian/browserslist-config": "^6.1.1",
     "@guardian/eslint-config": "8.0.1",
     "@guardian/eslint-config-typescript": "10.0.1",
     "@guardian/paparazzi": "^0.3.1",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -2186,10 +2186,10 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.1.tgz#1a5b1959a528e374e8037c4396c3e825d6cf4a83"
   integrity sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==
 
-"@guardian/browserslist-config@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-5.0.0.tgz#734603a4553670abb69ff290e9ff20ef61b17218"
-  integrity sha512-NrmQflwQKWYSNHUXsq9uroPIp+d5+mzZrDUy8MEFdNDqVjy8WPfbhANhQtFWGGjRifL0Z7yrfG/cYyBxbKFY3w==
+"@guardian/browserslist-config@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-6.1.1.tgz#acca57ca0666490ca2dd67522a9fbaf5c7ef4b4d"
+  integrity sha512-62fVcqE5opXxN1bgm5lF6ykPrKM2/U8WdGH7gcrFGV6f5VVz+oFloMX+C2Svj19fdmXpfHj6+I1AmJbqSAX5CQ==
 
 "@guardian/eslint-config-typescript@10.0.1":
   version "10.0.1"
@@ -6458,15 +6458,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001538:
-  version "1.0.30001538"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001538.tgz#9dbc6b9af1ff06b5eb12350c2012b3af56744f3f"
-  integrity sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==
-
-caniuse-lite@^1.0.30001565:
-  version "1.0.30001568"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001568.tgz#53fa9297273c9a977a560663f48cbea1767518b7"
-  integrity sha512-vSUkH84HontZJ88MiNrOau1EBrCqEQYgkC5gIySiDlpsm8sGVrhU7Kx4V6h0tnqaHzIHZv08HlJIwPbL4XL9+A==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001565:
+  version "1.0.30001628"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001628.tgz"
+  integrity sha512-S3BnR4Kh26TBxbi5t5kpbcUlLJb9lhtDXISDPwOfI+JoC+ik0QksvkZtUVyikw3hjnkgkMPSJ8oIM9yMm9vflA==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
10% time prototype

Testing React's `Lazy` / `Suspense`  exports: https://react.dev/reference/react/lazy#suspense-for-code-splitting

I'm interested to see whether we could loading component’s code until they're rendered for the first time, eg. Checkout or Thankyou page. Currently everything's loaded in one bundle. I wanted to see whether deferring loading of components has any descernable improvement to page speed performance on the 3-tier landing page.
