### PR TITLE
feat: add fulfilmentOptions to SupporterPlus

### DIFF
--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -63,6 +63,7 @@ type SupporterPlus = {
 	amount: number;
 	currency: string;
 	billingPeriod: BillingPeriod;
+	fulfilmentOptions?: FulfilmentOptions;
 };
 export type DigitalSubscription = {
 	productType: typeof DigitalPack;

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -289,68 +289,6 @@ function CheckoutComponent({ geoId }: Props) {
 		: undefined;
 	const ratePlanDescription = productDescription?.ratePlans[query.ratePlan];
 
-	/**
-	 * This is the data structure used by the `/subscribe/create` endpoint.
-	 *
-	 * This must match the types in `CreateSupportWorkersRequest#product`
-	 * and readerRevenueApis - `RegularPaymentRequest#product`.
-	 *
-	 * We might be able to defer this to the backend.
-	 */
-	let productFields: RegularPaymentRequest['product'] | undefined;
-	if (ratePlanDescription) {
-		if (productId === 'Contribution') {
-			productFields = {
-				productType: 'Contribution',
-				currency: currencyKey,
-				billingPeriod: ratePlanDescription.billingPeriod,
-				amount: query.price ?? 0,
-			};
-		} else if (productId === 'SupporterPlus') {
-			productFields = {
-				productType: 'SupporterPlus',
-				currency: currencyKey,
-				billingPeriod: ratePlanDescription.billingPeriod,
-				amount: query.price ?? 0,
-			};
-		} else if (productId === 'GuardianWeeklyDomestic') {
-			productFields = {
-				productType: 'GuardianWeekly',
-				currency: currencyKey,
-				fulfilmentOptions: 'Domestic',
-				billingPeriod: ratePlanDescription.billingPeriod,
-			};
-		} else if (productId === 'GuardianWeeklyRestOfWorld') {
-			productFields = {
-				productType: 'GuardianWeekly',
-				fulfilmentOptions: 'RestOfWorld',
-				currency: currencyKey,
-				billingPeriod: ratePlanDescription.billingPeriod,
-			};
-		} else if (productId === 'DigitalSubscription') {
-			productFields = {
-				productType: 'DigitalPack',
-				currency: currencyKey,
-				billingPeriod: ratePlanDescription.billingPeriod,
-				// TODO - this needs filling in properly, I am not sure where this value comes from
-				readerType: 'Direct',
-			};
-		} else if (
-			productId === 'NationalDelivery' ||
-			productId === 'SubscriptionCard' ||
-			productId === 'HomeDelivery'
-		) {
-			productFields = {
-				productType: 'Paper',
-				currency: currencyKey,
-				billingPeriod: ratePlanDescription.billingPeriod,
-				// TODO - this needs filling in properly
-				fulfilmentOptions: NoFulfilmentOptions,
-				productOptions: NoProductOptions,
-			};
-		}
-	}
-
 	if (
 		/** These are all the things we need to parse the page */
 		!(
@@ -359,13 +297,88 @@ function CheckoutComponent({ geoId }: Props) {
 			productDescription &&
 			ratePlan &&
 			ratePlanDescription &&
-			price &&
-			productFields
+			price
 		)
 	) {
 		return (
 			<div>
 				Could not find product: {query.product} ratePlan: {query.ratePlan}
+			</div>
+		);
+	}
+
+	/**
+	 * This is the data structure used by the `/subscribe/create` endpoint.
+	 *
+	 * This must match the types in `CreateSupportWorkersRequest#product`
+	 * and readerRevenueApis - `RegularPaymentRequest#product`.
+	 *
+	 * We might be able to defer this to the backend.
+	 */
+	let productFields: RegularPaymentRequest['product'];
+
+	if (productId === 'Contribution') {
+		productFields = {
+			productType: 'Contribution',
+			currency: currencyKey,
+			billingPeriod: ratePlanDescription.billingPeriod,
+			amount: query.price ?? 0,
+		};
+	} else if (productId === 'SupporterPlus') {
+		productFields = {
+			productType: 'SupporterPlus',
+			currency: currencyKey,
+			billingPeriod: ratePlanDescription.billingPeriod,
+			fulfilmentOptions:
+				query.ratePlan === 'GuardianWeeklyDomesticMonthly' ||
+				query.ratePlan === 'GuardianWeeklyDomesticAnnual'
+					? 'Domestic'
+					: query.ratePlan === 'GuardianWeeklyRestOfWorldMonthly' ||
+					  query.ratePlan === 'GuardianWeeklyRestOfWorldAnnual'
+					? 'RestOfWorld'
+					: undefined,
+			amount: price,
+		};
+	} else if (productId === 'GuardianWeeklyDomestic') {
+		productFields = {
+			productType: 'GuardianWeekly',
+			currency: currencyKey,
+			fulfilmentOptions: 'Domestic',
+			billingPeriod: ratePlanDescription.billingPeriod,
+		};
+	} else if (productId === 'GuardianWeeklyRestOfWorld') {
+		productFields = {
+			productType: 'GuardianWeekly',
+			fulfilmentOptions: 'RestOfWorld',
+			currency: currencyKey,
+			billingPeriod: ratePlanDescription.billingPeriod,
+		};
+	} else if (productId === 'DigitalSubscription') {
+		productFields = {
+			productType: 'DigitalPack',
+			currency: currencyKey,
+			billingPeriod: ratePlanDescription.billingPeriod,
+			// TODO - this needs filling in properly, I am not sure where this value comes from
+			readerType: 'Direct',
+		};
+	} else if (
+		productId === 'NationalDelivery' ||
+		productId === 'SubscriptionCard' ||
+		productId === 'HomeDelivery'
+	) {
+		productFields = {
+			productType: 'Paper',
+			currency: currencyKey,
+			billingPeriod: ratePlanDescription.billingPeriod,
+			// TODO - this needs filling in properly
+			fulfilmentOptions: NoFulfilmentOptions,
+			productOptions: NoProductOptions,
+		};
+	} else {
+		return (
+			<div>
+				Could not find productFields for: {query.product} ratePlan:{' '}
+				{query.ratePlan}
 			</div>
 		);
 	}
@@ -637,7 +650,7 @@ function CheckoutComponent({ geoId }: Props) {
 		const ophanIds = getOphanIds();
 		const referrerAcquisitionData = getReferrerAcquisitionData();
 
-		if (paymentFields && productFields) {
+		if (paymentFields) {
 			/** TODO
 			 * - add supportAbTests
 			 * - add debugInfo

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -322,7 +322,7 @@ function CheckoutComponent({ geoId }: Props) {
 			productType: 'Contribution',
 			currency: currencyKey,
 			billingPeriod: ratePlanDescription.billingPeriod,
-			amount: query.price ?? 0,
+			amount: price,
 		};
 	} else if (productId === 'SupporterPlus') {
 		productFields = {


### PR DESCRIPTION
Adds `fulfilmentOptions` to the `SupporterPlus` product on the checkout based on the new `GuardianWeekly` `ratePlans`.

This is then [picked up by `support-workers`](https://github.com/guardian/support-frontend/pull/5968) and makes it way through the pipes. Thank @AndreaDiotallevi and @rupertbates!

<img width="1235" alt="Screenshot 2024-06-06 at 11 51 45" src="https://github.com/guardian/support-frontend/assets/31692/f6145c80-1c49-4896-8db8-bf1a9067c8ab">

I think it is about time we relook at the parsing and error handling.