### PR TITLE
Add `isLoading` to checkout button

### DIFF
--- a/support-frontend/assets/components/paymentButton/defaultPaymentButton.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButton.tsx
@@ -1,5 +1,6 @@
 import { css, ThemeProvider } from '@emotion/react';
 import { neutral } from '@guardian/source/foundations';
+import type { ButtonProps } from '@guardian/source/react-components';
 import {
 	Button,
 	buttonThemeReaderRevenueBrand,
@@ -11,7 +12,7 @@ const buttonOverrides = css`
 	color: ${neutral[7]};
 `;
 
-export type DefaultPaymentButtonProps = {
+export type DefaultPaymentButtonProps = ButtonProps & {
 	id?: string;
 	buttonText: string;
 	onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
@@ -22,16 +23,15 @@ export type DefaultPaymentButtonProps = {
 export function DefaultPaymentButton({
 	id,
 	buttonText,
-	onClick,
-	type,
+	...buttonProps
 }: DefaultPaymentButtonProps): JSX.Element {
 	return (
 		<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
 			<Button
 				id={id}
 				cssOverrides={buttonOverrides}
-				onClick={onClick}
-				type={type}
+				isLoading={false}
+				{...buttonProps}
 			>
 				{buttonText}
 			</Button>

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -1318,9 +1318,10 @@ function CheckoutComponent({ geoId }: Props) {
 									>
 										{paymentMethod !== 'PayPal' && (
 											<DefaultPaymentButton
+												isLoading={stripeClientSecretInProgress}
 												buttonText={
 													stripeClientSecretInProgress
-														? 'Loading...'
+														? 'Validating reCAPTCHA...'
 														: `Pay ${simpleFormatAmount(currency, price)} per ${
 																ratePlanDescription.billingPeriod === 'Annual'
 																	? 'year'


### PR DESCRIPTION
Adds the [Source isLoading prop](https://guardian.github.io/storybooks/?path=/story/source_react-components-button--is-loading-primary) to the Pay button.

I updated the text to be more specific about what triggered the load to add clarity.

I've done pass-

https://github.com/guardian/support-frontend/assets/31692/320888f9-97a3-43d8-bf79-866ddc852a17

thru props to the button to make change quicker.

