### PR TITLE
Don't set abandoned basket cookie for guardian weekly checkout

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -40,7 +40,6 @@ import Text from 'components/text/text';
 import { setupSubscriptionPayPalPaymentNoShipping } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 import { DirectDebit, PayPal, Stripe } from 'helpers/forms/paymentMethods';
 import { billableCountries } from 'helpers/internationalisation/billableCountries';
-import { countryGroups } from 'helpers/internationalisation/countryGroup';
 import {
 	currencies,
 	currencyFromCountryCode,
@@ -60,7 +59,6 @@ import type {
 	SubscriptionsDispatch,
 	SubscriptionsState,
 } from 'helpers/redux/subscriptionsStore';
-import { useAbandonedBasketCookie } from 'helpers/storage/abandonedBasketCookies';
 import {
 	formActionCreators,
 	setCsrCustomerData,
@@ -256,15 +254,6 @@ function WeeklyCheckoutForm(props: PropTypes) {
 				] as 'month' | 'year',
 		  }
 		: undefined;
-
-	const { supportInternationalisationId } = countryGroups[props.countryGroupId];
-
-	useAbandonedBasketCookie(
-		props.product,
-		props.price.price,
-		tierBillingPeriodName,
-		supportInternationalisationId,
-	);
 
 	return (
 		<Content>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Remove the logic to set the abandoned basket cookie for tier three of support/Guardian Weekly

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


## Why are you doing this?

The cookie set from the third tier checkout (Digital + Print) and the Guardian Weekly checkout (just Guardian Weekly) are identical - so we can't easily recreate the URL to return a user back to the same step in the checkout.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Go to `/subscribe/weekly/checkout?period=Monthly` and do not see `GU_CO_INCOMPLETE` cookie set.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Considerations

Traffic for the 3rd tier is relatively low - so it should be fine to exclude this option from the abandoned basket test.

