### PR TITLE
Update payment-api to use alarms-handler

### DIFF
--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -943,7 +943,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":reader-revenue-24-7",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -1022,7 +1022,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":reader-revenue-24-7",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -253,7 +253,7 @@ export class PaymentApi extends GuStack {
         period: Duration.seconds(600),
       }),
       treatMissingData: TreatMissingData.BREACHING,
-      snsTopicName: "reader-revenue-24-7",
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
     });
 
     new GuAlarm(this, "NoStripePaymentsInThreeHours247Alarm", {
@@ -275,7 +275,7 @@ export class PaymentApi extends GuStack {
         period: Duration.seconds(900),
       }),
       treatMissingData: TreatMissingData.BREACHING,
-      snsTopicName: "reader-revenue-24-7",
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
     });
 
     new GuAlarm(this, "NoPaypalPaymentsInOneHourAlarm", {

--- a/support-payment-api/src/main/resources/cloud-formation.yaml
+++ b/support-payment-api/src/main/resources/cloud-formation.yaml
@@ -472,7 +472,7 @@ Resources:
       Condition: CreateProdResources
       Properties:
         AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-24-7
+          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
         AlarmName: !Sub ${App} ${Stage} CP One-off contributions with PayPal might be down
         AlarmDescription: There have been no one-off contributions using paypal in the last 2 hours
         MetricName: payment-success
@@ -492,7 +492,7 @@ Resources:
       Condition: CreateProdResources
       Properties:
         AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-24-7
+          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
         AlarmName: !Sub ${App} ${Stage} CP One-off contributions with Card might be down
         AlarmDescription: There have been no one-off contributions using card payment in the last 3 hours
         MetricName: payment-success


### PR DESCRIPTION
Updates the `payment-api` to use [`alarms-handler`](https://github.com/guardian/support-service-lambdas/pull/2311).

We're in draft while I try to figure out why we have this infrastructure in 2 places.