### PR TITLE
feat: use roundel text on lozenge on product cards

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -45,8 +45,9 @@ export type ThreeTierCardProps = {
 	link: string;
 	productDescription: ProductDescription;
 	price: number;
-	promotion?: Promotion;
 	ctaCopy: string;
+	lozengeText?: string;
+	promotion?: Promotion;
 };
 
 const container = (
@@ -216,7 +217,10 @@ export function ThreeTierCard({
 		>
 			{isUserSelected && <ThreeTierLozenge title="Your selection" />}
 			{isRecommended && !isUserSelected && (
-				<ThreeTierLozenge subdue={isRecommendedSubdued} title="Recommended" />
+				<ThreeTierLozenge
+					subdue={isRecommendedSubdued}
+					title={promotion?.landingPage?.roundel ?? 'Recommended'}
+				/>
 			)}
 			<h2 css={titleCss}>{label}</h2>
 			<p css={priceCss(!!promotion)}>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierLozenge.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierLozenge.tsx
@@ -11,6 +11,7 @@ const container = (isSubdued?: boolean) => css`
 	top: 0;
 	left: 50%;
 	transform: translate(-50%, -50%);
+	white-space: nowrap;
 	padding: ${space[1]}px ${space[4]}px;
 	border-radius: ${space[1]}px;
 	background-color: ${isSubdued ? palette.neutral[100] : palette.brand[500]};


### PR DESCRIPTION
Takes the text from the promo tool (called `roundel`) and, if present, uses it instead of "Recommended" on the tier card.

![image](https://github.com/guardian/support-frontend/assets/76729591/d32eb34d-eb27-477d-bd1d-3e6cde22b3d5)

There has been no text limi imposed, we could recommend this to editors or enforce it on the tooling side.