### PR TITLE
feat: add starts and expires to PromotionSummary

### DIFF
--- a/support-frontend/app/services/pricing/PriceSummary.scala
+++ b/support-frontend/app/services/pricing/PriceSummary.scala
@@ -2,7 +2,7 @@ package services.pricing
 
 import com.gu.i18n.Currency
 import com.gu.support.promotions._
-import com.gu.support.zuora.api.ReaderType
+import org.joda.time.DateTime
 
 case class PriceSummary(
     price: BigDecimal,
@@ -23,12 +23,15 @@ case class PromotionSummary(
     incentive: Option[IncentiveBenefit] = None,
     introductoryPrice: Option[IntroductoryPriceBenefit] = None,
     landingPage: Option[PromotionCopy] = None,
+    starts: DateTime,
+    expires: Option[DateTime],
 )
 
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec._
 
 object PromotionSummary {
+  import com.gu.support.encoding.CustomCodecs.ISODate._
   implicit val codec: Codec[PromotionSummary] = deriveCodec
 }
 

--- a/support-frontend/app/services/pricing/PriceSummaryService.scala
+++ b/support-frontend/app/services/pricing/PriceSummaryService.scala
@@ -111,6 +111,8 @@ class PriceSummaryService(
       incentive = promotion.incentive,
       introductoryPrice = promotion.introductoryPrice,
       landingPage = promotion.landingPage,
+      starts = promotion.starts,
+      expires = promotion.expires,
     )
   }
 

--- a/support-frontend/test/controllers/PricesControllerSerialisationTest.scala
+++ b/support-frontend/test/controllers/PricesControllerSerialisationTest.scala
@@ -9,7 +9,7 @@ import com.gu.support.promotions.{
   Issue,
 }
 import controllers.PricesController.{CountryGroupPriceData, Prices, ProductPriceData, RatePlanPriceData}
-import org.joda.time.Days
+import org.joda.time.{DateTime, Days}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import services.pricing.{PriceSummary, PromotionSummary}
@@ -30,6 +30,8 @@ class PricesControllerSerialisationTest extends AnyFlatSpec with Matchers {
       Some(FreeTrialBenefit(Days.SEVEN)),
       None,
       Some(IntroductoryPriceBenefit(0.5, 3, Issue)),
+      None,
+      new DateTime("2020-01-01"),
       None,
     )
     val priceSummary = PriceSummary(BigDecimal(1.2), Some(50), Currency.GBP, false, List(promotionSummary))

--- a/support-frontend/test/controllers/PricesControllerTest.scala
+++ b/support-frontend/test/controllers/PricesControllerTest.scala
@@ -7,7 +7,7 @@ import services.pricing.{PriceSummary, ProductPrices, PromotionSummary}
 import com.gu.support.promotions.{DiscountBenefit, PromotionCopy}
 import com.gu.support.workers.{Annual, Monthly}
 import controllers.PricesController.{ProductPriceData, RatePlanPriceData}
-import org.joda.time.Months
+import org.joda.time.{DateTime, Months}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -45,6 +45,8 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
                               Some("50% off for 3 months"),
                             ),
                           ),
+                          new DateTime("2020-01-01"),
+                          None,
                         ),
                       ),
                     ),
@@ -68,6 +70,8 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
                           None,
                           None,
                           Some(PromotionCopy(None, None, Some("Subscribe for 12 months and save 10%"))),
+                          new DateTime("2020-01-01"),
+                          None,
                         ),
                       ),
                     ),
@@ -126,6 +130,8 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
                   None,
                   None,
                   None, // no landing page text
+                  new DateTime("2020-01-01"),
+                  None,
                 ),
               ),
             ),
@@ -152,6 +158,8 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
                   None,
                   None,
                   None, // no landing page text
+                  new DateTime("2020-01-01"),
+                  None,
                 ),
               ),
             ),


### PR DESCRIPTION
Adds `starts` and `expires` to the `PromotionSummary` model for us to be able to use in in the rendering of the Ts and Cs for promotions.

<img width="518" alt="Screenshot 2024-06-10 at 17 07 56" src="https://github.com/guardian/support-frontend/assets/31692/e99d8361-fece-431b-82e5-fb59206d0fd7">
