### PR TITLE
Abandoned Basket: create AB test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -610,7 +610,7 @@ function targetPageMatches(
 	return locationPath.match(targetPage) != null;
 }
 
-export { init, getAmountsTestVariant };
+export { init, randomNumber, getMvtId, getAmountsTestVariant };
 
 // Exported for testing only
 export const _ = {

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -610,7 +610,7 @@ function targetPageMatches(
 	return locationPath.match(targetPage) != null;
 }
 
-export { init, randomNumber, getMvtId, getAmountsTestVariant };
+export { init, getAmountsTestVariant };
 
 // Exported for testing only
 export const _ = {

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -160,6 +160,7 @@ export const tests: Tests = {
 		isActive: true,
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 1,
+		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -142,4 +142,24 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
+	abandonedBasket: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		isActive: true,
+		referrerControlled: false, // ab-test name not needed to be in paramURL
+		seed: 1,
+		excludeCountriesSubjectToContributionsOnlyAmounts: true,
+	},
 };

--- a/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
+++ b/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
@@ -30,6 +30,7 @@ export function useAbandonedBasketCookie(
 	amount: number,
 	billingPeriod: string,
 	region: string,
+	inAbandonedBasketVariant: boolean,
 ) {
 	const abandonedBasket = {
 		product,
@@ -38,11 +39,13 @@ export function useAbandonedBasketCookie(
 		region,
 	};
 	useEffect(() => {
-		cookie.set(
-			ABANDONED_BASKET_COOKIE_NAME,
-			JSON.stringify(abandonedBasket),
-			COOKIE_EXPIRY_DAYS,
-		);
+		if (inAbandonedBasketVariant) {
+			cookie.set(
+				ABANDONED_BASKET_COOKIE_NAME,
+				JSON.stringify(abandonedBasket),
+				COOKIE_EXPIRY_DAYS,
+			);
+		}
 	}, []);
 }
 

--- a/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
+++ b/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
@@ -9,6 +9,11 @@ import {
 	string,
 	union,
 } from 'valibot';
+import {
+	getMvtId,
+	randomNumber as getRandomNumber,
+} from 'helpers/abTests/abtest';
+import { sendTrackingEventsOnView } from 'helpers/productPrice/subscriptions';
 import * as cookie from 'helpers/storage/cookie';
 import type { ProductCheckout } from 'helpers/tracking/behaviour';
 import { logException } from 'helpers/utilities/logger';
@@ -44,6 +49,19 @@ export function useAbandonedBasketCookie(
 			COOKIE_EXPIRY_DAYS,
 		);
 	}, []);
+
+	sendTrackingEventsOnView({
+		id: getAbTestId(getMvtId()),
+		componentType: 'ACQUISITIONS_OTHER',
+	})();
+}
+
+function getAbTestId(mvtId: number) {
+	const randomNumber = getRandomNumber(mvtId, 1) % 2;
+
+	return randomNumber === 0
+		? 'abandoned-basket-control'
+		: 'abandoned-basket-variant';
 }
 
 function parseAmount(amount: number): number | 'other' {

--- a/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
+++ b/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
@@ -9,11 +9,6 @@ import {
 	string,
 	union,
 } from 'valibot';
-import {
-	getMvtId,
-	randomNumber as getRandomNumber,
-} from 'helpers/abTests/abtest';
-import { sendTrackingEventsOnView } from 'helpers/productPrice/subscriptions';
 import * as cookie from 'helpers/storage/cookie';
 import type { ProductCheckout } from 'helpers/tracking/behaviour';
 import { logException } from 'helpers/utilities/logger';
@@ -49,19 +44,6 @@ export function useAbandonedBasketCookie(
 			COOKIE_EXPIRY_DAYS,
 		);
 	}, []);
-
-	sendTrackingEventsOnView({
-		id: getAbTestId(getMvtId()),
-		componentType: 'ACQUISITIONS_OTHER',
-	})();
-}
-
-function getAbTestId(mvtId: number) {
-	const randomNumber = getRandomNumber(mvtId, 1) % 2;
-
-	return randomNumber === 0
-		? 'abandoned-basket-control'
-		: 'abandoned-basket-variant';
 }
 
 function parseAmount(amount: number): number | 'other' {

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -78,6 +78,7 @@ export function SupporterPlusCheckout({
 		amount,
 		contributionType,
 		supportInternationalisationId,
+		abParticipations.abandonedBasket === 'variant',
 	);
 
 	const changeButton = (


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Create an AB test definition for the abandoned basket banner. If a user is in the variant - drop a cookie which will surface a banner on dotcom.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/T7RKwJI9/475-abandoned-basket-special-ab-test)

## Why are you doing this?

We need to be able to analyse the overall revenue brought in by the new abandoned basket banner, to do this we will have a control group who do not see this new banner, and a variant who will see the banner.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Go to https://support.thegulocal.com/uk/contribute/checkout?selected-amount=3&selected-contribution-type=monthly#ab-abandonedBasket=variant and see the `GU_CO_INCOMPLETE` cookie.

Go to https://support.thegulocal.com/uk/contribute/checkout?selected-amount=3&selected-contribution-type=monthly#ab-abandonedBasket=control and do not see a `GU_CO_INCOMPLETE` cookie.


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

