### PR TITLE
Revert "Revert "chore(test): activate `useGenericCheckout` test""

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -108,9 +108,9 @@ export const tests: Tests = {
 			{
 				id: 'control',
 			},
-			// {
-			// 	id: 'variant',
-			// },
+			{
+				id: 'variant',
+			},
 		],
 		audiences: {
 			ALL: {


### PR DESCRIPTION
Reverts guardian/support-frontend#6087

We fixed the issue here: https://github.com/guardian/support-frontend/pull/6088 and tested live payments.