### PR TITLE
Add product queryParam to contribute checkout

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -502,6 +502,7 @@ export function ThreeTierLanding(): JSX.Element {
 	const tier1UrlParams = new URLSearchParams({
 		'selected-amount': recurringAmount.toString(),
 		'selected-contribution-type': selectedContributionType,
+		product: 'Contribution',
 	});
 	const tier1Link = `contribute/checkout?${tier1UrlParams.toString()}`;
 
@@ -531,6 +532,7 @@ export function ThreeTierLanding(): JSX.Element {
 	const tier2UrlParams = new URLSearchParams({
 		'selected-amount': tier2Pricing.toString(),
 		'selected-contribution-type': selectedContributionType,
+		product: 'SupporterPlus',
 	});
 	if (promotion) {
 		tier2UrlParams.set('promoCode', promotion.promoCode);


### PR DESCRIPTION
Adds the `product` queryParam to the contribute checkout e.g.

- **current:** `/uk/contribute/checkout?selected-amount=30&selected-contribution-type=annual&product=Contribution`
- **next:** `/uk/contribute/checkout?selected-amount=30&selected-contribution-type=annual`

This should be a no-op but will make it easier to compare against the generic checkout we are testing.