### PR TITLE
Add TierThree product to checkout

### DIFF
--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -63,7 +63,13 @@ type SupporterPlus = {
 	amount: number;
 	currency: string;
 	billingPeriod: BillingPeriod;
-	fulfilmentOptions?: FulfilmentOptions;
+};
+export type TierThree = {
+	productType: 'TierThree';
+	amount: number;
+	currency: string;
+	billingPeriod: BillingPeriod;
+	fulfilmentOptions: FulfilmentOptions;
 };
 export type DigitalSubscription = {
 	productType: typeof DigitalPack;
@@ -90,7 +96,8 @@ export type SubscriptionProductFields =
 	| SupporterPlus
 	| DigitalSubscription
 	| PaperSubscription
-	| GuardianWeeklySubscription;
+	| GuardianWeeklySubscription
+	| TierThree;
 type ProductFields = RegularContribution | SubscriptionProductFields;
 type RegularPayPalPaymentFields = {
 	baid: string;

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -66,7 +66,6 @@ type SupporterPlus = {
 };
 export type TierThree = {
 	productType: 'TierThree';
-	amount: number;
 	currency: string;
 	billingPeriod: BillingPeriod;
 	fulfilmentOptions: FulfilmentOptions;

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -156,22 +156,6 @@ export const productCatalogDescription: Record<string, ProductDescription> = {
 			Annual: {
 				billingPeriod: 'Annual',
 			},
-			GuardianWeeklyRestOfWorldMonthly: {
-				billingPeriod: 'Monthly',
-				deliverableTo: gwDeliverableCountries,
-			},
-			GuardianWeeklyRestOfWorldAnnual: {
-				billingPeriod: 'Annual',
-				deliverableTo: gwDeliverableCountries,
-			},
-			GuardianWeeklyDomesticMonthly: {
-				billingPeriod: 'Monthly',
-				deliverableTo: gwDeliverableCountries,
-			},
-			GuardianWeeklyDomesticAnnual: {
-				billingPeriod: 'Annual',
-				deliverableTo: gwDeliverableCountries,
-			},
 		},
 	},
 	GuardianWeeklyRestOfWorld: {

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -10,11 +10,11 @@ export type ProductDescription = {
 	benefitsSummary?: Array<string | { strong: boolean; copy: string }>;
 	offers?: Array<{ copy: JSX.Element; tooltip?: string }>;
 	offersSummary?: Array<string | { strong: boolean; copy: string }>;
+	deliverableTo?: Record<string, string>;
 	ratePlans: Record<
 		string,
 		{
 			billingPeriod: 'Annual' | 'Monthly' | 'Quarterly';
-			deliverableTo?: Record<string, string>;
 		}
 	>;
 };
@@ -36,22 +36,19 @@ export const productCatalogDescription: Record<string, ProductDescription> = {
 				tooltip: `Guardian Weekly is a beautifully concise magazine featuring a handpicked selection of in-depth articles, global news, long reads, opinion and more. Delivered to you every week, wherever you are in the world.`,
 			},
 		],
+		deliverableTo: gwDeliverableCountries,
 		ratePlans: {
 			MonthlyWithGuardianWeekly: {
 				billingPeriod: 'Monthly',
-				deliverableTo: gwDeliverableCountries,
 			},
 			AnnualWithGuardianWeekly: {
 				billingPeriod: 'Annual',
-				deliverableTo: gwDeliverableCountries,
 			},
 			MonthlyWithGuardianWeeklyInt: {
 				billingPeriod: 'Monthly',
-				deliverableTo: gwDeliverableCountries,
 			},
 			AnnualWithGuardianWeeklyInt: {
 				billingPeriod: 'Annual',
-				deliverableTo: gwDeliverableCountries,
 			},
 		},
 	},
@@ -68,22 +65,19 @@ export const productCatalogDescription: Record<string, ProductDescription> = {
 				tooltip: `Guardian Weekly is a beautifully concise magazine featuring a handpicked selection of in-depth articles, global news, long reads, opinion and more. Delivered to you every week, wherever you are in the world.`,
 			},
 		],
+		deliverableTo: gwDeliverableCountries,
 		ratePlans: {
 			DomesticMonthly: {
 				billingPeriod: 'Monthly',
-				deliverableTo: gwDeliverableCountries,
 			},
 			DomesticAnnual: {
 				billingPeriod: 'Annual',
-				deliverableTo: gwDeliverableCountries,
 			},
 			RestOfWorldMonthly: {
 				billingPeriod: 'Monthly',
-				deliverableTo: gwDeliverableCountries,
 			},
 			RestOfWorldAnnual: {
 				billingPeriod: 'Annual',
-				deliverableTo: gwDeliverableCountries,
 			},
 		},
 	},
@@ -118,18 +112,16 @@ export const productCatalogDescription: Record<string, ProductDescription> = {
 	NationalDelivery: {
 		label: 'National Delivery',
 		benefits: [],
+		deliverableTo: newspaperCountries,
 		ratePlans: {
 			Sixday: {
 				billingPeriod: 'Monthly',
-				deliverableTo: newspaperCountries,
 			},
 			Weekend: {
 				billingPeriod: 'Annual',
-				deliverableTo: newspaperCountries,
 			},
 			Everyday: {
 				billingPeriod: 'Monthly',
-				deliverableTo: newspaperCountries,
 			},
 		},
 	},
@@ -161,60 +153,50 @@ export const productCatalogDescription: Record<string, ProductDescription> = {
 	GuardianWeeklyRestOfWorld: {
 		label: 'The Guardian Weekly',
 		benefits: [],
+		deliverableTo: gwDeliverableCountries,
 		ratePlans: {
 			Monthly: {
 				billingPeriod: 'Monthly',
-				deliverableTo: gwDeliverableCountries,
 			},
 			OneYearGift: {
 				billingPeriod: 'Annual',
-				deliverableTo: gwDeliverableCountries,
 			},
 			Annual: {
 				billingPeriod: 'Annual',
-				deliverableTo: gwDeliverableCountries,
 			},
 			SixWeekly: {
 				billingPeriod: 'Monthly',
-				deliverableTo: gwDeliverableCountries,
 			},
 			Quarterly: {
 				billingPeriod: 'Quarterly',
-				deliverableTo: gwDeliverableCountries,
 			},
 			ThreeMonthGift: {
 				billingPeriod: 'Monthly',
-				deliverableTo: gwDeliverableCountries,
 			},
 		},
 	},
 	GuardianWeeklyDomestic: {
 		label: 'The Guardian Weekly',
 		benefits: [],
+		deliverableTo: gwDeliverableCountries,
 		ratePlans: {
 			Monthly: {
 				billingPeriod: 'Monthly',
-				deliverableTo: gwDeliverableCountries,
 			},
 			OneYearGift: {
 				billingPeriod: 'Annual',
-				deliverableTo: gwDeliverableCountries,
 			},
 			Annual: {
 				billingPeriod: 'Annual',
-				deliverableTo: gwDeliverableCountries,
 			},
 			SixWeekly: {
 				billingPeriod: 'Monthly',
-				deliverableTo: gwDeliverableCountries,
 			},
 			Quarterly: {
 				billingPeriod: 'Quarterly',
-				deliverableTo: gwDeliverableCountries,
 			},
 			ThreeMonthGift: {
 				billingPeriod: 'Monthly',
-				deliverableTo: gwDeliverableCountries,
 			},
 		},
 	},
@@ -269,26 +251,22 @@ export const productCatalogDescription: Record<string, ProductDescription> = {
 	HomeDelivery: {
 		label: 'Home Delivery',
 		benefits: [],
+		deliverableTo: newspaperCountries,
 		ratePlans: {
 			Everyday: {
 				billingPeriod: 'Monthly',
-				deliverableTo: newspaperCountries,
 			},
 			Sunday: {
 				billingPeriod: 'Monthly',
-				deliverableTo: newspaperCountries,
 			},
 			Sixday: {
 				billingPeriod: 'Monthly',
-				deliverableTo: newspaperCountries,
 			},
 			Weekend: {
 				billingPeriod: 'Monthly',
-				deliverableTo: newspaperCountries,
 			},
 			Saturday: {
 				billingPeriod: 'Monthly',
-				deliverableTo: newspaperCountries,
 			},
 		},
 	},

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -20,6 +20,10 @@ export type ProductDescription = {
 };
 
 export const productCatalogDescription: Record<string, ProductDescription> = {
+	/**
+	 * We need `SupporterPlusWithGuardianWeekly` for the the landing page while we migrate
+	 * away from the hacked TierThree product to the actual TierThree product below.
+	 */
 	SupporterPlusWithGuardianWeekly: {
 		label: 'Digital + print',
 		benefitsSummary: [
@@ -51,6 +55,39 @@ export const productCatalogDescription: Record<string, ProductDescription> = {
 			},
 		},
 	},
+
+	TierThree: {
+		label: 'Digital + print',
+		benefitsSummary: [
+			'The rewards from ',
+			{ strong: true, copy: 'All-access digital' },
+		],
+		benefits: [
+			{
+				copy: 'Guardian Weekly print magazine delivered to your door every week  ',
+				tooltip: `Guardian Weekly is a beautifully concise magazine featuring a handpicked selection of in-depth articles, global news, long reads, opinion and more. Delivered to you every week, wherever you are in the world.`,
+			},
+		],
+		ratePlans: {
+			DomesticMonthly: {
+				billingPeriod: 'Monthly',
+				deliverableTo: gwDeliverableCountries,
+			},
+			DomesticAnnual: {
+				billingPeriod: 'Annual',
+				deliverableTo: gwDeliverableCountries,
+			},
+			RestOfWorldMonthly: {
+				billingPeriod: 'Monthly',
+				deliverableTo: gwDeliverableCountries,
+			},
+			RestOfWorldAnnual: {
+				billingPeriod: 'Annual',
+				deliverableTo: gwDeliverableCountries,
+			},
+		},
+	},
+
 	DigitalSubscription: {
 		label: 'The Guardian Digital Edition',
 		benefits: [

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -351,7 +351,6 @@ function CheckoutComponent({ geoId }: Props) {
 					  query.ratePlan === 'RestOfWorldAnnual'
 					? 'RestOfWorld'
 					: 'Domestic',
-			amount: price,
 		};
 	} else if (productId === 'Contribution') {
 		productFields = {

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -593,7 +593,7 @@ function CheckoutComponent({ geoId }: Props) {
 		 */
 		let billingAddress;
 		let deliveryAddress;
-		if (ratePlanDescription.deliverableTo) {
+		if (productDescription.deliverableTo) {
 			deliveryAddress = {
 				lineOne: formData.get('delivery-lineOne') as string,
 				lineTwo: formData.get('delivery-lineTwo') as string,
@@ -1013,14 +1013,14 @@ function CheckoutComponent({ geoId }: Props) {
 									 * We need the billing-country for all transactions, even non-deliverable ones
 									 * which we get from the GU_country cookie which comes from the Fastly geo client.
 									 */}
-									{!ratePlanDescription.deliverableTo && (
+									{!productDescription.deliverableTo && (
 										<input
 											type="hidden"
 											name="billing-country"
 											value={countryId}
 										/>
 									)}
-									{ratePlanDescription.deliverableTo && (
+									{productDescription.deliverableTo && (
 										<>
 											<fieldset>
 												<legend css={legend}>
@@ -1034,7 +1034,7 @@ function CheckoutComponent({ geoId }: Props) {
 													country={deliveryCountry}
 													state={deliveryState}
 													postCode={deliveryPostcode}
-													countries={ratePlanDescription.deliverableTo}
+													countries={productDescription.deliverableTo}
 													errors={[]}
 													postcodeState={{
 														results: deliveryPostcodeStateResults,
@@ -1129,7 +1129,7 @@ function CheckoutComponent({ geoId }: Props) {
 														country={billingCountry}
 														state={billingState}
 														postCode={billingPostcode}
-														countries={ratePlanDescription.deliverableTo}
+														countries={productDescription.deliverableTo}
 														errors={[]}
 														postcodeState={{
 															results: billingPostcodeStateResults,

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -338,7 +338,22 @@ function CheckoutComponent({ geoId }: Props) {
 	 */
 	let productFields: RegularPaymentRequest['product'];
 
-	if (productId === 'Contribution') {
+	if (productId === 'TierThree') {
+		productFields = {
+			productType: 'TierThree',
+			currency: currencyKey,
+			billingPeriod: ratePlanDescription.billingPeriod,
+			fulfilmentOptions:
+				query.ratePlan === 'DomesticMonthly' ||
+				query.ratePlan === 'DomesticAnnual'
+					? 'Domestic'
+					: query.ratePlan === 'RestOfWorldMonthly' ||
+					  query.ratePlan === 'RestOfWorldAnnual'
+					? 'RestOfWorld'
+					: 'Domestic',
+			amount: price,
+		};
+	} else if (productId === 'Contribution') {
 		productFields = {
 			productType: 'Contribution',
 			currency: currencyKey,
@@ -350,14 +365,6 @@ function CheckoutComponent({ geoId }: Props) {
 			productType: 'SupporterPlus',
 			currency: currencyKey,
 			billingPeriod: ratePlanDescription.billingPeriod,
-			fulfilmentOptions:
-				query.ratePlan === 'GuardianWeeklyDomesticMonthly' ||
-				query.ratePlan === 'GuardianWeeklyDomesticAnnual'
-					? 'Domestic'
-					: query.ratePlan === 'GuardianWeeklyRestOfWorldMonthly' ||
-					  query.ratePlan === 'GuardianWeeklyRestOfWorldAnnual'
-					? 'RestOfWorld'
-					: undefined,
 			amount: price,
 		};
 	} else if (productId === 'GuardianWeeklyDomestic') {


### PR DESCRIPTION
Adds the TierThree product to the frontend.

- Adds it to the `productCatalogDescription`
- Adds it to the types (this could use a nice little refactor)
- Adds it to the `productFields` of the checkout to `POST` to the `create` endpoint.
- Removes unused `ratePlans` from `SupporterPlus`
- hoists `deliverableTo` back into the product as we no longer need it per `ratePlan`


## Network request
<img width="275" alt="Screenshot 2024-06-12 at 12 39 54" src="https://github.com/guardian/support-frontend/assets/31692/4f659f5e-eb1f-4ec7-9290-a8d58d1a3dc9">

## Network response
<img width="428" alt="Screenshot 2024-06-12 at 12 39 37" src="https://github.com/guardian/support-frontend/assets/31692/437259dc-4ffd-46cf-8cd1-39e1a7649bb2">

[The error is because the `support-workers` needs updating (coming soon 🥳)](https://github.com/guardian/support-frontend/pull/6090)
