### PR TITLE
update google auth library

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "identity-test-users" % "0.8",
   "com.google.guava" % "guava" % "32.1.1-jre",
   "io.lemonlabs" %% "scala-uri" % scalaUriVersion,
-  "com.gu.play-googleauth" %% "play-v30" % "3.0.6",
+  "com.gu.play-googleauth" %% "play-v30" % "8.0.0",
   "io.github.bonigarcia" % "webdrivermanager" % "5.5.3" % "test",
   "org.scalatestplus" %% "scalatestplus-mockito" % "1.0.0-M2" % Test,
   "com.squareup.okhttp3" % "okhttp" % "4.11.0",

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "identity-test-users" % "0.8",
   "com.google.guava" % "guava" % "32.1.1-jre",
   "io.lemonlabs" %% "scala-uri" % scalaUriVersion,
-  "com.gu.play-googleauth" %% "play-v30" % "8.0.0",
+  "com.gu.play-googleauth" %% "play-v30" % "8.0.1",
   "io.github.bonigarcia" % "webdrivermanager" % "5.5.3" % "test",
   "org.scalatestplus" %% "scalatestplus-mockito" % "1.0.0-M2" % Test,
   "com.squareup.okhttp3" % "okhttp" % "4.11.0",


### PR DESCRIPTION
the /test-users page was breaking with an error
JsResultException(errors:List((/locale,List(JsonValidationError(List(error.path.missing),List())))))

This PR seems to fix it - tested locally and in CODE.
Probably due to this fix https://github.com/guardian/play-googleauth/pull/218

I also raised this PR (edit: which has now been merged and released as 8.0.1), as we shoudl not be writing exception information to the UI
https://github.com/guardian/play-googleauth/pull/233