### PR TITLE
NavigateWithPageView

### DIFF
--- a/support-frontend/assets/helpers/__tests__/urlTest.ts
+++ b/support-frontend/assets/helpers/__tests__/urlTest.ts
@@ -3,7 +3,6 @@
 import type { JSDOM } from 'jsdom';
 import {
 	addQueryParamsToURL,
-	getAbsoluteURL,
 	getAllQueryParams,
 	getAllQueryParamsWithExclusions,
 } from '../urls/url';
@@ -140,45 +139,6 @@ describe('url', () => {
 			expect(getAllQueryParamsWithExclusions(['foo'])).toEqual([
 				['spam', 'eggs'],
 			]);
-		});
-	});
-
-	describe('getAbsoluteURL', () => {
-		it('should return the absolute URL if you call it without any path (with path in the original URL)', () => {
-			const origin = 'https://support.theguardian.com';
-			const path = 'uk';
-			jsdom.reconfigure({
-				url: `${origin}/${path}`,
-			});
-			expect(getAbsoluteURL()).toEqual(origin);
-		});
-
-		it('should return the absolute URL (including path) if you call it wit a path', () => {
-			const origin = 'https://support.theguardian.com';
-			const path = 'uk';
-			const expectedURL = `${origin}/example`;
-			jsdom.reconfigure({
-				url: `${origin}/${path}`,
-			});
-			expect(getAbsoluteURL('/example')).toEqual(expectedURL);
-		});
-
-		it('should return the absolute URL if you call it without any path (no path in the original URL)', () => {
-			const origin = 'https://support.theguardian.com/';
-			const expected = 'https://support.theguardian.com';
-			jsdom.reconfigure({
-				url: `${origin}`,
-			});
-			expect(getAbsoluteURL()).toEqual(expected);
-		});
-
-		it('should return the absolute URL (including path) if you call it wit a path', () => {
-			const origin = 'https://support.theguardian.com';
-			const expectedURL = `${origin}/example`;
-			jsdom.reconfigure({
-				url: `${origin}`,
-			});
-			expect(getAbsoluteURL('/example')).toEqual(expectedURL);
 		});
 	});
 });

--- a/support-frontend/assets/helpers/tracking/NavigateWithPageView.tsx
+++ b/support-frontend/assets/helpers/tracking/NavigateWithPageView.tsx
@@ -1,0 +1,34 @@
+import * as ophan from 'ophan';
+import { Navigate } from 'react-router-dom';
+import type { Participations } from 'helpers/abTests/abtest';
+import { getAbsoluteURL } from 'helpers/urls/url';
+import { pageView, setReferrerDataInLocalStorage, trackAbTests } from './ophan';
+
+type NavigateWithPageViewProps = {
+	destination: string;
+	participations?: Participations;
+};
+
+function NavigateWithPageView({
+	destination,
+	participations,
+}: NavigateWithPageViewProps) {
+	const refererData = {
+		referrerUrl: document.location.href,
+		referrerPageviewId: ophan.viewId,
+	};
+
+	// store referer data to be read and transmitted on manual pageView
+	setReferrerDataInLocalStorage(refererData);
+
+	// manual pageView
+	pageView(document.location.href, getAbsoluteURL(destination));
+
+	if (participations) {
+		trackAbTests(participations);
+	}
+
+	return <Navigate to={destination} replace />;
+}
+
+export { NavigateWithPageView };

--- a/support-frontend/assets/helpers/tracking/NavigateWithPageView.tsx
+++ b/support-frontend/assets/helpers/tracking/NavigateWithPageView.tsx
@@ -1,8 +1,11 @@
-import * as ophan from 'ophan';
 import { Navigate } from 'react-router-dom';
 import type { Participations } from 'helpers/abTests/abtest';
-import { getAbsoluteURL } from 'helpers/urls/url';
-import { pageView, setReferrerDataInLocalStorage, trackAbTests } from './ophan';
+import {
+	getPageViewId,
+	pageView,
+	setReferrerDataInLocalStorage,
+	trackAbTests,
+} from './ophan';
 
 type NavigateWithPageViewProps = {
 	destination: string;
@@ -13,16 +16,21 @@ function NavigateWithPageView({
 	destination,
 	participations,
 }: NavigateWithPageViewProps) {
+	const referrerUrl = document.location.href;
+
 	const refererData = {
-		referrerUrl: document.location.href,
-		referrerPageviewId: ophan.viewId,
+		referrerUrl,
+		referrerPageviewId: getPageViewId(),
 	};
 
 	// store referer data to be read and transmitted on manual pageView
 	setReferrerDataInLocalStorage(refererData);
 
 	// manual pageView
-	pageView(document.location.href, getAbsoluteURL(destination));
+	pageView(
+		`${document.location.origin}${destination}}`,
+		document.location.href,
+	);
 
 	if (participations) {
 		trackAbTests(participations);

--- a/support-frontend/assets/helpers/tracking/NavigateWithPageView.tsx
+++ b/support-frontend/assets/helpers/tracking/NavigateWithPageView.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Navigate } from 'react-router-dom';
 import type { Participations } from 'helpers/abTests/abtest';
 import {
@@ -26,15 +27,14 @@ function NavigateWithPageView({
 	// store referer data to be read and transmitted on manual pageView
 	setReferrerDataInLocalStorage(refererData);
 
-	// manual pageView
-	pageView(
-		`${document.location.origin}${destination}}`,
-		document.location.href,
-	);
+	useEffect(() => {
+		// manual pageView
+		pageView(document.location.href, referrerUrl);
 
-	if (participations) {
-		trackAbTests(participations);
-	}
+		if (participations) {
+			trackAbTests(participations);
+		}
+	});
 
 	return <Navigate to={destination} replace />;
 }

--- a/support-frontend/assets/helpers/tracking/ophan.ts
+++ b/support-frontend/assets/helpers/tracking/ophan.ts
@@ -1,7 +1,6 @@
 // ----- Imports ----- //
 import * as ophan from 'ophan';
-import type { NavigateFunction } from 'react-router';
-import type { NavigateOptions } from 'react-router-dom';
+import type { NavigateFunction, NavigateOptions } from 'react-router';
 import type { Participations } from 'helpers/abTests/abtest';
 import { getLocal, setLocal } from 'helpers/storage/storage';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';

--- a/support-frontend/assets/helpers/tracking/ophan.ts
+++ b/support-frontend/assets/helpers/tracking/ophan.ts
@@ -4,7 +4,6 @@ import type { NavigateFunction, NavigateOptions } from 'react-router';
 import type { Participations } from 'helpers/abTests/abtest';
 import { getLocal, setLocal } from 'helpers/storage/storage';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
-import { getAbsoluteURL } from 'helpers/urls/url';
 
 // ----- Types ----- //
 // These are to match Thrift definitions which can be found here:
@@ -141,8 +140,10 @@ const navigateWithPageView = (
 	participations?: Participations,
 	options?: NavigateOptions,
 ): void => {
+	const referrerUrl = document.location.href;
+
 	const refererData = {
-		referrerUrl: document.location.href,
+		referrerUrl,
 		referrerPageviewId: getPageViewId(),
 	};
 
@@ -152,7 +153,7 @@ const navigateWithPageView = (
 	navigate(destination, options);
 
 	// manual pageView
-	pageView(document.location.href, getAbsoluteURL(destination));
+	pageView(document.location.href, referrerUrl);
 
 	if (participations) {
 		trackAbTests(participations);
@@ -165,4 +166,5 @@ export {
 	trackAbTests,
 	setReferrerDataInLocalStorage,
 	navigateWithPageView,
+	getPageViewId,
 };

--- a/support-frontend/assets/helpers/urls/url.ts
+++ b/support-frontend/assets/helpers/urls/url.ts
@@ -75,10 +75,6 @@ function getBaseDomain(): Domain {
 	return DOMAINS.PROD;
 }
 
-function getAbsoluteURL(path = ''): string {
-	return `${getOrigin()}${path}`;
-}
-
 function isProd(): boolean {
 	return getBaseDomain() === 'theguardian.com';
 }
@@ -95,7 +91,6 @@ export {
 	getOrigin,
 	getBaseDomain,
 	addQueryParamsToURL,
-	getAbsoluteURL,
 	isProd,
 	isCodeOrProd,
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -1,13 +1,7 @@
 // ----- Imports ----- //
 import { useEffect } from 'react';
 import { Provider } from 'react-redux';
-import {
-	BrowserRouter,
-	Navigate,
-	Route,
-	Routes,
-	useLocation,
-} from 'react-router-dom';
+import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { validateWindowGuardian } from 'helpers/globalsAndSwitches/window';
 import { CountryGroup } from 'helpers/internationalisation';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -16,6 +10,7 @@ import { setUpTrackingAndConsents } from 'helpers/page/page';
 import { isDetailsSupported, polyfillDetails } from 'helpers/polyfills/details';
 import { initReduxForContributions } from 'helpers/redux/contributionsStore';
 import { renderPage } from 'helpers/rendering/render';
+import { NavigateWithPageView } from 'helpers/tracking/NavigateWithPageView';
 import { SupporterPlusThankYou } from 'pages/supporter-plus-thank-you/supporterPlusThankYou';
 import { setUpRedux } from './setup/setUpRedux';
 import { threeTierCheckoutEnabled } from './setup/threeTierChecks';
@@ -50,7 +45,7 @@ const countryIds = Object.values(countryGroups).map(
 
 // ----- ScrollToTop on Navigate: https://v5.reactrouter.com/web/guides/scroll-restoration ---- //
 
-function ScrollToTop() {
+function ScrollToTop(): null {
 	const { pathname } = useLocation();
 
 	useEffect(() => {
@@ -76,11 +71,10 @@ function ThreeTierRedirectOneOffToCheckout({
 	const oneOff = urlSelectedContributionType === 'ONE_OFF';
 
 	return oneOff ? (
-		<Navigate
-			to={`/${countryId}/contribute/checkout${`${
+		<NavigateWithPageView
+			destination={`/${countryId}/contribute/checkout${`${
 				urlParamsString ? `?${urlParamsString}` : ''
 			}${window.location.hash}`}`}
-			replace
 		/>
 	) : (
 		<>{children}</>

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -75,6 +75,7 @@ function ThreeTierRedirectOneOffToCheckout({
 			destination={`/${countryId}/contribute/checkout${`${
 				urlParamsString ? `?${urlParamsString}` : ''
 			}${window.location.hash}`}`}
+			participations={commonState.abParticipations}
 		/>
 	) : (
 		<>{children}</>


### PR DESCRIPTION
## What are you doing in this PR?

Currently when a user lands on the 3-tier landing page via the Banner / Epic having pre-selected a single contribution amount we automatically redirect them to Page 2 of the checkout, the single contribution checkout form using client-side routing via React-Router-Dom's  `<Navigate>` component. The issue is we don't notify Ophan, so Ophan's data indicates they are still on Page 1 (`/contribute`) rather than Page 2 (`/contribute/checkout`) when they checkout. This has caused some issues in Data Analysis. 

Data Design have requested we notify Ophan that a user has landed on Page 2 via a new Page View event. I've therefore set-up a `<NavigateWithPageView>` component that wraps React-Router-Dom's  `<Navigate>` component and fires a new Ophan Page view. 

**Test url:** https://support.thegulocal.com/uk/contribute?selected-contribution-type=ONE_OFF&selected-amount=60

**Page View 1**
```
{
  url: https://support.thegulocal.com/uk/contribute?selected-contribution-type=ONE_OFF&selected-amount=60
}
``` 

_**Action:** User gets immediately auto redirected to single contribution checkout form._

**Page View 2**
```
{
  url: https://support.thegulocal.com/uk/contribute/checkout?selected-contribution-type=ONE_OFF&selected-amount=60
  ref: https://support.thegulocal.com/uk/contribute?selected-contribution-type=ONE_OFF&selected-amount=60
}
``` 

_**Action:** User submits single contribution checkout form and goes to Thank You page._

**Page View 3**
```
{
  url: https://support.thegulocal.com/uk/thankyou
  ref: https://support.thegulocal.com/uk/contribute/checkout?selected-contribution-type=ONE_OFF&selected-amount=60
}
``` 