### PR TITLE
Non mandatory ZipCode in US checkout

### DIFF
--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -17,21 +17,6 @@ export function getStateOrProvinceError(
 	return {};
 }
 
-function getZipCodeErrors(state: ContributionsState): ErrorCollection {
-	const { internationalisation } = state.common;
-	const shouldShowZipCode = internationalisation.countryId === 'US';
-
-	if (shouldShowZipCode) {
-		const zipCode =
-			state.page.checkoutForm.billingAddress.fields.errorObject?.postCode;
-		return {
-			zipCode,
-		};
-	}
-
-	return {};
-}
-
 export function getPersonalDetailsErrors(
 	state: ContributionsState,
 ): ErrorCollection {
@@ -41,13 +26,11 @@ export function getPersonalDetailsErrors(
 		state.page.checkoutForm.personalDetails.errors ?? {};
 
 	const stateOrProvinceErrors = getStateOrProvinceError(state);
-	const zipCodeErrors = getZipCodeErrors(state);
 
 	if (contributionType === 'ONE_OFF') {
 		return {
 			email,
 			...stateOrProvinceErrors,
-			...zipCodeErrors,
 		};
 	}
 	return {
@@ -55,6 +38,5 @@ export function getPersonalDetailsErrors(
 		firstName,
 		lastName,
 		...stateOrProvinceErrors,
-		...zipCodeErrors,
 	};
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -192,7 +192,8 @@ function regularPaymentRequestFromAuthorisation(
 	state: ContributionsState,
 ): RegularPaymentRequest {
 	const { actionHistory } = state.debug;
-	const { billingCountry, billingState } = getBillingCountryAndState(state);
+	const { billingCountry, billingState, postCode } =
+		getBillingCountryAndState(state);
 	const recaptchaToken = state.page.checkoutForm.recaptcha.token;
 	const contributionType = getContributionType(state);
 
@@ -220,7 +221,7 @@ function regularPaymentRequestFromAuthorisation(
 				? billingState
 				: null,
 			// required Zuora field if country is US or CA
-			postCode: null,
+			postCode: billingCountry === 'US' ? postCode : null,
 			// required go cardless field
 			country: billingCountry, // required Zuora field
 		},

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -192,8 +192,7 @@ function regularPaymentRequestFromAuthorisation(
 	state: ContributionsState,
 ): RegularPaymentRequest {
 	const { actionHistory } = state.debug;
-	const { billingCountry, billingState, postCode } =
-		getBillingCountryAndState(state);
+	const { billingCountry, billingState } = getBillingCountryAndState(state);
 	const recaptchaToken = state.page.checkoutForm.recaptcha.token;
 	const contributionType = getContributionType(state);
 
@@ -221,7 +220,7 @@ function regularPaymentRequestFromAuthorisation(
 				? billingState
 				: null,
 			// required Zuora field if country is US or CA
-			postCode: billingCountry === 'US' ? postCode : null,
+			postCode: null,
 			// required go cardless field
 			country: billingCountry, // required Zuora field
 		},


### PR DESCRIPTION
## What are you doing in this PR?

We would like to make the US ZipCode field non-mandatory (ie Displayed but not required to be filled in to checkout).  Currently this affects->
1. US Contributions : Contribution Checkout
2. US Recurring S+ Contributions : Contribution Checkout
3. US Recurring Contribution: Generic Checkout

This is the client-side aspect ONLY. Server-side aspects to be determined in follow-up PR.

## Why are we doing in this?

As part of a change we made in Sep’23 we changes both the position of the Zipcode and made it mandatory , that has lead to an issue with Apple and Google pay payment in the US , as in these fail when the mandory field is not filled.

[**Trello Card**](https://trello.com/c/Cpvg3n5l/896-zipcode-make-it-non-mandatory-on-the-checkout-page-for-single-recurring-and-s-for-us)