### PR TITLE
feat: add product query param to thank you  pages

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -38,12 +38,7 @@ const store = initReduxForContributions();
 
 setUpRedux(store);
 
-const urlParams = new URLSearchParams(window.location.search);
-const promoCode = urlParams.get('promoCode');
-const thankYouRouteParams = promoCode
-	? `?${new URLSearchParams({ promoCode }).toString()}`
-	: '';
-const thankYouRoute = `/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou${thankYouRouteParams}`;
+const thankYouRoute = `/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou`;
 const countryIds = Object.values(countryGroups).map(
 	(group) => group.supportInternationalisationId,
 );

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
@@ -167,9 +167,26 @@ export function SupporterPlusCheckoutScaffold({
 
 	useEffect(() => {
 		if (paymentComplete) {
-			navigateWithPageView(navigate, thankYouRoute, abParticipations, {
-				replace: true,
-			});
+			const urlParams = new URLSearchParams(window.location.search);
+			const promoCode = urlParams.get('promoCode');
+			const product = urlParams.get('product');
+
+			const thankYouUrlSearchParams = new URLSearchParams();
+			if (promoCode) {
+				thankYouUrlSearchParams.set('promoCode', promoCode);
+			}
+			if (product) {
+				thankYouUrlSearchParams.set('product', product);
+			}
+			const thankYouRouteWithSearchParams = `${thankYouRoute}?${thankYouUrlSearchParams.toString()}`;
+			navigateWithPageView(
+				navigate,
+				thankYouRouteWithSearchParams,
+				abParticipations,
+				{
+					replace: true,
+				},
+			);
 		}
 	}, [paymentComplete]);
 


### PR DESCRIPTION
As per this pr https://github.com/guardian/support-frontend/pull/6092 - we'd like a querystring param on the thank you page to aid with tracking drop-off.

- **current:** `/uk/thankyou` | `/uk/thank-you`
- **next:** `/uk/thankyou?product=Contribution` | `/uk/thank-you?product=Contribution`

![Screenshot 2024-06-14 at 09 48 25](https://github.com/guardian/support-frontend/assets/31692/8ca1cfd0-2e1f-4e6e-adb6-090bbb0f375d)
![Screenshot 2024-06-14 at 10 04 58](https://github.com/guardian/support-frontend/assets/31692/874042b1-3dd8-4eec-9e67-669a1aefd562)

