### PR TITLE
feat: add abtest to have Tier Three on landing page from api

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -118,7 +118,28 @@ export const tests: Tests = {
 				size: 1,
 			},
 		},
-		isActive: true,
+		isActive: false,
+		referrerControlled: false,
+		seed: 5,
+		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+		excludeCountriesSubjectToContributionsOnlyAmounts: true,
+	},
+	tierThreeFromApi: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		isActive: false,
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 5,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -573,7 +573,7 @@ export function ThreeTierLanding(): JSX.Element {
 		supporterPlusWithGuardianWeekly.ratePlans[
 			supporterPlusWithGuardianWeeklyRatePlan
 		].pricing[currencyId];
-	const tier3Card = {
+	const tier3CardHarcoded = {
 		productDescription:
 			productCatalogDescription.SupporterPlusWithGuardianWeekly,
 		price: tier3Pricing,
@@ -586,6 +586,49 @@ export function ThreeTierLanding(): JSX.Element {
 		),
 		ctaCopy: getThreeTierCardCtaCopy(countryGroupId),
 	};
+
+	/**
+	 * tierThree is from the product catalog API
+	 * tier3 is hardcoded for now
+	 */
+	const tierThreeRatePlans =
+		countryGroupId === International
+			? {
+					MONTHLY: 'RestOfWorldMonthly',
+					ANNUAL: 'RestOfWorldAnnual',
+			  }
+			: {
+					MONTHLY: 'DomesticMonthly',
+					ANNUAL: 'DomesticAnnual',
+			  };
+	const tierThreeRatePlan = tierThreeRatePlans[contributionType];
+	const tierThreePricing =
+		productCatalog.TierThree.ratePlans[tierThreeRatePlan].pricing[currencyId];
+	const tierThreeUrlParams = new URLSearchParams({
+		product: 'TierThree',
+		ratePlan: tierThreeRatePlan,
+	});
+	const tierThreeGenericCheckoutLink = `checkout?${tierThreeUrlParams.toString()}`;
+	const tierThreeCardFromApi = {
+		productDescription: productCatalogDescription.TierThree,
+		price: tierThreePricing,
+		link: tierThreeGenericCheckoutLink,
+		// TODO: we'll need to update this once TierThree promotions are supported
+		promotion: undefined,
+		isRecommended: false,
+		isUserSelected: isCardUserSelected(
+			tierThreePricing,
+			// TODO: we'll need to update this once TierThree promotions are supported
+			undefined,
+		),
+		ctaCopy: getThreeTierCardCtaCopy(countryGroupId),
+	};
+
+	const useTierThreeOnLandingPage =
+		abParticipations.tierThreeFromApi === 'variant';
+	const tier3Card = useTierThreeOnLandingPage
+		? tierThreeCardFromApi
+		: tier3CardHarcoded;
 
 	return (
 		<PageScaffold


### PR DESCRIPTION
Adds an A/B test to have the `TierThree` card be populated from the [product catalog API](https://product-catalog.guardianapis.com/product-catalog.json).

![Screenshot 2024-06-14 at 10 56 19](https://github.com/guardian/support-frontend/assets/31692/9f18b5f3-ecda-4393-8392-dcd5152c59e2)

Next steps would be getting the promo codes to work. 