### PR TITLE
Ts&Cs moved to white background, font theme should be dark default

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -1472,7 +1472,6 @@ function CheckoutComponent({ geoId }: Props) {
 										)}
 									</div>
 									<PaymentTsAndCs
-										mobileTheme={'light'}
 										countryGroupId={countryGroupId}
 										contributionType={
 											productFields.billingPeriod === 'Monthly'


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Ts&Cs moved to white background, font theme should be dark default

## Screenshots

|From|To|
|-----|-----|
|![image](https://github.com/guardian/support-frontend/assets/76729591/1887ea18-2eaa-4507-bc39-e71b73278122)|![image](https://github.com/guardian/support-frontend/assets/76729591/b55ef171-e155-4e66-83ff-116e4f2e138e)|
