### PR TITLE
Mandatory ZipCode in US  for payments EXCEPT ApplePay & GooglePay

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -64,6 +64,27 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
+	usZipCodeMandatory: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 0,
+			},
+		},
+		isActive: false,
+		referrerControlled: true,
+		seed: 7,
+		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+		excludeCountriesSubjectToContributionsOnlyAmounts: true,
+	},
 	supporterPlusOnly: {
 		variants: [
 			{

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -45,20 +45,37 @@ export function getPersonalDetailsErrors(
 		state.page.checkoutForm.personalDetails.errors ?? {};
 
 	const stateOrProvinceErrors = getStateOrProvinceError(state);
-	const zipCodeErrors = getZipCodeErrors(state);
 
-	if (contributionType === 'ONE_OFF') {
+	const usZipCodeMandatory =
+		state.common.abParticipations.usZipCodeMandatory === 'variant';
+	if (usZipCodeMandatory) {
+		const zipCodeErrors = getZipCodeErrors(state);
+		if (contributionType === 'ONE_OFF') {
+			return {
+				email,
+				...stateOrProvinceErrors,
+				...zipCodeErrors,
+			};
+		}
 		return {
 			email,
+			firstName,
+			lastName,
 			...stateOrProvinceErrors,
 			...zipCodeErrors,
 		};
+	} else {
+		if (contributionType === 'ONE_OFF') {
+			return {
+				email,
+				...stateOrProvinceErrors,
+			};
+		}
+		return {
+			email,
+			firstName,
+			lastName,
+			...stateOrProvinceErrors,
+		};
 	}
-	return {
-		email,
-		firstName,
-		lastName,
-		...stateOrProvinceErrors,
-		...zipCodeErrors,
-	};
 }

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -25,18 +25,14 @@ function getZipCodeErrors(state: ContributionsState): ErrorCollection {
 		paymentMethod.name === 'Stripe' &&
 		(paymentMethod.stripePaymentMethod === 'StripeApplePay' ||
 			paymentMethod.stripePaymentMethod === 'StripePaymentRequestButton');
-	console.log('TEST getZipCodeErrors.paymentMethod', paymentMethod);
-	console.log('TEST getZipCodeErrors.shouldShowZipCode', shouldShowZipCode);
-	console.log('TEST getZipCodeErrors.isApplePayGooglePay', isApplePayGooglePay);
+
 	if (shouldShowZipCode && !isApplePayGooglePay) {
-		console.log('TEST getZipCodeErrors.APPLY ZipCode Check');
 		const zipCode =
 			state.page.checkoutForm.billingAddress.fields.errorObject?.postCode;
 		return {
 			zipCode,
 		};
 	}
-	console.log('TEST getZipCodeErrors.DONOT ZipCode Check');
 	return {};
 }
 

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -28,14 +28,15 @@ function getZipCodeErrors(state: ContributionsState): ErrorCollection {
 	console.log('TEST getZipCodeErrors.paymentMethod', paymentMethod);
 	console.log('TEST getZipCodeErrors.shouldShowZipCode', shouldShowZipCode);
 	console.log('TEST getZipCodeErrors.isApplePayGooglePay', isApplePayGooglePay);
-	if (isApplePayGooglePay && shouldShowZipCode) {
+	if (shouldShowZipCode && !isApplePayGooglePay) {
+		console.log('TEST getZipCodeErrors.APPLY ZipCode Check');
 		const zipCode =
 			state.page.checkoutForm.billingAddress.fields.errorObject?.postCode;
 		return {
 			zipCode,
 		};
 	}
-
+	console.log('TEST getZipCodeErrors.DONOT ZipCode Check');
 	return {};
 }
 

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -17,6 +17,28 @@ export function getStateOrProvinceError(
 	return {};
 }
 
+function getZipCodeErrors(state: ContributionsState): ErrorCollection {
+	const { internationalisation } = state.common;
+	const { paymentMethod } = state.page.checkoutForm.payment;
+	const shouldShowZipCode = internationalisation.countryId === 'US';
+	const isApplePayGooglePay =
+		paymentMethod.name === 'Stripe' &&
+		(paymentMethod.stripePaymentMethod === 'StripeApplePay' ||
+			paymentMethod.stripePaymentMethod === 'StripePaymentRequestButton');
+	console.log('TEST getZipCodeErrors.paymentMethod', paymentMethod);
+	console.log('TEST getZipCodeErrors.shouldShowZipCode', shouldShowZipCode);
+	console.log('TEST getZipCodeErrors.isApplePayGooglePay', isApplePayGooglePay);
+	if (isApplePayGooglePay && shouldShowZipCode) {
+		const zipCode =
+			state.page.checkoutForm.billingAddress.fields.errorObject?.postCode;
+		return {
+			zipCode,
+		};
+	}
+
+	return {};
+}
+
 export function getPersonalDetailsErrors(
 	state: ContributionsState,
 ): ErrorCollection {
@@ -26,11 +48,13 @@ export function getPersonalDetailsErrors(
 		state.page.checkoutForm.personalDetails.errors ?? {};
 
 	const stateOrProvinceErrors = getStateOrProvinceError(state);
+	const zipCodeErrors = getZipCodeErrors(state);
 
 	if (contributionType === 'ONE_OFF') {
 		return {
 			email,
 			...stateOrProvinceErrors,
+			...zipCodeErrors,
 		};
 	}
 	return {
@@ -38,5 +62,6 @@ export function getPersonalDetailsErrors(
 		firstName,
 		lastName,
 		...stateOrProvinceErrors,
+		...zipCodeErrors,
 	};
 }


### PR DESCRIPTION
## What are you doing in this PR?

Further to this [PR](https://github.com/guardian/support-frontend/pull/6099)

Re-introduce US ZipCode checking for payments other than ApplePay & GooglePay.

[**Trello Card**](https://trello.com/c/Cpvg3n5l/896-zipcode-make-it-non-mandatory-on-the-checkout-page-for-single-recurring-and-s-for-us)