### PR TITLE
fix: reactivate useGenericCheckoutTest

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -118,7 +118,7 @@ export const tests: Tests = {
 				size: 1,
 			},
 		},
-		isActive: false,
+		isActive: true,
 		referrerControlled: false,
 		seed: 5,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,


### PR DESCRIPTION
[In a PR that had a hard-to-read diff](https://github.com/guardian/support-frontend/commit/4d56bd5a6a0a9052f41b6c9b69bc76d0b059ecf1#diff-1673db1c74e930dd41928f75fce7d8c3dbf52774becd7e891adfc034a8b7c19cL121-R121) - we inadvertantly deactivated the three tier test.

I'll let D&I know about this.