### PR TITLE
fix: do a heading check for thank you pages e2e test

### DIFF
--- a/support-e2e/tests/genericCheckout.test.ts
+++ b/support-e2e/tests/genericCheckout.test.ts
@@ -119,10 +119,9 @@ test.describe('Generic Checkout', () => {
 					.click();
 			}
 
-			await expect(page).toHaveURL(
-				`/${testDetails.country?.toLowerCase() || 'uk'}/thank-you`,
-				{ timeout: 600000 },
-			);
+			await expect(
+				page.getByRole('heading', { name: 'Thank you' }),
+			).toBeVisible({ timeout: 600000 });
 		});
 	});
 });

--- a/support-e2e/tests/landingPages.test.ts
+++ b/support-e2e/tests/landingPages.test.ts
@@ -18,7 +18,9 @@ test.describe('Paper product page', () => {
 		await page.goto(pageUrl);
 
 		await expect(page.locator('id=qa-paper-subscriptions')).toBeVisible();
-		await expect(page).toHaveURL(/\/uk\/subscribe\/paper/);
+		await expect(
+			page.getByRole('heading', { name: 'Newspaper subscription' }).first(),
+		).toBeVisible();
 	});
 });
 
@@ -35,7 +37,9 @@ test.describe('Weekly product page', () => {
 		await page.goto(pageUrl);
 
 		await expect(page.locator('id=qa-guardian-weekly')).toBeVisible();
-		await expect(page).toHaveURL(/\/uk\/subscribe\/weekly/);
+		await expect(
+			page.getByRole('heading', { name: 'The Guardian Weekly' }).first(),
+		).toBeVisible();
 	});
 });
 
@@ -52,7 +56,9 @@ test.describe('Weekly gift product page', () => {
 		await page.goto(pageUrl);
 
 		await expect(page.locator('id=qa-guardian-weekly-gift')).toBeVisible();
-		await expect(page).toHaveURL(/\/uk\/subscribe\/weekly\/gift/);
+		await expect(
+			page.getByRole('heading', { name: 'Give the Guardian Weekly' }).first(),
+		).toBeVisible();
 	});
 });
 
@@ -71,6 +77,12 @@ test.describe('Subscriptions landing page', () => {
 		await expect(
 			page.locator('id=qa-subscriptions-landing-page'),
 		).toBeVisible();
-		await expect(page).toHaveURL(/\/uk\/subscribe/);
+		await expect(
+			page
+				.getByRole('heading', {
+					name: 'Support the Guardian with a print subscription',
+				})
+				.first(),
+		).toBeVisible();
 	});
 });

--- a/support-e2e/tests/oneOffContributions.test.ts
+++ b/support-e2e/tests/oneOffContributions.test.ts
@@ -50,7 +50,9 @@ test.describe('Sign up for a one-off contribution', () => {
 					fillInPayPalDetails(page);
 					break;
 			}
-			await expect(page).toHaveURL(/\/uk\/thankyou/);
+			await expect(
+				page.getByRole('heading', { name: 'Thank you' }),
+			).toBeVisible({ timeout: 600000 });
 		});
 	});
 });

--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -106,10 +106,11 @@ test.describe('Subscribe/Contribute via the Tiered checkout)', () => {
 				);
 				await page.getByText(paymentButtonRegex).click();
 			}
-			await expect(page).toHaveURL(
-				`/${testDetails.country?.toLowerCase() || 'uk'}/thankyou`,
-				{ timeout: 600000 },
-			);
+			await expect(
+				page.getByRole('heading', { name: 'Thank you' }),
+			).toBeVisible({
+				timeout: 600000,
+			});
 			await checkAbandonedBasketCookieRemoved(context);
 		});
 	});
@@ -184,11 +185,12 @@ test.describe('Supporter Plus promoCodes', () => {
 
 			// Thank you
 			await expect(
+				page.getByRole('heading', { name: 'Thank you' }),
+			).toBeVisible({ timeout: 600000 });
+
+			await expect(
 				page.getByText(testDetails.expectedThankYouText).first(),
 			).toBeVisible({ timeout: 600000 });
-			await expect(page).toHaveURL(
-				`/uk/thankyou?promoCode=${testDetails.promoCode}`,
-			);
 		});
 	});
 });


### PR DESCRIPTION
As per testing libraries ideology:

> [The more your tests resemble the way your software is used, the more confidence they can give you.](https://testing-library.com/docs/guiding-principles)

This checks for a "thank you" `heading` on the page, rather than checking the URL, which, from a users perspective, is irrelevant 🐘.

We have extended this to subscription pages too.

<img width="547" alt="Screenshot 2024-06-17 at 14 13 21" src="https://github.com/guardian/support-frontend/assets/31692/bfb15541-2e4f-4844-81b3-37f799696528">
