### PR TITLE
US Support another way, copy change

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/patronsMessage.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/patronsMessage.tsx
@@ -44,8 +44,9 @@ export function PatronsMessage({
 			</h2>
 			{isUSA ? (
 				<p>
-					To learn more about other ways to support the Guardian, including
-					checks and tax-exempt options, please visit our{' '}
+					If you are interested in contributing through a donor-advised fund,
+					foundation or retirement account, or by mailing a check, please visit
+					our{' '}
 					<Link
 						css={linkStyles}
 						priority="secondary"
@@ -53,7 +54,7 @@ export function PatronsMessage({
 					>
 						help page
 					</Link>{' '}
-					on this topic.
+					to learn how.
 				</p>
 			) : (
 				<p>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -695,12 +695,13 @@ export function ThreeTierLanding(): JSX.Element {
 					<div css={suppportAnotherWayContainer}>
 						<h4>Support another way</h4>
 						<p>
-							To learn more about other ways to support the Guardian, including
-							checks and tax-exempt options, please visit our{' '}
+							If you are interested in contributing through a donor-advised
+							fund, foundation or retirement account, or by mailing a check,
+							please visit our{' '}
 							<a href="https://manage.theguardian.com/help-centre/article/contribute-another-way?INTCMP=gdnwb_copts_support_contributions_referral">
 								help page
 							</a>{' '}
-							on this topic.
+							to learn how.
 						</p>
 					</div>
 				)}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Copy Change to US support another way as shown. 

Affects:-
1. ThreeTierLanding Page
2. Patrons Checkout message

[**Trello Card**](https://trello.com/c/T0tvhsgX/873-copy-change-on-3-tiers-lp-the-us)

|Before|After|
|-----|-----|
|![image](https://github.com/guardian/support-frontend/assets/76729591/1cce5dba-61c1-4ae5-bf8f-d8a7d0a74604)|![image](https://github.com/guardian/support-frontend/assets/76729591/e01316ad-3a7c-4d12-b011-a67900295356)|

FROM: `To learn more about other ways to support the Guardian, including checks and tax-exempt options, please visit our `[help page](https://manage.theguardian.com/help-centre/article/contribute-another-way?INTCMP=gdnwb_copts_support_contributions_referral)` on this topic.`
TO : `If you are interested in contributing through a donor-advised fund, foundation or retirement account, or by mailing a check, please visit our `[help page](https://manage.theguardian.com/help-centre/article/contribute-another-way?INTCMP=gdnwb_copts_support_contributions_referral)` to learn how.`