### PR TITLE
Update bigquery-acquisitions-publisher alarm description

### DIFF
--- a/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
+++ b/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
@@ -40,11 +40,11 @@ exports[`The BigqueryAcquisitionsPublisher stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "There is one or more event in the dead-letters-bigquery-acquisitions-publisher-PROD dead letter queue. Check the logs for details of the exception and then use the dead letter queue redrive functionality to replay the failed event if appropriate. If the redrive functionality is not used then purge the queue instead or the alarm will remain in an alarm state and not send this email again in future.
+        "AlarmDescription": "There is one or more event in the dead-letters-bigquery-acquisitions-publisher-PROD dead letter queue. Check the logs for details of the exception and use the details to confirm that the event was not written to the fact_acquisition_event table in BigQuery. If the event is not in the table then use the dead letter queue redrive functionality to replay the failed event. If the redrive functionality is not used then purge the queue instead or the alarm will remain in an alarm state and not send this email again in future.
 The main queue is at https://eu-west-1.console.aws.amazon.com/sqs/v2/home?region=eu-west-1#/queues/https%3A%2F%2Fsqs.eu-west-1.amazonaws.com%2F865473395570%2Fbigquery-acquisitions-publisher-queue-PROD
 The dead letter queue is at https://eu-west-1.console.aws.amazon.com/sqs/v2/home?region=eu-west-1#/queues/https%3A%2F%2Fsqs.eu-west-1.amazonaws.com%2F865473395570%2Fdead-letters-bigquery-acquisitions-publisher-PROD
 Logs are at https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fbigquery-acquisitions-publisher-PROD",
-        "AlarmName": "The PROD big-query-acquisitions-publisher lambda has failed",
+        "AlarmName": "The PROD bigquery-acquisitions-publisher lambda has failed",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {

--- a/cdk/lib/bigquery-acquisitions-publisher.ts
+++ b/cdk/lib/bigquery-acquisitions-publisher.ts
@@ -125,12 +125,13 @@ export class BigqueryAcquisitionsPublisher extends GuStack {
 
     new GuAlarm(this, "DeadLetterQueueAlarm", {
       app: appName,
-      alarmName: `The ${props.stage} big-query-acquisitions-publisher lambda has failed`,
+      alarmName: `The ${props.stage} ${appName} lambda has failed`,
       alarmDescription:
         `There is one or more event in the ${deadLetterQueueName} dead letter queue. ` +
-        "Check the logs for details of the exception and then use the dead letter queue redrive functionality " +
-        "to replay the failed event if appropriate. If the redrive functionality is not used then purge the queue " +
-        "instead or the alarm will remain in an alarm state and not send this email again in future.\n" +
+        "Check the logs for details of the exception and use the details to confirm that the event was not written " +
+        "to the fact_acquisition_event table in BigQuery. If the event is not in the table then use the dead letter " +
+        "queue redrive functionality to replay the failed event. If the redrive functionality is not used " +
+        "then purge the queue instead or the alarm will remain in an alarm state and not send this email again in future.\n" +
         `The main queue is at https://eu-west-1.console.aws.amazon.com/sqs/v2/home?region=eu-west-1#/queues/https%3A%2F%2Fsqs.eu-west-1.amazonaws.com%2F865473395570%2F${queueName}\n` +
         `The dead letter queue is at https://eu-west-1.console.aws.amazon.com/sqs/v2/home?region=eu-west-1#/queues/https%3A%2F%2Fsqs.eu-west-1.amazonaws.com%2F865473395570%2F${deadLetterQueueName}\n` +
         `Logs are at https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252F${functionName}`,


### PR DESCRIPTION
we should first check if the acquisition event was successfully written to BigQuery before replaying it from the DLQ