### PR TITLE
fix: use international pricing for int on tier three

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -560,19 +560,31 @@ export function ThreeTierLanding(): JSX.Element {
 		contributionType === 'ANNUAL'
 			? supporterPlusWithGuardianWeeklyAnnualPromos[countryGroupId]
 			: supporterPlusWithGuardianWeeklyMonthlyPromos[countryGroupId];
-	const supporterPlusWithGuardianWeeklyRatePlan =
+	const supporterPlusWithGuardianWeeklyDomesticRatePlan =
 		contributionType === 'ANNUAL'
 			? 'AnnualWithGuardianWeekly'
 			: 'MonthlyWithGuardianWeekly';
+
+	const supporterPlusWithGuardianWeeklyInternationalRatePlan =
+		contributionType === 'ANNUAL'
+			? 'AnnualWithGuardianWeeklyInt'
+			: 'MonthlyWithGuardianWeeklyInt';
+
+	const tier3Pricing =
+		countryGroupId === 'International'
+			? supporterPlusWithGuardianWeekly.ratePlans[
+					supporterPlusWithGuardianWeeklyInternationalRatePlan
+			  ].pricing['USD']
+			: supporterPlusWithGuardianWeekly.ratePlans[
+					supporterPlusWithGuardianWeeklyDomesticRatePlan
+			  ].pricing[currencyId];
+
 	const tier3UrlParams = new URLSearchParams({
 		promoCode: tier3Promotion.promoCode,
 		threeTierCreateSupporterPlusSubscription: 'true',
 		period: paymentFrequencyMap[contributionType],
 	});
-	const tier3Pricing =
-		supporterPlusWithGuardianWeekly.ratePlans[
-			supporterPlusWithGuardianWeeklyRatePlan
-		].pricing[currencyId];
+
 	const tier3CardHarcoded = {
 		productDescription:
 			productCatalogDescription.SupporterPlusWithGuardianWeekly,


### PR DESCRIPTION
Uses international pricing for `int` on tier three of the landing page.

| before | after |
|---|---|
| ![Screenshot 2024-06-19 at 13 59 15](https://github.com/guardian/support-frontend/assets/31692/4f8ce26d-d5e6-4a8d-92a5-d3c293977c41) | ![Screenshot 2024-06-19 at 13 54 56](https://github.com/guardian/support-frontend/assets/31692/e0e5617f-7fc6-4e43-ad90-d0014293db58) |

