### PR TITLE
feat: add checkout redirect without qs params

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -308,6 +308,34 @@ class Application(
     ).withSettingsSurrogateKey
   }
 
+  def checkoutRedirectWithPrice(
+      countryGroupId: String,
+      product: String,
+      ratePlan: String,
+      price: String,
+  ): Action[AnyContent] = checkoutRedirect(countryGroupId, product, ratePlan, Some(price))
+
+  def checkoutRedirect(
+      countryGroupId: String,
+      product: String,
+      ratePlan: String,
+      price: Option[String],
+  ): Action[AnyContent] = CachedAction() {
+    val queryStringMap = price.map(price =>
+      Map(
+        "product" -> Seq(product),
+        "ratePlan" -> Seq(ratePlan),
+        "price" -> Seq(price),
+      ),
+    ) getOrElse Map(product -> Seq(product), ratePlan -> Seq(ratePlan))
+
+    RedirectWithEncodedQueryString(
+      s"/${countryGroupId}/checkout",
+      queryStringMap,
+      status = FOUND,
+    )
+  }
+
   def eventsRouter(countryGroupId: String, eventId: Option[String]) = authAction { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     Ok(views.html.eventsRouter()).withHeaders(CacheControl.noCache)

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -90,8 +90,10 @@ GET  /subscribe                                                    controllers.S
 GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe                  controllers.SubscriptionsController.landing(country: String)
 
 # Checkout
-GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/checkout            controllers.Application.router(countryGroupId: String)
-GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/thank-you           controllers.Application.router(countryGroupId: String)
+GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/checkout                             controllers.Application.router(countryGroupId: String)
+GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/thank-you                            controllers.Application.router(countryGroupId: String)
+GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/checkout/:product/:ratePlan          controllers.Application.checkoutRedirect(countryGroupId: String, product: String, ratePlan: String, price: Option[String] = None)
+GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/checkout/:product/:ratePlan/:price   controllers.Application.checkoutRedirectWithPrice(countryGroupId: String, product: String, ratePlan: String, price: String)
 
 # Events
 GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/events              controllers.Application.eventsRouter(countryGroupId: String, eventId: Option[String] = None)


### PR DESCRIPTION
The identity API strips out querystring parameters for security reasons.

see https://github.com/guardian/gateway/blob/940e33d41e0921fd96db9370f195a93ef1787858/src/server/lib/validateUrl.ts

This offers a URL that takes specific URL path segments, and breaks them into a querystring.

**This is in draft as ID are looking if they can append QS parameters which would make this obsolete**