### PR TITLE
Remove abandoned basket cookie when cta clicked

### DIFF
--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -11,6 +11,7 @@ import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { getLowerBenefitsThreshold } from 'helpers/supporterPlus/benefitsThreshold';
 import { threeTierCheckoutEnabled } from 'pages/supporter-plus-landing/setup/threeTierChecks';
+import { deleteAbandonedBasketCookie } from "../../helpers/storage/abandonedBasketCookies";
 import { DefaultPaymentButton } from './defaultPaymentButton';
 
 const contributionTypeToPaymentInterval: Partial<
@@ -104,7 +105,10 @@ export function DefaultPaymentButtonContainer({
 		<DefaultPaymentButton
 			id={testId}
 			buttonText={buttonText}
-			onClick={onClick}
+			onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+				deleteAbandonedBasketCookie();
+				onClick(event);
+			}}
 		/>
 	);
 }

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButtonContainer.tsx
@@ -11,7 +11,7 @@ import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import { getLowerBenefitsThreshold } from 'helpers/supporterPlus/benefitsThreshold';
 import { threeTierCheckoutEnabled } from 'pages/supporter-plus-landing/setup/threeTierChecks';
-import { deleteAbandonedBasketCookie } from "../../helpers/storage/abandonedBasketCookies";
+import { deleteAbandonedBasketCookie } from '../../helpers/storage/abandonedBasketCookies';
 import { DefaultPaymentButton } from './defaultPaymentButton';
 
 const contributionTypeToPaymentInterval: Partial<

--- a/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
+++ b/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
@@ -82,3 +82,7 @@ export function updateAbandonedBasketCookie(amount: string) {
 		);
 	}
 }
+
+export function deleteAbandonedBasketCookie() {
+  cookie.remove(ABANDONED_BASKET_COOKIE_NAME);
+}

--- a/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
+++ b/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
@@ -84,5 +84,5 @@ export function updateAbandonedBasketCookie(amount: string) {
 }
 
 export function deleteAbandonedBasketCookie() {
-  cookie.remove(ABANDONED_BASKET_COOKIE_NAME);
+	cookie.remove(ABANDONED_BASKET_COOKIE_NAME);
 }


### PR DESCRIPTION
Currently we use the backend to remove this cookie for recurring/subscriptions.
But we also need to delete it for single contributions. This PR adds logic to the CTA click handler to do this