### PR TITLE
Read product catalog from CODE in DEV & CODE

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -194,7 +194,7 @@ class Application(
     val productPrices =
       priceSummaryServiceProvider.forUser(isTestUser).getPrices(SupporterPlus, queryPromos)
 
-    val productCatalog = cachedProductCatalogServiceProvider.forUser(isTestUser).get()
+    val productCatalog = cachedProductCatalogServiceProvider.fromStage(stage, isTestUser).get()
 
     views.html.contributions(
       title = "Support the Guardian",
@@ -281,7 +281,7 @@ class Application(
     val isTestUser = testUserService.isTestUser(request)
     // This will be present if the token has been flashed into the session by the PayPal redirect endpoint
     val guestAccountCreationToken = request.flash.get("guestAccountCreationToken")
-    val productCatalog = cachedProductCatalogServiceProvider.forUser(isTestUser).get()
+    val productCatalog = cachedProductCatalogServiceProvider.fromStage(stage, isTestUser).get()
 
     Ok(
       views.html.router(

--- a/support-frontend/app/services/ProductCatalogService.scala
+++ b/support-frontend/app/services/ProductCatalogService.scala
@@ -2,6 +2,8 @@ package services
 
 import com.gu.okhttp.RequestRunners.FutureHttpClient
 import com.gu.rest.WebServiceHelper
+import com.gu.support.config.Stage
+import com.gu.support.config.Stages.{CODE, DEV}
 import io.circe.{Decoder, Json, JsonObject}
 import io.circe.generic.semiauto.deriveDecoder
 import org.apache.pekko.actor.ActorSystem
@@ -53,6 +55,8 @@ class CachedProductCatalogServiceProvider(
     codeCachedProductCatalogService: CachedProductCatalogService,
     prodCachedProductCatalogService: CachedProductCatalogService,
 ) {
-  def forUser(isTestUser: Boolean) =
-    if (isTestUser) codeCachedProductCatalogService else prodCachedProductCatalogService
+  def fromStage(stage: Stage, isTestUser: Boolean) =
+    if (stage == DEV || stage == CODE || isTestUser)
+      codeCachedProductCatalogService
+    else prodCachedProductCatalogService
 }


### PR DESCRIPTION
Reads the product-catalog from [`CODE`](https://product-catalog.code.dev-guardianapis.com/product-catalog.json) when you are in `DEV`, `CODE` or a test user. 

This allows us to test updates to the catalog in `DEV` from `CODE`