### PR TITLE
Add a function to work out the correct first delivery date for T3

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -96,7 +96,7 @@ import { GuardianTsAndCs } from 'pages/supporter-plus-landing/components/guardia
 import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsMessage';
 import { PaymentTsAndCs } from 'pages/supporter-plus-landing/components/paymentTsAndCs';
 import { formatMachineDate } from '../../helpers/utilities/dateConversions';
-import { getWeeklyDays } from '../weekly-subscription-checkout/helpers/deliveryDays';
+import { getTierThreeDeliveryDate } from '../weekly-subscription-checkout/helpers/deliveryDays';
 import { setThankYouOrder, unsetThankYouOrder } from './thank-you';
 
 /** App config - this is config that should persist throughout the app */
@@ -702,7 +702,7 @@ function CheckoutComponent({ geoId }: Props) {
 			);
 			const firstDeliveryDate =
 				productId === 'TierThree'
-					? formatMachineDate(getWeeklyDays()[0])
+					? formatMachineDate(getTierThreeDeliveryDate())
 					: null;
 
 			const createSupportWorkersRequest: RegularPaymentRequest = {

--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/__tests__/tierThreeDeliveryDays.ts
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/__tests__/tierThreeDeliveryDays.ts
@@ -22,7 +22,11 @@ describe('getTierThreeDeliveryDate', () => {
 			const deliveryDate = dayjs(
 				getTierThreeDeliveryDate(day.toDate().getTime()),
 			);
-			expect(deliveryDate.isAfter(day.add(15, 'day'))).toBe(true);
+			const fifteenDaysTime = day.add(15, 'day');
+			expect(
+				deliveryDate.isSame(fifteenDaysTime) ||
+					deliveryDate.isAfter(fifteenDaysTime),
+			).toBe(true);
 		});
 	});
 });

--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/__tests__/tierThreeDeliveryDays.ts
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/__tests__/tierThreeDeliveryDays.ts
@@ -1,0 +1,47 @@
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
+import { addDays, getTierThreeDeliveryDate } from '../deliveryDays';
+
+export function getDaysBetween(start: Dayjs, end: Dayjs) {
+	const range = [];
+	let current = start;
+	while (!current.isAfter(end)) {
+		range.push(current);
+		current = current.add(1, 'days');
+	}
+	return range;
+}
+
+describe('getTierThreeDeliveryDate', () => {
+	it('will always find a delivery date at least 15 days from today', () => {
+		const startDate = dayjs('2024-01-01');
+		const endDate = dayjs('2024-12-31');
+		const daysIn2024 = getDaysBetween(startDate, endDate);
+
+		daysIn2024.map((day) => {
+			const deliveryDate = dayjs(
+				getTierThreeDeliveryDate(day.toDate().getTime()),
+			);
+			expect(deliveryDate.isAfter(day.add(15, 'day'))).toBe(true);
+		});
+	});
+});
+describe('addDays', () => {
+	// The addDays function was written to avoid adding a dependency to support-frontend
+	// this test checks its outputs against the Dayjs library to ensure correctness
+	it('matches the output of Dayjs for a range of dates', () => {
+		const testForDateAndNumberOfDays = (
+			startDate: Dayjs,
+			daysToAdd: number,
+		) => {
+			expect(addDays(startDate.toDate(), daysToAdd)).toEqual(
+				startDate.add(daysToAdd, 'day').toDate(),
+			);
+		};
+		testForDateAndNumberOfDays(dayjs('2024-01-01'), 1);
+		testForDateAndNumberOfDays(dayjs('2024-01-01'), 31);
+		testForDateAndNumberOfDays(dayjs('2024-12-31'), 3);
+		testForDateAndNumberOfDays(dayjs('2024-02-28'), 3);
+		testForDateAndNumberOfDays(dayjs('2024-02-29'), 1); // 2024 is a leap year
+	});
+});

--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.ts
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.ts
@@ -49,9 +49,13 @@ function getTierThreeDeliveryDate(today?: number) {
 		15,
 	);
 	const weeklyDays = getWeeklyDays(today);
-	return weeklyDays.find(
+	const result = weeklyDays.find(
 		(date) => date.getTime() >= firstValidDeliveryDate.getTime(),
 	);
+	if (result === undefined) {
+		throw new Error('We couldn\t find a valid three tier delivery date');
+	}
+	return result;
 }
 
 export { getWeeklyDays, addDays, getTierThreeDeliveryDate };

--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.ts
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.ts
@@ -3,7 +3,6 @@ import {
 	getNextDeliveryDay,
 	numberOfWeeksWeDeliverTo,
 } from 'helpers/subscriptionsForms/deliveryDays';
-import { formatUserDate } from 'helpers/utilities/dateConversions';
 
 const extraDelayCutoffWeekday = 3;
 const normalDelayWeeks = 1;
@@ -35,9 +34,24 @@ const getWeeklyDays = (today?: number): Date[] => {
 	return nonChrismassy.splice(weeksToAdd);
 };
 
-function getDisplayDays(): string[] {
-	const today = new Date().getTime();
-	return getWeeklyDays(today).map((day) => formatUserDate(day));
+function addDays(date: Date, days: number) {
+	const result = new Date(date);
+	result.setDate(result.getDate() + days);
+	return result;
 }
 
-export { getWeeklyDays, getDisplayDays };
+function getTierThreeDeliveryDate(today?: number) {
+	// For the Tier Three (t3) product we want users to be able to cancel within 14 days without being charged.
+	// To do this we need the first delivery date of the Guardian Weekly part of the subscription, which is the date
+	// on which the first payment will be taken, to be at least 14 (actually 15 to be safe) days from today.
+	const firstValidDeliveryDate = addDays(
+		new Date(today ?? new Date().getTime()),
+		15,
+	);
+	const weeklyDays = getWeeklyDays(today);
+	return weeklyDays.find(
+		(date) => date.getTime() >= firstValidDeliveryDate.getTime(),
+	);
+}
+
+export { getWeeklyDays, addDays, getTierThreeDeliveryDate };

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -165,6 +165,7 @@
     "css-loader": "^6.7.1",
     "css-minimizer-webpack-plugin": "^4.2.2",
     "cssnano": "^6.0.1",
+    "dayjs": "^1.11.11",
     "eslint": "^8.51.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-nibble": "^8.1.0",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -6982,6 +6982,11 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
+dayjs@^1.11.11:
+  version "1.11.11"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.11.tgz#dfe0e9d54c5f8b68ccf8ca5f72ac603e7e5ed59e"
+  integrity sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?
For the Tier Three (t3) product we want users to be able to cancel within 14 days without being charged as this is a regulatory requirement in some jurisdictions.

To do this we set the first delivery date of the Guardian Weekly part of the subscription, which is the date
on which the first payment will be taken, to be at least 14 (actually 15 to be safe) days from today.

