### PR TITLE
fix: be price dynamic in e2e tests

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -215,7 +215,7 @@ export function ContributionsOrderSummary({
 							<span css={originalPriceStrikeThrough}>
 								<span css={visuallyHiddenCss}>Was </span>
 								{formattedAmount}
-								<span css={visuallyHiddenCss}>, now </span>
+								<span css={visuallyHiddenCss}>, now</span>
 							</span>{' '}
 							{paymentFrequency
 								? `${formattedPromotionAmount}/${paymentFrequency}`

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -183,8 +183,8 @@ const discountSummaryCopy = (
 		paymentFrequency === 'ANNUAL' ? durationMonths / 12 : durationMonths;
 
 	return `${formattedPromotionPrice}/${period} for ${
-		period === 'year' ? ' the first ' : ''
-	} ${duration > 1 ? duration : ''} ${period}${
+		period === 'year' ? 'the first' : ''
+	}${duration > 1 ? duration : ''} ${period}${
 		duration > 1 ? 's' : ''
 	}, then ${formattedPrice}/${period}${'*'.repeat(promoCount)}`;
 };


### PR DESCRIPTION
Be price dynamic in our E2E tests.

This has come at a cost of
- readability
- annoyingly, being more whitespace sensitive

I think at a time of high rate of change - these tests really do help ensure we're not breaking core functionality, so this is a decent payoff. I assume we'll get to redinfing these once we reach a more stable set of user journeys.

Annoyingly I am not confident as I think they are failing in letting us know they're failing. I'll be looking into this next.