### PR TITLE
Set abandoned basket cookie on generic checkout

### DIFF
--- a/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
+++ b/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
@@ -10,7 +10,6 @@ import {
 	union,
 } from 'valibot';
 import * as cookie from 'helpers/storage/cookie';
-import type { ProductCheckout } from 'helpers/tracking/behaviour';
 import { logException } from 'helpers/utilities/logger';
 
 const COOKIE_EXPIRY_DAYS = 3;
@@ -26,7 +25,7 @@ const abandonedBasketSchema = object({
 type AbandonedBasket = InferInput<typeof abandonedBasketSchema>;
 
 export function useAbandonedBasketCookie(
-	product: ProductCheckout,
+	product: string,
 	amount: number,
 	billingPeriod: string,
 	region: string,
@@ -38,8 +37,14 @@ export function useAbandonedBasketCookie(
 		billingPeriod: billingPeriod.toUpperCase(),
 		region,
 	};
+
+	// support-dotcom-components can only return a user to the checkout for these products
+	// don't drop the cookie if they came from a different checkout
+	const isSupportedProduct =
+		product === 'Contribution' || product === 'SupporterPlus';
+
 	useEffect(() => {
-		if (inAbandonedBasketVariant) {
+		if (inAbandonedBasketVariant && isSupportedProduct) {
 			cookie.set(
 				ABANDONED_BASKET_COOKIE_NAME,
 				JSON.stringify(abandonedBasket),

--- a/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
+++ b/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
@@ -9,6 +9,7 @@ import {
 	string,
 	union,
 } from 'valibot';
+import type { ProductId } from 'helpers/productCatalog';
 import * as cookie from 'helpers/storage/cookie';
 import { logException } from 'helpers/utilities/logger';
 
@@ -25,7 +26,7 @@ const abandonedBasketSchema = object({
 type AbandonedBasket = InferInput<typeof abandonedBasketSchema>;
 
 export function useAbandonedBasketCookie(
-	product: string,
+	product: ProductId,
 	amount: number,
 	billingPeriod: string,
 	region: string,

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -79,9 +79,11 @@ import { getStripeKey } from 'helpers/forms/stripe';
 import { validateWindowGuardian } from 'helpers/globalsAndSwitches/window';
 import CountryHelper from 'helpers/internationalisation/classes/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import { countryGroups } from 'helpers/internationalisation/countryGroup';
 import { productCatalogDescription } from 'helpers/productCatalog';
 import { NoFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
+import { useAbandonedBasketCookie } from 'helpers/storage/abandonedBasketCookies';
 import {
 	getOphanIds,
 	getReferrerAcquisitionData,
@@ -579,6 +581,9 @@ function CheckoutComponent({ geoId }: Props) {
 	const [errorMessage, setErrorMessage] = useState<string>();
 	const [errorContext, setErrorContext] = useState<string>();
 
+	const abParticipations = abTestInit({ countryId, countryGroupId });
+	const supportAbTests = getSupportAbTests(abParticipations);
+
 	const formOnSubmit = async (formData: FormData) => {
 		setIsProcessingPayment(true);
 		/**
@@ -697,9 +702,6 @@ function CheckoutComponent({ geoId }: Props) {
 			 * - add debugInfo
 			 * - add firstDeliveryDate
 			 */
-			const supportAbTests = getSupportAbTests(
-				abTestInit({ countryId, countryGroupId }),
-			);
 			const firstDeliveryDate =
 				productId === 'TierThree'
 					? formatMachineDate(getTierThreeDeliveryDate())
@@ -754,6 +756,16 @@ function CheckoutComponent({ geoId }: Props) {
 			setIsProcessingPayment(false);
 		}
 	};
+
+	const { supportInternationalisationId } = countryGroups[countryGroupId];
+
+	useAbandonedBasketCookie(
+		productId,
+		price,
+		ratePlanDescription.billingPeriod,
+		supportInternationalisationId,
+		abParticipations.abandonedBasket === 'variant',
+	);
 
 	return (
 		<PageScaffold


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Setting the Abandoned Basket cookie on the generic checkout.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/fJQjsvzY/513-enable-abandoned-basket-cookie-on-new-checkout)

## Why are you doing this?

The generic checkout is being AB tested at the same time as the abandoned basket banner. Currently the cooke is not set on the generic checkout, which means we're losing out on some potential banner views.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Go to `https://support.thegulocal.com/uk/contribute#ab-useGenericCheckout=variant`, select tier one.
Then add `#ab-abandonedBasket=variant` to the URL.
See `GU_CO_INCOMPLETE` cookie set.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?


<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

The banner CTA URL goes to the existing checkout, not sure if this is a risk.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Screenshots

![image](https://github.com/guardian/support-frontend/assets/114918544/e5aa826b-cb79-4db0-bef2-ed0fc22afa02)

