### PR TITLE
Update ProductCatalog every minute

### DIFF
--- a/support-frontend/app/services/ProductCatalogService.scala
+++ b/support-frontend/app/services/ProductCatalogService.scala
@@ -44,7 +44,7 @@ class CachedProductCatalogService(system: ActorSystem, productCatalogService: Pr
   }
   def get(): JsonObject = json.get()
 
-  system.scheduler.scheduleWithFixedDelay(0.minutes, 10.minutes) { () =>
+  system.scheduler.scheduleWithFixedDelay(0.minutes, 1.minutes) { () =>
     {
       update()
     }


### PR DESCRIPTION
To help ensure the new prices are picket up as quickly as possible, we want to refresh the cache of the [Product API](https://product-catalog.guardianapis.com/product-catalog.json) every minute.