### PR TITLE
update docs for test user page

### DIFF
--- a/support-frontend/app/views/testUsers.scala.html
+++ b/support-frontend/app/views/testUsers.scala.html
@@ -22,9 +22,7 @@
             All other fields can be populated as you wish.
             <h2>All recurring product purchases</h2>
             <ul>
-                <li><strong>First Name:</strong> @key</li>
-                <br><strong>(Optional) Recommended Email (if you do not want to receive emails):</strong> @{key}@@thegulocal.com<br>
-                <li>If you DO want to receive emails: @{email}</li>
+                <li>Email: @{email}</li>
             </ul>
             <h2>Single contributions</h2>
             <ul>


### PR DESCRIPTION
as per this PR https://github.com/guardian/members-data-api/pull/1088, we now use email address not first name to detect test users in MDAPI/manage

This PR updates the bumf on the test users page to illustrate that.