### PR TITLE
refactor: add pseudo ProductId type

### DIFF
--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -19,6 +19,13 @@ export type ProductDescription = {
 	>;
 };
 
+/**
+ * TODO: make this stricter.
+ * Currently we have this so that other places can use it,
+ * but when we make it more constrained, we should pick up any type errors.
+ */
+export type ProductId = string;
+
 export const productCatalogDescription: Record<string, ProductDescription> = {
 	/**
 	 * We need `SupporterPlusWithGuardianWeekly` for the the landing page while we migrate


### PR DESCRIPTION
Adds a type alias of `ProductId` => `string`. 

This way features implementing anything to do with the product catalog could use this type and as we make it stricter, all should be good, but we'll pick up on the errors.

The reason to not do it properly now is that [we have a use case](https://github.com/guardian/support-frontend/pull/6129#discussion_r1655120195), and it will take a few minutes / hours to update this as it's used a lot across the checkout. 