### PR TITLE
use updated test users library to produce lower case only tokens

### DIFF
--- a/support-frontend/app/controllers/TestUsersManagement.scala
+++ b/support-frontend/app/controllers/TestUsersManagement.scala
@@ -21,9 +21,9 @@ class TestUsersManagement(
   private val cookieDomain = guardianDomain
 
   def createTestUser: Action[AnyContent] = authAction { request =>
-    val testUser = testUsers.testUsers.generate()
-    Ok(testUsersView(testUser, request.user.email.replace("@", s"+$testUser@")))
+    val testUser = testUsers.testUsers.generateEmail(request.user.email)
+    Ok(testUsersView(testUser))
       .withHeaders(CacheControl.noCache)
-      .withCookies(Cookie("_test_username", testUser, httpOnly = false, domain = Some(cookieDomain.value)))
+      .withCookies(Cookie("_test_username", testUser.token, httpOnly = false, domain = Some(cookieDomain.value)))
   }
 }

--- a/support-frontend/app/controllers/TestUsersManagement.scala
+++ b/support-frontend/app/controllers/TestUsersManagement.scala
@@ -21,7 +21,7 @@ class TestUsersManagement(
   private val cookieDomain = guardianDomain
 
   def createTestUser: Action[AnyContent] = authAction { request =>
-    val testUser = testUsers.testUsers.generateEmail(request.user.email)
+    val testUser = testUsers.testUsers.generateEmail(Some(request.user.email))
     Ok(testUsersView(testUser))
       .withHeaders(CacheControl.noCache)
       .withCookies(Cookie("_test_username", testUser.token, httpOnly = false, domain = Some(cookieDomain.value)))

--- a/support-frontend/app/views/testUsers.scala.html
+++ b/support-frontend/app/views/testUsers.scala.html
@@ -1,6 +1,6 @@
+@import com.gu.identity.testing.usernames.TestUsernames.TestUser
 @(
-    key: String,
-    email: String
+    testUser: TestUser,
 )
 
 <!DOCTYPE html>
@@ -13,22 +13,12 @@
     <body>
         <h1>Test User generator.</h1>
         <p>This page makes it possible to test without using real payment details.</p>
-        <p>A cookie has been set with the name <em>_test_username</em> and the value <em>@key</em></p>
+        <p>A cookie has been set with the name <em>_test_username</em> and the value <em>@{testUser.token}</em></p>
         <p>
           This is all you need to be recognised as a test user on support.theguardian.com for the next 48 hours, however if you want to be recognised as a test user in
-          other systems, follow the instructions below.
+          other systems, populate the email address with @{testUser.email}.
         </p>
-        <div>When registering please populate the following fields with your new test user key.<br/>
-            All other fields can be populated as you wish.
-            <h2>All recurring product purchases</h2>
-            <ul>
-                <li>Email: @{email}</li>
-            </ul>
-            <h2>Single contributions</h2>
-            <ul>
-                <li><strong>Email (if you do not want to receive emails):</strong> @{key}@@thegulocal.com</li>
-                <li>If you DO want to receive emails: @{email}</li>
-            </ul>
+        <div>
             <h2>Redemption of gift subscriptions</h2>
             <p>You do not have to use any details, just make sure you are logged out, have visited this page before hand and the red flash is visible.</p>
             <p>Alternatively, register an identity account as per a recurring product purchase, and make sure you are logged in.</p>

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -25,7 +25,7 @@ libraryDependencies ++= Seq(
   "com.gu.identity" %% "identity-auth-play" % "4.12",
   "com.okta.jwt" % "okta-jwt-verifier" % oktaJwtVerifierVersion,
   "com.okta.jwt" % "okta-jwt-verifier-impl" % oktaJwtVerifierVersion % Runtime,
-  "com.gu" %% "identity-test-users" % "0.8",
+  "com.gu" %% "identity-test-users" % "0.10.2-SNAPSHOT",
   "com.google.guava" % "guava" % "32.1.1-jre",
   "io.lemonlabs" %% "scala-uri" % scalaUriVersion,
   "com.gu.play-googleauth" %% "play-v30" % "8.0.1",

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -25,7 +25,7 @@ libraryDependencies ++= Seq(
   "com.gu.identity" %% "identity-auth-play" % "4.12",
   "com.okta.jwt" % "okta-jwt-verifier" % oktaJwtVerifierVersion,
   "com.okta.jwt" % "okta-jwt-verifier-impl" % oktaJwtVerifierVersion % Runtime,
-  "com.gu" %% "identity-test-users" % "0.10.2-SNAPSHOT",
+  "com.gu" %% "identity-test-users" % "0.10.2",
   "com.google.guava" % "guava" % "32.1.1-jre",
   "io.lemonlabs" %% "scala-uri" % scalaUriVersion,
   "com.gu.play-googleauth" %% "play-v30" % "8.0.1",


### PR DESCRIPTION
use lower case only test user tokens by pulling in updated library - see https://github.com/guardian/identity-test-users/pull/10

I have tested locally and it generates test users that work with MDAPI locally.

Also the test-users page is updated accordingly 
<img width="736" alt="image" src="https://github.com/guardian/support-frontend/assets/7304387/126b3741-aa8d-445e-99c3-b5678658e920">
