### PR TITLE
Price Rise: Activate Tier3 pricing manually

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -157,8 +157,8 @@ export const tests: Tests = {
 				size: 1,
 			},
 		},
-		isActive: false,
-		referrerControlled: false, // ab-test name not needed to be in paramURL
+		isActive: true,
+		referrerControlled: true, // ab-test name not needed to be in paramURL
 		seed: 5,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -59,7 +59,7 @@ export const tests: Tests = {
 			},
 		},
 		isActive: true,
-		referrerControlled: true,
+		referrerControlled: true, // paramURL needs ab-test name
 		seed: 1,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
@@ -80,7 +80,7 @@ export const tests: Tests = {
 			},
 		},
 		isActive: true,
-		referrerControlled: true,
+		referrerControlled: true, // paramURL needs ab-test name
 		seed: 2,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
@@ -119,7 +119,7 @@ export const tests: Tests = {
 			},
 		},
 		isActive: true,
-		referrerControlled: false,
+		referrerControlled: false, // ab-test name not required in paramURL
 		seed: 5,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
@@ -140,7 +140,7 @@ export const tests: Tests = {
 			},
 		},
 		isActive: false,
-		referrerControlled: false, // ab-test name not needed to be in paramURL
+		referrerControlled: false, /// ab-test name not required in paramURL
 		seed: 5,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
@@ -158,7 +158,7 @@ export const tests: Tests = {
 			},
 		},
 		isActive: true,
-		referrerControlled: true, // ab-test name not needed to be in paramURL
+		referrerControlled: false, // ab-test name not required in paramURL
 		seed: 5,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
@@ -176,7 +176,7 @@ export const tests: Tests = {
 			},
 		},
 		isActive: false,
-		referrerControlled: false, // ab-test name not needed to be in paramURL
+		referrerControlled: false, // ab-test name not required in paramURL
 		seed: 3,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
@@ -197,7 +197,7 @@ export const tests: Tests = {
 			},
 		},
 		isActive: true,
-		referrerControlled: false, // ab-test name not needed to be in paramURL
+		referrerControlled: false, // ab-test name not required in paramURL
 		seed: 1,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This price rise should trigger when the `GB` `SupporterPlus` reaches £12.

However, this PR is to force/enable the Tier3 price rise in Production (if required).

[**Trello Card**](https://trello.com/c/eJQJy58y/924-price-rise-tier2-tier3-on-the-day-10am-target)