### PR TITLE
Clean up US book offer AB test

### DIFF
--- a/support-frontend/assets/components/offer/offer.tsx
+++ b/support-frontend/assets/components/offer/offer.tsx
@@ -27,32 +27,6 @@ const feastStyle = css`
 	margin-right: ${space[4]}px;
 `;
 
-export function OfferBook(): JSX.Element {
-	return (
-		<p>
-			<span style={{ fontWeight: 'bold' }}>
-				A free book as our gift to you
-				<sup style={{ fontWeight: 'lighter', fontSize: '14px' }}>**</sup>{' '}
-			</span>
-			Choose from a selection curated by Guardian staff{' '}
-			<span css={tooltipOfferStyle}>
-				<Tooltip
-					children={
-						<p>
-							{
-								'Books are redeemed with a unique code from Tertulia, an online co-op bookstore loved by avid readers and writers. Instructions to redeem your free book offer will be sent to your email within 24 hours.'
-							}
-						</p>
-					}
-					xAxisOffset={108}
-					yAxisOffset={12}
-					placement="bottom"
-				></Tooltip>
-			</span>
-		</p>
-	);
-}
-
 export function OfferFeast(): JSX.Element {
 	return (
 		<div css={containerStyle}>

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -85,24 +85,6 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
-	usFreeBookOffer: {
-		variants: [
-			{
-				id: 'control',
-			},
-		],
-		audiences: {
-			US: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		isActive: false,
-		referrerControlled: false, // ab-test name not needed to be in paramURL
-		seed: 3,
-		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
-		excludeCountriesSubjectToContributionsOnlyAmounts: true,
-	},
 	useGenericCheckout: {
 		variants: [
 			{

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -1,4 +1,4 @@
-import { OfferBook, OfferFeast } from 'components/offer/offer';
+import { OfferFeast } from 'components/offer/offer';
 import { newspaperCountries } from './internationalisation/country';
 import { gwDeliverableCountries } from './internationalisation/gwDeliverableCountries';
 
@@ -307,35 +307,6 @@ export const productCatalogDescInclFeast: typeof productCatalogDescription = {
 		ratePlans: productCatalogDescription.SupporterPlus.ratePlans,
 	},
 };
-
-export const productCatalogDescInclBookOffers: typeof productCatalogDescription =
-	{
-		...productCatalogDescription,
-		SupporterPlusWithGuardianWeekly: {
-			label: productCatalogDescription.SupporterPlusWithGuardianWeekly.label,
-			benefitsSummary: ['The rewards from All-access digital'],
-			offersSummary: [
-				{
-					strong: true,
-					copy: `including a free book as our gift to${'\u00A0'}you**`,
-				},
-			],
-			benefits:
-				productCatalogDescription.SupporterPlusWithGuardianWeekly.benefits,
-			ratePlans:
-				productCatalogDescription.SupporterPlusWithGuardianWeekly.ratePlans,
-		},
-		SupporterPlus: {
-			label: productCatalogDescription.SupporterPlus.label,
-			benefits: productCatalogDescription.SupporterPlus.benefits,
-			offers: [
-				{
-					copy: <OfferBook></OfferBook>,
-				},
-			],
-			ratePlans: productCatalogDescription.SupporterPlus.ratePlans,
-		},
-	};
 
 export const supporterPlusWithGuardianWeekly = {
 	ratePlans: {

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -1,3 +1,4 @@
+import { OfferBook, OfferFeast } from 'components/offer/offer';
 import { newspaperCountries } from './internationalisation/country';
 import { gwDeliverableCountries } from './internationalisation/gwDeliverableCountries';
 
@@ -278,6 +279,63 @@ export const productCatalogDescription: Record<string, ProductDescription> = {
 		},
 	},
 };
+
+export const productCatalogDescInclFeast: typeof productCatalogDescription = {
+	...productCatalogDescription,
+	SupporterPlusWithGuardianWeekly: {
+		label: productCatalogDescription.SupporterPlusWithGuardianWeekly.label,
+		benefitsSummary: ['The rewards from All-access digital'],
+		offersSummary: [
+			{
+				strong: true,
+				copy: `including unlimited access to the Guardian Feast App.`,
+			},
+		],
+		benefits:
+			productCatalogDescription.SupporterPlusWithGuardianWeekly.benefits,
+		ratePlans:
+			productCatalogDescription.SupporterPlusWithGuardianWeekly.ratePlans,
+	},
+	SupporterPlus: {
+		label: productCatalogDescription.SupporterPlus.label,
+		benefits: productCatalogDescription.SupporterPlus.benefits,
+		offers: [
+			{
+				copy: <OfferFeast></OfferFeast>,
+			},
+		],
+		ratePlans: productCatalogDescription.SupporterPlus.ratePlans,
+	},
+};
+
+export const productCatalogDescInclBookOffers: typeof productCatalogDescription =
+	{
+		...productCatalogDescription,
+		SupporterPlusWithGuardianWeekly: {
+			label: productCatalogDescription.SupporterPlusWithGuardianWeekly.label,
+			benefitsSummary: ['The rewards from All-access digital'],
+			offersSummary: [
+				{
+					strong: true,
+					copy: `including a free book as our gift to${'\u00A0'}you**`,
+				},
+			],
+			benefits:
+				productCatalogDescription.SupporterPlusWithGuardianWeekly.benefits,
+			ratePlans:
+				productCatalogDescription.SupporterPlusWithGuardianWeekly.ratePlans,
+		},
+		SupporterPlus: {
+			label: productCatalogDescription.SupporterPlus.label,
+			benefits: productCatalogDescription.SupporterPlus.benefits,
+			offers: [
+				{
+					copy: <OfferBook></OfferBook>,
+				},
+			],
+			ratePlans: productCatalogDescription.SupporterPlus.ratePlans,
+		},
+	};
 
 export const supporterPlusWithGuardianWeekly = {
 	ratePlans: {

--- a/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
@@ -15,7 +15,6 @@ import { PageScaffold } from 'components/page/pageScaffold';
 import type { ThankYouModuleType } from 'components/thankYou/thankYouModule';
 import ThankYouModule from 'components/thankYou/thankYouModule';
 import { getThankYouModuleData } from 'components/thankYou/thankYouModuleData';
-import { init as abTestInit } from 'helpers/abTests/abtest';
 import CountryHelper from 'helpers/internationalisation/classes/country';
 import { get } from 'helpers/storage/cookie';
 import { OPHAN_COMPONENT_ID_RETURN_TO_GUARDIAN } from 'helpers/thankYouPages/utils/ophan';
@@ -137,10 +136,6 @@ export function ThankYou({ geoId }: Props) {
 		return <div>Unable to find contribution type {contributionType}</div>;
 	}
 
-	const abParticipations = abTestInit({ countryId, countryGroupId });
-	const showOffer =
-		!!abParticipations.usFreeBookOffer && order.product === 'SupporterPlus';
-
 	const isOneOff = order.product === 'Contribution';
 	const isOneOffPayPal = order.paymentMethod === 'PayPal' && isOneOff;
 	const isSupporterPlus = order.product === 'SupporterPlus';
@@ -205,7 +200,6 @@ export function ThankYou({ geoId }: Props) {
 							isOneOffPayPal={isOneOffPayPal}
 							showDirectDebitMessage={order.paymentMethod === 'DirectDebit'}
 							currency={currencyKey}
-							showOffer={showOffer}
 							// TODO - generic checkout support promotions
 							promotion={undefined}
 							// TODO - get this from the /identity/get-user-type endpoint

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -18,7 +18,6 @@ import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSw
 import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countrySwitcherContainer';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
-import { OfferBook, OfferFeast } from 'components/offer/offer';
 import { PageScaffold } from 'components/page/pageScaffold';
 import { PaymentFrequencyButtons } from 'components/paymentFrequencyButtons/paymentFrequencyButtons';
 import type {
@@ -40,6 +39,7 @@ import { currencies } from 'helpers/internationalisation/currency';
 import {
 	productCatalog,
 	productCatalogDescription as productCatalogDescExclOffers,
+	productCatalogDescInclFeast,
 	supporterPlusWithGuardianWeeklyAnnualPromos,
 	supporterPlusWithGuardianWeeklyMonthlyPromos,
 } from 'helpers/productCatalog';
@@ -62,7 +62,7 @@ import { navigateWithPageView } from 'helpers/tracking/ophan';
 import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
 import { SupportOnce } from '../components/supportOnce';
 import { ThreeTierCards } from '../components/threeTierCards';
-import { OfferTsAndCs, ThreeTierTsAndCs } from '../components/threeTierTsAndCs';
+import { ThreeTierTsAndCs } from '../components/threeTierTsAndCs';
 import type { TierPlans } from '../setup/threeTierConfig';
 
 const recurringContainer = css`
@@ -237,62 +237,6 @@ const isCardUserSelected = (
 	);
 };
 
-const productCatalogDescInclFeast: typeof productCatalogDescExclOffers = {
-	...productCatalogDescExclOffers,
-	SupporterPlusWithGuardianWeekly: {
-		label: productCatalogDescExclOffers.SupporterPlusWithGuardianWeekly.label,
-		benefitsSummary: ['The rewards from All-access digital'],
-		offersSummary: [
-			{
-				strong: true,
-				copy: `including unlimited access to the Guardian Feast App.`,
-			},
-		],
-		benefits:
-			productCatalogDescExclOffers.SupporterPlusWithGuardianWeekly.benefits,
-		ratePlans:
-			productCatalogDescExclOffers.SupporterPlusWithGuardianWeekly.ratePlans,
-	},
-	SupporterPlus: {
-		label: productCatalogDescExclOffers.SupporterPlus.label,
-		benefits: productCatalogDescExclOffers.SupporterPlus.benefits,
-		offers: [
-			{
-				copy: <OfferFeast></OfferFeast>,
-			},
-		],
-		ratePlans: productCatalogDescExclOffers.SupporterPlus.ratePlans,
-	},
-};
-
-const productCatalogDescInclBookOffers: typeof productCatalogDescExclOffers = {
-	...productCatalogDescExclOffers,
-	SupporterPlusWithGuardianWeekly: {
-		label: productCatalogDescExclOffers.SupporterPlusWithGuardianWeekly.label,
-		benefitsSummary: ['The rewards from All-access digital'],
-		offersSummary: [
-			{
-				strong: true,
-				copy: `including a free book as our gift to${'\u00A0'}you**`,
-			},
-		],
-		benefits:
-			productCatalogDescExclOffers.SupporterPlusWithGuardianWeekly.benefits,
-		ratePlans:
-			productCatalogDescExclOffers.SupporterPlusWithGuardianWeekly.ratePlans,
-	},
-	SupporterPlus: {
-		label: productCatalogDescExclOffers.SupporterPlus.label,
-		benefits: productCatalogDescExclOffers.SupporterPlus.benefits,
-		offers: [
-			{
-				copy: <OfferBook></OfferBook>,
-			},
-		],
-		ratePlans: productCatalogDescExclOffers.SupporterPlus.ratePlans,
-	},
-};
-
 /**
  * @deprecated - we should be useing ProductCatalog data types.
  * TODO - remove this once TsAndCs work of ☝️ types
@@ -376,13 +320,9 @@ export function ThreeTierLanding(): JSX.Element {
 
 	const useGenericCheckout = abParticipations.useGenericCheckout === 'variant';
 	const showFeast = abParticipations.feast === 'variant';
-	const showBookOffer =
-		!!abParticipations.usFreeBookOffer && countryGroupId === 'UnitedStates';
 
 	const productCatalogDescription = showFeast
 		? productCatalogDescInclFeast
-		: showBookOffer
-		? productCatalogDescInclBookOffers
 		: productCatalogDescExclOffers;
 
 	useEffect(() => {
@@ -759,29 +699,6 @@ export function ThreeTierLanding(): JSX.Element {
 					]}
 					currency={currencies[currencyId].glyph}
 				></ThreeTierTsAndCs>
-				{showBookOffer && (
-					<OfferTsAndCs
-						currency={currencies[currencyId].glyph}
-						offerCostMonthly={
-							getPlanCost(
-								productCatalog.SupporterPlus.ratePlans.Monthly.pricing[
-									currencyId
-								],
-								'MONTHLY',
-								promotion,
-							).price
-						}
-						offerCostAnnual={
-							getPlanCost(
-								productCatalog.SupporterPlus.ratePlans.Annual.pricing[
-									currencyId
-								],
-								'ANNUAL',
-								promotion,
-							).price
-						}
-					></OfferTsAndCs>
-				)}
 			</Container>
 		</PageScaffold>
 	);

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -261,8 +261,6 @@ export function SupporterPlusThankYou({
 	const firstColumn = thankYouModules.slice(0, numberOfModulesInFirstColumn);
 	const secondColumn = thankYouModules.slice(numberOfModulesInFirstColumn);
 
-	const showOffer = !!abParticipations.usFreeBookOffer && isSupporterPlus;
-
 	return (
 		<PageScaffold
 			header={<Header />}
@@ -285,7 +283,6 @@ export function SupporterPlusThankYou({
 							amountIsAboveThreshold={isSupporterPlus}
 							isSignedIn={isSignedIn}
 							userTypeFromIdentityResponse={userTypeFromIdentityResponse}
-							showOffer={showOffer}
 							promotion={promotion}
 						/>
 					</div>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Tidy up the US book offer AB test, but keep the benefits component for future use.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/98SiCSTO/907-clean-up-usfreebookoffer-ab-test)

## Why are you doing this?

The test has been inactive since #5956 

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Checkout Supporter Plus in US, do not see book offer.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
