### PR TITLE
Update feast copy

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
@@ -71,8 +71,8 @@ export const checkListData = ({ higherTier }: TierUnlocks): CheckListData[] => {
 			isChecked: higherTier,
 			text: (
 				<p>
-					<span css={boldText}>Feast. </span> Unlimited access to the Guardian
-					Feast App
+					<span css={boldText}>The Guardian Feast App. </span> Unlimited access
+					to the ultimate recipe app
 				</p>
 			),
 			maybeGreyedOut: maybeGreyedOutHigherTier,

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -246,6 +246,9 @@ export const productCatalogDescription: Record<string, ProductDescription> = {
 				copy: 'Far fewer asks for support',
 				tooltip: `You'll see far fewer financial support asks at the bottom of articles or in pop-up banners.`,
 			},
+			{
+				copy: 'Unlimited access to the Guardian Feast App',
+			},
 		],
 		ratePlans: {
 			Monthly: {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Update the copy of the Feast benefit in tier 1 and 2 non-generic checkouts, and add it as a missing benefit to tier 1 generic.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/pkmsmREF/949-change-copy-on-checkout-pages-dropdown-menu-for-feast-tier-2-checkout-page)

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Non-generic
Go to `/uk/contribute/checkout?selected-amount=12&selected-contribution-type=monthly` and see benefit. 
Go to `/uk/contribute/checkout?selected-amount=4&selected-contribution-type=monthly` and see benefit greyed out.

Generic

Go to `/uk/checkout?product=Contribution&ratePlan=Annual` and see benefit greyed out.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


## Screenshots
### Non-generic
Before
![image](https://github.com/guardian/support-frontend/assets/114918544/6098b692-d218-4c67-a4ca-bc639e7ef46e)
After
![image](https://github.com/guardian/support-frontend/assets/114918544/b022f31f-61a5-44d7-ab4e-052a3439c869)


### Generic (Tier 1 only)

Before
![image](https://github.com/guardian/support-frontend/assets/114918544/4076b621-7807-4d55-8c81-a7a2309cee7f)

After
![image](https://github.com/guardian/support-frontend/assets/114918544/3eb77e21-2a79-46cf-a6ed-7c7c91fef9b5)
