### PR TITLE
refactor: remove feast ab test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -127,24 +127,6 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
-	feast: {
-		variants: [
-			{
-				id: 'variant',
-			},
-		],
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		isActive: true,
-		referrerControlled: false, // ab-test name not needed to be in paramURL
-		seed: 3,
-		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
-		excludeCountriesSubjectToContributionsOnlyAmounts: true,
-	},
 	abandonedBasket: {
 		variants: [
 			{

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -38,7 +38,6 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { currencies } from 'helpers/internationalisation/currency';
 import {
 	productCatalog,
-	productCatalogDescription as productCatalogDescExclOffers,
 	productCatalogDescInclFeast,
 	supporterPlusWithGuardianWeeklyAnnualPromos,
 	supporterPlusWithGuardianWeeklyMonthlyPromos,
@@ -319,11 +318,8 @@ export function ThreeTierLanding(): JSX.Element {
 	);
 
 	const useGenericCheckout = abParticipations.useGenericCheckout === 'variant';
-	const showFeast = abParticipations.feast === 'variant';
 
-	const productCatalogDescription = showFeast
-		? productCatalogDescInclFeast
-		: productCatalogDescExclOffers;
+	const productCatalogDescription = productCatalogDescInclFeast;
 
 	useEffect(() => {
 		dispatch(resetValidation());

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -113,9 +113,7 @@ export function SupporterPlusThankYou({
 		() => getCampaignSettings(campaignCode),
 		[],
 	);
-	const { abParticipations, amounts } = useContributionsSelector(
-		(state) => state.common,
-	);
+	const { amounts } = useContributionsSelector((state) => state.common);
 	const { countryId, countryGroupId, currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
@@ -238,16 +236,13 @@ export function SupporterPlusThankYou({
 		moduleType: ThankYouModuleType,
 	): ThankYouModuleType[] => (condition ? [moduleType] : []);
 
-	// abParticipation, upon refresh, defaults to active abtTests only
-	const showFeast = !!abParticipations.feast && isSupporterPlus;
 	const thankYouModules: ThankYouModuleType[] = [
 		...maybeThankYouModule(isNewAccount, 'signUp'),
 		...maybeThankYouModule(
 			!isNewAccount && !isSignedIn && email.length > 0,
 			'signIn',
 		),
-		...maybeThankYouModule(isSupporterPlus && !showFeast, 'appDownload'),
-		...maybeThankYouModule(showFeast, 'appsDownload'),
+		...maybeThankYouModule(isSupporterPlus, 'appsDownload'),
 		...maybeThankYouModule(
 			contributionType === 'ONE_OFF' && email.length > 0,
 			'supportReminder',


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Remove the Feast ab test, which wasn't really an AB test but used as a feature switch - and is now live
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->