### PR TITLE
Regionalised benefits and AUS partner offers

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListContainer.tsx
@@ -52,7 +52,7 @@ export function CheckoutBenefitsListContainer({
 		return null;
 	}
 
-	const { currencyId } = useContributionsSelector(
+	const { currencyId, countryGroupId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
 
@@ -100,6 +100,7 @@ export function CheckoutBenefitsListContainer({
 		),
 		checkListData: checkListData({
 			higherTier,
+			countryGroupId,
 		}),
 		buttonCopy: getbuttonCopy(
 			higherTier,

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
@@ -2,6 +2,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { palette } from '@guardian/source/foundations';
 import { SvgCrossRound, SvgTickRound } from '@guardian/source/react-components';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 const greyedOut = css`
 	color: ${palette.neutral[60]};
@@ -24,6 +25,7 @@ export type CheckListData = {
 	isChecked: boolean;
 	text?: JSX.Element;
 	maybeGreyedOut?: SerializedStyles;
+	specificToRegions?: CountryGroupId[];
 };
 
 export const getSvgIcon = (isUnlocked: boolean): JSX.Element =>
@@ -36,7 +38,7 @@ export const getSvgIcon = (isUnlocked: boolean): JSX.Element =>
 export const checkListData = ({ higherTier }: TierUnlocks): CheckListData[] => {
 	const maybeGreyedOutHigherTier = higherTier ? undefined : greyedOut;
 
-	const higherTierItems = [
+	const higherTierItems: CheckListData[] = [
 		{
 			isChecked: higherTier,
 			text: (
@@ -76,6 +78,16 @@ export const checkListData = ({ higherTier }: TierUnlocks): CheckListData[] => {
 				</p>
 			),
 			maybeGreyedOut: maybeGreyedOutHigherTier,
+		},
+		{
+			isChecked: higherTier,
+			text: (
+				<p>
+					<span css={boldText}>Exclusive access</span> to partner offers
+				</p>
+			),
+			maybeGreyedOut: maybeGreyedOutHigherTier,
+			specificToRegions: ['AUDCountries'],
 		},
 	];
 

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { palette } from '@guardian/source/foundations';
 import { SvgCrossRound, SvgTickRound } from '@guardian/source/react-components';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { filterBenefitByRegion } from 'helpers/productCatalog';
 
 const greyedOut = css`
 	color: ${palette.neutral[60]};
@@ -18,7 +19,7 @@ const boldText = css`
 
 type TierUnlocks = {
 	higherTier: boolean;
-	showUnchecked?: boolean;
+	countryGroupId: CountryGroupId;
 };
 
 export type CheckListData = {
@@ -35,7 +36,10 @@ export const getSvgIcon = (isUnlocked: boolean): JSX.Element =>
 		<SvgCrossRound isAnnouncedByScreenReader size="small" />
 	);
 
-export const checkListData = ({ higherTier }: TierUnlocks): CheckListData[] => {
+export const checkListData = ({
+	higherTier,
+	countryGroupId,
+}: TierUnlocks): CheckListData[] => {
 	const maybeGreyedOutHigherTier = higherTier ? undefined : greyedOut;
 
 	const higherTierItems: CheckListData[] = [
@@ -101,6 +105,8 @@ export const checkListData = ({ higherTier }: TierUnlocks): CheckListData[] => {
 				</p>
 			),
 		},
-		...higherTierItems,
+		...higherTierItems.filter((checkListItem) =>
+			filterBenefitByRegion(checkListItem, countryGroupId),
+		),
 	];
 };

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
@@ -3,7 +3,6 @@ import { type ContributionType, getAmount } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { currencies } from 'helpers/internationalisation/currency';
 import { supporterPlusLegal } from 'helpers/legalCopy';
-import { filterBenefitByRegion } from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { isSupporterPlusFromState } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
@@ -83,9 +82,8 @@ export function ContributionsOrderSummaryContainer({
 			? []
 			: checkListData({
 					higherTier: isSupporterPlus,
-			  }).filter((checkListItem) =>
-					filterBenefitByRegion(checkListItem, countryGroupId),
-			  );
+					countryGroupId,
+			  });
 
 	function onCheckListToggle(isOpen: boolean) {
 		trackComponentClick(

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummaryContainer.tsx
@@ -3,6 +3,7 @@ import { type ContributionType, getAmount } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { currencies } from 'helpers/internationalisation/currency';
 import { supporterPlusLegal } from 'helpers/legalCopy';
+import { filterBenefitByRegion } from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { isSupporterPlusFromState } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
@@ -82,7 +83,9 @@ export function ContributionsOrderSummaryContainer({
 			? []
 			: checkListData({
 					higherTier: isSupporterPlus,
-			  });
+			  }).filter((checkListItem) =>
+					filterBenefitByRegion(checkListItem, countryGroupId),
+			  );
 
 	function onCheckListToggle(isOpen: boolean) {
 		trackComponentClick(

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -1,13 +1,20 @@
 import { OfferFeast } from 'components/offer/offer';
 import { newspaperCountries } from './internationalisation/country';
+import type { CountryGroupId } from './internationalisation/countryGroup';
 import { gwDeliverableCountries } from './internationalisation/gwDeliverableCountries';
 
 export const productCatalog = window.guardian.productCatalog;
 
+type ProductBenefit = {
+	copy: string;
+	tooltip?: string;
+	specificToRegions?: CountryGroupId[];
+};
+
 export type ProductDescription = {
 	label: string;
-	benefits: Array<{ copy: string; tooltip?: string }>;
-	missingBenefits?: Array<{ copy: string; tooltip?: string }>;
+	benefits: ProductBenefit[];
+	missingBenefits?: ProductBenefit[];
 	benefitsSummary?: Array<string | { strong: boolean; copy: string }>;
 	offers?: Array<{ copy: JSX.Element; tooltip?: string }>;
 	offersSummary?: Array<string | { strong: boolean; copy: string }>;
@@ -19,6 +26,19 @@ export type ProductDescription = {
 		}
 	>;
 };
+
+export function filterBenefitByRegion(
+	benefit: {
+		specificToRegions?: CountryGroupId[];
+	},
+	countryGroupId: CountryGroupId,
+) {
+	if (benefit.specificToRegions !== undefined) {
+		return benefit.specificToRegions.includes(countryGroupId);
+	}
+
+	return true;
+}
 
 /**
  * TODO: make this stricter.
@@ -148,6 +168,12 @@ export const productCatalogDescription: Record<string, ProductDescription> = {
 				copy: 'Far fewer asks for support',
 				tooltip: `You'll see far fewer financial support asks at the bottom of articles or in pop-up banners.`,
 			},
+			{
+				copy: 'Exclusive access to partner offers',
+				tooltip:
+					'Access to special offers (such as free and discounted tickets) from our values-aligned partners, including museums, festivals and cultural institutions.',
+				specificToRegions: ['AUDCountries'],
+			},
 		],
 		ratePlans: {
 			Monthly: {
@@ -248,6 +274,12 @@ export const productCatalogDescription: Record<string, ProductDescription> = {
 			},
 			{
 				copy: 'Unlimited access to the Guardian Feast App',
+			},
+			{
+				copy: 'Exclusive access to partner offers',
+				tooltip:
+					'Access to special offers (such as free and discounted tickets) from our values-aligned partners, including museums, festivals and cultural institutions.',
+				specificToRegions: ['AUDCountries'],
 			},
 		],
 		ratePlans: {

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -80,7 +80,10 @@ import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import CountryHelper from 'helpers/internationalisation/classes/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
-import { productCatalogDescription } from 'helpers/productCatalog';
+import {
+	filterBenefitByRegion,
+	productCatalogDescription,
+} from 'helpers/productCatalog';
 import { NoFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
 import { getPromotion } from 'helpers/productPrice/promotions';
@@ -813,12 +816,19 @@ function CheckoutComponent({ geoId, appConfig }: Props) {
 									promotion={promotion}
 									currency={currency}
 									checkListData={[
-										...productDescription.benefits.map((benefit) => ({
-											isChecked: true,
-											text: benefit.copy,
-										})),
-										...(productDescription.missingBenefits ?? []).map(
-											(benefit) => ({
+										...productDescription.benefits
+											.filter((benefit) =>
+												filterBenefitByRegion(benefit, countryGroupId),
+											)
+											.map((benefit) => ({
+												isChecked: true,
+												text: benefit.copy,
+											})),
+										...(productDescription.missingBenefits ?? [])
+											.filter((benefit) =>
+												filterBenefitByRegion(benefit, countryGroupId),
+											)
+											.map((benefit) => ({
 												isChecked: false,
 												text: benefit.copy,
 												maybeGreyedOut: css`
@@ -828,8 +838,7 @@ function CheckoutComponent({ geoId, appConfig }: Props) {
 														fill: ${palette.neutral[60]};
 													}
 												`,
-											}),
-										),
+											})),
 									]}
 									onCheckListToggle={(isOpen) => {
 										trackComponentClick(

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -16,12 +16,16 @@ import type {
 	RegularContributionType,
 } from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { currencies } from 'helpers/internationalisation/currency';
 import type {
 	Currency,
 	IsoCurrency,
 } from 'helpers/internationalisation/currency';
-import type { ProductDescription } from 'helpers/productCatalog';
+import {
+	filterBenefitByRegion,
+	type ProductDescription,
+} from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
 import { ThreeTierLozenge } from './threeTierLozenge';
@@ -33,6 +37,7 @@ export type ThreeTierCardProps = {
 	isRecommendedSubdued: boolean;
 	isUserSelected: boolean;
 	currencyId: IsoCurrency;
+	countryGroupId: CountryGroupId;
 	paymentFrequency: RegularContributionType;
 	linkCtaClickHandler: (
 		event: React.MouseEvent<HTMLAnchorElement>,
@@ -196,6 +201,7 @@ export function ThreeTierCard({
 	isRecommendedSubdued,
 	isUserSelected,
 	currencyId,
+	countryGroupId,
 	paymentFrequency,
 	linkCtaClickHandler,
 	link,
@@ -294,13 +300,15 @@ export function ThreeTierCard({
 				<span css={benefitsPrefixPlus}>plus</span>
 			)}
 			<CheckList
-				checkListData={benefits.map((benefit) => {
-					return {
-						text: benefit.copy,
-						isChecked: true,
-						toolTip: benefit.tooltip,
-					};
-				})}
+				checkListData={benefits
+					.filter((benefit) => filterBenefitByRegion(benefit, countryGroupId))
+					.map((benefit) => {
+						return {
+							text: benefit.copy,
+							isChecked: true,
+							toolTip: benefit.tooltip,
+						};
+					})}
 				style={'compact'}
 				iconColor={palette.brand[500]}
 				cssOverrides={checkmarkBenefitList}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
@@ -4,6 +4,7 @@ import type {
 	ContributionType,
 	RegularContributionType,
 } from 'helpers/contributions';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { ProductDescription } from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
@@ -20,6 +21,7 @@ export type ThreeTierCardsProps = {
 		ctaCopy: string;
 	}>;
 	currencyId: IsoCurrency;
+	countryGroupId: CountryGroupId;
 	paymentFrequency: RegularContributionType;
 	linkCtaClickHandler: (
 		event: React.MouseEvent<HTMLAnchorElement>,
@@ -63,6 +65,7 @@ const cardIndexToTier = (index: number): 1 | 2 | 3 => {
 export function ThreeTierCards({
 	cardsContent,
 	currencyId,
+	countryGroupId,
 	paymentFrequency,
 	linkCtaClickHandler,
 }: ThreeTierCardsProps): JSX.Element {
@@ -89,6 +92,7 @@ export function ThreeTierCards({
 						{...cardContent}
 						isRecommendedSubdued={haveRecommendedAndSelectedCards}
 						currencyId={currencyId}
+						countryGroupId={countryGroupId}
 						paymentFrequency={paymentFrequency}
 						linkCtaClickHandler={linkCtaClickHandler}
 						ctaCopy={cardContent.ctaCopy}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -619,6 +619,7 @@ export function ThreeTierLanding(): JSX.Element {
 					<ThreeTierCards
 						cardsContent={[tier1Card, tier2Card, tier3Card]}
 						currencyId={currencyId}
+						countryGroupId={countryGroupId}
 						paymentFrequency={contributionType}
 						linkCtaClickHandler={handleLinkCtaClick}
 					/>

--- a/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
+++ b/support-frontend/stories/checkoutLayout/CheckoutBenefitsList.stories.tsx
@@ -45,7 +45,10 @@ export const AllBenefitsUnlocked = Template.bind({});
 
 AllBenefitsUnlocked.args = {
 	title: "For £12 per month, you'll unlock",
-	checkListData: checkListData({ higherTier: true }),
+	checkListData: checkListData({
+		higherTier: true,
+		countryGroupId: 'GBPCountries',
+	}),
 	buttonCopy: null,
 };
 
@@ -53,6 +56,9 @@ export const LowerTierUnlocked = Template.bind({});
 
 LowerTierUnlocked.args = {
 	title: "For £5 per month, you'll unlock",
-	checkListData: checkListData({ higherTier: false }),
+	checkListData: checkListData({
+		higherTier: false,
+		countryGroupId: 'GBPCountries',
+	}),
 	buttonCopy: 'Switch to £12 per month to unlock all extras',
 };

--- a/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
@@ -52,7 +52,10 @@ Default.args = {
 		isSuffixGlyph: false,
 		isPaddedGlyph: false,
 	},
-	checkListData: checkListData({ higherTier: true }),
+	checkListData: checkListData({
+		higherTier: true,
+		countryGroupId: 'GBPCountries',
+	}),
 	headerButton: (
 		<Button priority="tertiary" size="xsmall">
 			Change

--- a/support-frontend/stories/content/CheckmarkList.stories.tsx
+++ b/support-frontend/stories/content/CheckmarkList.stories.tsx
@@ -41,12 +41,18 @@ Template.args = {} as CheckListProps;
 export const Default = Template.bind({});
 
 Default.args = {
-	checkListData: checkListData({ higherTier: true }),
+	checkListData: checkListData({
+		higherTier: true,
+		countryGroupId: 'GBPCountries',
+	}),
 };
 
 export const Compact = Template.bind({});
 
 Compact.args = {
-	checkListData: checkListData({ higherTier: true }),
+	checkListData: checkListData({
+		higherTier: true,
+		countryGroupId: 'GBPCountries',
+	}),
 	style: 'compact',
 };


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Add support for regionalised benefits on landing page, generic and contributions checkout and a specific partner offer benefit in Australia.  🇦🇺

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/ltQnm7HS/925-aus-partner-offers-copy-add-on-tier-2-lp-checkout-drop-down-menu)

## Why are you doing this?

New benefit specifically for Australia - and in future we may want other regionalised benefits.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Go to `au/contribute`, checkout tier 1 or tier 2 and see new benefit for tier 2. 

Go to `uk/contribute`, checkout tier 1 or tier 2 do not see new benefit.


## Screenshots

AU Landing page 
![image](https://github.com/user-attachments/assets/9ed2bb27-8dea-41ca-ab03-c5101b0f42a3)

AU Generic checkout
![image](https://github.com/user-attachments/assets/afc7d03c-1dcd-4063-8be9-5b640fb13f53)

AU Contributions checkout
![image](https://github.com/user-attachments/assets/eff24d22-edb7-4b00-8e41-7cd7acd7cf7d)


