### PR TITLE
Increase timeout from e2e workflow to 45 mins

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -12,7 +12,7 @@ jobs:
   test:
     if: ${{ github.event.label.name == 'Seen-on-PROD' }}
     name: Playwright
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     env:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}


### PR DESCRIPTION
## What are you doing in this PR?

This e2e workflow has been timing out after 30 mins, the chance of it timing out is greater on runs when a test has failed as we retry failed test runs, when the workflow times out no alerts are sent to inform us the test run has failed. I'm increasing to 45 mins to hopefully improve the chances of test runs completing and alerting in the event of failure.