### PR TITLE
fix: reinstate productPrices on contributions template

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -230,7 +230,7 @@ class Application(
       shareUrl = "https://support.theguardian.com/contribute",
       v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(isTestUser).v2PublicKey,
       serversideTests = serversideTests,
-      productPrices = LandingPageProductPrices(supporterPlusProductPrices, tierThreeProductPrices),
+      landingPageProductPrices = LandingPageProductPrices(supporterPlusProductPrices, tierThreeProductPrices),
       productCatalog = productCatalog,
     )
   }

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -1,6 +1,6 @@
 @import admin.settings.AllSettings
 @import admin.ServersideAbTest.Participation
-@import assets.{AssetsResolver, RefPath, StyleContent}
+@import assets.{AssetsResolver, RefPath}
 @import com.gu.identity.model.{User => IdUser}
 @import views.ReactDiv
 @import models.GeoData
@@ -28,7 +28,7 @@
   shareUrl: String,
   v2recaptchaConfigPublicKey: String,
   serversideTests: Map[String, Participation] = Map(),
-  productPrices: LandingPageProductPrices,
+  landingPageProductPrices: LandingPageProductPrices,
   productCatalog: JsonObject,
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
@@ -55,8 +55,16 @@
       };
     }
 
-    window.guardian.supporterPlusProductPrices = @Html(outputJson(productPrices.supporterPlusProductPrices))
-    window.guardian.tierThreeProductPrices = @Html(outputJson(productPrices.tierThreeProductPrices))
+    /** Both the landing page (`/uk/contribution`) and contributions checkout (`/uk/contribution/checkout`) are rendered from this template.
+     *
+     * We use `supporterPlusProductPrices` and `tierThreeProductPrices` on the landing page as it renders both products with their promotions.
+     *
+     * We use `productPrices` in the checkout as the value is coupled across the codebase via redux state used across multiple checkouts i.e. Guardian Weekly, Paper, Contribution etc
+     * so we need to retain that name.
+     */
+    window.guardian.productPrices = @Html(outputJson(landingPageProductPrices.supporterPlusProductPrices))
+    window.guardian.supporterPlusProductPrices = @Html(outputJson(landingPageProductPrices.supporterPlusProductPrices))
+    window.guardian.tierThreeProductPrices = @Html(outputJson(landingPageProductPrices.tierThreeProductPrices))
   </script>
 
   @windowGuardianPaymentConfig(


### PR DESCRIPTION
`productPrices` is used throughout the codebase, mostly in redux, so is used a lot in the redux state. This reinstates it in the contributions template.

We were trying to be more specific in our naming, but unfortunately this coupling caught us. We started to explore using the more explicit naming, but realised that the coupling is quite deep. 

Given that we are hoping to deprecate this template, and thus this implementation, I have just sign-posted how we use the values. 

## `main`
<img width="507" alt="Screenshot 2024-07-17 at 11 09 55" src="https://github.com/user-attachments/assets/f616a226-4973-4c5e-bf69-4ba4d62aa046">

## `product-prices` playwright
<img width="511" alt="Screenshot 2024-07-17 at 11 25 31" src="https://github.com/user-attachments/assets/8546aea3-f63c-4ee1-9005-ecbfff338632">


