### PR TITLE
fix: add productCatalog to subscriptionCheckout

### DIFF
--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -2,19 +2,15 @@
 @import assets.AssetsResolver
 @import com.gu.identity.model.{User => IdUser}
 @import com.gu.support.config._
-@import helper.CSRF
 @import services.pricing.ProductPrices
 @import views.ViewHelpers._
-@import io.circe.syntax._
 @import com.gu.support.encoding.CustomCodecs._
-@import com.gu.support.catalog.Paper
 
 @import assets.RefPath
-@import views.EmptyDiv
 @import views.ReactDiv
-@import assets.StyleContent
 @import com.gu.support.promotions.PromotionCopy
 
+@import io.circe.JsonObject
 @(
   title: String,
   mainElement: ReactDiv,
@@ -32,6 +28,7 @@
   v2recaptchaConfigPublicKey: String,
   orderIsAGift: Boolean = false,
   homeDeliveryPostcodes: Option[List[String]] = None,
+  productCatalog: JsonObject,
 )(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: AllSettings)
 
   @main(title = title, mainJsBundle = RefPath(js), mainElement = mainElement, mainStyleBundle = Some(RefPath(css)), csrf = csrf) {
@@ -89,6 +86,8 @@
       window.guardian.recaptchaEnabled = @settings.switches.recaptchaSwitches.enableRecaptchaFrontend.isOn
 
       window.guardian.isTestUser = @testMode
+
+      window.guardian.productCatalog = @Html(outputJson(productCatalog))
 
     </script>
 

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -87,6 +87,9 @@ trait Controllers {
     controllerComponents,
     allSettingsProvider,
     appConfig.recaptchaConfigProvider,
+    cachedProductCatalogServiceProvider,
+    appConfig.stage,
+    testUsers,
     appConfig.supportUrl,
   )
 
@@ -122,6 +125,8 @@ trait Controllers {
     controllerComponents,
     allSettingsProvider,
     appConfig.recaptchaConfigProvider,
+    cachedProductCatalogServiceProvider,
+    appConfig.stage,
   )
 
   lazy val paperFormController = new PaperSubscriptionFormController(
@@ -134,6 +139,8 @@ trait Controllers {
     controllerComponents,
     allSettingsProvider,
     appConfig.recaptchaConfigProvider,
+    cachedProductCatalogServiceProvider,
+    appConfig.stage,
   )
 
   lazy val weeklyFormController = new WeeklySubscriptionFormController(
@@ -146,6 +153,8 @@ trait Controllers {
     controllerComponents,
     allSettingsProvider,
     appConfig.recaptchaConfigProvider,
+    cachedProductCatalogServiceProvider,
+    appConfig.stage,
   )
 
   lazy val createSubscriptionController = new CreateSubscriptionController(

--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -248,7 +248,8 @@ class DigitalPackEmailFields(
       unmanaged_digital_subscription_gift_end_date: String,
   )
   object GifteeRedemptionUserAttributes {
-    implicit val encoder: Encoder.AsObject[GifteeRedemptionUserAttributes] = deriveEncoder[GifteeRedemptionUserAttributes]
+    implicit val encoder: Encoder.AsObject[GifteeRedemptionUserAttributes] =
+      deriveEncoder[GifteeRedemptionUserAttributes]
   }
 
   private def giftRedemption(state: SendThankYouEmailDigitalSubscriptionGiftRedemptionState) =

--- a/support-workers/src/main/scala/com/gu/threadpools/CustomPool.scala
+++ b/support-workers/src/main/scala/com/gu/threadpools/CustomPool.scala
@@ -5,6 +5,7 @@ import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 object CustomPool {
 
-  implicit val executionContext: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(4))
+  implicit val executionContext: ExecutionContextExecutor =
+    ExecutionContext.fromExecutor(Executors.newFixedThreadPool(4))
 
 }


### PR DESCRIPTION
Currently when trying to purchase [a digital edition](https://support.theguardian.com/uk/subscribe/digitaledition) - the loading screen never makes it to the thank you page as it breaks  when trying to read the `productCatalog`.

The purchase is still made, and emails sent, the user just never get's the feedback from the web UI that the transaction was successful.

As this template is used by all subscription checkouts, we needed to add it to all the controllers. This hopefully creates a little consistency in the short term.

Long term we are going to deprecate these checkout with the generic checkout.