### PR TITLE
Provide a default product match for /p/ endpoint

### DIFF
--- a/support-frontend/app/controllers/Promotions.scala
+++ b/support-frontend/app/controllers/Promotions.scala
@@ -3,7 +3,7 @@ package controllers
 import actions.CustomActionBuilders
 import admin.settings.{AllSettings, AllSettingsProvider}
 import assets.{AssetsResolver, RefPath, StyleContent}
-import com.gu.support.catalog.{Contribution, DigitalPack, GuardianWeekly, Paper}
+import com.gu.support.catalog.{Contribution, DigitalPack, GuardianWeekly, Paper, SupporterPlus}
 import com.gu.support.config.Stage
 import com.gu.support.encoding.CustomCodecs._
 import services.pricing.PriceSummaryServiceProvider
@@ -14,7 +14,7 @@ import play.twirl.api.Html
 import services.TestUserService
 import views.EmptyDiv
 import views.ViewHelpers.outputJson
-import admin.ServersideAbTest.{Participation}
+import admin.ServersideAbTest.Participation
 
 class Promotions(
     promotionServiceProvider: PromotionServiceProvider,
@@ -39,7 +39,7 @@ class Promotions(
         case GuardianWeekly => routes.WeeklySubscriptionController.weeklyGeoRedirect(promotionTerms.isGift).url
         case DigitalPack => routes.DigitalSubscriptionController.digitalGeoRedirect(false).url
         case Paper => routes.PaperSubscriptionController.paper().url
-        case Contribution => routes.Application.contributeGeoRedirect("").url
+        case _ => routes.Application.contributeGeoRedirect("").url
       }
       val queryString = {
         if (promoCode == "WINTERSAMPLER") {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
support-frontend has some funtionality where a user can put in a url in the form `/p/[promocode]` and they will be redirected to the landing page for the particular product which the promo applies to.

It seems that this functionality has been forgotten about when recent products (supporter plus and tier three) have been added, so any promotions for those products which were sent through this endpoint were causing 500 errors.

This PR provides a default case for any unknown product types which is to redirect to the main three tier landing page. This is correct for supporter plus and tier three, and is better than an error page for any future products that we might develop.