### PR TITLE
Generic checkout delivery address design changes

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -11,9 +11,11 @@ import {
 } from '@guardian/source/foundations';
 import {
 	Button,
+	Checkbox,
 	Column,
 	Columns,
 	Container,
+	Label,
 	Radio,
 	RadioGroup,
 	TextInput,
@@ -1099,9 +1101,7 @@ function CheckoutComponent({ geoId, appConfig }: Props) {
 									{productDescription.deliverableTo && (
 										<>
 											<fieldset>
-												<legend css={legend}>
-													Where should we deliver to?
-												</legend>
+												<legend css={legend}>2. Delivery address</legend>
 												<AddressFields
 													scope={'delivery'}
 													lineOne={deliveryLineOne}
@@ -1154,49 +1154,31 @@ function CheckoutComponent({ geoId, appConfig }: Props) {
 												/>
 											</fieldset>
 
-											<CheckoutDivider spacing="loose" />
-
-											<RadioGroup
-												label="Is the billing address the same as the delivery address?"
-												hideLabel
-												id="billingAddressMatchesDelivery"
-												name="billingAddressMatchesDelivery"
-												orientation="vertical"
-												error={undefined}
+											<fieldset
+												css={css`
+													margin-bottom: ${space[6]}px;
+												`}
 											>
-												<h2 css={legend}>
-													Is the billing address the same as the delivery
-													address?
-												</h2>
-
-												<Radio
-													id="qa-billing-address-same"
-													value="yes"
-													label="Yes"
-													name="billingAddressMatchesDelivery"
+												<Label
+													text="Billing address"
+													htmlFor="billingAddressMatchesDelivery"
+												/>
+												<Checkbox
 													checked={billingAddressMatchesDelivery}
+													value="yes"
 													onChange={() => {
-														setBillingAddressMatchesDelivery(true);
+														setBillingAddressMatchesDelivery(
+															!billingAddressMatchesDelivery,
+														);
 													}}
-												/>
-
-												<Radio
-													id="qa-billing-address-different"
-													label="No"
-													value="no"
+													id="billingAddressMatchesDelivery"
 													name="billingAddressMatchesDelivery"
-													checked={!billingAddressMatchesDelivery}
-													onChange={() => {
-														setBillingAddressMatchesDelivery(false);
-													}}
+													label="Billing address same as delivery address"
 												/>
-											</RadioGroup>
-
-											<CheckoutDivider spacing="loose" />
+											</fieldset>
 
 											{!billingAddressMatchesDelivery && (
 												<fieldset>
-													<legend css={legend}>Your billing address</legend>
 													<AddressFields
 														scope={'billing'}
 														lineOne={billingLineOne}
@@ -1247,14 +1229,17 @@ function CheckoutComponent({ geoId, appConfig }: Props) {
 															);
 														}}
 													/>
-													<CheckoutDivider spacing="loose" />
 												</fieldset>
 											)}
+
+											<CheckoutDivider spacing="loose" />
 										</>
 									)}
+
 									<fieldset css={fieldset}>
 										<legend css={legend}>
-											2. Payment method
+											{productDescription.deliverableTo ? '3' : '2'}. Payment
+											method
 											<SecureTransactionIndicator
 												hideText={true}
 												cssOverrides={css``}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Updating the design of the delivery and billing address section of the generic checkout.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/0wihft4N/937-generic-checkout-implement-design-change-for-address-fields-for-top-tier-checkout)


<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Head to `/uk/checkout?product=TierThree&ratePlan=DomesticMonthly`, check design and successfully check out.

Also check design on Contributions and S+ has not changed.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Screenshots
Before
![image](https://github.com/user-attachments/assets/362f167b-f069-4a08-98c2-a972e287632c)

After
![image](https://github.com/user-attachments/assets/617c7511-143e-4dd1-9b73-47f146c4d358)
![image](https://github.com/user-attachments/assets/77c111e0-5694-4a51-bdce-d62d2b38dc4b)

