### PR TITLE
payment-api: block unsupported http methods

### DIFF
--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -127,6 +127,37 @@ exports[`The Payment API stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "AllowKnownMethods07D772B3": {
+      "Properties": {
+        "Actions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "TargetGroupPaymentapiE63889C3",
+            },
+            "Type": "forward",
+          },
+        ],
+        "Conditions": [
+          {
+            "Field": "http-request-method",
+            "HttpRequestMethodConfig": {
+              "Values": [
+                "GET",
+                "POST",
+                "PUT",
+                "DELETE",
+                "HEAD",
+              ],
+            },
+          },
+        ],
+        "ListenerArn": {
+          "Ref": "ListenerPaymentapi860EC20D",
+        },
+        "Priority": 1,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    },
     "AmazonPayPaymentErrorAECECF4D": {
       "Properties": {
         "ActionsEnabled": true,
@@ -250,6 +281,35 @@ exports[`The Payment API stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "BlockUnknownMethods281EDB58": {
+      "Properties": {
+        "Actions": [
+          {
+            "FixedResponseConfig": {
+              "ContentType": "application/json",
+              "MessageBody": "Unsupported http method",
+              "StatusCode": "400",
+            },
+            "Type": "fixed-response",
+          },
+        ],
+        "Conditions": [
+          {
+            "Field": "path-pattern",
+            "PathPatternConfig": {
+              "Values": [
+                "*",
+              ],
+            },
+          },
+        ],
+        "ListenerArn": {
+          "Ref": "ListenerPaymentapi860EC20D",
+        },
+        "Priority": 2,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
     },
     "CertificatePaymentapi8AACB639": {
       "DeletionPolicy": "Retain",

--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -144,7 +144,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
               "Values": [
                 "GET",
                 "POST",
-                "PUT",
+                "OPTIONS",
                 "DELETE",
                 "HEAD",
               ],

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -197,7 +197,7 @@ export class PaymentApi extends GuStack {
     new ApplicationListenerRule(this, 'AllowKnownMethods', {
       listener: playApp.listener,
       priority: 1,
-      conditions: [ListenerCondition.httpRequestMethods(['GET', 'POST', 'PUT', 'DELETE', 'HEAD'])],
+      conditions: [ListenerCondition.httpRequestMethods(['GET', 'POST', 'OPTIONS', 'DELETE', 'HEAD'])],
       targetGroups: [playApp.targetGroup],
     });
     // Default rule to block requests which don't match the above rule


### PR DESCRIPTION
Bots regularly hit the loadbalancer probing for vulnerabilities. Most result in a 4XX from the server.
But Play handles unknown http methods by returning a 501. This is a problem because it triggers our 5XX alarm. We don't want to change the threshold for that alarm as in general we _do_ want to know when the server returns errors.

E.g. from the logs:
`Illegal request, responding with status '501 Not Implemented': Unsupported HTTP method: IOLFJZ`

This PR adds a loadbalancer target rule to only route requests with supported http methods to the server. Anything else will receive a 400.

Tested by making a single contribution in CODE