### PR TITLE
fix: prevent form submitting for direct debit without recaptcha token

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -704,7 +704,7 @@ function CheckoutComponent({ geoId, appConfig }: Props) {
 			};
 		}
 
-		if (paymentMethod === 'DirectDebit') {
+		if (paymentMethod === 'DirectDebit' && recaptchaToken !== undefined) {
 			paymentFields = {
 				accountHolderName: formData.get('accountHolderName') as string,
 				accountNumber: formData.get('accountNumber') as string,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Fix a bug on generic checkout - you can submit the form paying by direct debit without ticking the recaptcha box. Only affects DD, not credit card or paypal.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/ARmVmrEY/945-generic-checkout-you-can-submit-the-form-without-checking-the-recaptcha-on-direct-debit-form)

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Go to generic checkout - select direct debit, enter required fields except for the recaptcha box. Form does not submit. Do not see payment overlay.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility 
There's no error validation on the screen when the recaptcha box is unticked, this is the existing behaviour but worth flagging.

## Screenshots

Before
![image](https://github.com/user-attachments/assets/0def9623-7c28-46c8-a4aa-6fa4d529ef7e)

After
![image](https://github.com/user-attachments/assets/858db3c4-5fa3-4ae7-9a4e-b84d79902202)
