### PR TITLE
Simplify playwright config

### DIFF
--- a/support-e2e/playwright.base.config.ts
+++ b/support-e2e/playwright.base.config.ts
@@ -10,9 +10,6 @@ export const baseObject: PlaywrightTestConfig = {
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
 	forbidOnly: !!process.env.CI,
 	retries: 1,
-	/* Opt out of parallel tests on CI. */
-	workers: process.env.CI ? 1 : undefined,
-	reporter: 'html',
 	use: {
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		trace: 'on-first-retry',

--- a/support-e2e/playwright.base.config.ts
+++ b/support-e2e/playwright.base.config.ts
@@ -4,12 +4,8 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 export const baseObject: PlaywrightTestConfig = {
 	testDir: 'tests',
 	testMatch: '**/*.test.ts',
-
 	/* Maximum time one test can run for. */
 	timeout: 120 * 1000,
-	expect: {
-		timeout: 90000,
-	},
 	fullyParallel: true,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
 	forbidOnly: !!process.env.CI,
@@ -18,13 +14,10 @@ export const baseObject: PlaywrightTestConfig = {
 	workers: process.env.CI ? 1 : undefined,
 	reporter: 'html',
 	use: {
-		/* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-		actionTimeout: 0,
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		trace: 'on-first-retry',
 		baseURL: 'https://support.theguardian.com',
 	},
-
 	projects: [
 		{
 			name: 'chromium',

--- a/support-e2e/playwright.local.config.ts
+++ b/support-e2e/playwright.local.config.ts
@@ -4,10 +4,6 @@ import { baseObject } from './playwright.base.config';
 export default defineConfig({
 	...baseObject,
 	use: {
-		/* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-		actionTimeout: 0,
-		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-		trace: 'on-first-retry',
 		baseURL: 'https://support.thegulocal.com', //To use CODE replace this with- https://support.code.dev-theguardian.com/
 	},
 });

--- a/support-e2e/tests/gwCheckout.test.ts
+++ b/support-e2e/tests/gwCheckout.test.ts
@@ -75,7 +75,7 @@ const testsDetailsGifted: TestDetailsGifted[] = [
 		frequency: '12 months',
 		paymentType: 'Direct debit',
 	},
-  /**
+	/**
 	 * PayPal is currently throwing a "to many login attempts" error, so we're
 	 * going to inactivate this test until we have a solution for it to avoid
 	 * alert numbness.
@@ -163,7 +163,7 @@ test.describe('Sign up for a Guardian Weekly subscription', () => {
 
 			await expect(
 				page.getByRole('heading', { name: successMsgRegex }),
-			).toBeVisible();
+			).toBeVisible({ timeout: 600000 });
 		});
 	});
 });
@@ -254,7 +254,7 @@ test.describe('Gifted subscriptions', () => {
 
 			await expect(
 				page.getByRole('heading', { name: successMsgRegex }),
-			).toBeVisible();
+			).toBeVisible({ timeout: 600000 });
 		});
 	});
 });

--- a/support-e2e/tests/newspaperCheckout.test.ts
+++ b/support-e2e/tests/newspaperCheckout.test.ts
@@ -128,7 +128,7 @@ test.describe('Sign up newspaper subscription', () => {
 
 			await expect(
 				page.getByRole('heading', { name: successMsgRegex }),
-			).toBeVisible();
+			).toBeVisible({ timeout: 600000 });
 		});
 	});
 });


### PR DESCRIPTION
- Removes the large, global `expect` timeout in favour of only using long running `expect` assertions for the thank-you page wait
- Removes the `workers` settings as this is set automatically to the best it can be i.e. `"Defaults to half of the number of logical CPU cores"`. We only have 1 in CI, so it runs with 1 worker.

None of this is expected to speed up our playwright tests, but simplifies the config to help make impactful changes.
 