### PR TITLE
fix: up the timeout for recaptcha in our e2e tests

### DIFF
--- a/support-e2e/browserstack.config.ts
+++ b/support-e2e/browserstack.config.ts
@@ -7,7 +7,8 @@ interface BrowserDetails {
 	browser_version: string;
 	os: string;
 	os_version: string;
-	name: string;
+	'browserstack.debug': string;
+	'browserstack.networkLogs': string;
 }
 
 const clientPlaywrightVersion = execSync('npx playwright --version')
@@ -44,11 +45,13 @@ export const getCdpEndpoint = (browserDetails: BrowserDetails) => {
 		second: 'numeric',
 		timeZone: 'Europe/London',
 	}).format(new Date());
+
 	const caps = {
 		...browserStackProperties,
 		...browserDetails,
-		build: `playwright-build-${latestCommitID}-${niceDateStringNow}`,
-		name: `playwright E2E test - ${niceDateStringNow}`,
+		build: `support-frontend-e2e-build-${latestCommitID}-${niceDateStringNow}`,
+		name: `Support frontend E2E - ${niceDateStringNow}`,
+		project: 'Support frontend E2E',
 	};
 	const cdpUrl = `wss://cdp.browserstack.com/playwright?caps=${encodeURIComponent(
 		JSON.stringify(caps),

--- a/support-e2e/tests/utils/recaptcha.ts
+++ b/support-e2e/tests/utils/recaptcha.ts
@@ -5,7 +5,9 @@ export const checkRecaptcha = async (page: Page) => {
 		await page
 			.frameLocator('[title="reCAPTCHA"]')
 			.locator('#recaptcha-anchor-label'),
-	).toBeVisible();
+	).toBeVisible({
+		timeout: 10000,
+	});
 
 	const recaptchaIframe = page.frameLocator('[title="reCAPTCHA"]');
 	const recaptchaCheckbox = recaptchaIframe.locator(


### PR DESCRIPTION
The reCaptcha can take more than the default `5000` milliseconds, so we've made it `10000`.

Standardising around the e2e naming as well.