### PR TITLE
fix: up paypal timeout to 10 seconds in e2e test

### DIFF
--- a/support-e2e/tests/oneOffContributions.test.ts
+++ b/support-e2e/tests/oneOffContributions.test.ts
@@ -46,7 +46,7 @@ test.describe('Sign up for a one-off contribution', () => {
 					break;
 				case 'PayPal':
 					await page.getByText(/Pay (£|\$)([0-9]+) with PayPal/).click();
-					await expect(page).toHaveURL(/.*paypal.com/);
+					await expect(page).toHaveURL(/.*paypal.com/, { timeout: 10000 });
 					fillInPayPalDetails(page);
 					break;
 			}


### PR DESCRIPTION
Upping the PayPal timeout as it was failing at 5 seconds.

It feels like PayPal should be able to handle this - it might be because it's a sandbox,  but still feels a little slow.