### PR TITLE
fix: check stripeExpressCheckout for On value

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -1764,7 +1764,7 @@ export function Checkout({ geoId, appConfig }: Props) {
 
 	const stripeExpressCheckoutSwitch =
 		window.guardian.settings.switches.recurringPaymentMethods
-			.stripeExpressCheckout;
+			.stripeExpressCheckout === 'On';
 
 	let elementsOptions = {};
 	let useStripeExpressCheckout = false;


### PR DESCRIPTION
Value of a switch is `On` or `Off` - so the current check will always pass. 
This fixes that.