### PR TITLE
Add billing_period into T3 email fields

### DIFF
--- a/support-workers/src/main/scala/com/gu/emailservices/TierThreeEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/TierThreeEmailFields.scala
@@ -11,7 +11,10 @@ class TierThreeEmailFields(
     touchPointEnvironment: TouchPointEnvironment,
 ) {
   def build(state: SendThankYouEmailTierThreeState)(implicit ec: ExecutionContext): Future[EmailFields] = {
-    // TODO: don't really know what we need here yet
+    val additionalFields = List(
+      ("billing_period", state.product.billingPeriod.toString.toLowerCase),
+    )
+
     paperFieldsGenerator
       .fieldsFor(
         state.paymentMethod,
@@ -29,7 +32,7 @@ class TierThreeEmailFields(
       )
       .map(fields =>
         EmailFields(
-          fields,
+          fields ++ additionalFields,
           state.user,
           "tier-three",
         ),

--- a/support-workers/src/main/scala/com/gu/emailservices/TierThreeEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/TierThreeEmailFields.scala
@@ -11,8 +11,22 @@ class TierThreeEmailFields(
     touchPointEnvironment: TouchPointEnvironment,
 ) {
   def build(state: SendThankYouEmailTierThreeState)(implicit ec: ExecutionContext): Future[EmailFields] = {
+    val firstPaymentDate =
+      SubscriptionEmailFieldHelpers.formatDate(SubscriptionEmailFieldHelpers.firstPayment(state.paymentSchedule).date)
+
+    val promotion = paperFieldsGenerator.getAppliedPromotion(
+      state.promoCode,
+      state.user.billingAddress.country,
+      ProductTypeRatePlans.tierThreeRatePlan(state.product, touchPointEnvironment).map(_.id).getOrElse(""),
+    )
+
+    val subscription_details = SubscriptionEmailFieldHelpers
+      .describe(state.paymentSchedule, state.product.billingPeriod, state.product.currency, promotion)
+
     val additionalFields = List(
       ("billing_period", state.product.billingPeriod.toString.toLowerCase),
+      ("first payment date", firstPaymentDate),
+      ("subscription_details", subscription_details),
     )
 
     paperFieldsGenerator

--- a/support-workers/src/main/scala/com/gu/emailservices/TierThreeEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/TierThreeEmailFields.scala
@@ -11,6 +11,8 @@ class TierThreeEmailFields(
     touchPointEnvironment: TouchPointEnvironment,
 ) {
   def build(state: SendThankYouEmailTierThreeState)(implicit ec: ExecutionContext): Future[EmailFields] = {
+
+    /** These fields are added to align with S+ fields as T3 is a combo of S+ and GW */
     val firstPaymentDate =
       SubscriptionEmailFieldHelpers.formatDate(SubscriptionEmailFieldHelpers.firstPayment(state.paymentSchedule).date)
 

--- a/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
@@ -153,9 +153,74 @@ class DigitalPackEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside
   }
 }
 
-class TierThreeEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside {
+class SupporterPlusEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside {
 
-  it should "generate the right json for direct subs" in {
+  it should "generate the right json for SupporterPlus" in {
+    val created = DateTime.now()
+    val expected = parse(s"""
+                           |{
+                           |  "To" : {
+                           |    "Address" : "test@theguardian.com",
+                           |    "ContactAttributes" : {
+                           |      "SubscriberAttributes" : {
+                           |        "first_name" : "Mickey",
+                           |        "email_address" : "test@theguardian.com",
+                           |        "account name" : "Mickey Mouse",
+                           |        "Mandate ID" : "65HK26E",
+                           |        "sort code" : "20-20-20",
+                           |        "payment method" : "Direct Debit",
+                           |        "first payment date" : "Thursday, 8 August 2024",
+                           |        "subscription_details" : "£10.00 for the first month, then £12.00 every month",
+                           |        "zuorasubscriberid" : "A-S00045678",
+                           |        "last_name" : "Mouse",
+                           |        "currency" : "GBP",
+                           |        "billing_period" : "monthly",
+                           |        "account number" : "******11",
+                           |        "created" : "$created",
+                           |        "product" : "monthly-supporter-plus"
+                           |      }
+                           |    }
+                           |  },
+                           |  "DataExtensionName" : "supporter-plus",
+                           |  "IdentityUserId" : "1234"
+                           |}""".stripMargin)
+
+    val today = new LocalDate(2019, 1, 14)
+    val state = SendThankYouEmailSupporterPlusState(
+      User(
+        "1234",
+        "test@theguardian.com",
+        None,
+        "Mickey",
+        "Mouse",
+        billingAddress = officeAddress,
+        deliveryAddress = Some(officeAddress),
+      ),
+      SupporterPlus(12, GBP, Monthly),
+      directDebitPaymentMethod,
+      PaymentSchedule(List(Payment(today, 10), Payment(today.plusMonths(1), 12))),
+      None,
+      "acno",
+      "A-S00045678",
+    )
+
+    val actual = new SupporterPlusEmailFields(
+      new PaperFieldsGenerator(TestData.promotionService, TestData.getMandate),
+      TestData.getMandate,
+      CODE,
+      created,
+    ).build(state).map(fields => parse(fields.payload))
+
+    actual.map(inside(_) { case actualJson =>
+      actualJson should be(expected)
+    })
+
+  }
+}
+
+class TierThreeEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside {
+  it should "generate the right json for TierThree" in {
+
     val expected = parse("""
         |{
         |  "To" : {
@@ -164,8 +229,10 @@ class TierThreeEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside {
         |      "SubscriberAttributes" : {
         |        "subscription_rate" : "£119.90 for the first year",
         |        "date_of_first_paper" : "Monday, 14 January 2019",
+        |        "first payment date" : "Monday, 14 January 2019",
         |        "subscriber_id" : "A-S00045678",
         |        "date_of_first_payment" : "Monday, 14 January 2019",
+        |        "subscription_details" : "£119.90 for the first year",
         |        "delivery_postcode" : "N1 9AG",
         |        "payment_method" : "Direct Debit",
         |        "delivery_address_line_1" : "90 York Way",
@@ -207,77 +274,14 @@ class TierThreeEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside {
       "A-S00045678",
       today,
     )
+
     val actual = new TierThreeEmailFields(
       new PaperFieldsGenerator(TestData.promotionService, TestData.getMandate),
       CODE,
     ).build(state).map(fields => parse(fields.payload))
+
     actual.map(inside(_) { case actualJson =>
       actualJson should be(expected)
     })
-  }
-}
-class SupporterPlusEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside {
-
-  it should "generate the right json for direct subs" in {
-    val expected = parse("""
-                           |{
-                           |  "To" : {
-                           |    "Address" : "test@theguardian.com",
-                           |    "ContactAttributes" : {
-                           |      "SubscriberAttributes" : {
-                           |        "subscription_rate" : "£119.90 for the first year",
-                           |        "date_of_first_paper" : "Monday, 14 January 2019",
-                           |        "subscriber_id" : "A-S00045678",
-                           |        "date_of_first_payment" : "Monday, 14 January 2019",
-                           |        "delivery_postcode" : "N1 9AG",
-                           |        "payment_method" : "Direct Debit",
-                           |        "delivery_address_line_1" : "90 York Way",
-                           |        "last_name" : "Mouse",
-                           |        "delivery_address_line_2" : "",
-                           |        "EmailAddress" : "test@theguardian.com",
-                           |        "delivery_country" : "United Kingdom",
-                           |        "first_name" : "Mickey",
-                           |        "ZuoraSubscriberId" : "A-S00045678",
-                           |        "delivery_address_town" : "London",
-                           |        "bank_sort_code" : "20-20-20",
-                           |        "mandate_id" : "65HK26E",
-                           |        "bank_account_no" : "******11",
-                           |        "billing_period" : "annual",
-                           |        "account_holder" : "Mickey Mouse"
-                           |      }
-                           |    }
-                           |  },
-                           |  "DataExtensionName" : "tier-three",
-                           |  "IdentityUserId" : "1234"
-                           |}""".stripMargin)
-
-    val today = new LocalDate(2019, 1, 14)
-    val state = SendThankYouEmailSupporterPlusState(
-      User(
-        "1234",
-        "test@theguardian.com",
-        None,
-        "Mickey",
-        "Mouse",
-        billingAddress = officeAddress,
-        deliveryAddress = Some(officeAddress),
-      ),
-      SupporterPlus(12, GBP, Monthly),
-      directDebitPaymentMethod,
-      PaymentSchedule(List(Payment(today, 10), Payment(today.plusMonths(1), 12))),
-      None,
-      "acno",
-      "A-S00045678",
-    )
-    val actual = new SupporterPlusEmailFields(
-      new PaperFieldsGenerator(TestData.promotionService, TestData.getMandate),
-      TestData.getMandate,
-      CODE,
-      DateTime.now(),
-    ).build(state).map(fields => parse(fields.payload))
-    actual.map(inside(_) { case actualJson =>
-      actualJson should be(expected)
-    })
-
   }
 }

--- a/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
@@ -1,9 +1,10 @@
 package com.gu.emailservices
 
 import com.gu.i18n.Currency.GBP
+import com.gu.support.catalog.Domestic
 import com.gu.support.config.TouchPointEnvironments.CODE
 import com.gu.support.workers.integration.TestData
-import com.gu.support.workers.integration.TestData.{countryOnlyAddress, directDebitPaymentMethod}
+import com.gu.support.workers.integration.TestData.{countryOnlyAddress, directDebitPaymentMethod, officeAddress}
 import com.gu.support.workers.states.SendThankYouEmailState._
 import com.gu.support.workers._
 import io.circe.parser._
@@ -150,5 +151,133 @@ class DigitalPackEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside
       actualJson should be(expectedJson)
     })
   }
+}
 
+class TierThreeEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside {
+
+  it should "generate the right json for direct subs" in {
+    val expected = parse("""
+        |{
+        |  "To" : {
+        |    "Address" : "test@theguardian.com",
+        |    "ContactAttributes" : {
+        |      "SubscriberAttributes" : {
+        |        "subscription_rate" : "£119.90 for the first year",
+        |        "date_of_first_paper" : "Monday, 14 January 2019",
+        |        "subscriber_id" : "A-S00045678",
+        |        "date_of_first_payment" : "Monday, 14 January 2019",
+        |        "delivery_postcode" : "N1 9AG",
+        |        "payment_method" : "Direct Debit",
+        |        "delivery_address_line_1" : "90 York Way",
+        |        "last_name" : "Mouse",
+        |        "delivery_address_line_2" : "",
+        |        "EmailAddress" : "test@theguardian.com",
+        |        "delivery_country" : "United Kingdom",
+        |        "first_name" : "Mickey",
+        |        "ZuoraSubscriberId" : "A-S00045678",
+        |        "delivery_address_town" : "London",
+        |        "bank_sort_code" : "20-20-20",
+        |        "mandate_id" : "65HK26E",
+        |        "bank_account_no" : "******11",
+        |        "billing_period" : "annual",
+        |        "account_holder" : "Mickey Mouse"
+        |      }
+        |    }
+        |  },
+        |  "DataExtensionName" : "tier-three",
+        |  "IdentityUserId" : "1234"
+        |}""".stripMargin)
+
+    val today = new LocalDate(2019, 1, 14)
+    val state = SendThankYouEmailTierThreeState(
+      User(
+        "1234",
+        "test@theguardian.com",
+        None,
+        "Mickey",
+        "Mouse",
+        billingAddress = officeAddress,
+        deliveryAddress = Some(officeAddress),
+      ),
+      TierThree(GBP, Annual, Domestic),
+      directDebitPaymentMethod,
+      PaymentSchedule(List(Payment(today, 119.90))),
+      None,
+      "acno",
+      "A-S00045678",
+      today,
+    )
+    val actual = new TierThreeEmailFields(
+      new PaperFieldsGenerator(TestData.promotionService, TestData.getMandate),
+      CODE,
+    ).build(state).map(fields => parse(fields.payload))
+    actual.map(inside(_) { case actualJson =>
+      actualJson should be(expected)
+    })
+  }
+}
+class SupporterPlusEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside {
+
+  it should "generate the right json for direct subs" in {
+    val expected = parse("""
+                           |{
+                           |  "To" : {
+                           |    "Address" : "test@theguardian.com",
+                           |    "ContactAttributes" : {
+                           |      "SubscriberAttributes" : {
+                           |        "subscription_rate" : "£119.90 for the first year",
+                           |        "date_of_first_paper" : "Monday, 14 January 2019",
+                           |        "subscriber_id" : "A-S00045678",
+                           |        "date_of_first_payment" : "Monday, 14 January 2019",
+                           |        "delivery_postcode" : "N1 9AG",
+                           |        "payment_method" : "Direct Debit",
+                           |        "delivery_address_line_1" : "90 York Way",
+                           |        "last_name" : "Mouse",
+                           |        "delivery_address_line_2" : "",
+                           |        "EmailAddress" : "test@theguardian.com",
+                           |        "delivery_country" : "United Kingdom",
+                           |        "first_name" : "Mickey",
+                           |        "ZuoraSubscriberId" : "A-S00045678",
+                           |        "delivery_address_town" : "London",
+                           |        "bank_sort_code" : "20-20-20",
+                           |        "mandate_id" : "65HK26E",
+                           |        "bank_account_no" : "******11",
+                           |        "billing_period" : "annual",
+                           |        "account_holder" : "Mickey Mouse"
+                           |      }
+                           |    }
+                           |  },
+                           |  "DataExtensionName" : "tier-three",
+                           |  "IdentityUserId" : "1234"
+                           |}""".stripMargin)
+
+    val today = new LocalDate(2019, 1, 14)
+    val state = SendThankYouEmailSupporterPlusState(
+      User(
+        "1234",
+        "test@theguardian.com",
+        None,
+        "Mickey",
+        "Mouse",
+        billingAddress = officeAddress,
+        deliveryAddress = Some(officeAddress),
+      ),
+      SupporterPlus(12, GBP, Monthly),
+      directDebitPaymentMethod,
+      PaymentSchedule(List(Payment(today, 10), Payment(today.plusMonths(1), 12))),
+      None,
+      "acno",
+      "A-S00045678",
+    )
+    val actual = new SupporterPlusEmailFields(
+      new PaperFieldsGenerator(TestData.promotionService, TestData.getMandate),
+      TestData.getMandate,
+      CODE,
+      DateTime.now(),
+    ).build(state).map(fields => parse(fields.payload))
+    actual.map(inside(_) { case actualJson =>
+      actualJson should be(expected)
+    })
+
+  }
 }


### PR DESCRIPTION
Adds these fields to the T3 email
- `billing_period`
- `first payment date`
- `subscription_details`

Whilst these fields are available via some of the other fields from the `paperFieldsGenerator` - I've chosen to just add these to align with the S+ fields as that's what we copied from in Braze.

We could probably start consolidating this - although I wonder if that would be part of a larger initiative to do this throughout the pipeline.