### PR TITLE
fix: update StripeExpressCheckout flow to include necessary steps

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -763,7 +763,7 @@ function CheckoutComponent({
 				return;
 			}
 
-			/** 2. Get the setupIntent from the paymentMethod */
+			/** 3. Get the setupIntent from the paymentMethod */
 			const { setupIntent, error: cardSetupError } =
 				await stripe.confirmCardSetup(stripeClientSecret, {
 					payment_method: stripePaymentMethod.id,
@@ -782,7 +782,7 @@ function CheckoutComponent({
 					? 'StripeApplePay'
 					: 'StripePaymentRequestButton';
 
-			/** 2. Pass the setupIntent through to the paymentFields sent to our /create endpoint */
+			/** 4. Pass the setupIntent through to the paymentFields sent to our /create endpoint */
 			paymentFields = {
 				paymentMethod: setupIntent.payment_method as string,
 				stripePaymentType,


### PR DESCRIPTION
Adds the steps needed in the `StripeExpressCheckout` to pass the `setupIntent` through to our `create` endpoint.

- get the `clientSecret` from the server
- use that to get the `paymentMethod` from `Stripe`
- validate the `setupIntent` with the `paymentMethod`
- send that ID to the `/create` endpoint

### screenshots

#### video

https://github.com/user-attachments/assets/833e3ec1-1b6a-45ef-9ab3-4a72331f1ce2


#### valid support-worker runs

<img width="686" alt="Screenshot 2024-07-29 at 14 21 33" src="https://github.com/user-attachments/assets/5941a8fa-18cd-4b2a-9a17-e952c1c6a110">
<img width="1484" alt="Screenshot 2024-07-29 at 14 21 08" src="https://github.com/user-attachments/assets/d4247ed6-9006-4717-aef0-2abe96677b90">
