### PR TITLE
fix: only show apple/google wallets if they're available

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -1059,8 +1059,8 @@ function CheckoutComponent({
 												}}
 												options={{
 													paymentMethods: {
-														applePay: 'always',
-														googlePay: 'always',
+														applePay: 'auto',
+														googlePay: 'auto',
 														link: 'never',
 													},
 												}}


### PR DESCRIPTION
Given this is the default way Stripe suggests doing this, it's the way it currently works, and we're unsure if asking someone for a card via this flow is a good UX, I've swapped this back.

It was also a mistake and was implemented as it was easier to test locally.