### PR TITLE
Generic Checkout: Tier2 S+ Setup ABTest

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -127,6 +127,27 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
+	tierTwoFromApi: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		isActive: false,
+		referrerControlled: false, // ab-test name not needed to be in paramURL
+		seed: 5,
+		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+		excludeCountriesSubjectToContributionsOnlyAmounts: true,
+	},
 	abandonedBasket: {
 		variants: [
 			{

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -393,7 +393,7 @@ export function ThreeTierLanding(): JSX.Element {
 			/**
 			 * Only Testing CardTier1 wth checkout
 			 */
-			if (useGenericCheckout && cardTier === 1) {
+			if ((useGenericCheckout && cardTier === 1) || tier2UseGenericCheckout) {
 				/**
 				 * Generic Checkout is not defined in supporterPlusRouter
 				 */
@@ -470,25 +470,38 @@ export function ThreeTierLanding(): JSX.Element {
 	};
 
 	/** Tier 2: SupporterPlus */
+	const tier2UseGenericCheckout = abParticipations.tierTwoFromApi === 'variant';
+
 	const supporterPlusRatePlan =
 		contributionType === 'ANNUAL' ? 'Annual' : 'Monthly';
 	const tier2Pricing =
 		productCatalog.SupporterPlus.ratePlans[supporterPlusRatePlan].pricing[
 			currencyId
 		];
-	const tier2UrlParams = new URLSearchParams({
+
+	const tier2GenericUrlParams = new URLSearchParams({
+		product: 'SupporterPlus',
+		ratePlan: supporterPlusRatePlan,
+		price: tier2Pricing.toString(),
+	});
+	const tier2ContributeUrlParams = new URLSearchParams({
 		'selected-amount': tier2Pricing.toString(),
 		'selected-contribution-type': selectedContributionType,
 		product: 'SupporterPlus',
 	});
+	const tier2UrlParams = tier2UseGenericCheckout
+		? tier2GenericUrlParams
+		: tier2ContributeUrlParams;
 	if (promotionTier2) {
 		tier2UrlParams.set('promoCode', promotionTier2.promoCode);
 	}
-
+	const tier2Url = `${
+		tier2UseGenericCheckout ? '' : 'contribute/'
+	}checkout?${tier2UrlParams.toString()}`;
 	const tier2Card = {
 		productDescription: productCatalogDescription.SupporterPlus,
 		price: tier2Pricing,
-		link: `contribute/checkout?${tier2UrlParams.toString()}`,
+		link: tier2Url,
 		/** The promotion from the querystring is for the SupporterPlus product only */
 		promotion: promotionTier2,
 		isRecommended: true,


### PR DESCRIPTION
## What are you doing in this PR?

Enable Generic checkout S+ 

1.  Setup abtest `ab-tierTwoFromApi=variant`
2. Tier2 card opens GenericCheckout whilst passing through Param Values
![image](https://github.com/user-attachments/assets/90f85d39-7812-43c0-858c-aca93212addc)


Associated Playwright tests remain at this location -> 
![image](https://github.com/user-attachments/assets/9c4d941c-e0ff-41bd-b217-a99edefd19c5)


[**Trello Card**](https://trello.com/c/CnkbfpDV/979-generic-checkout-tier2-s-setup-abtest-identify-remaining-work)

## How to test

https://support.thegulocal.com/uk/contribute#ab-tierTwoFromApi=variant
->
https://support.thegulocal.com/uk/checkout?product=SupporterPlus&ratePlan=Monthly&price=12


## Screenshots

|control|variant|
|-----|-----|
|![image](https://github.com/user-attachments/assets/788815c2-5112-4180-8759-b4c389a45455)|![image](https://github.com/user-attachments/assets/c19d9b7c-3152-481d-af9f-e6e80becf251)|



