### PR TITLE
Enable the TicketTailor 'chk' value to be passed in for now till we can build the API call to retrieve it

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -15,6 +15,7 @@ const checkoutContainer = css`
 export function Events() {
 	const searchParams = new URLSearchParams(window.location.search);
 	const eventId = searchParams.get('eventId') ?? '4180362';
+  const chk = searchParams.get('chk') ?? '9fa2';
 	return (
 		<PageScaffold
 			header={<Header />}
@@ -30,7 +31,7 @@ export function Events() {
 						<div className="tt-widget-fallback">
 							<p>
 								<a
-									href={`https://tickets.theguardian.live/checkout/new-session/id/${eventId}/chk/9fa2/?ref=support-theguardian-com`}
+									href={`https://tickets.theguardian.live/checkout/new-session/id/${eventId}/chk/${chk}/?ref=support-theguardian-com`}
 									target="_blank"
 								>
 									Click here to buy tickets
@@ -39,7 +40,7 @@ export function Events() {
 						</div>
 						<script
 							src="https://cdn.tickettailor.com/js/widgets/min/widget.js"
-							data-url={`https://tickets.theguardian.live/checkout/new-session/id/${eventId}/chk/9fa2/?ref=support-theguardian-com`}
+							data-url={`https://tickets.theguardian.live/checkout/new-session/id/${eventId}/chk/${chk}/?ref=support-theguardian-com`}
 							data-type="inline"
 							data-inline-minimal="true"
 							data-inline-show-logo="false"

--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -15,7 +15,7 @@ const checkoutContainer = css`
 export function Events() {
 	const searchParams = new URLSearchParams(window.location.search);
 	const eventId = searchParams.get('eventId') ?? '4180362';
-  const chk = searchParams.get('chk') ?? '9fa2';
+	const chk = searchParams.get('chk') ?? '9fa2';
 	return (
 		<PageScaffold
 			header={<Header />}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Enable the TicketTailor `chk` value (an identifier for the event's custom checkout) to be passed in for now till we can build the [`retrieve-an-event` API call](https://developers.tickettailor.com/#retrieve-an-event) in the Scala controller to get it from the public TT Event ID.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/915GAuRd/965-ticket-tailor-ui-refinement)

## Why are you doing this?
Progress forward with solution and stakeholder testing.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
Tested on CODE.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
