### PR TITLE
fix: remove selectedContributionType from sessionStorage

### DIFF
--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -107,10 +107,6 @@ function toHumanReadableContributionType(
 	}
 }
 
-function getContributionTypeFromSession(): ContributionType | null | undefined {
-	return toContributionType(storage.getSession('selectedContributionType'));
-}
-
 function getContributionTypeFromUrl(): ContributionType | null | undefined {
 	return toContributionType(getQueryParameter('selected-contribution-type'));
 }
@@ -346,7 +342,6 @@ export {
 	simpleFormatAmount,
 	formatAmount,
 	getValidContributionTypesFromUrlOrElse,
-	getContributionTypeFromSession,
 	getContributionTypeFromUrl,
 	getAmountFromUrl,
 	toHumanReadableContributionType,

--- a/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/contributionsSideEffects.ts
@@ -67,20 +67,6 @@ export function addProductSideEffects(
 	});
 
 	startListening({
-		actionCreator: setProductType,
-		effect(action) {
-			/**
-			 * selectedContributionType is read from storage in 2 places:
-			 * 1) It is used to set the selected contribution type on return
-			 * visits to the Contributions Landing Page in the same session.
-			 * 2) It is used on the Contributions Thank You page to send data to Quantum
-			 * Metric, and to also set a cookie for one off contributions.
-			 */
-			storage.setSession('selectedContributionType', action.payload);
-		},
-	});
-
-	startListening({
 		actionCreator: setSelectedAmount,
 		effect(action, listenerApi) {
 			const { countryGroupId } =

--- a/support-frontend/assets/pages/digital-subscriber-checkout/setup/setUpRedux.ts
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/setup/setUpRedux.ts
@@ -6,7 +6,6 @@ import type {
 } from 'helpers/contributions';
 import {
 	getAmountFromUrl,
-	getContributionTypeFromSession,
 	getContributionTypeFromUrl,
 	getPaymentMethodFromSession,
 	getValidContributionTypesFromUrlOrElse,
@@ -63,8 +62,7 @@ function getInitialContributionType(
 	countryGroupId: CountryGroupId,
 	contributionTypes: ContributionTypes,
 ): ContributionType {
-	const contributionType =
-		getContributionTypeFromUrl() ?? getContributionTypeFromSession();
+	const contributionType = getContributionTypeFromUrl();
 
 	// make sure we don't select a contribution type which isn't on the page
 	if (

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/setUpRedux.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/setUpRedux.ts
@@ -2,7 +2,6 @@
 import type { ContributionType } from 'helpers/contributions';
 import {
 	getAmountFromUrl,
-	getContributionTypeFromSession,
 	getContributionTypeFromUrl,
 	getPaymentMethodFromSession,
 	getValidPaymentMethods,
@@ -61,8 +60,7 @@ function getInitialContributionType(
 	const { defaultContributionType, displayContributionType } =
 		state.common.amounts;
 
-	const contributionType =
-		getContributionTypeFromUrl() ?? getContributionTypeFromSession();
+	const contributionType = getContributionTypeFromUrl();
 
 	// make sure we don't select a contribution type which isn't on the page
 	if (contributionType && displayContributionType.includes(contributionType)) {


### PR DESCRIPTION
Removes `selectedContributionType` from `sessionStorage`. This adds complexity both to the code and to the UX.

If we want to store this information - we should use either URL params (already exist) or `window.location.hash` values if we're controlling the UI.

This was identified as I was looking a the tab interface on the landing page in preparing for the Growth team working on it.