### PR TITLE
Digital Edition: PayPal Checkout amount shown incorrect

### DIFF
--- a/support-frontend/assets/components/payPalPaymentButton/payPalRecurringContainer.tsx
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalRecurringContainer.tsx
@@ -3,10 +3,7 @@ import { useState } from 'react';
 import type { PayPalCheckoutDetails } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 import { PayPal } from 'helpers/forms/paymentMethods';
 import { validateForm } from 'helpers/redux/checkout/checkoutActions';
-import {
-	setUpPayPalPayment,
-	setUpPayPalPaymentDigitalEdition,
-} from 'helpers/redux/checkout/payment/payPal/thunks';
+import { setUpPayPalPayment } from 'helpers/redux/checkout/payment/payPal/thunks';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import {
 	useContributionsDispatch,
@@ -57,15 +54,7 @@ export function PayPalButtonRecurringContainer({
 
 	const onWindowOpen: OnPaypalWindowOpen = (resolve, reject) => {
 		dispatch(validateForm('PayPal'));
-		const { productType } = useContributionsSelector(
-			(state) => state.page.checkoutForm.product,
-		);
-		if (productType === 'DigitalPack') {
-			// Separated to ease removal when DigtalEdition checkout replaced by generic checkout
-			void dispatch(setUpPayPalPaymentDigitalEdition({ resolve, reject }));
-		} else {
-			void dispatch(setUpPayPalPayment({ resolve, reject }));
-		}
+		void dispatch(setUpPayPalPayment({ resolve, reject }));
 	};
 
 	const buttonProps = getPayPalButtonProps({

--- a/support-frontend/assets/components/payPalPaymentButton/payPalRecurringContainer.tsx
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalRecurringContainer.tsx
@@ -3,7 +3,10 @@ import { useState } from 'react';
 import type { PayPalCheckoutDetails } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 import { PayPal } from 'helpers/forms/paymentMethods';
 import { validateForm } from 'helpers/redux/checkout/checkoutActions';
-import { setUpPayPalPayment } from 'helpers/redux/checkout/payment/payPal/thunks';
+import {
+	setUpPayPalPayment,
+	setUpPayPalPaymentDigitalEdition,
+} from 'helpers/redux/checkout/payment/payPal/thunks';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import {
 	useContributionsDispatch,
@@ -54,7 +57,15 @@ export function PayPalButtonRecurringContainer({
 
 	const onWindowOpen: OnPaypalWindowOpen = (resolve, reject) => {
 		dispatch(validateForm('PayPal'));
-		void dispatch(setUpPayPalPayment({ resolve, reject }));
+		const { productType } = useContributionsSelector(
+			(state) => state.page.checkoutForm.product,
+		);
+		if (productType === 'DigitalPack') {
+			// Separated to ease removal when DigtalEdition checkout replaced by generic checkout
+			void dispatch(setUpPayPalPaymentDigitalEdition({ resolve, reject }));
+		} else {
+			void dispatch(setUpPayPalPayment({ resolve, reject }));
+		}
 	};
 
 	const buttonProps = getPayPalButtonProps({

--- a/support-frontend/assets/helpers/redux/checkout/payment/payPal/thunks.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/payPal/thunks.ts
@@ -2,6 +2,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { fetchJson } from 'helpers/async/fetch';
 import { billingPeriodFromContrib, getAmount } from 'helpers/contributions';
 import { loadPayPalRecurring } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
+import { getProductPrice } from 'helpers/productPrice/productPrices';
 import { getPromotion } from 'helpers/productPrice/promotions';
 import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import { contributionsFormHasErrors } from 'helpers/redux/selectors/formValidation';
@@ -43,6 +44,68 @@ export const setUpPayPalPayment = createAsyncThunk<
 			state.page.checkoutForm.product.otherAmounts,
 			contributionType,
 		);
+		const finalAmount = promotion?.discountedPrice ?? amount;
+
+		const requestBody = {
+			amount: finalAmount,
+			billingPeriod,
+			currency: currencyId,
+			requireShippingAddress: false,
+		};
+
+		const payPalResponse = await fetchJson<{ token?: string }>(
+			routes.payPalSetupPayment,
+			{
+				credentials: 'include',
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Csrf-Token': csrfToken,
+				},
+				body: JSON.stringify(requestBody),
+			},
+		);
+
+		if (payPalResponse.token) {
+			resolve(payPalResponse.token);
+		} else {
+			throw new Error('PayPal token came back blank');
+		}
+	} catch (error) {
+		logException((error as Error).message);
+		reject(error as Error);
+	}
+});
+
+export const setUpPayPalPaymentDigitalEdition = createAsyncThunk<
+	unknown,
+	PayPalLoadFns,
+	{
+		state: ContributionsState;
+	}
+>('paypal/setUpPayment', async function setUp({ resolve, reject }, thunkApi) {
+	try {
+		const state = thunkApi.getState();
+		const errorsPreventOpening = contributionsFormHasErrors(state);
+
+		if (errorsPreventOpening) {
+			reject(new Error('form invalid'));
+		}
+
+		const { currencyId, countryId } = state.common.internationalisation;
+		const csrfToken = state.page.checkoutForm.csrf.token ?? '';
+		const { billingPeriod } = state.page.checkoutForm.product;
+		const promotion = getPromotion(
+			state.page.checkoutForm.product.productPrices,
+			countryId,
+			billingPeriod === 'Annual' ? 'Annual' : 'Monthly',
+		);
+		const amount = getProductPrice(
+			state.page.checkoutForm.product.productPrices,
+			countryId,
+			billingPeriod === 'Annual' ? 'Annual' : 'Monthly',
+		).price;
+
 		const finalAmount = promotion?.discountedPrice ?? amount;
 
 		const requestBody = {

--- a/support-frontend/assets/helpers/redux/checkout/payment/payPal/thunks.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/payPal/thunks.ts
@@ -32,80 +32,28 @@ export const setUpPayPalPayment = createAsyncThunk<
 		if (errorsPreventOpening) {
 			reject(new Error('form invalid'));
 		}
+		const isDigitalPack =
+			state.page.checkoutForm.product.productType === 'DigitalPack';
 
 		const { currencyId, countryId } = state.common.internationalisation;
 		const csrfToken = state.page.checkoutForm.csrf.token ?? '';
 		const contributionType = getContributionType(state);
 		const { productPrices } = state.page.checkoutForm.product;
-		const billingPeriod = billingPeriodFromContrib(contributionType);
+		const billingPeriod = isDigitalPack
+			? state.page.checkoutForm.product.billingPeriod
+			: billingPeriodFromContrib(contributionType);
 		const promotion = getPromotion(productPrices, countryId, billingPeriod);
-		const amount = getAmount(
-			state.page.checkoutForm.product.selectedAmounts,
-			state.page.checkoutForm.product.otherAmounts,
-			contributionType,
-		);
-		const finalAmount = promotion?.discountedPrice ?? amount;
-
-		const requestBody = {
-			amount: finalAmount,
-			billingPeriod,
-			currency: currencyId,
-			requireShippingAddress: false,
-		};
-
-		const payPalResponse = await fetchJson<{ token?: string }>(
-			routes.payPalSetupPayment,
-			{
-				credentials: 'include',
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					'Csrf-Token': csrfToken,
-				},
-				body: JSON.stringify(requestBody),
-			},
-		);
-
-		if (payPalResponse.token) {
-			resolve(payPalResponse.token);
-		} else {
-			throw new Error('PayPal token came back blank');
-		}
-	} catch (error) {
-		logException((error as Error).message);
-		reject(error as Error);
-	}
-});
-
-export const setUpPayPalPaymentDigitalEdition = createAsyncThunk<
-	unknown,
-	PayPalLoadFns,
-	{
-		state: ContributionsState;
-	}
->('paypal/setUpPayment', async function setUp({ resolve, reject }, thunkApi) {
-	try {
-		const state = thunkApi.getState();
-		const errorsPreventOpening = contributionsFormHasErrors(state);
-
-		if (errorsPreventOpening) {
-			reject(new Error('form invalid'));
-		}
-
-		const { currencyId, countryId } = state.common.internationalisation;
-		const csrfToken = state.page.checkoutForm.csrf.token ?? '';
-		const { billingPeriod } = state.page.checkoutForm.product;
-		const promotion = getPromotion(
-			state.page.checkoutForm.product.productPrices,
-			countryId,
-			billingPeriod === 'Annual' ? 'Annual' : 'Monthly',
-		);
-		const amount = getProductPrice(
-			state.page.checkoutForm.product.productPrices,
-			countryId,
-			billingPeriod === 'Annual' ? 'Annual' : 'Monthly',
-		).price;
-
+		const amount = isDigitalPack
+			? getProductPrice(
+					state.page.checkoutForm.product.productPrices,
+					countryId,
+					billingPeriod === 'Annual' ? 'Annual' : 'Monthly',
+			  ).price
+			: getAmount(
+					state.page.checkoutForm.product.selectedAmounts,
+					state.page.checkoutForm.product.otherAmounts,
+					contributionType,
+			  );
 		const finalAmount = promotion?.discountedPrice ?? amount;
 
 		const requestBody = {


### PR DESCRIPTION
## What are you doing in this PR?

Digital Edition PayPal checkout amounts shown incorrectly on Paypal confirmation screen. The correct amount is being charged in Zuora however.

[**Trello Card**](https://trello.com/c/4xkb0eHP/997-paypal-x-annual-on-digital-edition-checkout-incorrectly-labelled-on-paypal-confirmation-screen)

## How to test
https://support.thegulocal.com/uk/subscribe/digitaledition
https://support.thegulocal.com/uk/subscribe/digitaledition?promoCode=KINDLE10

## Screenshots
UK Annual 
|Before|After|Promo 10%|
|-----|-----|-----|
|![image](https://github.com/user-attachments/assets/d94fe3d9-41cf-4068-88b8-1b25e71e7608)|![image](https://github.com/user-attachments/assets/a14d94cf-a87b-484c-8a8a-754dba5a89f3)|![image](https://github.com/user-attachments/assets/536e3eef-2f2e-46cf-9515-32d166ab5fb7)|

