### PR TITLE
refactor: move data fetching and validation outside of checkout component

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -89,9 +89,11 @@ import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import CountryHelper from 'helpers/internationalisation/classes/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
+import type { ProductKey } from 'helpers/productCatalog';
 import {
 	filterBenefitByRegion,
 	isProductKey,
+	productCatalog,
 	productCatalogDescription,
 } from 'helpers/productCatalog';
 import { NoFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
@@ -262,21 +264,6 @@ const processPayment = async (
 	});
 };
 
-/** QueryString - this is setup specifically for the checkout page */
-function isNumeric(str: string) {
-	return !isNaN(parseFloat(str));
-}
-const searchParams = new URLSearchParams(window.location.search);
-const searchParamsPrice = searchParams.get('price');
-const query = {
-	product: searchParams.get('product') ?? '',
-	ratePlan: searchParams.get('ratePlan') ?? '',
-	price:
-		searchParamsPrice && isNumeric(searchParamsPrice)
-			? parseFloat(searchParamsPrice)
-			: undefined,
-};
-
 /** Form Validation */
 /**
  * This uses a Unicode character class escape
@@ -316,10 +303,51 @@ function ChangeButton({ geoId }: ChangeButtonProps) {
 type Props = {
 	geoId: GeoId;
 	appConfig: AppConfig;
-	useStripeExpressCheckout?: boolean;
 };
 export function Checkout({ geoId, appConfig }: Props) {
 	const { currencyKey } = getGeoIdConfig(geoId);
+	const searchParams = new URLSearchParams(window.location.search);
+
+	/** Get and validate product */
+	const productParam = searchParams.get('product');
+	const productKey =
+		productParam && isProductKey(productParam) ? productParam : undefined;
+	const product = productKey && productCatalog[productKey];
+	if (!product) {
+		return <div>Product not found</div>;
+	}
+
+	/**
+	 * Get and validate ratePlan
+	 * TODO: This type should be more specific e.g. `ProductRatePlanKey<P>`.
+	 * Annoyingly the TypeScript for this is a little fiddly due to the
+	 * API being completely based on literals, so we've left it as `string`
+	 * although we do validate it is a valid ratePlan for this product
+	 */
+	const ratePlanParam = searchParams.get('ratePlan');
+	const ratePlanKey =
+		ratePlanParam && ratePlanParam in product.ratePlans
+			? ratePlanParam
+			: undefined;
+	const ratePlan = ratePlanKey && product.ratePlans[ratePlanKey];
+	if (!ratePlan) {
+		return <div>Rate plan not found</div>;
+	}
+
+	/** Get and validate price */
+	let price: number | undefined;
+	if (productKey === 'Contribution') {
+		const priceParam = searchParams.get('price');
+		price = priceParam ? parseInt(priceParam, 10) : undefined;
+	} else {
+		price =
+			currencyKey in ratePlan.pricing
+				? ratePlan.pricing[currencyKey]
+				: undefined;
+	}
+	if (!price) {
+		return <div>Price not found</div>;
+	}
 
 	/**
 	 * TODO: We should probaly send this down from the server as
@@ -371,17 +399,31 @@ export function Checkout({ geoId, appConfig }: Props) {
 			<CheckoutComponent
 				geoId={geoId}
 				appConfig={appConfig}
+				productKey={productKey}
+				ratePlanKey={ratePlanKey}
+				price={price}
 				useStripeExpressCheckout={useStripeExpressCheckout}
 			/>
 		</Elements>
 	);
 }
 
+type CheckoutComponentProps = {
+	geoId: GeoId;
+	appConfig: AppConfig;
+	productKey: ProductKey;
+	ratePlanKey: string;
+	price: number;
+	useStripeExpressCheckout: boolean;
+};
 function CheckoutComponent({
 	geoId,
 	appConfig,
-	useStripeExpressCheckout = false,
-}: Props) {
+	productKey,
+	ratePlanKey,
+	price: priceOriginal,
+	useStripeExpressCheckout,
+}: CheckoutComponentProps) {
 	/** we unset any previous orders that have been made */
 	unsetThankYouOrder();
 
@@ -390,38 +432,15 @@ function CheckoutComponent({
 	const isSignedIn = !!user?.email;
 	const isTestUser = !!cookie.get('_test_username');
 	const productPrices = window.guardian.productPrices;
+
 	const productCatalog = appConfig.productCatalog;
 	const { currency, currencyKey, countryGroupId } = getGeoIdConfig(geoId);
-	const productId = isProductKey(query.product) ? query.product : undefined;
-	const product = productId ? productCatalog[productId] : undefined;
-	const ratePlan = product?.ratePlans[query.ratePlan];
-	const priceOriginal = query.price ?? ratePlan?.pricing[currencyKey];
 
 	const fulfilmentOption =
 		countryGroupId === 'International' ? 'RestOfWorld' : 'Domestic';
 
-	const productDescription = productId
-		? productCatalogDescription[productId]
-		: undefined;
-	const ratePlanDescription = productDescription?.ratePlans[query.ratePlan];
-
-	if (
-		/** These are all the things we need to parse the page */
-		!(
-			productId &&
-			product &&
-			productDescription &&
-			ratePlan &&
-			ratePlanDescription &&
-			priceOriginal
-		)
-	) {
-		return (
-			<div>
-				Could not find product: {query.product} ratePlan: {query.ratePlan}
-			</div>
-		);
-	}
+	const productDescription = productCatalogDescription[productKey];
+	const ratePlanDescription = productDescription.ratePlans[ratePlanKey];
 
 	const promotion = getPromotion(
 		productPrices,
@@ -442,76 +461,78 @@ function CheckoutComponent({
 	 * We might be able to defer this to the backend.
 	 */
 	let productFields: RegularPaymentRequest['product'];
+	switch (productKey) {
+		case 'TierThree':
+			productFields = {
+				productType: 'TierThree',
+				currency: currencyKey,
+				billingPeriod: ratePlanDescription.billingPeriod,
+				fulfilmentOptions:
+					ratePlanKey === 'DomesticMonthly' || ratePlanKey === 'DomesticAnnual'
+						? 'Domestic'
+						: ratePlanKey === 'RestOfWorldMonthly' ||
+						  ratePlanKey === 'RestOfWorldAnnual'
+						? 'RestOfWorld'
+						: 'Domestic',
+			};
+			break;
 
-	if (productId === 'TierThree') {
-		productFields = {
-			productType: 'TierThree',
-			currency: currencyKey,
-			billingPeriod: ratePlanDescription.billingPeriod,
-			fulfilmentOptions:
-				query.ratePlan === 'DomesticMonthly' ||
-				query.ratePlan === 'DomesticAnnual'
-					? 'Domestic'
-					: query.ratePlan === 'RestOfWorldMonthly' ||
-					  query.ratePlan === 'RestOfWorldAnnual'
-					? 'RestOfWorld'
-					: 'Domestic',
-		};
-	} else if (productId === 'Contribution') {
-		productFields = {
-			productType: 'Contribution',
-			currency: currencyKey,
-			billingPeriod: ratePlanDescription.billingPeriod,
-			amount: price,
-		};
-	} else if (productId === 'SupporterPlus') {
-		productFields = {
-			productType: 'SupporterPlus',
-			currency: currencyKey,
-			billingPeriod: ratePlanDescription.billingPeriod,
-			amount: price,
-		};
-	} else if (productId === 'GuardianWeeklyDomestic') {
-		productFields = {
-			productType: 'GuardianWeekly',
-			currency: currencyKey,
-			fulfilmentOptions: 'Domestic',
-			billingPeriod: ratePlanDescription.billingPeriod,
-		};
-	} else if (productId === 'GuardianWeeklyRestOfWorld') {
-		productFields = {
-			productType: 'GuardianWeekly',
-			fulfilmentOptions: 'RestOfWorld',
-			currency: currencyKey,
-			billingPeriod: ratePlanDescription.billingPeriod,
-		};
-	} else if (productId === 'DigitalSubscription') {
-		productFields = {
-			productType: 'DigitalPack',
-			currency: currencyKey,
-			billingPeriod: ratePlanDescription.billingPeriod,
-			// TODO - this needs filling in properly, I am not sure where this value comes from
-			readerType: 'Direct',
-		};
-	} else if (
-		productId === 'NationalDelivery' ||
-		productId === 'SubscriptionCard'
-	) {
-		productFields = {
-			productType: 'Paper',
-			currency: currencyKey,
-			billingPeriod: ratePlanDescription.billingPeriod,
-			// TODO - this needs filling in properly
-			fulfilmentOptions: NoFulfilmentOptions,
-			productOptions: NoProductOptions,
-		};
-	} else {
-		return (
-			<div>
-				Could not find productFields for: {query.product} ratePlan:{' '}
-				{query.ratePlan}
-			</div>
-		);
+		case 'Contribution':
+			productFields = {
+				productType: 'Contribution',
+				currency: currencyKey,
+				billingPeriod: ratePlanDescription.billingPeriod,
+				amount: price,
+			};
+			break;
+
+		case 'SupporterPlus':
+			productFields = {
+				productType: 'SupporterPlus',
+				currency: currencyKey,
+				billingPeriod: ratePlanDescription.billingPeriod,
+				amount: price,
+			};
+			break;
+
+		case 'GuardianWeeklyDomestic':
+			productFields = {
+				productType: 'GuardianWeekly',
+				currency: currencyKey,
+				fulfilmentOptions: 'Domestic',
+				billingPeriod: ratePlanDescription.billingPeriod,
+			};
+			break;
+
+		case 'GuardianWeeklyRestOfWorld':
+			productFields = {
+				productType: 'GuardianWeekly',
+				fulfilmentOptions: 'RestOfWorld',
+				currency: currencyKey,
+				billingPeriod: ratePlanDescription.billingPeriod,
+			};
+			break;
+
+		case 'DigitalSubscription':
+			productFields = {
+				productType: 'DigitalPack',
+				currency: currencyKey,
+				billingPeriod: ratePlanDescription.billingPeriod,
+				readerType: 'Direct',
+			};
+			break;
+
+		case 'NationalDelivery':
+		case 'SubscriptionCard':
+		case 'HomeDelivery':
+			productFields = {
+				productType: 'Paper',
+				currency: currencyKey,
+				billingPeriod: ratePlanDescription.billingPeriod,
+				fulfilmentOptions: NoFulfilmentOptions,
+				productOptions: NoProductOptions,
+			};
+			break;
 	}
 
 	/**
@@ -519,48 +540,27 @@ function CheckoutComponent({
 	 *    If queryPrice above ratePlanPrice, in a upgrade to S+ country, invalid amount
 	 */
 	let isInvalidAmount = false;
-	if (productId === 'Contribution' && query.price) {
+	if (productKey === 'Contribution') {
 		const supporterPlusRatePlanPrice =
-			productCatalog.SupporterPlus.ratePlans[query.ratePlan].pricing[
-				currencyKey
-			];
+			productCatalog.SupporterPlus.ratePlans[ratePlanKey].pricing[currencyKey];
 
 		const { selectedAmountsVariant } = getAmountsTestVariant(
 			countryId,
 			countryGroupId,
 			appConfig.settings,
 		);
-		if (query.price < 1) {
+		if (priceOriginal < 1) {
 			isInvalidAmount = true;
 		}
 		if (!isContributionsOnlyCountry(selectedAmountsVariant)) {
-			if (query.price >= supporterPlusRatePlanPrice) {
+			if (priceOriginal >= supporterPlusRatePlanPrice) {
 				isInvalidAmount = true;
 			}
 		}
 	}
 
-	/**
-	 * Is It a SupporterPlus? URL queryPrice supplied?
-	 *    If queryPrice below S+ ratePlanPrice, invalid amount
-	 */
-	if (productId === 'SupporterPlus' && query.price) {
-		const supporterPlusRatePlanPrice =
-			productCatalog.SupporterPlus.ratePlans[query.ratePlan].pricing[
-				currencyKey
-			];
-
-		if (query.price < supporterPlusRatePlanPrice) {
-			isInvalidAmount = true;
-		}
-	}
 	if (isInvalidAmount) {
-		return (
-			<div>
-				Invalid Amount In Query String: {query.product} ratePlan:{' '}
-				{query.ratePlan} amount: {query.price}
-			</div>
-		);
+		return <div>Invalid Amount {priceOriginal}</div>;
 	}
 
 	const validPaymentMethods = [
@@ -874,7 +874,7 @@ function CheckoutComponent({
 			 * - add debugInfo
 			 */
 			const firstDeliveryDate =
-				productId === 'TierThree'
+				productKey === 'TierThree'
 					? formatMachineDate(getTierThreeDeliveryDate())
 					: null;
 			const promoCode = promotion?.promoCode;
@@ -912,12 +912,12 @@ function CheckoutComponent({
 				const order = {
 					firstName: personalData.firstName,
 					price: price,
-					product: productId,
-					ratePlan: query.ratePlan,
+					product: productKey,
+					ratePlan: ratePlanKey,
 					paymentMethod: paymentMethod,
 				};
 				setThankYouOrder(order);
-				window.location.href = `/${geoId}/thank-you?product=${productId}&ratePlan=${query.ratePlan}&promoCode=${promoCode}`;
+				window.location.href = `/${geoId}/thank-you?product=${productKey}&ratePlan=${ratePlanKey}&promoCode=${promoCode}`;
 			} else {
 				// TODO - error handling
 				console.error(
@@ -933,7 +933,7 @@ function CheckoutComponent({
 	const { supportInternationalisationId } = countryGroups[countryGroupId];
 
 	useAbandonedBasketCookie(
-		productId,
+		productKey,
 		price,
 		ratePlanDescription.billingPeriod,
 		supportInternationalisationId,
@@ -1015,7 +1015,7 @@ function CheckoutComponent({
 									}}
 									enableCheckList={true}
 									tsAndCsTier3={
-										productId === 'TierThree'
+										productKey === 'TierThree'
 											? getTermsStartDateTier3(
 													formatUserDate(getTierThreeDeliveryDate()),
 											  )


### PR DESCRIPTION
Moves _some_ (soon to be more) data fetching and validation outside the component and into the fetcher.

This is a common pattern in [NextJS](https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating), [Astro](https://docs.astro.build/en/guides/data-fetching/) and many others. 

I've done this as I was preparing the way for S+ to make it's way into the checkout and was finding it quite complex, so I hope this simplifies the path.

There is a small challenge that the data fetching is from a JS literal. You might normally have an API that 404s etc, but we are having to do those checks explicitly in the fetching method.

i.e.
- Get the `product` query string param
- Check it exists in the `products` object
- fail if not
- Get the `ratePlan` query string param
- Check it exists in the `product` object
- Do the same for price

The code is a bit verbose, but I think it's clear and easy to change - which feels like a decent payoff.
