### PR TITLE
Make payment api switches optional

### DIFF
--- a/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
+++ b/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
@@ -43,9 +43,7 @@ class AmazonPayBackend(
     with PaymentBackend {
 
   private def amazonPayEnabled =
-    switchService.allSwitches.map(switch =>
-      switch.oneOffPaymentMethods.exists(s => s.switches.amazonPay.exists(_.state.isOn)),
-    )
+    switchService.allSwitches.map(_.oneOffPaymentMethods.exists(_.switches.amazonPay.exists(_.state.isOn)))
 
   def makePayment(
       amazonPayRequest: AmazonPayRequest,

--- a/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
+++ b/support-payment-api/src/main/scala/backend/AmazonPayBackend.scala
@@ -43,7 +43,9 @@ class AmazonPayBackend(
     with PaymentBackend {
 
   private def amazonPayEnabled =
-    switchService.allSwitches.map(switch => switch.oneOffPaymentMethods.exists(s => s.switches.amazonPay.state.isOn))
+    switchService.allSwitches.map(switch =>
+      switch.oneOffPaymentMethods.exists(s => s.switches.amazonPay.exists(_.state.isOn)),
+    )
 
   def makePayment(
       amazonPayRequest: AmazonPayRequest,

--- a/support-payment-api/src/main/scala/backend/PaypalBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaypalBackend.scala
@@ -52,9 +52,7 @@ class PaypalBackend(
    */
 
   private def paypalEnabled = {
-    switchService.allSwitches.map(switch =>
-      switch.oneOffPaymentMethods.exists(s => s.switches.payPal.exists(_.state.isOn)),
-    )
+    switchService.allSwitches.map(_.oneOffPaymentMethods.exists(_.switches.payPal.exists(_.state.isOn)))
   }
   def isValidEmail(email: String): Boolean =
     !email.contains(",")

--- a/support-payment-api/src/main/scala/backend/PaypalBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaypalBackend.scala
@@ -52,7 +52,9 @@ class PaypalBackend(
    */
 
   private def paypalEnabled = {
-    switchService.allSwitches.map(switch => switch.oneOffPaymentMethods.exists(s => s.switches.payPal.state.isOn))
+    switchService.allSwitches.map(switch =>
+      switch.oneOffPaymentMethods.exists(s => s.switches.payPal.exists(_.state.isOn)),
+    )
   }
   def isValidEmail(email: String): Boolean =
     !email.contains(",")

--- a/support-payment-api/src/main/scala/backend/StripeBackend.scala
+++ b/support-payment-api/src/main/scala/backend/StripeBackend.scala
@@ -53,7 +53,9 @@ class StripeBackend(
     switchService.allSwitches
       .map(s =>
         s.recaptchaSwitches.exists(switch =>
-          switch.switches.enableRecaptchaFrontend.state.isOn && switch.switches.enableRecaptchaBackend.state.isOn,
+          switch.switches.enableRecaptchaFrontend.exists(_.state.isOn) && switch.switches.enableRecaptchaBackend.exists(
+            _.state.isOn,
+          ),
         ),
       )
 
@@ -66,16 +68,18 @@ class StripeBackend(
     }
 
   private def stripeCheckoutEnabled =
-    switchService.allSwitches.map(switch => switch.oneOffPaymentMethods.exists(s => s.switches.stripe.state.isOn))
+    switchService.allSwitches.map(switch =>
+      switch.oneOffPaymentMethods.exists(s => s.switches.stripe.exists(_.state.isOn)),
+    )
 
   private def stripeApplePayEnabled =
     switchService.allSwitches.map(switch =>
-      switch.oneOffPaymentMethods.exists(s => s.switches.stripeApplePay.state.isOn),
+      switch.oneOffPaymentMethods.exists(s => s.switches.stripeApplePay.exists(_.state.isOn)),
     )
 
   private def stripePaymentRequestEnabled =
     switchService.allSwitches.map(switch =>
-      switch.oneOffPaymentMethods.exists(s => s.switches.stripePaymentRequestButton.state.isOn),
+      switch.oneOffPaymentMethods.exists(s => s.switches.stripePaymentRequestButton.exists(_.state.isOn)),
     )
 
   // Ok using the default thread pool - the mapping function is not computationally intensive, nor does is perform IO.

--- a/support-payment-api/src/main/scala/backend/StripeBackend.scala
+++ b/support-payment-api/src/main/scala/backend/StripeBackend.scala
@@ -68,18 +68,14 @@ class StripeBackend(
     }
 
   private def stripeCheckoutEnabled =
-    switchService.allSwitches.map(switch =>
-      switch.oneOffPaymentMethods.exists(s => s.switches.stripe.exists(_.state.isOn)),
-    )
+    switchService.allSwitches.map(_.oneOffPaymentMethods.exists(_.switches.stripe.exists(_.state.isOn)))
 
   private def stripeApplePayEnabled =
-    switchService.allSwitches.map(switch =>
-      switch.oneOffPaymentMethods.exists(s => s.switches.stripeApplePay.exists(_.state.isOn)),
-    )
+    switchService.allSwitches.map(_.oneOffPaymentMethods.exists(_.switches.stripeApplePay.exists(_.state.isOn)))
 
   private def stripePaymentRequestEnabled =
-    switchService.allSwitches.map(switch =>
-      switch.oneOffPaymentMethods.exists(s => s.switches.stripePaymentRequestButton.exists(_.state.isOn)),
+    switchService.allSwitches.map(
+      _.oneOffPaymentMethods.exists(_.switches.stripePaymentRequestButton.exists(_.state.isOn)),
     )
 
   // Ok using the default thread pool - the mapping function is not computationally intensive, nor does is perform IO.

--- a/support-payment-api/src/main/scala/services/SwitchService.scala
+++ b/support-payment-api/src/main/scala/services/SwitchService.scala
@@ -46,21 +46,21 @@ case class FeatureSwitches(switches: FeatureSwitchesTypes)
 case class SwitchDetails(state: SwitchState)
 
 case class RecaptchaSwitchTypes(
-    enableRecaptchaBackend: SwitchDetails,
-    enableRecaptchaFrontend: SwitchDetails,
+    enableRecaptchaBackend: Option[SwitchDetails],
+    enableRecaptchaFrontend: Option[SwitchDetails],
 )
 
 case class OneOffPaymentMethodsSwitchesTypes(
-    stripe: SwitchDetails,
-    stripeApplePay: SwitchDetails,
-    stripePaymentRequestButton: SwitchDetails,
-    stripeExpressCheckout: SwitchDetails,
-    payPal: SwitchDetails,
-    amazonPay: SwitchDetails,
+    stripe: Option[SwitchDetails],
+    stripeApplePay: Option[SwitchDetails],
+    stripePaymentRequestButton: Option[SwitchDetails],
+    stripeExpressCheckout: Option[SwitchDetails],
+    payPal: Option[SwitchDetails],
+    amazonPay: Option[SwitchDetails],
 )
 
 case class FeatureSwitchesTypes(
-    enableSoftOptInsForSingle: SwitchDetails,
+    enableSoftOptInsForSingle: Option[SwitchDetails],
 )
 
 object Switches {

--- a/support-payment-api/src/test/resources/switches_v2.json
+++ b/support-payment-api/src/test/resources/switches_v2.json
@@ -71,10 +71,6 @@
       "payPal": {
         "description": "PayPal",
         "state": "On"
-      },
-      "stripe": {
-        "description": "Stripe - Credit/Debit card",
-        "state": "Off"
       }
     }
   },

--- a/support-payment-api/src/test/scala/backend/AmazonPayBackendIntegrationSpec.scala
+++ b/support-payment-api/src/test/scala/backend/AmazonPayBackendIntegrationSpec.scala
@@ -54,20 +54,20 @@ class AmazonPayBackendIntegrationSpec
     EitherT.right(
       Future.successful(
         Switches(
-          Some(RecaptchaSwitches(RecaptchaSwitchTypes(SwitchDetails(On), SwitchDetails(On)))),
+          Some(RecaptchaSwitches(RecaptchaSwitchTypes(Some(SwitchDetails(On)), Some(SwitchDetails(On))))),
           Some(
             OneOffPaymentMethodsSwitches(
               OneOffPaymentMethodsSwitchesTypes(
-                SwitchDetails(On),
-                SwitchDetails(On),
-                SwitchDetails(On),
-                SwitchDetails(On),
-                SwitchDetails(On),
-                SwitchDetails(On),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
               ),
             ),
           ),
-          Some(FeatureSwitches(FeatureSwitchesTypes(SwitchDetails(On)))),
+          Some(FeatureSwitches(FeatureSwitchesTypes(Some(SwitchDetails(On))))),
         ),
       ),
     )

--- a/support-payment-api/src/test/scala/backend/AmazonPayBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/AmazonPayBackendSpec.scala
@@ -123,20 +123,20 @@ class AmazonPayBackendFixture(implicit ec: ExecutionContext) extends MockitoSuga
     EitherT.right(
       Future.successful(
         Switches(
-          Some(RecaptchaSwitches(RecaptchaSwitchTypes(SwitchDetails(On), SwitchDetails(On)))),
+          Some(RecaptchaSwitches(RecaptchaSwitchTypes(Some(SwitchDetails(On)), Some(SwitchDetails(On))))),
           Some(
             OneOffPaymentMethodsSwitches(
               OneOffPaymentMethodsSwitchesTypes(
-                SwitchDetails(On),
-                SwitchDetails(On),
-                SwitchDetails(On),
-                SwitchDetails(On),
-                SwitchDetails(On),
-                SwitchDetails(On),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
               ),
             ),
           ),
-          Some(FeatureSwitches(FeatureSwitchesTypes(SwitchDetails(On)))),
+          Some(FeatureSwitches(FeatureSwitchesTypes(Some(SwitchDetails(On))))),
         ),
       ),
     )
@@ -183,20 +183,20 @@ class AmazonPayBackendSpec extends AnyWordSpec with Matchers with FutureEitherVa
           EitherT.right(
             Future.successful(
               Switches(
-                Some(RecaptchaSwitches(RecaptchaSwitchTypes(SwitchDetails(On), SwitchDetails(On)))),
+                Some(RecaptchaSwitches(RecaptchaSwitchTypes(Some(SwitchDetails(On)), Some(SwitchDetails(On))))),
                 Some(
                   OneOffPaymentMethodsSwitches(
                     OneOffPaymentMethodsSwitchesTypes(
-                      SwitchDetails(On),
-                      SwitchDetails(On),
-                      SwitchDetails(On),
-                      SwitchDetails(On),
-                      SwitchDetails(On),
-                      SwitchDetails(Off),
+                      Some(SwitchDetails(On)),
+                      Some(SwitchDetails(On)),
+                      Some(SwitchDetails(On)),
+                      Some(SwitchDetails(On)),
+                      Some(SwitchDetails(On)),
+                      Some(SwitchDetails(Off)),
                     ),
                   ),
                 ),
-                Some(FeatureSwitches(FeatureSwitchesTypes(SwitchDetails(On)))),
+                Some(FeatureSwitches(FeatureSwitchesTypes(Some(SwitchDetails(On))))),
               ),
             ),
           )

--- a/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
@@ -116,20 +116,20 @@ class PaypalBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
     EitherT.right(
       Future.successful(
         Switches(
-          Some(RecaptchaSwitches(RecaptchaSwitchTypes(SwitchDetails(On), SwitchDetails(On)))),
+          Some(RecaptchaSwitches(RecaptchaSwitchTypes(Some(SwitchDetails(On)), Some(SwitchDetails(On))))),
           Some(
             OneOffPaymentMethodsSwitches(
               OneOffPaymentMethodsSwitchesTypes(
-                SwitchDetails(On),
-                SwitchDetails(On),
-                SwitchDetails(On),
-                SwitchDetails(On),
-                SwitchDetails(On),
-                SwitchDetails(On),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
               ),
             ),
           ),
-          Some(FeatureSwitches(FeatureSwitchesTypes(SwitchDetails(On)))),
+          Some(FeatureSwitches(FeatureSwitchesTypes(Some(SwitchDetails(On))))),
         ),
       ),
     )
@@ -197,20 +197,20 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
           EitherT.right(
             Future.successful(
               Switches(
-                Some(RecaptchaSwitches(RecaptchaSwitchTypes(SwitchDetails(On), SwitchDetails(On)))),
+                Some(RecaptchaSwitches(RecaptchaSwitchTypes(Some(SwitchDetails(On)), Some(SwitchDetails(On))))),
                 Some(
                   OneOffPaymentMethodsSwitches(
                     OneOffPaymentMethodsSwitchesTypes(
-                      SwitchDetails(On),
-                      SwitchDetails(On),
-                      SwitchDetails(On),
-                      SwitchDetails(On),
-                      SwitchDetails(Off),
-                      SwitchDetails(On),
+                      Some(SwitchDetails(On)),
+                      Some(SwitchDetails(On)),
+                      Some(SwitchDetails(On)),
+                      Some(SwitchDetails(On)),
+                      Some(SwitchDetails(Off)),
+                      Some(SwitchDetails(On)),
                     ),
                   ),
                 ),
-                Some(FeatureSwitches(FeatureSwitchesTypes(SwitchDetails(On)))),
+                Some(FeatureSwitches(FeatureSwitchesTypes(Some(SwitchDetails(On))))),
               ),
             ),
           )

--- a/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
@@ -136,20 +136,20 @@ class StripeBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
     EitherT.right(
       Future.successful(
         Switches(
-          Some(RecaptchaSwitches(RecaptchaSwitchTypes(SwitchDetails(On), SwitchDetails(On)))),
+          Some(RecaptchaSwitches(RecaptchaSwitchTypes(Some(SwitchDetails(On)), Some(SwitchDetails(On))))),
           Some(
             OneOffPaymentMethodsSwitches(
               OneOffPaymentMethodsSwitchesTypes(
-                SwitchDetails(On),
-                SwitchDetails(On),
-                SwitchDetails(On),
-                SwitchDetails(On),
-                SwitchDetails(On),
-                SwitchDetails(On),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
               ),
             ),
           ),
-          Some(FeatureSwitches(FeatureSwitchesTypes(SwitchDetails(On)))),
+          Some(FeatureSwitches(FeatureSwitchesTypes(Some(SwitchDetails(On))))),
         ),
       ),
     )
@@ -157,20 +157,20 @@ class StripeBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
     EitherT.right(
       Future.successful(
         Switches(
-          Some(RecaptchaSwitches(RecaptchaSwitchTypes(SwitchDetails(On), SwitchDetails(On)))),
+          Some(RecaptchaSwitches(RecaptchaSwitchTypes(Some(SwitchDetails(On)), Some(SwitchDetails(On))))),
           Some(
             OneOffPaymentMethodsSwitches(
               OneOffPaymentMethodsSwitchesTypes(
-                SwitchDetails(Off),
-                SwitchDetails(Off),
-                SwitchDetails(Off),
-                SwitchDetails(Off),
-                SwitchDetails(On),
-                SwitchDetails(On),
+                Some(SwitchDetails(Off)),
+                Some(SwitchDetails(Off)),
+                Some(SwitchDetails(Off)),
+                Some(SwitchDetails(Off)),
+                Some(SwitchDetails(On)),
+                Some(SwitchDetails(On)),
               ),
             ),
           ),
-          Some(FeatureSwitches(FeatureSwitchesTypes(SwitchDetails(On)))),
+          Some(FeatureSwitches(FeatureSwitchesTypes(Some(SwitchDetails(On))))),
         ),
       ),
     )

--- a/support-payment-api/src/test/scala/model/switches/SwitchSerializationSpec.scala
+++ b/support-payment-api/src/test/scala/model/switches/SwitchSerializationSpec.scala
@@ -8,6 +8,7 @@ import services.SwitchState.On
 import services.Switches
 
 import scala.io.Source
+import services.SwitchDetails
 
 class SwitchSerializationSpec extends AnyFlatSpec with Matchers {
 
@@ -17,13 +18,17 @@ class SwitchSerializationSpec extends AnyFlatSpec with Matchers {
     val switches: Either[circe.Error, Switches] = decode[Switches](loadSwitches)
     switches.isRight mustBe true
     switches.map(switch =>
-      switch.recaptchaSwitches.map(recaptchaSwitch => recaptchaSwitch.switches.enableRecaptchaBackend.state mustBe On),
+      switch.recaptchaSwitches.map(recaptchaSwitch =>
+        recaptchaSwitch.switches.enableRecaptchaBackend mustBe Some(SwitchDetails(On)),
+      ),
     )
     switches.map(switch =>
       switch.oneOffPaymentMethods.map(oneOffPaymentSwitch => oneOffPaymentSwitch.switches.stripe mustBe None),
     )
     switches.map(switch =>
-      switch.oneOffPaymentMethods.map(oneOffPaymentSwitch => oneOffPaymentSwitch.switches.payPal.state mustBe On),
+      switch.oneOffPaymentMethods.map(oneOffPaymentSwitch =>
+        oneOffPaymentSwitch.switches.payPal mustBe Some(SwitchDetails(On)),
+      ),
     )
   }
 

--- a/support-payment-api/src/test/scala/model/switches/SwitchSerializationSpec.scala
+++ b/support-payment-api/src/test/scala/model/switches/SwitchSerializationSpec.scala
@@ -20,6 +20,9 @@ class SwitchSerializationSpec extends AnyFlatSpec with Matchers {
       switch.recaptchaSwitches.map(recaptchaSwitch => recaptchaSwitch.switches.enableRecaptchaBackend.state mustBe On),
     )
     switches.map(switch =>
+      switch.oneOffPaymentMethods.map(oneOffPaymentSwitch => oneOffPaymentSwitch.switches.stripe mustBe None),
+    )
+    switches.map(switch =>
       switch.oneOffPaymentMethods.map(oneOffPaymentSwitch => oneOffPaymentSwitch.switches.payPal.state mustBe On),
     )
   }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Making payment api switches optional, after doing the same for the frontend in #6209 

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/1PkjvuVX/971-deleting-a-switch-in-rrcp-takes-the-whole-site-down)

## Why are you doing this?

We've prevented deleted feature switches crashing the frontend, it makes sense to do this for the payment-api too.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Tests pass, will deploy to `CODE` and test a payment

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
