### PR TITLE
fix: add productPrices to appConfig

### DIFF
--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -6,7 +6,6 @@
 @import models.GeoData
 @import controllers.PaymentMethodConfigs
 @import com.gu.support.encoding.CustomCodecs._
-@import services.pricing.ProductPrices
 @import controllers.LandingPageProductPrices
 @import views.ViewHelpers.outputJson
 @import io.circe.JsonObject

--- a/support-frontend/assets/helpers/globalsAndSwitches/window.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/window.ts
@@ -4,6 +4,7 @@ import {
 	boolean,
 	intersect,
 	literal,
+	looseObject,
 	number,
 	object,
 	optional,
@@ -14,6 +15,7 @@ import {
 	union,
 } from 'valibot';
 import { isoCountries } from 'helpers/internationalisation/country';
+import type { ProductPrices } from 'helpers/productPrice/productPrices';
 
 /**
  * This file is used to validate data that get's injected from
@@ -67,11 +69,6 @@ const PaymentConfigSchema = object({
 			lastName: optional(string()),
 		}),
 	),
-	/**
-	 * productPrices, strangely, is valid as an empty object.
-	 * We should be trying to avoid using this anywho, and use productCatalog instead.
-	 */
-	productPrices: optional(object({})),
 	serversideTests: optional(object({})),
 	settings: object({
 		/**
@@ -215,15 +212,34 @@ const ProductCatalogSchema = object({
 							id: string(),
 						}),
 					),
+					billingPeriod: optional(picklist(['Quarter', 'Month', 'Annual'])),
 				}),
 			),
 		}),
 	),
 });
 
-const AppConfigSchema = intersect([PaymentConfigSchema, ProductCatalogSchema]);
+/**
+ * We parse productPrices through as a looseObject (no validation)
+ * and then type it on the InferOutput using the existing types.
+ *
+ * This is partly because it is a model that needs refactoring now
+ * we're moving into a more product focussed world, but also because
+ * when creating the valibot schema we get this error
+ * `Type instantiation is excessively deep and possibly infinite.`
+ */
+const ProductPricesSchema = object({
+	productPrices: optional(looseObject({})),
+});
+const AppConfigSchema = intersect([
+	PaymentConfigSchema,
+	ProductCatalogSchema,
+	ProductPricesSchema,
+]);
 
-export type AppConfig = InferOutput<typeof AppConfigSchema>;
+export type AppConfig = InferOutput<typeof AppConfigSchema> & {
+	productPrices?: ProductPrices;
+};
 
 export const parseAppConfig = (obj: unknown) => {
 	const appConfig = safeParse(AppConfigSchema, obj);


### PR DESCRIPTION
Adds `productPrices` parsing to `AppConfig`. This means that the value is passed through to the app, and we can then calculate promotions.

This fixes the bug that promotions aren't working on the generic checkout - specifically for `SupporterPlus`.