### PR TITLE
fix: use `currencyKey` instead of hardcoded `gbp` on `StripeExpressCheckout`

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -387,7 +387,7 @@ export function Checkout({ geoId, appConfig }: Props) {
 				 * @see https://docs.stripe.com/currencies#zero-decimal
 				 */
 				amount: priceInt * 100,
-				currency: 'gbp',
+				currency: currencyKey.toLowerCase(),
 				paymentMethodCreation: 'manual',
 			} as const;
 			useStripeExpressCheckout = true;


### PR DESCRIPTION
Uses the dynamic currencyKey instead of hardcoded `gbp` when making a recurring contribution.

## Screenshots

### €
<img width="705" alt="Screenshot 2024-08-08 at 16 10 02" src="https://github.com/user-attachments/assets/630a4391-8113-4758-9ba9-cdfce6ff2fd9">

### $
<img width="699" alt="Screenshot 2024-08-08 at 16 09 45" src="https://github.com/user-attachments/assets/28611a0b-cde5-4187-9c1e-57f9a2c4903a">
