### PR TITLE
fix: set StripeExpress payment postcode and state

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -1102,6 +1102,14 @@ function CheckoutComponent({
 													setFirstName(firstName);
 													setLastName(lastName);
 
+													event.billingDetails?.address.postal_code &&
+														setBillingPostcode(
+															event.billingDetails.address.postal_code,
+														);
+
+													event.billingDetails?.address.state &&
+														setBillingState(event.billingDetails.address.state);
+
 													event.billingDetails?.email &&
 														setEmail(event.billingDetails.email);
 


### PR DESCRIPTION
Sets a the postcode and state of a person from the [Stripe billingAddress](https://docs.stripe.com/js/custom_checkout/session_object#custom_checkout_session_object-savedPaymentMethods-billingDetails-address) to ensure we pass the state validation.

This has a bug where if a person is accessing the site from `/us/checkout` but has a e.g. UK address and thus no state, we cannot take a payment as state is required.

https://trello.com/c/ZD2BbAod/932-supportworkers-alarm-promocode-country-not-aligning-with-applepay-googlepay-country