### PR TITLE
feat: add checkout label to referrerAcquisitionData

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -867,7 +867,10 @@ function CheckoutComponent({
 
 		/** Form: tracking data  */
 		const ophanIds = getOphanIds();
-		const referrerAcquisitionData = getReferrerAcquisitionData();
+		const referrerAcquisitionData = {
+			...getReferrerAcquisitionData(),
+			labels: ['generic-checkout'],
+		};
 
 		if (paymentMethod && paymentFields) {
 			/** TODO

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -234,7 +234,10 @@ function regularPaymentRequestFromAuthorisation(
 		},
 		...getPromoCode(state),
 		ophanIds: getOphanIds(),
-		referrerAcquisitionData: state.common.referrerAcquisitionData,
+		referrerAcquisitionData: {
+			...state.common.referrerAcquisitionData,
+			labels: ['contribution-checkout'],
+		},
 		supportAbTests: getSupportAbTests(state.common.abParticipations),
 		debugInfo: actionHistory,
 	};


### PR DESCRIPTION
This adds the `contribution-checkout | generic-checkout` to the `referrerAcquisitionData` posted to the create endpoint.

We are doing this to help with the analysis of how the new checkouts are performing.

The data we hope to compare is:
- Pageviews to contribution checkout / acquisitions from contributions checkout
- Pageviews to generic checkout / acquisitions from generic checkout

This PR should help with the right hand/consequent part of that ratio.

Currently we are using the `abTest: { useGenericCheckout: control | variant }` which is not completely reliable as there are multiple entry points into a checkout e.g. an email. So if you have a link that directly takes you to `/uk/contribute/checkout` you might be designated to `variant`, which in this case would be false data.

## testing

I have run this through on multiple products, in the output data of the step-functions:
- `"labels": ["contribution-checkout"]` for `/{geo}/contribute/checkout`
- `"labels": ["generic-checkout"]` for `/{geo}/checkout`
- `"labels": null` for everything else

Given [there is a `labels` field in the `fact_acquisitions_event` table](https://github.com/guardian/data-platform-models/blob/e7a01afc379589b65060246f13b93a69dbb48259/dbt/models/staging/acquisition/stg_fact_acquisition_event.sql#L58), I assume this will propagate there on `PROD` but it's hard to test as we don't have a `CODE` stage for BigQuery.