### PR TITLE
feat: use payment abstraction in checkout

### DIFF
--- a/support-frontend/assets/helpers/globalsAndSwitches/window.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/window.ts
@@ -229,7 +229,7 @@ const ProductCatalogSchema = object({
  * `Type instantiation is excessively deep and possibly infinite.`
  */
 const ProductPricesSchema = object({
-	productPrices: optional(looseObject({})),
+	productPrices: looseObject({}),
 });
 const AppConfigSchema = intersect([
 	PaymentConfigSchema,
@@ -238,7 +238,7 @@ const AppConfigSchema = intersect([
 ]);
 
 export type AppConfig = InferOutput<typeof AppConfigSchema> & {
-	productPrices?: ProductPrices;
+	productPrices: ProductPrices;
 };
 
 export const parseAppConfig = (obj: unknown) => {

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -349,7 +349,7 @@ export function Checkout({ geoId, appConfig }: Props) {
 	 * - `discountredAmount` the amount with a discountApplied
 	 * - `finalAmount` is the amount a person will pay
 	 */
-	let amount: {
+	let payment: {
 		originalAmount: number;
 		discountedAmount?: number;
 		finalAmount: number;
@@ -370,7 +370,7 @@ export function Checkout({ geoId, appConfig }: Props) {
 			return <div>Contribution not specified</div>;
 		}
 
-		amount = {
+		payment = {
 			originalAmount: contributionAmount,
 			finalAmount: contributionAmount,
 		};
@@ -416,13 +416,13 @@ export function Checkout({ geoId, appConfig }: Props) {
 
 		if (productKey === 'SupporterPlus') {
 			/** SupporterPlus can have an additional contribution bolted onto the base price */
-			amount = {
+			payment = {
 				originalAmount: productPrice,
 				discountedAmount: discountedPrice,
 				finalAmount: price + (contributionAmount ?? 0),
 			};
 		} else {
-			amount = {
+			payment = {
 				originalAmount: productPrice,
 				discountedAmount: discountedPrice,
 				finalAmount: price,
@@ -464,7 +464,7 @@ export function Checkout({ geoId, appConfig }: Props) {
 				 * @see https://docs.stripe.com/api/charges/object
 				 * @see https://docs.stripe.com/currencies#zero-decimal
 				 */
-				amount: amount.finalAmount * 100,
+				amount: payment.finalAmount * 100,
 				currency: currencyKey.toLowerCase(),
 				paymentMethodCreation: 'manual',
 			} as const;
@@ -480,9 +480,9 @@ export function Checkout({ geoId, appConfig }: Props) {
 				productKey={productKey}
 				ratePlanKey={ratePlanKey}
 				promotion={promotion}
-				originalAmount={amount.originalAmount}
-				finalAmount={amount.finalAmount}
-				discountedAmount={amount.discountedAmount}
+				originalAmount={payment.originalAmount}
+				finalAmount={payment.finalAmount}
+				discountedAmount={payment.discountedAmount}
 				useStripeExpressCheckout={useStripeExpressCheckout}
 			/>
 		</Elements>

--- a/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
@@ -9,7 +9,7 @@ import {
 } from '@guardian/source/react-components';
 import { FooterWithContents } from '@guardian/source-development-kitchen/react-components';
 import type { InferInput } from 'valibot';
-import { number, object, picklist, safeParse, string } from 'valibot';
+import { number, object, optional, picklist, safeParse, string } from 'valibot';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
 import type { ThankYouModuleType } from 'components/thankYou/thankYouModule';
@@ -60,7 +60,9 @@ export const buttonContainer = css`
  */
 const OrderSchema = object({
 	firstName: string(),
-	price: number(),
+	originalAmount: number(),
+	discountedAmount: optional(number()),
+	finalAmount: number(),
 	product: picklist(productKeys),
 	ratePlan: string(),
 	paymentMethod: picklist([
@@ -133,14 +135,14 @@ export function ThankYou({ geoId }: Props) {
 				? 'Stripe'
 				: order.paymentMethod;
 		successfulContributionConversion(
-			order.price,
+			order.originalAmount,
 			contributionType,
 			currencyKey,
 			paymentMethod,
 		);
 		// track conversion with QM
 		sendEventContributionCheckoutConversion(
-			order.price,
+			order.originalAmount,
 			contributionType,
 			currencyKey,
 		);
@@ -223,7 +225,7 @@ export function ThankYou({ geoId }: Props) {
 						<ThankYouHeader
 							isSignedIn={isSignedIn}
 							name={order.firstName}
-							amount={order.price}
+							amount={order.originalAmount}
 							contributionType={contributionType}
 							amountIsAboveThreshold={isSupporterPlus}
 							isTier3={isTier3}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -455,7 +455,7 @@ export function ThreeTierLanding(): JSX.Element {
 	const tier1GenericCheckoutUrlParams = new URLSearchParams({
 		product: 'Contribution',
 		ratePlan: selectedContributionRatePlan,
-		price: recurringAmount.toString(),
+		contribution: recurringAmount.toString(),
 	});
 	const tier1GenericCheckoutLink = `checkout?${tier1GenericCheckoutUrlParams.toString()}`;
 


### PR DESCRIPTION
Whilst trying to get the right abstraction to allow for both
- `Contribution`: a product, no price, a voluntary contribution, no discount
- `SupporterPlus`: a product, a price, a voluntary contribution, promotional discounts

And having 1 eye on the fact we will have to support
- `OneTime`: not a product, no price, a voluntary contribution, no discounts

It felt that could be abstracted to:
- `originalAmount` the person would pay without a discount or contribution
- `discountedAmount` the amount a person would pay with a discount applied
- `contribution` and amount extra to the `originalAmount`
- `finalAmount` the amount a person will pay

This PR has the naming in such a way that we transform product prices (what something costs) => payment (what someone pays).

While this isn't anything new per say - I feel the naming is a little clearer and should be easier to get `OneTime` payments to fit this abstraction.

We could also write a test for the `product` => `payment` abstraction. 

This also enables `ExpressCheckout` for `SupporterPlus`