### PR TITLE
Generic Checkout : Tier2 and Tier3 Promotions Supported

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -96,6 +96,7 @@ import {
 	productCatalog,
 	productCatalogDescription,
 } from 'helpers/productCatalog';
+import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { NoFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
 import type { Promotion } from 'helpers/productPrice/promotions';
@@ -306,7 +307,7 @@ type Props = {
 	appConfig: AppConfig;
 };
 export function Checkout({ geoId, appConfig }: Props) {
-	const { currencyKey } = getGeoIdConfig(geoId);
+	const { currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 	const searchParams = new URLSearchParams(window.location.search);
 
 	/** Get and validate product */
@@ -365,6 +366,22 @@ export function Checkout({ geoId, appConfig }: Props) {
 				? 'Monthly'
 				: 'Annual';
 
+		let fulfilmentOption: FulfilmentOptions;
+
+		switch (productKey) {
+			case 'SupporterPlus':
+			case 'Contribution':
+				fulfilmentOption = 'NoFulfilmentOptions';
+				break;
+			case 'TierThree':
+				fulfilmentOption =
+					countryGroupId === 'International' ? 'RestOfWorld' : 'Domestic';
+				break;
+			default:
+				// ToDo: define for every product here
+				fulfilmentOption = 'NoFulfilmentOptions';
+		}
+
 		promotion = getPromotion(
 			productPrices,
 			countryId,
@@ -373,7 +390,7 @@ export function Checkout({ geoId, appConfig }: Props) {
 			 * TODO: This is going to have to be changed when we start supporting products
 			 * with fulfilmentOptions
 			 */
-			'NoFulfilmentOptions',
+			fulfilmentOption,
 		);
 	}
 

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -386,10 +386,6 @@ export function Checkout({ geoId, appConfig }: Props) {
 			productPrices,
 			countryId,
 			billingPeriod,
-			/**
-			 * TODO: This is going to have to be changed when we start supporting products
-			 * with fulfilmentOptions
-			 */
 			fulfilmentOption,
 		);
 	}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -366,21 +366,21 @@ export function Checkout({ geoId, appConfig }: Props) {
 				? 'Monthly'
 				: 'Annual';
 
-		let fulfilmentOption: FulfilmentOptions;
-
-		switch (productKey) {
-			case 'SupporterPlus':
-			case 'Contribution':
-				fulfilmentOption = 'NoFulfilmentOptions';
-				break;
-			case 'TierThree':
-				fulfilmentOption =
-					countryGroupId === 'International' ? 'RestOfWorld' : 'Domestic';
-				break;
-			default:
-				// ToDo: define for every product here
-				fulfilmentOption = 'NoFulfilmentOptions';
-		}
+		const getFulfilmentOptions = (productKey: string): FulfilmentOptions => {
+			switch (productKey) {
+				case 'SupporterPlus':
+				case 'Contribution':
+					return 'NoFulfilmentOptions';
+				case 'TierThree':
+					return countryGroupId === 'International'
+						? 'RestOfWorld'
+						: 'Domestic';
+				default:
+					// ToDo: define for every product here
+					return 'NoFulfilmentOptions';
+			}
+		};
+		const fulfilmentOption = getFulfilmentOptions(productKey);
 
 		promotion = getPromotion(
 			productPrices,


### PR DESCRIPTION
## What are you doing in this PR?

FulfilmentOptions change dependent on ProductType ->
S+/Contribution :  `NoFulFilmentOption`
TierThree :  `Domestic` / `RestOfWorld`

## How to test

https://support.thegulocal.com/us/checkout?product=SupporterPlus&ratePlan=Monthly&price=15&promoCode=LX4FFRA8

https://support.thegulocal.com/uk/checkout?product=TierThree&ratePlan=DomesticMonthly&promoCode=TIER3_UK_MONTHLY

## Screenshots
|S+|Tier3|
|-----|-----|
|![image](https://github.com/user-attachments/assets/60e500bc-75dc-418b-b3eb-9826b5f0399c)|![image](https://github.com/user-attachments/assets/fe95ddb3-5895-4b79-bd39-b0c526772055)|

