### PR TITLE
Remove unused setupSubscriptionPayPalPaymentWithShipping method

### DIFF
--- a/support-frontend/assets/helpers/forms/paymentIntegrations/payPalRecurringCheckout.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/payPalRecurringCheckout.ts
@@ -127,7 +127,6 @@ const setupSubscriptionPayPalPayment =
 		csrf: CsrfState,
 		amount: number,
 		billingPeriod: BillingPeriod,
-		requireShippingAddress: boolean,
 	) =>
 	(): void => {
 		const csrfToken = csrf.token;
@@ -136,7 +135,7 @@ const setupSubscriptionPayPalPayment =
 			amount,
 			billingPeriod,
 			currency,
-			requireShippingAddress,
+			requireShippingAddress: false,
 		};
 		fetch(
 			routes.payPalSetupPayment,
@@ -161,42 +160,6 @@ const setupSubscriptionPayPalPayment =
 				reject(err);
 			});
 	};
-
-const setupSubscriptionPayPalPaymentNoShipping = (
-	resolve: (arg0: string) => void,
-	reject: (arg0: Error) => void,
-	currency: IsoCurrency,
-	csrf: CsrfState,
-	amount: number,
-	billingPeriod: BillingPeriod,
-): (() => void) =>
-	setupSubscriptionPayPalPayment(
-		resolve,
-		reject,
-		currency,
-		csrf,
-		amount,
-		billingPeriod,
-		false,
-	);
-
-const setupSubscriptionPayPalPaymentWithShipping = (
-	resolve: (arg0: string) => void,
-	reject: (arg0: Error) => void,
-	currency: IsoCurrency,
-	csrf: CsrfState,
-	amount: number,
-	billingPeriod: BillingPeriod,
-): (() => void) =>
-	setupSubscriptionPayPalPayment(
-		resolve,
-		reject,
-		currency,
-		csrf,
-		amount,
-		billingPeriod,
-		true,
-	);
 
 const setupPayment = (
 	currencyId: IsoCurrency,
@@ -309,7 +272,6 @@ export {
 	getPayPalOptions,
 	loadPayPalRecurring,
 	payPalRequestData,
-	setupSubscriptionPayPalPaymentNoShipping,
+	setupSubscriptionPayPalPayment,
 	setupRecurringPayPalPayment,
-	setupSubscriptionPayPalPaymentWithShipping,
 };

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -35,7 +35,7 @@ import { PayPalSubmitButton } from 'components/subscriptionCheckouts/payPalSubmi
 import PersonalDetails from 'components/subscriptionCheckouts/personalDetails';
 import { StripeProviderForCountry } from 'components/subscriptionCheckouts/stripeForm/stripeProviderForCountry';
 import Text from 'components/text/text';
-import { setupSubscriptionPayPalPaymentNoShipping } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
+import { setupSubscriptionPayPalPayment } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 import { DirectDebit, PayPal, Stripe } from 'helpers/forms/paymentMethods';
 import { newspaperCountries } from 'helpers/internationalisation/country';
 import {
@@ -164,7 +164,7 @@ function mapDispatchToProps() {
 					);
 				}
 			},
-		setupRecurringPayPalPayment: setupSubscriptionPayPalPaymentNoShipping,
+		setupRecurringPayPalPayment: setupSubscriptionPayPalPayment,
 		signOut,
 		setCsrCustomerData: (customerData: CsrCustomerData) =>
 			setCsrCustomerData('delivery', customerData),

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -37,7 +37,7 @@ import Summary from 'components/subscriptionCheckouts/summary';
 import ThreeTierTerms from 'components/subscriptionCheckouts/threeTierTerms';
 import Total from 'components/subscriptionCheckouts/total/total';
 import Text from 'components/text/text';
-import { setupSubscriptionPayPalPaymentNoShipping } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
+import { setupSubscriptionPayPalPayment } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 import { DirectDebit, PayPal, Stripe } from 'helpers/forms/paymentMethods';
 import {
 	currencies,
@@ -149,7 +149,7 @@ function mapDispatchToProps() {
 					trackSubmitAttempt(PayPal, GuardianWeekly, NoProductOptions);
 				}
 			},
-		setupRecurringPayPalPayment: setupSubscriptionPayPalPaymentNoShipping,
+		setupRecurringPayPalPayment: setupSubscriptionPayPalPayment,
 		setCsrCustomerData: (customerData: CsrCustomerData) =>
 			setCsrCustomerData('delivery', customerData),
 		setStripePublicKey,

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
@@ -35,7 +35,7 @@ import { StripeProviderForCountry } from 'components/subscriptionCheckouts/strip
 import Summary from 'components/subscriptionCheckouts/summary';
 import Total from 'components/subscriptionCheckouts/total/total';
 import Text from 'components/text/text';
-import { setupSubscriptionPayPalPaymentNoShipping } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
+import { setupSubscriptionPayPalPayment } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 import { DirectDebit, PayPal, Stripe } from 'helpers/forms/paymentMethods';
 import { currencyFromCountryCode } from 'helpers/internationalisation/currency';
 import { gwCountries } from 'helpers/internationalisation/gwCountries';
@@ -139,7 +139,7 @@ function mapDispatchToProps() {
 					trackSubmitAttempt(PayPal, GuardianWeekly, NoProductOptions);
 				}
 			},
-		setupRecurringPayPalPayment: setupSubscriptionPayPalPaymentNoShipping,
+		setupRecurringPayPalPayment: setupSubscriptionPayPalPayment,
 		setStripePublicKey,
 	};
 }


### PR DESCRIPTION
## What are you doing in this PR?

Removes unused `setupSubscriptionPayPalPaymentWithShipping` from `payPalRecurringCheckout.ts` module, this export was not imported anywhere.

### Changes
- Delete `setupSubscriptionPayPalPaymentWithShipping` as wasn't used anywhere.
- `setupSubscriptionPayPalPaymentNoShipping` was now only place where `setupSubscriptionPayPalPayment` was called, so I've removed `setupSubscriptionPayPalPaymentNoShipping` and replaced any places it was called with a direct call to `setupSubscriptionPayPalPayment`
- The `requireShippingAddress` parameter in `setupSubscriptionPayPalPayment` is no longer needed so I've removed it, and we just set this to `false` in the function.

The  `setupSubscriptionPayPalPaymentWithShipping`/``setupSubscriptionPayPalPaymentNoShipping`  functions were introduced in an AB test on the old Digi Sub landing page: https://github.com/guardian/support-frontend/pull/3249

## Why are you doing this?

Tidying-up code 

## Testing

Tested Newspaper, GW, GW Gift subscriptions checkouts locally w/ Paypal