### PR TITLE
PayPal env in generic checkout

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -1794,7 +1794,7 @@ function CheckoutComponent({
 
 												<PayPalButton
 													env={
-														isTestUser || !isProd() ? 'sandbox' : 'production'
+														isProd() && !isTestUser ? 'production': 'sandbox'
 													}
 													style={{
 														color: 'blue',

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -1794,7 +1794,7 @@ function CheckoutComponent({
 
 												<PayPalButton
 													env={
-														isProd() && !isTestUser ? 'production': 'sandbox'
+														isProd() && !isTestUser ? 'production' : 'sandbox'
 													}
 													style={{
 														color: 'blue',

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -109,6 +109,7 @@ import {
 	getSupportAbTests,
 } from 'helpers/tracking/acquisitions';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
+import { isProd } from 'helpers/urls/url';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
 import { CheckoutDivider } from 'pages/supporter-plus-landing/components/checkoutDivider';
@@ -1792,7 +1793,9 @@ function CheckoutComponent({
 												/>
 
 												<PayPalButton
-													env={isTestUser ? 'sandbox' : 'production'}
+													env={
+														isTestUser || !isProd() ? 'sandbox' : 'production'
+													}
 													style={{
 														color: 'blue',
 														size: 'responsive',


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Check what env we're in when selecting the PayPal env on the generic checkout

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


## Why are you doing this?

We were seeing this when testing Paypal locally/in CODE
![image](https://github.com/user-attachments/assets/ce82a242-4d82-4ec3-9507-560235f9203d)


<!--
Remember, PRs are documentation for future contributors.
-->