### PR TITLE
fix: send correct amount to /create endpoint for `SupporterPlus`

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -357,6 +357,7 @@ export function Checkout({ geoId, appConfig }: Props) {
 	let payment: {
 		originalAmount: number;
 		discountedAmount?: number;
+		contributionAmount?: number;
 		finalAmount: number;
 	};
 
@@ -436,12 +437,14 @@ export function Checkout({ geoId, appConfig }: Props) {
 			payment = {
 				originalAmount: productPrice,
 				discountedAmount: discountedPrice,
+				contributionAmount,
 				finalAmount: price + (contributionAmount ?? 0),
 			};
 		} else {
 			payment = {
 				originalAmount: productPrice,
 				discountedAmount: discountedPrice,
+				contributionAmount,
 				finalAmount: price,
 			};
 		}
@@ -498,8 +501,9 @@ export function Checkout({ geoId, appConfig }: Props) {
 				ratePlanKey={ratePlanKey}
 				promotion={promotion}
 				originalAmount={payment.originalAmount}
-				finalAmount={payment.finalAmount}
 				discountedAmount={payment.discountedAmount}
+				contributionAmount={payment.contributionAmount}
+				finalAmount={payment.finalAmount}
 				useStripeExpressCheckout={useStripeExpressCheckout}
 			/>
 		</Elements>
@@ -513,6 +517,7 @@ type CheckoutComponentProps = {
 	ratePlanKey: string;
 	originalAmount: number;
 	discountedAmount?: number;
+	contributionAmount?: number;
 	finalAmount: number;
 	promotion?: Promotion;
 	useStripeExpressCheckout: boolean;
@@ -524,6 +529,7 @@ function CheckoutComponent({
 	ratePlanKey,
 	originalAmount,
 	discountedAmount,
+	contributionAmount,
 	finalAmount,
 	promotion,
 	useStripeExpressCheckout,
@@ -581,7 +587,17 @@ function CheckoutComponent({
 				productType: 'SupporterPlus',
 				currency: currencyKey,
 				billingPeriod: ratePlanDescription.billingPeriod,
-				amount: finalAmount,
+				/**
+				 * We shouldn't have to calculate these amounts here.
+				 *
+				 * TODO: remove the amount altogether and send only the contribution amount.
+				 * but they're a legacy of how the support-workers works i.e
+				 * - contribution = thisAmount - original
+				 * - if contribution < 0, fail
+				 * - apply any promo
+				 * @see https://github.com/guardian/support-frontend/blob/51b06f33a0f9f70628154e100374d5933708e38f/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/SupporterPlusSubcriptionBuilder.scala#L38-L42
+				 */
+				amount: originalAmount + (contributionAmount ?? 0),
 			};
 			break;
 

--- a/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
@@ -224,7 +224,7 @@ export function ThankYou({ geoId }: Props) {
 						<ThankYouHeader
 							isSignedIn={isSignedIn}
 							name={order.firstName}
-							amount={order.originalAmount}
+							amount={order.finalAmount}
 							contributionType={contributionType}
 							amountIsAboveThreshold={isSupporterPlus}
 							isTier3={isTier3}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -481,7 +481,6 @@ export function ThreeTierLanding(): JSX.Element {
 	const tier2GenericUrlParams = new URLSearchParams({
 		product: 'SupporterPlus',
 		ratePlan: supporterPlusRatePlan,
-		price: tier2Pricing.toString(),
 	});
 	const tier2ContributeUrlParams = new URLSearchParams({
 		'selected-amount': tier2Pricing.toString(),


### PR DESCRIPTION
Sends the correct `amount` to the `/create` endpoint for `SupporterPlus`.

The logic is described in a comment in the code.

Currently `promoCodes` don't work on the generic checkout for `SupporterPlus` because of this.

[This will get us closer to releasing the test for generic checkout for S+](https://github.com/guardian/support-frontend/pull/6236).