### PR TITLE
feat: Enable generic checkout 50% test for SupporterPlus

### DIFF
--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -279,10 +279,36 @@ const testDetailsPromo = [
 		expectedThankYouText:
 			/You'll pay £(\d|\.)+\/year for the first year, then £(\d|\.)+\/year afterwards unless you cancel\./i,
 	},
+	{
+		tier: 2,
+		frequency: 'Monthly',
+		promoCode: 'E2E_TEST_SPLUS_MONTHLY',
+		expectedCardHeading: 'All-access digital',
+		expectedPromoText:
+			/£(\d|\.)+\/month for (\d|\.) months, then £(\d|\.)+\/month/,
+		expectedCheckoutTotalText: 'Was £12, now £9.60/month',
+		expectedThankYouText:
+			/You'll pay £(\d|\.)+\/month for the first (\d|\.)+ months, then £(\d|\.)+\/month afterwards unless you cancel\./,
+		abTestHash: '#ab-useGenericCheckout=variant',
+	},
+	{
+		tier: 2,
+		frequency: 'Annual',
+		promoCode: 'E2E_TEST_SPLUS_ANNUAL',
+		expectedCardHeading: 'All-access digital',
+		expectedPromoText:
+			/£(\d|\.)+\/year for the first year, then £(\d|\.)+\/year/i,
+		expectedCheckoutTotalText: /Was £(\d|\.)+, now £(\d|\.)+\/year/i,
+		expectedThankYouText:
+			/You'll pay £(\d|\.)+\/year for the first year, then £(\d|\.)+\/year afterwards unless you cancel\./i,
+		abTestHash: '#ab-useGenericCheckout=variant',
+	},
 ];
 test.describe('SupporterPlus promoCodes', () => {
 	testDetailsPromo.forEach((testDetails) => {
-		test(`Tier-${testDetails.tier} incl PromoCode ${testDetails.frequency} with Credit/Debit card - UK`, async ({
+		test(`Tier-${testDetails.tier} incl PromoCode ${
+			testDetails.frequency
+		} with Credit/Debit card - UK${testDetails.abTestHash ?? ''}`, async ({
 			context,
 			baseURL,
 		}) => {
@@ -297,7 +323,9 @@ test.describe('SupporterPlus promoCodes', () => {
 				page,
 				context,
 				baseURL,
-				`/uk/contribute?promoCode=${testDetails.promoCode}`,
+				`/uk/contribute?promoCode=${testDetails.promoCode}${
+					testDetails.abTestHash ?? ''
+				}`,
 			);
 			await page.getByRole('tab').getByText(testDetails.frequency).click();
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -392,7 +392,7 @@ export function ThreeTierLanding(): JSX.Element {
 			/**
 			 * Only Testing CardTier1 wth checkout
 			 */
-			if ((useGenericCheckout && cardTier === 1) || tier2UseGenericCheckout) {
+			if (useGenericCheckout) {
 				/**
 				 * Generic Checkout is not defined in supporterPlusRouter
 				 */
@@ -469,8 +469,6 @@ export function ThreeTierLanding(): JSX.Element {
 	};
 
 	/** Tier 2: SupporterPlus */
-	const tier2UseGenericCheckout = abParticipations.tierTwoFromApi === 'variant';
-
 	const supporterPlusRatePlan =
 		contributionType === 'ANNUAL' ? 'Annual' : 'Monthly';
 	const tier2Pricing =
@@ -488,14 +486,14 @@ export function ThreeTierLanding(): JSX.Element {
 		'selected-contribution-type': selectedContributionType,
 		product: 'SupporterPlus',
 	});
-	const tier2UrlParams = tier2UseGenericCheckout
+	const tier2UrlParams = useGenericCheckout
 		? tier2GenericUrlParams
 		: tier2ContributeUrlParams;
 	if (promotionTier2) {
 		tier2UrlParams.set('promoCode', promotionTier2.promoCode);
 	}
 	const tier2Url = `${
-		tier2UseGenericCheckout ? '' : 'contribute/'
+		useGenericCheckout ? '' : 'contribute/'
 	}checkout?${tier2UrlParams.toString()}`;
 	const tier2Card = {
 		productDescription: productCatalogDescription.SupporterPlus,


### PR DESCRIPTION
Enabled the 50% test for sending people to the generic checkout for SupporterPlus from Tier 2 of the landing page.

This also adds some test to ensure that we're working and that we don't add any regressions.

![Screenshot 2024-08-20 at 11 50 58](https://github.com/user-attachments/assets/f49352cd-4479-485b-bc24-82752379fd3d)

~Currently the tests do not pass - so I will be attaching some PRs until they do.~