### PR TITLE
Use qs params to power thank-you page

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -314,6 +314,7 @@ export function Checkout({ geoId, appConfig }: Props) {
 	const { currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 	const searchParams = new URLSearchParams(window.location.search);
 
+	/** 👇 a lot of this is copy/pasted into the thank you page */
 	/** Get and validate product */
 	const productParam = searchParams.get('product');
 	const productKey =
@@ -517,13 +518,13 @@ type CheckoutComponentProps = {
 	promotion?: Promotion;
 	useStripeExpressCheckout: boolean;
 };
+
 function CheckoutComponent({
 	geoId,
 	appConfig,
 	productKey,
 	ratePlanKey,
 	originalAmount,
-	discountedAmount,
 	finalAmount,
 	promotion,
 	useStripeExpressCheckout,
@@ -1004,11 +1005,6 @@ function CheckoutComponent({
 			if (processPaymentResponse.status === 'success') {
 				const order = {
 					firstName: personalData.firstName,
-					originalAmount,
-					discountedAmount,
-					finalAmount,
-					product: productKey,
-					ratePlan: ratePlanKey,
 					paymentMethod: paymentMethod,
 				};
 				setThankYouOrder(order);

--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -17,7 +17,7 @@ const router = createBrowserRouter(
 		},
 		{
 			path: `/${geoId}/thank-you`,
-			element: <ThankYou geoId={geoId} />,
+			element: <ThankYou geoId={geoId} appConfig={appConfig} />,
 		},
 	]),
 );

--- a/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
@@ -9,18 +9,24 @@ import {
 } from '@guardian/source/react-components';
 import { FooterWithContents } from '@guardian/source-development-kitchen/react-components';
 import type { InferInput } from 'valibot';
-import { number, object, optional, picklist, safeParse, string } from 'valibot';
+import { object, picklist, safeParse, string } from 'valibot';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
 import type { ThankYouModuleType } from 'components/thankYou/thankYouModule';
 import ThankYouModule from 'components/thankYou/thankYouModule';
 import { getThankYouModuleData } from 'components/thankYou/thankYouModuleData';
+import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import CountryHelper from 'helpers/internationalisation/classes/country';
+import type { ProductKey } from 'helpers/productCatalog';
 import {
 	filterBenefitByRegion,
+	isProductKey,
+	productCatalog,
 	productCatalogDescription,
-	productKeys,
 } from 'helpers/productCatalog';
+import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import type { Promotion } from 'helpers/productPrice/promotions';
+import { getPromotion } from 'helpers/productPrice/promotions';
 import { get } from 'helpers/storage/cookie';
 import { OPHAN_COMPONENT_ID_RETURN_TO_GUARDIAN } from 'helpers/thankYouPages/utils/ophan';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
@@ -60,11 +66,6 @@ export const buttonContainer = css`
  */
 const OrderSchema = object({
 	firstName: string(),
-	originalAmount: number(),
-	discountedAmount: optional(number()),
-	finalAmount: number(),
-	product: picklist(productKeys),
-	ratePlan: string(),
 	paymentMethod: picklist([
 		'Stripe',
 		'StripeExpressCheckoutElement',
@@ -84,8 +85,160 @@ export function unsetThankYouOrder() {
 
 type Props = {
 	geoId: GeoId;
+	appConfig: AppConfig;
 };
-export function ThankYou({ geoId }: Props) {
+
+export function ThankYou({ geoId, appConfig }: Props) {
+	/** 👇 a lot of this is copy/pasted from the checkout */
+	const countryId = CountryHelper.detect();
+
+	const { currencyKey, countryGroupId } = getGeoIdConfig(geoId);
+	const searchParams = new URLSearchParams(window.location.search);
+
+	/** Get and validate product */
+	const productParam = searchParams.get('product');
+	const productKey =
+		productParam && isProductKey(productParam) ? productParam : undefined;
+	const product = productKey && productCatalog[productKey];
+	if (!product) {
+		return <div>Product not found</div>;
+	}
+
+	/** Get and validate ratePlan */
+	const ratePlanParam = searchParams.get('ratePlan');
+	const ratePlanKey =
+		ratePlanParam && ratePlanParam in product.ratePlans
+			? ratePlanParam
+			: undefined;
+	const ratePlan = ratePlanKey && product.ratePlans[ratePlanKey];
+	if (!ratePlan) {
+		return <div>Rate plan not found</div>;
+	}
+
+	/** Get and validate the amount */
+	let payment: {
+		originalAmount: number;
+		discountedAmount?: number;
+		contributionAmount?: number;
+		finalAmount: number;
+	};
+
+	const contributionParam = searchParams.get('contribution');
+	const contributionAmount = contributionParam
+		? parseInt(contributionParam, 10)
+		: undefined;
+
+	let promotion;
+	if (productKey === 'Contribution') {
+		if (!contributionAmount) {
+			return <div>Contribution not specified</div>;
+		}
+
+		payment = {
+			originalAmount: contributionAmount,
+			finalAmount: contributionAmount,
+		};
+	} else {
+		const productPrice =
+			currencyKey in ratePlan.pricing
+				? ratePlan.pricing[currencyKey]
+				: undefined;
+
+		if (!productPrice) {
+			return <div>Price not found in product catalog</div>;
+		}
+
+		/** Get any promotions */
+		const productPrices = appConfig.productPrices;
+
+		/**
+		 * This is some annoying transformation we need from
+		 * Product API => Contributions work we need to do
+		 */
+		const billingPeriod =
+			ratePlan.billingPeriod === 'Quarter'
+				? 'Quarterly'
+				: ratePlan.billingPeriod === 'Month'
+				? 'Monthly'
+				: 'Annual';
+
+		const getFulfilmentOptions = (productKey: string): FulfilmentOptions => {
+			switch (productKey) {
+				case 'SupporterPlus':
+				case 'Contribution':
+					return 'NoFulfilmentOptions';
+				case 'TierThree':
+					return countryGroupId === 'International'
+						? 'RestOfWorld'
+						: 'Domestic';
+				default:
+					// ToDo: define for every product here
+					return 'NoFulfilmentOptions';
+			}
+		};
+		const fulfilmentOption = getFulfilmentOptions(productKey);
+
+		promotion = getPromotion(
+			productPrices,
+			countryId,
+			billingPeriod,
+			fulfilmentOption,
+		);
+		const discountedPrice = promotion?.discountedPrice
+			? promotion.discountedPrice
+			: undefined;
+
+		const price = discountedPrice ?? productPrice;
+
+		if (productKey === 'SupporterPlus') {
+			/** SupporterPlus can have an additional contribution bolted onto the base price */
+			payment = {
+				originalAmount: productPrice,
+				discountedAmount: discountedPrice,
+				contributionAmount,
+				finalAmount: price + (contributionAmount ?? 0),
+			};
+		} else {
+			payment = {
+				originalAmount: productPrice,
+				discountedAmount: discountedPrice,
+				contributionAmount,
+				finalAmount: price,
+			};
+		}
+	}
+	return (
+		<ThankYouComponent
+			productKey={productKey}
+			ratePlanKey={ratePlanKey}
+			geoId={geoId}
+			appConfig={appConfig}
+			payment={payment}
+			promotion={promotion}
+		/>
+	);
+}
+
+type CheckoutComponentProps = {
+	geoId: GeoId;
+	appConfig: AppConfig;
+	productKey: ProductKey;
+	ratePlanKey: string;
+	payment: {
+		originalAmount: number;
+		discountedAmount?: number;
+		contributionAmount?: number;
+		finalAmount: number;
+	};
+	promotion?: Promotion;
+};
+function ThankYouComponent({
+	geoId,
+	productKey,
+	ratePlanKey,
+	payment,
+	promotion,
+}: CheckoutComponentProps) {
 	const countryId = CountryHelper.fromString(get('GU_country') ?? 'GB') ?? 'GB';
 	const user = getUser();
 	const isSignedIn = user.isSignedIn;
@@ -98,7 +251,6 @@ export function ThankYou({ geoId }: Props) {
 		OrderSchema,
 		storage.session.get('thankYouOrder'),
 	);
-
 	if (!parsedOrder.success) {
 		return (
 			<div>Unable to read your order {JSON.stringify(sessionStorageOrder)}</div>
@@ -111,20 +263,20 @@ export function ThankYou({ geoId }: Props) {
 	 * We should remove it for something more generic.
 	 */
 	const isContributionProduct =
-		order.product === 'Contribution' ||
-		order.product === 'SupporterPlus' ||
-		order.product === 'TierThree';
+		productKey === 'Contribution' ||
+		productKey === 'SupporterPlus' ||
+		productKey === 'TierThree';
 	const contributionType =
 		isContributionProduct &&
-		(order.ratePlan === 'Monthly' ||
-		order.ratePlan === 'RestOfWorldMonthly' ||
-		order.ratePlan === 'DomesticMonthly'
+		(ratePlanKey === 'Monthly' ||
+		ratePlanKey === 'RestOfWorldMonthly' ||
+		ratePlanKey === 'DomesticMonthly'
 			? 'MONTHLY'
-			: order.ratePlan === 'Annual' ||
-			  order.ratePlan === 'RestOfWorldAnnual' ||
-			  order.ratePlan === 'DomesticAnnual'
+			: ratePlanKey === 'Annual' ||
+			  ratePlanKey === 'RestOfWorldAnnual' ||
+			  ratePlanKey === 'DomesticAnnual'
 			? 'ANNUAL'
-			: order.product === 'Contribution'
+			: productKey === 'Contribution'
 			? 'ONE_OFF'
 			: undefined);
 
@@ -134,15 +286,16 @@ export function ThankYou({ geoId }: Props) {
 			order.paymentMethod === 'StripeExpressCheckoutElement'
 				? 'Stripe'
 				: order.paymentMethod;
+
 		successfulContributionConversion(
-			order.originalAmount,
+			payment.originalAmount,
 			contributionType,
 			currencyKey,
 			paymentMethod,
 		);
 		// track conversion with QM
 		sendEventContributionCheckoutConversion(
-			order.originalAmount,
+			payment.originalAmount,
 			contributionType,
 			currencyKey,
 		);
@@ -152,16 +305,16 @@ export function ThankYou({ geoId }: Props) {
 		return <div>Unable to find contribution type {contributionType}</div>;
 	}
 
-	const isOneOff = order.product === 'Contribution';
+	const isOneOff = productKey === 'Contribution';
 	const isOneOffPayPal = order.paymentMethod === 'PayPal' && isOneOff;
-	const isSupporterPlus = order.product === 'SupporterPlus';
-	const isTier3 = order.product === 'TierThree';
+	const isSupporterPlus = productKey === 'SupporterPlus';
+	const isTier3 = productKey === 'TierThree';
 	// TODO - get this from the /identity/get-user-type endpoint
 	const userTypeFromIdentityResponse = isSignedIn ? 'current' : 'new';
 	const isNewAccount = userTypeFromIdentityResponse === 'new';
 	const emailExists = !isNewAccount && isSignedIn;
 
-	const productDescription = productCatalogDescription[order.product];
+	const productDescription = productCatalogDescription[productKey];
 	const benefitsChecklist = [
 		...productDescription.benefits
 			.filter((benefit) => filterBenefitByRegion(benefit, countryGroupId))
@@ -224,15 +377,14 @@ export function ThankYou({ geoId }: Props) {
 						<ThankYouHeader
 							isSignedIn={isSignedIn}
 							name={order.firstName}
-							amount={order.originalAmount}
+							amount={payment.finalAmount}
 							contributionType={contributionType}
 							amountIsAboveThreshold={isSupporterPlus}
 							isTier3={isTier3}
 							isOneOffPayPal={isOneOffPayPal}
 							showDirectDebitMessage={order.paymentMethod === 'DirectDebit'}
 							currency={currencyKey}
-							// TODO - generic checkout support promotions
-							promotion={undefined}
+							promotion={promotion}
 							// TODO - get this from the /identity/get-user-type endpoint
 							userTypeFromIdentityResponse={userTypeFromIdentityResponse}
 						/>


### PR DESCRIPTION
Brings the way we get data into the thank you page more inline with the checkout page (as suggested by @rupertbates in a PR I can't find).

It is a copy/paste job (and labelled as such) - I'm not sure we're at the stage of abstracting it just yet. As we get into the world of working on the one-time checkout I think we will start to find good abstractions.

Fixes some bugs raised in https://github.com/guardian/support-frontend/pull/6236