### PR TITLE
Tidy old campaigns code

### DIFF
--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -7,7 +7,6 @@ type CampaignCopy = {
 };
 
 export type CampaignSettings = {
-	campaignCode: string;
 	campaignPath: string;
 	tickerId: string;
 	copy?: (goalReached: boolean) => CampaignCopy;
@@ -25,36 +24,7 @@ export type CampaignSettings = {
 	// If set, the form will be replaced with this if goal reached
 };
 
-export const activeCampaigns: Record<string, CampaignSettings> = {};
-
-function campaignEnabledForUser(campaignCode?: string): boolean {
-	if (campaignCode && isCampaignEnabled(campaignCode)) {
-		const matchingCampaign = activeCampaigns[campaignCode];
-		return window.location.pathname.endsWith(
-			`/${matchingCampaign.campaignPath}`,
-		);
-	}
-
-	return false;
-}
-
-export function getCampaignSettings(
-	campaignCode?: string,
-): CampaignSettings | null {
-	if (campaignCode && campaignEnabledForUser(campaignCode)) {
-		return activeCampaigns[campaignCode];
-	}
-
-	return null;
-}
-
-export function getCampaignCode(campaignCode?: string): string | null {
-	const campaignSettings = getCampaignSettings(campaignCode ?? '');
-
-	if (campaignSettings) {
-		return campaignSettings.campaignCode;
-	}
-
+export function getCampaignSettings(): CampaignSettings | null {
 	return null;
 }
 

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -7,6 +7,7 @@ type CampaignCopy = {
 };
 
 export type CampaignSettings = {
+	campaignCode: string;
 	campaignPath: string;
 	tickerId: string;
 	copy?: (goalReached: boolean) => CampaignCopy;

--- a/support-frontend/assets/helpers/tracking/acquisitions.ts
+++ b/support-frontend/assets/helpers/tracking/acquisitions.ts
@@ -3,7 +3,6 @@
 import { viewId } from 'ophan';
 import type { $Keys } from 'utility-types';
 import type { Participations } from 'helpers/abTests/abtest';
-import { getCampaignCode } from 'helpers/campaigns/campaigns';
 import { get as getCookie } from 'helpers/storage/cookie';
 import * as storage from 'helpers/storage/storage';
 import {
@@ -147,9 +146,7 @@ function buildReferrerAcquisitionData(
 		getQueryParameter('REFPVID');
 
 	const campaignCode =
-		getCampaignCode() ??
-		(acquisitionData.campaignCode as string | undefined) ??
-		(getQueryParameter('INTCMP') || getQueryParameter('CMP') || undefined);
+		getQueryParameter('INTCMP') || getQueryParameter('CMP') || undefined;
 
 	const parameterExclusions = [
 		'REFPVID',

--- a/support-frontend/assets/pages/digital-subscriber-checkout/setup/setUpRedux.ts
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/setup/setUpRedux.ts
@@ -1,5 +1,4 @@
 // ----- Imports ----- //
-import { getCampaignSettings } from 'helpers/campaigns/campaigns';
 import type {
 	ContributionType,
 	ContributionTypes,
@@ -144,14 +143,8 @@ function selectInitialAmounts(
 	}
 }
 
-// Override the settings from the server if contributionTypes are defined in url params or campaign settings
+// Override the settings from the server if contributionTypes are defined in url params
 function getContributionTypes(state: ContributionsState): ContributionTypes {
-	const campaignSettings = getCampaignSettings();
-
-	if (campaignSettings?.contributionTypes) {
-		return campaignSettings.contributionTypes;
-	}
-
 	return getValidContributionTypesFromUrlOrElse(
 		state.common.settings.contributionTypes,
 	);

--- a/support-frontend/assets/pages/digital-subscriber-thank-you/digitalSubscriptionThankYou.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-thank-you/digitalSubscriptionThankYou.tsx
@@ -1,14 +1,11 @@
 import { Column, Columns, LinkButton } from '@guardian/source/react-components';
 import { FooterWithContents } from '@guardian/source-development-kitchen/react-components';
-import { useMemo } from 'preact/hooks';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { Container } from 'components/layout/container';
 import { PageScaffold } from 'components/page/pageScaffold';
 import type { ThankYouModuleType } from 'components/thankYou/thankYouModule';
 import ThankYouModule from 'components/thankYou/thankYouModule';
 import { getThankYouModuleData } from 'components/thankYou/thankYouModuleData';
-import type { CampaignSettings } from 'helpers/campaigns/campaigns';
-import { getCampaignSettings } from 'helpers/campaigns/campaigns';
 import { DirectDebit } from 'helpers/forms/paymentMethods';
 import { isSupporterPlusFromState } from 'helpers/redux/checkout/product/selectors/isSupporterPlus';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
@@ -25,17 +22,10 @@ import {
 import ThankYouHeader from './components/thankYouHeader';
 
 export function DigitalSubscriptionThankYou(): JSX.Element {
-	const campaignSettings = useMemo<CampaignSettings | null>(
-		() => getCampaignSettings(campaignCode),
-		[],
-	);
 	const { countryId, countryGroupId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
 	const { csrf } = useContributionsSelector((state) => state.page.checkoutForm);
-	const { campaignCode } = useContributionsSelector(
-		(state) => state.common.referrerAcquisitionData,
-	);
 	const { firstName, email, userTypeFromIdentityResponse } =
 		useContributionsSelector(
 			(state) => state.page.checkoutForm.personalDetails,
@@ -56,7 +46,6 @@ export function DigitalSubscriptionThankYou(): JSX.Element {
 		false,
 		amountIsAboveThreshold,
 		email,
-		campaignSettings?.campaignCode,
 	);
 
 	const maybeThankYouModule = (

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -1,5 +1,3 @@
-import { css } from '@emotion/react';
-import { from, space } from '@guardian/source/foundations';
 import { CheckoutBenefitsList } from 'components/checkoutBenefits/checkoutBenefitsList';
 import { CheckoutBenefitsListContainer } from 'components/checkoutBenefits/checkoutBenefitsListContainer';
 import { BoxContents } from 'components/checkoutBox/checkoutBox';
@@ -12,27 +10,9 @@ import { PaymentFrequencyTabsContainer } from 'components/paymentFrequencyTabs/p
 import { PaymentFrequencyTabs } from 'components/paymentFrequencyTabs/paymentFrequenncyTabs';
 import { PriceCards } from 'components/priceCards/priceCards';
 import { PriceCardsContainer } from 'components/priceCards/priceCardsContainer';
-import { Ticker } from 'components/ticker/ticker';
-import { TickerContainer } from 'components/ticker/tickerContainer';
 import Tooltip from 'components/tooltip/Tooltip';
 import { TooltipContainer } from 'components/tooltip/TooltipContainer';
-import { getCampaignSettings } from 'helpers/campaigns/campaigns';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { useContributionsSelector } from 'helpers/redux/storeHooks';
-
-const tickerSpacing = css`
-	margin-top: ${space[2]}px;
-	margin-bottom: ${space[5]}px;
-
-	${from.desktop} {
-		margin-bottom: 32px;
-	}
-`;
-
-const tickerCampaigns: Partial<Record<CountryGroupId, string>> = {
-	UnitedStates: 'usEoy2023',
-	AUDCountries: 'ausTicker2023',
-};
 
 export function AmountAndBenefits({
 	countryGroupId,
@@ -47,15 +27,6 @@ export function AmountAndBenefits({
 	addBackgroundToBenefitsList?: boolean;
 	isCompactBenefitsList?: boolean;
 }): JSX.Element {
-	const { internationalisation } = useContributionsSelector(
-		(state) => state.common,
-	);
-	const campaignCode = tickerCampaigns[internationalisation.countryGroupId];
-
-	const campaignSettings = getCampaignSettings(campaignCode);
-
-	const showCampaignTicker = !!campaignSettings;
-
 	return (
 		<PaymentFrequencyTabsContainer
 			render={(tabProps) => (
@@ -104,17 +75,6 @@ export function AmountAndBenefits({
 									</>
 								)}
 							/>
-							{showCampaignTicker && (
-								<div css={tickerSpacing}>
-									<TickerContainer
-										tickerId={campaignSettings.tickerId}
-										countType={campaignSettings.tickerSettings.countType}
-										endType={campaignSettings.tickerSettings.endType}
-										headline={campaignSettings.tickerSettings.headline}
-										render={(tickerProps) => <Ticker {...tickerProps} />}
-									/>
-								</div>
-							)}
 							<CheckoutBenefitsListContainer
 								renderBenefitsList={(benefitsListProps) => (
 									<CheckoutBenefitsList

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -8,15 +8,13 @@ import {
 } from '@guardian/source/foundations';
 import { Column, Columns, LinkButton } from '@guardian/source/react-components';
 import { FooterWithContents } from '@guardian/source-development-kitchen/react-components';
-import { useEffect, useMemo } from 'preact/hooks';
+import { useEffect } from 'preact/hooks';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { Container } from 'components/layout/container';
 import { PageScaffold } from 'components/page/pageScaffold';
 import type { ThankYouModuleType } from 'components/thankYou/thankYouModule';
 import ThankYouModule from 'components/thankYou/thankYouModule';
 import { getThankYouModuleData } from 'components/thankYou/thankYouModuleData';
-import type { CampaignSettings } from 'helpers/campaigns/campaigns';
-import { getCampaignSettings } from 'helpers/campaigns/campaigns';
 import type { ContributionType } from 'helpers/contributions';
 import { getAmount, isContributionsOnlyCountry } from 'helpers/contributions';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
@@ -109,18 +107,11 @@ export type SupporterPlusThankYouProps = {
 export function SupporterPlusThankYou({
 	overideThresholdPrice,
 }: SupporterPlusThankYouProps): JSX.Element {
-	const campaignSettings = useMemo<CampaignSettings | null>(
-		() => getCampaignSettings(campaignCode),
-		[],
-	);
 	const { amounts } = useContributionsSelector((state) => state.common);
 	const { countryId, countryGroupId, currencyId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
 	const { csrf } = useContributionsSelector((state) => state.page.checkoutForm);
-	const { campaignCode } = useContributionsSelector(
-		(state) => state.common.referrerAcquisitionData,
-	);
 	const { firstName, email, userTypeFromIdentityResponse } =
 		useContributionsSelector(
 			(state) => state.page.checkoutForm.personalDetails,
@@ -228,7 +219,6 @@ export function SupporterPlusThankYou({
 		isOneOff,
 		amountIsAboveThreshold,
 		email,
-		campaignSettings?.campaignCode,
 	);
 
 	const maybeThankYouModule = (


### PR DESCRIPTION
Historically we've used the `CampaignSettings` model to customise parts of the support site for campaigns.
It's not currently in use, and much of the code is very old and not relevant.
We're going to revive the concept for the upcoming US end-of-year moment (and beyond), but first I want to clean up legacy code.