### PR TITLE
feat: add testing for preset_data on events

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -332,6 +332,10 @@ class Application(
 
   def eventsRouter(countryGroupId: String, eventId: String) = MaybeAuthenticatedAction { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
-    Ok(views.html.eventsRouter()).withSettingsSurrogateKey
+    Ok(
+      views.html.eventsRouter(
+        user = request.user,
+      ),
+    ).withSettingsSurrogateKey
   }
 }

--- a/support-frontend/app/views/eventsRouter.scala.html
+++ b/support-frontend/app/views/eventsRouter.scala.html
@@ -3,7 +3,10 @@
 @import views.EmptyDiv
 @import assets.RefPath
 @import assets.StyleContent
-@()(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
+@import com.gu.identity.model.User
+@(
+  user: Option[User]
+)(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
 @main(
   title = "Support the Guardian | Events",
@@ -18,5 +21,5 @@
   shareUrl = None,
   noindex = true
 ){
-
+  @windowGuardianUser(user)
 }

--- a/support-frontend/app/views/windowGuardianPaymentConfig.scala.html
+++ b/support-frontend/app/views/windowGuardianPaymentConfig.scala.html
@@ -89,16 +89,5 @@
 
   window.guardian.productCatalog = @Html(outputJson(productCatalog))
 
-  @user.map { user =>
-    window.guardian.user = {
-      id: "@user.id",
-      email: "@user.primaryEmailAddress",
-      @user.privateFields.firstName.map { firstName =>
-        firstName: "@firstName",
-      }
-      @user.privateFields.secondName.map { secondName =>
-        lastName: "@secondName",
-      }
-    };
-  }
+  @windowGuardianUser(user)
 </script>

--- a/support-frontend/app/views/windowGuardianUser.scala.html
+++ b/support-frontend/app/views/windowGuardianUser.scala.html
@@ -1,0 +1,18 @@
+@import com.gu.identity.model.User
+@(
+  user: Option[User],
+)(implicit request: RequestHeader)
+<script type="text/javascript">
+  @user.map { user =>
+    window.guardian.user = {
+      id: "@user.id",
+      email: "@user.primaryEmailAddress",
+      @user.privateFields.firstName.map { firstName =>
+        firstName: "@firstName",
+      }
+      @user.privateFields.secondName.map { secondName =>
+        lastName: "@secondName",
+      }
+    };
+  }
+</script>

--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -9,6 +9,7 @@ import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
 import { guardianLiveTermsLink, privacyLink } from 'helpers/legal';
 import * as cookie from 'helpers/storage/cookie';
+import { getPageViewId } from 'helpers/tracking/ophan';
 import { isProd } from 'helpers/urls/url';
 
 const darkBackgroundContainerMobile = css`
@@ -67,6 +68,30 @@ export function Events() {
 	const termsEvents = <a href={guardianLiveTermsLink}>Terms and Conditions</a>;
 	const privacyPolicy = <a href={privacyLink}>Privacy Policy</a>;
 
+	const urlSearchParams = new URLSearchParams(window.location.search);
+	const presetData = urlSearchParams.get('presetData') === '1';
+	let presetDataUrl = '';
+	if (presetData) {
+		const pageviewId = getPageViewId();
+		const hashUrlSearchParams = new URLSearchParams({
+			'p[meta_page_view_id]': pageviewId,
+		});
+		const user = window.guardian.user;
+		if (user) {
+			hashUrlSearchParams.set('p[meta_identity_id]', user.id);
+			user.firstName &&
+				hashUrlSearchParams.set('p[first_name]', user.firstName);
+			user.lastName && hashUrlSearchParams.set('p[last_name]', user.lastName);
+			user.email && hashUrlSearchParams.set('p[email]', user.email);
+		}
+		/** we decode this as that is what Ticket Tailor want */
+		presetDataUrl = `?preset_data=1#${decodeURIComponent(
+			hashUrlSearchParams.toString(),
+		)}`;
+	}
+
+	const embedUrl = `${ticketTailorUrl}/${eventId}/book${presetDataUrl}`;
+
 	return (
 		<PageScaffold
 			header={<Header />}
@@ -96,7 +121,7 @@ export function Events() {
 									</div>
 									<script
 										src="https://cdn.tickettailor.com/js/widgets/min/widget.js"
-										data-url={`${ticketTailorUrl}/${eventId}/book`}
+										data-url={`${embedUrl}`}
 										data-type="inline"
 										data-inline-minimal="true"
 										data-inline-show-logo="false"


### PR DESCRIPTION
This enables sending meta data to Ticket Tailor via the querystring. 

I have put it behind a `presetData` querystring parameter as it currently breaks things locally due to a `frame-ancestors` `Content-Security-Policy` header set on the Ticket Tailor to `content-security-policy: frame-ancestors 'self' *.theguardian.live`.

While this will still break on prod due to the main ancestor being `support.theguardian.com`, it will allow us to share this with Ticket Tailor without breaking the current implementation.