### PR TITLE
fix: remove script tag from inside script tag

### DIFF
--- a/support-frontend/app/views/windowGuardianPaymentConfig.scala.html
+++ b/support-frontend/app/views/windowGuardianPaymentConfig.scala.html
@@ -88,6 +88,5 @@
   window.guardian.checkoutPostcodeLookup = @settings.switches.subscriptionsSwitches.checkoutPostcodeLookup.contains(On)
 
   window.guardian.productCatalog = @Html(outputJson(productCatalog))
-
-  @windowGuardianUser(user)
 </script>
+@windowGuardianUser(user)


### PR DESCRIPTION
Currently this renders
```html
<script>
  <script></script>
</script>
```

which is no good. This PR unnests that.