### PR TITLE
Add campaign settings for US EOY

### DIFF
--- a/support-frontend/app/admin/settings/Switches.scala
+++ b/support-frontend/app/admin/settings/Switches.scala
@@ -25,6 +25,7 @@ case class FeatureSwitches(
 case class CampaignSwitches(
     enableContributionsCampaign: Option[SwitchState],
     forceContributionsCampaign: Option[SwitchState],
+    usEoy2024: Option[SwitchState] = None,
 )
 
 case class SubscriptionsSwitches(

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -1,39 +1,43 @@
-import type { TickerSettings } from 'components/ticker/types';
-import type { ContributionTypes } from 'helpers/contributions';
-
-type CampaignCopy = {
-	headerCopy?: string | JSX.Element;
-	contributeCopy?: string | JSX.Element;
-};
+import type { CountryGroupId } from '../internationalisation/countryGroup';
+import { UnitedStates } from '../internationalisation/countryGroup';
 
 export type CampaignSettings = {
-	campaignCode: string;
-	campaignPath: string;
-	tickerId: string;
-	copy?: (goalReached: boolean) => CampaignCopy;
-	formMessage?: JSX.Element;
-	termsAndConditions?: (
-		contributionsTermsLink: string,
-		contactEmail: string,
-	) => JSX.Element;
-	cssModifiers?: string[];
-	contributionTypes?: ContributionTypes;
-	backgroundImage?: string;
-	extraComponent?: JSX.Element;
-	tickerSettings: TickerSettings;
-	goalReachedCopy?: JSX.Element;
-	// If set, the form will be replaced with this if goal reached
+	isEligible: (countryGroupId: CountryGroupId) => boolean;
+	enableSingleContributions: boolean;
 };
 
-export function getCampaignSettings(): CampaignSettings | null {
+const campaigns: Record<string, CampaignSettings> = {
+	usEoy2024: {
+		isEligible: (countryGroupId: CountryGroupId) =>
+			countryGroupId === UnitedStates,
+		enableSingleContributions: true,
+	},
+};
+
+const forceCampaign = (campaignId: string): boolean => {
+	const urlParams = new URLSearchParams(window.location.search);
+	return urlParams.get('forceCampaign') === campaignId;
+};
+
+export function getCampaignSettings(
+	countryGroupId: CountryGroupId,
+): CampaignSettings | null {
+	for (const campaignId in campaigns) {
+		const isEligible =
+			isCampaignEnabled(campaignId) &&
+			campaigns[campaignId].isEligible(countryGroupId);
+		if (isEligible || forceCampaign(campaignId)) {
+			return campaigns[campaignId];
+		}
+	}
 	return null;
 }
 
-export function isCampaignEnabled(campaignCode: string): boolean {
+function isCampaignEnabled(campaignId: string): boolean {
 	const { campaignSwitches } = window.guardian.settings.switches;
 	return (
 		window.location.hash ===
-			`#settings.switches.campaignSwitches.${campaignCode}=On` ||
-		campaignSwitches[campaignCode] === 'On'
+			`#settings.switches.campaignSwitches.${campaignId}=On` ||
+		campaignSwitches[campaignId] === 'On'
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -60,6 +60,7 @@ import {
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { navigateWithPageView } from 'helpers/tracking/ophan';
 import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
+import { getCampaignSettings } from '../../../helpers/campaigns/campaigns';
 import { OneOffCard } from '../components/oneOffCard';
 import { SupportOnce } from '../components/supportOnce';
 import { ThreeTierCards } from '../components/threeTierCards';
@@ -330,7 +331,8 @@ export function ThreeTierLanding(): JSX.Element {
 
 	const useGenericCheckout = abParticipations.useGenericCheckout === 'variant';
 
-	const enableSingle = countryGroupId === UnitedStates; // TODO - use campaign config
+	const campaignSettings = getCampaignSettings(countryGroupId);
+	const enableSingle = campaignSettings?.enableSingleContributions;
 
 	useEffect(() => {
 		dispatch(resetValidation());


### PR DESCRIPTION
This will make the support site configurable for the upcoming moment.
To begin with it'll be used to enable single contributions on the landing page.

Users will be eligible for the campaign if either:
1. the `usEoy2024` switch is enabled (from the RRCP) and the user is in the `UnitedStates` country group,
2. the url querystring contains `forceCampaign=usEoy2024`