### PR TITLE
fix: widget the event URL

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -85,7 +85,7 @@ export function Events() {
 			user.email && hashUrlSearchParams.set('p[email]', user.email);
 		}
 		/** we decode this as that is what Ticket Tailor want */
-		presetDataUrl = `?preset_data=1#${decodeURIComponent(
+		presetDataUrl = `?preset_data=1&widget=true#${decodeURIComponent(
 			hashUrlSearchParams.toString(),
 		)}`;
 	}


### PR DESCRIPTION
This is required to get the iFrame resizer working from Ticket Tailor (as per an email with their team).