### PR TITLE
One Time Checkout - Amounts component

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -9,7 +9,6 @@ import {
 	until,
 } from '@guardian/source/foundations';
 import {
-	Button,
 	Checkbox,
 	Label,
 	Radio,
@@ -115,6 +114,7 @@ import {
 	formatUserDate,
 } from '../../helpers/utilities/dateConversions';
 import { getTierThreeDeliveryDate } from '../weekly-subscription-checkout/helpers/deliveryDays';
+import { BackButton } from './components/backButton';
 import { CheckoutLayout } from './components/checkoutLayout';
 import { setThankYouOrder, unsetThankYouOrder } from './thank-you';
 
@@ -260,20 +260,6 @@ function preventDefaultValidityMessage(
 		// 2. setCustomValidity to " " which avoids the browser's default message
 		currentTarget.setCustomValidity(' ');
 	}
-}
-
-type ChangeButtonProps = {
-	geoId: GeoId;
-};
-
-function ChangeButton({ geoId }: ChangeButtonProps) {
-	return (
-		<a href={`/${geoId}/contribute`}>
-			<Button priority="tertiary" size="xsmall" role="link">
-				Change
-			</Button>
-		</a>
-	);
 }
 
 type Props = {
@@ -1100,7 +1086,7 @@ function CheckoutComponent({
 							productFields.productType,
 							promotion,
 						)}
-						headerButton={<ChangeButton geoId={geoId} />}
+						headerButton={<BackButton geoId={geoId} buttonText="Change" />}
 					/>
 				</BoxContents>
 			</Box>

--- a/support-frontend/assets/pages/[countryGroupId]/components/backButton.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/backButton.tsx
@@ -1,0 +1,17 @@
+import { Button } from '@guardian/source/react-components';
+import type { GeoId } from 'pages/geoIdConfig';
+
+type BackButtonProps = {
+	geoId: GeoId;
+	buttonText: string;
+};
+
+export function BackButton({ geoId, buttonText }: BackButtonProps) {
+	return (
+		<a href={`/${geoId}/contribute`}>
+			<Button priority="tertiary" size="xsmall" role="link">
+				{buttonText}
+			</Button>
+		</a>
+	);
+}

--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -17,6 +17,7 @@ import { Country } from 'helpers/internationalisation';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
 import { GuardianTsAndCs } from 'pages/supporter-plus-landing/components/guardianTsAndCs';
 import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsMessage';
+import { BackButton } from './components/backButton';
 import { CheckoutLayout } from './components/checkoutLayout';
 
 const countryId = Country.detect();
@@ -86,7 +87,7 @@ function OneTimeCheckoutComponent({ geoId }: Props) {
 					>
 						<div css={titleAndButtonContainer}>
 							<h2 css={title}>Support just once</h2>
-							<Link href="" />
+							<BackButton geoId={geoId} buttonText="back" />
 						</div>
 						<p css={standFirst}>Support us with the amount of your choice.</p>
 						<PriceCards

--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -1,20 +1,25 @@
 import { css } from '@emotion/react';
 import {
 	from,
-	headline,
+	headlineBold24,
 	space,
 	textSans17,
 } from '@guardian/source/foundations';
-import { Link } from '@guardian/source/react-components';
 import { useState } from 'react';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { OtherAmount } from 'components/otherAmount/otherAmount';
 import { PriceCards } from 'components/priceCards/priceCards';
+import { getAmountsTestVariant } from 'helpers/abTests/abtest';
+import { config } from 'helpers/contributions';
+import { getSettings } from 'helpers/globalsAndSwitches/globals';
 import type { AppConfig } from 'helpers/globalsAndSwitches/window';
+import { Country } from 'helpers/internationalisation';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
 import { GuardianTsAndCs } from 'pages/supporter-plus-landing/components/guardianTsAndCs';
 import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsMessage';
 import { CheckoutLayout } from './components/checkoutLayout';
+
+const countryId = Country.detect();
 
 const titleAndButtonContainer = css`
 	display: flex;
@@ -27,7 +32,7 @@ const titleAndButtonContainer = css`
 `;
 
 const title = css`
-	${headline.xsmall({ fontWeight: 'bold' })}
+	${headlineBold24};
 	${from.tablet} {
 		font-size: 28px;
 	}
@@ -45,14 +50,30 @@ type Props = {
 	geoId: GeoId;
 	appConfig: AppConfig;
 };
+
 export function OneTimeCheckout({ geoId, appConfig }: Props) {
 	return <OneTimeCheckoutComponent geoId={geoId} appConfig={appConfig} />;
 }
 
 function OneTimeCheckoutComponent({ geoId }: Props) {
 	const { currencyKey, countryGroupId } = getGeoIdConfig(geoId);
-	const [amount, setAmount] = useState<string>('other');
+
+	const settings = getSettings();
+	const { selectedAmountsVariant } = getAmountsTestVariant(
+		countryId,
+		countryGroupId,
+		settings,
+	);
+
+	const { amountsCardData } = selectedAmountsVariant;
+	const { amounts, defaultAmount, hideChooseYourAmount } =
+		amountsCardData['ONE_OFF'];
+
+	const minAmount = config[countryGroupId]['ONE_OFF'].min;
+
+	const [amount, setAmount] = useState<number | 'other'>(defaultAmount);
 	const [otherAmount, setOtherAmount] = useState<string>('');
+	const [otherAmountErrors] = useState<string[]>([]);
 
 	return (
 		<CheckoutLayout>
@@ -69,31 +90,30 @@ function OneTimeCheckoutComponent({ geoId }: Props) {
 						</div>
 						<p css={standFirst}>Support us with the amount of your choice.</p>
 						<PriceCards
-							amounts={[1, 5, 10]}
-							selectedAmount={amount as number | 'other'}
+							amounts={amounts}
+							selectedAmount={amount}
 							currency={currencyKey}
-							paymentInterval={'month'}
-							onAmountChange={setAmount}
-							hideChooseYourAmount={false}
+							onAmountChange={(amount: string) => {
+								setAmount(
+									amount === 'other' ? amount : Number.parseFloat(amount),
+								);
+							}}
+							hideChooseYourAmount={hideChooseYourAmount}
 							otherAmountField={
 								<OtherAmount
 									currency={currencyKey}
-									minAmount={2}
-									selectedAmount={amount as number | 'other'}
+									minAmount={minAmount}
+									selectedAmount={amount}
 									otherAmount={otherAmount}
 									onOtherAmountChange={setOtherAmount}
-									errors={[]}
+									errors={otherAmountErrors}
 								/>
 							}
 						/>
 					</div>
 				</BoxContents>
 			</Box>
-			<form
-				css={css`
-					height: 50px;
-				`}
-			></form>
+			<form></form>
 			<PatronsMessage countryGroupId={countryGroupId} mobileTheme={'light'} />
 			<GuardianTsAndCs mobileTheme={'light'} displayPatronsCheckout={false} />
 		</CheckoutLayout>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

As part of building the new one time checkout - we created a skeleton page in #6247. This PR populates the amounts component with the correct props, for example the correct amounts test from the window object.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/LimWTJAA/1027-one-time-checkout-amounts)


<!--
Remember, PRs are documentation for future contributors.
-->


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Screenshots
US
![image](https://github.com/user-attachments/assets/0e9189bf-03c7-4206-b9d4-d3c903e19fd5)
UK
![image](https://github.com/user-attachments/assets/ecd5828e-1605-4100-9cec-103ae35f97e9)

