### PR TITLE
Allow unknown country in acquisition rows

### DIFF
--- a/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/AcquisitionToJson.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/main/scala/com/gu/acquisitionFirehoseTransformer/AcquisitionToJson.scala
@@ -37,7 +37,7 @@ object AcquisitionToJson {
   ): Json = {
     AcquisitionOutput(
       acquisition.paymentFrequency.value,
-      acquisition.country.alpha2,
+      acquisition.country.map(_.alpha2).getOrElse(""),
       amount,
       annualisedValue,
       annualisedValueGBP,

--- a/support-lambdas/acquisitions-firehose-transformer/src/test/scala/com/gu/acquisitionFirehoseTransformer/LambdaSpec.scala
+++ b/support-lambdas/acquisitions-firehose-transformer/src/test/scala/com/gu/acquisitionFirehoseTransformer/LambdaSpec.scala
@@ -64,7 +64,7 @@ class LambdaSpec extends AnyFlatSpec with Matchers {
       eventTimeStamp = new DateTime(1544710504165L),
       product = AcquisitionProduct.RecurringContribution,
       amount = amount,
-      country = Country.UK,
+      country = Some(Country.UK),
       currency = Currency.USD,
       componentId = Some("MY_COMPONENT_ID"),
       componentType = None,

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/bigquery/AcquisitionDataRowMapper.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/bigquery/AcquisitionDataRowMapper.scala
@@ -34,6 +34,7 @@ object AcquisitionDataRowMapper {
       acquisition.zuoraSubscriptionNumber.map("zuora_subscription_number" -> _),
       acquisition.contributionId.map("contribution_id" -> _),
       acquisition.paymentId.map("payment_id" -> _),
+      acquisition.country.map("country_code" -> _.alpha2),
     ).flatten.toMap
 
     new JSONObject(
@@ -41,7 +42,6 @@ object AcquisitionDataRowMapper {
         "event_timestamp" -> ISODateTimeFormat.dateTime().print(acquisition.eventTimeStamp),
         "product" -> acquisition.product.value,
         "payment_frequency" -> acquisition.paymentFrequency.value,
-        "country_code" -> acquisition.country.alpha2,
         "currency" -> acquisition.currency.iso,
         "reused_existing_payment_method" -> acquisition.reusedExistingPaymentMethod,
         "acquisition_type" -> acquisition.acquisitionType.value,

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
@@ -16,7 +16,7 @@ case class AcquisitionDataRow(
     eventTimeStamp: DateTime,
     product: AcquisitionProduct,
     amount: Option[BigDecimal],
-    country: Country,
+    country: Option[Country],
     currency: Currency,
     componentId: Option[String],
     componentType: Option[String],

--- a/support-payment-api/src/main/scala/model/acquisition/AcquisitionDataRowBuilder.scala
+++ b/support-payment-api/src/main/scala/model/acquisition/AcquisitionDataRowBuilder.scala
@@ -34,8 +34,7 @@ object AcquisitionDataRowBuilder {
       eventTimeStamp = DateTime.now(DateTimeZone.UTC),
       product = AcquisitionProduct.Contribution,
       amount = Some(paymentData.amount),
-      country =
-        StripeCharge.getCountryCode(acquisition.charge).flatMap(CountryGroup.countryByCode).getOrElse(Country.UK),
+      country = StripeCharge.getCountryCode(acquisition.charge).flatMap(CountryGroup.countryByCode),
       currency = mapCurrency(paymentData.currency),
       componentId = acquisitionData.componentId,
       componentType = acquisitionData.componentType,
@@ -74,7 +73,7 @@ object AcquisitionDataRowBuilder {
       eventTimeStamp = DateTime.now(DateTimeZone.UTC),
       product = AcquisitionProduct.Contribution,
       amount = Some(paymentData.amount),
-      country = acquisition.countryCode.flatMap(CountryGroup.countryByCode).getOrElse(Country.UK),
+      country = acquisition.countryCode.flatMap(CountryGroup.countryByCode),
       currency = mapCurrency(paymentData.currency),
       componentId = acquisitionData.flatMap(_.componentId),
       componentType = acquisitionData.flatMap(_.componentType),
@@ -109,7 +108,7 @@ object AcquisitionDataRowBuilder {
     val acquisitionData = acquisition.acquisitionData
     val transaction = acquisition.payment.getTransactions.get(0)
     val country =
-      CountryGroup.countryByCode(acquisition.payment.getPayer.getPayerInfo.getCountryCode).getOrElse(Country.UK)
+      CountryGroup.countryByCode(acquisition.payment.getPayer.getPayerInfo.getCountryCode)
 
     AcquisitionDataRow(
       eventTimeStamp = DateTime.now(DateTimeZone.UTC),

--- a/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
@@ -65,7 +65,7 @@ object AcquisitionDataRowBuilder {
       eventTimeStamp = DateTime.now(DateTimeZone.UTC),
       product = acquisitionProduct,
       amount = amount,
-      country = commonState.user.billingAddress.country,
+      country = Some(commonState.user.billingAddress.country),
       currency = commonState.product.currency,
       componentId = state.acquisitionData.flatMap(_.referrerAcquisitionData.componentId),
       componentType = state.acquisitionData.flatMap(_.referrerAcquisitionData.componentType),


### PR DESCRIPTION
Currently the `AcquisitionDataRow` model requires a `country`. This means we cannot write an acquisition row to BigQuery if the country code is not one of the expected countries.
We've had an acquisition with country code of `IC`, which is not supported currently, and would be difficult to support (java locale library doesn't have a 3 character code for it).
Instead, it's better to write a `null` country value for an event like this.