### PR TITLE
Use Source Components validation error message on generic checkout addresses

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
@@ -84,48 +84,47 @@ function statesForCountry(country: Option<IsoCountry>): React.ReactNode {
 
 type ValidityStateError = 'valueMissing' | 'patternMismatch';
 
-function getErrorMessage(
-	field: keyof AddressFieldsType,
-	scope: 'delivery' | 'billing',
-	validityStateError: ValidityStateError,
-	country: IsoCountry,
-): string {
-	const patternMismatch = 'Please use only letters, numbers and punctuation.';
-	const errorMessages: Record<string, {
-			[key in ValidityStateError]?: string;
-		}> = {
-		lineOne: {
-			valueMissing: `Please enter a ${scope} address.`,
-			patternMismatch,
-		},
-		lineTwo: {
-			patternMismatch,
-		},
-		city: {
-			valueMissing: `Please enter a ${scope} town/city.`,
-			patternMismatch,
-		},
-		state: {
-			valueMissing:
-				country === 'CA'
-					? `Please select a ${scope} province/territory.`
-					: `Please select a ${scope} state.`,
-			patternMismatch,
-		},
-		postCode: {
-			valueMissing: `Please enter a ${scope} ${
-				country === 'US' ? 'ZIP code' : 'postcode'
-			}`,
-			patternMismatch,
-		},
+export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
+	const getErrorMessage = (
+		field: keyof AddressFieldsType,
+		validityStateError: ValidityStateError,
+	): string => {
+		const patternMismatch = 'Please use only letters, numbers and punctuation.';
+		const errorMessages: Record<
+			string,
+			{
+				[key in ValidityStateError]?: string;
+			}
+		> = {
+			lineOne: {
+				valueMissing: `Please enter a ${scope} address.`,
+				patternMismatch,
+			},
+			lineTwo: {
+				patternMismatch,
+			},
+			city: {
+				valueMissing: `Please enter a ${scope} town/city.`,
+				patternMismatch,
+			},
+			state: {
+				valueMissing:
+					props.country === 'CA'
+						? `Please select a ${scope} province/territory.`
+						: `Please select a ${scope} state.`,
+				patternMismatch,
+			},
+			postCode: {
+				valueMissing: `Please enter a ${scope} ${
+					props.country === 'US' ? 'ZIP code' : 'postcode'
+				}`,
+				patternMismatch,
+			},
+		};
+
+		return errorMessages[field][validityStateError] ?? '';
 	};
 
-	return (
-		(errorMessages[field][validityStateError]) ?? ''
-	);
-}
-
-export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 	const onAddressFieldInvalid = (
 		event:
 			| React.FormEvent<HTMLInputElement>
@@ -161,12 +160,7 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 						if (validityState[possibleValidityStateError]) {
 							return {
 								field,
-								message: getErrorMessage(
-									field,
-									scope,
-									possibleValidityStateError,
-									props.country,
-								),
+								message: getErrorMessage(field, possibleValidityStateError),
 							};
 						}
 					})

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
@@ -85,52 +85,55 @@ function statesForCountry(country: Option<IsoCountry>): React.ReactNode {
 type ValidityStateError = 'valueMissing' | 'patternMismatch';
 
 export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
+	const patternMismatch = 'Please use only letters, numbers and punctuation.';
+	const errorMessages: Record<
+		string,
+		{
+			[key in ValidityStateError]?: string;
+		}
+	> = {
+		lineOne: {
+			valueMissing: `Please enter a ${scope} address.`,
+			patternMismatch,
+		},
+		lineTwo: {
+			patternMismatch,
+		},
+		city: {
+			valueMissing: `Please enter a ${scope} town/city.`,
+			patternMismatch,
+		},
+		state: {
+			valueMissing:
+				props.country === 'CA'
+					? `Please select a ${scope} province/territory.`
+					: `Please select a ${scope} state.`,
+			patternMismatch,
+		},
+		postCode: {
+			valueMissing: `Please enter a ${scope} ${
+				props.country === 'US' ? 'ZIP code' : 'postcode'
+			}`,
+			patternMismatch,
+		},
+	};
 	const getErrorMessage = (
 		field: keyof AddressFieldsType,
 		validityStateError: ValidityStateError,
 	): string => {
-		const patternMismatch = 'Please use only letters, numbers and punctuation.';
-		const errorMessages: Record<
-			string,
-			{
-				[key in ValidityStateError]?: string;
-			}
-		> = {
-			lineOne: {
-				valueMissing: `Please enter a ${scope} address.`,
-				patternMismatch,
-			},
-			lineTwo: {
-				patternMismatch,
-			},
-			city: {
-				valueMissing: `Please enter a ${scope} town/city.`,
-				patternMismatch,
-			},
-			state: {
-				valueMissing:
-					props.country === 'CA'
-						? `Please select a ${scope} province/territory.`
-						: `Please select a ${scope} state.`,
-				patternMismatch,
-			},
-			postCode: {
-				valueMissing: `Please enter a ${scope} ${
-					props.country === 'US' ? 'ZIP code' : 'postcode'
-				}`,
-				patternMismatch,
-			},
-		};
-
 		return errorMessages[field][validityStateError] ?? '';
 	};
-
-	const onAddressFieldInvalid = (
+	const setErrorsOnInvalid = (
 		event:
 			| React.FormEvent<HTMLInputElement>
 			| React.FormEvent<HTMLSelectElement>,
 		field: keyof AddressFieldsType,
 	) => {
+		/**
+		 * We only pass/use setErrors on the generic checkout
+		 * If it's not been passed to AddressFields then Redux handles
+		 * validation errors.
+		 **/
 		if (!props.setErrors) {
 			return;
 		}
@@ -154,7 +157,7 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 				...props.errors.filter((error) => {
 					return error.field != field;
 				}),
-				// include all unresolved errors for the field
+				// add all unresolved errors for the field
 				...(possibleValidityStateErrors
 					.map((possibleValidityStateError) => {
 						if (validityState[possibleValidityStateError]) {
@@ -230,7 +233,7 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 					event.target.checkValidity();
 				}}
 				onInvalid={(event) => {
-					onAddressFieldInvalid(event, 'lineOne');
+					setErrorsOnInvalid(event, 'lineOne');
 				}}
 			/>
 			<TextInput
@@ -250,7 +253,7 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 					event.target.checkValidity();
 				}}
 				onInvalid={(event) => {
-					onAddressFieldInvalid(event, 'lineTwo');
+					setErrorsOnInvalid(event, 'lineTwo');
 				}}
 			/>
 			<TextInput
@@ -269,7 +272,7 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 					event.target.checkValidity();
 				}}
 				onInvalid={(event) => {
-					onAddressFieldInvalid(event, 'city');
+					setErrorsOnInvalid(event, 'city');
 				}}
 			/>
 			<MaybeSelect
@@ -287,7 +290,7 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 					event.target.checkValidity();
 				}}
 				onInvalid={(event) => {
-					onAddressFieldInvalid(event, 'state');
+					setErrorsOnInvalid(event, 'state');
 				}}
 			>
 				<>
@@ -313,7 +316,7 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 					event.target.checkValidity();
 				}}
 				onInvalid={(event) => {
-					onAddressFieldInvalid(event, 'state');
+					setErrorsOnInvalid(event, 'state');
 				}}
 			/>
 			<TextInput
@@ -333,7 +336,7 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 					event.target.checkValidity();
 				}}
 				onInvalid={(event) => {
-					onAddressFieldInvalid(event, 'postCode');
+					setErrorsOnInvalid(event, 'postCode');
 				}}
 			/>
 		</div>

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
@@ -153,7 +153,7 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 					props.onAddressFieldInvalid?.(
 						event,
 						'lineOne',
-						'Please enter a delivery address.',
+						`Please enter a ${scope} address.`,
 					);
 				}}
 			/>
@@ -188,7 +188,7 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 					props.onAddressFieldInvalid?.(
 						event,
 						'city',
-						'Please enter a delivery town/city.',
+						`Please enter a ${scope} town/city.`,
 					);
 				}}
 			/>
@@ -211,8 +211,8 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 						event,
 						'state',
 						props.country === 'CA'
-							? `Please select a delivery province/territory.`
-							: `Please select a delivery state.`,
+							? `Please select a ${scope} province/territory.`
+							: `Please select a ${scope} state.`,
 					);
 				}}
 			>
@@ -254,7 +254,7 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 					props.onAddressFieldInvalid?.(
 						event,
 						'postCode',
-						`Please enter a delivery ${
+						`Please enter a ${scope} ${
 							props.country === 'US' ? 'ZIP code' : 'postcode'
 						}`,
 					);

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
@@ -126,9 +126,9 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 		field: keyof AddressFieldsType,
 	) => {
 		/**
-		 * We only pass/use setErrors on the generic checkout
-		 * If it's not been passed to AddressFields then Redux handles
-		 * validation errors.
+		 * We only pass/use setErrors on the generic checkout.
+		 * On the non-generic checkouts we don't pass it
+		 * to AddressFields as Redux/Zod handles validation errors.
 		 **/
 		if (!props.setErrors) {
 			return;

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
@@ -17,8 +17,8 @@ import {
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type {
 	AddressFieldsState,
-	PostcodeFinderState,
-} from 'helpers/redux/checkout/address/state';
+	AddressFields as AddressFieldsType,
+ PostcodeFinderState } from 'helpers/redux/checkout/address/state';
 import { isPostcodeOptional } from 'helpers/redux/checkout/address/validation';
 import type { AddressType } from 'helpers/subscriptionsForms/addressType';
 import { firstError } from 'helpers/subscriptionsForms/validation';
@@ -42,6 +42,11 @@ type PropTypes = StatePropTypes & {
 	setPostcodeForFinder: (postcode: string) => void;
 	setPostcodeErrorForFinder: (error: string) => void;
 	onFindAddress: (postcode: string) => void;
+	onAddressFieldInvalid?: (
+		event: React.FormEvent<HTMLInputElement>,
+		field: keyof AddressFieldsType,
+		message: string,
+	) => void;
 };
 
 const marginBottom = css`
@@ -130,6 +135,17 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 				onChange={(e) => props.setLineOne(e.target.value)}
 				error={firstError('lineOne', props.errors)}
 				name={`${scope}-lineOne`}
+				maxLength={100}
+				onBlur={(event) => {
+					event.target.checkValidity();
+				}}
+				onInvalid={(event) => {
+					props.onAddressFieldInvalid?.(
+						event,
+						'lineOne',
+						'Please enter a delivery address.',
+					);
+				}}
 			/>
 			<TextInput
 				css={marginBottom}
@@ -142,6 +158,7 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 				onChange={(e) => props.setLineTwo(e.target.value)}
 				error={firstError('lineTwo', props.errors)}
 				name={`${scope}-lineTwo`}
+				maxLength={100}
 			/>
 			<TextInput
 				css={marginBottom}

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { palette, space } from '@guardian/source/foundations';
+import { space } from '@guardian/source/foundations';
 import {
 	Option as OptionForSelect,
 	Select,
@@ -54,13 +54,6 @@ type PropTypes = StatePropTypes & {
 
 const marginBottom = css`
 	margin-bottom: ${space[6]}px;
-`;
-
-const requiredSelectStyles = css`
-	&:invalid {
-		/* Remove styling of invalid select element */
-		border: 1px solid ${palette.neutral[46]};
-	}
 `;
 
 const MaybeSelect = canShow(Select);
@@ -193,7 +186,7 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 				}}
 			/>
 			<MaybeSelect
-				css={[marginBottom, requiredSelectStyles]}
+				css={marginBottom}
 				id={`${scope}-stateProvince`}
 				data-qm-masking="blocklist"
 				label={props.country === 'CA' ? 'Province/Territory' : 'State'}

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { isNonNullable } from '@guardian/libs';
 import { space } from '@guardian/source/foundations';
 import {
 	Option as OptionForSelect,
@@ -87,11 +88,12 @@ type ValidityStateError = 'valueMissing' | 'patternMismatch';
 export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 	const patternMismatch = 'Please use only letters, numbers and punctuation.';
 	const errorMessages: Record<
-		string,
-		{
-			[key in ValidityStateError]?: string;
-		}
+		keyof AddressFieldsType,
+		{ [key in ValidityStateError]?: string }
 	> = {
+		country: {
+			valueMissing: `Please enter a ${scope} country.`,
+		},
 		lineOne: {
 			valueMissing: `Please enter a ${scope} address.`,
 			patternMismatch,
@@ -116,12 +118,6 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 			}`,
 			patternMismatch,
 		},
-	};
-	const getErrorMessage = (
-		field: keyof AddressFieldsType,
-		validityStateError: ValidityStateError,
-	): string => {
-		return errorMessages[field][validityStateError] ?? '';
 	};
 	const setErrorsOnInvalid = (
 		event:
@@ -158,16 +154,16 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 					return error.field != field;
 				}),
 				// add all unresolved errors for the field
-				...(possibleValidityStateErrors
+				...possibleValidityStateErrors
 					.map((possibleValidityStateError) => {
 						if (validityState[possibleValidityStateError]) {
 							return {
 								field,
-								message: getErrorMessage(field, possibleValidityStateError),
+								message: errorMessages[field][possibleValidityStateError] ?? '',
 							};
 						}
 					})
-					.filter(Boolean) as AddressFormFieldError[]),
+					.filter(isNonNullable),
 			];
 			props.setErrors(updatedErrors);
 		}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -977,29 +977,33 @@ function CheckoutComponent({
 		abParticipations.abandonedBasket === 'variant',
 	);
 
+	type SetAddressErrors = React.Dispatch<
+		React.SetStateAction<AddressFormFieldError[]>
+	>;
+
 	const onAddressFieldInvalid = (
 		event: React.FormEvent<HTMLInputElement>,
 		field: keyof AddressFieldsType,
 		message: string,
+		errorList: AddressFormFieldError[],
+		setErrorList: SetAddressErrors,
 	) => {
 		preventDefaultValidityMessage(event.currentTarget);
 		const validityState = event.currentTarget.validity;
 		if (validityState.valid) {
-			const filteredDeliveryAddressErrors = deliveryAddressErrors.filter(
-				(error: AddressFormFieldError) => {
+			setErrorList(
+				errorList.filter((error) => {
 					return error.field != field;
-				},
+				}),
 			);
-			setDeliveryAddressErrors(filteredDeliveryAddressErrors);
 		} else {
-			const updatedDeliveryAddressErrors = [
-				...deliveryAddressErrors,
+			setErrorList([
+				...errorList,
 				{
 					field,
 					message,
 				},
-			];
-			setDeliveryAddressErrors(updatedDeliveryAddressErrors);
+			]);
 		}
 	};
 
@@ -1439,7 +1443,19 @@ function CheckoutComponent({
 												},
 											);
 										}}
-										onAddressFieldInvalid={onAddressFieldInvalid}
+										onAddressFieldInvalid={(
+											event: React.FormEvent<HTMLInputElement>,
+											field: keyof AddressFieldsType,
+											message: string,
+										) => {
+											onAddressFieldInvalid(
+												event,
+												field,
+												message,
+												deliveryAddressErrors,
+												setDeliveryAddressErrors,
+											);
+										}}
 									/>
 								</fieldset>
 

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -984,6 +984,17 @@ function CheckoutComponent({
 		React.SetStateAction<AddressFormFieldError[]>
 	>;
 
+	/**
+	 * onAddressFieldInvalid can be passed to the AddressFields
+	 * component. It can then be used as onInvalid handler
+	 * on an address field to add / remove errors to the
+	 * deliveryAddressErrors or billingAddressErrors lists
+	 * @param event Invalid Form Input Event
+	 * @param field ID of the field
+	 * @param message Error message
+	 * @param errorList deliveryAddressErrors OR billingAddressErrors list
+	 * @param setErrorList setDeliveryAddressErrors OR setBillingAddressErrors
+	 */
 	const onAddressFieldInvalid = (
 		event:
 			| React.FormEvent<HTMLInputElement>

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -986,7 +986,7 @@ function CheckoutComponent({
 
 	/**
 	 * onAddressFieldInvalid can be passed to the AddressFields
-	 * component. It can then be used as onInvalid handler
+	 * component. It can then be called as the onInvalid event handler
 	 * on an address field to add / remove errors to the
 	 * deliveryAddressErrors or billingAddressErrors lists
 	 * @param event Invalid Form Input Event

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -982,7 +982,9 @@ function CheckoutComponent({
 	>;
 
 	const onAddressFieldInvalid = (
-		event: React.FormEvent<HTMLInputElement>,
+		event:
+			| React.FormEvent<HTMLInputElement>
+			| React.FormEvent<HTMLSelectElement>,
 		field: keyof AddressFieldsType,
 		message: string,
 		errorList: AddressFormFieldError[],
@@ -1444,7 +1446,9 @@ function CheckoutComponent({
 											);
 										}}
 										onAddressFieldInvalid={(
-											event: React.FormEvent<HTMLInputElement>,
+											event:
+												| React.FormEvent<HTMLInputElement>
+												| React.FormEvent<HTMLSelectElement>,
 											field: keyof AddressFieldsType,
 											message: string,
 										) => {

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -89,10 +89,7 @@ import { NoFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { getPromotion } from 'helpers/productPrice/promotions';
-import type {
-	AddressFields as AddressFieldsType,
-	AddressFormFieldError,
-} from 'helpers/redux/checkout/address/state';
+import type { AddressFormFieldError } from 'helpers/redux/checkout/address/state';
 import { useAbandonedBasketCookie } from 'helpers/storage/abandonedBasketCookies';
 import * as cookie from 'helpers/storage/cookie';
 import {
@@ -980,49 +977,6 @@ function CheckoutComponent({
 		abParticipations.abandonedBasket === 'variant',
 	);
 
-	type SetAddressErrors = React.Dispatch<
-		React.SetStateAction<AddressFormFieldError[]>
-	>;
-
-	/**
-	 * onAddressFieldInvalid can be passed to the AddressFields
-	 * component. It can then be called as the onInvalid event handler
-	 * on an address field to add / remove errors to the
-	 * deliveryAddressErrors or billingAddressErrors lists
-	 * @param event Invalid Form Input Event
-	 * @param field ID of the field
-	 * @param message Error message
-	 * @param errorList deliveryAddressErrors OR billingAddressErrors list
-	 * @param setErrorList setDeliveryAddressErrors OR setBillingAddressErrors
-	 */
-	const onAddressFieldInvalid = (
-		event:
-			| React.FormEvent<HTMLInputElement>
-			| React.FormEvent<HTMLSelectElement>,
-		field: keyof AddressFieldsType,
-		message: string,
-		errorList: AddressFormFieldError[],
-		setErrorList: SetAddressErrors,
-	) => {
-		preventDefaultValidityMessage(event.currentTarget);
-		const validityState = event.currentTarget.validity;
-		if (validityState.valid) {
-			setErrorList(
-				errorList.filter((error) => {
-					return error.field != field;
-				}),
-			);
-		} else {
-			setErrorList([
-				...errorList,
-				{
-					field,
-					message,
-				},
-			]);
-		}
-	};
-
 	return (
 		<CheckoutLayout>
 			<Box cssOverrides={shorterBoxMargin}>
@@ -1450,6 +1404,9 @@ function CheckoutComponent({
 										setPostcodeErrorForFinder={() => {
 											// no-op
 										}}
+										setErrors={(errors) => {
+											setDeliveryAddressErrors(errors);
+										}}
 										onFindAddress={(postcode) => {
 											setDeliveryPostcodeStateLoading(true);
 											void findAddressesForPostcode(postcode).then(
@@ -1457,21 +1414,6 @@ function CheckoutComponent({
 													setDeliveryPostcodeStateLoading(false);
 													setDeliveryPostcodeStateResults(results);
 												},
-											);
-										}}
-										onAddressFieldInvalid={(
-											event:
-												| React.FormEvent<HTMLInputElement>
-												| React.FormEvent<HTMLSelectElement>,
-											field: keyof AddressFieldsType,
-											message: string,
-										) => {
-											onAddressFieldInvalid(
-												event,
-												field,
-												message,
-												deliveryAddressErrors,
-												setDeliveryAddressErrors,
 											);
 										}}
 									/>
@@ -1542,6 +1484,9 @@ function CheckoutComponent({
 											setPostcodeErrorForFinder={() => {
 												// no-op
 											}}
+											setErrors={(errors) => {
+												setBillingAddressErrors(errors);
+											}}
 											onFindAddress={(postcode) => {
 												setBillingPostcodeStateLoading(true);
 												void findAddressesForPostcode(postcode).then(
@@ -1549,21 +1494,6 @@ function CheckoutComponent({
 														setBillingPostcodeStateLoading(false);
 														setBillingPostcodeStateResults(results);
 													},
-												);
-											}}
-											onAddressFieldInvalid={(
-												event:
-													| React.FormEvent<HTMLInputElement>
-													| React.FormEvent<HTMLSelectElement>,
-												field: keyof AddressFieldsType,
-												message: string,
-											) => {
-												onAddressFieldInvalid(
-													event,
-													field,
-													message,
-													billingAddressErrors,
-													setBillingAddressErrors,
 												);
 											}}
 										/>

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -702,6 +702,9 @@ function CheckoutComponent({
 	const [billingPostcodeStateLoading, setBillingPostcodeStateLoading] =
 		useState(false);
 	const [billingCountry, setBillingCountry] = useState(countryId);
+	const [billingAddressErrors, setBillingAddressErrors] = useState<
+		AddressFormFieldError[]
+	>([]);
 
 	const formRef = useRef<HTMLFormElement>(null);
 
@@ -1497,7 +1500,7 @@ function CheckoutComponent({
 											state={billingState}
 											postCode={billingPostcode}
 											countries={productDescription.deliverableTo}
-											errors={[]}
+											errors={billingAddressErrors}
 											postcodeState={{
 												results: billingPostcodeStateResults,
 												isLoading: billingPostcodeStateLoading,
@@ -1535,6 +1538,21 @@ function CheckoutComponent({
 														setBillingPostcodeStateLoading(false);
 														setBillingPostcodeStateResults(results);
 													},
+												);
+											}}
+											onAddressFieldInvalid={(
+												event:
+													| React.FormEvent<HTMLInputElement>
+													| React.FormEvent<HTMLSelectElement>,
+												field: keyof AddressFieldsType,
+												message: string,
+											) => {
+												onAddressFieldInvalid(
+													event,
+													field,
+													message,
+													billingAddressErrors,
+													setBillingAddressErrors,
 												);
 											}}
 										/>


### PR DESCRIPTION
## What are you doing in this PR?

this is a first pass at using the validation error messaging builid into `@guardian/source` components  on the generic checkouts address fields, this is an alternative approach to using native browser validation error messaging, implemented here: https://github.com/guardian/support-frontend/pull/6251



**support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx**
- I've set-up an `setErrorsOnInvalid` function that we can attach to our form fields and execute via the `onInvalid` handler. The `onInvalid` event handler  fires when a submittable element has been checked for validity and doesn't satisfy its constraints (see: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event). `onAddressFieldInvalid`  manages adding/removing error message to either the `errors` prop via the `setErrors` prop.
- I've added an `onBlur` handler to the form fields, this revalidates the form fields when a user has entered content and triggers `onInvalid`, if the input is valid any error related to the field will be removed from the `errors` list, and will disappear from the UI.
- I've added some `maxLength` content restrictions to the form fields, which were in place in the non-generic GW checkout, these stop invalid content causing step function failures because the fields content exceeds a limit in Zuora.
- I've added some `maxLength`/`doesNotContainEmojiPattern` content restrictions to the form fields, which were in place in the non-generic GW checkout, these stop invalid content causing step function failures because the fields content exceeds a limit in Zuora or contains invalid characters.
  
## Screenshots

`@guardian/source` component validation doing it's thing...

https://github.com/user-attachments/assets/88ca1ac8-851d-4134-a29b-ece1f2da8f55


