### PR TITLE
Add new countdown component for US EOY 2024

### DIFF
--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -27,18 +27,18 @@ const campaigns: Record<string, CampaignSettings> = {
 			{
 				label: 'Discount',
 				countdownStartInMillis: Date.parse('Dec 09, 2024 00:00:00'),
-				countdownDeadlineInMillis: Date.parse('Dec 12, 2024 00:00:00'),
+				countdownDeadlineInMillis: Date.parse('Dec 13, 2024 00:00:00'),
 			},
 			{
 				label: 'Final Countdown',
 				countdownStartInMillis: Date.parse('Dec 23, 2024 00:00:00'),
-				countdownDeadlineInMillis: Date.parse('Jan 02, 2025 00:00:00'),
+				countdownDeadlineInMillis: Date.parse('Jan 01, 2025 00:00:00'),
 			},
-			{
-				label: 'testing',
-				countdownStartInMillis: Date.parse('Sept 05, 2024 00:00:00'),
-				countdownDeadlineInMillis: Date.parse('Sep 05, 2024 12:17:00'),
-			},
+			// {
+			// 	label: 'testing', // adjust this one as needed
+			// 	countdownStartInMillis: Date.parse('Sept 05, 2024 00:00:00'),
+			// 	countdownDeadlineInMillis: Date.parse('Sep 06, 2024 00:00:00'),
+			// },
 		],
 	},
 };

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -5,6 +5,12 @@ export type CountdownSetting = {
 	label: string;
 	countdownStartInMillis: number;
 	countdownDeadlineInMillis: number;
+	// TODO: when design agreed add theme
+	//theme: {
+	//	backgroundColor: string;
+	// 	primaryColor: string;
+	//  secondaryColor: string;
+	//};
 };
 
 export type CampaignSettings = {

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -5,7 +5,6 @@ export type CountdownSetting = {
 	label: string;
 	countdownStartInMillis: number;
 	countdownDeadlineInMillis: number;
-	countdownHideInMillis: number;
 };
 
 export type CampaignSettings = {
@@ -24,25 +23,21 @@ const campaigns: Record<string, CampaignSettings> = {
 				label: 'Giving Tuesday',
 				countdownStartInMillis: Date.parse('Nov 29, 2024 00:00:00'),
 				countdownDeadlineInMillis: Date.parse('Dec 04, 2024 00:00:00'),
-				countdownHideInMillis: Date.parse('Dec 05, 2024 00:01:00'),
 			},
 			{
 				label: 'Discount',
 				countdownStartInMillis: Date.parse('Dec 09, 2024 00:00:00'),
 				countdownDeadlineInMillis: Date.parse('Dec 12, 2024 00:00:00'),
-				countdownHideInMillis: Date.parse('Dec 12, 2024 00:01:00'),
 			},
 			{
 				label: 'Final Countdown',
 				countdownStartInMillis: Date.parse('Dec 23, 2024 00:00:00'),
 				countdownDeadlineInMillis: Date.parse('Jan 02, 2025 00:00:00'),
-				countdownHideInMillis: Date.parse('Jan 03, 2025 00:01:00'),
 			},
 			{
 				label: 'testing',
 				countdownStartInMillis: Date.parse('Sept 05, 2024 00:00:00'),
-				countdownDeadlineInMillis: Date.parse('Sep 06, 2024 12:04:00'),
-				countdownHideInMillis: Date.parse('Sept 06, 2024 12:05:00'),
+				countdownDeadlineInMillis: Date.parse('Sep 05, 2024 12:17:00'),
 			},
 		],
 	},

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -6,7 +6,7 @@ export type CountdownSetting = {
 	countdownStartInMillis: number;
 	countdownDeadlineInMillis: number;
 	countdownHideInMillis: number;
-}
+};
 
 export type CampaignSettings = {
 	isEligible: (countryGroupId: CountryGroupId) => boolean;
@@ -22,10 +22,10 @@ const campaigns: Record<string, CampaignSettings> = {
 		countdownSettings: [
 			{
 				label: 'testing',
-				countdownStartInMillis: Date.parse('Aug 28, 2024 17:30:00'), 
-				countdownDeadlineInMillis: Date.parse('Sep 03, 2024 17:45:00'), 
-				countdownHideInMillis: Date.parse('Sept 04, 2024 17:50:00'), 
-			}
+				countdownStartInMillis: Date.parse('Aug 28, 2024 17:30:00'),
+				countdownDeadlineInMillis: Date.parse('Sep 03, 2024 17:45:00'),
+				countdownHideInMillis: Date.parse('Sept 04, 2024 17:50:00'),
+			},
 		],
 	},
 };

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -21,19 +21,25 @@ const campaigns: Record<string, CampaignSettings> = {
 		enableSingleContributions: true,
 		countdownSettings: [
 			{
+				label: 'Giving Tuesday',
+				countdownStartInMillis: Date.parse('Nov 29, 2024 00:00:00'),
+				countdownDeadlineInMillis: Date.parse('Dec 04, 2024 00:00:00'),
+				countdownHideInMillis: Date.parse('Dec 05, 2024 00:01:00'),
+			},
+			{
+				label: 'Discount',
+				countdownStartInMillis: Date.parse('Dec 09, 2024 00:00:00'),
+				countdownDeadlineInMillis: Date.parse('Dec 12, 2024 00:00:00'),
+				countdownHideInMillis: Date.parse('Dec 12, 2024 00:01:00'),
+			},
+			{
+				label: 'Final Countdown',
+				countdownStartInMillis: Date.parse('Dec 23, 2024 00:00:00'),
+				countdownDeadlineInMillis: Date.parse('Jan 02, 2025 00:00:00'),
+				countdownHideInMillis: Date.parse('Jan 03, 2025 00:01:00'),
+			},
+			{
 				label: 'testing',
-				countdownStartInMillis: Date.parse('Sept 01, 2024 00:00:00'),
-				countdownDeadlineInMillis: Date.parse('Sep 02, 2024 10:15:00'),
-				countdownHideInMillis: Date.parse('Sept 02, 2024 10:20:00'),
-			},
-			{
-				label: 'testing 2',
-				countdownStartInMillis: Date.parse('Sept 02, 2024 00:00:00'),
-				countdownDeadlineInMillis: Date.parse('Sep 04, 2024 16:59:00'),
-				countdownHideInMillis: Date.parse('Sept 04, 2024 17:00:00'),
-			},
-			{
-				label: 'testing 3',
 				countdownStartInMillis: Date.parse('Sept 05, 2024 00:00:00'),
 				countdownDeadlineInMillis: Date.parse('Sep 06, 2024 12:04:00'),
 				countdownHideInMillis: Date.parse('Sept 06, 2024 12:05:00'),

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -29,8 +29,8 @@ const campaigns: Record<string, CampaignSettings> = {
 			{
 				label: 'testing 2',
 				countdownStartInMillis: Date.parse('Sept 02, 2024 00:00:00'),
-				countdownDeadlineInMillis: Date.parse('Sep 03, 2024 14:26:00'),
-				countdownHideInMillis: Date.parse('Sept 03, 2024 14:27:00'),
+				countdownDeadlineInMillis: Date.parse('Sep 04, 2024 16:59:00'),
+				countdownHideInMillis: Date.parse('Sept 04, 2024 17:00:00'),
 			},
 			{
 				label: 'testing 3',

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -22,9 +22,9 @@ const campaigns: Record<string, CampaignSettings> = {
 		countdownSettings: [
 			{
 				label: 'testing',
-				countdownStartInMillis: Date.parse('Aug 28, 2024 17:30:00'),
-				countdownDeadlineInMillis: Date.parse('Sep 03, 2024 17:45:00'),
-				countdownHideInMillis: Date.parse('Sept 04, 2024 17:50:00'),
+				countdownStartInMillis: Date.parse('Sept 02, 2024 00:00:00'),
+				countdownDeadlineInMillis: Date.parse('Sep 03, 2024 14:15:00'),
+				countdownHideInMillis: Date.parse('Sept 03, 2024 14:20:00'),
 			},
 		],
 	},

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -1,9 +1,17 @@
 import type { CountryGroupId } from '../internationalisation/countryGroup';
 import { UnitedStates } from '../internationalisation/countryGroup';
 
+export type CountdownSetting = {
+	label: string;
+	countdownStartInMillis: number;
+	countdownDeadlineInMillis: number;
+	countdownHideInMillis: number;
+}
+
 export type CampaignSettings = {
 	isEligible: (countryGroupId: CountryGroupId) => boolean;
 	enableSingleContributions: boolean;
+	countdownSettings: CountdownSetting[];
 };
 
 const campaigns: Record<string, CampaignSettings> = {
@@ -11,6 +19,14 @@ const campaigns: Record<string, CampaignSettings> = {
 		isEligible: (countryGroupId: CountryGroupId) =>
 			countryGroupId === UnitedStates,
 		enableSingleContributions: true,
+		countdownSettings: [
+			{
+				label: 'testing',
+				countdownStartInMillis: Date.parse('Aug 28, 2024 17:30:00'), 
+				countdownDeadlineInMillis: Date.parse('Sep 03, 2024 17:45:00'), 
+				countdownHideInMillis: Date.parse('Sept 04, 2024 17:50:00'), 
+			}
+		],
 	},
 };
 

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -16,7 +16,7 @@ export type CountdownSetting = {
 export type CampaignSettings = {
 	isEligible: (countryGroupId: CountryGroupId) => boolean;
 	enableSingleContributions: boolean;
-	countdownSettings: CountdownSetting[];
+	countdownSettings?: CountdownSetting[];
 };
 
 const campaigns: Record<string, CampaignSettings> = {

--- a/support-frontend/assets/helpers/campaigns/campaigns.ts
+++ b/support-frontend/assets/helpers/campaigns/campaigns.ts
@@ -22,9 +22,21 @@ const campaigns: Record<string, CampaignSettings> = {
 		countdownSettings: [
 			{
 				label: 'testing',
+				countdownStartInMillis: Date.parse('Sept 01, 2024 00:00:00'),
+				countdownDeadlineInMillis: Date.parse('Sep 02, 2024 10:15:00'),
+				countdownHideInMillis: Date.parse('Sept 02, 2024 10:20:00'),
+			},
+			{
+				label: 'testing 2',
 				countdownStartInMillis: Date.parse('Sept 02, 2024 00:00:00'),
-				countdownDeadlineInMillis: Date.parse('Sep 03, 2024 14:15:00'),
-				countdownHideInMillis: Date.parse('Sept 03, 2024 14:20:00'),
+				countdownDeadlineInMillis: Date.parse('Sep 03, 2024 14:26:00'),
+				countdownHideInMillis: Date.parse('Sept 03, 2024 14:27:00'),
+			},
+			{
+				label: 'testing 3',
+				countdownStartInMillis: Date.parse('Sept 05, 2024 00:00:00'),
+				countdownDeadlineInMillis: Date.parse('Sep 06, 2024 12:04:00'),
+				countdownHideInMillis: Date.parse('Sept 06, 2024 12:05:00'),
 			},
 		],
 	},

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -54,17 +54,8 @@ const millisecondsInMinute = 60 * millisecondsInSecond;
 const millisecondsInHour = 60 * millisecondsInMinute;
 const millisecondsInDay = 24 * millisecondsInHour;
 
-// Questions:
-// handle inactive tabs via the Page Visibility API and calculate on visibility change?
-
-const ensureDoubleDigits = (timeSection: number): string => {
-	if (timeSection < 0) {
-		return '00';
-	} else {
-		return timeSection > 9
-			? timeSection.toString()
-			: `0${timeSection.toString()}`;
-	}
+const ensureRoundedDoubleDigits = (timeSection: number): string => {
+	return String(Math.floor(timeSection)).padStart(2, '0');
 };
 
 // return the countdown component
@@ -95,25 +86,23 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 			);
 
 			setDays(
-				ensureDoubleDigits(Math.floor(timeRemaining / millisecondsInDay)),
+				ensureRoundedDoubleDigits(
+					Math.floor(timeRemaining / millisecondsInDay),
+				),
 			);
 			setHours(
-				ensureDoubleDigits(
-					Math.floor((timeRemaining % millisecondsInDay) / millisecondsInHour),
+				ensureRoundedDoubleDigits(
+					(timeRemaining % millisecondsInDay) / millisecondsInHour,
 				),
 			);
 			setMinutes(
-				ensureDoubleDigits(
-					Math.floor(
-						(timeRemaining % millisecondsInHour) / millisecondsInMinute,
-					),
+				ensureRoundedDoubleDigits(
+					(timeRemaining % millisecondsInHour) / millisecondsInMinute,
 				),
 			);
 			setSeconds(
-				ensureDoubleDigits(
-					Math.floor(
-						(timeRemaining % millisecondsInMinute) / millisecondsInSecond,
-					),
+				ensureRoundedDoubleDigits(
+					(timeRemaining % millisecondsInMinute) / millisecondsInSecond,
 				),
 			);
 		}
@@ -125,10 +114,10 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 			return () => clearInterval(id); // clear on on unmount
 		} else {
 			// deadline already passed on page load
-			setSeconds(ensureDoubleDigits(0));
-			setMinutes(ensureDoubleDigits(0));
-			setHours(ensureDoubleDigits(0));
-			setDays(ensureDoubleDigits(0));
+			setSeconds(ensureRoundedDoubleDigits(0));
+			setMinutes(ensureRoundedDoubleDigits(0));
+			setHours(ensureRoundedDoubleDigits(0));
+			setDays(ensureRoundedDoubleDigits(0));
 		}
 	}, [campaign]);
 

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -55,7 +55,7 @@ const millisecondsInHour = 60 * millisecondsInMinute;
 const millisecondsInDay = 24 * millisecondsInHour;
 
 const ensureRoundedDoubleDigits = (timeSection: number): string => {
-	return String(Math.floor(timeSection)).padStart(2, '0');
+	return timeSection < 0 ? String(0).padStart(2, '0') : String(Math.floor(timeSection)).padStart(2, '0');
 };
 
 // return the countdown component

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -82,7 +82,6 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 		};
 		const canDisplayCountdown = () => {
 			const now = Date.now();
-			// console.log('Checking if campaign currently active...');
 			const isActive =
 				campaign.countdownStartInMillis < now &&
 				campaign.countdownDeadlineInMillis > now;
@@ -94,13 +93,6 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 			const timeRemaining = getTotalMillisRemaining(
 				campaign.countdownDeadlineInMillis,
 			);
-
-			// console.log(`time > 0: ${timeRemaining}`);
-
-			// const now = Date.now();
-			// if (now > campaign.countdownHideInMillis) {
-			// 	setShowCountdown(false);
-			// }
 
 			setDays(
 				ensureDoubleDigits(Math.floor(timeRemaining / millisecondsInDay)),

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -72,7 +72,6 @@ const ensureDoubleDigits = (timeSection: number): string => {
 export default function Countdown({
 	deadlineDateTime,
 }: CountdownProps): JSX.Element {
-
 	// one for each timepart to reduce DOM updates where unnecessary.
 	const [seconds, setSeconds] = useState<string>(initialTimePart);
 	const [minutes, setMinutes] = useState<string>(initialTimePart);
@@ -80,75 +79,76 @@ export default function Countdown({
 	const [days, setDays] = useState<string>(initialTimePart);
 
 	useEffect(() => {
-		
-		// console.log('The time now is: ', new Date());
-		
+		console.log('The time now is: ', new Date());
+
 		const getTotalMillisRemaining = (targetDate: number) => {
 			return targetDate - Date.now();
 		};
-		
-		function updateTimeParts() {
 
+		function updateTimeParts() {
 			const timeRemaining = getTotalMillisRemaining(deadlineDateTime);
 
 			// console.log(`time > 0 ${timeRemaining}`);
-			setDays(ensureDoubleDigits(Math.floor(
-				timeRemaining / millisecondsInDay))
+			setDays(
+				ensureDoubleDigits(Math.floor(timeRemaining / millisecondsInDay)),
 			);
-			setHours(ensureDoubleDigits(Math.floor(
-				(timeRemaining % millisecondsInDay) / 
-				millisecondsInHour))
+			setHours(
+				ensureDoubleDigits(
+					Math.floor((timeRemaining % millisecondsInDay) / millisecondsInHour),
+				),
 			);
-			setMinutes(ensureDoubleDigits(Math.floor(
-				(timeRemaining % millisecondsInHour) /
-				millisecondsInMinute))
+			setMinutes(
+				ensureDoubleDigits(
+					Math.floor(
+						(timeRemaining % millisecondsInHour) / millisecondsInMinute,
+					),
+				),
 			);
-			setSeconds(ensureDoubleDigits(Math.floor(
-				(timeRemaining % millisecondsInMinute) /
-				millisecondsInSecond))
+			setSeconds(
+				ensureDoubleDigits(
+					Math.floor(
+						(timeRemaining % millisecondsInMinute) / millisecondsInSecond,
+					),
+				),
 			);
-		};
-		
+		}
+
 		if (getTotalMillisRemaining(deadlineDateTime) > 0) {
 			const id = setInterval(updateTimeParts, 1000); // run once per second
 			return () => clearInterval(id); // clear on onload
-		} 
-		else {
+		} else {
 			// console.log(`deadline already passed on page load`);
 			setSeconds(ensureDoubleDigits(0));
 			setMinutes(ensureDoubleDigits(0));
 			setHours(ensureDoubleDigits(0));
-			setDays(ensureDoubleDigits(0)); 
-		};
-		
+			setDays(ensureDoubleDigits(0));
+		}
 	}, [deadlineDateTime]);
 
 	return (
 		<>
 			<div css={grid}>
-				<TimePart timePart={days} label={"days"} />
-				<TimePart timePart={hours} label={"hours"} />
-				<TimePart timePart={minutes} label={"mins"} />
-				<TimePart timePart={seconds} label={"secs"} />
+				<TimePart timePart={days} label={'days'} />
+				<TimePart timePart={hours} label={'hours'} />
+				<TimePart timePart={minutes} label={'mins'} />
+				<TimePart timePart={seconds} label={'secs'} />
 			</div>
 		</>
 	);
-};
+}
 
 // internal components
 
 type TimePartProps = {
 	timePart: string;
 	label: string;
-}
+};
 
-function TimePart({
-	timePart, label
-}: TimePartProps): JSX.Element {
+function TimePart({ timePart, label }: TimePartProps): JSX.Element {
 	return (
 		<div css={gridItem}>
 			<div>{timePart}</div>
 			<div css={timePortion}>{label}</div>
 		</div>
 	);
-};
+}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -55,7 +55,9 @@ const millisecondsInHour = 60 * millisecondsInMinute;
 const millisecondsInDay = 24 * millisecondsInHour;
 
 const ensureRoundedDoubleDigits = (timeSection: number): string => {
-	return timeSection < 0 ? String(0).padStart(2, '0') : String(Math.floor(timeSection)).padStart(2, '0');
+	return timeSection < 0
+		? String(0).padStart(2, '0')
+		: String(Math.floor(timeSection)).padStart(2, '0');
 };
 
 // return the countdown component

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -45,7 +45,6 @@ export type CountdownProps = {
 };
 
 // create countdown logic
-
 const initialTimePart = '00';
 const millisecondsinSecond = 1000;
 const millisecondsinMinute = 60 * millisecondsinSecond;
@@ -75,6 +74,8 @@ const ensureDoubleDigits = (timeSection: number): string => {
 export default function Countdown({
 	deadlineDateTime,
 }: CountdownProps): JSX.Element {
+
+	// one for each timepart to reduce DOM updates where unnecessary.
 	const [seconds, setSeconds] = useState<string>(initialTimePart);
 	const [minutes, setMinutes] = useState<string>(initialTimePart);
 	const [hours, setHours] = useState<string>(initialTimePart);
@@ -82,37 +83,36 @@ export default function Countdown({
 
 	useEffect(() => {
 		function updateTimeparts() {
-			const timeRemainingOnInitialLoad =
-				getTotalMillisRemaining(deadlineDateTime);
-			if (timeRemainingOnInitialLoad <= 0) {
-				setSeconds(ensureDoubleDigits(0));
-				setMinutes(ensureDoubleDigits(0));
-				setHours(ensureDoubleDigits(0));
-				setDays(ensureDoubleDigits(0));
-				// console.log(`time <= 0 ${timeRemainingOnInitialLoad}`);
-			} else {
-				// console.log(`time > 0 ${timeRemainingOnInitialLoad}`);
-				const d = Math.floor(timeRemainingOnInitialLoad / millisecondsInDay);
-				const h = Math.floor(
-					(timeRemainingOnInitialLoad % millisecondsInDay) / millisecondsinHour,
-				);
-				const m = Math.floor(
-					(timeRemainingOnInitialLoad % millisecondsinHour) /
-						millisecondsinMinute,
-				);
-				const s = Math.floor(
-					(timeRemainingOnInitialLoad % millisecondsinMinute) /
-						millisecondsinSecond,
-				);
-				setSeconds(ensureDoubleDigits(s));
-				setMinutes(ensureDoubleDigits(m));
-				setHours(ensureDoubleDigits(h));
-				setDays(ensureDoubleDigits(d));
-			}
+
+			const timeRemaining = getTotalMillisRemaining(deadlineDateTime);
+			console.log(`time > 0 ${timeRemaining}`);
+			setDays(ensureDoubleDigits(Math.floor(
+				timeRemaining / millisecondsInDay))
+			);
+			setHours(ensureDoubleDigits(Math.floor(
+				(timeRemaining % millisecondsInDay) / 
+					millisecondsinHour))
+			);
+			setMinutes(ensureDoubleDigits(Math.floor(
+				(timeRemaining % millisecondsinHour) /
+					millisecondsinMinute))
+			);
+			setSeconds(ensureDoubleDigits(Math.floor(
+				(timeRemaining % millisecondsinMinute) /
+					millisecondsinSecond))
+			);
 		}
-		updateTimeparts();
-		const id = setInterval(updateTimeparts, 1000);
-		return () => clearInterval(id);
+
+		if(getTotalMillisRemaining(deadlineDateTime) > 0) {
+			const id = setInterval(updateTimeparts, 1000); // run once per second
+			return () => clearInterval(id); // clear on onload
+		} 
+		else {
+			setSeconds(ensureDoubleDigits(0));
+			setMinutes(ensureDoubleDigits(0));
+			setHours(ensureDoubleDigits(0));
+			setDays(ensureDoubleDigits(0)); 
+		}
 	}, [deadlineDateTime]);
 
 	return (

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -77,14 +77,15 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 	const [showCountdown, setShowCountdown] = useState<boolean>(false);
 
 	useEffect(() => {
-
 		const getTotalMillisRemaining = (targetDate: number) => {
 			return targetDate - Date.now();
 		};
 		const canDisplayCountdown = () => {
 			const now = Date.now();
 			// console.log('Checking if campaign currently active...');
-			const isActive = campaign.countdownStartInMillis < now && campaign.countdownHideInMillis > now;
+			const isActive =
+				campaign.countdownStartInMillis < now &&
+				campaign.countdownHideInMillis > now;
 			setShowCountdown(isActive);
 			return isActive;
 		};
@@ -126,7 +127,7 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 		}
 
 		if (canDisplayCountdown()) {
-			const id = setInterval(updateTimeParts, 1000); // run once per second 
+			const id = setInterval(updateTimeParts, 1000); // run once per second
 			// console.log(`The timer has been created.`);
 			return () => clearInterval(id); // clear on on unmount
 		} else {

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -48,19 +48,15 @@ export type CountdownProps = {
 
 // create countdown logic
 const initialTimePart = '00';
-const millisecondsinSecond = 1000;
-const millisecondsinMinute = 60 * millisecondsinSecond;
-const millisecondsinHour = 60 * millisecondsinMinute;
-const millisecondsInDay = 24 * millisecondsinHour;
+const millisecondsInSecond = 1000;
+const millisecondsInMinute = 60 * millisecondsInSecond;
+const millisecondsInHour = 60 * millisecondsInMinute;
+const millisecondsInDay = 24 * millisecondsInHour;
 
 // Questions:
 // could each portion be a component so that not everything gets updated each time?
 // handle inactive tabs via the Page Visibility API and calculate on visibility change?
 // how do we assess performance?
-
-const getTotalMillisRemaining = (targetDate: number) => {
-	return targetDate - Date.now();
-};
 
 const ensureDoubleDigits = (timeSection: number): string => {
 	if (timeSection < 0) {
@@ -85,34 +81,40 @@ export default function Countdown({
 
 	useEffect(() => {
 		
-		function updateTimeparts() {
+		// console.log('The time now is: ', new Date());
+		
+		const getTotalMillisRemaining = (targetDate: number) => {
+			return targetDate - Date.now();
+		};
+		
+		function updateTimeParts() {
 
 			const timeRemaining = getTotalMillisRemaining(deadlineDateTime);
 
-			console.log(`time > 0 ${timeRemaining}`);
+			// console.log(`time > 0 ${timeRemaining}`);
 			setDays(ensureDoubleDigits(Math.floor(
 				timeRemaining / millisecondsInDay))
 			);
 			setHours(ensureDoubleDigits(Math.floor(
 				(timeRemaining % millisecondsInDay) / 
-				millisecondsinHour))
+				millisecondsInHour))
 			);
 			setMinutes(ensureDoubleDigits(Math.floor(
-				(timeRemaining % millisecondsinHour) /
-				millisecondsinMinute))
+				(timeRemaining % millisecondsInHour) /
+				millisecondsInMinute))
 			);
 			setSeconds(ensureDoubleDigits(Math.floor(
-				(timeRemaining % millisecondsinMinute) /
-				millisecondsinSecond))
+				(timeRemaining % millisecondsInMinute) /
+				millisecondsInSecond))
 			);
 		};
 		
 		if (getTotalMillisRemaining(deadlineDateTime) > 0) {
-			const id = setInterval(updateTimeparts, 1000); // run once per second
+			const id = setInterval(updateTimeParts, 1000); // run once per second
 			return () => clearInterval(id); // clear on onload
 		} 
 		else {
-			console.log(`deadline already passed on page load`);
+			// console.log(`deadline already passed on page load`);
 			setSeconds(ensureDoubleDigits(0));
 			setMinutes(ensureDoubleDigits(0));
 			setHours(ensureDoubleDigits(0));

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -1,0 +1,136 @@
+import { css } from '@emotion/react';
+import { headlineBold28, palette } from '@guardian/source/foundations';
+import { useEffect, useState } from 'react';
+/** 
+ * This is used during the annual US End of Year Campaign.
+ */
+
+// create the style - TODO: design not yet confirmed... 
+const grid = css`
+    display: flex;
+    padding-top: 33px;
+    justify-content: center;
+    align-items: center;
+    `
+const gridItem = css`
+    font-variant-numeric: lining-nums proportional-nums;
+    color: ${palette.brand[400]};
+    background-color: ${palette.neutral[100]};
+    /* 🖥 Headline/headline.bld.28 */
+    ${headlineBold28}
+    /* font-family: 'headlineBold28';
+    font-size: 28px;
+    font-style: normal;
+    font-weight: 700; 
+    line-height: 115%;*/ /* 32.2px */
+    width: 65px;
+    margin: 3px;
+    padding: 2px;
+    border: 1px solid ${palette.brand[400]};
+    border-radius: 4px;
+    `
+const timePortion = css`
+    color: ${palette.brand[400]};
+    /* 🖥 Text Sans/text.sans.12 */
+    font-family: 'GuardianTextSans';
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 130%; /* 15.6px */
+    `
+
+// props
+export type CountdownProps = {
+    deadlineDateTime: number; 
+}
+
+// create countdown logic
+
+const initialTimePart = "00";
+const millisecondsinSecond = 1000;
+const millisecondsinMinute = 60 * millisecondsinSecond;
+const millisecondsinHour = 60 * millisecondsinMinute;
+const millisecondsInDay = 24 * millisecondsinHour;
+
+// Questions:
+    // could each portion be a component so that not everything gets updated each time? 
+    // handle inactive tabs via the Page Visibility API and calculate on visibility change?
+    // how do we assess performance?
+
+const getTotalMillisRemaining = (targetDate: number) => {
+    return targetDate - Date.now();
+}
+
+const ensureDoubleDigits = (timeSection: number): string => {
+    if (timeSection < 0) {
+        return '00'
+    }
+    else {
+        return timeSection > 9 ?  timeSection.toString() : `0${timeSection.toString()}`
+    }
+}
+
+// return a component
+export default function Countdown({
+    deadlineDateTime
+}: CountdownProps): JSX.Element {
+
+    const [seconds, setSeconds] = useState<string>(initialTimePart);
+    const [minutes, setMinutes] = useState<string>(initialTimePart);
+    const [hours, setHours] = useState<string>(initialTimePart);
+    const [days, setDays] = useState<string>(initialTimePart);
+
+    useEffect(() => {
+
+        function updateTimeparts() {
+
+            const timeRemainingOnInitialLoad = getTotalMillisRemaining(deadlineDateTime);
+            if (timeRemainingOnInitialLoad <= 0) {
+                setSeconds(ensureDoubleDigits(0));
+                setMinutes(ensureDoubleDigits(0));
+                setHours(ensureDoubleDigits(0)); 
+                setDays(ensureDoubleDigits(0));               
+                // console.log(`time <= 0 ${timeRemainingOnInitialLoad}`);
+            }
+            else {
+                // console.log(`time > 0 ${timeRemainingOnInitialLoad}`);
+                const d = Math.floor(timeRemainingOnInitialLoad/millisecondsInDay);
+                const h = Math.floor(timeRemainingOnInitialLoad % millisecondsInDay / millisecondsinHour);
+                const m = Math.floor(timeRemainingOnInitialLoad % millisecondsinHour / millisecondsinMinute);
+                const s = Math.floor(timeRemainingOnInitialLoad % millisecondsinMinute / millisecondsinSecond);
+                setSeconds(ensureDoubleDigits(s));
+                setMinutes(ensureDoubleDigits(m));
+                setHours(ensureDoubleDigits(h)); 
+                setDays(ensureDoubleDigits(d)); 
+            }
+        }
+        updateTimeparts();
+        const id = setInterval(updateTimeparts, 1000);
+        return () => clearInterval(id);
+
+    },[deadlineDateTime]);
+
+
+    return(
+        <>
+        <div css={grid}>
+            <div css={gridItem}>
+                <div>{days}</div>
+                <div css={timePortion}>days</div>
+            </div>
+            <div css={gridItem}>
+                <div>{hours}</div>
+                <div css={timePortion}>hours</div>
+            </div>
+            <div css={gridItem}>
+                <div>{minutes}</div>
+                <div css={timePortion}>mins</div>
+            </div>
+            <div css={gridItem}>
+                <div>{seconds}</div>
+                <div css={timePortion}>secs</div>
+            </div>
+        </div>
+        </>
+    );
+}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -127,6 +127,7 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 		}
 
 		if (canDisplayCountdown()) {
+			updateTimeParts(); // called first
 			const id = setInterval(updateTimeParts, 1000); // run once per second
 			// console.log(`The timer has been created.`);
 			return () => clearInterval(id); // clear on on unmount

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -7,14 +7,14 @@ import type { CountdownSetting } from 'helpers/campaigns/campaigns';
  */
 
 // create the style - TODO: design not yet confirmed...
-const grid = css`
+const gridStyle = css`
 	display: flex;
 	padding-top: 33px;
 	padding-bottom: 15px;
 	justify-content: center;
 	align-items: center;
 `;
-const gridItem = css`
+const gridItemStyle = css`
 	font-variant-numeric: lining-nums proportional-nums;
 	color: ${palette.brand[400]};
 	background-color: ${palette.neutral[100]};
@@ -32,7 +32,7 @@ const gridItem = css`
 	border-radius: 4px;
 	text-align: center;
 `;
-const timePortion = css`
+const timePortionStyle = css`
 	color: ${palette.brand[400]};
 	/* 🖥 Text Sans/text.sans.12 */
 	font-family: 'GuardianTextSans';
@@ -83,7 +83,7 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 		};
 		const canDisplayCountdown = () => {
 			const now = Date.now();
-			console.log('Checking if campaign currently active...');
+			// console.log('Checking if campaign currently active...');
 			const isActive = campaign.countdownStartInMillis < now && campaign.countdownHideInMillis > now;
 			setShowCountdown(isActive);
 			return isActive;
@@ -93,14 +93,14 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 			const timeRemaining = getTotalMillisRemaining(
 				campaign.countdownDeadlineInMillis,
 			);
-			// setTimeRemainingInMillis(timeRemaining);
-			console.log(`time > 0: ${timeRemaining}`);
+
+			// console.log(`time > 0: ${timeRemaining}`);
+
 			const now = Date.now();
 			if (now > campaign.countdownHideInMillis) {
 				setShowCountdown(false);
 			}
 
-			// console.log(`time > 0 ${timeRemaining}`);
 			setDays(
 				ensureDoubleDigits(Math.floor(timeRemaining / millisecondsInDay)),
 			);
@@ -127,7 +127,7 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 
 		if (canDisplayCountdown()) {
 			const id = setInterval(updateTimeParts, 1000); // run once per second 
-			console.log(`The timer has been created.`);
+			// console.log(`The timer has been created.`);
 			return () => clearInterval(id); // clear on on unmount
 		} else {
 			// deadline already passed on page load
@@ -141,7 +141,7 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 	return (
 		<>
 			{showCountdown && (
-				<div role="timer" css={grid}>
+				<div role="timer" css={gridStyle}>
 					<TimePart timePart={days} label={'days'} />
 					<TimePart timePart={hours} label={'hours'} />
 					<TimePart timePart={minutes} label={'mins'} />
@@ -161,9 +161,9 @@ type TimePartProps = {
 
 function TimePart({ timePart, label }: TimePartProps): JSX.Element {
 	return (
-		<div css={gridItem}>
+		<div css={gridItemStyle}>
 			<div>{timePart}</div>
-			<div css={timePortion}>{label}</div>
+			<div css={timePortionStyle}>{label}</div>
 		</div>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -86,11 +86,18 @@ export default function Countdown({
 		const getTotalMillisRemaining = (targetDate: number) => {
 			return targetDate - Date.now();
 		};
+
+		const canDisplayCountdown = () => {
+			const now = Date.now();
+			console.log('Checking if campaign currently active...');
+			return (
+				campaign.countdownStartInMillis < now &&
+				campaign.countdownHideInMillis > now
+			);
+		}
 		
 		function updateTimeParts() {
-			// TODO: add some validation of the dates
-			// TODO: handle hiding if the start date is in the future.
-			
+
 			const timeRemaining = getTotalMillisRemaining(campaign.countdownDeadlineInMillis);
 			setTimeRemainingInMillis(timeRemaining);
 
@@ -119,11 +126,12 @@ export default function Countdown({
 			);
 		}
 
-		if (getTotalMillisRemaining(campaign.countdownDeadlineInMillis) > 0) {
+		if (canDisplayCountdown()) {
 			const id = setInterval(updateTimeParts, 1000); // run once per second
-			console.log(`The timer has been created.`);
+			// console.log(`The timer has been created.`);
 			return () => clearInterval(id); // clear on on unmount
-		} else {
+		} 
+		else {
 			// deadline already passed on page load
 			setSeconds(ensureDoubleDigits(0));
 			setMinutes(ensureDoubleDigits(0));

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -74,30 +74,31 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 	const [minutes, setMinutes] = useState<string>(initialTimePart);
 	const [hours, setHours] = useState<string>(initialTimePart);
 	const [days, setDays] = useState<string>(initialTimePart);
-	const [timeRemainingInMillis, setTimeRemainingInMillis] = useState<number>(0);
+	const [showCountdown, setShowCountdown] = useState<boolean>(false);
 
 	useEffect(() => {
-		// console.log('The time now is: ', new Date());
-		// console.log(`the campaign start time is: ${currentCampaign.countdownStartInMillis}`);
 
 		const getTotalMillisRemaining = (targetDate: number) => {
 			return targetDate - Date.now();
 		};
-
 		const canDisplayCountdown = () => {
 			const now = Date.now();
 			console.log('Checking if campaign currently active...');
-			return (
-				campaign.countdownStartInMillis < now &&
-				campaign.countdownHideInMillis > now
-			);
+			const isActive = campaign.countdownStartInMillis < now && campaign.countdownHideInMillis > now;
+			setShowCountdown(isActive);
+			return isActive;
 		};
 
 		function updateTimeParts() {
 			const timeRemaining = getTotalMillisRemaining(
 				campaign.countdownDeadlineInMillis,
 			);
-			setTimeRemainingInMillis(timeRemaining);
+			// setTimeRemainingInMillis(timeRemaining);
+			console.log(`time > 0: ${timeRemaining}`);
+			const now = Date.now();
+			if (now > campaign.countdownHideInMillis) {
+				setShowCountdown(false);
+			}
 
 			// console.log(`time > 0 ${timeRemaining}`);
 			setDays(
@@ -125,8 +126,8 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 		}
 
 		if (canDisplayCountdown()) {
-			const id = setInterval(updateTimeParts, 1000); // run once per second
-			// console.log(`The timer has been created.`);
+			const id = setInterval(updateTimeParts, 1000); // run once per second 
+			console.log(`The timer has been created.`);
 			return () => clearInterval(id); // clear on on unmount
 		} else {
 			// deadline already passed on page load
@@ -139,7 +140,7 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 
 	return (
 		<>
-			{timeRemainingInMillis > 0 && (
+			{showCountdown && (
 				<div role="timer" css={grid}>
 					<TimePart timePart={days} label={'days'} />
 					<TimePart timePart={hours} label={'hours'} />

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -1,136 +1,140 @@
 import { css } from '@emotion/react';
 import { headlineBold28, palette } from '@guardian/source/foundations';
 import { useEffect, useState } from 'react';
-/** 
+/**
  * This is used during the annual US End of Year Campaign.
  */
 
-// create the style - TODO: design not yet confirmed... 
+// create the style - TODO: design not yet confirmed...
 const grid = css`
-    display: flex;
-    padding-top: 33px;
-    justify-content: center;
-    align-items: center;
-    `
+	display: flex;
+	padding-top: 33px;
+	justify-content: center;
+	align-items: center;
+`;
 const gridItem = css`
-    font-variant-numeric: lining-nums proportional-nums;
-    color: ${palette.brand[400]};
-    background-color: ${palette.neutral[100]};
-    /* 🖥 Headline/headline.bld.28 */
-    ${headlineBold28}
-    /* font-family: 'headlineBold28';
+	font-variant-numeric: lining-nums proportional-nums;
+	color: ${palette.brand[400]};
+	background-color: ${palette.neutral[100]};
+	/* 🖥 Headline/headline.bld.28 */
+	${headlineBold28}
+	/* font-family: 'headlineBold28';
     font-size: 28px;
     font-style: normal;
     font-weight: 700; 
     line-height: 115%;*/ /* 32.2px */
     width: 65px;
-    margin: 3px;
-    padding: 2px;
-    border: 1px solid ${palette.brand[400]};
-    border-radius: 4px;
-    `
+	margin: 3px;
+	padding: 2px;
+	border: 1px solid ${palette.brand[400]};
+	border-radius: 4px;
+`;
 const timePortion = css`
-    color: ${palette.brand[400]};
-    /* 🖥 Text Sans/text.sans.12 */
-    font-family: 'GuardianTextSans';
-    font-size: 12px;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 130%; /* 15.6px */
-    `
+	color: ${palette.brand[400]};
+	/* 🖥 Text Sans/text.sans.12 */
+	font-family: 'GuardianTextSans';
+	font-size: 12px;
+	font-style: normal;
+	font-weight: 400;
+	line-height: 130%; /* 15.6px */
+`;
 
 // props
 export type CountdownProps = {
-    deadlineDateTime: number; 
-}
+	deadlineDateTime: number;
+};
 
 // create countdown logic
 
-const initialTimePart = "00";
+const initialTimePart = '00';
 const millisecondsinSecond = 1000;
 const millisecondsinMinute = 60 * millisecondsinSecond;
 const millisecondsinHour = 60 * millisecondsinMinute;
 const millisecondsInDay = 24 * millisecondsinHour;
 
 // Questions:
-    // could each portion be a component so that not everything gets updated each time? 
-    // handle inactive tabs via the Page Visibility API and calculate on visibility change?
-    // how do we assess performance?
+// could each portion be a component so that not everything gets updated each time?
+// handle inactive tabs via the Page Visibility API and calculate on visibility change?
+// how do we assess performance?
 
 const getTotalMillisRemaining = (targetDate: number) => {
-    return targetDate - Date.now();
-}
+	return targetDate - Date.now();
+};
 
 const ensureDoubleDigits = (timeSection: number): string => {
-    if (timeSection < 0) {
-        return '00'
-    }
-    else {
-        return timeSection > 9 ?  timeSection.toString() : `0${timeSection.toString()}`
-    }
-}
+	if (timeSection < 0) {
+		return '00';
+	} else {
+		return timeSection > 9
+			? timeSection.toString()
+			: `0${timeSection.toString()}`;
+	}
+};
 
 // return a component
 export default function Countdown({
-    deadlineDateTime
+	deadlineDateTime,
 }: CountdownProps): JSX.Element {
+	const [seconds, setSeconds] = useState<string>(initialTimePart);
+	const [minutes, setMinutes] = useState<string>(initialTimePart);
+	const [hours, setHours] = useState<string>(initialTimePart);
+	const [days, setDays] = useState<string>(initialTimePart);
 
-    const [seconds, setSeconds] = useState<string>(initialTimePart);
-    const [minutes, setMinutes] = useState<string>(initialTimePart);
-    const [hours, setHours] = useState<string>(initialTimePart);
-    const [days, setDays] = useState<string>(initialTimePart);
+	useEffect(() => {
+		function updateTimeparts() {
+			const timeRemainingOnInitialLoad =
+				getTotalMillisRemaining(deadlineDateTime);
+			if (timeRemainingOnInitialLoad <= 0) {
+				setSeconds(ensureDoubleDigits(0));
+				setMinutes(ensureDoubleDigits(0));
+				setHours(ensureDoubleDigits(0));
+				setDays(ensureDoubleDigits(0));
+				// console.log(`time <= 0 ${timeRemainingOnInitialLoad}`);
+			} else {
+				// console.log(`time > 0 ${timeRemainingOnInitialLoad}`);
+				const d = Math.floor(timeRemainingOnInitialLoad / millisecondsInDay);
+				const h = Math.floor(
+					(timeRemainingOnInitialLoad % millisecondsInDay) / millisecondsinHour,
+				);
+				const m = Math.floor(
+					(timeRemainingOnInitialLoad % millisecondsinHour) /
+						millisecondsinMinute,
+				);
+				const s = Math.floor(
+					(timeRemainingOnInitialLoad % millisecondsinMinute) /
+						millisecondsinSecond,
+				);
+				setSeconds(ensureDoubleDigits(s));
+				setMinutes(ensureDoubleDigits(m));
+				setHours(ensureDoubleDigits(h));
+				setDays(ensureDoubleDigits(d));
+			}
+		}
+		updateTimeparts();
+		const id = setInterval(updateTimeparts, 1000);
+		return () => clearInterval(id);
+	}, [deadlineDateTime]);
 
-    useEffect(() => {
-
-        function updateTimeparts() {
-
-            const timeRemainingOnInitialLoad = getTotalMillisRemaining(deadlineDateTime);
-            if (timeRemainingOnInitialLoad <= 0) {
-                setSeconds(ensureDoubleDigits(0));
-                setMinutes(ensureDoubleDigits(0));
-                setHours(ensureDoubleDigits(0)); 
-                setDays(ensureDoubleDigits(0));               
-                // console.log(`time <= 0 ${timeRemainingOnInitialLoad}`);
-            }
-            else {
-                // console.log(`time > 0 ${timeRemainingOnInitialLoad}`);
-                const d = Math.floor(timeRemainingOnInitialLoad/millisecondsInDay);
-                const h = Math.floor(timeRemainingOnInitialLoad % millisecondsInDay / millisecondsinHour);
-                const m = Math.floor(timeRemainingOnInitialLoad % millisecondsinHour / millisecondsinMinute);
-                const s = Math.floor(timeRemainingOnInitialLoad % millisecondsinMinute / millisecondsinSecond);
-                setSeconds(ensureDoubleDigits(s));
-                setMinutes(ensureDoubleDigits(m));
-                setHours(ensureDoubleDigits(h)); 
-                setDays(ensureDoubleDigits(d)); 
-            }
-        }
-        updateTimeparts();
-        const id = setInterval(updateTimeparts, 1000);
-        return () => clearInterval(id);
-
-    },[deadlineDateTime]);
-
-
-    return(
-        <>
-        <div css={grid}>
-            <div css={gridItem}>
-                <div>{days}</div>
-                <div css={timePortion}>days</div>
-            </div>
-            <div css={gridItem}>
-                <div>{hours}</div>
-                <div css={timePortion}>hours</div>
-            </div>
-            <div css={gridItem}>
-                <div>{minutes}</div>
-                <div css={timePortion}>mins</div>
-            </div>
-            <div css={gridItem}>
-                <div>{seconds}</div>
-                <div css={timePortion}>secs</div>
-            </div>
-        </div>
-        </>
-    );
+	return (
+		<>
+			<div css={grid}>
+				<div css={gridItem}>
+					<div>{days}</div>
+					<div css={timePortion}>days</div>
+				</div>
+				<div css={gridItem}>
+					<div>{hours}</div>
+					<div css={timePortion}>hours</div>
+				</div>
+				<div css={gridItem}>
+					<div>{minutes}</div>
+					<div css={timePortion}>mins</div>
+				</div>
+				<div css={gridItem}>
+					<div>{seconds}</div>
+					<div css={timePortion}>secs</div>
+				</div>
+			</div>
+		</>
+	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -85,7 +85,7 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 			// console.log('Checking if campaign currently active...');
 			const isActive =
 				campaign.countdownStartInMillis < now &&
-				campaign.countdownHideInMillis > now;
+				campaign.countdownDeadlineInMillis > now;
 			setShowCountdown(isActive);
 			return isActive;
 		};
@@ -97,10 +97,10 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 
 			// console.log(`time > 0: ${timeRemaining}`);
 
-			const now = Date.now();
-			if (now > campaign.countdownHideInMillis) {
-				setShowCountdown(false);
-			}
+			// const now = Date.now();
+			// if (now > campaign.countdownHideInMillis) {
+			// 	setShowCountdown(false);
+			// }
 
 			setDays(
 				ensureDoubleDigits(Math.floor(timeRemaining / millisecondsInDay)),

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -68,16 +68,13 @@ const ensureDoubleDigits = (timeSection: number): string => {
 };
 
 // return the countdown component
-export default function Countdown({
-	campaign,
-}: CountdownProps): JSX.Element {
-		
+export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 	// one for each timepart to reduce DOM updates where unnecessary.
 	const [seconds, setSeconds] = useState<string>(initialTimePart);
 	const [minutes, setMinutes] = useState<string>(initialTimePart);
 	const [hours, setHours] = useState<string>(initialTimePart);
 	const [days, setDays] = useState<string>(initialTimePart);
-	const [timeRemainingInMillis, setTimeRemainingInMillis] = useState<number>(0);	
+	const [timeRemainingInMillis, setTimeRemainingInMillis] = useState<number>(0);
 
 	useEffect(() => {
 		// console.log('The time now is: ', new Date());
@@ -94,11 +91,12 @@ export default function Countdown({
 				campaign.countdownStartInMillis < now &&
 				campaign.countdownHideInMillis > now
 			);
-		}
-		
-		function updateTimeParts() {
+		};
 
-			const timeRemaining = getTotalMillisRemaining(campaign.countdownDeadlineInMillis);
+		function updateTimeParts() {
+			const timeRemaining = getTotalMillisRemaining(
+				campaign.countdownDeadlineInMillis,
+			);
 			setTimeRemainingInMillis(timeRemaining);
 
 			// console.log(`time > 0 ${timeRemaining}`);
@@ -130,8 +128,7 @@ export default function Countdown({
 			const id = setInterval(updateTimeParts, 1000); // run once per second
 			// console.log(`The timer has been created.`);
 			return () => clearInterval(id); // clear on on unmount
-		} 
-		else {
+		} else {
 			// deadline already passed on page load
 			setSeconds(ensureDoubleDigits(0));
 			setMinutes(ensureDoubleDigits(0));
@@ -142,15 +139,14 @@ export default function Countdown({
 
 	return (
 		<>
-			{
-				timeRemainingInMillis > 0 && 
+			{timeRemainingInMillis > 0 && (
 				<div role="timer" css={grid}>
 					<TimePart timePart={days} label={'days'} />
 					<TimePart timePart={hours} label={'hours'} />
 					<TimePart timePart={minutes} label={'mins'} />
 					<TimePart timePart={seconds} label={'secs'} />
 				</div>
-			}
+			)}
 		</>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react';
 const grid = css`
 	display: flex;
 	padding-top: 33px;
+	padding-bottom: 15px;
 	justify-content: center;
 	align-items: center;
 `;
@@ -28,6 +29,7 @@ const gridItem = css`
 	padding: 2px;
 	border: 1px solid ${palette.brand[400]};
 	border-radius: 4px;
+	text-align: center;
 `;
 const timePortion = css`
 	color: ${palette.brand[400]};
@@ -70,7 +72,7 @@ const ensureDoubleDigits = (timeSection: number): string => {
 	}
 };
 
-// return a component
+// return the countdown component
 export default function Countdown({
 	deadlineDateTime,
 }: CountdownProps): JSX.Element {
@@ -82,59 +84,69 @@ export default function Countdown({
 	const [days, setDays] = useState<string>(initialTimePart);
 
 	useEffect(() => {
+		
 		function updateTimeparts() {
 
 			const timeRemaining = getTotalMillisRemaining(deadlineDateTime);
+
 			console.log(`time > 0 ${timeRemaining}`);
 			setDays(ensureDoubleDigits(Math.floor(
 				timeRemaining / millisecondsInDay))
 			);
 			setHours(ensureDoubleDigits(Math.floor(
 				(timeRemaining % millisecondsInDay) / 
-					millisecondsinHour))
+				millisecondsinHour))
 			);
 			setMinutes(ensureDoubleDigits(Math.floor(
 				(timeRemaining % millisecondsinHour) /
-					millisecondsinMinute))
+				millisecondsinMinute))
 			);
 			setSeconds(ensureDoubleDigits(Math.floor(
 				(timeRemaining % millisecondsinMinute) /
-					millisecondsinSecond))
+				millisecondsinSecond))
 			);
-		}
-
-		if(getTotalMillisRemaining(deadlineDateTime) > 0) {
+		};
+		
+		if (getTotalMillisRemaining(deadlineDateTime) > 0) {
 			const id = setInterval(updateTimeparts, 1000); // run once per second
 			return () => clearInterval(id); // clear on onload
 		} 
 		else {
+			console.log(`deadline already passed on page load`);
 			setSeconds(ensureDoubleDigits(0));
 			setMinutes(ensureDoubleDigits(0));
 			setHours(ensureDoubleDigits(0));
 			setDays(ensureDoubleDigits(0)); 
-		}
+		};
+		
 	}, [deadlineDateTime]);
 
 	return (
 		<>
 			<div css={grid}>
-				<div css={gridItem}>
-					<div>{days}</div>
-					<div css={timePortion}>days</div>
-				</div>
-				<div css={gridItem}>
-					<div>{hours}</div>
-					<div css={timePortion}>hours</div>
-				</div>
-				<div css={gridItem}>
-					<div>{minutes}</div>
-					<div css={timePortion}>mins</div>
-				</div>
-				<div css={gridItem}>
-					<div>{seconds}</div>
-					<div css={timePortion}>secs</div>
-				</div>
+				<TimePart timePart={days} label={"days"} />
+				<TimePart timePart={hours} label={"hours"} />
+				<TimePart timePart={minutes} label={"mins"} />
+				<TimePart timePart={seconds} label={"secs"} />
 			</div>
 		</>
 	);
+};
+
+// internal components
+
+type TimePartProps = {
+	timePart: string;
+	label: string;
 }
+
+function TimePart({
+	timePart, label
+}: TimePartProps): JSX.Element {
+	return (
+		<div css={gridItem}>
+			<div>{timePart}</div>
+			<div css={timePortion}>{label}</div>
+		</div>
+	);
+};

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -355,7 +355,8 @@ export function ThreeTierLanding({
 
 		const now = Date.now();
 		return campaignSettings.countdownSettings.find(
-			(c) => c.countdownStartInMillis < now && c.countdownDeadlineInMillis > now,
+			(c) =>
+				c.countdownStartInMillis < now && c.countdownDeadlineInMillis > now,
 		);
 	}, [campaignSettings?.countdownSettings]);
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -350,30 +350,18 @@ export function ThreeTierLanding({
 	const [showCountdown, setShowCountdown] = useState<boolean>(false);
 
 	useEffect(() => {
-		// console.log(`in useEffect where countdownSettings passed in.`);
-		const isThisCampaignCurrent = (campaign:CountdownSetting | undefined):boolean => {
-			if (!campaign) { // is defined
-				return false;
-			} 
-			else {
-				const isCampaignStarted = campaign.countdownStartInMillis < Date.now();
-				const isCampaignEnded = campaign.countdownHideInMillis < Date.now();
-				// console.log(`isCampaignStarted: ${isCampaignStarted}, isCampaignEnded ${!isCampaignEnded}`);
-				return isCampaignStarted && !isCampaignEnded;
-			}
-		};
-		// assumes there will only be one current campaign.
-		if (campaignSettings){
-			const currentCampaign:CountdownSetting | undefined = campaignSettings.countdownSettings.findLast((campaign) => isThisCampaignCurrent(campaign));
-	
-			if(currentCampaign) {
-				setCurrentCampaign(currentCampaign);
-				setShowCountdown(true);
-			}
-		}
+		if (!campaignSettings) { return; }
 
-	}, [campaignSettings?.isEligible, campaignSettings?.countdownSettings]); 
-	// TODO: something not right here...
+		const now = Date.now();
+		const currentCampaign = campaignSettings.countdownSettings.find((c) => 
+			c.countdownStartInMillis < now && c.countdownHideInMillis > now
+		);
+	
+		if (currentCampaign) {
+			setCurrentCampaign(currentCampaign);
+			setShowCountdown(true);
+		}
+	}, [campaignSettings?.countdownSettings]); 
 	
 	/*
 	* /////////////// END US EOY 2024 Campaign

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -334,8 +334,8 @@ export function ThreeTierLanding({
 	const useGenericCheckout = abParticipations.useGenericCheckout === 'variant';
 
 	/*
-	* US EOY 2024 Campaign
-	*/
+	 * US EOY 2024 Campaign
+	 */
 	const campaignSettings = getCampaignSettings(countryGroupId);
 	const enableSingleContributionsTab =
 		campaignSettings?.enableSingleContributions;
@@ -343,29 +343,31 @@ export function ThreeTierLanding({
 	// Handle which countdown to show (if any).
 	const [currentCampaign, setCurrentCampaign] = useState<CountdownSetting>({
 		label: 'testing',
-		countdownStartInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'), 
-		countdownDeadlineInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'), 
-		countdownHideInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'), 
+		countdownStartInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'),
+		countdownDeadlineInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'),
+		countdownHideInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'),
 	});
 	const [showCountdown, setShowCountdown] = useState<boolean>(false);
 
 	useEffect(() => {
-		if (!campaignSettings) { return; }
+		if (!campaignSettings) {
+			return;
+		}
 
 		const now = Date.now();
-		const currentCampaign = campaignSettings.countdownSettings.find((c) => 
-			c.countdownStartInMillis < now && c.countdownHideInMillis > now
+		const currentCampaign = campaignSettings.countdownSettings.find(
+			(c) => c.countdownStartInMillis < now && c.countdownHideInMillis > now,
 		);
-	
+
 		if (currentCampaign) {
 			setCurrentCampaign(currentCampaign);
 			setShowCountdown(true);
 		}
-	}, [campaignSettings?.countdownSettings]); 
-	
+	}, [campaignSettings?.countdownSettings]);
+
 	/*
-	* /////////////// END US EOY 2024 Campaign
-	*/
+	 * /////////////// END US EOY 2024 Campaign
+	 */
 
 	useEffect(() => {
 		dispatch(resetValidation());
@@ -622,9 +624,7 @@ export function ThreeTierLanding({
 				cssOverrides={recurringContainer}
 			>
 				<div css={innerContentContainer}>
-					{showCountdown && (
-						<Countdown campaign={currentCampaign} />
-					)}
+					{showCountdown && <Countdown campaign={currentCampaign} />}
 					<h1 css={heading}>
 						Support fearless, <br css={tabletLineBreak} />
 						independent journalism

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -428,6 +428,7 @@ export function ThreeTierLanding({
 	};
 
 	const EOYDeadline = 'Nov 26, 2024 23:59:59';
+	// const EOYDeadline = 'Aug 26, 2024 23:59:59'; // deadline passed TODO: remove
 	const countdownDateTime = Date.parse(EOYDeadline);
 
 	const generateOneOffCheckoutLink = () => {

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -350,7 +350,7 @@ export function ThreeTierLanding({
 	const [showCountdown, setShowCountdown] = useState<boolean>(false);
 
 	const memoizedCurrentCampaign = useMemo(() => {
-		if (!campaignSettings) {
+		if (!campaignSettings?.countdownSettings) {
 			return undefined;
 		}
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -12,7 +12,7 @@ import {
 	FooterLinks,
 	FooterWithContents,
 } from '@guardian/source-development-kitchen/react-components';
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 import { useNavigate } from 'react-router-dom';
 import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
@@ -349,21 +349,23 @@ export function ThreeTierLanding({
 	});
 	const [showCountdown, setShowCountdown] = useState<boolean>(false);
 
-	useEffect(() => {
+	const memoizedCurrentCampaign = useMemo(() => {
 		if (!campaignSettings) {
-			return;
+			return undefined;
 		}
-
+	
 		const now = Date.now();
-		const currentCampaign = campaignSettings.countdownSettings.find(
-			(c) => c.countdownStartInMillis < now && c.countdownHideInMillis > now,
+		return campaignSettings.countdownSettings.find((c) => 
+			c.countdownStartInMillis < now && c.countdownHideInMillis > now
 		);
+	}, [campaignSettings?.countdownSettings]);
 
-		if (currentCampaign) {
-			setCurrentCampaign(currentCampaign);
+	useEffect(() => {
+		if (memoizedCurrentCampaign) {
+			setCurrentCampaign(memoizedCurrentCampaign);
 			setShowCountdown(true);
 		}
-	}, [campaignSettings?.countdownSettings]);
+	}, [memoizedCurrentCampaign]);
 
 	/*
 	 * /////////////// END US EOY 2024 Campaign

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -62,6 +62,7 @@ import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
 import { getCampaignSettings } from '../../../helpers/campaigns/campaigns';
+import Countdown from '../components/countdown';
 import { OneOffCard } from '../components/oneOffCard';
 import { SupportOnce } from '../components/supportOnce';
 import { ThreeTierCards } from '../components/threeTierCards';
@@ -426,6 +427,9 @@ export function ThreeTierLanding({
 		);
 	};
 
+	const EOYDeadline = 'Nov 26, 2024 23:59:59';
+	const countdownDateTime = Date.parse(EOYDeadline);
+
 	const generateOneOffCheckoutLink = () => {
 		const urlParams = new URLSearchParams();
 		urlParams.set('selected-contribution-type', 'one_off');
@@ -590,6 +594,9 @@ export function ThreeTierLanding({
 				cssOverrides={recurringContainer}
 			>
 				<div css={innerContentContainer}>
+					{campaignSettings?.isEligible && <Countdown
+						deadlineDateTime={countdownDateTime} />
+					}
 					<h1 css={heading}>
 						Support fearless, <br css={tabletLineBreak} />
 						independent journalism

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -594,9 +594,9 @@ export function ThreeTierLanding({
 				cssOverrides={recurringContainer}
 			>
 				<div css={innerContentContainer}>
-					{campaignSettings?.isEligible && <Countdown
-						deadlineDateTime={countdownDateTime} />
-					}
+					{campaignSettings?.isEligible && (
+						<Countdown deadlineDateTime={countdownDateTime} />
+					)}
 					<h1 css={heading}>
 						Support fearless, <br css={tabletLineBreak} />
 						independent journalism

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -353,10 +353,10 @@ export function ThreeTierLanding({
 		if (!campaignSettings) {
 			return undefined;
 		}
-	
+
 		const now = Date.now();
-		return campaignSettings.countdownSettings.find((c) => 
-			c.countdownStartInMillis < now && c.countdownHideInMillis > now
+		return campaignSettings.countdownSettings.find(
+			(c) => c.countdownStartInMillis < now && c.countdownHideInMillis > now,
 		);
 	}, [campaignSettings?.countdownSettings]);
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -345,7 +345,6 @@ export function ThreeTierLanding({
 		label: 'testing',
 		countdownStartInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'),
 		countdownDeadlineInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'),
-		countdownHideInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'),
 	});
 	const [showCountdown, setShowCountdown] = useState<boolean>(false);
 
@@ -356,7 +355,7 @@ export function ThreeTierLanding({
 
 		const now = Date.now();
 		return campaignSettings.countdownSettings.find(
-			(c) => c.countdownStartInMillis < now && c.countdownHideInMillis > now,
+			(c) => c.countdownStartInMillis < now && c.countdownDeadlineInMillis > now,
 		);
 	}, [campaignSettings?.countdownSettings]);
 

--- a/support-frontend/stories/landingPage/Countdown.stories.tsx
+++ b/support-frontend/stories/landingPage/Countdown.stories.tsx
@@ -6,6 +6,13 @@ import Countdown from "pages/supporter-plus-landing/components/countdown";
 export default {
     title: 'LandingPage/Countdown',
     component: Countdown,
+    parameters: {
+		docs: {
+			description: {
+				component: `A countdown component for use in campaigns, particularly for example, the US end of year. Note that the current date set in Storybook is 01-01-2024 so that will affect the countdown values.`,
+			},
+		},
+	},
 };
 
 function Template(args: CountdownProps) {
@@ -23,7 +30,10 @@ function Template(args: CountdownProps) {
 Template.args = {} as CountdownProps;
 
 export const Default = Template.bind({});
-Default.args = {deadlineDateTime: Date.parse('Nov 26, 2024 23:59:59')};
+Default.args = {deadlineDateTime: Date.parse('Mar 26, 2024 23:59:59')};
+
+export const DeadlineNear = Template.bind({});
+DeadlineNear.args = {deadlineDateTime: Date.parse('Jan 1, 2024 12:10:59')};
 
 export const DeadlinePassed = Template.bind({});
-DeadlinePassed.args = {deadlineDateTime: Date.parse('Aug 26, 2024 23:59:59')};
+DeadlinePassed.args = {deadlineDateTime: Date.parse('Aug 26, 2023 23:59:59')};

--- a/support-frontend/stories/landingPage/Countdown.stories.tsx
+++ b/support-frontend/stories/landingPage/Countdown.stories.tsx
@@ -1,0 +1,29 @@
+import { css } from "@emotion/react";
+import { palette } from "@guardian/source/foundations";
+import type { CountdownProps } from "pages/supporter-plus-landing/components/countdown";
+import Countdown from "pages/supporter-plus-landing/components/countdown";
+
+export default {
+    title: 'LandingPage/Countdown',
+    component: Countdown,
+};
+
+function Template(args: CountdownProps) {
+	const innerContentContainer = css`
+		margin: 0 auto;
+		background-color: ${palette.brand[400]};
+	`;
+	return (
+		<div css={innerContentContainer} >
+            <Countdown {...args} />
+        </div>
+    );
+};
+
+Template.args = {} as CountdownProps;
+
+export const Default = Template.bind({});
+Default.args = {deadlineDateTime: Date.parse('Nov 26, 2024 23:59:59')};
+
+export const DeadlinePassed = Template.bind({});
+DeadlinePassed.args = {deadlineDateTime: Date.parse('Aug 26, 2024 23:59:59')};

--- a/support-frontend/stories/landingPage/Countdown.stories.tsx
+++ b/support-frontend/stories/landingPage/Countdown.stories.tsx
@@ -15,6 +15,11 @@ export default {
 	},
 };
 
+const millisecondsInSecond = 1000;
+const millisecondsInMinute = 60 * millisecondsInSecond;
+const millisecondsInHour = 60 * millisecondsInMinute;
+const millisecondsInDay = 24 * millisecondsInHour;
+
 function Template(args: CountdownProps) {
 	const innerContentContainer = css`
 		margin: 0 auto;
@@ -29,45 +34,42 @@ function Template(args: CountdownProps) {
 
 Template.args = {} as CountdownProps;
 
-// TODO: is there a way of getting the mocked date and adding some months to it (as it likely changes to the mocked date)?
-
-
 export const Default = Template.bind({});
 Default.args = { campaign: 
-		{
-			label: 'default',
-			countdownStartInMillis: Date.parse('Dec 30, 2023 12:10:59'), 
-			countdownDeadlineInMillis: Date.parse('Jan 30, 2024 12:10:59'), 
-			countdownHideInMillis: Date.parse('Feb 01, 2024 15:06:00'), 
-		},
-	};
+	{
+		label: 'default',
+		countdownStartInMillis: (Date.now() - (1 * millisecondsInDay) + (1 * millisecondsInHour)),
+		countdownDeadlineInMillis: (Date.now() + ((2 * millisecondsInDay) + (1 * millisecondsInHour) + (45 * millisecondsInMinute) + (30 * millisecondsInSecond))),
+		countdownHideInMillis: (Date.now() + (6 * millisecondsInDay))
+	}
+};
 
 export const DeadlineNear = Template.bind({});
 DeadlineNear.args = { campaign: 
-		{
-			label: 'deadline near',
-			countdownStartInMillis: Date.parse('Dec 30, 2023 12:10:59'), 
-			countdownDeadlineInMillis: Date.parse('Jan 1, 2024 12:10:59'), 
-			countdownHideInMillis: Date.parse('Jan 1, 2024 13:10:59'), 
-		},
-	};
+	{
+		label: 'deadline near',
+		countdownStartInMillis: (Date.now() - (1 * millisecondsInDay)),
+		countdownDeadlineInMillis: (Date.now() + (5 * millisecondsInSecond)),
+		countdownHideInMillis: (Date.now() + (6 * millisecondsInSecond)), 
+	}
+};
 
 export const DeadlinePassedHidden = Template.bind({});
 DeadlinePassedHidden.args = { campaign: 
-		{
-			label: 'deadline passed',
-			countdownStartInMillis: Date.parse('Aug 29, 2023 15:00:00'), 
-			countdownDeadlineInMillis: Date.parse('Aug 29, 2023 15:05:00'), 
-			countdownHideInMillis: Date.parse('Aug 29, 2023 15:06:00'), 
-		},
-	};
+	{
+		label: 'deadline passed',
+		countdownStartInMillis: (Date.now() - (1 * millisecondsInDay)),
+		countdownDeadlineInMillis: (Date.now() - (5 * millisecondsInSecond)),
+		countdownHideInMillis: (Date.now() - (4 * millisecondsInSecond)),
+	}
+};
 
 export const NotYetAvailableHidden = Template.bind({});
 NotYetAvailableHidden.args = { campaign: 
 	{
 		label: 'start date well in future',
-		countdownStartInMillis: Date.parse('Aug 29, 2025 15:00:00'), 
-		countdownDeadlineInMillis: Date.parse('Aug 29, 2025 15:05:00'), 
-		countdownHideInMillis: Date.parse('Aug 29, 2025 15:06:00'), 
-	},
+		countdownStartInMillis: (Date.now() + (1 * millisecondsInDay)),
+		countdownDeadlineInMillis: (Date.now() + (5 * millisecondsInDay)),
+		countdownHideInMillis: (Date.now() + (4 * millisecondsInDay)),
+	}
 };

--- a/support-frontend/stories/landingPage/Countdown.stories.tsx
+++ b/support-frontend/stories/landingPage/Countdown.stories.tsx
@@ -29,11 +29,16 @@ function Template(args: CountdownProps) {
 
 Template.args = {} as CountdownProps;
 
+// is there a way of getting the mocked date and adding some months to it (as it likely changes)?
+const deadlineFar = 'Mar 26, 2024 23:59:59'; 
+const deadlineNear = 'Jan 1, 2024 12:10:59';
+const deadlinePassed = 'Aug 26, 2023 23:59:59';
+
 export const Default = Template.bind({});
-Default.args = {deadlineDateTime: Date.parse('Mar 26, 2024 23:59:59')};
+Default.args = {deadlineDateTime: Date.parse(deadlineFar)};
 
 export const DeadlineNear = Template.bind({});
-DeadlineNear.args = {deadlineDateTime: Date.parse('Jan 1, 2024 12:10:59')};
+DeadlineNear.args = {deadlineDateTime: Date.parse(deadlineNear)};
 
 export const DeadlinePassed = Template.bind({});
-DeadlinePassed.args = {deadlineDateTime: Date.parse('Aug 26, 2023 23:59:59')};
+DeadlinePassed.args = {deadlineDateTime: Date.parse(deadlinePassed)};

--- a/support-frontend/stories/landingPage/Countdown.stories.tsx
+++ b/support-frontend/stories/landingPage/Countdown.stories.tsx
@@ -40,7 +40,6 @@ Default.args = { campaign:
 		label: 'default',
 		countdownStartInMillis: (Date.now() - (1 * millisecondsInDay) + (1 * millisecondsInHour)),
 		countdownDeadlineInMillis: (Date.now() + ((2 * millisecondsInDay) + (1 * millisecondsInHour) + (45 * millisecondsInMinute) + (30 * millisecondsInSecond))),
-		countdownHideInMillis: (Date.now() + (6 * millisecondsInDay))
 	}
 };
 
@@ -50,7 +49,6 @@ DeadlineNear.args = { campaign:
 		label: 'deadline near',
 		countdownStartInMillis: (Date.now() - (1 * millisecondsInDay)),
 		countdownDeadlineInMillis: (Date.now() + (5 * millisecondsInSecond)),
-		countdownHideInMillis: (Date.now() + (6 * millisecondsInSecond)), 
 	}
 };
 
@@ -60,7 +58,6 @@ DeadlinePassedHidden.args = { campaign:
 		label: 'deadline passed',
 		countdownStartInMillis: (Date.now() - (1 * millisecondsInDay)),
 		countdownDeadlineInMillis: (Date.now() - (5 * millisecondsInSecond)),
-		countdownHideInMillis: (Date.now() - (4 * millisecondsInSecond)),
 	}
 };
 
@@ -70,6 +67,5 @@ NotYetAvailableHidden.args = { campaign:
 		label: 'start date well in future',
 		countdownStartInMillis: (Date.now() + (1 * millisecondsInDay)),
 		countdownDeadlineInMillis: (Date.now() + (5 * millisecondsInDay)),
-		countdownHideInMillis: (Date.now() + (4 * millisecondsInDay)),
 	}
 };

--- a/support-frontend/stories/landingPage/Countdown.stories.tsx
+++ b/support-frontend/stories/landingPage/Countdown.stories.tsx
@@ -29,16 +29,45 @@ function Template(args: CountdownProps) {
 
 Template.args = {} as CountdownProps;
 
-// is there a way of getting the mocked date and adding some months to it (as it likely changes)?
-const deadlineFar = 'Mar 26, 2024 23:59:59'; 
-const deadlineNear = 'Jan 1, 2024 12:10:59';
-const deadlinePassed = 'Aug 26, 2023 23:59:59';
+// TODO: is there a way of getting the mocked date and adding some months to it (as it likely changes to the mocked date)?
+
 
 export const Default = Template.bind({});
-Default.args = {deadlineDateTime: Date.parse(deadlineFar)};
+Default.args = { campaign: 
+		{
+			label: 'default',
+			countdownStartInMillis: Date.parse('Dec 30, 2023 12:10:59'), 
+			countdownDeadlineInMillis: Date.parse('Jan 30, 2024 12:10:59'), 
+			countdownHideInMillis: Date.parse('Feb 01, 2024 15:06:00'), 
+		},
+	};
 
 export const DeadlineNear = Template.bind({});
-DeadlineNear.args = {deadlineDateTime: Date.parse(deadlineNear)};
+DeadlineNear.args = { campaign: 
+		{
+			label: 'deadline near',
+			countdownStartInMillis: Date.parse('Dec 30, 2023 12:10:59'), 
+			countdownDeadlineInMillis: Date.parse('Jan 1, 2024 12:10:59'), 
+			countdownHideInMillis: Date.parse('Jan 1, 2024 13:10:59'), 
+		},
+	};
 
-export const DeadlinePassed = Template.bind({});
-DeadlinePassed.args = {deadlineDateTime: Date.parse(deadlinePassed)};
+export const DeadlinePassedHidden = Template.bind({});
+DeadlinePassedHidden.args = { campaign: 
+		{
+			label: 'deadline passed',
+			countdownStartInMillis: Date.parse('Aug 29, 2023 15:00:00'), 
+			countdownDeadlineInMillis: Date.parse('Aug 29, 2023 15:05:00'), 
+			countdownHideInMillis: Date.parse('Aug 29, 2023 15:06:00'), 
+		},
+	};
+
+export const NotYetAvailableHidden = Template.bind({});
+NotYetAvailableHidden.args = { campaign: 
+	{
+		label: 'start date well in future',
+		countdownStartInMillis: Date.parse('Aug 29, 2025 15:00:00'), 
+		countdownDeadlineInMillis: Date.parse('Aug 29, 2025 15:05:00'), 
+		countdownHideInMillis: Date.parse('Aug 29, 2025 15:06:00'), 
+	},
+};


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Adding a new component to countdown to the US end of year Giving Tuesday event.
This is added to the threeTierLanding page but hidden with the campaign setting isEligible flag.
[**Trello card**](https://trello.com/c/MLXWgpD4/625-add-countdown-to-landing-page)

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

## Why are you doing this?

This is a feature request for the US End of Year 2024 campaign.

## How to test
Uncomment and update the labelled test CountdownSetting in the usEoy2024 campaign in campaigns.ts to the appropriate date, time for testing the countdown to appear or not.
Run locally and force the flag in the parameter to see the countdown with: 
[https://support.thegulocal.com/us/contribute?forceCampaign=usEoy2024](https://support.thegulocal.com/us/contribute?forceCampaign=usEoy2024).

## How can we measure success?

When the date and time in the settings are correct, can you see the countdown without detriment to the performance of the 3 tier checkout?

## Have we considered potential risks?

Investigated any performance impacts of having a timer updating a component once a second.  Confirmed that only one timer is created.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots

<img width="1080" alt="ScreenshotOfCountdown" src="https://github.com/user-attachments/assets/33f09ad1-b849-4537-9812-62dcb5f53cab">


