### PR TITLE
feat: add region to events metadata and always send it

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -11,6 +11,7 @@ import { guardianLiveTermsLink, privacyLink } from 'helpers/legal';
 import * as cookie from 'helpers/storage/cookie';
 import { getPageViewId } from 'helpers/tracking/ophan';
 import { isProd } from 'helpers/urls/url';
+import type { GeoId } from 'pages/geoIdConfig';
 
 const darkBackgroundContainerMobile = css`
 	background-color: ${palette.neutral[97]};
@@ -56,7 +57,10 @@ const footerWiden = css`
 	margin-top: ${space[8]}px;
 `;
 
-export function Events() {
+type Props = {
+	geoId: GeoId;
+};
+export function Events({ geoId }: Props) {
 	const isTestUser = !!cookie.get('_test_username');
 	const shouldUseCode = isTestUser || !isProd();
 	const ticketTailorUrl = shouldUseCode
@@ -68,27 +72,22 @@ export function Events() {
 	const termsEvents = <a href={guardianLiveTermsLink}>Terms and Conditions</a>;
 	const privacyPolicy = <a href={privacyLink}>Privacy Policy</a>;
 
-	const urlSearchParams = new URLSearchParams(window.location.search);
-	const presetData = urlSearchParams.get('presetData') === '1';
-	let presetDataUrl = '';
-	if (presetData) {
-		const pageviewId = getPageViewId();
-		const hashUrlSearchParams = new URLSearchParams({
-			'p[meta_page_view_id]': pageviewId,
-		});
-		const user = window.guardian.user;
-		if (user) {
-			hashUrlSearchParams.set('p[meta_identity_id]', user.id);
-			user.firstName &&
-				hashUrlSearchParams.set('p[first_name]', user.firstName);
-			user.lastName && hashUrlSearchParams.set('p[last_name]', user.lastName);
-			user.email && hashUrlSearchParams.set('p[email]', user.email);
-		}
-		/** we decode this as that is what Ticket Tailor want */
-		presetDataUrl = `?preset_data=1&widget=true#${decodeURIComponent(
-			hashUrlSearchParams.toString(),
-		)}`;
+	const pageviewId = getPageViewId();
+	const hashUrlSearchParams = new URLSearchParams({
+		'p[meta_page_view_id]': pageviewId,
+		'p[meta_region_id]': geoId,
+	});
+	const user = window.guardian.user;
+	if (user) {
+		hashUrlSearchParams.set('p[meta_identity_id]', user.id);
+		user.firstName && hashUrlSearchParams.set('p[first_name]', user.firstName);
+		user.lastName && hashUrlSearchParams.set('p[last_name]', user.lastName);
+		user.email && hashUrlSearchParams.set('p[email]', user.email);
 	}
+	/** we decode this as that is what Ticket Tailor want */
+	const presetDataUrl = `?preset_data=1&widget=true#${decodeURIComponent(
+		hashUrlSearchParams.toString(),
+	)}`;
 
 	const embedUrl = `${ticketTailorUrl}/${eventId}/book${presetDataUrl}`;
 

--- a/support-frontend/assets/pages/[countryGroupId]/events/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/router.tsx
@@ -20,7 +20,7 @@ const router = createBrowserRouter(
 	geoIds.flatMap((geoId) => [
 		{
 			path: `/${geoId}/events/:eventId`,
-			element: <Events />,
+			element: <Events geoId={geoId} />,
 		},
 	]),
 );


### PR DESCRIPTION
- Adds the geoId to the Ticket Tailor metadata as `meta_region_id`. This is the name used in TT  meetings - but I am still not sure what to call it. [Maybe `InternationalizationId`](https://github.com/guardian/support-frontend/pull/6094#issuecomment-2178378940)?
- Removes the QS check and always send this data across