### PR TITLE
fix: add oauth callback URL for events domain

### DIFF
--- a/support-frontend/app/config/Identity.scala
+++ b/support-frontend/app/config/Identity.scala
@@ -32,5 +32,6 @@ class Identity(config: Config) {
   lazy val oauthAuthorizeUrl = config.getString("oauth.authorize.url")
   lazy val oauthTokenUrl = config.getString("oauth.token.url")
   lazy val oauthCallbackUrl = config.getString("oauth.callback.url")
+  lazy val oauthEventsCallbackUrl = config.getString("oauth.eventsCallback.url")
   lazy val oauthScopes = config.getString("oauth.scopes")
 }

--- a/support-frontend/app/controllers/AuthCodeFlowController.scala
+++ b/support-frontend/app/controllers/AuthCodeFlowController.scala
@@ -45,10 +45,16 @@ class AuthCodeFlowController(cc: ControllerComponents, authService: AsyncAuthent
     val state = Random.alphanumeric.take(32).mkString
     val codeVerifier = Pkce.codeVerifier()
     val codeChallenge = Pkce.codeChallenge(codeVerifier)
+
+    /** /events is served from live.theguardian.com to avoid apps blocking the domain as an in app purchase. We should
+      * redirect to this domain. We have no testing
+      */
+    val oauthCallbackUrl =
+      if (request.host.startsWith("live.")) config.oauthEventsCallbackUrl else config.oauthCallbackUrl
     val queryParams = Map(
       "response_type" -> "code",
       "client_id" -> config.oauthClientId,
-      "redirect_uri" -> config.oauthCallbackUrl,
+      "redirect_uri" -> oauthCallbackUrl,
       "scope" -> config.oauthScopes.trim.replaceAll("\\s+", " "),
       "state" -> state,
       "code_challenge" -> codeChallenge,

--- a/support-frontend/app/controllers/AuthCodeFlowController.scala
+++ b/support-frontend/app/controllers/AuthCodeFlowController.scala
@@ -47,7 +47,7 @@ class AuthCodeFlowController(cc: ControllerComponents, authService: AsyncAuthent
     val codeChallenge = Pkce.codeChallenge(codeVerifier)
 
     /** /events is served from live.theguardian.com to avoid apps blocking the domain as an in app purchase. We should
-      * redirect to this domain. We have no testing
+      * redirect back to this domain.
       */
     val oauthCallbackUrl =
       if (request.host.startsWith("live.")) config.oauthEventsCallbackUrl else config.oauthCallbackUrl

--- a/support-frontend/conf/CODE.public.conf
+++ b/support-frontend/conf/CODE.public.conf
@@ -19,10 +19,15 @@ identity {
     authorize.url = "https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7/v1/authorize"
     token.url = "https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7/v1/token"
     callback.url = "https://support.code.dev-theguardian.com/oauth/callback"
+    # /events is served from live.{support.domain} to avoid apps blocking the domain as an in app purchase, so we should
+    # ensure that we redirect to that URL to avoid validation errors.
+    eventsCallback.url="https://live.code.dev-theguardian.com/oauth/callback"
   }
 }
 
 guardianDomain=".code.dev-theguardian.com"
+support.host="support.code.dev-theguardian.com"
+support.eventsHost="live.code.dev-theguardian.com"
 support.url="https://support.code.dev-theguardian.com"
 googleAuth.redirectUrl = "https://support.code.dev-theguardian.com/oauth2callback"
 paymentApi.url="https://payment.code.dev-guardianapis.com"

--- a/support-frontend/conf/DEV.public.conf
+++ b/support-frontend/conf/DEV.public.conf
@@ -19,13 +19,16 @@ identity {
     authorize.url = "https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7/v1/authorize"
     token.url = "https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7/v1/token"
     callback.url = "https://support.thegulocal.com/oauth/callback"
+    # /events is served from live.{support.domain} to avoid apps blocking the domain as an in app purchase, so we should
+    # ensure that we redirect to that URL to avoid validation errors.
+    eventsCallback.url="https://live.thegulocal.com/oauth/callback"
   }
 }
 
 guardianDomain=".thegulocal.com"
-
+support.host="support.thegulocal.com"
+support.eventsHost="support.thegulocal.com"
 support.url="https://support.thegulocal.com"
-
 googleAuth.redirectUrl = "https://support.thegulocal.com/oauth2callback"
 paymentApi.url="https://payment.code.dev-guardianapis.com"
 membersDataService.api.url="https://members-data-api.thegulocal.com"

--- a/support-frontend/conf/PROD.public.conf
+++ b/support-frontend/conf/PROD.public.conf
@@ -18,6 +18,9 @@ identity {
     authorize.url="https://profile.theguardian.com/oauth2/aus3xgj525jYQRowl417/v1/authorize"
     token.url="https://profile.theguardian.com/oauth2/aus3xgj525jYQRowl417/v1/token"
     callback.url="https://support.theguardian.com/oauth/callback"
+    # /events is served from live.{support.domain} to avoid apps blocking the domain as an in app purchase, so we should
+    # ensure that we redirect to that URL to avoid validation errors.
+    eventsCallback.url="https://live.theguardian.com/oauth/callback"
   }
 }
 


### PR DESCRIPTION
This adds the ability to use `support.` _**OR**_ `live.` as a redirect URL for auth.

Currently we use `live.` to serve `/events`. This is because `support.` is considered a in-app-purchase URL from our apps and if we link to it, it's blocked.

An example workflow this supports
* Editor creates a new event
* The event is linked to from the site as `live.theguardian.com/events/{eventId}`
* A person has outdated cookies
* They're re-logged in, and redirected back to live.theguardian.com

- [x] Tests will be added retrospectively as we are on a bit of a deadline.

