### PR TITLE
Categorise Playwright tests

### DIFF
--- a/.github/workflows/playwright-cron.yml
+++ b/.github/workflows/playwright-cron.yml
@@ -1,0 +1,32 @@
+name: Playwright Cron Tests
+on:
+  workflow_dispatch:  
+  schedule:
+    # every hour, 9-17:00, Mon - Fri
+    - cron: "0 9-17 * * 1-5"
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    env:
+      PAYPAL_TEST_PASSWORD: ${{ secrets.PAYPAL_TEST_PASSWORD }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20.11.0
+    - name: Install dependencies
+      working-directory: ./support-e2e
+      run: yarn install
+    - name: Install Playwright Browsers
+      working-directory: ./support-e2e
+      run: yarn playwright install --with-deps
+    - name: Run Playwright tests
+      working-directory: ./support-e2e
+      run: yarn playwright test --project=cron --config=playwright.config.ts
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: support-e2e/playwright-report/
+        retention-days: 30

--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -1,0 +1,33 @@
+name: Playwright Smoke Tests
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled] # Only run when a PR is labeled with the 'Seen-on-PROD' label set by prout
+concurrency:
+  group: "playwright-${{ github.head_ref }}"
+  cancel-in-progress: true
+jobs:
+  test:
+    if: ${{ github.event.label.name == 'Seen-on-PROD' }}
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20.11.0
+    - name: Install dependencies
+      working-directory: ./support-e2e
+      run: yarn install
+    - name: Install Playwright Browsers
+      working-directory: ./support-e2e
+      run: yarn playwright install --with-deps
+    - name: Run Playwright tests
+      working-directory: ./support-e2e
+      run: yarn playwright test --project=smoke --config=playwright.config.ts
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: support-e2e/playwright-report/
+        retention-days: 30

--- a/support-e2e/package.json
+++ b/support-e2e/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "support-e2e",
-	"version": "0.0.0",
+	"version": "1.0.0",
+	"license": "Apache-2.0",
 	"scripts": {
 		"prettier-check": "prettier --check ./",
 		"prettier-fix": "prettier --write ./",
@@ -9,26 +10,26 @@
 		"test-prod": "playwright test --ui --config=playwright.prod.config.ts"
 	},
 	"dependencies": {
-		"@playwright/test": "1.40.1",
+		"@playwright/test": "1.46.1",
 		"browserstack-local": "^1.5.5",
 		"nanoid": "3.1.31"
 	},
 	"devDependencies": {
-    "@guardian/prettier": "^8.0.0",
+		"@guardian/prettier": "^8.0.0",
 		"dotenv": "^16.3.1",
-    "husky": "^9.0.11",
-    "lint-staged": "^15.2.2",
+		"husky": "^9.0.11",
+		"lint-staged": "^15.2.2",
 		"prettier": "^3.0.3"
 	},
-  "lint-staged": {
-    "*.ts": [
-      "prettier --write",
-      "git add"
-    ]
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  }
+	"lint-staged": {
+		"*.ts": [
+			"prettier --write",
+			"git add"
+		]
+	},
+	"husky": {
+		"hooks": {
+			"pre-commit": "lint-staged"
+		}
+	}
 }

--- a/support-e2e/playwright.base.config.ts
+++ b/support-e2e/playwright.base.config.ts
@@ -4,6 +4,11 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 export const baseObject: PlaywrightTestConfig = {
 	testDir: 'tests',
 	testMatch: '**/*.test.ts',
+	testIgnore: [
+		'tests/smoke/**/*.test.ts',
+		'tests/cron/**/*.test.ts',
+		'tests/test/**/*.test.ts',
+	],
 	/* Maximum time one test can run for. */
 	timeout: 120 * 1000,
 	fullyParallel: true,

--- a/support-e2e/playwright.config.ts
+++ b/support-e2e/playwright.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+	testDir: 'tests',
+	testMatch: '**/*.test.ts',
+	/* Maximum time one test can run for. */
+	timeout: 120 * 1000,
+	fullyParallel: true,
+	/** Fail the build on CI if you accidentally left test.only in the source code. */
+	forbidOnly: !!process.env.CI,
+	// maxFailures: process.env.CI ? 1 : undefined,
+	retries: 1,
+	use: {
+		/** Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+		trace: 'on-first-retry',
+		screenshot: 'only-on-failure',
+		video: 'on-first-retry',
+		baseURL: 'https://support.theguardian.com',
+	},
+	reporter: 'html',
+
+	/** We are using projects to split tests into priorities, and thus when they are run */
+	projects: [
+		/** This is an example of another project we might have, running pre-merge of a PR */
+		// {
+		// 	name: 'Pre-deploy'
+		// },
+		{
+			name: 'smoke',
+			testMatch: 'tests/smoke/*.test.ts',
+			use: {
+				...devices['Desktop Chrome'],
+				viewport: { width: 1280, height: 720 },
+			},
+		},
+		{
+			/** We run some tests on a Cron as they are sensitive to timeouts and limits from external services */
+			name: 'cron',
+			testMatch: 'tests/cron/*.test.ts',
+			use: {
+				...devices['Desktop Chrome'],
+				viewport: { width: 1280, height: 720 },
+			},
+		},
+	],
+});

--- a/support-e2e/tests/cron/checkout.test.ts
+++ b/support-e2e/tests/cron/checkout.test.ts
@@ -1,0 +1,19 @@
+import { test } from '@playwright/test';
+import { afterEachTasks } from '../utils/afterEachTest';
+import { testCheckout } from '../test/checkout.test';
+
+afterEachTasks(test);
+
+test.describe('Checkout', () => {
+	[
+		{
+			product: 'SupporterPlus',
+			ratePlan: 'Monthly',
+			paymentType: 'PayPal',
+			internationalisationId: 'au',
+			paymentFrequency: 'month',
+		},
+	].forEach((testDetails) => {
+		testCheckout(testDetails);
+	});
+});

--- a/support-e2e/tests/smoke/checkout.test.ts
+++ b/support-e2e/tests/smoke/checkout.test.ts
@@ -1,0 +1,19 @@
+import { test } from '@playwright/test';
+import { afterEachTasks } from '../utils/afterEachTest';
+import { testCheckout } from '../test/checkout.test';
+
+afterEachTasks(test);
+
+test.describe('Checkout', () => {
+	[
+		{
+			product: 'SupporterPlus',
+			ratePlan: 'Annual',
+			paymentType: 'Credit/Debit card',
+			internationalisationId: 'eu',
+			paymentFrequency: 'year',
+		},
+	].forEach((testDetails) => {
+		testCheckout(testDetails);
+	});
+});

--- a/support-e2e/tests/smoke/consent-management.test.ts
+++ b/support-e2e/tests/smoke/consent-management.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+
+test('Should show a dismissable consent management banner', async ({
+	context,
+	baseURL,
+}) => {
+	const page = await context.newPage();
+	await page.goto(`${baseURL}/uk/contribute`);
+
+	const consentManagementBanner = page.frameLocator(
+		'[title="The Guardian consent message"]',
+	);
+
+	await expect(
+		consentManagementBanner.getByRole('button', { name: 'No' }),
+	).toBeVisible({ timeout: 50000 });
+	await expect(
+		consentManagementBanner.getByRole('button', { name: 'Yes' }),
+	).toBeVisible();
+	await consentManagementBanner.getByRole('button', { name: 'Yes' }).click();
+	await expect(
+		consentManagementBanner.getByRole('button', { name: 'No' }),
+	).not.toBeVisible();
+	await expect(
+		consentManagementBanner.getByRole('button', { name: 'Yes' }),
+	).not.toBeVisible();
+});

--- a/support-e2e/tests/test/checkout.test.ts
+++ b/support-e2e/tests/test/checkout.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test';
+import { email, firstName, lastName } from '../utils/users';
+import { setupPage } from '../utils/page';
+import { setTestUserRequiredDetails } from '../utils/testUserDetails';
+import { fillInPayPalDetails } from '../utils/paypal';
+import { fillInCardDetails } from '../utils/cardDetails';
+import { checkRecaptcha } from '../utils/recaptcha';
+
+type TestDetails = {
+	product: string;
+	ratePlan: string;
+	paymentType: string;
+	internationalisationId: string;
+	paymentFrequency: string;
+};
+
+export const testCheckout = (testDetails: TestDetails) => {
+	const { internationalisationId, product, ratePlan, paymentType } =
+		testDetails;
+
+	test(`${product} ${ratePlan} with ${paymentType} in ${internationalisationId}`, async ({
+		context,
+		baseURL,
+	}) => {
+		const url = `/${internationalisationId}/checkout?product=${product}&ratePlan=${ratePlan}`;
+		const page = await context.newPage();
+		const testFirstName = firstName();
+		const testLastName = lastName();
+		const testEmail = email();
+		await setupPage(page, context, baseURL, url);
+
+		await setTestUserRequiredDetails(
+			page,
+			testFirstName,
+			testLastName,
+			testEmail,
+		);
+		if (internationalisationId === 'au') {
+			await page.getByLabel('State').selectOption({ label: 'New South Wales' });
+		}
+		await page.getByRole('radio', { name: paymentType }).check();
+		switch (paymentType) {
+			case 'PayPal':
+				const popupPagePromise = page.waitForEvent('popup');
+				await page
+					.locator("iframe[name^='xcomponent__ppbutton']")
+					.scrollIntoViewIfNeeded();
+				await page
+					.frameLocator("iframe[name^='xcomponent__ppbutton']")
+					// this class gets added to the iframe body after the JavaScript has finished executing
+					.locator('body.dom-ready')
+					.locator('[role="button"]:has-text("Pay with")')
+					.click({ delay: 2000 });
+				const popupPage = await popupPagePromise;
+				fillInPayPalDetails(popupPage);
+				break;
+			case 'Credit/Debit card':
+			default:
+				await fillInCardDetails(page);
+				break;
+		}
+
+		if (paymentType === 'Credit/Debit card') {
+			await checkRecaptcha(page);
+			await page
+				.getByRole('button', {
+					name: `Pay`,
+				})
+				.click();
+		}
+
+		await expect(page.getByRole('heading', { name: 'Thank you' })).toBeVisible({
+			timeout: 600000,
+		});
+	});
+};

--- a/support-e2e/yarn.lock
+++ b/support-e2e/yarn.lock
@@ -7,12 +7,12 @@
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-8.0.0.tgz#d621f01ad5ae7fa8579a966045ed0e3748beaede"
   integrity sha512-Q2z9jDTf+38hXpfXSq4whbvfh5CpkB+z7DbL6AvO3O0+Kl6/FOCQLyFJe3YWT1WnnZPf/iF3VvVr/zjtRcBkuA==
 
-"@playwright/test@1.40.1":
-  version "1.40.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.40.1.tgz#9e66322d97b1d74b9f8718bacab15080f24cde65"
-  integrity sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==
+"@playwright/test@1.46.1":
+  version "1.46.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.46.1.tgz#a8dfdcd623c4c23bb1b7ea588058aad41055c188"
+  integrity sha512-Fq6SwLujA/DOIvNC2EL/SojJnkKf/rAwJ//APpJJHRyMi1PdKrY3Az+4XNQ51N4RTbItbIByQ0jgd1tayq1aeA==
   dependencies:
-    playwright "1.40.1"
+    playwright "1.46.1"
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -424,17 +424,17 @@ pidtree@0.6.0:
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.6.0.tgz#90ad7b6d42d5841e69e0a2419ef38f8883aa057c"
   integrity sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==
 
-playwright-core@1.40.1:
-  version "1.40.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.40.1.tgz#442d15e86866a87d90d07af528e0afabe4c75c05"
-  integrity sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==
+playwright-core@1.46.1:
+  version "1.46.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.46.1.tgz#28f3ab35312135dda75b0c92a3e5c0e7edb9cc8b"
+  integrity sha512-h9LqIQaAv+CYvWzsZ+h3RsrqCStkBHlgo6/TJlFst3cOTlLghBQlJwPOZKQJTKNaD3QIB7aAVQ+gfWbN3NXB7A==
 
-playwright@1.40.1:
-  version "1.40.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.40.1.tgz#a11bf8dca15be5a194851dbbf3df235b9f53d7ae"
-  integrity sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==
+playwright@1.46.1:
+  version "1.46.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.46.1.tgz#ea562bc48373648e10420a10c16842f0b227c218"
+  integrity sha512-oPcr1yqoXLCkgKtD5eNUPLiN40rYEM39odNpIb6VE6S7/15gJmA1NzVv6zJYusV0e7tzvkU/utBFNa/Kpxmwng==
   dependencies:
-    playwright-core "1.40.1"
+    playwright-core "1.46.1"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
This PR creates and categorises some Playwright tests to try and address the speed of the suite, as well as some flakiness issues we've been seeing with third party services timing out e.g. `PayPal`.

The categories we have created are:
- Smoke: tests to be run post-deploy
- Cron: tests that suffer from rate limiting, run on a schedule

Other changes that have been made in this PR:
- moving away from the `GitHub Action => Playwright => Browserstack` pattern to a `GitHub Action => Playwright` model

