### PR TITLE
fix: add consents to event page

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/events/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/router.tsx
@@ -1,21 +1,10 @@
-import ophan from 'ophan';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import * as abTest from 'helpers/abTests/abtest';
-import { Country, CountryGroup } from 'helpers/internationalisation';
+import { setUpTrackingAndConsents } from 'helpers/page/page';
 import { renderPage } from 'helpers/rendering/render';
-import { trackAbTests } from 'helpers/tracking/ophan';
 import { geoIds } from 'pages/geoIdConfig';
 import { Events } from './events';
 
-const countryId = Country.detect();
-const countryGroupId = CountryGroup.detect();
-const participations = abTest.init({
-	countryId,
-	countryGroupId,
-});
-ophan.init();
-trackAbTests(participations);
-
+setUpTrackingAndConsents();
 const router = createBrowserRouter(
 	geoIds.flatMap((geoId) => [
 		{


### PR DESCRIPTION
Uses the standard `setUpTrackingAndConsents`.
Not 100% sure why we didn't in the first place.

<img width="1380" alt="Screenshot 2024-08-29 at 10 50 07" src="https://github.com/user-attachments/assets/2934fff2-c220-42f7-bc43-5a6f10f5c4a5">
