### PR TITLE
Generic checkout: Optional Zip Code

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -1279,13 +1279,14 @@ function CheckoutComponent({
 										value={billingPostcode}
 										pattern={doesNotContainEmojiPattern}
 										error={billingPostcodeError}
+										optional
 										onInvalid={(event) => {
 											preventDefaultValidityMessage(event.currentTarget);
 											const validityState = event.currentTarget.validity;
 											if (validityState.valid) {
 												setBillingPostcodeError(undefined);
 											} else {
-												if (!validityState.valueMissing) {
+												if (validityState.patternMismatch) {
 													setBillingPostcodeError(
 														'Please enter a valid zip code.',
 													);


### PR DESCRIPTION
## What are you doing in this PR?

On the non-generic checkout we removed the mandatory requirement to submit a Zip Code for users in the US Billing Region (https://github.com/guardian/support-frontend/pull/6099), this was in response to an issue (documented here in [Trello](https://trello.com/c/Cpvg3n5l/896-zipcode-make-it-non-mandatory-on-the-checkout-page-for-single-recurring-and-s-for-us?filter=zip)) that caused users checking out with the Stripe Payment Request Button to be blocked from submitting the form because of this requirement.

However, on the generic checkout this input element was still marked as `required`, by default the `<TextInput>` element has the required attribute, unless we override with the [optional](https://github.com/guardian/csnx/blob/main/libs/%40guardian/source/src/react-components/text-input/TextInput.tsx#L48) property.

Another issue we had was that because the input element had the `required` attribute the form would fail to submit unless a zip code was entered, however our `onInvalid` error handling for the element only rendered a client-side error message for any other error other than valueMissing!

To fix this I've added the `optional` property, and I've made a change to the `onInvalid` to only show an error in the event of a `patternMismatch` error (eg. the user enters an emoji)

I believe this issue would explain why the generic checkout has had a lower conversion rate than the non-generic in the US.
