### PR TITLE
feat: add non-deliverable product state select tests

### DIFF
--- a/support-e2e/tests/cron/checkout.test.ts
+++ b/support-e2e/tests/cron/checkout.test.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
 import { afterEachTasks } from '../utils/afterEachTest';
-import { testCheckout } from '../test/checkout.test';
+import { testCheckout } from '../test/checkout';
 
 afterEachTasks(test);
 

--- a/support-e2e/tests/smoke/checkout.test.ts
+++ b/support-e2e/tests/smoke/checkout.test.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
 import { afterEachTasks } from '../utils/afterEachTest';
-import { testCheckout } from '../test/checkout.test';
+import { testCheckout } from '../test/checkout';
 
 afterEachTasks(test);
 

--- a/support-e2e/tests/smoke/non-delivery-state-selector.test.ts
+++ b/support-e2e/tests/smoke/non-delivery-state-selector.test.ts
@@ -1,0 +1,43 @@
+import { test } from '@playwright/test';
+import { afterEachTasks } from '../utils/afterEachTest';
+import { setTestCookies } from '../utils/cookies';
+
+afterEachTasks(test);
+
+const countryGroupsWithStates = ['us', 'au', 'ca'];
+const nonDeliveryProducts = [
+	{ product: 'SupporterPlus', ratePlan: 'Monthly' },
+	{ product: 'Contribution', ratePlan: 'Monthly', contribution: 10 },
+];
+
+/** We require state for non-deliverable products as we use different taxes within those regions upstream */
+countryGroupsWithStates.forEach((internationalisationId) => {
+	nonDeliveryProducts.forEach(({ product, ratePlan, contribution }) => {
+		test(`${internationalisationId} has a required state selector for a non-delivery ${product}`, async ({
+			context,
+			baseURL,
+		}) => {
+			const page = await context.newPage();
+			const domain = new URL(baseURL ?? 'support.theguardian.com').hostname;
+			await setTestCookies(context, 'SupportPostDeployTestF', domain);
+
+			await page.goto(
+				`/${internationalisationId}/checkout?product=${product}&ratePlan=${ratePlan}${
+					contribution ? `&contribution=${contribution}` : ''
+				}`,
+			);
+			await page.getByLabel('State').isVisible();
+			await page
+				.getByRole('button', {
+					name: `Pay`,
+				})
+				.click();
+
+			await page
+				.getByRole('alert', {
+					name: 'Please enter a state, province or territory.',
+				})
+				.isVisible();
+		});
+	});
+});

--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -35,9 +35,11 @@ export const testCheckout = (testDetails: TestDetails) => {
 			testLastName,
 			testEmail,
 		);
+
 		if (internationalisationId === 'au') {
 			await page.getByLabel('State').selectOption({ label: 'New South Wales' });
 		}
+
 		await page.getByRole('radio', { name: paymentType }).check();
 		switch (paymentType) {
 			case 'PayPal':

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -541,9 +541,6 @@ function CheckoutComponent({
 		countryId === 'US' && AmazonPay,
 	].filter(isPaymentMethod);
 
-	const showStateSelect =
-		countryId === 'US' || countryId === 'CA' || countryId === 'AU';
-
 	const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>();
 
 	/** Payment methods: Stripe */
@@ -1163,9 +1160,7 @@ function CheckoutComponent({
 									}}
 								/>
 							</div>
-
 							<Signout isSignedIn={isSignedIn} />
-
 							<>
 								<div>
 									<TextInput
@@ -1236,33 +1231,36 @@ function CheckoutComponent({
 									/>
 								</div>
 							</>
-							{/*For deliverable products we take the state and
-                    zip code with the delivery address*/}
-							{showStateSelect && !productDescription.deliverableTo && (
-								<StateSelect
-									countryId={countryId}
-									state={billingState}
-									onStateChange={(event) => {
-										setBillingState(event.currentTarget.value);
-									}}
-									onBlur={(event) => {
-										event.currentTarget.checkValidity();
-									}}
-									onInvalid={(event) => {
-										preventDefaultValidityMessage(event.currentTarget);
-										const validityState = event.currentTarget.validity;
-										if (validityState.valid) {
-											setBillingStateError(undefined);
-										} else {
-											setBillingStateError(
-												'Please enter a state, province or territory.',
-											);
-										}
-									}}
-									error={billingStateError}
-								/>
-							)}
 
+							{/**
+							 * We require state for non-deliverable products as we use different taxes within those regions upstream
+							 * For deliverable products we take the state and zip code with the delivery address
+							 */}
+							{['US', 'CA', 'AU'].includes(countryId) &&
+								!productDescription.deliverableTo && (
+									<StateSelect
+										countryId={countryId}
+										state={billingState}
+										onStateChange={(event) => {
+											setBillingState(event.currentTarget.value);
+										}}
+										onBlur={(event) => {
+											event.currentTarget.checkValidity();
+										}}
+										onInvalid={(event) => {
+											preventDefaultValidityMessage(event.currentTarget);
+											const validityState = event.currentTarget.validity;
+											if (validityState.valid) {
+												setBillingStateError(undefined);
+											} else {
+												setBillingStateError(
+													'Please enter a state, province or territory.',
+												);
+											}
+										}}
+										error={billingStateError}
+									/>
+								)}
 							{countryId === 'US' && !productDescription.deliverableTo && (
 								<div>
 									<TextInput


### PR DESCRIPTION
This adds tests to ensure we sure the `StateSelect` for non-deliverable products.

The more important thing I am trying to capture here is the reason why, using comments and tests to explain that. 

This is part of a large set of institutional / team knowledge that it would be good to codify to socialise between ourselves, but also future folks who join the team and fancy changing this at some stage. 

This PR is more for discussion as opposed to a "We should do this".