### PR TITLE
Generic checkout - comment out amazon pay option

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -57,7 +57,6 @@ import type {
 	StripePaymentMethod,
 } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
 import {
-	AmazonPay,
 	DirectDebit,
 	isPaymentMethod,
 	type PaymentMethod as LegacyPaymentMethod,
@@ -538,7 +537,8 @@ function CheckoutComponent({
 		countryId === 'GB' && DirectDebit,
 		Stripe,
 		PayPal,
-		countryId === 'US' && AmazonPay,
+		// Todo shouldn't this be checking the switches?
+		//countryId === 'US' && AmazonPay,
 	].filter(isPaymentMethod);
 
 	const showStateSelect =


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

In the US Amazon Pay is rendered as an option but it's not implemented! It's not an option on the non-generic checkout 