### PR TITLE
Comment out SEPA from validPaymenMethods on generic checkout

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -61,7 +61,7 @@ import {
 	isPaymentMethod,
 	type PaymentMethod as LegacyPaymentMethod,
 	PayPal,
-	Sepa,
+	// Sepa,
 	Stripe,
 } from 'helpers/forms/paymentMethods';
 import { getStripeKey } from 'helpers/forms/stripe';
@@ -532,12 +532,12 @@ function CheckoutComponent({
 		return <div>Invalid Amount {originalAmount}</div>;
 	}
 
+	// Todo shouldn't this be checking the switches?
 	const validPaymentMethods = [
-		countryGroupId === 'EURCountries' && Sepa,
+		// countryGroupId === 'EURCountries' && Sepa,
 		countryId === 'GB' && DirectDebit,
 		Stripe,
 		PayPal,
-		// Todo shouldn't this be checking the switches?
 		//countryId === 'US' && AmazonPay,
 	].filter(isPaymentMethod);
 


### PR DESCRIPTION
## What are you doing in this PR?

Currently we show users from the EU "SEPA" as a payment method on the generic checkout. There are 2 issues here, 1) we have not implemented SEPA as a payment method, so selecting the payment method does nothing, and 2) SEPA is currently turned off on the non-generic checkout, so it shouldn't be listed as a valid payment method. The quickest change to resolve the issue we have right now is to comment out SEPA. Next steps would be:

1) Check payment method switch is ON when adding them to `validPaymentMethods`
2) Check whether we intend to reintroduce SEPA, and if so reimplement on the generic checkout.