### PR TITLE
fix: add error handling from support-workers on checkout

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -891,11 +891,17 @@ function CheckoutComponent({
 
 				window.location.href = `/${geoId}/thank-you?${thankYouUrlSearchParams.toString()}`;
 			} else {
-				// TODO - error handling
 				console.error(
 					'processPaymentResponse error:',
 					processPaymentResponse.failureReason,
 				);
+				setErrorMessage('Sorry, something went wrong.');
+				setErrorContext(
+					appropriateErrorMessage(
+						processPaymentResponse.failureReason ?? 'unknown',
+					),
+				);
+				setIsProcessingPayment(false);
 			}
 		} else {
 			setIsProcessingPayment(false);


### PR DESCRIPTION
Adds error handling from support-workers onto the checkout.

<img width="686" alt="Screenshot 2024-09-02 at 14 51 40" src="https://github.com/user-attachments/assets/0a1cb2b5-cb97-4cf5-848d-7a9cac65e264">
