### PR TITLE
Newspaper archive benefit and new New benefit pill

### DIFF
--- a/support-frontend/assets/components/checkoutBenefits/benefitsCheckList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/benefitsCheckList.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { from, palette, space, textSans } from '@guardian/source/foundations';
 import { SvgCrossRound, SvgTickRound } from '@guardian/source/react-components';
 import Tooltip from 'components/tooltip/Tooltip';
+import { NewBenefitPill } from './newBenefitPill';
 
 const checkListIconCss = (style: CheckListStyle) => css`
 	vertical-align: top;
@@ -57,18 +58,19 @@ const tableCss = (style: CheckListStyle) => css`
 	}
 `;
 
-export type CheckListData = {
+export type BenefitsCheckListData = {
 	isChecked: boolean;
 	text?: JSX.Element | string;
 	maybeGreyedOut?: SerializedStyles;
 	toolTip?: string;
 	strong?: boolean;
+	isNew?: boolean;
 };
 
 type CheckListStyle = 'standard' | 'compact' | 'hidden';
 
-export type CheckListProps = {
-	checkListData: CheckListData[];
+export type BenefitsCheckListProps = {
+	checkListData: BenefitsCheckListData[];
 	style?: CheckListStyle;
 	iconColor?: string;
 	cssOverrides?: SerializedStyles;
@@ -94,12 +96,12 @@ function ChecklistItemIcon({
 	);
 }
 
-export function CheckList({
+export function BenefitsCheckList({
 	checkListData,
 	style = 'standard',
 	iconColor = style === 'compact' ? palette.success[400] : palette.brand[500],
 	cssOverrides,
-}: CheckListProps): JSX.Element {
+}: BenefitsCheckListProps): JSX.Element {
 	return (
 		<table css={[tableCss(style), cssOverrides]}>
 			{checkListData.map((item) => (
@@ -120,6 +122,7 @@ export function CheckList({
 					<td css={[checkListTextCss, item.maybeGreyedOut]}>
 						{typeof item.text === 'string' ? (
 							<span css={checkListTextItemCss}>
+								{item.isNew && <NewBenefitPill />}
 								{item.strong ? <strong>{item.text}</strong> : item.text}
 								{item.toolTip && (
 									<Tooltip

--- a/support-frontend/assets/components/checkoutBenefits/benefitsCheckList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/benefitsCheckList.tsx
@@ -70,7 +70,7 @@ export type BenefitsCheckListData = {
 type CheckListStyle = 'standard' | 'compact' | 'hidden';
 
 export type BenefitsCheckListProps = {
-	checkListData: BenefitsCheckListData[];
+	benefitsCheckListData: BenefitsCheckListData[];
 	style?: CheckListStyle;
 	iconColor?: string;
 	cssOverrides?: SerializedStyles;
@@ -97,14 +97,14 @@ function ChecklistItemIcon({
 }
 
 export function BenefitsCheckList({
-	checkListData,
+	benefitsCheckListData,
 	style = 'standard',
 	iconColor = style === 'compact' ? palette.success[400] : palette.brand[500],
 	cssOverrides,
 }: BenefitsCheckListProps): JSX.Element {
 	return (
 		<table css={[tableCss(style), cssOverrides]}>
-			{checkListData.map((item) => (
+			{benefitsCheckListData.map((item) => (
 				<tr>
 					{style !== 'hidden' && (
 						<td

--- a/support-frontend/assets/components/checkoutBenefits/benefitsCheckList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/benefitsCheckList.tsx
@@ -122,7 +122,11 @@ export function BenefitsCheckList({
 					<td css={[checkListTextCss, item.maybeGreyedOut]}>
 						{typeof item.text === 'string' ? (
 							<span css={checkListTextItemCss}>
-								{item.isNew && <NewBenefitPill />}
+								{item.isNew && (
+									<>
+										<NewBenefitPill />{' '}
+									</>
+								)}
 								{item.strong ? <strong>{item.text}</strong> : item.text}
 								{item.toolTip && (
 									<Tooltip

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
@@ -8,8 +8,8 @@ import {
 	textSans,
 	until,
 } from '@guardian/source/foundations';
-import { CheckList } from 'components/checkList/checkList';
-import type { CheckListData } from 'components/checkList/checkList';
+import type { BenefitsCheckListData } from './benefitsCheckList';
+import { BenefitsCheckList } from './benefitsCheckList';
 
 const containerCss = css`
 	${textSans.medium({ lineHeight: 'tight' })};
@@ -56,7 +56,7 @@ const hrCss = (margin: string) => css`
 
 export type CheckoutBenefitsListProps = {
 	title: string;
-	checkListData: CheckListData[];
+	checkListData: BenefitsCheckListData[];
 	buttonCopy: string | null;
 	handleButtonClick: () => void;
 	withBackground?: boolean;
@@ -85,7 +85,7 @@ export function CheckoutBenefitsList({
 				<span>{title}</span>
 			</h2>
 			<hr css={hrCss(`${space[4]}px 0`)} />
-			<CheckList
+			<BenefitsCheckList
 				checkListData={checkListData}
 				style={isCompactList ? 'compact' : 'standard'}
 				iconColor={palette.brand[500]}

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsList.tsx
@@ -86,7 +86,7 @@ export function CheckoutBenefitsList({
 			</h2>
 			<hr css={hrCss(`${space[4]}px 0`)} />
 			<BenefitsCheckList
-				checkListData={checkListData}
+				benefitsCheckListData={checkListData}
 				style={isCompactList ? 'compact' : 'standard'}
 				iconColor={palette.brand[500]}
 			/>

--- a/support-frontend/assets/components/checkoutBenefits/newBenefitPill.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/newBenefitPill.tsx
@@ -15,5 +15,5 @@ const newBenefitPill = css`
 `;
 
 export function NewBenefitPill() {
-	return <div css={newBenefitPill}>New</div>;
+	return <span css={newBenefitPill}>New</span>;
 }

--- a/support-frontend/assets/components/checkoutBenefits/newBenefitPill.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/newBenefitPill.tsx
@@ -1,0 +1,3 @@
+export function NewBenefitPill() {
+	return <>New</>;
+}

--- a/support-frontend/assets/components/checkoutBenefits/newBenefitPill.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/newBenefitPill.tsx
@@ -1,3 +1,19 @@
+import { css } from '@emotion/react';
+import {
+	neutral,
+	news,
+	space,
+	textSansBold14,
+} from '@guardian/source/foundations';
+
+const newBenefitPill = css`
+	background-color: ${news[400]};
+	color: ${neutral[100]};
+	${textSansBold14};
+	border-radius: 4px;
+	padding: ${space[1]}px;
+`;
+
 export function NewBenefitPill() {
-	return <>New</>;
+	return <div css={newBenefitPill}>New</div>;
 }

--- a/support-frontend/assets/components/checkoutBenefits/newBenefitPill.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/newBenefitPill.tsx
@@ -11,7 +11,7 @@ const newBenefitPill = css`
 	color: ${neutral[100]};
 	${textSansBold14};
 	border-radius: 4px;
-	padding: ${space[1]}px;
+	padding: 0 ${space[1]}px;
 `;
 
 export function NewBenefitPill() {

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -182,7 +182,7 @@ export function ContributionsOrderSummary({
 	const hasCheckList = enableCheckList && checkListData.length > 0;
 	const checkList = hasCheckList && (
 		<BenefitsCheckList
-			checkListData={checkListData}
+			benefitsCheckListData={checkListData}
 			style="compact"
 			iconColor={palette.brand[500]}
 		/>

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -12,8 +12,10 @@ import {
 	SvgChevronDownSingle,
 } from '@guardian/source/react-components';
 import { useState } from 'react';
-import type { CheckListData } from 'components/checkList/checkList';
-import { CheckList } from 'components/checkList/checkList';
+import {
+	BenefitsCheckList,
+	type BenefitsCheckListData,
+} from 'components/checkoutBenefits/benefitsCheckList';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import type { Currency } from 'helpers/internationalisation/currency';
 import type { Promotion } from 'helpers/productPrice/promotions';
@@ -144,7 +146,7 @@ export type ContributionsOrderSummaryProps = {
 	promotion?: Promotion;
 	currency: Currency;
 	enableCheckList: boolean;
-	checkListData: CheckListData[];
+	checkListData: BenefitsCheckListData[];
 	paymentFrequency?: string;
 	onCheckListToggle?: (opening: boolean) => void;
 	headerButton?: React.ReactNode;
@@ -179,7 +181,7 @@ export function ContributionsOrderSummary({
 
 	const hasCheckList = enableCheckList && checkListData.length > 0;
 	const checkList = hasCheckList && (
-		<CheckList
+		<BenefitsCheckList
 			checkListData={checkListData}
 			style="compact"
 			iconColor={palette.brand[500]}

--- a/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
@@ -1,7 +1,10 @@
 import { css } from '@emotion/react';
 import { from, space } from '@guardian/source/foundations';
 import { useState } from 'react';
-import { CheckList, type CheckListData } from 'components/checkList/checkList';
+import {
+	BenefitsCheckList,
+	type BenefitsCheckListData,
+} from 'components/checkoutBenefits/benefitsCheckList';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { CsrfState } from 'helpers/redux/checkout/csrf/state';
@@ -102,7 +105,7 @@ export const getThankYouModuleData = (
 	email?: string,
 	campaignCode?: string,
 	isTier3?: boolean,
-	checklistData?: CheckListData[],
+	checklistData?: BenefitsCheckListData[],
 	supportReminder?: ThankYouSupportReminderState,
 	feedbackSurveyHasBeenCompleted?: boolean,
 ): Record<ThankYouModuleType, ThankYouModuleData> => {
@@ -208,7 +211,7 @@ export const getThankYouModuleData = (
 				<>
 					<BenefitsBodyCopy />
 					{checklistData && (
-						<CheckList
+						<BenefitsCheckList
 							checkListData={checklistData}
 							cssOverrides={checklistCss}
 						/>

--- a/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
@@ -212,7 +212,7 @@ export const getThankYouModuleData = (
 					<BenefitsBodyCopy />
 					{checklistData && (
 						<BenefitsCheckList
-							checkListData={checklistData}
+							benefitsCheckListData={checklistData}
 							cssOverrides={checklistCss}
 						/>
 					)}

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -104,4 +104,26 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
+	newspaperArchiveBenefit: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'v1',
+			},
+			{ id: 'v2' },
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		isActive: false,
+		referrerControlled: false, // ab-test name not needed to be in paramURL
+		seed: 2,
+		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+		excludeCountriesSubjectToContributionsOnlyAmounts: true,
+	},
 };

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -64,10 +64,6 @@ export const productCatalogDescription: Record<ProductKey, ProductDescription> =
 					copy: 'Guardian Weekly print magazine delivered to your door every week  ',
 					tooltip: `Guardian Weekly is a beautifully concise magazine featuring a handpicked selection of in-depth articles, global news, long reads, opinion and more. Delivered to you every week, wherever you are in the world.`,
 				},
-				{
-					copy: 'Newspaper archive',
-					isNew: true,
-				},
 			],
 			/** These are just the SupporterPlus benefits */
 			benefitsAdditional: [
@@ -106,7 +102,6 @@ export const productCatalogDescription: Record<ProductKey, ProductDescription> =
 				},
 			},
 		},
-
 		DigitalSubscription: {
 			label: 'The Guardian Digital Edition',
 			benefits: [
@@ -317,3 +312,33 @@ export const productCatalogDescription: Record<ProductKey, ProductDescription> =
 			},
 		},
 	};
+
+export const productCatalogDescriptionNewBenefits: Record<
+	ProductKey,
+	ProductDescription
+> = {
+	...productCatalogDescription,
+	TierThree: {
+		...productCatalogDescription.TierThree,
+		benefits: [
+			...productCatalogDescription.TierThree.benefits,
+			{
+				copy: 'Newspaper archive',
+				isNew: true,
+			},
+		],
+	},
+	SupporterPlus: {
+		...productCatalogDescription.SupporterPlus,
+		benefits: [
+			...productCatalogDescription.SupporterPlus.benefits,
+			{
+				copy: 'Unlimited access to the Guardian Feast App',
+				isNew: true,
+				tooltip:
+					'Make a feast out of anything with the Guardian’s new recipe app. Feast has thousands of recipes including quick and budget-friendly weeknight dinners, and showstopping weekend dishes – plus smart app features to make mealtimes inspiring.',
+			},
+		],
+		offers: [],
+	},
+};

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -13,6 +13,7 @@ type ProductBenefit = {
 	copy: string;
 	tooltip?: string;
 	specificToRegions?: CountryGroupId[];
+	isNew?: boolean;
 };
 
 export type ProductDescription = {
@@ -62,6 +63,10 @@ export const productCatalogDescription: Record<ProductKey, ProductDescription> =
 				{
 					copy: 'Guardian Weekly print magazine delivered to your door every week  ',
 					tooltip: `Guardian Weekly is a beautifully concise magazine featuring a handpicked selection of in-depth articles, global news, long reads, opinion and more. Delivered to you every week, wherever you are in the world.`,
+				},
+				{
+					copy: 'Newspaper archive',
+					isNew: true,
 				},
 			],
 			/** These are just the SupporterPlus benefits */

--- a/support-frontend/assets/pages/digital-subscriber-checkout/components/subscriptionBenefitsListData.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/components/subscriptionBenefitsListData.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/react';
-import type { CheckListData } from 'components/checkList/checkList';
+import type { BenefitsCheckListData } from 'components/checkoutBenefits/benefitsCheckList';
 
 const boldText = css`
 	font-weight: bold;
 `;
 
-export const checkListData = (): CheckListData[] => {
+export const checkListData = (): BenefitsCheckListData[] => {
 	return [
 		{
 			isChecked: true,

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -300,7 +300,7 @@ export function ThreeTierCard({
 				<span css={benefitsPrefixPlus}>plus</span>
 			)}
 			<BenefitsCheckList
-				checkListData={benefits
+				benefitsCheckListData={benefits
 					.filter((benefit) => filterBenefitByRegion(benefit, countryGroupId))
 					.map((benefit) => {
 						return {
@@ -318,7 +318,7 @@ export function ThreeTierCard({
 				<>
 					<span css={benefitsPrefixPlus}>new</span>
 					<BenefitsCheckList
-						checkListData={offers.map((offer) => {
+						benefitsCheckListData={offers.map((offer) => {
 							return {
 								text: offer.copy,
 								isChecked: true,

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -10,7 +10,7 @@ import {
 	buttonThemeReaderRevenueBrand,
 	LinkButton,
 } from '@guardian/source/react-components';
-import { CheckList } from 'components/checkList/checkList';
+import { BenefitsCheckList } from 'components/checkoutBenefits/benefitsCheckList';
 import type {
 	ContributionType,
 	RegularContributionType,
@@ -299,7 +299,7 @@ export function ThreeTierCard({
 			{(benefitsSummary ?? offersSummary) && (
 				<span css={benefitsPrefixPlus}>plus</span>
 			)}
-			<CheckList
+			<BenefitsCheckList
 				checkListData={benefits
 					.filter((benefit) => filterBenefitByRegion(benefit, countryGroupId))
 					.map((benefit) => {
@@ -307,6 +307,7 @@ export function ThreeTierCard({
 							text: benefit.copy,
 							isChecked: true,
 							toolTip: benefit.tooltip,
+							isNew: benefit.isNew,
 						};
 					})}
 				style={'compact'}
@@ -316,7 +317,7 @@ export function ThreeTierCard({
 			{offers && offers.length > 0 && (
 				<>
 					<span css={benefitsPrefixPlus}>new</span>
-					<CheckList
+					<BenefitsCheckList
 						checkListData={offers.map((offer) => {
 							return {
 								text: offer.copy,

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -38,8 +38,9 @@ import {
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { currencies } from 'helpers/internationalisation/currency';
 import {
+	productCatalogDescription as canonicalProductCatalogDescription,
 	productCatalog,
-	productCatalogDescription,
+	productCatalogDescriptionNewBenefits,
 } from 'helpers/productCatalog';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { Promotion } from 'helpers/productPrice/promotions';
@@ -436,6 +437,12 @@ export function ThreeTierLanding({
 		contributionType === 'ANNUAL' ? 'annual' : 'monthly';
 	const selectedContributionRatePlan =
 		contributionType === 'ANNUAL' ? 'Annual' : 'Monthly';
+
+	const productCatalogDescription = ['v1', 'v2'].includes(
+		abParticipations.newspaperArchiveBenefit,
+	)
+		? productCatalogDescriptionNewBenefits
+		: canonicalProductCatalogDescription;
 
 	/**
 	 * Tier 1: Contributions

--- a/support-frontend/stories/content/CheckList.stories.tsx
+++ b/support-frontend/stories/content/CheckList.stories.tsx
@@ -41,7 +41,7 @@ Template.args = {} as BenefitsCheckListProps;
 export const Default = Template.bind({});
 
 Default.args = {
-	checkListData: checkListData({
+	benefitsCheckListData: checkListData({
 		higherTier: true,
 		countryGroupId: 'GBPCountries',
 	}),
@@ -50,7 +50,7 @@ Default.args = {
 export const Compact = Template.bind({});
 
 Compact.args = {
-	checkListData: checkListData({
+	benefitsCheckListData: checkListData({
 		higherTier: true,
 		countryGroupId: 'GBPCountries',
 	}),

--- a/support-frontend/stories/content/CheckList.stories.tsx
+++ b/support-frontend/stories/content/CheckList.stories.tsx
@@ -1,15 +1,15 @@
 import { css } from '@emotion/react';
 import { Column, Columns } from '@guardian/source/react-components';
-import type { CheckListProps } from 'components/checkList/checkList';
-import { CheckList } from 'components/checkList/checkList';
+import type { BenefitsCheckListProps } from 'components/checkoutBenefits/benefitsCheckList';
+import { BenefitsCheckList } from 'components/checkoutBenefits/benefitsCheckList';
 import { checkListData } from 'components/checkoutBenefits/checkoutBenefitsListData';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { withCenterAlignment } from '../../.storybook/decorators/withCenterAlignment';
 import { withSourceReset } from '../../.storybook/decorators/withSourceReset';
 
 export default {
-	title: 'Content/Check List',
-	component: CheckList,
+	title: 'Content/Benefits Check List',
+	component: BenefitsCheckList,
 	decorators: [
 		(Story: React.FC): JSX.Element => (
 			<Columns
@@ -32,11 +32,11 @@ export default {
 	],
 };
 
-function Template(args: CheckListProps) {
-	return <CheckList {...args} />;
+function Template(args: BenefitsCheckListProps) {
+	return <BenefitsCheckList {...args} />;
 }
 
-Template.args = {} as CheckListProps;
+Template.args = {} as BenefitsCheckListProps;
 
 export const Default = Template.bind({});
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Adding an AB test for testing the newspaper archive benefit on the checkout landing page. Including a new "New" benefit pill. This constitutes Variant A. Variant B still to come (banner with images).

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/gFLnj2Vu/1017-add-newspaper-archive-benefit-to-lp-new-benefit-tooltip-and-checkout-test-a-b-c)

## Why are you doing this?

Testing the new newspaper archive benefit at point of conversion.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

(Turn on AB test) go to `uk/contribute#ab-newspaperArchiveBenefit=v1` and see "New" benefit

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


## Screenshots
![image](https://github.com/user-attachments/assets/6e5bb1b6-bc17-4dd3-b37a-392e7322554d)

