### PR TITLE
feat: add Guardian Weekly playwright tests

### DIFF
--- a/support-e2e/tests/consent-management.test.ts
+++ b/support-e2e/tests/consent-management.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 
+/** These have been covered in smoke/cron tests */
 test('Should show a dismissable consent management banner', async ({
 	context,
 	baseURL,

--- a/support-e2e/tests/cron/guardian-weekly-checkout.test.ts
+++ b/support-e2e/tests/cron/guardian-weekly-checkout.test.ts
@@ -1,0 +1,19 @@
+import { testGuardianWeeklyCheckout } from '../test/guardianWeeklyCheckout';
+
+/**
+ * These tests are to ensure that we can buy the different ratePlans of
+ * Guardian Weekly with multiple payment types.
+ *
+ * This is only PayPal as we try to avoid "To many login attempts" and
+ * other rate limiting errors.
+ */
+(
+	[
+		{
+			frequency: 'Monthly',
+			paymentType: 'PayPal',
+		},
+	] as const
+).map((testDetails) => {
+	testGuardianWeeklyCheckout(testDetails);
+});

--- a/support-e2e/tests/cron/guardian-weekly-gift-checkout.test.ts
+++ b/support-e2e/tests/cron/guardian-weekly-gift-checkout.test.ts
@@ -1,0 +1,19 @@
+import { testGuardianWeeklyGiftCheckout } from '../test/guardianWeeklyGiftCheckout';
+
+/**
+ * These tests are to ensure that we can buy the different ratePlans of
+ * Guardian Weekly as a gift with multiple payment types.
+ *
+ * This is only PayPal as we try to avoid "To many login attempts" and
+ * other rate limiting errors.
+ */
+(
+	[
+		{
+			frequency: '3 months',
+			paymentType: 'PayPal',
+		},
+	] as const
+).map((testDetails) => {
+	testGuardianWeeklyGiftCheckout(testDetails);
+});

--- a/support-e2e/tests/genericCheckout.test.ts
+++ b/support-e2e/tests/genericCheckout.test.ts
@@ -8,6 +8,7 @@ import { fillInPayPalDetails } from './utils/paypal';
 import { setupPage } from './utils/page';
 import { afterEachTasks } from './utils/afterEachTest';
 
+/** These have been covered in smoke/cron tests */
 const testDetails = [
 	{
 		product: 'SupporterPlus',

--- a/support-e2e/tests/gwCheckout.test.ts
+++ b/support-e2e/tests/gwCheckout.test.ts
@@ -8,6 +8,7 @@ import { fillInPayPalDetails } from './utils/paypal';
 import { setupPage } from './utils/page';
 import { afterEachTasks } from './utils/afterEachTest';
 
+/** These have been covered in smoke/cron tests */
 type PaymentType = 'Credit/Debit card' | 'Direct debit' | 'PayPal';
 
 interface TestDetails {

--- a/support-e2e/tests/smoke/guardian-weekly-checkout.test.ts
+++ b/support-e2e/tests/smoke/guardian-weekly-checkout.test.ts
@@ -1,0 +1,36 @@
+import { testGuardianWeeklyCheckout } from '../test/guardianWeeklyCheckout';
+
+/**
+ * These tests are to ensure that we can buy the different ratePlans of
+ * Guardian Weekly with multiple payment types.
+ */
+(
+	[
+		{
+			frequency: 'Monthly',
+			paymentType: 'Credit/Debit card',
+		},
+		{
+			frequency: 'Monthly',
+			paymentType: 'Direct debit',
+		},
+		{
+			frequency: 'Quarterly',
+			paymentType: 'Credit/Debit card',
+		},
+		{
+			frequency: 'Quarterly',
+			paymentType: 'Direct debit',
+		},
+		{
+			frequency: 'Annual',
+			paymentType: 'Credit/Debit card',
+		},
+		{
+			frequency: 'Annual',
+			paymentType: 'Direct debit',
+		},
+	] as const
+).map((testDetails) => {
+	testGuardianWeeklyCheckout(testDetails);
+});

--- a/support-e2e/tests/smoke/guardian-weekly-gift-checkout.test.ts
+++ b/support-e2e/tests/smoke/guardian-weekly-gift-checkout.test.ts
@@ -1,0 +1,28 @@
+import { testGuardianWeeklyGiftCheckout } from '../test/guardianWeeklyGiftCheckout';
+
+/**
+ * These tests are to ensure that we can buy the different ratePlans of
+ * Guardian Weekly as a gift with multiple payment types.
+ */
+(
+	[
+		{
+			frequency: '3 months',
+			paymentType: 'Credit/Debit card',
+		},
+		{
+			frequency: '3 months',
+			paymentType: 'Direct debit',
+		},
+		{
+			frequency: '12 months',
+			paymentType: 'Credit/Debit card',
+		},
+		{
+			frequency: '12 months',
+			paymentType: 'Direct debit',
+		},
+	] as const
+).map((testDetails) => {
+	testGuardianWeeklyGiftCheckout(testDetails);
+});

--- a/support-e2e/tests/test/guardianWeeklyCheckout.ts
+++ b/support-e2e/tests/test/guardianWeeklyCheckout.ts
@@ -1,0 +1,89 @@
+import 'dotenv/config';
+import { expect, test } from '@playwright/test';
+import { email, firstName, lastName } from '../utils/users';
+import { checkRecaptcha } from '../utils/recaptcha';
+import { fillInCardDetails } from '../utils/cardDetails';
+import { fillInDirectDebitDetails } from '../utils/directDebitDetails';
+import { fillInPayPalDetails } from '../utils/paypal';
+import { setupPage } from '../utils/page';
+
+type TestDetails = {
+	frequency: 'Monthly' | 'Quarterly' | 'Annual';
+	paymentType: 'Credit/Debit card' | 'Direct debit' | 'PayPal';
+};
+
+export const testGuardianWeeklyCheckout = (testDetails: TestDetails) => {
+	test(`Guardian Weekly - ${testDetails.frequency} - ${testDetails.paymentType} - GBP`, async ({
+		context,
+		baseURL,
+	}) => {
+		const page = await context.newPage();
+		const testFirstName = firstName();
+		const testEmail = email();
+		await setupPage(page, context, baseURL, '/uk/subscribe/weekly');
+		await page
+			.locator(`a[aria-label='${testDetails.frequency}- Subscribe now']`)
+			.click();
+		await page.getByLabel('title').selectOption('Ms');
+		await page.getByLabel('First name').fill(testFirstName);
+		await page.getByLabel('Last name').fill(lastName());
+		await page.getByLabel('Email', { exact: true }).fill(testEmail);
+		await page.getByLabel('Confirm email').fill(testEmail);
+		await page.getByLabel('Address Line 1').fill('Kings Place');
+		await page.getByLabel('Address Line 2').fill('Kings Cross');
+		await page.getByLabel('Town/City').fill('London');
+		await page.getByLabel('Postcode').last().fill('N1 9GU');
+		await page.getByRole('radio', { name: testDetails.paymentType }).check();
+		switch (testDetails.paymentType) {
+			case 'Credit/Debit card':
+				await fillInCardDetails(page);
+				await checkRecaptcha(page);
+				await page.locator('button:has-text("Pay now")').click();
+				break;
+			case 'Direct debit':
+				await fillInDirectDebitDetails(page, 'subscription');
+				await page.locator('button:has-text("Confirm")').click();
+				await checkRecaptcha(page);
+				await page.locator('button:has-text("Subscribe")').click();
+				break;
+			case 'PayPal':
+				const popupPagePromise = page.waitForEvent('popup');
+				await page
+					.locator("iframe[name^='xcomponent__ppbutton']")
+					.scrollIntoViewIfNeeded();
+				await page
+					.frameLocator("iframe[name^='xcomponent__ppbutton']")
+					// this class gets added to the iframe body after the JavaScript has finished executing
+					.locator('body.dom-ready')
+					.getByRole('button', { name: 'PayPal' })
+					.click({ delay: 2000 });
+
+				const popupPage = await popupPagePromise;
+				fillInPayPalDetails(popupPage);
+				break;
+		}
+
+		const getSuccessPackageTitle = () => {
+			switch (testDetails.frequency) {
+				case 'Quarterly':
+					return ' / quarterly package';
+
+				case 'Annual':
+					return ' / annual package';
+
+				default:
+					return '';
+			}
+		};
+
+		const subscribedMessage = `You have now subscribed to the Guardian Weekly${getSuccessPackageTitle()}`;
+		const processingSubscriptionMessage = `Your subscription to the Guardian Weekly${getSuccessPackageTitle()} is being processed`;
+		const successMsgRegex = new RegExp(
+			`${processingSubscriptionMessage}|${subscribedMessage}`,
+		);
+
+		await expect(
+			page.getByRole('heading', { name: successMsgRegex }),
+		).toBeVisible({ timeout: 600000 });
+	});
+};

--- a/support-e2e/tests/test/guardianWeeklyGiftCheckout.ts
+++ b/support-e2e/tests/test/guardianWeeklyGiftCheckout.ts
@@ -1,0 +1,100 @@
+import 'dotenv/config';
+import { expect, test } from '@playwright/test';
+import { email, firstName, lastName } from '../utils/users';
+import { checkRecaptcha } from '../utils/recaptcha';
+import { fillInCardDetails } from '../utils/cardDetails';
+import { fillInDirectDebitDetails } from '../utils/directDebitDetails';
+import { fillInPayPalDetails } from '../utils/paypal';
+import { setupPage } from '../utils/page';
+
+type TestDetails = {
+	frequency: '3 months' | '12 months';
+	paymentType: 'Credit/Debit card' | 'Direct debit' | 'PayPal';
+};
+
+export const testGuardianWeeklyGiftCheckout = (testDetails: TestDetails) => {
+	test(`Guardian Weekly - Gifted - ${testDetails.frequency} - ${testDetails.paymentType} - GBP`, async ({
+		page,
+		context,
+		baseURL,
+	}) => {
+		const testFirstName = firstName();
+		const testLastName = lastName();
+		const testEmail = email();
+		await setupPage(page, context, baseURL, '/uk/subscribe/weekly/gift');
+		await page
+			.locator(`a[aria-label='${testDetails.frequency}- Subscribe now']`)
+			.click();
+		const gifteeDetails = await page
+			.getByText("Gift recipient's details", { exact: true })
+			.locator('..');
+		await gifteeDetails.getByLabel('title').selectOption('Mr');
+		await gifteeDetails
+			.getByLabel('First name')
+			.fill(`${testFirstName}-giftee`);
+		await gifteeDetails.getByLabel('Last name').fill(`${testLastName}-giftee`);
+		await gifteeDetails.getByLabel('Email').fill(`giftee-${testEmail}`);
+
+		const gifteeAddress = await page
+			.getByText("Gift recipient's address", { exact: true })
+			.locator('..');
+		await gifteeAddress
+			.getByLabel('Address Line 1')
+			.fill('Kings Place - giftee');
+		await gifteeAddress.getByLabel('Address Line 2').fill('Kings Cross');
+		await gifteeAddress.getByLabel('Town/City').fill('London');
+		await gifteeAddress.getByLabel('Postcode').last().fill('N1 9GU');
+
+		const yourDetails = await page
+			.getByText('Your details', { exact: true })
+			.locator('..');
+		await yourDetails.getByLabel('First name').fill(testFirstName);
+		await yourDetails.getByLabel('Last name').fill(testLastName);
+		await yourDetails.getByLabel('Email', { exact: true }).fill(testEmail);
+		await yourDetails
+			.getByLabel('Confirm email', { exact: true })
+			.fill(testEmail);
+		await page.getByRole('radio', { name: testDetails.paymentType }).check();
+
+		switch (testDetails.paymentType) {
+			case 'Credit/Debit card':
+				await fillInCardDetails(page);
+				await checkRecaptcha(page);
+				await page.locator('button:has-text("Pay now")').click();
+				break;
+			case 'Direct debit':
+				await fillInDirectDebitDetails(page, 'subscription');
+				await page.locator('button:has-text("Confirm")').click();
+				await checkRecaptcha(page);
+				await page.locator('button:has-text("Subscribe")').click();
+				break;
+			case 'PayPal':
+				const popupPagePromise = page.waitForEvent('popup');
+				await page
+					.locator("iframe[name^='xcomponent__ppbutton']")
+					.scrollIntoViewIfNeeded();
+				await page
+					.frameLocator("iframe[name^='xcomponent__ppbutton']")
+					// this class gets added to the iframe body after the JavaScript has finished executing
+					.locator('body.dom-ready')
+					.getByRole('button', { name: 'PayPal' })
+					.click({ delay: 2000 });
+
+				const popupPage = await popupPagePromise;
+				fillInPayPalDetails(popupPage);
+				break;
+		}
+
+		const subscribedMessage =
+			'Your purchase of a Guardian Weekly gift subscription is now complete';
+		const processingSubscriptionMessage =
+			'Your Guardian Weekly gift subscription is being processed';
+		const successMsgRegex = new RegExp(
+			`${processingSubscriptionMessage}|${subscribedMessage}`,
+		);
+
+		await expect(
+			page.getByRole('heading', { name: successMsgRegex }),
+		).toBeVisible({ timeout: 600000 });
+	});
+};


### PR DESCRIPTION
Adds Guardian Weekly and Guardian Weekly playwright tests.
This includes PayPal tests in the `cron` category.