### PR TITLE
fix: add host and path to auth logging

### DIFF
--- a/support-frontend/app/controllers/AuthCodeFlowController.scala
+++ b/support-frontend/app/controllers/AuthCodeFlowController.scala
@@ -146,7 +146,9 @@ class AuthCodeFlowController(cc: ControllerComponents, authService: AsyncAuthent
                 secureCookie(config.accessTokenCookieName, accessToken),
               )
             } else {
-              logger.error(s"Failed to generate auth tokens: HTTP ${response.status}: ${response.body}")
+              logger.error(
+                s"[${request.host}] [${request.path}] Failed to generate auth tokens: HTTP ${response.status}: ${response.body}",
+              )
               redirect
             }
           }
@@ -156,12 +158,12 @@ class AuthCodeFlowController(cc: ControllerComponents, authService: AsyncAuthent
         Future.successful(redirect)
 
       case (None, _, _, Some(error), Some(errorDescription)) =>
-        logger.error(s"Failed to generate auth tokens: $error: $errorDescription")
+        logger.error(s"[${request.host}] [${request.path}] Failed to generate auth tokens: $error: $errorDescription")
         Future.successful(cleansed(BadRequest(s"$error: $errorDescription")))
 
       case _ =>
         // Should never get to this case
-        logger.error(s"Failed to generate auth tokens for request: ${request.body}")
+        logger.error(s"[${request.host}] [${request.path}] Failed to generate auth tokens for request: ${request.body}")
         Future.successful(cleansed(BadRequest))
     }
   }


### PR DESCRIPTION
We're seeing the errors

```
{
    "error": "invalid_grant",
    "error_description": "The 'redirect_uri' does not match the redirection URI used in the authorization request."
}
```

popping up quite a lot [from `AuthCodeFlowController`](https://github.com/guardian/support-frontend/blob/main/support-frontend/app/controllers/AuthCodeFlowController.scala#L159). 

My hunch is this is for events that are hosted on live.theguardian.com.

This is with the aim of debugging why login isn't working on live.theguardian.com