### PR TITLE
CDK upgrade

### DIFF
--- a/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
+++ b/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
@@ -142,6 +142,9 @@ Logs: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#
         },
         "FunctionName": "bigquery-acquisitions-publisher-PROD",
         "Handler": "com.gu.bigqueryAcquisitionsPublisher.Lambda::handler",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
         "MemorySize": 1024,
         "Role": {
           "Fn::GetAtt": [

--- a/cdk/lib/__snapshots__/frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/frontend.test.ts.snap
@@ -19,6 +19,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
       "GuEc2App",
       "GuCertificate",
       "GuInstanceRole",
+      "GuSsmSshPolicy",
       "GuDescribeEC2Policy",
       "GuLoggingStreamNameParameter",
       "GuLogShippingPolicy",
@@ -104,6 +105,15 @@ exports[`The Frontend stack matches the snapshot 1`] = `
           },
         },
         "MaxSize": "6",
+        "MetricsCollection": [
+          {
+            "Granularity": "1Minute",
+            "Metrics": [
+              "GroupTotalInstances",
+              "GroupInServiceInstances",
+            ],
+          },
+        ],
         "MinSize": "3",
         "Tags": [
           {
@@ -663,20 +673,6 @@ exports[`The Frontend stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
-              ],
-            ],
-          },
-        ],
         "Path": "/",
         "Tags": [
           {
@@ -778,6 +774,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
         },
         "Port": 443,
         "Protocol": "HTTPS",
+        "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
@@ -786,6 +783,14 @@ exports[`The Frontend stack matches the snapshot 1`] = `
         "LoadBalancerAttributes": [
           {
             "Key": "deletion_protection.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.drop_invalid_header_fields.enabled",
             "Value": "true",
           },
         ],
@@ -1216,6 +1221,42 @@ exports[`The Frontend stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "SsmSshPolicy4CFC977E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply",
+                "ssm:UpdateInstanceInformation",
+                "ssm:ListInstanceAssociations",
+                "ssm:DescribeInstanceProperties",
+                "ssm:DescribeDocumentParameters",
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ssm-ssh-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleFrontend9A970131",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "StateMachineUnavailableAlarm43BA4A0D": {
       "Properties": {
         "ActionsEnabled": true,
@@ -1556,6 +1597,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
           "InstanceType": "t4g.small",
           "MetadataOptions": {
             "HttpTokens": "required",
+            "InstanceMetadataTags": "enabled",
           },
           "SecurityGroupIds": [
             {
@@ -1575,6 +1617,10 @@ exports[`The Frontend stack matches the snapshot 1`] = `
             {
               "ResourceType": "instance",
               "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "frontend",
+                },
                 {
                   "Key": "gu:cdk:version",
                   "Value": "TEST",
@@ -1600,6 +1646,10 @@ exports[`The Frontend stack matches the snapshot 1`] = `
             {
               "ResourceType": "volume",
               "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "frontend",
+                },
                 {
                   "Key": "gu:cdk:version",
                   "Value": "TEST",
@@ -1628,7 +1678,8 @@ exports[`The Frontend stack matches the snapshot 1`] = `
               "Fn::Join": [
                 "",
                 [
-                  "#!/bin/bash -ev
+                  "#!/bin/bash
+#!/bin/bash -ev
     mkdir /etc/gu
     aws --region ",
                   {
@@ -1646,6 +1697,10 @@ exports[`The Frontend stack matches the snapshot 1`] = `
           {
             "ResourceType": "launch-template",
             "Tags": [
+              {
+                "Key": "App",
+                "Value": "frontend",
+              },
               {
                 "Key": "gu:cdk:version",
                 "Value": "TEST",

--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -29,6 +29,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
       "GuPlayApp",
       "GuCertificate",
       "GuInstanceRole",
+      "GuSsmSshPolicy",
       "GuDescribeEC2Policy",
       "GuLoggingStreamNameParameter",
       "GuLogShippingPolicy",
@@ -236,6 +237,15 @@ exports[`The Payment API stack matches the snapshot 1`] = `
           },
         },
         "MaxSize": "6",
+        "MetricsCollection": [
+          {
+            "Granularity": "1Minute",
+            "Metrics": [
+              "GroupTotalInstances",
+              "GroupInServiceInstances",
+            ],
+          },
+        ],
         "MinSize": "3",
         "Tags": [
           {
@@ -680,20 +690,6 @@ exports[`The Payment API stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
-              ],
-            ],
-          },
-        ],
         "Path": "/",
         "Tags": [
           {
@@ -765,6 +761,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
         },
         "Port": 443,
         "Protocol": "HTTPS",
+        "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
@@ -773,6 +770,14 @@ exports[`The Payment API stack matches the snapshot 1`] = `
         "LoadBalancerAttributes": [
           {
             "Key": "deletion_protection.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.drop_invalid_header_fields.enabled",
             "Value": "true",
           },
         ],
@@ -1384,6 +1389,42 @@ exports[`The Payment API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "SsmSshPolicy4CFC977E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply",
+                "ssm:UpdateInstanceInformation",
+                "ssm:ListInstanceAssociations",
+                "ssm:DescribeInstanceProperties",
+                "ssm:DescribeDocumentParameters",
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ssm-ssh-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRolePaymentapi2FA25312",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "StripePaymentError235E2E2D": {
       "Properties": {
         "ActionsEnabled": true,
@@ -1623,6 +1664,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
           "InstanceType": "t4g.small",
           "MetadataOptions": {
             "HttpTokens": "required",
+            "InstanceMetadataTags": "enabled",
           },
           "SecurityGroupIds": [
             {
@@ -1642,6 +1684,10 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             {
               "ResourceType": "instance",
               "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "payment-api",
+                },
                 {
                   "Key": "gu:cdk:version",
                   "Value": "TEST",
@@ -1667,6 +1713,10 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             {
               "ResourceType": "volume",
               "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "payment-api",
+                },
                 {
                   "Key": "gu:cdk:version",
                   "Value": "TEST",
@@ -1695,7 +1745,8 @@ exports[`The Payment API stack matches the snapshot 1`] = `
               "Fn::Join": [
                 "",
                 [
-                  "#!/bin/bash -ev
+                  "#!/bin/bash
+#!/bin/bash -ev
     mkdir /etc/gu
 
     echo PROD > /etc/gu/stage
@@ -1716,6 +1767,10 @@ exports[`The Payment API stack matches the snapshot 1`] = `
           {
             "ResourceType": "launch-template",
             "Tags": [
+              {
+                "Key": "App",
+                "Value": "payment-api",
+              },
               {
                 "Key": "gu:cdk:version",
                 "Value": "TEST",

--- a/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
+++ b/cdk/lib/__snapshots__/stripe-patrons-data.test.ts.snap
@@ -577,6 +577,9 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
         },
         "FunctionName": "stripe-patrons-data-PROD",
         "Handler": "com.gu.patrons.lambdas.ProcessStripeSubscriptionsLambda::handleRequest",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
         "MemorySize": 1536,
         "Role": {
           "Fn::GetAtt": [
@@ -621,7 +624,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "StripePatronsDataPRODCurrentVersion700541B465621c82ee6833a6ab679e7e10d9ad5e",
+            "StripePatronsDataPRODCurrentVersion700541B4b1d2d8a58d99ba71fb5ad59d50569516",
             "Version",
           ],
         },
@@ -629,7 +632,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Alias",
     },
-    "StripePatronsDataPRODCurrentVersion700541B465621c82ee6833a6ab679e7e10d9ad5e": {
+    "StripePatronsDataPRODCurrentVersion700541B4b1d2d8a58d99ba71fb5ad59d50569516": {
       "Properties": {
         "FunctionName": {
           "Ref": "StripePatronsDataPROD61F45521",
@@ -961,6 +964,9 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
         },
         "FunctionName": "stripe-patrons-data-cancelled-PROD",
         "Handler": "com.gu.patrons.lambdas.PatronCancelledEventLambda::handleRequest",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
         "MemorySize": 1536,
         "Role": {
           "Fn::GetAtt": [
@@ -1005,7 +1011,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "stripepatronsdatacancelledCurrentVersion23EC801Eb15ada947f2b1c050fce4ce19ae71fa6",
+            "stripepatronsdatacancelledCurrentVersion23EC801Ebaa302193dd1e54115b09f3ea1a6bcc7",
             "Version",
           ],
         },
@@ -1013,7 +1019,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Alias",
     },
-    "stripepatronsdatacancelledCurrentVersion23EC801Eb15ada947f2b1c050fce4ce19ae71fa6": {
+    "stripepatronsdatacancelledCurrentVersion23EC801Ebaa302193dd1e54115b09f3ea1a6bcc7": {
       "Properties": {
         "FunctionName": {
           "Ref": "stripepatronsdatacancelled2E3CED96",
@@ -1227,6 +1233,9 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
         },
         "FunctionName": "stripe-patrons-data-sign-up-PROD",
         "Handler": "com.gu.patrons.lambdas.PatronSignUpEventLambda::handleRequest",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
         "MemorySize": 1536,
         "Role": {
           "Fn::GetAtt": [
@@ -1271,7 +1280,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "stripepatronsdatasignupCurrentVersionCB0F0BAAed955197ca6426d2357b69ebab143a5f",
+            "stripepatronsdatasignupCurrentVersionCB0F0BAAc41971ff7e0c47681d13f4df990e0037",
             "Version",
           ],
         },
@@ -1279,7 +1288,7 @@ exports[`The Stripe patrons data stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Alias",
     },
-    "stripepatronsdatasignupCurrentVersionCB0F0BAAed955197ca6426d2357b69ebab143a5f": {
+    "stripepatronsdatasignupCurrentVersionCB0F0BAAc41971ff7e0c47681d13f4df990e0037": {
       "Properties": {
         "FunctionName": {
           "Ref": "stripepatronsdatasignup4E7F0A3F",

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -16,7 +16,12 @@ import {
   Metric,
   TreatMissingData,
 } from "aws-cdk-lib/aws-cloudwatch";
-import { InstanceClass, InstanceSize, InstanceType } from "aws-cdk-lib/aws-ec2";
+import {
+  InstanceClass,
+  InstanceSize,
+  InstanceType,
+  UserData,
+} from "aws-cdk-lib/aws-ec2";
 import { FilterPattern, LogGroup, MetricFilter } from "aws-cdk-lib/aws-logs";
 
 interface FrontendProps extends GuStackProps {
@@ -39,11 +44,12 @@ export class Frontend extends GuStack {
 
     const app = "frontend";
 
-    const userData = `#!/bin/bash -ev
+    const userData = UserData.forLinux();
+    userData.addCommands(`#!/bin/bash -ev
     mkdir /etc/gu
     aws --region ${this.region} s3 cp s3://membership-dist/${this.stack}/${this.stage}/${app}/support-frontend_1.0-SNAPSHOT_all.deb /tmp
     dpkg -i /tmp/support-frontend_1.0-SNAPSHOT_all.deb
-    /opt/cloudwatch-logs/configure-logs application ${this.stack} ${this.stage} ${app} /var/log/support-frontend/application.log '%Y-%m-%dT%H:%M:%S,%f%z'`;
+    /opt/cloudwatch-logs/configure-logs application ${this.stack} ${this.stage} ${app} /var/log/support-frontend/application.log '%Y-%m-%dT%H:%M:%S,%f%z'`);
 
     const policies = [
       // TODO: can we 'standardise' the way we load config to use the default permissons from GuEc2App?

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@aws-cdk/aws-apigatewayv2": "1.113.0",
     "@aws-cdk/aws-apigatewayv2-alpha": "^2.14.0-alpha.0",
-    "@guardian/cdk": "v53.1.0",
+    "@guardian/cdk": "v59.3.1",
     "@guardian/eslint-config-typescript": "1.0.11",
     "@guardian/prettier": "2.1.5",
     "@types/jest": "^29.5.12",

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -787,16 +787,16 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
-"@guardian/cdk@v53.1.0":
-  version "53.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-53.1.0.tgz#7bf28599f0cbbaca6a934513d4f2a20d92e0d349"
-  integrity sha512-VtozsbRERDSW/UnsJ/kv3KdRmILuwQ0t4aBjrjjU3JmBRiZ8hdL0amTJYuvpiGVAkpmCbCazIbbIVRUcphNyTw==
+"@guardian/cdk@v59.3.1":
+  version "59.3.1"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-59.3.1.tgz#cc841e28186959e64c34585d8eaa16db4df76c49"
+  integrity sha512-Y6ZpDNuUpXGs2Rxaw8f4G3k507pqx42ZdVkRIRePIRIOPXNSZ03OEAfhMrc+n0M7kG3/JZYZsUNWCF5ihUy67w==
   dependencies:
-    "@oclif/core" "3.18.1"
-    aws-sdk "^2.1542.0"
+    "@oclif/core" "3.26.6"
+    aws-sdk "^2.1687.0"
     chalk "^4.1.2"
-    codemaker "^1.94.0"
-    git-url-parse "^14.0.0"
+    codemaker "^1.103.1"
+    git-url-parse "^14.1.0"
     js-yaml "^4.1.0"
     lodash.camelcase "^4.3.0"
     lodash.kebabcase "^4.1.1"
@@ -1183,10 +1183,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@oclif/core@3.18.1":
-  version "3.18.1"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-3.18.1.tgz#a8c9ee3848ad663d5694bef6079116c70d32fc55"
-  integrity sha512-l0LsjzGcqjbUEdeSBX6bdZieVmEv82Q0W3StiyaDMEnPZ9KLH28HrLpcZg6d50mCYW9CUZNzmRo6qrCHWrgLKw==
+"@oclif/core@3.26.6":
+  version "3.26.6"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-3.26.6.tgz#f371868cfa0fe150a6547e6af98b359065d2f971"
+  integrity sha512-+FiTw1IPuJTF9tSAlTsY8bGK4sgthehjz7c2SvYdgQncTkxI2xvUch/8QpjNYGLEmUneNygvYMRBax2KJcLccA==
   dependencies:
     "@types/cli-progress" "^3.11.5"
     ansi-escapes "^4.3.2"
@@ -1197,13 +1197,14 @@
     cli-progress "^3.12.0"
     color "^4.2.3"
     debug "^4.3.4"
-    ejs "^3.1.9"
+    ejs "^3.1.10"
     get-package-type "^0.1.0"
     globby "^11.1.0"
     hyperlinker "^1.0.0"
     indent-string "^4.0.0"
     is-wsl "^2.2.0"
     js-yaml "^3.14.1"
+    minimatch "^9.0.4"
     natural-orderby "^2.0.3"
     object-treeify "^1.1.33"
     password-prompt "^1.1.3"
@@ -1635,10 +1636,10 @@ aws-cdk@2.122.0:
   optionalDependencies:
     fsevents "2.3.2"
 
-aws-sdk@^2.1542.0:
-  version "2.1548.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1548.0.tgz#f888f266b0675e5021f48704df7a56de9856caa1"
-  integrity sha512-kmo3FvO7xKuB7WfLKm6ABuecZeUTFtfwrbrGjWMiCC/yNwP1S3oSm/j/Yy7LO8sQfukWSOXpnPfMk5yhhqq3UQ==
+aws-sdk@^2.1687.0:
+  version "2.1687.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1687.0.tgz#dd1d7e78b252842ea292a2d28d22c720b97a824b"
+  integrity sha512-Pk7RbIxJ8yDmFJRKzaapiUsAvz5cTPKCz7soomU+lASx1jvO29Z9KAPB6KJR22m7rDDMO/HNNN9OJRzfdvh7xQ==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -1883,10 +1884,10 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
-codemaker@^1.94.0:
-  version "1.94.0"
-  resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.94.0.tgz#c5d79cf5580ea673edd14e648891c5a1256026db"
-  integrity sha512-V+896C7RojQVfG0UlOXaFfVVxmFb08rPtJvzcxhdJfowc2o6xGwGG0OpWSLHy6fQrmt4BxLXnKZ6Xeuqt4aKjw==
+codemaker@^1.103.1:
+  version "1.103.1"
+  resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.103.1.tgz#93426532883633081104651dd5aa0f4dffdaea92"
+  integrity sha512-y3Ru0bZV6qiuPAt8c/Hik1dCI0dVb6lj/6gAIWckvNYVu5FS51avr3FU/mRtuPrY3b1bW/EA0pszGB/P54Bl5A==
   dependencies:
     camelcase "^6.3.0"
     decamelize "^5.0.1"
@@ -2081,7 +2082,7 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-ejs@^3.1.9:
+ejs@^3.1.10:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
   integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
@@ -2648,10 +2649,10 @@ git-up@^7.0.0:
     is-ssh "^1.4.0"
     parse-url "^8.1.0"
 
-git-url-parse@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-14.0.0.tgz#18ce834726d5fbca0c25a4555101aa277017418f"
-  integrity sha512-NnLweV+2A4nCvn4U/m2AoYu0pPKlsmhK9cknG7IMwsjFY1S2jxM+mAhsDxyxfCIGfGaD+dozsyX4b6vkYc83yQ==
+git-url-parse@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-14.1.0.tgz#01cb70000666c11a7230aceec1fd518c416c224c"
+  integrity sha512-8xg65dTxGHST3+zGpycMMFZcoTzAdZ2dOtu4vmgIfkTFnVHBxHMzBC2L1k8To7EmrSiHesT8JgPLT91VKw1B5g==
   dependencies:
     git-up "^7.0.0"
 
@@ -3685,6 +3686,13 @@ minimatch@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
   integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^9.0.4:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
+  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
   dependencies:
     brace-expansion "^2.0.1"
 

--- a/support-frontend/app/controllers/AuthCodeFlowController.scala
+++ b/support-frontend/app/controllers/AuthCodeFlowController.scala
@@ -146,9 +146,7 @@ class AuthCodeFlowController(cc: ControllerComponents, authService: AsyncAuthent
                 secureCookie(config.accessTokenCookieName, accessToken),
               )
             } else {
-              logger.error(
-                s"[${request.host}] [${request.path}] Failed to generate auth tokens: HTTP ${response.status}: ${response.body}",
-              )
+              logger.error(s"Failed to generate auth tokens: HTTP ${response.status}: ${response.body}")
               redirect
             }
           }
@@ -158,12 +156,12 @@ class AuthCodeFlowController(cc: ControllerComponents, authService: AsyncAuthent
         Future.successful(redirect)
 
       case (None, _, _, Some(error), Some(errorDescription)) =>
-        logger.error(s"[${request.host}] [${request.path}] Failed to generate auth tokens: $error: $errorDescription")
+        logger.error(s"Failed to generate auth tokens: $error: $errorDescription")
         Future.successful(cleansed(BadRequest(s"$error: $errorDescription")))
 
       case _ =>
         // Should never get to this case
-        logger.error(s"[${request.host}] [${request.path}] Failed to generate auth tokens for request: ${request.body}")
+        logger.error(s"Failed to generate auth tokens for request: ${request.body}")
         Future.successful(cleansed(BadRequest))
     }
   }


### PR DESCRIPTION
Dependabot seems to be having a hard time doing this, probably because there's some breaking changes. 

This upgrades `@guardian/cdk` and fixes the related issues.