### PR TITLE
Dynamic oauth redirect uri

### DIFF
--- a/support-frontend/app/controllers/CanonicalLinks.scala
+++ b/support-frontend/app/controllers/CanonicalLinks.scala
@@ -6,13 +6,13 @@ trait CanonicalLinks {
 
   def buildCanonicalDigitalSubscriptionLink(countryCode: String, orderIsAGift: Boolean): String =
     if (orderIsAGift) s"${supportUrl}/${countryCode}/subscribe/digital/gift"
-    else s"${supportUrl}/${countryCode}/subscribe/digital"
+    else s"/${countryCode}/subscribe/digital"
 
   def buildCanonicalWeeklySubscriptionLink(countryCode: String, orderIsAGift: Boolean): String =
     if (orderIsAGift) s"${supportUrl}/${countryCode}/subscribe/weekly/gift"
-    else s"${supportUrl}/${countryCode}/subscribe/weekly"
+    else s"/${countryCode}/subscribe/weekly"
 
   def buildCanonicalContributeLink(countryCode: String): String =
-    s"${supportUrl}/${countryCode}/contribute"
+    s"/${countryCode}/contribute"
 
 }

--- a/support-frontend/nginx/config.yml
+++ b/support-frontend/nginx/config.yml
@@ -1,0 +1,9 @@
+name: support-frontend
+domain-root: thegulocal.com
+mappings:
+  - port: 9211
+    prefix: support
+    websocket: /ws
+  - port: 9211
+    prefix: live
+    websocket: /ws


### PR DESCRIPTION
- Uses a dynamic oauth `redirect_url` based on if you're on `live.` or `support.` 🗡️ 
- Adds support to test `live.` locally
- Removes the baseURL from redirect URLs as they are no longer static i.e. `support.`


🗡️ this is what was causing the bug