### PR TITLE
Landing page - Newspaper archive banner

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/newspaperArchiveBanner.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/newspaperArchiveBanner.tsx
@@ -1,0 +1,68 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headlineBold20,
+	headlineBold24,
+	neutral,
+	space,
+	textSans17,
+	until,
+} from '@guardian/source/foundations';
+import { NewBenefitPill } from 'components/checkoutBenefits/newBenefitPill';
+
+const newspaperArchiveBanner = css`
+	margin-top: ${space[8]}px;
+	border-radius: 12px;
+	background-color: #1e3e72;
+	padding: ${space[4]}px;
+`;
+
+const headline = css`
+	${headlineBold20};
+	${from.desktop} {
+		${headlineBold24};
+	}
+	color: ${neutral[100]};
+	margin-bottom: ${space[3]}px;
+`;
+
+export function NewspaperArchiveBanner() {
+	return (
+		<div css={newspaperArchiveBanner}>
+			<div
+				css={css`
+					text-align: left;
+					${from.desktop} {
+						max-width: 400px;
+					}
+				`}
+			>
+				<div css={headline}>
+					<div
+						css={css`
+							${until.desktop} {
+								display: inline;
+								margin-right: ${space[2]}px;
+							}
+							vertical-align: super;
+						`}
+					>
+						<NewBenefitPill />
+					</div>
+					The Guardian archives: discover 200 years of journalism
+				</div>
+				<div
+					css={css`
+						${textSans17};
+						color: ${neutral[100]};
+					`}
+				>
+					Lorem Ipsum, sometimes referred to as 'lipsum', is the placeholder
+					text used in design when creating content. It helps designers plan out
+					where the content will sit, without needing to wait for the content to
+					be written and approved
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/newspaperArchiveBanner.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/newspaperArchiveBanner.tsx
@@ -5,25 +5,62 @@ import {
 	headlineBold24,
 	neutral,
 	space,
+	textSans15,
 	textSans17,
 	until,
 } from '@guardian/source/foundations';
+import { Hide } from '@guardian/source/react-components';
 import { NewBenefitPill } from 'components/checkoutBenefits/newBenefitPill';
 
 const newspaperArchiveBanner = css`
-	margin-top: ${space[8]}px;
-	border-radius: 12px;
+	${until.desktop} {
+		margin: ${space[9]}px -10px 0;
+		padding-bottom: 0;
+	}
+	${from.desktop} {
+		margin-top: ${space[8]}px;
+		border-radius: 12px;
+		background-image: url(https://i.guim.co.uk/img/media/28125ed36669d6e27356d28044ba5db19cde11d1/0_0_3747_1007/2000.png?width=1300&quality=75&s=4d14643a2ebe76812931d8028f2e2150);
+		background-size: contain;
+		background-position: right;
+		background-repeat: no-repeat;
+	}
 	background-color: #1e3e72;
-	padding: ${space[4]}px;
+	padding: ${space[4]}px ${space[6]}px;
+	text-align: left;
 `;
 
-const headline = css`
+const headlineText = css`
 	${headlineBold20};
 	${from.desktop} {
 		${headlineBold24};
 	}
 	color: ${neutral[100]};
-	margin-bottom: ${space[3]}px;
+`;
+
+const newBenefitPill = css`
+	${until.desktop} {
+		display: inline;
+		margin-right: ${space[2]}px;
+	}
+	${from.desktop} {
+		margin-bottom: ${space[1]}px;
+	}
+	vertical-align: text-top;
+`;
+
+const paragraph = css`
+	${textSans15};
+	${from.desktop} {
+		${textSans17};
+	}
+	color: ${neutral[100]};
+`;
+
+const mobileImage = css`
+	width: 100%;
+	object-fit: contain;
+	vertical-align: top;
 `;
 
 export function NewspaperArchiveBanner() {
@@ -31,38 +68,37 @@ export function NewspaperArchiveBanner() {
 		<div css={newspaperArchiveBanner}>
 			<div
 				css={css`
-					text-align: left;
 					${from.desktop} {
 						max-width: 400px;
 					}
 				`}
 			>
-				<div css={headline}>
-					<div
-						css={css`
-							${until.desktop} {
-								display: inline;
-								margin-right: ${space[2]}px;
-							}
-							vertical-align: super;
-						`}
-					>
-						<NewBenefitPill />
-					</div>
-					The Guardian archives: discover 200 years of journalism
-				</div>
-				<div
+				<h2
 					css={css`
-						${textSans17};
-						color: ${neutral[100]};
+						margin-bottom: ${space[3]}px;
 					`}
 				>
+					<div css={newBenefitPill}>
+						<NewBenefitPill />
+					</div>
+					<span css={headlineText}>
+						The Guardian archives: discover 200 years of journalism
+					</span>
+				</h2>
+				<p css={paragraph}>
 					Lorem Ipsum, sometimes referred to as 'lipsum', is the placeholder
 					text used in design when creating content. It helps designers plan out
 					where the content will sit, without needing to wait for the content to
 					be written and approved
-				</div>
+				</p>
 			</div>
+			<Hide from="desktop">
+				<img
+					css={mobileImage}
+					alt=""
+					src="https://i.guim.co.uk/img/media/6a10c564d225dc23d3a24098a033464769740f01/0_0_1781_868/1000.png?width=1000&quality=75&s=16aec938fdd59f7a23f14fa7131fe554"
+				/>
+			</Hide>
 		</div>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -62,6 +62,7 @@ import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
 import { getCampaignSettings } from '../../../helpers/campaigns/campaigns';
+import { NewspaperArchiveBanner } from '../components/newspaperArchiveBanner';
 import { OneOffCard } from '../components/oneOffCard';
 import { SupportOnce } from '../components/supportOnce';
 import { ThreeTierCards } from '../components/threeTierCards';
@@ -566,6 +567,9 @@ export function ThreeTierLanding({
 		ctaCopy: getThreeTierCardCtaCopy(countryGroupId),
 	};
 
+	const showNewspaperArchiveBanner =
+		abParticipations.newspaperArchiveBenefit === 'v2';
+
 	return (
 		<PageScaffold
 			header={
@@ -625,6 +629,7 @@ export function ThreeTierLanding({
 							linkCtaClickHandler={handleLinkCtaClick}
 						/>
 					)}
+					{showNewspaperArchiveBanner && <NewspaperArchiveBanner />}
 				</div>
 			</Container>
 			<Container

--- a/support-frontend/stories/landingPage/NewspaperArchiveBanner.stories.tsx
+++ b/support-frontend/stories/landingPage/NewspaperArchiveBanner.stories.tsx
@@ -1,0 +1,20 @@
+import { NewspaperArchiveBanner } from 'pages/supporter-plus-landing/components/newspaperArchiveBanner';
+
+export default {
+	title: 'LandingPage/Newspaper Archive Banner',
+	component: NewspaperArchiveBanner,
+	// decorators: [withCenterAlignment, withSourceReset],
+	parameters: {
+		docs: {
+			description: {
+				component: `A product slice banner displaying the Newspaper archive benefit.`,
+			},
+		},
+	},
+};
+
+function Template() {
+	return <NewspaperArchiveBanner />;
+}
+
+export const Default = Template.bind({});


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Add a new banner (or product slice) promoting the new newspaper archive benefit. 

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/gFLnj2Vu/1017-add-newspaper-archive-benefit-to-lp-new-benefit-tooltip-and-checkout-test-a-b-c)

## Why are you doing this?

We are testing the new benefit at the point of acquisition, this is variant B. The final copy and images are TBC

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Activate `newspaperArchiveBenefit` ab test. Go to `/contribute#ab-newspaperArchiveBenefit=v2` 

Or see Storybook - LandingPage: Newspaper Archive Banner

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Screenshots

Mobile
![image](https://github.com/user-attachments/assets/75f3d0e8-978d-4300-8df1-ced1fed399da)
Desktop
![image](https://github.com/user-attachments/assets/19ddb81e-b82c-4531-bcd9-586f5793ee6f)

