### PR TITLE
Address State Select - remove validation error style on page load

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { isNonNullable } from '@guardian/libs';
-import { space } from '@guardian/source/foundations';
+import { palette, space } from '@guardian/source/foundations';
 import {
 	Option as OptionForSelect,
 	Select,
@@ -54,6 +54,13 @@ type PropTypes = StatePropTypes & {
 
 const marginBottom = css`
 	margin-bottom: ${space[6]}px;
+`;
+
+const selectStateStyles = css`
+	&:invalid:not(&:user-invalid) {
+		/* Remove styling of invalid select element */
+		border: 1px solid ${palette.neutral[46]};
+	}
 `;
 
 const MaybeSelect = canShow(Select);
@@ -272,7 +279,7 @@ export function AddressFields({ scope, ...props }: PropTypes): JSX.Element {
 				}}
 			/>
 			<MaybeSelect
-				css={marginBottom}
+				css={[marginBottom, selectStateStyles]}
 				id={`${scope}-stateProvince`}
 				data-qm-masking="blocklist"
 				label={props.country === 'CA' ? 'Province/Territory' : 'State'}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Add styling to prevent the state select having a red error border on page load. Use the [user-invalid](https://developer.mozilla.org/en-US/docs/Web/CSS/:user-invalid) selector to check whether it was actually the user form submission that caused the error. It seems like a [known issue](https://stackoverflow.com/questions/27021801/inputinvalid-css-rule-is-applied-on-page-load) that the `invalid` selector is applied on page load. Should this change in [source](https://github.com/guardian/csnx/blob/67fbe1c1ed95c043ede73fc48020fb4b1bfc5e4f/libs/%40guardian/source/src/react-components/select/styles.ts#L84)?

## Screenshots
Before (on page load)
![image](https://github.com/user-attachments/assets/6f69e40a-8f76-4bb6-9bb2-28ce4563c94d)

After (on page load)
![image](https://github.com/user-attachments/assets/3b46a5a4-79e2-47d9-9b6f-9da2894b2a67)

However there is some strange behaviour now when interacting with the select but not selecting another option
![image](https://github.com/user-attachments/assets/19a463d8-75f8-4f0e-8f15-257a62482807)

After submit it looks as expected
![image](https://github.com/user-attachments/assets/a68dffec-4d9b-461e-9413-956ba66360db)

