### PR TITLE
Adding China and Qatar to the list of countries where we sell only sell contributions to

### DIFF
--- a/support-frontend/conf/fastly-snippets/vat-compliance-redirects-recv.vcl
+++ b/support-frontend/conf/fastly-snippets/vat-compliance-redirects-recv.vcl
@@ -40,6 +40,7 @@ if (
     client.geo.country_code == "CK" ||
     client.geo.country_code == "CL" ||
     client.geo.country_code == "CM" ||
+    client.geo.country_code == "CN" ||
     client.geo.country_code == "CO" ||
     client.geo.country_code == "CR" ||
     client.geo.country_code == "CU" ||
@@ -142,6 +143,7 @@ if (
     client.geo.country_code == "PR" ||
     client.geo.country_code == "PW" ||
     client.geo.country_code == "PY" ||
+    client.geo.country_code == "QA" ||
     client.geo.country_code == "RE" ||
     client.geo.country_code == "RS" ||
     client.geo.country_code == "RW" ||


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Adding China and Qatar to the list of countries where we sell only sell contributions to, meaning that the `/subscribe/digitaledition` URL will redirect to `/contributions`

## Why are you doing this?
Request from Tax/Finance team.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Tried and tested principle. Unit tests pass proving no typo in configuration.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Correct ISO country codes checked against [Wikipedia](https://en.wikipedia.org/wiki/ISO_3166-1). China = CN, Qatar = QA.
