### PR TITLE
fix: move generic checkout to 100%

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -86,9 +86,6 @@ export const tests: Tests = {
 			{
 				id: 'control',
 			},
-			{
-				id: 'variant',
-			},
 		],
 		audiences: {
 			ALL: {


### PR DESCRIPTION
[After an incredible investigation](https://docs.google.com/spreadsheets/d/19kkkQfEHxWx-hyvgXOaTS3YU9aYs2qDfvzFW8dn7RIM/edit?gid=872405396#gid=872405396)(🔒 Private) from @GHaberis - it looks like we're hitting at least parity with the contributions checkout - so off we pop to 100%

Great work by all.