### PR TITLE
fix: make variant the default for useGenericCheckout test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -84,7 +84,7 @@ export const tests: Tests = {
 	useGenericCheckout: {
 		variants: [
 			{
-				id: 'control',
+				id: 'variant',
 			},
 		],
 		audiences: {


### PR DESCRIPTION
Changes the default for `useGenericCheckout` test to `variant`.
Oopsie.