### PR TITLE
Ticket Tailor: widget border hide

### DIFF
--- a/support-frontend/assets/components/checkoutHeading/checkoutHeading.tsx
+++ b/support-frontend/assets/components/checkoutHeading/checkoutHeading.tsx
@@ -1,3 +1,4 @@
+import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import {
 	brand,
@@ -19,8 +20,8 @@ const mainStyles = css`
 
 const headingContentContainer = css`
 	min-height: 480px;
-	${from.desktop} {
-		min-height: 440px;
+	${from.tablet} {
+		min-height: 432px;
 	}
 	padding-top: ${space[6]}px;
 	${textSans.large({ fontWeight: 'bold' })}
@@ -31,6 +32,7 @@ export interface CheckoutHeadingProps extends CSSOverridable {
 	children?: React.ReactNode;
 	image?: React.ReactNode;
 	withTopBorder?: true;
+	cssOverrides?: SerializedStyles;
 }
 
 export function CheckoutHeading(props: CheckoutHeadingProps): JSX.Element {
@@ -44,7 +46,7 @@ export function CheckoutHeading(props: CheckoutHeadingProps): JSX.Element {
 			>
 				<Columns collapseUntil="desktop">
 					<Column span={[1, 2, 5]}>
-						<div css={headingContentContainer}>
+						<div css={[headingContentContainer, props.cssOverrides]}>
 							<Hide until="desktop">
 								{props.heading}
 								{props.children}

--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -91,7 +91,11 @@ export function Events({ geoId }: Props) {
 
 	const params = useParams();
 	const eventId = params.eventId;
-	const termsEvents = <a href={guardianLiveTermsLink}>Terms and Conditions</a>;
+	const termsEvents = (
+		<a href={guardianLiveTermsLink} target="_blank">
+			Terms and Conditions
+		</a>
+	);
 	const privacyPolicy = <a href={privacyLink}>Privacy Policy</a>;
 
 	const pageviewId = getPageViewId();

--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -31,9 +31,19 @@ const columns = css`
 `;
 
 const shorterBoxMargin = css`
-	border-radius: ${space[2]}px;
+	border-radius: ${space[4]}px;
 	:not(:last-child) {
 		margin-bottom: ${space[4]}px;
+	}
+
+	> div {
+		padding: 0;
+	}
+
+	// ticket tailor widget (class:box-color-background) margin
+	// needs removal, its container we can reduce to hide
+	> div div div {
+		margin: -2px -2px -8px -2px;
 	}
 `;
 

--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -42,7 +42,7 @@ const columns = css`
 	}
 `;
 
-const shorterBoxMargin = css`
+const narrowBoxMarginAndPadding = css`
 	border-radius: ${space[4]}px;
 	:not(:last-child) {
 		margin-bottom: ${space[4]}px;
@@ -52,8 +52,10 @@ const shorterBoxMargin = css`
 		padding: 0;
 	}
 
-	// ticket tailor widget (class:box-color-background) margin
-	// needs removal, its container we can reduce to hide
+	// Ticket Tailor widget itself contains a margin & border
+	// not accessible directly (class:box-color-background)
+	// We can reduce its container box to hide
+	// the margin & border
 	> div div div {
 		margin: -2px -2px -8px -2px;
 	}
@@ -134,7 +136,7 @@ export function Events({ geoId }: Props) {
 				<Columns cssOverrides={columns} collapseUntil="tablet">
 					<Column span={[0, 2, 2, 3, 4]}></Column>
 					<Column span={[1, 8, 8, 8, 8]}>
-						<Box cssOverrides={shorterBoxMargin}>
+						<Box cssOverrides={narrowBoxMarginAndPadding}>
 							<BoxContents>
 								<div className="tt-widget">
 									<div className="tt-widget-fallback">

--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -1,5 +1,11 @@
 import { css } from '@emotion/react';
-import { palette, space, textSans, until } from '@guardian/source/foundations';
+import {
+	from,
+	palette,
+	space,
+	textSans,
+	until,
+} from '@guardian/source/foundations';
 import { Column, Columns, Container } from '@guardian/source/react-components';
 import { FooterWithContents } from '@guardian/source-development-kitchen/react-components';
 import { useParams } from 'react-router-dom';
@@ -17,6 +23,12 @@ const darkBackgroundContainerMobile = css`
 	background-color: ${palette.neutral[97]};
 	${until.tablet} {
 		background-color: ${palette.brand[400]};
+	}
+`;
+
+const darkBackgroundContainerTablet = css`
+	${from.tablet} {
+		min-height: 400px;
 	}
 `;
 
@@ -110,7 +122,10 @@ export function Events({ geoId }: Props) {
 				</FooterWithContents>
 			}
 		>
-			<CheckoutHeading withTopBorder={true}></CheckoutHeading>
+			<CheckoutHeading
+				withTopBorder={true}
+				cssOverrides={darkBackgroundContainerTablet}
+			></CheckoutHeading>
 			<Container sideBorders cssOverrides={darkBackgroundContainerMobile}>
 				<Columns cssOverrides={columns} collapseUntil="tablet">
 					<Column span={[0, 2, 2, 3, 4]}></Column>


### PR DESCRIPTION
## What are you doing in this PR?

- Ts&Cs creates new tab
- Tablet resize backdrop upwards to display Ts&Cs clearly
- Remove border shown here ->

|before|after|
|-----|-----|
|![image](https://github.com/user-attachments/assets/4a3bd2ab-b8d6-4df6-b16d-5a0792cac331)|![image](https://github.com/user-attachments/assets/41abac08-bf70-4d19-9cd9-a1dda9e9e07f)|

[**Trello Card**](https://trello.com/c/j6F32kdQ/1064-ticket-tailor-ui-border-tweak)
