### PR TITLE
Fix Cover transaction checkbox on mobile

### DIFF
--- a/support-frontend/assets/components/checkbox/Checkbox.tsx
+++ b/support-frontend/assets/components/checkbox/Checkbox.tsx
@@ -1,0 +1,217 @@
+import type { Theme as EmotionTheme, SerializedStyles } from '@emotion/react';
+import { generateSourceId } from '@guardian/source/foundations';
+import type { InputHTMLAttributes, ReactNode } from 'react';
+import {
+	checkbox,
+	checkboxContainer,
+	errorCheckbox,
+	label,
+	labelText,
+	supportingText,
+	tick,
+} from './styles';
+import { themeCheckbox as defaultTheme, transformProviderTheme } from './theme';
+import type { checkboxThemeDefault, ThemeCheckbox } from './theme';
+
+/** TODO: Remove this file and folder!
+ *  This has been copied wholesale from Source in order to fix spacing.
+ *  Pre v7 at small screen sizes if the label is more 3 lines the checkmark
+ *  moves outside of the box.
+ *
+ *  This repo is (or was) behind on Source and we had breaking changes preventing
+ *  an upgrade to get this styling fixed.
+ */
+
+export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
+	className?: string;
+	/**
+	 * Override component styles by passing in the result of [emotion's `css` function/prop](https://emotion.sh/docs/introduction).
+	 */
+	cssOverrides?: SerializedStyles | SerializedStyles[];
+	/**
+	 * Do not use `css` on Source components, use `cssOverrides` instead.
+	 *
+	 * **Why?**
+	 *
+	 * `css` is an emotion prop, and while
+	 * Source components _are_ emotion components, it's an internal implementation detail that is liable to break/change
+	 * at any point.
+	 */
+	css?: never;
+
+	id?: string;
+	/**
+	 * Whether checkbox is checked. This is necessary when using the
+	 * [controlled approach](https://reactjs.org/docs/forms.html#controlled-components)
+	 * (recommended) to form state management.
+	 *
+	 * _Note: if you pass the `checked` prop, you MUST also pass an `onChange`
+	 * handler, or the field will be rendered as read-only._
+	 */
+	checked?: boolean;
+	/**
+	 * When using the [uncontrolled approach](https://reactjs.org/docs/uncontrolled-components.html),
+	 * use defaultChecked to indicate the whether the checkbox is checked intially.
+	 */
+	defaultChecked?: boolean;
+	/**
+	 * Appears to the right of the checkbox. If a visible label is
+	 * undesirable (e.g. for layout reasons) use `aria-label` instead.
+	 *
+	 * If label is omitted, supporting text will not appear either.
+	 */
+	label?: ReactNode;
+	/**
+	 * Additional text or a component that appears below the label
+	 */
+	supporting?: ReactNode;
+	/**
+	 * Whether checkbox is in an indeterminate ("mixed") state
+	 */
+	indeterminate?: boolean;
+	/**
+	 * @ignore passed down by the parent
+	 */
+	error?: boolean;
+	/**
+	 * Partial or complete theme to override the component's colour palette.
+	 * The sanctioned colours have been set out by the design system team.
+	 * The colours which can be changed are:
+	 *
+	 *  `borderUnselected`<br>
+	 *  `borderHover`<br>
+	 *  `borderSelected`<br>
+	 *  `borderError`<br>
+	 *  `fillSelected`<br>
+	 *  `fillUnselected`<br>
+	 *  `textLabel`<br>
+	 *  `textSupporting`<br>
+	 *  `textIndeterminate`
+	 *
+	 */
+	theme?: Partial<ThemeCheckbox>;
+}
+
+const mergeThemes = <ComponentTheme, ProviderTheme>(
+	defaultTheme: ComponentTheme,
+	themeOverrides: Partial<ComponentTheme> | undefined,
+	providerTheme: ProviderTheme,
+	transform?: (providerTheme: ProviderTheme) => Partial<ComponentTheme>,
+): ComponentTheme => ({
+	...defaultTheme,
+	...(transform ? transform(providerTheme) : providerTheme),
+	...themeOverrides,
+});
+
+export interface Theme extends EmotionTheme {
+	checkbox?: typeof checkboxThemeDefault.checkbox;
+}
+
+/**
+ * [Storybook](https://guardian.github.io/storybooks/?path=/story/source_react-components-checkbox--default-default-theme) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/466fad-checkbox/b/33fc2f) •
+ * [GitHub](https://github.com/guardian/csnx/tree/main/libs/@guardian/source/src/react-components/checkbox/Checkbox.tsx) •
+ * [NPM](https://www.npmjs.com/package/@guardian/source)
+ *
+ * Checkboxes allow users to select multiple options from a list of individual
+ * items or to indicate agreement of terms and  services.
+ *
+ * The following themes are supported: `default`, `brand`
+ */
+export function Checkbox({
+	id,
+	label: labelContent,
+	checked,
+	supporting,
+	defaultChecked,
+	error,
+	indeterminate,
+	cssOverrides,
+	theme,
+	...props
+}: CheckboxProps) {
+	const defaultId = generateSourceId();
+	const checkboxId = id ?? defaultId;
+	const isChecked = (): boolean => {
+		if (checked != null) {
+			return checked;
+		}
+
+		return !!defaultChecked;
+	};
+	const setIndeterminate = (el: HTMLInputElement | null): void => {
+		if (el) {
+			el.indeterminate = !!indeterminate;
+		}
+	};
+	const mergedTheme = (providerTheme: Theme['checkbox']) =>
+		mergeThemes<ThemeCheckbox, Theme['checkbox']>(
+			defaultTheme,
+			theme,
+			providerTheme,
+			transformProviderTheme,
+		);
+
+	function SupportingText({ children }: { children: ReactNode }) {
+		return (
+			<div
+				css={(providerTheme: Theme) =>
+					supportingText(mergedTheme(providerTheme.checkbox))
+				}
+			>
+				{children}
+			</div>
+		);
+	}
+
+	function LabelText({ children }: { children: ReactNode }) {
+		return (
+			<div
+				css={(providerTheme: Theme) =>
+					labelText(mergedTheme(providerTheme.checkbox))
+				}
+			>
+				{children}
+			</div>
+		);
+	}
+
+	return (
+		<div
+			css={(providerTheme: Theme) =>
+				checkboxContainer(mergedTheme(providerTheme.checkbox), error)
+			}
+		>
+			<input
+				id={checkboxId}
+				type="checkbox"
+				css={(providerTheme: Theme) => [
+					checkbox(mergedTheme(providerTheme.checkbox), error),
+					error ? errorCheckbox(mergedTheme(providerTheme.checkbox)) : '',
+					cssOverrides,
+				]}
+				aria-invalid={!!error}
+				ref={setIndeterminate}
+				defaultChecked={defaultChecked ?? undefined}
+				checked={checked != null ? isChecked() : undefined}
+				{...props}
+			/>
+			<span
+				css={(providerTheme: Theme) =>
+					tick(mergedTheme(providerTheme.checkbox))
+				}
+			/>
+
+			<label htmlFor={checkboxId} css={label}>
+				{supporting ? (
+					<div>
+						<LabelText>{labelContent}</LabelText>
+						<SupportingText>{supporting}</SupportingText>
+					</div>
+				) : (
+					<LabelText>{labelContent}</LabelText>
+				)}
+			</label>
+		</div>
+	);
+}

--- a/support-frontend/assets/components/checkbox/styles.ts
+++ b/support-frontend/assets/components/checkbox/styles.ts
@@ -1,0 +1,192 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import {
+	appearance,
+	focusHalo,
+	height,
+	resets,
+	space,
+	textSans15,
+	textSans17,
+	textSans24,
+	transitions,
+	width,
+} from '@guardian/source/foundations';
+import type { ThemeCheckbox } from './theme';
+
+export const fieldset = css`
+	${resets.fieldset};
+	display: flex;
+	justify-content: flex-start;
+	flex-direction: column;
+`;
+
+export const checkboxContainer = (
+	checkbox: ThemeCheckbox,
+	error = false,
+): SerializedStyles => css`
+	position: relative;
+	display: flex;
+	align-items: flex-start;
+	/**
+	 * Ensure minimum height of 44px by applying 10px padding to top and bottom
+	 * of container. This ensures consistent spacing when supporting text present.
+	 */
+	padding: ${(height.inputMedium - height.inputXsmall) / 2}px 0;
+	cursor: pointer;
+
+	&:hover {
+		input {
+			border: ${error
+				? `2px solid ${checkbox.borderError}`
+				: `2px solid ${checkbox.borderHover}`};
+			/*
+				In the indeterminate state, we increase the border width by 1px on
+				hover. This causes the position of the indeterminate dash to shift as it
+				is absolutely positioned. This negative margin accounts for the extra
+				border width and prevents the shift. We need to locate this css here as
+				the hover sits on the container, rather than the input element.
+			*/
+			&:indeterminate {
+				&:after {
+					margin: -1px;
+				}
+			}
+		}
+	}
+	&:active {
+		input {
+			border-color: ${checkbox.borderHover};
+		}
+	}
+`;
+
+export const label: SerializedStyles = css`
+	cursor: pointer;
+`;
+
+export const checkbox = (
+	checkbox: ThemeCheckbox,
+	error = false,
+): SerializedStyles => css`
+	flex: 0 0 auto;
+	box-sizing: border-box;
+	display: inline-block;
+	cursor: pointer;
+	width: ${width.inputXsmall}px;
+	height: ${height.inputXsmall}px;
+	margin: 0 ${space[2]}px 0 0;
+
+	border: 1px solid currentColor;
+	background: ${checkbox.fillUnselected};
+	border-radius: 4px;
+	position: relative;
+	transition: box-shadow ${transitions.short};
+	transition-delay: 0.08s;
+	color: ${checkbox.borderUnselected};
+
+	&:focus {
+		${focusHalo};
+	}
+
+	@supports (${appearance}) {
+		appearance: none;
+		&:checked {
+			border: ${error
+				? `2px solid ${checkbox.borderError}`
+				: `2px solid ${checkbox.borderSelected}`};
+			& ~ span:before {
+				right: 0;
+			}
+			& ~ span:after {
+				top: 0;
+			}
+		}
+
+		&:indeterminate {
+			&:after {
+				${textSans24};
+				color: ${checkbox.textIndeterminate};
+				content: '-';
+				position: absolute;
+				top: -7px;
+				left: 6px;
+				z-index: 5;
+			}
+		}
+	}
+`;
+
+export const labelText = (checkbox: ThemeCheckbox): SerializedStyles => css`
+	${textSans17};
+	color: ${checkbox.textLabel};
+	width: 100%;
+	margin-top: 1px;
+	/* If label text is empty, add additional spacing to align supporting text */
+	&:empty {
+		margin-top: 2px;
+	}
+`;
+
+export const supportingText = (
+	checkbox: ThemeCheckbox,
+): SerializedStyles => css`
+	${textSans15};
+	color: ${checkbox.textSupporting};
+`;
+
+export const tick = (checkbox: ThemeCheckbox): SerializedStyles => css`
+	@supports (
+		(appearance: none) or (-webkit-appearance: none) or (-moz-appearance: none)
+	) {
+		/* overall positional properties */
+		position: absolute;
+		width: 6px;
+		height: 12px;
+		transform: rotate(45deg);
+		top: 15px;
+		left: 9px;
+		/**
+		 * This prevents simulated click events to the checkbox (eg. from Selenium
+		 * tests) being intercepted by the tick
+		 */
+		pointer-events: none;
+
+		/* the checkmark ✓ */
+		&:after,
+		&:before {
+			position: absolute;
+			display: block;
+			background-color: ${checkbox.fillSelected};
+			transition: all ${transitions.short} ease-in-out;
+			content: '';
+		}
+
+		/* the short side */
+		&:before {
+			height: 2px;
+			bottom: 0;
+			left: 0;
+			right: 100%;
+			transition-delay: 0.05s;
+		}
+
+		/* the long side */
+		&:after {
+			bottom: 0;
+			right: 0;
+			top: 100%;
+			width: 2px;
+			transition-delay: 0.1s;
+		}
+	}
+`;
+
+export const errorCheckbox = (checkbox: ThemeCheckbox): SerializedStyles => css`
+	border: 2px solid ${checkbox.borderError};
+	border-radius: 4px;
+	&:not(:checked):hover,
+	&:active {
+		border: 2px solid ${checkbox.borderHover};
+	}
+`;

--- a/support-frontend/assets/components/checkbox/theme.ts
+++ b/support-frontend/assets/components/checkbox/theme.ts
@@ -1,0 +1,123 @@
+import { palette } from '@guardian/source/foundations';
+import type {
+	ThemeLabel,
+	ThemeUserFeedback,
+} from '@guardian/source/react-components';
+import {
+	labelThemeBrand,
+	labelThemeDefault,
+	themeLabel,
+	themeLabelBrand,
+} from '@guardian/source/react-components';
+import type { Theme } from './Checkbox';
+
+export type ThemeCheckbox = {
+	borderUnselected: string;
+	borderHover: string;
+	borderSelected: string;
+	borderError: string;
+	fillSelected: string;
+	fillUnselected: string;
+	textLabel: string;
+	textSupporting: string;
+	textIndeterminate: string;
+};
+
+export type ThemeCheckboxGroup = ThemeLabel & ThemeUserFeedback;
+
+export const themeCheckbox: ThemeCheckbox = {
+	borderUnselected: palette.neutral[46],
+	borderHover: palette.brand[500],
+	borderSelected: palette.brand[500],
+	borderError: palette.error[400],
+	fillSelected: palette.brand[500],
+	fillUnselected: 'transparent',
+	textLabel: palette.neutral[7],
+	textSupporting: palette.neutral[46],
+	textIndeterminate: palette.neutral[46],
+} as const;
+
+export const themeCheckboxGroup: ThemeCheckboxGroup = {
+	...themeLabel,
+} as const;
+
+export const themeCheckboxBrand: ThemeCheckbox = {
+	borderUnselected: palette.brand[800],
+	borderSelected: palette.neutral[100],
+	borderHover: palette.neutral[100],
+	borderError: palette.error[500],
+	fillSelected: palette.neutral[100],
+	fillUnselected: 'transparent',
+	textLabel: palette.neutral[100],
+	textSupporting: palette.brand[800],
+	textIndeterminate: palette.brand[800],
+} as const;
+
+export const themeCheckboxGroupBrand: ThemeCheckboxGroup = {
+	...themeLabelBrand,
+} as const;
+
+const userFeedbackThemeBrand = {
+	userFeedback: {
+		textSuccess: palette.success[500],
+		textError: palette.error[500],
+	},
+};
+
+const userFeedbackThemeDefault = {
+	userFeedback: {
+		textSuccess: palette.success[400],
+		textError: palette.error[400],
+	},
+};
+
+/** @deprecated Use `themeCheckbox` and component `theme` prop instead of emotion's `ThemeProvider` */
+export const checkboxThemeDefault = {
+	checkbox: {
+		border: palette.neutral[46],
+		borderHover: palette.brand[500],
+		borderChecked: palette.brand[500],
+		borderError: palette.error[400],
+		backgroundChecked: palette.brand[500],
+		textLabel: palette.neutral[7],
+		textLabelSupporting: palette.neutral[46],
+		textIndeterminate: palette.neutral[46],
+	},
+	...userFeedbackThemeDefault,
+	...labelThemeDefault,
+};
+/** @deprecated Use `themeCheckboxBrand` and component `theme` prop instead of emotion's `ThemeProvider` */
+export const checkboxThemeBrand = {
+	checkbox: {
+		border: palette.brand[800],
+		borderHover: palette.neutral[100],
+		borderChecked: palette.neutral[100],
+		borderError: palette.error[500],
+		backgroundChecked: palette.neutral[100],
+		textLabel: palette.neutral[100],
+		textLabelSupporting: palette.brand[800],
+		textIndeterminate: palette.brand[800],
+	},
+	...userFeedbackThemeBrand,
+	...labelThemeBrand,
+};
+
+export const transformProviderTheme = (
+	providerTheme: Theme['checkbox'],
+): Partial<ThemeCheckbox> => {
+	const transformedTheme: Partial<ThemeCheckbox> = {};
+
+	if (providerTheme?.backgroundChecked) {
+		transformedTheme.fillSelected = providerTheme.backgroundChecked;
+	}
+	if (providerTheme?.borderChecked) {
+		transformedTheme.borderSelected = providerTheme.borderChecked;
+	}
+	if (providerTheme?.border) {
+		transformedTheme.borderUnselected = providerTheme.border;
+	}
+	if (providerTheme?.textLabelSupporting) {
+		transformedTheme.textSupporting = providerTheme.textLabelSupporting;
+	}
+	return { ...transformedTheme, ...providerTheme };
+};

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/react';
 import { from, neutral, space, until } from '@guardian/source/foundations';
-import { Button, Checkbox } from '@guardian/source/react-components';
+import { Button } from '@guardian/source/react-components';
 import { useNavigate } from 'react-router-dom';
+import { Checkbox } from 'components/checkbox/Checkbox';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { ContributionsOrderSummary } from 'components/orderSummary/contributionsOrderSummary';
 import { ContributionsOrderSummaryContainer } from 'components/orderSummary/contributionsOrderSummaryContainer';


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Cherry picking the latest Checkbox from Source to fix the Cover transaction checkbox styling from misaligning on mobile.

Unfortunately we have quite a few breaking changes in the upgrade path to source v7, which is where this fix is from.

The AB test is meant go live ASAP, so doing this hack should give us some time to upgrade smoothly and remove this temporary measure after

## Screenshots
Before
![image](https://github.com/user-attachments/assets/89857c26-35ad-4935-808e-517513d5a58f)


After
![image](https://github.com/user-attachments/assets/60d7c8eb-0146-40c0-b537-0795006aba85)
