### PR TITLE
Add finalAmount (including contribution) to order-summary

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -934,7 +934,7 @@ function CheckoutComponent({
 								? 'month'
 								: 'quarter'
 						}
-						amount={originalAmount}
+						amount={finalAmount}
 						promotion={promotion}
 						currency={currency}
 						checkListData={[


### PR DESCRIPTION
Makes sure the `OrderSummary` shows the value with the contribution amount included.

This functionality currently breaks when used with `promoCodes`, but it does in `PROD` as well.  

Looking at the screenshot - I think the contribution checkout is actually broken in both states (with added contribution or `promoCodes`)

### Contribution checkout
![Screenshot 2024-09-10 at 15 12 05](https://github.com/user-attachments/assets/76dcdab0-8c1f-45cf-98aa-8490d1a73342)

### Before
![Screenshot 2024-09-10 at 15 11 23](https://github.com/user-attachments/assets/fdf2f0ae-50ba-4b81-ac5e-0c14c49f62db)

### After
![Screenshot 2024-09-10 at 15 11 37](https://github.com/user-attachments/assets/84fc8fe0-c38e-42f9-a80d-6d988aeeced2)


