### PR TITLE
feat: add GChat notification to playwright CI

### DIFF
--- a/.github/workflows/playwright-cron.yml
+++ b/.github/workflows/playwright-cron.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PAYPAL_TEST_PASSWORD: ${{ secrets.PAYPAL_TEST_PASSWORD }}
+      GOOGLE_CHAT_WEB_HOOK: ${{ secrets.GOOGLE_CHAT_WEB_HOOK }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -30,3 +31,9 @@ jobs:
         name: playwright-report
         path: support-e2e/playwright-report/
         retention-days: 30
+    - name: Notify on Failure
+      if: ${{ failure() }}
+      run: |
+        failedWorkflowRun="https://github.com/guardian/support-frontend/actions/runs/$GITHUB_RUN_ID"
+        prTrigger="https://github.com/guardian/support-frontend/pull/${{ github.event.number }}"
+        curl -X POST -H "Content-Type: application/json" "$GOOGLE_CHAT_WEB_HOOK" -d '{"text": "🚨 The Playwright cron tests for support-frontend have failed 🚨\n\n- <'"$failedWorkflowRun"'|You can see the reason for this failure on GitHub>. \n- <'"$prTrigger"'|PR that triggered this>.\n\n 📖 <https://github.com/guardian/support-frontend/wiki/Post-deployment-test-runbook|Check the runbook for a step by step guide>"}'

--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -11,6 +11,8 @@ jobs:
     if: ${{ github.event.label.name == 'Seen-on-PROD' }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    env:
+      GOOGLE_CHAT_WEB_HOOK: ${{ secrets.GOOGLE_CHAT_WEB_HOOK }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -31,3 +33,9 @@ jobs:
         name: playwright-report
         path: support-e2e/playwright-report/
         retention-days: 30
+    - name: Notify on Failure
+      if: ${{ failure() }}
+      run: |
+        failedWorkflowRun="https://github.com/guardian/support-frontend/actions/runs/$GITHUB_RUN_ID"
+        prTrigger="https://github.com/guardian/support-frontend/pull/${{ github.event.number }}"
+        curl -X POST -H "Content-Type: application/json" "$GOOGLE_CHAT_WEB_HOOK" -d '{"text": "🚨 The Playwright smoke tests for support-frontend have failed 🚨\n\n- <'"$failedWorkflowRun"'|You can see the reason for this failure on GitHub>. \n- <'"$prTrigger"'|PR that triggered this>.\n\n 📖 <https://github.com/guardian/support-frontend/wiki/Post-deployment-test-runbook|Check the runbook for a step by step guide>"}'


### PR DESCRIPTION
Adds the Google Chat integration to the Playwright tests.

This is with the aim of having this implementation more fully featured and to remove the Browserstack integration.

## Testing 
[Here is a forced failure that we saw appear in our chat channel](https://github.com/guardian/support-frontend/actions/runs/10829675792/job/30047743319).

<img width="496" alt="Screenshot 2024-09-12 at 12 45 14" src="https://github.com/user-attachments/assets/e2bb9f35-d679-4c40-9ea5-2a391887b5bc">
