### PR TITLE
Generic checkout - check payment method feature switches

### DIFF
--- a/support-frontend/assets/helpers/forms/paymentMethods.ts
+++ b/support-frontend/assets/helpers/forms/paymentMethods.ts
@@ -1,3 +1,4 @@
+import type { PaymentMethodSwitch } from './checkouts';
 import type { StripePaymentMethod } from './paymentIntegrations/readerRevenueApis';
 
 const Stripe = 'Stripe';
@@ -43,5 +44,29 @@ export const isPaymentMethod = (
 		typeof paymentMethod === 'string' && paymentMethods.includes(paymentMethod)
 	);
 };
+
+export function toPaymentMethodSwitchNaming(
+	paymentMethod: PaymentMethod,
+): PaymentMethodSwitch | null {
+	switch (paymentMethod) {
+		case PayPal:
+			return 'payPal';
+
+		case Stripe:
+			return 'stripe';
+
+		case DirectDebit:
+			return 'directDebit';
+
+		case AmazonPay:
+			return 'amazonPay';
+
+		case Sepa:
+			return 'sepa';
+
+		case None:
+			return null;
+	}
+}
 
 export { Stripe, PayPal, DirectDebit, Sepa, AmazonPay };

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -62,8 +62,10 @@ import {
 	type PaymentMethod as LegacyPaymentMethod,
 	PayPal,
 	Stripe,
+	toPaymentMethodSwitchNaming,
 } from 'helpers/forms/paymentMethods';
 import { getStripeKey } from 'helpers/forms/stripe';
+import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import CountryHelper from 'helpers/internationalisation/classes/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
@@ -128,6 +130,12 @@ import {
  */
 type PaymentMethod = LegacyPaymentMethod | 'StripeExpressCheckoutElement';
 const countryId: IsoCountry = CountryHelper.detect();
+
+function paymentMethodIsActive(paymentMethod: LegacyPaymentMethod) {
+	return isSwitchOn(
+		`recurringPaymentMethods.${toPaymentMethodSwitchNaming(paymentMethod)}`,
+	);
+}
 
 /**
  * This method removes the `pending` state by retrying,
@@ -532,15 +540,16 @@ function CheckoutComponent({
 	}
 
 	const validPaymentMethods = [
-		/* NOT YET IMPLEMENTED -
-    SHOULD CHECK FEATURE SWITCHES
+		/* NOT YET IMPLEMENTED
 		countryGroupId === 'EURCountries' && Sepa,
     countryId === 'US' && AmazonPay,
     */
 		countryId === 'GB' && DirectDebit,
 		Stripe,
 		PayPal,
-	].filter(isPaymentMethod);
+	]
+		.filter(isPaymentMethod)
+		.filter(paymentMethodIsActive);
 
 	const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>();
 

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -61,7 +61,6 @@ import {
 	isPaymentMethod,
 	type PaymentMethod as LegacyPaymentMethod,
 	PayPal,
-	// Sepa,
 	Stripe,
 } from 'helpers/forms/paymentMethods';
 import { getStripeKey } from 'helpers/forms/stripe';
@@ -532,13 +531,15 @@ function CheckoutComponent({
 		return <div>Invalid Amount {originalAmount}</div>;
 	}
 
-	// Todo shouldn't this be checking the switches?
 	const validPaymentMethods = [
-		// countryGroupId === 'EURCountries' && Sepa,
+		/* NOT YET IMPLEMENTED -
+    SHOULD CHECK FEATURE SWITCHES
+		countryGroupId === 'EURCountries' && Sepa,
+    countryId === 'US' && AmazonPay,
+    */
 		countryId === 'GB' && DirectDebit,
 		Stripe,
 		PayPal,
-		//countryId === 'US' && AmazonPay,
 	].filter(isPaymentMethod);
 
 	const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>();

--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -46,9 +46,10 @@ import {
 	isPaymentMethod,
 	PayPal,
 	Stripe,
+	toPaymentMethodSwitchNaming,
 } from 'helpers/forms/paymentMethods';
 import { getStripeKey } from 'helpers/forms/stripe';
-import { getSettings } from 'helpers/globalsAndSwitches/globals';
+import { getSettings, isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import { Country } from 'helpers/internationalisation';
 import * as cookie from 'helpers/storage/cookie';
@@ -113,6 +114,12 @@ type OneTimeCheckoutComponentProps = OneTimeCheckoutProps & {
 	stripePublicKey: string;
 	isTestUser: boolean;
 };
+
+function paymentMethodIsActive(paymentMethod: PaymentMethod) {
+	return isSwitchOn(
+		`oneOffPaymentMethods.${toPaymentMethodSwitchNaming(paymentMethod)}`,
+	);
+}
 
 export function OneTimeCheckout({ geoId, appConfig }: OneTimeCheckoutProps) {
 	const { currencyKey } = getGeoIdConfig(geoId);
@@ -191,11 +198,9 @@ function OneTimeCheckoutComponent({
 
 	const [isProcessingPayment, setIsProcessingPayment] = useState(false);
 
-	const validPaymentMethods = [
-		Stripe,
-		PayPal,
-		countryId === 'US' && AmazonPay,
-	].filter(isPaymentMethod);
+	const validPaymentMethods = [Stripe, PayPal, countryId === 'US' && AmazonPay]
+		.filter(isPaymentMethod)
+		.filter(paymentMethodIsActive);
 
 	const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>();
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Updating generic and one-time checkout to check payment method feature switches.

This is a screenshot of the payment method switches. The notion of recurring vs subscriptions isn't a distinction the generic checkout currently makes, so the plan is to use the recurring payment methods for all products on generic checkout and phase out `subscriptionsPaymentMethods`.

![image](https://github.com/user-attachments/assets/6e7dfe22-1000-4323-9c67-187762eb57d9)

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/V5Y5w0xO/1044-check-feature-switches-when-populating-validpaymentmethods-on-generic-checkout)


<!--
Remember, PRs are documentation for future contributors.
-->
