### PR TITLE
Fix payment frequency tab widths

### DIFF
--- a/support-frontend/assets/components/paymentFrequencyButtons/paymentFrequencyButtons.tsx
+++ b/support-frontend/assets/components/paymentFrequencyButtons/paymentFrequencyButtons.tsx
@@ -19,7 +19,7 @@ export interface PaymentFrequencyButtonsProps {
 const container = (numberOfChildren: number) => css`
 	display: grid;
 	width: 100%;
-	grid-template-columns: repeat(${numberOfChildren}, 1fr);
+	grid-template-columns: repeat(${numberOfChildren}, minmax(0, 1fr));
 	gap: 1px;
 	${from.tablet} {
 		width: fit-content;
@@ -33,7 +33,12 @@ const button = (isSelected: boolean) => css`
 		fontWeight: 'bold',
 	})}
 	border: 0;
-	padding: ${space[3]}px ${space[9]}px;
+
+	padding: ${space[3]}px 0;
+	${from.tablet} {
+	  padding: ${space[3]}px ${space[9]}px;
+  }
+
 	color: ${palette.brand[400]};
 	:hover {
 		background-color: ${isSelected ? palette.neutral[100] : '#DAE0EA'};


### PR DESCRIPTION
Currently, when there are three payment frequency tabs, the widths are not consistent:
<img width="373" alt="Screenshot 2024-09-16 at 13 45 04" src="https://github.com/user-attachments/assets/84386f30-1e40-4f7e-bf75-17d17dc1fabf">

After change:
<img width="320" alt="Screenshot 2024-09-16 at 13 36 57" src="https://github.com/user-attachments/assets/df12a612-9322-4997-b96d-0e0391ea04cf">
<img width="451" alt="Screenshot 2024-09-16 at 13 37 16" src="https://github.com/user-attachments/assets/b9e22b17-a339-4b53-851b-10abd2e6ab4e">
<img width="319" alt="Screenshot 2024-09-16 at 13 38 11" src="https://github.com/user-attachments/assets/0ee380fe-31e5-4d6e-be61-cc0aeab9a627">
<img width="319" alt="Screenshot 2024-09-16 at 13 38 21" src="https://github.com/user-attachments/assets/35b67369-458b-4776-aac0-e7547469c8f1">
<img width="411" alt="Screenshot 2024-09-16 at 13 38 43" src="https://github.com/user-attachments/assets/cd013fb8-a6e1-4c52-8295-ee6ed426fca6">
<img width="411" alt="Screenshot 2024-09-16 at 13 38 49" src="https://github.com/user-attachments/assets/5dd9abc2-a01f-486d-bd6f-9cfb191ae288">
<img width="411" alt="Screenshot 2024-09-16 at 13 39 10" src="https://github.com/user-attachments/assets/251d6321-c84e-42ea-b333-3676ef415704">
<img width="427" alt="Screenshot 2024-09-16 at 13 39 20" src="https://github.com/user-attachments/assets/541f8722-b618-463c-babd-b80cb9c5ee96">
