### PR TITLE
feat: add ticket tailor e2e test

### DIFF
--- a/.github/workflows/playwright-cron.yml
+++ b/.github/workflows/playwright-cron.yml
@@ -24,7 +24,7 @@ jobs:
       run: yarn playwright install --with-deps
     - name: Run Playwright tests
       working-directory: ./support-e2e
-      run: yarn playwright test --project=cron --config=playwright.config.ts
+      run: yarn test-cron
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -26,7 +26,7 @@ jobs:
       run: yarn playwright install --with-deps
     - name: Run Playwright tests
       working-directory: ./support-e2e
-      run: yarn playwright test --project=smoke --config=playwright.config.ts
+      run: yarn test-smoke
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/support-e2e/package.json
+++ b/support-e2e/package.json
@@ -8,8 +8,10 @@
 		"test-browserstack": "RUNNING_IN_BROWSERSTACK=true playwright test --config=playwright.browserstack.config.ts",
 		"test-local": "playwright test --ui --config=playwright.local.config.ts",
 		"test-prod": "playwright test --ui --config=playwright.prod.config.ts",
-		"test-smoke": "playwright test --project=smoke --ui --config=playwright.config.ts",
-		"test-cron": "playwright test --project=cron --ui --config=playwright.config.ts"
+		"test-smoke": "playwright test --project=smoke --config=playwright.config.ts",
+		"test-smoke-ui": "playwright test --project=smoke --config=playwright.config.ts --ui",
+		"test-cron": "playwright test --project=cron --config=playwright.config.ts",
+		"test-cron-ui": "playwright test --project=cron --config=playwright.config.ts --ui"
 	},
 	"dependencies": {
 		"@playwright/test": "1.46.1",

--- a/support-e2e/package.json
+++ b/support-e2e/package.json
@@ -7,7 +7,9 @@
 		"prettier-fix": "prettier --write ./",
 		"test-browserstack": "RUNNING_IN_BROWSERSTACK=true playwright test --config=playwright.browserstack.config.ts",
 		"test-local": "playwright test --ui --config=playwright.local.config.ts",
-		"test-prod": "playwright test --ui --config=playwright.prod.config.ts"
+		"test-prod": "playwright test --ui --config=playwright.prod.config.ts",
+		"test-smoke": "playwright test --project=smoke --ui --config=playwright.config.ts",
+		"test-cron": "playwright test --project=cron --ui --config=playwright.config.ts"
 	},
 	"dependencies": {
 		"@playwright/test": "1.46.1",

--- a/support-e2e/tests/smoke/ticket-tailor.test.ts
+++ b/support-e2e/tests/smoke/ticket-tailor.test.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+test('Ticket Tailor iframe loads correctly', async ({
+	page,
+	context,
+	baseURL,
+}) => {
+	// Avoid CMP
+	await context.addCookies([
+		{
+			name: '_post_deploy_user',
+			value: 'true',
+			domain: baseURL ? new URL(baseURL).hostname : undefined,
+			path: '/',
+		},
+	]);
+
+	// Navigate to the page containing the iframe
+	await page.goto('https://support.theguardian.com/uk/events/1347872');
+
+	// Wait for the iframe to be present in the DOM
+	const iframe = await page.waitForSelector(
+		'iframe[src*="https://tickets.theguardian.live"]',
+	);
+
+	// Check if the iframe is visible
+	expect(await iframe.isVisible()).toBeTruthy();
+
+	// Get the iframe contentFrame
+	const frame = await iframe.contentFrame();
+
+	// Check if the frame is loaded
+	expect(frame).not.toBeNull();
+
+	// Check for specific content within the iframe
+	if (frame) {
+		await frame.waitForSelector('body');
+		const content = await frame.content();
+		expect(content).toContain('Next');
+	}
+});


### PR DESCRIPTION
Adds an e2e test that checks the ticket tailor iframe loads correctly.

90% generated with the prompt
```
Write me a playwright test that checks that an iframe with a tickettailor.com URL loads correctly
```

and then refined with 
```
elementHandle doesn't seem to be available on the iframe
```

Which then fixed trying access a method on the `frame` called `elementHandle` which didn't exist.

The main difference between #6313 and this is we use the [`contentFrame`](https://playwright.dev/docs/api/class-elementhandle#element-handle-content-frame) on the `iframe` element.


## Testing

1. `test-smoke` script added.
2. `test-cron` script added.

To run script containing ticket tailor e2e test->
`yarn test-smoke`


## Screenshots
<img width="1320" alt="Screenshot 2024-09-17 at 08 24 39" src="https://github.com/user-attachments/assets/e6ef2e00-6bf9-42f5-a517-dc1c745f3cbd">
