### PR TITLE
fix: add SSR pre-render to events page

### DIFF
--- a/support-frontend/app/views/eventsRouter.scala.html
+++ b/support-frontend/app/views/eventsRouter.scala.html
@@ -10,7 +10,7 @@
 
 @main(
   title = "Support the Guardian | Events",
-  mainElement = EmptyDiv("events"),
+  mainElement = assets.getSsrCacheContentsAsHtml(divId = "router", file = "ssr-holding-content.html"),
   mainJsBundle = RefPath("[countryGroupId]/events/router.js"),
   mainStyleBundle = None,
   description = Some("Help us deliver the independent journalism the world needs. Support the Guardian by making a contribution."),


### PR DESCRIPTION
Adds the SSR pre-render placeholder to the events route.

https://github.com/user-attachments/assets/f3ccf0fa-7be5-4a6b-adca-e58df251d04b

