### PR TITLE
New Plans for T3 archive benefit

### DIFF
--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -67,6 +67,7 @@ export type TierThree = {
 	currency: string;
 	billingPeriod: BillingPeriod;
 	fulfilmentOptions: FulfilmentOptions;
+	productOptions: ProductOptions;
 };
 export type DigitalSubscription = {
 	productType: typeof DigitalPack;

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -103,6 +103,18 @@ export const productCatalogDescription: Record<ProductKey, ProductDescription> =
 				RestOfWorldAnnual: {
 					billingPeriod: 'Annual',
 				},
+				DomesticMonthlyV2: {
+					billingPeriod: 'Monthly',
+				},
+				DomesticAnnualV2: {
+					billingPeriod: 'Annual',
+				},
+				RestOfWorldMonthlyV2: {
+					billingPeriod: 'Monthly',
+				},
+				RestOfWorldAnnualV2: {
+					billingPeriod: 'Annual',
+				},
 			},
 		},
 		DigitalSubscription: {

--- a/support-frontend/assets/helpers/productPrice/productOptions.ts
+++ b/support-frontend/assets/helpers/productPrice/productOptions.ts
@@ -10,6 +10,7 @@ const Sixday = 'Sixday';
 const SixdayPlus = 'SixdayPlus';
 const Everyday = 'Everyday';
 const EverydayPlus = 'EverydayPlus';
+const NewspaperArchive = 'NewspaperArchive';
 
 export type ProductOptions =
 	| typeof NoProductOptions
@@ -22,7 +23,8 @@ export type ProductOptions =
 	| typeof Sixday
 	| typeof SixdayPlus
 	| typeof Everyday
-	| typeof EverydayPlus;
+	| typeof EverydayPlus
+	| typeof NewspaperArchive;
 
 export type PaperProductOptions =
 	| typeof Saturday
@@ -99,6 +101,7 @@ export {
 	SixdayPlus,
 	Everyday,
 	EverydayPlus,
+	NewspaperArchive,
 	ActivePaperProductTypes,
 	paperProductsWithDigital,
 	paperProductsWithoutDigital,

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -434,10 +434,15 @@ function CheckoutComponent({
 				currency: currencyKey,
 				billingPeriod: ratePlanDescription.billingPeriod,
 				fulfilmentOptions:
-					ratePlanKey === 'DomesticMonthly' || ratePlanKey === 'DomesticAnnual'
+					ratePlanKey === 'DomesticMonthly' ||
+					ratePlanKey === 'DomesticAnnual' ||
+					ratePlanKey === 'DomesticMonthlyV2' ||
+					ratePlanKey === 'DomesticAnnualV2'
 						? 'Domestic'
 						: ratePlanKey === 'RestOfWorldMonthly' ||
-						  ratePlanKey === 'RestOfWorldAnnual'
+						  ratePlanKey === 'RestOfWorldAnnual' ||
+						  ratePlanKey === 'RestOfWorldMonthlyV2' ||
+						  ratePlanKey === 'RestOfWorldAnnualV2'
 						? 'RestOfWorld'
 						: 'Domestic',
 			};

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -79,7 +79,10 @@ import {
 } from 'helpers/productCatalog';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { NoFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import { NoProductOptions } from 'helpers/productPrice/productOptions';
+import {
+	NoProductOptions,
+	type ProductOptions,
+} from 'helpers/productPrice/productOptions';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { getPromotion } from 'helpers/productPrice/promotions';
 import type { AddressFormFieldError } from 'helpers/redux/checkout/address/state';
@@ -285,12 +288,27 @@ export function Checkout({ geoId, appConfig }: Props) {
 			}
 		};
 		const fulfilmentOption = getFulfilmentOptions(productKey);
+		const getProductOptions = (productKey: string): ProductOptions => {
+			switch (productKey) {
+				case 'SupporterPlus':
+				case 'Contribution':
+					return 'NoProductOptions';
+				case 'TierThree':
+					return ratePlanKey.endsWith('V2')
+						? 'NewspaperArchive'
+						: 'NoProductOptions';
+				default:
+					return 'NoProductOptions';
+			}
+		};
+		const productOptions: ProductOptions = getProductOptions(productKey);
 
 		promotion = getPromotion(
 			productPrices,
 			countryId,
 			billingPeriod,
 			fulfilmentOption,
+			productOptions,
 		);
 		const discountedPrice = promotion?.discountedPrice
 			? promotion.discountedPrice
@@ -445,6 +463,9 @@ function CheckoutComponent({
 						  ratePlanKey === 'RestOfWorldAnnualV2'
 						? 'RestOfWorld'
 						: 'Domestic',
+				productOptions: ratePlanKey.endsWith('V2')
+					? 'NewspaperArchive'
+					: 'NoProductOptions',
 			};
 			break;
 

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -290,13 +290,11 @@ export function Checkout({ geoId, appConfig }: Props) {
 		const fulfilmentOption = getFulfilmentOptions(productKey);
 		const getProductOptions = (productKey: string): ProductOptions => {
 			switch (productKey) {
-				case 'SupporterPlus':
-				case 'Contribution':
-					return 'NoProductOptions';
 				case 'TierThree':
 					return ratePlanKey.endsWith('V2')
 						? 'NewspaperArchive'
 						: 'NoProductOptions';
+				// TODO: define for newspaper
 				default:
 					return 'NoProductOptions';
 			}

--- a/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
@@ -271,11 +271,15 @@ function ThankYouComponent({
 		isContributionProduct &&
 		(ratePlanKey === 'Monthly' ||
 		ratePlanKey === 'RestOfWorldMonthly' ||
-		ratePlanKey === 'DomesticMonthly'
+		ratePlanKey === 'DomesticMonthly' ||
+		ratePlanKey === 'RestOfWorldMonthlyV2' ||
+		ratePlanKey === 'DomesticMonthlyV2'
 			? 'MONTHLY'
 			: ratePlanKey === 'Annual' ||
 			  ratePlanKey === 'RestOfWorldAnnual' ||
-			  ratePlanKey === 'DomesticAnnual'
+			  ratePlanKey === 'DomesticAnnual' ||
+			  ratePlanKey === 'RestOfWorldAnnualV2' ||
+			  ratePlanKey === 'DomesticAnnualV2'
 			? 'ANNUAL'
 			: productKey === 'Contribution'
 			? 'ONE_OFF'

--- a/support-frontend/assets/pages/paper-subscription-checkout/helpers/orderSummaryText.ts
+++ b/support-frontend/assets/pages/paper-subscription-checkout/helpers/orderSummaryText.ts
@@ -17,6 +17,7 @@ const productOptionDisplayNames = {
 	SixdayPlus: 'Six day',
 	Everyday: 'Every day',
 	EverydayPlus: 'Every day',
+	NewspaperArchive: 'Newspaper Archive',
 };
 export function getOrderSummaryTitle(
 	productOption: ProductOptions,

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -329,6 +329,9 @@ export function ThreeTierLanding({
 			countryId,
 			billingPeriod,
 			countryGroupId === 'International' ? 'RestOfWorld' : 'Domestic',
+			abParticipations.newspaperArchiveBenefit === 'control'
+				? 'NoProductOptions'
+				: 'NewspaperArchive',
 		),
 	);
 
@@ -571,15 +574,23 @@ export function ThreeTierLanding({
 	 *
 	 * This should only exist as long as the Tier three hack is in place.
 	 */
+	const getTier3RatePlan = () => {
+		const ratePlan =
+			countryGroupId === 'International'
+				? contributionType === 'ANNUAL'
+					? 'RestOfWorldAnnual'
+					: 'RestOfWorldMonthly'
+				: contributionType === 'ANNUAL'
+				? 'DomesticAnnual'
+				: 'DomesticMonthly';
 
-	const tier3RatePlan =
-		countryGroupId === 'International'
-			? contributionType === 'ANNUAL'
-				? 'RestOfWorldAnnualV2'
-				: 'RestOfWorldMonthlyV2'
-			: contributionType === 'ANNUAL'
-			? 'DomesticAnnualV2'
-			: 'DomesticMonthlyV2';
+		if (abParticipations.newspaperArchiveBenefit === 'control') {
+			return ratePlan;
+		}
+		return `${ratePlan}V2`;
+	};
+
+	const tier3RatePlan = getTier3RatePlan();
 	const tier3Pricing =
 		productCatalog.TierThree.ratePlans[tier3RatePlan].pricing[currencyId];
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -575,11 +575,11 @@ export function ThreeTierLanding({
 	const tier3RatePlan =
 		countryGroupId === 'International'
 			? contributionType === 'ANNUAL'
-				? 'RestOfWorldAnnual'
-				: 'RestOfWorldMonthly'
+				? 'RestOfWorldAnnualV2'
+				: 'RestOfWorldMonthlyV2'
 			: contributionType === 'ANNUAL'
-			? 'DomesticAnnual'
-			: 'DomesticMonthly';
+			? 'DomesticAnnualV2'
+			: 'DomesticMonthlyV2';
 	const tier3Pricing =
 		productCatalog.TierThree.ratePlans[tier3RatePlan].pricing[currencyId];
 

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -64,6 +64,10 @@ case object TierThree extends Product {
         productRatePlan("8a1288a38ff2af980190025b32591ccc", Annual, Domestic, NoProductOptions),
         productRatePlan("8a128ab18ff2af9301900255d77979ac", Monthly, RestOfWorld, NoProductOptions),
         productRatePlan("8a1299788ff2ec100190024d1e3b1a09", Annual, RestOfWorld, NoProductOptions),
+        productRatePlan("8a128dfb91f04b9a0191fa315d091c51", Monthly, Domestic, NewspaperArchive),
+        productRatePlan("8a128dfb91f04b9a0191fa30ae2e1b7e", Annual, Domestic, NewspaperArchive),
+        productRatePlan("8a12891291f04b9d0191fa2ffbe10975", Monthly, RestOfWorld, NewspaperArchive),
+        productRatePlan("8a129c2591f06a5d0191fa2edb383026", Annual, RestOfWorld, NewspaperArchive),
       ),
       CODE -> List(
         productRatePlan("8ad097b48ff26452019001cebac92376", Monthly, Domestic, NoProductOptions),

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -65,10 +65,10 @@ case object TierThree extends Product {
         productRatePlan("8a1299788ff2ec100190024d1e3b1a09", Annual, RestOfWorld),
       ),
       CODE -> List(
-        productRatePlan("8ad097b48ff26452019001cebac92376", Monthly, Domestic),
-        productRatePlan("8ad081dd8ff24a9a019001d95e4e3574", Annual, Domestic),
-        productRatePlan("8ad081dd8ff24a9a019001df2ce83657", Monthly, RestOfWorld),
-        productRatePlan("8ad097b48ff26452019001e65bbf2ca8", Annual, RestOfWorld),
+        productRatePlan("8ad081dd91dae1d30191e0ce082d18d3", Monthly, Domestic),
+        productRatePlan("8ad097b491daf9180191e0cd58e5180b", Annual, Domestic),
+        productRatePlan("8ad097b491daf9180191e0cdba5f183c", Monthly, RestOfWorld),
+        productRatePlan("8ad097b491daf9180191e0cdf34e185e", Annual, RestOfWorld),
       ),
     )
 }

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -46,29 +46,34 @@ case object TierThree extends Product {
   private def productRatePlan(
       id: String,
       billingPeriod: BillingPeriod,
-      fulfilmentOptions: FulfilmentOptions = NoFulfilmentOptions,
+      fulfilmentOptions: FulfilmentOptions,
+      productOptions: ProductOptions,
   ) =
     ProductRatePlan(
       id,
       billingPeriod,
       fulfilmentOptions,
-      NoProductOptions,
+      productOptions,
       s"Tier Three ${billingPeriod.getClass.getSimpleName}",
     )
 
   lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[SupporterPlus.type]]] =
     Map(
       PROD -> List(
-        productRatePlan("8a1299788ff2ec100190025fccc32bb1", Monthly, Domestic),
-        productRatePlan("8a1288a38ff2af980190025b32591ccc", Annual, Domestic),
-        productRatePlan("8a128ab18ff2af9301900255d77979ac", Monthly, RestOfWorld),
-        productRatePlan("8a1299788ff2ec100190024d1e3b1a09", Annual, RestOfWorld),
+        productRatePlan("8a1299788ff2ec100190025fccc32bb1", Monthly, Domestic, NoProductOptions),
+        productRatePlan("8a1288a38ff2af980190025b32591ccc", Annual, Domestic, NoProductOptions),
+        productRatePlan("8a128ab18ff2af9301900255d77979ac", Monthly, RestOfWorld, NoProductOptions),
+        productRatePlan("8a1299788ff2ec100190024d1e3b1a09", Annual, RestOfWorld, NoProductOptions),
       ),
       CODE -> List(
-        productRatePlan("8ad081dd91dae1d30191e0ce082d18d3", Monthly, Domestic),
-        productRatePlan("8ad097b491daf9180191e0cd58e5180b", Annual, Domestic),
-        productRatePlan("8ad097b491daf9180191e0cdba5f183c", Monthly, RestOfWorld),
-        productRatePlan("8ad097b491daf9180191e0cdf34e185e", Annual, RestOfWorld),
+        productRatePlan("8ad097b48ff26452019001cebac92376", Monthly, Domestic, NoProductOptions),
+        productRatePlan("8ad081dd8ff24a9a019001d95e4e3574", Annual, Domestic, NoProductOptions),
+        productRatePlan("8ad081dd8ff24a9a019001df2ce83657", Monthly, RestOfWorld, NoProductOptions),
+        productRatePlan("8ad097b48ff26452019001e65bbf2ca8", Annual, RestOfWorld, NoProductOptions),
+        productRatePlan("8ad081dd91dae1d30191e0ce082d18d3", Monthly, Domestic, NewspaperArchive),
+        productRatePlan("8ad097b491daf9180191e0cd58e5180b", Annual, Domestic, NewspaperArchive),
+        productRatePlan("8ad097b491daf9180191e0cdba5f183c", Monthly, RestOfWorld, NewspaperArchive),
+        productRatePlan("8ad097b491daf9180191e0cdf34e185e", Annual, RestOfWorld, NewspaperArchive),
       ),
     )
 }

--- a/support-models/src/main/scala/com/gu/support/catalog/ProductOptions.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/ProductOptions.scala
@@ -30,9 +30,11 @@ case object EverydayPlus extends PaperProductOptions(true)
 
 case object Everyday extends PaperProductOptions(false)
 
+case object NewspaperArchive extends ProductOptions
+
 object ProductOptions {
   val allProductOptions =
-    NoProductOptions :: PaperProductOptions.productOptions
+    NoProductOptions :: NewspaperArchive :: PaperProductOptions.productOptions
 
   def fromString[T](code: String, productOptions: List[T]): Option[T] =
     productOptions.find(_.getClass.getSimpleName == s"$code$$")

--- a/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
@@ -63,7 +63,8 @@ object ProductTypeRatePlans {
       .getOrElse(environment, Nil)
       .find(productRatePlan =>
         productRatePlan.billingPeriod == product.billingPeriod &&
-          productRatePlan.fulfilmentOptions == product.fulfilmentOptions,
+          productRatePlan.fulfilmentOptions == product.fulfilmentOptions &&
+          productRatePlan.productOptions == product.productOptions,
       )
 
   def paperRatePlan(product: Paper, environment: TouchPointEnvironment): Option[ProductRatePlan[catalog.Paper.type]] =

--- a/support-models/src/main/scala/com/gu/support/workers/Products.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/Products.scala
@@ -3,7 +3,13 @@ package com.gu.support.workers
 import cats.syntax.functor._
 import com.gu.i18n.Currency
 import com.gu.i18n.Currency.GBP
-import com.gu.support.catalog.{FulfilmentOptions, PaperProductOptions}
+import com.gu.support.catalog.{
+  FulfilmentOptions,
+  NoFulfilmentOptions,
+  NoProductOptions,
+  PaperProductOptions,
+  ProductOptions,
+}
 import com.gu.support.encoding.{Codec, DiscriminatedType}
 import com.gu.support.encoding.Codec.deriveCodec
 import com.gu.support.encoding.JsonHelpers._
@@ -13,7 +19,6 @@ import com.gu.support.zuora.api.ReaderType.Direct
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, Json}
-import com.gu.support.catalog.NoFulfilmentOptions
 import com.gu.support.workers.ProductType.discriminatedType
 
 sealed trait ProductType {
@@ -36,8 +41,9 @@ case class TierThree(
     currency: Currency,
     billingPeriod: BillingPeriod,
     fulfilmentOptions: FulfilmentOptions,
+    productOptions: ProductOptions = NoProductOptions,
 ) extends ProductType {
-  override def describe: String = s"$billingPeriod-TierThree-$currency-$fulfilmentOptions"
+  override def describe: String = s"$billingPeriod-TierThree-$currency-$fulfilmentOptions-$productOptions"
 }
 
 case class SupporterPlus(

--- a/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
@@ -160,9 +160,9 @@ object AcquisitionDataRowBuilder {
         case (Collection, Sunday) => VoucherSunday
         case (Collection, SundayPlus) => VoucherSundayPlus
         case (NoFulfilmentOptions, _) | (_, NoProductOptions) | (Domestic, _) | (RestOfWorld, _) |
-            (NationalDelivery, Saturday) | (NationalDelivery, Sunday) | (NationalDelivery, EverydayPlus) |
-            (NationalDelivery, SixdayPlus) | (NationalDelivery, WeekendPlus) | (NationalDelivery, SaturdayPlus) |
-            (NationalDelivery, SundayPlus) =>
+            (_, NewspaperArchive) | (NationalDelivery, Saturday) | (NationalDelivery, Sunday) |
+            (NationalDelivery, EverydayPlus) | (NationalDelivery, SixdayPlus) | (NationalDelivery, WeekendPlus) |
+            (NationalDelivery, SaturdayPlus) | (NationalDelivery, SundayPlus) =>
           throw new RuntimeException(
             s"Invalid combination of fulfilmentOptions ($fulfilmentOptions) and productOptions ($productOptions)",
           )


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We want to AB test adding the newspaper archive benefit to the tier three product, to see whether it causes an uplift in conversion - [more details in this presentation](https://docs.google.com/presentation/d/18f1uYissTG27WCxDrfV69fBG2tYX90aG_0cE1PkDvWI/edit#slide=id.g2fbf351fd3e_0_102)

To do this we need to introduce new product rate plans with an additional archive charge and sell these plans to users in the cohort who will be getting the new benefit. 
Because currently we only have one rate plan per billing period and fulfilment option for tier three, this PR differentiates the new plans by using a `productOption` value of `NewspaperArchive`, the original non-archive plans have a `productOption` value of `NoProductOptions`

[More details in this doc](https://docs.google.com/document/d/1lL8SCyy-LRrHOxzP9C3HV1UFdQ8AMOuQxQEK77j4ogs/edit?usp=sharing)