### PR TITLE
refactor: use product qs param to calculate user selected tier

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -481,6 +481,8 @@ export function ThreeTierLanding({
 		? productCatalogDescriptionNewBenefits
 		: canonicalProductCatalogDescription;
 
+	const urlSearchParams = new URLSearchParams(window.location.search);
+	const urlSearchParamsProduct = urlSearchParams.get('product');
 	/**
 	 * Tier 1: Contributions
 	 * We use the amounts from RRCP to populate the Contribution tier
@@ -510,7 +512,9 @@ export function ThreeTierLanding({
 		productDescription: productCatalogDescription.Contribution,
 		price: recurringAmount,
 		link: useGenericCheckout ? tier1GenericCheckoutLink : tier1Link,
-		isUserSelected: isCardUserSelected(recurringAmount),
+		isUserSelected:
+			urlSearchParamsProduct === 'Contribution' ||
+			isCardUserSelected(recurringAmount),
 		isRecommended: false,
 		ctaCopy: getThreeTierCardCtaCopy(countryGroupId),
 	};
@@ -548,10 +552,9 @@ export function ThreeTierLanding({
 		/** The promotion from the querystring is for the SupporterPlus product only */
 		promotion: promotionTier2,
 		isRecommended: true,
-		isUserSelected: isCardUserSelected(
-			tier2Pricing,
-			promotionTier2?.discount?.amount,
-		),
+		isUserSelected:
+			urlSearchParamsProduct === 'SupporterPlus' ||
+			isCardUserSelected(tier2Pricing, promotionTier2?.discount?.amount),
 		ctaCopy: getThreeTierCardCtaCopy(countryGroupId),
 	};
 
@@ -596,10 +599,9 @@ export function ThreeTierLanding({
 		link: `checkout?${tier3UrlParams.toString()}`,
 		promotion: promotionTier3,
 		isRecommended: false,
-		isUserSelected: isCardUserSelected(
-			tier3Pricing,
-			promotionTier3?.discount?.amount,
-		),
+		isUserSelected:
+			urlSearchParamsProduct === 'TierThree' ||
+			isCardUserSelected(tier3Pricing, promotionTier3?.discount?.amount),
 		ctaCopy: getThreeTierCardCtaCopy(countryGroupId),
 	};
 

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -91,7 +91,7 @@ GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe                  controllers.S
 
 # Checkout
 GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/checkout            controllers.Application.router(countryGroupId: String)
-GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/one-time-checkout            controllers.Application.router(countryGroupId: String)
+GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/one-time-checkout   controllers.Application.router(countryGroupId: String)
 GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/thank-you           controllers.Application.router(countryGroupId: String)
 
 # Events


### PR DESCRIPTION
Uses the `product` query string to choose whether the tier is selected.

@paul-daniel-dempsey and I discussed using a `selected-tier` or similar - but figured currently there is a 1-1 mapping between tier and product, so let's keep the simplicity.

Once [this PR](https://github.com/guardian/dotcom-rendering/pull/12403) is merged we can remove the `isCardUserSelected` method.