### PR TITLE
refactor: remove redux from oneOffCard

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/oneOffCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/oneOffCard.tsx
@@ -128,7 +128,11 @@ export function OneOffCard({
 			<div css={buttonContainer}>
 				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
 					<LinkButton
-						href={`/${countryGroups[countryGroupId].supportInternationalisationId}/contribute/checkout?selected-contribution-type=one_off&selected-amount=${selectedAmount}`}
+						href={`/${
+							countryGroups[countryGroupId].supportInternationalisationId
+						}/contribute/checkout?selected-contribution-type=one_off&selected-amount=${
+							selectedAmount === 'other' ? otherAmount : selectedAmount
+						}`}
 						cssOverrides={btnStyleOverrides}
 						onClick={() => {
 							trackComponentClick(

--- a/support-frontend/assets/pages/supporter-plus-landing/components/oneOffCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/oneOffCard.tsx
@@ -8,12 +8,19 @@ import {
 	until,
 } from '@guardian/source/foundations';
 import {
-	Button,
 	buttonThemeReaderRevenueBrand,
+	LinkButton,
 } from '@guardian/source/react-components';
+import { useState } from 'react';
+import { config, type SelectedAmountsVariant } from 'helpers/contributions';
+import {
+	type CountryGroupId,
+	countryGroups,
+} from 'helpers/internationalisation/countryGroup';
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { OtherAmount } from '../../../components/otherAmount/otherAmount';
 import { PriceCards } from '../../../components/priceCards/priceCards';
-import { PriceCardsContainer } from '../../../components/priceCards/priceCardsContainer';
 import { PaymentCards } from './PaymentIcons';
 
 const sectionStyle = css`
@@ -55,11 +62,25 @@ const buttonContainer = css`
 `;
 
 interface Props {
+	amounts: SelectedAmountsVariant;
 	currencyGlyph: string;
-	btnClickHandler: () => void;
+	countryGroupId: CountryGroupId;
+	currencyId: IsoCurrency;
 }
 
-export function OneOffCard({ currencyGlyph, btnClickHandler }: Props) {
+export function OneOffCard({
+	currencyGlyph,
+	countryGroupId,
+	amounts,
+	currencyId,
+}: Props) {
+	const oneOffAmounts = amounts.amountsCardData.ONE_OFF;
+	const [selectedAmount, setSelectedAmount] = useState<number | 'other'>(
+		oneOffAmounts.defaultAmount,
+	);
+	const [otherAmount, setOtherAmount] = useState('');
+	const { min: minAmount } = config[countryGroupId].ONE_OFF;
+
 	return (
 		<section css={sectionStyle}>
 			<div
@@ -72,46 +93,51 @@ export function OneOffCard({ currencyGlyph, btnClickHandler }: Props) {
 					We welcome support of any size, any time, whether you choose to give{' '}
 					{currencyGlyph}1 or much more.
 				</p>
-				<PriceCardsContainer
-					paymentFrequency={'ONE_OFF'}
-					renderPriceCards={({
-						amounts,
-						selectedAmount,
-						otherAmount,
-						currency,
-						paymentInterval,
-						onAmountChange,
-						minAmount,
-						onOtherAmountChange,
-						hideChooseYourAmount,
-						errors,
-					}) => (
-						<PriceCards
-							amounts={amounts}
-							selectedAmount={selectedAmount}
-							currency={currency}
-							paymentInterval={paymentInterval}
-							onAmountChange={onAmountChange}
-							hideChooseYourAmount={hideChooseYourAmount}
-							otherAmountField={
-								<OtherAmount
-									currency={currency}
-									minAmount={minAmount}
-									selectedAmount={selectedAmount}
-									otherAmount={otherAmount}
-									onOtherAmountChange={onOtherAmountChange}
-									errors={errors}
-								/>
+
+				<PriceCards
+					amounts={oneOffAmounts.amounts}
+					selectedAmount={selectedAmount}
+					currency={currencyId}
+					// This is always undefined as we're ONE_OFF
+					paymentInterval={undefined}
+					onAmountChange={(amount: string) => {
+						if (amount === 'other') {
+							setSelectedAmount(amount);
+						} else {
+							const amountNumber = parseInt(amount, 10);
+							if (!isNaN(amountNumber)) {
+								setSelectedAmount(amountNumber);
 							}
+						}
+					}}
+					hideChooseYourAmount={oneOffAmounts.hideChooseYourAmount}
+					otherAmountField={
+						<OtherAmount
+							currency={currencyId}
+							minAmount={minAmount}
+							selectedAmount={selectedAmount}
+							otherAmount={otherAmount}
+							onOtherAmountChange={(otherAmount) => {
+								setOtherAmount(otherAmount);
+							}}
+							errors={[]}
 						/>
-					)}
+					}
 				/>
 			</div>
 			<div css={buttonContainer}>
 				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-					<Button cssOverrides={btnStyleOverrides} onClick={btnClickHandler}>
+					<LinkButton
+						href={`/${countryGroups[countryGroupId].supportInternationalisationId}/contribute/checkout?selected-contribution-type=one_off&selected-amount=${selectedAmount}`}
+						cssOverrides={btnStyleOverrides}
+						onClick={() => {
+							trackComponentClick(
+								`npf-contribution-amount-toggle-${countryGroupId}-ONE_OFF`,
+							);
+						}}
+					>
 						Continue to checkout
-					</Button>
+					</LinkButton>
 				</ThemeProvider>
 				<PaymentCards />
 			</div>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
@@ -7,7 +7,12 @@ import {
 	space,
 	textSans,
 } from '@guardian/source/foundations';
-import { Button } from '@guardian/source/react-components';
+import { LinkButton } from '@guardian/source/react-components';
+import {
+	type CountryGroupId,
+	countryGroups,
+} from 'helpers/internationalisation/countryGroup';
+import { trackComponentClick } from 'helpers/tracking/behaviour';
 
 const container = css`
 	text-align: center;
@@ -56,12 +61,12 @@ const btnStyleOverrides = css`
 
 interface SupportOnceProps {
 	currency: string;
-	btnClickHandler: () => void;
+	countryGroupId: CountryGroupId;
 }
 
 export function SupportOnce({
 	currency,
-	btnClickHandler,
+	countryGroupId,
 }: SupportOnceProps): JSX.Element {
 	return (
 		<div css={container}>
@@ -71,16 +76,21 @@ export function SupportOnce({
 				give&nbsp;
 				{currency}1 or more.
 			</p>
-			<Button
+			<LinkButton
+				href={`/${countryGroups[countryGroupId].supportInternationalisationId}/contribute/checkout?selected-contribution-type=one_off`}
 				iconSide="left"
 				priority="primary"
 				size="default"
 				cssOverrides={btnStyleOverrides}
-				onClick={() => btnClickHandler()}
+				onClick={() => {
+					trackComponentClick(
+						`npf-contribution-amount-toggle-${countryGroupId}-ONE_OFF`,
+					);
+				}}
 				data-qm-trackable="support-once-button"
 			>
 				Support now
-			</Button>
+			</LinkButton>
 		</div>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -451,25 +451,6 @@ export function ThreeTierLanding({
 		}
 	};
 
-	const handleSupportOnceBtnClick = () => {
-		dispatch(setProductType('ONE_OFF'));
-		navigateWithPageView(
-			navigate,
-			generateOneOffCheckoutLink(),
-			abParticipations,
-		);
-		trackComponentClick(
-			`npf-contribution-amount-toggle-${countryGroupId}-ONE_OFF`,
-		);
-	};
-
-	const generateOneOffCheckoutLink = () => {
-		const urlParams = new URLSearchParams();
-		urlParams.set('selected-contribution-type', 'one_off');
-
-		return `checkout?${urlParams.toString()}${window.location.hash}`;
-	};
-
 	const selectedContributionType =
 		contributionType === 'ANNUAL' ? 'annual' : 'monthly';
 	const selectedContributionRatePlan =
@@ -655,8 +636,10 @@ export function ThreeTierLanding({
 					/>
 					{contributionType === 'ONE_OFF' && (
 						<OneOffCard
+							amounts={amounts}
 							currencyGlyph={currencies[currencyId].glyph}
-							btnClickHandler={handleSupportOnceBtnClick}
+							countryGroupId={countryGroupId}
+							currencyId={currencyId}
 						/>
 					)}
 					{contributionType !== 'ONE_OFF' && (
@@ -679,7 +662,7 @@ export function ThreeTierLanding({
 				{!enableSingleContributionsTab && (
 					<SupportOnce
 						currency={currencies[currencyId].glyph}
-						btnClickHandler={handleSupportOnceBtnClick}
+						countryGroupId={countryGroupId}
 					/>
 				)}
 				{countryGroupId === UnitedStates && (


### PR DESCRIPTION
In prepping to get the homepage redux-free - I am removing the `PriceCardsContainer` from the `oneOffCard`.

This either replaces the values from the container with values from internal state (using `useState`) or passed down from the `threeTierLanding`.

This PR also hardcodes the `href` values of the one time checkout link (previously `Button`, now `LinkButton`).

~Screenshots coming once this is merged https://github.com/guardian/support-frontend/pull/6324~

https://github.com/user-attachments/assets/b35e1027-b01a-4330-81fd-3fbdf99ff839


