### PR TITLE
feat: add local e2e testing

### DIFF
--- a/support-e2e/package.json
+++ b/support-e2e/package.json
@@ -10,8 +10,10 @@
 		"test-prod": "playwright test --ui --config=playwright.prod.config.ts",
 		"test-smoke": "playwright test --project=smoke --config=playwright.config.ts",
 		"test-smoke-ui": "playwright test --project=smoke --config=playwright.config.ts --ui",
+		"test-smoke-dev": "playwright test --project=smoke --config=playwright.dev.config.ts --ui",
 		"test-cron": "playwright test --project=cron --config=playwright.config.ts",
-		"test-cron-ui": "playwright test --project=cron --config=playwright.config.ts --ui"
+		"test-cron-ui": "playwright test --project=cron --config=playwright.config.ts --ui",
+		"test-cron-dev": "playwright test --project=cron --config=playwright.dev.config.ts --ui"
 	},
 	"dependencies": {
 		"@playwright/test": "1.46.1",

--- a/support-e2e/playwright.config.ts
+++ b/support-e2e/playwright.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig, devices } from '@playwright/test';
+import { devices } from '@playwright/test';
 
-export default defineConfig({
+export const config = {
 	testDir: 'tests',
 	testMatch: '**/*.test.ts',
 	/* Maximum time one test can run for. */
@@ -43,4 +43,6 @@ export default defineConfig({
 			},
 		},
 	],
-});
+};
+
+export default config;

--- a/support-e2e/playwright.dev.config.ts
+++ b/support-e2e/playwright.dev.config.ts
@@ -1,0 +1,10 @@
+import { config as baseConfig } from './playwright.config';
+
+const config = {
+	...baseConfig,
+	use: {
+		baseURL: 'https://support.thegulocal.com',
+	},
+};
+
+export default config;


### PR DESCRIPTION
## What
Adds the ability to run the new style of e2e tests locally.

## Why
I'd like to make a change that I would feel way more comfortable knowing works locally - this would allow me to do that.

I've gone with the `.dev` naming as that what we, and other frameworks, tend to use e.g. `make dev` in dcr, `npm run dev` in other places in the ecosystem.

It also means I can keep the `.local` file which will be deleted soon.

I've left this running in `--ui` mode as I feel this is the most common `dev` way of doing it from working with @paul-daniel-dempsey and @andrewHEguardian 