### PR TITLE
refactor: rename assets.map to assets.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ public/stylesheets
 assets/javascripts/lib/bower-components/
 
 support-frontend/conf/keys.conf
-support-frontend/conf/assets.map
+support-frontend/conf/assets.json
 support-frontend/conf/ssr-cache/
 !support-frontend/conf/ssr-cache/.gitexists
 support-frontend/public/compiled-assets/
@@ -40,7 +40,7 @@ support-frontend/Brewfile.lock.json
 support-frontend/project
 tools/
 
-conf/assets.map
+conf/assets.json
 assets/images/inline-svgs/*.svg
 /assets/images/svg-sprite.svg
 /public/compiled-assets/

--- a/support-frontend/app/wiring/Assets.scala
+++ b/support-frontend/app/wiring/Assets.scala
@@ -4,5 +4,5 @@ import assets.AssetsResolver
 import play.api.BuiltInComponentsFromContext
 
 trait Assets { self: BuiltInComponentsFromContext =>
-  val assetsResolver = new AssetsResolver("", "assets.map", environment)
+  val assetsResolver = new AssetsResolver("", "assets.json", environment)
 }

--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -65,7 +65,7 @@ class CleanUpStatsPlugin {
 module.exports = (cssFilename, jsFilename, minimizeCss) => ({
 	plugins: [
 		new WebpackManifestPlugin({
-			fileName: '../../conf/assets.map',
+			fileName: '../../conf/assets.json',
 			writeToFileEmit: true,
 		}),
 		...(process.env.CI_ENV === 'github'


### PR DESCRIPTION
Renames the map generated by [Webpack Manifest Plugin](https://github.com/shellscape/webpack-manifest-plugin) to JSON.

This is so we can `import` it in NodeJs files without having to build any fancy loader for it as Node supporting JSON imports by default.

Another reason is that this is a JSON file