### PR TITLE
Use new T3 archive rate plans for all cohorts in archive AB test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -37,7 +37,7 @@ type BreakpointRange = {
 	maxWidth?: Breakpoint;
 };
 
-export type Participations = Record<string, string>;
+export type Participations = Record<string, string | undefined>;
 
 export type Audience = {
 	offset: number;

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -39,6 +39,10 @@ type BreakpointRange = {
 
 export type Participations = Record<string, string | undefined>;
 
+export const testIsActive = (
+	value: [string, string | undefined],
+): value is [string, string] => value[1] !== undefined;
+
 export type Audience = {
 	offset: number;
 	size: number;

--- a/support-frontend/assets/helpers/tracking/acquisitions.ts
+++ b/support-frontend/assets/helpers/tracking/acquisitions.ts
@@ -2,7 +2,7 @@
 
 import { viewId } from 'ophan';
 import type { $Keys } from 'utility-types';
-import type { Participations } from 'helpers/abTests/abtest';
+import { type Participations, testIsActive } from 'helpers/abTests/abtest';
 import { get as getCookie } from 'helpers/storage/cookie';
 import * as storage from 'helpers/storage/storage';
 import {
@@ -130,7 +130,10 @@ const toAcquisitionQueryParameters = (
 const participationsToAcquisitionABTest = (
 	participations: Participations,
 ): AcquisitionABTest[] => {
-	return Object.entries(participations).map(([name, variant]) => ({
+	const activeTests: Array<[string, string]> =
+		Object.entries(participations).filter(testIsActive);
+
+	return activeTests.map(([name, variant]) => ({
 		name,
 		variant,
 	}));

--- a/support-frontend/assets/helpers/tracking/trackingOphan.ts
+++ b/support-frontend/assets/helpers/tracking/trackingOphan.ts
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 import * as ophan from 'ophan';
 import type { NavigateFunction, NavigateOptions } from 'react-router';
-import type { Participations } from 'helpers/abTests/abtest';
+import { type Participations, testIsActive } from 'helpers/abTests/abtest';
 import { getLocal, setLocal } from 'helpers/storage/storage';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
@@ -93,17 +93,21 @@ const pageView = (url: string, referrer: string): void => {
 
 export const buildOphanPayload = (
 	participations: Participations,
-): OphanABPayload =>
-	Object.keys(participations).reduce((payload, participation) => {
+): OphanABPayload => {
+	const activeTests: Array<[string, string]> =
+		Object.entries(participations).filter(testIsActive);
+
+	return activeTests.reduce((payload, participation) => {
 		const ophanABEvent: OphanABEvent = {
-			variantName: participations[participation],
+			variantName: participation[1],
 			complete: false,
 			campaignCodes: [],
 		};
 		return Object.assign({}, payload, {
-			[participation]: ophanABEvent,
+			[participation[0]]: ophanABEvent,
 		});
 	}, {});
+};
 
 const trackAbTests = (participations: Participations): void =>
 	ophan.record({

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -61,6 +61,7 @@ import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
 import { navigateWithPageView } from 'helpers/tracking/trackingOphan';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
+import { tests } from '../../../helpers/abTests/abtestDefinitions';
 import { getCampaignSettings } from '../../../helpers/campaigns/campaigns';
 import type { CountdownSetting } from '../../../helpers/campaigns/campaigns';
 import Countdown from '../components/countdown';
@@ -339,9 +340,9 @@ export function ThreeTierLanding({
 			billingPeriod,
 			countryGroupId === 'International' ? 'RestOfWorld' : 'Domestic',
 
-			abParticipations.newspaperArchiveBenefit === undefined
-				? 'NoProductOptions'
-				: 'NewspaperArchive',
+			tests.newspaperArchiveBenefit.isActive
+				? 'NewspaperArchive'
+				: 'NoProductOptions',
 		),
 	);
 
@@ -576,9 +577,7 @@ export function ThreeTierLanding({
 				? 'DomesticAnnual'
 				: 'DomesticMonthly';
 
-		return abParticipations.newspaperArchiveBenefit === undefined
-			? ratePlan
-			: `${ratePlan}V2`;
+		return tests.newspaperArchiveBenefit.isActive ? `${ratePlan}V2` : ratePlan;
 	};
 
 	const tier3RatePlan = getTier3RatePlan();

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -61,7 +61,6 @@ import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
 import { navigateWithPageView } from 'helpers/tracking/trackingOphan';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
-import { tests } from '../../../helpers/abTests/abtestDefinitions';
 import { getCampaignSettings } from '../../../helpers/campaigns/campaigns';
 import type { CountdownSetting } from '../../../helpers/campaigns/campaigns';
 import Countdown from '../components/countdown';
@@ -340,9 +339,9 @@ export function ThreeTierLanding({
 			billingPeriod,
 			countryGroupId === 'International' ? 'RestOfWorld' : 'Domestic',
 
-			tests.newspaperArchiveBenefit.isActive
-				? 'NewspaperArchive'
-				: 'NoProductOptions',
+			abParticipations.newspaperArchiveBenefit === undefined
+				? 'NoProductOptions'
+				: 'NewspaperArchive',
 		),
 	);
 
@@ -577,7 +576,9 @@ export function ThreeTierLanding({
 				? 'DomesticAnnual'
 				: 'DomesticMonthly';
 
-		return tests.newspaperArchiveBenefit.isActive ? `${ratePlan}V2` : ratePlan;
+		return abParticipations.newspaperArchiveBenefit === undefined
+			? ratePlan
+			: `${ratePlan}V2`;
 	};
 
 	const tier3RatePlan = getTier3RatePlan();

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -339,9 +339,9 @@ export function ThreeTierLanding({
 			billingPeriod,
 			countryGroupId === 'International' ? 'RestOfWorld' : 'Domestic',
 
-			abParticipations.newspaperArchiveBenefit !== undefined
-				? 'NewspaperArchive'
-				: 'NoProductOptions',
+			abParticipations.newspaperArchiveBenefit === undefined
+				? 'NoProductOptions'
+				: 'NewspaperArchive',
 		),
 	);
 
@@ -576,9 +576,9 @@ export function ThreeTierLanding({
 				? 'DomesticAnnual'
 				: 'DomesticMonthly';
 
-		return abParticipations.newspaperArchiveBenefit !== undefined
-			? `${ratePlan}V2`
-			: ratePlan;
+		return abParticipations.newspaperArchiveBenefit === undefined
+			? ratePlan
+			: `${ratePlan}V2`;
 	};
 
 	const tier3RatePlan = getTier3RatePlan();

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -338,8 +338,8 @@ export function ThreeTierLanding({
 			countryId,
 			billingPeriod,
 			countryGroupId === 'International' ? 'RestOfWorld' : 'Domestic',
-			abParticipations.newspaperArchiveBenefit === 'v1' ||
-				abParticipations.newspaperArchiveBenefit === 'v2'
+
+			abParticipations.newspaperArchiveBenefit !== undefined
 				? 'NewspaperArchive'
 				: 'NoProductOptions',
 		),
@@ -470,7 +470,7 @@ export function ThreeTierLanding({
 		contributionType === 'ANNUAL' ? 'Annual' : 'Monthly';
 
 	const productCatalogDescription = ['v1', 'v2'].includes(
-		abParticipations.newspaperArchiveBenefit,
+		abParticipations.newspaperArchiveBenefit ?? '',
 	)
 		? productCatalogDescriptionNewBenefits
 		: canonicalProductCatalogDescription;
@@ -576,13 +576,9 @@ export function ThreeTierLanding({
 				? 'DomesticAnnual'
 				: 'DomesticMonthly';
 
-		if (
-			abParticipations.newspaperArchiveBenefit === 'v1' ||
-			abParticipations.newspaperArchiveBenefit === 'v2'
-		) {
-			return `${ratePlan}V2`;
-		}
-		return ratePlan;
+		return abParticipations.newspaperArchiveBenefit !== undefined
+			? `${ratePlan}V2`
+			: ratePlan;
 	};
 
 	const tier3RatePlan = getTier3RatePlan();


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR changes the newspaper archive AB test to use the new archive rate plans for all variants of the test, so the control group will also receive the new benefits. The only time when the old rate plans are used now is when the test is inactive.

More information about this test is [here](https://docs.google.com/document/d/1lL8SCyy-LRrHOxzP9C3HV1UFdQ8AMOuQxQEK77j4ogs/edit?usp=sharing)

## Changes
To support this behaviour I have had to make a change to the `Participations` type in our TS code. This was not accurately describing the possible values of an AB test because it was of type `[string, string]` where the first string is the test name and the second is the variant which the user is in, however when a test is inactive (`isActive: false`) the variant value will be undefined. I have redefined the type as `[string, string | undefined]` to more accurately model the possible values a test participation can be in.

## [Trello Card](https://trello.com/c/gVvJIwvC/1091-all-ab-test-cohorts-should-get-new-archive-rate-plans)