### PR TITLE
Rename ophan file to enable testing

### DIFF
--- a/support-frontend/assets/components/paymentRequestButton/hooks/paymentAuthorisation.ts
+++ b/support-frontend/assets/components/paymentRequestButton/hooks/paymentAuthorisation.ts
@@ -11,11 +11,11 @@ import type { CsrfState } from 'helpers/redux/checkout/csrf/state';
 import { setPaymentRequestError } from 'helpers/redux/checkout/payment/paymentRequestButton/actions';
 import type { ContributionsDispatch } from 'helpers/redux/contributionsStore';
 import { trackComponentLoad } from 'helpers/tracking/behaviour';
+import { trackComponentEvents } from 'helpers/tracking/trackingOphan';
 import {
 	onThirdPartyPaymentAuthorised,
 	paymentWaiting,
 } from 'pages/supporter-plus-landing/setup/legacyActionCreators';
-import { trackComponentEvents } from '../../../helpers/tracking/trackingOphan';
 
 export async function fetchClientSecret(
 	stripePublicKey: string,

--- a/support-frontend/assets/components/paymentRequestButton/hooks/paymentAuthorisation.ts
+++ b/support-frontend/assets/components/paymentRequestButton/hooks/paymentAuthorisation.ts
@@ -11,11 +11,11 @@ import type { CsrfState } from 'helpers/redux/checkout/csrf/state';
 import { setPaymentRequestError } from 'helpers/redux/checkout/payment/paymentRequestButton/actions';
 import type { ContributionsDispatch } from 'helpers/redux/contributionsStore';
 import { trackComponentLoad } from 'helpers/tracking/behaviour';
-import { trackComponentEvents } from 'helpers/tracking/ophan';
 import {
 	onThirdPartyPaymentAuthorised,
 	paymentWaiting,
 } from 'pages/supporter-plus-landing/setup/legacyActionCreators';
+import { trackComponentEvents } from '../../../helpers/tracking/trackingOphan';
 
 export async function fetchClientSecret(
 	stripePublicKey: string,

--- a/support-frontend/assets/components/paymentRequestButton/hooks/usePaymentRequestEvent.ts
+++ b/support-frontend/assets/components/paymentRequestButton/hooks/usePaymentRequestEvent.ts
@@ -10,7 +10,7 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
-import { trackComponentEvents } from 'helpers/tracking/ophan';
+import { trackComponentEvents } from '../../../helpers/tracking/trackingOphan';
 import { addPayerDetailsToRedux } from './payerDetails';
 
 export type PaymentEventDetails = {

--- a/support-frontend/assets/components/paymentRequestButton/hooks/usePaymentRequestEvent.ts
+++ b/support-frontend/assets/components/paymentRequestButton/hooks/usePaymentRequestEvent.ts
@@ -10,7 +10,7 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
-import { trackComponentEvents } from '../../../helpers/tracking/trackingOphan';
+import { trackComponentEvents } from 'helpers/tracking/trackingOphan';
 import { addPayerDetailsToRedux } from './payerDetails';
 
 export type PaymentEventDetails = {

--- a/support-frontend/assets/helpers/page/analyticsAndConsent.ts
+++ b/support-frontend/assets/helpers/page/analyticsAndConsent.ts
@@ -6,13 +6,13 @@ import type { Participations } from 'helpers/abTests/abtest';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import * as googleTagManager from 'helpers/tracking/googleTagManager';
-import {
-	setReferrerDataInLocalStorage,
-	trackAbTests,
-} from 'helpers/tracking/ophan';
 import { init as initQuantumMetric } from 'helpers/tracking/quantumMetric';
 import { isPostDeployUser } from 'helpers/user/user';
 import { init as initLogger } from 'helpers/utilities/logger';
+import {
+	setReferrerDataInLocalStorage,
+	trackAbTests,
+} from '../tracking/trackingOphan';
 import 'helpers/internationalisation/country';
 
 // ----- Functions ----- //

--- a/support-frontend/assets/helpers/productPrice/subscriptions.ts
+++ b/support-frontend/assets/helpers/productPrice/subscriptions.ts
@@ -4,12 +4,12 @@ import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import { Monthly, Quarterly } from 'helpers/productPrice/billingPeriods';
 import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
 import { currencies, detect } from '../internationalisation/currency';
-import { trackComponentEvents } from '../tracking/ophan';
+import { trackComponentEvents } from '../tracking/trackingOphan';
 import type {
 	OphanAction,
 	OphanComponentEvent,
 	OphanComponentType,
-} from '../tracking/ophan';
+} from '../tracking/trackingOphan';
 
 // ----- Types ------ //
 const DigitalPack = 'DigitalPack';

--- a/support-frontend/assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.ts
@@ -8,8 +8,6 @@ import { createReducer } from 'helpers/subscriptionsForms/subscriptionCheckoutRe
 import type { FormField, Stage } from '../formFields';
 import type { FormError } from '../validation';
 
-jest.mock('ophan', () => () => ({}));
-
 // ----- Tests ----- //
 
 describe('Subscription Checkout Reducer', () => {

--- a/support-frontend/assets/helpers/thankYouPages/utils/ophan.ts
+++ b/support-frontend/assets/helpers/thankYouPages/utils/ophan.ts
@@ -1,6 +1,6 @@
 import type { ContributionType } from 'helpers/contributions';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
-import { trackComponentEvents } from 'helpers/tracking/ophan';
+import { trackComponentEvents } from '../../tracking/trackingOphan';
 
 export const OPHAN_COMPONENT_ID_SIGN_IN = 'sign-into-the-guardian-link';
 export const OPHAN_COMPONENT_ID_SIGN_UP = 'set-password';

--- a/support-frontend/assets/helpers/tracking/NavigateWithPageView.tsx
+++ b/support-frontend/assets/helpers/tracking/NavigateWithPageView.tsx
@@ -6,7 +6,7 @@ import {
 	pageView,
 	setReferrerDataInLocalStorage,
 	trackAbTests,
-} from './ophan';
+} from './trackingOphan';
 
 type NavigateWithPageViewProps = {
 	destination: string;

--- a/support-frontend/assets/helpers/tracking/__tests__/ophanTest.ts
+++ b/support-frontend/assets/helpers/tracking/__tests__/ophanTest.ts
@@ -1,0 +1,26 @@
+import type { Participations } from '../../abTests/abtest';
+import type { OphanABPayload } from '../trackingOphan';
+import { buildOphanPayload } from '../trackingOphan';
+
+describe('Ophan AB Payload', () => {
+	it('should build a payload from participations', () => {
+		const input: Participations = {
+			test1: 'control',
+			test2: 'variant',
+		};
+		const expected: OphanABPayload = {
+			test1: {
+				variantName: 'control',
+				complete: false,
+				campaignCodes: [],
+			},
+			test2: {
+				variantName: 'variant',
+				complete: false,
+				campaignCodes: [],
+			},
+		};
+		const payload = buildOphanPayload(input);
+		expect(payload).toEqual(expected);
+	});
+});

--- a/support-frontend/assets/helpers/tracking/behaviour.ts
+++ b/support-frontend/assets/helpers/tracking/behaviour.ts
@@ -1,6 +1,6 @@
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import type { SubscriptionProduct } from 'helpers/productPrice/subscriptions';
-import { trackComponentEvents } from 'helpers/tracking/ophan';
+import { trackComponentEvents } from './trackingOphan';
 
 export type ProductCheckout =
 	| 'Contribution'

--- a/support-frontend/assets/helpers/tracking/trackingOphan.ts
+++ b/support-frontend/assets/helpers/tracking/trackingOphan.ts
@@ -69,13 +69,13 @@ export type OphanComponentEvent = {
 	};
 };
 
-type OphanABEvent = {
+export type OphanABEvent = {
 	variantName: string;
 	complete: boolean;
 	campaignCodes?: string[];
 };
 
-type OphanABPayload = Record<string, OphanABEvent>;
+export type OphanABPayload = Record<string, OphanABEvent>;
 
 // ----- Functions ----- //
 const trackComponentEvents = (componentEvent: OphanComponentEvent): void =>
@@ -91,7 +91,9 @@ const pageView = (url: string, referrer: string): void => {
 	}
 };
 
-const buildOphanPayload = (participations: Participations): OphanABPayload =>
+export const buildOphanPayload = (
+	participations: Participations,
+): OphanABPayload =>
 	Object.keys(participations).reduce((payload, participation) => {
 		const ophanABEvent: OphanABEvent = {
 			variantName: participations[participation],

--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -15,9 +15,9 @@ import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
 import { guardianLiveTermsLink, privacyLink } from 'helpers/legal';
 import * as cookie from 'helpers/storage/cookie';
+import { getPageViewId } from 'helpers/tracking/trackingOphan';
 import { isProd } from 'helpers/urls/url';
 import type { GeoId } from 'pages/geoIdConfig';
-import { getPageViewId } from '../../../helpers/tracking/trackingOphan';
 
 const darkBackgroundContainerMobile = css`
 	background-color: ${palette.neutral[97]};

--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -15,9 +15,9 @@ import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
 import { guardianLiveTermsLink, privacyLink } from 'helpers/legal';
 import * as cookie from 'helpers/storage/cookie';
-import { getPageViewId } from 'helpers/tracking/ophan';
 import { isProd } from 'helpers/urls/url';
 import type { GeoId } from 'pages/geoIdConfig';
+import { getPageViewId } from '../../../helpers/tracking/trackingOphan';
 
 const darkBackgroundContainerMobile = css`
 	background-color: ${palette.neutral[97]};

--- a/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
@@ -12,7 +12,7 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
-import { navigateWithPageView } from 'helpers/tracking/ophan';
+import { navigateWithPageView } from '../../../helpers/tracking/trackingOphan';
 
 const titleAndButtonContainer = css`
 	display: flex;

--- a/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
@@ -12,7 +12,7 @@ import {
 	useContributionsDispatch,
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
-import { navigateWithPageView } from '../../../helpers/tracking/trackingOphan';
+import { navigateWithPageView } from 'helpers/tracking/trackingOphan';
 
 const titleAndButtonContainer = css`
 	display: flex;

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
@@ -39,9 +39,9 @@ import {
 	UnitedStates,
 } from 'helpers/internationalisation/countryGroup';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
-import { navigateWithPageView } from 'helpers/tracking/ophan';
 import HeadlineImagePatronsDesktop from '../../../components/svgs/headlineImagePatronsDesktop';
 import HeadlineImagePatronsMobile from '../../../components/svgs/headlineImagePatronsMobile';
+import { navigateWithPageView } from '../../../helpers/tracking/trackingOphan';
 import { GuardianTsAndCs } from '../components/guardianTsAndCs';
 import { PatronsMessage } from '../components/patronsMessage';
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
@@ -39,9 +39,9 @@ import {
 	UnitedStates,
 } from 'helpers/internationalisation/countryGroup';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
+import { navigateWithPageView } from 'helpers/tracking/trackingOphan';
 import HeadlineImagePatronsDesktop from '../../../components/svgs/headlineImagePatronsDesktop';
 import HeadlineImagePatronsMobile from '../../../components/svgs/headlineImagePatronsMobile';
-import { navigateWithPageView } from '../../../helpers/tracking/trackingOphan';
 import { GuardianTsAndCs } from '../components/guardianTsAndCs';
 import { PatronsMessage } from '../components/patronsMessage';
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/firstStepLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/firstStepLanding.tsx
@@ -25,7 +25,7 @@ import {
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
 import { getThresholdPrice } from 'helpers/supporterPlus/benefitsThreshold';
-import { navigateWithPageView } from '../../../helpers/tracking/trackingOphan';
+import { navigateWithPageView } from 'helpers/tracking/trackingOphan';
 import { AmountAndBenefits } from '../formSections/amountAndBenefits';
 import { PatronsPriceCards } from '../formSections/patronsPriceCards';
 import { SupporterPlusCheckoutScaffold } from './checkoutScaffold';

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/firstStepLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/firstStepLanding.tsx
@@ -25,7 +25,7 @@ import {
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
 import { getThresholdPrice } from 'helpers/supporterPlus/benefitsThreshold';
-import { navigateWithPageView } from 'helpers/tracking/ophan';
+import { navigateWithPageView } from '../../../helpers/tracking/trackingOphan';
 import { AmountAndBenefits } from '../formSections/amountAndBenefits';
 import { PatronsPriceCards } from '../formSections/patronsPriceCards';
 import { SupporterPlusCheckoutScaffold } from './checkoutScaffold';

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -37,7 +37,7 @@ import {
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
 import { useAbandonedBasketCookie } from 'helpers/storage/abandonedBasketCookies';
-import { navigateWithPageView } from 'helpers/tracking/ophan';
+import { navigateWithPageView } from '../../../helpers/tracking/trackingOphan';
 import { CheckoutDivider } from '../components/checkoutDivider';
 import { ContributionsPriceCards } from '../components/contributionsPriceCards';
 import { PaymentFailureMessage } from '../components/paymentFailure';

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -37,7 +37,7 @@ import {
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
 import { useAbandonedBasketCookie } from 'helpers/storage/abandonedBasketCookies';
-import { navigateWithPageView } from '../../../helpers/tracking/trackingOphan';
+import { navigateWithPageView } from 'helpers/tracking/trackingOphan';
 import { CheckoutDivider } from '../components/checkoutDivider';
 import { ContributionsPriceCards } from '../components/contributionsPriceCards';
 import { PaymentFailureMessage } from '../components/paymentFailure';

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -57,12 +57,12 @@ import {
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
-import { navigateWithPageView } from 'helpers/tracking/ophan';
 import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
 import { getCampaignSettings } from '../../../helpers/campaigns/campaigns';
 import type { CountdownSetting } from '../../../helpers/campaigns/campaigns';
+import { navigateWithPageView } from '../../../helpers/tracking/trackingOphan';
 import Countdown from '../components/countdown';
 import { NewspaperArchiveBanner } from '../components/newspaperArchiveBanner';
 import { OneOffCard } from '../components/oneOffCard';

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -58,11 +58,11 @@ import {
 } from 'helpers/redux/storeHooks';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { sendEventContributionCartValue } from 'helpers/tracking/quantumMetric';
+import { navigateWithPageView } from 'helpers/tracking/trackingOphan';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
 import { getCampaignSettings } from '../../../helpers/campaigns/campaigns';
 import type { CountdownSetting } from '../../../helpers/campaigns/campaigns';
-import { navigateWithPageView } from '../../../helpers/tracking/trackingOphan';
 import Countdown from '../components/countdown';
 import { NewspaperArchiveBanner } from '../components/newspaperArchiveBanner';
 import { OneOffCard } from '../components/oneOffCard';

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
@@ -30,8 +30,8 @@ import {
 	sendTrackingEventsOnClick,
 	sendTrackingEventsOnView,
 } from 'helpers/productPrice/subscriptions';
+import type { OphanComponentType } from 'helpers/tracking/trackingOphan';
 import { getOrigin, getQueryParameter } from 'helpers/urls/url';
-import type { OphanComponentType } from '../../../helpers/tracking/trackingOphan';
 import Prices from './content/prices';
 
 const getCheckoutUrl = (

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
@@ -31,7 +31,7 @@ import {
 	sendTrackingEventsOnView,
 } from 'helpers/productPrice/subscriptions';
 import { getOrigin, getQueryParameter } from 'helpers/urls/url';
-import type { OphanComponentType } from '../../../helpers/tracking/ophan';
+import type { OphanComponentType } from '../../../helpers/tracking/trackingOphan';
 import Prices from './content/prices';
 
 const getCheckoutUrl = (


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR renames the ophan module to trackingOphan. 

The reason for doing this is that when it was named ophan it was not possible to test any functions in it because it is getting mocked by this code here: https://github.com/guardian/support-frontend/blob/08643c2d5aa3875a5934db82758c2d3f73852a06/support-frontend/jestSetup.js#L6-L10

Strangely, changing the module name to eg. ophanTracking still results in the same issue, the name needs to start with something other than ophan to work.

If anyone has a better solution for this please chip in!
