### PR TITLE
Use the correct productOptions when updating supporter-product-data

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
@@ -112,7 +112,7 @@ object UpdateSupporterProductData {
 
       case SendThankYouEmailTierThreeState(user, product, _, _, _, _, subscriptionNumber, _) =>
         catalogService
-          .getProductRatePlan(TierThree, product.billingPeriod, product.fulfilmentOptions, NoProductOptions)
+          .getProductRatePlan(TierThree, product.billingPeriod, product.fulfilmentOptions, product.productOptions)
           .map(productRatePlan =>
             Some(
               supporterRatePlanItem(


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
#6322 Added new rateplans for the newspaper archive benefit and introduced a new `productOptions` value to determine when they should be used. However it missed out some code in the UpdateSupporterProductData lambda which needs to take account of the new productOptions value - this PR fixes that.