### PR TITLE
Info box with country change alert message

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -43,25 +43,6 @@ export const pageUrlRegexes = {
 };
 
 export const tests: Tests = {
-	redirectCountryToCountryGroup: {
-		variants: [
-			// not really an AB test
-			{
-				id: 'variant',
-			},
-		],
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 0,
-			},
-		},
-		isActive: false,
-		referrerControlled: true,
-		seed: 1,
-		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
-		excludeCountriesSubjectToContributionsOnlyAmounts: true,
-	},
 	patronsOneOffOnly: {
 		variants: [
 			// not really an AB test

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -379,7 +379,7 @@ export function Checkout({ geoId, appConfig }: Props) {
 	 * Where this is currently used is in the addressFields when someone selects
 	 * a country that doesn't correspond to the countryGroup a product is in.
 	 */
-	const forcedCountry = urlSearchParams.get('country');
+	const forcedCountry = urlSearchParams.get('country') ?? undefined;
 	return (
 		<Elements stripe={stripePromise} options={elementsOptions}>
 			<CheckoutComponent

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -968,7 +968,7 @@ function CheckoutComponent({
 				<BoxContents>
 					{forcedCountry &&
 						productDescription.deliverableTo?.[forcedCountry] && (
-							<div role="alert" data-qm-error>
+							<div role="alert">
 								<InfoSummary
 									cssOverrides={css`
 										margin-bottom: ${space[6]}px;

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -10,6 +10,7 @@ import {
 import {
 	Divider,
 	ErrorSummary,
+	InfoSummary,
 } from '@guardian/source-development-kitchen/react-components';
 import {
 	CardNumberElement,
@@ -179,11 +180,11 @@ type Props = {
 
 export function Checkout({ geoId, appConfig }: Props) {
 	const { currencyKey, countryGroupId } = getGeoIdConfig(geoId);
-	const searchParams = new URLSearchParams(window.location.search);
+	const urlSearchParams = new URLSearchParams(window.location.search);
 
 	/** 👇 a lot of this is copy/pasted into the thank you page */
 	/** Get and validate product */
-	const productParam = searchParams.get('product');
+	const productParam = urlSearchParams.get('product');
 	const productKey =
 		productParam && isProductKey(productParam) ? productParam : undefined;
 	const product = productKey && productCatalog[productKey];
@@ -198,7 +199,7 @@ export function Checkout({ geoId, appConfig }: Props) {
 	 * API being completely based on literals, so we've left it as `string`
 	 * although we do validate it is a valid ratePlan for this product
 	 */
-	const ratePlanParam = searchParams.get('ratePlan');
+	const ratePlanParam = urlSearchParams.get('ratePlan');
 	const ratePlanKey =
 		ratePlanParam && ratePlanParam in product.ratePlans
 			? ratePlanParam
@@ -229,7 +230,7 @@ export function Checkout({ geoId, appConfig }: Props) {
 		finalAmount: number;
 	};
 
-	const contributionParam = searchParams.get('contribution');
+	const contributionParam = urlSearchParams.get('contribution');
 	const contributionAmount = contributionParam
 		? parseInt(contributionParam, 10)
 		: undefined;
@@ -373,6 +374,12 @@ export function Checkout({ geoId, appConfig }: Props) {
 		}
 	}
 
+	/**
+	 * We use the country ULRSearchParam to force a person into a country.
+	 * Where this is currently used is in the addressFields when someone selects
+	 * a country that doesn't correspond to the countryGroup a product is in.
+	 */
+	const forcedCountry = urlSearchParams.get('country');
 	return (
 		<Elements stripe={stripePromise} options={elementsOptions}>
 			<CheckoutComponent
@@ -388,6 +395,7 @@ export function Checkout({ geoId, appConfig }: Props) {
 				contributionAmount={payment.contributionAmount}
 				finalAmount={payment.finalAmount}
 				useStripeExpressCheckout={useStripeExpressCheckout}
+				forcedCountry={forcedCountry}
 			/>
 		</Elements>
 	);
@@ -406,6 +414,7 @@ type CheckoutComponentProps = {
 	finalAmount: number;
 	promotion?: Promotion;
 	useStripeExpressCheckout: boolean;
+	forcedCountry?: string;
 };
 
 function CheckoutComponent({
@@ -420,6 +429,7 @@ function CheckoutComponent({
 	finalAmount,
 	promotion,
 	useStripeExpressCheckout,
+	forcedCountry,
 }: CheckoutComponentProps) {
 	/** we unset any previous orders that have been made */
 	unsetThankYouOrder();
@@ -952,13 +962,22 @@ function CheckoutComponent({
 		abParticipations.abandonedBasket === 'variant',
 	);
 
-	const redirectCountryToCountryGroup =
-		abParticipations.redirectCountryToCountryGroup === 'variant';
-
 	return (
 		<CheckoutLayout>
 			<Box cssOverrides={shorterBoxMargin}>
 				<BoxContents>
+					{forcedCountry &&
+						productDescription.deliverableTo?.[forcedCountry] && (
+							<div role="alert" data-qm-error>
+								<InfoSummary
+									cssOverrides={css`
+										margin-bottom: ${space[6]}px;
+									`}
+									message={`You've changed your delivery country to ${productDescription.deliverableTo[forcedCountry]}.`}
+									context={`Your subscription price has been updated to reflect the rates in your new location.`}
+								/>
+							</div>
+						)}
 					<ContributionsOrderSummary
 						description={productDescription.label}
 						paymentFrequency={
@@ -1358,9 +1377,7 @@ function CheckoutComponent({
 										country={deliveryCountry}
 										state={deliveryState}
 										postCode={deliveryPostcode}
-										countryGroupId={
-											redirectCountryToCountryGroup ? countryGroupId : undefined
-										}
+										countryGroupId={countryGroupId}
 										countries={productDescription.deliverableTo}
 										errors={deliveryAddressErrors}
 										postcodeState={{
@@ -1441,11 +1458,7 @@ function CheckoutComponent({
 											country={billingCountry}
 											state={billingState}
 											postCode={billingPostcode}
-											countryGroupId={
-												redirectCountryToCountryGroup
-													? countryGroupId
-													: undefined
-											}
+											countryGroupId={countryGroupId}
 											countries={productDescription.deliverableTo}
 											errors={billingAddressErrors}
 											postcodeState={{


### PR DESCRIPTION
If you select a country that isn't in the correct location for a product, we redirect you to the correct country group and alert you to the fact this has happened.

This completes the work started in https://github.com/guardian/support-frontend/pull/6238

https://github.com/user-attachments/assets/547926fe-8b49-414c-b26d-59244b987a1f

