### PR TITLE
Use productPrices consistently across landing/checkout in AppConfig.

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -47,7 +47,7 @@ case class AppConfig private (
     v2recaptchaPublicKey: String,
     checkoutPostcodeLookup: Boolean,
     productCatalog: JsonObject,
-    productPrices: ProductPrices,
+    allProductPrices: AllProductPrices,
     serversideTests: Map[String, Participation],
     user: Option[AppConfig.User],
     settings: AllSettings,
@@ -75,7 +75,7 @@ object AppConfig extends InternationalisationCodecs {
       recaptchaConfigProvider: RecaptchaConfigProvider,
       productCatalog: JsonObject,
       serversideTests: Map[String, Participation],
-      productPrices: ProductPrices,
+      allProductPrices: AllProductPrices,
       user: Option[IdUser],
       isTestUser: Boolean,
       settings: AllSettings,
@@ -151,7 +151,7 @@ object AppConfig extends InternationalisationCodecs {
       checkoutPostcodeLookup = settings.switches.subscriptionsSwitches.checkoutPostcodeLookup.contains(On),
       productCatalog = productCatalog,
       serversideTests = serversideTests,
-      productPrices = productPrices,
+      allProductPrices = allProductPrices,
       user = user.map(user =>
         User(
           id = user.id,
@@ -553,7 +553,10 @@ class Application(
     val isTestUser = testUserService.isTestUser(request)
 
     val queryPromos = request.queryString.getOrElse("promoCode", Nil).toList
-    val productPrices = priceSummaryServiceProvider.forUser(isTestUser).getPrices(SupporterPlus, queryPromos)
+    val allProductPrices = AllProductPrices(
+      SupporterPlus = priceSummaryServiceProvider.forUser(isTestUser).getPrices(SupporterPlus, queryPromos),
+      TierThree = priceSummaryServiceProvider.forUser(isTestUser).getPrices(TierThree, queryPromos),
+    )
 
     val appConfig = AppConfig.fromConfig(
       geoData = request.geoData,
@@ -575,7 +578,7 @@ class Application(
       recaptchaConfigProvider: RecaptchaConfigProvider,
       productCatalog = cachedProductCatalogServiceProvider.fromStage(stage, isTestUser).get(),
       serversideTests = generateParticipations(Nil),
-      productPrices = productPrices,
+      allProductPrices = allProductPrices,
       user = request.user,
       isTestUser = isTestUser,
       settings = settings,

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -5,12 +5,10 @@ import actions.CustomActionBuilders
 import admin.ServersideAbTest.{Participation, generateParticipations}
 import admin.settings.{AllSettings, AllSettingsProvider, On, SettingsSurrogateKeySyntax}
 import assets.{AssetsResolver, RefPath}
-import cats.data.EitherT
-import com.gu.googleauth.AuthAction
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup._
 import com.gu.identity.model.{User => IdUser}
-import com.gu.support.catalog.{Product, SupporterPlus, TierThree}
+import com.gu.support.catalog.{SupporterPlus, TierThree}
 import com.gu.support.config._
 import com.gu.support.encoding.InternationalisationCodecs
 import com.typesafe.scalalogging.StrictLogging
@@ -183,9 +181,16 @@ case class PaymentMethodConfigs(
     testAmazonPayConfig: AmazonPayConfig,
 )
 
-// This class is only needed because you can't pass more than 22 arguments to a twirl template and passing both types of
-// product prices to the contributions template would exceed that limit.
-case class AllProductPrices(supporterPlusProductPrices: ProductPrices, tierThreeProductPrices: ProductPrices)
+/** This class is only needed because you can't pass more than 22 arguments to a twirl template and passing both types
+  * of product prices to the contributions template would exceed that limit.
+  *
+  * We've also gone against the grain with Capitalising the prop names, but that's to match the ProductKeys in the
+  * Product API.
+  *
+  * @see
+  *   https://product-catalog.guardianapis.com/product-catalog.json
+  */
+case class AllProductPrices(SupporterPlus: ProductPrices, TierThree: ProductPrices)
 object AllProductPrices extends InternationalisationCodecs {
   implicit val allProductPricesEncoder: Encoder[AllProductPrices] = deriveEncoder
 }
@@ -504,9 +509,8 @@ class Application(
         .toList
 
     val allProductPrices = AllProductPrices(
-      supporterPlusProductPrices =
-        priceSummaryServiceProvider.forUser(isTestUser).getPrices(SupporterPlus, queryPromos),
-      tierThreeProductPrices = priceSummaryServiceProvider.forUser(isTestUser).getPrices(TierThree, queryPromos),
+      SupporterPlus = priceSummaryServiceProvider.forUser(isTestUser).getPrices(SupporterPlus, queryPromos),
+      TierThree = priceSummaryServiceProvider.forUser(isTestUser).getPrices(TierThree, queryPromos),
     )
 
     Ok(

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -184,9 +184,9 @@ case class PaymentMethodConfigs(
 
 // This class is only needed because you can't pass more than 22 arguments to a twirl template and passing both types of
 // product prices to the contributions template would exceed that limit.
-case class LandingPageProductPrices(supporterPlusProductPrices: ProductPrices, tierThreeProductPrices: ProductPrices)
-object LandingPageProductPrices extends InternationalisationCodecs {
-  implicit val landingPageProductPricesEncoder: Encoder[LandingPageProductPrices] = deriveEncoder
+case class AllProductPrices(supporterPlusProductPrices: ProductPrices, tierThreeProductPrices: ProductPrices)
+object AllProductPrices extends InternationalisationCodecs {
+  implicit val allProductPricesEncoder: Encoder[AllProductPrices] = deriveEncoder
 }
 
 class Application(
@@ -375,7 +375,7 @@ class Application(
       shareUrl = "https://support.theguardian.com/contribute",
       v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(isTestUser).v2PublicKey,
       serversideTests = serversideTests,
-      landingPageProductPrices = LandingPageProductPrices(supporterPlusProductPrices, tierThreeProductPrices),
+      allProductPrices = AllProductPrices(supporterPlusProductPrices, tierThreeProductPrices),
       productCatalog = productCatalog,
     )
   }
@@ -439,7 +439,7 @@ class Application(
         .getOrElse("promoCode", Nil)
         .toList
 
-    val landingPageProductPrices = LandingPageProductPrices(
+    val allProductPrices = AllProductPrices(
       supporterPlusProductPrices =
         priceSummaryServiceProvider.forUser(isTestUser).getPrices(SupporterPlus, queryPromos),
       tierThreeProductPrices = priceSummaryServiceProvider.forUser(isTestUser).getPrices(TierThree, queryPromos),
@@ -465,7 +465,7 @@ class Application(
         membersDataApiUrl = membersDataApiUrl,
         guestAccountCreationToken = guestAccountCreationToken,
         productCatalog = productCatalog,
-        landingPageProductPrices = landingPageProductPrices,
+        allProductPrices = allProductPrices,
         user = request.user,
       ),
     ).withSettingsSurrogateKey

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -64,6 +64,7 @@
     window.guardian.productPrices = @Html(outputJson(landingPageProductPrices.supporterPlusProductPrices))
     window.guardian.supporterPlusProductPrices = @Html(outputJson(landingPageProductPrices.supporterPlusProductPrices))
     window.guardian.tierThreeProductPrices = @Html(outputJson(landingPageProductPrices.tierThreeProductPrices))
+    window.guardian.allProductPrices = @Html(outputJson(landingPageProductPrices))
   </script>
 
   @windowGuardianPaymentConfig(

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -6,7 +6,7 @@
 @import models.GeoData
 @import controllers.PaymentMethodConfigs
 @import com.gu.support.encoding.CustomCodecs._
-@import controllers.LandingPageProductPrices
+@import controllers.AllProductPrices
 @import views.ViewHelpers.outputJson
 @import io.circe.JsonObject
 @(
@@ -27,7 +27,7 @@
   shareUrl: String,
   v2recaptchaConfigPublicKey: String,
   serversideTests: Map[String, Participation] = Map(),
-  landingPageProductPrices: LandingPageProductPrices,
+  allProductPrices: AllProductPrices,
   productCatalog: JsonObject,
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
@@ -54,17 +54,7 @@
       };
     }
 
-    /** Both the landing page (`/uk/contribution`) and contributions checkout (`/uk/contribution/checkout`) are rendered from this template.
-     *
-     * We use `supporterPlusProductPrices` and `tierThreeProductPrices` on the landing page as it renders both products with their promotions.
-     *
-     * We use `productPrices` in the checkout as the value is coupled across the codebase via redux state used across multiple checkouts i.e. Guardian Weekly, Paper, Contribution etc
-     * so we need to retain that name.
-     */
-    window.guardian.productPrices = @Html(outputJson(landingPageProductPrices.supporterPlusProductPrices))
-    window.guardian.supporterPlusProductPrices = @Html(outputJson(landingPageProductPrices.supporterPlusProductPrices))
-    window.guardian.tierThreeProductPrices = @Html(outputJson(landingPageProductPrices.tierThreeProductPrices))
-    window.guardian.allProductPrices = @Html(outputJson(landingPageProductPrices))
+    window.guardian.allProductPrices = @Html(outputJson(allProductPrices))
   </script>
 
   @windowGuardianPaymentConfig(

--- a/support-frontend/app/views/router.scala.html
+++ b/support-frontend/app/views/router.scala.html
@@ -1,14 +1,10 @@
 @import admin.ServersideAbTest.Participation
-@import assets.StyleContent
 @import assets.RefPath
 @import assets.AssetsResolver
 @import admin.settings.AllSettings
-@import views.EmptyDiv
 @import io.circe.JsonObject
 
 @import com.gu.identity.model.User
-@import com.gu.support.encoding.CustomCodecs._
-@import services.pricing.ProductPrices
 @import views.ViewHelpers.outputJson
 @(
   geoData: GeoData,
@@ -19,7 +15,7 @@
   membersDataApiUrl: String,
   guestAccountCreationToken: Option[String],
   v2recaptchaConfigPublicKey: String,
-  productPrices: ProductPrices,
+  landingPageProductPrices: LandingPageProductPrices,
   productCatalog: JsonObject,
   user: Option[User]
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
@@ -40,7 +36,7 @@
 ){
   <script type="text/javascript">
     window.guardian = window.guardian || {};
-    window.guardian.productPrices = @Html(outputJson(productPrices))
+    window.guardian.allProductPrices = @Html(outputJson(landingPageProductPrices))
   </script>
 
   @windowGuardianPaymentConfig(

--- a/support-frontend/app/views/router.scala.html
+++ b/support-frontend/app/views/router.scala.html
@@ -15,7 +15,7 @@
   membersDataApiUrl: String,
   guestAccountCreationToken: Option[String],
   v2recaptchaConfigPublicKey: String,
-  landingPageProductPrices: LandingPageProductPrices,
+  allProductPrices: AllProductPrices,
   productCatalog: JsonObject,
   user: Option[User]
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
@@ -36,7 +36,7 @@
 ){
   <script type="text/javascript">
     window.guardian = window.guardian || {};
-    window.guardian.allProductPrices = @Html(outputJson(landingPageProductPrices))
+    window.guardian.allProductPrices = @Html(outputJson(allProductPrices))
   </script>
 
   @windowGuardianPaymentConfig(

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -36,7 +36,6 @@ trait Controllers {
     stringsConfig,
     allSettingsProvider,
     appConfig.stage,
-    authAction,
     priceSummaryServiceProvider,
     cachedProductCatalogServiceProvider,
     appConfig.supportUrl,

--- a/support-frontend/assets/helpers/globalsAndSwitches/window.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/window.ts
@@ -230,8 +230,8 @@ const ProductCatalogSchema = object({
  */
 const ProductPricesSchema = object({
 	allProductPrices: object({
-		supporterPlusProductPrices: looseObject({}),
-		tierThreeProductPrices: looseObject({}),
+		SupporterPlus: looseObject({}),
+		TierThree: looseObject({}),
 	}),
 });
 const AppConfigSchema = intersect([
@@ -242,8 +242,8 @@ const AppConfigSchema = intersect([
 
 export type AppConfig = InferOutput<typeof AppConfigSchema> & {
 	allProductPrices: {
-		supporterPlusProductPrices: ProductPrices;
-		tierThreeProductPrices: ProductPrices;
+		SupporterPlus: ProductPrices;
+		TierThree: ProductPrices;
 	};
 };
 

--- a/support-frontend/assets/helpers/globalsAndSwitches/window.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/window.ts
@@ -229,7 +229,10 @@ const ProductCatalogSchema = object({
  * `Type instantiation is excessively deep and possibly infinite.`
  */
 const ProductPricesSchema = object({
-	productPrices: looseObject({}),
+	allProductPrices: object({
+		supporterPlusProductPrices: looseObject({}),
+		tierThreeProductPrices: looseObject({}),
+	}),
 });
 const AppConfigSchema = intersect([
 	PaymentConfigSchema,
@@ -238,7 +241,10 @@ const AppConfigSchema = intersect([
 ]);
 
 export type AppConfig = InferOutput<typeof AppConfigSchema> & {
-	productPrices: ProductPrices;
+	allProductPrices: {
+		supporterPlusProductPrices: ProductPrices;
+		tierThreeProductPrices: ProductPrices;
+	};
 };
 
 export const parseAppConfig = (obj: unknown) => {

--- a/support-frontend/assets/helpers/redux/checkout/product/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/state.ts
@@ -47,8 +47,8 @@ export type ProductState = {
 	billingPeriod: BillingPeriod;
 	productPrices: ProductPrices;
 	allProductPrices: {
-		supporterPlusProductPrices: ProductPrices;
-		tierThreeProductPrices: ProductPrices;
+		SupporterPlus: ProductPrices;
+		TierThree: ProductPrices;
 	};
 	selectedAmounts: SelectedAmounts;
 	otherAmounts: OtherAmounts;

--- a/support-frontend/assets/helpers/redux/checkout/product/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/state.ts
@@ -46,8 +46,10 @@ export type ProductState = {
 	fulfilmentOption: FulfilmentOptions;
 	billingPeriod: BillingPeriod;
 	productPrices: ProductPrices;
-	supporterPlusProductPrices: ProductPrices;
-	tierThreeProductPrices: ProductPrices;
+	allProductPrices: {
+		supporterPlusProductPrices: ProductPrices;
+		tierThreeProductPrices: ProductPrices;
+	};
 	selectedAmounts: SelectedAmounts;
 	otherAmounts: OtherAmounts;
 	coverTransactionCost?: boolean;
@@ -67,8 +69,7 @@ export const initialProductState: ProductState = {
 	fulfilmentOption: 'NoFulfilmentOptions',
 	billingPeriod: 'Monthly',
 	productPrices: getGlobal('productPrices') ?? {},
-	supporterPlusProductPrices: getGlobal('supporterPlusProductPrices') ?? {},
-	tierThreeProductPrices: getGlobal('tierThreeProductPrices') ?? {},
+	allProductPrices: window.guardian.allProductPrices,
 	selectedAmounts: {
 		ONE_OFF: 0,
 		MONTHLY: 0,

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -261,16 +261,10 @@ export function Checkout({ geoId, appConfig }: Props) {
 		}
 
 		/** Get any promotions */
-		const allProductPrices = appConfig.allProductPrices;
-		const productPricesKey =
-			productKey === 'TierThree'
-				? 'tierThreeProductPrices'
-				: productKey === 'SupporterPlus'
-				? 'supporterPlusProductPrices'
+		const productPrices =
+			productKey === 'SupporterPlus' || productKey === 'TierThree'
+				? appConfig.allProductPrices[productKey]
 				: undefined;
-		const productPrices = productPricesKey
-			? allProductPrices[productPricesKey]
-			: undefined;
 
 		/**
 		 * This is some annoying transformation we need from

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -261,7 +261,16 @@ export function Checkout({ geoId, appConfig }: Props) {
 		}
 
 		/** Get any promotions */
-		const productPrices = appConfig.productPrices;
+		const allProductPrices = appConfig.allProductPrices;
+		const productPricesKey =
+			productKey === 'TierThree'
+				? 'tierThreeProductPrices'
+				: productKey === 'SupporterPlus'
+				? 'supporterPlusProductPrices'
+				: undefined;
+		const productPrices = productPricesKey
+			? allProductPrices[productPricesKey]
+			: undefined;
 
 		/**
 		 * This is some annoying transformation we need from
@@ -302,13 +311,15 @@ export function Checkout({ geoId, appConfig }: Props) {
 		};
 		const productOptions: ProductOptions = getProductOptions(productKey);
 
-		promotion = getPromotion(
-			productPrices,
-			countryId,
-			billingPeriod,
-			fulfilmentOption,
-			productOptions,
-		);
+		promotion = productPrices
+			? getPromotion(
+					productPrices,
+					countryId,
+					billingPeriod,
+					fulfilmentOption,
+					productOptions,
+			  )
+			: undefined;
 		const discountedPrice = promotion?.discountedPrice
 			? promotion.discountedPrice
 			: undefined;

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -260,7 +260,10 @@ export function Checkout({ geoId, appConfig }: Props) {
 			return <div>Price not found in product catalog</div>;
 		}
 
-		/** Get any promotions */
+		/**
+		 * Get any promotions.
+		 * Promos are only available on SupporterPlus and TierThree and we only use this value to determine promotion values
+		 */
 		const productPrices =
 			productKey === 'SupporterPlus' || productKey === 'TierThree'
 				? appConfig.allProductPrices[productKey]

--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -9,6 +9,7 @@ import { ThankYou } from './thank-you';
 
 setUpTrackingAndConsents();
 const appConfig = parseAppConfig(window.guardian);
+appConfig.allProductPrices;
 
 const router = createBrowserRouter(
 	geoIds.flatMap((geoId) => [

--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -9,7 +9,6 @@ import { ThankYou } from './thank-you';
 
 setUpTrackingAndConsents();
 const appConfig = parseAppConfig(window.guardian);
-appConfig.allProductPrices;
 
 const router = createBrowserRouter(
 	geoIds.flatMap((geoId) => [

--- a/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
@@ -150,16 +150,10 @@ export function ThankYou({ geoId, appConfig }: Props) {
 		}
 
 		/** Get any promotions */
-		const allProductPrices = appConfig.allProductPrices;
-		const productPricesKey =
-			productKey === 'TierThree'
-				? 'tierThreeProductPrices'
-				: productKey === 'SupporterPlus'
-				? 'supporterPlusProductPrices'
+		const productPrices =
+			productKey === 'SupporterPlus' || productKey === 'TierThree'
+				? appConfig.allProductPrices[productKey]
 				: undefined;
-		const productPrices = productPricesKey
-			? allProductPrices[productPricesKey]
-			: undefined;
 
 		/**
 		 * This is some annoying transformation we need from

--- a/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
@@ -150,7 +150,16 @@ export function ThankYou({ geoId, appConfig }: Props) {
 		}
 
 		/** Get any promotions */
-		const productPrices = appConfig.productPrices;
+		const allProductPrices = appConfig.allProductPrices;
+		const productPricesKey =
+			productKey === 'TierThree'
+				? 'tierThreeProductPrices'
+				: productKey === 'SupporterPlus'
+				? 'supporterPlusProductPrices'
+				: undefined;
+		const productPrices = productPricesKey
+			? allProductPrices[productPricesKey]
+			: undefined;
 
 		/**
 		 * This is some annoying transformation we need from
@@ -179,12 +188,9 @@ export function ThankYou({ geoId, appConfig }: Props) {
 		};
 		const fulfilmentOption = getFulfilmentOptions(productKey);
 
-		promotion = getPromotion(
-			productPrices,
-			countryId,
-			billingPeriod,
-			fulfilmentOption,
-		);
+		promotion = productPrices
+			? getPromotion(productPrices, countryId, billingPeriod, fulfilmentOption)
+			: undefined;
 		const discountedPrice = promotion?.discountedPrice
 			? promotion.discountedPrice
 			: undefined;

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/secondStepCheckout.tsx
@@ -18,7 +18,6 @@ import { getAmount } from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
 import { currencies } from 'helpers/internationalisation/currency';
-import { getPromotion } from 'helpers/productPrice/promotions';
 import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
 import { resetValidation } from 'helpers/redux/checkout/checkoutActions';
 import {
@@ -144,16 +143,6 @@ export function SupporterPlusCheckout({
 	const showCoverTransactionCost =
 		abParticipations.coverTransactionCost === 'variant';
 
-	/** Promotions on the checkout are for SupporterPlus only for now */
-	const promotion = isSupporterPlus
-		? useContributionsSelector((state) =>
-				getPromotion(
-					state.page.checkoutForm.product.productPrices,
-					countryId,
-					state.page.checkoutForm.product.billingPeriod,
-				),
-		  )
-		: undefined;
 	return (
 		<SupporterPlusCheckoutScaffold thankYouRoute={thankYouRoute} isPaymentPage>
 			<Box cssOverrides={shorterBoxMargin}>
@@ -162,7 +151,6 @@ export function SupporterPlusCheckout({
 						<ContributionsPriceCards paymentFrequency={contributionType} />
 					) : (
 						<ContributionsOrderSummaryContainer
-							promotion={promotion}
 							renderOrderSummary={(orderSummaryProps) => (
 								<ContributionsOrderSummary
 									{...orderSummaryProps}
@@ -202,7 +190,6 @@ export function SupporterPlusCheckout({
 								currency={currencyId}
 								amount={amount}
 								productKey={product}
-								promotion={promotion}
 							/>
 						)}
 						{showCoverTransactionCost && contributionType === 'ONE_OFF' && (
@@ -245,7 +232,6 @@ export function SupporterPlusCheckout({
 						amount={amount}
 						amountIsAboveThreshold={isSupporterPlus}
 						productKey={product}
-						promotion={promotion}
 					/>
 				</BoxContents>
 			</Box>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -320,15 +320,14 @@ export function ThreeTierLanding({
 
 	const promotionTier2 = useContributionsSelector((state) =>
 		getPromotion(
-			state.page.checkoutForm.product.allProductPrices
-				.supporterPlusProductPrices,
+			state.page.checkoutForm.product.allProductPrices.SupporterPlus,
 			countryId,
 			billingPeriod,
 		),
 	);
 	const promotionTier3 = useContributionsSelector((state) =>
 		getPromotion(
-			state.page.checkoutForm.product.allProductPrices.tierThreeProductPrices,
+			state.page.checkoutForm.product.allProductPrices.TierThree,
 			countryId,
 			billingPeriod,
 			countryGroupId === 'International' ? 'RestOfWorld' : 'Domestic',

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -327,14 +327,15 @@ export function ThreeTierLanding({
 
 	const promotionTier2 = useContributionsSelector((state) =>
 		getPromotion(
-			state.page.checkoutForm.product.supporterPlusProductPrices,
+			state.page.checkoutForm.product.allProductPrices
+				.supporterPlusProductPrices,
 			countryId,
 			billingPeriod,
 		),
 	);
 	const promotionTier3 = useContributionsSelector((state) =>
 		getPromotion(
-			state.page.checkoutForm.product.tierThreeProductPrices,
+			state.page.checkoutForm.product.allProductPrices.tierThreeProductPrices,
 			countryId,
 			billingPeriod,
 			countryGroupId === 'International' ? 'RestOfWorld' : 'Domestic',

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -90,9 +90,9 @@ GET  /subscribe                                                    controllers.S
 GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe                  controllers.SubscriptionsController.landing(country: String)
 
 # Checkout
-GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/checkout            controllers.Application.router(countryGroupId: String)
-GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/one-time-checkout   controllers.Application.router(countryGroupId: String)
-GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/thank-you           controllers.Application.router(countryGroupId: String)
+GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/checkout            controllers.Application.productCheckoutRouter(countryGroupId: String)
+GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/one-time-checkout   controllers.Application.productCheckoutRouter(countryGroupId: String)
+GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/thank-you           controllers.Application.productCheckoutRouter(countryGroupId: String)
 
 # Events
 GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/events/:eventId     controllers.Application.eventsRouter(countryGroupId: String, eventId: String)

--- a/support-frontend/test/controllers/ApplicationTest.scala
+++ b/support-frontend/test/controllers/ApplicationTest.scala
@@ -4,7 +4,6 @@ import actions.{CustomActionBuilders, UserFromAuthCookiesActionBuilder, UserFrom
 import admin.settings.{AllSettingsProvider, FeatureSwitches, On}
 import org.apache.pekko.util.Timeout
 import assets.AssetsResolver
-import com.gu.googleauth.AuthAction
 import com.gu.i18n.CountryGroup
 import com.gu.support.catalog.SupporterPlus
 import com.gu.support.config._
@@ -18,7 +17,6 @@ import org.scalatest.EitherValues
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar._
-import play.api.mvc.AnyContent
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsString, header, stubControllerComponents}
 import services._
@@ -72,7 +70,6 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
     mock[StringsConfig],
     mock[AllSettingsProvider],
     mock[Stage],
-    mock[AuthAction[AnyContent]],
     priceSummaryServiceProvider,
     mock[CachedProductCatalogServiceProvider],
     "support.thegulocal.com",

--- a/support-frontend/window.d.ts
+++ b/support-frontend/window.d.ts
@@ -42,8 +42,8 @@ declare global {
 			orderIsAGift: boolean;
 			productPrices?: ProductPrices;
 			allProductPrices?: {
-				supporterPlusProductPrices: ProductPrices;
-				tierThreeProductPrices: ProductPrices;
+				SupporterPlus: ProductPrices;
+				TierThree: ProductPrices;
 			};
 			serversideTests?: Participations | null;
 			settings: Settings;

--- a/support-frontend/window.d.ts
+++ b/support-frontend/window.d.ts
@@ -40,7 +40,11 @@ declare global {
 			email?: string;
 			gitCommitId?: string;
 			orderIsAGift: boolean;
-			productPrices: ProductPrices;
+			productPrices?: ProductPrices;
+			allProductPrices?: {
+				supporterPlusProductPrices: ProductPrices;
+				tierThreeProductPrices: ProductPrices;
+			};
 			serversideTests?: Participations | null;
 			settings: Settings;
 			testMode?: boolean;


### PR DESCRIPTION
Adds the `allProductPrices` object to the `window.guardian` `AppConfig`.

This makes the config less stateful - and relies on the client to calculate which bit of the config it should use.

It also unblocks the work @paul-daniel-dempsey is working on with the one off checkout.

The idea here is to have 1 `AppConfig` that each page can read from consistently. We have already seen on the Landing page that we need both `SupporterPlus` and `TierThree` - so why not just use that model. It's 1 extra lookup, but when you;'re swapping between the pages, you know where to look.