### PR TITLE
Remove redux from landing

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -19,6 +19,7 @@ import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countr
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
 import { PaymentFrequencyButtons } from 'components/paymentFrequencyButtons/paymentFrequencyButtons';
+import { getAmountsTestVariant } from 'helpers/abTests/abtest';
 import type {
 	ContributionType,
 	RegularContributionType,
@@ -297,9 +298,7 @@ export function ThreeTierLanding({
 	};
 
 	const initialContributionType =
-		urlSearchParamsRatePlan && urlSearchParamsRatePlan === 'Annual'
-			? 'ANNUAL'
-			: 'MONTHLY';
+		urlSearchParamsRatePlan === 'Annual' ? 'ANNUAL' : 'MONTHLY';
 
 	const [contributionType, setContributionType] = useState<ContributionType>(
 		initialContributionType,
@@ -368,7 +367,11 @@ export function ThreeTierLanding({
 	 * Tier 1: Contributions
 	 * We use the amounts from RRCP to populate the Contribution tier
 	 */
-	const { amounts } = useContributionsSelector((state) => state.common);
+	const { selectedAmountsVariant: amounts } = getAmountsTestVariant(
+		countryId,
+		countryGroupId,
+		window.guardian.settings,
+	);
 	const monthlyRecurringAmount = amounts.amountsCardData.MONTHLY.amounts[0];
 	const annualRecurringAmount = amounts.amountsCardData.ANNUAL.amounts[0];
 	const recurringAmount =

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -43,7 +43,6 @@ import {
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { getPromotion } from 'helpers/productPrice/promotions';
-import { resetValidation } from 'helpers/redux/checkout/checkoutActions';
 import {
 	setBillingPeriod,
 	setProductType,
@@ -357,7 +356,6 @@ export function ThreeTierLanding({
 	 */
 
 	useEffect(() => {
-		dispatch(resetValidation());
 		if (!enableSingleContributionsTab && contributionType === 'ONE_OFF') {
 			/*
 			 * Reset the product type to monthly if one_off not available

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -43,11 +43,7 @@ import {
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { getPromotion } from 'helpers/productPrice/promotions';
-import {
-	setBillingPeriod,
-	setProductType,
-} from 'helpers/redux/checkout/product/actions';
-import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
+import { setBillingPeriod } from 'helpers/redux/checkout/product/actions';
 import {
 	useContributionsDispatch,
 	useContributionsSelector,
@@ -307,11 +303,13 @@ export function ThreeTierLanding({
 		subPath: '/contribute',
 	};
 
-	const contributionType = urlSearchParamsRatePlan
-		? urlSearchParamsRatePlan === 'Monthly'
+	const initialContributionType =
+		urlSearchParamsRatePlan && urlSearchParamsRatePlan === 'Monthly'
 			? 'MONTHLY'
-			: 'ANNUAL'
-		: useContributionsSelector(getContributionType);
+			: 'ANNUAL';
+	const [contributionType, setContributionType] = useState<ContributionType>(
+		initialContributionType,
+	);
 
 	const tierPlanPeriod = contributionType.toLowerCase();
 	const billingPeriod = (tierPlanPeriod[0].toUpperCase() +
@@ -355,22 +353,12 @@ export function ThreeTierLanding({
 	 * /////////////// END US EOY 2024 Campaign
 	 */
 
-	useEffect(() => {
-		if (!enableSingleContributionsTab && contributionType === 'ONE_OFF') {
-			/*
-			 * Reset the product type to monthly if one_off not available
-			 */
-			dispatch(setProductType('MONTHLY'));
-		}
-		dispatch(setBillingPeriod(billingPeriod));
-	}, []);
-
 	const paymentFrequencies: ContributionType[] = enableSingleContributionsTab
 		? ['ONE_OFF', 'MONTHLY', 'ANNUAL']
 		: ['MONTHLY', 'ANNUAL'];
 
 	const handlePaymentFrequencyBtnClick = (buttonIndex: number) => {
-		dispatch(setProductType(paymentFrequencies[buttonIndex]));
+		setContributionType(paymentFrequencies[buttonIndex]);
 		dispatch(setBillingPeriod(billingFrequencies[buttonIndex]));
 	};
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -43,11 +43,7 @@ import {
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { getPromotion } from 'helpers/productPrice/promotions';
-import { setBillingPeriod } from 'helpers/redux/checkout/product/actions';
-import {
-	useContributionsDispatch,
-	useContributionsSelector,
-} from 'helpers/redux/storeHooks';
+import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
 import { getCampaignSettings } from '../../../helpers/campaigns/campaigns';
@@ -208,8 +204,6 @@ const links = [
 	},
 ];
 
-// The three tier checkout only supports monthly and annual contributions
-const billingFrequencies: BillingPeriod[] = ['Monthly', 'Annual'];
 const paymentFrequencyMap = {
 	ONE_OFF: 'One-time',
 	MONTHLY: 'Monthly',
@@ -281,7 +275,6 @@ export function ThreeTierLanding({
 	const urlSearchParamsProduct = urlSearchParams.get('product');
 	const urlSearchParamsRatePlan = urlSearchParams.get('ratePlan');
 
-	const dispatch = useContributionsDispatch();
 	const { abParticipations } = useContributionsSelector(
 		(state) => state.common,
 	);
@@ -304,9 +297,10 @@ export function ThreeTierLanding({
 	};
 
 	const initialContributionType =
-		urlSearchParamsRatePlan && urlSearchParamsRatePlan === 'Monthly'
-			? 'MONTHLY'
-			: 'ANNUAL';
+		urlSearchParamsRatePlan && urlSearchParamsRatePlan === 'Annual'
+			? 'ANNUAL'
+			: 'MONTHLY';
+
 	const [contributionType, setContributionType] = useState<ContributionType>(
 		initialContributionType,
 	);
@@ -359,7 +353,6 @@ export function ThreeTierLanding({
 
 	const handlePaymentFrequencyBtnClick = (buttonIndex: number) => {
 		setContributionType(paymentFrequencies[buttonIndex]);
-		dispatch(setBillingPeriod(billingFrequencies[buttonIndex]));
 	};
 
 	const selectedContributionRatePlan =

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -19,7 +19,10 @@ import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countr
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
 import { PaymentFrequencyButtons } from 'components/paymentFrequencyButtons/paymentFrequencyButtons';
-import { getAmountsTestVariant } from 'helpers/abTests/abtest';
+import {
+	init as abTestInit,
+	getAmountsTestVariant,
+} from 'helpers/abTests/abtest';
 import type {
 	ContributionType,
 	RegularContributionType,
@@ -44,7 +47,6 @@ import {
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { getPromotion } from 'helpers/productPrice/promotions';
-import { useContributionsSelector } from 'helpers/redux/storeHooks';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
 import { getCampaignSettings } from '../../../helpers/campaigns/campaigns';
@@ -276,10 +278,6 @@ export function ThreeTierLanding({
 	const urlSearchParamsProduct = urlSearchParams.get('product');
 	const urlSearchParamsRatePlan = urlSearchParams.get('ratePlan');
 
-	const { abParticipations } = useContributionsSelector(
-		(state) => state.common,
-	);
-
 	const { currencyKey: currencyId, countryGroupId } = getGeoIdConfig(geoId);
 	const countryId = CountryHelper.detect();
 
@@ -296,6 +294,8 @@ export function ThreeTierLanding({
 		selectedCountryGroup: countryGroupId,
 		subPath: '/contribute',
 	};
+
+	const abParticipations = abTestInit({ countryId, countryGroupId });
 
 	const initialContributionType =
 		urlSearchParamsRatePlan === 'Annual' ? 'ANNUAL' : 'MONTHLY';

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -318,26 +318,6 @@ export function ThreeTierLanding({
 	const billingPeriod = (tierPlanPeriod[0].toUpperCase() +
 		tierPlanPeriod.slice(1)) as BillingPeriod;
 
-	const promotionTier2 = useContributionsSelector((state) =>
-		getPromotion(
-			state.page.checkoutForm.product.allProductPrices.SupporterPlus,
-			countryId,
-			billingPeriod,
-		),
-	);
-	const promotionTier3 = useContributionsSelector((state) =>
-		getPromotion(
-			state.page.checkoutForm.product.allProductPrices.TierThree,
-			countryId,
-			billingPeriod,
-			countryGroupId === 'International' ? 'RestOfWorld' : 'Domestic',
-
-			abParticipations.newspaperArchiveBenefit === undefined
-				? 'NoProductOptions'
-				: 'NewspaperArchive',
-		),
-	);
-
 	/*
 	 * US EOY 2024 Campaign
 	 */
@@ -448,6 +428,11 @@ export function ThreeTierLanding({
 		ratePlan: supporterPlusRatePlan,
 	});
 
+	const promotionTier2 = getPromotion(
+		window.guardian.allProductPrices.SupporterPlus,
+		countryId,
+		billingPeriod,
+	);
 	if (promotionTier2) {
 		tier2UrlParams.set('promoCode', promotionTier2.promoCode);
 	}
@@ -504,6 +489,16 @@ export function ThreeTierLanding({
 		product: 'TierThree',
 		ratePlan: tier3RatePlan,
 	});
+	const promotionTier3 = getPromotion(
+		window.guardian.allProductPrices.TierThree,
+		countryId,
+		billingPeriod,
+		countryGroupId === 'International' ? 'RestOfWorld' : 'Domestic',
+
+		abParticipations.newspaperArchiveBenefit === undefined
+			? 'NoProductOptions'
+			: 'NewspaperArchive',
+	);
 	if (promotionTier3) {
 		tier3UrlParams.set('promoCode', promotionTier3.promoCode);
 	}


### PR DESCRIPTION
This removes all `useContributionsDispatch` and `useContributionsSelector` from the landing page, probably meaning we can implement this page without setting up redux.

I've branched off `remove-server-product-lookup` as that has [a couple changes](https://github.com/guardian/support-frontend/pull/6342/files#diff-9e9d19a3470db4ff48cd4c73865be05d061001afc0751360451d6d509f390e9b) that would be overridden here.

Part of #5722 