### PR TITLE
Roll out 3-tab landing page to all US users

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -126,25 +126,4 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: false,
 	},
-	landingPageOneTimeTab: {
-		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'oneTimeTab',
-			},
-		],
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		isActive: true,
-		referrerControlled: false,
-		seed: 6,
-		targetPage: pageUrlRegexes.contributions.usLandingPage,
-		excludeCountriesSubjectToContributionsOnlyAmounts: false,
-	},
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -312,8 +312,7 @@ export function ThreeTierLanding({
 	 * US EOY 2024 Campaign
 	 */
 	const campaignSettings = getCampaignSettings(countryGroupId);
-	const enableSingleContributionsTab =
-		abParticipations.landingPageOneTimeTab === 'oneTimeTab';
+	const enableSingleContributionsTab = countryGroupId === UnitedStates;
 
 	// Handle which countdown to show (if any).
 	const [currentCampaign, setCurrentCampaign] = useState<CountdownSetting>({


### PR DESCRIPTION
We've been running an AB test with a 3rd tab for "One-time" on the landing page.
We've decided to end it early and show it to all users in the US.
This will help with an AB test we're about to run on the epic, which will link users to the landing page.