### PR TITLE
Only create alarms in PROD

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -22,7 +22,7 @@ new Frontend(app, "Frontend-PROD", {
     minimumInstances: 3,
     maximumInstances: 6,
   },
-  shouldEnableAlarms: true,
+  shouldCreateAlarms: true,
 });
 
 new Frontend(app, "Frontend-CODE", {
@@ -37,7 +37,7 @@ new Frontend(app, "Frontend-CODE", {
     minimumInstances: 1,
     maximumInstances: 2,
   },
-  shouldEnableAlarms: false,
+  shouldCreateAlarms: false,
 });
 
 new StripePatronsData(app, "StripePatronsData-CODE", {

--- a/cdk/lib/frontend.test.ts
+++ b/cdk/lib/frontend.test.ts
@@ -16,7 +16,7 @@ describe("The Frontend stack", () => {
         minimumInstances: 3,
         maximumInstances: 6,
       },
-      shouldEnableAlarms: true,
+      shouldCreateAlarms: true,
     });
 
     const template = Template.fromStack(stack);

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -114,6 +114,17 @@ export class Frontend extends GuStack {
     const alarmDescription = (description: string) =>
       `Impact - ${description}. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit`;
 
+    const http5xxAlarm = shouldCreateAlarms
+      ? {
+          alarmName: alarmName("support-frontend is returning 5XX errors"),
+          alarmDescription: alarmDescription(
+            "Some or all actions on support website are failing"
+          ),
+          actionsEnabled: shouldCreateAlarms,
+          tolerated5xxPercentage: 5,
+        }
+      : false;
+
     const ec2App = new GuEc2App(this, {
       applicationPort: 9000,
       app: "frontend",
@@ -124,15 +135,8 @@ export class Frontend extends GuStack {
       },
       monitoringConfiguration: {
         snsTopicName: `alarms-handler-topic-${this.stage}`,
-        http5xxAlarm: {
-          alarmName: alarmName("support-frontend is returning 5XX errors"),
-          alarmDescription: alarmDescription(
-            "Some or all actions on support website are failing"
-          ),
-          actionsEnabled: shouldCreateAlarms,
-          tolerated5xxPercentage: 5,
-        },
-        unhealthyInstancesAlarm: true,
+        http5xxAlarm: http5xxAlarm,
+        unhealthyInstancesAlarm: shouldCreateAlarms,
       },
       userData,
       roleConfiguration: {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We don't want to create alarms in code for support-frontend. Previously we had a boolean which meant they were inactive, but there's no point in creating them at all as they just clutter things up, so this PR ensures that alarms are only created in PROD.