### PR TITLE
Landing page - Support another way and padding tweaks

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/oneOffCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/oneOffCard.tsx
@@ -28,13 +28,13 @@ const sectionStyle = css`
 	margin: auto;
 	background-color: ${palette.neutral[100]};
 	border-radius: ${space[3]}px;
-	padding: 32px 48px ${space[6]}px 48px;
+	padding: 32px;
 	${until.desktop} {
 		padding-top: ${space[6]}px;
 	}
 `;
 const titleStyle = css`
-	margin: 0 0 ${space[3]}px;
+	margin: 0 0 ${space[2]}px;
 	text-align: center;
 	${headline.xsmall({ fontWeight: 'bold' })}
 	${from.tablet} {
@@ -52,8 +52,8 @@ const standFirst = css`
 const btnStyleOverrides = css`
 	width: 100%;
 	justify-content: center;
-	margin-bottom: ${space[6]}px;
-	margin-top: ${space[6]}px;
+	margin-bottom: ${space[3]}px;
+	margin-top: ${space[5]}px;
 `;
 
 const buttonContainer = css`

--- a/support-frontend/assets/pages/supporter-plus-landing/components/oneOffCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/oneOffCard.tsx
@@ -38,7 +38,7 @@ const titleStyle = css`
 	text-align: center;
 	${headline.xsmall({ fontWeight: 'bold' })}
 	${from.tablet} {
-		font-size: 22px;
+		font-size: 28px;
 	}
 `;
 const standFirst = css`
@@ -85,7 +85,7 @@ export function OneOffCard({
 		<section css={sectionStyle}>
 			<div
 				css={css`
-					${textSans.medium()}
+					${textSans.small()}
 				`}
 			>
 				<h2 css={titleStyle}>Support just once</h2>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -54,7 +54,6 @@ import type { CountdownSetting } from '../../../helpers/campaigns/campaigns';
 import Countdown from '../components/countdown';
 import { NewspaperArchiveBanner } from '../components/newspaperArchiveBanner';
 import { OneOffCard } from '../components/oneOffCard';
-import { SupportOnce } from '../components/supportOnce';
 import { ThreeTierCards } from '../components/threeTierCards';
 import { ThreeTierTsAndCs } from '../components/threeTierTsAndCs';
 
@@ -82,17 +81,12 @@ const recurringContainer = css`
 	}
 `;
 
-const oneTimeContainer = (withShortPaddingBottom: boolean) => css`
+const oneTimeContainer = css`
 	display: flex;
-	background-color: ${palette.neutral[97]};
+	background-color: #1E3E72;
 	> div {
-		padding: ${space[6]}px 10px ${withShortPaddingBottom ? space[6] : '72'}px;
-	}
-	${from.desktop} {
-		> div {
-			padding-bottom: ${withShortPaddingBottom ? space[9] : space[24]}px;
-		}
-	}
+		padding: ${space[6]}px 10px ${space[6]}px;
+}
 `;
 
 const innerContentContainer = css`
@@ -148,12 +142,11 @@ const tabletLineBreak = css`
 `;
 
 const supportAnotherWayContainer = css`
-	margin: ${space[9]}px auto 0;
-	border-top: 1px solid ${palette.neutral[86]};
 	padding-top: 32px;
 	max-width: 940px;
 	text-align: left;
-	color: #606060;
+	color:  ${palette.neutral[100]};
+  background-color: #1E3E72;
 	h4 {
 		${textSans.medium({ fontWeight: 'bold' })};
 	}
@@ -161,10 +154,9 @@ const supportAnotherWayContainer = css`
 		${textSans.small()};
 	}
 	a {
-		color: #606060;
+		color: ${palette.neutral[100]};
 	}
 	${from.desktop} {
-		text-align: center;
 		padding-top: ${space[9]}px;
 	}
 `;
@@ -565,25 +557,18 @@ export function ThreeTierLanding({
 			<Container
 				sideBorders
 				borderColor="rgba(170, 170, 180, 0.5)"
-				cssOverrides={oneTimeContainer(countryGroupId === UnitedStates)}
+				cssOverrides={oneTimeContainer}
 			>
-				{!enableSingleContributionsTab && (
-					<SupportOnce
-						currency={currencies[currencyId].glyph}
-						countryGroupId={countryGroupId}
-					/>
-				)}
 				{countryGroupId === UnitedStates && (
 					<div css={supportAnotherWayContainer}>
 						<h4>Support another way</h4>
 						<p>
-							If you are interested in contributing through a donor-advised
-							fund, foundation or retirement account, or by mailing a check,
-							please visit our{' '}
+              To learn more about other ways to support the Guardian, including checks and tax-exempt options, <br />
+              please visit our {' '}
 							<a href="https://manage.theguardian.com/help-centre/article/contribute-another-way?INTCMP=gdnwb_copts_support_contributions_referral">
 								help page
 							</a>{' '}
-							to learn how.
+              on this topic.
 						</p>
 					</div>
 				)}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -77,7 +77,7 @@ const recurringContainer = css`
 	}
 	${from.desktop} {
 		> div {
-			padding: 40px 10px ${space[6]}px;
+			padding: 40px 10px 72px;
 		}
 	}
 `;
@@ -104,7 +104,6 @@ const innerContentContainer = css`
 const heading = css`
 	text-align: left;
 	color: ${palette.neutral[100]};
-	margin-top: ${space[4]}px;
 	${headline.xsmall({
 		fontWeight: 'bold',
 	})}
@@ -131,14 +130,14 @@ const standFirst = css`
 		margin: 0 auto;
 	}
 	${from.desktop} {
-		margin: ${space[4]}px auto ${space[6]}px;
+		margin: ${space[4]}px auto ${space[10]}px;
 	}
 `;
 
 const paymentFrequencyButtonsCss = css`
 	margin: ${space[4]}px auto 32px;
 	${from.desktop} {
-		margin: ${space[6]}px auto ${space[12]}px;
+		margin: 0 auto ${space[9]}px;
 	}
 `;
 
@@ -148,7 +147,7 @@ const tabletLineBreak = css`
 	}
 `;
 
-const suppportAnotherWayContainer = css`
+const supportAnotherWayContainer = css`
 	margin: ${space[9]}px auto 0;
 	border-top: 1px solid ${palette.neutral[86]};
 	padding-top: 32px;
@@ -348,7 +347,7 @@ export function ThreeTierLanding({
 
 	const paymentFrequencies: ContributionType[] = enableSingleContributionsTab
 		? ['ONE_OFF', 'MONTHLY', 'ANNUAL']
-		: ['MONTHLY', 'ANNUAL'];
+		: ['ONE_OFF','MONTHLY', 'ANNUAL'];
 
 	const handlePaymentFrequencyBtnClick = (buttonIndex: number) => {
 		setContributionType(paymentFrequencies[buttonIndex]);
@@ -575,7 +574,7 @@ export function ThreeTierLanding({
 					/>
 				)}
 				{countryGroupId === UnitedStates && (
-					<div css={suppportAnotherWayContainer}>
+					<div css={supportAnotherWayContainer}>
 						<h4>Support another way</h4>
 						<p>
 							If you are interested in contributing through a donor-advised

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -84,14 +84,14 @@ const recurringContainer = css`
 
 const oneTimeContainer = (withShortPaddingBottom: boolean) => css`
 	display: flex;
-	background-color:  ${withShortPaddingBottom ? '#1e3e72' : palette.neutral[97]};
+	background-color: ${withShortPaddingBottom ? '#1e3e72' : palette.neutral[97]};
 	> div {
 		padding: ${space[6]}px 10px ${withShortPaddingBottom ? space[6] : '72'}px;
 	}
 	${from.desktop} {
 		> div {
 			padding-bottom: ${withShortPaddingBottom ? space[9] : space[24]}px;
-    }
+		}
 	}
 `;
 
@@ -565,7 +565,7 @@ export function ThreeTierLanding({
 				borderColor="rgba(170, 170, 180, 0.5)"
 				cssOverrides={oneTimeContainer(countryGroupId === UnitedStates)}
 			>
-				{!enableSingleContributionsTab && countryGroupId !== UnitedStates &&  (
+				{!enableSingleContributionsTab && countryGroupId !== UnitedStates && (
 					<SupportOnce
 						currency={currencies[currencyId].glyph}
 						countryGroupId={countryGroupId}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -337,7 +337,7 @@ export function ThreeTierLanding({
 
 	const paymentFrequencies: ContributionType[] = enableSingleContributionsTab
 		? ['ONE_OFF', 'MONTHLY', 'ANNUAL']
-		: ['ONE_OFF','MONTHLY', 'ANNUAL'];
+		: ['MONTHLY', 'ANNUAL'];
 
 	const handlePaymentFrequencyBtnClick = (buttonIndex: number) => {
 		setContributionType(paymentFrequencies[buttonIndex]);

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -84,9 +84,6 @@ const recurringContainer = css`
 const oneTimeContainer = css`
 	display: flex;
 	background-color: #1E3E72;
-	> div {
-		padding: ${space[6]}px 10px ${space[6]}px;
-}
 `;
 
 const innerContentContainer = css`
@@ -142,10 +139,9 @@ const tabletLineBreak = css`
 `;
 
 const supportAnotherWayContainer = css`
-	padding-top: 32px;
 	max-width: 940px;
 	text-align: left;
-	color:  ${palette.neutral[100]};
+	color: ${palette.neutral[100]};
   background-color: #1E3E72;
 	h4 {
 		${textSans.medium({ fontWeight: 'bold' })};
@@ -157,8 +153,10 @@ const supportAnotherWayContainer = css`
 		color: ${palette.neutral[100]};
 	}
 	${from.desktop} {
-		padding-top: ${space[9]}px;
-	}
+		padding-top: ${space[5]}px;
+    padding-bottom: ${space[5]}px;
+
+  }
 `;
 
 const disclaimerContainer = css`
@@ -169,7 +167,7 @@ const disclaimerContainer = css`
 	}
 	${from.mobileLandscape} {
 		> div {
-			padding: ${space[4]}px ${space[5]}px;
+			padding: ${space[5]}px ${space[5]}px;
 		}
 	}
 `;

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -82,9 +82,17 @@ const recurringContainer = css`
 	}
 `;
 
-const oneTimeContainer = css`
+const oneTimeContainer = (withShortPaddingBottom: boolean) => css`
 	display: flex;
-	background-color: #1e3e72;
+	background-color:  ${withShortPaddingBottom ? '#1e3e72' : palette.neutral[97]};
+	> div {
+		padding: ${space[6]}px 10px ${withShortPaddingBottom ? space[6] : '72'}px;
+	}
+	${from.desktop} {
+		> div {
+			padding-bottom: ${withShortPaddingBottom ? space[9] : space[24]}px;
+    }
+	}
 `;
 
 const innerContentContainer = css`
@@ -555,9 +563,9 @@ export function ThreeTierLanding({
 			<Container
 				sideBorders
 				borderColor="rgba(170, 170, 180, 0.5)"
-				cssOverrides={oneTimeContainer}
+				cssOverrides={oneTimeContainer(countryGroupId === UnitedStates)}
 			>
-				{!enableSingleContributionsTab && (
+				{!enableSingleContributionsTab && countryGroupId !== UnitedStates &&  (
 					<SupportOnce
 						currency={currencies[currencyId].glyph}
 						countryGroupId={countryGroupId}
@@ -580,7 +588,6 @@ export function ThreeTierLanding({
 			</Container>
 			<Container
 				sideBorders
-				topBorder
 				borderColor="rgba(170, 170, 180, 0.5)"
 				cssOverrides={disclaimerContainer}
 			>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -58,8 +58,6 @@ import { SupportOnce } from '../components/supportOnce';
 import { ThreeTierCards } from '../components/threeTierCards';
 import { ThreeTierTsAndCs } from '../components/threeTierTsAndCs';
 
-//TODO REMOVE https://support.thegulocal.com/us/contribute#ab-landingPageOneTimeTab=oneTimeTab
-
 const recurringContainer = css`
 	background-color: ${palette.brand[400]};
 	border-bottom: 1px solid ${palette.brand[600]};
@@ -88,12 +86,8 @@ const oneTimeContainer = (withShortPaddingBottom: boolean) => css`
 	display: flex;
 	background-color: ${withShortPaddingBottom ? '#1e3e72' : palette.neutral[97]};
 	> div {
-		padding: ${space[6]}px 10px ${withShortPaddingBottom ? space[6] : '72'}px;
+		padding: ${space[5]}px ${withShortPaddingBottom ? space[5] : '72'}px;
 	}
-	${from.desktop} {
-		> div {
-			padding-bottom: ${withShortPaddingBottom ? space[9] : space[24]}px;
-		}
 	}
 `;
 
@@ -132,7 +126,7 @@ const standFirst = css`
 		margin: 0 auto;
 	}
 	${from.desktop} {
-		margin: ${space[4]}px auto ${space[10]}px;
+		margin: ${space[4]}px auto ${space[9]}px;
 	}
 `;
 
@@ -162,10 +156,6 @@ const supportAnotherWayContainer = css`
 	}
 	a {
 		color: ${palette.neutral[100]};
-	}
-	${from.desktop} {
-		padding-top: ${space[5]}px;
-		padding-bottom: ${space[5]}px;
 	}
 `;
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -83,7 +83,7 @@ const recurringContainer = css`
 
 const oneTimeContainer = css`
 	display: flex;
-	background-color: #1E3E72;
+	background-color: #1e3e72;
 `;
 
 const innerContentContainer = css`
@@ -142,7 +142,7 @@ const supportAnotherWayContainer = css`
 	max-width: 940px;
 	text-align: left;
 	color: ${palette.neutral[100]};
-  background-color: #1E3E72;
+	background-color: #1e3e72;
 	h4 {
 		${textSans.medium({ fontWeight: 'bold' })};
 	}
@@ -154,9 +154,8 @@ const supportAnotherWayContainer = css`
 	}
 	${from.desktop} {
 		padding-top: ${space[5]}px;
-    padding-bottom: ${space[5]}px;
-
-  }
+		padding-bottom: ${space[5]}px;
+	}
 `;
 
 const disclaimerContainer = css`
@@ -561,12 +560,13 @@ export function ThreeTierLanding({
 					<div css={supportAnotherWayContainer}>
 						<h4>Support another way</h4>
 						<p>
-              To learn more about other ways to support the Guardian, including checks and tax-exempt options, <br />
-              please visit our {' '}
+							To learn more about other ways to support the Guardian, including
+							checks and tax-exempt options, <br />
+							please visit our{' '}
 							<a href="https://manage.theguardian.com/help-centre/article/contribute-another-way?INTCMP=gdnwb_copts_support_contributions_referral">
 								help page
 							</a>{' '}
-              on this topic.
+							on this topic.
 						</p>
 					</div>
 				)}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -144,10 +144,10 @@ const supportAnotherWayContainer = css`
 	color: ${palette.neutral[100]};
 	background-color: #1e3e72;
 	h4 {
-		${textSans.medium({ fontWeight: 'bold' })};
+		${textSans.large({ fontWeight: 'bold' })};
 	}
 	p {
-		${textSans.small()};
+		${textSans.medium()};
 	}
 	a {
 		color: ${palette.neutral[100]};

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -54,6 +54,7 @@ import type { CountdownSetting } from '../../../helpers/campaigns/campaigns';
 import Countdown from '../components/countdown';
 import { NewspaperArchiveBanner } from '../components/newspaperArchiveBanner';
 import { OneOffCard } from '../components/oneOffCard';
+import { SupportOnce } from '../components/supportOnce';
 import { ThreeTierCards } from '../components/threeTierCards';
 import { ThreeTierTsAndCs } from '../components/threeTierTsAndCs';
 
@@ -556,6 +557,12 @@ export function ThreeTierLanding({
 				borderColor="rgba(170, 170, 180, 0.5)"
 				cssOverrides={oneTimeContainer}
 			>
+				{!enableSingleContributionsTab && (
+					<SupportOnce
+						currency={currencies[currencyId].glyph}
+						countryGroupId={countryGroupId}
+					/>
+				)}
 				{countryGroupId === UnitedStates && (
 					<div css={supportAnotherWayContainer}>
 						<h4>Support another way</h4>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -287,8 +287,7 @@ export function ThreeTierLanding({
 
 	const abParticipations = abTestInit({ countryId, countryGroupId });
 
-	const enableSingleContributionsTab =
-		abParticipations.landingPageOneTimeTab === 'oneTimeTab';
+	const enableSingleContributionsTab = countryGroupId === UnitedStates;
 
 	const getInitialContributionType = () => {
 		if (enableSingleContributionsTab && urlSearchParamsOneTime) {
@@ -309,8 +308,6 @@ export function ThreeTierLanding({
 	 * US EOY 2024 Campaign
 	 */
 	const campaignSettings = getCampaignSettings(countryGroupId);
-	const enableSingleContributionsTab = countryGroupId === UnitedStates;
-
 
 	// Handle which countdown to show (if any).
 	const [currentCampaign, setCurrentCampaign] = useState<CountdownSetting>({

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -58,6 +58,8 @@ import { SupportOnce } from '../components/supportOnce';
 import { ThreeTierCards } from '../components/threeTierCards';
 import { ThreeTierTsAndCs } from '../components/threeTierTsAndCs';
 
+//TODO REMOVE https://support.thegulocal.com/us/contribute#ab-landingPageOneTimeTab=oneTimeTab
+
 const recurringContainer = css`
 	background-color: ${palette.brand[400]};
 	border-bottom: 1px solid ${palette.brand[600]};
@@ -565,7 +567,7 @@ export function ThreeTierLanding({
 				borderColor="rgba(170, 170, 180, 0.5)"
 				cssOverrides={oneTimeContainer(countryGroupId === UnitedStates)}
 			>
-				{!enableSingleContributionsTab && countryGroupId !== UnitedStates && (
+				{!enableSingleContributionsTab && (
 					<SupportOnce
 						currency={currencies[currencyId].glyph}
 						countryGroupId={countryGroupId}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Changing the UI of the _Support another way_ section of the landing page following this [design](https://www.figma.com/design/ijioQ84Nmo2IrMzLol33XV/US-EOY-Appeal-2024?node-id=455-39547&node-type=canvas&t=6e3sYcGTiPGWbVVI-0) which also includes some minor padding tweaks to the choice cards 

[**Trello Card**](https://trello.com/c/UGL60hAh/688-update-support-another-way-design-on-3tlp)

## How to test
On the landing page check that the new 'Support another way' design is showing and that the padding is accurate - you can do this by using the dev tools on your browser.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
US
![image](https://github.com/user-attachments/assets/883f8238-a7ac-4192-9d6e-b11bef1d6648)

![image](https://github.com/user-attachments/assets/e3361027-742d-4065-b468-af9d92c36623)


UK

![image](https://github.com/user-attachments/assets/d8157bdd-b4d5-4fb7-b2ce-515c1969158e)
