### PR TITLE
Test the value of S+ partner offers in AU

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -122,8 +122,8 @@ export const tests: Tests = {
 		},
 		isActive: true,
 		referrerControlled: false, // ab-test name not needed to be in paramURL
-		seed: 9,
-		targetPage: pageUrlRegexes.contributions.auLandingPage,
+		seed: 8,
+		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
 	coverTransactionCost: {

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -105,6 +105,27 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
+	auPartnerBenefit: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		isActive: true,
+		referrerControlled: false, // ab-test name not needed to be in paramURL
+		seed: 9,
+		targetPage: pageUrlRegexes.contributions.auLandingPage,
+		excludeCountriesSubjectToContributionsOnlyAmounts: true,
+	},
 	coverTransactionCost: {
 		variants: [
 			{

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -84,6 +84,7 @@ export const productCatalogDescription: Record<ProductKey, ProductDescription> =
 					tooltip: `Guardian Weekly is a beautifully concise magazine featuring a handpicked selection of in-depth articles, global news, long reads, opinion and more. Delivered to you every week, wherever you are in the world.`,
 				},
 			],
+			/** These are just the SupporterPlus benefits */
 			benefitsAdditional: [
 				{
 					copy: 'Unlimited access to the Guardian app',
@@ -102,6 +103,9 @@ export const productCatalogDescription: Record<ProductKey, ProductDescription> =
 					tooltip:
 						'Access to special offers (such as free and discounted tickets) from our values-aligned partners, including museums, festivals and cultural institutions.',
 					specificToRegions: ['AUDCountries'],
+					specificToAbTest: [
+						{ name: 'auPartnerBenefit', variants: ['control'] },
+					],
 				},
 			],
 			deliverableTo: gwDeliverableCountries,

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -1,6 +1,7 @@
 import type { ProductKey } from '@guardian/support-service-lambdas/modules/product-catalog/src/productCatalog';
 import { typeObject } from '@guardian/support-service-lambdas/modules/product-catalog/src/typeObject';
 import { OfferFeast } from 'components/offer/offer';
+import type { Participations } from './abTests/abtest';
 import { newspaperCountries } from './internationalisation/country';
 import type {
 	CountryGroupId,
@@ -16,6 +17,7 @@ type ProductBenefit = {
 	copy: string;
 	tooltip?: string;
 	specificToRegions?: CountryGroupId[];
+	specificToAbTest?: Array<{ name: string; variants: string[] }>;
 	isNew?: boolean;
 };
 
@@ -49,6 +51,20 @@ export function filterBenefitByRegion(
 	return true;
 }
 
+export function filterBenefitByABTest(
+	benefit: ProductBenefit,
+	participations?: Participations,
+) {
+	if (participations && benefit.specificToAbTest !== undefined) {
+		return benefit.specificToAbTest.some(({ name, variants }) =>
+			participations[name]
+				? variants.includes(participations[name] ?? '')
+				: false,
+		);
+	}
+	return true;
+}
+
 export const productKeys = Object.keys(typeObject) as ProductKey[];
 export function isProductKey(val: unknown): val is ProductKey {
 	return productKeys.includes(val as ProductKey);
@@ -68,7 +84,6 @@ export const productCatalogDescription: Record<ProductKey, ProductDescription> =
 					tooltip: `Guardian Weekly is a beautifully concise magazine featuring a handpicked selection of in-depth articles, global news, long reads, opinion and more. Delivered to you every week, wherever you are in the world.`,
 				},
 			],
-			/** These are just the SupporterPlus benefits */
 			benefitsAdditional: [
 				{
 					copy: 'Unlimited access to the Guardian app',
@@ -181,6 +196,9 @@ export const productCatalogDescription: Record<ProductKey, ProductDescription> =
 					tooltip:
 						'Access to special offers (such as free and discounted tickets) from our values-aligned partners, including museums, festivals and cultural institutions.',
 					specificToRegions: ['AUDCountries'],
+					specificToAbTest: [
+						{ name: 'auPartnerBenefit', variants: ['control'] },
+					],
 				},
 			],
 			offers: [

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -71,12 +71,13 @@ import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import CountryHelper from 'helpers/internationalisation/classes/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
-import type { ProductKey } from 'helpers/productCatalog';
 import {
+	filterBenefitByABTest,
 	filterBenefitByRegion,
 	isProductKey,
 	productCatalog,
 	productCatalogDescription,
+	type ProductKey,
 } from 'helpers/productCatalog';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { NoFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
@@ -1003,6 +1004,9 @@ function CheckoutComponent({
 								.filter((benefit) =>
 									filterBenefitByRegion(benefit, countryGroupId),
 								)
+								.filter((benefit) =>
+									filterBenefitByABTest(benefit, abParticipations),
+								)
 								.map((benefit) => ({
 									isChecked: true,
 									text: benefit.copy,
@@ -1010,6 +1014,9 @@ function CheckoutComponent({
 							...(productDescription.benefitsAdditional ?? [])
 								.filter((benefit) =>
 									filterBenefitByRegion(benefit, countryGroupId),
+								)
+								.filter((benefit) =>
+									filterBenefitByABTest(benefit, abParticipations),
 								)
 								.map((benefit) => ({
 									isChecked: true,

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -11,6 +11,7 @@ import {
 	LinkButton,
 } from '@guardian/source/react-components';
 import { BenefitsCheckList } from 'components/checkoutBenefits/benefitsCheckList';
+import type { Participations } from 'helpers/abTests/abtest';
 import type { RegularContributionType } from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -20,6 +21,7 @@ import type {
 	IsoCurrency,
 } from 'helpers/internationalisation/currency';
 import {
+	filterBenefitByABTest,
 	filterBenefitByRegion,
 	type ProductDescription,
 } from 'helpers/productCatalog';
@@ -42,6 +44,7 @@ export type ThreeTierCardProps = {
 	ctaCopy: string;
 	lozengeText?: string;
 	promotion?: Promotion;
+	abParticipations?: Participations | undefined;
 };
 
 const container = (
@@ -62,6 +65,7 @@ const container = (
 			: palette.neutral[100]};
 		border-radius: ${space[3]}px;
 		padding: 32px ${space[3]}px ${space[6]}px ${space[3]}px;
+
 		${until.desktop} {
 			order: ${cardOrder};
 			padding-top: ${space[6]}px;
@@ -79,6 +83,7 @@ const priceCss = (hasPromotion: boolean) => css`
 	${textSans.xlarge({ fontWeight: 'bold' })};
 	position: relative;
 	margin-bottom: ${hasPromotion ? '0' : `${space[4]}px`};
+
 	${from.desktop} {
 		margin-bottom: ${space[6]}px;
 	}
@@ -90,6 +95,7 @@ const discountSummaryCss = css`
 	font-weight: 400;
 	color: #606060;
 	margin-bottom: ${space[4]}px;
+
 	${from.desktop} {
 		position: absolute;
 		top: 100%;
@@ -114,6 +120,7 @@ const btnStyleOverrides = css`
 const checkmarkBenefitList = css`
 	width: 100%;
 	text-align: left;
+
 	${from.desktop} {
 		width: 90%;
 	}
@@ -128,6 +135,7 @@ const benefitsPrefixCss = css`
 	${textSans.small()};
 	color: ${palette.neutral[7]};
 	text-align: left;
+
 	strong {
 		font-weight: bold;
 	}
@@ -139,6 +147,7 @@ const benefitsPrefixPlus = css`
 	display: flex;
 	align-items: center;
 	margin: ${space[3]}px 0;
+
 	:before,
 	:after {
 		content: '';
@@ -146,9 +155,11 @@ const benefitsPrefixPlus = css`
 		background-color: ${palette.neutral[86]};
 		flex-grow: 2;
 	}
+
 	:before {
 		margin-right: ${space[2]}px;
 	}
+
 	:after {
 		margin-left: ${space[2]}px;
 	}
@@ -197,6 +208,7 @@ export function ThreeTierCard({
 	price,
 	promotion,
 	ctaCopy,
+	abParticipations,
 }: ThreeTierCardProps): JSX.Element {
 	const currency = currencies[currencyId];
 	const period = recurringContributionPeriodMap[paymentFrequency];
@@ -280,6 +292,7 @@ export function ThreeTierCard({
 			<BenefitsCheckList
 				benefitsCheckListData={benefits
 					.filter((benefit) => filterBenefitByRegion(benefit, countryGroupId))
+					.filter((benefit) => filterBenefitByABTest(benefit, abParticipations))
 					.map((benefit) => {
 						return {
 							text: benefit.copy,

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { between, from, space } from '@guardian/source/foundations';
+import type { Participations } from 'helpers/abTests/abtest';
 import type { RegularContributionType } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
@@ -20,19 +21,23 @@ export type ThreeTierCardsProps = {
 	currencyId: IsoCurrency;
 	countryGroupId: CountryGroupId;
 	paymentFrequency: RegularContributionType;
+	abParticipations?: Participations;
 };
 
 const container = (cardCount: number) => css`
 	display: flex;
 	flex-direction: column;
 	gap: ${space[3]}px;
+
 	> * {
 		flex-basis: ${100 / cardCount}%;
 	}
+
 	${between.tablet.and.desktop} {
 		margin: 0 auto;
 		max-width: 340px;
 	}
+
 	${from.desktop} {
 		gap: ${space[5]}px;
 		flex-direction: row;
@@ -56,6 +61,7 @@ export function ThreeTierCards({
 	currencyId,
 	countryGroupId,
 	paymentFrequency,
+	abParticipations,
 }: ThreeTierCardsProps): JSX.Element {
 	const haveRecommendedAndSelectedCards =
 		cardsContent.filter((card) => card.isRecommended || card.isUserSelected)
@@ -83,6 +89,7 @@ export function ThreeTierCards({
 						countryGroupId={countryGroupId}
 						paymentFrequency={paymentFrequency}
 						ctaCopy={cardContent.ctaCopy}
+						abParticipations={abParticipations}
 					/>
 				);
 			})}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -558,6 +558,7 @@ export function ThreeTierLanding({
 							currencyId={currencyId}
 							countryGroupId={countryGroupId}
 							paymentFrequency={contributionType}
+							abParticipations={abParticipations}
 						/>
 					)}
 					{showNewspaperArchiveBanner && <NewspaperArchiveBanner />}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We want to test what the value of the 'Exclusive access to partner offers' benefit is in converting AU supporter plus customers, so this PR sets up an AB test - `auPartnerBenefit`:
- `control` - see the copy, as is the case now
- `variant` - do not see the copy
## Screenshots
### Landing page in control
![Screenshot 2024-09-27 at 14 41 13](https://github.com/user-attachments/assets/32c17889-7506-4fff-a5ff-c516e4f24dc7)
### Landing page in variant
![Screenshot 2024-09-27 at 14 40 40](https://github.com/user-attachments/assets/7b4c9238-5095-4811-afe3-6adc2bb2efdf)
### Checkout page in control
![Screenshot 2024-09-27 at 14 41 30](https://github.com/user-attachments/assets/86fe1677-2c1e-42e1-8371-0403f5031b37)
### Checkout page in variant
![Screenshot 2024-09-27 at 14 41 46](https://github.com/user-attachments/assets/587efe85-d8ac-42c7-9c09-4303f0023ab3)



