### PR TITLE
Prevent layout shift on generic checkout

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -1082,7 +1082,12 @@ function CheckoutComponent({
 				<Box cssOverrides={shorterBoxMargin}>
 					<BoxContents>
 						{useStripeExpressCheckout && (
-							<>
+							<div
+								css={css`
+									/* Prevent content layout shift */
+									min-height: 8px;
+								`}
+							>
 								<ExpressCheckoutElement
 									onReady={({ availablePaymentMethods }) => {
 										/**
@@ -1197,7 +1202,7 @@ function CheckoutComponent({
 										`}
 									/>
 								)}
-							</>
+							</div>
 						)}
 						<FormSection>
 							<Legend>1. Your details</Legend>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Adding a minimum height to the Stripe Express Checkout element to prevent CLS.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/32XTJ332/1070-layout-shift-on-generic-checkout)


<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Load generic checkout - do not see spacing shift.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


## Screen recordings (element highlighted in red to show shift)

Before: 

https://github.com/user-attachments/assets/c87218d8-e368-441b-a3e6-942c951595bc


After

https://github.com/user-attachments/assets/e779b723-76b7-44be-8986-b2380082ca42

