### PR TITLE
Disable one-time tab on LP

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -82,12 +82,11 @@ const recurringContainer = css`
 	}
 `;
 
-const oneTimeContainer = (withShortPaddingBottom: boolean) => css`
+const oneTimeContainer = css`
 	display: flex;
-	background-color: ${withShortPaddingBottom ? '#1e3e72' : palette.neutral[97]};
+	background-color: ${palette.neutral[97]};
 	> div {
-		padding: ${space[5]}px ${withShortPaddingBottom ? space[5] : '72'}px;
-	}
+		padding: ${space[5]}px 72px;
 	}
 `;
 
@@ -144,10 +143,15 @@ const tabletLineBreak = css`
 `;
 
 const supportAnotherWayContainer = css`
+	display: flex;
+	background-color: #1e3e72;
+`;
+
+const supportAnotherWay = css`
+	margin: 20px 0;
 	max-width: 940px;
 	text-align: left;
 	color: ${palette.neutral[100]};
-	background-color: #1e3e72;
 	h4 {
 		${textSans.large({ fontWeight: 'bold' })};
 	}
@@ -557,19 +561,25 @@ export function ThreeTierLanding({
 					{showNewspaperArchiveBanner && <NewspaperArchiveBanner />}
 				</div>
 			</Container>
-			<Container
-				sideBorders
-				borderColor="rgba(170, 170, 180, 0.5)"
-				cssOverrides={oneTimeContainer(countryGroupId === UnitedStates)}
-			>
-				{!enableSingleContributionsTab && (
+			{!enableSingleContributionsTab && (
+				<Container
+					sideBorders
+					borderColor="rgba(170, 170, 180, 0.5)"
+					cssOverrides={oneTimeContainer}
+				>
 					<SupportOnce
 						currency={currencies[currencyId].glyph}
 						countryGroupId={countryGroupId}
 					/>
-				)}
-				{countryGroupId === UnitedStates && (
-					<div css={supportAnotherWayContainer}>
+				</Container>
+			)}
+			{countryGroupId === UnitedStates && (
+				<Container
+					sideBorders
+					borderColor="rgba(170, 170, 180, 0.5)"
+					cssOverrides={supportAnotherWayContainer}
+				>
+					<div css={supportAnotherWay}>
 						<h4>Support another way</h4>
 						<p>
 							To learn more about other ways to support the Guardian, including
@@ -581,8 +591,8 @@ export function ThreeTierLanding({
 							on this topic.
 						</p>
 					</div>
-				)}
-			</Container>
+				</Container>
+			)}
 			<Container
 				sideBorders
 				borderColor="rgba(170, 170, 180, 0.5)"

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -267,6 +267,7 @@ export function ThreeTierLanding({
 	const urlSearchParamsProduct = urlSearchParams.get('product');
 	const urlSearchParamsRatePlan = urlSearchParams.get('ratePlan');
 	const urlSearchParamsOneTime = urlSearchParams.has('oneTime');
+	const enableSingleContributionsTab = urlSearchParams.has('enableOneTime');
 
 	const { currencyKey: currencyId, countryGroupId } = getGeoIdConfig(geoId);
 	const countryId = CountryHelper.detect();
@@ -286,8 +287,6 @@ export function ThreeTierLanding({
 	};
 
 	const abParticipations = abTestInit({ countryId, countryGroupId });
-
-	const enableSingleContributionsTab = countryGroupId === UnitedStates;
 
 	const getInitialContributionType = () => {
 		if (enableSingleContributionsTab && urlSearchParamsOneTime) {


### PR DESCRIPTION
We're disabling the one-time tab for now.
It can only be seen by adding `?enableOneTime` to the url.

I've also fixed the design when both the "support once" and "support another way" are displayed:

Mobile, no "support once":
![Screenshot 2024-10-02 at 13 51 06](https://github.com/user-attachments/assets/0b6d296f-4fb6-4899-bc28-635888e418e2)

Mobile, with "support once":
![Screenshot 2024-10-02 at 13 51 17](https://github.com/user-attachments/assets/3d63a75f-a8fe-4c2f-8ff3-a2be26ee790c)

Desktop, no "support once":
![Screenshot 2024-10-02 at 13 51 42](https://github.com/user-attachments/assets/f34c8503-7528-4336-94b4-815264e73f48)

Desktop, with "support once":
![Screenshot 2024-10-02 at 13 51 30](https://github.com/user-attachments/assets/68508cae-c990-4e8a-8de4-2f356ed58457)
