### PR TITLE
Recaptcha alarm

### DIFF
--- a/support-frontend/app/actions/CustomActionBuilders.scala
+++ b/support-frontend/app/actions/CustomActionBuilders.scala
@@ -12,6 +12,7 @@ import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.filters.csrf._
 import services.AsyncAuthenticationService
+import services.RecaptchaResponse.recaptchaFailedCode
 import utils.FastlyGEOIP
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -66,17 +67,21 @@ class CustomActionBuilders(
       AwsCloudWatchMetricPut(AwsCloudWatchMetricPut.client)(cloudwatchEvent)
     }
 
-    private def maybePushAlarmMetric(result: Result) =
-      if (
-        result.header.status.toString.head != '2' && !result.header.reasonPhrase.contains(
-          emailProviderRejectedCode,
-        ) && !result.header.reasonPhrase.contains(
-          invalidEmailAddressCode,
+    private def maybePushAlarmMetric(result: Result) = {
+      val silentFailureReasons = Set(
+        emailProviderRejectedCode,
+        invalidEmailAddressCode,
+        recaptchaFailedCode,
+      )
+      if (!silentFailureReasons.contains(result.header.reasonPhrase.getOrElse(""))) {
+        logger.error(
+          scrub"pushing alarm metric - non 2xx response. Http code: ${result.header.status}, reason: ${result.header.reasonPhrase}",
         )
-      ) {
-        logger.error(scrub"pushing alarm metric - non 2xx response ${result.toString()}")
         pushAlarmMetric
+      } else {
+        logger.info(s"not pushing alarm metric for ${result.header.status} ${result.header.reasonPhrase}")
       }
+    }
 
     def apply(requestHeader: RequestHeader): Accumulator[ByteString, Result] = {
       val accumulator = chainedAction.apply(requestHeader)

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -114,6 +114,7 @@ class CreateSubscriptionController(
     val v2RecaptchaSecretKey = recaptchaConfigProvider.get(isTestUser).v2SecretKey
 
     if (recaptchaEnabled) {
+      logDetailedMessage("validating recaptcha")
       recaptchaService
         .verify(token, v2RecaptchaSecretKey)
         .leftMap(err => RequestValidationError(err))
@@ -122,7 +123,7 @@ class CreateSubscriptionController(
 
           case RecaptchaResponse(false, _) =>
             logErrorDetailedMessage("recaptcha failed")
-            Left(RequestValidationError("Recaptcha validation failed"))
+            Left(RequestValidationError(RecaptchaResponse.recaptchaFailedCode))
         }
     } else {
       EitherT.rightT(())
@@ -159,9 +160,9 @@ class CreateSubscriptionController(
       case InvalidEmailAddress(_) => RequestValidationError(invalidEmailAddressCode)
       case OtherIdentityError(message, description, endpoint) =>
         endpoint match {
-          case Some(GuestEndpoint) => ServerError(s"Error calling /guest: $message; $description")
-          case Some(UserEndpoint) => ServerError(s"Error calling /user: $message; $description")
-          case None => ServerError(s"$message: $description")
+          case Some(GuestEndpoint) => ServerError(s"Identity error calling /guest: $message; $description")
+          case Some(UserEndpoint) => ServerError(s"Identity error calling /user: $message; $description")
+          case None => ServerError(s"Error calling Identity: $message: $description")
         }
     }
 

--- a/support-frontend/app/services/RecaptchaService.scala
+++ b/support-frontend/app/services/RecaptchaService.scala
@@ -14,6 +14,7 @@ case class RecaptchaResponse(success: Boolean, score: Option[BigDecimal])
 object RecaptchaResponse {
   implicit val readsGetUserTypeResponse: Reads[RecaptchaResponse] = Json.reads[RecaptchaResponse]
   implicit val getUserTypeEncoder: Encoder[RecaptchaResponse] = deriveEncoder
+  val recaptchaFailedCode = "recaptcha_validation_failed"
 }
 
 class RecaptchaService(wsClient: WSClient)(implicit ec: ExecutionContext) extends SafeLogging {

--- a/support-frontend/assets/helpers/forms/errorReasons.ts
+++ b/support-frontend/assets/helpers/forms/errorReasons.ts
@@ -20,6 +20,7 @@ const errorReasons = [
 	'amazon_pay_fatal',
 	'email_provider_rejected',
 	'invalid_email_address',
+	'recaptcha_validation_failed',
 	'unknown',
 ] as const;
 function isErrorReason(value: string): value is ErrorReason {
@@ -79,6 +80,9 @@ function appropriateErrorMessage(errorReason: string): string {
 
 			case 'invalid_email_address':
 				return 'Please enter a valid email address';
+
+			case 'recaptcha_validation_failed':
+				return 'Please prove you are not a robot';
 		}
 	}
 	return 'The transaction was temporarily declined. Please try entering your payment details again. Alternatively, try another payment method.';


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR does a number of things:
- Adds recaptcha failure to the list of ignored alarms
- Fixes handling of error responses from the `/create` endpoint (CreateSubscriptionController.create) - previously these were not being handled, leaving the user with a never ending spinner
- Improve the logging of Identity errors to make it clear that they are from Identity