### PR TITLE
One Time Checkout: pre-selected amount from URL

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -136,6 +136,34 @@ function paymentMethodIsActive(paymentMethod: PaymentMethod) {
 	);
 }
 
+function getPreSelectedAmount(
+	preSelectedAmountParam: string | null,
+	amountChoices: number[],
+): {
+	preSelectedOtherAmount?: string;
+	preSelectedPriceCard?: number | 'other';
+} {
+	const preSelectedAmount = preSelectedAmountParam
+		? parseInt(preSelectedAmountParam, 10)
+		: undefined;
+
+	if (preSelectedAmount === undefined) {
+		return {
+			preSelectedOtherAmount: undefined,
+			preSelectedPriceCard: undefined,
+		};
+	}
+
+	const preSelectedPriceCard = amountChoices.includes(preSelectedAmount)
+		? preSelectedAmount
+		: 'other';
+
+	return {
+		preSelectedOtherAmount: preSelectedAmount.toString(),
+		preSelectedPriceCard,
+	};
+}
+
 export function OneTimeCheckout({ geoId, appConfig }: OneTimeCheckoutProps) {
 	const { currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 	const isTestUser = !!cookie.get('_test_username');
@@ -180,6 +208,9 @@ function OneTimeCheckoutComponent({
 	stripePublicKey,
 }: OneTimeCheckoutComponentProps) {
 	const { currency, currencyKey, countryGroupId } = getGeoIdConfig(geoId);
+	const urlSearchParams = new URLSearchParams(window.location.search);
+
+	const preSelectedAmountParam = urlSearchParams.get('contribution');
 
 	const user = appConfig.user;
 	const isSignedIn = !!user?.email;
@@ -197,17 +228,28 @@ function OneTimeCheckoutComponent({
 	const { amounts, defaultAmount, hideChooseYourAmount } =
 		amountsCardData['ONE_OFF'];
 
+	const { preSelectedPriceCard, preSelectedOtherAmount } = getPreSelectedAmount(
+		preSelectedAmountParam,
+		amounts,
+	);
+
 	const minAmount = config[countryGroupId]['ONE_OFF'].min;
 
-	const [amount, setAmount] = useState<number | 'other'>(defaultAmount);
-	const [otherAmount, setOtherAmount] = useState<string>('');
+	const [selectedPriceCard, setSelectedPriceCard] = useState<number | 'other'>(
+		preSelectedPriceCard ?? defaultAmount,
+	);
+
+	const [otherAmount, setOtherAmount] = useState<string>(
+		preSelectedOtherAmount ?? '',
+	);
+
 	const [otherAmountError, setOtherAmountError] = useState<string>();
 	const finalAmount =
-		amount === 'other'
+		selectedPriceCard === 'other'
 			? Number.isNaN(parseFloat(otherAmount))
 				? undefined
 				: parseFloat(otherAmount)
-			: amount;
+			: selectedPriceCard;
 
 	useEffect(() => {
 		if (finalAmount) {
@@ -400,10 +442,10 @@ function OneTimeCheckoutComponent({
 						<p css={standFirst}>Support us with the amount of your choice.</p>
 						<PriceCards
 							amounts={amounts}
-							selectedAmount={amount}
+							selectedAmount={selectedPriceCard}
 							currency={currencyKey}
 							onAmountChange={(amount: string) => {
-								setAmount(
+								setSelectedPriceCard(
 									amount === 'other' ? amount : Number.parseFloat(amount),
 								);
 							}}
@@ -412,7 +454,7 @@ function OneTimeCheckoutComponent({
 								<OtherAmount
 									currency={currencyKey}
 									minAmount={minAmount}
-									selectedAmount={amount}
+									selectedAmount={selectedPriceCard}
 									otherAmount={otherAmount}
 									onBlur={(event) => {
 										event.target.checkValidity(); // loose focus, onInvalid check fired


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Adds pre-selection of an amount card and "other amount" to the new one time checkout.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/uSm7lmme/1108-one-time-checkout-url-params)

## Why are you doing this?

For feature parity with the old one time checkout. And for the use case where a user is given the choice cards on the landing page (or possibly an epic). The pre-filled 'other' amount doesn't seem to be a use case at the moment but for parity with the old checkout it seems worth carrying over.
![image](https://github.com/user-attachments/assets/ecbd6535-6a26-414f-8365-ed58d3327ce7)

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Go to `uk/one-time-checkout` with no param. See default amount selected.

Go to `uk/one-time-checkout?contribution=30`. See 30 selected.

Go to `uk/one-time-checkout?contribution=35`. See "Other" amount selected and 35 pre-filled.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


## Screenshots

![image](https://github.com/user-attachments/assets/db20cf09-6f45-4eec-ba48-7b589c7f5c2c)

![image](https://github.com/user-attachments/assets/6317e527-9141-42ba-b527-db556f6775a3)
