### PR TITLE
One Time Checkout - AB Testing

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -8,7 +8,7 @@ import type { Tests } from './abtest';
 export const pageUrlRegexes = {
 	contributions: {
 		allLandingPagesAndThankyouPages:
-			'/checkout|contribute|thankyou|thank-you(/.*)?$',
+			'/checkout|one-time-checkout|contribute|thankyou|thank-you(/.*)?$',
 		notUkLandingPage: '/us|au|eu|int|nz|ca/contribute(/.*)?$',
 		notUsLandingPage: '/uk|au|eu|int|nz|ca/contribute(/.*)?$',
 		auLandingPage: '/au/contribute(/.*)?$',

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -147,4 +147,25 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: false,
 	},
+	newOneTimeCheckout: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		isActive: false,
+		referrerControlled: false, // ab-test name not needed to be in paramURL
+		seed: 4,
+		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+		excludeCountriesSubjectToContributionsOnlyAmounts: false,
+	},
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
@@ -62,12 +62,18 @@ const btnStyleOverrides = css`
 interface SupportOnceProps {
 	currency: string;
 	countryGroupId: CountryGroupId;
+	useNewOneTimeCheckout: boolean;
 }
 
 export function SupportOnce({
 	currency,
 	countryGroupId,
+	useNewOneTimeCheckout,
 }: SupportOnceProps): JSX.Element {
+	const checkoutUrlFragment = useNewOneTimeCheckout
+		? 'one-time-checkout'
+		: 'contribute/checkout?selected-contribution-type=one_off';
+
 	return (
 		<div css={container}>
 			<h2 css={heading}>Support us just once</h2>
@@ -77,7 +83,7 @@ export function SupportOnce({
 				{currency}1 or more.
 			</p>
 			<LinkButton
-				href={`/${countryGroups[countryGroupId].supportInternationalisationId}/contribute/checkout?selected-contribution-type=one_off`}
+				href={`/${countryGroups[countryGroupId].supportInternationalisationId}/${checkoutUrlFragment}`}
 				iconSide="left"
 				priority="primary"
 				size="default"

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -496,6 +496,9 @@ export function ThreeTierLanding({
 	const showNewspaperArchiveBanner =
 		abParticipations.newspaperArchiveBenefit === 'v2';
 
+	const useNewOneTimeCheckout =
+		abParticipations.newOneTimeCheckout === 'variant';
+
 	return (
 		<PageScaffold
 			header={
@@ -570,6 +573,7 @@ export function ThreeTierLanding({
 					<SupportOnce
 						currency={currencies[currencyId].glyph}
 						countryGroupId={countryGroupId}
+						useNewOneTimeCheckout={useNewOneTimeCheckout}
 					/>
 				</Container>
 			)}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Adding 

1.  An AB test for the new one time checkout (inactive)
2. Capability for AB tests on the checkout

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/1s1OSFLd/1039-generic-checkout-one-time-ab-test-setup)

## Why are you doing this?

Once its ready we'll launch an AB test of the new one time checkout vs the old. We also want other AB testing to be possible on the page.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Activate AB test, go to landing page and add `uk/contribute#ab-newOneTimeCheckout=variant` to the URL. Click the support just once CTA and see the new checkout.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Screenshots

Datalake showing labels and AB test participations 
![image](https://github.com/user-attachments/assets/3434cf11-285b-4df3-b7b3-2c8fccfebd3c)

