### PR TITLE
Log recaptcha error codes

### DIFF
--- a/support-frontend/app/actions/CustomActionBuilders.scala
+++ b/support-frontend/app/actions/CustomActionBuilders.scala
@@ -73,7 +73,7 @@ class CustomActionBuilders(
       val ignoreList = Set(
         emailProviderRejectedCode,
         invalidEmailAddressCode,
-        recaptchaFailedCode,
+        // recaptchaFailedCode, We want to be notified about recaptcha failures so we can check the logs
       )
       if (isNon200Result(result)) {
         if (!ignoreList.contains(result.header.reasonPhrase.getOrElse(""))) {

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -121,8 +121,8 @@ class CreateSubscriptionController(
         .subflatMap {
           case RecaptchaResponse(true, _) => Right(())
 
-          case RecaptchaResponse(false, _) =>
-            logErrorDetailedMessage("recaptcha failed")
+          case RecaptchaResponse(false, errorCodes) =>
+            logErrorDetailedMessage(s"recaptcha failed with error codes: ${errorCodes.getOrElse(Nil).mkString(", ")}")
             Left(RequestValidationError(RecaptchaResponse.recaptchaFailedCode))
         }
     } else {

--- a/support-frontend/app/services/RecaptchaService.scala
+++ b/support-frontend/app/services/RecaptchaService.scala
@@ -10,7 +10,7 @@ import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ExecutionContext, Future}
 
-case class RecaptchaResponse(success: Boolean, score: Option[BigDecimal])
+case class RecaptchaResponse(success: Boolean, `error-codes`: Option[List[String]])
 object RecaptchaResponse {
   implicit val readsGetUserTypeResponse: Reads[RecaptchaResponse] = Json.reads[RecaptchaResponse]
   implicit val getUserTypeEncoder: Encoder[RecaptchaResponse] = deriveEncoder
@@ -32,5 +32,8 @@ class RecaptchaService(wsClient: WSClient)(implicit ec: ExecutionContext) extend
         logger.error(scrub"Recaptcha failed on ${err.toString}")
         err.toString
       }
-      .subflatMap(resp => (resp.json).validate[RecaptchaResponse].asEither.leftMap(_.mkString(",")))
+      .subflatMap(resp => {
+        logger.info(s"Recaptcha response: ${resp.json}")
+        resp.json.validate[RecaptchaResponse].asEither.leftMap(_.mkString(","))
+      })
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Up until now we haven't been logging any [error codes returned from the Recaptcha service](https://developers.google.com/recaptcha/docs/verify#error_code_reference). As we are seeing regular checkout failures due to Recaptcha errors it makes sense to log these to see if there is a common theme.