### PR TITLE
Log exception on issues that prevent page rendering

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -193,7 +193,6 @@ export function Checkout({ geoId, appConfig }: Props) {
 	const product = productKey && productCatalog[productKey];
 	if (!product) {
 		logException('Product not found');
-
 		return <div>Product not found</div>;
 	}
 
@@ -212,7 +211,6 @@ export function Checkout({ geoId, appConfig }: Props) {
 	const ratePlan = ratePlanKey && product.ratePlans[ratePlanKey];
 	if (!ratePlan) {
 		logException('Rate plan not found');
-
 		return <div>Rate plan not found</div>;
 	}
 
@@ -250,7 +248,6 @@ export function Checkout({ geoId, appConfig }: Props) {
 		 */
 		if (!contributionAmount) {
 			logException('Contribution not specified');
-
 			return <div>Contribution not specified</div>;
 		}
 
@@ -267,7 +264,6 @@ export function Checkout({ geoId, appConfig }: Props) {
 
 		if (!productPrice) {
 			logException('Price not found in product catalog');
-
 			return <div>Price not found in product catalog</div>;
 		}
 

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -192,6 +192,8 @@ export function Checkout({ geoId, appConfig }: Props) {
 		productParam && isProductKey(productParam) ? productParam : undefined;
 	const product = productKey && productCatalog[productKey];
 	if (!product) {
+		logException('Product not found');
+
 		return <div>Product not found</div>;
 	}
 
@@ -209,6 +211,8 @@ export function Checkout({ geoId, appConfig }: Props) {
 			: undefined;
 	const ratePlan = ratePlanKey && product.ratePlans[ratePlanKey];
 	if (!ratePlan) {
+		logException('Rate plan not found');
+
 		return <div>Rate plan not found</div>;
 	}
 
@@ -245,6 +249,8 @@ export function Checkout({ geoId, appConfig }: Props) {
 		 * @see https://support.gutools.co.uk/amounts
 		 */
 		if (!contributionAmount) {
+			logException('Contribution not specified');
+
 			return <div>Contribution not specified</div>;
 		}
 
@@ -260,6 +266,8 @@ export function Checkout({ geoId, appConfig }: Props) {
 				: undefined;
 
 		if (!productPrice) {
+			logException('Price not found in product catalog');
+
 			return <div>Price not found in product catalog</div>;
 		}
 

--- a/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thank-you.tsx
@@ -4,6 +4,7 @@ import { isProductKey, productCatalog } from 'helpers/productCatalog';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { getPromotion } from 'helpers/productPrice/promotions';
+import { logException } from 'helpers/utilities/logger';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
 import { ThankYouComponent } from './components/thankyou';
 
@@ -54,9 +55,11 @@ export function ThankYou({ geoId, appConfig }: ThankYouProps) {
 	} else {
 		/** Recurring product must have product & ratePlan */
 		if (!product) {
+			logException('Product not found');
 			return <div>Product not found</div>;
 		}
 		if (!ratePlan) {
+			logException('Rate plan not found');
 			return <div>Rate plan not found</div>;
 		}
 


### PR DESCRIPTION
## What are you doing in this PR?

There are certain pieces of core product info that are required in the querystring params in order to render the generic checkout and thank-you page. If they're not present the client renders an almost entirely blank screen with a simple message, which won't mean much to users but indicates the problem.

This PR introduces some Sentry logging so we can be aware of if these issues are occurring, as right now we don't have this visibility.

