### PR TITLE
Change BigQuery loglevel

### DIFF
--- a/support-lambdas/bigquery-acquisitions-publisher/src/main/resources/logback.xml
+++ b/support-lambdas/bigquery-acquisitions-publisher/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
         </encoder>
     </appender>
 
-    <logger name="com.google.cloud.bigquery" level="WARN"/>
+    <logger name="com.google.cloud" level="WARN"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/support-lambdas/bigquery-acquisitions-publisher/src/main/resources/logback.xml
+++ b/support-lambdas/bigquery-acquisitions-publisher/src/main/resources/logback.xml
@@ -5,6 +5,8 @@
         </encoder>
     </appender>
 
+    <logger name="com.google.cloud.bigquery" level="WARN"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>


### PR DESCRIPTION
There's an INFO log from the BigQuery library with an "error":
<img width="1167" alt="Screenshot 2024-10-03 at 10 24 28" src="https://github.com/user-attachments/assets/493dd6f4-d5a0-470d-86eb-2ace389acc23">

This isn't actually causing any issues - we are writing successfully to BigQuery.
The log occurs when the StreamWriter is closed:
https://github.com/googleapis/java-bigquerystorage/blob/main/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/StreamConnection.java#L94
This library reports the status info in the form of exceptions, which is quite strange. The exception is then logged at INFO level.