### PR TITLE
Generic checkout: fix paypal button load after validating form

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -1750,11 +1750,14 @@ function CheckoutComponent({
 
 											/** And then run it on form change */
 											formRef.current?.addEventListener('change', (event) => {
-												const valid =
-													// TODO - we shouldn't have to type infer here
-													(
-														event.currentTarget as HTMLFormElement
-													).checkValidity();
+												const element = event.currentTarget as HTMLFormElement;
+												/* We call this twice because the first time does not
+                           not give us an accurate state of the form.
+                           This seems to be because we use `setCustomValidity` on the elements
+                        */
+												element.checkValidity();
+												const valid = element.checkValidity();
+
 												if (valid) {
 													enable();
 												} else {
@@ -1766,7 +1769,7 @@ function CheckoutComponent({
 											disallowed: [window.paypal.FUNDING.CREDIT],
 										}}
 										onClick={() => {
-											// TODO
+											// TODO - add tracking
 										}}
 										/** the order is Button.payment(opens PayPal window).then(Button.onAuthorize) */
 										payment={(resolve, reject) => {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Fixing the PayPal button enabling after the form has been completed and validation passes. We're having to workaround the fact that calling `checkValidity` on the form returns `false` even when the form is correctly filled out, this appears to be because we're using `setCustomValidity`. The solution is to call `checkValidity` a second time and use that result.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/xt6Ikhcy/1093-generic-checkout-paypal-client-side-validation)

## Why are you doing this?

Previously a bug occurred where the button was disabled even after filling in the form.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

1.  Go to any tier of the generic checkout eg. Tier 1: https://support.thegulocal.com/uk/checkout?product=Contribution&ratePlan=Monthly&contribution=3
2. Skip the required fields: Email, first name and last name and select the Paypal Payment Method.
3. At the point we render the Paypal Payment button, but also render the client-side validation errors. Click the blue Paypal button, nothing happens.
4. Fix the client-side validation errors by completing the email, first name and last name, and click the blue Paypal button, a popup appears.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

