### PR TITLE
Supress ProductCatalogService logging

### DIFF
--- a/support-frontend/app/services/ProductCatalogService.scala
+++ b/support-frontend/app/services/ProductCatalogService.scala
@@ -21,6 +21,7 @@ trait ProductCatalogService extends WebServiceHelper[ProductCatalogServiceError]
   val client: FutureHttpClient
   override val wsUrl: String
   override val httpClient: FutureHttpClient = client
+  override val verboseLogging: Boolean = false
 
   def get(): Future[JsonObject] = {
     get[JsonObject](endpoint = "product-catalog.json")
@@ -55,7 +56,7 @@ class CachedProductCatalogServiceProvider(
     codeCachedProductCatalogService: CachedProductCatalogService,
     prodCachedProductCatalogService: CachedProductCatalogService,
 ) {
-  def fromStage(stage: Stage, isTestUser: Boolean) =
+  def fromStage(stage: Stage, isTestUser: Boolean): CachedProductCatalogService =
     if (stage == DEV || stage == CODE || isTestUser)
       codeCachedProductCatalogService
     else prodCachedProductCatalogService


### PR DESCRIPTION
The ProductCatalogService polls the product catalog api once a minute to retrieve the latest version. As each request logs the request details and the full response, it quickly fills up the logs with identical messages. This can be particularly annoying when running the site locally as log files can quickly reach multiple megabytes in size making them hard to open and scan in an editor.

This PR allows WebServiceHelper derived classes (which ProductCatalogService is) to switch off verbose logging, and does switch them off for the ProductCatalogService.
