### PR TITLE
Persist landing page test tracking

### DIFF
--- a/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
@@ -19,7 +19,6 @@ import {
 } from '../../internationalisation/countryGroup';
 import { _, init as abInit, getAmountsTestVariant } from '../abtest';
 import type { Audience, Participations, Test, Variant } from '../abtest';
-import {storage} from "@guardian/libs";
 
 const { targetPageMatches } = _;
 const { subsDigiSubPages, digiSub } = pageUrlRegexes.subscriptions;
@@ -52,7 +51,7 @@ describe('init', () => {
 
 	afterEach(() => {
 		window.localStorage.clear();
-    window.sessionStorage.clear();
+		window.sessionStorage.clear();
 	});
 
 	it('assigns a user to a variant', () => {
@@ -403,110 +402,87 @@ describe('init', () => {
 		});
 	});
 
-  describe('path matching', () => {
-    beforeEach(() => {
-      window.sessionStorage.clear();
-      delete window.location;
-      Object.defineProperty(window, 'location', {
-        value: {
-          // href: 'https://support.theguardian.com/uk/contribute',
-          // pathname: '/uk/contribute'
-        },
-      });
-    });
+	describe('path matching', () => {
+		beforeEach(() => {
+			window.sessionStorage.clear();
+		});
 
-    it('does not assign to test if targetPage does not match', () => {
-      Object.defineProperty(window, 'location', {
-        value: {
-          href: 'https://support.theguardian.com/uk/contribute',
-          pathname: '/uk/contribute'
-        },
-      });
+		it('does not assign to test if targetPage does not match', () => {
+			const abTests = {
+				t1: buildTest({
+					targetPage: '/us/contribute$',
+				}),
+			};
 
-      const abTests = {
-        t1: buildTest({
-          targetPage: '/us/contribute$',
-        }),
-      };
+			const participations: Participations = abInit({
+				...abtestInitalizerData,
+				abTests,
+				path: '/uk/contribute',
+			});
 
-      const participations: Participations = abInit({
-        ...abtestInitalizerData,
-        abTests,
-      });
+			expect(participations).toEqual({});
+		});
 
-      expect(participations).toEqual({});
-    });
+		it('assign to test if targetPage matches', () => {
+			const abTests = {
+				t1: buildTest({
+					targetPage: '/uk/contribute$',
+				}),
+			};
 
-    it('assign to test if targetPage matches', () => {
-      Object.defineProperty(window, 'location', {
-        value: {
-          href: 'https://support.theguardian.com/uk/contribute',
-          pathname: '/uk/contribute'
-        },
-      });
+			const participations: Participations = abInit({
+				...abtestInitalizerData,
+				abTests,
+				path: '/uk/contribute',
+			});
 
-      const abTests = {
-        t1: buildTest({
-          targetPage: '/uk/contribute$',
-        }),
-      };
+			expect(participations).toEqual({ t1: 'control' });
+		});
 
-      const participations: Participations = abInit({
-        ...abtestInitalizerData,
-        abTests,
-      });
+		it('assign to test if persistPage matches and test is in session storage', () => {
+			window.sessionStorage.setItem(
+				'abParticipations',
+				JSON.stringify({ t1: 'control' }),
+			);
 
-      expect(participations).toEqual({ t1: 'control' });
-    });
+			const abTests = {
+				t1: buildTest({
+					targetPage: '/uk/contribute$',
+					persistPage: '/uk/checkout$',
+				}),
+			};
 
-    it('assign to test if persistPage matches and test is in session storage', () => {
-      window.sessionStorage.setItem('abParticipations', JSON.stringify({t1: 'control'}));
-      Object.defineProperty(window, 'location', {
-        value: {
-          href: 'https://support.theguardian.com/uk/checkout',
-          pathname: '/uk/checkout'
-        },
-      });
+			const participations: Participations = abInit({
+				...abtestInitalizerData,
+				abTests,
+				path: '/uk/checkout',
+			});
 
-      const abTests = {
-        t1: buildTest({
-          targetPage: '/uk/contribute$',
-          persistPage: '/uk/checkout$',
-        }),
-      };
+			expect(participations).toEqual({ t1: 'control' });
+		});
 
-      const participations: Participations = abInit({
-        ...abtestInitalizerData,
-        abTests,
-      });
+		it('does not assign to test if persistPage does not match and test is in session storage', () => {
+			window.sessionStorage.setItem(
+				'abParticipations',
+				JSON.stringify({ t1: 'control' }),
+			);
 
-      expect(participations).toEqual({ t1: 'control' });
-    });
+			const abTests = {
+				t1: buildTest({
+					targetPage: '/uk/contribute$',
+					persistPage: '/uk/checkout$',
+				}),
+			};
 
-    it('does not assign to test if persistPage does not match and test is in session storage', () => {
-      window.sessionStorage.setItem('abParticipations', JSON.stringify({t1: 'control'}));
-      Object.defineProperty(window, 'location', {
-        value: {
-          href: 'https://support.theguardian.com/uk/blah',
-          pathname: '/uk/blah'
-        },
-      });
+			const participations: Participations = abInit({
+				...abtestInitalizerData,
+				abTests,
+				path: '/uk/blah',
+			});
 
-      const abTests = {
-        t1: buildTest({
-          targetPage: '/uk/contribute$',
-          persistPage: '/uk/checkout$',
-        }),
-      };
-
-      const participations: Participations = abInit({
-        ...abtestInitalizerData,
-        abTests,
-      });
-
-      expect(participations).toEqual({ });
-    });
-  });
+			expect(participations).toEqual({});
+		});
+	});
 });
 
 it('targetPage matching', () => {
@@ -912,8 +888,8 @@ function buildTest({
 	seed = 0,
 	excludeIfInReferrerControlledTest = false,
 	excludeCountriesSubjectToContributionsOnlyAmounts = true,
-  targetPage = undefined,
-  persistPage = undefined,
+	targetPage = undefined,
+	persistPage = undefined,
 }: Partial<Test>): Test {
 	return {
 		variants,
@@ -923,8 +899,8 @@ function buildTest({
 		seed,
 		excludeIfInReferrerControlledTest,
 		excludeCountriesSubjectToContributionsOnlyAmounts,
-    targetPage,
-    persistPage,
+		targetPage,
+		persistPage,
 	};
 }
 

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -102,6 +102,7 @@ type ABtestInitalizerData = {
 	abTests?: Tests;
 	mvt?: number;
 	acquisitionDataTests?: AcquisitionABTest[];
+	path?: string;
 };
 
 function init({
@@ -111,6 +112,7 @@ function init({
 	abTests = tests,
 	mvt = getMvtId(),
 	acquisitionDataTests = getTestFromAcquisitionData() ?? [],
+	path = window.location.pathname,
 }: ABtestInitalizerData): Participations {
 	const sessionParticipations = getParticipationsFromSession();
 	const participations = getParticipations(
@@ -118,6 +120,7 @@ function init({
 		mvt,
 		countryId,
 		countryGroupId,
+		path,
 		acquisitionDataTests,
 		selectedAmountsVariant,
 		sessionParticipations,
@@ -160,6 +163,7 @@ function getParticipations(
 	mvtId: number,
 	country: IsoCountry,
 	countryGroupId: CountryGroupId,
+	path: string,
 	acquisitionDataTests?: AcquisitionABTest[],
 	selectedAmountsVariant?: SelectedAmountsVariant,
 	sessionParticipations: Participations = {},
@@ -180,19 +184,15 @@ function getParticipations(
 		}
 
 		// Is the user already in this test in the current browser session?
-    console.log('pathname', window.location.pathname)
-    console.log('target', test.targetPage)
-    console.log('persist', test.persistPage)
-    console.log('window.sessionStorage', window.sessionStorage.getItem('abParticipations'))
 		if (
 			!!sessionParticipations[testId] &&
-			targetPageMatches(window.location.pathname, test.persistPage)
+			targetPageMatches(path, test.persistPage)
 		) {
 			participations[testId] = sessionParticipations[testId];
 			return;
 		}
 
-		if (!targetPageMatches(window.location.pathname, test.targetPage)) {
+		if (!targetPageMatches(path, test.targetPage)) {
 			return;
 		}
 

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -8,6 +8,7 @@ import type { Settings } from 'helpers/globalsAndSwitches/settings';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import * as cookie from 'helpers/storage/cookie';
+import * as storage from 'helpers/storage/storage';
 import { getQueryParameter } from 'helpers/urls/url';
 import type {
 	AmountsTest,
@@ -109,6 +110,7 @@ function init({
 	mvt = getMvtId(),
 	acquisitionDataTests = getTestFromAcquisitionData() ?? [],
 }: ABtestInitalizerData): Participations {
+	const sessionParticipations = getParticipationsFromSession();
 	const participations = getParticipations(
 		abTests,
 		mvt,
@@ -120,6 +122,7 @@ function init({
 	const urlParticipations = getParticipationsFromUrl();
 	const serverSideParticipations = getServerSideParticipations();
 	return {
+		...sessionParticipations,
 		...participations,
 		...serverSideParticipations,
 		...urlParticipations,
@@ -235,6 +238,21 @@ function getParticipationsFromUrl(): Participations | undefined {
 	}
 
 	return;
+}
+
+function getParticipationsFromSession(): Participations | undefined {
+	const participations = storage.getSession('abParticipations');
+	if (participations) {
+		try {
+			return JSON.parse(participations) as Participations;
+		} catch (error) {
+			console.error(
+				'Failed to parse abParticipations from session storage',
+				error,
+			);
+			return undefined;
+		}
+	}
 }
 
 function getServerSideParticipations(): Participations | null | undefined {

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -270,6 +270,7 @@ function getParticipationsFromSession(): Participations | undefined {
 			return undefined;
 		}
 	}
+	return undefined;
 }
 
 function getServerSideParticipations(): Participations | null | undefined {

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -13,8 +13,6 @@ export const pageUrlRegexes = {
 		notUsLandingPage: '/uk|au|eu|int|nz|ca/contribute(/.*)?$',
 		auLandingPage: '/au/contribute(/.*)?$',
 		usLandingPage: '/us/contribute(/.*)?$',
-		landingPageOnly: '/(uk|us|au|eu|int|nz|ca)/contribute$',
-		ukCheckout: '/uk/checkout$',
 	},
 	subscriptions: {
 		subsDigiSubPages: '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)',
@@ -172,25 +170,5 @@ export const tests: Tests = {
 		seed: 4,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: false,
-	},
-	landingPageOnlyTest: {
-		variants: [
-			// not really an AB test
-			{
-				id: 'variant',
-			},
-		],
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		isActive: true,
-		referrerControlled: false,
-		seed: 6,
-		targetPage: pageUrlRegexes.contributions.landingPageOnly,
-		persistPage: pageUrlRegexes.contributions.ukCheckout,
-		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -13,6 +13,8 @@ export const pageUrlRegexes = {
 		notUsLandingPage: '/uk|au|eu|int|nz|ca/contribute(/.*)?$',
 		auLandingPage: '/au/contribute(/.*)?$',
 		usLandingPage: '/us/contribute(/.*)?$',
+		landingPageOnly: '/(uk|us|au|eu|int|nz|ca)/contribute$',
+		ukCheckout: '/uk/checkout$',
 	},
 	subscriptions: {
 		subsDigiSubPages: '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)',
@@ -170,5 +172,25 @@ export const tests: Tests = {
 		seed: 4,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: false,
+	},
+	landingPageOnlyTest: {
+		variants: [
+			// not really an AB test
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		isActive: true,
+		referrerControlled: false,
+		seed: 6,
+		targetPage: pageUrlRegexes.contributions.landingPageOnly,
+		persistPage: pageUrlRegexes.contributions.ukCheckout,
+		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -47,6 +47,7 @@ import {
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { getPromotion } from 'helpers/productPrice/promotions';
+import * as storage from 'helpers/storage/storage';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
 import { getCampaignSettings } from '../../../helpers/campaigns/campaigns';
@@ -285,6 +286,8 @@ export function ThreeTierLanding({
 	};
 
 	const abParticipations = abTestInit({ countryId, countryGroupId });
+	// Persist any tests for tracking in the checkout page
+	storage.setSession('abParticipations', JSON.stringify(abParticipations));
 
 	const campaignSettings = getCampaignSettings(countryGroupId);
 


### PR DESCRIPTION
Currently, if an AB test is targeted specifically at the landing page then the tracking doesn't carry through to the checkout. This means it doesn't get included in the acquisition event.

This PR fixes this by changing the landing page to add the AB test participations to session storage.
Subsequent pages will then pick up participations from session storage.
This is limited by the new `persistPage` field on the AB test model. A page will only pick up participations from session storage if `persistPage` matches the current path.