### PR TITLE
Make whole payment radio area clickable

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -1561,7 +1561,12 @@ function CheckoutComponent({
 										<PaymentMethodSelector selected={selected}>
 											<PaymentMethodRadio selected={selected}>
 												<Radio
-													label={label}
+													label={
+														<>
+															{label}
+															<div>{icon}</div>
+														</>
+													}
 													name="paymentMethod"
 													value={validPaymentMethod}
 													css={
@@ -1573,7 +1578,6 @@ function CheckoutComponent({
 														setPaymentMethod(validPaymentMethod);
 													}}
 												/>
-												<div>{icon}</div>
 											</PaymentMethodRadio>
 											{validPaymentMethod === 'Stripe' && selected && (
 												<div css={paymentMethodBody}>

--- a/support-frontend/assets/pages/[countryGroupId]/components/paymentMethod.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/paymentMethod.tsx
@@ -3,12 +3,18 @@ import { palette, space } from '@guardian/source/foundations';
 import type { ReactNode } from 'react';
 
 const paymentMethodRadioWithImage = css`
-	display: inline-flex;
-	justify-content: space-between;
-	align-items: center;
-	width: 100%;
 	padding: ${space[2]}px ${space[3]}px;
-	font-weight: bold;
+
+	div label {
+		width: 100%;
+	}
+
+	div label > div {
+		display: inline-flex;
+		justify-content: space-between;
+		align-items: center;
+		font-weight: bold;
+	}
 `;
 
 const paymentMethodRadioWithImageSelected = css`

--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -658,7 +658,11 @@ function OneTimeCheckoutComponent({
 										<PaymentMethodSelector selected={selected}>
 											<PaymentMethodRadio selected={selected}>
 												<Radio
-													label={label}
+													label={
+														<>
+															{label} <div>{icon}</div>
+														</>
+													}
 													name="paymentMethod"
 													value={validPaymentMethod}
 													css={
@@ -670,7 +674,6 @@ function OneTimeCheckoutComponent({
 														setPaymentMethod(validPaymentMethod);
 													}}
 												/>
-												<div>{icon}</div>
 											</PaymentMethodRadio>
 											{validPaymentMethod === 'Stripe' && selected && (
 												<div css={paymentMethodBody}>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Making the entire payment method label clickable in the payment selection radio group. 

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments. Previously on the generic checkout only the label text was clickable.
-->

[**Trello Card**](https://trello.com/c/EaD6HHGx/1128-checkout-payment-selector-selection-beyond-radio-button)

## Why are you doing this?

Before only the label of the text selected the radio, which isn't a great user experience.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Go to generic checkout, hover over icon area of payment method - cursor is a pointer and clicking selects that box.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots

Before
<img width="746" alt="image" src="https://github.com/user-attachments/assets/149147d3-4584-481b-8662-0c794dc5092c">

After
<img width="742" alt="image" src="https://github.com/user-attachments/assets/f00551e4-4660-4bd8-a704-0becef589860">

