### PR TITLE
try google chrome lhci

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,0 +1,19 @@
+name: Lighthouse CI
+on:
+  push
+  # workflow_dispatch:
+  # pull_request:
+  #   types: [labeled] # Only run when a PR is labeled with the 'Seen-on-PROD' label set by prout
+jobs:
+  Lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.11.0
+      - name: run Lighthouse CI
+        run: |
+          yarn install -g @lhci/cli@0.14.x
+          lhci autorun

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -15,5 +15,5 @@ jobs:
           node-version: 20.11.0
       - name: run Lighthouse CI
         run: |
-          yarn install -g @lhci/cli@0.14.x
+          yarn global add @lhci/cli@0.14.x
           lhci autorun

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  ci: {
+    upload: {
+      target: "temporary-public-storage",
+    },
+    collect: {
+      url: "https://support.theguardian.com/uk/contribute",
+      method: "psi",
+    },
+  },
+};

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -6,6 +6,7 @@ module.exports = {
     collect: {
       url: "https://support.theguardian.com/uk/contribute",
       method: "psi",
+      psiApiKey: "",
     },
   },
 };


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Tried to implement https://github.com/GoogleChrome/lighthouse-ci - but it requires an API key to use pagespeedinsights on a real URL, rather than against a locally running site.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/rZDwH4l3/1102-spike-page-speed-github-actions)
