### PR TITLE
Suppress client-side validation on state field when Google Pay used

### DIFF
--- a/support-frontend/assets/components/personalDetails/stateSelect.tsx
+++ b/support-frontend/assets/components/personalDetails/stateSelect.tsx
@@ -17,6 +17,7 @@ type StateSelectProps = {
 	onBlur?: FormEventHandler<HTMLSelectElement>;
 	onInvalid?: FormEventHandler<HTMLSelectElement>;
 	error?: string;
+	optional?: boolean;
 };
 
 const stateDescriptors: Partial<Record<CountryGroupId, string>> = {
@@ -38,6 +39,7 @@ export function StateSelect({
 	onBlur,
 	onInvalid,
 	error,
+	optional,
 }: StateSelectProps): JSX.Element | null {
 	const countryGroupId = CountryGroup.fromCountry(countryId);
 	const statesList = (countryGroupId ? stateLists[countryGroupId] : {}) ?? {};
@@ -55,7 +57,7 @@ export function StateSelect({
 				onInvalid={onInvalid}
 				error={error}
 				name={'billing-state'}
-				required
+				required={!optional}
 				cssOverrides={
 					/**
 					 * Source applies a red border initially unlike textInput's

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -1352,6 +1352,7 @@ function CheckoutComponent({
 											}
 										}}
 										error={billingStateError}
+										optional={paymentMethod === 'StripeExpressCheckoutElement'}
 									/>
 								)}
 							{countryId === 'US' && !productDescription.deliverableTo && (

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -1352,7 +1352,7 @@ function CheckoutComponent({
 											}
 										}}
 										error={billingStateError}
-										optional={paymentMethod === 'StripeExpressCheckoutElement'}
+										optional={stripeExpressCheckoutPaymentType === 'google_pay'}
 									/>
 								)}
 							{countryId === 'US' && !productDescription.deliverableTo && (


### PR DESCRIPTION
## What are you doing in this PR?

If you try and checkout in the US, CA, AUS (where Billing State is mandatory) using Stripe Express Component Element & a card registered in a country without Billing State then the checkout fails, the existing client-side validation blocks the submission, however the UX is poor, particularly with Google Pay. With Google Pay the modal just hangs in a "processing state". Behind the modal the Billing State field shows a client-side validation message (see screen grab below). Also unless you're on desktop the validation error on the Billing State field is below the fold, which makes it even less visible.

I've tested with Apple Pay too, and the modal closes with a payment failure message, which is better, although the Billing State field is still below the gold on most mobile devices, so the error that caused the failure is not. immediately apparent, so it's not perfect.

Logs show ~10 people a day experience this error.

A firs pass at fixing this is to remove the client-side validation on the Billing State for Google Pay **only**. This has improved things slightly in terms of UX as the modal closes without getting stuck in a processing state, however issues with it include:

1. The form allows a submission to the server, which returns a validation error, however the validation error shown to the user does indicate the Billing State is the cause of the error.
2. A user would need to scroll to the bottom of the form to see the validation error message.
3. Sending a request to the server with invalid data causes the server to catch the error which will result in an `/create` end point alarm, this could be very noisey!

[Trello](https://trello.com/c/m7sc3Ubk/1127-apple-google-pay-mandatory-state-blocking-checkouts)

## Screenshots

Paying with a UK registered Google Pay card without a state on the US checkout where state is required.

###  Before

The Google Pay modal hangs without ever closing, with no indication why it failed...

https://github.com/user-attachments/assets/f5f15d6e-85bf-42e2-b7e1-5fdcf187f030

###  After

The Google Pay modal closes, however the error message is not on the Billing State field, and the server side validation error message is only visible if a user scrolls to the end of the form, and the error message is not helpful.

https://github.com/user-attachments/assets/1d406794-1b22-4a89-8dc5-a12cf250ea60



