### PR TITLE
Fix build: use setup-sbt action

### DIFF
--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - uses: sbt/setup-sbt@v1
       - name: Setup Node for CDK
         uses: actions/setup-node@v4
         with:
@@ -48,6 +47,8 @@ jobs:
         with:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
+
+      - uses: sbt/setup-sbt@v1
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - uses: sbt/setup-sbt@v1
       - name: Setup Node for CDK
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/stripe-patrons-data.yml
+++ b/.github/workflows/stripe-patrons-data.yml
@@ -37,6 +37,8 @@ jobs:
         run: ./script/ci
         working-directory: cdk
 
+      - uses: sbt/setup-sbt@v1
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -63,6 +63,8 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
+      - uses: sbt/setup-sbt@v1
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/support-lambdas-build.yml
+++ b/.github/workflows/support-lambdas-build.yml
@@ -46,6 +46,8 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
+      - uses: sbt/setup-sbt@v1
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/support-workers-build.yml
+++ b/.github/workflows/support-workers-build.yml
@@ -46,6 +46,8 @@ jobs:
         run: yarn run build-cfn
         working-directory: support-workers/cloud-formation/src
 
+      - uses: sbt/setup-sbt@v1
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/supporter-product-data.yml
+++ b/.github/workflows/supporter-product-data.yml
@@ -34,6 +34,8 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
+      - uses: sbt/setup-sbt@v1
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

We've had several Scala builds fail  with the message `sbt: command not found`. It turns out the latest Ubuntu image doesn't have SBT available by default. 22.04 (the previous version) did, but 24.04 doesn't: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md. Using the `setup-sbt` action seems to fix the problem.
