### PR TITLE
Assign payment-api alarms to Portfolio team

### DIFF
--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -175,7 +175,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":contributions-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -658,7 +658,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":contributions-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -953,7 +953,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":contributions-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -1023,7 +1023,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":contributions-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -1080,7 +1080,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":reader-revenue-24-7",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -1138,7 +1138,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":contributions-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -1195,7 +1195,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":reader-revenue-24-7",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -1312,7 +1312,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":contributions-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -1369,7 +1369,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":contributions-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -1603,7 +1603,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":contributions-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },
@@ -1660,7 +1660,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":contributions-dev",
+                ":alarms-handler-topic-PROD",
               ],
             ],
           },

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -282,7 +282,7 @@ export class PaymentApi extends GuStack {
       comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
       metric: new Metric({
         metricName: "payment-success",
-        namespace: "support-payment-api-PROD",
+        namespace: `support-payment-api-${this.stage}`,
         dimensionsMap: {
           "payment-provider": "Paypal",
         },
@@ -304,7 +304,7 @@ export class PaymentApi extends GuStack {
       comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
       metric: new Metric({
         metricName: "payment-success",
-        namespace: "support-payment-api-PROD",
+        namespace: `support-payment-api-${this.stage}`,
         dimensionsMap: {
           "payment-provider": "Stripe",
         },
@@ -324,7 +324,7 @@ export class PaymentApi extends GuStack {
       comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
       metric: new Metric({
         metricName: "payment-success",
-        namespace: "support-payment-api-PROD",
+        namespace: `support-payment-api-${this.stage}`,
         dimensionsMap: {
           "payment-provider": "Paypal",
         },
@@ -344,7 +344,7 @@ export class PaymentApi extends GuStack {
       comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
       metric: new Metric({
         metricName: "payment-success",
-        namespace: "support-payment-api-PROD",
+        namespace: `support-payment-api-${this.stage}`,
         dimensionsMap: {
           "payment-provider": "Stripe",
         },
@@ -364,7 +364,7 @@ export class PaymentApi extends GuStack {
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
       metric: new Metric({
         metricName: "payment-error",
-        namespace: "support-payment-api-PROD",
+        namespace: `support-payment-api-${this.stage}`,
         dimensionsMap: {
           "payment-provider": "Paypal",
         },
@@ -384,7 +384,7 @@ export class PaymentApi extends GuStack {
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
       metric: new Metric({
         metricName: "payment-error",
-        namespace: "support-payment-api-PROD",
+        namespace: `support-payment-api-${this.stage}`,
         dimensionsMap: {
           "payment-provider": "Stripe",
         },
@@ -404,7 +404,7 @@ export class PaymentApi extends GuStack {
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
       metric: new Metric({
         metricName: "payment-error",
-        namespace: "support-payment-api-PROD",
+        namespace: `support-payment-api-${this.stage}`,
         dimensionsMap: {
           "payment-provider": "AmazonPay",
         },
@@ -441,7 +441,7 @@ export class PaymentApi extends GuStack {
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
       metric: new Metric({
         metricName: "stripe-rate-limit-exceeded",
-        namespace: "support-payment-api-PROD",
+        namespace: `support-payment-api-${this.stage}`,
         dimensionsMap: {
           "payment-provider": "Stripe",
         },

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -248,7 +248,7 @@ export class PaymentApi extends GuStack {
         statistic: "Average",
         period: Duration.seconds(60),
       }),
-      snsTopicName: "contributions-dev",
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
     });
 
     new GuAlarm(this, "High5XXRateAlarm", {
@@ -268,7 +268,7 @@ export class PaymentApi extends GuStack {
         statistic: "Sum",
         period: Duration.seconds(60),
       }),
-      snsTopicName: "contributions-dev",
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
     });
 
     new GuAlarm(this, "NoPaypalPaymentsInTwoHours247Alarm", {
@@ -290,7 +290,7 @@ export class PaymentApi extends GuStack {
         period: Duration.seconds(600),
       }),
       treatMissingData: TreatMissingData.BREACHING,
-      snsTopicName: "reader-revenue-24-7",
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
     });
 
     new GuAlarm(this, "NoStripePaymentsInThreeHours247Alarm", {
@@ -312,7 +312,7 @@ export class PaymentApi extends GuStack {
         period: Duration.seconds(900),
       }),
       treatMissingData: TreatMissingData.BREACHING,
-      snsTopicName: "reader-revenue-24-7",
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
     });
 
     new GuAlarm(this, "NoPaypalPaymentsInOneHourAlarm", {
@@ -332,7 +332,7 @@ export class PaymentApi extends GuStack {
         period: Duration.seconds(300),
       }),
       treatMissingData: TreatMissingData.BREACHING,
-      snsTopicName: "contributions-dev",
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
     });
 
     new GuAlarm(this, "NoStripePaymentsInOneHourAlarm", {
@@ -352,7 +352,7 @@ export class PaymentApi extends GuStack {
         period: Duration.seconds(300),
       }),
       treatMissingData: TreatMissingData.BREACHING,
-      snsTopicName: "contributions-dev",
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
     });
 
     new GuAlarm(this, "PaypalPaymentError", {
@@ -372,7 +372,7 @@ export class PaymentApi extends GuStack {
         period: Duration.seconds(60),
       }),
       treatMissingData: TreatMissingData.NOT_BREACHING,
-      snsTopicName: "contributions-dev",
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
     });
 
     new GuAlarm(this, "StripePaymentError", {
@@ -392,7 +392,7 @@ export class PaymentApi extends GuStack {
         period: Duration.seconds(60),
       }),
       treatMissingData: TreatMissingData.NOT_BREACHING,
-      snsTopicName: "contributions-dev",
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
     });
 
     new GuAlarm(this, "AmazonPayPaymentError", {
@@ -412,7 +412,7 @@ export class PaymentApi extends GuStack {
         period: Duration.seconds(60),
       }),
       treatMissingData: TreatMissingData.NOT_BREACHING,
-      snsTopicName: "contributions-dev",
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
     });
 
     new GuAlarm(this, "PostPaymentError", {
@@ -429,7 +429,7 @@ export class PaymentApi extends GuStack {
         period: Duration.seconds(60),
       }),
       treatMissingData: TreatMissingData.NOT_BREACHING,
-      snsTopicName: "contributions-dev",
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
     });
 
     new GuAlarm(this, "StripeRateLimitingAlarm", {
@@ -449,7 +449,7 @@ export class PaymentApi extends GuStack {
         period: Duration.seconds(900),
       }),
       treatMissingData: TreatMissingData.NOT_BREACHING,
-      snsTopicName: "contributions-dev",
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
     });
   }
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
The Portfolio team is responsible for payment-api alarms as per this spreadsheet: https://docs.google.com/spreadsheets/d/1bb8WB-6ZFRdUwERHMOVIolN8WU8zJMcsyi-WJuwp07Q/edit?gid=0#gid=0