### PR TITLE
Revert "AB test Amazon Pay"

### DIFF
--- a/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
+++ b/support-frontend/assets/components/paymentMethodSelector/PaymentMethodSelectorContainer.tsx
@@ -38,23 +38,11 @@ function PaymentMethodSelectorContainer({
 		(state) => state.page.checkoutForm.payment.paymentMethod,
 	);
 
-	const { abParticipations } = useContributionsSelector(
-		(state) => state.common,
-	);
-
 	const availablePaymentMethods = getValidPaymentMethods(
 		contributionType,
 		countryId,
 		countryGroupId,
 	);
-
-	if (abParticipations.amazonPay === 'variant') {
-		const index = availablePaymentMethods.indexOf('AmazonPay');
-		if (index > -1) {
-			// Only splice availablePaymentMethods when AmazonPay is found
-			availablePaymentMethods.splice(index, 1);
-		}
-	}
 
 	function onPaymentMethodEvent(
 		event: 'select' | 'render',

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -166,38 +166,6 @@ export const tests: Tests = {
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 4,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
-		excludeCountriesSubjectToContributionsOnlyAmounts: true,
-	},
-	amazonPay: {
-		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'variant',
-			},
-		],
-		audiences: {
-			US: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		canRun: () => {
-			/**
-			 * Only allocate users on old one-time
-			 * checkout to this AB test.
-			 */
-			const urlSearchParams = new URLSearchParams(window.location.search);
-			const selectedContributionType = urlSearchParams.get(
-				'selected-contribution-type',
-			);
-			return selectedContributionType === 'one_off';
-		},
-		isActive: true,
-		referrerControlled: false, // ab-test name not needed to be in paramURL
-		seed: 5,
-		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
-		excludeCountriesSubjectToContributionsOnlyAmounts: true,
+		excludeCountriesSubjectToContributionsOnlyAmounts: false,
 	},
 };


### PR DESCRIPTION
Reverts guardian/support-frontend#6374

This test can end, we're removing Amazon Pay, I've switched the payment method off for now until we remove it.