### PR TITLE
chore: update missing returns and turn on `noImplicitReturns`

### DIFF
--- a/support-frontend/assets/components/paymentRequestButton/hooks/usePaymentRequestCompletion.ts
+++ b/support-frontend/assets/components/paymentRequestButton/hooks/usePaymentRequestCompletion.ts
@@ -62,6 +62,7 @@ export function usePaymentRequestCompletion(
 					.then((result) => {
 						if (result.error) {
 							errorHandler('card_authentication_error');
+							return;
 						} else {
 							return dispatch(
 								onPaymentAuthorised(

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
@@ -174,6 +174,8 @@ export function AddressFields({ scope, countryGroupId, ...props }: PropTypes) {
 								message: errorMessages[field][possibleValidityStateError] ?? '',
 							};
 						}
+
+						return;
 					})
 					.filter(isNonNullable),
 			];

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.tsx
@@ -179,6 +179,8 @@ function StripeForm(props: StripeFormPropTypes): JSX.Element {
 					return result.setupIntent.payment_method ?? undefined;
 				});
 		}
+
+		return;
 	};
 
 	const fetchPaymentIntent = (token: string) =>

--- a/support-frontend/assets/components/subscriptionCheckouts/summary.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/summary.tsx
@@ -370,6 +370,8 @@ export default function Summary({
 				}
 			}
 		}
+
+		return;
 	};
 
 	const toggleDetails = () => {

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -233,6 +233,8 @@ function getParticipationsFromUrl(): Participations | undefined {
 			return { [testId]: variant };
 		}
 	}
+
+	return;
 }
 
 function getServerSideParticipations(): Participations | null | undefined {
@@ -286,6 +288,8 @@ function getAmountsTestVariant(
 				[testName]: variantName,
 			};
 		}
+
+		return;
 	};
 
 	const contribOnlyAmounts = amounts.find((t) => {

--- a/support-frontend/assets/helpers/productPrice/paperSavingsVsRetail.ts
+++ b/support-frontend/assets/helpers/productPrice/paperSavingsVsRetail.ts
@@ -32,6 +32,8 @@ function getMaxSavingVsRetail(
 
 		return Math.max(...allSavings);
 	}
+
+	return;
 }
 
 export { getMaxSavingVsRetail };

--- a/support-frontend/assets/helpers/redux/checkout/personalDetails/thunks.ts
+++ b/support-frontend/assets/helpers/redux/checkout/personalDetails/thunks.ts
@@ -41,6 +41,8 @@ export const getUserTypeFromIdentity = createAsyncThunk<
 			if (isSignedIn || emailInvalid || requestInFlight || isStorybookUser) {
 				return false;
 			}
+
+			return;
 		},
 	},
 );

--- a/support-frontend/assets/helpers/redux/checkout/product/selectors/subscriptionPrice.ts
+++ b/support-frontend/assets/helpers/redux/checkout/product/selectors/subscriptionPrice.ts
@@ -118,6 +118,8 @@ export function getSubscriptionPromotionForBillingPeriod(
 			).promotions,
 		);
 	}
+
+	return;
 }
 
 export function getSubscriptionPriceForBillingPeriod(

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/otherAmountValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/otherAmountValidation.ts
@@ -14,4 +14,6 @@ export function getOtherAmountErrors(
 	if (errors.otherAmount?.length) {
 		return errors.otherAmount;
 	}
+
+	return;
 }

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
@@ -87,6 +87,8 @@ export function getRecaptchaError(
 	if (recaptchaRequiredPaymentMethods.includes(paymentMethod.name)) {
 		return state.page.checkoutForm.recaptcha.errors;
 	}
+
+	return;
 }
 
 export function getPaymentRequestButtonErrors(

--- a/support-frontend/assets/helpers/supporterPlus/benefitsThreshold.ts
+++ b/support-frontend/assets/helpers/supporterPlus/benefitsThreshold.ts
@@ -96,4 +96,6 @@ export function getThresholdPrice(
 	if (isRecurring(contributionType)) {
 		return getLowerBenefitsThreshold(state);
 	}
+
+	return;
 }

--- a/support-frontend/assets/helpers/tracking/acquisitions.ts
+++ b/support-frontend/assets/helpers/tracking/acquisitions.ts
@@ -298,6 +298,8 @@ function getAcquisitionDataFromUtmParams():
 			queryParameters: toAcquisitionQueryParameters(getAllQueryParams()),
 		};
 	}
+
+	return;
 }
 
 // Reads the acquisition data from the &acquistionData param containing a serialised JSON string.

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -206,7 +206,12 @@ function sendEventSubscriptionCheckoutEvent(
 function productToCheckoutEvents(
 	product: SubscriptionProduct,
 	orderIsAGift: boolean,
-) {
+):
+	| {
+			start: SendEventSubscriptionCheckoutStart;
+			conversion: SendEventSubscriptionCheckoutConversion;
+	  }
+	| undefined {
 	switch (product) {
 		case 'DigitalPack':
 			return orderIsAGift
@@ -234,6 +239,8 @@ function productToCheckoutEvents(
 				SendEventSubscriptionCheckoutStart.PaperSub,
 				SendEventSubscriptionCheckoutConversion.PaperSub,
 			);
+		default:
+			return;
 	}
 }
 

--- a/support-frontend/assets/helpers/tracking/quantumMetricHelpers.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetricHelpers.ts
@@ -69,6 +69,8 @@ export function getContributionAnnualValue(
 			);
 		return convertedValue;
 	}
+
+	return;
 }
 
 export function waitForQuantumMetricAPi(onReady: () => void): void {

--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -486,6 +486,8 @@ function OneTimeCheckoutComponent({
 				return `/${geoId}/thank-you?${thankYouUrlSearchParams.toString()}`;
 			}
 		}
+
+		return;
 	}
 
 	const paymentButtonText = finalAmount

--- a/support-frontend/assets/pages/aus-moment-map/components/testimonialsContainer.tsx
+++ b/support-frontend/assets/pages/aus-moment-map/components/testimonialsContainer.tsx
@@ -168,6 +168,8 @@ function TestimonialsForTerritory(props: TestimonialsForTerritoryProps) {
 			document.addEventListener('scroll', onScroll);
 			return () => document.removeEventListener('scroll', onScroll);
 		}
+
+		return;
 	}, [ref.current]);
 
 	React.useEffect(() => {
@@ -193,6 +195,8 @@ function TestimonialsForTerritory(props: TestimonialsForTerritoryProps) {
 					testimonialsContainer.removeEventListener('scroll', onScroll);
 			}
 		}
+
+		return;
 	}, [ref.current]);
 
 	React.useEffect(() => {
@@ -304,6 +308,8 @@ function TestimonialsContainerHeader() {
 			document.addEventListener('scroll', handleScroll);
 			return () => document.removeEventListener('scroll', handleScroll);
 		}
+
+		return;
 	}, [self.current]);
 
 	return (

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -142,6 +142,8 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 			setHours(ensureRoundedDoubleDigits(0));
 			setDays(ensureRoundedDoubleDigits(0));
 		}
+
+		return;
 	}, [campaign]);
 
 	return (

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierTsAndCs.tsx
@@ -45,7 +45,10 @@ const container = css`
 	}
 `;
 
-const discountSummaryCopy = (currency: string, planCost: TierPlanCosts) => {
+const discountSummaryCopy = (
+	currency: string,
+	planCost: TierPlanCosts,
+): string | undefined => {
 	// EXAMPLE: £16/month for the first 12 months, then £25/month
 	if (planCost.discount) {
 		const duration = planCost.discount.duration.value;
@@ -61,6 +64,8 @@ const discountSummaryCopy = (currency: string, planCost: TierPlanCosts) => {
 			recurringContributionPeriodMap[planCost.discount.duration.period]
 		}`;
 	}
+
+	return;
 };
 
 export function ThreeTierTsAndCs({
@@ -100,6 +105,8 @@ export function ThreeTierTsAndCs({
 						</div>
 					);
 				}
+
+				return;
 			})}
 		</>
 	);

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -79,6 +79,8 @@ export function getAmountFromSessionStorage(): number | undefined {
 	if (amount) {
 		return parseFloat(amount);
 	}
+
+	return;
 }
 
 export const largeDonations: Record<ContributionType, number> = {

--- a/support-frontend/tsconfig.json
+++ b/support-frontend/tsconfig.json
@@ -20,7 +20,6 @@
 		// These override @guardian/tsconfig as they have introduced a lot of errors.
 		// The number of errors indicated below is at the time of writing to give an idea of the scale of the fix needed.
 		// We should look at removing these as soon as we can.
-		"noImplicitReturns": false, // Found 16 errors in 14 files.
 		"noUncheckedIndexedAccess": false // 209 errors in 63 files.
 	},
 	"include": [


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Turn off the `tsconfig` override of the `noImplicitReturns` rule and fix the errors 

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


## Why are you doing this?

This gets us closer to the @guardian/tsconfig ruleset
<!--
Remember, PRs are documentation for future contributors.
-->


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

