### PR TITLE
Fix to the main build to use new source update

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/coverTransactionCost.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/coverTransactionCost.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, neutral, space, textSans } from '@guardian/source/foundations';
+import { from, neutral, space, textSansBold12 } from '@guardian/source/foundations';
 import { useState } from 'react';
 import { Checkbox } from 'components/checkbox/Checkbox';
 import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
@@ -28,7 +28,7 @@ const coverTransactionCheckboxContainer = css`
 `;
 
 const coverTransactionSummaryContainer = css`
-	${textSans.medium({ fontWeight: 'bold' })};
+	${textSansBold12};
 	display: flex;
 	justify-content: space-between;
 	padding: 0px 0px ${space[2]}px;

--- a/support-frontend/assets/pages/supporter-plus-landing/components/coverTransactionCost.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/coverTransactionCost.tsx
@@ -1,5 +1,10 @@
 import { css } from '@emotion/react';
-import { from, neutral, space, textSansBold12 } from '@guardian/source/foundations';
+import {
+	from,
+	neutral,
+	space,
+	textSansBold12,
+} from '@guardian/source/foundations';
 import { useState } from 'react';
 import { Checkbox } from 'components/checkbox/Checkbox';
 import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
After [this PR](https://github.com/guardian/support-frontend/pull/6318) was merged, the main build started failing due to a change using the 'old' font style from source
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
