### PR TITLE
Source Upgrade : Font Sizing Corrections

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/react';
 import {
 	from,
+	headlineBold24,
 	space,
 	textSans17,
-	textSansBold14,
 } from '@guardian/source/foundations';
 import { Button } from '@guardian/source/react-components';
 import { useNavigate } from 'react-router-dom';
@@ -30,7 +30,7 @@ const titleAndButtonContainer = css`
 `;
 
 const title = css`
-	${textSansBold14}
+	${headlineBold24};
 	${from.tablet} {
 		font-size: 28px;
 	}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/coverTransactionCost.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/coverTransactionCost.tsx
@@ -3,7 +3,7 @@ import {
 	from,
 	neutral,
 	space,
-	textSansBold12,
+	textSansBold17,
 } from '@guardian/source/foundations';
 import { useState } from 'react';
 import { Checkbox } from 'components/checkbox/Checkbox';
@@ -33,7 +33,7 @@ const coverTransactionCheckboxContainer = css`
 `;
 
 const coverTransactionSummaryContainer = css`
-	${textSansBold12};
+	${textSansBold17};
 	display: flex;
 	justify-content: space-between;
 	padding: 0px 0px ${space[2]}px;

--- a/support-frontend/assets/pages/supporter-plus-landing/components/finePrint.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/finePrint.tsx
@@ -1,9 +1,9 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { neutral, textSans14, until } from '@guardian/source/foundations';
+import { neutral, textSans12, until } from '@guardian/source/foundations';
 
 const textStyles = (theme: FinePrintTheme) => css`
-	${textSans14};
+	${textSans12};
 	color: #606060;
 
 	${until.tablet} {

--- a/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
@@ -1,11 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import {
-	neutral,
-	space,
-	textSans12,
-	textSans14,
-} from '@guardian/source/foundations';
+import { neutral, space, textSans12 } from '@guardian/source/foundations';
 import { StripeDisclaimer } from 'components/stripe/stripeDisclaimer';
 import TierThreeTerms from 'components/subscriptionCheckouts/tierThreeTerms';
 import type {
@@ -56,7 +51,7 @@ const containerSummaryTsCs = css`
 	border-radius: ${space[2]}px;
 	background-color: ${neutral[97]};
 	padding: ${space[3]}px;
-	${textSans14};
+	${textSans12};
 	color: ${neutral[7]};
 	& a {
 		color: ${neutral[7]};


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Looks like a few sizing tweaks needed after a major Source update->

`secondStepCheckout` (old one-time) Change Summary->
1. TC's: changed to textSans14, set back to textSans12
2. Cover Transaction Cost Summary: changed to textSansBold12, set back to textSansBold17
3. Title `SupportUs`: changed to textSansBold14, set back to headlineBold24 (this appeared to be set to 28px from tablet previously to match `1 Your Details` & `2 Payment Method`)

`one-time-checkout` (new one-time) Summary->
1. TC's: changed to textSans14, set back to textSans12

`checkout` (new recurring) Summary->
1. TC's: changed to textSans14, set back to textSans12


[**Trello Card**](https://trello.com)