### PR TITLE
Configure US EOY copy

### DIFF
--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -13,10 +13,16 @@ export type CountdownSetting = {
 	//};
 };
 
+interface CampaignCopy {
+	subheading?: JSX.Element;
+	oneTimeHeading?: JSX.Element;
+}
+
 export type CampaignSettings = {
 	isEligible: (countryGroupId: CountryGroupId) => boolean;
 	enableSingleContributions: boolean;
 	countdownSettings?: CountdownSetting[];
+	copy: CampaignCopy;
 };
 
 const campaigns: Record<string, CampaignSettings> = {
@@ -46,6 +52,16 @@ const campaigns: Record<string, CampaignSettings> = {
 			// 	countdownDeadlineInMillis: Date.parse('Sep 06, 2024 00:00:00'),
 			// },
 		],
+		copy: {
+			subheading: (
+				<>
+					We're not owned by a billionaire or shareholders - our readers support
+					us. Can you help us reach our goal? Regular giving is most valuable to
+					us. <strong>You can cancel anytime.</strong>
+				</>
+			),
+			oneTimeHeading: <>Choose your gift amount</>,
+		},
 	},
 };
 

--- a/support-frontend/assets/pages/supporter-plus-landing/components/oneOffCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/oneOffCard.tsx
@@ -65,6 +65,7 @@ interface Props {
 	currencyGlyph: string;
 	countryGroupId: CountryGroupId;
 	currencyId: IsoCurrency;
+	heading: JSX.Element | undefined;
 }
 
 export function OneOffCard({
@@ -72,6 +73,7 @@ export function OneOffCard({
 	countryGroupId,
 	amounts,
 	currencyId,
+	heading,
 }: Props) {
 	const oneOffAmounts = amounts.amountsCardData.ONE_OFF;
 	const [selectedAmount, setSelectedAmount] = useState<number | 'other'>(
@@ -87,7 +89,7 @@ export function OneOffCard({
 					${textSans15}
 				`}
 			>
-				<h2 css={titleStyle}>Support just once</h2>
+				<h2 css={titleStyle}>{heading ?? 'Support just once'}</h2>
 				<p css={standFirst}>
 					We welcome support of any size, any time, whether you choose to give{' '}
 					{currencyGlyph}1 or much more.

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -523,9 +523,13 @@ export function ThreeTierLanding({
 						independent journalism
 					</h1>
 					<p css={standFirst}>
-						We're not owned by a billionaire or shareholders - our readers
-						support us. Choose to join with one of the options below.{' '}
-						<strong>Cancel anytime.</strong>
+						{campaignSettings?.copy.subheading ?? (
+							<>
+								We're not owned by a billionaire or shareholders - our readers
+								support us. Choose to join with one of the options below.{' '}
+								<strong>Cancel anytime.</strong>
+							</>
+						)}
 					</p>
 					<PaymentFrequencyButtons
 						paymentFrequencies={paymentFrequencies.map(
@@ -544,6 +548,7 @@ export function ThreeTierLanding({
 							currencyGlyph={currencies[currencyId].glyph}
 							countryGroupId={countryGroupId}
 							currencyId={currencyId}
+							heading={campaignSettings?.copy.oneTimeHeading}
 						/>
 					)}
 					{contributionType !== 'ONE_OFF' && (


### PR DESCRIPTION
Configures the main subheading, and the one-time tab heading.

Before:

<img width="818" alt="Screenshot 2024-10-17 at 15 03 59" src="https://github.com/user-attachments/assets/cc63822a-7863-47c6-9189-4d07ec550d6f">

After:
<img width="818" alt="Screenshot 2024-10-17 at 15 01 08" src="https://github.com/user-attachments/assets/5483d580-cf15-4cf3-b68e-a1d7454e6c5e">
