### PR TITLE
[Fix Scala Warnings] - Add explicit types to implicits

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -2,3 +2,4 @@ rules = [
  ExplicitResultTypes,
 ]
 ExplicitResultTypes.onlyImplicits = true
+ExplicitResultTypes.skipSimpleDefinitions = false

--- a/support-frontend/app/actions/CachedActionBuilder.scala
+++ b/support-frontend/app/actions/CachedActionBuilder.scala
@@ -13,7 +13,7 @@ class CachedActionBuilder(
     val headers: List[(String, String)],
 ) extends ActionBuilder[Request, AnyContent] {
 
-  implicit private val ec = executionContext
+  implicit private val ec: ExecutionContext = executionContext
   private val maximumBrowserAge = 1.minute
 
   override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] =

--- a/support-frontend/app/actions/NoCacheActionBuilder.scala
+++ b/support-frontend/app/actions/NoCacheActionBuilder.scala
@@ -9,7 +9,7 @@ class NoCacheActionBuilder(
     val executionContext: ExecutionContext,
     val headers: List[(String, String)],
 ) extends ActionBuilder[Request, AnyContent] {
-  implicit private val ec = executionContext
+  implicit private val ec: ExecutionContext = executionContext
 
   override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] =
     block(request).map(_.withHeaders(mergeHeader("Vary", List(CacheControl.noCache) ++ headers): _*))

--- a/support-frontend/app/actions/PrivateActionBuilder.scala
+++ b/support-frontend/app/actions/PrivateActionBuilder.scala
@@ -13,7 +13,7 @@ class PrivateActionBuilder(
     val executionContext: ExecutionContext,
 ) extends ActionBuilder[Request, AnyContent] {
 
-  private implicit val ec = executionContext
+  private implicit val ec: ExecutionContext = executionContext
 
   override def composeAction[A](action: Action[A]): Action[A] =
     new CSRFAction(action, csrfConfig, addToken, checkToken)

--- a/support-frontend/app/admin/ServersideAbTest.scala
+++ b/support-frontend/app/admin/ServersideAbTest.scala
@@ -18,7 +18,7 @@ object ServersideAbTest {
   case object Variant extends Participation
 
   object Participation {
-    implicit val encoder = Encoder.encodeString.contramap[Participation] {
+    implicit val encoder: Encoder[Participation] = Encoder.encodeString.contramap[Participation] {
       case Control => "Control"
       case Variant => "Variant"
     }

--- a/support-frontend/app/admin/settings/ContributionTypes.scala
+++ b/support-frontend/app/admin/settings/ContributionTypes.scala
@@ -4,6 +4,7 @@ import com.gu.support.encoding.Codec.deriveCodec
 import com.gu.support.encoding.JsonHelpers
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
+import com.gu.support.encoding.Codec
 
 sealed trait ContributionType
 case object ONE_OFF extends ContributionType
@@ -24,7 +25,7 @@ case object ContributionType {
 case class ContributionTypeSetting(contributionType: ContributionType, isDefault: Option[Boolean])
 
 object ContributionTypeSetting {
-  implicit val codec = deriveCodec[ContributionTypeSetting]
+  implicit val codec: Codec[ContributionTypeSetting] = deriveCodec[ContributionTypeSetting]
 }
 
 case class ContributionTypes(

--- a/support-frontend/app/models/identity/responses/SetGuestPasswordResponseCookie.scala
+++ b/support-frontend/app/models/identity/responses/SetGuestPasswordResponseCookie.scala
@@ -23,7 +23,7 @@ object SetGuestPasswordResponseCookie {
 case class SetGuestPasswordResponseCookies(expiresAt: DateTime, values: List[SetGuestPasswordResponseCookie])
 
 object SetGuestPasswordResponseCookies {
-  implicit val jodaDateReads =
+  implicit val jodaDateReads: Reads[DateTime] =
     Reads[DateTime](js => js.validate[String].map[DateTime](dtString => DateTime.parse(dtString)))
   implicit val readsCookieResponse: Reads[SetGuestPasswordResponseCookie] = Json.reads[SetGuestPasswordResponseCookie]
   implicit val readsCookiesResponse: Reads[SetGuestPasswordResponseCookies] =

--- a/support-frontend/test/controllers/ApplicationTest.scala
+++ b/support-frontend/test/controllers/ApplicationTest.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration._
 
 class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents with EitherValues {
 
-  implicit val timeout = Timeout(2.seconds)
+  implicit val timeout: Timeout = Timeout(2.seconds)
   val stage = Stages.DEV
 
   val actionRefiner = new CustomActionBuilders(

--- a/support-frontend/test/controllers/SiteMapTest.scala
+++ b/support-frontend/test/controllers/SiteMapTest.scala
@@ -18,7 +18,7 @@ import scala.concurrent.duration._
 
 class SiteMapTest extends AnyWordSpec with Matchers with TestCSRFComponents {
 
-  implicit val timeout = Timeout(2.seconds)
+  implicit val timeout: Timeout = Timeout(2.seconds)
   val stage = Stages.DEV
 
   val actionRefiner = new CustomActionBuilders(

--- a/support-models/src/main/scala/com/gu/support/paperround/PaperRound.scala
+++ b/support-models/src/main/scala/com/gu/support/paperround/PaperRound.scala
@@ -41,11 +41,11 @@ object AgentsEndpoint {
       email: String,
   )
   object AgentDetails {
-    implicit val config = DecoderConfiguration.lowercase
+    implicit val config: Configuration = DecoderConfiguration.lowercase
     implicit val agentDetailsDecoder: Decoder[AgentDetails] = deriveConfiguredDecoder
   }
 
-  implicit val config = DecoderConfiguration.snakeCase
+  implicit val config: Configuration = DecoderConfiguration.snakeCase
   implicit val responseDecoder: Decoder[Response] = deriveConfiguredDecoder
   implicit val agentsListDecoder: Decoder[AgentsList] = deriveConfiguredDecoder
 }
@@ -66,7 +66,7 @@ object ChargeBandsEndpoint {
       sunday: Double,
   )
 
-  implicit val config = DecoderConfiguration.snakeCase
+  implicit val config: Configuration = DecoderConfiguration.snakeCase
   implicit val responseDecoder: Decoder[Response] = deriveConfiguredDecoder
   implicit val deliveryChargeProfilesDecoder: Decoder[DeliveryChargeProfiles] = deriveConfiguredDecoder
   implicit val deliveryChargeProfileDecoder: Decoder[DeliveryChargeProfile] = Decoder.forProduct9(
@@ -121,7 +121,7 @@ object CoverageEndpoint {
       summary: String,
   )
   object AgentsCoverage {
-    implicit val config = DecoderConfiguration.lowercase
+    implicit val config: Configuration = DecoderConfiguration.lowercase
     implicit val decoder: Decoder[AgentsCoverage] = deriveConfiguredDecoder
   }
 
@@ -142,7 +142,7 @@ object CoverageEndpoint {
   /** Internal PaperRound system error. */
   case object IE extends CoverageStatus
 
-  implicit val config = DecoderConfiguration.snakeCase
+  implicit val config: Configuration = DecoderConfiguration.snakeCase
   implicit val responseDecoder: Decoder[Response] = deriveConfiguredDecoder
   implicit val postcodeCoverageDecoder: Decoder[PostcodeCoverage] = deriveConfiguredDecoder
   implicit val coverageStatusDecoder: Decoder[CoverageStatus] = deriveEnumerationDecoder
@@ -153,7 +153,7 @@ object ServerStatusEndpoint {
 
   case class Server(status: String)
 
-  implicit val config = DecoderConfiguration.snakeCase
+  implicit val config: Configuration = DecoderConfiguration.snakeCase
   implicit val responseDecoder: Decoder[Response] = deriveConfiguredDecoder
   implicit val serverDecoder: Decoder[Server] = deriveConfiguredDecoder
 }
@@ -162,7 +162,7 @@ object PaperRound {
   case class Error(statusCode: Integer, message: String, errorCode: ZonedDateTime)
       extends Throwable(s"Error(statusCode = $statusCode, message = $message, errorCode = $errorCode)")
   object Error {
-    implicit val config = DecoderConfiguration.snakeCase
+    implicit val config: Configuration = DecoderConfiguration.snakeCase
     implicit val errorDecoder: Decoder[Error] = deriveConfiguredDecoder
   }
 }

--- a/support-models/src/main/scala/com/gu/support/workers/GiftRecipient.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/GiftRecipient.scala
@@ -6,6 +6,7 @@ import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.workers.GiftRecipient.{DigitalSubscriptionGiftRecipient, WeeklyGiftRecipient}
 import io.circe._
 import org.joda.time.LocalDate
+import com.gu.support.encoding
 
 sealed trait GiftRecipient {
   val firstName: String
@@ -32,9 +33,11 @@ object GiftRecipient {
   ) extends GiftRecipient
 
   val discriminatedType = new DiscriminatedType[GiftRecipient]("giftRecipientType")
-  implicit val weeklyCodec = discriminatedType.variant[WeeklyGiftRecipient]("Weekly")
-  implicit val dsCodec = discriminatedType.variant[DigitalSubscriptionGiftRecipient]("DigitalSubscription")
-  implicit val codec = discriminatedType.codec(List(weeklyCodec, dsCodec))
+  implicit val weeklyCodec: discriminatedType.VariantCodec[WeeklyGiftRecipient] =
+    discriminatedType.variant[WeeklyGiftRecipient]("Weekly")
+  implicit val dsCodec: discriminatedType.VariantCodec[DigitalSubscriptionGiftRecipient] =
+    discriminatedType.variant[DigitalSubscriptionGiftRecipient]("DigitalSubscription")
+  implicit val codec: encoding.Codec[GiftRecipient] = discriminatedType.codec(List(weeklyCodec, dsCodec))
 
 }
 
@@ -47,7 +50,8 @@ object GeneratedGiftCode {
       .filter(_.matches(raw"""gd(03|06|12)-[a-km-z02-9]{8}"""))
       .map(new GeneratedGiftCode(_))
 
-  implicit val e1 = Encoder.encodeString.contramap[GeneratedGiftCode](_.value)
-  implicit val d1 = Decoder.decodeString.emap(GeneratedGiftCode(_).toRight("invalid gift code"))
+  implicit val e1: Encoder[GeneratedGiftCode] = Encoder.encodeString.contramap[GeneratedGiftCode](_.value)
+  implicit val d1: Decoder[GeneratedGiftCode] =
+    Decoder.decodeString.emap(GeneratedGiftCode(_).toRight("invalid gift code"))
 
 }

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
@@ -56,7 +56,7 @@ object AcquisitionDataRow {
   implicit val encodeDateTime: Encoder[DateTime] =
     Encoder.encodeString.contramap[DateTime](dt => ISODateTimeFormat.dateTime().print(dt))
 
-  implicit val codec = deriveCodec[AcquisitionDataRow]
+  implicit val codec: Codec[AcquisitionDataRow] = deriveCodec[AcquisitionDataRow]
 }
 
 case class PrintOptions(

--- a/support-modules/rest/src/main/scala/com/gu/stripe/StripeError.scala
+++ b/support-modules/rest/src/main/scala/com/gu/stripe/StripeError.scala
@@ -2,6 +2,7 @@ package com.gu.stripe
 
 import io.circe.Json
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
 
 //See docs here: https://stripe.com/docs/api/curl#errors
 case class StripeError(
@@ -22,8 +23,10 @@ case class StripeError(
 
 object StripeError {
 
-  implicit val encoder = deriveEncoder[StripeError].mapJson { json => Json.fromFields(List("error" -> json)) }
+  implicit val encoder: Encoder[StripeError] = deriveEncoder[StripeError].mapJson { json =>
+    Json.fromFields(List("error" -> json))
+  }
 
-  implicit val decoder = deriveDecoder[StripeError].prepare { _.downField("error") }
+  implicit val decoder: Decoder[StripeError] = deriveDecoder[StripeError].prepare { _.downField("error") }
 
 }

--- a/support-payment-api/src/main/scala/MyApplicationLoader.scala
+++ b/support-payment-api/src/main/scala/MyApplicationLoader.scala
@@ -92,7 +92,7 @@ class MyComponents(context: Context)
       .buildRequestBasedProvider(requestEnvironments)
       .valueOr(throw _)
 
-  implicit val allowedCorsUrl = configuration.get[Seq[String]](s"cors.allowedOrigins").toList
+  implicit val allowedCorsUrl: List[String] = configuration.get[Seq[String]](s"cors.allowedOrigins").toList
 
   // Usually the cloudWatchService is determined based on the request (live vs test). But inside the controllers
   // we may not know the environment, so we just use live. Note - in DEV/CODE, there is no difference between test/live

--- a/support-payment-api/src/main/scala/model/stripe/StripePaymentIntentsApiResponse.scala
+++ b/support-payment-api/src/main/scala/model/stripe/StripePaymentIntentsApiResponse.scala
@@ -1,6 +1,7 @@
 package model.stripe
 
 import io.circe.generic.semiauto._
+import io.circe.Encoder
 
 sealed trait StripePaymentIntentsApiResponse
 
@@ -9,6 +10,6 @@ object StripePaymentIntentsApiResponse {
 
   case class RequiresAction(clientSecret: String) extends StripePaymentIntentsApiResponse
 
-  implicit val successEncoder = deriveEncoder[Success]
-  implicit val requiresActionEncoder = deriveEncoder[RequiresAction]
+  implicit val successEncoder: Encoder.AsObject[Success] = deriveEncoder[Success]
+  implicit val requiresActionEncoder: Encoder.AsObject[RequiresAction] = deriveEncoder[RequiresAction]
 }

--- a/support-payment-api/src/main/scala/model/stripe/StripeRequest.scala
+++ b/support-payment-api/src/main/scala/model/stripe/StripeRequest.scala
@@ -169,6 +169,6 @@ object StripePaymentIntentRequest {
   ) extends StripeRequest
 
   import controllers.JsonReadableOps._
-  implicit val createPaymentIntentDecoder = deriveDecoder[CreatePaymentIntent]
-  implicit val confirmPaymentIntent = deriveDecoder[ConfirmPaymentIntent]
+  implicit val createPaymentIntentDecoder: Decoder[CreatePaymentIntent] = deriveDecoder[CreatePaymentIntent]
+  implicit val confirmPaymentIntent: Decoder[ConfirmPaymentIntent] = deriveDecoder[ConfirmPaymentIntent]
 }

--- a/support-payment-api/src/main/scala/services/ContributionsStoreService.scala
+++ b/support-payment-api/src/main/scala/services/ContributionsStoreService.scala
@@ -55,7 +55,7 @@ object ContributionsStoreQueueService {
   case class RefundedPaymentId(paymentId: String) extends Message
 
   object Message {
-    private implicit val messageEncoder = Encoder[Message] { message =>
+    private implicit val messageEncoder: Encoder[Message] = Encoder[Message] { message =>
       Json.obj {
         message match {
           case NewContributionData(contributionData) =>

--- a/support-payment-api/src/test/scala/controllers/AmazonPayControllerSpec.scala
+++ b/support-payment-api/src/test/scala/controllers/AmazonPayControllerSpec.scala
@@ -80,7 +80,7 @@ class AmazonPayControllerFixture(implicit ec: ExecutionContext, context: Applica
 
 class AmazonPayControllerSpec extends AnyWordSpec with Status with Matchers {
 
-  implicit val actorSystem = ActorSystem("rest-server")
+  implicit val actorSystem: ActorSystem = ActorSystem("rest-server")
   implicit val materializer: Materializer = ActorMaterializer()
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 

--- a/support-payment-api/src/test/scala/controllers/GoCardlessControllerSpec.scala
+++ b/support-payment-api/src/test/scala/controllers/GoCardlessControllerSpec.scala
@@ -86,7 +86,7 @@ class GoCardlessControllerFixture(implicit ec: ExecutionContext, context: Applic
 
 class GoCardlessControllerSpec extends AnyWordSpec with Status with Matchers {
 
-  implicit val actorSystem = ActorSystem("rest-server")
+  implicit val actorSystem: ActorSystem = ActorSystem("rest-server")
   implicit val materializer: Materializer = ActorMaterializer()
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 

--- a/support-payment-api/src/test/scala/controllers/PaypalControllerSpec.scala
+++ b/support-payment-api/src/test/scala/controllers/PaypalControllerSpec.scala
@@ -92,7 +92,7 @@ class PaypalControllerFixture(implicit ec: ExecutionContext, context: Applicatio
 
 class PaypalControllerSpec extends AnyWordSpec with Status with Matchers {
 
-  implicit val actorSystem = ActorSystem("rest-server")
+  implicit val actorSystem: ActorSystem = ActorSystem("rest-server")
   implicit val materializer: Materializer = ActorMaterializer()
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 

--- a/support-payment-api/src/test/scala/controllers/StripeControllerSpec.scala
+++ b/support-payment-api/src/test/scala/controllers/StripeControllerSpec.scala
@@ -103,7 +103,7 @@ class StripeControllerFixture(implicit ec: ExecutionContext, context: Applicatio
 
 class StripeControllerSpec extends AnyWordSpec with Status with Matchers {
 
-  implicit val actorSystem = ActorSystem("rest-server")
+  implicit val actorSystem: ActorSystem = ActorSystem("rest-server")
   implicit val materializer: Materializer = ActorMaterializer()
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 

--- a/support-payment-api/src/test/scala/services/EmailServiceSpec.scala
+++ b/support-payment-api/src/test/scala/services/EmailServiceSpec.scala
@@ -24,7 +24,7 @@ class EmailServiceSpec extends AnyFlatSpec with Matchers with MockitoSugar with 
   behavior of "Email Service"
 
   trait EmailServiceTestFixture {
-    implicit val executionContextTest = DefaultThreadPool(ExecutionContext.global)
+    implicit val executionContextTest: DefaultThreadPool = DefaultThreadPool(ExecutionContext.global)
     val sqsClient = mock[AmazonSQSAsync]
     val getQueueUrlResult = mock[GetQueueUrlResult]
     when(getQueueUrlResult.getQueueUrl()).thenReturn("test-queue-name")

--- a/support-payment-api/src/test/scala/services/PaypalServiceSpec.scala
+++ b/support-payment-api/src/test/scala/services/PaypalServiceSpec.scala
@@ -18,7 +18,7 @@ class PaypalServiceSpec extends AnyFlatSpec with Matchers with MockitoSugar with
 
   trait PaypalServiceTestFixture {
     val paypalConfig = PaypalConfig("clientIdTest", "clientSecretTest", "hookId", PaypalMode.Sandbox)
-    implicit val executionContextTest = PaypalThreadPool(ExecutionContext.global)
+    implicit val executionContextTest: PaypalThreadPool = PaypalThreadPool(ExecutionContext.global)
     val buildPaypalTransactions = PrivateMethod[java.util.List[Transaction]]('buildPaypalTransactions)
     val buildCaptureByTransaction = PrivateMethod[Capture]('buildCaptureByTransaction)
     val getTransaction = PrivateMethod[Either[PaypalApiError, Transaction]]('getTransaction)


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR is the first of potentially several to fix Scala warnings in the support-frontend codebase, it contains two main changes:
- Add [Scalafix](https://scalacenter.github.io/scalafix/) to the project to enable a number of automated fixes
- Use Scalafix to carry out the [ExplicitResultTypes](https://scalacenter.github.io/scalafix/docs/rules/ExplicitResultTypes.html) fix to add explicit types to all implicit vals in the project