### PR TITLE
Lighthouse - alarm on failure

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -7,6 +7,8 @@ jobs:
   Lighthouse:
     if: ${{ github.event.label.name == 'Seen-on-PROD' }}
     runs-on: ubuntu-latest
+    env:
+      GOOGLE_CHAT_WEB_HOOK: ${{ secrets.GOOGLE_CHAT_WEB_HOOK }}
     steps:
       - uses: actions/checkout@v4
       - name: Audit URLs using Lighthouse
@@ -16,3 +18,9 @@ jobs:
             https://support.theguardian.com/uk/contribute
           configPath: ./lighthouserc.json
           uploadArtifacts: true # save results as an action artifacts
+      - name: Notify on failure
+        if: ${{ failure() }}
+        run: |
+          failedWorkflowRun="https://github.com/guardian/support-frontend/actions/runs/$GITHUB_RUN_ID"
+          prTrigger="https://github.com/guardian/support-frontend/pull/${{ github.event.number }}"
+          curl -X POST -H "Content-Type: application/json" "$GOOGLE_CHAT_WEB_HOOK" -d '{"text": "🚨 The Lighthouse performance tests for support-frontend have failed 🚨\n\n- <'"$failedWorkflowRun"'|You can see the reason for this failure on GitHub>. \n- <'"$prTrigger"'|PR that triggered this>.\n\n Has this introduced a peformance regression or do the metrics need tweaking? "}'

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -23,4 +23,4 @@ jobs:
         run: |
           failedWorkflowRun="https://github.com/guardian/support-frontend/actions/runs/$GITHUB_RUN_ID"
           prTrigger="https://github.com/guardian/support-frontend/pull/${{ github.event.number }}"
-          curl -X POST -H "Content-Type: application/json" "$GOOGLE_CHAT_WEB_HOOK" -d '{"text": "🚨 The Lighthouse performance tests for support-frontend have failed 🚨\n\n- <'"$failedWorkflowRun"'|You can see the reason for this failure on GitHub>. \n- <'"$prTrigger"'|PR that triggered this>.\n\n Has this introduced a peformance regression or do the metrics need tweaking? "}'
+          curl -X POST -H "Content-Type: application/json" "$GOOGLE_CHAT_WEB_HOOK" -d '{"text": "🚨 The Lighthouse performance tests for support-frontend have failed 🚨\n\n- <'"$failedWorkflowRun"'|You can see the reason for this failure on GitHub>. \n- <'"$prTrigger"'|PR that triggered this>.\n\n Has this introduced a performance regression or do the metrics need tweaking? "}'

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -2,9 +2,9 @@
   "ci": {
     "assert": {
       "assertions": {
-        "first-contentful-paint": ["error", { "maxNumericValue": 2500 }],
-        "largest-contentful-paint": ["error", { "maxNumericValue": 6000 }],
-        "interactive": ["error", { "maxNumericValue": 8000 }],
+        "first-contentful-paint": ["error", { "maxNumericValue": 3000 }],
+        "largest-contentful-paint": ["error", { "maxNumericValue": 7000 }],
+        "interactive": ["error", { "maxNumericValue": 9500 }],
         "resource-summary:document:size": [
           "error",
           { "maxNumericValue": 20000 }


### PR DESCRIPTION
## What are you doing in this PR?

Tweaking the lighthouse performance params, based on recent failures of the CI action (added in #4626 ). And alarm to the Google chat when the action fails