### PR TITLE
Omit users on the Contributions Only checkout from the coverTransactionCost test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -148,7 +148,7 @@ export const tests: Tests = {
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 3,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
-		excludeCountriesSubjectToContributionsOnlyAmounts: false,
+		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
 	newOneTimeCheckout: {
 		variants: [


### PR DESCRIPTION
## What are you doing in this PR?

We have a  "Contributions Only" checkout flow for some countries: eg. https://support.theguardian.com/int/contribute?country=OM

We shouldn't be bucketing users on this "Contributions Only" checkout flow in the `coverTransactionCost` A/B/C test because this checkout doesn't show the one-time choice cards component on the checkout page, which means we users allocated to `variantB` will never see the cover transaction component as it sits in this component.