### PR TITLE
Only throw missing Billing State error if required by checkout's country group

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -136,7 +136,7 @@ import {
  */
 type PaymentMethod = LegacyPaymentMethod | 'StripeExpressCheckoutElement';
 const countryId: IsoCountry = CountryHelper.detect();
-const countryGroupIdsRequiringBillingState = ['US', 'CA', 'AU'];
+const countryIdsRequiringBillingState = ['US', 'CA', 'AU'];
 
 function paymentMethodIsActive(paymentMethod: LegacyPaymentMethod) {
 	return isSwitchOn(
@@ -1175,7 +1175,7 @@ function CheckoutComponent({
 
 										if (
 											!event.billingDetails?.address.state &&
-											countryGroupIdsRequiringBillingState.includes(countryId)
+											countryIdsRequiringBillingState.includes(countryId)
 										) {
 											logException(
 												"Could not find state from Stripe's billingDetails",
@@ -1351,7 +1351,7 @@ function CheckoutComponent({
 							 * We require state for non-deliverable products as we use different taxes within those regions upstream
 							 * For deliverable products we take the state and zip code with the delivery address
 							 */}
-							{countryGroupIdsRequiringBillingState.includes(countryId) &&
+							{countryIdsRequiringBillingState.includes(countryId) &&
 								!productDescription.deliverableTo && (
 									<StateSelect
 										countryId={countryId}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -136,7 +136,7 @@ import {
  */
 type PaymentMethod = LegacyPaymentMethod | 'StripeExpressCheckoutElement';
 const countryId: IsoCountry = CountryHelper.detect();
-const countryIdsRequiringBillingState = ['US', 'CA', 'AU'];
+const countriesRequiringBillingState = ['US', 'CA', 'AU'];
 
 function paymentMethodIsActive(paymentMethod: LegacyPaymentMethod) {
 	return isSwitchOn(
@@ -1175,7 +1175,7 @@ function CheckoutComponent({
 
 										if (
 											!event.billingDetails?.address.state &&
-											countryIdsRequiringBillingState.includes(countryId)
+											countriesRequiringBillingState.includes(countryId)
 										) {
 											logException(
 												"Could not find state from Stripe's billingDetails",
@@ -1351,7 +1351,7 @@ function CheckoutComponent({
 							 * We require state for non-deliverable products as we use different taxes within those regions upstream
 							 * For deliverable products we take the state and zip code with the delivery address
 							 */}
-							{countryIdsRequiringBillingState.includes(countryId) &&
+							{countriesRequiringBillingState.includes(countryId) &&
 								!productDescription.deliverableTo && (
 									<StateSelect
 										countryId={countryId}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -136,6 +136,7 @@ import {
  */
 type PaymentMethod = LegacyPaymentMethod | 'StripeExpressCheckoutElement';
 const countryId: IsoCountry = CountryHelper.detect();
+const countryGroupIdsRequiringBillingState = ['US', 'CA', 'AU'];
 
 function paymentMethodIsActive(paymentMethod: LegacyPaymentMethod) {
 	return isSwitchOn(
@@ -1172,7 +1173,10 @@ function CheckoutComponent({
 												event.billingDetails.address.postal_code,
 											);
 
-										if (!event.billingDetails?.address.state) {
+										if (
+											!event.billingDetails?.address.state &&
+											countryGroupIdsRequiringBillingState.includes(countryId)
+										) {
 											logException(
 												"Could not find state from Stripe's billingDetails",
 												{ geoId, countryGroupId, countryId },
@@ -1347,7 +1351,7 @@ function CheckoutComponent({
 							 * We require state for non-deliverable products as we use different taxes within those regions upstream
 							 * For deliverable products we take the state and zip code with the delivery address
 							 */}
-							{['US', 'CA', 'AU'].includes(countryId) &&
+							{countryGroupIdsRequiringBillingState.includes(countryId) &&
 								!productDescription.deliverableTo && (
 									<StateSelect
 										countryId={countryId}


### PR DESCRIPTION
## What are you doing in this PR?

We're logging an error in Sentry if a user pays with a wallet payment method, but that payment method does not have a Billing State associated to it. Currently we throw this error in all country group id regions, however it's only an issue we care about in countries that require Billing State, eg. US, CA, AU. 

This PR updates the code that logs this issue, so we only report in the US, CA, AU. This will give us a better idea of how many users are experiencing an issue due to the missing Billing State.

Note: The objective here is to get a clearer picture of how many users are affected by a known issue where they're in the US, CA, AU but the Billing Address associated with their "wallet" payment method does not have a Billing State. Although we send `countryId` to `logException` this info is impossible to find/filer on in Sentry's UI (I've tried!), otherwise I could have used that to help estimate the impact of this issue.