### PR TITLE
New One Time - use old type for stripe payment method

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -292,7 +292,7 @@ function OneTimeCheckoutComponent({
 	const stripePaymentMethod: StripePaymentMethod =
 		stripeExpressCheckoutPaymentType === 'apple_pay'
 			? 'StripeApplePay'
-			: 'StripeCheckout';
+			: 'StripePaymentRequestButton';
 
 	const [stripeExpressCheckoutSuccessful, setStripeExpressCheckoutSuccessful] =
 		useState(false);


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Change the stripe payment method passed to the backend to the old (inaccurate) value of 'stripePaymentRequestButton'. Our backend is expecting this
<!--