### PR TITLE
Newspaper Archive : Checkout Benefit Add, Copy Checks

### DIFF
--- a/support-frontend/assets/components/offer/offer.tsx
+++ b/support-frontend/assets/components/offer/offer.tsx
@@ -31,7 +31,7 @@ export function OfferFeast(): JSX.Element {
 	return (
 		<div css={containerStyle}>
 			<p css={paragraphStyle}>
-				Unlimited access to the Guardian Feast App{' '}
+				Unlimited access to the Guardian Feast app{' '}
 				<span css={tooltipOfferStyle}>
 					<Tooltip
 						children={

--- a/support-frontend/assets/components/thankYou/appDownload/appDownloadItems.tsx
+++ b/support-frontend/assets/components/thankYou/appDownload/appDownloadItems.tsx
@@ -28,9 +28,9 @@ export function AppDownloadEditionsBodyCopy(): JSX.Element {
 	);
 }
 
-export const appsDownloadHeader = 'Explore your subscriber’s App';
+export const appsDownloadHeader = 'Explore your subscriber’s app';
 
-export const appNewsDownloadHeader = 'The Guardian News App';
+export const appNewsDownloadHeader = 'The Guardian News app';
 
 export function AppNewsDownloadBodyCopy(): JSX.Element {
 	return (
@@ -40,12 +40,12 @@ export function AppNewsDownloadBodyCopy(): JSX.Element {
 	);
 }
 
-export const appFeastDownloadHeader = 'The Guardian Feast App';
+export const appFeastDownloadHeader = 'The Guardian Feast app';
 
 export function AppFeastDownloadBodyCopy(): JSX.Element {
 	return (
 		<span css={downloadCopy}>
-			Make a feast out of anything with the Guardian’s new recipe app – Feast.
+			Make a feast out of anything with the Guardian’s new recipe app : Feast.
 		</span>
 	);
 }

--- a/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
@@ -226,13 +226,12 @@ export const getThankYouModuleData = (
 		},
 		newspaperArchiveBenefit: {
 			icon: getThankYouModuleIcon('newspaperArchiveBenefit'),
-			header: 'The Guardian newspapers archive',
+			header: 'The Guardian newspaper archive',
 			bodyCopy: (
 				<>
 					Sign in to start exploring more than 200 years of world history with
 					our newspaper archive. View digital reproductions of every front page,
-					article and advertisement as it was printed in the
-					{countryGroupId === 'GBPCountries' ? ' Guardian' : ' UK,'} from 1821
+					article and advertisement as it was printed in the Guardian from 1821.
 				</>
 			),
 			ctas: null,

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -356,7 +356,7 @@ export const productCatalogDescriptionNewBenefits: Record<
 			{
 				copy: `Unlimited access to the Guardian's 200-year newspaper archive`,
 				isNew: true,
-				tooltip: `Look back on more than 200 years of world history with the Guardian archive. Get digital access to every front page, article and advertisement printed in the newspaper from 1981.`,
+				tooltip: `Look back on more than 200 years of world history with the Guardian archive. Get digital access to every front page, article and advertisement printed in the newspaper from 1821.`,
 			},
 		],
 	},

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -344,39 +344,36 @@ export const productCatalogDescription: Record<ProductKey, ProductDescription> =
 		},
 	};
 
-export function productCatalogDescriptionNewBenefits(
-	countryGroupId: CountryGroupId,
-): Record<ProductKey, ProductDescription> {
-	return {
-		...productCatalogDescription,
-		TierThree: {
-			...productCatalogDescription.TierThree,
-			benefits: [
-				...productCatalogDescription.TierThree.benefits,
-				{
-					copy: `Unlimited access to the Guardian's 200-year newspaper archive`,
-					isNew: true,
-					tooltip: `Look back on more than 200 years of world history with the Guardian newspaper archive. Get digital access to every front page, article and advertisement, as it was printed ${
-						countryGroupId === 'GBPCountries' ? '' : ' in the UK'
-					}, since 1821.`,
-				},
-			],
-		},
-		SupporterPlus: {
-			...productCatalogDescription.SupporterPlus,
-			benefits: [
-				...productCatalogDescription.SupporterPlus.benefits,
-				{
-					copy: 'Unlimited access to the Guardian Feast app',
-					isNew: true,
-					tooltip:
-						'Make a feast out of anything with the Guardian’s new recipe app. Feast has thousands of recipes including quick and budget-friendly weeknight dinners, and showstopping weekend dishes – plus smart app features to make mealtimes inspiring.',
-				},
-			],
-			offers: [],
-		},
-	};
-}
+export const productCatalogDescriptionNewBenefits: Record<
+	ProductKey,
+	ProductDescription
+> = {
+	...productCatalogDescription,
+	TierThree: {
+		...productCatalogDescription.TierThree,
+		benefits: [
+			...productCatalogDescription.TierThree.benefits,
+			{
+				copy: `Unlimited access to the Guardian's 200-year newspaper archive`,
+				isNew: true,
+				tooltip: `Look back on more than 200 years of world history with the Guardian archive. Get digital access to every front page, article and advertisement printed in the newspaper from 1981.`,
+			},
+		],
+	},
+	SupporterPlus: {
+		...productCatalogDescription.SupporterPlus,
+		benefits: [
+			...productCatalogDescription.SupporterPlus.benefits,
+			{
+				copy: 'Unlimited access to the Guardian Feast app',
+				isNew: true,
+				tooltip:
+					'Make a feast out of anything with the Guardian’s new recipe app. Feast has thousands of recipes including quick and budget-friendly weeknight dinners, and showstopping weekend dishes – plus smart app features to make mealtimes inspiring.',
+			},
+		],
+		offers: [],
+	},
+};
 
 /**
  * This method is to help us determine which product and rateplan to

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -302,7 +302,7 @@ export const productCatalogDescription: Record<ProductKey, ProductDescription> =
 					tooltip: `You'll see far fewer financial support asks at the bottom of articles or in pop-up banners.`,
 				},
 				{
-					copy: 'Unlimited access to the Guardian Feast App',
+					copy: 'Unlimited access to the Guardian Feast app',
 				},
 				{
 					copy: 'Exclusive access to partner offers',
@@ -367,7 +367,7 @@ export function productCatalogDescriptionNewBenefits(
 			benefits: [
 				...productCatalogDescription.SupporterPlus.benefits,
 				{
-					copy: 'Unlimited access to the Guardian Feast App',
+					copy: 'Unlimited access to the Guardian Feast app',
 					isNew: true,
 					tooltip:
 						'Make a feast out of anything with the Guardian’s new recipe app. Feast has thousands of recipes including quick and budget-friendly weeknight dinners, and showstopping weekend dishes – plus smart app features to make mealtimes inspiring.',

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -463,7 +463,7 @@ function CheckoutComponent({
 	const supportAbTests = getSupportAbTests(abParticipations);
 
 	const productDescription = abParticipations.newspaperArchiveBenefit
-		? productCatalogDescriptionNewBenefits(countryGroupId)[productKey]
+		? productCatalogDescriptionNewBenefits[productKey]
 		: productCatalogDescription[productKey];
 	const ratePlanDescription = productDescription.ratePlans[ratePlanKey];
 

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -77,6 +77,7 @@ import {
 	isProductKey,
 	productCatalog,
 	productCatalogDescription,
+	productCatalogDescriptionNewBenefits,
 	type ProductKey,
 } from 'helpers/productCatalog';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
@@ -458,7 +459,14 @@ function CheckoutComponent({
 	const productCatalog = appConfig.productCatalog;
 	const { currency, currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 
-	const productDescription = productCatalogDescription[productKey];
+	const abParticipations = abTestInit({ countryId, countryGroupId });
+	const supportAbTests = getSupportAbTests(abParticipations);
+
+	const productDescription = ['v1', 'v2'].includes(
+		abParticipations.newspaperArchiveBenefit ?? '',
+	)
+		? productCatalogDescriptionNewBenefits(countryGroupId)[productKey]
+		: productCatalogDescription[productKey];
 	const ratePlanDescription = productDescription.ratePlans[ratePlanKey];
 
 	/**
@@ -716,9 +724,6 @@ function CheckoutComponent({
 	/** General error that can occur via fetch validations */
 	const [errorMessage, setErrorMessage] = useState<string>();
 	const [errorContext, setErrorContext] = useState<string>();
-
-	const abParticipations = abTestInit({ countryId, countryGroupId });
-	const supportAbTests = getSupportAbTests(abParticipations);
 
 	const useLinkExpressCheckout =
 		abParticipations.linkExpressCheckout === 'variant';

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -462,9 +462,7 @@ function CheckoutComponent({
 	const abParticipations = abTestInit({ countryId, countryGroupId });
 	const supportAbTests = getSupportAbTests(abParticipations);
 
-	const productDescription = ['v1', 'v2'].includes(
-		abParticipations.newspaperArchiveBenefit ?? '',
-	)
+	const productDescription = abParticipations.newspaperArchiveBenefit
 		? productCatalogDescriptionNewBenefits(countryGroupId)[productKey]
 		: productCatalogDescription[productKey];
 	const ratePlanDescription = productDescription.ratePlans[ratePlanKey];

--- a/support-frontend/assets/pages/supporter-plus-landing/components/newspaperArchiveBanner.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/newspaperArchiveBanner.tsx
@@ -87,9 +87,9 @@ export function NewspaperArchiveBanner() {
 					</span>
 				</h2>
 				<p css={paragraph}>
-					Since 1821, the world’s major events have been documented in the pages
-					of the Guardian’s UK newspaper. Today, you can journey through the
-					archive and search records of world history from wherever you are
+					Since 1821, the world's major events have been documented in the pages
+					of the Guardian. Today, you can search through and view that record of
+					history with access to the Guardian archives.
 				</p>
 			</div>
 			<Hide from="desktop">

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -356,7 +356,7 @@ export function ThreeTierLanding({
 	const productCatalogDescription = ['v1', 'v2'].includes(
 		abParticipations.newspaperArchiveBenefit ?? '',
 	)
-		? productCatalogDescriptionNewBenefits(countryGroupId)
+		? productCatalogDescriptionNewBenefits
 		: canonicalProductCatalogDescription;
 
 	/**


### PR DESCRIPTION
## What are you doing in this PR?

Update:
- Checkout benefit list includes newspaper archive benefit for v1,v2,control (see screenshot below)
- Recheck copy throughout against latest [**Figma**](https://www.figma.com/design/h53HMhA753GLQ4ycN1uoPc/newspaper-archive?node-id=545-17670&t=Lm4eiadk4JMJGR7f-1) updates

![image](https://github.com/user-attachments/assets/a8ec5a6a-d076-4fe2-a261-9ce26e38b0e7)

[**Trello Card**](https://trello.com/c/FjKV8faD/1054-update-copy-and-imagery-newspaper-archive-benefit-to-lp)

## How to test

dev => `https://support.thegulocal.com/...`
prod => `https://support.theguardian.com/...`

`.../uk/contribute#ab-newspaperArchiveBenefit=v1`
`.../uk/contribute#ab-newspaperArchiveBenefit=v2`
`.../uk/contribute#ab-newspaperArchiveBenefit=control`


eg prod
`https://support.theguardian.com/uk/contribute#ab-newspaperArchiveBenefit=v1`