### PR TITLE
One Time Checkout - validation message

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -395,7 +395,12 @@ function OneTimeCheckoutComponent({
 					elements,
 				});
 			}
-			if (paymentMethod === 'Stripe' && stripe && cardElement) {
+			if (
+				paymentMethod === 'Stripe' &&
+				stripe &&
+				cardElement &&
+				recaptchaToken
+			) {
 				paymentMethodResult = await stripe.createPaymentMethod({
 					type: 'card',
 					card: cardElement,
@@ -448,7 +453,6 @@ function OneTimeCheckoutComponent({
 							billingPostcode,
 						),
 						publicKey: stripePublicKey,
-						// ToDo: validate recaptchaToken for card payments
 						recaptchaToken: recaptchaToken ?? '',
 						paymentMethodId: paymentMethodResult.paymentMethod.id,
 					};

--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -459,29 +459,31 @@ function OneTimeCheckoutComponent({
 				}
 			}
 
-			setThankYouOrder({
-				firstName: '',
-				paymentMethod: paymentMethod,
-			});
-			const thankYouUrlSearchParams = new URLSearchParams();
-			thankYouUrlSearchParams.set('contribution', finalAmount.toString());
-			const nextStepRoute = paymentResultThankyouRoute(
-				paymentResult,
-				geoId,
-				thankYouUrlSearchParams,
-			);
-			setIsProcessingPayment(false);
-			if (nextStepRoute) {
-				window.location.href = nextStepRoute;
-			} else {
-				setErrorMessage('Sorry, something went wrong.');
-				if (
-					paymentResult &&
-					'paymentStatus' in paymentResult &&
-					paymentResult.paymentStatus === 'failure'
-				) {
-					setErrorContext(appropriateErrorMessage(paymentResult.error ?? ''));
+			if (paymentResult) {
+				setThankYouOrder({
+					firstName: '',
+					paymentMethod: paymentMethod,
+				});
+				const thankYouUrlSearchParams = new URLSearchParams();
+				thankYouUrlSearchParams.set('contribution', finalAmount.toString());
+				const nextStepRoute = paymentResultThankyouRoute(
+					paymentResult,
+					geoId,
+					thankYouUrlSearchParams,
+				);
+				if (nextStepRoute) {
+					window.location.href = nextStepRoute;
+				} else {
+					setErrorMessage('Sorry, something went wrong.');
+					if (
+						'paymentStatus' in paymentResult &&
+						paymentResult.paymentStatus === 'failure'
+					) {
+						setErrorContext(appropriateErrorMessage(paymentResult.error ?? ''));
+					}
 				}
+			} else {
+				setIsProcessingPayment(false);
 			}
 		}
 	};
@@ -821,11 +823,6 @@ function OneTimeCheckoutComponent({
 								type="submit"
 							/>
 						</div>
-						<div css={tcContainer}>
-							<FinePrint mobileTheme={'dark'}>
-								<TsAndCsFooterLinks countryGroupId={countryGroupId} />
-							</FinePrint>
-						</div>
 						{errorMessage && (
 							<div role="alert" data-qm-error>
 								<ErrorSummary
@@ -837,6 +834,11 @@ function OneTimeCheckoutComponent({
 								/>
 							</div>
 						)}
+						<div css={tcContainer}>
+							<FinePrint mobileTheme={'dark'}>
+								<TsAndCsFooterLinks countryGroupId={countryGroupId} />
+							</FinePrint>
+						</div>
 					</BoxContents>
 				</Box>
 			</form>

--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -767,7 +767,7 @@ function OneTimeCheckoutComponent({
 													}
 													onChange={() => {
 														setPaymentMethod(validPaymentMethod);
-
+														setPaymentMethodError(undefined);
 														// Track payment method selection with QM
 														sendEventPaymentMethodSelected(validPaymentMethod);
 													}}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Only show "Something went wrong" message when payment has been attempted. Also move this message to the right place.

Unset payment method validation on selection of a payment method.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/LqHf2Xpl/1166-one-time-checkout-testing-pickups-validation)

## Why are you doing this?

Fixing some bugs found in end to end testing

<!--
Remember, PRs are documentation for future contributors.
-->

## Screenshots

### Something went wrong:

Before (when should not show)
![image](https://github.com/user-attachments/assets/be59e23b-00bc-4033-8bfa-1f2f185fdfb4)

After (when should not show)
![image](https://github.com/user-attachments/assets/2f60e2be-5089-48a5-888c-15aa8a8dd7b7)

After (when should show)
![image](https://github.com/user-attachments/assets/85617f73-bc9d-4dd4-959d-874e6743334c)

### Payment Method Validation unset

Before 
![image](https://github.com/user-attachments/assets/0d9b60fa-5a1d-4c16-9021-c21f38594c85)

After
![image](https://github.com/user-attachments/assets/271973f5-9089-4594-ac62-a3feee48b83b)

