### PR TITLE
End 3-tab LP test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -201,27 +201,4 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.genericCheckoutOnly,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
-	landingPageOneTimeTab2: {
-		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'oneTimeTab',
-			},
-		],
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		isActive: true,
-		referrerControlled: false,
-		seed: 6,
-		targetPage: pageUrlRegexes.contributions.usLandingPageOnly,
-		// Track this landing page test through to the checkout
-		persistPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
-		excludeCountriesSubjectToContributionsOnlyAmounts: false,
-	},
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -292,8 +292,7 @@ export function ThreeTierLanding({
 	const campaignSettings = getCampaignSettings(countryGroupId);
 
 	const enableSingleContributionsTab =
-		(abParticipations.landingPageOneTimeTab2 === 'oneTimeTab' &&
-			campaignSettings?.enableSingleContributions) ??
+		campaignSettings?.enableSingleContributions ??
 		urlSearchParams.has('enableOneTime');
 
 	const getInitialContributionType = () => {


### PR DESCRIPTION
The variant with the one-time tab has performed well.
Now all users in the US EOY campaign will see it.
When the campaign ends, it will go back to normal (no one-time tab)

<img width="777" alt="Screenshot 2024-10-29 at 09 35 15" src="https://github.com/user-attachments/assets/d28f3cf3-e001-477b-a5e9-a3789e782cfb">
