### PR TITLE
New One Time Checkout - validate minimum amount

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -183,6 +183,22 @@ function getPreSelectedAmount(
 	};
 }
 
+function getFinalAmount(
+	selectedPriceCard: number | 'other',
+	otherAmount: string,
+	minAmount: number,
+): number | undefined {
+	if (selectedPriceCard === 'other') {
+		const parsedAmount = parseFloat(otherAmount);
+
+		return Number.isNaN(parsedAmount) || parsedAmount < minAmount
+			? undefined
+			: parsedAmount;
+	}
+
+	return selectedPriceCard;
+}
+
 export function OneTimeCheckout({ geoId, appConfig }: OneTimeCheckoutProps) {
 	const { currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 	const isTestUser = !!cookie.get('_test_username');
@@ -263,12 +279,7 @@ function OneTimeCheckoutComponent({
 	);
 
 	const [otherAmountError, setOtherAmountError] = useState<string>();
-	const finalAmount =
-		selectedPriceCard === 'other'
-			? Number.isNaN(parseFloat(otherAmount))
-				? undefined
-				: parseFloat(otherAmount)
-			: selectedPriceCard;
+	const finalAmount = getFinalAmount(selectedPriceCard, otherAmount, minAmount);
 
 	useEffect(() => {
 		if (finalAmount) {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Add a validation that checks the minimum amount for an 'other' amount input by the user.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/LqHf2Xpl/1166-one-time-checkout-testing-pickups-validation)

## Why are you doing this?

We found that entering a negative amount caused Stripe JS to crash on the page

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Go to `/one-time-checkout` and Choose your amount. Enter a negative number, cannot press the CTA.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->


<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Screenshots

Before
![image](https://github.com/user-attachments/assets/c810d7b0-a510-4796-a464-1c0df1e3ea85)

After
![image](https://github.com/user-attachments/assets/d29616d5-500f-45a0-9531-c400110afabe)


