### PR TITLE
Newspaper Archive : Thankyou cards re-sort, display missing benefit

### DIFF
--- a/support-frontend/assets/components/thankYou/thankyouModules.tsx
+++ b/support-frontend/assets/components/thankYou/thankyouModules.tsx
@@ -25,16 +25,20 @@ const firstColumnContainer = css`
 
 export interface ThankYouModulesProps {
 	isSignedIn?: boolean;
+	showNewspaperArchiveBenefit?: boolean;
 	thankYouModules: ThankYouModuleType[];
 	thankYouModulesData: Record<ThankYouModuleType, ThankYouModuleData>;
 }
 
 export function ThankYouModules({
 	isSignedIn,
+	showNewspaperArchiveBenefit,
 	thankYouModules,
 	thankYouModulesData,
 }: ThankYouModulesProps): JSX.Element {
-	const numberOfModulesInFirstColumn = thankYouModules.length >= 6 ? 3 : 2;
+	const maxModules = showNewspaperArchiveBenefit ? 5 : 6;
+	const numberOfModulesInFirstColumn =
+		thankYouModules.length >= maxModules ? 3 : 2;
 	const firstColumn = thankYouModules.slice(0, numberOfModulesInFirstColumn);
 	const secondColumn = thankYouModules.slice(numberOfModulesInFirstColumn);
 

--- a/support-frontend/assets/components/thankYou/thankyouModules.tsx
+++ b/support-frontend/assets/components/thankYou/thankyouModules.tsx
@@ -25,14 +25,14 @@ const firstColumnContainer = css`
 
 export interface ThankYouModulesProps {
 	isSignedIn?: boolean;
-	showNewspaperArchiveBenefit?: boolean;
+	showNewspaperArchiveBenefit: boolean;
 	thankYouModules: ThankYouModuleType[];
 	thankYouModulesData: Record<ThankYouModuleType, ThankYouModuleData>;
 }
 
 export function ThankYouModules({
 	isSignedIn,
-	showNewspaperArchiveBenefit,
+	showNewspaperArchiveBenefit = false,
 	thankYouModules,
 	thankYouModulesData,
 }: ThankYouModulesProps): JSX.Element {

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankyou.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankyou.tsx
@@ -17,6 +17,7 @@ import type { ProductKey } from 'helpers/productCatalog';
 import {
 	filterBenefitByRegion,
 	productCatalogDescription,
+	productCatalogDescriptionNewBenefits,
 } from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { get } from 'helpers/storage/cookie';
@@ -177,9 +178,16 @@ export function ThankYouComponent({
 	const isNewAccount = userTypeFromIdentityResponse === 'new';
 	const emailExists = !isNewAccount && isSignedIn;
 
+	const abParticipations = abTestInit({ countryId, countryGroupId });
+	const showNewspaperArchiveBenefit = ['v1', 'v2', 'control'].includes(
+		abParticipations.newspaperArchiveBenefit ?? '',
+	);
+
 	let benefitsChecklist;
 	if (isTier) {
-		const productDescription = productCatalogDescription[productKey];
+		const productDescription = showNewspaperArchiveBenefit
+			? productCatalogDescriptionNewBenefits[productKey]
+			: productCatalogDescription[productKey];
 		benefitsChecklist = [
 			...productDescription.benefits
 				.filter((benefit) => filterBenefitByRegion(benefit, countryGroupId))
@@ -195,11 +203,6 @@ export function ThankYouComponent({
 				})),
 		];
 	}
-
-	const abParticipations = abTestInit({ countryId, countryGroupId });
-	const showNewspaperArchiveBenefit = ['v1', 'v2', 'control'].includes(
-		abParticipations.newspaperArchiveBenefit ?? '',
-	);
 
 	const thankYouModuleData = getThankYouModuleData(
 		countryId,

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankyou.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankyou.tsx
@@ -221,6 +221,10 @@ export function ThankYouComponent({
 		...maybeThankYouModule(isNewAccount, 'signUp'), // Create your Guardian account
 		...maybeThankYouModule(!isNewAccount && !isSignedIn, 'signIn'), // Sign in to access your benefits
 		...maybeThankYouModule(isTier3, 'benefits'),
+		...maybeThankYouModule(
+			isTier3 && showNewspaperArchiveBenefit,
+			'newspaperArchiveBenefit',
+		),
 		...maybeThankYouModule(isTier3, 'subscriptionStart'),
 		...maybeThankYouModule(isTier3 || isSupporterPlus, 'appsDownload'),
 		...maybeThankYouModule(isOneOff && emailExists, 'supportReminder'),
@@ -230,10 +234,6 @@ export function ThankYouComponent({
 		),
 		...maybeThankYouModule(countryId === 'AU', 'ausMap'),
 		...maybeThankYouModule(!isTier3, 'socialShare'),
-		...maybeThankYouModule(
-			isTier3 && showNewspaperArchiveBenefit,
-			'newspaperArchiveBenefit',
-		),
 	];
 
 	return (
@@ -266,6 +266,7 @@ export function ThankYouComponent({
 
 					<ThankYouModules
 						isSignedIn={isSignedIn}
+						showNewspaperArchiveBenefit={showNewspaperArchiveBenefit}
 						thankYouModules={thankYouModules}
 						thankYouModulesData={thankYouModuleData}
 					/>


### PR DESCRIPTION
## What are you doing in this PR?

Thankyou cards re-sort, display missing benefit

1.  re-sort
2. missing benefit display

[**Trello Card**](https://trello.com/c/FjKV8faD/1054-update-copy-and-imagery-newspaper-archive-benefit-to-lp)

## How to test

dev => `https://support.thegulocal.com/...`
prod => `https://support.theguardian.com/...`

`...uk/checkout?product=TierThree&ratePlan=DomesticMonthlyV2#ab-newspaperArchiveBenefit=control`
`...uk/thank-you?product=TierThree&ratePlan=DomesticMonthlyV2#ab-newspaperArchiveBenefit=control`


eg prod
`https://support.theguardian.com/uk/thank-you?product=TierThree&ratePlan=DomesticMonthlyV2#ab-newspaperArchiveBenefit=control`