### PR TITLE
temporarily force saving vs retail for WAITROSE promotion

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/components/paperProductPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/paperProductPrices.tsx
@@ -53,6 +53,15 @@ const getOfferText = (price: ProductPrice, promo?: Promotion) => {
 			promo.discount.amount,
 		);
 		if (discount > 0) {
+			/**
+			 * Temporary hack, as WAITROSE_SATSUNHD campaign goes live 31/10/2024
+			 * and we don't have time to dig into why the saving vs retail
+			 * is over reporting 15% saving. to be removed when WAITROSE_SATSUNHD campaign ends.
+			 */
+			if (promo.promoCode === 'WAITROSE_SATSUNHD' && discount === 15) {
+				return 'Save 10% on retail price';
+			}
+
 			return `Save ${discount}% on retail price`;
 		} else {
 			return '';


### PR DESCRIPTION
## What are you doing in this PR?

Marketing have a promotion targeting Waitrose customers launching tomorrow. They've reached out as the campaign/promotion has been set-up however when the promotion is applied to the Newspaper landing pahe the Saturday & Sunday Home Delivery pricing cards are showing an overly high discount vs retail, the cards show 15% saving vs retail, when it's actually 10%, the price on the cards of £15.60 is correct.

There's concern about launching this promotion when incorrectly reporting the saving, for legal reasons. The logic to calculate this saving is complex and straddles the server & client, it's hard to troubleshoot given the time sensitivity! I'm  therefore proposing a temporary solution so this campaign can go live, of hardcoding the saving when the promo code used  applied to a pricing card is "WAITROSE_SATSUNHD" (this is the effected promo code), which targets the Saturday and Sunday Home Delivery products only.

I've tested this locally against a promo with the code "WAITROSE_SATSUNHD" set-up on the CODE promo code tool.

### Before 
<img width="521" alt="Screenshot 2024-10-30 at 14 48 46" src="https://github.com/user-attachments/assets/8dae5239-75cd-4b47-9b9a-c9bb4b12dd01">

### After
<img width="515" alt="Screenshot 2024-10-30 at 16 19 35" src="https://github.com/user-attachments/assets/fed8b530-2a79-4fe7-95cc-45486ad7f215">
