### PR TITLE
Reinstate landingPageOneTimeTab2 ab test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -177,4 +177,27 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.genericCheckoutOnly,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
+	landingPageOneTimeTab2: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'oneTimeTab',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		isActive: true,
+		referrerControlled: false,
+		seed: 6,
+		targetPage: pageUrlRegexes.contributions.usLandingPageOnly,
+		// Track this landing page test through to the checkout
+		persistPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+		excludeCountriesSubjectToContributionsOnlyAmounts: false,
+	},
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -293,7 +293,7 @@ export function ThreeTierLanding({
 
 	const enableSingleContributionsTab =
 		(abParticipations.landingPageOneTimeTab2 === 'oneTimeTab' &&
-		campaignSettings?.enableSingleContributions) ??
+			campaignSettings?.enableSingleContributions) ??
 		urlSearchParams.has('enableOneTime');
 
 	const getInitialContributionType = () => {

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -292,7 +292,8 @@ export function ThreeTierLanding({
 	const campaignSettings = getCampaignSettings(countryGroupId);
 
 	const enableSingleContributionsTab =
-		campaignSettings?.enableSingleContributions ??
+		(abParticipations.landingPageOneTimeTab2 === 'oneTimeTab' &&
+		campaignSettings?.enableSingleContributions) ??
 		urlSearchParams.has('enableOneTime');
 
 	const getInitialContributionType = () => {


### PR DESCRIPTION
## What are you doing in this PR?

We have been asked to reinstate the ab test to confirm earlier findings.

[**Trello Card**](https://trello.com/c/KAl5dgg6)

## Why are you doing this?

MRR are concerned about the RC levels and want to iterate on the 3-tabbed variant
This reverts this reversion: [PR6450](https://github.com/guardian/support-frontend/pull/6450).
There will also be another PR to change some copy that is not part of the AB test.