### PR TITLE
small copy changes for us eoy campaign

### DIFF
--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -55,9 +55,7 @@ const campaigns: Record<string, CampaignSettings> = {
 			},
 		],
 		copy: {
-			headingFragment: (
-				<>Protect </>
-			),
+			headingFragment: <>Protect </>,
 			subheading: (
 				<>
 					We're not owned by a billionaire or shareholders - our readers support

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -15,6 +15,7 @@ export type CountdownSetting = {
 };
 
 interface CampaignCopy {
+	headingFragment?: JSX.Element;
 	subheading?: JSX.Element;
 	oneTimeHeading?: JSX.Element;
 }
@@ -54,10 +55,13 @@ const campaigns: Record<string, CampaignSettings> = {
 			},
 		],
 		copy: {
+			headingFragment: (
+				<>Protect </>
+			),
 			subheading: (
 				<>
 					We're not owned by a billionaire or shareholders - our readers support
-					us. Can you help us reach our goal? Regular giving is most valuable to
+					us. Can you help us reach our goal? Monthly giving is most valuable to
 					us. <strong>You can cancel anytime.</strong>
 				</>
 			),

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -524,10 +524,8 @@ export function ThreeTierLanding({
 				<div css={innerContentContainer}>
 					{showCountdown && <Countdown campaign={currentCampaign} />}
 					<h1 css={heading}>
-						{campaignSettings?.copy.headingFragment ?? (
-							<>Support </>
-						)}
-						 fearless, <br css={tabletLineBreak} />
+						{campaignSettings?.copy.headingFragment ?? <>Support </>}
+						fearless, <br css={tabletLineBreak} />
 						independent journalism
 					</h1>
 					<p css={standFirst}>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -524,7 +524,10 @@ export function ThreeTierLanding({
 				<div css={innerContentContainer}>
 					{showCountdown && <Countdown campaign={currentCampaign} />}
 					<h1 css={heading}>
-						Support fearless, <br css={tabletLineBreak} />
+						{campaignSettings?.copy.headingFragment ?? (
+							<>Support </>
+						)}
+						 fearless, <br css={tabletLineBreak} />
 						independent journalism
 					</h1>
 					<p css={standFirst}>


### PR DESCRIPTION
## What are you doing in this PR?
Small alterations to the heading and subheading copy for the US EOY 2024 campaign only.

[**Trello Card**](https://trello.com/c/KAl5dgg6)

## Why are you doing this?
Concerns over the reduction in Supporter+ and towards less effective one-off contributions.

## Screenshots:

###  Non-campaign:
<img width="1000" alt="Screenshot 2024-10-31 at 12 06 31" src="https://github.com/user-attachments/assets/796f9e12-de63-479c-88a4-5912871db74d">

### US EOY campaign Before: 
<img width="1000" alt="Screenshot 2024-10-31 at 12 29 38" src="https://github.com/user-attachments/assets/7edb7f05-f92e-4c39-89ce-44ec8baebafd">

### US EOY campaign After: 
<img width="1000" alt="Screenshot 2024-10-31 at 12 00 44" src="https://github.com/user-attachments/assets/69f796f8-6d78-4f4d-a448-1e30c454fa1b">
