### PR TITLE
simplify cookies diagnostic info

### DIFF
--- a/support-frontend/app/controllers/DiagnosticsController.scala
+++ b/support-frontend/app/controllers/DiagnosticsController.scala
@@ -35,16 +35,11 @@ class DiagnosticsController(
         " immediately before sending the information from this page" ::
         request.cookies.collect {
           case cookie if relevantCookies.contains(cookie.name) =>
-            getShareableCookieData(cookie) + " = " + cookie.value
+            "* " + cookie.name + "\n  " + cookie.value
           case cookie if privateCookies.contains(cookie.name) =>
-            getShareableCookieData(cookie) + " = (private - length: " + cookie.value.length + ")"
+            "* " + cookie.name + "\n  (private - length: " + cookie.value.length + ")"
         }.toList
     Ok(humanReadableCookies.mkString("\n\n"))
   }
 
-  private def getShareableCookieData(cookie: Cookie) = {
-    "* " + cookie.name + "\n" +
-      " ( domain: " + cookie.domain + ", httpOnly: " + cookie.httpOnly + ", path: " + cookie.path + ", maxAge: " + cookie.maxAge + ", sameSite: " +
-      cookie.sameSite + ", secure: " + cookie.secure + " )\n"
-  }
 }


### PR DESCRIPTION
following https://github.com/guardian/support-frontend/pull/6489
I realised that none of the additional information comes from the client side, it's just key and value, so it's totally misleading and pointless

This PR removes all the info that is just default values.

OLD
![image](https://github.com/user-attachments/assets/1860fe41-b49b-423d-b9ce-954ba9130386)

NEW
![image](https://github.com/user-attachments/assets/18fe74d1-dcff-40e7-a966-e29e49989ac0)
