### PR TITLE
add JS cookies info to diagnostics

### DIFF
--- a/support-frontend/app/controllers/DiagnosticsController.scala
+++ b/support-frontend/app/controllers/DiagnosticsController.scala
@@ -3,6 +3,7 @@ package controllers
 import actions.CustomActionBuilders
 import play.api.mvc._
 import Results.Ok
+import play.twirl.api.Html
 
 class DiagnosticsController(
     actionRefiners: CustomActionBuilders,
@@ -39,7 +40,15 @@ class DiagnosticsController(
           case cookie if privateCookies.contains(cookie.name) =>
             "* " + cookie.name + "\n  (private - length: " + cookie.value.length + ")"
         }.toList
-    Ok(humanReadableCookies.mkString("\n\n"))
+    Ok(withHtml(humanReadableCookies.mkString("\n\n")))
+  }
+
+  def withHtml(body: String): Html = {
+    val cookiesJS =
+      "<pre><script>document.write(document.cookie.split('; ').map((a) => a.split('=')).map((a) => a[0] + ' ' + a[1]?.length).join('\\n'))</script></pre>"
+    Html(
+      s"<html><body><h2>HTTP cookies</h2><pre>$body</pre><h2>JS cookie keys and lengths</h2>$cookiesJS</body></html>",
+    )
   }
 
 }


### PR DESCRIPTION
it would be useful to have a guide as to whether JS can get hold of cookies on the client side when users are having trouble

This PR adds these to the https://support.theguardian.com/cookies endpoint at the bottom

The JS is super hacky but it just about does the job.  But improvements appreciated in case I've missed something (tested in latest chrome on desktop only)

![image](https://github.com/user-attachments/assets/42fe6327-7a8a-4fff-8c32-3eb8a089ef7e)
