### PR TITLE
Newspaper Archive Header - Add non-breaking space in "The Guardian"

### DIFF
--- a/support-frontend/assets/components/serverSideRendered/newspaperArchiveHeader.tsx
+++ b/support-frontend/assets/components/serverSideRendered/newspaperArchiveHeader.tsx
@@ -128,8 +128,8 @@ export function NewspaperArchiveHeader() {
 				<div css={body}>
 					<div css={description}>
 						<p css={paragraph}>
-							Journey through more than 200 years of the Guardian and Observer
-							and search through every page printed in our newspapers.
+							Journey through more than 200 years of the&nbsp;Guardian and
+							Observer and search through every page printed in our newspapers.
 						</p>
 					</div>
 					<div css={logos}>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Add a non-breaking space in "The Guardian" in header copy

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/b4WrMs2D/1244-set-live-new-header-on-newspaper-archive-on-https-theguardiannewspaperscom)

## Screenshots

Before
<img width="1040" alt="image" src="https://github.com/user-attachments/assets/b62b6c19-3d7b-45c5-9a03-1ab3926bc290">


After
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/17cf3747-652e-41d7-a26c-74e6138cd5f8">

