### PR TITLE
First steps to support Guardian Light in the generic checkout

### DIFF
--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -70,6 +70,11 @@ export type TierThree = {
 	fulfilmentOptions: FulfilmentOptions;
 	productOptions: ProductOptions;
 };
+export type GuardianLight = {
+	productType: 'GuardianLight';
+	currency: string;
+	billingPeriod: BillingPeriod;
+};
 export type DigitalSubscription = {
 	productType: typeof DigitalPack;
 	currency: string;
@@ -96,7 +101,8 @@ export type SubscriptionProductFields =
 	| DigitalSubscription
 	| PaperSubscription
 	| GuardianWeeklySubscription
-	| TierThree;
+	| TierThree
+	| GuardianLight;
 type ProductFields = RegularContribution | SubscriptionProductFields;
 type RegularPayPalPaymentFields = {
 	paymentType: typeof PayPal;

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -107,6 +107,15 @@ const supporterPlusBenefits = [
 
 export const productCatalogDescription: Record<ProductKey, ProductDescription> =
 	{
+		GuardianLight: {
+			label: 'Guardian Light',
+			ratePlans: {
+				Monthly: {
+					billingPeriod: 'Monthly',
+				},
+			},
+			benefits: [],
+		},
 		TierThree: {
 			label: 'Digital + print',
 			benefitsSummary: [

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -115,6 +115,7 @@ export const productCatalogDescription: Record<ProductKey, ProductDescription> =
 				},
 			},
 			benefits: [],
+			benefitsAdditional: [{ copy: 'Lorem ipsum' }],
 		},
 		TierThree: {
 			label: 'Digital + print',

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -496,6 +496,14 @@ function CheckoutComponent({
 	 */
 	let productFields: RegularPaymentRequest['product'];
 	switch (productKey) {
+		case 'GuardianLight':
+			productFields = {
+				productType: 'GuardianLight',
+				currency: currencyKey,
+				billingPeriod: ratePlanDescription.billingPeriod,
+			};
+			break;
+
 		case 'TierThree':
 			productFields = {
 				productType: 'TierThree',

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -1129,7 +1129,14 @@ function CheckoutComponent({
 							promotion,
 						)}
 						headerButton={
-							<BackButton path={`/${geoId}/contribute`} buttonText="Change" />
+							productKey === 'GuardianLight' ? (
+								<BackButton
+									path={`/${geoId}/guardianlight`}
+									buttonText="Back"
+								/>
+							) : (
+								<BackButton path={`/${geoId}/contribute`} buttonText="Change" />
+							)
 						}
 					/>
 				</BoxContents>

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -1128,7 +1128,9 @@ function CheckoutComponent({
 							productFields.productType,
 							promotion,
 						)}
-						headerButton={<BackButton geoId={geoId} buttonText="Change" />}
+						headerButton={
+							<BackButton path={`/${geoId}/contribute`} buttonText="Change" />
+						}
 					/>
 				</BoxContents>
 			</Box>

--- a/support-frontend/assets/pages/[countryGroupId]/components/backButton.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/backButton.tsx
@@ -1,14 +1,13 @@
 import { Button } from '@guardian/source/react-components';
-import type { GeoId } from 'pages/geoIdConfig';
 
 type BackButtonProps = {
-	geoId: GeoId;
+	path: string;
 	buttonText: string;
 };
 
-export function BackButton({ geoId, buttonText }: BackButtonProps) {
+export function BackButton({ path, buttonText }: BackButtonProps) {
 	return (
-		<a href={`/${geoId}/contribute`}>
+		<a href={path}>
 			<Button priority="tertiary" size="xsmall" role="link">
 				{buttonText}
 			</Button>

--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -560,7 +560,7 @@ function OneTimeCheckoutComponent({
 					>
 						<div css={titleAndButtonContainer}>
 							<h2 css={title}>Support just once</h2>
-							<BackButton geoId={geoId} buttonText="back" />
+							<BackButton path={`/${geoId}/contribute`} buttonText="back" />
 						</div>
 						<p css={standFirst}>Support us with the amount of your choice.</p>
 						<PriceCards

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -89,7 +89,7 @@
 		"@guardian/pasteup": "1.0.0-alpha.7",
 		"@guardian/source": "8.0.0",
 		"@guardian/source-development-kitchen": "13.0.0",
-		"@guardian/support-service-lambdas": "guardian/support-service-lambdas#70e330b5c433184981e2c6955025cbaa7666f353",
+		"@guardian/support-service-lambdas": "guardian/support-service-lambdas#eb71f269df9564a77171dc15c6c0e31d664d3c64",
 		"@guardian/tsconfig": "^0.2.0",
 		"@reduxjs/toolkit": "^1.9.4",
 		"@sentry/browser": "^8.33.1",

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -89,7 +89,7 @@
 		"@guardian/pasteup": "1.0.0-alpha.7",
 		"@guardian/source": "8.0.0",
 		"@guardian/source-development-kitchen": "13.0.0",
-		"@guardian/support-service-lambdas": "guardian/support-service-lambdas#eb71f269df9564a77171dc15c6c0e31d664d3c64",
+		"@guardian/support-service-lambdas": "guardian/support-service-lambdas#1b8f4f6be8e1e4e7f86572817ccc0ea36fc79a71",
 		"@guardian/tsconfig": "^0.2.0",
 		"@reduxjs/toolkit": "^1.9.4",
 		"@sentry/browser": "^8.33.1",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1870,9 +1870,9 @@
   dependencies:
     mini-svg-data-uri "1.4.4"
 
-"@guardian/support-service-lambdas@guardian/support-service-lambdas#eb71f269df9564a77171dc15c6c0e31d664d3c64":
+"@guardian/support-service-lambdas@guardian/support-service-lambdas#1b8f4f6be8e1e4e7f86572817ccc0ea36fc79a71":
   version "1.0.0"
-  resolved "https://codeload.github.com/guardian/support-service-lambdas/tar.gz/eb71f269df9564a77171dc15c6c0e31d664d3c64"
+  resolved "https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1b8f4f6be8e1e4e7f86572817ccc0ea36fc79a71"
 
 "@guardian/tsconfig@^0.2.0":
   version "0.2.0"

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1870,9 +1870,9 @@
   dependencies:
     mini-svg-data-uri "1.4.4"
 
-"@guardian/support-service-lambdas@guardian/support-service-lambdas#70e330b5c433184981e2c6955025cbaa7666f353":
+"@guardian/support-service-lambdas@guardian/support-service-lambdas#eb71f269df9564a77171dc15c6c0e31d664d3c64":
   version "1.0.0"
-  resolved "https://codeload.github.com/guardian/support-service-lambdas/tar.gz/70e330b5c433184981e2c6955025cbaa7666f353"
+  resolved "https://codeload.github.com/guardian/support-service-lambdas/tar.gz/eb71f269df9564a77171dc15c6c0e31d664d3c64"
 
 "@guardian/tsconfig@^0.2.0":
   version "0.2.0"


### PR DESCRIPTION
## What are you doing in this PR?

First steps to support Guardian Light in the generic checkout.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/5Bjvwbvg/1204-checkout-support-for-new-product-investigate-frontend-and-if-it-needs-light-design-if-any)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
