### PR TITLE
Guardian Light Backend Support

### DIFF
--- a/support-config/src/main/resources/touchpoint.CODE.conf
+++ b/support-config/src/main/resources/touchpoint.CODE.conf
@@ -60,6 +60,10 @@ touchpoint.backend.environments {
             annual.contribution.productRatePlanChargeId = "8ad096ca858682bb0185881568385d73"
         }
       }
+      guardianlight {
+          paymentGracePeriod = 2 // TODO: check how we handle this (and the value)
+          monthly.productRatePlanChargeId = "71a1c43a10792b28f702b3bf5d380037"
+      }
     }
     promotions {
       discount {

--- a/support-config/src/main/resources/touchpoint.CODE.conf
+++ b/support-config/src/main/resources/touchpoint.CODE.conf
@@ -60,10 +60,6 @@ touchpoint.backend.environments {
             annual.contribution.productRatePlanChargeId = "8ad096ca858682bb0185881568385d73"
         }
       }
-      guardianlight {
-          paymentGracePeriod = 2 // TODO: check how we handle this (and the value)
-          monthly.productRatePlanChargeId = "71a1c43a10792b28f702b3bf5d380037"
-      }
     }
     promotions {
       discount {

--- a/support-config/src/main/scala/com/gu/support/config/ZuoraConfigProvider.scala
+++ b/support-config/src/main/scala/com/gu/support/config/ZuoraConfigProvider.scala
@@ -16,11 +16,6 @@ case class ZuoraDigitalPackConfig(
     annualChargeId: String,
 )
 
-case class ZuoraGuardianLightConfig(
-    paymentGracePeriod: Int,
-    monthlyChargeId: String,
-)
-
 case class ZuoraSupporterPlusConfig(
     monthlyChargeId: String,
     annualChargeId: String,
@@ -40,7 +35,6 @@ case class ZuoraConfig(
     annualContribution: ZuoraContributionConfig,
     digitalPack: ZuoraDigitalPackConfig,
     supporterPlusConfig: ZuoraSupporterPlusConfig,
-    guardianLight: ZuoraGuardianLightConfig,
 ) {
 
   def contributionConfig(billingPeriod: BillingPeriod): ZuoraContributionConfig =
@@ -61,7 +55,6 @@ class ZuoraConfigProvider(config: Config, defaultStage: Stage)
     annualContribution = contributionFromConfig(config.getConfig("zuora.contribution.annual")),
     digitalPack = digitalPackFromConfig(config.getConfig("zuora.digitalpack")),
     supporterPlusConfig = supporterPlusFromConfig(config.getConfig("zuora.supporterplus")),
-    guardianLight = guardianLightFromConfig(config.getConfig("zuora.guardianlight")),
   )
 
   private def contributionFromConfig(config: Config): ZuoraContributionConfig = ZuoraContributionConfig(
@@ -74,11 +67,6 @@ class ZuoraConfigProvider(config: Config, defaultStage: Stage)
     paymentGracePeriod = config.getInt("paymentGracePeriod"),
     monthlyChargeId = config.getString("monthly.productRatePlanChargeId"),
     annualChargeId = config.getString("annual.productRatePlanChargeId"),
-  )
-
-  private def guardianLightFromConfig(config: Config): ZuoraGuardianLightConfig = ZuoraGuardianLightConfig(
-    paymentGracePeriod = config.getInt("paymentGracePeriod"),
-    monthlyChargeId = config.getString("monthly.productRatePlanChargeId"),
   )
 
   private def supporterPlusFromConfig(config: Config) = ZuoraSupporterPlusConfig(

--- a/support-config/src/main/scala/com/gu/support/config/ZuoraConfigProvider.scala
+++ b/support-config/src/main/scala/com/gu/support/config/ZuoraConfigProvider.scala
@@ -16,6 +16,11 @@ case class ZuoraDigitalPackConfig(
     annualChargeId: String,
 )
 
+case class ZuoraGuardianLightConfig(
+    paymentGracePeriod: Int,
+    monthlyChargeId: String,
+)
+
 case class ZuoraSupporterPlusConfig(
     monthlyChargeId: String,
     annualChargeId: String,
@@ -35,6 +40,7 @@ case class ZuoraConfig(
     annualContribution: ZuoraContributionConfig,
     digitalPack: ZuoraDigitalPackConfig,
     supporterPlusConfig: ZuoraSupporterPlusConfig,
+    guardianLight: ZuoraGuardianLightConfig,
 ) {
 
   def contributionConfig(billingPeriod: BillingPeriod): ZuoraContributionConfig =
@@ -55,6 +61,7 @@ class ZuoraConfigProvider(config: Config, defaultStage: Stage)
     annualContribution = contributionFromConfig(config.getConfig("zuora.contribution.annual")),
     digitalPack = digitalPackFromConfig(config.getConfig("zuora.digitalpack")),
     supporterPlusConfig = supporterPlusFromConfig(config.getConfig("zuora.supporterplus")),
+    guardianLight = guardianLightFromConfig(config.getConfig("zuora.guardianlight")),
   )
 
   private def contributionFromConfig(config: Config): ZuoraContributionConfig = ZuoraContributionConfig(
@@ -67,6 +74,11 @@ class ZuoraConfigProvider(config: Config, defaultStage: Stage)
     paymentGracePeriod = config.getInt("paymentGracePeriod"),
     monthlyChargeId = config.getString("monthly.productRatePlanChargeId"),
     annualChargeId = config.getString("annual.productRatePlanChargeId"),
+  )
+
+  private def guardianLightFromConfig(config: Config): ZuoraGuardianLightConfig = ZuoraGuardianLightConfig(
+    paymentGracePeriod = config.getInt("paymentGracePeriod"),
+    monthlyChargeId = config.getString("monthly.productRatePlanChargeId"),
   )
 
   private def supporterPlusFromConfig(config: Config) = ZuoraSupporterPlusConfig(

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -379,8 +379,11 @@ class CreateSubscriptionController(
         )
       case _: Paper => List.empty
       case _: GuardianWeekly => List.empty
-      // TODO: Revisit this
-      case _: GuardianLight => List.empty
+      // TODO: Confirm this
+      case _: GuardianLight =>
+        List(
+          "gu_guardian_light" -> true.toString,
+        )
     }
 
     val standardAndProductCookies = (standardCookies ++ productCookies).map { case (name, value) =>

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -379,6 +379,8 @@ class CreateSubscriptionController(
         )
       case _: Paper => List.empty
       case _: GuardianWeekly => List.empty
+      // TODO: Revisit this
+      case _: GuardianLight => List.empty
     }
 
     val standardAndProductCookies = (standardCookies ++ productCookies).map { case (name, value) =>

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -379,11 +379,7 @@ class CreateSubscriptionController(
         )
       case _: Paper => List.empty
       case _: GuardianWeekly => List.empty
-      // TODO: Confirm this
-      case _: GuardianLight =>
-        List(
-          "gu_guardian_light" -> true.toString,
-        )
+      case _: GuardianLight => List("gu_guardian_light" -> true.toString)
     }
 
     val standardAndProductCookies = (standardCookies ++ productCookies).map { case (name, value) =>

--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -107,6 +107,7 @@ object CheckoutValidationRules {
           createSupportWorkersRequest,
         ) // Tier three has the same fields as Guardian Weekly
       case _: Contribution => PaidProductValidation.passes(createSupportWorkersRequest)
+      case _: GuardianLight => PaidProductValidation.passes(createSupportWorkersRequest)
     }) match {
       case Invalid(message) =>
         Invalid(s"validation of the request body failed with $message - body was $createSupportWorkersRequest")

--- a/support-models/src/main/scala/com/gu/support/catalog/Catalog.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Catalog.scala
@@ -14,7 +14,7 @@ case class Catalog(
 
 object Catalog {
   lazy val productRatePlansWithPrices: List[ProductRatePlanId] = for {
-    product <- List(SupporterPlus, DigitalPack, Paper, GuardianWeekly, TierThree)
+    product <- List(SupporterPlus, DigitalPack, Paper, GuardianWeekly, TierThree, GuardianLight)
     env <- List(PROD, CODE)
     plan <- product.ratePlans(env)
   } yield plan.id

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -109,6 +109,31 @@ case object SupporterPlus extends Product {
     )
 }
 
+case object GuardianLight extends Product {
+  private def productRatePlan(
+      id: String,
+      billingPeriod: BillingPeriod,
+      fulfilmentOptions: FulfilmentOptions = NoFulfilmentOptions,
+  ) =
+    ProductRatePlan(
+      id,
+      billingPeriod,
+      fulfilmentOptions,
+      NoProductOptions,
+      s"Guardian Light ${billingPeriod.getClass.getSimpleName}",
+    )
+
+  lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[GuardianLight.type]]] =
+    Map(
+      PROD -> List(
+        productRatePlan("8a12831492c341730192dd1c39207038", Monthly),
+      ),
+      CODE -> List(
+        productRatePlan("", Monthly),
+      ),
+    )
+}
+
 case object DigitalPack extends Product {
   private def productRatePlan(
       id: String,

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -129,7 +129,7 @@ case object GuardianLight extends Product {
         productRatePlan("8a12831492c341730192dd1c39207038", Monthly),
       ),
       CODE -> List(
-        productRatePlan("TODO: fill this in", Monthly),
+        productRatePlan("71a1c43a1e192b28f702b3b47113000a", Monthly),
       ),
     )
 }

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -110,26 +110,22 @@ case object SupporterPlus extends Product {
 }
 
 case object GuardianLight extends Product {
-  private def productRatePlan(
-      id: String,
-      billingPeriod: BillingPeriod,
-      fulfilmentOptions: FulfilmentOptions = NoFulfilmentOptions,
-  ) =
+  private def productRatePlan(id: String) =
     ProductRatePlan(
       id,
-      billingPeriod,
-      fulfilmentOptions,
+      Monthly,
+      NoFulfilmentOptions,
       NoProductOptions,
-      s"Guardian Light ${billingPeriod.getClass.getSimpleName}",
+      s"Guardian Light Monthly",
     )
 
   lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[GuardianLight.type]]] =
     Map(
       PROD -> List(
-        productRatePlan("8a12831492c341730192dd1c39207038", Monthly),
+        productRatePlan("8a12831492c341730192dd1c39207038"),
       ),
       CODE -> List(
-        productRatePlan("71a1c43a1e192b28f702b3b47113000a", Monthly),
+        productRatePlan("71a1c43a1e192b28f702b3b47113000a"),
       ),
     )
 }

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -129,7 +129,7 @@ case object GuardianLight extends Product {
         productRatePlan("8a12831492c341730192dd1c39207038", Monthly),
       ),
       CODE -> List(
-        productRatePlan("", Monthly),
+        productRatePlan("TODO: fill this in", Monthly),
       ),
     )
 }

--- a/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
@@ -39,6 +39,14 @@ object ProductTypeRatePlans {
       .getOrElse(environment, Nil)
       .find(productRatePlan => productRatePlan.billingPeriod == product.billingPeriod)
 
+  def guardianLightRatePlan(
+      product: GuardianLight,
+      environment: TouchPointEnvironment,
+  ): Option[ProductRatePlan[catalog.GuardianLight.type]] =
+    catalog.GuardianLight.ratePlans
+      .getOrElse(environment, Nil)
+      .find(productRatePlan => productRatePlan.billingPeriod == product.billingPeriod)
+
   def tierThreeRatePlan(
       product: TierThree,
       environment: TouchPointEnvironment,

--- a/support-models/src/main/scala/com/gu/support/workers/Products.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/Products.scala
@@ -81,6 +81,14 @@ case class GuardianWeekly(
   override def describe: String = s"$billingPeriod-GuardianWeekly-$fulfilmentOptions-$currency"
 }
 
+case class GuardianLight(
+    amount: BigDecimal,
+    currency: Currency,
+    billingPeriod: BillingPeriod,
+) extends ProductType {
+  override def describe: String = s"$billingPeriod-GuardianLight-$currency-$amount"
+}
+
 object ProductType {
   import com.gu.support.encoding.CustomCodecs._
 
@@ -97,6 +105,8 @@ object ProductType {
     discriminatedType.variant[GuardianWeekly]("GuardianWeekly")
   implicit val codecDigital: discriminatedType.VariantCodec[DigitalPack] =
     discriminatedType.variant[DigitalPack]("DigitalPack")
+  implicit val codecGuardianLight: discriminatedType.VariantCodec[GuardianLight] =
+    discriminatedType.variant[GuardianLight]("GuardianLight")
 
   implicit val codec: Codec[ProductType] =
     discriminatedType.codec(

--- a/support-models/src/main/scala/com/gu/support/workers/Products.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/Products.scala
@@ -83,9 +83,10 @@ case class GuardianWeekly(
 
 case class GuardianLight(
     currency: Currency,
-    billingPeriod: BillingPeriod,
 ) extends ProductType {
   override def describe: String = s"$billingPeriod-GuardianLight-$currency"
+
+  override def billingPeriod: BillingPeriod = Monthly
 }
 
 object ProductType {

--- a/support-models/src/main/scala/com/gu/support/workers/Products.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/Products.scala
@@ -82,11 +82,10 @@ case class GuardianWeekly(
 }
 
 case class GuardianLight(
-    amount: BigDecimal,
     currency: Currency,
     billingPeriod: BillingPeriod,
 ) extends ProductType {
-  override def describe: String = s"$billingPeriod-GuardianLight-$currency-$amount"
+  override def describe: String = s"$billingPeriod-GuardianLight-$currency"
 }
 
 object ProductType {

--- a/support-models/src/main/scala/com/gu/support/workers/Products.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/Products.scala
@@ -84,7 +84,7 @@ case class GuardianWeekly(
 case class GuardianLight(
     currency: Currency,
 ) extends ProductType {
-  override def describe: String = s"$billingPeriod-GuardianLight-$currency"
+  override def describe: String = s"GuardianLight-$currency"
 
   override def billingPeriod: BillingPeriod = Monthly
 }

--- a/support-models/src/main/scala/com/gu/support/workers/Products.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/Products.scala
@@ -109,7 +109,15 @@ object ProductType {
 
   implicit val codec: Codec[ProductType] =
     discriminatedType.codec(
-      List(codecContribution, codecSupporterPlus, codecTierThree, codecPaper, codecGuardianWeekly, codecDigital),
+      List(
+        codecContribution,
+        codecSupporterPlus,
+        codecTierThree,
+        codecPaper,
+        codecGuardianWeekly,
+        codecDigital,
+        codecGuardianLight,
+      ),
     )
 
 }

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
@@ -61,7 +61,6 @@ object CreateZuoraSubscriptionProductState {
   ) extends CreateZuoraSubscriptionProductState
 
   case class GuardianLightState(
-      user: User, // Is this user property needed?
       product: GuardianLight,
       paymentMethod: PaymentMethod,
       salesForceContact: SalesforceContactRecord,

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
@@ -61,7 +61,7 @@ object CreateZuoraSubscriptionProductState {
   ) extends CreateZuoraSubscriptionProductState
 
   case class GuardianLightState(
-      user: User,
+      user: User, // Is this user property needed?
       product: GuardianLight,
       paymentMethod: PaymentMethod,
       salesForceContact: SalesforceContactRecord,

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
@@ -60,6 +60,13 @@ object CreateZuoraSubscriptionProductState {
       salesForceContact: SalesforceContactRecord,
   ) extends CreateZuoraSubscriptionProductState
 
+  case class GuardianLightState(
+      user: User,
+      product: GuardianLight,
+      paymentMethod: PaymentMethod,
+      salesForceContact: SalesforceContactRecord,
+  ) extends CreateZuoraSubscriptionProductState
+
   case class DigitalSubscriptionDirectPurchaseState(
       billingCountry: Country,
       product: DigitalPack,

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
@@ -122,6 +122,7 @@ object CreateZuoraSubscriptionProductState {
       discriminatedType.variant[PaperState](paper),
       discriminatedType.variant[GuardianWeeklyState](guardianWeekly),
       discriminatedType.variant[TierThreeState](tierThree),
+      discriminatedType.variant[GuardianLightState](guardianLight),
     ),
   )
 

--- a/support-models/src/main/scala/com/gu/support/workers/states/ExecutionTypeDiscriminators.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/ExecutionTypeDiscriminators.scala
@@ -12,5 +12,6 @@ object ExecutionTypeDiscriminators {
   val digitalSubscriptionGiftRedemption = "DigitalSubscriptionGiftRedemption"
   val paper = "Paper"
   val guardianWeekly = "GuardianWeekly"
+  val guardianLight = "GuardianLight"
 
 }

--- a/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
@@ -50,6 +50,15 @@ object SendThankYouEmailState {
       firstDeliveryDate: LocalDate,
   ) extends SendThankYouEmailState
 
+  case class SendThankYouEmailGuardianLightState(
+      user: User,
+      product: GuardianLight,
+      paymentMethod: PaymentMethod,
+      paymentSchedule: PaymentSchedule,
+      accountNumber: String,
+      subscriptionNumber: String,
+  ) extends SendThankYouEmailState
+
   case class SendThankYouEmailDigitalSubscriptionDirectPurchaseState(
       user: User,
       product: DigitalPack,

--- a/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
@@ -141,6 +141,7 @@ object SendThankYouEmailState {
       ),
       discriminatedType.variant[SendThankYouEmailPaperState](paper),
       discriminatedType.variant[SendThankYouEmailGuardianWeeklyState](guardianWeekly),
+      discriminatedType.variant[SendThankYouEmailGuardianLightState](guardianLight),
     ),
   )
 

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
@@ -111,6 +111,8 @@ object AcquisitionProduct {
 
   case object AppPremiumTier extends AcquisitionProduct("APP_PREMIUM_TIER")
 
+  case object GuardianLight extends AcquisitionProduct("GUARDIAN_LIGHT")
+
   def fromString(code: String): Option[AcquisitionProduct] = {
     List(
       Contribution,
@@ -121,6 +123,7 @@ object AcquisitionProduct {
       GuardianWeekly,
       AppPremiumTier,
       TierThree,
+      GuardianLight,
     )
       .find(
         _.value == code,

--- a/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
@@ -259,6 +259,15 @@ object AcquisitionDataRowBuilder {
           None, // TODO: if we rework digital gift modelling in Zuora we should include the relevant ids here
           None,
         )
+      case s: SendThankYouEmailGuardianLightState =>
+        AcquisitionTypeDetails(
+          paymentMethod = Some(s.paymentMethod),
+          promoCode = None,
+          readerType = Direct,
+          acquisitionType = Purchase,
+          zuoraAccountNumber = Some(s.accountNumber),
+          zuoraSubscriptionNumber = Some(s.subscriptionNumber),
+        )
     }
 
   private def buildLabels(state: SendAcquisitionEventState, accountExists: Boolean) = {

--- a/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
@@ -27,6 +27,7 @@ import com.gu.support.workers.{
   StripePaymentType,
   SupporterPlus,
   TierThree,
+  GuardianLight,
 }
 import com.gu.support.zuora.api.ReaderType.{Direct, Gift}
 import org.joda.time.{DateTime, DateTimeZone}
@@ -126,6 +127,7 @@ object AcquisitionDataRowBuilder {
     case _: DigitalPack => (AcquisitionProduct.DigitalSubscription, None)
     case _: Paper => (AcquisitionProduct.Paper, None)
     case _: GuardianWeekly => (AcquisitionProduct.GuardianWeekly, None)
+    case _: GuardianLight => (AcquisitionProduct.GuardianLight, None)
   }
 
   private def printOptionsFromProduct(product: ProductType, deliveryCountry: Option[Country]): Option[PrintOptions] = {

--- a/support-workers/src/main/scala/com/gu/emailservices/FailedContributionEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/FailedContributionEmailFields.scala
@@ -20,6 +20,9 @@ object FailedEmailFields {
   def paper(email: String, identityUserId: IdentityUserId): EmailFields =
     failedEmailFields("paper-failed", email, identityUserId)
 
+  def guardianLight(email: String, identityUserId: IdentityUserId): EmailFields =
+    failedEmailFields("guardian-light-failed", email, identityUserId)
+
   private def failedEmailFields(dataExtensionName: String, email: String, identityUserId: IdentityUserId): EmailFields =
     EmailFields(Nil, Right(identityUserId), email, dataExtensionName, None, None)
 

--- a/support-workers/src/main/scala/com/gu/emailservices/GuardianLightEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/GuardianLightEmailFields.scala
@@ -1,0 +1,16 @@
+package com.gu.emailservices
+
+import com.gu.support.workers.states.SendThankYouEmailState.SendThankYouEmailGuardianLightState
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class GuardianLightEmailFields {
+  def build(
+      state: SendThankYouEmailGuardianLightState,
+  )(implicit ec: ExecutionContext): Future[EmailFields] = {
+    // TODO: populate this when we know what's needed
+    val fields = List()
+
+    Future.successful(EmailFields(fields, state.user, "guardian-light"))
+  }
+}

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -10,6 +10,7 @@ import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.{
   DigitalSubscriptionDirectPurchaseState,
   DigitalSubscriptionGiftPurchaseState,
   DigitalSubscriptionGiftRedemptionState,
+  GuardianLightState,
   GuardianWeeklyState,
   PaperState,
   SupporterPlusState,
@@ -63,6 +64,8 @@ class NextState(state: CreateSalesforceContactState) {
         toNextSupporterPlus(salesforceContactRecords, product, purchase)
       case (product: TierThree, Purchase(purchase)) =>
         toNextTierThree(salesforceContactRecords, product, purchase)
+      case (product: GuardianLight, Purchase(purchase)) =>
+        toNextGuardianLight(salesforceContactRecords, product, purchase)
       case (product: DigitalPack, Purchase(purchase)) if product.readerType == ReaderType.Direct =>
         toNextDSDirect(salesforceContactRecords.buyer, product, purchase)
       case (product: DigitalPack, Purchase(purchase)) if product.readerType == ReaderType.Gift =>
@@ -135,6 +138,29 @@ class NextState(state: CreateSalesforceContactState) {
         purchase,
         firstDeliveryDate.get,
         appliedPromotion,
+        salesforceContactRecords.buyer,
+      ),
+      requestId,
+      user,
+      product,
+      analyticsInfo,
+      firstDeliveryDate,
+      appliedPromotion,
+      state.csrUsername,
+      state.salesforceCaseId,
+      acquisitionData,
+    )
+
+  def toNextGuardianLight(
+      salesforceContactRecords: SalesforceContactRecords,
+      product: GuardianLight,
+      purchase: PaymentMethod,
+  ): CreateZuoraSubscriptionState =
+    CreateZuoraSubscriptionState(
+      GuardianLightState(
+        user,
+        product,
+        purchase,
         salesforceContactRecords.buyer,
       ),
       requestId,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -158,7 +158,6 @@ class NextState(state: CreateSalesforceContactState) {
   ): CreateZuoraSubscriptionState =
     CreateZuoraSubscriptionState(
       GuardianLightState(
-        user,
         product,
         purchase,
         salesforceContactRecords.buyer,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -161,11 +161,13 @@ class ZuoraProductHandlers(services: Services, state: CreateZuoraSubscriptionSta
   lazy val zuoraGuardianLightHandler = new ZuoraGuardianLightHandler(
     zuoraSubscriptionCreator,
     new GuardianLightSubscriptionBuilder(
-      services.promotionService,
-      touchPointEnvironment,
+      services.config.zuoraConfigProvider.get(isTestUser).guardianLight,
+      services.catalogService,
       dateGenerator,
+      touchPointEnvironment,
       subscribeItemBuilder,
     ),
+    state.user,
   )
   lazy val zuoraPaperHandler = new ZuoraPaperHandler(
     zuoraSubscriptionCreator,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -161,8 +161,6 @@ class ZuoraProductHandlers(services: Services, state: CreateZuoraSubscriptionSta
   lazy val zuoraGuardianLightHandler = new ZuoraGuardianLightHandler(
     zuoraSubscriptionCreator,
     new GuardianLightSubscriptionBuilder(
-      services.config.zuoraConfigProvider.get(isTestUser).guardianLight,
-      services.catalogService,
       dateGenerator,
       touchPointEnvironment,
       subscribeItemBuilder,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -71,6 +71,12 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
           zuoraSubscriptionState.csrUsername,
           zuoraSubscriptionState.salesforceCaseId,
         )
+      case state: GuardianLightState =>
+        zuoraGuardianLightHandler.subscribe(
+          state,
+          zuoraSubscriptionState.csrUsername,
+          zuoraSubscriptionState.salesforceCaseId,
+        )
     }
 
     eventualSendThankYouEmailState.map { nextState =>
@@ -146,6 +152,15 @@ class ZuoraProductHandlers(services: Services, state: CreateZuoraSubscriptionSta
   lazy val zuoraTierThreeHandler = new ZuoraTierThreeHandler(
     zuoraSubscriptionCreator,
     new TierThreeSubscriptionBuilder(
+      services.promotionService,
+      touchPointEnvironment,
+      dateGenerator,
+      subscribeItemBuilder,
+    ),
+  )
+  lazy val zuoraGuardianLightHandler = new ZuoraGuardianLightHandler(
+    zuoraSubscriptionCreator,
+    new GuardianLightSubscriptionBuilder(
       services.promotionService,
       touchPointEnvironment,
       dateGenerator,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -49,6 +49,8 @@ class FailureHandler(emailService: EmailService) extends Handler[FailureHandlerS
       case _: Paper => FailedEmailFields.paper(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
       case _: GuardianWeekly =>
         FailedEmailFields.guardianWeekly(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
+      case _: GuardianLight =>
+        FailedEmailFields.guardianLight(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
     }
     logger.info(s"Sending a failure email. Email fields: $emailFields")
     emailService.send(emailFields)

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -79,6 +79,7 @@ class EmailBuilder(
       created = DateTime.now(),
     )
     val tierThreeEmailFields = new TierThreeEmailFields(paperFieldsGenerator, touchpointEnvironment)
+    val guardianLightEmailFields = new GuardianLightEmailFields()
 
     state match {
       case contribution: SendThankYouEmailContributionState => contributionEmailFields.build(contribution).map(List(_))
@@ -90,7 +91,8 @@ class EmailBuilder(
       case paper: SendThankYouEmailPaperState =>
         getAgentDetails(paper.product.deliveryAgent).flatMap(paperEmailFields.build(paper, _)).map(List(_))
       case weekly: SendThankYouEmailGuardianWeeklyState => guardianWeeklyEmailFields.build(weekly).map(List(_))
-      case guardianLight: SendThankYouEmailGuardianLightState => ??? // TODO
+      case guardianLight: SendThankYouEmailGuardianLightState =>
+        guardianLightEmailFields.build(guardianLight).map(List(_))
     }
   }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -90,6 +90,7 @@ class EmailBuilder(
       case paper: SendThankYouEmailPaperState =>
         getAgentDetails(paper.product.deliveryAgent).flatMap(paperEmailFields.build(paper, _)).map(List(_))
       case weekly: SendThankYouEmailGuardianWeeklyState => guardianWeeklyEmailFields.build(weekly).map(List(_))
+      case guardianLight: SendThankYouEmailGuardianLightState => ??? // TODO
     }
   }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
@@ -1,7 +1,6 @@
 package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
-import com.gu.monitoring.SafeLogger
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.catalog._
 import com.gu.support.workers.RequestInfo

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
@@ -11,6 +11,7 @@ import com.gu.support.workers.states.SendThankYouEmailState.{
   SendThankYouEmailDigitalSubscriptionDirectPurchaseState,
   SendThankYouEmailDigitalSubscriptionGiftPurchaseState,
   SendThankYouEmailDigitalSubscriptionGiftRedemptionState,
+  SendThankYouEmailGuardianLightState,
   SendThankYouEmailGuardianWeeklyState,
   SendThankYouEmailPaperState,
   SendThankYouEmailSupporterPlusState,
@@ -183,6 +184,20 @@ object UpdateSupporterProductData {
       case SendThankYouEmailPaperState(user, product, _, _, _, _, subscriptionNumber, _) =>
         catalogService
           .getProductRatePlan(Paper, product.billingPeriod, product.fulfilmentOptions, product.productOptions)
+          .map(productRatePlan =>
+            Some(
+              supporterRatePlanItem(
+                subscriptionName = subscriptionNumber,
+                identityId = user.id,
+                productRatePlanId = productRatePlan.id,
+                productRatePlanName = s"support-workers added ${product.describe}",
+              ),
+            ),
+          )
+          .toRight(s"Unable to create SupporterRatePlanItem from state $state")
+      case SendThankYouEmailGuardianLightState(user, product, _, _, _, subscriptionNumber) =>
+        catalogService
+          .getProductRatePlan(Paper, product.billingPeriod, NoFulfilmentOptions, NoProductOptions)
           .map(productRatePlan =>
             Some(
               supporterRatePlanItem(

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
@@ -197,7 +197,7 @@ object UpdateSupporterProductData {
           .toRight(s"Unable to create SupporterRatePlanItem from state $state")
       case SendThankYouEmailGuardianLightState(user, product, _, _, _, subscriptionNumber) =>
         catalogService
-          .getProductRatePlan(Paper, product.billingPeriod, NoFulfilmentOptions, NoProductOptions)
+          .getProductRatePlan(GuardianLight, product.billingPeriod, NoFulfilmentOptions, NoProductOptions)
           .map(productRatePlan =>
             Some(
               supporterRatePlanItem(

--- a/support-workers/src/main/scala/com/gu/zuora/productHandlers/ZuoraGuardianLightHandler.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/productHandlers/ZuoraGuardianLightHandler.scala
@@ -1,0 +1,40 @@
+package com.gu.zuora.productHandlers
+
+import com.gu.support.acquisitions.AcquisitionData
+import com.gu.support.workers.User
+import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.GuardianLightState
+import com.gu.support.workers.states.SendThankYouEmailState
+import com.gu.support.workers.states.SendThankYouEmailState.SendThankYouEmailGuardianLightState
+import com.gu.zuora.ZuoraSubscriptionCreator
+import com.gu.zuora.subscriptionBuilders.GuardianLightSubscriptionBuilder
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class ZuoraGuardianLightHandler(
+    zuoraSubscriptionCreator: ZuoraSubscriptionCreator,
+    subscriptionBuilder: GuardianLightSubscriptionBuilder,
+    user: User,
+) {
+
+  def subscribe(
+      state: GuardianLightState,
+      csrUsername: Option[String],
+      salesforceCaseId: Option[String],
+  ): Future[SendThankYouEmailState] = {
+    val subscribeItem = subscriptionBuilder.build(state, csrUsername, salesforceCaseId)
+
+    for {
+      paymentSchedule <- zuoraSubscriptionCreator.preview(subscribeItem, state.product.billingPeriod)
+      (account, sub) <- zuoraSubscriptionCreator.ensureSubscriptionCreated(subscribeItem)
+    } yield SendThankYouEmailGuardianLightState(
+      user,
+      state.product,
+      state.paymentMethod,
+      paymentSchedule,
+      account.value,
+      sub.value,
+    )
+
+  }
+}

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/GuardianLightSubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/GuardianLightSubscriptionBuilder.scala
@@ -1,0 +1,76 @@
+package com.gu.zuora.subscriptionBuilders
+
+import com.gu.helpers.DateGenerator
+import com.gu.support.catalog.CatalogService
+import com.gu.support.config.{TouchPointEnvironment, ZuoraSupporterPlusConfig}
+import com.gu.support.promotions.{PromoError, PromotionService}
+import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.GuardianLightState
+import com.gu.support.zuora.api.SubscribeItem
+import com.gu.zuora.subscriptionBuilders.ProductSubscriptionBuilders.validateRatePlan
+
+class GuardianLightSubscriptionBuilder(
+    config: ZuoraSupporterPlusConfig,
+    promotionService: PromotionService,
+    catalogService: CatalogService,
+    dateGenerator: DateGenerator,
+    environment: TouchPointEnvironment,
+    subscribeItemBuilder: SubscribeItemBuilder,
+) {
+  def build(
+      state: GuardianLightState,
+      csrUsername: Option[String],
+      salesforceCaseId: Option[String],
+  ): Either[PromoError, SubscribeItem] = {
+    val productRatePlanId =
+      validateRatePlan(guardianLightRatePlan(state.product, environment), state.product.describe)
+    val contributionRatePlanChargeId =
+      if (state.product.billingPeriod == Monthly) config.v2.monthlyContributionChargeId
+      else config.v2.annualContributionChargeId
+    val todaysDate = dateGenerator.today
+
+    val contributionAmount = state.product.amount - getBaseProductPrice(productRatePlanId, state.product.currency)
+    if (contributionAmount < 0)
+      throw new BadRequestException(
+        s"The contribution amount of a supporter plus subscription cannot be less than zero, but here it would be $contributionAmount",
+      )
+
+    val subscriptionData = subscribeItemBuilder.buildProductSubscription(
+      productRatePlanId = productRatePlanId,
+      ratePlanCharges = List(
+        RatePlanChargeData(
+          RatePlanChargeOverride(
+            contributionRatePlanChargeId,
+            price = contributionAmount, // Pass the amount of the cost which counts as a contribution into Zuora
+          ),
+        ),
+      ),
+      contractEffectiveDate = todaysDate,
+      contractAcceptanceDate = todaysDate,
+      readerType = Direct,
+      csrUsername = csrUsername,
+      salesforceCaseId = salesforceCaseId,
+    )
+
+    applyPromoCodeIfPresent(
+      promotionService,
+      state.appliedPromotion,
+      productRatePlanId,
+      subscriptionData,
+    ).map { subscriptionData =>
+      subscribeItemBuilder.build(subscriptionData, state.salesForceContact, Some(state.paymentMethod), None)
+    }
+  }
+
+  private def getBaseProductPrice(productRatePlanId: ProductRatePlanId, currency: Currency) =
+    (for {
+      priceList <- catalogService.getPriceList(productRatePlanId)
+      price <- priceList.prices.find(_.currency == currency)
+    } yield price.value) match {
+      case Some(amount) => amount
+      case _ =>
+        throw new CatalogDataNotFoundException(
+          s"Missing price data for supporter plus product rateplan with id $productRatePlanId with currency $currency",
+        )
+    }
+
+}

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/GuardianLightSubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/GuardianLightSubscriptionBuilder.scala
@@ -1,16 +1,19 @@
 package com.gu.zuora.subscriptionBuilders
 
 import com.gu.helpers.DateGenerator
-import com.gu.support.catalog.CatalogService
-import com.gu.support.config.{TouchPointEnvironment, ZuoraSupporterPlusConfig}
+import com.gu.i18n.Currency
+import com.gu.support.catalog.{CatalogService, ProductRatePlanId}
+import com.gu.support.config.{TouchPointEnvironment, ZuoraGuardianLightConfig, ZuoraSupporterPlusConfig}
 import com.gu.support.promotions.{PromoError, PromotionService}
+import com.gu.support.workers.ProductTypeRatePlans.guardianLightRatePlan
+import com.gu.support.workers.exceptions.CatalogDataNotFoundException
 import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.GuardianLightState
-import com.gu.support.zuora.api.SubscribeItem
+import com.gu.support.zuora.api.ReaderType.Direct
+import com.gu.support.zuora.api.{RatePlanChargeData, RatePlanChargeOverride, SubscribeItem}
 import com.gu.zuora.subscriptionBuilders.ProductSubscriptionBuilders.validateRatePlan
 
 class GuardianLightSubscriptionBuilder(
-    config: ZuoraSupporterPlusConfig,
-    promotionService: PromotionService,
+    config: ZuoraGuardianLightConfig,
     catalogService: CatalogService,
     dateGenerator: DateGenerator,
     environment: TouchPointEnvironment,
@@ -20,27 +23,21 @@ class GuardianLightSubscriptionBuilder(
       state: GuardianLightState,
       csrUsername: Option[String],
       salesforceCaseId: Option[String],
-  ): Either[PromoError, SubscribeItem] = {
+  ): SubscribeItem = {
     val productRatePlanId =
       validateRatePlan(guardianLightRatePlan(state.product, environment), state.product.describe)
-    val contributionRatePlanChargeId =
-      if (state.product.billingPeriod == Monthly) config.v2.monthlyContributionChargeId
-      else config.v2.annualContributionChargeId
+
+    // This is hardcoded to monthly
+    val contributionRatePlanChargeId = config.monthlyChargeId
+
     val todaysDate = dateGenerator.today
-
-    val contributionAmount = state.product.amount - getBaseProductPrice(productRatePlanId, state.product.currency)
-    if (contributionAmount < 0)
-      throw new BadRequestException(
-        s"The contribution amount of a supporter plus subscription cannot be less than zero, but here it would be $contributionAmount",
-      )
-
     val subscriptionData = subscribeItemBuilder.buildProductSubscription(
       productRatePlanId = productRatePlanId,
       ratePlanCharges = List(
         RatePlanChargeData(
           RatePlanChargeOverride(
-            contributionRatePlanChargeId,
-            price = contributionAmount, // Pass the amount of the cost which counts as a contribution into Zuora
+            productRatePlanChargeId = contributionRatePlanChargeId,
+            price = getBaseProductPrice(productRatePlanId, state.product.currency),
           ),
         ),
       ),
@@ -51,14 +48,7 @@ class GuardianLightSubscriptionBuilder(
       salesforceCaseId = salesforceCaseId,
     )
 
-    applyPromoCodeIfPresent(
-      promotionService,
-      state.appliedPromotion,
-      productRatePlanId,
-      subscriptionData,
-    ).map { subscriptionData =>
-      subscribeItemBuilder.build(subscriptionData, state.salesForceContact, Some(state.paymentMethod), None)
-    }
+    subscribeItemBuilder.build(subscriptionData, state.salesForceContact, Some(state.paymentMethod), None)
   }
 
   private def getBaseProductPrice(productRatePlanId: ProductRatePlanId, currency: Currency) =
@@ -69,7 +59,7 @@ class GuardianLightSubscriptionBuilder(
       case Some(amount) => amount
       case _ =>
         throw new CatalogDataNotFoundException(
-          s"Missing price data for supporter plus product rateplan with id $productRatePlanId with currency $currency",
+          s"Missing price data for Guardian Light product rateplan with id $productRatePlanId with currency $currency",
         )
     }
 

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -699,13 +699,13 @@ object JsonFixtures {
     CreateZuoraSubscriptionState(
       GuardianLightState(
         userJsonWithDeliveryAddress,
-        GuardianLight(GBP, Monthly),
+        GuardianLight(GBP),
         stripePaymentMethodObj,
         salesforceContact,
       ),
       UUID.randomUUID(),
       user(),
-      GuardianLight(GBP, Monthly),
+      GuardianLight(GBP),
       AnalyticsInfo(isGiftPurchase = false, Stripe),
       None,
       None,

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -17,6 +17,7 @@ import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.{
   DigitalSubscriptionDirectPurchaseState,
   DigitalSubscriptionGiftPurchaseState,
   DigitalSubscriptionGiftRedemptionState,
+  GuardianLightState,
   GuardianWeeklyState,
   PaperState,
   SupporterPlusState,
@@ -688,6 +689,25 @@ object JsonFixtures {
       GuardianWeekly(GBP, Quarterly, RestOfWorld),
       AnalyticsInfo(isGiftPurchase = false, Stripe),
       Some(LocalDate.now(DateTimeZone.UTC).plusDays(10)),
+      None,
+      None,
+      None,
+      None,
+    ).asJson.spaces2
+
+  val createGuardianLightZuoraSubscriptionJson =
+    CreateZuoraSubscriptionState(
+      GuardianLightState(
+        userJsonWithDeliveryAddress,
+        GuardianLight(GBP, Monthly),
+        stripePaymentMethodObj,
+        salesforceContact,
+      ),
+      UUID.randomUUID(),
+      user(),
+      GuardianLight(GBP, Monthly),
+      AnalyticsInfo(isGiftPurchase = false, Stripe),
+      None,
       None,
       None,
       None,

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -698,7 +698,6 @@ object JsonFixtures {
   val createGuardianLightZuoraSubscriptionJson =
     CreateZuoraSubscriptionState(
       GuardianLightState(
-        userJsonWithDeliveryAddress,
         GuardianLight(GBP),
         stripePaymentMethodObj,
         salesforceContact,

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -155,6 +155,12 @@ class CreateZuoraSubscriptionSpec extends AsyncLambdaSpec with MockServicesCreat
       })
   }
 
+  it should "create a Guardian Light monthly subscription" in {
+    createZuoraHelper
+      .createSubscription(createGuardianLightZuoraSubscriptionJson)
+      .map(_ should matchPattern { case s: SendThankYouEmailGuardianLightState =>
+      })
+  }
 }
 
 class CreateZuoraSubscriptionHelper(implicit executionContext: ExecutionContext)

--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/UpdateSupporterProductDataSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/UpdateSupporterProductDataSpec.scala
@@ -5,6 +5,7 @@ import com.gu.support.config.TouchPointEnvironments.PROD
 import com.gu.support.workers.lambdas.UpdateSupporterProductDataSpec.{
   digitalSubscriptionGiftRedemptionState,
   digitalSusbcriptionGiftPurchaseState,
+  guardianLightState,
   serviceWithFixtures,
   supporterPlusState,
 }
@@ -43,6 +44,13 @@ class UpdateSupporterProductDataSpec extends AnyFlatSpec with EitherValues {
       UpdateSupporterProductData.getSupporterRatePlanItemFromState(state, serviceWithFixtures).value
     supporterRatePlanItem.value.identityId shouldBe "200092951"
     supporterRatePlanItem.value.contributionAmount shouldBe None // not guaranteed right if discounted, and unused anyway
+  }
+
+  "UpdateSupporterProductData" should "return a valid SupporterRatePlanItem for a Guardian Light purchase" in {
+    val state = decode[SendThankYouEmailState](guardianLightState).value
+    val supporterRatePlanItem =
+      UpdateSupporterProductData.getSupporterRatePlanItemFromState(state, serviceWithFixtures).value
+    supporterRatePlanItem.value.identityId shouldBe "200092951"
   }
 }
 
@@ -102,6 +110,61 @@ object UpdateSupporterProductDataSpec {
           "productType": "SupporterPlus"
         }
     """
+
+  val guardianLightState =
+    """
+    {
+        "user": {
+          "id": "200092951",
+          "primaryEmailAddress": "test+2343343jj28323@test.com",
+          "title": null,
+          "firstName": "yy",
+          "lastName": "yy",
+          "billingAddress": {
+            "lineOne": null,
+            "lineTwo": null,
+            "city": null,
+            "state": "",
+            "postCode": null,
+            "country": "GB"
+          },
+          "deliveryAddress": null,
+          "telephoneNumber": null,
+          "isTestUser": false,
+          "deliveryInstructions": null
+        },
+        "product": {
+          "amount": 2,
+          "currency": "GBP",
+          "billingPeriod": "Monthly",
+          "fulfilmentOptions": "NoFulfilmentOptions",
+          "productType": "GuardianLight"
+        },
+        "paymentMethod": {
+          "TokenId": "pm_0MZap9ItVxyc3Q6nRNfyJHfO",
+          "SecondTokenId": "cus_NKFK2NAwJc9tH3",
+          "CreditCardNumber": "4242",
+          "CreditCardCountry": "GB",
+          "CreditCardExpirationMonth": 2,
+          "CreditCardExpirationYear": 2029,
+          "CreditCardType": "Visa",
+          "PaymentGateway": "Stripe PaymentIntents GNM Membership",
+          "Type": "CreditCardReferenceTransaction",
+          "StripePaymentType": "StripeCheckout"
+        },
+        "paymentSchedule": {
+          "payments": [
+            {
+              "date": "2024-01-08",
+              "amount": 20
+            }
+          ]
+        },
+        "accountNumber": "A00485141",
+        "subscriptionNumber": "A-S00489451",
+        "productType": "GuardianLight"
+      }
+  """
 
   val digitalSubscriptionGiftRedemptionState = """
     {


### PR DESCRIPTION
## What are you doing in this PR?

Following on from #6498 this PR adds support for purchasing Guardian Light on the backend.

**Note: does not include the thank you page or completed thank you/failure emails, this work will be done in future PRs.**

[**Trello Card**](https://trello.com/c/V7r1ALrC/1211-checkout-support-for-new-product-backend)

## Why are you doing this?

So that users can purchase Guardian Light and the correct data is added to Zuora.

## How to test

I've been able to put through a transaction successfully in CODE:

- [x] The support-workers state machine execution completes successfully
- [x] The correct cookie is dropped
- [x] Thank you email message sent to the membership-workflow queue
- [x] Data added to the `SupporterProductData` Dynamo table

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots

<img width="700" alt="Screenshot 2024-11-21 at 13 16 27" src="https://github.com/user-attachments/assets/98a98ddd-b04f-4eb6-8cd5-a9be04a21974">

![Screenshot 2024-11-20 at 16 49 58](https://github.com/user-attachments/assets/7b26cf4c-62e7-4d3c-ad8a-dfeacdeaf3f2)

