### PR TITLE
Update prout checklist to link to correct workflow

### DIFF
--- a/prout/seen.md
+++ b/prout/seen.md
@@ -1,3 +1,3 @@
 
-- Keep an eye out for the post deployment tests [github action](https://github.com/guardian/support-frontend/actions/workflows/support-frontend-post-deploy-tests-using-playwright.yml)
+- Keep an eye out for the post deployment Playwright smoke tests [github action](https://github.com/guardian/support-frontend/actions/workflows/playwright-smoke.yml)
 - If the tests have failed, the [post deployment test runbook](https://github.com/guardian/support-frontend/wiki/Post-deployment-test-runbook) should help troubleshoot.


### PR DESCRIPTION
## What are you doing in this PR?

Update prout checklist to link to correct workflow:

<img width="860" alt="Screenshot 2024-11-12 at 10 40 13" src="https://github.com/user-attachments/assets/1e2495f3-f8d1-4db9-a87f-e79792d2b3a9">


## Why are you doing this?

I noticed the workflow linked to from the prout-bot comment is one which is no longer run. So update it to point to the correct workflow, i.e. the one which runs the Playwright smoke tests against prod.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
