### PR TITLE
Make alarm names different to existing non-cdk alarms

### DIFF
--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -791,7 +791,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
           },
         ],
         "AlarmDescription": "There was a failure whilst setting up recurring payments after the user attempted to complete a checkout process. Check https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/statemachines/view/arn:aws:states:eu-west-1:865473395570:stateMachine:support-workers-PROD?statusFilter=FAILED",
-        "AlarmName": "Support Workers Execution Failure in PROD (Recurring Contributions or Subscriptions Checkout)",
+        "AlarmName": "Support Workers Execution Failure in PROD (Recurring Contributions or Subscriptions Checkout).",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -1103,7 +1103,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "support-workers PROD No successful recurring gocardless contributions recently",
+        "AlarmName": "support-workers PROD No successful recurring gocardless contributions recently.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -1173,7 +1173,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "support-workers PROD No successful recurring gocardless supporter plus contributions recently",
+        "AlarmName": "support-workers PROD No successful recurring gocardless supporter plus contributions recently.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -1243,7 +1243,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "URGENT 9-5 - PROD support-workers No successful paper checkouts in 24h",
+        "AlarmName": "URGENT 9-5 - PROD support-workers No successful paper checkouts in 24h.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "EvaluationPeriods": 288,
         "Metrics": [
@@ -1380,7 +1380,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "support-workers PROD No successful recurring paypal contributions recently",
+        "AlarmName": "support-workers PROD No successful recurring paypal contributions recently.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -1450,7 +1450,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "support-workers PROD No successful recurring paypal supporter plus contributions recently",
+        "AlarmName": "support-workers PROD No successful recurring paypal supporter plus contributions recently.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -1520,7 +1520,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "support-workers PROD No successful recurring stripe contributions recently",
+        "AlarmName": "support-workers PROD No successful recurring stripe contributions recently.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -1590,7 +1590,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "support-workers PROD No successful recurring stripe supporter plus contributions recently",
+        "AlarmName": "support-workers PROD No successful recurring stripe supporter plus contributions recently.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -1660,7 +1660,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "URGENT 9-5 - PROD support-workers No successful guardian weekly checkouts in 8h",
+        "AlarmName": "URGENT 9-5 - PROD support-workers No successful guardian weekly checkouts in 8h.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "EvaluationPeriods": 96,
         "Metrics": [
@@ -2924,7 +2924,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
           },
         ],
         "AlarmDescription": "There was a timeout whilst setting up recurring payments after the user attempted to complete a checkout process. Check https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/statemachines/view/arn:aws:states:eu-west-1:865473395570:stateMachine:support-workers-PROD?statusFilter=TIMED_OUT",
-        "AlarmName": "Support Workers Timeout in PROD (Recurring Contributions or Subscriptions Checkout)",
+        "AlarmName": "Support Workers Timeout in PROD (Recurring Contributions or Subscriptions Checkout).",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -251,7 +251,7 @@ export class SupportWorkers extends GuStack {
       app,
       actionsEnabled: isProd,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `Support Workers Execution Failure in ${this.stage} (Recurring Contributions or Subscriptions Checkout)`,
+      alarmName: `Support Workers Execution Failure in ${this.stage} (Recurring Contributions or Subscriptions Checkout).`,
       alarmDescription: `There was a failure whilst setting up recurring payments after the user attempted to complete a checkout process. Check https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/statemachines/view/arn:aws:states:eu-west-1:865473395570:stateMachine:support-workers-${this.stage}?statusFilter=FAILED`,
       metric: new Metric({
         metricName: "ExecutionsFailed",
@@ -271,7 +271,7 @@ export class SupportWorkers extends GuStack {
       app,
       actionsEnabled: isProd,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `Support Workers Timeout in ${this.stage} (Recurring Contributions or Subscriptions Checkout)`,
+      alarmName: `Support Workers Timeout in ${this.stage} (Recurring Contributions or Subscriptions Checkout).`,
       alarmDescription: `There was a timeout whilst setting up recurring payments after the user attempted to complete a checkout process. Check https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/statemachines/view/arn:aws:states:eu-west-1:865473395570:stateMachine:support-workers-${this.stage}?statusFilter=TIMED_OUT`,
       metric: new Metric({
         metricName: "ExecutionsTimedOut",
@@ -317,7 +317,7 @@ export class SupportWorkers extends GuStack {
       app,
       actionsEnabled: isProd,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `support-workers ${this.stage} No successful recurring paypal contributions recently`,
+      alarmName: `support-workers ${this.stage} No successful recurring paypal contributions recently.`,
       metric: new Metric({
         metricName: "PaymentSuccess",
         namespace: "support-frontend",
@@ -339,7 +339,7 @@ export class SupportWorkers extends GuStack {
       app,
       actionsEnabled: isProd,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `support-workers ${this.stage} No successful recurring stripe contributions recently`,
+      alarmName: `support-workers ${this.stage} No successful recurring stripe contributions recently.`,
       metric: new Metric({
         metricName: "PaymentSuccess",
         namespace: "support-frontend",
@@ -361,7 +361,7 @@ export class SupportWorkers extends GuStack {
       app,
       actionsEnabled: isProd,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `support-workers ${this.stage} No successful recurring gocardless contributions recently`,
+      alarmName: `support-workers ${this.stage} No successful recurring gocardless contributions recently.`,
       metric: new Metric({
         metricName: "PaymentSuccess",
         namespace: "support-frontend",
@@ -383,7 +383,7 @@ export class SupportWorkers extends GuStack {
       app,
       actionsEnabled: isProd,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `support-workers ${this.stage} No successful recurring paypal supporter plus contributions recently`,
+      alarmName: `support-workers ${this.stage} No successful recurring paypal supporter plus contributions recently.`,
       metric: new Metric({
         metricName: "PaymentSuccess",
         namespace: "support-frontend",
@@ -405,7 +405,7 @@ export class SupportWorkers extends GuStack {
       app,
       actionsEnabled: isProd,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `support-workers ${this.stage} No successful recurring stripe supporter plus contributions recently`,
+      alarmName: `support-workers ${this.stage} No successful recurring stripe supporter plus contributions recently.`,
       metric: new Metric({
         metricName: "PaymentSuccess",
         namespace: "support-frontend",
@@ -427,7 +427,7 @@ export class SupportWorkers extends GuStack {
       app,
       actionsEnabled: isProd,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `support-workers ${this.stage} No successful recurring gocardless supporter plus contributions recently`,
+      alarmName: `support-workers ${this.stage} No successful recurring gocardless supporter plus contributions recently.`,
       metric: new Metric({
         metricName: "PaymentSuccess",
         namespace: "support-frontend",
@@ -451,7 +451,7 @@ export class SupportWorkers extends GuStack {
       app,
       actionsEnabled: isProd,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `URGENT 9-5 - ${this.stage} support-workers No successful paper checkouts in 24h`,
+      alarmName: `URGENT 9-5 - ${this.stage} support-workers No successful paper checkouts in 24h.`,
       metric: new MathExpression({
         expression: "SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0)])",
         label: "AllPaperConversions",
@@ -501,7 +501,7 @@ export class SupportWorkers extends GuStack {
       app,
       actionsEnabled: isProd,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `URGENT 9-5 - ${this.stage} support-workers No successful guardian weekly checkouts in 8h`,
+      alarmName: `URGENT 9-5 - ${this.stage} support-workers No successful guardian weekly checkouts in 8h.`,
       metric: new MathExpression({
         label: "AllWeeklyConversions",
         expression: "SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0)])",


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
#6449 failed to deploy because the names of the alarms defined in the new CDK were identical to the already existing ones in PROD but the logical ids were different. Rather than setting the logical ids to the old versions which are long and unwieldy, I've just changed the names slightly so we create new ones.