### PR TITLE
Exclude `net.sourceforge.htmlunit:htmlunit` from the project

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -44,6 +44,9 @@ libraryDependencies ++= Seq(
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
 
 excludeDependencies ++= Seq(
+  // Exclude htmlunit due to a vulnerability. Brought in via org.scalatestplus.play:scalatestplus-play but we don't need
+  // it. The vulnerability is fixed in v3 onwards, but the lib was renamed so I don't think we can force a newer version
+  // by specifying is in the dependencies.
   ExclusionRule("net.sourceforge.htmlunit", "htmlunit"),
 )
 

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -43,6 +43,10 @@ libraryDependencies ++= Seq(
 )
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
 
+excludeDependencies ++= Seq(
+  ExclusionRule("net.sourceforge.htmlunit", "htmlunit"),
+)
+
 ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Exclude `net.sourceforge.htmlunit:htmlunit` from the project. 

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

Dependabot has reported a vulnerability for this library. It's brought in via `org.scalatestplus.play:scalatestplus-play` > `org.seleniumhq.selenium:htmlunit-driver` and even the latest version of those libraries rely on a vulnerable version, so there isn't an obvious upgrade path.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
