### PR TITLE
Add sub-campaign theme to countdown

### DIFF
--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -12,16 +12,6 @@ export type CountdownSetting = {
 	};
 };
 
-export const defaultInitialCampaign: CountdownSetting = {
-	label: 'initial',
-	countdownStartInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'),
-	countdownDeadlineInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'),
-	theme: {
-		backgroundColor: '#1e3e72',
-		foregroundColor: '#ffffff',
-	},
-};
-
 interface CampaignCopy {
 	headingFragment?: JSX.Element;
 	subheading?: JSX.Element;
@@ -70,15 +60,6 @@ const campaigns: Record<string, CampaignSettings> = {
 				countdownDeadlineInMillis: Date.parse('Jan 01, 2025 00:00:00'),
 				theme: {
 					backgroundColor: '#1e3e72',
-					foregroundColor: '#ffffff',
-				},
-			},
-			{
-				label: 'Testing Giving Tuesday',
-				countdownStartInMillis: Date.parse('Nov 21, 2024 00:00:00'),
-				countdownDeadlineInMillis: Date.parse('Nov 22, 2024 00:00:00'),
-				theme: {
-					backgroundColor: '#ab0613',
 					foregroundColor: '#ffffff',
 				},
 			},

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -63,6 +63,15 @@ const campaigns: Record<string, CampaignSettings> = {
 					foregroundColor: '#ffffff',
 				},
 			},
+			{
+				label: 'last testing - REMOVE',
+				countdownStartInMillis: Date.parse('Nov 21, 2024 00:00:00'),
+				countdownDeadlineInMillis: Date.parse('Nov 21, 2024 15:00:00'),
+				theme: {
+					backgroundColor: '#ab0613',
+					foregroundColor: '#ffffff',
+				},
+			},
 		],
 		copy: {
 			headingFragment: <>Protect </>,

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -73,6 +73,15 @@ const campaigns: Record<string, CampaignSettings> = {
 					foregroundColor: '#ffffff',
 				},
 			},
+			{
+				label: 'Testing Giving Tuesday',
+				countdownStartInMillis: Date.parse('Nov 21, 2024 00:00:00'),
+				countdownDeadlineInMillis: Date.parse('Nov 22, 2024 00:00:00'),
+				theme: {
+					backgroundColor: '#ab0613',
+					foregroundColor: '#ffffff',
+				},
+			},
 		],
 		copy: {
 			headingFragment: <>Protect </>,

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -12,6 +12,16 @@ export type CountdownSetting = {
 	};
 };
 
+export const defaultInitialCampaign:CountdownSetting = {
+	label: 'initial',
+	countdownStartInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'),
+	countdownDeadlineInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'),
+	theme: {
+		backgroundColor: '#1e3e72',
+		foregroundColor: '#ffffff',
+	}
+};
+
 interface CampaignCopy {
 	headingFragment?: JSX.Element;
 	subheading?: JSX.Element;
@@ -62,7 +72,7 @@ const campaigns: Record<string, CampaignSettings> = {
 					backgroundColor: '#1e3e72',
 					foregroundColor: '#ffffff',
 				},
-			},
+			}
 		],
 		copy: {
 			headingFragment: <>Protect </>,

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -63,15 +63,6 @@ const campaigns: Record<string, CampaignSettings> = {
 					foregroundColor: '#ffffff',
 				},
 			},
-			// {
-			// 	label: 'Testing',
-			// 	countdownStartInMillis: Date.parse('Nov 13, 2024 00:00:00'),
-			// 	countdownDeadlineInMillis: Date.parse('Nov 13, 2024 13:00:00'),
-			// 	theme: {
-			// 		backgroundColor: '#1e3e72',
-			// 		foregroundColor: '#ffffff',
-			// 	},
-			// },
 		],
 		copy: {
 			headingFragment: <>Protect </>,

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -63,15 +63,6 @@ const campaigns: Record<string, CampaignSettings> = {
 					foregroundColor: '#ffffff',
 				},
 			},
-			{
-				label: 'last testing - REMOVE',
-				countdownStartInMillis: Date.parse('Nov 21, 2024 00:00:00'),
-				countdownDeadlineInMillis: Date.parse('Nov 21, 2024 15:00:00'),
-				theme: {
-					backgroundColor: '#ab0613',
-					foregroundColor: '#ffffff',
-				},
-			},
 		],
 		copy: {
 			headingFragment: <>Protect </>,

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -12,14 +12,14 @@ export type CountdownSetting = {
 	};
 };
 
-export const defaultInitialCampaign:CountdownSetting = {
+export const defaultInitialCampaign: CountdownSetting = {
 	label: 'initial',
 	countdownStartInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'),
 	countdownDeadlineInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'),
 	theme: {
 		backgroundColor: '#1e3e72',
 		foregroundColor: '#ffffff',
-	}
+	},
 };
 
 interface CampaignCopy {
@@ -72,7 +72,7 @@ const campaigns: Record<string, CampaignSettings> = {
 					backgroundColor: '#1e3e72',
 					foregroundColor: '#ffffff',
 				},
-			}
+			},
 		],
 		copy: {
 			headingFragment: <>Protect </>,

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -41,7 +41,7 @@ const campaigns: Record<string, CampaignSettings> = {
 				countdownStartInMillis: Date.parse('Nov 29, 2024 00:00:00'),
 				countdownDeadlineInMillis: Date.parse('Dec 04, 2024 00:00:00'),
 				theme: {
-					backgroundColor: '#1e3e72',
+					backgroundColor: '#ab0613',
 					foregroundColor: '#ffffff',
 				},
 			},

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -6,12 +6,10 @@ export type CountdownSetting = {
 	label: string;
 	countdownStartInMillis: number;
 	countdownDeadlineInMillis: number;
-	// TODO: when design agreed add theme
-	//theme: {
-	//	backgroundColor: string;
-	// 	primaryColor: string;
-	//  secondaryColor: string;
-	//};
+	theme: {
+		backgroundColor: string;
+		foregroundColor: string;
+	};
 };
 
 interface CampaignCopy {
@@ -42,17 +40,38 @@ const campaigns: Record<string, CampaignSettings> = {
 				label: 'Giving Tuesday',
 				countdownStartInMillis: Date.parse('Nov 29, 2024 00:00:00'),
 				countdownDeadlineInMillis: Date.parse('Dec 04, 2024 00:00:00'),
+				theme: {
+					backgroundColor: '#1e3e72',
+					foregroundColor: '#ffffff',
+				},
 			},
 			{
 				label: 'Discount',
 				countdownStartInMillis: Date.parse('Dec 09, 2024 00:00:00'),
 				countdownDeadlineInMillis: Date.parse('Dec 13, 2024 00:00:00'),
+				theme: {
+					backgroundColor: '#1e3e72',
+					foregroundColor: '#ffffff',
+				},
 			},
 			{
 				label: 'Final Countdown',
 				countdownStartInMillis: Date.parse('Dec 23, 2024 00:00:00'),
 				countdownDeadlineInMillis: Date.parse('Jan 01, 2025 00:00:00'),
+				theme: {
+					backgroundColor: '#1e3e72',
+					foregroundColor: '#ffffff',
+				},
 			},
+			// {
+			// 	label: 'Testing',
+			// 	countdownStartInMillis: Date.parse('Nov 13, 2024 00:00:00'),
+			// 	countdownDeadlineInMillis: Date.parse('Nov 13, 2024 13:00:00'),
+			// 	theme: {
+			// 		backgroundColor: '#1e3e72',
+			// 		foregroundColor: '#ffffff',
+			// 	},
+			// },
 		],
 		copy: {
 			headingFragment: <>Protect </>,

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { palette } from '@guardian/source/foundations';
+import { from, palette } from '@guardian/source/foundations';
 import { useEffect, useState } from 'react';
 import type { CountdownSetting } from 'helpers/campaigns/campaigns';
 /**
@@ -10,8 +10,12 @@ import type { CountdownSetting } from 'helpers/campaigns/campaigns';
 const outer = css`
 	width: 272px;
 	margin: auto;
-	margin-top: 0px; // TODO: check with Sasha
-	margin-bottom: 10px; // TODO: check with Sasha
+	margin-bottom: 16px; // mobile
+	margin-top: 0px;
+	${from.mobileLandscape} {
+		margin-bottom: 24px;
+		margin-top: 0px;
+	}
 `;
 
 const container = (colours?: CountdownSetting) => css`

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -70,7 +70,7 @@ const timeLabelStyle = css`
 
 // props
 export type CountdownProps = {
-	campaign: CountdownSetting;
+	countdownCampaign: CountdownSetting;
 };
 
 // create countdown logic
@@ -87,7 +87,9 @@ const ensureRoundedDoubleDigits = (timeSection: number): string => {
 };
 
 // return the countdown component
-export default function Countdown({ campaign }: CountdownProps): JSX.Element {
+export default function Countdown({
+	countdownCampaign: campaign,
+}: CountdownProps): JSX.Element {
 	// one for each timepart to reduce DOM updates where unnecessary.
 	const [seconds, setSeconds] = useState<string>(initialTimePart);
 	const [minutes, setMinutes] = useState<string>(initialTimePart);

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -11,12 +11,12 @@ const outer = css`
 	width: 272px;
 	margin: auto;
 	margin-top: 0px; // TODO: check with Sasha
-	margin-bottom: 10px;  // TODO: check with Sasha
+	margin-bottom: 10px; // TODO: check with Sasha
 `;
 
 const container = (colours?: CountdownSetting) => css`
 	width: 100%;
-	background-color: ${colours ? colours.theme.backgroundColor : '#1e3e72'} ;
+	background-color: ${colours ? colours.theme.backgroundColor : '#1e3e72'};
 	color: ${colours ? colours.theme.foregroundColor : palette.neutral[100]};
 	padding: 12px 40px;
 	border-radius: 8px;

--- a/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/countdown.tsx
@@ -7,16 +7,17 @@ import type { CountdownSetting } from 'helpers/campaigns/campaigns';
  * Beware that this is only accurate to less than a second and is locale specific.
  */
 
-// TODO: colours will change with sub-campaigns and design not yet confirmed...
 const outer = css`
 	width: 272px;
 	margin: auto;
+	margin-top: 0px; // TODO: check with Sasha
+	margin-bottom: 10px;  // TODO: check with Sasha
 `;
 
-const container = css`
+const container = (colours?: CountdownSetting) => css`
 	width: 100%;
-	background-color: #1e3e72;
-	color: ${palette.neutral[100]};
+	background-color: ${colours ? colours.theme.backgroundColor : '#1e3e72'} ;
+	color: ${colours ? colours.theme.foregroundColor : palette.neutral[100]};
 	padding: 12px 40px;
 	border-radius: 8px;
 
@@ -150,7 +151,7 @@ export default function Countdown({ campaign }: CountdownProps): JSX.Element {
 		<>
 			{showCountdown && (
 				<div id="timer" role="timer" css={outer}>
-					<div css={container}>
+					<div css={container(campaign)}>
 						<TimePart timePart={days} label={'days'} />
 						<div css={[flexItem, colon]}>:</div>
 						<TimePart timePart={hours} label={'hrs'} />

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -24,6 +24,8 @@ import {
 	init as abTestInit,
 	getAmountsTestVariant,
 } from 'helpers/abTests/abtest';
+import { defaultInitialCampaign, getCampaignSettings } from 'helpers/campaigns/campaigns';
+import type { CountdownSetting } from 'helpers/campaigns/campaigns';
 import type {
 	ContributionType,
 	RegularContributionType,
@@ -50,8 +52,6 @@ import { getPromotion } from 'helpers/productPrice/promotions';
 import * as storage from 'helpers/storage/storage';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
-import { getCampaignSettings } from '../../../helpers/campaigns/campaigns';
-import type { CountdownSetting } from '../../../helpers/campaigns/campaigns';
 import Countdown from '../components/countdown';
 import { LandingPageBanners } from '../components/landingPageBanners';
 import { OneOffCard } from '../components/oneOffCard';
@@ -311,15 +311,7 @@ export function ThreeTierLanding({
 		tierPlanPeriod.slice(1)) as BillingPeriod;
 
 	// Handle which countdown to show (if any).
-	const [currentCampaign, setCurrentCampaign] = useState<CountdownSetting>({
-		label: 'testing',
-		countdownStartInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'),
-		countdownDeadlineInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'),
-		theme: {
-			backgroundColor: '#1e3e72',
-			foregroundColor: '#ffffff',
-		},
-	});
+	const [currentCampaign, setCurrentCampaign] = useState<CountdownSetting>(defaultInitialCampaign);
 	const [showCountdown, setShowCountdown] = useState<boolean>(false);
 
 	const memoizedCurrentCampaign = useMemo(() => {

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -24,9 +24,7 @@ import {
 	init as abTestInit,
 	getAmountsTestVariant,
 } from 'helpers/abTests/abtest';
-import {
-	getCampaignSettings,
-} from 'helpers/campaigns/campaigns';
+import { getCampaignSettings } from 'helpers/campaigns/campaigns';
 import type { CountdownSetting } from 'helpers/campaigns/campaigns';
 import type {
 	ContributionType,

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -315,6 +315,10 @@ export function ThreeTierLanding({
 		label: 'testing',
 		countdownStartInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'),
 		countdownDeadlineInMillis: Date.parse('01 Jan 1970 00:00:00 GMT'),
+		theme: {
+			backgroundColor: '#1e3e72',
+			foregroundColor: '#ffffff',
+		},
 	});
 	const [showCountdown, setShowCountdown] = useState<boolean>(false);
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -24,7 +24,10 @@ import {
 	init as abTestInit,
 	getAmountsTestVariant,
 } from 'helpers/abTests/abtest';
-import { defaultInitialCampaign, getCampaignSettings } from 'helpers/campaigns/campaigns';
+import {
+	defaultInitialCampaign,
+	getCampaignSettings,
+} from 'helpers/campaigns/campaigns';
 import type { CountdownSetting } from 'helpers/campaigns/campaigns';
 import type {
 	ContributionType,
@@ -311,7 +314,9 @@ export function ThreeTierLanding({
 		tierPlanPeriod.slice(1)) as BillingPeriod;
 
 	// Handle which countdown to show (if any).
-	const [currentCampaign, setCurrentCampaign] = useState<CountdownSetting>(defaultInitialCampaign);
+	const [currentCampaign, setCurrentCampaign] = useState<CountdownSetting>(
+		defaultInitialCampaign,
+	);
 	const [showCountdown, setShowCountdown] = useState<boolean>(false);
 
 	const memoizedCurrentCampaign = useMemo(() => {

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -25,7 +25,6 @@ import {
 	getAmountsTestVariant,
 } from 'helpers/abTests/abtest';
 import {
-	defaultInitialCampaign,
 	getCampaignSettings,
 } from 'helpers/campaigns/campaigns';
 import type { CountdownSetting } from 'helpers/campaigns/campaigns';
@@ -314,12 +313,11 @@ export function ThreeTierLanding({
 		tierPlanPeriod.slice(1)) as BillingPeriod;
 
 	// Handle which countdown to show (if any).
-	const [currentCampaign, setCurrentCampaign] = useState<CountdownSetting>(
-		defaultInitialCampaign,
-	);
+	const [currentCountdownSettings, setCurrentCountdownSettings] =
+		useState<CountdownSetting>();
 	const [showCountdown, setShowCountdown] = useState<boolean>(false);
 
-	const memoizedCurrentCampaign = useMemo(() => {
+	const memoizedCurrentCountdownCampaign = useMemo(() => {
 		if (!campaignSettings?.countdownSettings) {
 			return undefined;
 		}
@@ -332,11 +330,11 @@ export function ThreeTierLanding({
 	}, [campaignSettings?.countdownSettings]);
 
 	useEffect(() => {
-		if (memoizedCurrentCampaign) {
-			setCurrentCampaign(memoizedCurrentCampaign);
+		if (memoizedCurrentCountdownCampaign) {
+			setCurrentCountdownSettings(memoizedCurrentCountdownCampaign);
 			setShowCountdown(true);
 		}
-	}, [memoizedCurrentCampaign]);
+	}, [memoizedCurrentCountdownCampaign]);
 
 	/*
 	 * /////////////// END US EOY 2024 Campaign
@@ -522,7 +520,9 @@ export function ThreeTierLanding({
 				cssOverrides={recurringContainer}
 			>
 				<div css={innerContentContainer}>
-					{showCountdown && <Countdown campaign={currentCampaign} />}
+					{showCountdown && currentCountdownSettings && (
+						<Countdown countdownCampaign={currentCountdownSettings} />
+					)}
 					<h1 css={heading}>
 						{campaignSettings?.copy.headingFragment ?? <>Support </>}
 						fearless, <br css={tabletLineBreak} />

--- a/support-frontend/stories/landingPage/Countdown.stories.tsx
+++ b/support-frontend/stories/landingPage/Countdown.stories.tsx
@@ -42,6 +42,10 @@ Default.args = { campaign:
 		label: 'default',
 		countdownStartInMillis: (Date.now() - (1 * millisecondsInDay) + (1 * millisecondsInHour)),
 		countdownDeadlineInMillis: (Date.now() + ((2 * millisecondsInDay) + (1 * millisecondsInHour) + (45 * millisecondsInMinute) + (30 * millisecondsInSecond))),
+		theme: {
+			backgroundColor: '#1e3e72',
+			foregroundColor: '#ffffff',
+		},
 	}
 };
 
@@ -51,6 +55,10 @@ DeadlineNear.args = { campaign:
 		label: 'deadline near',
 		countdownStartInMillis: (Date.now() - (1 * millisecondsInDay)),
 		countdownDeadlineInMillis: (Date.now() + (5 * millisecondsInSecond)),
+		theme: {
+			backgroundColor: '#1e3e72',
+			foregroundColor: '#ffffff',
+		},
 	}
 };
 
@@ -60,6 +68,10 @@ DeadlinePassedHidden.args = { campaign:
 		label: 'deadline passed',
 		countdownStartInMillis: (Date.now() - (1 * millisecondsInDay)),
 		countdownDeadlineInMillis: (Date.now() - (5 * millisecondsInSecond)),
+		theme: {
+			backgroundColor: '#1e3e72',
+			foregroundColor: '#ffffff',
+		},
 	}
 };
 
@@ -69,5 +81,22 @@ NotYetAvailableHidden.args = { campaign:
 		label: 'start date well in future',
 		countdownStartInMillis: (Date.now() + (1 * millisecondsInDay)),
 		countdownDeadlineInMillis: (Date.now() + (5 * millisecondsInDay)),
+		theme: {
+			backgroundColor: '#1e3e72',
+			foregroundColor: '#ffffff',
+		},
+	}
+};
+
+export const ThemedSubCampaign = Template.bind({});
+ThemedSubCampaign.args = { campaign: 
+	{
+		label: 'change colour theme',
+		countdownStartInMillis: (Date.now() - (1 * millisecondsInDay) + (1 * millisecondsInHour)),
+		countdownDeadlineInMillis: (Date.now() + ((2 * millisecondsInDay) + (1 * millisecondsInHour) + (45 * millisecondsInMinute) + (30 * millisecondsInSecond))),
+		theme: {
+			backgroundColor: '#f36161',
+			foregroundColor: '#060e08',
+		},
 	}
 };

--- a/support-frontend/stories/landingPage/Countdown.stories.tsx
+++ b/support-frontend/stories/landingPage/Countdown.stories.tsx
@@ -1,12 +1,12 @@
-import { css } from "@emotion/react";
-import { palette } from "@guardian/source/foundations";
-import type { CountdownProps } from "pages/supporter-plus-landing/components/countdown";
-import Countdown from "pages/supporter-plus-landing/components/countdown";
+import { css } from '@emotion/react';
+import { palette } from '@guardian/source/foundations';
+import type { CountdownProps } from 'pages/supporter-plus-landing/components/countdown';
+import Countdown from 'pages/supporter-plus-landing/components/countdown';
 
 export default {
-    title: 'LandingPage/Countdown',
-    component: Countdown,
-    parameters: {
+	title: 'LandingPage/Countdown',
+	component: Countdown,
+	parameters: {
 		docs: {
 			description: {
 				component: `A countdown component for use in campaigns, particularly for example, the US end of year. NOTE: that the versions are fixed against the mocked current date set in Storybook and do not actually count down in Storybook.`,
@@ -24,79 +24,91 @@ function Template(args: CountdownProps) {
 	const contentContainer = css`
 		height: 500px;
 		width: 100%;
-		padding-top: 40px; 
+		padding-top: 40px;
 		background: ${palette.brand[400]};
 	`;
 	return (
-		<div css={contentContainer} >
-            <Countdown {...args} />
-        </div>
-    );
-};
+		<div css={contentContainer}>
+			<Countdown {...args} />
+		</div>
+	);
+}
 
 Template.args = {} as CountdownProps;
 
 export const Default = Template.bind({});
-Default.args = { campaign: 
-	{
+Default.args = {
+	countdownCampaign: {
 		label: 'default',
-		countdownStartInMillis: (Date.now() - (1 * millisecondsInDay) + (1 * millisecondsInHour)),
-		countdownDeadlineInMillis: (Date.now() + ((2 * millisecondsInDay) + (1 * millisecondsInHour) + (45 * millisecondsInMinute) + (30 * millisecondsInSecond))),
+		countdownStartInMillis:
+			Date.now() - 1 * millisecondsInDay + 1 * millisecondsInHour,
+		countdownDeadlineInMillis:
+			Date.now() +
+			(2 * millisecondsInDay +
+				1 * millisecondsInHour +
+				45 * millisecondsInMinute +
+				30 * millisecondsInSecond),
 		theme: {
 			backgroundColor: '#1e3e72',
 			foregroundColor: '#ffffff',
 		},
-	}
+	},
 };
 
 export const DeadlineNear = Template.bind({});
-DeadlineNear.args = { campaign: 
-	{
+DeadlineNear.args = {
+	countdownCampaign: {
 		label: 'deadline near',
-		countdownStartInMillis: (Date.now() - (1 * millisecondsInDay)),
-		countdownDeadlineInMillis: (Date.now() + (5 * millisecondsInSecond)),
+		countdownStartInMillis: Date.now() - 1 * millisecondsInDay,
+		countdownDeadlineInMillis: Date.now() + 5 * millisecondsInSecond,
 		theme: {
 			backgroundColor: '#1e3e72',
 			foregroundColor: '#ffffff',
 		},
-	}
+	},
 };
 
 export const DeadlinePassedHidden = Template.bind({});
-DeadlinePassedHidden.args = { campaign: 
-	{
+DeadlinePassedHidden.args = {
+	countdownCampaign: {
 		label: 'deadline passed',
-		countdownStartInMillis: (Date.now() - (1 * millisecondsInDay)),
-		countdownDeadlineInMillis: (Date.now() - (5 * millisecondsInSecond)),
+		countdownStartInMillis: Date.now() - 1 * millisecondsInDay,
+		countdownDeadlineInMillis: Date.now() - 5 * millisecondsInSecond,
 		theme: {
 			backgroundColor: '#1e3e72',
 			foregroundColor: '#ffffff',
 		},
-	}
+	},
 };
 
 export const NotYetAvailableHidden = Template.bind({});
-NotYetAvailableHidden.args = { campaign: 
-	{
+NotYetAvailableHidden.args = {
+	countdownCampaign: {
 		label: 'start date well in future',
-		countdownStartInMillis: (Date.now() + (1 * millisecondsInDay)),
-		countdownDeadlineInMillis: (Date.now() + (5 * millisecondsInDay)),
+		countdownStartInMillis: Date.now() + 1 * millisecondsInDay,
+		countdownDeadlineInMillis: Date.now() + 5 * millisecondsInDay,
 		theme: {
 			backgroundColor: '#1e3e72',
 			foregroundColor: '#ffffff',
 		},
-	}
+	},
 };
 
 export const ThemedSubCampaign = Template.bind({});
-ThemedSubCampaign.args = { campaign: 
-	{
+ThemedSubCampaign.args = {
+	countdownCampaign: {
 		label: 'change colour theme',
-		countdownStartInMillis: (Date.now() - (1 * millisecondsInDay) + (1 * millisecondsInHour)),
-		countdownDeadlineInMillis: (Date.now() + ((2 * millisecondsInDay) + (1 * millisecondsInHour) + (45 * millisecondsInMinute) + (30 * millisecondsInSecond))),
+		countdownStartInMillis:
+			Date.now() - 1 * millisecondsInDay + 1 * millisecondsInHour,
+		countdownDeadlineInMillis:
+			Date.now() +
+			(2 * millisecondsInDay +
+				1 * millisecondsInHour +
+				45 * millisecondsInMinute +
+				30 * millisecondsInSecond),
 		theme: {
 			backgroundColor: '#ab0613',
 			foregroundColor: '#ffffff',
 		},
-	}
+	},
 };

--- a/support-frontend/stories/landingPage/Countdown.stories.tsx
+++ b/support-frontend/stories/landingPage/Countdown.stories.tsx
@@ -95,8 +95,8 @@ ThemedSubCampaign.args = { campaign:
 		countdownStartInMillis: (Date.now() - (1 * millisecondsInDay) + (1 * millisecondsInHour)),
 		countdownDeadlineInMillis: (Date.now() + ((2 * millisecondsInDay) + (1 * millisecondsInHour) + (45 * millisecondsInMinute) + (30 * millisecondsInSecond))),
 		theme: {
-			backgroundColor: '#f36161',
-			foregroundColor: '#060e08',
+			backgroundColor: '#ab0613',
+			foregroundColor: '#ffffff',
 		},
 	}
 };


### PR DESCRIPTION
## What are you doing in this PR?

Adds the ability to set up different colour and background colours for countdowns for each sub-campaign for US EOY.

[**Trello Card**](https://trello.com/c/gECTtqrM)

## Why are you doing this?

The US would like each sub-campaign to have a different colour scheme.

## How to test

Set the datetime for the campaign to be around 'now' then run locally and go to the US 3-tier landing page with the feature flag of ?forceCampaign=usEoy2024 or check storybook

## Screenshots

### Default countdown colour scheme:
<img width="322" alt="Screenshot 2024-11-20 at 13 03 21" src="https://github.com/user-attachments/assets/41916b82-1930-4f68-9487-5b47f3da9b2b">

### Giving Tuesday countdown colour scheme:
<img width="322" alt="Screenshot 2024-11-20 at 13 03 09" src="https://github.com/user-attachments/assets/81af3ba4-162b-4732-ab39-4b45aecb69e5">