### PR TITLE
Add pubdata to cmp init

### DIFF
--- a/support-frontend/assets/helpers/page/analyticsAndConsent.ts
+++ b/support-frontend/assets/helpers/page/analyticsAndConsent.ts
@@ -34,10 +34,9 @@ function analyticsInitialisation(
 }
 
 function consentInitialisation(country: IsoCountry): void {
-
 	if (shouldInitCmp()) {
 		try {
-	    const browserId = getCookie({ name: 'bwid', shouldMemoize: true });
+			const browserId = getCookie({ name: 'bwid', shouldMemoize: true });
 			cmp.init({
 				pubData: {
 					pageViewId: ophan.viewId,

--- a/support-frontend/assets/helpers/page/analyticsAndConsent.ts
+++ b/support-frontend/assets/helpers/page/analyticsAndConsent.ts
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { cmp } from '@guardian/libs';
+import { cmp, getCookie } from '@guardian/libs';
 import ophan from 'ophan';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { IsoCountry } from 'helpers/internationalisation/country';
@@ -34,9 +34,16 @@ function analyticsInitialisation(
 }
 
 function consentInitialisation(country: IsoCountry): void {
+
 	if (shouldInitCmp()) {
 		try {
+	    const browserId = getCookie({ name: 'bwid', shouldMemoize: true });
 			cmp.init({
+				pubData: {
+					pageViewId: ophan.viewId,
+					browserId: browserId ?? undefined,
+					platform: 'support', // TO BE CONFIRMED
+				},
 				country,
 			});
 		} catch (e) {

--- a/support-frontend/assets/helpers/tracking/__tests__/thirdPartyTrackingConsentTest.ts
+++ b/support-frontend/assets/helpers/tracking/__tests__/thirdPartyTrackingConsentTest.ts
@@ -40,12 +40,12 @@ describe('thirdPartyTrackingConsent', () => {
 		});
 	});
 
-	describe('CCPA mode', () => {
+	describe('USNAT mode', () => {
 		it('calls dummyCallback with false if CCPA doNotSell is true', async () => {
 			onConsentChange.mockImplementation(
 				(callback: (callback: ConsentState) => void) =>
 					callback({
-						ccpa: {
+						usnat: {
 							doNotSell: true,
 						},
 					} as ConsentState),
@@ -61,11 +61,11 @@ describe('thirdPartyTrackingConsent', () => {
 			});
 		});
 
-		it('calls dummyCallback with true if CCPA doNotSell is false', async () => {
+		it('calls dummyCallback with true if USNAT doNotSell is false', async () => {
 			onConsentChange.mockImplementation(
 				(callback: (callback: ConsentState) => void) =>
 					callback({
-						ccpa: {
+						usnat: {
 							doNotSell: false,
 						},
 					} as ConsentState),

--- a/support-frontend/assets/helpers/tracking/thirdPartyTrackingConsent.ts
+++ b/support-frontend/assets/helpers/tracking/thirdPartyTrackingConsent.ts
@@ -1,20 +1,6 @@
 import { onConsentChange } from '@guardian/libs';
+import type { ConsentState } from '@guardian/libs';
 import { logException } from 'helpers/utilities/logger';
-
-type ConsentVector = Record<string, boolean>;
-type ConsentState = {
-	tcfv2?: {
-		consents: ConsentVector;
-		eventStatus: 'tcloaded' | 'cmpuishown' | 'useractioncomplete';
-		vendorConsents: ConsentVector;
-	};
-	ccpa?: {
-		doNotSell: boolean;
-	};
-	aus?: {
-		personalisedAdvertising: boolean;
-	};
-};
 
 const onConsentChangeEvent = async (
 	onConsentChangeCallback: (
@@ -37,11 +23,11 @@ const onConsentChangeEvent = async (
 	 */
 	try {
 		onConsentChange((state: ConsentState) => {
-			if (state.ccpa) {
+			if (state.usnat) {
 				consentGranted = Object.keys(vendorIds).reduce(
 					(accumulator, vendorKey) => ({
 						...accumulator,
-						[vendorKey]: state.ccpa ? !state.ccpa.doNotSell : false,
+						[vendorKey]: state.usnat ? !state.usnat.doNotSell : false,
 					}),
 					{},
 				);

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -85,7 +85,7 @@
 		"@emotion/serialize": "^1.1.2",
 		"@emotion/utils": "^1.1.0",
 		"@floating-ui/react": "^0.19.2",
-		"@guardian/libs": "16.1.0",
+		"@guardian/libs": "^19.1.0",
 		"@guardian/pasteup": "1.0.0-alpha.7",
 		"@guardian/source": "8.0.0",
 		"@guardian/source-development-kitchen": "13.0.0",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1841,10 +1841,10 @@
     eslint-plugin-eslint-comments "3.2.0"
     eslint-plugin-import "2.29.1"
 
-"@guardian/libs@16.1.0":
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-16.1.0.tgz#70d986a312a04e609a89ef1a631f6a3000e322da"
-  integrity sha512-nb7r0C+UO4P6f0wH8sATtGYnGrfqCzOX4M1Pp2G+uj9c3tehMRSum4mgnqxSAVXN50LtkL2bwd4u3Ichk6670Q==
+"@guardian/libs@^19.1.0":
+  version "19.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-19.1.0.tgz#df30c98c51303f6e1e7b5750838892b60ee43323"
+  integrity sha512-hH+yMhsBwUU7p8BdmbSqjk9hwp5obtglugviwSIeu89JqlDQnC1LrYKw0kVZbkn+P4sW+aQDYg7OVswgpNPOHg==
 
 "@guardian/paparazzi@^0.3.1":
   version "0.3.1"
@@ -11459,16 +11459,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11639,7 +11630,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11659,13 +11650,6 @@ strip-ansi@^3.0.0:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -12789,7 +12773,7 @@ word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.4.tgz#cb4b50ec9aca570abd1f52f33cd45b6c61739a9f"
   integrity sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12802,15 +12786,6 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
- Sending the pageviewId, platform and browserId as pubData to cmp.
- Updating @guardian/libs to latest version.
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
