### PR TITLE
Exclude `net.sourceforge.htmlunit:htmlunit` from support-payment-api

### DIFF
--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -66,6 +66,13 @@ libraryDependencies ++= Seq(
   "com.sun.xml.bind" % "jaxb-impl" % "2.3.1",
 )
 
+excludeDependencies ++= Seq(
+  // Exclude htmlunit due to a vulnerability. Brought in via org.scalatestplus.play:scalatestplus-play but we don't need
+  // it. The vulnerability is fixed in v3 onwards, but the lib was renamed so I don't think we can force a newer version
+  // by specifying is in the dependencies.
+  ExclusionRule("net.sourceforge.htmlunit", "htmlunit"),
+)
+
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -67,9 +67,9 @@ libraryDependencies ++= Seq(
 )
 
 excludeDependencies ++= Seq(
-  // Exclude htmlunit due to a vulnerability. Brought in via org.scalatestplus.play:scalatestplus-play but we don't need
-  // it. The vulnerability is fixed in v3 onwards, but the lib was renamed so I don't think we can force a newer version
-  // by specifying is in the dependencies.
+  // Exclude htmlunit due to a vulnerability. Brought in via play-test via fluentlenium-core and htmlunit-driver but we
+  // don't need it. The vulnerability is fixed in v3 onwards, but the lib was renamed so I don't think we can force a
+  // newer version by specifying it in the dependencies.
   ExclusionRule("net.sourceforge.htmlunit", "htmlunit"),
 )
 


### PR DESCRIPTION

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Exclude `net.sourceforge.htmlunit:htmlunit` from the `support-payment-api` project.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

This library has a vulnerability and there isn't an obvious upgrade path. Follow on from #6510, which didn't completely get rid of the vulnerable dependency from the project.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
