### PR TITLE
Increase max one-off contribution by 4 percent

### DIFF
--- a/support-payment-api/src/main/scala/model/Currency.scala
+++ b/support-payment-api/src/main/scala/model/Currency.scala
@@ -29,6 +29,6 @@ object Currency extends Enum[Currency] with CirceEnum[Currency] {
       case USD => 10000
       case _ => 2000
     }
-    amount > maxAmount
+    amount > maxAmount * 1.04
   }
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Increasing the maximum allowed one-off contribution by 4% to allow people to use the "cover transaction cost" checkbox on the highest contributions.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/y5Mk6jbI/1224-when-user-chooses-max-contr-amount-cover-transaction-fee-amount-4-can-be-added-on-top-on-all-regions)

## Why are you doing this?

We've seen alarms since adding the checkbox (#6277) that people went over the maximum! This is because the client did not validate the maximum after the additional 4% added by the checkbox. This maximum amount is not a legal / tax decision and is just reputational, so adding 4% is OK.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
I pointed the payment-api to local and ran it there with the changes. Then in the UK made a one off contribution of £1991 plus the checkbox

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Screenshots
Before
![image](https://github.com/user-attachments/assets/4d96766d-e55c-43c8-a5df-d5551f9ff877)
After
![image](https://github.com/user-attachments/assets/7b27967f-04fb-4336-ac1d-47be43326d09)

