### PR TITLE
Remove getUserType from backend

### DIFF
--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -88,7 +88,6 @@ POST  /stripe/create-setup-intent/prb                              controllers.S
 POST  /contribute/send-marketing                                   controllers.IdentityController.submitMarketing()
 
 # ------ Identity ------ #
-GET /identity/get-user-type                                        controllers.IdentityController.getUserType(maybeEmail: Option[String])
 POST /identity/signin-url                                          controllers.IdentityController.createSignInURL()
 
 # ----- Subscriptions ----- #


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Remove the "getUserType" endpoint from the support-frontend backend. 

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

## Why are you doing this?

We're now returning this information in the create endpoint (#6507). This PR needs to go in after #6523 
<!--
Remember, PRs are documentation for future contributors.
-->

