### PR TITLE
Add geo redirect for one time checkout

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -29,6 +29,7 @@ import views.EmptyDiv
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
+import com.gu.support.workers.StripePublicKey.get
 
 case class AppConfig private (
     geoip: AppConfig.Geoip,
@@ -271,6 +272,14 @@ class Application(
     List(getGeoRedirectUrl(request.geoData.countryGroup, product), campaignCode)
       .filter(_.nonEmpty)
       .mkString("/")
+  }
+
+  def oneTimeGeoRedirect(): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
+    val url = List(getGeoRedirectUrl(request.geoData.countryGroup, "one-time-checkout"))
+      .filter(_.nonEmpty)
+      .mkString("/")
+
+    RedirectWithEncodedQueryString(url, request.queryString, status = FOUND)
   }
 
   def redirect(location: String): Action[AnyContent] = CachedAction() { implicit request =>

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -263,8 +263,8 @@ class Application(
     RedirectWithEncodedQueryString(url, request.queryString, status = FOUND)
   }
 
-  def guardianLightGeoRedirect(): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
-    val url = getGeoPath(request, "", "guardian-light")
+  def geoRedirectToPath(path: String): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
+    val url = getGeoPath(request, "", path)
     RedirectWithEncodedQueryString(url, request.queryString, status = FOUND)
   }
 
@@ -272,14 +272,6 @@ class Application(
     List(getGeoRedirectUrl(request.geoData.countryGroup, product), campaignCode)
       .filter(_.nonEmpty)
       .mkString("/")
-  }
-
-  def oneTimeGeoRedirect(): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
-    val url = List(getGeoRedirectUrl(request.geoData.countryGroup, "one-time-checkout"))
-      .filter(_.nonEmpty)
-      .mkString("/")
-
-    RedirectWithEncodedQueryString(url, request.queryString, status = FOUND)
   }
 
   def redirect(location: String): Action[AnyContent] = CachedAction() { implicit request =>

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -29,7 +29,6 @@ import views.EmptyDiv
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
-import com.gu.support.workers.StripePublicKey.get
 
 case class AppConfig private (
     geoip: AppConfig.Geoip,

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -61,6 +61,7 @@ GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/contribute/checkout controllers.A
 
 # Checkout
 GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/checkout            controllers.Application.productCheckoutRouter(countryGroupId: String)
+GET  /one-time-checkout                                            controllers.Application.oneTimeGeoRedirect()
 GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/one-time-checkout   controllers.Application.productCheckoutRouter(countryGroupId: String)
 GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/thank-you           controllers.Application.productCheckoutRouter(countryGroupId: String)
 

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -61,7 +61,7 @@ GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/contribute/checkout controllers.A
 
 # Checkout
 GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/checkout            controllers.Application.productCheckoutRouter(countryGroupId: String)
-GET  /one-time-checkout                                            controllers.Application.oneTimeGeoRedirect()
+GET  /one-time-checkout                                            controllers.Application.geoRedirectToPath(path = "one-time-checkout")
 GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/one-time-checkout   controllers.Application.productCheckoutRouter(countryGroupId: String)
 GET  /$countryGroupId<(uk|us|au|eu|int|nz|ca)>/thank-you           controllers.Application.productCheckoutRouter(countryGroupId: String)
 
@@ -72,7 +72,7 @@ GET /eu/guardian-light                                             controllers.A
 GET /int/guardian-light                                            controllers.Application.contributeGeoRedirect(campaignCode = "")
 GET /nz/guardian-light                                             controllers.Application.contributeGeoRedirect(campaignCode = "")
 GET /ca/guardian-light                                             controllers.Application.contributeGeoRedirect(campaignCode = "")
-GET /guardian-light                                                controllers.Application.guardianLightGeoRedirect()
+GET /guardian-light                                                controllers.Application.geoRedirectToPath(path = "guardian-light")
 
 GET  /contribute                                                   controllers.Application.contributeGeoRedirect(campaignCode = "")
 GET  /contribute/:campaignCode                                     controllers.Application.contributeGeoRedirect(campaignCode: String)


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Adding a geo redirect for the one time checkout, so that we can use the link https://support.theguardian.com/one-time-checkout

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/Xrbrvakd/1251-https-supporttheguardiancom-one-time-checkout-does-not-geo-redirect)


<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Go to `support.thegulocal.com/one-time-checkout`, be redirected to `support.thegulocal.com/uk/one-time-checkout`

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

