### PR TITLE
Enable newOneTimeCheckout AB test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -117,7 +117,7 @@ export const tests: Tests = {
 		audiences: {
 			ALL: {
 				offset: 0,
-				size: 0.05, // 5% initially before ramping up
+				size: 1,
 			},
 		},
 		isActive: true,

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -117,10 +117,10 @@ export const tests: Tests = {
 		audiences: {
 			ALL: {
 				offset: 0,
-				size: 1,
+				size: 0.05, // 5% initially before ramping up
 			},
 		},
-		isActive: false,
+		isActive: true,
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 4,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,


### PR DESCRIPTION
Reverts guardian/support-frontend#6517 (which turned the test off), and increases the coverage to 100%