### PR TITLE
Turn off zip code autocomplete

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -1194,6 +1194,8 @@ export function CheckoutComponent({
 												}
 											}
 										}}
+										// We have seen this field be filled in with an email address
+										autoComplete={'postal-code'}
 									/>
 								</div>
 							)}

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -1195,7 +1195,7 @@ export function CheckoutComponent({
 											}
 										}}
 										// We have seen this field be filled in with an email address
-										autoComplete={'postal-code'}
+										autoComplete={'off'}
 									/>
 								</div>
 							)}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Turning off autocomplete on the zip code field. We've seen this be filled in with an email address when payment method is PayPal. Our theory is somehow the modal or browser is autofilling this.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

## How do we measure success?

No PayPal email address in postcode support worker failures!