### PR TITLE
Fix broken `PreparePaymentMethodForReuseSpec` it test

### DIFF
--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -998,12 +998,15 @@ object JsonFixtures {
             $requestIdJson,
             ${userJson(userId)},
             "product": ${contribution()},
-          "analyticsInfo": {
-            "paymentProvider": "Existing",
-            "isGiftPurchase": false
-          },
-            "paymentFields" : {"billingAccountId" : "$billingAccountId"}
+            "analyticsInfo": {
+              "paymentProvider": "Existing",
+              "isGiftPurchase": false
+            },
+            "paymentFields" : {
+              "billingAccountId": "$billingAccountId",
+              "paymentType": "Existing"
             }
+          }
         """
 
   val previewSubscribeResponseJson = """


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Fix broken `PreparePaymentMethodForReuseSpec` it test.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

## Why are you doing this?

In #6485 a mandatory `paymentType` field was added to this json data structure, so we need to add it to this fixture.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
