### PR TITLE
Fix stripe payment method tracking on one time

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -275,10 +275,6 @@ export function OneTimeCheckoutComponent({
 		stripeExpressCheckoutPaymentType,
 		setStripeExpressCheckoutPaymentType,
 	] = useState<ExpressPaymentType>();
-	const stripePaymentMethod: StripePaymentMethod =
-		stripeExpressCheckoutPaymentType === 'apple_pay'
-			? 'StripeApplePay'
-			: 'StripePaymentRequestButton';
 
 	const [stripeExpressCheckoutSuccessful, setStripeExpressCheckoutSuccessful] =
 		useState(false);
@@ -423,6 +419,13 @@ export function OneTimeCheckoutComponent({
 						);
 					}
 				} else {
+					const stripePaymentMethod: StripePaymentMethod =
+						paymentMethod === 'StripeExpressCheckoutElement'
+							? stripeExpressCheckoutPaymentType === 'apple_pay'
+								? 'StripeApplePay'
+								: 'StripePaymentRequestButton'
+							: 'StripeCheckout';
+
 					const stripeData: CreateStripePaymentIntentRequest = {
 						paymentData: {
 							currency: currencyKey,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Fix the payment method tracking of Stripe payments by adding the 'StripeCheckout' case for non Google or Apple pay.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


## Why are you doing this?
We noticed in the data that no payments were recorded as 'Stripe' in the variant, which was obviously suspicious.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
Put through a credit card payment. See 'Stripe' in the data.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
## Screenshots
Purchases with credit card on CODE before and after this change:
![image](https://github.com/user-attachments/assets/f527dd63-b2b7-4454-a734-867847f43fd8)
