### PR TITLE
Newspaper Archive - add iframe properties to header page

### DIFF
--- a/support-frontend/app/views/newspaperArchive.scala.html
+++ b/support-frontend/app/views/newspaperArchive.scala.html
@@ -3,13 +3,13 @@
 )()
 
 <!DOCTYPE html>
-<html lang="en">
+<html data-iframe-height="160" lang="en">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <meta name="robots" content="noindex">
-
+    <base target="_top">
     <title>Newspaper Archive</title>
 
   </head>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Adding data-iframe-height and base target="_top"

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

## Why are you doing this?

Requirements from newspapers dot com to fix the height of the header, and target="_top" ensures links open outside the iframe

<!--
Remember, PRs are documentation for future contributors.
-->

