### PR TITLE
Validation: update pattern to check for whitespace and more emoji-ish characters

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
@@ -32,7 +32,7 @@ import { firstError } from 'helpers/subscriptionsForms/validation';
 import type { Option } from 'helpers/types/option';
 import { canShow } from 'hocs/canShow';
 import {
-	doesNotContainEmojiPattern,
+	doesNotContainEmojiOrWhitespacePattern,
 	preventDefaultValidityMessage,
 } from '../../../pages/[countryGroupId]/validation';
 import type { PostcodeFinderResult } from './postcodeLookup';
@@ -279,7 +279,7 @@ export function AddressFields({ scope, countryGroupId, ...props }: PropTypes) {
 				error={firstError('lineOne', props.errors)}
 				name={`${scope}-lineOne`}
 				maxLength={100}
-				pattern={doesNotContainEmojiPattern}
+				pattern={doesNotContainEmojiOrWhitespacePattern}
 				onBlur={(event) => {
 					event.target.checkValidity();
 				}}
@@ -299,7 +299,7 @@ export function AddressFields({ scope, countryGroupId, ...props }: PropTypes) {
 				error={firstError('lineTwo', props.errors)}
 				name={`${scope}-lineTwo`}
 				maxLength={100}
-				pattern={doesNotContainEmojiPattern}
+				pattern={doesNotContainEmojiOrWhitespacePattern}
 				onBlur={(event) => {
 					event.target.checkValidity();
 				}}
@@ -318,7 +318,7 @@ export function AddressFields({ scope, countryGroupId, ...props }: PropTypes) {
 				onChange={(e) => props.setTownCity(e.target.value)}
 				error={firstError('city', props.errors)}
 				name={`${scope}-city`}
-				pattern={doesNotContainEmojiPattern}
+				pattern={doesNotContainEmojiOrWhitespacePattern}
 				onBlur={(event) => {
 					event.target.checkValidity();
 				}}
@@ -362,7 +362,7 @@ export function AddressFields({ scope, countryGroupId, ...props }: PropTypes) {
 				optional
 				isShown={shouldShowStateInput(props.country)}
 				name={`${scope}-stateProvince`}
-				pattern={doesNotContainEmojiPattern}
+				pattern={doesNotContainEmojiOrWhitespacePattern}
 				onBlur={(event) => {
 					event.target.checkValidity();
 				}}
@@ -382,7 +382,7 @@ export function AddressFields({ scope, countryGroupId, ...props }: PropTypes) {
 				error={firstError('postCode', props.errors)}
 				name={`${scope}-postcode`}
 				maxLength={20}
-				pattern={doesNotContainEmojiPattern}
+				pattern={doesNotContainEmojiOrWhitespacePattern}
 				onBlur={(event) => {
 					event.target.checkValidity();
 				}}

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -105,7 +105,7 @@ import {
 } from '../../../helpers/utilities/dateConversions';
 import { getTierThreeDeliveryDate } from '../../weekly-subscription-checkout/helpers/deliveryDays';
 import {
-	doesNotContainEmojiPattern,
+	doesNotContainEmojiOrWhitespacePattern,
 	preventDefaultValidityMessage,
 } from '../validation';
 import { BackButton } from './backButton';
@@ -1083,7 +1083,7 @@ export function CheckoutComponent({
 										required
 										maxLength={40}
 										error={firstNameError}
-										pattern={doesNotContainEmojiPattern}
+										pattern={doesNotContainEmojiOrWhitespacePattern}
 										onInvalid={(event) => {
 											preventDefaultValidityMessage(event.currentTarget);
 											const validityState = event.currentTarget.validity;
@@ -1117,7 +1117,7 @@ export function CheckoutComponent({
 										required
 										maxLength={40}
 										error={lastNameError}
-										pattern={doesNotContainEmojiPattern}
+										pattern={doesNotContainEmojiOrWhitespacePattern}
 										onInvalid={(event) => {
 											preventDefaultValidityMessage(event.currentTarget);
 											const validityState = event.currentTarget.validity;
@@ -1178,7 +1178,7 @@ export function CheckoutComponent({
 										}}
 										maxLength={20}
 										value={billingPostcode}
-										pattern={doesNotContainEmojiPattern}
+										pattern={doesNotContainEmojiOrWhitespacePattern}
 										error={billingPostcodeError}
 										optional
 										onInvalid={(event) => {

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -84,7 +84,7 @@ import { GuardianTsAndCs } from 'pages/supporter-plus-landing/components/guardia
 import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsMessage';
 import { TsAndCsFooterLinks } from 'pages/supporter-plus-landing/components/paymentTsAndCs';
 import {
-	doesNotContainEmojiPattern,
+	doesNotContainEmojiOrWhitespacePattern,
 	preventDefaultValidityMessage,
 } from '../validation';
 import { BackButton } from './backButton';
@@ -710,7 +710,7 @@ export function OneTimeCheckoutComponent({
 										}}
 										maxLength={20}
 										value={billingPostcode}
-										pattern={doesNotContainEmojiPattern}
+										pattern={doesNotContainEmojiOrWhitespacePattern}
 										error={billingPostcodeError}
 										optional
 										onInvalid={(event) => {

--- a/support-frontend/assets/pages/[countryGroupId]/validation.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/validation.ts
@@ -18,4 +18,5 @@ export function preventDefaultValidityMessage(
  * This uses a Unicode character class escape
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape
  */
-export const doesNotContainEmojiPattern = '^[^\\p{Emoji_Presentation}]+$';
+export const doesNotContainEmojiOrWhitespacePattern =
+	'^(?!.*[\\p{Extended_Pictographic}\\s]).*$';


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Add whitespace to field validation, and extend the emoji matching.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/AMNkTmfY/1208-generic-checkout-user-can-submit-whitespace-as-name)

## Why are you doing this?

We had an alarm where a user had submitted whitespace in the first name field. The extended pictograph regex matches more emojis, eg I tested  ✈️ which isn't strictly an emoji
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

On generic checkout, cannot submit whitespace or emoji. 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


## Screenshots
### Whitespace
Before
![image](https://github.com/user-attachments/assets/0d886a7d-bd3f-424b-bc09-3372154462bb)

After
![image](https://github.com/user-attachments/assets/4232fa4a-35b4-4b76-87aa-7774bf9ec4d0)

### Emoji
Before
![image](https://github.com/user-attachments/assets/cef9a7db-21ab-4e67-a891-83b7aa3c630f)

After
![image](https://github.com/user-attachments/assets/e5ce4cbb-a2ee-4493-9a8e-c7eecdcbdcc2)
