### PR TITLE
Update newspaperArchive iframe height

### DIFF
--- a/support-frontend/app/views/newspaperArchive.scala.html
+++ b/support-frontend/app/views/newspaperArchive.scala.html
@@ -3,7 +3,7 @@
 )()
 
 <!DOCTYPE html>
-<html data-iframe-height="160" lang="en">
+<html data-iframe-height="125" lang="en">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Changing the newspaper archive header iframe height to 125 as that's the intended design height

## Screenshots

Before: 
White space is in our iframe
![image](https://github.com/user-attachments/assets/1ce167ac-e233-4e41-89df-14fee7e9a8c3)

After:
... wait and see