### PR TITLE
Fix back link to guardian light landing page

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -873,10 +873,7 @@ export function CheckoutComponent({
 						)}
 						headerButton={
 							productKey === 'GuardianLight' ? (
-								<BackButton
-									path={`/${geoId}/guardianlight`}
-									buttonText="Back"
-								/>
+								<BackButton path={`/guardian-light`} buttonText="Back" />
 							) : (
 								<BackButton path={`/${geoId}/contribute`} buttonText="Change" />
 							)


### PR DESCRIPTION


<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

From the checkout, fix the `Back` link when the product is Guardian Light. When this link was added we hadn't decided on the landing page path.

## Why are you doing this?

So the link doesn't 404.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
