### PR TITLE
Set expiry to test user cookie

### DIFF
--- a/support-frontend/app/controllers/TestUsersManagement.scala
+++ b/support-frontend/app/controllers/TestUsersManagement.scala
@@ -24,6 +24,14 @@ class TestUsersManagement(
     val testUser = testUsers.testUsers.generateEmail(Some(request.user.email))
     Ok(testUsersView(testUser))
       .withHeaders(CacheControl.noCache)
-      .withCookies(Cookie("_test_username", testUser.token, httpOnly = false, domain = Some(cookieDomain.value)))
+      .withCookies(
+        Cookie(
+          "_test_username",
+          testUser.token,
+          maxAge = Some(24 * 60 * 2),
+          httpOnly = false,
+          domain = Some(cookieDomain.value),
+        ),
+      )
   }
 }

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -190,11 +190,6 @@ export function Checkout({ geoId, appConfig }: Props) {
 		}
 	}
 
-	/**
-	 * TODO: We should probaly send this down from the server as
-	 * this cookie is not always an accurate indicator as to
-	 * whether an account is still valid
-	 */
 	const isTestUser = !!cookie.get('_test_username');
 	const stripePublicKey = getStripeKey(
 		'REGULAR',


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Adding an expiry of two days to the test_username cookie.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/RsJrEweH/1159-test-users-cookie-out-of-sync-with-backend)

## Why are you doing this?

The cookie seems to persist longer than the backend accepts a test user (the old cookie maxAge was session, and modern browsers persist the session for a long time). The red banner stays present for days on end.

![image](https://github.com/user-attachments/assets/73bec9fa-6002-491e-bb8e-e2ad03ec6265)

 This mismatch causes an alarm if you actually try to make a purchase, as the frontend uses the test Stripe key, and the backend isn't expecting it.

I came up with 2 days because I found this [code](https://github.com/guardian/support-frontend/blob/5a7b58ae37d3142239704b38a8a4ea2ffa57b6ed/support-frontend/app/services/TestUserService.scala#L13) -> 
`  val ValidityPeriod = ofDays(2)`

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
I set the maxAge to a few seconds and went to `/test-users`, the red banner then disappeared after the time elapsed.

I will test a test user in prod once merged (slightly hard to do this in dev because the non-test mode would work anyway)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->



## Screenshots
![image](https://github.com/user-attachments/assets/247e4552-25ac-4f43-9ec0-321ba5df2f70)
