### PR TITLE
Revert "Validation: update pattern to check for whitespace and more emoji-ish characters"

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
@@ -32,7 +32,7 @@ import { firstError } from 'helpers/subscriptionsForms/validation';
 import type { Option } from 'helpers/types/option';
 import { canShow } from 'hocs/canShow';
 import {
-	doesNotContainEmojiOrWhitespacePattern,
+	doesNotContainEmojiPattern,
 	preventDefaultValidityMessage,
 } from '../../../pages/[countryGroupId]/validation';
 import type { PostcodeFinderResult } from './postcodeLookup';
@@ -279,7 +279,7 @@ export function AddressFields({ scope, countryGroupId, ...props }: PropTypes) {
 				error={firstError('lineOne', props.errors)}
 				name={`${scope}-lineOne`}
 				maxLength={100}
-				pattern={doesNotContainEmojiOrWhitespacePattern}
+				pattern={doesNotContainEmojiPattern}
 				onBlur={(event) => {
 					event.target.checkValidity();
 				}}
@@ -299,7 +299,7 @@ export function AddressFields({ scope, countryGroupId, ...props }: PropTypes) {
 				error={firstError('lineTwo', props.errors)}
 				name={`${scope}-lineTwo`}
 				maxLength={100}
-				pattern={doesNotContainEmojiOrWhitespacePattern}
+				pattern={doesNotContainEmojiPattern}
 				onBlur={(event) => {
 					event.target.checkValidity();
 				}}
@@ -318,7 +318,7 @@ export function AddressFields({ scope, countryGroupId, ...props }: PropTypes) {
 				onChange={(e) => props.setTownCity(e.target.value)}
 				error={firstError('city', props.errors)}
 				name={`${scope}-city`}
-				pattern={doesNotContainEmojiOrWhitespacePattern}
+				pattern={doesNotContainEmojiPattern}
 				onBlur={(event) => {
 					event.target.checkValidity();
 				}}
@@ -362,7 +362,7 @@ export function AddressFields({ scope, countryGroupId, ...props }: PropTypes) {
 				optional
 				isShown={shouldShowStateInput(props.country)}
 				name={`${scope}-stateProvince`}
-				pattern={doesNotContainEmojiOrWhitespacePattern}
+				pattern={doesNotContainEmojiPattern}
 				onBlur={(event) => {
 					event.target.checkValidity();
 				}}
@@ -382,7 +382,7 @@ export function AddressFields({ scope, countryGroupId, ...props }: PropTypes) {
 				error={firstError('postCode', props.errors)}
 				name={`${scope}-postcode`}
 				maxLength={20}
-				pattern={doesNotContainEmojiOrWhitespacePattern}
+				pattern={doesNotContainEmojiPattern}
 				onBlur={(event) => {
 					event.target.checkValidity();
 				}}

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -105,7 +105,7 @@ import {
 } from '../../../helpers/utilities/dateConversions';
 import { getTierThreeDeliveryDate } from '../../weekly-subscription-checkout/helpers/deliveryDays';
 import {
-	doesNotContainEmojiOrWhitespacePattern,
+	doesNotContainEmojiPattern,
 	preventDefaultValidityMessage,
 } from '../validation';
 import { BackButton } from './backButton';
@@ -1080,7 +1080,7 @@ export function CheckoutComponent({
 										required
 										maxLength={40}
 										error={firstNameError}
-										pattern={doesNotContainEmojiOrWhitespacePattern}
+										pattern={doesNotContainEmojiPattern}
 										onInvalid={(event) => {
 											preventDefaultValidityMessage(event.currentTarget);
 											const validityState = event.currentTarget.validity;
@@ -1114,7 +1114,7 @@ export function CheckoutComponent({
 										required
 										maxLength={40}
 										error={lastNameError}
-										pattern={doesNotContainEmojiOrWhitespacePattern}
+										pattern={doesNotContainEmojiPattern}
 										onInvalid={(event) => {
 											preventDefaultValidityMessage(event.currentTarget);
 											const validityState = event.currentTarget.validity;
@@ -1175,7 +1175,7 @@ export function CheckoutComponent({
 										}}
 										maxLength={20}
 										value={billingPostcode}
-										pattern={doesNotContainEmojiOrWhitespacePattern}
+										pattern={doesNotContainEmojiPattern}
 										error={billingPostcodeError}
 										optional
 										onInvalid={(event) => {

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -84,7 +84,7 @@ import { GuardianTsAndCs } from 'pages/supporter-plus-landing/components/guardia
 import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsMessage';
 import { TsAndCsFooterLinks } from 'pages/supporter-plus-landing/components/paymentTsAndCs';
 import {
-	doesNotContainEmojiOrWhitespacePattern,
+	doesNotContainEmojiPattern,
 	preventDefaultValidityMessage,
 } from '../validation';
 import { BackButton } from './backButton';
@@ -716,7 +716,7 @@ export function OneTimeCheckoutComponent({
 										}}
 										maxLength={20}
 										value={billingPostcode}
-										pattern={doesNotContainEmojiOrWhitespacePattern}
+										pattern={doesNotContainEmojiPattern}
 										error={billingPostcodeError}
 										optional
 										onInvalid={(event) => {

--- a/support-frontend/assets/pages/[countryGroupId]/validation.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/validation.ts
@@ -18,5 +18,4 @@ export function preventDefaultValidityMessage(
  * This uses a Unicode character class escape
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape
  */
-export const doesNotContainEmojiOrWhitespacePattern =
-	'^(?!.*[\\p{Extended_Pictographic}\\s]).*$';
+export const doesNotContainEmojiPattern = '^[^\\p{Emoji_Presentation}]+$';


### PR DESCRIPTION
Validation is broken on the delivery address, reverting 
![image](https://github.com/user-attachments/assets/1daca86e-ec86-411d-a356-109886c6f1b7)