### PR TITLE
Add explicit dependency on protobuf-java

### DIFF
--- a/support-modules/acquisition-events/build.sbt
+++ b/support-modules/acquisition-events/build.sbt
@@ -15,6 +15,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
+  "com.google.protobuf" % "protobuf-java" % "3.25.5",
 )
 
 scalacOptions += "-Xlint:unused"


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Add explicit dependency on `protobuf-java` so we can force `v3.25.5`.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/g3pRbNsI/1276-dependabot-high-vulnerability-protobuf-java-has-potential-denial-of-service-issue)

## Why are you doing this?

This is to force a newer version than that brought in by `google-cloud-bigquery`. Dependabot has reported a vulnerability for the version we're on.

We tried upgrading `google-cloud-bigquery` itself, but this resulted in an issue with deploying as it pushed us over the lambda S3 compressed file size limit.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

I deployed `support:lambdas:bigquery-acquisitions-publisher` to CODE and put through a transaction. I see the data as expected in the fact acquisition events BQ table.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
