### PR TITLE
One time checkout - get user type

### DIFF
--- a/support-frontend/assets/components/test-user-banner/thankYouUserTypeSelector.tsx
+++ b/support-frontend/assets/components/test-user-banner/thankYouUserTypeSelector.tsx
@@ -16,7 +16,7 @@ const selectorStyles = css`
 `;
 
 export function ThankYouUserTypeSelector(): JSX.Element {
-	const [selectedUserType, setSelectedUserType] = useState<UserType>('guest');
+	const [selectedUserType, setSelectedUserType] = useState<UserType>('new');
 
 	useEffect(() => {
 		// ToDo: refactor this to use the query param instead of redux
@@ -32,13 +32,8 @@ export function ThankYouUserTypeSelector(): JSX.Element {
 				cssOverrides={selectorStyles}
 			>
 				<Radio
-					// the default user type response from identity as a test user is "guest"
+					// the default user type response from identity as a test user is "new"
 					defaultChecked
-					label="Guest"
-					value="guest"
-					onChange={() => setSelectedUserType('guest')}
-				/>
-				<Radio
 					label="New"
 					value="new"
 					onChange={() => setSelectedUserType('new')}

--- a/support-frontend/assets/helpers/forms/errorReasons.ts
+++ b/support-frontend/assets/helpers/forms/errorReasons.ts
@@ -23,7 +23,7 @@ const errorReasons = [
 	'recaptcha_validation_failed',
 	'unknown',
 ] as const;
-function isErrorReason(value: string): value is ErrorReason {
+export function isErrorReason(value: string): value is ErrorReason {
 	return errorReasons.includes(value as ErrorReason);
 }
 export type ErrorReason = (typeof errorReasons)[number];

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/oneOffContributions.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/oneOffContributions.ts
@@ -3,6 +3,7 @@ import { fetchJson, requestOptions } from 'helpers/async/fetch';
 import { logPromise } from 'helpers/async/promise';
 import type { ErrorReason } from 'helpers/forms/errorReasons';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import type { UserType } from 'helpers/redux/checkout/personalDetails/state';
 import * as cookie from 'helpers/storage/cookie';
 import type { PaymentAPIAcquisitionData } from 'helpers/tracking/acquisitions';
 import 'helpers/tracking/acquisitions';
@@ -147,7 +148,10 @@ function paymentResultFromObject(
 		});
 	}
 
-	return Promise.resolve(PaymentSuccess);
+	const response = json as { data?: { userType: UserType } };
+	const maybeUserType = response.data?.userType;
+
+	return Promise.resolve({ ...PaymentSuccess, userType: maybeUserType });
 }
 
 const postToPaymentApi = (

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/oneOffContributions.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/oneOffContributions.ts
@@ -136,8 +136,6 @@ const errorResponseSchema = z.object({
 const successResponseSchema = z.object({
 	type: z.literal('success'),
 	data: z.object({
-		currency: z.string(),
-		amount: z.number(),
 		userType: userTypeSchema.optional(),
 	}),
 });

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -25,6 +25,7 @@ import type {
 	Paper,
 } from 'helpers/productPrice/subscriptions';
 import type { CsrfState } from 'helpers/redux/checkout/csrf/state';
+import type { UserType } from 'helpers/redux/checkout/personalDetails/state';
 import type {
 	AcquisitionABTest,
 	OphanIds,
@@ -236,6 +237,7 @@ export type PaymentResult = {
 	paymentStatus: Status;
 	subscriptionCreationPending?: true;
 	error?: ErrorReason;
+	userType?: UserType;
 };
 
 export type StatusResponse = {

--- a/support-frontend/assets/helpers/redux/checkout/personalDetails/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/personalDetails/state.ts
@@ -6,7 +6,8 @@ import {
 import type { SliceErrors } from 'helpers/redux/utils/validation/errors';
 import { getUser } from 'helpers/user/user';
 
-export type UserType = 'new' | 'guest' | 'current';
+export const userTypeSchema = z.union([z.literal('new'), z.literal('current')]);
+export type UserType = z.infer<typeof userTypeSchema>;
 
 export const emailRules = zuoraCompatibleString(
 	z

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -463,6 +463,9 @@ export function OneTimeCheckoutComponent({
 				});
 				const thankYouUrlSearchParams = new URLSearchParams();
 				thankYouUrlSearchParams.set('contribution', finalAmount.toString());
+				'paymentStatus' in paymentResult &&
+					paymentResult.userType &&
+					thankYouUrlSearchParams.set('userType', paymentResult.userType);
 				const nextStepRoute = paymentResultThankyouRoute(
 					paymentResult,
 					geoId,

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -463,7 +463,7 @@ export function OneTimeCheckoutComponent({
 				});
 				const thankYouUrlSearchParams = new URLSearchParams();
 				thankYouUrlSearchParams.set('contribution', finalAmount.toString());
-				'paymentStatus' in paymentResult &&
+				'userType' in paymentResult &&
 					paymentResult.userType &&
 					thankYouUrlSearchParams.set('userType', paymentResult.userType);
 				const nextStepRoute = paymentResultThankyouRoute(

--- a/support-payment-api/src/main/scala/backend/PaypalBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaypalBackend.scala
@@ -130,34 +130,6 @@ class PaypalBackend(
         },
       )
 
-//  def capturePaymentOld(
-//      capturePaymentData: CapturePaypalPaymentData,
-//      clientBrowserInfo: ClientBrowserInfo,
-//  ): EitherT[Future, PaypalApiError, EnrichedPaypalPayment] =
-//    paypalService
-//      .capturePayment(capturePaymentData)
-//      .bimap(
-//        err => {
-//          cloudWatchService.recordFailedPayment(err, PaymentProvider.Paypal)
-//          err
-//        },
-//        payment => {
-//          cloudWatchService.recordPaymentSuccess(PaymentProvider.Paypal)
-//
-//          val maybeEmail = capturePaymentData.signedInUserEmail.orElse(
-//            Try(payment.getPayer.getPayerInfo.getEmail).toOption.filterNot(_.isEmpty),
-//          )
-//
-//          maybeEmail.foreach { email =>
-//            getOrCreateIdentityIdFromEmail(email).foreach { identityId =>
-//              postPaymentTasks(payment, email, identityId, capturePaymentData.acquisitionData, clientBrowserInfo)
-//            }
-//          }
-//
-//          EnrichedPaypalPayment(payment, maybeEmail)
-//        },
-//      )
-
   def executePayment(
       executePaymentData: ExecutePaypalPaymentData,
       clientBrowserInfo: ClientBrowserInfo,
@@ -254,7 +226,7 @@ class PaypalBackend(
     }
   }
 
-  private def getOrCreateIdentityIdFromEmail(email: String) =
+  private def getOrCreateIdentityIdFromEmail(email: String): Future[Option[IdentityUserDetails]] =
     identityService
       .getOrCreateIdentityIdFromEmail(email)
       .fold(

--- a/support-payment-api/src/main/scala/backend/StripeBackend.scala
+++ b/support-payment-api/src/main/scala/backend/StripeBackend.scala
@@ -253,9 +253,10 @@ class StripeBackend(
             PaymentProvider.Stripe,
             s"No charge found on completed Stripe Payment Intent, cannot do post-payment tasks. Request was $request",
           )
+          identityUserDetails
       }
 
-      StripePaymentIntentsApiResponse.Success()
+      StripePaymentIntentsApiResponse.Success(identityUserDetails.map(_.userType))
     }
   }
 

--- a/support-payment-api/src/main/scala/backend/StripeBackend.scala
+++ b/support-payment-api/src/main/scala/backend/StripeBackend.scala
@@ -94,10 +94,16 @@ class StripeBackend(
       .semiflatMap { charge =>
         cloudWatchService.recordPaymentSuccess(PaymentProvider.Stripe)
 
-        getOrCreateIdentityIdFromEmail(chargeData.paymentData.email.value).map { identityId =>
-          postPaymentTasks(chargeData.paymentData.email.value, chargeData, charge, clientBrowserInfo, identityId)
+        getOrCreateIdentityIdFromEmail(chargeData.paymentData.email.value).map { identityUserDetails =>
+          postPaymentTasks(
+            chargeData.paymentData.email.value,
+            chargeData,
+            charge,
+            clientBrowserInfo,
+            identityUserDetails.map(_.id),
+          )
 
-          StripeCreateChargeResponse.fromCharge(charge)
+          StripeCreateChargeResponse.fromCharge(charge, identityUserDetails.map(_.userType))
         }
       }
 
@@ -228,10 +234,16 @@ class StripeBackend(
 
     cloudWatchService.recordPaymentSuccess(PaymentProvider.Stripe)
 
-    getOrCreateIdentityIdFromEmail(request.paymentData.email.value).map { identityId =>
+    getOrCreateIdentityIdFromEmail(request.paymentData.email.value).map { identityUserDetails =>
       paymentIntent.getCharges.getData.asScala.toList.headOption match {
         case Some(charge) =>
-          postPaymentTasks(request.paymentData.email.value, request, charge, clientBrowserInfo, identityId)
+          postPaymentTasks(
+            request.paymentData.email.value,
+            request,
+            charge,
+            clientBrowserInfo,
+            identityUserDetails.map(_.id),
+          )
         case None =>
           /** This should never happen, but in case it does we still return success to the client because the payment
             * was reported as successful by Stripe. It does however prevent us from executing post-payment tasks and so
@@ -294,7 +306,7 @@ class StripeBackend(
     )
   }
 
-  private def getOrCreateIdentityIdFromEmail(email: String): Future[Option[String]] =
+  private def getOrCreateIdentityIdFromEmail(email: String) =
     identityService
       .getOrCreateIdentityIdFromEmail(email)
       .fold(

--- a/support-payment-api/src/main/scala/controllers/StripeController.scala
+++ b/support-payment-api/src/main/scala/controllers/StripeController.scala
@@ -83,7 +83,7 @@ class StripeController(
             new Status(errorResponse.statusCode)(ResultBody.Error(errorResponse.checkoutError))
           },
           {
-            case success: StripePaymentIntentsApiResponse.Success => Ok(ResultBody.Success("ok"))
+            case response: StripePaymentIntentsApiResponse.Success => Ok(ResultBody.Success(response))
             case requiresAction: StripePaymentIntentsApiResponse.RequiresAction =>
               Ok(ResultBody.RequiresAction(requiresAction))
           },

--- a/support-payment-api/src/main/scala/model/UserType.scala
+++ b/support-payment-api/src/main/scala/model/UserType.scala
@@ -1,0 +1,7 @@
+package model
+
+object UserType {
+  type UserType = String
+  val New = "new"
+  val Current = "current"
+}

--- a/support-payment-api/src/main/scala/model/paypal/EnrichedPaypalPayment.scala
+++ b/support-payment-api/src/main/scala/model/paypal/EnrichedPaypalPayment.scala
@@ -2,4 +2,4 @@ package model.paypal
 
 import com.paypal.api.payments.Payment
 
-case class EnrichedPaypalPayment(payment: Payment, email: Option[String])
+case class EnrichedPaypalPayment(payment: Payment, email: Option[String], userType: Option[String])

--- a/support-payment-api/src/main/scala/model/stripe/StripeCreateChargeResponse.scala
+++ b/support-payment-api/src/main/scala/model/stripe/StripeCreateChargeResponse.scala
@@ -3,12 +3,17 @@ package model.stripe
 import com.stripe.model.Charge
 import io.circe.generic.JsonCodec
 
-@JsonCodec case class StripeCreateChargeResponse private (currency: String, amount: BigDecimal)
+@JsonCodec case class StripeCreateChargeResponse private (
+    currency: String,
+    amount: BigDecimal,
+    userType: Option[String],
+)
 
 object StripeCreateChargeResponse {
-  def fromCharge(charge: Charge): StripeCreateChargeResponse =
+  def fromCharge(charge: Charge, userType: Option[String]): StripeCreateChargeResponse =
     StripeCreateChargeResponse(
       charge.getCurrency,
       BigDecimal(charge.getAmount) / 100,
+      userType,
     )
 }

--- a/support-payment-api/src/main/scala/model/stripe/StripePaymentIntentsApiResponse.scala
+++ b/support-payment-api/src/main/scala/model/stripe/StripePaymentIntentsApiResponse.scala
@@ -2,11 +2,12 @@ package model.stripe
 
 import io.circe.generic.semiauto._
 import io.circe.Encoder
+import model.UserType.UserType
 
 sealed trait StripePaymentIntentsApiResponse
 
 object StripePaymentIntentsApiResponse {
-  case class Success() extends StripePaymentIntentsApiResponse
+  case class Success(userType: Option[UserType]) extends StripePaymentIntentsApiResponse
 
   case class RequiresAction(clientSecret: String) extends StripePaymentIntentsApiResponse
 

--- a/support-payment-api/src/main/scala/services/IdentityService.scala
+++ b/support-payment-api/src/main/scala/services/IdentityService.scala
@@ -1,49 +1,48 @@
 package services
 
-import cats.Monad
 import cats.data.EitherT
 import cats.instances.future._
-import com.gu.retry.EitherTRetry
 import com.gu.retry.EitherTRetry.retry
 import com.typesafe.scalalogging.StrictLogging
 import conf.IdentityConfig
 import model.DefaultThreadPool
 import play.api.libs.ws.WSClient
-import services.IdentityClient.{ApiError, ContextualError}
 
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
+case class IdentityUserDetails(id: String, userType: String)
+
 trait IdentityService extends StrictLogging {
 
   // Should return the identity id associated with the email, or an error if there isn't one.
-  def getIdentityIdFromEmail(email: String): IdentityClient.Result[String]
+  def getIdentityIdFromEmail(email: String): IdentityClient.Result[IdentityUserDetails]
 
   // Should return the identity id of the created account along with an optional guest account token.
-  def createGuestAccount(email: String): IdentityClient.Result[String]
+  def createGuestAccount(email: String): IdentityClient.Result[IdentityUserDetails]
 
   // Look up the identity id for the given email address.
   // If one exists then return it, otherwise create a guest account and return the associated identity id.
-  def getOrCreateIdentityIdFromEmail(email: String): IdentityClient.Result[String]
+  def getOrCreateIdentityIdFromEmail(email: String): IdentityClient.Result[IdentityUserDetails]
 
 }
 
 // Default implementation of the IdentityService trait using the client to the Guardian identity API.
 class GuardianIdentityService(client: IdentityClient)(implicit pool: DefaultThreadPool) extends IdentityService {
 
-  override def getIdentityIdFromEmail(email: String): IdentityClient.Result[String] =
-    client.getUser(email).map(response => response.user.id)
+  override def getIdentityIdFromEmail(email: String): IdentityClient.Result[IdentityUserDetails] =
+    client.getUser(email).map(response => IdentityUserDetails(response.user.id, "current"))
 
-  override def createGuestAccount(email: String): EitherT[Future, IdentityClient.ContextualError, String] =
+  override def createGuestAccount(email: String): EitherT[Future, IdentityClient.ContextualError, IdentityUserDetails] =
     client.createGuestAccount(email).map { response =>
       // Logs are only retained for 14 days so we're OK to log email address
       logger.info(s"guest account created for email address: $email")
-      response.guestRegistrationRequest.userId
+      IdentityUserDetails(response.guestRegistrationRequest.userId, "new")
     }
 
   override def getOrCreateIdentityIdFromEmail(
       email: String,
-  ): EitherT[Future, IdentityClient.ContextualError, String] = {
+  ): EitherT[Future, IdentityClient.ContextualError, IdentityUserDetails] = {
     // Try to fetch the user's information with their email address and if it does not exist
     // or there is an error try again up to a total of 3 times with a 500 millisecond delay between
     // each attempt.

--- a/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
@@ -106,9 +106,9 @@ class PaypalBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
   val acquisitionsEventBusErrorMessage = "an event bus error"
   val acquisitionsEventBusResponseError: Future[Either[String, Unit]] =
     Future.successful(Left(acquisitionsEventBusErrorMessage))
-  val identityResponse: EitherT[Future, IdentityClient.ContextualError, String] =
-    EitherT.right(Future.successful("1"))
-  val identityResponseError: EitherT[Future, IdentityClient.ContextualError, String] =
+  val identityResponse: EitherT[Future, IdentityClient.ContextualError, IdentityUserDetails] =
+    EitherT.right(Future.successful(IdentityUserDetails("1", "current")))
+  val identityResponseError: EitherT[Future, IdentityClient.ContextualError, IdentityUserDetails] =
     EitherT.left(Future.successful(identityError))
   val emailResponseError: EitherT[Future, EmailService.Error, SendMessageResult] =
     EitherT.left(Future.successful(emailError))
@@ -275,7 +275,7 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
         "databaseService and emailService fail" in new PaypalBackendFixture {
           populatePaymentMock()
           val enrichedPaypalPaymentMock =
-            EnrichedPaypalPayment(paymentMock, Some(paymentMock.getPayer.getPayerInfo.getEmail))
+            EnrichedPaypalPayment(paymentMock, Some(paymentMock.getPayer.getPayerInfo.getEmail), None)
           when(mockSwitchService.allSwitches).thenReturn(switchServiceOnResponse)
           when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
           when(mockAcquisitionsEventBusService.putAcquisitionEvent(any()))
@@ -301,7 +301,7 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
         "databaseService and emailService fail" in new PaypalBackendFixture {
           populatePaymentMock()
           val enrichedPaypalPaymentMock =
-            EnrichedPaypalPayment(paymentMock, Some(paymentMock.getPayer.getPayerInfo.getEmail))
+            EnrichedPaypalPayment(paymentMock, Some(paymentMock.getPayer.getPayerInfo.getEmail), None)
           when(mockSwitchService.allSwitches).thenReturn(switchServiceOnResponse)
           when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
           when(mockSupporterProductDataService.insertContributionData(any())(any()))
@@ -323,7 +323,7 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
       "return successful payment response with guestAccountRegistrationToken if available" in new PaypalBackendFixture {
         populatePaymentMock()
         val enrichedPaypalPaymentMock =
-          EnrichedPaypalPayment(paymentMock, Some(paymentMock.getPayer.getPayerInfo.getEmail))
+          EnrichedPaypalPayment(paymentMock, Some(paymentMock.getPayer.getPayerInfo.getEmail), Some("current"))
         when(mockSwitchService.allSwitches).thenReturn(switchServiceOnResponse)
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
         when(mockSupporterProductDataService.insertContributionData(any())(any()))

--- a/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
@@ -6,6 +6,7 @@ import cats.implicits._
 import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.support.acquisitions.eventbridge.AcquisitionsEventBusService
 import com.paypal.api.payments.{Amount, Payer, PayerInfo, Payment}
+import model.UserType.Current
 import model._
 import model.paypal._
 import org.mockito.ArgumentMatchers.any
@@ -107,7 +108,7 @@ class PaypalBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
   val acquisitionsEventBusResponseError: Future[Either[String, Unit]] =
     Future.successful(Left(acquisitionsEventBusErrorMessage))
   val identityResponse: EitherT[Future, IdentityClient.ContextualError, IdentityUserDetails] =
-    EitherT.right(Future.successful(IdentityUserDetails("1", "current")))
+    EitherT.right(Future.successful(IdentityUserDetails("1", Current)))
   val identityResponseError: EitherT[Future, IdentityClient.ContextualError, IdentityUserDetails] =
     EitherT.left(Future.successful(identityError))
   val emailResponseError: EitherT[Future, EmailService.Error, SendMessageResult] =
@@ -323,7 +324,7 @@ class PaypalBackendSpec extends AnyWordSpec with Matchers with FutureEitherValue
       "return successful payment response with guestAccountRegistrationToken if available" in new PaypalBackendFixture {
         populatePaymentMock()
         val enrichedPaypalPaymentMock =
-          EnrichedPaypalPayment(paymentMock, Some(paymentMock.getPayer.getPayerInfo.getEmail), Some("current"))
+          EnrichedPaypalPayment(paymentMock, Some(paymentMock.getPayer.getPayerInfo.getEmail), Some(Current))
         when(mockSwitchService.allSwitches).thenReturn(switchServiceOnResponse)
         when(mockDatabaseService.insertContributionData(any())).thenReturn(databaseResponseError)
         when(mockSupporterProductDataService.insertContributionData(any())(any()))

--- a/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
@@ -11,6 +11,7 @@ import com.stripe.model.Charge.PaymentMethodDetails
 import com.stripe.model.{Charge, ChargeCollection, Event, PaymentIntent}
 import io.circe.Json
 import model.Environment.Live
+import model.UserType.Current
 import model._
 import model.paypal.PaypalApiError
 import model.stripe.StripePaymentIntentRequest.{ConfirmPaymentIntent, CreatePaymentIntent}
@@ -98,7 +99,7 @@ class StripeBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
   val paymentServiceIntentResponse: EitherT[Future, StripeApiError, PaymentIntent] =
     EitherT.right(Future.successful(paymentIntentMock))
   val identityResponse: EitherT[Future, IdentityClient.ContextualError, IdentityUserDetails] =
-    EitherT.right(Future.successful(IdentityUserDetails("1", "current")))
+    EitherT.right(Future.successful(IdentityUserDetails("1", Current)))
   val identityResponseError: EitherT[Future, IdentityClient.ContextualError, IdentityUserDetails] =
     EitherT.left(Future.successful(identityError))
   val validateRefundHookSuccess: EitherT[Future, StripeApiError, Unit] =
@@ -453,7 +454,7 @@ class StripeBackendSpec
         stripeBackend.createCharge(stripeChargeRequest, clientBrowserInfo).futureRight mustBe StripeCreateChargeResponse
           .fromCharge(
             chargeMock,
-            Some("current"),
+            Some(Current),
           )
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())

--- a/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
@@ -97,9 +97,9 @@ class StripeBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
     EitherT.left(Future.successful(stripeApiError))
   val paymentServiceIntentResponse: EitherT[Future, StripeApiError, PaymentIntent] =
     EitherT.right(Future.successful(paymentIntentMock))
-  val identityResponse: EitherT[Future, IdentityClient.ContextualError, String] =
-    EitherT.right(Future.successful("1"))
-  val identityResponseError: EitherT[Future, IdentityClient.ContextualError, String] =
+  val identityResponse: EitherT[Future, IdentityClient.ContextualError, IdentityUserDetails] =
+    EitherT.right(Future.successful(IdentityUserDetails("1", "current")))
+  val identityResponseError: EitherT[Future, IdentityClient.ContextualError, IdentityUserDetails] =
     EitherT.left(Future.successful(identityError))
   val validateRefundHookSuccess: EitherT[Future, StripeApiError, Unit] =
     EitherT.right(Future.successful(()))
@@ -433,6 +433,7 @@ class StripeBackendSpec
             .createCharge(stripeChargeRequest, clientBrowserInfo)
             .futureRight mustBe StripeCreateChargeResponse.fromCharge(
             chargeMock,
+            None,
           )
 
           verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
@@ -452,6 +453,7 @@ class StripeBackendSpec
         stripeBackend.createCharge(stripeChargeRequest, clientBrowserInfo).futureRight mustBe StripeCreateChargeResponse
           .fromCharge(
             chargeMock,
+            Some("current"),
           )
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())

--- a/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
@@ -326,7 +326,7 @@ class StripeBackendSpec
         when(mockSwitchService.allSwitches).thenReturn(switchServiceOnResponse)
 
         stripeBackend.createPaymentIntent(createPaymentIntentWithStripeCheckout, clientBrowserInfo).futureRight mustBe
-          StripePaymentIntentsApiResponse.Success()
+          StripePaymentIntentsApiResponse.Success(Some(Current))
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
       }
@@ -359,7 +359,7 @@ class StripeBackendSpec
         when(mockSwitchService.allSwitches).thenReturn(switchServiceOnResponse)
 
         stripeBackend.createPaymentIntent(createPaymentIntentWithStripeApplePay, clientBrowserInfo).futureRight mustBe
-          StripePaymentIntentsApiResponse.Success()
+          StripePaymentIntentsApiResponse.Success(Some(Current))
       }
       "return Success if stripe payment request button  switch is On in support-admin-console" in new StripeBackendFixture {
         val stripePaymentDataWithStripePaymentRequest =
@@ -392,7 +392,7 @@ class StripeBackendSpec
         stripeBackend
           .createPaymentIntent(createPaymentIntentWithStripePaymentRequest, clientBrowserInfo)
           .futureRight mustBe
-          StripePaymentIntentsApiResponse.Success()
+          StripePaymentIntentsApiResponse.Success(Some(Current))
       }
     }
 
@@ -542,7 +542,7 @@ class StripeBackendSpec
         when(mockRecaptchaService.verify(recaptchaToken)).thenReturn(recaptchaServiceSuccess)
 
         stripeBackend.createPaymentIntent(createPaymentIntent, clientBrowserInfo).futureRight mustBe
-          StripePaymentIntentsApiResponse.Success()
+          StripePaymentIntentsApiResponse.Success(Some(Current))
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
       }
@@ -619,7 +619,7 @@ class StripeBackendSpec
         when(mockEmailService.sendThankYouEmail(any())).thenReturn(emailServiceErrorResponse)
 
         stripeBackend.confirmPaymentIntent(confirmPaymentIntent, clientBrowserInfo).futureRight mustBe
-          StripePaymentIntentsApiResponse.Success()
+          StripePaymentIntentsApiResponse.Success(Some(Current))
 
         verify(mockSoftOptInsService, times(1)).sendMessage(any(), any())(any())
       }

--- a/support-payment-api/src/test/scala/controllers/StripeControllerSpec.scala
+++ b/support-payment-api/src/test/scala/controllers/StripeControllerSpec.scala
@@ -46,7 +46,7 @@ class StripeControllerFixture(implicit ec: ExecutionContext, context: Applicatio
   val mockStripeRequestBasedProvider: RequestBasedProvider[StripeBackend] =
     mock[RequestBasedProvider[StripeBackend]]
 
-  val stripeChargeSuccessMock: StripeCreateChargeResponse = StripeCreateChargeResponse.fromCharge(mockCharge)
+  val stripeChargeSuccessMock: StripeCreateChargeResponse = StripeCreateChargeResponse.fromCharge(mockCharge, None)
 
   val stripeServiceResponse: EitherT[Future, StripeApiError, StripeCreateChargeResponse] =
     EitherT.right(Future.successful(stripeChargeSuccessMock))

--- a/support-payment-api/src/test/scala/model/stripe/StripeCreateChargeResponseSpec.scala
+++ b/support-payment-api/src/test/scala/model/stripe/StripeCreateChargeResponseSpec.scala
@@ -15,7 +15,7 @@ class StripeChargeSuccessSpec extends AnyWordSpec with Matchers with MockitoSuga
         val chargeMock: Charge = mock[Charge]
         when(chargeMock.getCurrency).thenReturn("GBP")
         when(chargeMock.getAmount).thenReturn(123L)
-        val stripeChargeSuccess = StripeCreateChargeResponse.fromCharge(chargeMock)
+        val stripeChargeSuccess = StripeCreateChargeResponse.fromCharge(chargeMock, None)
         stripeChargeSuccess.amount mustBe 1.23
       }
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Returning the identity user type for one time payments through the API, and using this information on the client to set a URL param on the thank you page.

This client side solution does not work for PayPal, as we redirect them to the site and can't set the URL params

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

## How to test

Use the new one time checkout and see "userType=x" when redirected to the thank you page. 

I used the [always authenticate](https://docs.stripe.com/testing?locale=en-GB#regulatory-cards) card to simulate 3DS, as that makes an additional API call 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
## Screenshots
![image](https://github.com/user-attachments/assets/66f61e6e-2a5d-4952-8b6a-e8a3f95d0fc7)
