### PR TITLE
Update supporter product data export schedule in CODE

### DIFF
--- a/supporter-product-data/cloudformation/cfn.yaml
+++ b/supporter-product-data/cloudformation/cfn.yaml
@@ -19,7 +19,7 @@ Mappings:
       S3Bucket: supporter-product-data-export-code
       CatalogBucket: arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-CODE/catalog.json
       # Run once at 6am Mon-Fri
-      scheduleRate: "cron(0 6 ? * 1-5 *)"
+      scheduleRate: "cron(0 6 ? * MON-FRI *)"
       lambdaConcurrency: 30
     PROD:
       S3Bucket: supporter-product-data-export-prod


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Updating the cron schedule for the supporter-product-data step function in CODE to run Monday - Friday.

## Why are you doing this?

We noticed that the supporter product data export was running Sunday - Thursday in CODE and not Monday - Friday as intented. It turns out the cron expression specified `1-5` for the days of the week, but this is indexed from 1 which corresponds to Sunday, so `1-5` actually means Sunday - Thursday. You can also specify this using abbreviated day names, which I think is easier to understand.

See: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-scheduled-rule-pattern.html

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots

From the schedule rule in AWS.

### Before

![Screenshot 2024-11-22 at 16 06 55](https://github.com/user-attachments/assets/f49ecfcf-9bdd-4d9a-ba9d-41ab30376c0f)

### After

![Screenshot 2024-11-22 at 16 08 32](https://github.com/user-attachments/assets/a41d8f91-81a1-414a-ad55-6612e3f481fb)
