### PR TITLE
Force commons-io:commons-io to 2.14.0

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -42,6 +42,7 @@ libraryDependencies ++= Seq(
   ws,
 )
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
+dependencyOverrides += "commons-io" % "commons-io" % "2.14.0" % Test
 
 excludeDependencies ++= Seq(
   // Exclude htmlunit due to a vulnerability. Brought in via org.scalatestplus.play:scalatestplus-play but we don't need

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -74,6 +74,7 @@ excludeDependencies ++= Seq(
 )
 
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
+dependencyOverrides += "commons-io" % "commons-io" % "2.14.0" % Test
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 


### PR DESCRIPTION

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Force `commons-io:commons-io` to 2.14.0

## Why are you doing this?

This addresses a vulnerability reported by dependabot.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
