### PR TITLE
documentation: update ExampleRequestBody.json

### DIFF
--- a/support-lambdas/acquisition-events-api/ExampleRequestBody.json
+++ b/support-lambdas/acquisition-events-api/ExampleRequestBody.json
@@ -23,7 +23,6 @@
   "readerType": "Direct",
   "acquisitionType": "Purchase",
   "zuoraSubscriptionNumber": null,
-  "zuoraAccountNumber": null,
   "contributionId": null,
   "paymentId": null,
   "queryParameters": [

--- a/support-lambdas/acquisition-events-api/ExampleRequestBody.json
+++ b/support-lambdas/acquisition-events-api/ExampleRequestBody.json
@@ -35,5 +35,8 @@
       "value": "value2"
     }
   ],
-  "platform": null
+  "platform": null,
+  "postalCode": null,
+  "state": null,
+  "email": null
 }


### PR DESCRIPTION
This change updates the sample json payload for acquisition-events-api, to match the schema from `AcquisitionDataRow`, defined here:  https://github.com/guardian/support-frontend/blob/f928ea46718881c867b649c139a5378ca361b84a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala (they have drifted from one another).

