### PR TITLE
Add UK Black Friday countdown

### DIFF
--- a/support-frontend/app/admin/settings/Switches.scala
+++ b/support-frontend/app/admin/settings/Switches.scala
@@ -34,6 +34,7 @@ case class CampaignSwitches(
     forceContributionsCampaign: Option[SwitchState],
     usEoy2024: Option[SwitchState] = None,
     ausEoy2024: Option[SwitchState] = None,
+    ukBlackFriday2024: Option[SwitchState] = None,
 )
 
 object CampaignSwitches {

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -2,6 +2,7 @@ import type { TickerSettings } from '@guardian/source-development-kitchen/dist/r
 import type { CountryGroupId } from '../internationalisation/countryGroup';
 import {
 	AUDCountries,
+	GBPCountries,
 	UnitedStates,
 } from '../internationalisation/countryGroup';
 
@@ -30,7 +31,7 @@ export type CampaignSettings = {
 	enableSingleContributions: boolean;
 	countdownSettings?: CountdownSetting[];
 	copy: CampaignCopy;
-	tickerSettings: CampaignTickerSettings;
+	tickerSettings?: CampaignTickerSettings;
 };
 
 const campaigns: Record<string, CampaignSettings> = {
@@ -120,6 +121,42 @@ const campaigns: Record<string, CampaignSettings> = {
 			},
 			size: 'large',
 			id: 'AU',
+		},
+	},
+	ukBlackFriday2024: {
+		isEligible: (countryGroupId: CountryGroupId) =>
+			countryGroupId === GBPCountries,
+		enableSingleContributions: false,
+		countdownSettings: [
+			// {
+			// 	label: 'This Black Friday, why not support fearless, independent journalism?',
+			// 	countdownStartInMillis: Date.parse('Nov 25, 2024 00:00:00'),
+			// 	countdownDeadlineInMillis: Date.parse('Dec 02, 2024 23:59:59'),
+			// 	theme: {
+			// 		backgroundColor: '#1e3e72',
+			// 		foregroundColor: '#ffffff',
+			// 	},
+			// }, // TODO: change the label on the 29th to: 'Just a few days left'
+			{
+				label: 'Test',
+				countdownStartInMillis: Date.parse('Nov 25, 2024 00:00:00'),
+				countdownDeadlineInMillis: Date.parse('Nov 25, 2024 17:00:00'),
+				theme: {
+					backgroundColor: '#1e3e72',
+					foregroundColor: '#ffffff',
+				},
+			},
+		],
+		copy: {
+			headingFragment: <>Support </>,
+			subheading: (
+				<>
+					We're not owned by a billionaire or shareholders - our readers support
+					us. Choose to join with one of the options below.
+					<strong>Cancel anytime.</strong>
+				</>
+			),
+			oneTimeHeading: <>Choose your gift amount</>,
 		},
 	},
 };

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -128,24 +128,15 @@ const campaigns: Record<string, CampaignSettings> = {
 			countryGroupId === GBPCountries,
 		enableSingleContributions: false,
 		countdownSettings: [
-			// {
-			// 	label: 'This Black Friday, why not support fearless, independent journalism?',
-			// 	countdownStartInMillis: Date.parse('Nov 25, 2024 00:00:00'),
-			// 	countdownDeadlineInMillis: Date.parse('Dec 02, 2024 23:59:59'),
-			// 	theme: {
-			// 		backgroundColor: '#1e3e72',
-			// 		foregroundColor: '#ffffff',
-			// 	},
-			// }, // TODO: change the label on the 29th to: 'Just a few days left'
 			{
-				label: 'Test',
+				label: 'This Black Friday, why not support fearless, independent journalism?',
 				countdownStartInMillis: Date.parse('Nov 25, 2024 00:00:00'),
-				countdownDeadlineInMillis: Date.parse('Nov 25, 2024 17:00:00'),
+				countdownDeadlineInMillis: Date.parse('Dec 02, 2024 23:59:59'),
 				theme: {
 					backgroundColor: '#1e3e72',
 					foregroundColor: '#ffffff',
 				},
-			},
+			}, // TODO: change the label on the 29th to: 'Just a few days left'
 		],
 		copy: {
 			headingFragment: <>Support </>,

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -139,17 +139,17 @@ const campaigns: Record<string, CampaignSettings> = {
 		countdownSettings: [
 			{
 				label:
-					'This Black Friday, why not support fearless, independent journalism?',
-				countdownStartInMillis: Date.parse('Nov 25, 2024 00:00:00'),
+					'Just a few days left',
+				countdownStartInMillis: Date.parse('Nov 29, 2024 00:00:00'),
 				countdownDeadlineInMillis: Date.parse('Dec 02, 2024 23:59:59'),
 				theme: {
 					backgroundColor: '#1e3e72',
 					foregroundColor: '#ffffff',
 				},
-			}, // TODO: change the label on the 29th to: 'Just a few days left'
+			},
 		],
 		copy: {
-			headingFragment: <>Support </>,
+			headingFragment: <>This Black Friday, why not support </>,
 			subheading: (
 				<>
 					We're not owned by a billionaire or shareholders - our readers support

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -138,8 +138,7 @@ const campaigns: Record<string, CampaignSettings> = {
 		enableSingleContributions: false,
 		countdownSettings: [
 			{
-				label:
-					'Just a few days left',
+				label: 'Just a few days left',
 				countdownStartInMillis: Date.parse('Nov 29, 2024 00:00:00'),
 				countdownDeadlineInMillis: Date.parse('Dec 02, 2024 23:59:59'),
 				theme: {

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -129,7 +129,8 @@ const campaigns: Record<string, CampaignSettings> = {
 		enableSingleContributions: false,
 		countdownSettings: [
 			{
-				label: 'This Black Friday, why not support fearless, independent journalism?',
+				label:
+					'This Black Friday, why not support fearless, independent journalism?',
 				countdownStartInMillis: Date.parse('Nov 25, 2024 00:00:00'),
 				countdownDeadlineInMillis: Date.parse('Dec 02, 2024 23:59:59'),
 				theme: {

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -20,6 +20,7 @@ interface CampaignCopy {
 	headingFragment?: JSX.Element;
 	subheading?: JSX.Element;
 	oneTimeHeading?: JSX.Element;
+	punctuation?: JSX.Element;
 }
 
 export type CampaignTickerSettings = Omit<TickerSettings, 'tickerData'> & {
@@ -157,6 +158,7 @@ const campaigns: Record<string, CampaignSettings> = {
 				</>
 			),
 			oneTimeHeading: <>Choose your gift amount</>,
+			punctuation: <>?</>,
 		},
 	},
 };

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -349,7 +349,7 @@ export function ThreeTierLanding({
 				<>
 					{campaignSettings?.copy.headingFragment ?? <>Support </>}
 					fearless, <br css={tabletLineBreak} />
-					independent journalism
+					independent journalism{campaignSettings?.copy.punctuation ?? campaignSettings?.copy.punctuation}
 				</>
 			);
 		}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -349,7 +349,9 @@ export function ThreeTierLanding({
 				<>
 					{campaignSettings?.copy.headingFragment ?? <>Support </>}
 					fearless, <br css={tabletLineBreak} />
-					independent journalism{campaignSettings?.copy.punctuation ?? campaignSettings?.copy.punctuation}
+					independent journalism
+					{campaignSettings?.copy.punctuation ??
+						campaignSettings?.copy.punctuation}
 				</>
 			);
 		}


### PR DESCRIPTION
## What are you doing in this PR?

Adds the settings required for the UK Black Friday Countdown.

[**Trello Card**](https://trello.com/c/AQiMH4wU)

## Why are you doing this?

To engage readers to take up the discount available for Black Friday before the deadline.

## How to test

Force campaign with `?forceCampaign=ukBlackFriday2024` at the end of the URL when running locally.