### PR TITLE
Requirement to hide the countdown unless there is a promotion

### DIFF
--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -15,6 +15,7 @@ export type CountdownSetting = {
 		backgroundColor: string;
 		foregroundColor: string;
 	};
+	requiresPromoCode?: boolean;
 };
 
 export function countdownSwitchOn(): boolean {
@@ -152,6 +153,7 @@ const campaigns: Record<string, CampaignSettings> = {
 					backgroundColor: '#1e3e72',
 					foregroundColor: '#ffffff',
 				},
+				requiresPromoCode: true,
 			},
 		],
 		copy: {

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -273,6 +273,7 @@ export function ThreeTierLanding({
 	const urlSearchParamsProduct = urlSearchParams.get('product');
 	const urlSearchParamsRatePlan = urlSearchParams.get('ratePlan');
 	const urlSearchParamsOneTime = urlSearchParams.has('oneTime');
+	const urlSearchParamsPromoCode = urlSearchParams.has('promoCode');
 
 	const { currencyKey: currencyId, countryGroupId } = getGeoIdConfig(geoId);
 	const countryId = Country.detect();
@@ -321,6 +322,16 @@ export function ThreeTierLanding({
 		useState<CountdownSetting>();
 	const [showCountdown, setShowCountdown] = useState<boolean>(false);
 
+	const checkForPromoCode = (
+		requiresPromoCode: boolean | undefined,
+		hasPromoCode: boolean,
+	) => {
+		if (requiresPromoCode) {
+			return hasPromoCode;
+		}
+		return true;
+	};
+
 	const memoizedCurrentCountdownCampaign = useMemo(() => {
 		if (!campaignSettings?.countdownSettings) {
 			return undefined;
@@ -329,7 +340,9 @@ export function ThreeTierLanding({
 		const now = Date.now();
 		return campaignSettings.countdownSettings.find(
 			(c) =>
-				c.countdownStartInMillis < now && c.countdownDeadlineInMillis > now,
+				c.countdownStartInMillis < now &&
+				c.countdownDeadlineInMillis > now &&
+				checkForPromoCode(c.requiresPromoCode, urlSearchParamsPromoCode),
 		);
 	}, [campaignSettings?.countdownSettings]);
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -331,8 +331,8 @@ export function ThreeTierLanding({
 		return campaignSettings.countdownSettings.find(
 			(c) =>
 				c.countdownStartInMillis < now &&
-				c.countdownDeadlineInMillis > now && 
-				(c.requiresPromoCode ? urlSearchParamsPromoCode : true)
+				c.countdownDeadlineInMillis > now &&
+				(c.requiresPromoCode ? urlSearchParamsPromoCode : true),
 		);
 	}, [campaignSettings?.countdownSettings]);
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -322,16 +322,6 @@ export function ThreeTierLanding({
 		useState<CountdownSetting>();
 	const [showCountdown, setShowCountdown] = useState<boolean>(false);
 
-	const checkForPromoCode = (
-		requiresPromoCode: boolean | undefined,
-		hasPromoCode: boolean,
-	) => {
-		if (requiresPromoCode) {
-			return hasPromoCode;
-		}
-		return true;
-	};
-
 	const memoizedCurrentCountdownCampaign = useMemo(() => {
 		if (!campaignSettings?.countdownSettings) {
 			return undefined;
@@ -341,8 +331,8 @@ export function ThreeTierLanding({
 		return campaignSettings.countdownSettings.find(
 			(c) =>
 				c.countdownStartInMillis < now &&
-				c.countdownDeadlineInMillis > now &&
-				checkForPromoCode(c.requiresPromoCode, urlSearchParamsPromoCode),
+				c.countdownDeadlineInMillis > now && 
+				(c.requiresPromoCode ? urlSearchParamsPromoCode : true)
 		);
 	}, [campaignSettings?.countdownSettings]);
 


### PR DESCRIPTION
## What are you doing in this PR?

The Black Friday countdown should not appear unless there is a promotion running - here we're using the promoCode URL parameter to determine this. We are not checking for any specific promo code at this point but we may change that in future to be more resilient.

The rest of the campaign should show regardless of the promoCode's existence - such as the title change, any ticker, etc.

[**Trello Card**](https://trello.com/c/wQSXGTnX)

## Why are you doing this?

We have been asked to ensure that the countdown is hidden unless there is a promotion.

## How to test

Run locally with the countdown settings appropriate to show. Ensure the url contains a promoCode and you can force the campaign with ?forceCampaign=usEoy2024

## Screenshots

### UK Black Friday set to require a promoCode but without one - countdown hidden
<img width="1300" alt="Screenshot 2024-11-26 at 15 32 57" src="https://github.com/user-attachments/assets/14a88d2a-0118-40c3-b494-cedc38e3f6af">

### UK Black Friday set to require a promoCode with one - countdown shows
<img width="1300" alt="Screenshot 2024-11-26 at 15 33 22" src="https://github.com/user-attachments/assets/f01bdc17-938d-413a-a689-5a5f6b65bfea">

### US EOY campaign which is not set to require a promoCode - countdown shows
<img width="1300" alt="Screenshot 2024-11-26 at 15 33 47" src="https://github.com/user-attachments/assets/7f5d4c20-b9f1-4a69-bee0-f44d51483c3b">
