### PR TITLE
Guardian Light: Initial Landing Page Structure 

### DIFF
--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -104,6 +104,16 @@ const supporterPlusBenefits = [
 	feastBenefit,
 ];
 
+const guardianLightBenefits = [
+	{
+		copy: 'A Guardian Light subscription enables you to read the Guardian without personalised advertising.',
+	},
+	{
+		copy: 'Guardian Light is a distinct product that is separate to other paid subscriptions. Readers with valid ad-free subscriptions should sign in to read the Guardian without advertising.',
+	},
+	{ copy: 'You can cancel anytime' },
+];
+
 export const productCatalogDescription: Record<ProductKey, ProductDescription> =
 	{
 		GuardianLight: {
@@ -113,8 +123,7 @@ export const productCatalogDescription: Record<ProductKey, ProductDescription> =
 					billingPeriod: 'Monthly',
 				},
 			},
-			benefits: [],
-			benefitsAdditional: [{ copy: 'Lorem ipsum' }],
+			benefits: guardianLightBenefits,
 		},
 		TierThree: {
 			label: 'Digital + print',
@@ -339,6 +348,28 @@ export function productCatalogDescriptionNewBenefits(
 					tooltip: `Look back on more than 200 years of world history with the Guardian newspaper archive. Get digital access to every front page, article and advertisement, as it was printed${
 						countryGroupId !== 'GBPCountries' ? ' in the UK' : ''
 					}, since 1821.`,
+				},
+			],
+		},
+	};
+}
+
+export function productCatalogGuardianLight(): Record<
+	ProductKey | 'GuardianLightGoBack',
+	ProductDescription
+> {
+	return {
+		...productCatalogDescription,
+		GuardianLight: {
+			...productCatalogDescription.GuardianLight,
+			label: 'Purchase Guardian Light',
+		},
+		GuardianLightGoBack: {
+			...productCatalogDescription.GuardianLight,
+			label: 'Read with personalised advertising',
+			benefits: [
+				{
+					copy: `Click ‘Go Back to Accept all’ if you do not want to purchase a Guardian Light subscription`,
 				},
 			],
 		},

--- a/support-frontend/assets/helpers/productCatalog.tsx
+++ b/support-frontend/assets/helpers/productCatalog.tsx
@@ -18,6 +18,7 @@ type ProductBenefit = {
 	specificToRegions?: CountryGroupId[];
 	specificToAbTest?: Array<{ name: string; variants: string[] }>;
 	isNew?: boolean;
+	hideBullet?: boolean;
 };
 
 export type ProductDescription = {
@@ -370,6 +371,7 @@ export function productCatalogGuardianLight(): Record<
 			benefits: [
 				{
 					copy: `Click ‘Go Back to Accept all’ if you do not want to purchase a Guardian Light subscription`,
+					hideBullet: true,
 				},
 			],
 		},

--- a/support-frontend/assets/helpers/urls/url.ts
+++ b/support-frontend/assets/helpers/urls/url.ts
@@ -79,6 +79,10 @@ function isProd(): boolean {
 	return getBaseDomain() === 'theguardian.com';
 }
 
+function isCode(): boolean {
+	return getBaseDomain() === 'code.dev-theguardian.com';
+}
+
 function isCodeOrProd(): boolean {
 	return window.location.hostname.includes('theguardian.com');
 }
@@ -92,5 +96,6 @@ export {
 	getBaseDomain,
 	addQueryParamsToURL,
 	isProd,
+	isCode,
 	isCodeOrProd,
 };

--- a/support-frontend/assets/pages/[countryGroupId]/components/accordianComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/accordianComponent.tsx
@@ -1,0 +1,3 @@
+export function AccordianComponent(): JSX.Element {
+	return <div>accordianComponent</div>;
+}

--- a/support-frontend/assets/pages/[countryGroupId]/components/componentContainer.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/componentContainer.tsx
@@ -1,0 +1,46 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import { from, space } from '@guardian/source/foundations';
+import type { ReactNode } from 'react';
+import { Container } from 'components/layout/container';
+
+const container = css`
+	> div {
+		padding: ${space[5]}px 10px;
+		${from.mobileLandscape} {
+			padding-left: ${space[5]}px;
+			padding-right: ${space[5]}px;
+		}
+		${from.desktop} {
+			max-width: 940px;
+		}
+	}
+`;
+
+export type ComponentContainerProps = {
+	children: ReactNode;
+	borderColor?: string;
+	sideBorders?: boolean;
+	topBorder?: boolean;
+	cssOverrides?: SerializedStyles;
+};
+
+export function ComponentContainer({
+	children,
+	borderColor,
+	sideBorders,
+	topBorder,
+	cssOverrides,
+}: ComponentContainerProps): JSX.Element {
+	const cssContainerAndOverride = css([cssOverrides, container]);
+	return (
+		<Container
+			sideBorders={!!sideBorders}
+			topBorder={!!topBorder}
+			borderColor={borderColor}
+			cssOverrides={cssContainerAndOverride}
+		>
+			{children}
+		</Container>
+	);
+}

--- a/support-frontend/assets/pages/[countryGroupId]/components/componentContainer.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/componentContainer.tsx
@@ -28,15 +28,15 @@ export type ComponentContainerProps = {
 export function ComponentContainer({
 	children,
 	borderColor,
-	sideBorders,
-	topBorder,
+	sideBorders = false,
+	topBorder = false,
 	cssOverrides,
 }: ComponentContainerProps): JSX.Element {
 	const cssContainerAndOverride = css([cssOverrides, container]);
 	return (
 		<Container
-			sideBorders={!!sideBorders}
-			topBorder={!!topBorder}
+			sideBorders={sideBorders}
+			topBorder={topBorder}
 			borderColor={borderColor}
 			cssOverrides={cssContainerAndOverride}
 		>

--- a/support-frontend/assets/pages/[countryGroupId]/components/guardianLightCards.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/guardianLightCards.tsx
@@ -1,0 +1,20 @@
+import type { ProductDescription } from 'helpers/productCatalog';
+
+export type GuardianLightCardsProps = {
+	cardsContent: Array<{
+		link: string;
+		productDescription: ProductDescription;
+		ctaCopy: string;
+	}>;
+};
+
+export function GuardianLightCards({
+	cardsContent,
+}: GuardianLightCardsProps): JSX.Element {
+	return (
+		<div>
+			GuardianLightCards {cardsContent[0].productDescription.label}{' '}
+			{cardsContent[1].productDescription.label}
+		</div>
+	);
+}

--- a/support-frontend/assets/pages/[countryGroupId]/components/headerCards.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/headerCards.tsx
@@ -13,6 +13,7 @@ import {
 	productCatalog,
 	productCatalogGuardianLight,
 } from 'helpers/productCatalog';
+import { isCode } from 'helpers/urls/url';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
 import { ComponentContainer } from './componentContainer';
@@ -63,7 +64,8 @@ const signIn = css`
 	}
 `;
 
-const SignInUrl = 'https://manage.theguardian.com/signin';
+const codeOrProd = isCode() ? 'code.dev-theguardian' : 'theguardian';
+const SignInUrl = `https://manage.${codeOrProd}.com`;
 const SignInLink = <a href={SignInUrl}>sign in</a>;
 
 type HeaderCardsProps = {

--- a/support-frontend/assets/pages/[countryGroupId]/components/headerCards.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/headerCards.tsx
@@ -18,14 +18,16 @@ import { getGeoIdConfig } from 'pages/geoIdConfig';
 import { ComponentContainer } from './componentContainer';
 import { GuardianLightCards } from './guardianLightCards';
 
-const container = css`
+const containerCards = css`
 	background-color: ${palette.brand[400]};
 	border-bottom: 1px solid ${palette.brand[600]};
-	> div {
-		padding: ${space[5]}px 10px ${space[4]}px;
+`;
+const containerSignIn = css`
+	background-color: ${palette.brand[400]};
+	${from.tablet} {
+		background-color: ${palette.neutral[97]};
 	}
 `;
-
 const heading = css`
 	color: ${palette.neutral[100]};
 	text-align: left;
@@ -43,21 +45,26 @@ const signIn = css`
 	color: ${palette.neutral[100]};
 	text-align: left;
 	${textSans15}
-	margin: ${space[5]}px 0px;
-	${from.tablet} {
-		text-align: center;
-	}
-	${from.desktop} {
-		${textSans17}
-	}
+	padding: 0px 0px ${space[1]}px;
 	> a {
 		color: ${palette.neutral[100]};
 		font-weight: bold;
 	}
+	${from.tablet} {
+		color: ${palette.neutral[7]};
+		padding: ${space[3]}px 0px ${space[4]}px;
+		text-align: center;
+		> a {
+			color: ${palette.brand[500]};
+		}
+	}
+	${from.desktop} {
+		${textSans17}
+	}
 `;
 
 const SignInUrl = 'https://manage.theguardian.com/signin';
-const SignInLink = <a href={SignInUrl}>Sign In</a>;
+const SignInLink = <a href={SignInUrl}>sign in</a>;
 
 type HeaderCardsProps = {
 	geoId: GeoId;
@@ -92,18 +99,26 @@ export function HeaderCards({ geoId }: HeaderCardsProps): JSX.Element {
 		ctaCopy: 'Go back to "accept all"',
 	};
 	return (
-		<ComponentContainer
-			sideBorders
-			topBorder
-			borderColor="rgba(170, 170, 180, 0.5)"
-			cssOverrides={container}
-		>
-			<h1 css={heading}>Choose how to read the Guardian</h1>
-			<GuardianLightCards cardsContent={[card1, card2]} />
-			<div css={signIn}>
-				If you already have Guardian Light or read the Guardian ad-free,{' '}
-				{SignInLink}
-			</div>
-		</ComponentContainer>
+		<>
+			<ComponentContainer
+				sideBorders
+				topBorder
+				borderColor="rgba(170, 170, 180, 0.5)"
+				cssOverrides={containerCards}
+			>
+				<h1 css={heading}>Choose how to read the Guardian</h1>
+				<GuardianLightCards cardsContent={[card1, card2]} />
+			</ComponentContainer>
+			<ComponentContainer
+				sideBorders
+				borderColor="rgba(170, 170, 180, 0.5)"
+				cssOverrides={containerSignIn}
+			>
+				<div css={signIn}>
+					If you already have Guardian Light or read the Guardian ad-free,{' '}
+					{SignInLink}
+				</div>
+			</ComponentContainer>
+		</>
 	);
 }

--- a/support-frontend/assets/pages/[countryGroupId]/components/headerCards.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/headerCards.tsx
@@ -1,9 +1,109 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headlineBold24,
+	palette,
+	space,
+	textSans15,
+	textSans17,
+} from '@guardian/source/foundations';
+import { simpleFormatAmount } from 'helpers/forms/checkouts';
+import { currencies } from 'helpers/internationalisation/currency';
+import {
+	productCatalog,
+	productCatalogGuardianLight,
+} from 'helpers/productCatalog';
 import type { GeoId } from 'pages/geoIdConfig';
+import { getGeoIdConfig } from 'pages/geoIdConfig';
+import { ComponentContainer } from './componentContainer';
+import { GuardianLightCards } from './guardianLightCards';
+
+const container = css`
+	background-color: ${palette.brand[400]};
+	border-bottom: 1px solid ${palette.brand[600]};
+	> div {
+		padding: ${space[5]}px 10px ${space[4]}px;
+	}
+`;
+
+const heading = css`
+	color: ${palette.neutral[100]};
+	text-align: left;
+	${headlineBold24}
+	margin-bottom: ${space[6]}px;
+	${from.tablet} {
+		text-align: center;
+	}
+	${from.desktop} {
+		font-size: 2.625rem;
+		margin-bottom: ${space[10]}px;
+	}
+`;
+const signIn = css`
+	color: ${palette.neutral[100]};
+	text-align: left;
+	${textSans15}
+	margin: ${space[5]}px 0px;
+	${from.tablet} {
+		text-align: center;
+	}
+	${from.desktop} {
+		${textSans17}
+	}
+	> a {
+		color: ${palette.neutral[100]};
+		font-weight: bold;
+	}
+`;
+
+const SignInUrl = 'https://manage.theguardian.com/signin';
+const SignInLink = <a href={SignInUrl}>Sign In</a>;
 
 type HeaderCardsProps = {
 	geoId: GeoId;
 };
 
 export function HeaderCards({ geoId }: HeaderCardsProps): JSX.Element {
-	return <div>HeaderCards {geoId}</div>;
+	const contributionType = 'Monthly';
+	const { currencyKey } = getGeoIdConfig(geoId);
+	const currency = currencies[currencyKey];
+	const price =
+		productCatalog.GuardianLight.ratePlans[contributionType].pricing[
+			currencyKey
+		];
+	const formattedPrice = simpleFormatAmount(currency, price);
+
+	const card1UrlParams = new URLSearchParams({
+		product: 'GuardianLight',
+		ratePlan: contributionType,
+		contribution: price.toString(),
+	});
+	const checkoutLink = `checkout?${card1UrlParams.toString()}`;
+	const card1 = {
+		link: checkoutLink,
+		productDescription: productCatalogGuardianLight().GuardianLight,
+		ctaCopy: `Get Guardian Light for ${formattedPrice}/month`,
+	};
+
+	const returnLink = `https://www.theguardian.com/${geoId}`; // ToDo : store and use return path
+	const card2 = {
+		link: returnLink,
+		productDescription: productCatalogGuardianLight().GuardianLightGoBack,
+		ctaCopy: 'Go back to "accept all"',
+	};
+	return (
+		<ComponentContainer
+			sideBorders
+			topBorder
+			borderColor="rgba(170, 170, 180, 0.5)"
+			cssOverrides={container}
+		>
+			<h1 css={heading}>Choose how to read the Guardian</h1>
+			<GuardianLightCards cardsContent={[card1, card2]} />
+			<div css={signIn}>
+				If you already have Guardian Light or read the Guardian ad-free,{' '}
+				{SignInLink}
+			</div>
+		</ComponentContainer>
+	);
 }

--- a/support-frontend/assets/pages/[countryGroupId]/components/headerCards.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/headerCards.tsx
@@ -1,0 +1,9 @@
+import type { GeoId } from 'pages/geoIdConfig';
+
+type HeaderCardsProps = {
+	geoId: GeoId;
+};
+
+export function HeaderCards({ geoId }: HeaderCardsProps): JSX.Element {
+	return <div>HeaderCards {geoId}</div>;
+}

--- a/support-frontend/assets/pages/[countryGroupId]/components/landingPageLayout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/landingPageLayout.tsx
@@ -1,0 +1,44 @@
+import {
+	FooterLinks,
+	FooterWithContents,
+} from '@guardian/source-development-kitchen/react-components';
+import type { ReactNode } from 'react';
+import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countrySwitcherContainer';
+import { Header } from 'components/headers/simpleHeader/simpleHeader';
+import { PageScaffold } from 'components/page/pageScaffold';
+
+type LandingPageLayoutProps = {
+	children: ReactNode;
+	countrySwitcherProps: CountryGroupSwitcherProps;
+};
+
+export function LandingPageLayout({
+	children,
+	countrySwitcherProps,
+}: LandingPageLayoutProps) {
+	const multipleCountries = countrySwitcherProps.countryGroupIds.length > 1;
+	return (
+		<PageScaffold
+			header={
+				<>
+					<Header>
+						{multipleCountries && (
+							<CountrySwitcherContainer>
+								<CountryGroupSwitcher {...countrySwitcherProps} />
+							</CountrySwitcherContainer>
+						)}
+					</Header>
+				</>
+			}
+			footer={
+				<FooterWithContents>
+					<FooterLinks></FooterLinks>
+				</FooterWithContents>
+			}
+		>
+			{children}
+		</PageScaffold>
+	);
+}

--- a/support-frontend/assets/pages/[countryGroupId]/components/posterComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/posterComponent.tsx
@@ -1,0 +1,3 @@
+export function PosterComponent(): JSX.Element {
+	return <div>posterComponent</div>;
+}

--- a/support-frontend/assets/pages/[countryGroupId]/guardianLightLanding.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianLightLanding.tsx
@@ -1,7 +1,11 @@
-import { Box } from 'components/checkoutBox/checkoutBox';
+import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
-import { CheckoutLayout } from './components/checkoutLayout';
+import { AccordianComponent } from './components/accordianComponent';
+import { HeaderCards } from './components/headerCards';
+import { LandingPageLayout } from './components/landingPageLayout';
+import { PosterComponent } from './components/posterComponent';
 
 type GuardianLightLandingProps = {
 	geoId: GeoId;
@@ -10,14 +14,17 @@ type GuardianLightLandingProps = {
 export function GuardianLightLanding({
 	geoId,
 }: GuardianLightLandingProps): JSX.Element {
-	const { currencyKey, countryGroupId } = getGeoIdConfig(geoId);
+	const { countryGroupId } = getGeoIdConfig(geoId);
+	const countrySwitcherProps: CountryGroupSwitcherProps = {
+		countryGroupIds: [GBPCountries],
+		selectedCountryGroup: countryGroupId,
+		subPath: '/guardian-light',
+	}; // hidden initially, will display with more regions
 	return (
-		<CheckoutLayout>
-			<Box>
-				<div>
-					GuardianLightLanding ${currencyKey} ${countryGroupId}
-				</div>
-			</Box>
-		</CheckoutLayout>
+		<LandingPageLayout countrySwitcherProps={countrySwitcherProps}>
+			<HeaderCards geoId={geoId} />
+			<PosterComponent />
+			<AccordianComponent />
+		</LandingPageLayout>
 	);
 }


### PR DESCRIPTION
## What are you doing in this PR?

Build Guardian Landing Page structure as per (initial / subject to change ) [Figma](https://www.figma.com/design/daOtcjwsPKfCc1GvSpuBn7/Consent-or-Pay---user-flows?node-id=1379-29821&t=Q1UQLFZz4buXMc00-1)

Will load the following PR components into this Structure->

- [HeaderCards](https://github.com/guardian/support-frontend/pull/6577)
- [PosterComponent](https://github.com/guardian/support-frontend/pull/6579)
- [AccordianComponent](https://github.com/guardian/support-frontend/pull/6578)

Note:
- Further PR's will refine this design as the Figma design gets approved. 
- Images/Icons to be confirmed, placeholders used currently.

[**Trello Card**](https://trello.com/c/AupUM3yM/1235-guardian-light-landing-page-structure)

## How to test

https://support.thegulocal.com/uk/guardian-light

## Final Screenshots (All Componetns Shown)

|mobile|tablet|desktop|
|-----|-----|-----|
|![image](https://github.com/user-attachments/assets/3a81a8cc-ca0b-4d9b-8358-8752d8f09f55)|![image](https://github.com/user-attachments/assets/b5bce0ff-ddbc-4535-adc6-9afba63a7a7d)|![image](https://github.com/user-attachments/assets/fdb9cce2-220a-4ee3-af7b-771ed95f97f7)|