### PR TITLE
Hide campaign without promo code

### DIFF
--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -34,7 +34,10 @@ export type CampaignTickerSettings = Omit<TickerSettings, 'tickerData'> & {
 };
 
 export type CampaignSettings = {
-	isEligible: (countryGroupId: CountryGroupId, promoCode?: string | null) => boolean;
+	isEligible: (
+		countryGroupId: CountryGroupId,
+		promoCode?: string | null,
+	) => boolean;
 	enableSingleContributions: boolean;
 	countdownSettings?: CountdownSetting[];
 	copy: CampaignCopy;
@@ -140,8 +143,9 @@ const campaigns: Record<string, CampaignSettings> = {
 		},
 	},
 	ukBlackFriday2024: {
-		isEligible: (countryGroupId: CountryGroupId, promoCode?: string | null) => 
-			countryGroupId === GBPCountries && promoCode === 'BLACK_FRIDAY_DISCOUNT_2024',
+		isEligible: (countryGroupId: CountryGroupId, promoCode?: string | null) =>
+			countryGroupId === GBPCountries &&
+			promoCode === 'BLACK_FRIDAY_DISCOUNT_2024',
 		enableSingleContributions: false,
 		countdownSettings: [
 			{
@@ -176,7 +180,7 @@ const forceCampaign = (campaignId: string): boolean => {
 
 export function getCampaignSettings(
 	countryGroupId: CountryGroupId,
-	promoCode?: string | null
+	promoCode?: string | null,
 ): CampaignSettings | null {
 	for (const campaignId in campaigns) {
 		const isEligible =

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -34,7 +34,7 @@ export type CampaignTickerSettings = Omit<TickerSettings, 'tickerData'> & {
 };
 
 export type CampaignSettings = {
-	isEligible: (countryGroupId: CountryGroupId) => boolean;
+	isEligible: (countryGroupId: CountryGroupId, promoCode?: string | null) => boolean;
 	enableSingleContributions: boolean;
 	countdownSettings?: CountdownSetting[];
 	copy: CampaignCopy;
@@ -140,8 +140,8 @@ const campaigns: Record<string, CampaignSettings> = {
 		},
 	},
 	ukBlackFriday2024: {
-		isEligible: (countryGroupId: CountryGroupId) =>
-			countryGroupId === GBPCountries,
+		isEligible: (countryGroupId: CountryGroupId, promoCode?: string | null) => 
+			countryGroupId === GBPCountries && promoCode === 'BLACK_FRIDAY_DISCOUNT_2024',
 		enableSingleContributions: false,
 		countdownSettings: [
 			{
@@ -176,11 +176,12 @@ const forceCampaign = (campaignId: string): boolean => {
 
 export function getCampaignSettings(
 	countryGroupId: CountryGroupId,
+	promoCode?: string | null
 ): CampaignSettings | null {
 	for (const campaignId in campaigns) {
 		const isEligible =
 			isCampaignEnabled(campaignId) &&
-			campaigns[campaignId].isEligible(countryGroupId);
+			campaigns[campaignId].isEligible(countryGroupId, promoCode);
 		if (isEligible || forceCampaign(campaignId)) {
 			return campaigns[campaignId];
 		}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -273,6 +273,7 @@ export function ThreeTierLanding({
 	const urlSearchParamsProduct = urlSearchParams.get('product');
 	const urlSearchParamsRatePlan = urlSearchParams.get('ratePlan');
 	const urlSearchParamsOneTime = urlSearchParams.has('oneTime');
+	const urlSearchParamsPromoCode = urlSearchParams.get('promoCode');
 
 	const { currencyKey: currencyId, countryGroupId } = getGeoIdConfig(geoId);
 	const countryId = Country.detect();
@@ -295,7 +296,7 @@ export function ThreeTierLanding({
 	// Persist any tests for tracking in the checkout page
 	storage.setSession('abParticipations', JSON.stringify(abParticipations));
 
-	const campaignSettings = getCampaignSettings(countryGroupId);
+	const campaignSettings = getCampaignSettings(countryGroupId, urlSearchParamsPromoCode);
 
 	const enableSingleContributionsTab =
 		campaignSettings?.enableSingleContributions ??

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -296,7 +296,10 @@ export function ThreeTierLanding({
 	// Persist any tests for tracking in the checkout page
 	storage.setSession('abParticipations', JSON.stringify(abParticipations));
 
-	const campaignSettings = getCampaignSettings(countryGroupId, urlSearchParamsPromoCode);
+	const campaignSettings = getCampaignSettings(
+		countryGroupId,
+		urlSearchParamsPromoCode,
+	);
 
 	const enableSingleContributionsTab =
 		campaignSettings?.enableSingleContributions ??


### PR DESCRIPTION
## What are you doing in this PR?

For the Black Friday 2024 campaign we have been asked to hide the campaign unless there is a promo code in the URL parameters.

[**Trello Card**](https://trello.com/c/wQSXGTnX)

## Why are you doing this?

So that users are not confused by the headline not matching the discount.