### PR TITLE
Update Giving Tuesday extension label to match Trello card requirements

### DIFF
--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -60,7 +60,7 @@ const campaigns: Record<string, CampaignSettings> = {
 				},
 			},
 			{
-				label: "It's not too late",
+				label: "It's not too late to give to the Guardian",
 				countdownStartInMillis: Date.parse('Dec 04, 2024 00:01:00'),
 				countdownDeadlineInMillis: Date.parse('Dec 05, 2024 00:01:00'),
 				theme: {


### PR DESCRIPTION
## What are you doing in this PR?

I noticed that the copy for the Giving Tuesday 24 hour extension label had changed slightly. The description text changes on the Trello card are not logged so it was not obvious that it had changed but spotted this morning.

[**Trello Card**](https://trello.com/c/gECTtqrM)

## Why are you doing this?

Update to text.
