### PR TITLE
Send all traffic from 3-tier LP to new one-time-checkout

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -105,27 +105,6 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeCountriesSubjectToContributionsOnlyAmounts: true,
 	},
-	newOneTimeCheckout: {
-		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'variant',
-			},
-		],
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		isActive: true,
-		referrerControlled: false, // ab-test name not needed to be in paramURL
-		seed: 4,
-		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
-		excludeCountriesSubjectToContributionsOnlyAmounts: true,
-	},
 	linkExpressCheckout: {
 		variants: [
 			{

--- a/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
@@ -60,17 +60,13 @@ const btnStyleOverrides = css`
 interface SupportOnceProps {
 	currency: string;
 	countryGroupId: CountryGroupId;
-	useNewOneTimeCheckout: boolean;
 }
 
 export function SupportOnce({
 	currency,
 	countryGroupId,
-	useNewOneTimeCheckout,
 }: SupportOnceProps): JSX.Element {
-	const checkoutUrlFragment = useNewOneTimeCheckout
-		? 'one-time-checkout'
-		: 'contribute/checkout?selected-contribution-type=one_off';
+	const checkoutUrlFragment = 'one-time-checkout';
 
 	return (
 		<div css={container}>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
@@ -66,8 +66,6 @@ export function SupportOnce({
 	currency,
 	countryGroupId,
 }: SupportOnceProps): JSX.Element {
-	const checkoutUrlFragment = 'one-time-checkout';
-
 	return (
 		<div css={container}>
 			<h2 css={heading}>Support us just once</h2>
@@ -77,7 +75,7 @@ export function SupportOnce({
 				{currency}1 or more.
 			</p>
 			<LinkButton
-				href={`/${countryGroups[countryGroupId].supportInternationalisationId}/${checkoutUrlFragment}`}
+				href={`/${countryGroups[countryGroupId].supportInternationalisationId}/one-time-checkout`}
 				iconSide="left"
 				priority="primary"
 				size="default"

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -517,9 +517,6 @@ export function ThreeTierLanding({
 	const showNewspaperArchiveBanner =
 		abParticipations.newspaperArchiveBenefit === 'v2';
 
-	const useNewOneTimeCheckout =
-		abParticipations.newOneTimeCheckout === 'variant';
-
 	return (
 		<PageScaffold
 			header={
@@ -611,7 +608,6 @@ export function ThreeTierLanding({
 					<SupportOnce
 						currency={currencies[currencyId].glyph}
 						countryGroupId={countryGroupId}
-						useNewOneTimeCheckout={useNewOneTimeCheckout}
 					/>
 				</Container>
 			)}


### PR DESCRIPTION
## What are you doing in this PR?

The `newOneTimeCheckout` A/B test has ended, the new one-time-checkout achieved parity with the existing checkout so we will be pushing all traffic to that. This is the first step in that roll-out, where we end the test and direct all traffic from 3-tier LP to new one-time-checkout.
