### PR TITLE
Start Giving Tuesday early - display countdown, headline copy

### DIFF
--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -52,7 +52,7 @@ const campaigns: Record<string, CampaignSettings> = {
 		countdownSettings: [
 			{
 				label: 'This Giving Tuesday, give to the Guardian',
-				countdownStartInMillis: Date.parse('Nov 29, 2024 00:01:00'),
+				countdownStartInMillis: Date.parse('Nov 27, 2024 00:01:00'),
 				countdownDeadlineInMillis: Date.parse('Dec 03, 2024 23:59:59'),
 				theme: {
 					backgroundColor: '#ab0613',


### PR DESCRIPTION
## What are you doing in this PR?

We have been asked to start the Giving Tuesday copy and countdown sub-campaign early so this brings the date forward.

[**Trello Card**](https://trello.com/c/gECTtqrM) see also team chat
