### PR TITLE
Add Black Friday to title to clarify discount

### DIFF
--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -149,7 +149,7 @@ const campaigns: Record<string, CampaignSettings> = {
 		enableSingleContributions: false,
 		countdownSettings: [
 			{
-				label: "Last chance to claim your Black Friday offer",
+				label: 'Last chance to claim your Black Friday offer',
 				countdownStartInMillis: Date.parse('Nov 29, 2024 00:00:00'),
 				countdownDeadlineInMillis: Date.parse('Dec 02, 2024 23:59:59'),
 				theme: {

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -149,7 +149,7 @@ const campaigns: Record<string, CampaignSettings> = {
 		enableSingleContributions: false,
 		countdownSettings: [
 			{
-				label: 'Just a few days left',
+				label: "Last chance to claim your Black Friday offer",
 				countdownStartInMillis: Date.parse('Nov 29, 2024 00:00:00'),
 				countdownDeadlineInMillis: Date.parse('Dec 02, 2024 23:59:59'),
 				theme: {


### PR DESCRIPTION
## What are you doing in this PR?

We noticed that the Black Friday campaign's extension label did not actually mention Black Friday so this is a quick fix for that.
Copy agreed with MRR.

[**Original Trello Card**](https://trello.com/c/AQiMH4wU)