### PR TITLE
Add redirect to new one time checkout from old checkout

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -454,7 +454,7 @@ class Application(
 
     val isOneOff = maybeSelectedContributionType.contains("one_off")
     if (isOneOff) {
-      ("OneOff", "OneOff", None)
+      ("OneOff", "OneOff", maybeSelectedAmount)
     } else if (isSupporterPlus) {
       ("SupporterPlus", ratePlan, None)
     } else {
@@ -471,13 +471,13 @@ class Application(
     val (product, ratePlan, maybeSelectedAmount) =
       getProductParamsFromContributionParams(countryGroupId, productCatalog, request.queryString)
 
-    /** we currently don't support one-time checkout outside of the contribution checkout. Once this is supported we
-      * should remove this.
-      */
     if (product == "OneOff") {
-      Ok(
-        contributionsHtml(countryGroupId, None),
-      ).withSettingsSurrogateKey
+      val queryString = request.queryString - "selected-contribution-type" - "selected-amount"
+      val queryStringMaybeWithContributionAmount = maybeSelectedAmount
+        .map(selectedAmount => queryString + ("contribution" -> Seq(selectedAmount.toString)))
+        .getOrElse(queryString)
+
+      Redirect(s"/$countryGroupId/one-time-checkout", queryStringMaybeWithContributionAmount, MOVED_PERMANENTLY)
     } else {
       val queryString = request.queryString - "selected-contribution-type" - "selected-amount" ++ Map(
         "product" -> Seq(product),

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -471,15 +471,16 @@ class Application(
     val (product, ratePlan, maybeSelectedAmount) =
       getProductParamsFromContributionParams(countryGroupId, productCatalog, request.queryString)
 
+    val qsWithoutTypeAndAmount = request.queryString - "selected-contribution-type" - "selected-amount"
+
     if (product == "OneOff") {
-      val queryString = request.queryString - "selected-contribution-type" - "selected-amount"
       val queryStringMaybeWithContributionAmount = maybeSelectedAmount
-        .map(selectedAmount => queryString + ("contribution" -> Seq(selectedAmount.toString)))
-        .getOrElse(queryString)
+        .map(selectedAmount => qsWithoutTypeAndAmount + ("contribution" -> Seq(selectedAmount.toString)))
+        .getOrElse(qsWithoutTypeAndAmount)
 
       Redirect(s"/$countryGroupId/one-time-checkout", queryStringMaybeWithContributionAmount, MOVED_PERMANENTLY)
     } else {
-      val queryString = request.queryString - "selected-contribution-type" - "selected-amount" ++ Map(
+      val queryString = qsWithoutTypeAndAmount ++ Map(
         "product" -> Seq(product),
         "ratePlan" -> Seq(ratePlan),
       )

--- a/support-frontend/test/controllers/ApplicationTest.scala
+++ b/support-frontend/test/controllers/ApplicationTest.scala
@@ -18,7 +18,7 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar._
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{contentAsString, header, stubControllerComponents}
+import play.api.test.Helpers.{contentAsString, header, status, stubControllerComponents}
 import services._
 import services.pricing.{CountryGroupPrices, PriceSummaryService, PriceSummaryServiceProvider}
 
@@ -195,6 +195,20 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
       assert(product === "SupporterPlus")
       assert(ratePlan === "Annual")
       assert(maybeContributionAmount === None)
+    }
+  }
+
+  "redirectContributionsCheckout" should {
+    "redirect the old one time checkout to the new path" in {
+      val geoCode = "uk"
+      val request = FakeRequest(
+        method = "GET",
+        path = s"/$geoCode/contribute/checkout?selected-contribution-type=one_off&selected-amount=30",
+      )
+
+      val result = applicationMock.redirectContributionsCheckout(geoCode).apply(request)
+
+      status(result) mustBe 301
     }
   }
 }

--- a/support-frontend/test/controllers/ApplicationTest.scala
+++ b/support-frontend/test/controllers/ApplicationTest.scala
@@ -1,28 +1,31 @@
 package controllers
 
+import actions.UserFromAuthCookiesActionBuilder.UserClaims
 import actions.{CustomActionBuilders, UserFromAuthCookiesActionBuilder, UserFromAuthCookiesOrAuthServerActionBuilder}
 import admin.settings.{AllSettingsProvider, FeatureSwitches, On}
 import org.apache.pekko.util.Timeout
 import assets.AssetsResolver
 import com.gu.i18n.CountryGroup
+import com.gu.identity.auth.{DefaultAccessClaims, OktaAuthService}
 import com.gu.support.catalog.SupporterPlus
 import com.gu.support.config._
 import com.gu.support.promotions.PromoCode
 import com.gu.support.zuora.api.ReaderType
-import config.{RecaptchaConfigProvider, StringsConfig}
+import config.{Identity, RecaptchaConfigProvider, StringsConfig}
 import fixtures.TestCSRFComponents
+import io.circe.JsonObject
 import org.mockito.ArgumentMatchers.{any, anyBoolean}
 import org.mockito.Mockito.when
 import org.scalatest.EitherValues
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar._
+import play.api.mvc.{AnyContent, BodyParser}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsString, header, status, stubControllerComponents}
 import services._
 import services.pricing.{CountryGroupPrices, PriceSummaryService, PriceSummaryServiceProvider}
-
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
@@ -31,9 +34,18 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
   implicit val timeout: Timeout = Timeout(2.seconds)
   val stage = Stages.DEV
 
+  val parser = mock[BodyParser[AnyContent]]
+  val authService = mock[OktaAuthService[DefaultAccessClaims, UserClaims]]
+  val config = mock[Identity]
+  val mockAuthActionBuilder = new UserFromAuthCookiesOrAuthServerActionBuilder(
+    parser,
+    authService,
+    config,
+    isAuthServerUp = () => Future.successful(true),
+  )
   val actionRefiner = new CustomActionBuilders(
     asyncAuthenticationService = mock[AsyncAuthenticationService],
-    userFromAuthCookiesOrAuthServerActionBuilder = mock[UserFromAuthCookiesOrAuthServerActionBuilder],
+    userFromAuthCookiesOrAuthServerActionBuilder = mockAuthActionBuilder,
     userFromAuthCookiesActionBuilder = mock[UserFromAuthCookiesActionBuilder],
     cc = stubControllerComponents(),
     addToken = csrfAddToken,
@@ -55,6 +67,11 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
     priceSummaryServiceProvider
   }
 
+  val cachedProductCatalogService = mock[CachedProductCatalogService]
+  when(cachedProductCatalogService.get()).thenReturn(JsonObject())
+  val productCatalog = mock[CachedProductCatalogServiceProvider]
+  when(productCatalog.fromStage(any, any)).thenReturn(cachedProductCatalogService)
+
   val applicationMock = new Application(
     actionRefiner,
     mock[AssetsResolver],
@@ -70,7 +87,7 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
     mock[AllSettingsProvider],
     mock[Stage],
     priceSummaryServiceProvider,
-    mock[CachedProductCatalogServiceProvider],
+    productCatalog,
     "support.thegulocal.com",
   )(mock[ExecutionContext])
 
@@ -199,16 +216,37 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
   }
 
   "redirectContributionsCheckout" should {
-    "redirect the old one time checkout to the new path" in {
+    "redirect one time contributions from the old checkout to the new path, rewriting the amount and keeping additional params" in {
+      // This means we won't attempt to authenticate the user
+      when(config.signedInCookieName).thenReturn("signed_in_cookie")
       val geoCode = "uk"
       val request = FakeRequest(
         method = "GET",
-        path = s"/$geoCode/contribute/checkout?selected-contribution-type=one_off&selected-amount=30",
+        path = s"/$geoCode/contribute/checkout?selected-contribution-type=one_off&selected-amount=30&extra=param",
       )
 
       val result = applicationMock.redirectContributionsCheckout(geoCode).apply(request)
 
-      status(result) mustBe 301
+      assert(status(result) === 301)
+      assert(header("Location", result) === Some(s"/$geoCode/one-time-checkout?extra=param&contribution=30"))
+    }
+
+    "redirect Supporter+ from the old checkout to the new path, keeping additional params" in {
+      // This means we won't attempt to authenticate the user
+      when(config.signedInCookieName).thenReturn("signed_in_cookie")
+      val geoCode = "uk"
+      val request = FakeRequest(
+        method = "GET",
+        // When the amount is missing, we default to being eligible for S+
+        path = s"/$geoCode/contribute/checkout?selected-contribution-type=recurring&extra=param",
+      )
+
+      val result = applicationMock.redirectContributionsCheckout(geoCode).apply(request)
+
+      assert(status(result) === 301)
+      assert(
+        header("Location", result) === Some(s"/$geoCode/checkout?extra=param&product=SupporterPlus&ratePlan=Monthly"),
+      )
     }
   }
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

We want to redirect from `/contribute/checkout?selected-contribution-type=one_off` to `/one-time-checkout`. If present we should convert the `selected-amount` query string parameter to `contribution`.

For example:

Old URL: https://support.theguardian.com/uk/contribute/checkout?selected-contribution-type=one_off&selected-amount=30

New URL: https://support.theguardian.com/uk/one-time-checkout?contribution=30

Note: we should preserve all other query string parameters.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/nTYMv0x1/1281-add-redirect-on-old-url-to-new-url-as-we-did-for-generic-checkout)

## Why are you doing this?

All one time contributions should now be going through the new checkout. This ensures any old links will get the new checkout.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
