### PR TITLE
Update AcquisitionData model to handle Feast app product

### DIFF
--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
@@ -113,6 +113,8 @@ object AcquisitionProduct {
 
   case object GuardianLight extends AcquisitionProduct("GUARDIAN_LIGHT")
 
+  case object FeastApp extends AcquisitionProduct("FEAST_APP")
+
   def fromString(code: String): Option[AcquisitionProduct] = {
     List(
       Contribution,
@@ -124,6 +126,7 @@ object AcquisitionProduct {
       AppPremiumTier,
       TierThree,
       GuardianLight,
+      FeastApp
     )
       .find(
         _.value == code,
@@ -134,7 +137,6 @@ object AcquisitionProduct {
     Decoder.decodeString.emap(code => AcquisitionProduct.fromString(code).toRight(s"unrecognised product '$code'"))
 
   implicit val encoder: Encoder[AcquisitionProduct] = Encoder.encodeString.contramap[AcquisitionProduct](_.value)
-
 }
 
 sealed abstract class PrintProduct(val value: String)


### PR DESCRIPTION
We will soon be sending Feast related subscription acquisitions to the web acquisition API and here we are updating the model used by bigquery-acquisitions-publisher, by registering the product we will be using: `FEAST_APP`. 