### PR TITLE
Refactor some server calls related to Stripe & PayPal out of checkout

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/paypal.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/paypal.ts
@@ -1,0 +1,53 @@
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
+
+export const setupPayPalPayment = async (
+	amount: number,
+	currency: IsoCurrency,
+	billingPeriod: BillingPeriod,
+	csrfToken: string,
+): Promise<string> => {
+	const body = JSON.stringify({
+		amount,
+		billingPeriod,
+		currency,
+		requireShippingAddress: false,
+	});
+
+	const response = await fetch('/paypal/setup-payment', {
+		credentials: 'include',
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'Csrf-Token': csrfToken,
+		},
+		body,
+	});
+
+	const json = (await response.json()) as { token: string };
+
+	return json.token;
+};
+
+export const paypalOneClickCheckout = async (
+	paymentToken: unknown,
+	csrfToken: string,
+): Promise<string> => {
+	const body = JSON.stringify({
+		token: paymentToken,
+	});
+
+	const response = await fetch('/paypal/one-click-checkout', {
+		credentials: 'include',
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'Csrf-Token': csrfToken,
+		},
+		body,
+	});
+
+	const json = (await response.json()) as { baid: string };
+
+	return json.baid;
+};

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripe.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripe.ts
@@ -1,6 +1,10 @@
+interface StripeResponseData {
+	client_secret: string;
+}
+
 export const stripeCreateSetupIntentPrb = async (
 	stripePublicKey: string,
-): Promise<{ client_secret: string }> => {
+): Promise<string> => {
 	const response = await fetch('/stripe/create-setup-intent/prb', {
 		method: 'POST',
 		headers: {
@@ -11,7 +15,9 @@ export const stripeCreateSetupIntentPrb = async (
 		}),
 	});
 
-	return response.json() as Promise<{ client_secret: string }>;
+	const json = (await response.json()) as StripeResponseData;
+
+	return json.client_secret;
 };
 
 export const stripeCreateSetupIntentRecaptcha = async (
@@ -31,7 +37,7 @@ export const stripeCreateSetupIntentRecaptcha = async (
 		}),
 	});
 
-	const json = (await response.json()) as Record<string, string>;
+	const json = (await response.json()) as StripeResponseData;
 
 	return json.client_secret;
 };

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripe.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripe.ts
@@ -1,0 +1,37 @@
+export const stripeCreateSetupIntentPrb = async (
+	stripePublicKey: string,
+): Promise<{ client_secret: string }> => {
+	const response = await fetch('/stripe/create-setup-intent/prb', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({
+			stripePublicKey,
+		}),
+	});
+
+	return response.json() as Promise<{ client_secret: string }>;
+};
+
+export const stripeCreateSetupIntentRecaptcha = async (
+	isTestUser: boolean,
+	stripePublicKey: string,
+	token: string,
+): Promise<string> => {
+	const response = await fetch('/stripe/create-setup-intent/recaptcha', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({
+			isTestUser,
+			stripePublicKey,
+			token,
+		}),
+	});
+
+	const json = (await response.json()) as Record<string, string>;
+
+	return json.client_secret;
+};

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -472,8 +472,9 @@ export function CheckoutComponent({
 			elements
 		) {
 			/** 1. Get a clientSecret from our server from the stripePublicKey */
-			const { client_secret: stripeClientSecret } =
-				await stripeCreateSetupIntentPrb(stripePublicKey);
+			const stripeClientSecret = await stripeCreateSetupIntentPrb(
+				stripePublicKey,
+			);
 
 			/** 2. Get the Stripe paymentMethod from the Stripe elements */
 			const { paymentMethod: stripePaymentMethod, error: paymentMethodError } =


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Refactor some server calls related to Stripe and PayPal out of the checkout. It's not a massive saving in terms of line numbers, but I think it reduces cognitive load because you don't have to mentally parse the ins and outs of the fetch calls when scanning the component, the nitty gritty is now abstracted away into another module.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

- [x] Put through a credit card transaction in CODE
- [x] Put through a PayPal transaction in CODE

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
