### PR TITLE
Add support for easily running playwright tests against CODE

### DIFF
--- a/support-e2e/package.json
+++ b/support-e2e/package.json
@@ -10,6 +10,8 @@
 		"test-prod": "playwright test --ui --config=playwright.prod.config.ts",
 		"test-smoke": "playwright test --project=smoke --config=playwright.config.ts",
 		"test-smoke-ui": "playwright test --project=smoke --config=playwright.config.ts --ui",
+		"test-smoke-code": "playwright test --project=smoke --config=playwright.code.config.ts",
+		"test-smoke-ui-code": "playwright test --project=smoke --config=playwright.code.config.ts --ui",
 		"test-smoke-dev": "playwright test --project=smoke --config=playwright.dev.config.ts --ui",
 		"test-cron": "playwright test --project=cron --config=playwright.config.ts",
 		"test-cron-ui": "playwright test --project=cron --config=playwright.config.ts --ui",

--- a/support-e2e/playwright.code.config.ts
+++ b/support-e2e/playwright.code.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test';
+import { baseObject } from './playwright.base.config';
+
+export default defineConfig({
+	...baseObject,
+	use: {
+		...baseObject.use,
+		baseURL: 'https://support.code.dev-theguardian.com',
+	},
+});

--- a/support-e2e/playwright.code.config.ts
+++ b/support-e2e/playwright.code.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig } from '@playwright/test';
-import { baseObject } from './playwright.base.config';
+import { config as baseConfig } from './playwright.config';
 
-export default defineConfig({
-	...baseObject,
+const config = {
+	...baseConfig,
 	use: {
-		...baseObject.use,
 		baseURL: 'https://support.code.dev-theguardian.com',
 	},
-});
+};
+
+export default config;


### PR DESCRIPTION

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Adds two new package scripts:

```
$ yarn test-smoke-code
$ yarn test-smoke-ui-code
```

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

## Why are you doing this?

So that we can run the playwright tests against CODE without having to manually change config.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
