### PR TITLE
Remove discount countdown from useoy campaign as it is not happening after all

### DIFF
--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -69,15 +69,6 @@ const campaigns: Record<string, CampaignSettings> = {
 				},
 			},
 			{
-				label: 'Discount',
-				countdownStartInMillis: Date.parse('Dec 09, 2024 00:00:00'),
-				countdownDeadlineInMillis: Date.parse('Dec 13, 2024 00:00:00'),
-				theme: {
-					backgroundColor: '#1e3e72',
-					foregroundColor: '#ffffff',
-				},
-			},
-			{
 				label: 'Final Countdown',
 				countdownStartInMillis: Date.parse('Dec 23, 2024 00:00:00'),
 				countdownDeadlineInMillis: Date.parse('Jan 01, 2025 00:00:00'),


### PR DESCRIPTION
## What are you doing in this PR?

Removing the countdown settings from the US End of Year campaign

[**Trello Card**](https://trello.com/c/zWf319Jp)

## Why are you doing this?

The US team have made the decision not to run the discount at this time.