### PR TITLE
Guardian-Light :  Viewable in Dev or Code (only)

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/guardianLightLanding/guardianLightLanding.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianLightLanding/guardianLightLanding.tsx
@@ -1,5 +1,6 @@
 import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
+import { isProd } from 'helpers/urls/url';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
 import { AccordianComponent } from './components/accordianComponent';
@@ -22,9 +23,15 @@ export function GuardianLightLanding({
 	}; // hidden initially, will display with more regions
 	return (
 		<LandingPageLayout countrySwitcherProps={countrySwitcherProps}>
-			<HeaderCards geoId={geoId} />
-			<PosterComponent />
-			<AccordianComponent />
+			{!isProd() ? (
+				<>
+					<HeaderCards geoId={geoId} />
+					<PosterComponent />
+					<AccordianComponent />
+				</>
+			) : (
+				<>Under Construction. Viewable within Code or Dev environments.</>
+			)}
 		</LandingPageLayout>
 	);
 }

--- a/support-frontend/assets/pages/[countryGroupId]/guardianLightLanding/guardianLightLanding.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianLightLanding/guardianLightLanding.tsx
@@ -1,3 +1,5 @@
+import { css } from '@emotion/react';
+import { textSans24 } from '@guardian/source/foundations';
 import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 import { isProd } from 'helpers/urls/url';
@@ -30,7 +32,16 @@ export function GuardianLightLanding({
 					<AccordianComponent />
 				</>
 			) : (
-				<>Under Construction. Viewable within Code or Dev environments.</>
+				<div
+					css={css`
+						position: relative;
+						${textSans24};
+						color: white;
+						text-align: center;
+					`}
+				>
+					Under Construction. Viewable within Code or Dev environments only.
+				</div>
 			)}
 		</LandingPageLayout>
 	);


### PR DESCRIPTION
## What are you doing in this PR?

Guardian Light Landing Pages 
- Code/Dev : Display
- Prod: Hide 

[**Trello Card**](https://trello.com)

## Why are you doing this?

To stop anyone checking out before the `GuardianLight` product is ready

## How to test

|Prod|Dev or Code|
|-----|-----|
|![image](https://github.com/user-attachments/assets/9249847d-e551-4351-9dd8-aceb1ee24806)|![image](https://github.com/user-attachments/assets/a7d9a837-0ea0-4ff9-8436-d1ab3f45482a)|