### PR TITLE
Add Tier Three to smoke & cron e2e checkout tests

### DIFF
--- a/support-e2e/README.md
+++ b/support-e2e/README.md
@@ -30,6 +30,12 @@ When the tests are run from the github action these are made available via githu
 
 Once the tests have been run (either via the github action or by yourself locally) you can view the results in the [Browserstack Automate dashboard](https://automate.browserstack.com/dashboard). Note again you will have to log in with your Browserstack account that has Automate access.
 
+### Type checking the tests
+
+```
+$ yarn tsc
+```
+
 ### Possible future work
 
 It would be nice to use Playwright for integration tests as well as E2E tests. Possibly we could split out the `test` directory into `e2e` and `integration` directories and modify the `testDir` config property in the Playwright config files to reflect whether you are running E2E or integration tests.

--- a/support-e2e/package.json
+++ b/support-e2e/package.json
@@ -24,10 +24,12 @@
 	},
 	"devDependencies": {
 		"@guardian/prettier": "^8.0.0",
+		"@types/node": "^22.10.1",
 		"dotenv": "^16.3.1",
 		"husky": "^9.0.11",
 		"lint-staged": "^15.2.2",
-		"prettier": "^3.0.3"
+		"prettier": "^3.0.3",
+		"typescript": "^5.7.2"
 	},
 	"lint-staged": {
 		"*.ts": [

--- a/support-e2e/tests/cron/checkout.test.ts
+++ b/support-e2e/tests/cron/checkout.test.ts
@@ -10,13 +10,13 @@ test.describe('Checkout', () => {
 			product: 'SupporterPlus',
 			ratePlan: 'Monthly',
 			paymentType: 'PayPal',
-			internationalisationId: 'au',
+			internationalisationId: 'AU',
 		},
 		{
 			product: 'TierThree',
 			ratePlan: 'DomesticMonthly',
 			paymentType: 'PayPal',
-			internationalisationId: 'au',
+			internationalisationId: 'UK',
 		},
 	].forEach((testDetails) => {
 		testCheckout(testDetails);

--- a/support-e2e/tests/cron/checkout.test.ts
+++ b/support-e2e/tests/cron/checkout.test.ts
@@ -12,6 +12,12 @@ test.describe('Checkout', () => {
 			paymentType: 'PayPal',
 			internationalisationId: 'au',
 		},
+		{
+			product: 'TierThree',
+			ratePlan: 'DomesticMonthly',
+			paymentType: 'PayPal',
+			internationalisationId: 'au',
+		},
 	].forEach((testDetails) => {
 		testCheckout(testDetails);
 	});

--- a/support-e2e/tests/cron/checkout.test.ts
+++ b/support-e2e/tests/cron/checkout.test.ts
@@ -11,7 +11,6 @@ test.describe('Checkout', () => {
 			ratePlan: 'Monthly',
 			paymentType: 'PayPal',
 			internationalisationId: 'au',
-			paymentFrequency: 'month',
 		},
 	].forEach((testDetails) => {
 		testCheckout(testDetails);

--- a/support-e2e/tests/smoke/checkout.test.ts
+++ b/support-e2e/tests/smoke/checkout.test.ts
@@ -11,14 +11,12 @@ test.describe('Checkout', () => {
 			ratePlan: 'Annual',
 			paymentType: 'Credit/Debit card',
 			internationalisationId: 'eu',
-			paymentFrequency: 'year',
 		},
 		{
 			product: 'TierThree',
 			ratePlan: 'DomesticMonthly',
 			paymentType: 'Credit/Debit card',
 			internationalisationId: 'uk',
-			paymentFrequency: 'year',
 		},
 	].forEach((testDetails) => {
 		testCheckout(testDetails);

--- a/support-e2e/tests/smoke/checkout.test.ts
+++ b/support-e2e/tests/smoke/checkout.test.ts
@@ -13,6 +13,13 @@ test.describe('Checkout', () => {
 			internationalisationId: 'eu',
 			paymentFrequency: 'year',
 		},
+		{
+			product: 'TierThree',
+			ratePlan: 'DomesticMonthly',
+			paymentType: 'Credit/Debit card',
+			internationalisationId: 'uk',
+			paymentFrequency: 'year',
+		},
 	].forEach((testDetails) => {
 		testCheckout(testDetails);
 	});

--- a/support-e2e/tests/smoke/checkout.test.ts
+++ b/support-e2e/tests/smoke/checkout.test.ts
@@ -10,13 +10,13 @@ test.describe('Checkout', () => {
 			product: 'SupporterPlus',
 			ratePlan: 'Annual',
 			paymentType: 'Credit/Debit card',
-			internationalisationId: 'eu',
+			internationalisationId: 'EU',
 		},
 		{
 			product: 'TierThree',
 			ratePlan: 'DomesticMonthly',
 			paymentType: 'Credit/Debit card',
-			internationalisationId: 'uk',
+			internationalisationId: 'UK',
 		},
 	].forEach((testDetails) => {
 		testCheckout(testDetails);

--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -10,6 +10,8 @@ import { fillInCardDetails } from '../utils/cardDetails';
 import { checkRecaptcha } from '../utils/recaptcha';
 import { TestFields, ukWithPostalAddressOnly } from '../utils/userFields';
 
+// TODO: it'd be great to make the types here more specific, possibly using the
+// shared types from the product catalog.
 type TestDetails = {
 	product: string;
 	ratePlan: string;

--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -15,7 +15,6 @@ type TestDetails = {
 	ratePlan: string;
 	paymentType: string;
 	internationalisationId: string;
-	paymentFrequency: string;
 };
 
 const setUserDetailsForProduct = async (

--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -199,9 +199,7 @@ afterEachTasks(test);
 
 test.describe('Contribute/Subscribe Tiered Checkout', () => {
 	testsDetails.forEach((testDetails) => {
-		test(`Tier-${testDetails.tier} ${testDetails.ratePlan} with ${
-			testDetails.paymentType
-		} - ${testDetails.internationalisationId ?? 'UK'}`, async ({
+		test(`Tier-${testDetails.tier} ${testDetails.ratePlan} with ${testDetails.paymentType} - ${testDetails.internationalisationId}`, async ({
 			context,
 			baseURL,
 		}) => {

--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -27,10 +27,10 @@ interface TestFields {
 
 export interface TestDetails {
 	tier: 1 | 2 | 3;
-	ratePlan: 'Monthly' | 'Annual';
+	ratePlan: 'Monthly' | 'Annual' | 'DomesticMonthly';
 	paymentType: 'Credit/Debit card' | 'Direct debit' | 'PayPal';
 	fields: TestFields;
-	internationalisationId: 'UK' | 'US' | 'AU';
+	internationalisationId: 'UK' | 'US' | 'AU' | 'EU';
 }
 
 export const testsDetails: TestDetails[] = [
@@ -147,6 +147,24 @@ export const testsDetails: TestDetails[] = [
 					firstLine: '3 Cross Street',
 					city: 'Manchester',
 				},
+				{
+					postCode: 'N1 9GU',
+					firstLine: '90 York Way',
+					city: 'London',
+				},
+			],
+		},
+		internationalisationId: 'UK',
+	},
+	{
+		tier: 3,
+		paymentType: 'Credit/Debit card',
+		ratePlan: 'DomesticMonthly',
+		fields: {
+			email: email(),
+			firstName: firstName(),
+			lastName: lastName(),
+			addresses: [
 				{
 					postCode: 'N1 9GU',
 					firstLine: '90 York Way',

--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -23,10 +23,10 @@ import {
 
 export interface TestDetails {
 	tier: 1 | 2 | 3;
-	ratePlan: 'Monthly' | 'Annual' | 'DomesticMonthly';
+	ratePlan: 'Monthly' | 'Annual';
 	paymentType: 'Credit/Debit card' | 'Direct debit' | 'PayPal';
 	fields: TestFields;
-	internationalisationId: 'UK' | 'US' | 'AU' | 'EU';
+	internationalisationId: 'UK' | 'US' | 'AU';
 }
 
 export const testsDetails: TestDetails[] = [

--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -30,15 +30,16 @@ export interface TestDetails {
 	ratePlan: 'Monthly' | 'Annual';
 	paymentType: 'Credit/Debit card' | 'Direct debit' | 'PayPal';
 	fields: TestFields;
-	internationalisationId?: 'US' | 'AU';
+	internationalisationId: 'UK' | 'US' | 'AU';
 }
 
-const testsDetails: TestDetails[] = [
+export const testsDetails: TestDetails[] = [
 	{
 		tier: 1,
 		ratePlan: 'Monthly',
 		paymentType: 'Direct debit',
 		fields: { email: email(), firstName: firstName(), lastName: lastName() },
+		internationalisationId: 'UK',
 	},
 	{
 		tier: 1,
@@ -95,6 +96,7 @@ const testsDetails: TestDetails[] = [
 		paymentType: 'Direct debit',
 		ratePlan: 'Monthly',
 		fields: { email: email(), firstName: firstName(), lastName: lastName() },
+		internationalisationId: 'UK',
 	},
 	{
 		tier: 2,
@@ -152,6 +154,7 @@ const testsDetails: TestDetails[] = [
 				},
 			],
 		},
+		internationalisationId: 'UK',
 	},
 	{
 		tier: 3,

--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -88,13 +88,6 @@ export const testsDetails: TestDetails[] = [
 	},
 	{
 		tier: 3,
-		paymentType: 'Credit/Debit card',
-		ratePlan: 'DomesticMonthly',
-		fields: ukWithPostalAddressOnly(),
-		internationalisationId: 'UK',
-	},
-	{
-		tier: 3,
 		paymentType: 'PayPal',
 		ratePlan: 'Monthly',
 		fields: usWithPostalAddressOnly(),

--- a/support-e2e/tests/tieredCheckout.test.ts
+++ b/support-e2e/tests/tieredCheckout.test.ts
@@ -10,20 +10,16 @@ import {
 	setTestUserDetails,
 	setTestUserRequiredDetails,
 } from './utils/testUserDetails';
-
-interface TestAddress {
-	postCode?: string;
-	state?: string;
-	firstLine?: string;
-	city?: string;
-}
-
-interface TestFields {
-	email: string;
-	firstName: string;
-	lastName: string;
-	addresses?: TestAddress[]; // 1st Delivery, 2nd Billing
-}
+import {
+	ausWithFullAddress,
+	ausWithStateOnly,
+	personalDetailsOnly,
+	TestFields,
+	ukWithBillingAndPostalAddress,
+	ukWithPostalAddressOnly,
+	usWithPostalAddressOnly,
+	usWithPostcodeAndState,
+} from './utils/userFields';
 
 export interface TestDetails {
 	tier: 1 | 2 | 3;
@@ -38,159 +34,70 @@ export const testsDetails: TestDetails[] = [
 		tier: 1,
 		ratePlan: 'Monthly',
 		paymentType: 'Direct debit',
-		fields: { email: email(), firstName: firstName(), lastName: lastName() },
+		fields: personalDetailsOnly(),
 		internationalisationId: 'UK',
 	},
 	{
 		tier: 1,
 		ratePlan: 'Annual',
 		paymentType: 'Credit/Debit card',
-		fields: {
-			email: email(),
-			firstName: firstName(),
-			lastName: lastName(),
-			addresses: [
-				{
-					postCode: '10006',
-					state: 'New York',
-				},
-			],
-		},
+		fields: usWithPostcodeAndState(),
 		internationalisationId: 'US',
 	},
 	{
 		tier: 1,
 		ratePlan: 'Monthly',
 		paymentType: 'PayPal',
-		fields: {
-			email: email(),
-			firstName: firstName(),
-			lastName: lastName(),
-			addresses: [
-				{
-					state: 'New South Wales',
-				},
-			],
-		},
+		fields: ausWithStateOnly(),
 		internationalisationId: 'AU',
 	},
 	{
 		tier: 2,
 		ratePlan: 'Annual',
 		paymentType: 'Credit/Debit card',
-		fields: {
-			email: email(),
-			firstName: firstName(),
-			lastName: lastName(),
-			addresses: [
-				{
-					postCode: '10006',
-					state: 'New York',
-				},
-			],
-		},
+		fields: usWithPostcodeAndState(),
 		internationalisationId: 'US',
 	},
 	{
 		tier: 2,
 		paymentType: 'Direct debit',
 		ratePlan: 'Monthly',
-		fields: { email: email(), firstName: firstName(), lastName: lastName() },
+		fields: personalDetailsOnly(),
 		internationalisationId: 'UK',
 	},
 	{
 		tier: 2,
 		paymentType: 'PayPal',
 		ratePlan: 'Monthly',
-		fields: {
-			email: email(),
-			firstName: firstName(),
-			lastName: lastName(),
-			addresses: [
-				{
-					state: 'New South Wales',
-				},
-			],
-		},
+		fields: ausWithStateOnly(),
 		internationalisationId: 'AU',
 	},
 	{
 		tier: 3,
 		paymentType: 'Credit/Debit card',
 		ratePlan: 'Annual',
-		fields: {
-			email: email(),
-			firstName: firstName(),
-			lastName: lastName(),
-			addresses: [
-				{
-					postCode: '2010',
-					state: 'New South Wales',
-					firstLine: '19 Foster Street',
-					city: 'Sydney',
-				},
-			],
-		},
+		fields: ausWithFullAddress(),
 		internationalisationId: 'AU',
 	},
 	{
 		tier: 3,
 		paymentType: 'Direct debit',
 		ratePlan: 'Monthly',
-		fields: {
-			email: email(),
-			firstName: firstName(),
-			lastName: lastName(),
-			addresses: [
-				{
-					postCode: 'M1 1PW',
-					firstLine: '3 Cross Street',
-					city: 'Manchester',
-				},
-				{
-					postCode: 'N1 9GU',
-					firstLine: '90 York Way',
-					city: 'London',
-				},
-			],
-		},
+		fields: ukWithBillingAndPostalAddress(),
 		internationalisationId: 'UK',
 	},
 	{
 		tier: 3,
 		paymentType: 'Credit/Debit card',
 		ratePlan: 'DomesticMonthly',
-		fields: {
-			email: email(),
-			firstName: firstName(),
-			lastName: lastName(),
-			addresses: [
-				{
-					postCode: 'N1 9GU',
-					firstLine: '90 York Way',
-					city: 'London',
-				},
-			],
-		},
+		fields: ukWithPostalAddressOnly(),
 		internationalisationId: 'UK',
 	},
 	{
 		tier: 3,
 		paymentType: 'PayPal',
 		ratePlan: 'Monthly',
-		fields: {
-			email: email(),
-			firstName: firstName(),
-			lastName: lastName(),
-			addresses: [
-				{
-					postCode: '10006',
-					state: 'New York',
-					firstLine: '61 Broadway',
-					city: 'New York',
-				},
-			],
-		},
+		fields: usWithPostalAddressOnly(),
 		internationalisationId: 'US',
 	},
 ];
@@ -224,7 +131,12 @@ test.describe('Contribute/Subscribe Tiered Checkout', () => {
 				.getByRole('link', { name: ctaCopy })
 				.nth(testDetails.tier - 1)
 				.click();
-			await setTestUserDetails(page, testDetails);
+			await setTestUserDetails(
+				page,
+				testDetails.fields,
+				testDetails.internationalisationId,
+				testDetails.tier,
+			);
 			await page.getByRole('radio', { name: testDetails.paymentType }).check();
 			switch (testDetails.paymentType) {
 				case 'Direct debit':

--- a/support-e2e/tests/utils/testUserDetails.ts
+++ b/support-e2e/tests/utils/testUserDetails.ts
@@ -1,5 +1,4 @@
 import { Page } from '@playwright/test';
-import { TestDetails } from '../tieredCheckout.test';
 import { TestFields } from './userFields';
 
 export const setTestUserRequiredDetails = async (

--- a/support-e2e/tests/utils/testUserDetails.ts
+++ b/support-e2e/tests/utils/testUserDetails.ts
@@ -1,5 +1,6 @@
 import { Page } from '@playwright/test';
 import { TestDetails } from '../tieredCheckout.test';
+import { TestFields } from './userFields';
 
 export const setTestUserRequiredDetails = async (
 	page: Page,
@@ -18,16 +19,18 @@ export const setTestUserRequiredDetails = async (
 
 export const setTestUserDetails = async (
 	page: Page,
-	testDetails: TestDetails,
+	testFields: TestFields,
+	internationalisationId: string,
+	tier: number,
 ) => {
 	await setTestUserRequiredDetails(
 		page,
-		testDetails.fields.email,
-		testDetails.fields.firstName,
-		testDetails.fields.lastName,
+		testFields.email,
+		testFields.firstName,
+		testFields.lastName,
 	);
 
-	if (testDetails.fields.addresses && testDetails.fields.addresses.length > 1) {
+	if (testFields.addresses && testFields.addresses.length > 1) {
 		await page
 			.getByRole('checkbox', {
 				name: 'Billing address same as delivery address',
@@ -35,14 +38,11 @@ export const setTestUserDetails = async (
 			.uncheck();
 	}
 
-	if (testDetails.fields.addresses) {
+	if (testFields.addresses) {
 		let index = 0;
 		// To run in sequence using async/await, for required over forEach
-		for (const address of testDetails.fields.addresses) {
-			if (
-				testDetails.internationalisationId === 'US' ||
-				testDetails.internationalisationId === 'AU'
-			) {
+		for (const address of testFields.addresses) {
+			if (internationalisationId === 'US' || internationalisationId === 'AU') {
 				await page
 					.getByLabel('State')
 					.nth(index)
@@ -51,17 +51,13 @@ export const setTestUserDetails = async (
 
 			if (address.postCode) {
 				await page
-					.getByLabel(
-						testDetails.internationalisationId === 'US'
-							? 'ZIP code'
-							: 'Postcode',
-					)
+					.getByLabel(internationalisationId === 'US' ? 'ZIP code' : 'Postcode')
 					// Skip UK postCode lookup component
-					.nth(testDetails.internationalisationId ? index : index + 1)
+					.nth(internationalisationId ? index : index + 1)
 					.fill(address.postCode);
 			}
 
-			if (testDetails.tier === 3) {
+			if (tier === 3) {
 				await page
 					.getByLabel(`Address Line 1`)
 					.nth(index)

--- a/support-e2e/tests/utils/userFields.ts
+++ b/support-e2e/tests/utils/userFields.ts
@@ -1,0 +1,105 @@
+import { email, firstName, lastName } from './users';
+
+export interface TestAddress {
+	postCode?: string;
+	state?: string;
+	firstLine?: string;
+	city?: string;
+}
+
+export interface TestFields {
+	email: string;
+	firstName: string;
+	lastName: string;
+	addresses?: TestAddress[]; // 0st Delivery, 2nd Billing
+}
+
+type TestFieldsGenerator = () => TestFields;
+
+export const usWithPostcodeAndState: TestFieldsGenerator = () => ({
+	email: email(),
+	firstName: firstName(),
+	lastName: lastName(),
+	addresses: [
+		{
+			postCode: '10006',
+			state: 'New York',
+		},
+	],
+});
+
+export const personalDetailsOnly: TestFieldsGenerator = () => ({
+	email: email(),
+	firstName: firstName(),
+	lastName: lastName(),
+});
+
+export const ausWithStateOnly: TestFieldsGenerator = () => ({
+	email: email(),
+	firstName: firstName(),
+	lastName: lastName(),
+	addresses: [
+		{
+			state: 'New South Wales',
+		},
+	],
+});
+
+export const ausWithFullAddress: TestFieldsGenerator = () => ({
+	email: email(),
+	firstName: firstName(),
+	lastName: lastName(),
+	addresses: [
+		{
+			postCode: '2010',
+			state: 'New South Wales',
+			firstLine: '19 Foster Street',
+			city: 'Sydney',
+		},
+	],
+});
+
+export const ukWithBillingAndPostalAddress: TestFieldsGenerator = () => ({
+	email: email(),
+	firstName: firstName(),
+	lastName: lastName(),
+	addresses: [
+		{
+			postCode: 'M1 1PW',
+			firstLine: '3 Cross Street',
+			city: 'Manchester',
+		},
+		{
+			postCode: 'N1 9GU',
+			firstLine: '90 York Way',
+			city: 'London',
+		},
+	],
+});
+
+export const ukWithPostalAddressOnly: TestFieldsGenerator = () => ({
+	email: email(),
+	firstName: firstName(),
+	lastName: lastName(),
+	addresses: [
+		{
+			postCode: 'N1 9GU',
+			firstLine: '90 York Way',
+			city: 'London',
+		},
+	],
+});
+
+export const usWithPostalAddressOnly: TestFieldsGenerator = () => ({
+	email: email(),
+	firstName: firstName(),
+	lastName: lastName(),
+	addresses: [
+		{
+			postCode: '10006',
+			state: 'New York',
+			firstLine: '61 Broadway',
+			city: 'New York',
+		},
+	],
+});

--- a/support-e2e/tsconfig.json
+++ b/support-e2e/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"include": [
+		"./tests"
+	],
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["es2015", "dom"]
+  },
+	"exclude": ["node_modules"]
+}

--- a/support-e2e/yarn.lock
+++ b/support-e2e/yarn.lock
@@ -14,6 +14,13 @@
   dependencies:
     playwright "1.46.1"
 
+"@types/node@^22.10.1":
+  version "22.10.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.1.tgz#41ffeee127b8975a05f8c4f83fb89bcb2987d766"
+  integrity sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==
+  dependencies:
+    undici-types "~6.20.0"
+
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -571,6 +578,16 @@ type-fest@^3.0.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.13.1.tgz#bb744c1f0678bea7543a2d1ec24e83e68e8c8706"
   integrity sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==
+
+typescript@^5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
+  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
+
+undici-types@~6.20.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
+  integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
## What are you doing in this PR?

Add a smoke test (card) and a cron test (PayPal) for Tier Three checkout.

I've done a bit of refactoring to pull some user details fixtures out into a separate file so they can be re-used.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/L8LD1pz3/1270-tier-3-e2e-test)

## Why are you doing this?

We'd like to know if Tier Three checkouts are broken in prod.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Locally we can run:

`$ yarn test-smoke-ui`
`$ yarn test-cron-ui`

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
