### PR TITLE
Apply min/max validation to other amount field on one-time checkout

### DIFF
--- a/support-frontend/assets/components/otherAmount/otherAmount.tsx
+++ b/support-frontend/assets/components/otherAmount/otherAmount.tsx
@@ -13,8 +13,8 @@ export type OtherAmountProps = {
 	selectedAmount: number | 'other';
 	otherAmount: string;
 	currency: IsoCurrency;
-	minAmount: number;
-	maxAmount: number;
+	minAmount?: number;
+	maxAmount?: number;
 	onOtherAmountChange: (newAmount: string) => void;
 	errors?: string[];
 } & HTMLAttributes<HTMLInputElement>;

--- a/support-frontend/assets/components/otherAmount/otherAmount.tsx
+++ b/support-frontend/assets/components/otherAmount/otherAmount.tsx
@@ -14,6 +14,7 @@ export type OtherAmountProps = {
 	otherAmount: string;
 	currency: IsoCurrency;
 	minAmount: number;
+	maxAmount: number;
 	onOtherAmountChange: (newAmount: string) => void;
 	errors?: string[];
 } & HTMLAttributes<HTMLInputElement>;
@@ -26,6 +27,8 @@ export function OtherAmount({
 	onBlur,
 	onInvalid,
 	errors,
+	minAmount,
+	maxAmount,
 }: OtherAmountProps): JSX.Element | null {
 	const currencyDetails = currencies[currency];
 	const glyph = currencyDetails.isPaddedGlyph
@@ -47,6 +50,8 @@ export function OtherAmount({
 					value={otherAmount === '0' ? '' : otherAmount}
 					type="number"
 					onBlur={onBlur}
+					min={minAmount}
+					max={maxAmount}
 					onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
 						onOtherAmountChange(e.target.value)
 					}

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -229,6 +229,7 @@ export function OneTimeCheckoutComponent({
 	);
 
 	const minAmount = config[countryGroupId]['ONE_OFF'].min;
+	const maxAmount = config[countryGroupId]['ONE_OFF'].max;
 
 	const [selectedPriceCard, setSelectedPriceCard] = useState<number | 'other'>(
 		preSelectedPriceCard ?? defaultAmount,
@@ -327,7 +328,7 @@ export function OneTimeCheckoutComponent({
 			if (validityState.valueMissing) {
 				setAction(missing); // required
 			} else {
-				setAction(invalid ?? ' '); // pattern mismatch
+				setAction(invalid ?? 'Invalid input'); // pattern mismatch
 			}
 		}
 	};
@@ -541,6 +542,7 @@ export function OneTimeCheckoutComponent({
 								<OtherAmount
 									currency={currencyKey}
 									minAmount={minAmount}
+									maxAmount={maxAmount}
 									selectedAmount={selectedPriceCard}
 									otherAmount={otherAmount}
 									onBlur={(event) => {
@@ -549,10 +551,12 @@ export function OneTimeCheckoutComponent({
 									onOtherAmountChange={setOtherAmount}
 									errors={[otherAmountError ?? '']}
 									onInvalid={(event) => {
+										console.log('event --->', event);
 										validate(
 											event,
 											setOtherAmountError,
 											'Please enter an amount.',
+											`Please enter an amount between ${minAmount} and ${maxAmount}`,
 										);
 									}}
 								/>

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -551,7 +551,6 @@ export function OneTimeCheckoutComponent({
 									onOtherAmountChange={setOtherAmount}
 									errors={[otherAmountError ?? '']}
 									onInvalid={(event) => {
-										console.log('event --->', event);
 										validate(
 											event,
 											setOtherAmountError,

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -555,7 +555,7 @@ export function OneTimeCheckoutComponent({
 											event,
 											setOtherAmountError,
 											'Please enter an amount.',
-											`Please enter an amount between ${minAmount} and ${maxAmount}`,
+											`Please enter an amount between ${minAmount} and ${maxAmount}.`,
 										);
 									}}
 								/>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/contributionsPriceCards.tsx
@@ -99,7 +99,6 @@ export function ContributionsPriceCards({
 					currency,
 					paymentInterval,
 					onAmountChange,
-					minAmount,
 					onOtherAmountChange,
 					hideChooseYourAmount,
 					errors,
@@ -114,7 +113,6 @@ export function ContributionsPriceCards({
 						otherAmountField={
 							<OtherAmount
 								currency={currency}
-								minAmount={minAmount}
 								selectedAmount={selectedAmount}
 								otherAmount={otherAmount}
 								onOtherAmountChange={onOtherAmountChange}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/oneOffCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/oneOffCard.tsx
@@ -15,7 +15,6 @@ import { useState } from 'react';
 import { OtherAmount } from '../../../components/otherAmount/otherAmount';
 import { PriceCards } from '../../../components/priceCards/priceCards';
 import type { SelectedAmountsVariant } from '../../../helpers/contributions';
-import { config } from '../../../helpers/contributions';
 import type { CountryGroupId } from '../../../helpers/internationalisation/countryGroup';
 import { countryGroups } from '../../../helpers/internationalisation/countryGroup';
 import type { IsoCurrency } from '../../../helpers/internationalisation/currency';
@@ -80,8 +79,6 @@ export function OneOffCard({
 		oneOffAmounts.defaultAmount,
 	);
 	const [otherAmount, setOtherAmount] = useState('');
-	const { min: minAmount } = config[countryGroupId].ONE_OFF;
-
 	return (
 		<section css={sectionStyle}>
 			<div
@@ -115,7 +112,6 @@ export function OneOffCard({
 					otherAmountField={
 						<OtherAmount
 							currency={currencyId}
-							minAmount={minAmount}
 							selectedAmount={selectedAmount}
 							otherAmount={otherAmount}
 							onOtherAmountChange={(otherAmount) => {

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/amountAndBenefits.tsx
@@ -48,7 +48,6 @@ export function AmountAndBenefits({
 									currency,
 									paymentInterval,
 									onAmountChange,
-									minAmount,
 									onOtherAmountChange,
 									hideChooseYourAmount,
 									errors,
@@ -64,7 +63,6 @@ export function AmountAndBenefits({
 											otherAmountField={
 												<OtherAmount
 													currency={currency}
-													minAmount={minAmount}
 													selectedAmount={selectedAmount}
 													otherAmount={otherAmount}
 													onOtherAmountChange={onOtherAmountChange}

--- a/support-frontend/assets/pages/supporter-plus-landing/formSections/patronsPriceCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/formSections/patronsPriceCards.tsx
@@ -54,7 +54,6 @@ export function PatronsPriceCards(): JSX.Element {
 							otherAmount,
 							currency,
 							onAmountChange,
-							minAmount,
 							onOtherAmountChange,
 							errors,
 						}) => {
@@ -68,7 +67,6 @@ export function PatronsPriceCards(): JSX.Element {
 									otherAmountField={
 										<OtherAmount
 											currency={currency}
-											minAmount={minAmount}
 											selectedAmount={selectedAmount}
 											otherAmount={otherAmount}
 											onOtherAmountChange={onOtherAmountChange}


### PR DESCRIPTION
## What are you doing in this PR?

We had some alarms from the one-time checkout where the other amount field was allowing large numbers, above the configured min/max contribution values, we found on investigation no validation to be in place on this input, so have used the native HTML min/max [attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number) available to `<input type='number />` to manage this validation: 

