### PR TITLE
Final countdown checkout colour, title, subheader changes

### DIFF
--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -82,7 +82,9 @@ const campaigns: Record<string, CampaignSettings> = {
 			headingFragment: <>Protect </>,
 			subheading: (
 				<>
-					We're not owned by a billionaire or shareholders: our fiercely independent journalism is funded by our readers. Monthly giving makes the most impact. <strong>You can cancel anytime.</strong>
+					We're not owned by a billionaire or shareholders: our fiercely
+					independent journalism is funded by our readers. Monthly giving makes
+					the most impact. <strong>You can cancel anytime.</strong>
 				</>
 			),
 			oneTimeHeading: <>Choose your gift amount</>,

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -69,11 +69,11 @@ const campaigns: Record<string, CampaignSettings> = {
 				},
 			},
 			{
-				label: 'Final Countdown',
+				label: 'Last chance to support us this year',
 				countdownStartInMillis: Date.parse('Dec 23, 2024 00:00:00'),
 				countdownDeadlineInMillis: Date.parse('Jan 01, 2025 00:00:00'),
 				theme: {
-					backgroundColor: '#1e3e72',
+					backgroundColor: '#ab0613',
 					foregroundColor: '#ffffff',
 				},
 			},
@@ -82,9 +82,7 @@ const campaigns: Record<string, CampaignSettings> = {
 			headingFragment: <>Protect </>,
 			subheading: (
 				<>
-					We're not owned by a billionaire or shareholders - our readers support
-					us. Can you help us reach our goal? Monthly giving is most valuable to
-					us. <strong>You can cancel anytime.</strong>
+					We're not owned by a billionaire or shareholders: our fiercely independent journalism is funded by our readers. Monthly giving makes the most impact. <strong>You can cancel anytime.</strong>
 				</>
 			),
 			oneTimeHeading: <>Choose your gift amount</>,

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -70,7 +70,7 @@ const campaigns: Record<string, CampaignSettings> = {
 			},
 			{
 				label: 'Last chance to support us this year',
-				countdownStartInMillis: Date.parse('Dec 23, 2024 00:00:00'),
+				countdownStartInMillis: Date.parse('Dec 20, 2024 00:00:00'),
 				countdownDeadlineInMillis: Date.parse('Jan 01, 2025 00:00:00'),
 				theme: {
 					backgroundColor: '#ab0613',

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -70,8 +70,8 @@ const campaigns: Record<string, CampaignSettings> = {
 			},
 			{
 				label: 'Last chance to support us this year',
-				countdownStartInMillis: Date.parse('Dec 20, 2024 00:00:00'),
-				countdownDeadlineInMillis: Date.parse('Jan 01, 2025 00:00:00'),
+				countdownStartInMillis: Date.parse('Dec 20, 2024 00:01:00'),
+				countdownDeadlineInMillis: Date.parse('Dec 31, 2024 23:59:59'),
 				theme: {
 					backgroundColor: '#ab0613',
 					foregroundColor: '#ffffff',


### PR DESCRIPTION
## What are you doing in this PR?

Updates the colour theme for the countdown, updates the label that becomes the title during the duration of the countdown and updates the subheading text for the campaign.

[**Trello Card**](https://trello.com/c/jK383PT4)

## Why are you doing this?

Update the countdown ahead of the final week of the US end of year campaign before the code chill.

## How to test

Clone the branch, duplicate the final countdown and alter the start and end date to around 'now'. Run locally and use the campaign id in the URL parameters to see the countdown in action.

## Screenshots

<img width="800" alt="Screenshot 2024-12-10 at 16 30 39" src="https://github.com/user-attachments/assets/e08ab0f5-7501-4a89-8120-2fb44987fa95">

