### PR TITLE
Fail e2e test noisily if the `PAYPAL_TEST_PASSWORD` env var isn't set

### DIFF
--- a/support-e2e/tests/utils/paypal.ts
+++ b/support-e2e/tests/utils/paypal.ts
@@ -7,6 +7,18 @@ const paypalUsernamePrefixes = [
 	'sb-hk3ov30650585',
 ];
 
+const getEnvVarOrThrow = (name: string) => {
+	const envVar = process.env[name];
+
+	if (envVar === undefined) {
+		throw new Error(
+			`Environment variable ${name} not set, I can't continue without it!`,
+		);
+	}
+
+	return envVar;
+};
+
 export const fillInPayPalDetails = async (page: Page) => {
 	const paypalUsernamePrefix =
 		paypalUsernamePrefixes[
@@ -31,9 +43,11 @@ export const fillInPayPalDetails = async (page: Page) => {
 
 	const passwordInput = page.locator('#password');
 
-	await passwordInput.fill(
-		`${paypalUsernamePrefix}-${process.env.PAYPAL_TEST_PASSWORD}`,
-	);
+	const password = `${paypalUsernamePrefix}-${getEnvVarOrThrow(
+		'PAYPAL_TEST_PASSWORD',
+	)}`;
+
+	await passwordInput.fill(password);
 
 	const loginButton = page.locator('#btnLogin');
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Fail e2e test noisily if the `PAYPAL_TEST_PASSWORD` env var isn't set.

## Why are you doing this?

Previously we silently allowed this env var to be undefined and then interpolated into the string we build up for the PayPal password, giving an incorrect password. Too many incorrect login attempts causes the account to be locked, which we want to avoid.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Run the tests locally with the env var: ✅ 

Run the tests locally without the env var:
![Screenshot 2024-12-11 at 09 38 09](https://github.com/user-attachments/assets/42f385b3-9e8e-488f-819e-864cc8eef0aa)

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
