### PR TITLE
Routing: lazy loading CountryGroup Routes

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -2,9 +2,13 @@ import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import { useEffect } from 'react';
 import { getStripeKey } from 'helpers/forms/stripe';
-import type { AppConfig } from 'helpers/globalsAndSwitches/window';
+import {
+	// type AppConfig,
+	parseAppConfig,
+} from 'helpers/globalsAndSwitches/window';
 import { Country } from 'helpers/internationalisation/classes/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import { setUpTrackingAndConsents } from 'helpers/page/page';
 import { isProductKey, productCatalog } from 'helpers/productCatalog';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { type ProductOptions } from 'helpers/productPrice/productOptions';
@@ -18,12 +22,14 @@ import { CheckoutComponent } from './components/checkoutComponent';
 
 type Props = {
 	geoId: GeoId;
-	appConfig: AppConfig;
 };
 
 const countryId: IsoCountry = Country.detect();
 
-export function Checkout({ geoId, appConfig }: Props) {
+export function Checkout({ geoId }: Props) {
+	setUpTrackingAndConsents();
+	const appConfig = parseAppConfig(window.guardian);
+
 	const { currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 	const urlSearchParams = new URLSearchParams(window.location.search);
 

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -2,13 +2,9 @@ import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import { useEffect } from 'react';
 import { getStripeKey } from 'helpers/forms/stripe';
-import {
-	// type AppConfig,
-	parseAppConfig,
-} from 'helpers/globalsAndSwitches/window';
+import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import { Country } from 'helpers/internationalisation/classes/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import { setUpTrackingAndConsents } from 'helpers/page/page';
 import { isProductKey, productCatalog } from 'helpers/productCatalog';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { type ProductOptions } from 'helpers/productPrice/productOptions';
@@ -22,14 +18,12 @@ import { CheckoutComponent } from './components/checkoutComponent';
 
 type Props = {
 	geoId: GeoId;
+	appConfig: AppConfig;
 };
 
 const countryId: IsoCountry = Country.detect();
 
-export function Checkout({ geoId }: Props) {
-	setUpTrackingAndConsents();
-	const appConfig = parseAppConfig(window.guardian);
-
+export function Checkout({ geoId, appConfig }: Props) {
 	const { currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 	const urlSearchParams = new URLSearchParams(window.location.search);
 

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -266,3 +266,5 @@ export function Checkout({ geoId, appConfig }: Props) {
 		</Elements>
 	);
 }
+
+export default Checkout;

--- a/support-frontend/assets/pages/[countryGroupId]/ghLazyRouter.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/ghLazyRouter.tsx
@@ -1,0 +1,53 @@
+import { lazy, Suspense } from 'react';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { HoldingContent } from 'components/serverSideRendered/holdingContent';
+import { parseAppConfig } from 'helpers/globalsAndSwitches/window';
+import { setUpTrackingAndConsents } from 'helpers/page/page';
+import { renderPage } from 'helpers/rendering/render';
+import { geoIds } from 'pages/geoIdConfig';
+
+setUpTrackingAndConsents();
+const appConfig = parseAppConfig(window.guardian);
+const Checkout = lazy(() => import('./checkout'));
+const OneTimeCheckout = lazy(() => import('./oneTimeCheckout'));
+const ThankYou = lazy(() => import('./thankYou'));
+const GuardianLightLanding = lazy(
+	() => import('./guardianLightLanding/guardianLightLanding'),
+);
+
+console.log('ghLazyRouter');
+
+const router = () => {
+	return (
+		<BrowserRouter>
+			<Suspense fallback={<HoldingContent />}>
+				<Routes>
+					{geoIds.map((geoId) => (
+						<>
+							<Route
+								path={`/${geoId}/checkout`}
+								element={<Checkout geoId={geoId} appConfig={appConfig} />}
+							/>
+							<Route
+								path={`/${geoId}/one-time-checkout`}
+								element={
+									<OneTimeCheckout geoId={geoId} appConfig={appConfig} />
+								}
+							/>
+							<Route
+								path={`/${geoId}/thank-you`}
+								element={<ThankYou geoId={geoId} appConfig={appConfig} />}
+							/>
+							<Route
+								path={`/${geoId}/guardian-light`}
+								element={<GuardianLightLanding geoId={geoId} />}
+							/>
+						</>
+					))}
+				</Routes>
+			</Suspense>
+		</BrowserRouter>
+	);
+};
+
+renderPage(router());

--- a/support-frontend/assets/pages/[countryGroupId]/ghLazyRouter.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/ghLazyRouter.tsx
@@ -8,11 +8,20 @@ import { geoIds } from 'pages/geoIdConfig';
 
 setUpTrackingAndConsents();
 const appConfig = parseAppConfig(window.guardian);
-const Checkout = lazy(() => import('./checkout'));
-const OneTimeCheckout = lazy(() => import('./oneTimeCheckout'));
-const ThankYou = lazy(() => import('./thankYou'));
+const Checkout = lazy(
+	() => import(/* webpackChunkName: "checkout" */ './checkout'),
+);
+const OneTimeCheckout = lazy(
+	() => import(/* webpackChunkName: "oneTimeCheckout" */ './oneTimeCheckout'),
+);
+const ThankYou = lazy(
+	() => import(/* webpackChunkName: "ThankYou" */ './thankYou'),
+);
 const GuardianLightLanding = lazy(
-	() => import('./guardianLightLanding/guardianLightLanding'),
+	() =>
+		import(
+			/* webpackChunkName: "GuardianLightLanding" */ './guardianLightLanding/guardianLightLanding'
+		),
 );
 
 console.log('ghLazyRouter');

--- a/support-frontend/assets/pages/[countryGroupId]/guardianLightLanding/guardianLightLanding.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianLightLanding/guardianLightLanding.tsx
@@ -46,3 +46,5 @@ export function GuardianLightLanding({
 		</LandingPageLayout>
 	);
 }
+
+export default GuardianLightLanding;

--- a/support-frontend/assets/pages/[countryGroupId]/lazyRouter.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/lazyRouter.tsx
@@ -1,21 +1,21 @@
 import { lazy, Suspense } from 'react';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { HoldingContent } from 'components/serverSideRendered/holdingContent';
-import { parseAppConfig } from 'helpers/globalsAndSwitches/window';
-import { setUpTrackingAndConsents } from 'helpers/page/page';
+// import { parseAppConfig } from 'helpers/globalsAndSwitches/window';
+// import { setUpTrackingAndConsents } from 'helpers/page/page';
 import { renderPage } from 'helpers/rendering/render';
 import { geoIds } from 'pages/geoIdConfig';
 
-setUpTrackingAndConsents();
-const appConfig = parseAppConfig(window.guardian);
+// setUpTrackingAndConsents();
+// const appConfig = parseAppConfig(window.guardian);
 
 const Checkout = lazy(() => import('./checkout'));
-const OneTimeCheckout = lazy(() => import('./oneTimeCheckout'));
-const ThankYou = lazy(() => import('./thankYou'));
-const GuardianLightLanding = lazy(
-	() => import('./guardianLightLanding/guardianLightLanding'),
-);
-console.log('LazyRouter');
+// const OneTimeCheckout = lazy(() => import('./oneTimeCheckout'));
+// const ThankYou = lazy(() => import('./thankYou'));
+// const GuardianLightLanding = lazy(
+// 	() => import('./guardianLightLanding/guardianLightLanding'),
+// );
+console.log('LazyRouterV2');
 
 const router = createBrowserRouter(
 	geoIds.flatMap((geoId) => [
@@ -23,34 +23,34 @@ const router = createBrowserRouter(
 			path: `/${geoId}/checkout`,
 			element: (
 				<Suspense fallback={<HoldingContent />}>
-					<Checkout geoId={geoId} appConfig={appConfig} />
+					<Checkout geoId={geoId} />
 				</Suspense>
 			),
 		},
-		{
-			path: `/${geoId}/one-time-checkout`,
-			element: (
-				<Suspense fallback={<HoldingContent />}>
-					<OneTimeCheckout geoId={geoId} appConfig={appConfig} />
-				</Suspense>
-			),
-		},
-		{
-			path: `/${geoId}/thank-you`,
-			element: (
-				<Suspense fallback={<HoldingContent />}>
-					<ThankYou geoId={geoId} appConfig={appConfig} />
-				</Suspense>
-			),
-		},
-		{
-			path: `/${geoId}/guardian-light`,
-			element: (
-				<Suspense fallback={<HoldingContent />}>
-					<GuardianLightLanding geoId={geoId} />
-				</Suspense>
-			),
-		},
+		// {
+		// 	path: `/${geoId}/one-time-checkout`,
+		// 	element: (
+		// 		<Suspense fallback={<HoldingContent />}>
+		// 			<OneTimeCheckout geoId={geoId} appConfig={appConfig} />
+		// 		</Suspense>
+		// 	),
+		// },
+		// {
+		// 	path: `/${geoId}/thank-you`,
+		// 	element: (
+		// 		<Suspense fallback={<HoldingContent />}>
+		// 			<ThankYou geoId={geoId} appConfig={appConfig} />
+		// 		</Suspense>
+		// 	),
+		// },
+		// {
+		// 	path: `/${geoId}/guardian-light`,
+		// 	element: (
+		// 		<Suspense fallback={<HoldingContent />}>
+		// 			<GuardianLightLanding geoId={geoId} />
+		// 		</Suspense>
+		// 	),
+		// },
 	]),
 );
 

--- a/support-frontend/assets/pages/[countryGroupId]/lazyRouter.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/lazyRouter.tsx
@@ -1,21 +1,21 @@
 import { lazy, Suspense } from 'react';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { HoldingContent } from 'components/serverSideRendered/holdingContent';
-// import { parseAppConfig } from 'helpers/globalsAndSwitches/window';
-// import { setUpTrackingAndConsents } from 'helpers/page/page';
+import { parseAppConfig } from 'helpers/globalsAndSwitches/window';
+import { setUpTrackingAndConsents } from 'helpers/page/page';
 import { renderPage } from 'helpers/rendering/render';
 import { geoIds } from 'pages/geoIdConfig';
 
-// setUpTrackingAndConsents();
-// const appConfig = parseAppConfig(window.guardian);
+setUpTrackingAndConsents();
+const appConfig = parseAppConfig(window.guardian);
 
 const Checkout = lazy(() => import('./checkout'));
-// const OneTimeCheckout = lazy(() => import('./oneTimeCheckout'));
-// const ThankYou = lazy(() => import('./thankYou'));
-// const GuardianLightLanding = lazy(
-// 	() => import('./guardianLightLanding/guardianLightLanding'),
-// );
-console.log('LazyRouterV2');
+const OneTimeCheckout = lazy(() => import('./oneTimeCheckout'));
+const ThankYou = lazy(() => import('./thankYou'));
+const GuardianLightLanding = lazy(
+	() => import('./guardianLightLanding/guardianLightLanding'),
+);
+console.log('LazyRouter');
 
 const router = createBrowserRouter(
 	geoIds.flatMap((geoId) => [
@@ -23,34 +23,34 @@ const router = createBrowserRouter(
 			path: `/${geoId}/checkout`,
 			element: (
 				<Suspense fallback={<HoldingContent />}>
-					<Checkout geoId={geoId} />
+					<Checkout geoId={geoId} appConfig={appConfig} />
 				</Suspense>
 			),
 		},
-		// {
-		// 	path: `/${geoId}/one-time-checkout`,
-		// 	element: (
-		// 		<Suspense fallback={<HoldingContent />}>
-		// 			<OneTimeCheckout geoId={geoId} appConfig={appConfig} />
-		// 		</Suspense>
-		// 	),
-		// },
-		// {
-		// 	path: `/${geoId}/thank-you`,
-		// 	element: (
-		// 		<Suspense fallback={<HoldingContent />}>
-		// 			<ThankYou geoId={geoId} appConfig={appConfig} />
-		// 		</Suspense>
-		// 	),
-		// },
-		// {
-		// 	path: `/${geoId}/guardian-light`,
-		// 	element: (
-		// 		<Suspense fallback={<HoldingContent />}>
-		// 			<GuardianLightLanding geoId={geoId} />
-		// 		</Suspense>
-		// 	),
-		// },
+		{
+			path: `/${geoId}/one-time-checkout`,
+			element: (
+				<Suspense fallback={<HoldingContent />}>
+					<OneTimeCheckout geoId={geoId} appConfig={appConfig} />
+				</Suspense>
+			),
+		},
+		{
+			path: `/${geoId}/thank-you`,
+			element: (
+				<Suspense fallback={<HoldingContent />}>
+					<ThankYou geoId={geoId} appConfig={appConfig} />
+				</Suspense>
+			),
+		},
+		{
+			path: `/${geoId}/guardian-light`,
+			element: (
+				<Suspense fallback={<HoldingContent />}>
+					<GuardianLightLanding geoId={geoId} />
+				</Suspense>
+			),
+		},
 	]),
 );
 

--- a/support-frontend/assets/pages/[countryGroupId]/lazyRouter.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/lazyRouter.tsx
@@ -1,0 +1,61 @@
+import { lazy, Suspense } from 'react';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { HoldingContent } from 'components/serverSideRendered/holdingContent';
+import { parseAppConfig } from 'helpers/globalsAndSwitches/window';
+import { setUpTrackingAndConsents } from 'helpers/page/page';
+import { renderPage } from 'helpers/rendering/render';
+import { geoIds } from 'pages/geoIdConfig';
+
+setUpTrackingAndConsents();
+const appConfig = parseAppConfig(window.guardian);
+
+const Checkout = lazy(() => import('./checkout'));
+const OneTimeCheckout = lazy(() => import('./oneTimeCheckout'));
+const ThankYou = lazy(() => import('./thankYou'));
+const GuardianLightLanding = lazy(
+	() => import('./guardianLightLanding/guardianLightLanding'),
+);
+console.log('LazyRouter');
+
+const router = createBrowserRouter(
+	geoIds.flatMap((geoId) => [
+		{
+			path: `/${geoId}/checkout`,
+			element: (
+				<Suspense fallback={<HoldingContent />}>
+					<Checkout geoId={geoId} appConfig={appConfig} />
+				</Suspense>
+			),
+		},
+		{
+			path: `/${geoId}/one-time-checkout`,
+			element: (
+				<Suspense fallback={<HoldingContent />}>
+					<OneTimeCheckout geoId={geoId} appConfig={appConfig} />
+				</Suspense>
+			),
+		},
+		{
+			path: `/${geoId}/thank-you`,
+			element: (
+				<Suspense fallback={<HoldingContent />}>
+					<ThankYou geoId={geoId} appConfig={appConfig} />
+				</Suspense>
+			),
+		},
+		{
+			path: `/${geoId}/guardian-light`,
+			element: (
+				<Suspense fallback={<HoldingContent />}>
+					<GuardianLightLanding geoId={geoId} />
+				</Suspense>
+			),
+		},
+	]),
+);
+
+function Router() {
+	return <RouterProvider router={router} />;
+}
+
+export default renderPage(<Router />);

--- a/support-frontend/assets/pages/[countryGroupId]/lazyRouter.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/lazyRouter.tsx
@@ -9,11 +9,20 @@ import { geoIds } from 'pages/geoIdConfig';
 setUpTrackingAndConsents();
 const appConfig = parseAppConfig(window.guardian);
 
-const Checkout = lazy(() => import('./checkout'));
-const OneTimeCheckout = lazy(() => import('./oneTimeCheckout'));
-const ThankYou = lazy(() => import('./thankYou'));
+const Checkout = lazy(
+	() => import(/* webpackChunkName: "checkout" */ './checkout'),
+);
+const OneTimeCheckout = lazy(
+	() => import(/* webpackChunkName: "oneTimeCheckout" */ './oneTimeCheckout'),
+);
+const ThankYou = lazy(
+	() => import(/* webpackChunkName: "ThankYou" */ './thankYou'),
+);
 const GuardianLightLanding = lazy(
-	() => import('./guardianLightLanding/guardianLightLanding'),
+	() =>
+		import(
+			/* webpackChunkName: "GuardianLightLanding" */ './guardianLightLanding/guardianLightLanding'
+		),
 );
 console.log('LazyRouter');
 

--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -52,3 +52,5 @@ export function OneTimeCheckout({ geoId, appConfig }: OneTimeCheckoutProps) {
 		</Elements>
 	);
 }
+
+export default OneTimeCheckout;

--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -10,6 +10,7 @@ import { ThankYou } from './thankYou';
 
 setUpTrackingAndConsents();
 const appConfig = parseAppConfig(window.guardian);
+console.log('Router');
 
 const router = createBrowserRouter(
 	geoIds.flatMap((geoId) => [

--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -1,35 +1,35 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-// import { parseAppConfig } from 'helpers/globalsAndSwitches/window';
-// import { setUpTrackingAndConsents } from 'helpers/page/page';
+import { parseAppConfig } from 'helpers/globalsAndSwitches/window';
+import { setUpTrackingAndConsents } from 'helpers/page/page';
 import { renderPage } from 'helpers/rendering/render';
 import { geoIds } from 'pages/geoIdConfig';
 import { Checkout } from './checkout';
-// import { GuardianLightLanding } from './guardianLightLanding/guardianLightLanding';
-// import { OneTimeCheckout } from './oneTimeCheckout';
-// import { ThankYou } from './thankYou';
+import { GuardianLightLanding } from './guardianLightLanding/guardianLightLanding';
+import { OneTimeCheckout } from './oneTimeCheckout';
+import { ThankYou } from './thankYou';
 
-// setUpTrackingAndConsents();
-// const appConfig = parseAppConfig(window.guardian);
+setUpTrackingAndConsents();
+const appConfig = parseAppConfig(window.guardian);
 console.log('Router');
 
 const router = createBrowserRouter(
 	geoIds.flatMap((geoId) => [
 		{
 			path: `/${geoId}/checkout`,
-			element: <Checkout geoId={geoId} />,
+			element: <Checkout geoId={geoId} appConfig={appConfig} />,
 		},
-		// {
-		// 	path: `/${geoId}/one-time-checkout`,
-		// 	element: <OneTimeCheckout geoId={geoId} appConfig={appConfig} />,
-		// },
-		// {
-		// 	path: `/${geoId}/thank-you`,
-		// 	element: <ThankYou geoId={geoId} appConfig={appConfig} />,
-		// },
-		// {
-		// 	path: `/${geoId}/guardian-light`,
-		// 	element: <GuardianLightLanding geoId={geoId} />,
-		// },
+		{
+			path: `/${geoId}/one-time-checkout`,
+			element: <OneTimeCheckout geoId={geoId} appConfig={appConfig} />,
+		},
+		{
+			path: `/${geoId}/thank-you`,
+			element: <ThankYou geoId={geoId} appConfig={appConfig} />,
+		},
+		{
+			path: `/${geoId}/guardian-light`,
+			element: <GuardianLightLanding geoId={geoId} />,
+		},
 	]),
 );
 

--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -1,35 +1,35 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import { parseAppConfig } from 'helpers/globalsAndSwitches/window';
-import { setUpTrackingAndConsents } from 'helpers/page/page';
+// import { parseAppConfig } from 'helpers/globalsAndSwitches/window';
+// import { setUpTrackingAndConsents } from 'helpers/page/page';
 import { renderPage } from 'helpers/rendering/render';
 import { geoIds } from 'pages/geoIdConfig';
 import { Checkout } from './checkout';
-import { GuardianLightLanding } from './guardianLightLanding/guardianLightLanding';
-import { OneTimeCheckout } from './oneTimeCheckout';
-import { ThankYou } from './thankYou';
+// import { GuardianLightLanding } from './guardianLightLanding/guardianLightLanding';
+// import { OneTimeCheckout } from './oneTimeCheckout';
+// import { ThankYou } from './thankYou';
 
-setUpTrackingAndConsents();
-const appConfig = parseAppConfig(window.guardian);
+// setUpTrackingAndConsents();
+// const appConfig = parseAppConfig(window.guardian);
 console.log('Router');
 
 const router = createBrowserRouter(
 	geoIds.flatMap((geoId) => [
 		{
 			path: `/${geoId}/checkout`,
-			element: <Checkout geoId={geoId} appConfig={appConfig} />,
+			element: <Checkout geoId={geoId} />,
 		},
-		{
-			path: `/${geoId}/one-time-checkout`,
-			element: <OneTimeCheckout geoId={geoId} appConfig={appConfig} />,
-		},
-		{
-			path: `/${geoId}/thank-you`,
-			element: <ThankYou geoId={geoId} appConfig={appConfig} />,
-		},
-		{
-			path: `/${geoId}/guardian-light`,
-			element: <GuardianLightLanding geoId={geoId} />,
-		},
+		// {
+		// 	path: `/${geoId}/one-time-checkout`,
+		// 	element: <OneTimeCheckout geoId={geoId} appConfig={appConfig} />,
+		// },
+		// {
+		// 	path: `/${geoId}/thank-you`,
+		// 	element: <ThankYou geoId={geoId} appConfig={appConfig} />,
+		// },
+		// {
+		// 	path: `/${geoId}/guardian-light`,
+		// 	element: <GuardianLightLanding geoId={geoId} />,
+		// },
 	]),
 );
 

--- a/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
@@ -163,3 +163,4 @@ export function ThankYou({ geoId, appConfig }: ThankYouProps) {
 		/>
 	);
 }
+export default ThankYou;

--- a/support-frontend/webpack.dev.js
+++ b/support-frontend/webpack.dev.js
@@ -22,4 +22,27 @@ module.exports = merge(common('[name].css', '[name].js', false), {
 	resolve: {
 		fallback: { crypto: false },
 	},
+	optimization: {
+		splitChunks: {
+			chunks: 'initial',
+			minSize: 20000,
+			minRemainingSize: 0,
+			minChunks: 1,
+			maxAsyncRequests: 30,
+			maxInitialRequests: 30,
+			enforceSizeThreshold: 50000,
+			cacheGroups: {
+				defaultVendors: {
+					test: /[\\/]node_modules[\\/]/,
+					priority: -10,
+					reuseExistingChunk: true,
+				},
+				default: {
+					minChunks: 2,
+					priority: -20,
+					reuseExistingChunk: true,
+				},
+			},
+		},
+	},
 });

--- a/support-frontend/webpack.dev.js
+++ b/support-frontend/webpack.dev.js
@@ -1,4 +1,3 @@
-const webpack = require('webpack');
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 
@@ -24,25 +23,32 @@ module.exports = merge(common('[name].css', '[name].js', false), {
 	},
 	optimization: {
 		splitChunks: {
-			chunks: 'initial',
-			minSize: 20000,
-			minRemainingSize: 0,
-			minChunks: 1,
-			maxAsyncRequests: 30,
-			maxInitialRequests: 30,
-			enforceSizeThreshold: 50000,
-			cacheGroups: {
-				defaultVendors: {
-					test: /[\\/]node_modules[\\/]/,
-					priority: -10,
-					reuseExistingChunk: true,
-				},
-				default: {
-					minChunks: 2,
-					priority: -20,
-					reuseExistingChunk: true,
-				},
+			chunks() {
+				return false;
 			},
 		},
 	},
+	// optimization: {
+	// 	splitChunks: {
+	// 		chunks: 'initial',
+	// 		minSize: 20000,
+	// 		minRemainingSize: 0,
+	// 		minChunks: 1,
+	// 		maxAsyncRequests: 30,
+	// 		maxInitialRequests: 30,
+	// 		enforceSizeThreshold: 50000,
+	// 		cacheGroups: {
+	// 			defaultVendors: {
+	// 				test: /[\\/]node_modules[\\/]/,
+	// 				priority: -10,
+	// 				reuseExistingChunk: true,
+	// 			},
+	// 			default: {
+	// 				minChunks: 2,
+	// 				priority: -20,
+	// 				reuseExistingChunk: true,
+	// 			},
+	// 		},
+	// 	},
+	// },
 });

--- a/support-frontend/webpack.dev.js
+++ b/support-frontend/webpack.dev.js
@@ -21,33 +21,11 @@ module.exports = merge(common('[name].css', '[name].js', false), {
 	resolve: {
 		fallback: { crypto: false },
 	},
-	optimization: {
-		splitChunks: {
-			chunks() {
-				return false;
-			},
-		},
-	},
+	// See https://webpack.js.org/configuration/optimization/
 	// optimization: {
 	// 	splitChunks: {
-	// 		chunks: 'initial',
-	// 		minSize: 20000,
-	// 		minRemainingSize: 0,
-	// 		minChunks: 1,
-	// 		maxAsyncRequests: 30,
-	// 		maxInitialRequests: 30,
-	// 		enforceSizeThreshold: 50000,
-	// 		cacheGroups: {
-	// 			defaultVendors: {
-	// 				test: /[\\/]node_modules[\\/]/,
-	// 				priority: -10,
-	// 				reuseExistingChunk: true,
-	// 			},
-	// 			default: {
-	// 				minChunks: 2,
-	// 				priority: -20,
-	// 				reuseExistingChunk: true,
-	// 			},
+	// 		chunks() {
+	// 			return false;
 	// 		},
 	// 	},
 	// },

--- a/support-frontend/webpack.entryPoints.js
+++ b/support-frontend/webpack.entryPoints.js
@@ -1,7 +1,7 @@
 module.exports = {
 	common: {
-		'[countryGroupId]/router': 'pages/[countryGroupId]/router.tsx',
-		// '[countryGroupId]/router': 'pages/[countryGroupId]/lazyRouter.tsx',
+		//'[countryGroupId]/router': 'pages/[countryGroupId]/router.tsx',
+		'[countryGroupId]/router': 'pages/[countryGroupId]/lazyRouter.tsx',
 		// '[countryGroupId]/router': 'pages/[countryGroupId]/ghLazyRouter.tsx',
 		'[countryGroupId]/events/router':
 			'pages/[countryGroupId]/events/router.tsx',

--- a/support-frontend/webpack.entryPoints.js
+++ b/support-frontend/webpack.entryPoints.js
@@ -1,6 +1,7 @@
 module.exports = {
 	common: {
-		'[countryGroupId]/router': 'pages/[countryGroupId]/router.tsx',
+		// '[countryGroupId]/router': 'pages/[countryGroupId]/router.tsx',
+		'[countryGroupId]/router': 'pages/[countryGroupId]/lazyRouter.tsx',
 		'[countryGroupId]/events/router':
 			'pages/[countryGroupId]/events/router.tsx',
 		favicons: 'images/favicons.ts',

--- a/support-frontend/webpack.entryPoints.js
+++ b/support-frontend/webpack.entryPoints.js
@@ -1,7 +1,8 @@
 module.exports = {
 	common: {
-		'[countryGroupId]/router': 'pages/[countryGroupId]/router.tsx',
+		// '[countryGroupId]/router': 'pages/[countryGroupId]/router.tsx',
 		// '[countryGroupId]/router': 'pages/[countryGroupId]/lazyRouter.tsx',
+		'[countryGroupId]/router': 'pages/[countryGroupId]/ghLazyRouter.tsx',
 		'[countryGroupId]/events/router':
 			'pages/[countryGroupId]/events/router.tsx',
 		favicons: 'images/favicons.ts',

--- a/support-frontend/webpack.entryPoints.js
+++ b/support-frontend/webpack.entryPoints.js
@@ -1,8 +1,8 @@
 module.exports = {
 	common: {
-		// '[countryGroupId]/router': 'pages/[countryGroupId]/router.tsx',
+		'[countryGroupId]/router': 'pages/[countryGroupId]/router.tsx',
 		// '[countryGroupId]/router': 'pages/[countryGroupId]/lazyRouter.tsx',
-		'[countryGroupId]/router': 'pages/[countryGroupId]/ghLazyRouter.tsx',
+		// '[countryGroupId]/router': 'pages/[countryGroupId]/ghLazyRouter.tsx',
 		'[countryGroupId]/events/router':
 			'pages/[countryGroupId]/events/router.tsx',
 		favicons: 'images/favicons.ts',

--- a/support-frontend/webpack.entryPoints.js
+++ b/support-frontend/webpack.entryPoints.js
@@ -1,7 +1,7 @@
 module.exports = {
 	common: {
-		// '[countryGroupId]/router': 'pages/[countryGroupId]/router.tsx',
-		'[countryGroupId]/router': 'pages/[countryGroupId]/lazyRouter.tsx',
+		'[countryGroupId]/router': 'pages/[countryGroupId]/router.tsx',
+		// '[countryGroupId]/router': 'pages/[countryGroupId]/lazyRouter.tsx',
 		'[countryGroupId]/events/router':
 			'pages/[countryGroupId]/events/router.tsx',
 		favicons: 'images/favicons.ts',

--- a/support-frontend/webpack.prod.js
+++ b/support-frontend/webpack.prod.js
@@ -30,33 +30,11 @@ module.exports = (
 				'process.env.NODE_ENV': JSON.stringify('production'),
 			}),
 		],
-		optimization: {
-			splitChunks: {
-				chunks() {
-					return false;
-				},
-			},
-		},
+		// See https://webpack.js.org/configuration/optimization/
 		// optimization: {
 		// 	splitChunks: {
-		// 		chunks: 'initial',
-		// 		minSize: 20000,
-		// 		minRemainingSize: 0,
-		// 		minChunks: 1,
-		// 		maxAsyncRequests: 30,
-		// 		maxInitialRequests: 30,
-		// 		enforceSizeThreshold: 50000,
-		// 		cacheGroups: {
-		// 			defaultVendors: {
-		// 				test: /[\\/]node_modules[\\/]/,
-		// 				priority: -10,
-		// 				reuseExistingChunk: true,
-		// 			},
-		// 			default: {
-		// 				minChunks: 2,
-		// 				priority: -20,
-		// 				reuseExistingChunk: true,
-		// 			},
+		// 		chunks() {
+		// 			return false;
 		// 		},
 		// 	},
 		// },

--- a/support-frontend/webpack.prod.js
+++ b/support-frontend/webpack.prod.js
@@ -32,26 +32,33 @@ module.exports = (
 		],
 		optimization: {
 			splitChunks: {
-				chunks: 'initial',
-				minSize: 20000,
-				minRemainingSize: 0,
-				minChunks: 1,
-				maxAsyncRequests: 30,
-				maxInitialRequests: 30,
-				enforceSizeThreshold: 50000,
-				cacheGroups: {
-					defaultVendors: {
-						test: /[\\/]node_modules[\\/]/,
-						priority: -10,
-						reuseExistingChunk: true,
-					},
-					default: {
-						minChunks: 2,
-						priority: -20,
-						reuseExistingChunk: true,
-					},
+				chunks() {
+					return false;
 				},
 			},
 		},
+		// optimization: {
+		// 	splitChunks: {
+		// 		chunks: 'initial',
+		// 		minSize: 20000,
+		// 		minRemainingSize: 0,
+		// 		minChunks: 1,
+		// 		maxAsyncRequests: 30,
+		// 		maxInitialRequests: 30,
+		// 		enforceSizeThreshold: 50000,
+		// 		cacheGroups: {
+		// 			defaultVendors: {
+		// 				test: /[\\/]node_modules[\\/]/,
+		// 				priority: -10,
+		// 				reuseExistingChunk: true,
+		// 			},
+		// 			default: {
+		// 				minChunks: 2,
+		// 				priority: -20,
+		// 				reuseExistingChunk: true,
+		// 			},
+		// 		},
+		// 	},
+		// },
 	});
 };

--- a/support-frontend/webpack.prod.js
+++ b/support-frontend/webpack.prod.js
@@ -30,5 +30,28 @@ module.exports = (
 				'process.env.NODE_ENV': JSON.stringify('production'),
 			}),
 		],
+		optimization: {
+			splitChunks: {
+				chunks: 'initial',
+				minSize: 20000,
+				minRemainingSize: 0,
+				minChunks: 1,
+				maxAsyncRequests: 30,
+				maxInitialRequests: 30,
+				enforceSizeThreshold: 50000,
+				cacheGroups: {
+					defaultVendors: {
+						test: /[\\/]node_modules[\\/]/,
+						priority: -10,
+						reuseExistingChunk: true,
+					},
+					default: {
+						minChunks: 2,
+						priority: -20,
+						reuseExistingChunk: true,
+					},
+				},
+			},
+		},
 	});
 };


### PR DESCRIPTION
We tested this branch vs main on `CODE` using [webpage test](https://www.webpagetest.org/) to compare page speed performance metrics when viewing the pages below supplied through the router (simple / median of 3 x Motorola 4G page loads). I tested these entry points->

- [checkout](https://support.code.dev-theguardian.com/uk/checkout?product=SupporterPlus&ratePlan=Monthly)
- [one-time-checkout](https://support.code.dev-theguardian.com/uk/one-time-checkout)
- [guardian-light landing page
](https://support.code.dev-theguardian.com/uk/guardian-light)

**Conclusion**

1. Speed results in-conclusive
2. Revisit this in a new PR after server-side Ab-Testing Available. 
3. This should work out if a 'faster' variant is more succesful.

[(Summary WorkSheet)](https://docs.google.com/spreadsheets/d/1TW4qLQSPhX-RFWOyVD0Tog_HUwXpUxJZoC6_A0VDzn8/edit?usp=sharing)

**Results: Checkout [(16/12/24)](https://www.webpagetest.org/video/compare.php?tests=241216_AiDcFW_97Y,241216_AiDcTS_9K0,241216_BiDcRE_8V0)**

| Metric    | Router | lazyRouter| ghlazyRouter |
| -------- | ------- | ------- | ------- | 
| FCP (How soon did text and images start to appear) | 1.577s | 2.371s | 1.873s |
| Speed Index (Speed Index (How soon did the page look usable) | 10.861s | 11.241s | 11.07s |
| LCP (When did the largest visible content finish loading) | 5.385s | 6.47s | 5.271s |
| Page Weight (How many bytes downloaded) | 2249kb |2310kb | 2294Kb |
| router.js g-zip | 264kb | 93kb+162Kb | 81.5Kb + 162Kb |

**Results: OneTimeCheckout [(16/12/24)](https://www.webpagetest.org/video/compare.php?tests=241216_AiDc3D_98G,241216_BiDcH6_9BC,241216_BiDcC4_8VX)**

| Metric    | Router | lazyRouter| ghlazyRouter |
| -------- | ------- | ------- | ------- | 
| FCP (How soon did text and images start to appear) | 1.652s | 1.761 s | 1.709s |
| Speed Index (Speed Index (How soon did the page look usable) | 11.532s | 10.38s | 10.462 |
| LCP (When did the largest visible content finish loading) | 5.016s | 5.946s | 5.526s |
| Page Weight (How many bytes downloaded) | 2326kb | 2236kb | 2296Kb |
| router.js g-zip | 264kb | 92.5kb + 158Kb | 81.4Kb + 158Kb |

**Results: GuardianLight Landing  [(16/12/24)](https://www.webpagetest.org/video/compare.php?tests=241216_BiDcNG_904,241216_BiDcXD_9CW,241216_AiDcNR_955)**

| Metric    | Router | lazyRouter| ghlazyRouter |
| -------- | ------- | ------- |  ------- | 
| FCP (How soon did text and images start to appear) | 1.943s | 1.98s | 1.674 |
| Speed Index (Speed Index (How soon did the page look usable) | 7.422s | 6.732s | 7.432s |
| LCP (When did the largest visible content finish loading) | 4.144s | 4.381s | 4.806s |
| Page Weight (How many bytes downloaded) | 952kb | 628kb | 616Kb |
| router.js g-zip | 264kb | 93.5Kb + 38Kb | 81.4Kb + 38Kb |