### PR TITLE
Preload mainJsBundle bundle

### DIFF
--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -58,6 +58,8 @@
       <meta property="og:url" content="@shareUrl" />
     }
 
+    <link href="@assets(mainJsBundle)" rel="preload" as="script">
+
     @canonicalLink.map { definedCanonicalLink =>
       <link rel="canonical" href="@definedCanonicalLink" />
     }


### PR DESCRIPTION
## What are you doing in this PR?

 "mainJsBundle" is just an example name here...

Currently on the support site we put our `<script async src="myScript.js"></script>` tag at the bottom of the `<body>`, doing so in combination with the `async` attribute ensures that the script is downloaded without blocking other resources or rendering and is executed as soon as it is ready. However the browser needs to parse the page before it reaches this `<script>` tag, and we don't initialise download until then.
 
Including `<link href="myScript.js" rel="preload" as="script">` in the `<head>` instructs the browser to start fetching the specified resource (`myScript.js`) as soon as it encounters the `<link>` tag in the `<head>`. This helps reduce latency because the browser doesn't need to wait until it encounters the `<script>` tag to start downloading the script. See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload for further info.

If a script is critical to the page rendering (as ours are), preloading can be a good optimisation because it ensures the download starts earlier, even before the browser reaches the `<script>` tag.

I tested main vs this branch on CODE using https://pagespeed.web.dev, which tested as an Emulated Moto G Power device and Slow 4G throttling (using Lighthouse).

The results look positive, I can't see a downside to including this `<link>`. A further optimisation could be using an HTTP/2  server push to deliver myScript.js even earlier.

### 3-tier landing page (https://support.code.dev-theguardian.com/uk/contribute)

| Metric                                          | main | gh-preload-js |
|-------------------------------------------------|------|---------------|
| | [PageSpeed Analysis (mobile)](https://pagespeed.web.dev/analysis/https-support-code-dev-theguardian-com-uk-contribute/2iizkmqqj1?form_factor=mobile) | [PageSpeed Analysis (mobile)](https://pagespeed.web.dev/analysis/https-support-code-dev-theguardian-com-uk-contribute/gzbccysg31?form_factor=mobile) |
| **FCP (How soon did text and images start to appear)** | 5.30 | 1.8 |
| **Speed Index (How soon did the page look usable)**    | 5.90 | 3.6 |
| **LCP (When did the largest visible content finish loading)** | 6.20 | 4 |

### Generic checkout (https://support.code.dev-theguardian.com/uk/checkout?product=SupporterPlus&ratePlan=Monthly)

| Metric                                          | main | gh-preload-js |
|-------------------------------------------------|------|---------------|
| | [PageSpeed Analysis (mobile)](https://pagespeed.web.dev/analysis/https-support-code-dev-theguardian-com-uk-checkout/o4ax516eky?form_factor=mobile) | [PageSpeed Analysis (mobile)](https://pagespeed.web.dev/analysis/https-support-code-dev-theguardian-com-uk-checkout/l56rr7vx2l?form_factor=mobile) |
| **FCP (How soon did text and images start to appear)** | 1.8  | 1.8 |
| **Speed Index (How soon did the page look usable)**    | 7.60 | 5.3 |
| **LCP (When did the largest visible content finish loading)** | 4.8  | 4   |

### New one-time checkout (https://support.code.dev-theguardian.com/uk/one-time-checkout)

| Metric                                          | main | gh-preload-js |
|-------------------------------------------------|------|---------------|
| | [PageSpeed Analysis (mobile)](https://pagespeed.web.dev/analysis/https-support-code-dev-theguardian-com-uk-one-time-checkout/hf9vm4xdwo?form_factor=mobile) | [PageSpeed Analysis (mobile)](https://pagespeed.web.dev/analysis/https-support-code-dev-theguardian-com-uk-one-time-checkout/y791bftfo8?form_factor=mobile) |
| **FCP (How soon did text and images start to appear)** | 1.8  | 1.8 |
| **Speed Index (How soon did the page look usable)**    | 6.8  | 5.4 |
| **LCP (When did the largest visible content finish loading)** | 1.8  | 1.8 |




