### PR TITLE
Update the Tier Three alarm description and increase period

### DIFF
--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -1661,9 +1661,9 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "URGENT 9-5 - PROD support-workers No successful Tier Three checkouts in 12 hours.",
+        "AlarmName": "URGENT 9-5 - PROD support-workers No successful Tier Three checkouts in 1 day.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "EvaluationPeriods": 144,
+        "EvaluationPeriods": 288,
         "Metrics": [
           {
             "Expression": "SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0)])",

--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -1661,7 +1661,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "URGENT 9-5 - PROD support-workers No successful Tier Three checkouts in 6h.",
+        "AlarmName": "URGENT 9-5 - PROD support-workers No successful Tier Three checkouts in 12 hours.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "EvaluationPeriods": 144,
         "Metrics": [

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -431,7 +431,7 @@ export class SupportWorkers extends GuStack {
     }).node.addDependency(stateMachine);
 
     const tierThreeMetricDuration = Duration.minutes(5);
-    const tierThreeEvaluationPeriods = 144; // The number of 5 minute periods in 12 hours
+    const tierThreeEvaluationPeriods = 288; // The number of 5 minute periods in 24 hours
     const tierThreeAlarmPeriod = Duration.minutes(
       tierThreeMetricDuration.toMinutes() * tierThreeEvaluationPeriods
     );

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -430,22 +430,41 @@ export class SupportWorkers extends GuStack {
       threshold: 0,
     }).node.addDependency(stateMachine);
 
+    const tierThreeMetricDuration = Duration.minutes(5);
+    const tierThreeEvaluationPeriods = 144; // The number of 5 minute periods in 12 hours
+    const tierThreeAlarmPeriod = Duration.minutes(
+      tierThreeMetricDuration.toMinutes() * tierThreeEvaluationPeriods
+    );
     new GuAlarm(this, `NoTierThreeAcquisitionInPeriodAlarm`, {
       app,
       actionsEnabled: isProd,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `URGENT 9-5 - ${this.stage} support-workers No successful Tier Three checkouts in 6h.`,
+      alarmName: `URGENT 9-5 - ${
+        this.stage
+      } support-workers No successful Tier Three checkouts in ${tierThreeAlarmPeriod.toHumanString()}.`,
       metric: new MathExpression({
         label: "AllTierThreeConversions",
         expression: "SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0)])",
         usingMetrics: {
-          m1: this.buildPaymentSuccessMetric("Stripe", "TierThree", Duration.minutes(5)),
-          m2: this.buildPaymentSuccessMetric("DirectDebit", "TierThree", Duration.minutes(5)),
-          m3: this.buildPaymentSuccessMetric("PayPal", "TierThree", Duration.minutes(5)),
+          m1: this.buildPaymentSuccessMetric(
+            "Stripe",
+            "TierThree",
+            tierThreeMetricDuration
+          ),
+          m2: this.buildPaymentSuccessMetric(
+            "DirectDebit",
+            "TierThree",
+            tierThreeMetricDuration
+          ),
+          m3: this.buildPaymentSuccessMetric(
+            "PayPal",
+            "TierThree",
+            tierThreeMetricDuration
+          ),
         },
       }),
       comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
-      evaluationPeriods: 144, // The number of 5 minute periods in 12 hours
+      evaluationPeriods: tierThreeEvaluationPeriods,
       treatMissingData: TreatMissingData.BREACHING,
       threshold: 0,
     }).node.addDependency(stateMachine);


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Fix the Tier Three alarm description and also increase the period to 24 hours.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

The Tier Three alarm description is currently out of sync with the alarm config. This is because I forgot to update the description in #6634. Instead of having to remember, this PR changes approach to deriving the description from the alarm config so it's impossible to get out of sync. If we like the approach we can use if for the other alarms in here.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

`yarn test` in the `cdk` dir. The snapshot contains the updated description.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->