### PR TITLE
Remove react-day-picker

### DIFF
--- a/support-frontend/assets/helpers/__tests__/formValidation.ts
+++ b/support-frontend/assets/helpers/__tests__/formValidation.ts
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 import {
 	amountOrOtherAmountIsValid,
+	isNotTooFarInTheFuture,
 	maxTwoDecimals,
 	notLongerThan,
 } from '../forms/formValidation';
@@ -104,6 +105,43 @@ describe('formValidation', () => {
 		});
 		it('should return true if string is under max length', () => {
 			expect(notLongerThan('hello world', 20)).toBeTruthy();
+		});
+	});
+
+	describe('isNotTooFarInFuture', () => {
+		it('returns true if the date is less than 89 days from now', () => {
+			const now = new Date(2024, 0, 1); // 1st Jan 2024
+			const oneDayFromNow = new Date(2024, 0, 2); // 2nd Jan 2024
+
+			expect(isNotTooFarInTheFuture(oneDayFromNow, now)).toEqual(true);
+		});
+
+		it('returns true if the date is exactly 89 days from now', () => {
+			const now = new Date(2024, 0, 1); // 1st Jan 2024
+			const eightyNineDaysFromNow = new Date(2024, 2, 30); // 30th Mar 2024
+
+			expect(isNotTooFarInTheFuture(eightyNineDaysFromNow, now)).toEqual(true);
+		});
+
+		it('returns true if the date is exactly 89 days from now, even at a later time in the day', () => {
+			const now = new Date(2024, 0, 1, 0, 0, 0); // 1st Jan 2024
+			const eightyNineDaysFromNow = new Date(2024, 2, 30, 1, 0, 0); // 30th Mar 2024
+
+			expect(isNotTooFarInTheFuture(eightyNineDaysFromNow, now)).toEqual(true);
+		});
+
+		it('returns false if the date is 1 day more than 89 days from now', () => {
+			const now = new Date(2024, 0, 1); // 1st Jan 2024
+			const ninetyDaysFromNow = new Date(2024, 2, 31); // 31st Mar 2024
+
+			expect(isNotTooFarInTheFuture(ninetyDaysFromNow, now)).toEqual(false);
+		});
+
+		it('returns false if the date is many days more than 89 days from now', () => {
+			const now = new Date(2024, 0, 1); // 1st Jan 2024
+			const manyDaysFromNow = new Date(2024, 12, 1); // 1st Dec 2024
+
+			expect(isNotTooFarInTheFuture(manyDaysFromNow, now)).toEqual(false);
 		});
 	});
 });

--- a/support-frontend/assets/helpers/__tests__/formValidation.ts
+++ b/support-frontend/assets/helpers/__tests__/formValidation.ts
@@ -108,7 +108,7 @@ describe('formValidation', () => {
 		});
 	});
 
-	describe('isNotTooFarInFuture', () => {
+	describe('isNotTooFarInTheFuture', () => {
 		it('returns true if the date is less than 89 days from now', () => {
 			const now = new Date(2024, 0, 1); // 1st Jan 2024
 			const oneDayFromNow = new Date(2024, 0, 2); // 2nd Jan 2024

--- a/support-frontend/assets/helpers/__tests__/formValidation.ts
+++ b/support-frontend/assets/helpers/__tests__/formValidation.ts
@@ -1,7 +1,6 @@
 // ----- Imports ----- //
 import {
 	amountOrOtherAmountIsValid,
-	isNotTooFarInTheFuture,
 	maxTwoDecimals,
 	notLongerThan,
 } from '../forms/formValidation';
@@ -105,43 +104,6 @@ describe('formValidation', () => {
 		});
 		it('should return true if string is under max length', () => {
 			expect(notLongerThan('hello world', 20)).toBeTruthy();
-		});
-	});
-
-	describe('isNotTooFarInTheFuture', () => {
-		it('returns true if the date is less than 89 days from now', () => {
-			const now = new Date(2024, 0, 1); // 1st Jan 2024
-			const oneDayFromNow = new Date(2024, 0, 2); // 2nd Jan 2024
-
-			expect(isNotTooFarInTheFuture(oneDayFromNow, now)).toEqual(true);
-		});
-
-		it('returns true if the date is exactly 89 days from now', () => {
-			const now = new Date(2024, 0, 1); // 1st Jan 2024
-			const eightyNineDaysFromNow = new Date(2024, 2, 30); // 30th Mar 2024
-
-			expect(isNotTooFarInTheFuture(eightyNineDaysFromNow, now)).toEqual(true);
-		});
-
-		it('returns true if the date is exactly 89 days from now, even at a later time in the day', () => {
-			const now = new Date(2024, 0, 1, 0, 0, 0); // 1st Jan 2024
-			const eightyNineDaysFromNow = new Date(2024, 2, 30, 1, 0, 0); // 30th Mar 2024
-
-			expect(isNotTooFarInTheFuture(eightyNineDaysFromNow, now)).toEqual(true);
-		});
-
-		it('returns false if the date is 1 day more than 89 days from now', () => {
-			const now = new Date(2024, 0, 1); // 1st Jan 2024
-			const ninetyDaysFromNow = new Date(2024, 2, 31); // 31st Mar 2024
-
-			expect(isNotTooFarInTheFuture(ninetyDaysFromNow, now)).toEqual(false);
-		});
-
-		it('returns false if the date is many days more than 89 days from now', () => {
-			const now = new Date(2024, 0, 1); // 1st Jan 2024
-			const manyDaysFromNow = new Date(2024, 12, 1); // 1st Dec 2024
-
-			expect(isNotTooFarInTheFuture(manyDaysFromNow, now)).toEqual(false);
 		});
 	});
 });

--- a/support-frontend/assets/helpers/forms/formValidation.ts
+++ b/support-frontend/assets/helpers/forms/formValidation.ts
@@ -6,8 +6,6 @@ import type {
 } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
-const daysFromNowForGift = 89;
-
 // Copied from
 // https://github.com/playframework/playframework/blob/master/framework/src/play/
 // src/main/scala/play/api/data/validation/Validation.scala#L81
@@ -21,16 +19,6 @@ export const isEmpty: (arg0?: string | null) => boolean = (input) =>
 
 export const isNotEmpty: (arg0?: string | null) => boolean = (input) =>
 	!isEmpty(input);
-
-export const isNotTooFarInTheFuture = (
-	date: Date,
-	now: Date = new Date(),
-): boolean => {
-	const rangeDate = new Date(now.getTime());
-	rangeDate.setDate(rangeDate.getDate() + daysFromNowForGift + 1);
-
-	return date < rangeDate;
-};
 
 export const isValidEmail: (arg0: string | null) => boolean = (input) =>
 	!!input && new RegExp(emailRegexPattern).test(input);
@@ -75,17 +63,6 @@ export const emailAddressesMatch: (
 
 export const checkOptionalEmail: (arg0: string | null) => boolean = (input) =>
 	isEmpty(input) || isValidEmail(input);
-
-export const checkGiftStartDate: (giftDeliveryDate?: string) => boolean = (
-	rawDate,
-) => {
-	const date = rawDate ? new Date(rawDate) : null;
-
-	if (isNotEmpty(rawDate) && date) {
-		return isNotTooFarInTheFuture(date);
-	}
-	return false;
-};
 
 export const amountIsValid = (
 	input: string,

--- a/support-frontend/assets/helpers/forms/formValidation.ts
+++ b/support-frontend/assets/helpers/forms/formValidation.ts
@@ -23,8 +23,11 @@ export const isEmpty: (arg0?: string | null) => boolean = (input) =>
 export const isNotEmpty: (arg0?: string | null) => boolean = (input) =>
 	!isEmpty(input);
 
-export const isNotTooFarInTheFuture: (arg0: Date) => boolean = (date) => {
-	const rangeDate = new Date();
+export const isNotTooFarInTheFuture = (
+	date: Date,
+	now: Date = new Date(),
+): boolean => {
+	const rangeDate = new Date(now.getTime());
 	rangeDate.setDate(rangeDate.getDate() + daysFromNowForGift);
 
 	const dateIsInsideRange = !DateUtils.isDayAfter(date, rangeDate);

--- a/support-frontend/assets/helpers/forms/formValidation.ts
+++ b/support-frontend/assets/helpers/forms/formValidation.ts
@@ -1,4 +1,3 @@
-import { DateUtils } from 'react-day-picker';
 import { config } from 'helpers/contributions';
 import type {
 	ContributionType,
@@ -28,10 +27,9 @@ export const isNotTooFarInTheFuture = (
 	now: Date = new Date(),
 ): boolean => {
 	const rangeDate = new Date(now.getTime());
-	rangeDate.setDate(rangeDate.getDate() + daysFromNowForGift);
+	rangeDate.setDate(rangeDate.getDate() + daysFromNowForGift + 1);
 
-	const dateIsInsideRange = !DateUtils.isDayAfter(date, rangeDate);
-	return dateIsInsideRange;
+	return date < rangeDate;
 };
 
 export const isValidEmail: (arg0: string | null) => boolean = (input) =>

--- a/support-frontend/assets/helpers/subscriptionsForms/rules.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/rules.ts
@@ -1,5 +1,4 @@
 import {
-	checkGiftStartDate,
 	checkOptionalEmail,
 	emailAddressesMatch,
 	isValidEmail,
@@ -199,13 +198,6 @@ function applyCheckoutRules(fields: FormFields): Array<FormError<FormField>> {
 						error: formError(
 							'emailGiftRecipient',
 							'Email address is too long.',
-						),
-					},
-					{
-						rule: checkGiftStartDate(fields.giftDeliveryDate),
-						error: formError(
-							'giftDeliveryDate',
-							'Please enter a valid delivery date for your gift.',
 						),
 					},
 			  ]

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -101,7 +101,6 @@
 		"lodash.debounce": "^4.0.6",
 		"mockdate": "^3.0.5",
 		"ophan-tracker-js": "^1.4.3",
-		"react-day-picker": "^7.4.8",
 		"react-redux": "^8.1.0",
 		"react-router-dom": "^6.23.0",
 		"redux": "^4.0.0",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -9624,7 +9624,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -9744,13 +9744,6 @@ raw-body@2.5.2:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
-
-react-day-picker@^7.4.8:
-  version "7.4.10"
-  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-7.4.10.tgz#d3928fa65c04379ad28c76de22aa85374a8361e1"
-  integrity sha512-/QkK75qLKdyLmv0kcVzhL7HoJPazoZXS8a6HixbVoK6vWey1Od1WRLcxfyEiUsRfccAlIlf6oKHShqY2SM82rA==
-  dependencies:
-    prop-types "^15.6.2"
 
 "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0":
   version "18.3.1"


### PR DESCRIPTION
## What are you doing in this PR?

Remove `react-day-picker` NPM package ~~and replace with our own implementation.~~ and the method which uses it (it's no longer needed, as it was only ever used for Digipack Gift subs which we no longer support).

[**Trello Card**](https://trello.com)

## Why are you doing this?

The version of `react-day-picker` we're on is 5 years old, and the interface has changed. The only code paths which use it are no longer needed.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

~~I took this approach:~~

~~1. Make the existing method (which does use `react-day-picker`) testable, by allowing passing in `now`~~
~~2. Add some tests~~
~~3. Update the method, removing `react-day-picker` and ensure tests still pass~~

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
