### PR TITLE
Contributions Only Landing - link to generic checkout

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/guardianTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/guardianTsAndCs.tsx
@@ -17,16 +17,18 @@ const guardianTsAndCsStyles = (displayPatronsCheckout: boolean) => css`
 export function GuardianTsAndCs({
 	mobileTheme = 'dark',
 	displayPatronsCheckout = true,
+	spacing = 'tight',
 }: {
 	mobileTheme?: FinePrintTheme;
 	displayPatronsCheckout: boolean;
+	spacing?: 'tight' | 'loose';
 }): JSX.Element {
 	return (
 		<FinePrint
 			mobileTheme={mobileTheme}
 			cssOverrides={guardianTsAndCsStyles(displayPatronsCheckout)}
 		>
-			<CheckoutDivider spacing="tight" mobileTheme={'light'} />
+			<CheckoutDivider spacing={spacing} mobileTheme={'light'} />
 			<p>
 				The ultimate owner of the Guardian is The Scott Trust Limited, whose
 				role it is to secure the editorial and financial independence of the

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
@@ -312,6 +312,7 @@ export function SupporterPlusCheckoutScaffold({
 						<GuardianTsAndCs
 							mobileTheme={'light'}
 							displayPatronsCheckout={displayPatronsCheckout}
+							spacing={displayPatronsCheckout ? 'tight' : 'loose'}
 						/>
 					</Column>
 				</Columns>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/checkoutScaffold.tsx
@@ -43,7 +43,6 @@ import { navigateWithPageView } from 'helpers/tracking/trackingOphan';
 import HeadlineImagePatronsDesktop from '../../../components/svgs/headlineImagePatronsDesktop';
 import HeadlineImagePatronsMobile from '../../../components/svgs/headlineImagePatronsMobile';
 import { GuardianTsAndCs } from '../components/guardianTsAndCs';
-import { PatronsMessage } from '../components/patronsMessage';
 
 const checkoutContainer = (isPaymentPage?: boolean) => {
 	type SpaceRange = 2 | 3 | 6;
@@ -310,12 +309,6 @@ export function SupporterPlusCheckoutScaffold({
 						)}
 						{children}
 
-						{!displayPatronsCheckout && (
-							<PatronsMessage
-								countryGroupId={countryGroupId}
-								mobileTheme={'light'}
-							/>
-						)}
 						<GuardianTsAndCs
 							mobileTheme={'light'}
 							displayPatronsCheckout={displayPatronsCheckout}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/firstStepLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/firstStepLanding.tsx
@@ -9,15 +9,13 @@ import {
 	until,
 } from '@guardian/source/foundations';
 import {
-	Button,
 	buttonThemeReaderRevenueBrand,
+	LinkButton,
 } from '@guardian/source/react-components';
 import { useEffect } from 'preact/hooks';
-import { useNavigate } from 'react-router';
 import { Box } from 'components/checkoutBox/checkoutBox';
 import { BrandedIcons } from 'components/paymentMethodSelector/creditDebitIcons';
 import { PaypalIcon } from 'components/paymentMethodSelector/paypalIcon';
-import { useOtherAmountValidation } from 'helpers/customHooks/useFormValidation';
 import { resetValidation } from 'helpers/redux/checkout/checkoutActions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { getUserSelectedAmount } from 'helpers/redux/checkout/product/selectors/selectedAmount';
@@ -26,7 +24,6 @@ import {
 	useContributionsSelector,
 } from 'helpers/redux/storeHooks';
 import { getThresholdPrice } from 'helpers/supporterPlus/benefitsThreshold';
-import { navigateWithPageView } from 'helpers/tracking/trackingOphan';
 import { AmountAndBenefits } from '../formSections/amountAndBenefits';
 import { PatronsPriceCards } from '../formSections/patronsPriceCards';
 import { SupporterPlusCheckoutScaffold } from './checkoutScaffold';
@@ -95,7 +92,6 @@ export function SupporterPlusInitialLandingPage({
 	const { countryGroupId } = useContributionsSelector(
 		(state) => state.common.internationalisation,
 	);
-	const navigate = useNavigate();
 	const contributionType = useContributionsSelector(getContributionType);
 	const amount = useContributionsSelector(getUserSelectedAmount);
 
@@ -108,11 +104,12 @@ export function SupporterPlusInitialLandingPage({
 	);
 
 	const displayPatronsCheckout = !!abParticipations.patronsOneOffOnly;
+	const billingPeriod = contributionType === 'ANNUAL' ? 'Annual' : 'Monthly';
 
-	const proceedToNextStep = useOtherAmountValidation(() => {
-		const destination = `checkout?selected-amount=${amount}&selected-contribution-type=${contributionType.toLowerCase()}`;
-		navigateWithPageView(navigate, destination, abParticipations);
-	}, false);
+	const checkoutLink =
+		contributionType === 'ONE_OFF'
+			? `one-time-checkout?contribution=${amount}`
+			: `checkout?product=Contribution&ratePlan=${billingPeriod}&contribution=${amount}`;
 
 	const paymentMethodsMarginOneOff = css`
 		margin: ${space[4]}px 0;
@@ -159,15 +156,14 @@ export function SupporterPlusInitialLandingPage({
 
 				<div css={checkoutBtnAndPaymentIconsHolder}>
 					<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-						<Button
-							iconSide="left"
+						<LinkButton
 							priority="primary"
 							size="default"
 							cssOverrides={checkoutBtnStyleOverrides}
-							onClick={proceedToNextStep}
+							href={checkoutLink}
 						>
 							Continue to checkout
-						</Button>
+						</LinkButton>
 					</ThemeProvider>
 					{contributionType !== 'ONE_OFF' && (
 						<p css={cancelAnytime}>Cancel or change at anytime</p>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Change the CTAs on the contributions only checkout (shown to users in certain countries) to redirect to the new generic or one time checkouts, instead of the old second step checkout.

Also remove the patrons section.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/rhciXIi5/1289-contributions-only-landing-page-for-users-in-vat-affected-country-list-countries-that-dons-sell-subs-phase-1)

## Why are you doing this?

Part one of deprecating the old two step checkout

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Go to https://support.thegulocal.com/int/contribute?country=lb (LB is an example that works in local), click "Continue to checkout" from any of the tabs and go to the correct checkout with the correct amount and rateplan

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Screenshots
![image](https://github.com/user-attachments/assets/c8d7e9ec-ae88-41f4-9ccd-1f3b2356aeb1)
Link
![image](https://github.com/user-attachments/assets/49f3608c-85b2-4eae-9798-1d226b49f388)
