### PR TITLE
Guardian Ad-Lite: Playwright tests

### DIFF
--- a/support-e2e/tests/cron/checkout.test.ts
+++ b/support-e2e/tests/cron/checkout.test.ts
@@ -7,6 +7,12 @@ afterEachTasks(test);
 test.describe('Checkout', () => {
 	[
 		{
+			product: 'GuardianLight',
+			ratePlan: 'Monthly',
+			paymentType: 'PayPal',
+			internationalisationId: 'UK',
+		},
+		{
 			product: 'SupporterPlus',
 			ratePlan: 'Monthly',
 			paymentType: 'PayPal',

--- a/support-e2e/tests/smoke/checkout.test.ts
+++ b/support-e2e/tests/smoke/checkout.test.ts
@@ -18,6 +18,12 @@ test.describe('Checkout', () => {
 			paymentType: 'Credit/Debit card',
 			internationalisationId: 'UK',
 		},
+		{
+			product: 'GuardianLight',
+			ratePlan: 'Monthly',
+			paymentType: 'Credit/Debit card',
+			internationalisationId: 'UK',
+		},
 	].forEach((testDetails) => {
 		testCheckout(testDetails);
 	});

--- a/support-e2e/tests/smoke/checkout.test.ts
+++ b/support-e2e/tests/smoke/checkout.test.ts
@@ -7,6 +7,12 @@ afterEachTasks(test);
 test.describe('Checkout', () => {
 	[
 		{
+			product: 'GuardianLight',
+			ratePlan: 'Monthly',
+			paymentType: 'Credit/Debit card',
+			internationalisationId: 'UK',
+		},
+		{
 			product: 'SupporterPlus',
 			ratePlan: 'Annual',
 			paymentType: 'Credit/Debit card',
@@ -15,12 +21,6 @@ test.describe('Checkout', () => {
 		{
 			product: 'TierThree',
 			ratePlan: 'DomesticMonthly',
-			paymentType: 'Credit/Debit card',
-			internationalisationId: 'UK',
-		},
-		{
-			product: 'GuardianLight',
-			ratePlan: 'Monthly',
 			paymentType: 'Credit/Debit card',
 			internationalisationId: 'UK',
 		},

--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -26,6 +26,7 @@ const setUserDetailsForProduct = async (
 ) => {
 	switch (product) {
 		case 'SupporterPlus':
+		case 'GuardianLight':
 			await setTestUserRequiredDetails(page, email(), firstName(), lastName());
 
 			break;


### PR DESCRIPTION
## What are you doing in this PR?

Add e2e Playwright tests for Guardian Ad-Lite, like we have for other products, so that we find out quickly if there are issues affecting users purchasing this product.
1. Add Smoke (`UK,Monthly,CC`) Guardian Light Test - GitHub Action Uon Build
2. Add Cron (`UK,Monthly`PayPal`) Guardian Light Test - GitHub Action Every Period

NOTE: 

- We will be in the process of renaming the product `guardianLight` to `guardianAdLite`. After this occurs, this product will be renamed.
- Preceeds Thankyou page work (as its in design currently)

[**Trello Card**](https://trello.com/c/zxHg6b8m/1274-prepare-guardian-light-e2e-playwright-tests)

## How to test

{within `.../support-e2e`}

Cmd-Line Results->
- `yarn test-smoke`
- `yarn test-cron`

Chromium Playwright Interface->
- `yarn test-smoke-ui`
- `yarn test-cron-ui`

## Screenshots

|cron|smoke|
|-----|-----|
|![image](https://github.com/user-attachments/assets/3d7bae48-128e-4826-aa6c-3971fb88c432)|![image](https://github.com/user-attachments/assets/ee820150-e20d-4f59-b2a4-7707a8cd5d98)|


