### PR TITLE
Add fields required for Guardian Ad Lite thank you email

### DIFF
--- a/support-workers/src/main/scala/com/gu/emailservices/GuardianLightEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/GuardianLightEmailFields.scala
@@ -1,16 +1,46 @@
 package com.gu.emailservices
 
+import com.gu.emailservices.SubscriptionEmailFieldHelpers.formatDate
+import com.gu.support.workers.{
+  ClonedDirectDebitPaymentMethod,
+  CreditCardReferenceTransaction,
+  DirectDebitPaymentMethod,
+  PayPalReferenceTransaction,
+  PaymentMethod,
+  SepaPaymentMethod,
+}
 import com.gu.support.workers.states.SendThankYouEmailState.SendThankYouEmailGuardianLightState
+import org.joda.time.DateTime
+import com.gu.zuora.subscriptionBuilders.GuardianLightSubscriptionBuilder
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class GuardianLightEmailFields {
+class GuardianLightEmailFields(created: DateTime) {
   def build(
       state: SendThankYouEmailGuardianLightState,
   )(implicit ec: ExecutionContext): Future[EmailFields] = {
-    // TODO: populate this when we know what's needed
-    val fields = List()
+    val subscription_details = SubscriptionEmailFieldHelpers
+      .describe(state.paymentSchedule, state.product.billingPeriod, state.product.currency)
+
+    val fields = List(
+      "zuorasubscriberid" -> state.subscriptionNumber,
+      "email_address" -> state.user.primaryEmailAddress,
+      "billing_period" -> state.product.billingPeriod.toString.toLowerCase,
+      "first_payment_date" -> formatDate(
+        created.plusDays(GuardianLightSubscriptionBuilder.gracePeriodInDays).toLocalDate,
+      ),
+      "payment_method" -> paymentMethodName(state.paymentMethod),
+      "subscription_details" -> subscription_details,
+    )
 
     Future.successful(EmailFields(fields, state.user, "guardian-light"))
+  }
+
+  private def paymentMethodName(method: PaymentMethod): String = method match {
+    case _: DirectDebitPaymentMethod => "Direct Debit"
+    case _: ClonedDirectDebitPaymentMethod => "Direct Debit"
+    case _: SepaPaymentMethod => "SEPA"
+    case _: PayPalReferenceTransaction => "PayPal"
+    case _: CreditCardReferenceTransaction => "credit / debit card"
   }
 }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -79,7 +79,7 @@ class EmailBuilder(
       created = DateTime.now(),
     )
     val tierThreeEmailFields = new TierThreeEmailFields(paperFieldsGenerator, touchpointEnvironment)
-    val guardianLightEmailFields = new GuardianLightEmailFields()
+    val guardianLightEmailFields = new GuardianLightEmailFields(created = DateTime.now())
 
     state match {
       case contribution: SendThankYouEmailContributionState => contributionEmailFields.build(contribution).map(List(_))

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/GuardianLightSubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/GuardianLightSubscriptionBuilder.scala
@@ -21,14 +21,12 @@ class GuardianLightSubscriptionBuilder(
     val productRatePlanId = {
       validateRatePlan(guardianLightRatePlan(state.product, environment), state.product.describe)
     }
-    // The user isn't charged until day 15
-    val gracePeriodInDays = 15
 
     val todaysDate = dateGenerator.today
     val subscriptionData = subscribeItemBuilder.buildProductSubscription(
       productRatePlanId = productRatePlanId,
       contractEffectiveDate = todaysDate,
-      contractAcceptanceDate = todaysDate.plusDays(gracePeriodInDays),
+      contractAcceptanceDate = todaysDate.plusDays(GuardianLightSubscriptionBuilder.gracePeriodInDays),
       readerType = Direct,
       csrUsername = csrUsername,
       salesforceCaseId = salesforceCaseId,
@@ -36,4 +34,9 @@ class GuardianLightSubscriptionBuilder(
 
     subscribeItemBuilder.build(subscriptionData, state.salesForceContact, Some(state.paymentMethod), None)
   }
+}
+
+object GuardianLightSubscriptionBuilder {
+  // The user isn't charged until day 15
+  val gracePeriodInDays = 15
 }


### PR DESCRIPTION
## What are you doing in this PR?

This PR adds the fields required for the thank you email. These will be provided as API trigger properties to the Braze campaign.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/wfrlwilG/1268-guardian-ad-lite-thank-you-and-failure-emails)

## Why are you doing this?

Currently Guardian Ad-Lite emails are not configured and we want to send thank you emails to users who purchase.

## How to test

I've deployed this PR and guardian/membership-workflow#561 to CODE and made a purchase. The email triggered successfully.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
