### PR TITLE
Set 'hide support messaging' cookie for one time contributors

### DIFF
--- a/support-frontend/assets/helpers/storage/contributionsCookies.ts
+++ b/support-frontend/assets/helpers/storage/contributionsCookies.ts
@@ -1,14 +1,12 @@
 import { set } from './cookie';
 
-const ONE_OFF_CONTRIBUTION_COOKIE_NAME = 'gu.contributions.contrib-timestamp';
-const ONE_OFF_CONTRIBUTION_COOKIE_NAME_DAYS_TO_LIVE = 365;
+const HIDE_SUPPORT_MESSAGING_COOKIE_NAME = 'gu_hide_support_messaging';
+const HIDE_SUPPORT_MESSAGING_COOKIE_DAYS_TO_LIVE = 90;
 
-export const setOneOffContributionCookie = (): void => {
-	const currentTimeInEpochMilliseconds: number = Date.now();
-
+export const setHideSupportMessagingCookie = (): void => {
 	set(
-		ONE_OFF_CONTRIBUTION_COOKIE_NAME,
-		currentTimeInEpochMilliseconds.toString(),
-		ONE_OFF_CONTRIBUTION_COOKIE_NAME_DAYS_TO_LIVE,
+		HIDE_SUPPORT_MESSAGING_COOKIE_NAME,
+		'true',
+		HIDE_SUPPORT_MESSAGING_COOKIE_DAYS_TO_LIVE,
 	);
 };

--- a/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/supporterPlusThankYou.tsx
@@ -22,7 +22,7 @@ import { DirectDebit, PayPal } from 'helpers/forms/paymentMethods';
 import { getPromotion } from 'helpers/productPrice/promotions';
 import { getContributionType } from 'helpers/redux/checkout/product/selectors/productType';
 import { useContributionsSelector } from 'helpers/redux/storeHooks';
-import { setOneOffContributionCookie } from 'helpers/storage/contributionsCookies';
+import { setHideSupportMessagingCookie } from 'helpers/storage/contributionsCookies';
 import { getSession } from 'helpers/storage/storage';
 import { getThresholdPrice } from 'helpers/supporterPlus/benefitsThreshold';
 import {
@@ -206,7 +206,7 @@ export function SupporterPlusThankYou({
 		);
 
 		if (contributionType === 'ONE_OFF') {
-			setOneOffContributionCookie();
+			setHideSupportMessagingCookie();
 		}
 	}, []);
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We want to stop working out user benefits from what products they have and instead delegate that to the user-benefits api.

As part of this work we no longer want to set a cookie to inform dotcom that a user has made a one time contribution, but instead set the 'hide support messaging' cookie which tells DCR & support-dotcom-components to show fewer support asks.

This PR works in combination with: https://github.com/guardian/dotcom-rendering/pull/13037