### PR TITLE
Remove utility types package and replace all usages of $Keys

### DIFF
--- a/support-frontend/assets/components/button/_sharedButton.tsx
+++ b/support-frontend/assets/components/button/_sharedButton.tsx
@@ -1,7 +1,6 @@
 // ----- Imports ----- //
 import type { ReactNode } from 'react';
 import { createElement } from 'react';
-import type { $Keys } from 'utility-types';
 import SvgArrowRightStraight from 'components/svgs/arrowRightStraight';
 import { classNameWithModifiers } from 'helpers/utilities/utilities';
 import './button.scss';
@@ -22,8 +21,8 @@ export const Sides = {
 	right: 'right',
 	left: 'left',
 };
-type Appearance = $Keys<typeof Appearances>;
-type IconSide = $Keys<typeof Sides>;
+type Appearance = keyof typeof Appearances;
+type IconSide = keyof typeof Sides;
 
 /* **********************************************************************
 Note: postDeploymentTestID will be prefixed with 'qa' to indicate it is

--- a/support-frontend/assets/components/content/content.tsx
+++ b/support-frontend/assets/components/content/content.tsx
@@ -1,6 +1,5 @@
 // ----- Imports ----- //
 import type { ReactNode } from 'react';
-import type { $Keys } from 'utility-types';
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import { classNameWithModifiers } from 'helpers/utilities/utilities';
 import 'helpers/types/option';
@@ -18,7 +17,8 @@ export const Sides = {
 	right: 'right',
 	left: 'left',
 };
-export type Appearance = $Keys<typeof Appearances>;
+export type Appearance = keyof typeof Appearances;
+
 type PropTypes = {
 	appearance: Appearance;
 	id?: string;

--- a/support-frontend/assets/helpers/images/theGrid.ts
+++ b/support-frontend/assets/helpers/images/theGrid.ts
@@ -1,4 +1,3 @@
-import type { $Keys } from 'utility-types';
 import catalogue from './imageCatalogue.json';
 // ----- Types ----- //
 export type ImageType = 'jpg' | 'png';
@@ -6,7 +5,7 @@ export type ImageType = 'jpg' | 'png';
 export const GRID_DOMAIN = 'https://i.guim.co.uk';
 export const imageCatalogue: Record<string, string> = catalogue;
 // Utility type: https://flow.org/en/docs/types/utilities/#toc-keys
-export type ImageId = $Keys<typeof imageCatalogue>;
+export type ImageId = keyof typeof imageCatalogue;
 // ----- Functions ----- //
 /**
  * Builds a fastly-image-service url from and id and an image size.

--- a/support-frontend/assets/helpers/internationalisation/country.ts
+++ b/support-frontend/assets/helpers/internationalisation/country.ts
@@ -1,9 +1,3 @@
-// ----- Imports ----- //
-
-import type { $Keys } from 'utility-types';
-
-// ----- Setup ----- //
-
 const usStates: Record<string, string> = {
 	AL: 'Alabama',
 	AK: 'Alaska',
@@ -599,9 +593,9 @@ const countries: Record<IsoCountry, string> = {
 	SH: 'Saint Helena',
 };
 // ----- Types ----- //
-export type UsState = $Keys<typeof usStates>;
-export type CaState = $Keys<typeof caStates>;
-export type AuState = $Keys<typeof auStates>;
+export type UsState = keyof typeof usStates;
+export type CaState = keyof typeof caStates;
+export type AuState = keyof typeof auStates;
 export type StateProvince = UsState;
 // Annoyingly, this isn't Stripe's documentation, but if you try and submit
 // a country that isn't on this list, you get an error

--- a/support-frontend/assets/helpers/tracking/acquisitions.ts
+++ b/support-frontend/assets/helpers/tracking/acquisitions.ts
@@ -1,7 +1,6 @@
 // ----- Imports ----- //
 
 import { viewId } from 'ophan';
-import type { $Keys } from 'utility-types';
 import { type Participations, testIsActive } from 'helpers/abTests/abtest';
 import { get as getCookie } from 'helpers/storage/cookie';
 import * as storage from 'helpers/storage/storage';
@@ -87,7 +86,7 @@ const campaigns: Record<string, string[]> = {
 	banner_just_one_just_one: ['banner_just_one_just_one'],
 };
 
-export type Campaign = $Keys<typeof campaigns>;
+export type Campaign = keyof typeof campaigns;
 
 // ----- Functions ----- //
 

--- a/support-frontend/assets/helpers/user/details.ts
+++ b/support-frontend/assets/helpers/user/details.ts
@@ -1,5 +1,3 @@
-import type { $Keys } from 'utility-types';
-
 export const titles: Record<string, string> = {
 	Ms: 'Ms',
 	Mr: 'Mr',
@@ -10,4 +8,4 @@ export const titles: Record<string, string> = {
 	Prof: 'Prof',
 	Rev: 'Rev',
 };
-export type Title = $Keys<typeof titles>;
+export type Title = keyof typeof titles;

--- a/support-frontend/assets/pages/aus-moment-map/hooks/useWindowWidth.ts
+++ b/support-frontend/assets/pages/aus-moment-map/hooks/useWindowWidth.ts
@@ -1,5 +1,4 @@
 import * as React from 'preact/compat';
-import type { $Keys } from 'utility-types';
 
 const breakpoints = {
 	mobile: 320,
@@ -12,7 +11,7 @@ const breakpoints = {
 	wide: 1300,
 };
 
-type Breakpoint = $Keys<typeof breakpoints>;
+type Breakpoint = keyof typeof breakpoints;
 
 export const useWindowWidth = (): Record<
 	string,

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -115,7 +115,6 @@
 		"seedrandom": "^3.0.5",
 		"snarkdown": "^2.0.0",
 		"tsx": "^4.19.2",
-		"utility-types": "^3.10.0",
 		"uuid": "^9.0.0",
 		"valibot": "^0.31.0",
 		"zod": "^3.22.4"

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -11880,11 +11880,6 @@ utila@~0.4:
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
   integrity sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=
 
-utility-types@^3.10.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.10.0.tgz#ea4148f9a741015f05ed74fd615e1d20e6bed82b"
-  integrity sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==
-
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Remove utility types package and replace all usages of $Keys with keyof

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


## Why are you doing this?

I noticed we had this dependency which only seemed to serve one purpose, which can be done with native Typescript

<!--
Remember, PRs are documentation for future contributors.
-->

