### PR TITLE
Copy change to headline and subhead for final countdown

### DIFF
--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -82,7 +82,7 @@ const campaigns: Record<string, CampaignSettings> = {
 			headingFragment: <>Protect </>,
 			subheading: (
 				<>
-					We're not owned by a billionaire or or profit-driven corporation: our
+					We're not owned by a billionaire or profit-driven corporation: our
 					fiercely independent journalism is funded by our readers. We welcome
 					all year-end gifts, but monthly giving makes the most impact (and you
 					can cancel anytime). Thank you.

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -82,9 +82,10 @@ const campaigns: Record<string, CampaignSettings> = {
 			headingFragment: <>Protect </>,
 			subheading: (
 				<>
-					We're not owned by a billionaire or or profit-driven corporation: our fiercely
-					independent journalism is funded by our readers. We welcome all year-end gifts, but monthly giving makes
-					the most impact (and you can cancel anytime). Thank you.
+					We're not owned by a billionaire or or profit-driven corporation: our
+					fiercely independent journalism is funded by our readers. We welcome
+					all year-end gifts, but monthly giving makes the most impact (and you
+					can cancel anytime). Thank you.
 				</>
 			),
 			oneTimeHeading: <>Choose your gift amount</>,

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -69,7 +69,7 @@ const campaigns: Record<string, CampaignSettings> = {
 				},
 			},
 			{
-				label: 'Last chance to support us this year',
+				label: 'Last chance to support our appeal',
 				countdownStartInMillis: Date.parse('Dec 20, 2024 00:01:00'),
 				countdownDeadlineInMillis: Date.parse('Dec 31, 2024 23:59:59'),
 				theme: {
@@ -82,9 +82,9 @@ const campaigns: Record<string, CampaignSettings> = {
 			headingFragment: <>Protect </>,
 			subheading: (
 				<>
-					We're not owned by a billionaire or shareholders: our fiercely
-					independent journalism is funded by our readers. Monthly giving makes
-					the most impact. <strong>You can cancel anytime.</strong>
+					We're not owned by a billionaire or or profit-driven corporation: our fiercely
+					independent journalism is funded by our readers. We welcome all year-end gifts, but monthly giving makes
+					the most impact (and you can cancel anytime). Thank you.
 				</>
 			),
 			oneTimeHeading: <>Choose your gift amount</>,


### PR DESCRIPTION
## What are you doing in this PR?

There has been a last minute request to change the headline and copy for the US end of year campaign.

[**Trello Card**](https://trello.com/c/t5guJPxW)

## How to test

Run locally or deploy to code and use the ?forceCampaign=usEoy2024 campaign parameter to force the campaign.

## Screenshots

### Before

<img width="750" alt="Screenshot 2024-12-24 at 11 11 45" src="https://github.com/user-attachments/assets/72477989-e496-4bd4-9226-c747b3f06197" />

### After

<img width="733" alt="Screenshot 2024-12-24 at 11 56 35" src="https://github.com/user-attachments/assets/845c4e2c-cc66-4c45-a62c-fa5ce936896e" />
