### PR TITLE
Extend client side input validation to reject all emojis

### DIFF
--- a/support-frontend/assets/helpers/__tests__/validationTest.ts
+++ b/support-frontend/assets/helpers/__tests__/validationTest.ts
@@ -1,6 +1,11 @@
 import { doesNotContainExtendedEmojiOrLeadingSpace } from 'pages/[countryGroupId]/validation';
 
-const regexToValidate = new RegExp(doesNotContainExtendedEmojiOrLeadingSpace);
+const regexToValidate = new RegExp(
+	doesNotContainExtendedEmojiOrLeadingSpace,
+	// The v flag here replicates the way a pattern attribute is used in an input element
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern#overview
+	'v',
+);
 
 describe('validateRegex', () => {
 	it('leading space', () => {
@@ -8,10 +13,26 @@ describe('validateRegex', () => {
 		expect('z z').toMatch(regexToValidate);
 	});
 	it('pictographic', () => {
-		expect('\\p✈️z').not.toMatch(regexToValidate);
+		expect('✈️z').not.toMatch(regexToValidate);
 	});
 	it('combined', () => {
-		expect(' z\\p✈️z').not.toMatch(regexToValidate);
-		expect('\\p✈️ z').not.toMatch(regexToValidate);
+		expect(' z✈️z').not.toMatch(regexToValidate);
+		expect('✈️ z').not.toMatch(regexToValidate);
+	});
+
+	it('does not match a string consisting of only a Pictographic', () => {
+		expect('★').not.toMatch(regexToValidate);
+	});
+
+	it('does not match a string containing a Pictographic', () => {
+		expect('hello ★ hello').not.toMatch(regexToValidate);
+	});
+
+	it('does not match a string containing only an emoji', () => {
+		expect('🇲🇾').not.toMatch(regexToValidate);
+	});
+
+	it('does not match a string containing an emoji', () => {
+		expect('hello 🇲🇾 hello ').not.toMatch(regexToValidate);
 	});
 });

--- a/support-frontend/assets/pages/[countryGroupId]/validation.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/validation.ts
@@ -19,4 +19,4 @@ export function preventDefaultValidityMessage(
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape
  */
 export const doesNotContainExtendedEmojiOrLeadingSpace =
-	'^[^\\p{Extended_Pictographic}\\s][^\\p{Extended_Pictographic}]*$';
+	'^[^\\p{Extended_Pictographic}\\p{Emoji_Presentation}\\s][^\\p{Extended_Pictographic}\\p{Emoji_Presentation}]*$';


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Extending the checkout client side input validation to reject all emojis.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

## Why are you doing this?

We had a case in prod where an emoji made it to the backend (and was correctly rejected). However we expected this to be rejected in the client side validation. It turns out that some emojis don't match `Extended_Pictographic` so the regex which said "anything other than `Extended_Pictographic`" let it through. We now reject `Extended_Pictographic` and `Emoji_Presentation`.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

I've extended the tests and checked in CODE.

### Before

Emoji character accepted by client side validation:

![Screenshot 2024-12-30 at 12 09 19](https://github.com/user-attachments/assets/accc3448-bc5f-4e6e-968b-973c2bd14161)

### After

Emoji character rejected by client side validation:

![Screenshot 2024-12-30 at 12 05 45](https://github.com/user-attachments/assets/24628c90-b0b0-4a37-835d-72b86198b38f)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
