### PR TITLE
Remove overlay if one time card payment fails server side

### DIFF
--- a/support-e2e/tests/test/oneTimeCheckout.ts
+++ b/support-e2e/tests/test/oneTimeCheckout.ts
@@ -3,13 +3,23 @@ import { email, firstName, lastName } from '../utils/users';
 import { setupPage } from '../utils/page';
 import { setTestUserRequiredDetails } from '../utils/testUserDetails';
 import { fillInPayPalDetails } from '../utils/paypal';
-import { fillInCardDetails } from '../utils/cardDetails';
+import {
+	fillInCardDetails,
+	fillInDeclinedCardDetails,
+} from '../utils/cardDetails';
 import { checkRecaptcha } from '../utils/recaptcha';
 
 type TestDetails = {
 	paymentType: string;
 	internationalisationId: string;
 };
+
+const submitForm = (page) =>
+	page
+		.getByRole('button', {
+			name: ` with `,
+		})
+		.click();
 
 export const testOneTimeCheckout = (testDetails: TestDetails) => {
 	const { internationalisationId, paymentType } = testDetails;
@@ -25,15 +35,22 @@ export const testOneTimeCheckout = (testDetails: TestDetails) => {
 		await page.getByRole('radio', { name: paymentType }).check();
 
 		if (paymentType === 'Credit/Debit card') {
+			// First check that a failed card payment behaves as expected
+			await fillInDeclinedCardDetails(page);
+			await checkRecaptcha(page);
+
+			await submitForm(page);
+
+			await expect(page.getByText('Sorry, something went wrong')).toBeVisible({
+				timeout: 30000,
+			});
+
+			// Now fill in with good card details
 			await fillInCardDetails(page);
 			await checkRecaptcha(page);
 		}
 
-		await page
-			.getByRole('button', {
-				name: ` with `,
-			})
-			.click();
+		await submitForm(page);
 
 		if (paymentType === 'PayPal') {
 			await expect(page).toHaveURL(/.*paypal.com/, { timeout: 600000 });

--- a/support-e2e/tests/utils/cardDetails.ts
+++ b/support-e2e/tests/utils/cardDetails.ts
@@ -1,9 +1,9 @@
 import { Page } from '@playwright/test';
 
-export const fillInCardDetails = async (page: Page) =>
+export const fillInCardDetails = (page: Page) =>
 	fillInCardDetailsWithNumber(page, '4242424242424242');
 
-export const fillInDeclinedCardDetails = async (page: Page) =>
+export const fillInDeclinedCardDetails = (page: Page) =>
 	fillInCardDetailsWithNumber(page, '4000000000000002');
 
 const fillInCardDetailsWithNumber = async (page: Page, cardNumber: string) => {

--- a/support-e2e/tests/utils/cardDetails.ts
+++ b/support-e2e/tests/utils/cardDetails.ts
@@ -1,12 +1,18 @@
 import { Page } from '@playwright/test';
 
-export const fillInCardDetails = async (page: Page) => {
+export const fillInCardDetails = async (page: Page) =>
+	fillInCardDetailsWithNumber(page, '4242424242424242');
+
+export const fillInDeclinedCardDetails = async (page: Page) =>
+	fillInCardDetailsWithNumber(page, '4000000000000002');
+
+const fillInCardDetailsWithNumber = async (page: Page, cardNumber: string) => {
 	// it would be nice to use aria style selectors here, but given Stripes
 	// very secure implementation, it is quite hard
 	await page
 		.frameLocator("iframe[title='Secure card number input frame']")
 		.locator('input[name="cardnumber"]')
-		.fill('4242424242424242');
+		.fill(cardNumber);
 
 	await page
 		.frameLocator("iframe[title='Secure expiration date input frame']")

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -482,6 +482,7 @@ export function OneTimeCheckoutComponent({
 					) {
 						setErrorContext(appropriateErrorMessage(paymentResult.error ?? ''));
 					}
+					setIsProcessingPayment(false);
 				}
 			} else {
 				setIsProcessingPayment(false);


### PR DESCRIPTION
## What are you doing in this PR?

Ensure that the overlay is cleared on the one time checkout if a card payment fails server side.

## Why are you doing this?

Previously we noticed that if there was a server side failure on the one time checkout, you'd see an error message but the "processing payment" overlay would remain up, which meant you couldn't interact with the form to fix whatever the problem was.

We've also added some playwright coverage for this scenario.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

We've added some playwright test coverage and tested in the browser.

I've also deployed this branch to CODE and put through a card and PayPal transaction.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
