### PR TITLE
Add min amount validation to server side one time payments

### DIFF
--- a/support-payment-api/src/main/scala/model/Currency.scala
+++ b/support-payment-api/src/main/scala/model/Currency.scala
@@ -4,6 +4,10 @@ import enumeratum.{CirceEnum, Enum, EnumEntry}
 
 import scala.collection.immutable.IndexedSeq
 
+case class Range(min: BigDecimal, max: BigDecimal) {
+  def contains(amount: BigDecimal): Boolean = (amount >= min) && (amount <= max)
+}
+
 // Models currencies supported by the API
 sealed trait Currency extends EnumEntry
 
@@ -24,12 +28,15 @@ object Currency extends Enum[Currency] with CirceEnum[Currency] {
   case object NZD extends Currency
 
   def exceedsMaxAmount(amount: BigDecimal, currency: Currency): Boolean = {
-    val maxAmount = currency match {
-      case AUD => 16000
-      case USD => 10000
-      case _ => 2000
-    }
     // Users can opt in to add 4% to cover the transaction cost
-    amount > maxAmount * 1.04
+    val transactionCostAsPercentage = 1.04
+
+    val currencyRange = currency match {
+      case AUD => Range(min = 1, max = 16000 * transactionCostAsPercentage)
+      case USD => Range(min = 1, max = 10000 * transactionCostAsPercentage)
+      case _ => Range(min = 1, max = 2000 * transactionCostAsPercentage)
+    }
+
+    !currencyRange.contains(amount)
   }
 }

--- a/support-payment-api/src/main/scala/model/Currency.scala
+++ b/support-payment-api/src/main/scala/model/Currency.scala
@@ -27,7 +27,7 @@ object Currency extends Enum[Currency] with CirceEnum[Currency] {
 
   case object NZD extends Currency
 
-  def exceedsMaxAmount(amount: BigDecimal, currency: Currency): Boolean = {
+  def isAmountOutOfBounds(amount: BigDecimal, currency: Currency): Boolean = {
     // Users can opt in to add 4% to cover the transaction cost
     val transactionCostAsPercentage = 1.04
 

--- a/support-payment-api/src/main/scala/services/PaypalService.scala
+++ b/support-payment-api/src/main/scala/services/PaypalService.scala
@@ -26,7 +26,7 @@ class PaypalService(config: PaypalConfig)(implicit pool: PaypalThreadPool) exten
 
   def createPayment(createPaypalPaymentData: CreatePaypalPaymentData): PaypalResult[Payment] = {
     if (model.Currency.isAmountOutOfBounds(createPaypalPaymentData.amount, createPaypalPaymentData.currency)) {
-      Left(PaypalApiError.fromString("Amount exceeds the maximum allowed ")).toEitherT[Future]
+      Left(PaypalApiError.fromString("Amount is outside the allowed range ")).toEitherT[Future]
     } else {
       Either
         .catchNonFatal {

--- a/support-payment-api/src/main/scala/services/PaypalService.scala
+++ b/support-payment-api/src/main/scala/services/PaypalService.scala
@@ -25,7 +25,7 @@ trait Paypal {
 class PaypalService(config: PaypalConfig)(implicit pool: PaypalThreadPool) extends Paypal with StrictLogging {
 
   def createPayment(createPaypalPaymentData: CreatePaypalPaymentData): PaypalResult[Payment] = {
-    if (model.Currency.exceedsMaxAmount(createPaypalPaymentData.amount, createPaypalPaymentData.currency)) {
+    if (model.Currency.isAmountOutOfBounds(createPaypalPaymentData.amount, createPaypalPaymentData.currency)) {
       Left(PaypalApiError.fromString("Amount exceeds the maximum allowed ")).toEitherT[Future]
     } else {
       Either

--- a/support-payment-api/src/main/scala/services/StripeService.scala
+++ b/support-payment-api/src/main/scala/services/StripeService.scala
@@ -46,7 +46,7 @@ class SingleAccountStripeService(config: StripeAccountConfig)(implicit pool: Str
 
   def createCharge(data: LegacyStripeChargeRequest): EitherT[Future, StripeApiError, Charge] = {
     if (model.Currency.isAmountOutOfBounds(data.paymentData.amount, data.paymentData.currency)) {
-      Left(StripeApiError.fromString("Amount exceeds the maximum allowed ", Some(config.publicKey))).toEitherT[Future]
+      Left(StripeApiError.fromString("Amount is outside the allowed range ", Some(config.publicKey))).toEitherT[Future]
     } else {
       Future(Charge.create(getChargeParams(data), requestOptions)).attemptT
         .bimap(
@@ -80,7 +80,7 @@ class SingleAccountStripeService(config: StripeAccountConfig)(implicit pool: Str
       data: StripePaymentIntentRequest.CreatePaymentIntent,
   ): EitherT[Future, StripeApiError, PaymentIntent] = {
     if (model.Currency.isAmountOutOfBounds(data.paymentData.amount, data.paymentData.currency)) {
-      Left(StripeApiError.fromString("Amount exceeds the maximum allowed ", Some(config.publicKey))).toEitherT[Future]
+      Left(StripeApiError.fromString("Amount is outside the allowed range ", Some(config.publicKey))).toEitherT[Future]
     } else
       {
         Future {

--- a/support-payment-api/src/main/scala/services/StripeService.scala
+++ b/support-payment-api/src/main/scala/services/StripeService.scala
@@ -45,7 +45,7 @@ class SingleAccountStripeService(config: StripeAccountConfig)(implicit pool: Str
     ).asJava
 
   def createCharge(data: LegacyStripeChargeRequest): EitherT[Future, StripeApiError, Charge] = {
-    if (model.Currency.exceedsMaxAmount(data.paymentData.amount, data.paymentData.currency)) {
+    if (model.Currency.isAmountOutOfBounds(data.paymentData.amount, data.paymentData.currency)) {
       Left(StripeApiError.fromString("Amount exceeds the maximum allowed ", Some(config.publicKey))).toEitherT[Future]
     } else {
       Future(Charge.create(getChargeParams(data), requestOptions)).attemptT
@@ -79,7 +79,7 @@ class SingleAccountStripeService(config: StripeAccountConfig)(implicit pool: Str
   def createPaymentIntent(
       data: StripePaymentIntentRequest.CreatePaymentIntent,
   ): EitherT[Future, StripeApiError, PaymentIntent] = {
-    if (model.Currency.exceedsMaxAmount(data.paymentData.amount, data.paymentData.currency)) {
+    if (model.Currency.isAmountOutOfBounds(data.paymentData.amount, data.paymentData.currency)) {
       Left(StripeApiError.fromString("Amount exceeds the maximum allowed ", Some(config.publicKey))).toEitherT[Future]
     } else
       {

--- a/support-payment-api/src/test/scala/model/CurrencyTest.scala
+++ b/support-payment-api/src/test/scala/model/CurrencyTest.scala
@@ -8,7 +8,7 @@ class CurrencyTest extends AnyFlatSpec with Matchers {
     Currency.isAmountOutOfBounds(2100, Currency.GBP) mustBe true
   }
 
-  it should "return false if the amount is below the allowed range" in {
+  it should "return true if the amount is below the allowed range" in {
     Currency.isAmountOutOfBounds(0.5, Currency.GBP) mustBe true
   }
 

--- a/support-payment-api/src/test/scala/model/CurrencyTest.scala
+++ b/support-payment-api/src/test/scala/model/CurrencyTest.scala
@@ -5,18 +5,18 @@ import org.scalatest.matchers.must.Matchers
 
 class CurrencyTest extends AnyFlatSpec with Matchers {
   "exceedsMaxAmount" should "return true if the amount is greater than the allowed range" in {
-    Currency.exceedsMaxAmount(2100, Currency.GBP) mustBe true
+    Currency.isAmountOutOfBounds(2100, Currency.GBP) mustBe true
   }
 
   it should "return false if the amount is below the allowed range" in {
-    Currency.exceedsMaxAmount(0.5, Currency.GBP) mustBe true
+    Currency.isAmountOutOfBounds(0.5, Currency.GBP) mustBe true
   }
 
   it should "return false if the amount is within the allowed range" in {
-    Currency.exceedsMaxAmount(100, Currency.GBP) mustBe false
+    Currency.isAmountOutOfBounds(100, Currency.GBP) mustBe false
   }
 
   it should "allow the max to be 4% larger than the value specified to allow for covering transaction cost" in {
-    Currency.exceedsMaxAmount(2080, Currency.GBP) mustBe false
+    Currency.isAmountOutOfBounds(2080, Currency.GBP) mustBe false
   }
 }

--- a/support-payment-api/src/test/scala/model/CurrencyTest.scala
+++ b/support-payment-api/src/test/scala/model/CurrencyTest.scala
@@ -1,0 +1,22 @@
+package model
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+
+class CurrencyTest extends AnyFlatSpec with Matchers {
+  "exceedsMaxAmount" should "return true if the amount is greater than the allowed range" in {
+    Currency.exceedsMaxAmount(2100, Currency.GBP) mustBe true
+  }
+
+  it should "return false if the amount is below the allowed range" in {
+    Currency.exceedsMaxAmount(0.5, Currency.GBP) mustBe true
+  }
+
+  it should "return false if the amount is within the allowed range" in {
+    Currency.exceedsMaxAmount(100, Currency.GBP) mustBe false
+  }
+
+  it should "allow the max to be 4% larger than the value specified to allow for covering transaction cost" in {
+    Currency.exceedsMaxAmount(2080, Currency.GBP) mustBe false
+  }
+}

--- a/support-payment-api/src/test/scala/model/CurrencyTest.scala
+++ b/support-payment-api/src/test/scala/model/CurrencyTest.scala
@@ -16,7 +16,7 @@ class CurrencyTest extends AnyFlatSpec with Matchers {
     Currency.isAmountOutOfBounds(100, Currency.GBP) mustBe false
   }
 
-  it should "allow the max to be 4% larger than the value specified to allow for covering transaction cost" in {
+  it should "allow the amount to be 4% larger than the nominal max to allow for covering transaction cost" in {
     Currency.isAmountOutOfBounds(2080, Currency.GBP) mustBe false
   }
 }

--- a/support-payment-api/src/test/scala/services/PaypalServiceSpec.scala
+++ b/support-payment-api/src/test/scala/services/PaypalServiceSpec.scala
@@ -114,14 +114,14 @@ class PaypalServiceSpec extends AnyFlatSpec with Matchers with MockitoSugar with
   it should "return an error if the payment amount exceeds Australia max" in new PaypalServiceTestFixture {
     val createPaypalPaymentData = CreatePaypalPaymentData(Currency.AUD, 16640.50, "url", "url")
     whenReady(paypalService.createPayment(createPaypalPaymentData).value) { result =>
-      result mustBe (Left(PaypalApiError.fromString("Amount exceeds the maximum allowed ")))
+      result mustBe (Left(PaypalApiError.fromString("Amount is outside the allowed range ")))
     }
   }
 
   it should "return an error if the payment amount exceeds non-Australia max" in new PaypalServiceTestFixture {
     val createPaypalPaymentData = CreatePaypalPaymentData(Currency.GBP, 2080.50, "url", "url")
     whenReady(paypalService.createPayment(createPaypalPaymentData).value) { result =>
-      result mustBe (Left(PaypalApiError.fromString("Amount exceeds the maximum allowed ")))
+      result mustBe (Left(PaypalApiError.fromString("Amount is outside the allowed range ")))
     }
   }
 


### PR DESCRIPTION
## What are you doing in this PR?

Add min amount validation to the payment API for one time contributions.

[**Trello Card**](https://trello.com/c/NXeDtm19/1305-min-max-amount-server-side-validation)

## Why are you doing this?

We already have client side validation for this, but we'd like to enforce server side too as this makes us more robust.

## How to test

I've tested this in CODE. In order to do this I had to temporarily remove the client side validation. The error message we show in this case is quite generic, but I think in general we don't expect users to hit this as the client side validation should kick in before the request even makes it to the backend.

Stripe:
<img width="617" alt="Screenshot 2025-01-06 at 13 49 26" src="https://github.com/user-attachments/assets/18f5c3f9-7a7f-41fc-8c70-24833169f64f" />

PayPal:
<img width="602" alt="Screenshot 2025-01-06 at 13 50 21" src="https://github.com/user-attachments/assets/b24c47a0-06f3-4a30-bc7e-a1eedff97130" />

If we need to, perhaps we could follow up with a more contextual error message in another PR.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
