### PR TITLE
Landing Page: Move ad-free benefit from tier2 to tier3 - ab-test enable

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -152,7 +152,7 @@ export const tests: Tests = {
 				size: 1,
 			},
 		},
-		isActive: false,
+		isActive: true,
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 6,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,


### PR DESCRIPTION
## What are you doing in this PR?

Enables the AB-Test in the `Move ad-free benefit from tier2 to tier3` [PR](https://github.com/guardian/support-frontend/pull/6637)

