### PR TITLE
Can we lazy load below the fold?

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/paymentSection.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/paymentSection.tsx
@@ -1,0 +1,201 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/source/foundations';
+import { Radio, RadioGroup } from '@guardian/source/react-components';
+import DirectDebitForm from 'components/directDebit/directDebitForm/directDebitForm';
+import { paymentMethodData } from 'components/paymentMethodSelector/paymentMethodData';
+import { Recaptcha } from 'components/recaptcha/recaptcha';
+import { SecureTransactionIndicator } from 'components/secureTransactionIndicator/secureTransactionIndicator';
+import { StripeCardForm } from 'components/stripeCardForm/stripeCardForm';
+import type { PaymentMethod } from 'helpers/forms/paymentMethods';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { sendEventPaymentMethodSelected } from 'helpers/tracking/quantumMetric';
+import { stripeCreateSetupIntentRecaptcha } from '../checkout/helpers/stripe';
+import { FormSection, Legend } from './form';
+import {
+	checkedRadioLabelColour,
+	defaultRadioLabelColour,
+	paymentMethodBody,
+	PaymentMethodRadio,
+	PaymentMethodSelector,
+} from './paymentMethod';
+
+export type PaymentSectionProps = {
+	validPaymentMethods: PaymentMethod[];
+	paymentMethodError: string | undefined;
+	setPaymentMethodError: (error: string | undefined) => void;
+	setStripeClientSecret: (clientSecret: string) => void;
+	setStripeClientSecretInProgress: (inProgress: boolean) => void;
+	recaptchaToken: string | undefined;
+	setRecaptchaToken: (token: string | undefined) => void;
+	accountHolderName: string;
+	setAccountHolderName: (name: string) => void;
+	accountNumber: string;
+	setAccountNumber: (number: string) => void;
+	sortCode: string;
+	setSortCode: (sortCode: string) => void;
+	accountHolderConfirmation: boolean;
+	setAccountHolderConfirmation: (confirmation: boolean) => void;
+	paymentMethod: PaymentMethod | 'StripeExpressCheckoutElement' | undefined;
+	setPaymentMethod: (paymentMethod: PaymentMethod) => void;
+	sectionNumber: number;
+	stripePublicKey: string;
+	isTestUser: boolean;
+	countryGroupId: CountryGroupId;
+};
+
+export default function PaymentSection({
+	validPaymentMethods,
+	paymentMethodError,
+	setPaymentMethodError,
+	setStripeClientSecret,
+	setStripeClientSecretInProgress,
+	recaptchaToken,
+	setRecaptchaToken,
+	accountHolderName,
+	setAccountHolderName,
+	accountNumber,
+	setAccountNumber,
+	sortCode,
+	setSortCode,
+	accountHolderConfirmation,
+	setAccountHolderConfirmation,
+	paymentMethod,
+	setPaymentMethod,
+	sectionNumber,
+	stripePublicKey,
+	isTestUser,
+	countryGroupId,
+}: PaymentSectionProps) {
+	return (
+		<FormSection>
+			<Legend>
+				{sectionNumber}. Payment method
+				<SecureTransactionIndicator hideText={true} cssOverrides={css``} />
+			</Legend>
+
+			<RadioGroup
+				role="radiogroup"
+				label="Select payment method"
+				hideLabel
+				error={paymentMethodError}
+			>
+				{validPaymentMethods.map((validPaymentMethod) => {
+					const selected = paymentMethod === validPaymentMethod;
+					const { label, icon } = paymentMethodData[validPaymentMethod];
+					return (
+						<PaymentMethodSelector selected={selected}>
+							<PaymentMethodRadio selected={selected}>
+								<Radio
+									label={
+										<>
+											{label}
+											<div>{icon}</div>
+										</>
+									}
+									name="paymentMethod"
+									value={validPaymentMethod}
+									cssOverrides={
+										selected ? checkedRadioLabelColour : defaultRadioLabelColour
+									}
+									onChange={() => {
+										setPaymentMethod(validPaymentMethod);
+										setPaymentMethodError(undefined);
+										// Track payment method selection with QM
+										sendEventPaymentMethodSelected(validPaymentMethod);
+									}}
+								/>
+							</PaymentMethodRadio>
+							{validPaymentMethod === 'Stripe' && selected && (
+								<div css={paymentMethodBody}>
+									<input
+										type="hidden"
+										name="recaptchaToken"
+										value={recaptchaToken}
+									/>
+									<StripeCardForm
+										onCardNumberChange={() => {
+											// no-op
+										}}
+										onExpiryChange={() => {
+											// no-op
+										}}
+										onCvcChange={() => {
+											// no-op
+										}}
+										errors={{}}
+										recaptcha={
+											<Recaptcha
+												// We could change the parents type to Promise and use await here, but that has
+												// a lot of refactoring with not too much gain
+												onRecaptchaCompleted={(token) => {
+													setStripeClientSecretInProgress(true);
+													setRecaptchaToken(token);
+													void stripeCreateSetupIntentRecaptcha(
+														isTestUser,
+														stripePublicKey,
+														token,
+													).then((client_secret) => {
+														setStripeClientSecret(client_secret);
+														setStripeClientSecretInProgress(false);
+													});
+												}}
+												onRecaptchaExpired={() => {
+													setRecaptchaToken(undefined);
+												}}
+											/>
+										}
+									/>
+								</div>
+							)}
+
+							{validPaymentMethod === 'DirectDebit' && selected && (
+								<div
+									css={css`
+										padding: ${space[5]}px ${space[3]}px ${space[6]}px;
+									`}
+								>
+									<DirectDebitForm
+										countryGroupId={countryGroupId}
+										accountHolderName={accountHolderName}
+										accountNumber={accountNumber}
+										accountHolderConfirmation={accountHolderConfirmation}
+										sortCode={sortCode}
+										recaptchaCompleted={false}
+										updateAccountHolderName={(name: string) => {
+											setAccountHolderName(name);
+										}}
+										updateAccountNumber={(number: string) => {
+											setAccountNumber(number);
+										}}
+										updateSortCode={(sortCode: string) => {
+											setSortCode(sortCode);
+										}}
+										updateAccountHolderConfirmation={(
+											confirmation: boolean,
+										) => {
+											setAccountHolderConfirmation(confirmation);
+										}}
+										recaptcha={
+											<Recaptcha
+												// We could change the parents type to Promise and uses await here, but that has
+												// a lot of refactoring with not too much gain
+												onRecaptchaCompleted={(token) => {
+													setRecaptchaToken(token);
+												}}
+												onRecaptchaExpired={() => {
+													setRecaptchaToken(undefined);
+												}}
+											/>
+										}
+										formError={''}
+										errors={{}}
+									/>
+								</div>
+							)}
+						</PaymentMethodSelector>
+					);
+				})}
+			</RadioGroup>
+		</FormSection>
+	);
+}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
