### PR TITLE
Update the US default copy

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -559,23 +559,29 @@ export function ThreeTierLanding({
 							campaignSettings,
 						)}
 					</h1>
-          {countryGroupId !=="UnitedStates" &&  <p css={standFirst}>
-						{campaignSettings?.copy.subheading ?? (
-							<>
-								We're not owned by a billionaire or shareholders - our readers
-								support us. Choose to join with one of the options below.{' '}
-								<strong>Cancel anytime.</strong>
-							</>
-						)}
-					</p>}
-          {countryGroupId==="UnitedStates" && <p css={standFirst}>
-            {	campaignSettings?.copy.subheading ??  (
-              <>
-                We're not owned by a billionaire or profit-driven corporation: our fiercely independent journalism
-                is funded by our readers. Monthly giving makes the most impact (and you can cancel anytime). Thank you.
-              </>
-            )}
-          </p>}
+					{countryGroupId !== 'UnitedStates' && (
+						<p css={standFirst}>
+							{campaignSettings?.copy.subheading ?? (
+								<>
+									We're not owned by a billionaire or shareholders - our readers
+									support us. Choose to join with one of the options below.{' '}
+									<strong>Cancel anytime.</strong>
+								</>
+							)}
+						</p>
+					)}
+					{countryGroupId === 'UnitedStates' && (
+						<p css={standFirst}>
+							{campaignSettings?.copy.subheading ?? (
+								<>
+									We're not owned by a billionaire or profit-driven corporation:
+									our fiercely independent journalism is funded by our readers.
+									Monthly giving makes the most impact (and you can cancel
+									anytime). Thank you.
+								</>
+							)}
+						</p>
+					)}
 					{campaignSettings?.tickerSettings && (
 						<TickerContainer tickerSettings={campaignSettings.tickerSettings} />
 					)}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -559,7 +559,7 @@ export function ThreeTierLanding({
 							campaignSettings,
 						)}
 					</h1>
-					<p css={standFirst}>
+          {countryGroupId !=="UnitedStates" &&  <p css={standFirst}>
 						{campaignSettings?.copy.subheading ?? (
 							<>
 								We're not owned by a billionaire or shareholders - our readers
@@ -567,7 +567,15 @@ export function ThreeTierLanding({
 								<strong>Cancel anytime.</strong>
 							</>
 						)}
-					</p>
+					</p>}
+          {countryGroupId==="UnitedStates" && <p css={standFirst}>
+            {	campaignSettings?.copy.subheading ??  (
+              <>
+                We're not owned by a billionaire or profit-driven corporation: our fiercely independent journalism
+                is funded by our readers. Monthly giving makes the most impact (and you can cancel anytime). Thank you.
+              </>
+            )}
+          </p>}
 					{campaignSettings?.tickerSettings && (
 						<TickerContainer tickerSettings={campaignSettings.tickerSettings} />
 					)}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This is to change the default copy in subheading for  US  post usEoy2024 campaign and after removing ticker

Change subheading for US  to:
We're not owned by a billionaire or profit-driven corporation: our fiercely independent journalism is funded by our readers. Monthly giving makes the most impact (and you can cancel anytime). Thank you.

[**Trello Card**](https://trello.com/c/Nw6Z4dG0/868-remove-ticker-on-us-lp-and-change-to-default-copy)


## How to test
Tested in CODE


## Screenshots

## Before Change while  usEoy2024 campaign is running
<img width="1373" alt="image" src="https://github.com/user-attachments/assets/70a165ef-0226-4ee9-b504-d4d4a59c5d31" />

## Before Change when no usEoy2024 campaign is running
<img width="1373" alt="image" src="https://github.com/user-attachments/assets/389c8132-1a41-4494-96d0-fef14ee566dc" />

## After Change  when no usEoy2024 campaign is running

<img width="1373" alt="image" src="https://github.com/user-attachments/assets/3030ff05-6236-4d1b-8bc9-810d2052ab5b" />
