### PR TITLE
Initialise ab participations once

### DIFF
--- a/support-frontend/assets/helpers/page/page.ts
+++ b/support-frontend/assets/helpers/page/page.ts
@@ -14,7 +14,16 @@ import {
 import { getReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import { getSettings } from '../globalsAndSwitches/globals';
 
-function setUpTrackingAndConsents(): void {
+function setUpTrackingAndConsents(participations: Participations): void {
+	const countryId: IsoCountry = Country.detect();
+	const acquisitionData = getReferrerAcquisitionData();
+
+	void consentInitialisation(countryId);
+	analyticsInitialisation(participations, acquisitionData);
+	sendConsentToOphan();
+}
+
+function getAbParticipations(): Participations {
 	const settings = getSettings();
 	const countryId: IsoCountry = Country.detect();
 	const countryGroupId: CountryGroupId = CountryGroup.detect();
@@ -22,21 +31,18 @@ function setUpTrackingAndConsents(): void {
 		countryId,
 		countryGroupId,
 	};
+
 	const participations: Participations = abTest.init(abtestInitalizerData);
 	const { amountsParticipation } = getAmountsTestVariant(
 		countryId,
 		countryGroupId,
 		settings,
 	);
-	const participationsWithAmountsTest = {
+	return {
 		...participations,
 		...amountsParticipation,
 	};
-	const acquisitionData = getReferrerAcquisitionData();
-	void consentInitialisation(countryId);
-	analyticsInitialisation(participationsWithAmountsTest, acquisitionData);
-	sendConsentToOphan();
 }
 
 // ----- Exports ----- //
-export { setUpTrackingAndConsents };
+export { getAbParticipations, setUpTrackingAndConsents };

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -14,16 +14,18 @@ import { sendEventCheckoutValue } from 'helpers/tracking/quantumMetric';
 import { logException } from 'helpers/utilities/logger';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
+import type { Participations } from '../../helpers/abTests/abtest';
 import { CheckoutComponent } from './components/checkoutComponent';
 
 type Props = {
 	geoId: GeoId;
 	appConfig: AppConfig;
+	abParticipations: Participations;
 };
 
 const countryId: IsoCountry = Country.detect();
 
-export function Checkout({ geoId, appConfig }: Props) {
+export function Checkout({ geoId, appConfig, abParticipations }: Props) {
 	const { currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 	const urlSearchParams = new URLSearchParams(window.location.search);
 
@@ -268,6 +270,7 @@ export function Checkout({ geoId, appConfig }: Props) {
 				countryId={countryId}
 				forcedCountry={forcedCountry}
 				returnLink={returnLink}
+				abParticipations={abParticipations}
 			/>
 		</Elements>
 	);

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -39,10 +39,8 @@ import { StripeCardForm } from 'components/stripeCardForm/stripeCardForm';
 import { AddressFields } from 'components/subscriptionCheckouts/address/addressFields';
 import type { PostcodeFinderResult } from 'components/subscriptionCheckouts/address/postcodeLookup';
 import { findAddressesForPostcode } from 'components/subscriptionCheckouts/address/postcodeLookup';
-import {
-	init as abTestInit,
-	getAmountsTestVariant,
-} from 'helpers/abTests/abtest';
+import type { Participations } from 'helpers/abTests/abtest';
+import { getAmountsTestVariant } from 'helpers/abTests/abtest';
 import { isContributionsOnlyCountry } from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import {
@@ -210,6 +208,7 @@ type CheckoutComponentProps = {
 	countryId: IsoCountry;
 	forcedCountry?: string;
 	returnLink?: string;
+	abParticipations: Participations;
 };
 
 export function CheckoutComponent({
@@ -227,6 +226,7 @@ export function CheckoutComponent({
 	countryId,
 	forcedCountry,
 	returnLink,
+	abParticipations,
 }: CheckoutComponentProps) {
 	/** we unset any previous orders that have been made */
 	unsetThankYouOrder();
@@ -238,7 +238,6 @@ export function CheckoutComponent({
 	const productCatalog = appConfig.productCatalog;
 	const { currency, currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 
-	const abParticipations = abTestInit({ countryId, countryGroupId });
 	const showNewspaperArchiveBenefit = ['v1', 'v2', 'control'].includes(
 		abParticipations.newspaperArchiveBenefit ?? '',
 	);

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -33,10 +33,8 @@ import { Recaptcha } from 'components/recaptcha/recaptcha';
 import { SecureTransactionIndicator } from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import Signout from 'components/signout/signout';
 import { StripeCardForm } from 'components/stripeCardForm/stripeCardForm';
-import {
-	init as abTestInit,
-	getAmountsTestVariant,
-} from 'helpers/abTests/abtest';
+import type { Participations } from 'helpers/abTests/abtest';
+import { getAmountsTestVariant } from 'helpers/abTests/abtest';
 import { config } from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import { appropriateErrorMessage } from 'helpers/forms/errorReasons';
@@ -142,6 +140,7 @@ type OneTimeCheckoutComponentProps = {
 	appConfig: AppConfig;
 	stripePublicKey: string;
 	countryId: IsoCountry;
+	abParticipations: Participations;
 };
 
 function paymentMethodIsActive(paymentMethod: PaymentMethod) {
@@ -201,6 +200,7 @@ export function OneTimeCheckoutComponent({
 	appConfig,
 	stripePublicKey,
 	countryId,
+	abParticipations,
 }: OneTimeCheckoutComponentProps) {
 	const { currency, currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 	const urlSearchParams = new URLSearchParams(window.location.search);
@@ -216,8 +216,6 @@ export function OneTimeCheckoutComponent({
 		countryGroupId,
 		settings,
 	);
-
-	const abParticipations = abTestInit({ countryId, countryGroupId });
 
 	const { amountsCardData } = selectedAmountsVariant;
 	const { amounts, defaultAmount, hideChooseYourAmount } =

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -9,7 +9,7 @@ import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
 import type { ThankYouModuleType } from 'components/thankYou/thankYouModule';
 import { getThankYouModuleData } from 'components/thankYou/thankYouModuleData';
-import { init as abTestInit } from 'helpers/abTests/abtest';
+import type { Participations } from 'helpers/abTests/abtest';
 import type { ContributionType } from 'helpers/contributions';
 import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import { Country } from 'helpers/internationalisation/classes/country';
@@ -93,6 +93,7 @@ export type CheckoutComponentProps = {
 	promotion?: Promotion;
 	returnLink?: string;
 	identityUserType: UserType;
+	abParticipations: Participations;
 };
 
 export function ThankYouComponent({
@@ -103,6 +104,7 @@ export function ThankYouComponent({
 	promotion,
 	returnLink,
 	identityUserType,
+	abParticipations,
 }: CheckoutComponentProps) {
 	const countryId = Country.fromString(get('GU_country') ?? 'GB') ?? 'GB';
 	const user = getUser();
@@ -208,7 +210,6 @@ export function ThankYouComponent({
 	const isSupporterPlus = productKey === 'SupporterPlus';
 	const isTier3 = productKey === 'TierThree';
 	const validEmail = order.email !== '';
-	const abParticipations = abTestInit({ countryId, countryGroupId });
 	const showNewspaperArchiveBenefit = ['v1', 'v2', 'control'].includes(
 		abParticipations.newspaperArchiveBenefit ?? '',
 	);

--- a/support-frontend/assets/pages/[countryGroupId]/events/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/router.tsx
@@ -1,10 +1,13 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import { setUpTrackingAndConsents } from 'helpers/page/page';
+import {
+	getAbParticipations,
+	setUpTrackingAndConsents,
+} from 'helpers/page/page';
 import { renderPage } from 'helpers/rendering/render';
 import { geoIds } from 'pages/geoIdConfig';
 import { Events } from './events';
 
-setUpTrackingAndConsents();
+setUpTrackingAndConsents(getAbParticipations());
 const router = createBrowserRouter(
 	geoIds.flatMap((geoId) => [
 		{

--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -6,6 +6,7 @@ import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import { Country } from 'helpers/internationalisation/classes/country';
 import * as cookie from 'helpers/storage/cookie';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
+import type { Participations } from '../../helpers/abTests/abtest';
 import { OneTimeCheckoutComponent } from './components/oneTimeCheckoutComponent';
 
 const countryId = Country.detect();
@@ -13,9 +14,14 @@ const countryId = Country.detect();
 type OneTimeCheckoutProps = {
 	geoId: GeoId;
 	appConfig: AppConfig;
+	abParticipations: Participations;
 };
 
-export function OneTimeCheckout({ geoId, appConfig }: OneTimeCheckoutProps) {
+export function OneTimeCheckout({
+	geoId,
+	appConfig,
+	abParticipations,
+}: OneTimeCheckoutProps) {
 	const { currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 	const isTestUser = !!cookie.get('_test_username');
 
@@ -48,6 +54,7 @@ export function OneTimeCheckout({ geoId, appConfig }: OneTimeCheckoutProps) {
 				appConfig={appConfig}
 				stripePublicKey={stripePublicKey}
 				countryId={countryId}
+				abParticipations={abParticipations}
 			/>
 		</Elements>
 	);

--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -1,6 +1,9 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { parseAppConfig } from 'helpers/globalsAndSwitches/window';
-import { setUpTrackingAndConsents } from 'helpers/page/page';
+import {
+	getAbParticipations,
+	setUpTrackingAndConsents,
+} from 'helpers/page/page';
 import { renderPage } from 'helpers/rendering/render';
 import { geoIds } from 'pages/geoIdConfig';
 import { Checkout } from './checkout';
@@ -8,22 +11,41 @@ import { GuardianAdLiteLanding } from './guardianAdLiteLanding/guardianAdLiteLan
 import { OneTimeCheckout } from './oneTimeCheckout';
 import { ThankYou } from './thankYou';
 
-setUpTrackingAndConsents();
+const abParticipations = getAbParticipations();
+setUpTrackingAndConsents(abParticipations);
 const appConfig = parseAppConfig(window.guardian);
 
 const router = createBrowserRouter(
 	geoIds.flatMap((geoId) => [
 		{
 			path: `/${geoId}/checkout`,
-			element: <Checkout geoId={geoId} appConfig={appConfig} />,
+			element: (
+				<Checkout
+					geoId={geoId}
+					appConfig={appConfig}
+					abParticipations={abParticipations}
+				/>
+			),
 		},
 		{
 			path: `/${geoId}/one-time-checkout`,
-			element: <OneTimeCheckout geoId={geoId} appConfig={appConfig} />,
+			element: (
+				<OneTimeCheckout
+					geoId={geoId}
+					appConfig={appConfig}
+					abParticipations={abParticipations}
+				/>
+			),
 		},
 		{
 			path: `/${geoId}/thank-you`,
-			element: <ThankYou geoId={geoId} appConfig={appConfig} />,
+			element: (
+				<ThankYou
+					geoId={geoId}
+					appConfig={appConfig}
+					abParticipations={abParticipations}
+				/>
+			),
 		},
 		{
 			path: `/${geoId}/guardian-light`,

--- a/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
@@ -8,14 +8,20 @@ import type { UserType } from 'helpers/redux/checkout/personalDetails/state';
 import { logException } from 'helpers/utilities/logger';
 import { roundToDecimalPlaces } from 'helpers/utilities/utilities';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
+import type { Participations } from '../../helpers/abTests/abtest';
 import { ThankYouComponent } from './components/thankYouComponent';
 
 export type ThankYouProps = {
 	geoId: GeoId;
 	appConfig: AppConfig;
+	abParticipations: Participations;
 };
 
-export function ThankYou({ geoId, appConfig }: ThankYouProps) {
+export function ThankYou({
+	geoId,
+	appConfig,
+	abParticipations,
+}: ThankYouProps) {
 	const countryId = Country.detect();
 	const { currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 
@@ -160,6 +166,7 @@ export function ThankYou({ geoId, appConfig }: ThankYouProps) {
 			promotion={promotion}
 			identityUserType={userType}
 			returnLink={urlSearchParamsReturn}
+			abParticipations={abParticipations}
 		/>
 	);
 }

--- a/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionRouter.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionRouter.tsx
@@ -2,7 +2,10 @@
 import { Provider } from 'react-redux';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
-import { setUpTrackingAndConsents } from 'helpers/page/page';
+import {
+	getAbParticipations,
+	setUpTrackingAndConsents,
+} from 'helpers/page/page';
 import { isDetailsSupported, polyfillDetails } from 'helpers/polyfills/details';
 import { initReduxForContributions } from 'helpers/redux/contributionsStore';
 import { renderPage } from 'helpers/rendering/render';
@@ -14,7 +17,7 @@ if (!isDetailsSupported) {
 	polyfillDetails();
 }
 
-setUpTrackingAndConsents();
+setUpTrackingAndConsents(getAbParticipations());
 
 // ----- Redux Store ----- //
 

--- a/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionRouter.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-checkout/digitalSubscriptionRouter.tsx
@@ -2,10 +2,7 @@
 import { Provider } from 'react-redux';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
-import {
-	getAbParticipations,
-	setUpTrackingAndConsents,
-} from 'helpers/page/page';
+import { setUpTrackingAndConsents } from 'helpers/page/page';
 import { isDetailsSupported, polyfillDetails } from 'helpers/polyfills/details';
 import { initReduxForContributions } from 'helpers/redux/contributionsStore';
 import { renderPage } from 'helpers/rendering/render';
@@ -17,11 +14,11 @@ if (!isDetailsSupported) {
 	polyfillDetails();
 }
 
-setUpTrackingAndConsents(getAbParticipations());
-
 // ----- Redux Store ----- //
 
 const store = initReduxForContributions();
+
+setUpTrackingAndConsents(store.getState().common.abParticipations);
 
 // Brute force override of the Sepa switch, as we can't accept Sepa for digi sub payments
 window.guardian.settings = {

--- a/support-frontend/assets/pages/error/error404.tsx
+++ b/support-frontend/assets/pages/error/error404.tsx
@@ -4,7 +4,7 @@ import { renderPage } from 'helpers/rendering/render';
 import ErrorPage from './components/errorPage';
 
 // ----- Page Startup ----- //
-setUpTrackingAndConsents();
+setUpTrackingAndConsents({});
 
 // ----- Render ----- //
 const content = (

--- a/support-frontend/assets/pages/error/error500.tsx
+++ b/support-frontend/assets/pages/error/error500.tsx
@@ -4,7 +4,7 @@ import { renderPage } from 'helpers/rendering/render';
 import ErrorPage from './components/errorPage';
 
 // ----- Page Startup ----- //
-setUpTrackingAndConsents();
+setUpTrackingAndConsents({});
 
 // ----- Render ----- //
 const content = (

--- a/support-frontend/assets/pages/error/maintenance.tsx
+++ b/support-frontend/assets/pages/error/maintenance.tsx
@@ -4,7 +4,7 @@ import { renderPage } from 'helpers/rendering/render';
 import ErrorPage from './components/errorPage';
 
 // ----- Page Startup ----- //
-setUpTrackingAndConsents();
+setUpTrackingAndConsents({});
 
 // ----- Render ----- //
 const content = (

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.tsx
@@ -5,10 +5,7 @@ import Footer from 'components/footerCompliant/Footer';
 import Page from 'components/page/page';
 import HeaderWrapper from 'components/subscriptionCheckouts/headerWrapper';
 import CheckoutStage from 'components/subscriptionCheckouts/stage';
-import {
-	getAbParticipations,
-	setUpTrackingAndConsents,
-} from 'helpers/page/page';
+import { setUpTrackingAndConsents } from 'helpers/page/page';
 import { Monthly } from 'helpers/productPrice/billingPeriods';
 import { Paper } from 'helpers/productPrice/subscriptions';
 import { initReduxForSubscriptions } from 'helpers/redux/subscriptionsStore';
@@ -23,7 +20,6 @@ import ThankYouContent from './components/thankYou';
 import 'stylesheets/skeleton/skeleton.scss';
 import './_legacyImports.scss';
 
-setUpTrackingAndConsents(getAbParticipations());
 // ----- Redux Store ----- //
 const fulfilmentOption = getFulfilmentOption();
 const productOption = getProductOption();
@@ -36,6 +32,8 @@ const store = initReduxForSubscriptions(
 	productOption,
 	getFulfilmentOption,
 );
+
+setUpTrackingAndConsents(store.getState().common.abParticipations);
 
 const { countryGroupId } = store.getState().common.internationalisation;
 FocusStyleManager.onlyShowFocusOnTabs();

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.tsx
@@ -5,7 +5,10 @@ import Footer from 'components/footerCompliant/Footer';
 import Page from 'components/page/page';
 import HeaderWrapper from 'components/subscriptionCheckouts/headerWrapper';
 import CheckoutStage from 'components/subscriptionCheckouts/stage';
-import { setUpTrackingAndConsents } from 'helpers/page/page';
+import {
+	getAbParticipations,
+	setUpTrackingAndConsents,
+} from 'helpers/page/page';
 import { Monthly } from 'helpers/productPrice/billingPeriods';
 import { Paper } from 'helpers/productPrice/subscriptions';
 import { initReduxForSubscriptions } from 'helpers/redux/subscriptionsStore';
@@ -20,7 +23,7 @@ import ThankYouContent from './components/thankYou';
 import 'stylesheets/skeleton/skeleton.scss';
 import './_legacyImports.scss';
 
-setUpTrackingAndConsents();
+setUpTrackingAndConsents(getAbParticipations());
 // ----- Redux Store ----- //
 const fulfilmentOption = getFulfilmentOption();
 const productOption = getProductOption();

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
@@ -10,7 +10,10 @@ import Header from 'components/headers/header/header';
 import Block from 'components/page/block';
 import Page from 'components/page/page';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
-import { setUpTrackingAndConsents } from 'helpers/page/page';
+import {
+	getAbParticipations,
+	setUpTrackingAndConsents,
+} from 'helpers/page/page';
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import {
 	Collection,
@@ -108,7 +111,7 @@ function PaperLandingPage({
 	);
 }
 
-setUpTrackingAndConsents();
+setUpTrackingAndConsents(getAbParticipations());
 const content = <PaperLandingPage {...paperLandingProps()} />;
 renderPage(content);
 export { content };

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
@@ -111,7 +111,8 @@ function PaperLandingPage({
 	);
 }
 
-setUpTrackingAndConsents(getAbParticipations());
-const content = <PaperLandingPage {...paperLandingProps()} />;
+const abParticipations = getAbParticipations();
+setUpTrackingAndConsents(abParticipations);
+const content = <PaperLandingPage {...paperLandingProps(abParticipations)} />;
 renderPage(content);
 export { content };

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingProps.ts
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingProps.ts
@@ -1,11 +1,8 @@
 import type { Participations } from 'helpers/abTests/abtest';
-import { init as initAbTests } from 'helpers/abTests/abtest';
 import {
 	getProductPrices,
 	getPromotionCopy,
 } from 'helpers/globalsAndSwitches/globals';
-import { Country } from 'helpers/internationalisation/classes/country';
-import { CountryGroup } from 'helpers/internationalisation/classes/countryGroup';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import type { PromotionCopy } from 'helpers/productPrice/promotions';
 
@@ -15,15 +12,10 @@ export type PaperLandingPropTypes = {
 	participations: Participations;
 };
 
-const countryGroupId = CountryGroup.detect();
-
-const abtestInitalizerData = {
-	countryId: Country.detect(),
-	countryGroupId,
-};
-
-export const paperLandingProps = (): PaperLandingPropTypes => ({
+export const paperLandingProps = (
+	participations: Participations,
+): PaperLandingPropTypes => ({
 	productPrices: getProductPrices(),
 	promotionCopy: getPromotionCopy(),
-	participations: initAbTests(abtestInitalizerData),
+	participations,
 });

--- a/support-frontend/assets/pages/paypal-error/payPalError.tsx
+++ b/support-frontend/assets/pages/paypal-error/payPalError.tsx
@@ -9,7 +9,7 @@ import { CountryGroup } from 'helpers/internationalisation/classes/countryGroup'
 import { setUpTrackingAndConsents } from 'helpers/page/page';
 import { renderPage } from 'helpers/rendering/render';
 // ----- Page Startup ----- //
-setUpTrackingAndConsents();
+setUpTrackingAndConsents({});
 // ----- Render ----- //
 const content = (
 	<Page

--- a/support-frontend/assets/pages/promotion-terms/promotionTerms.tsx
+++ b/support-frontend/assets/pages/promotion-terms/promotionTerms.tsx
@@ -2,7 +2,10 @@ import Footer from 'components/footerCompliant/Footer';
 import Header from 'components/headers/header/header';
 import Page from 'components/page/page';
 import { CountryGroup } from 'helpers/internationalisation/classes/countryGroup';
-import { setUpTrackingAndConsents } from 'helpers/page/page';
+import {
+	getAbParticipations,
+	setUpTrackingAndConsents,
+} from 'helpers/page/page';
 import type { PromotionTerms } from 'helpers/productPrice/promotions';
 import {
 	DigitalPack,
@@ -15,7 +18,7 @@ import type { PromotionTermsPropTypes } from './promotionTermsReducer';
 import getPromotionTermsProps from './promotionTermsReducer';
 import './promotionTerms.scss';
 
-setUpTrackingAndConsents();
+setUpTrackingAndConsents(getAbParticipations());
 
 function getTermsConditionsLink({ product }: PromotionTerms) {
 	if (product === DigitalPack) {

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
@@ -34,5 +34,8 @@ function SubscriptionsLandingPage({
 	);
 }
 
-setUpTrackingAndConsents(getAbParticipations());
-renderPage(<SubscriptionsLandingPage {...subscriptionsLandingProps()} />);
+const abParticipations = getAbParticipations();
+setUpTrackingAndConsents(abParticipations);
+renderPage(
+	<SubscriptionsLandingPage {...subscriptionsLandingProps(abParticipations)} />,
+);

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.tsx
@@ -2,7 +2,10 @@
 import Footer from 'components/footerCompliant/Footer';
 import Header from 'components/headers/header/header';
 import Page from 'components/page/page';
-import { setUpTrackingAndConsents } from 'helpers/page/page';
+import {
+	getAbParticipations,
+	setUpTrackingAndConsents,
+} from 'helpers/page/page';
 import { renderPage } from 'helpers/rendering/render';
 import './subscriptionsLanding.scss';
 import SubscriptionLandingContent from './components/subscriptionsLandingContent';
@@ -31,5 +34,5 @@ function SubscriptionsLandingPage({
 	);
 }
 
-setUpTrackingAndConsents();
+setUpTrackingAndConsents(getAbParticipations());
 renderPage(<SubscriptionsLandingPage {...subscriptionsLandingProps()} />);

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLandingProps.ts
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLandingProps.ts
@@ -1,8 +1,6 @@
 // ----- Imports ----- //
 import type { Participations } from 'helpers/abTests/abtest';
-import { init as initAbTests } from 'helpers/abTests/abtest';
 import { getGlobal } from 'helpers/globalsAndSwitches/globals';
-import { Country } from 'helpers/internationalisation/classes/country';
 import { CountryGroup } from 'helpers/internationalisation/classes/countryGroup';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { SubscriptionProduct } from 'helpers/productPrice/subscriptions';
@@ -21,13 +19,12 @@ export type SubscriptionsLandingPropTypes = {
 	referrerAcquisitions: ReferrerAcquisitionData;
 };
 const countryGroupId = CountryGroup.detect();
-const abtestInitalizerData = {
-	countryId: Country.detect(),
+
+export const subscriptionsLandingProps = (
+	participations: Participations,
+): SubscriptionsLandingPropTypes => ({
 	countryGroupId,
-};
-export const subscriptionsLandingProps = (): SubscriptionsLandingPropTypes => ({
-	countryGroupId,
-	participations: initAbTests(abtestInitalizerData),
+	participations,
 	pricingCopy: getGlobal('pricingCopy'),
 	referrerAcquisitions: getReferrerAcquisitionData(),
 });

--- a/support-frontend/assets/pages/subscriptions-redemption/subscriptionsRedemption.tsx
+++ b/support-frontend/assets/pages/subscriptions-redemption/subscriptionsRedemption.tsx
@@ -2,7 +2,10 @@ import { Provider } from 'react-redux';
 import Footer from 'components/footerCompliant/Footer';
 import Header from 'components/headers/header/header';
 import Page from 'components/page/page';
-import { setUpTrackingAndConsents } from 'helpers/page/page';
+import {
+	getAbParticipations,
+	setUpTrackingAndConsents,
+} from 'helpers/page/page';
 import { initReduxForRedemption } from 'helpers/redux/redemptionsStore';
 import { renderPage } from 'helpers/rendering/render';
 import 'stylesheets/skeleton/skeleton.scss';
@@ -12,7 +15,7 @@ import ThankYouPendingContent from 'pages/subscriptions-redemption/thankYouPendi
 import CheckoutStage from './components/stage';
 import MarketingConsent from './marketingConsentContainer';
 
-setUpTrackingAndConsents();
+setUpTrackingAndConsents(getAbParticipations());
 
 // ----- Redux Store ----- //
 const store = initReduxForRedemption();

--- a/support-frontend/assets/pages/subscriptions-redemption/subscriptionsRedemption.tsx
+++ b/support-frontend/assets/pages/subscriptions-redemption/subscriptionsRedemption.tsx
@@ -2,10 +2,7 @@ import { Provider } from 'react-redux';
 import Footer from 'components/footerCompliant/Footer';
 import Header from 'components/headers/header/header';
 import Page from 'components/page/page';
-import {
-	getAbParticipations,
-	setUpTrackingAndConsents,
-} from 'helpers/page/page';
+import { setUpTrackingAndConsents } from 'helpers/page/page';
 import { initReduxForRedemption } from 'helpers/redux/redemptionsStore';
 import { renderPage } from 'helpers/rendering/render';
 import 'stylesheets/skeleton/skeleton.scss';
@@ -15,12 +12,12 @@ import ThankYouPendingContent from 'pages/subscriptions-redemption/thankYouPendi
 import CheckoutStage from './components/stage';
 import MarketingConsent from './marketingConsentContainer';
 
-setUpTrackingAndConsents(getAbParticipations());
-
 // ----- Redux Store ----- //
 const store = initReduxForRedemption();
 const state = store.getState();
 const { countryGroupId } = state.common.internationalisation;
+
+setUpTrackingAndConsents(state.common.abParticipations);
 
 const thankyouProps = {
 	countryGroupId,

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -49,7 +49,6 @@ function ScrollToTop(): null {
 
 const commonState = store.getState().common;
 
-// TODO - check this does have everything
 setUpTrackingAndConsents(commonState.abParticipations);
 
 export const inThreeTier = threeTierCheckoutEnabled(

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -23,8 +23,6 @@ if (!isDetailsSupported) {
 	polyfillDetails();
 }
 
-setUpTrackingAndConsents();
-
 // ----- Redux Store ----- //
 
 const countryGroupId: CountryGroupId = CountryGroup.detect();
@@ -50,6 +48,9 @@ function ScrollToTop(): null {
 }
 
 const commonState = store.getState().common;
+
+// TODO - check this does have everything
+setUpTrackingAndConsents(commonState.abParticipations);
 
 export const inThreeTier = threeTierCheckoutEnabled(
 	commonState.abParticipations,

--- a/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/supporterPlusRouter.tsx
@@ -71,7 +71,10 @@ const router = () => {
 								path={`/${countryId}/contribute/:campaignCode?`}
 								element={
 									inThreeTier ? (
-										<ThreeTierLanding geoId={countryId} />
+										<ThreeTierLanding
+											geoId={countryId}
+											abParticipations={commonState.abParticipations}
+										/>
 									) : (
 										<SupporterPlusInitialLandingPage
 											thankYouRoute={thankYouRoute}

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -20,10 +20,8 @@ import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countr
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
 import { PaymentFrequencyButtons } from 'components/paymentFrequencyButtons/paymentFrequencyButtons';
-import {
-	init as abTestInit,
-	getAmountsTestVariant,
-} from 'helpers/abTests/abtest';
+import type { Participations } from 'helpers/abTests/abtest';
+import { getAmountsTestVariant } from 'helpers/abTests/abtest';
 import {
 	countdownSwitchOn,
 	getCampaignSettings,
@@ -265,9 +263,11 @@ function getPlanCost(
 
 type ThreeTierLandingProps = {
 	geoId: GeoId;
+	abParticipations: Participations;
 };
 export function ThreeTierLanding({
 	geoId,
+	abParticipations,
 }: ThreeTierLandingProps): JSX.Element {
 	const urlSearchParams = new URLSearchParams(window.location.search);
 	const urlSearchParamsProduct = urlSearchParams.get('product');
@@ -292,7 +292,6 @@ export function ThreeTierLanding({
 		subPath: '/contribute',
 	};
 
-	const abParticipations = abTestInit({ countryId, countryGroupId });
 	// Persist any tests for tracking in the checkout page
 	storage.setSession('abParticipations', JSON.stringify(abParticipations));
 

--- a/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx
@@ -4,7 +4,10 @@ import { Provider } from 'react-redux';
 import Page from 'components/page/page';
 import HeaderWrapper from 'components/subscriptionCheckouts/headerWrapper';
 import CheckoutStage from 'components/subscriptionCheckouts/stage';
-import { setUpTrackingAndConsents } from 'helpers/page/page';
+import {
+	getAbParticipations,
+	setUpTrackingAndConsents,
+} from 'helpers/page/page';
 import type { WeeklyBillingPeriod } from 'helpers/productPrice/billingPeriods';
 import { getWeeklyFulfilmentOption } from 'helpers/productPrice/fulfilmentOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
@@ -20,7 +23,7 @@ import WeeklyCheckoutForm from './components/weeklyCheckoutForm';
 import WeeklyCheckoutFormGifting from './components/weeklyCheckoutFormGifting';
 import 'stylesheets/skeleton/skeleton.scss';
 
-setUpTrackingAndConsents();
+setUpTrackingAndConsents(getAbParticipations());
 // ----- Redux Store ----- //
 const billingPeriodInUrl = getQueryParameter('period');
 const initialBillingPeriod: WeeklyBillingPeriod =

--- a/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.tsx
@@ -4,10 +4,7 @@ import { Provider } from 'react-redux';
 import Page from 'components/page/page';
 import HeaderWrapper from 'components/subscriptionCheckouts/headerWrapper';
 import CheckoutStage from 'components/subscriptionCheckouts/stage';
-import {
-	getAbParticipations,
-	setUpTrackingAndConsents,
-} from 'helpers/page/page';
+import { setUpTrackingAndConsents } from 'helpers/page/page';
 import type { WeeklyBillingPeriod } from 'helpers/productPrice/billingPeriods';
 import { getWeeklyFulfilmentOption } from 'helpers/productPrice/fulfilmentOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
@@ -23,7 +20,6 @@ import WeeklyCheckoutForm from './components/weeklyCheckoutForm';
 import WeeklyCheckoutFormGifting from './components/weeklyCheckoutFormGifting';
 import 'stylesheets/skeleton/skeleton.scss';
 
-setUpTrackingAndConsents(getAbParticipations());
 // ----- Redux Store ----- //
 const billingPeriodInUrl = getQueryParameter('period');
 const initialBillingPeriod: WeeklyBillingPeriod =
@@ -41,6 +37,8 @@ const store = initReduxForSubscriptions(
 	NoProductOptions,
 	getWeeklyFulfilmentOption,
 );
+
+setUpTrackingAndConsents(store.getState().common.abParticipations);
 
 const { orderIsAGift, productPrices } =
 	store.getState().page.checkoutForm.product;

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -17,7 +17,10 @@ import {
 	NZDCountries,
 	UnitedStates,
 } from 'helpers/internationalisation/countryGroup';
-import { setUpTrackingAndConsents } from 'helpers/page/page';
+import {
+	getAbParticipations,
+	setUpTrackingAndConsents,
+} from 'helpers/page/page';
 import { getPromotionCopy } from 'helpers/productPrice/promotions';
 import { renderPage } from 'helpers/rendering/render';
 import { routes } from 'helpers/urls/routes';
@@ -174,5 +177,5 @@ function WeeklyLandingPage({
 	);
 }
 
-setUpTrackingAndConsents();
+setUpTrackingAndConsents(getAbParticipations());
 renderPage(<WeeklyLandingPage {...weeklyLandingProps()} />);

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -177,5 +177,6 @@ function WeeklyLandingPage({
 	);
 }
 
-setUpTrackingAndConsents(getAbParticipations());
-renderPage(<WeeklyLandingPage {...weeklyLandingProps()} />);
+const abParticipations = getAbParticipations();
+setUpTrackingAndConsents(abParticipations);
+renderPage(<WeeklyLandingPage {...weeklyLandingProps(abParticipations)} />);

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingProps.ts
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingProps.ts
@@ -1,5 +1,4 @@
 import type { Participations } from 'helpers/abTests/abtest';
-import { init as initAbTests } from 'helpers/abTests/abtest';
 import {
 	getGlobal,
 	getProductPrices,
@@ -34,16 +33,14 @@ export type WeeklyLPContentPropTypes = {
 };
 
 const countryGroupId = CountryGroup.detect();
-const abtestInitalizerData = {
-	countryId: Country.detect(),
-	countryGroupId,
-};
 
-export const weeklyLandingProps = (): WeeklyLandingPropTypes => ({
+export const weeklyLandingProps = (
+	participations: Participations,
+): WeeklyLandingPropTypes => ({
 	countryGroupId,
 	countryId: Country.detect(),
 	productPrices: getProductPrices(),
 	promotionCopy: getPromotionCopy(),
 	orderIsAGift: getGlobal('orderIsAGift'),
-	participations: initAbTests(abtestInitalizerData),
+	participations,
 });


### PR DESCRIPTION
The existing `setUpTrackingAndConsents` function calls `abTest.init` in order to register ab tests with ophan.
We then call `abTest.init` again in various places, to decide what to render based on the ab participations.
This means we're running the same logic twice per pageview, and we call `abTest.init` from an awful lot of places.

With this refactor, we instead call `abTest.init` once at the start, and pass this down into the places it's needed.
This means `setUpTrackingAndConsents` now takes a `participations` parameter.

Also, any pages which are still using Redux already have the ab participations available in the store. So in these cases we now use this.

Context: I'm trying to simplify ab test participations logic ahead of some work on the landing page.