### PR TITLE
PROD payment api needs to be able to write to CODE SupporterProductData dynamo table for test users

### DIFF
--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -1715,7 +1715,10 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                 "dynamodb:DescribeTable",
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:dynamodb:*:*:table/SupporterProductData-PROD",
+              "Resource": [
+                "arn:aws:dynamodb:*:*:table/SupporterProductData-PROD",
+                "arn:aws:dynamodb:*:*:table/SupporterProductData-CODE",
+              ],
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -122,9 +122,13 @@ export class PaymentApi extends GuStack {
               "dynamodb:Query",
               "dynamodb:DescribeTable",
             ],
-            resources: [
-              `arn:aws:dynamodb:*:*:table/SupporterProductData-${this.stage}`,
-            ],
+            resources:
+              this.stage === "PROD"
+                ? [
+                    "arn:aws:dynamodb:*:*:table/SupporterProductData-PROD",
+                    "arn:aws:dynamodb:*:*:table/SupporterProductData-CODE",
+                  ]
+                : ["arn:aws:dynamodb:*:*:table/SupporterProductData-CODE"],
           }),
 
           new GuAllowPolicy(this, "CloudwatchLogs", {


### PR DESCRIPTION


<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We are seeing regular errors in the payment-api logs whenever a test user makes a one time contribution. This is because we record these contributions in the SupporterProductData DynamoDB table, and for test users these are written to the CODE version of the table. However currently the PROD app doesn't have permissions to write to the CODE table so there is an exception. This PR fixes the issue.
