### PR TITLE
One-time checkout: prevent large other amount causing error

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -183,12 +183,15 @@ function getFinalAmount(
 	selectedPriceCard: number | 'other',
 	otherAmount: string,
 	minAmount: number,
+	maxAmount: number,
 	coverTransactionCostSelected: boolean,
 ): number | undefined {
 	const transactionMultiplier: number = coverTransactionCostSelected ? 1.04 : 1;
 	if (selectedPriceCard === 'other') {
 		const parsedAmount = parseFloat(otherAmount);
-		return Number.isNaN(parsedAmount) || parsedAmount < minAmount
+		return Number.isNaN(parsedAmount) ||
+			parsedAmount < minAmount ||
+			parsedAmount > maxAmount
 			? undefined
 			: roundToDecimalPlaces(parsedAmount * transactionMultiplier);
 	}
@@ -242,13 +245,20 @@ export function OneTimeCheckoutComponent({
 		useState<boolean>(false);
 
 	const amountWithoutCoverCost =
-		getFinalAmount(selectedPriceCard, otherAmount, minAmount, false) ?? 0;
+		getFinalAmount(
+			selectedPriceCard,
+			otherAmount,
+			minAmount,
+			maxAmount,
+			false,
+		) ?? 0;
 	const transactionCoverCost = amountWithoutCoverCost * 0.04;
 
 	const finalAmount = getFinalAmount(
 		selectedPriceCard,
 		otherAmount,
 		minAmount,
+		maxAmount,
 		coverTransactionCost,
 	);
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Add a max amount check to the 'Other' amount in one time checkout. If it is above the maximum - it does not go into the `finalAmount` variable where it can be used to set the amount in the rest of the page. This stops it reaching Stripe's JS where it could be above the maximum.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/HPxFALFh/1360-revisit-client-side-max-validation-on-amount-field-in-one-time-checkout)


<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Type in a _very_ large number in the other amount, the amount is not listed in the payment button and does not crash the page.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


## Screenshots

Before:
(Above our max)
![image](https://github.com/user-attachments/assets/7699ff8c-897a-44de-a915-7b35ce3f4955)


(Above Stripe's max)
![image](https://github.com/user-attachments/assets/9b74c0ec-d905-45f8-8deb-e3db9e6bf9a9)


After:
![image](https://github.com/user-attachments/assets/3fbad063-26d5-4f31-a174-f5cdc5f5e893)


