### PR TITLE
Create server side test for lazy loading router

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -496,7 +496,7 @@ class Application(
   def productCheckoutRouter(countryGroupId: String) = MaybeAuthenticatedAction { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val geoData = request.geoData
-    val serversideTests = generateParticipations(Nil)
+    val serversideTests = generateParticipations(List("lazyLoading"))
     val isTestUser = testUserService.isTestUser(request)
     // This will be present if the token has been flashed into the session by the PayPal redirect endpoint
     val guestAccountCreationToken = request.flash.get("guestAccountCreationToken")

--- a/support-frontend/app/views/router.scala.html
+++ b/support-frontend/app/views/router.scala.html
@@ -1,4 +1,4 @@
-@import admin.ServersideAbTest.Participation
+@import admin.ServersideAbTest.{Participation, Variant}
 @import assets.RefPath
 @import assets.AssetsResolver
 @import admin.settings.AllSettings
@@ -23,7 +23,7 @@
 @main(
   title = "Support the Guardian | Checkout",
   mainElement = assets.getSsrCacheContentsAsHtml(divId = "router", file = "ssr-holding-content.html"),
-  mainJsBundle = RefPath("[countryGroupId]/router.js"),
+  mainJsBundle = if (serversideTests.get("lazyLoading").contains(Variant)) RefPath("[countryGroupId]/lazyRouter.js")  else RefPath("[countryGroupId]/router.js"),
   mainStyleBundle = None,
   description = Some("Help us deliver the independent journalism the world needs. Support the Guardian by making a contribution."),
   canonicalLink = Some("https://support.theguardian.com/checkout"),

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -275,3 +275,5 @@ export function Checkout({ geoId, appConfig, abParticipations }: Props) {
 		</Elements>
 	);
 }
+
+export default Checkout;

--- a/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/guardianAdLiteLanding.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/guardianAdLiteLanding.tsx
@@ -49,3 +49,5 @@ export function GuardianAdLiteLanding({
 		</LandingPageLayout>
 	);
 }
+
+export default GuardianAdLiteLanding;

--- a/support-frontend/assets/pages/[countryGroupId]/lazyRouter.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/lazyRouter.tsx
@@ -1,0 +1,85 @@
+import { lazy, Suspense } from 'react';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { HoldingContent } from 'components/serverSideRendered/holdingContent';
+import { parseAppConfig } from 'helpers/globalsAndSwitches/window';
+import {
+	getAbParticipations,
+	setUpTrackingAndConsents,
+} from 'helpers/page/page';
+import { renderPage } from 'helpers/rendering/render';
+import { geoIds } from 'pages/geoIdConfig';
+
+const abParticipations = getAbParticipations();
+setUpTrackingAndConsents(abParticipations);
+const appConfig = parseAppConfig(window.guardian);
+
+const Checkout = lazy(
+	() => import(/* webpackChunkName: "checkout" */ './checkout'),
+);
+const OneTimeCheckout = lazy(
+	() => import(/* webpackChunkName: "oneTimeCheckout" */ './oneTimeCheckout'),
+);
+const ThankYou = lazy(
+	() => import(/* webpackChunkName: "ThankYou" */ './thankYou'),
+);
+const GuardianAdLiteLanding = lazy(
+	() =>
+		import(
+			/* webpackChunkName: "GuardianAdLiteLanding" */ './guardianAdLiteLanding/guardianAdLiteLanding'
+		),
+);
+
+const router = createBrowserRouter(
+	geoIds.flatMap((geoId) => [
+		{
+			path: `/${geoId}/checkout`,
+			element: (
+				<Suspense fallback={<HoldingContent />}>
+					<Checkout
+						geoId={geoId}
+						appConfig={appConfig}
+						abParticipations={abParticipations}
+					/>
+				</Suspense>
+			),
+		},
+		{
+			path: `/${geoId}/one-time-checkout`,
+			element: (
+				<Suspense fallback={<HoldingContent />}>
+					<OneTimeCheckout
+						geoId={geoId}
+						appConfig={appConfig}
+						abParticipations={abParticipations}
+					/>
+				</Suspense>
+			),
+		},
+		{
+			path: `/${geoId}/thank-you`,
+			element: (
+				<Suspense fallback={<HoldingContent />}>
+					<ThankYou
+						geoId={geoId}
+						appConfig={appConfig}
+						abParticipations={abParticipations}
+					/>
+				</Suspense>
+			),
+		},
+		{
+			path: `/${geoId}/guardian-light`,
+			element: (
+				<Suspense fallback={<HoldingContent />}>
+					<GuardianAdLiteLanding geoId={geoId} />
+				</Suspense>
+			),
+		},
+	]),
+);
+
+function Router() {
+	return <RouterProvider router={router} />;
+}
+
+export default renderPage(<Router />);

--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -59,3 +59,5 @@ export function OneTimeCheckout({
 		</Elements>
 	);
 }
+
+export default OneTimeCheckout;

--- a/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
@@ -173,3 +173,5 @@ export function ThankYou({
 		/>
 	);
 }
+
+export default ThankYou;

--- a/support-frontend/webpack.entryPoints.js
+++ b/support-frontend/webpack.entryPoints.js
@@ -1,6 +1,7 @@
 module.exports = {
 	common: {
 		'[countryGroupId]/router': 'pages/[countryGroupId]/router.tsx',
+		'[countryGroupId]/lazyRouter': 'pages/[countryGroupId]/lazyRouter.tsx',
 		'[countryGroupId]/events/router':
 			'pages/[countryGroupId]/events/router.tsx',
 		favicons: 'images/favicons.ts',


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Creating a server side A/B test: the variant is a lazy loading router previously implemented in #6628, the control is the router as normal.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/ZWtVE5Xg/1313-spike-server-side-performance-a-b-test)

## Why are you doing this?

We want to test the changes by seeing whether better page performance improves our conversion and business metrics
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

We will probably use the normal A/B test dashboard for results. The participation in the test is rendered as a script tag in the HTML and is passed to the normal participations object.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


## Screenshots
![image](https://github.com/user-attachments/assets/9b79bd3b-0605-4aeb-a75d-c540fc8d071a)
