### PR TITLE
Only check abParticipations in session storage if persistPage is defined in the abTestDefinition

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -182,6 +182,7 @@ function getParticipations(
 		// Is the user already in this test in the current browser session?
 		if (
 			!!sessionParticipations[testId] &&
+			test.persistPage &&
 			targetPageMatches(path, test.persistPage)
 		) {
 			participations[testId] = sessionParticipations[testId];

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -181,8 +181,8 @@ function getParticipations(
 
 		// Is the user already in this test in the current browser session?
 		if (
-			!!sessionParticipations[testId] &&
 			test.persistPage &&
+			!!sessionParticipations[testId] &&
 			targetPageMatches(path, test.persistPage)
 		) {
 			participations[testId] = sessionParticipations[testId];

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -238,6 +238,14 @@ function getParticipations(
 		});
 	}
 
+	// Store participations which use the persistPage prop in sessionStorage
+	Object.keys(participations).forEach((testId) => {
+		if (abTests[testId]?.persistPage) {
+			sessionParticipations[testId] = participations[testId];
+		}
+	});
+	storage.setSession('abParticipations', JSON.stringify(sessionParticipations));
+
 	return participations;
 }
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -53,7 +53,6 @@ import {
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { getPromotion } from 'helpers/productPrice/promotions';
-import * as storage from 'helpers/storage/storage';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
 import Countdown from '../components/countdown';
@@ -291,9 +290,6 @@ export function ThreeTierLanding({
 		selectedCountryGroup: countryGroupId,
 		subPath: '/contribute',
 	};
-
-	// Persist any tests for tracking in the checkout page
-	storage.setSession('abParticipations', JSON.stringify(abParticipations));
 
 	const campaignSettings = getCampaignSettings(
 		countryGroupId,


### PR DESCRIPTION
## What are you doing in this PR?

We noted an issue when making the `adFreeTierThree` A/B test target the US only.

**Main issue identified:** Once allocated to a country specific A/B test a user remains allocated to that test for the duration of their session, regardless of whether they change country to one not covered by the A/B test (eg. uses the country group switcher).

**Expected behaviour:** The user would not remain allocated to a country specific A/B test if they are no longer in the target country. 

**Underlying cause of issue:** The initial allocation to the country specific A/B test (eg. adFreeTierThree) is saved in session storage, any subsequent page views in the session reallocate the user to the test because of it's presence in session storage.

**Reproduce issue (dependent on country specific adFreeTierThree test running):**
- Go to US landing page https://support.theguardian.com/us/contribute
- Open dev tools / session storage and see you have been allocated to “adFreeTierThree” (US specific A/B test)
- Using country drop down switch to the UK, we are still allocated to `adFreeTierThree` A/B test (you can confirm this by looking at the Ophan network request that tracks abTest registrations).

## What does this change?

This PR doesn't address the main issue that a user may be able to invalidate themself out of a test midway through a session.

However whilst investigating the main issue I noted the `adFreeTierThree` A/B test doesn't actually have the `persistPage` prop defined in it's abTestDefinition, given this I was surprised the test is stored in and retrieved from from session storage - I would've thought this storage object only needs to be used when a test makes use of the `persistPage` attribute? 

I had 3 thoughts regarding how this could be optimised:

1. In abtest.ts we should only read session storage when allocating ab tests if the test makes use of of the `persistPage` attribute.
2. When allocating ab tests we should only store the participation in session storage if the test makes use of of the `persistPage` attribute.
3. We could move the logic that saves tests participations in session storage into abtest.ts, currently it lives in https://github.com/guardian/support-frontend/blob/44410b267e73f63306c926456ce05190a6b301a2/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx#L296. 

~~This PR addresses point 1 only, which fixes the issue with `adFreeTierThree` as we no longer check for it's presence in session storage as the abtestDefinition for `adFreeTierThree` does not contain the `persistPage` property.~~ Edit: I've now implemented all 3 changes above.

[**Trello Card**](https://trello.com/c/yWgx6fqN/1363-ab-test-allocation-issue-session-storage)
