### PR TITLE
Landing Page: Disable Move ad-free benefit from tier2 to tier3 - all regions

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -155,7 +155,7 @@ export const tests: Tests = {
 				size: 1,
 			},
 		},
-		isActive: true,
+		isActive: false,
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 6,
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,


### PR DESCRIPTION
What are you doing in this PR?
Disable AB-Test in the `Move ad-free benefit from tier2 to tier3` for US-Only #6637
