### PR TITLE
use sentry to log if pageviewId not available on event listing

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -18,6 +18,7 @@ import { guardianLiveTermsLink, privacyLink } from 'helpers/legal';
 import * as cookie from 'helpers/storage/cookie';
 import { getPageViewId } from 'helpers/tracking/trackingOphan';
 import { isProd } from 'helpers/urls/url';
+import { logException } from 'helpers/utilities/logger';
 import type { GeoId } from 'pages/geoIdConfig';
 
 const darkBackgroundContainerMobile = css`
@@ -102,6 +103,11 @@ export function Events({ geoId }: Props) {
 	const privacyPolicy = <a href={privacyLink}>Privacy Policy</a>;
 
 	const pageviewId = getPageViewId();
+
+	if (!pageviewId) {
+		logException('pageviewId not available on event listing');
+	}
+
 	const hashUrlSearchParams = new URLSearchParams({
 		'p[meta_page_view_id]': pageviewId,
 		'p[meta_region_id]': geoId,


### PR DESCRIPTION
## What are you doing in this PR?

We attach the `pageViewId` to the URL of the Ticket Tailor iframe as a query string parameter, this allows us to track in the data-lake page view IDs against ticket purchases. However a high percentage (~60%) of ticket purchases in the data-lake have a `null` page view id. I'd like to rule out this being down to a race condition, where pageViewId is not defined when we construct the URL. I'm using sentry to log instances of `pageViewId` being falsy.

[**Trello Card**](https://trello.com/c/kCakcGbK/1322-page-view-id-missing-from-60-of-ticket-tailor-events)
