### PR TITLE
Fix thank you page typo

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/subheading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/subheading.tsx
@@ -43,7 +43,9 @@ const pendingCopy = () => {
 				padding-bottom: ${space[3]}px;
 			`}
 		>
-			{`Thankyou for subscribing to a recurring subscription. Your subscription is being processed and you will receive an email when your account is live.`}
+			Thank you for subscribing to a recurring subscription. Your subscription
+			is being processed and you will receive an email when your account is
+			live.
 		</p>
 	);
 };


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Fixing a typo on the generic thank you page

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

## Screenshots
Before
![image](https://github.com/user-attachments/assets/3c07eed7-fcda-4f4f-b745-ec7cf6dbf539)

After
![image](https://github.com/user-attachments/assets/c797a58c-31b7-43e9-8399-d5030d26fe8f)
