### PR TITLE
Guardian Ad-Lite backend rename

### DIFF
--- a/support-e2e/tests/cron/checkout.test.ts
+++ b/support-e2e/tests/cron/checkout.test.ts
@@ -7,7 +7,7 @@ afterEachTasks(test);
 test.describe('Checkout', () => {
 	[
 		{
-			product: 'GuardianLight',
+			product: 'GuardianAdLite',
 			ratePlan: 'Monthly',
 			paymentType: 'PayPal',
 			internationalisationId: 'UK',

--- a/support-e2e/tests/smoke/checkout.test.ts
+++ b/support-e2e/tests/smoke/checkout.test.ts
@@ -7,7 +7,7 @@ afterEachTasks(test);
 test.describe('Checkout', () => {
 	[
 		{
-			product: 'GuardianLight',
+			product: 'GuardianAdLite',
 			ratePlan: 'Monthly',
 			paymentType: 'Credit/Debit card',
 			internationalisationId: 'UK',

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -379,7 +379,7 @@ class CreateSubscriptionController(
         )
       case _: Paper => List.empty
       case _: GuardianWeekly => List.empty
-      case _: GuardianAdLite => List("gu_guardian_light" -> true.toString)
+      case _: GuardianAdLite => List("gu_guardian_ad_lite" -> true.toString)
     }
 
     val standardAndProductCookies = (standardCookies ++ productCookies).map { case (name, value) =>

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -379,7 +379,7 @@ class CreateSubscriptionController(
         )
       case _: Paper => List.empty
       case _: GuardianWeekly => List.empty
-      case _: GuardianAdLite => List("gu_guardian_ad_lite" -> true.toString)
+      case _: GuardianAdLite => List("gu_allow_reject_all" -> true.toString)
     }
 
     val standardAndProductCookies = (standardCookies ++ productCookies).map { case (name, value) =>

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -379,7 +379,7 @@ class CreateSubscriptionController(
         )
       case _: Paper => List.empty
       case _: GuardianWeekly => List.empty
-      case _: GuardianLight => List("gu_guardian_light" -> true.toString)
+      case _: GuardianAdLite => List("gu_guardian_light" -> true.toString)
     }
 
     val standardAndProductCookies = (standardCookies ++ productCookies).map { case (name, value) =>

--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -105,7 +105,7 @@ object CheckoutValidationRules {
           createSupportWorkersRequest,
         ) // Tier three has the same fields as Guardian Weekly
       case _: Contribution => PaidProductValidation.passes(createSupportWorkersRequest)
-      case _: GuardianLight => PaidProductValidation.passes(createSupportWorkersRequest)
+      case _: GuardianAdLite => PaidProductValidation.passes(createSupportWorkersRequest)
     }) match {
       case Invalid(message) =>
         Invalid(s"validation of the request body failed with $message - body was $createSupportWorkersRequest")

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -436,11 +436,11 @@ export function productCatalogGuardianAdLite(): Record<
 	return {
 		...productCatalogDescription,
 		GuardianAdLite: {
-			...productCatalogDescription.GuardianLight,
+			...productCatalogDescription.GuardianAdLite,
 			label: 'Purchase Guardian Ad-Lite',
 		},
 		GuardianAdLiteGoBack: {
-			...productCatalogDescription.GuardianLight,
+			...productCatalogDescription.GuardianAdLite,
 			label: 'Read the Guardian with personalised ads',
 			benefits: [
 				{

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -673,7 +673,7 @@ export function CheckoutComponent({
 
 	const returnParam = returnLink ? '?returnAddress=' + returnLink : '';
 	const returnToLandingPage =
-		productKey === 'GuardianLight'
+		productKey === 'GuardianLight' || productKey === 'GuardianAdLite'
 			? `/guardian-ad-lite${returnParam}`
 			: `/${geoId}/contribute`;
 
@@ -770,7 +770,12 @@ export function CheckoutComponent({
 						headerButton={
 							<BackButton
 								path={returnToLandingPage}
-								buttonText={productKey === 'GuardianLight' ? 'Back' : 'Change'}
+								buttonText={
+									productKey === 'GuardianLight' ||
+									productKey === 'GuardianAdLite'
+										? 'Back'
+										: 'Change'
+								}
 							/>
 						}
 					/>

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -207,7 +207,8 @@ export function ThankYouComponent({
 		return <div>Unable to find contribution type {contributionType}</div>;
 	}
 
-	const isGuardianAdLite = productKey === 'GuardianLight';
+	const isGuardianAdLite =
+		productKey === 'GuardianLight' || productKey === 'GuardianAdLite';
 	const isOneOffPayPal = order.paymentMethod === 'PayPal' && isOneOff;
 	const isSupporterPlus = productKey === 'SupporterPlus';
 	const isTier3 = productKey === 'TierThree';

--- a/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/headerCards.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/headerCards.tsx
@@ -87,7 +87,7 @@ export function HeaderCards({
 	const { currencyKey } = getGeoIdConfig(geoId);
 	const currency = currencies[currencyKey];
 	const price =
-		productCatalog.GuardianLight?.ratePlans[contributionType]?.pricing[
+		productCatalog.GuardianAdLite?.ratePlans[contributionType]?.pricing[
 			currencyKey
 		];
 	const formattedPrice = simpleFormatAmount(currency, price ?? 0);

--- a/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/headerCards.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/headerCards.tsx
@@ -93,9 +93,8 @@ export function HeaderCards({
 	const formattedPrice = simpleFormatAmount(currency, price ?? 0);
 
 	const guardianAdLiteParams = {
-		product: 'GuardianLight',
+		product: 'GuardianAdLite',
 		ratePlan: contributionType,
-		contribution: price?.toString() ?? '',
 	};
 	const card1UrlParams = new URLSearchParams(
 		returnLink

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
@@ -197,7 +197,8 @@ function Heading({
 	promotion,
 }: HeadingProps): JSX.Element {
 	const isPending = paymentStatus === 'pending';
-	const isGuardianAdLite = productKey === 'GuardianLight';
+	const isGuardianAdLite =
+		productKey === 'GuardianLight' || productKey === 'GuardianAdLite';
 	const isTier3 = productKey === 'TierThree';
 	const maybeNameAndTrailingSpace: string =
 		name && name.length < 10 ? `${name} ` : '';

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/subheading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/subheading.tsx
@@ -107,7 +107,8 @@ function Subheading({
 	paymentStatus,
 }: SubheadingProps): JSX.Element {
 	const isTier3 = productKey === 'TierThree';
-	const isGuardianAdLite = productKey === 'GuardianLight';
+	const isGuardianAdLite =
+		productKey === 'GuardianLight' || productKey === 'GuardianAdLite';
 	const subheadingCopy = getSubHeadingCopy(
 		productKey,
 		amountIsAboveThreshold,

--- a/support-frontend/stories/landingPage/GuardianLightCard.stories.tsx
+++ b/support-frontend/stories/landingPage/GuardianLightCard.stories.tsx
@@ -29,7 +29,7 @@ export const Default = Template.bind({});
 
 Default.args = {
 	cardPosition: 1,
-	link: 'https://support.theguardian.com/uk/checkout?product=GuardianLight&ratePlan=Monthly',
+	link: 'https://support.theguardian.com/uk/checkout?product=GuardianAdLite&ratePlan=Monthly',
 	productDescription: productCatalogGuardianAdLite().GuardianAdLite,
 	ctaCopy: 'Get Guardian Ad-Lite for XX/month',
 };

--- a/support-frontend/stories/landingPage/GuardianLightCards.stories.tsx
+++ b/support-frontend/stories/landingPage/GuardianLightCards.stories.tsx
@@ -34,7 +34,7 @@ Default.args = {
 	cardsContent: [
 		{
 			cardPosition: 1,
-			link: 'https://support.theguardian.com/uk/checkout?product=GuardianLight&ratePlan=Monthly',
+			link: 'https://support.theguardian.com/uk/checkout?product=GuardianAdLite&ratePlan=Monthly',
 			productDescription: productCatalogGuardianAdLite().GuardianAdLite,
 			ctaCopy: 'Get Guardian Ad-Lite for XX/month',
 		},

--- a/support-models/src/main/scala/com/gu/support/catalog/Catalog.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Catalog.scala
@@ -14,7 +14,7 @@ case class Catalog(
 
 object Catalog {
   lazy val productRatePlansWithPrices: List[ProductRatePlanId] = for {
-    product <- List(SupporterPlus, DigitalPack, Paper, GuardianWeekly, TierThree, GuardianLight)
+    product <- List(SupporterPlus, DigitalPack, Paper, GuardianWeekly, TierThree, GuardianAdLite)
     env <- List(PROD, CODE)
     plan <- product.ratePlans(env)
   } yield plan.id

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -109,7 +109,7 @@ case object SupporterPlus extends Product {
     )
 }
 
-case object GuardianLight extends Product {
+case object GuardianAdLite extends Product {
   private def productRatePlan(id: String) =
     ProductRatePlan(
       id,
@@ -119,13 +119,13 @@ case object GuardianLight extends Product {
       s"Guardian Ad-Lite Monthly",
     )
 
-  lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[GuardianLight.type]]] =
+  lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[GuardianAdLite.type]]] =
     Map(
       PROD -> List(
-        productRatePlan("8a12831492c341730192dd1c39207038"),
+        productRatePlan("8a1285e294443da501944b04cb692c9e"),
       ),
       CODE -> List(
-        productRatePlan("71a1c43a1e192b28f702b3b47113000a"),
+        productRatePlan("71a1bebf6be9444afad446c5ebaf0019"),
       ),
     )
 }

--- a/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
@@ -40,7 +40,7 @@ object ProductTypeRatePlans {
       .find(productRatePlan => productRatePlan.billingPeriod == product.billingPeriod)
 
   def guardianLightRatePlan(
-      product: GuardianLight,
+      product: GuardianAdLite,
       environment: TouchPointEnvironment,
   ): Option[ProductRatePlan[catalog.GuardianLight.type]] =
     catalog.GuardianLight.ratePlans

--- a/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
@@ -39,11 +39,11 @@ object ProductTypeRatePlans {
       .getOrElse(environment, Nil)
       .find(productRatePlan => productRatePlan.billingPeriod == product.billingPeriod)
 
-  def guardianLightRatePlan(
+  def guardianAdLiteRatePlan(
       product: GuardianAdLite,
       environment: TouchPointEnvironment,
-  ): Option[ProductRatePlan[catalog.GuardianLight.type]] =
-    catalog.GuardianLight.ratePlans
+  ): Option[ProductRatePlan[catalog.GuardianAdLite.type]] =
+    catalog.GuardianAdLite.ratePlans
       .getOrElse(environment, Nil)
       .find(productRatePlan => productRatePlan.billingPeriod == product.billingPeriod)
 

--- a/support-models/src/main/scala/com/gu/support/workers/Products.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/Products.scala
@@ -81,10 +81,10 @@ case class GuardianWeekly(
   override def describe: String = s"$billingPeriod-GuardianWeekly-$fulfilmentOptions-$currency"
 }
 
-case class GuardianLight(
+case class GuardianAdLite(
     currency: Currency,
 ) extends ProductType {
-  override def describe: String = s"GuardianLight-$currency"
+  override def describe: String = s"GuardianAdLite-$currency"
 
   override def billingPeriod: BillingPeriod = Monthly
 }
@@ -105,8 +105,8 @@ object ProductType {
     discriminatedType.variant[GuardianWeekly]("GuardianWeekly")
   implicit val codecDigital: discriminatedType.VariantCodec[DigitalPack] =
     discriminatedType.variant[DigitalPack]("DigitalPack")
-  implicit val codecGuardianLight: discriminatedType.VariantCodec[GuardianLight] =
-    discriminatedType.variant[GuardianLight]("GuardianLight")
+  implicit val codecGuardianAdLite: discriminatedType.VariantCodec[GuardianAdLite] =
+    discriminatedType.variant[GuardianAdLite]("GuardianAdLite")
 
   implicit val codec: Codec[ProductType] =
     discriminatedType.codec(
@@ -117,7 +117,7 @@ object ProductType {
         codecPaper,
         codecGuardianWeekly,
         codecDigital,
-        codecGuardianLight,
+        codecGuardianAdLite,
       ),
     )
 

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
@@ -60,8 +60,8 @@ object CreateZuoraSubscriptionProductState {
       salesForceContact: SalesforceContactRecord,
   ) extends CreateZuoraSubscriptionProductState
 
-  case class GuardianLightState(
-      product: GuardianLight,
+  case class GuardianAdLiteState(
+      product: GuardianAdLite,
       paymentMethod: PaymentMethod,
       salesForceContact: SalesforceContactRecord,
   ) extends CreateZuoraSubscriptionProductState
@@ -121,7 +121,7 @@ object CreateZuoraSubscriptionProductState {
       discriminatedType.variant[PaperState](paper),
       discriminatedType.variant[GuardianWeeklyState](guardianWeekly),
       discriminatedType.variant[TierThreeState](tierThree),
-      discriminatedType.variant[GuardianLightState](guardianLight),
+      discriminatedType.variant[GuardianAdLiteState](guardianAdLite),
     ),
   )
 

--- a/support-models/src/main/scala/com/gu/support/workers/states/ExecutionTypeDiscriminators.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/ExecutionTypeDiscriminators.scala
@@ -12,6 +12,6 @@ object ExecutionTypeDiscriminators {
   val digitalSubscriptionGiftRedemption = "DigitalSubscriptionGiftRedemption"
   val paper = "Paper"
   val guardianWeekly = "GuardianWeekly"
-  val guardianLight = "GuardianLight"
+  val guardianAdLite = "GuardianAdLite"
 
 }

--- a/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
@@ -50,9 +50,9 @@ object SendThankYouEmailState {
       firstDeliveryDate: LocalDate,
   ) extends SendThankYouEmailState
 
-  case class SendThankYouEmailGuardianLightState(
+  case class SendThankYouEmailGuardianAdLiteState(
       user: User,
-      product: GuardianLight,
+      product: GuardianAdLite,
       paymentMethod: PaymentMethod,
       paymentSchedule: PaymentSchedule,
       accountNumber: String,
@@ -141,7 +141,7 @@ object SendThankYouEmailState {
       ),
       discriminatedType.variant[SendThankYouEmailPaperState](paper),
       discriminatedType.variant[SendThankYouEmailGuardianWeeklyState](guardianWeekly),
-      discriminatedType.variant[SendThankYouEmailGuardianLightState](guardianLight),
+      discriminatedType.variant[SendThankYouEmailGuardianAdLiteState](guardianAdLite),
     ),
   )
 

--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
@@ -111,7 +111,7 @@ object AcquisitionProduct {
 
   case object AppPremiumTier extends AcquisitionProduct("APP_PREMIUM_TIER")
 
-  case object GuardianLight extends AcquisitionProduct("GUARDIAN_LIGHT")
+  case object GuardianAdLite extends AcquisitionProduct("GUARDIAN_AD_LITE")
 
   case object FeastApp extends AcquisitionProduct("FEAST_APP")
 
@@ -125,8 +125,8 @@ object AcquisitionProduct {
       GuardianWeekly,
       AppPremiumTier,
       TierThree,
-      GuardianLight,
-      FeastApp
+      GuardianAdLite,
+      FeastApp,
     )
       .find(
         _.value == code,

--- a/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
@@ -124,7 +124,7 @@ object AcquisitionDataRowBuilder {
     case _: DigitalPack => (AcquisitionProduct.DigitalSubscription, None)
     case _: Paper => (AcquisitionProduct.Paper, None)
     case _: GuardianWeekly => (AcquisitionProduct.GuardianWeekly, None)
-    case _: GuardianAdLite => (AcquisitionProduct.GuardianLight, None)
+    case _: GuardianAdLite => (AcquisitionProduct.GuardianAdLite, None)
   }
 
   private def printOptionsFromProduct(product: ProductType, deliveryCountry: Option[Country]): Option[PrintOptions] = {

--- a/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
@@ -26,7 +26,7 @@ import com.gu.support.workers.{
   StripePaymentType,
   SupporterPlus,
   TierThree,
-  GuardianLight,
+  GuardianAdLite,
 }
 import com.gu.support.zuora.api.ReaderType.{Direct, Gift}
 import org.joda.time.{DateTime, DateTimeZone}
@@ -124,7 +124,7 @@ object AcquisitionDataRowBuilder {
     case _: DigitalPack => (AcquisitionProduct.DigitalSubscription, None)
     case _: Paper => (AcquisitionProduct.Paper, None)
     case _: GuardianWeekly => (AcquisitionProduct.GuardianWeekly, None)
-    case _: GuardianLight => (AcquisitionProduct.GuardianLight, None)
+    case _: GuardianAdLite => (AcquisitionProduct.GuardianLight, None)
   }
 
   private def printOptionsFromProduct(product: ProductType, deliveryCountry: Option[Country]): Option[PrintOptions] = {
@@ -256,7 +256,7 @@ object AcquisitionDataRowBuilder {
           None, // TODO: if we rework digital gift modelling in Zuora we should include the relevant ids here
           None,
         )
-      case s: SendThankYouEmailGuardianLightState =>
+      case s: SendThankYouEmailGuardianAdLiteState =>
         AcquisitionTypeDetails(
           paymentMethod = Some(s.paymentMethod),
           promoCode = None,

--- a/support-workers/src/main/scala/com/gu/emailservices/FailedContributionEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/FailedContributionEmailFields.scala
@@ -20,8 +20,8 @@ object FailedEmailFields {
   def paper(email: String, identityUserId: IdentityUserId): EmailFields =
     failedEmailFields("paper-failed", email, identityUserId)
 
-  def guardianLight(email: String, identityUserId: IdentityUserId): EmailFields =
-    failedEmailFields("guardian-light-failed", email, identityUserId)
+  def guardianAdLite(email: String, identityUserId: IdentityUserId): EmailFields =
+    failedEmailFields("guardian-ad-lite-failed", email, identityUserId)
 
   private def failedEmailFields(dataExtensionName: String, email: String, identityUserId: IdentityUserId): EmailFields =
     EmailFields(Nil, Right(identityUserId), email, dataExtensionName, None, None)

--- a/support-workers/src/main/scala/com/gu/emailservices/GuardianAdLiteEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/GuardianAdLiteEmailFields.scala
@@ -11,11 +11,11 @@ import com.gu.support.workers.{
 }
 import com.gu.support.workers.states.SendThankYouEmailState.SendThankYouEmailGuardianAdLiteState
 import org.joda.time.DateTime
-import com.gu.zuora.subscriptionBuilders.GuardianLightSubscriptionBuilder
+import com.gu.zuora.subscriptionBuilders.GuardianAdLiteSubscriptionBuilder
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class GuardianLightEmailFields(created: DateTime) {
+class GuardianAdLiteEmailFields(created: DateTime) {
   def build(
       state: SendThankYouEmailGuardianAdLiteState,
   )(implicit ec: ExecutionContext): Future[EmailFields] = {
@@ -27,7 +27,7 @@ class GuardianLightEmailFields(created: DateTime) {
       "email_address" -> state.user.primaryEmailAddress,
       "billing_period" -> state.product.billingPeriod.toString.toLowerCase,
       "first_payment_date" -> formatDate(
-        created.plusDays(GuardianLightSubscriptionBuilder.gracePeriodInDays).toLocalDate,
+        created.plusDays(GuardianAdLiteSubscriptionBuilder.gracePeriodInDays).toLocalDate,
       ),
       "payment_method" -> paymentMethodName(state.paymentMethod),
       "subscription_details" -> subscription_details,

--- a/support-workers/src/main/scala/com/gu/emailservices/GuardianAdLiteEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/GuardianAdLiteEmailFields.scala
@@ -33,7 +33,7 @@ class GuardianAdLiteEmailFields(created: DateTime) {
       "subscription_details" -> subscription_details,
     )
 
-    Future.successful(EmailFields(fields, state.user, "guardian-light"))
+    Future.successful(EmailFields(fields, state.user, "guardian-ad-lite"))
   }
 
   private def paymentMethodName(method: PaymentMethod): String = method match {

--- a/support-workers/src/main/scala/com/gu/emailservices/GuardianLightEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/GuardianLightEmailFields.scala
@@ -9,7 +9,7 @@ import com.gu.support.workers.{
   PaymentMethod,
   SepaPaymentMethod,
 }
-import com.gu.support.workers.states.SendThankYouEmailState.SendThankYouEmailGuardianLightState
+import com.gu.support.workers.states.SendThankYouEmailState.SendThankYouEmailGuardianAdLiteState
 import org.joda.time.DateTime
 import com.gu.zuora.subscriptionBuilders.GuardianLightSubscriptionBuilder
 
@@ -17,7 +17,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class GuardianLightEmailFields(created: DateTime) {
   def build(
-      state: SendThankYouEmailGuardianLightState,
+      state: SendThankYouEmailGuardianAdLiteState,
   )(implicit ec: ExecutionContext): Future[EmailFields] = {
     val subscription_details = SubscriptionEmailFieldHelpers
       .describe(state.paymentSchedule, state.product.billingPeriod, state.product.currency)

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -65,7 +65,7 @@ class NextState(state: CreateSalesforceContactState) {
       case (product: TierThree, Purchase(purchase)) =>
         toNextTierThree(salesforceContactRecords, product, purchase)
       case (product: GuardianAdLite, Purchase(purchase)) =>
-        toNextGuardianLight(salesforceContactRecords, product, purchase)
+        toNextGuardianAdLite(salesforceContactRecords, product, purchase)
       case (product: DigitalPack, Purchase(purchase)) if product.readerType == ReaderType.Direct =>
         toNextDSDirect(salesforceContactRecords.buyer, product, purchase)
       case (product: DigitalPack, Purchase(purchase)) if product.readerType == ReaderType.Gift =>
@@ -151,7 +151,7 @@ class NextState(state: CreateSalesforceContactState) {
       acquisitionData,
     )
 
-  def toNextGuardianLight(
+  def toNextGuardianAdLite(
       salesforceContactRecords: SalesforceContactRecords,
       product: GuardianAdLite,
       purchase: PaymentMethod,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -10,7 +10,7 @@ import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.{
   DigitalSubscriptionDirectPurchaseState,
   DigitalSubscriptionGiftPurchaseState,
   DigitalSubscriptionGiftRedemptionState,
-  GuardianLightState,
+  GuardianAdLiteState,
   GuardianWeeklyState,
   PaperState,
   SupporterPlusState,
@@ -64,7 +64,7 @@ class NextState(state: CreateSalesforceContactState) {
         toNextSupporterPlus(salesforceContactRecords, product, purchase)
       case (product: TierThree, Purchase(purchase)) =>
         toNextTierThree(salesforceContactRecords, product, purchase)
-      case (product: GuardianLight, Purchase(purchase)) =>
+      case (product: GuardianAdLite, Purchase(purchase)) =>
         toNextGuardianLight(salesforceContactRecords, product, purchase)
       case (product: DigitalPack, Purchase(purchase)) if product.readerType == ReaderType.Direct =>
         toNextDSDirect(salesforceContactRecords.buyer, product, purchase)
@@ -153,11 +153,11 @@ class NextState(state: CreateSalesforceContactState) {
 
   def toNextGuardianLight(
       salesforceContactRecords: SalesforceContactRecords,
-      product: GuardianLight,
+      product: GuardianAdLite,
       purchase: PaymentMethod,
   ): CreateZuoraSubscriptionState =
     CreateZuoraSubscriptionState(
-      GuardianLightState(
+      GuardianAdLiteState(
         product,
         purchase,
         salesforceContactRecords.buyer,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -72,7 +72,7 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
           zuoraSubscriptionState.salesforceCaseId,
         )
       case state: GuardianAdLiteState =>
-        zuoraGuardianLightHandler.subscribe(
+        zuoraGuardianAdLiteHandler.subscribe(
           state,
           zuoraSubscriptionState.csrUsername,
           zuoraSubscriptionState.salesforceCaseId,
@@ -158,9 +158,9 @@ class ZuoraProductHandlers(services: Services, state: CreateZuoraSubscriptionSta
       subscribeItemBuilder,
     ),
   )
-  lazy val zuoraGuardianLightHandler = new ZuoraGuardianLightHandler(
+  lazy val zuoraGuardianAdLiteHandler = new ZuoraGuardianAdLiteHandler(
     zuoraSubscriptionCreator,
-    new GuardianLightSubscriptionBuilder(
+    new GuardianAdLiteSubscriptionBuilder(
       dateGenerator,
       touchPointEnvironment,
       subscribeItemBuilder,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -71,7 +71,7 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
           zuoraSubscriptionState.csrUsername,
           zuoraSubscriptionState.salesforceCaseId,
         )
-      case state: GuardianLightState =>
+      case state: GuardianAdLiteState =>
         zuoraGuardianLightHandler.subscribe(
           state,
           zuoraSubscriptionState.csrUsername,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -50,7 +50,7 @@ class FailureHandler(emailService: EmailService) extends Handler[FailureHandlerS
       case _: GuardianWeekly =>
         FailedEmailFields.guardianWeekly(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
       case _: GuardianAdLite =>
-        FailedEmailFields.guardianLight(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
+        FailedEmailFields.guardianAdLite(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
     }
     logger.info(s"Sending a failure email. Email fields: $emailFields")
     emailService.send(emailFields)

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -49,7 +49,7 @@ class FailureHandler(emailService: EmailService) extends Handler[FailureHandlerS
       case _: Paper => FailedEmailFields.paper(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
       case _: GuardianWeekly =>
         FailedEmailFields.guardianWeekly(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
-      case _: GuardianLight =>
+      case _: GuardianAdLite =>
         FailedEmailFields.guardianLight(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
     }
     logger.info(s"Sending a failure email. Email fields: $emailFields")

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -79,7 +79,7 @@ class EmailBuilder(
       created = DateTime.now(),
     )
     val tierThreeEmailFields = new TierThreeEmailFields(paperFieldsGenerator, touchpointEnvironment)
-    val guardianLightEmailFields = new GuardianLightEmailFields(created = DateTime.now())
+    val guardianAdLiteEmailFields = new GuardianAdLiteEmailFields(created = DateTime.now())
 
     state match {
       case contribution: SendThankYouEmailContributionState => contributionEmailFields.build(contribution).map(List(_))
@@ -91,8 +91,8 @@ class EmailBuilder(
       case paper: SendThankYouEmailPaperState =>
         getAgentDetails(paper.product.deliveryAgent).flatMap(paperEmailFields.build(paper, _)).map(List(_))
       case weekly: SendThankYouEmailGuardianWeeklyState => guardianWeeklyEmailFields.build(weekly).map(List(_))
-      case guardianLight: SendThankYouEmailGuardianAdLiteState =>
-        guardianLightEmailFields.build(guardianLight).map(List(_))
+      case guardianAdLite: SendThankYouEmailGuardianAdLiteState =>
+        guardianAdLiteEmailFields.build(guardianAdLite).map(List(_))
     }
   }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -91,7 +91,7 @@ class EmailBuilder(
       case paper: SendThankYouEmailPaperState =>
         getAgentDetails(paper.product.deliveryAgent).flatMap(paperEmailFields.build(paper, _)).map(List(_))
       case weekly: SendThankYouEmailGuardianWeeklyState => guardianWeeklyEmailFields.build(weekly).map(List(_))
-      case guardianLight: SendThankYouEmailGuardianLightState =>
+      case guardianLight: SendThankYouEmailGuardianAdLiteState =>
         guardianLightEmailFields.build(guardianLight).map(List(_))
     }
   }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
@@ -196,7 +196,7 @@ object UpdateSupporterProductData {
           .toRight(s"Unable to create SupporterRatePlanItem from state $state")
       case SendThankYouEmailGuardianAdLiteState(user, product, _, _, _, subscriptionNumber) =>
         catalogService
-          .getProductRatePlan(GuardianLight, product.billingPeriod, NoFulfilmentOptions, NoProductOptions)
+          .getProductRatePlan(GuardianAdLite, product.billingPeriod, NoFulfilmentOptions, NoProductOptions)
           .map(productRatePlan =>
             Some(
               supporterRatePlanItem(

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
@@ -10,7 +10,7 @@ import com.gu.support.workers.states.SendThankYouEmailState.{
   SendThankYouEmailDigitalSubscriptionDirectPurchaseState,
   SendThankYouEmailDigitalSubscriptionGiftPurchaseState,
   SendThankYouEmailDigitalSubscriptionGiftRedemptionState,
-  SendThankYouEmailGuardianLightState,
+  SendThankYouEmailGuardianAdLiteState,
   SendThankYouEmailGuardianWeeklyState,
   SendThankYouEmailPaperState,
   SendThankYouEmailSupporterPlusState,
@@ -194,7 +194,7 @@ object UpdateSupporterProductData {
             ),
           )
           .toRight(s"Unable to create SupporterRatePlanItem from state $state")
-      case SendThankYouEmailGuardianLightState(user, product, _, _, _, subscriptionNumber) =>
+      case SendThankYouEmailGuardianAdLiteState(user, product, _, _, _, subscriptionNumber) =>
         catalogService
           .getProductRatePlan(GuardianLight, product.billingPeriod, NoFulfilmentOptions, NoProductOptions)
           .map(productRatePlan =>

--- a/support-workers/src/main/scala/com/gu/zuora/productHandlers/ZuoraGuardianAdLiteHandler.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/productHandlers/ZuoraGuardianAdLiteHandler.scala
@@ -6,14 +6,14 @@ import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.Guardia
 import com.gu.support.workers.states.SendThankYouEmailState
 import com.gu.support.workers.states.SendThankYouEmailState.SendThankYouEmailGuardianAdLiteState
 import com.gu.zuora.ZuoraSubscriptionCreator
-import com.gu.zuora.subscriptionBuilders.GuardianLightSubscriptionBuilder
+import com.gu.zuora.subscriptionBuilders.GuardianAdLiteSubscriptionBuilder
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class ZuoraGuardianLightHandler(
+class ZuoraGuardianAdLiteHandler(
     zuoraSubscriptionCreator: ZuoraSubscriptionCreator,
-    subscriptionBuilder: GuardianLightSubscriptionBuilder,
+    subscriptionBuilder: GuardianAdLiteSubscriptionBuilder,
     user: User,
 ) {
 

--- a/support-workers/src/main/scala/com/gu/zuora/productHandlers/ZuoraGuardianLightHandler.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/productHandlers/ZuoraGuardianLightHandler.scala
@@ -2,9 +2,9 @@ package com.gu.zuora.productHandlers
 
 import com.gu.support.acquisitions.AcquisitionData
 import com.gu.support.workers.User
-import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.GuardianLightState
+import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.GuardianAdLiteState
 import com.gu.support.workers.states.SendThankYouEmailState
-import com.gu.support.workers.states.SendThankYouEmailState.SendThankYouEmailGuardianLightState
+import com.gu.support.workers.states.SendThankYouEmailState.SendThankYouEmailGuardianAdLiteState
 import com.gu.zuora.ZuoraSubscriptionCreator
 import com.gu.zuora.subscriptionBuilders.GuardianLightSubscriptionBuilder
 
@@ -18,7 +18,7 @@ class ZuoraGuardianLightHandler(
 ) {
 
   def subscribe(
-      state: GuardianLightState,
+      state: GuardianAdLiteState,
       csrUsername: Option[String],
       salesforceCaseId: Option[String],
   ): Future[SendThankYouEmailState] = {
@@ -27,7 +27,7 @@ class ZuoraGuardianLightHandler(
     for {
       paymentSchedule <- zuoraSubscriptionCreator.preview(subscribeItem, state.product.billingPeriod)
       (account, sub) <- zuoraSubscriptionCreator.ensureSubscriptionCreated(subscribeItem)
-    } yield SendThankYouEmailGuardianLightState(
+    } yield SendThankYouEmailGuardianAdLiteState(
       user,
       state.product,
       state.paymentMethod,

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/GuardianAdLiteSubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/GuardianAdLiteSubscriptionBuilder.scala
@@ -2,13 +2,13 @@ package com.gu.zuora.subscriptionBuilders
 
 import com.gu.helpers.DateGenerator
 import com.gu.support.config.TouchPointEnvironment
-import com.gu.support.workers.ProductTypeRatePlans.guardianLightRatePlan
+import com.gu.support.workers.ProductTypeRatePlans.guardianAdLiteRatePlan
 import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.GuardianAdLiteState
 import com.gu.support.zuora.api.ReaderType.Direct
 import com.gu.support.zuora.api.SubscribeItem
 import com.gu.zuora.subscriptionBuilders.ProductSubscriptionBuilders.validateRatePlan
 
-class GuardianLightSubscriptionBuilder(
+class GuardianAdLiteSubscriptionBuilder(
     dateGenerator: DateGenerator,
     environment: TouchPointEnvironment,
     subscribeItemBuilder: SubscribeItemBuilder,
@@ -19,14 +19,14 @@ class GuardianLightSubscriptionBuilder(
       salesforceCaseId: Option[String],
   ): SubscribeItem = {
     val productRatePlanId = {
-      validateRatePlan(guardianLightRatePlan(state.product, environment), state.product.describe)
+      validateRatePlan(guardianAdLiteRatePlan(state.product, environment), state.product.describe)
     }
 
     val todaysDate = dateGenerator.today
     val subscriptionData = subscribeItemBuilder.buildProductSubscription(
       productRatePlanId = productRatePlanId,
       contractEffectiveDate = todaysDate,
-      contractAcceptanceDate = todaysDate.plusDays(GuardianLightSubscriptionBuilder.gracePeriodInDays),
+      contractAcceptanceDate = todaysDate.plusDays(GuardianAdLiteSubscriptionBuilder.gracePeriodInDays),
       readerType = Direct,
       csrUsername = csrUsername,
       salesforceCaseId = salesforceCaseId,
@@ -36,7 +36,7 @@ class GuardianLightSubscriptionBuilder(
   }
 }
 
-object GuardianLightSubscriptionBuilder {
+object GuardianAdLiteSubscriptionBuilder {
   // The user isn't charged until day 15
   val gracePeriodInDays = 15
 }

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/GuardianLightSubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/GuardianLightSubscriptionBuilder.scala
@@ -3,7 +3,7 @@ package com.gu.zuora.subscriptionBuilders
 import com.gu.helpers.DateGenerator
 import com.gu.support.config.TouchPointEnvironment
 import com.gu.support.workers.ProductTypeRatePlans.guardianLightRatePlan
-import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.GuardianLightState
+import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.GuardianAdLiteState
 import com.gu.support.zuora.api.ReaderType.Direct
 import com.gu.support.zuora.api.SubscribeItem
 import com.gu.zuora.subscriptionBuilders.ProductSubscriptionBuilders.validateRatePlan
@@ -14,7 +14,7 @@ class GuardianLightSubscriptionBuilder(
     subscribeItemBuilder: SubscribeItemBuilder,
 ) {
   def build(
-      state: GuardianLightState,
+      state: GuardianAdLiteState,
       csrUsername: Option[String],
       salesforceCaseId: Option[String],
   ): SubscribeItem = {

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -17,7 +17,7 @@ import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.{
   DigitalSubscriptionDirectPurchaseState,
   DigitalSubscriptionGiftPurchaseState,
   DigitalSubscriptionGiftRedemptionState,
-  GuardianLightState,
+  GuardianAdLiteState,
   GuardianWeeklyState,
   PaperState,
   SupporterPlusState,
@@ -697,14 +697,14 @@ object JsonFixtures {
 
   val createGuardianLightZuoraSubscriptionJson =
     CreateZuoraSubscriptionState(
-      GuardianLightState(
-        GuardianLight(GBP),
+      GuardianAdLiteState(
+        GuardianAdLite(GBP),
         stripePaymentMethodObj,
         salesforceContact,
       ),
       UUID.randomUUID(),
       user(),
-      GuardianLight(GBP),
+      GuardianAdLite(GBP),
       AnalyticsInfo(isGiftPurchase = false, Stripe),
       None,
       None,

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -695,7 +695,7 @@ object JsonFixtures {
       None,
     ).asJson.spaces2
 
-  val createGuardianLightZuoraSubscriptionJson =
+  val createGuardianAdLiteZuoraSubscriptionJson =
     CreateZuoraSubscriptionState(
       GuardianAdLiteState(
         GuardianAdLite(GBP),

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -157,7 +157,7 @@ class CreateZuoraSubscriptionSpec extends AsyncLambdaSpec with MockServicesCreat
 
   it should "create a Guardian Ad-Lite monthly subscription" in {
     createZuoraHelper
-      .createSubscription(createGuardianLightZuoraSubscriptionJson)
+      .createSubscription(createGuardianAdLiteZuoraSubscriptionJson)
       .map(_ should matchPattern { case s: SendThankYouEmailGuardianAdLiteState =>
       })
   }

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -158,7 +158,7 @@ class CreateZuoraSubscriptionSpec extends AsyncLambdaSpec with MockServicesCreat
   it should "create a Guardian Ad-Lite monthly subscription" in {
     createZuoraHelper
       .createSubscription(createGuardianLightZuoraSubscriptionJson)
-      .map(_ should matchPattern { case s: SendThankYouEmailGuardianLightState =>
+      .map(_ should matchPattern { case s: SendThankYouEmailGuardianAdLiteState =>
       })
   }
 }

--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/UpdateSupporterProductDataSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/UpdateSupporterProductDataSpec.scala
@@ -5,7 +5,7 @@ import com.gu.support.config.TouchPointEnvironments.PROD
 import com.gu.support.workers.lambdas.UpdateSupporterProductDataSpec.{
   digitalSubscriptionGiftRedemptionState,
   digitalSusbcriptionGiftPurchaseState,
-  guardianLightState,
+  guardianAdLiteState,
   serviceWithFixtures,
   supporterPlusState,
 }
@@ -47,7 +47,7 @@ class UpdateSupporterProductDataSpec extends AnyFlatSpec with EitherValues {
   }
 
   "UpdateSupporterProductData" should "return a valid SupporterRatePlanItem for a Guardian Ad-Lite purchase" in {
-    val state = decode[SendThankYouEmailState](guardianLightState).value
+    val state = decode[SendThankYouEmailState](guardianAdLiteState).value
     val supporterRatePlanItem =
       UpdateSupporterProductData.getSupporterRatePlanItemFromState(state, serviceWithFixtures).value
     supporterRatePlanItem.value.identityId shouldBe "200092951"
@@ -111,7 +111,7 @@ object UpdateSupporterProductDataSpec {
         }
     """
 
-  val guardianLightState =
+  val guardianAdLiteState =
     """
     {
         "user": {
@@ -138,7 +138,7 @@ object UpdateSupporterProductDataSpec {
           "currency": "GBP",
           "billingPeriod": "Monthly",
           "fulfilmentOptions": "NoFulfilmentOptions",
-          "productType": "GuardianLight"
+          "productType": "GuardianAdLite"
         },
         "paymentMethod": {
           "TokenId": "pm_0MZap9ItVxyc3Q6nRNfyJHfO",
@@ -162,7 +162,7 @@ object UpdateSupporterProductDataSpec {
         },
         "accountNumber": "A00485141",
         "subscriptionNumber": "A-S00489451",
-        "productType": "GuardianLight"
+        "productType": "GuardianAdLite"
       }
   """
 


### PR DESCRIPTION
## What are you doing in this PR?

This PR updates the backend and support-workers code to handle the new product `Guardian Ad-Lite`. I've done this as a rename, so after this PR is merged GuardianLight purchases will no longer work (even though the client will continue handling GuardianLight until it's removed). ~~**This means the playwright tests will need updating before merging this.**~~ **Done**.

Changes which have an impact outside of this codebase:

* The cookie dropped has been renamed - communicate this to affected teams.
* The email IDs have changed, so will need updating in membership-workflow (https://github.com/guardian/membership-workflow/pull/572 - should be deployed at the same time).
* The acquisition ID has changed - communicate this to affected teams.

[**Trello Card**](https://trello.com/c/3Hs3ntw0/1347-rename-guardian-light-to-guardian-ad-lite-in-the-product-catalogue)

Now that the backend supports `GuardianAdLite` (and no longer supports `GuardianLight`) I've moved over some final references in the frontend to use the new product name, e.g. we now link from the landing page to the checkout with the new product ID.

## Why are you doing this?

The product name has changed, this follows on from #6692 to move the support site over to the newly named product.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
