### PR TITLE
Landing Page: Remove code associated with the ad-free ab-test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -137,30 +137,6 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.genericCheckoutOnly,
 		excludeContributionsOnlyCountries: true,
 	},
-	adFreeTierThree: {
-		variants: [
-			{
-				id: 'control', // Tier2 ad-free
-			},
-			{
-				id: 'v1', // Tier3 ad-free
-			},
-			{
-				id: 'v2', // No ad-free
-			},
-		],
-		audiences: {
-			UnitedStates: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		isActive: false,
-		referrerControlled: false, // ab-test name not needed to be in paramURL
-		seed: 6,
-		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
-		excludeContributionsOnlyCountries: true,
-	},
 	contributionsOnly: {
 		variants: [
 			{

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -100,15 +100,6 @@ const appBenefit = {
 };
 const addFreeBenefit = {
 	copy: 'Ad-free reading on all your devices',
-	specificToAbTest: [
-		{ name: 'adFreeTierThree', variants: ['v1', 'v2'], display: false },
-	],
-};
-const addFreeBenefitTierThree = {
-	copy: 'Ad-free reading on all your devices',
-	specificToAbTest: [
-		{ name: 'adFreeTierThree', variants: ['v1'], display: true },
-	],
 };
 const newsletterBenefit = {
 	copy: 'Regular dispatches from the newsroom to see the impact of your support',
@@ -184,7 +175,7 @@ export const productCatalogDescription: Record<
 			'The rewards from ',
 			{ strong: true, copy: 'All-access digital' },
 		],
-		benefits: [addFreeBenefitTierThree, guardianWeeklyBenefit],
+		benefits: [guardianWeeklyBenefit],
 		/** These are just the SupporterPlus benefits */
 		benefitsAdditional: supporterPlusBenefits,
 		deliverableTo: gwDeliverableCountries,


### PR DESCRIPTION
## What are you doing in this PR?

Removes the unused code associated with this [Ad-free PR](https://github.com/guardian/support-frontend/pull/6637) 

Keeps  ab-test filter of `productCatalog` benefits for future use (including new display field)
