### PR TITLE
Update support-service-lambdas package and remove remaining GuardianLight references

### DIFF
--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -26,7 +26,6 @@ const setUserDetailsForProduct = async (
 ) => {
 	switch (product) {
 		case 'SupporterPlus':
-		case 'GuardianLight':
 		case 'GuardianAdLite':
 			await setTestUserRequiredDetails(page, email(), firstName(), lastName());
 

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -69,11 +69,6 @@ export type TierThree = {
 	fulfilmentOptions: FulfilmentOptions;
 	productOptions: ProductOptions;
 };
-export type GuardianLight = {
-	productType: 'GuardianLight';
-	currency: string;
-	billingPeriod: BillingPeriod;
-};
 export type GuardianAdLite = {
 	productType: 'GuardianAdLite';
 	currency: string;
@@ -106,7 +101,6 @@ export type SubscriptionProductFields =
 	| PaperSubscription
 	| GuardianWeeklySubscription
 	| TierThree
-	| GuardianLight
 	| GuardianAdLite;
 type ProductFields = RegularContribution | SubscriptionProductFields;
 type RegularPayPalPaymentFields = {

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -148,16 +148,6 @@ export const productCatalogDescription: Record<
 	ActiveProductKey,
 	ProductDescription
 > = {
-	GuardianLight: {
-		label: 'Guardian Ad-Lite',
-		thankyouMessage: `Your valued support powers our journalism${' '}`,
-		ratePlans: {
-			Monthly: {
-				billingPeriod: 'Monthly',
-			},
-		},
-		benefits: guardianAdLiteBenefits,
-	},
 	GuardianAdLite: {
 		label: 'Guardian Ad-Lite',
 		thankyouMessage: `Your valued support powers our journalism${' '}`,

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/getProductFields.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/getProductFields.ts
@@ -45,13 +45,6 @@ export const getProductFields = ({
 	 * We might be able to defer this to the backend.
 	 */
 	switch (productKey) {
-		case 'GuardianLight':
-			return {
-				productType: 'GuardianLight',
-				currency: currencyKey,
-				billingPeriod: ratePlanDescription.billingPeriod,
-			};
-
 		case 'GuardianAdLite':
 			return {
 				productType: 'GuardianAdLite',

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -669,7 +669,7 @@ export function CheckoutComponent({
 
 	const returnParam = returnLink ? '?returnAddress=' + returnLink : '';
 	const returnToLandingPage =
-		productKey === 'GuardianLight' || productKey === 'GuardianAdLite'
+		productKey === 'GuardianAdLite'
 			? `/guardian-ad-lite${returnParam}`
 			: `/${geoId}/contribute`;
 
@@ -766,12 +766,7 @@ export function CheckoutComponent({
 						headerButton={
 							<BackButton
 								path={returnToLandingPage}
-								buttonText={
-									productKey === 'GuardianLight' ||
-									productKey === 'GuardianAdLite'
-										? 'Back'
-										: 'Change'
-								}
+								buttonText={productKey === 'GuardianAdLite' ? 'Back' : 'Change'}
 							/>
 						}
 					/>

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -206,8 +206,7 @@ export function ThankYouComponent({
 		return <div>Unable to find contribution type {contributionType}</div>;
 	}
 
-	const isGuardianAdLite =
-		productKey === 'GuardianLight' || productKey === 'GuardianAdLite';
+	const isGuardianAdLite = productKey === 'GuardianAdLite';
 	const isOneOffPayPal = order.paymentMethod === 'PayPal' && isOneOff;
 	const isSupporterPlus = productKey === 'SupporterPlus';
 	const isTier3 = productKey === 'TierThree';

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
@@ -197,8 +197,7 @@ function Heading({
 	promotion,
 }: HeadingProps): JSX.Element {
 	const isPending = paymentStatus === 'pending';
-	const isGuardianAdLite =
-		productKey === 'GuardianLight' || productKey === 'GuardianAdLite';
+	const isGuardianAdLite = productKey === 'GuardianAdLite';
 	const isTier3 = productKey === 'TierThree';
 	const maybeNameAndTrailingSpace: string =
 		name && name.length < 10 ? `${name} ` : '';

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/subheading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/subheading.tsx
@@ -109,8 +109,7 @@ function Subheading({
 	paymentStatus,
 }: SubheadingProps): JSX.Element {
 	const isTier3 = productKey === 'TierThree';
-	const isGuardianAdLite =
-		productKey === 'GuardianLight' || productKey === 'GuardianAdLite';
+	const isGuardianAdLite = productKey === 'GuardianAdLite';
 	const subheadingCopy = getSubHeadingCopy(
 		productKey,
 		amountIsAboveThreshold,

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -85,7 +85,7 @@
 		"@guardian/pasteup": "1.0.0-alpha.7",
 		"@guardian/source": "8.0.0",
 		"@guardian/source-development-kitchen": "13.1.0",
-		"@guardian/support-service-lambdas": "guardian/support-service-lambdas#1cac223aa8cf278f4e70cb39dc0f7740304e4566",
+		"@guardian/support-service-lambdas": "guardian/support-service-lambdas#954a612fbce077790fa2d00c6e159b8d384f3e14",
 		"@guardian/tsconfig": "^0.2.0",
 		"@reduxjs/toolkit": "^1.9.4",
 		"@sentry/browser": "^8.33.1",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1836,9 +1836,9 @@
   dependencies:
     mini-svg-data-uri "1.4.4"
 
-"@guardian/support-service-lambdas@guardian/support-service-lambdas#1cac223aa8cf278f4e70cb39dc0f7740304e4566":
+"@guardian/support-service-lambdas@guardian/support-service-lambdas#954a612fbce077790fa2d00c6e159b8d384f3e14":
   version "1.0.0"
-  resolved "https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1cac223aa8cf278f4e70cb39dc0f7740304e4566"
+  resolved "https://codeload.github.com/guardian/support-service-lambdas/tar.gz/954a612fbce077790fa2d00c6e159b8d384f3e14"
 
 "@guardian/tsconfig@^0.2.0":
   version "0.2.0"


### PR DESCRIPTION
## What are you doing in this PR?

Update the support-services-lambdas package to bring in removal of the `GuardianLight` product from the catalog and type object.

[**Trello Card**](https://trello.com/c/3Hs3ntw0/1347-rename-guardian-light-to-guardian-ad-lite-in-the-product-catalogue)

~~**Note: this is based on #6700 and should be merged after that PR. Will need rebasing first.**~~ Done!

## Why are you doing this?

We've moved over to the newly named `GuardianAdLite`.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Visiting the checkout with the old product name now returns an error `Product not found`. Can put through a purchase of the new Ad-Lite product (and other products) successfully.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
