### PR TITLE
Remove Link as payment method AB test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -105,38 +105,6 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeContributionsOnlyCountries: true,
 	},
-	linkExpressCheckout: {
-		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'variant',
-			},
-		],
-		audiences: {
-			UnitedStates: {
-				offset: 0,
-				size: 1,
-			},
-			GBPCountries: {
-				offset: 0,
-				size: 1,
-			},
-			EURCountries: {
-				offset: 0,
-				size: 1,
-			},
-			Canada: { offset: 0, size: 1 },
-			NZDCountries: { offset: 0, size: 1 },
-			International: { offset: 0, size: 1 },
-		},
-		isActive: false,
-		referrerControlled: false, // ab-test name not needed to be in paramURL
-		seed: 5,
-		targetPage: pageUrlRegexes.contributions.genericCheckoutOnly,
-		excludeContributionsOnlyCountries: true,
-	},
 	contributionsOnly: {
 		variants: [
 			{

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -419,9 +419,6 @@ export function CheckoutComponent({
 	const [errorMessage, setErrorMessage] = useState<string>();
 	const [errorContext, setErrorContext] = useState<string>();
 
-	const useLinkExpressCheckout =
-		abParticipations.linkExpressCheckout === 'variant';
-
 	const formOnSubmit = async (formData: FormData) => {
 		setIsProcessingPayment(true);
 		/**
@@ -882,7 +879,7 @@ export function CheckoutComponent({
 										paymentMethods: {
 											applePay: 'auto',
 											googlePay: 'auto',
-											link: useLinkExpressCheckout ? 'auto' : 'never',
+											link: 'never',
 										},
 									}}
 								/>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Removing the A/B test for the Link Stripe (Express checkout) payment method, which has been off for a while

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/uQE2EUU6/1329-remove-link-payment-method-ab-test)

