### PR TITLE
Reinstate one-time contribution cookie.

### DIFF
--- a/support-frontend/assets/helpers/storage/contributionsCookies.ts
+++ b/support-frontend/assets/helpers/storage/contributionsCookies.ts
@@ -1,12 +1,14 @@
 import { set } from './cookie';
 
-const HIDE_SUPPORT_MESSAGING_COOKIE_NAME = 'gu_hide_support_messaging';
-const HIDE_SUPPORT_MESSAGING_COOKIE_DAYS_TO_LIVE = 90;
+const ONE_OFF_CONTRIBUTION_COOKIE_NAME = 'gu.contributions.contrib-timestamp';
+const ONE_OFF_CONTRIBUTION_COOKIE_NAME_DAYS_TO_LIVE = 90;
 
-export const setHideSupportMessagingCookie = (): void => {
+export const setOneOffContributionCookie = (): void => {
+	const currentTimeInEpochMilliseconds: number = Date.now();
+
 	set(
-		HIDE_SUPPORT_MESSAGING_COOKIE_NAME,
-		'true',
-		HIDE_SUPPORT_MESSAGING_COOKIE_DAYS_TO_LIVE,
+		ONE_OFF_CONTRIBUTION_COOKIE_NAME,
+		currentTimeInEpochMilliseconds.toString(),
+		ONE_OFF_CONTRIBUTION_COOKIE_NAME_DAYS_TO_LIVE,
 	);
 };

--- a/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
@@ -5,11 +5,11 @@ import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { getPromotion } from 'helpers/productPrice/promotions';
 import type { UserType } from 'helpers/redux/checkout/personalDetails/state';
-import { setHideSupportMessagingCookie } from 'helpers/storage/contributionsCookies';
 import { logException } from 'helpers/utilities/logger';
 import { roundToDecimalPlaces } from 'helpers/utilities/utilities';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
 import type { Participations } from '../../helpers/abTests/abtest';
+import { setOneOffContributionCookie } from '../../helpers/storage/contributionsCookies';
 import { ThankYouComponent } from './components/thankYouComponent';
 
 export type ThankYouProps = {
@@ -68,7 +68,7 @@ export function ThankYou({
 			finalAmount: finalAmount,
 		};
 
-		setHideSupportMessagingCookie();
+		setOneOffContributionCookie();
 	} else {
 		/** Recurring product must have product & ratePlan */
 		if (!product) {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We set a cookie after a successful one-time contribution on support-fronted so that the contributor will not see any support messaging on dotcom for 90 days.

In https://github.com/guardian/support-frontend/pull/6643 I switched from using the one-time contribution cookie for this to the gu_hide_support_messaging cookie which is used by dotcom to store the value returned from members-data-api/user-benefits api.

However dotcom will delete this cookie if it exists for non signed in users, so it is not suitable without reworking the behaviour in dotcom which I would rather not do at this point.

This PR reverts the earlier PR, taking account of the fact that the cookie is now set in the new one-time checkout thank you page rather than the old thank you page.