### PR TITLE
Revert "use sentry to log if pageviewId not available on event listing"

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -18,7 +18,6 @@ import { guardianLiveTermsLink, privacyLink } from 'helpers/legal';
 import * as cookie from 'helpers/storage/cookie';
 import { getPageViewId } from 'helpers/tracking/trackingOphan';
 import { isProd } from 'helpers/urls/url';
-import { logException } from 'helpers/utilities/logger';
 import type { GeoId } from 'pages/geoIdConfig';
 
 const darkBackgroundContainerMobile = css`
@@ -103,11 +102,6 @@ export function Events({ geoId }: Props) {
 	const privacyPolicy = <a href={privacyLink}>Privacy Policy</a>;
 
 	const pageviewId = getPageViewId();
-
-	if (!pageviewId) {
-		logException('pageviewId not available on event listing');
-	}
-
 	const hashUrlSearchParams = new URLSearchParams({
 		'p[meta_page_view_id]': pageviewId,
 		'p[meta_region_id]': geoId,


### PR DESCRIPTION
No events have been tracked in ~5 days since this went live so we can remove this

Reverts guardian/support-frontend#6694