### PR TITLE
Fix LazyRouter /guardian-ad-lite landing page path

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/lazyRouter.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/lazyRouter.tsx
@@ -68,7 +68,7 @@ const router = createBrowserRouter(
 			),
 		},
 		{
-			path: `/${geoId}/guardian-light`,
+			path: `/${geoId}/guardian-ad-lite`,
 			element: (
 				<Suspense fallback={<HoldingContent />}>
 					<GuardianAdLiteLanding geoId={geoId} />


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Use the updated path for the Guardian Ad-Lite landing page in the LazyRouter.

## Why are you doing this?

We noticed this path was sporadically 404ing (at the client side routing layer) before, it turns out this was because the path in the LazyRouter was still using the old name (the branch must have been created before the re-name, but merged after the re-name).

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
