### PR TITLE
Check if hashUrlSearchParams has p[meta_page_view_id]

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -120,7 +120,10 @@ export function Events({ geoId }: Props) {
 		hashUrlSearchParams.toString(),
 	)}`;
 
-	if (!hashUrlSearchParams.has('p[meta_page_view_id]', pageviewId)) {
+	if (
+		!hashUrlSearchParams.has('p[meta_page_view_id]') ||
+		hashUrlSearchParams.get('p[meta_page_view_id]') !== pageviewId
+	) {
 		logException(`hashUrlSearchParams pageviewId mismatch: ${pageviewId}`);
 	}
 

--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -120,8 +120,8 @@ export function Events({ geoId }: Props) {
 		hashUrlSearchParams.toString(),
 	)}`;
 
-	if (!hashUrlSearchParams.has('p[meta_page_view_id]')) {
-		logException('pageviewId not available in hashUrlSearchParams');
+	if (!hashUrlSearchParams.has('p[meta_page_view_id]', pageviewId)) {
+		logException(`hashUrlSearchParams pageviewId mismatch: ${pageviewId}`);
 	}
 
 	const embedUrl = `${ticketTailorUrl}/${eventId}/book${presetDataUrl}`;

--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -104,10 +104,6 @@ export function Events({ geoId }: Props) {
 
 	const pageviewId = getPageViewId();
 
-	if (!pageviewId) {
-		logException('pageviewId not available on event listing');
-	}
-
 	const hashUrlSearchParams = new URLSearchParams({
 		'p[meta_page_view_id]': pageviewId,
 		'p[meta_region_id]': geoId,
@@ -123,6 +119,10 @@ export function Events({ geoId }: Props) {
 	const presetDataUrl = `?preset_data=1&widget=true#${decodeURIComponent(
 		hashUrlSearchParams.toString(),
 	)}`;
+
+	if (!hashUrlSearchParams.has('p[meta_page_view_id]')) {
+		logException('pageviewId not available in hashUrlSearchParams');
+	}
 
 	const embedUrl = `${ticketTailorUrl}/${eventId}/book${presetDataUrl}`;
 

--- a/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/events/events.tsx
@@ -124,7 +124,7 @@ export function Events({ geoId }: Props) {
 		!hashUrlSearchParams.has('p[meta_page_view_id]') ||
 		hashUrlSearchParams.get('p[meta_page_view_id]') !== pageviewId
 	) {
-		logException(`hashUrlSearchParams pageviewId mismatch: ${pageviewId}`);
+		logException('hashUrlSearchParams pageviewId mismatch');
 	}
 
 	const embedUrl = `${ticketTailorUrl}/${eventId}/book${presetDataUrl}`;


### PR DESCRIPTION
## What are you doing in this PR?

An alternate log to https://github.com/guardian/support-frontend/pull/6694, as the original log didn't report anything in ~5 days. I wondered whether `hashUrlSearchParams` contained a `'p[meta_page_view_id]` key as we'd expect, we can check this using https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/has. If not log an expection in Sentry.

