### PR TITLE
Update cookie set by Guardian Ad-Lite purchase to be persistent

### DIFF
--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -19,7 +19,6 @@ import io.circe.syntax._
 import lib.PlayImplicits._
 import models.identity.responses.IdentityErrorResponse._
 import org.apache.pekko.actor.{ActorSystem, Scheduler}
-import org.joda.time.DateTime
 import play.api.http.Writeable
 import play.api.libs.circe.Circe
 import play.api.mvc._
@@ -342,76 +341,10 @@ class CreateSubscriptionController(
       )
   }
 
-  sealed trait SupportCookie {
-    def toPlayCookie: Cookie
-  }
-  case class SessionCookie(name: String, value: String) extends SupportCookie {
-    def toPlayCookie: Cookie = Cookie(
-      name = name,
-      value = value,
-      secure = true,
-      httpOnly = false,
-      domain = Some(guardianDomain.value),
-    )
-  }
-  case class PersistentCookie(name: String, value: String, maxAge: Int) extends SupportCookie {
-    def toPlayCookie: Cookie = Cookie(
-      name = name,
-      value = value,
-      maxAge = Some(maxAge),
-      secure = true,
-      httpOnly = false,
-      domain = Some(guardianDomain.value),
-    )
-  }
-
   private def cookies(product: ProductType, userEmail: String): Future[List[Cookie]] = {
-    // Setting the user attributes cookies used by frontend. See:
-    // https://github.com/guardian/dotcom-rendering/blob/3c4700cae532993ace6f40c3b59c337f3efe2247/dotcom-rendering/src/client/userFeatures/user-features.ts
-    val standardCookies: List[SupportCookie] = List(
-      SessionCookie("gu_user_features_expiry", DateTime.now.plusDays(1).getMillis.toString),
-      SessionCookie("gu_hide_support_messaging", true.toString),
-    )
-    val oneWeekInSeconds = 604800
-    val productCookies: List[SupportCookie] = product match {
-      case Contribution(_, _, billingPeriod) =>
-        List(
-          SessionCookie(
-            s"gu.contributions.recurring.contrib-timestamp.$billingPeriod",
-            DateTime.now.getMillis.toString,
-          ),
-          SessionCookie("gu_recurring_contributor", true.toString),
-        )
-      case _: SupporterPlus =>
-        List(
-          SessionCookie("gu_digital_subscriber", true.toString),
-          // "gu_supporter_plus" -> true.toString, // TODO: add this and remove the digisub one now that the CMP cookie list has been updated
-          SessionCookie("GU_AF1", DateTime.now().plusDays(1).getMillis.toString),
-        )
-      case _: TierThree =>
-        List(
-          SessionCookie("gu_digital_subscriber", true.toString),
-          // SessionCookie("gu_supporter_plus", true.toString), // TODO: add this and remove the digisub one now that the CMP cookie list has been updated
-          SessionCookie("GU_AF1", DateTime.now().plusDays(1).getMillis.toString),
-        )
-      case _: DigitalPack =>
-        List(
-          SessionCookie("gu_digital_subscriber", true.toString),
-          SessionCookie("GU_AF1", DateTime.now().plusDays(1).getMillis.toString),
-        )
-      case p: Paper if p.productOptions.hasDigitalSubscription =>
-        List(
-          SessionCookie("gu_digital_subscriber", true.toString),
-          SessionCookie("GU_AF1", DateTime.now().plusDays(1).getMillis.toString),
-        )
-      case _: Paper => List.empty
-      case _: GuardianWeekly => List.empty
-      case _: GuardianAdLite => List(PersistentCookie("gu_allow_reject_all", true.toString, oneWeekInSeconds))
-    }
-
-    val standardAndProductCookies = (standardCookies ++ productCookies).map(_.toPlayCookie)
-
-    checkoutCompleteCookies(product, userEmail).map(_ ++ standardAndProductCookies)
+    val productCookiesCreator = SubscriptionProductCookiesCreator(guardianDomain)
+    val productCookies = productCookiesCreator.createCookiesForProduct(product)
+    checkoutCompleteCookies(product, userEmail).map(_ ++ productCookies)
   }
 
   private def buildSupportWorkersUser(

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -342,55 +342,74 @@ class CreateSubscriptionController(
       )
   }
 
+  sealed trait SupportCookie {
+    def toPlayCookie: Cookie
+  }
+  case class SessionCookie(name: String, value: String) extends SupportCookie {
+    def toPlayCookie: Cookie = Cookie(
+      name = name,
+      value = value,
+      secure = true,
+      httpOnly = false,
+      domain = Some(guardianDomain.value),
+    )
+  }
+  case class PersistentCookie(name: String, value: String, maxAge: Int) extends SupportCookie {
+    def toPlayCookie: Cookie = Cookie(
+      name = name,
+      value = value,
+      maxAge = Some(maxAge),
+      secure = true,
+      httpOnly = false,
+      domain = Some(guardianDomain.value),
+    )
+  }
+
   private def cookies(product: ProductType, userEmail: String): Future[List[Cookie]] = {
     // Setting the user attributes cookies used by frontend. See:
     // https://github.com/guardian/dotcom-rendering/blob/3c4700cae532993ace6f40c3b59c337f3efe2247/dotcom-rendering/src/client/userFeatures/user-features.ts
-    val standardCookies = List(
-      "gu_user_features_expiry" -> DateTime.now.plusDays(1).getMillis.toString,
-      "gu_hide_support_messaging" -> true.toString,
+    val standardCookies: List[SupportCookie] = List(
+      SessionCookie("gu_user_features_expiry", DateTime.now.plusDays(1).getMillis.toString),
+      SessionCookie("gu_hide_support_messaging", true.toString),
     )
-    val productCookies = product match {
+    val oneWeekInSeconds = 604800
+    val productCookies: List[SupportCookie] = product match {
       case Contribution(_, _, billingPeriod) =>
         List(
-          s"gu.contributions.recurring.contrib-timestamp.$billingPeriod" -> DateTime.now.getMillis.toString,
-          "gu_recurring_contributor" -> true.toString,
+          SessionCookie(
+            s"gu.contributions.recurring.contrib-timestamp.$billingPeriod",
+            DateTime.now.getMillis.toString,
+          ),
+          SessionCookie("gu_recurring_contributor", true.toString),
         )
       case _: SupporterPlus =>
         List(
-          "gu_digital_subscriber" -> true.toString,
+          SessionCookie("gu_digital_subscriber", true.toString),
           // "gu_supporter_plus" -> true.toString, // TODO: add this and remove the digisub one now that the CMP cookie list has been updated
-          "GU_AF1" -> DateTime.now().plusDays(1).getMillis.toString,
+          SessionCookie("GU_AF1", DateTime.now().plusDays(1).getMillis.toString),
         )
       case _: TierThree =>
         List(
-          "gu_digital_subscriber" -> true.toString,
-          // "gu_supporter_plus" -> true.toString, // TODO: add this and remove the digisub one now that the CMP cookie list has been updated
-          "GU_AF1" -> DateTime.now().plusDays(1).getMillis.toString,
+          SessionCookie("gu_digital_subscriber", true.toString),
+          // SessionCookie("gu_supporter_plus", true.toString), // TODO: add this and remove the digisub one now that the CMP cookie list has been updated
+          SessionCookie("GU_AF1", DateTime.now().plusDays(1).getMillis.toString),
         )
       case _: DigitalPack =>
         List(
-          "gu_digital_subscriber" -> true.toString,
-          "GU_AF1" -> DateTime.now().plusDays(1).getMillis.toString,
+          SessionCookie("gu_digital_subscriber", true.toString),
+          SessionCookie("GU_AF1", DateTime.now().plusDays(1).getMillis.toString),
         )
       case p: Paper if p.productOptions.hasDigitalSubscription =>
         List(
-          "gu_digital_subscriber" -> true.toString,
-          "GU_AF1" -> DateTime.now().plusDays(1).getMillis.toString,
+          SessionCookie("gu_digital_subscriber", true.toString),
+          SessionCookie("GU_AF1", DateTime.now().plusDays(1).getMillis.toString),
         )
       case _: Paper => List.empty
       case _: GuardianWeekly => List.empty
-      case _: GuardianAdLite => List("gu_allow_reject_all" -> true.toString)
+      case _: GuardianAdLite => List(PersistentCookie("gu_allow_reject_all", true.toString, oneWeekInSeconds))
     }
 
-    val standardAndProductCookies = (standardCookies ++ productCookies).map { case (name, value) =>
-      Cookie(
-        name = name,
-        value = value,
-        secure = true,
-        httpOnly = false,
-        domain = Some(guardianDomain.value),
-      )
-    }
+    val standardAndProductCookies = (standardCookies ++ productCookies).map(_.toPlayCookie)
 
     checkoutCompleteCookies(product, userEmail).map(_ ++ standardAndProductCookies)
   }

--- a/support-frontend/app/controllers/SubscriptionProductCookiesCreator.scala
+++ b/support-frontend/app/controllers/SubscriptionProductCookiesCreator.scala
@@ -1,0 +1,81 @@
+package controllers
+
+import com.gu.support.workers.ProductType
+import config.Configuration.GuardianDomain
+import org.joda.time.DateTime
+import play.api.mvc.Cookie
+import com.gu.support.workers._
+
+case class SubscriptionProductCookiesCreator(domain: GuardianDomain) {
+  sealed trait SupportCookie {
+    def toPlayCookie: Cookie
+  }
+
+  case class SessionCookie(name: String, value: String) extends SupportCookie {
+    def toPlayCookie: Cookie = Cookie(
+      name = name,
+      value = value,
+      secure = true,
+      httpOnly = false,
+      domain = Some(domain.value),
+    )
+  }
+
+  case class PersistentCookie(name: String, value: String, maxAge: Int) extends SupportCookie {
+    def toPlayCookie: Cookie = Cookie(
+      name = name,
+      value = value,
+      maxAge = Some(maxAge),
+      secure = true,
+      httpOnly = false,
+      domain = Some(domain.value),
+    )
+  }
+
+  def createCookiesForProduct(product: ProductType): List[Cookie] = {
+    // Setting the user attributes cookies used by frontend. See:
+    // https://github.com/guardian/dotcom-rendering/blob/3c4700cae532993ace6f40c3b59c337f3efe2247/dotcom-rendering/src/client/userFeatures/user-features.ts
+    val standardCookies: List[SupportCookie] = List(
+      SessionCookie("gu_user_features_expiry", DateTime.now.plusDays(1).getMillis.toString),
+      SessionCookie("gu_hide_support_messaging", true.toString),
+    )
+    val oneWeekInSeconds = 604800
+    val productCookies: List[SupportCookie] = product match {
+      case Contribution(_, _, billingPeriod) =>
+        List(
+          SessionCookie(
+            s"gu.contributions.recurring.contrib-timestamp.$billingPeriod",
+            DateTime.now.getMillis.toString,
+          ),
+          SessionCookie("gu_recurring_contributor", true.toString),
+        )
+      case _: SupporterPlus =>
+        List(
+          SessionCookie("gu_digital_subscriber", true.toString),
+          // "gu_supporter_plus" -> true.toString, // TODO: add this and remove the digisub one now that the CMP cookie list has been updated
+          SessionCookie("GU_AF1", DateTime.now().plusDays(1).getMillis.toString),
+        )
+      case _: TierThree =>
+        List(
+          SessionCookie("gu_digital_subscriber", true.toString),
+          // SessionCookie("gu_supporter_plus", true.toString), // TODO: add this and remove the digisub one now that the CMP cookie list has been updated
+          SessionCookie("GU_AF1", DateTime.now().plusDays(1).getMillis.toString),
+        )
+      case _: DigitalPack =>
+        List(
+          SessionCookie("gu_digital_subscriber", true.toString),
+          SessionCookie("GU_AF1", DateTime.now().plusDays(1).getMillis.toString),
+        )
+      case p: Paper if p.productOptions.hasDigitalSubscription =>
+        List(
+          SessionCookie("gu_digital_subscriber", true.toString),
+          SessionCookie("GU_AF1", DateTime.now().plusDays(1).getMillis.toString),
+        )
+      case _: Paper => List.empty
+      case _: GuardianWeekly => List.empty
+      case _: GuardianAdLite => List(PersistentCookie("gu_allow_reject_all", true.toString, oneWeekInSeconds))
+    }
+
+    (standardCookies ++ productCookies).map(_.toPlayCookie)
+  }
+}

--- a/support-frontend/test/controllers/SubscriptionProductCookiesCreatorTest.scala
+++ b/support-frontend/test/controllers/SubscriptionProductCookiesCreatorTest.scala
@@ -1,0 +1,43 @@
+package controllers
+
+import com.gu.i18n.Currency.GBP
+import com.gu.support.workers.{GuardianAdLite, Monthly, SupporterPlus}
+import config.Configuration.GuardianDomain
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.mvc.Cookie
+
+class SubscriptionProductCookiesCreatorTest extends AnyFlatSpec with Matchers {
+  "createCookiesForProduct" should "set the gu_allow_reject_all cookie for GuardianAdLite" in {
+    val guardianAdLite = GuardianAdLite(GBP)
+    val creator = SubscriptionProductCookiesCreator(GuardianDomain("thegulocal.com"))
+
+    val cookies = creator.createCookiesForProduct(guardianAdLite)
+
+    val expectedCookie = Cookie(
+      name = "gu_allow_reject_all",
+      value = "true",
+      maxAge = Some(604800),
+      secure = true,
+      httpOnly = false,
+      domain = Some("thegulocal.com"),
+    )
+    cookies should contain(expectedCookie)
+  }
+
+  it should "set the gu_digital_subscriber cookie for SupporterPlus" in {
+    val supporterPlus = SupporterPlus(BigDecimal(12), GBP, Monthly)
+    val creator = SubscriptionProductCookiesCreator(GuardianDomain("thegulocal.com"))
+
+    val cookies = creator.createCookiesForProduct(supporterPlus)
+
+    val expectedCookie = Cookie(
+      name = "gu_digital_subscriber",
+      value = "true",
+      secure = true,
+      httpOnly = false,
+      domain = Some("thegulocal.com"),
+    )
+    cookies should contain(expectedCookie)
+  }
+}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Update the cookie set by the checkout when a user makes a Guardian Ad-Lite purchase to be persistent. It should persist for 7 days. Previously it was a session cookie. This includes a refactoring to support persistent cookies on the checkout in a product specific way.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/fzP5uikS/1369-update-cookies-set-by-support-frontend)

## Why are you doing this?

This gives the user a 7 day grace period to sign in after purchasing.

## How to test

Purchase Guardian Ad-Lite in CODE, see that the cookie is set correctly:

<img width="641" alt="Screenshot 2025-01-21 at 12 47 36" src="https://github.com/user-attachments/assets/e24995be-a052-42b7-be8e-92095ed03783" />

For other products, cookies continue to be correctly set as session cookies:

<img width="733" alt="Screenshot 2025-01-21 at 12 52 41" src="https://github.com/user-attachments/assets/d42c3485-8fdc-4648-99c3-58822b3f0249" />

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
