### PR TITLE
Remove some cookies set by the checkout

### DIFF
--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -19,6 +19,7 @@ import io.circe.syntax._
 import lib.PlayImplicits._
 import models.identity.responses.IdentityErrorResponse._
 import org.apache.pekko.actor.{ActorSystem, Scheduler}
+import org.joda.time.DateTime
 import play.api.http.Writeable
 import play.api.libs.circe.Circe
 import play.api.mvc._
@@ -416,7 +417,7 @@ class CreateSubscriptionController(
 
   private def cookies(product: ProductType, userEmail: String): Future[List[Cookie]] = {
     val productCookiesCreator = SubscriptionProductCookiesCreator(guardianDomain)
-    val productCookies = productCookiesCreator.createCookiesForProduct(product)
+    val productCookies = productCookiesCreator.createCookiesForProduct(product, DateTime.now())
     checkoutCompleteCookies(product, userEmail).map(_ ++ productCookies)
   }
 

--- a/support-frontend/app/controllers/SubscriptionProductCookiesCreator.scala
+++ b/support-frontend/app/controllers/SubscriptionProductCookiesCreator.scala
@@ -32,47 +32,25 @@ case class SubscriptionProductCookiesCreator(domain: GuardianDomain) {
     )
   }
 
-  def createCookiesForProduct(product: ProductType): List[Cookie] = {
+  def createCookiesForProduct(product: ProductType, now: DateTime): List[Cookie] = {
     // Setting the user attributes cookies used by frontend. See:
     // https://github.com/guardian/dotcom-rendering/blob/3c4700cae532993ace6f40c3b59c337f3efe2247/dotcom-rendering/src/client/userFeatures/user-features.ts
     val standardCookies: List[SupportCookie] = List(
-      SessionCookie("gu_user_features_expiry", DateTime.now.plusDays(1).getMillis.toString),
+      SessionCookie("gu_user_features_expiry", now.plusDays(1).getMillis.toString),
       SessionCookie("gu_hide_support_messaging", true.toString),
     )
+
     val oneWeekInSeconds = 604800
+
     val productCookies: List[SupportCookie] = product match {
-      case Contribution(_, _, billingPeriod) =>
-        List(
-          SessionCookie(
-            s"gu.contributions.recurring.contrib-timestamp.$billingPeriod",
-            DateTime.now.getMillis.toString,
-          ),
-          SessionCookie("gu_recurring_contributor", true.toString),
-        )
-      case _: SupporterPlus =>
-        List(
-          SessionCookie("gu_digital_subscriber", true.toString),
-          // "gu_supporter_plus" -> true.toString, // TODO: add this and remove the digisub one now that the CMP cookie list has been updated
-          SessionCookie("GU_AF1", DateTime.now().plusDays(1).getMillis.toString),
-        )
-      case _: TierThree =>
-        List(
-          SessionCookie("gu_digital_subscriber", true.toString),
-          // SessionCookie("gu_supporter_plus", true.toString), // TODO: add this and remove the digisub one now that the CMP cookie list has been updated
-          SessionCookie("GU_AF1", DateTime.now().plusDays(1).getMillis.toString),
-        )
-      case _: DigitalPack =>
-        List(
-          SessionCookie("gu_digital_subscriber", true.toString),
-          SessionCookie("GU_AF1", DateTime.now().plusDays(1).getMillis.toString),
-        )
+      case _: SupporterPlus | _: TierThree | _: DigitalPack =>
+        List(SessionCookie("GU_AF1", now.plusDays(1).getMillis.toString))
+
       case p: Paper if p.productOptions.hasDigitalSubscription =>
-        List(
-          SessionCookie("gu_digital_subscriber", true.toString),
-          SessionCookie("GU_AF1", DateTime.now().plusDays(1).getMillis.toString),
-        )
-      case _: Paper => List.empty
-      case _: GuardianWeekly => List.empty
+        List(SessionCookie("GU_AF1", now.plusDays(1).getMillis.toString))
+
+      case _: Contribution | _: Paper | _: GuardianWeekly => List.empty
+
       case _: GuardianAdLite => List(PersistentCookie("gu_allow_reject_all", true.toString, oneWeekInSeconds))
     }
 

--- a/support-frontend/app/controllers/SubscriptionProductCookiesCreator.scala
+++ b/support-frontend/app/controllers/SubscriptionProductCookiesCreator.scala
@@ -7,53 +7,45 @@ import play.api.mvc.Cookie
 import com.gu.support.workers._
 
 case class SubscriptionProductCookiesCreator(domain: GuardianDomain) {
-  sealed trait SupportCookie {
-    def toPlayCookie: Cookie
-  }
+  private val oneDayInSeconds = 60 * 60 * 24;
+  private val maxAgeInDays = 7
 
-  case class SessionCookie(name: String, value: String) extends SupportCookie {
-    def toPlayCookie: Cookie = Cookie(
+  private def persistentCookieWithMaxAge(name: String, now: DateTime) = {
+    val expiryTime = now.plusDays(maxAgeInDays).withTimeAtStartOfDay().getMillis.toString
+    Cookie(
       name = name,
-      value = value,
+      value = expiryTime,
+      maxAge = Some(oneDayInSeconds * maxAgeInDays),
       secure = true,
       httpOnly = false,
       domain = Some(domain.value),
     )
   }
+  private def adFreeCookie(now: DateTime) =
+    persistentCookieWithMaxAge("GU_AF1", now)
 
-  case class PersistentCookie(name: String, value: String, maxAge: Int) extends SupportCookie {
-    def toPlayCookie: Cookie = Cookie(
-      name = name,
-      value = value,
-      maxAge = Some(maxAge),
-      secure = true,
-      httpOnly = false,
-      domain = Some(domain.value),
-    )
-  }
+  private def hideSupportMessagingCookie(now: DateTime) =
+    persistentCookieWithMaxAge("gu_hide_support_messaging", now)
+
+  private def allowRejectAllCookie(now: DateTime) =
+    persistentCookieWithMaxAge("gu_allow_reject_all", now)
+
+  private def userFeaturesExpiryCookie(now: DateTime) =
+    persistentCookieWithMaxAge("gu_user_features_expiry", now)
 
   def createCookiesForProduct(product: ProductType, now: DateTime): List[Cookie] = {
-    // Setting the user attributes cookies used by frontend. See:
+    // Setting the user benefits cookies used by frontend. See:
     // https://github.com/guardian/dotcom-rendering/blob/3c4700cae532993ace6f40c3b59c337f3efe2247/dotcom-rendering/src/client/userFeatures/user-features.ts
-    val standardCookies: List[SupportCookie] = List(
-      SessionCookie("gu_user_features_expiry", now.plusDays(1).getMillis.toString),
-      SessionCookie("gu_hide_support_messaging", true.toString),
-    )
 
-    val oneWeekInSeconds = 604800
+    val productCookies: List[Cookie] = product match {
+      case _: SupporterPlus | _: TierThree | _: DigitalPack | _: Paper =>
+        List(adFreeCookie(now), allowRejectAllCookie(now), hideSupportMessagingCookie(now))
 
-    val productCookies: List[SupportCookie] = product match {
-      case _: SupporterPlus | _: TierThree | _: DigitalPack =>
-        List(SessionCookie("GU_AF1", now.plusDays(1).getMillis.toString))
+      case _: Contribution | _: GuardianWeekly => List(hideSupportMessagingCookie(now))
 
-      case p: Paper if p.productOptions.hasDigitalSubscription =>
-        List(SessionCookie("GU_AF1", now.plusDays(1).getMillis.toString))
-
-      case _: Contribution | _: Paper | _: GuardianWeekly => List.empty
-
-      case _: GuardianAdLite => List(PersistentCookie("gu_allow_reject_all", true.toString, oneWeekInSeconds))
+      case _: GuardianAdLite => List(allowRejectAllCookie(now))
     }
 
-    (standardCookies ++ productCookies).map(_.toPlayCookie)
+    userFeaturesExpiryCookie(now) :: productCookies
   }
 }

--- a/support-frontend/test/controllers/SubscriptionProductCookiesCreatorTest.scala
+++ b/support-frontend/test/controllers/SubscriptionProductCookiesCreatorTest.scala
@@ -9,38 +9,47 @@ import play.api.mvc.Cookie
 import org.joda.time.DateTime
 
 class SubscriptionProductCookiesCreatorTest extends AnyFlatSpec with Matchers {
+  private val now = DateTime.parse("2025-01-01T00:00:00")
+  private val creator = SubscriptionProductCookiesCreator(GuardianDomain("thegulocal.com"))
+
+  private def expectedCookie(name: String) = Cookie(
+    name = name,
+    value = "1736294400000", // 2025-01-08T00:00:00 as epoch timestamp,
+    maxAge = Some(60 * 60 * 24 * 7),
+    secure = true,
+    httpOnly = false,
+    domain = Some("thegulocal.com"),
+  )
+
   "createCookiesForProduct" should "set the gu_allow_reject_all cookie for GuardianAdLite" in {
     val guardianAdLite = GuardianAdLite(GBP)
-    val creator = SubscriptionProductCookiesCreator(GuardianDomain("thegulocal.com"))
-
-    val now = DateTime.now()
     val cookies = creator.createCookiesForProduct(guardianAdLite, now)
 
-    val expectedCookie = Cookie(
-      name = "gu_allow_reject_all",
-      value = "true",
-      maxAge = Some(604800),
-      secure = true,
-      httpOnly = false,
-      domain = Some("thegulocal.com"),
-    )
-    cookies should contain(expectedCookie)
+    cookies should contain(expectedCookie("gu_allow_reject_all"))
+    cookies should contain(
+      expectedCookie("gu_user_features_expiry"),
+    ) // It should also contain the user features expiry cookie
+  }
+  it should "not set the hide support messaging cookie for Guardian Ad Lite because it is not a supporter product" in {
+    val guardianAdLite = GuardianAdLite(GBP)
+    val cookies = creator.createCookiesForProduct(guardianAdLite, now)
+
+    cookies should not contain expectedCookie("gu_hide_support_messaging")
+    cookies should contain(
+      expectedCookie("gu_user_features_expiry"),
+    ) // It should also contain the user features expiry cookie
   }
 
-  it should "set the gu_digital_subscriber cookie for SupporterPlus" in {
+  it should "set the ad-free cookie, the hide supporter revenue cookie and the allow reject all cookie for SupporterPlus" in {
     val supporterPlus = SupporterPlus(BigDecimal(12), GBP, Monthly)
-    val creator = SubscriptionProductCookiesCreator(GuardianDomain("thegulocal.com"))
-
-    val now = new DateTime("2025-01-01T00:00:00")
     val cookies = creator.createCookiesForProduct(supporterPlus, now)
 
-    val expectedCookie = Cookie(
-      name = "GU_AF1",
-      value = "1735776000000", // Jan 2nd 2024 millis
-      secure = true,
-      httpOnly = false,
-      domain = Some("thegulocal.com"),
-    )
-    cookies should contain(expectedCookie)
+    cookies should contain(expectedCookie("GU_AF1"))
+    cookies should contain(expectedCookie("gu_hide_support_messaging"))
+    cookies should contain(expectedCookie("gu_allow_reject_all"))
+    cookies should contain(
+      expectedCookie("gu_user_features_expiry"),
+    ) // It should also contain the user features expiry cookie
   }
+
 }

--- a/support-frontend/test/controllers/SubscriptionProductCookiesCreatorTest.scala
+++ b/support-frontend/test/controllers/SubscriptionProductCookiesCreatorTest.scala
@@ -6,13 +6,15 @@ import config.Configuration.GuardianDomain
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import play.api.mvc.Cookie
+import org.joda.time.DateTime
 
 class SubscriptionProductCookiesCreatorTest extends AnyFlatSpec with Matchers {
   "createCookiesForProduct" should "set the gu_allow_reject_all cookie for GuardianAdLite" in {
     val guardianAdLite = GuardianAdLite(GBP)
     val creator = SubscriptionProductCookiesCreator(GuardianDomain("thegulocal.com"))
 
-    val cookies = creator.createCookiesForProduct(guardianAdLite)
+    val now = DateTime.now()
+    val cookies = creator.createCookiesForProduct(guardianAdLite, now)
 
     val expectedCookie = Cookie(
       name = "gu_allow_reject_all",
@@ -29,11 +31,12 @@ class SubscriptionProductCookiesCreatorTest extends AnyFlatSpec with Matchers {
     val supporterPlus = SupporterPlus(BigDecimal(12), GBP, Monthly)
     val creator = SubscriptionProductCookiesCreator(GuardianDomain("thegulocal.com"))
 
-    val cookies = creator.createCookiesForProduct(supporterPlus)
+    val now = new DateTime("2025-01-01T00:00:00")
+    val cookies = creator.createCookiesForProduct(supporterPlus, now)
 
     val expectedCookie = Cookie(
-      name = "gu_digital_subscriber",
-      value = "true",
+      name = "GU_AF1",
+      value = "1735776000000", // Jan 2nd 2024 millis
       secure = true,
       httpOnly = false,
       domain = Some("thegulocal.com"),


### PR DESCRIPTION
## What are you doing in this PR?

I've removed the following as they're no longer needed:

* `gu_recurring_contributor`
* `gu_digital_subscriber`
* `gu.contributions.recurring.contrib-timestamp.<billing period>`

I've refactored the cookie setting code a bit to consolidate things and make it clear where products set the same cookie(s).

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/fzP5uikS/1369-update-cookies-set-by-support-frontend)

## Why are you doing this?

These cookies are no longer needed.

## How to test

Put through a purchase, see that these cookies are no longer set.