### PR TITLE
Change Knip `ignoreExportsUsedInFile` to false and fix

### DIFF
--- a/support-frontend/assets/components/button/_sharedButton.tsx
+++ b/support-frontend/assets/components/button/_sharedButton.tsx
@@ -6,7 +6,7 @@ import { classNameWithModifiers } from 'helpers/utilities/utilities';
 import './button.scss';
 
 // ----- PropTypes ----- //
-export const Appearances = {
+const Appearances = {
 	primary: 'primary',
 	secondary: 'secondary',
 	tertiary: 'tertiary',
@@ -17,7 +17,7 @@ export const Appearances = {
 	greyHollow: 'greyHollow',
 	disabled: 'disabled',
 };
-export const Sides = {
+const Sides = {
 	right: 'right',
 	left: 'left',
 };
@@ -83,5 +83,5 @@ export const defaultProps = {
 	modifierClasses: [],
 };
 SharedButton.defaultProps = { ...defaultProps };
-export type { SharedButtonPropTypes, IconSide, Appearance };
+export type { SharedButtonPropTypes };
 export default SharedButton;

--- a/support-frontend/assets/components/button/anchorButton.tsx
+++ b/support-frontend/assets/components/button/anchorButton.tsx
@@ -4,7 +4,7 @@ import SharedButton, { defaultProps } from './_sharedButton';
 import './button.scss';
 
 // ----- Render ----- //
-export type PropTypes = SharedButtonPropTypes & {
+type PropTypes = SharedButtonPropTypes & {
 	'aria-label'?: string | null | undefined;
 	href: string;
 	onClick?: () => void;

--- a/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/checkoutBenefitsListData.tsx
@@ -21,7 +21,7 @@ type TierUnlocks = {
 	countryGroupId: CountryGroupId;
 };
 
-export type CheckListData = {
+type CheckListData = {
 	isChecked: boolean;
 	text?: JSX.Element;
 	maybeGreyedOut?: SerializedStyles;

--- a/support-frontend/assets/components/content/content.tsx
+++ b/support-frontend/assets/components/content/content.tsx
@@ -6,7 +6,7 @@ import 'helpers/types/option';
 import './content.scss';
 
 // ---- Types ----- //
-export const Appearances = {
+const Appearances = {
 	white: 'white',
 	grey: 'grey',
 	highlight: 'highlight',

--- a/support-frontend/assets/components/csr/csrMode.ts
+++ b/support-frontend/assets/components/csr/csrMode.ts
@@ -96,9 +96,4 @@ const useCsrCustomerData = (
 const csrUserName = (csrCustomerData: CsrCustomerData): string =>
 	`${csrCustomerData.csr.firstName} ${csrCustomerData.csr.lastName}`;
 
-export {
-	useCsrCustomerData,
-	isSalesforceDomain,
-	csrUserName,
-	parseCustomerData,
-};
+export { useCsrCustomerData, csrUserName, parseCustomerData };

--- a/support-frontend/assets/components/dialog/dialog.tsx
+++ b/support-frontend/assets/components/dialog/dialog.tsx
@@ -48,7 +48,7 @@ const backdrop = css`
 	width: 100%;
 `;
 
-export type PropTypes = {
+type PropTypes = {
 	closeDialog: () => void;
 	styled?: boolean;
 	open?: boolean;

--- a/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.tsx
@@ -51,7 +51,7 @@ const mapDispatchToProps = {
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
-export type PropTypes = ConnectedProps<typeof connector> & {
+type PropTypes = ConnectedProps<typeof connector> & {
 	allErrors: Array<Record<string, string>>;
 	buttonText: string;
 	submissionErrorHeading: string;

--- a/support-frontend/assets/components/footerCompliant/FooterWithPromoTerms.tsx
+++ b/support-frontend/assets/components/footerCompliant/FooterWithPromoTerms.tsx
@@ -7,10 +7,7 @@ import {
 	Quarterly,
 } from 'helpers/productPrice/billingPeriods';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import {
-	Domestic,
-	NoFulfilmentOptions,
-} from 'helpers/productPrice/fulfilmentOptions';
+import { Domestic } from 'helpers/productPrice/fulfilmentOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { getPromotion } from 'helpers/productPrice/promotions';
@@ -176,24 +173,4 @@ function GuardianWeeklyFooter({
 	);
 }
 
-function DigitalFooter({
-	productPrices,
-	orderIsAGift,
-	country,
-}: FooterWithPromoTermsProps): JSX.Element {
-	const termsConditionsLink = orderIsAGift
-		? 'https://www.theguardian.com/help/2020/nov/24/gift-digital-subscriptions-terms-and-conditions'
-		: 'https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions';
-
-	return (
-		<FooterWithPromoTerms
-			productPrices={productPrices}
-			orderIsAGift={orderIsAGift}
-			country={country}
-			fulfillmentOption={NoFulfilmentOptions}
-			termsConditionsLink={termsConditionsLink}
-		/>
-	);
-}
-
-export { DigitalFooter, GuardianWeeklyFooter };
+export { GuardianWeeklyFooter };

--- a/support-frontend/assets/components/headers/header/header.tsx
+++ b/support-frontend/assets/components/headers/header/header.tsx
@@ -9,12 +9,12 @@ import Links from '../links/links';
 import MobileMenuToggler from './mobileMenuToggler';
 import './header.scss';
 
-export type PropTypes = {
+type PropTypes = {
 	utility?: JSX.Element;
 	countryGroupId: CountryGroupId;
 	display?: 'navigation' | 'checkout' | 'guardianLogo' | void;
 };
-export type State = {
+type State = {
 	isTestUser: boolean | null | undefined;
 };
 

--- a/support-frontend/assets/components/headers/mobileMenu/mobileMenu.tsx
+++ b/support-frontend/assets/components/headers/mobileMenu/mobileMenu.tsx
@@ -9,7 +9,7 @@ export type Position = {
 	y: number;
 };
 
-export type PropTypes = {
+type PropTypes = {
 	onClose: () => void;
 	utility: ReactNode;
 	links: ReactNode;

--- a/support-frontend/assets/components/page/heroRoundel.tsx
+++ b/support-frontend/assets/components/page/heroRoundel.tsx
@@ -11,8 +11,8 @@ import {
 import type { ReactElement, ReactNode } from 'react';
 import { digitalSubscriptionsBlue } from 'stylesheets/emotion/colours';
 
-export const roundelSizeMob = 100;
-export const roundelSize = 180;
+const roundelSizeMob = 100;
+const roundelSize = 180;
 
 const heroRoundelStyles = css`
 	display: flex;

--- a/support-frontend/assets/components/page/pageTitle.tsx
+++ b/support-frontend/assets/components/page/pageTitle.tsx
@@ -61,7 +61,7 @@ const header = css`
 		}
 	}
 `;
-export const pageTitle = css`
+const pageTitle = css`
 	${titlepiece42};
 	font-weight: bold;
 	z-index: 10;
@@ -88,7 +88,7 @@ export const pageTitle = css`
 	}
 `;
 
-function PageTitle({
+export function PageTitle({
 	title,
 	theme,
 	cssOverrides,
@@ -103,8 +103,3 @@ function PageTitle({
 		</div>
 	);
 }
-
-PageTitle.defaultProps = {
-	cssOverrides: '',
-};
-export default PageTitle;

--- a/support-frontend/assets/components/payPalPaymentButton/payPalButtonProps.ts
+++ b/support-frontend/assets/components/payPalPaymentButton/payPalButtonProps.ts
@@ -8,7 +8,7 @@ import type {
 import { routes } from 'helpers/urls/routes';
 import { logException } from 'helpers/utilities/logger';
 
-export type PayPalButtonControls = {
+type PayPalButtonControls = {
 	enable?: () => void;
 	disable?: () => void;
 };

--- a/support-frontend/assets/components/paymentFrequencyTabs/paymentFrequenncyTabs.tsx
+++ b/support-frontend/assets/components/paymentFrequencyTabs/paymentFrequenncyTabs.tsx
@@ -18,7 +18,7 @@ const tabPanelStyles = css`
 	}
 `;
 
-export type TabProps = {
+type TabProps = {
 	id: ContributionType;
 	labelText: string;
 	selected: boolean;

--- a/support-frontend/assets/components/personalDetails/personalDetails.tsx
+++ b/support-frontend/assets/components/personalDetails/personalDetails.tsx
@@ -132,5 +132,3 @@ export function PersonalDetails({
 		</div>
 	);
 }
-
-export default PersonalDetails;

--- a/support-frontend/assets/components/priceLabel/priceLabel.tsx
+++ b/support-frontend/assets/components/priceLabel/priceLabel.tsx
@@ -5,7 +5,7 @@ import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import { showPrice } from 'helpers/productPrice/productPrices';
 import { getAppliedPromo, hasDiscount } from 'helpers/productPrice/promotions';
 
-export type PropTypes = {
+type PropTypes = {
 	productPrice: ProductPrice;
 	billingPeriod: BillingPeriod;
 	className: string;

--- a/support-frontend/assets/components/productPage/productPageHero/productPageHero.tsx
+++ b/support-frontend/assets/components/productPage/productPageHero/productPageHero.tsx
@@ -146,5 +146,4 @@ ProductPageHeroHeader.defaultProps = {
 	orderIsAGift: false,
 	giftImage: null,
 };
-export { HeroWrapper, HeroHeading, ProductPageHeroHeader };
-export default ProductPageHero;
+export { HeroWrapper };

--- a/support-frontend/assets/components/stripeCardForm/stripeCardForm.tsx
+++ b/support-frontend/assets/components/stripeCardForm/stripeCardForm.tsx
@@ -22,7 +22,7 @@ const inlineContainer = css`
 	}
 `;
 
-export type StripeCardFormProps = {
+type StripeCardFormProps = {
 	onCardNumberChange: (event: StripeCardNumberElementChangeEvent) => void;
 	onExpiryChange: (event: StripeCardExpiryElementChangeEvent) => void;
 	onCvcChange: (event: StripeCardCvcElementChangeEvent) => void;

--- a/support-frontend/assets/components/subscriptionCheckouts/cancellationPolicy.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/cancellationPolicy.tsx
@@ -1,6 +1,6 @@
 import Text from 'components/text/text';
 
-export const cancellationCopy = {
+const cancellationCopy = {
 	title: 'You can cancel any time',
 	body: 'There is no set time on your agreement with us so you can end your subscription whenever you wish',
 };

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetails.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetails.tsx
@@ -23,7 +23,7 @@ const paragraphWithButton = css`
 	${textSans17};
 `;
 
-export type PropTypes = {
+type PropTypes = {
 	firstName: string;
 	setFirstName: (firstName: string) => void;
 	lastName: string;

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.tsx
@@ -9,7 +9,7 @@ import 'helpers/subscriptionsForms/formFields';
 const marginBotom = css`
 	margin-bottom: ${space[6]}px;
 `;
-export type PropTypes = {
+type PropTypes = {
 	firstNameGiftRecipient: string;
 	setFirstNameGift: (firstName: string) => void;
 	lastNameGiftRecipient: string;
@@ -57,41 +57,4 @@ function PersonalDetailsGift(props: PropTypes): JSX.Element {
 	);
 }
 
-function PersonalDetailsDigitalGift(props: PropTypes): JSX.Element {
-	return (
-		<div>
-			<TextInput
-				cssOverrides={marginBotom}
-				id="firstNameGiftRecipient"
-				data-qm-masking="blocklist"
-				label="First name"
-				type="text"
-				value={props.firstNameGiftRecipient}
-				onChange={(e) => props.setFirstNameGift(e.target.value)}
-				error={firstError('firstNameGiftRecipient', props.formErrors)}
-			/>
-			<TextInput
-				cssOverrides={marginBotom}
-				id="lastNameGiftRecipient"
-				data-qm-masking="blocklist"
-				label="Last name"
-				type="text"
-				value={props.lastNameGiftRecipient}
-				onChange={(e) => props.setLastNameGift(e.target.value)}
-				error={firstError('lastNameGiftRecipient', props.formErrors)}
-			/>
-			<TextInput
-				cssOverrides={marginBotom}
-				id="emailGiftRecipient"
-				data-qm-masking="blocklist"
-				label="Email"
-				type="email"
-				onChange={(e) => props.setEmailGift(e.target.value)}
-				value={props.emailGiftRecipient}
-				error={firstError('emailGiftRecipient', props.formErrors)}
-			/>
-		</div>
-	);
-}
-
-export { PersonalDetailsGift, PersonalDetailsDigitalGift };
+export { PersonalDetailsGift };

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.tsx
@@ -40,7 +40,7 @@ import {
 } from './composedStripeElements';
 
 // Types
-export type StripeFormPropTypes = {
+type StripeFormPropTypes = {
 	allErrors: Array<FormError<FormField>>;
 	stripeKey: string;
 	submitForm: () => void;

--- a/support-frontend/assets/components/thankYou/guardianAdLite/addressCta.tsx
+++ b/support-frontend/assets/components/thankYou/guardianAdLite/addressCta.tsx
@@ -10,7 +10,7 @@ const btnStyleOverrides = css`
 	margin-bottom: ${space[5]}px;
 `;
 
-export type AddressCtaProp = {
+type AddressCtaProp = {
 	copy: string;
 	address: string;
 	hasArrow?: boolean;

--- a/support-frontend/assets/components/thankYou/thankyouModules.tsx
+++ b/support-frontend/assets/components/thankYou/thankyouModules.tsx
@@ -23,7 +23,7 @@ const firstColumnContainer = css`
 	}
 `;
 
-export interface ThankYouModulesProps {
+interface ThankYouModulesProps {
 	isSignedIn?: boolean;
 	showNewspaperArchiveBenefit: boolean;
 	thankYouModules: ThankYouModuleType[];

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -46,13 +46,9 @@ export type Audience = {
 	breakpoint?: BreakpointRange;
 };
 
-export type AudienceType =
-	| IsoCountry
-	| CountryGroupId
-	| 'ALL'
-	| 'CONTRIBUTIONS_ONLY';
+type AudienceType = IsoCountry | CountryGroupId | 'ALL' | 'CONTRIBUTIONS_ONLY';
 
-export type Audiences = {
+type Audiences = {
 	[key in AudienceType]?: Audience;
 };
 

--- a/support-frontend/assets/helpers/abTests/helpers.ts
+++ b/support-frontend/assets/helpers/abTests/helpers.ts
@@ -14,7 +14,7 @@ type NonEmptyAmountsTestArray = [
 	...AmountsTestWithVariants[],
 ];
 
-export const FALLBACK_AMOUNTS: NonEmptyAmountsTestArray = [
+const FALLBACK_AMOUNTS: NonEmptyAmountsTestArray = [
 	{
 		testName: 'FALLBACK_AMOUNTS__GBPCountries',
 		liveTestName: '',

--- a/support-frontend/assets/helpers/contributions.ts
+++ b/support-frontend/assets/helpers/contributions.ts
@@ -5,11 +5,6 @@ import type {
 } from 'helpers/forms/paymentMethods';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { countryGroups } from 'helpers/internationalisation/countryGroup';
-import {
-	currencies,
-	spokenCurrencies,
-} from 'helpers/internationalisation/currency';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import { Annual, Monthly } from 'helpers/productPrice/billingPeriods';
 import { logException } from 'helpers/utilities/logger';
@@ -18,12 +13,12 @@ import { roundToDecimalPlaces } from 'helpers/utilities/utilities';
 // ----- Types ----- //
 export const contributionTypes = ['ONE_OFF', 'MONTHLY', 'ANNUAL'];
 
-export type RegularContributionTypeMap<T> = {
+type RegularContributionTypeMap<T> = {
 	MONTHLY: T;
 	ANNUAL: T;
 };
 
-export type ContributionTypeMap<T> = RegularContributionTypeMap<T> & {
+type ContributionTypeMap<T> = RegularContributionTypeMap<T> & {
 	ONE_OFF: T;
 };
 
@@ -46,7 +41,7 @@ export interface AmountValuesObject {
 	hideChooseYourAmount: boolean;
 }
 
-export type AmountsCardData = {
+type AmountsCardData = {
 	[key in ContributionType]: AmountValuesObject;
 };
 
@@ -89,10 +84,9 @@ export type ContributionTypes = Record<
 
 type ParseError = 'ParseError';
 
-export type ValidationError = 'TooMuch' | 'TooLittle';
-export type ContributionError = ParseError | ValidationError;
+type ValidationError = 'TooMuch' | 'TooLittle';
 
-export type ParsedContribution =
+type ParsedContribution =
 	| {
 			valid: true;
 			amount: number;
@@ -101,7 +95,7 @@ export type ParsedContribution =
 			error: ParseError;
 	  };
 
-export type Config = Record<
+type Config = Record<
 	ContributionType,
 	{
 		min: number;
@@ -387,14 +381,6 @@ function generateContributionTypes(
 	};
 }
 
-function parseRegularContributionType(s: string): RegularContributionType {
-	if (s === 'ANNUAL') {
-		return 'ANNUAL';
-	}
-
-	return 'MONTHLY';
-}
-
 function billingPeriodFromContrib(
 	contributionType: ContributionType,
 ): BillingPeriod {
@@ -406,108 +392,6 @@ function billingPeriodFromContrib(
 			return Monthly;
 	}
 }
-
-function errorMessage(
-	error: ContributionError,
-	contributionType: ContributionType,
-	countryGroupId: CountryGroupId,
-): string | null | undefined {
-	const minContrib = config[countryGroupId][contributionType].min;
-	const maxContrib = config[countryGroupId][contributionType].max;
-	const currency = currencies[countryGroups[countryGroupId].currency];
-
-	switch (error) {
-		case 'TooLittle':
-			return `Please enter at least ${currency.glyph}${minContrib}`;
-
-		case 'TooMuch':
-			return `${currency.glyph}${maxContrib} is the maximum we can accept`;
-
-		case 'ParseError':
-			return 'Please enter a numeric amount';
-
-		default:
-			return null;
-	}
-}
-
-function getContributionTypeClassName(
-	contributionType: ContributionType,
-): string {
-	if (contributionType === 'ONE_OFF') {
-		return 'one-off';
-	} else if (contributionType === 'ANNUAL') {
-		return 'annual';
-	}
-
-	return 'monthly';
-}
-
-function getSpokenType(contributionType: ContributionType): string {
-	if (contributionType === 'ONE_OFF') {
-		return 'single';
-	} else if (contributionType === 'ANNUAL') {
-		return 'annual';
-	}
-
-	return 'monthly';
-}
-
-function getFrequency(contributionType: ContributionType): string {
-	if (contributionType === 'ONE_OFF') {
-		return '';
-	} else if (contributionType === 'MONTHLY') {
-		return 'per month';
-	}
-
-	return 'per year';
-}
-
-function getCustomAmountA11yHint(
-	contributionType: ContributionType,
-	countryGroupId: CountryGroupId,
-): string {
-	const isoCurrency = countryGroups[countryGroupId].currency;
-	let spokenCurrency = spokenCurrencies[isoCurrency].plural;
-
-	if (contributionType === 'ONE_OFF') {
-		spokenCurrency = spokenCurrencies[isoCurrency].singular;
-	}
-
-	return `Enter an amount of ${
-		config[countryGroupId][contributionType].minInWords
-	}
-    ${spokenCurrency} or more for your
-    ${getSpokenType(contributionType)} contribution.`;
-}
-
-const contributionTypeRadios = [
-	{
-		value: 'ONE_OFF',
-		text: 'Single',
-		accessibilityHint: 'Make a single contribution',
-		id: 'qa-one-off-toggle',
-	},
-	{
-		value: 'MONTHLY',
-		text: 'Monthly',
-		accessibilityHint: 'Make a regular monthly contribution',
-	},
-	{
-		value: 'ANNUAL',
-		text: 'Annually',
-		accessibilityHint: 'Make a regular annual contribution',
-	},
-];
-
-const contributionTypeAvailable = (
-	contributionType: ContributionType,
-	countryGroupId: CountryGroupId,
-	contributionTypes: ContributionTypes,
-): boolean =>
-	contributionTypes[countryGroupId].some(
-		(settings) => settings.contributionType === contributionType,
-	);
 
 const contributionsOnlyAmountsTestName = 'VAT_COMPLIANCE';
 
@@ -528,15 +412,7 @@ export {
 	parseContribution,
 	getMinContribution,
 	billingPeriodFromContrib,
-	errorMessage,
-	getContributionTypeClassName,
-	getSpokenType,
-	getFrequency,
-	getCustomAmountA11yHint,
-	contributionTypeRadios,
-	parseRegularContributionType,
 	getAmount,
-	contributionTypeAvailable,
 	contributionsOnlyAmountsTestName,
 	isContributionsOnlyCountry,
 };

--- a/support-frontend/assets/helpers/forms/formValidation.ts
+++ b/support-frontend/assets/helpers/forms/formValidation.ts
@@ -9,7 +9,7 @@ export const emailRegexPattern =
 export const isEmpty: (arg0?: string | null) => boolean = (input) =>
 	typeof input === 'undefined' || input == null || input.trim().length === 0;
 
-export const isNotEmpty: (arg0?: string | null) => boolean = (input) =>
+const isNotEmpty: (arg0?: string | null) => boolean = (input) =>
 	!isEmpty(input);
 
 export const isValidEmail: (arg0: string | null) => boolean = (input) =>

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/oneOffContributions.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/oneOffContributions.ts
@@ -31,7 +31,7 @@ type PaymentApiSuccess<A> = {
 	data: A;
 };
 
-export type PaymentApiResponse<E, A> =
+type PaymentApiResponse<E, A> =
 	| UnexpectedError
 	| PaymentApiError<E>
 	| PaymentApiSuccess<A>;
@@ -39,14 +39,14 @@ export type PaymentApiResponse<E, A> =
 // Models a PayPal payment being successfully created.
 // The user should be redirected to the approvalUrl so that they can authorize the payment.
 // https://github.com/guardian/payment-api/blob/master/src/main/scala/model/paypal/PaypalPaymentSuccess.scala
-export type CreatePayPalPaymentSuccess = {
+type CreatePayPalPaymentSuccess = {
 	// For brevity, unneeded fields are omitted
 	approvalUrl: string; // paymentId: string,
 };
 
 // Models a failure to create a PayPal payment.
 // https://github.com/guardian/payment-api/blob/master/src/main/scala/model/paypal/PaypalApiError.scala
-export type PayPalApiError = {
+type PayPalApiError = {
 	// For brevity, unneeded fields are omitted
 	// responseCode: number | null,
 	// errorName: number | null,
@@ -80,7 +80,7 @@ export type CreateStripePaymentIntentRequest = StripeChargeData & {
 // Data that should be posted to the payment API to get a url for the PayPal UI
 // where the user is redirected to so that they can authorize the payment.
 // https://github.com/guardian/payment-api/blob/master/src/main/scala/model/paypal/PaypalPaymentData.scala#L74
-export type CreatePaypalPaymentData = {
+type CreatePaypalPaymentData = {
 	currency: IsoCurrency;
 	amount: number;
 	// Specifies the url that PayPal should make a GET request to, should the user authorize the payment.

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -62,26 +62,26 @@ type SupporterPlus = {
 	currency: string;
 	billingPeriod: BillingPeriod;
 };
-export type TierThree = {
+type TierThree = {
 	productType: 'TierThree';
 	currency: string;
 	billingPeriod: BillingPeriod;
 	fulfilmentOptions: FulfilmentOptions;
 	productOptions: ProductOptions;
 };
-export type GuardianAdLite = {
+type GuardianAdLite = {
 	productType: 'GuardianAdLite';
 	currency: string;
 	billingPeriod: BillingPeriod;
 };
-export type DigitalSubscription = {
+type DigitalSubscription = {
 	productType: typeof DigitalPack;
 	currency: string;
 	billingPeriod: BillingPeriod;
 	readerType: ReaderType;
 	amount?: number;
 };
-export type PaperSubscription = {
+type PaperSubscription = {
 	productType: typeof Paper;
 	currency: string;
 	billingPeriod: BillingPeriod;
@@ -89,7 +89,7 @@ export type PaperSubscription = {
 	productOptions: ProductOptions;
 	deliveryAgent?: number;
 };
-export type GuardianWeeklySubscription = {
+type GuardianWeeklySubscription = {
 	productType: typeof GuardianWeekly;
 	currency: string;
 	billingPeriod: BillingPeriod;
@@ -153,7 +153,7 @@ type GiftRecipientType = {
 	message?: string;
 	deliveryDate?: string;
 };
-export type AppliedPromotion = {
+type AppliedPromotion = {
 	promoCode: string;
 	countryGroupId: SupportInternationalisationId; // There is a bit of naming mismatch between the front and back end
 };
@@ -186,17 +186,17 @@ export type StripePaymentIntentAuthorisation = {
 	paymentMethodId: string | PaymentMethod;
 	handle3DS?: (clientSecret: string) => Promise<PaymentIntentResult>;
 };
-export type PayPalAuthorisation = {
+type PayPalAuthorisation = {
 	paymentMethod: typeof PayPal;
 	token: string;
 };
-export type DirectDebitAuthorisation = {
+type DirectDebitAuthorisation = {
 	paymentMethod: typeof DirectDebit;
 	accountHolderName: string;
 	sortCode: string;
 	accountNumber: string;
 };
-export type SepaAuthorisation = {
+type SepaAuthorisation = {
 	paymentMethod: typeof Sepa;
 	accountHolderName: string;
 	iban: string;

--- a/support-frontend/assets/helpers/forms/stripe.ts
+++ b/support-frontend/assets/helpers/forms/stripe.ts
@@ -2,15 +2,8 @@ import type { Stripe as StripeJs } from '@stripe/stripe-js';
 import { loadStripe } from '@stripe/stripe-js/pure';
 import { useEffect, useState } from 'react';
 import type { ContributionType } from 'helpers/contributions';
-import type { PaymentMethod } from 'helpers/forms/paymentMethods';
-import { Stripe } from 'helpers/forms/paymentMethods';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { IsoCurrency } from '../internationalisation/currency';
-
-const stripeCardFormIsIncomplete = (
-	paymentMethod: PaymentMethod,
-	stripeCardFormComplete: boolean,
-): boolean => paymentMethod === Stripe && !stripeCardFormComplete;
 
 export type StripeAccount = 'ONE_OFF' | 'REGULAR';
 
@@ -77,8 +70,4 @@ export function useStripeAccount(stripeKey: string): StripeJs | null {
 	return stripeSdk;
 }
 
-export {
-	stripeCardFormIsIncomplete,
-	stripeAccountForContributionType,
-	getStripeKey,
-};
+export { stripeAccountForContributionType, getStripeKey };

--- a/support-frontend/assets/helpers/globalsAndSwitches/settings.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/settings.ts
@@ -3,7 +3,7 @@ import 'helpers/contributions';
 
 export type Status = 'On' | 'Off';
 
-export type SwitchObject = Record<string, Status | undefined>;
+type SwitchObject = Record<string, Status | undefined>;
 
 /**
  * These keys are generated in Switches.scala
@@ -21,7 +21,7 @@ type SwitchesKeys =
 	| 'campaignSwitches'
 	| 'recaptchaSwitches';
 
-export type Switches = Record<SwitchesKeys, SwitchObject>;
+type Switches = Record<SwitchesKeys, SwitchObject>;
 
 export type Settings = {
 	switches: Switches;

--- a/support-frontend/assets/helpers/images/theGrid.ts
+++ b/support-frontend/assets/helpers/images/theGrid.ts
@@ -3,7 +3,7 @@ import catalogue from './imageCatalogue.json';
 export type ImageType = 'jpg' | 'png';
 // ----- Setup ----- //
 export const GRID_DOMAIN = 'https://i.guim.co.uk';
-export const imageCatalogue: Record<string, string> = catalogue;
+const imageCatalogue: Record<string, string> = catalogue;
 // Utility type: https://flow.org/en/docs/types/utilities/#toc-keys
 export type ImageId = keyof typeof imageCatalogue;
 // ----- Functions ----- //

--- a/support-frontend/assets/helpers/internationalisation/currency.ts
+++ b/support-frontend/assets/helpers/internationalisation/currency.ts
@@ -144,10 +144,6 @@ const glyph = (c: IsoCurrency): string => currencies[c].glyph;
 
 const extendedGlyph = (c: IsoCurrency): string => currencies[c].extendedGlyph;
 
-const isSuffixGlyph = (c: IsoCurrency): boolean => currencies[c].isSuffixGlyph;
-
-const isPaddedGlyph = (c: IsoCurrency): boolean => currencies[c].isPaddedGlyph;
-
 // ----- Exports ----- //
 export {
 	detect,
@@ -157,6 +153,4 @@ export {
 	currencies,
 	glyph,
 	extendedGlyph,
-	isSuffixGlyph,
-	isPaddedGlyph,
 };

--- a/support-frontend/assets/helpers/legal.ts
+++ b/support-frontend/assets/helpers/legal.ts
@@ -1,6 +1,5 @@
 // ----- Imports ----- //
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import type { SubscriptionProduct } from './productPrice/subscriptions';
 // ----- Terms & Conditions ----- //
 const defaultContributionTermsLink =
 	'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions';
@@ -14,31 +13,6 @@ const contributionsTermsLinks: Record<CountryGroupId, string> = {
 	International: defaultContributionTermsLink,
 	NZDCountries: defaultContributionTermsLink,
 	Canada: defaultContributionTermsLink,
-};
-// TBD update these before or early in the moment launch
-const defaultPhilanthropyContactEmail = 'us.philanthropy@theguardian.com';
-const philanthropyContactEmail: Record<CountryGroupId, string> = {
-	GBPCountries: defaultPhilanthropyContactEmail,
-	UnitedStates: defaultPhilanthropyContactEmail,
-	AUDCountries: 'australia.philanthropy@theguardian.com',
-	EURCountries: defaultPhilanthropyContactEmail,
-	International: defaultPhilanthropyContactEmail,
-	NZDCountries: defaultPhilanthropyContactEmail,
-	Canada: defaultPhilanthropyContactEmail,
-};
-const subscriptionsTermsLinks: Record<SubscriptionProduct, string> = {
-	DigitalPack:
-		'https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions',
-	PremiumTier:
-		'https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions',
-	DailyEdition:
-		'https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions',
-	GuardianWeekly:
-		'https://www.theguardian.com/info/2014/jul/10/guardian-weekly-print-subscription-services-terms-conditions',
-	Paper:
-		'https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions',
-	PaperAndDigital:
-		'https://www.theguardian.com/info/2014/jul/10/guardian-weekly-print-subscription-services-terms-conditions',
 };
 const privacyLink = 'https://www.theguardian.com/help/privacy-policy';
 const defaultContributionEmail = 'mailto:contribution.support@theguardian.com';
@@ -62,11 +36,9 @@ const tierThreeTermsLink =
 // ----- Exports ----- //
 export {
 	contributionsTermsLinks,
-	subscriptionsTermsLinks,
 	privacyLink,
 	copyrightNotice,
 	contributionsEmail,
-	philanthropyContactEmail,
 	guardianLiveTermsLink,
 	supporterPlusTermsLink,
 	tierThreeTermsLink,

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -12,8 +12,8 @@ export type { ActiveProductKey };
 
 export const productCatalog = window.guardian.productCatalog;
 
-export type SupporterPlusVariants = 'control' | 'v1' | 'v2';
-export type ContributionVariants = 'control' | 'v1' | 'v2Annual' | 'v2Monthly';
+type SupporterPlusVariants = 'control' | 'v1' | 'v2';
+type ContributionVariants = 'control' | 'v1' | 'v2Annual' | 'v2Monthly';
 
 type ProductBenefit = {
 	copy: string;
@@ -92,7 +92,7 @@ function displayBenefitByABTestVariant(
 	return display ? variantFound : !variantFound; // abtest variantFound opposite if hiding
 }
 
-export const productKeys = Object.keys(activeTypeObject) as ActiveProductKey[];
+const productKeys = Object.keys(activeTypeObject) as ActiveProductKey[];
 export function isProductKey(val: unknown): val is ActiveProductKey {
 	return productKeys.includes(val as ActiveProductKey);
 }

--- a/support-frontend/assets/helpers/productPrice/billingPeriods.ts
+++ b/support-frontend/assets/helpers/productPrice/billingPeriods.ts
@@ -4,10 +4,6 @@ const Quarterly = 'Quarterly';
 
 export type BillingPeriod = typeof Annual | typeof Monthly | typeof Quarterly;
 
-export type DigitalBillingPeriod = typeof Monthly | typeof Annual;
-
-export type DigitalGiftBillingPeriod = typeof Annual | typeof Quarterly;
-
 export type WeeklyBillingPeriod =
 	| typeof Monthly
 	| typeof Quarterly

--- a/support-frontend/assets/helpers/productPrice/fulfilmentOptions.ts
+++ b/support-frontend/assets/helpers/productPrice/fulfilmentOptions.ts
@@ -9,9 +9,7 @@ const Domestic = 'Domestic';
 const RestOfWorld = 'RestOfWorld';
 const NoFulfilmentOptions = 'NoFulfilmentOptions';
 
-export type GuardianWeeklyFulfilmentOptions =
-	| typeof Domestic
-	| typeof RestOfWorld;
+type GuardianWeeklyFulfilmentOptions = typeof Domestic | typeof RestOfWorld;
 
 export type PaperFulfilmentOptions = typeof HomeDelivery | typeof Collection;
 

--- a/support-frontend/assets/helpers/productPrice/productOptions.ts
+++ b/support-frontend/assets/helpers/productPrice/productOptions.ts
@@ -92,7 +92,6 @@ export {
 	SixdayPlus,
 	Everyday,
 	EverydayPlus,
-	NewspaperArchive,
 	ActivePaperProductTypes,
 	paperProductsWithDigital,
 	paperProductsWithoutDigital,

--- a/support-frontend/assets/helpers/productPrice/productPrices.ts
+++ b/support-frontend/assets/helpers/productPrice/productPrices.ts
@@ -27,7 +27,7 @@ export type ProductPrice = {
 	promotions?: Promotion[];
 };
 
-export type BillingPeriods = {
+type BillingPeriods = {
 	[K in BillingPeriod]?: { [K in IsoCurrency]?: ProductPrice };
 };
 

--- a/support-frontend/assets/helpers/productPrice/promotions.tsx
+++ b/support-frontend/assets/helpers/productPrice/promotions.tsx
@@ -15,7 +15,7 @@ import type { SubscriptionProduct } from 'helpers/productPrice/subscriptions';
 import type { Option } from 'helpers/types/option';
 import { getQueryParameter } from 'helpers/urls/url';
 
-export type DiscountBenefit = {
+type DiscountBenefit = {
 	amount: number;
 	durationMonths?: number;
 };

--- a/support-frontend/assets/helpers/productPrice/subscriptions.ts
+++ b/support-frontend/assets/helpers/productPrice/subscriptions.ts
@@ -1,9 +1,4 @@
 // ----- Imports ----- //
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
-import { Monthly, Quarterly } from 'helpers/productPrice/billingPeriods';
-import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
-import { currencies, detect } from '../internationalisation/currency';
 import { trackComponentEvents } from '../tracking/trackingOphan';
 import type {
 	OphanAction,
@@ -31,7 +26,7 @@ export type SubscriptionProduct =
 
 type OphanSubscriptionsProduct = 'DIGITAL_SUBSCRIPTION' | 'PRINT_SUBSCRIPTION';
 
-export type ComponentAbTest = {
+type ComponentAbTest = {
 	name: string;
 	variant: string;
 };
@@ -41,32 +36,6 @@ export type TrackingProperties = {
 	product?: SubscriptionProduct;
 	abTest?: ComponentAbTest;
 	componentType: OphanComponentType;
-};
-
-// ----- Config ----- //
-const dailyNewsstandPrice = 2.2;
-const weekendNewsstandPrice = 3.2;
-const newsstandPrices: Record<PaperProductOptions, number> = {
-	Saturday: weekendNewsstandPrice,
-	Sunday: weekendNewsstandPrice,
-	Everyday: dailyNewsstandPrice * 5 + weekendNewsstandPrice * 2,
-	Weekend: weekendNewsstandPrice * 2,
-	Sixday: dailyNewsstandPrice * 5 + weekendNewsstandPrice,
-};
-
-export const subscriptionPricesForDefaultBillingPeriod = {
-	PaperAndDigital: {
-		GBPCountries: 21.99,
-	},
-} as Record<SubscriptionProduct, Record<CountryGroupId, number>>;
-
-const defaultBillingPeriods: Record<SubscriptionProduct, BillingPeriod> = {
-	PremiumTier: Monthly,
-	DigitalPack: Monthly,
-	GuardianWeekly: Quarterly,
-	Paper: Monthly,
-	PaperAndDigital: Monthly,
-	DailyEdition: Monthly,
 };
 
 // ----- Functions ----- //
@@ -88,24 +57,6 @@ function fixDecimals(number: number): string {
 	}
 
 	return number.toFixed(2);
-}
-
-function getProductPrice(
-	product: SubscriptionProduct,
-	countryGroupId: CountryGroupId,
-): string {
-	return fixDecimals(
-		subscriptionPricesForDefaultBillingPeriod[product][countryGroupId],
-	);
-}
-
-function displayPrice(
-	product: SubscriptionProduct,
-	countryGroupId: CountryGroupId,
-): string {
-	const currency = currencies[detect(countryGroupId)].glyph;
-	const price = getProductPrice(product, countryGroupId);
-	return `${currency}${price}/${defaultBillingPeriods[product]}`;
 }
 
 // ----- Ophan Tracking ----- //
@@ -161,46 +112,14 @@ const sendTrackingEventsOnView =
 		sendTrackingEvent({ ...trackingProperties, action: 'VIEW' });
 	};
 
-// ----- Newsstand savings ----- //
-const getMonthlyNewsStandPrice = (newsstand: number) => (newsstand * 52) / 12;
-
-const getNewsstandSaving = (
-	subscriptionMonthlyCost: number,
-	newsstandWeeklyCost: number,
-): string =>
-	fixDecimals(
-		getMonthlyNewsStandPrice(newsstandWeeklyCost) - subscriptionMonthlyCost,
-	);
-
-const getNewsstandSavingPercentage = (
-	subscriptionMonthlyCost: number,
-	newsstandWeeklyCost: number,
-): number =>
-	Math.floor(
-		100 -
-			(subscriptionMonthlyCost /
-				getMonthlyNewsStandPrice(newsstandWeeklyCost)) *
-				100,
-	);
-
-const getNewsstandPrice = (productOption: PaperProductOptions): number =>
-	newsstandPrices[productOption];
-
 // ----- Exports ----- //
 export {
 	sendTrackingEventsOnClick,
 	sendTrackingEventsOnView,
-	displayPrice,
-	getProductPrice,
-	getNewsstandSaving,
-	getNewsstandSavingPercentage,
-	getNewsstandPrice,
 	fixDecimals,
 	DigitalPack,
 	PaperAndDigital,
 	Paper,
-	PremiumTier,
-	DailyEdition,
 	GuardianWeekly,
 	isPhysicalProduct,
 };

--- a/support-frontend/assets/helpers/redux/checkout/csrf/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/csrf/reducer.ts
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { initialCsrfState } from './state';
 
-export const csrfSlice = createSlice({
+const csrfSlice = createSlice({
 	name: 'csrf',
 	initialState: initialCsrfState,
 	reducers: {},

--- a/support-frontend/assets/helpers/redux/checkout/payment/directDebit/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/directDebit/state.ts
@@ -22,7 +22,7 @@ export const directDebitSchema = z.object({
 	}),
 });
 
-export type DirectDebitValidateableState = z.infer<typeof directDebitSchema>;
+type DirectDebitValidateableState = z.infer<typeof directDebitSchema>;
 
 export type DirectDebitState = DirectDebitValidateableState & {
 	isPopUpOpen: boolean;

--- a/support-frontend/assets/helpers/redux/checkout/payment/sepa/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/sepa/state.ts
@@ -14,7 +14,7 @@ export const sepaSchema = z.object({
 	country: z.string().min(1, 'Please select a billing country'),
 });
 
-export type SepaValidateableState = z.infer<typeof sepaSchema>;
+type SepaValidateableState = z.infer<typeof sepaSchema>;
 
 export type SepaState = SepaValidateableState & {
 	errors: SliceErrors<SepaValidateableState>;

--- a/support-frontend/assets/helpers/redux/checkout/personalDetails/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/personalDetails/state.ts
@@ -9,7 +9,7 @@ import { getUser } from 'helpers/user/user';
 export const userTypeSchema = z.union([z.literal('new'), z.literal('current')]);
 export type UserType = z.infer<typeof userTypeSchema>;
 
-export const emailRules = zuoraCompatibleString(
+const emailRules = zuoraCompatibleString(
 	z
 		.string()
 		.regex(/^[^,]+$/, 'Please enter a valid email address.')

--- a/support-frontend/assets/helpers/redux/contributionsStore.ts
+++ b/support-frontend/assets/helpers/redux/contributionsStore.ts
@@ -20,10 +20,10 @@ export type ContributionsStartListening = TypedStartListening<
 	ContributionsDispatch
 >;
 
-export const startContributionsListening =
+const startContributionsListening =
 	listenerMiddleware.startListening as ContributionsStartListening;
 
-export const contributionsStore = configureStore({
+const contributionsStore = configureStore({
 	reducer: {
 		common: commonReducer,
 		page: initReducer(),

--- a/support-frontend/assets/helpers/redux/debug/reducer.ts
+++ b/support-frontend/assets/helpers/redux/debug/reducer.ts
@@ -2,7 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const isAnyAction = () => true;
 
-export const debugSlice = createSlice({
+const debugSlice = createSlice({
 	name: 'debug',
 	initialState: {
 		actionHistory: '',

--- a/support-frontend/assets/helpers/redux/redemptionsStore.ts
+++ b/support-frontend/assets/helpers/redux/redemptionsStore.ts
@@ -12,11 +12,11 @@ const baseReducer = {
 	debug: debugReducer,
 };
 
-export const redemptionStore = configureStore({
+const redemptionStore = configureStore({
 	reducer: baseReducer,
 });
 
-export type RedemptionStore = typeof redemptionStore;
+type RedemptionStore = typeof redemptionStore;
 
 export function initReduxForRedemption(): RedemptionStore {
 	try {

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/paymentValidation.ts
@@ -60,9 +60,7 @@ export function getPaymentMethodErrors(
 	}
 }
 
-export function getRecaptchaError(
-	state: ContributionsState,
-): string[] | undefined {
+function getRecaptchaError(state: ContributionsState): string[] | undefined {
 	const { paymentMethod } = state.page.checkoutForm.payment;
 
 	if (recaptchaRequiredPaymentMethods.includes(paymentMethod.name)) {

--- a/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
+++ b/support-frontend/assets/helpers/redux/selectors/formValidation/personalDetailsValidation.ts
@@ -4,9 +4,7 @@ import type { ContributionsState } from 'helpers/redux/contributionsStore';
 import { getBillingCountryAndState } from 'pages/supporter-plus-landing/setup/legacyActionCreators';
 import type { ErrorCollection } from './utils';
 
-export function getStateOrProvinceError(
-	state: ContributionsState,
-): ErrorCollection {
+function getStateOrProvinceError(state: ContributionsState): ErrorCollection {
 	const contributionType = getContributionType(state);
 	const billingCountry = getBillingCountryAndState(state).billingCountry;
 	if (shouldCollectStateForContributions(billingCountry, contributionType)) {

--- a/support-frontend/assets/helpers/redux/subscriptionsStore.ts
+++ b/support-frontend/assets/helpers/redux/subscriptionsStore.ts
@@ -42,7 +42,7 @@ export type SubscriptionsStartListening = TypedStartListening<
 	SubscriptionsDispatch
 >;
 
-export const startSubscriptionsListening =
+const startSubscriptionsListening =
 	listenerMiddleware.startListening as SubscriptionsStartListening;
 
 const subscriptionsStore = configureStore({

--- a/support-frontend/assets/helpers/subscriptionsForms/checkoutFormIsSubmittableActions.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/checkoutFormIsSubmittableActions.ts
@@ -1,10 +1,6 @@
 // ----- Imports ----- //
 import type { Dispatch } from 'redux';
-import type {
-	SubscriptionsDispatch,
-	SubscriptionsState,
-} from 'helpers/redux/subscriptionsStore';
-import type { Action } from 'helpers/subscriptionsForms/formActions';
+import type { SubscriptionsState } from 'helpers/redux/subscriptionsStore';
 import { checkoutFormIsValid } from 'helpers/subscriptionsForms/formValidation';
 
 // ----- Functions ----- //
@@ -24,18 +20,4 @@ function enableOrDisableForm() {
 	};
 }
 
-function setFormSubmissionDependentValue(setStateValue: () => Action) {
-	return (
-		dispatch: SubscriptionsDispatch,
-		getState: () => SubscriptionsState,
-	): void => {
-		dispatch(setStateValue());
-		enableOrDisableForm()(dispatch, getState);
-	};
-}
-
-export {
-	setFormSubmissionDependentValue,
-	enableOrDisableForm,
-	enableOrDisablePayPalExpressCheckoutButton,
-};
+export { enableOrDisableForm };

--- a/support-frontend/assets/helpers/subscriptionsForms/formValidation.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formValidation.ts
@@ -31,15 +31,6 @@ type AnyErrorType = Error<AddressFormField> | Error<FormField>;
 
 // ---- Validation ---- //
 
-export function validateCheckoutForm(
-	dispatch: Dispatch,
-	state: SubscriptionsState,
-): boolean {
-	const allErrors = checkoutValidation(state);
-	dispatchAllErrors(dispatch, allErrors);
-	return allErrors.length === 0;
-}
-
 export function validateWithDeliveryForm(
 	dispatch: Dispatch<Action>,
 	state: SubscriptionsState,

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -47,10 +47,7 @@ import {
 	setStage,
 	setSubmissionError,
 } from 'helpers/subscriptionsForms/formActions';
-import {
-	validateCheckoutForm,
-	validateWithDeliveryForm,
-} from 'helpers/subscriptionsForms/formValidation';
+import { validateWithDeliveryForm } from 'helpers/subscriptionsForms/formValidation';
 import type { AnyCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import { getOphanIds, getSupportAbTests } from 'helpers/tracking/acquisitions';
 import { successfulSubscriptionConversion } from 'helpers/tracking/googleTagManager';
@@ -443,20 +440,5 @@ function submitWithDeliveryForm(
 	}
 }
 
-function submitCheckoutForm(
-	dispatch: Dispatch<Action>,
-	state: SubscriptionsState,
-): void {
-	if (validateCheckoutForm(dispatch, state)) {
-		submitForm(dispatch, state);
-	}
-}
-
 // ----- Export ----- //
-export {
-	onPaymentAuthorised,
-	showPaymentMethod,
-	submitCheckoutForm,
-	submitWithDeliveryForm,
-	trackSubmitAttempt,
-};
+export { onPaymentAuthorised, submitWithDeliveryForm, trackSubmitAttempt };

--- a/support-frontend/assets/helpers/subscriptionsForms/subscriptionCheckoutReducer.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/subscriptionCheckoutReducer.ts
@@ -29,12 +29,12 @@ import type { FormState } from 'helpers/subscriptionsForms/formFields';
 import { createFormReducer } from 'helpers/subscriptionsForms/formReducer';
 import type { Option } from 'helpers/types/option';
 
-export type ReduxState<PageState> = {
+type ReduxState<PageState> = {
 	common: CommonState;
 	page: PageState;
 };
 
-export type CheckoutFormState = {
+type CheckoutFormState = {
 	personalDetails: PersonalDetailsState;
 	gifting: GiftingState;
 	product: ProductState;

--- a/support-frontend/assets/helpers/subscriptionsForms/supportedPaymentMethods.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/supportedPaymentMethods.ts
@@ -3,7 +3,7 @@ import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 
-export type SubscriptionsPaymentMethod =
+type SubscriptionsPaymentMethod =
 	| typeof DirectDebit
 	| typeof PayPal
 	| typeof Stripe;

--- a/support-frontend/assets/helpers/supporterPlus/benefitsThreshold.ts
+++ b/support-frontend/assets/helpers/supporterPlus/benefitsThreshold.ts
@@ -21,7 +21,7 @@ export function getLowerBenefitsThreshold(
 	return getLowerBenefitThreshold(contributionType, currency);
 }
 
-export function getLowerBenefitThreshold(
+function getLowerBenefitThreshold(
 	contributionType: ContributionType,
 	currencyId: IsoCurrency,
 ): number {

--- a/support-frontend/assets/helpers/tracking/acquisitions.ts
+++ b/support-frontend/assets/helpers/tracking/acquisitions.ts
@@ -18,12 +18,12 @@ export type AcquisitionABTest = {
 	variant: string;
 };
 
-export type QueryParameter = {
+type QueryParameter = {
 	name: string;
 	value: string;
 };
 
-export type AcquisitionQueryParameters = QueryParameter[];
+type AcquisitionQueryParameters = QueryParameter[];
 
 export type OphanIds = {
 	pageviewId: string;
@@ -247,15 +247,6 @@ function derivePaymentApiAcquisitionData(
 	};
 }
 
-function deriveSubsAcquisitionData(
-	referrerAcquisitionData: ReferrerAcquisitionData,
-	nativeAbParticipations: Participations,
-): ReferrerAcquisitionData {
-	const abTests = getAbTests(referrerAcquisitionData, nativeAbParticipations);
-
-	return { ...referrerAcquisitionData, abTests };
-}
-
 // Reads the acquisition data from sessionStorage.
 function getReferrerAcquisitionDataFromSessionStorage():
 	| ReferrerAcquisitionData
@@ -355,6 +346,5 @@ export {
 	getOphanIds,
 	participationsToAcquisitionABTest,
 	derivePaymentApiAcquisitionData,
-	deriveSubsAcquisitionData,
 	getSupportAbTests,
 };

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -527,7 +527,6 @@ export {
 	sendEventContributionCartValue,
 	sendEventPaymentMethodSelected,
 	sendEventConversionPaymentMethod,
-	sendEventAcquisitionDataFromQueryParamEvent,
 	sendEventCheckoutValue,
 	sendEventOneTimeCheckoutValue,
 };

--- a/support-frontend/assets/helpers/tracking/trackingOphan.ts
+++ b/support-frontend/assets/helpers/tracking/trackingOphan.ts
@@ -69,7 +69,7 @@ export type OphanComponentEvent = {
 	};
 };
 
-export type OphanABEvent = {
+type OphanABEvent = {
 	variantName: string;
 	complete: boolean;
 	campaignCodes?: string[];
@@ -168,7 +168,6 @@ const navigateWithPageView = (
 
 export {
 	trackComponentEvents,
-	pageView,
 	trackAbTests,
 	setReferrerDataInLocalStorage,
 	navigateWithPageView,

--- a/support-frontend/assets/helpers/urls/externalLinks.ts
+++ b/support-frontend/assets/helpers/urls/externalLinks.ts
@@ -2,17 +2,9 @@
 
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
-import type {
-	DigitalBillingPeriod,
-	DigitalGiftBillingPeriod,
-} from 'helpers/productPrice/billingPeriods';
-import { promoQueryParam } from 'helpers/productPrice/promotions';
-import type { Option } from 'helpers/types/option';
-import { getBaseDomain, getOrigin } from 'helpers/urls/url';
+import { getBaseDomain } from 'helpers/urls/url';
 
 // ----- Types ----- //
-
-export type MemProduct = 'events';
 
 // ----- Setup ----- //
 
@@ -31,19 +23,8 @@ const androidDailyUrl =
 const myAccountUrl = `${profileUrl}/account/edit`;
 const manageSubsUrl = `${manageUrl}/subscriptions`;
 const helpCentreUrl = `${manageUrl}/help-centre`;
-const emailPreferences = `${manageUrl}/email-prefs`;
-const memUrls: Record<MemProduct, string> = {
-	events: 'https://membership.theguardian.com/events',
-};
 
 // ----- Functions ----- //
-
-// Creates URLs for the membership site from promo codes and intCmp.
-function getMemLink(product: MemProduct, intCmp?: string | null): string {
-	const params = new URLSearchParams();
-	params.append('INTCMP', intCmp ?? defaultIntCmp);
-	return `${memUrls[product]}?${params.toString()}`;
-}
 
 function getPatronsLink(
 	intCmp?: string,
@@ -54,27 +35,6 @@ function getPatronsLink(
 
 	const url = countryGroupId === 'UnitedStates' ? patronsUrlUS : patronsUrl;
 	return `${url}?${params.toString()}`;
-}
-
-// Builds a link to the digital pack checkout.
-function getDigitalCheckout(
-	billingPeriod: DigitalBillingPeriod | DigitalGiftBillingPeriod,
-	promoCode: Option<string>,
-	orderIsAGift: boolean,
-): string {
-	const params = new URLSearchParams(window.location.search);
-
-	if (promoCode) {
-		params.set(promoQueryParam, promoCode);
-	}
-
-	params.set('period', billingPeriod);
-
-	if (orderIsAGift) {
-		return `${getOrigin()}/subscribe/digital/checkout/gift?${params.toString()}`;
-	}
-
-	return `${getOrigin()}/subscribe/digital/checkout?${params.toString()}`;
 }
 
 function convertCountryGroupIdToAppStoreCountryCode(cgId: CountryGroupId) {
@@ -123,9 +83,7 @@ const getReauthenticateUrl = getProfileUrl('reauthenticate');
 // ----- Exports ----- //
 
 export {
-	getMemLink,
 	getPatronsLink,
-	getDigitalCheckout,
 	getIosAppUrl,
 	androidAppUrl,
 	androidDailyUrl,
@@ -136,6 +94,5 @@ export {
 	manageSubsUrl,
 	homeDeliveryUrl,
 	helpCentreUrl,
-	emailPreferences,
 	feastAppUrl,
 };

--- a/support-frontend/assets/helpers/urls/url.ts
+++ b/support-frontend/assets/helpers/urls/url.ts
@@ -1,9 +1,6 @@
 // ----- Types ----- //
-export type Domain =
-	| 'thegulocal.com'
-	| 'code.dev-theguardian.com'
-	| 'theguardian.com';
-export type Env = 'DEV' | 'CODE' | 'PROD';
+type Domain = 'thegulocal.com' | 'code.dev-theguardian.com' | 'theguardian.com';
+type Env = 'DEV' | 'CODE' | 'PROD';
 // ----- Setup ----- //
 const DOMAINS: Record<Env, Domain> = {
 	DEV: 'thegulocal.com',

--- a/support-frontend/assets/helpers/user/user.ts
+++ b/support-frontend/assets/helpers/user/user.ts
@@ -1,5 +1,5 @@
 // ----- Imports ----- //
-import { getGlobal, isSwitchOn } from 'helpers/globalsAndSwitches/globals';
+import { getGlobal } from 'helpers/globalsAndSwitches/globals';
 import * as cookie from 'helpers/storage/cookie';
 import { getSignoutUrl } from 'helpers/urls/externalLinks';
 
@@ -49,11 +49,6 @@ const signOut = (): void => {
 	window.location.href = getSignoutUrl();
 };
 
-const doesUserAppearToBeSignedIn = (): boolean =>
-	isSwitchOn('featureSwitches.authenticateWithOkta')
-		? !!cookie.get('GU_ID_TOKEN')
-		: !!cookie.get('GU_U');
-
 // JTL: The user cookie is built to have particular values at
 // particular indices by design. Index 7 in the cookie object represents
 // whether a signed in user is validated or not. Though it's not ideal
@@ -92,6 +87,5 @@ export {
 	isPostDeployUser,
 	getUserStateField,
 	signOut,
-	doesUserAppearToBeSignedIn,
 	getEmailValidatedFromUserCookie,
 };

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -79,7 +79,7 @@ export function unsetThankYouOrder() {
 	storage.session.remove('thankYouOrder');
 }
 
-export type CheckoutComponentProps = {
+type CheckoutComponentProps = {
 	geoId: GeoId;
 	appConfig: AppConfig;
 	payment: {

--- a/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
@@ -12,7 +12,7 @@ import type { Participations } from '../../helpers/abTests/abtest';
 import { setOneOffContributionCookie } from '../../helpers/storage/contributionsCookies';
 import { ThankYouComponent } from './components/thankYouComponent';
 
-export type ThankYouProps = {
+type ThankYouProps = {
 	geoId: GeoId;
 	appConfig: AppConfig;
 	abParticipations: Participations;

--- a/support-frontend/assets/pages/paper-subscription-checkout/helpers/subsCardDays.ts
+++ b/support-frontend/assets/pages/paper-subscription-checkout/helpers/subsCardDays.ts
@@ -121,4 +121,4 @@ const getPaymentStartDate = (
 	return new Date(date + delayInMils);
 };
 
-export { getFormattedStartDate, getPaymentStartDate, monthText };
+export { getFormattedStartDate, getPaymentStartDate };

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.tsx
@@ -37,7 +37,7 @@ const paragraph = css`
 		color: inherit;
 	}
 `;
-export const accordionContainer = css`
+const accordionContainer = css`
 	background-color: ${neutral['97']};
 
 	p,

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
@@ -18,7 +18,7 @@ import {
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import LinkTo from './linkTo';
 
-export type PaperPricesPropTypes = {
+type PaperPricesPropTypes = {
 	activeTab: PaperFulfilmentOptions;
 	setTabAction: (arg0: PaperFulfilmentOptions) => void;
 	products: Product[];

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/subsCardTab.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/subsCardTab.tsx
@@ -34,7 +34,7 @@ const paragraphSpacing = css`
 		padding: 0 ${space[2]}px;
 	}
 `;
-export const accordionContainer = css`
+const accordionContainer = css`
 	background-color: ${neutral['97']};
 
 	p,

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/discountCopy.ts
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/discountCopy.ts
@@ -1,7 +1,7 @@
 import type { Option } from 'helpers/types/option';
 import 'helpers/types/option';
 
-export type DiscountCopy = {
+type DiscountCopy = {
 	roundel: string[];
 	heading: Option<string>;
 };

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.tsx
@@ -18,7 +18,7 @@ import CentredContainer from 'components/containers/centredContainer';
 import GridImage from 'components/gridImage/gridImage';
 import Hero from 'components/page/hero';
 import OfferStrapline from 'components/page/offerStrapline';
-import PageTitle from 'components/page/pageTitle';
+import { PageTitle } from 'components/page/pageTitle';
 import { getMaxSavingVsRetail } from 'helpers/productPrice/paperSavingsVsRetail';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import type { PromotionCopy } from 'helpers/productPrice/promotions';

--- a/support-frontend/assets/pages/paper-subscription-landing/components/paperTabs.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/paperTabs.tsx
@@ -14,7 +14,7 @@ type TabOptions = {
 	href: string;
 	content: typeof SubsCardFaqBlock | typeof ContentDeliveryFaqBlock;
 };
-export const tabs: Record<PaperFulfilmentOptions, TabOptions> = {
+const tabs: Record<PaperFulfilmentOptions, TabOptions> = {
 	HomeDelivery: {
 		name: 'Home Delivery',
 		href: `#${HomeDelivery}`,

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
@@ -34,7 +34,7 @@ export type ProductButton = {
 	modifierClasses?: string;
 };
 
-export type ProductCopy = {
+type ProductCopy = {
 	title: string;
 	subtitle: Option<string>;
 	description: string;

--- a/support-frontend/assets/pages/subscriptions-redemption/api.ts
+++ b/support-frontend/assets/pages/subscriptions-redemption/api.ts
@@ -254,4 +254,4 @@ function createSubscription(
 		.catch(() => null);
 }
 
-export { validateUserCode, submitCode, createSubscription };
+export { validateUserCode, submitCode };

--- a/support-frontend/assets/pages/subscriptions-redemption/subscriptionsRedemptionReducer.ts
+++ b/support-frontend/assets/pages/subscriptions-redemption/subscriptionsRedemptionReducer.ts
@@ -13,13 +13,13 @@ import type { Option } from 'helpers/types/option';
 
 export type Stage = 'form' | 'processing' | 'thankyou' | 'thankyou-pending';
 
-export type RedemptionCheckoutState = {
+type RedemptionCheckoutState = {
 	stage: Stage;
 	errors: Array<FormError<FormField>>;
 };
 
 // ------- Actions ---------- //
-export type Action =
+type Action =
 	| {
 			type: 'SET_STAGE';
 			stage: Stage;

--- a/support-frontend/assets/pages/subscriptions-redemption/thankYouContent.tsx
+++ b/support-frontend/assets/pages/subscriptions-redemption/thankYouContent.tsx
@@ -18,7 +18,7 @@ import ThankYouHero from './components/thankYou/hero';
 import 'helpers/abTests/abtest';
 
 // ----- Types ----- //
-export type PropTypes = {
+type PropTypes = {
 	countryGroupId: CountryGroupId;
 	paymentMethod: Option<PaymentMethod>;
 	marketingConsent: React.ReactNode;

--- a/support-frontend/assets/pages/supporter-plus-landing/components/coverTransactionCost.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/coverTransactionCost.tsx
@@ -39,7 +39,7 @@ const coverTransactionSummaryContainer = css`
 	padding: 0px 0px ${space[2]}px;
 `;
 
-export type CoverTransactionCostProps = {
+type CoverTransactionCostProps = {
 	transactionCost: boolean;
 	transactionCostAmount: string;
 	transactionCostTotal: string;

--- a/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
@@ -78,7 +78,7 @@ interface SummaryTsAndCsProps {
 	cssOverrides?: SerializedStyles;
 }
 
-export const termsSupporterPlus = (linkText: string) => (
+const termsSupporterPlus = (linkText: string) => (
 	<a href={supporterPlusTermsLink}>{linkText}</a>
 );
 

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierTsAndCs.tsx
@@ -8,7 +8,7 @@ import {
 } from 'helpers/utilities/dateFormatting';
 import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
 
-export interface TsAndCsProps {
+interface TsAndCsProps {
 	title: string;
 	planCost: TierPlanCosts;
 	starts?: Date;

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyReducer.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyReducer.ts
@@ -32,7 +32,7 @@ interface FormState {
 	paymentError: ErrorReason | null;
 }
 
-export interface PageState {
+interface PageState {
 	form: FormState;
 	checkoutForm: {
 		personalDetails: PersonalDetailsState;

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
@@ -18,7 +18,7 @@ import ProductInfoChip from 'components/product/productInfoChip';
 import type { Product } from 'components/product/productOption';
 import ProductOption from 'components/product/productOption';
 
-export type PropTypes = {
+type PropTypes = {
 	orderIsAGift: boolean;
 	products: Product[];
 };

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
@@ -19,7 +19,7 @@ import CentredContainer from 'components/containers/centredContainer';
 import GridImage from 'components/gridImage/gridImage';
 import Hero from 'components/page/hero';
 import OfferStrapline from 'components/page/offerStrapline';
-import PageTitle from 'components/page/pageTitle';
+import { PageTitle } from 'components/page/pageTitle';
 import { CountryGroup } from 'helpers/internationalisation/classes/countryGroup';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
@@ -75,7 +75,7 @@ const styles = {
 	`,
 };
 
-export const getRegionalCopyFor = (region: CountryGroupId): JSX.Element =>
+const getRegionalCopyFor = (region: CountryGroupId): JSX.Element =>
 	region === GBPCountries ? (
 		<span>
 			Find clarity
@@ -88,7 +88,7 @@ export const getRegionalCopyFor = (region: CountryGroupId): JSX.Element =>
 		</span>
 	);
 
-export const getFirstParagraph = (
+const getFirstParagraph = (
 	promotionCopy: PromotionCopy,
 	orderIsAGift: boolean,
 ): JSX.Element | null => {

--- a/support-frontend/knip.config.js
+++ b/support-frontend/knip.config.js
@@ -8,7 +8,7 @@ module.exports = {
 	// ! signals that this is production code https://knip.dev/features/production-mode
 	entry: [...flattenedEntryPoints, 'scripts/build-ssr-content.tsx!'],
 	project: ['**/*.{js,jsx,ts,tsx,scss}!'],
-	ignoreExportsUsedInFile: true,
+	ignoreExportsUsedInFile: false,
 	ignoreDependencies: [
 		// used in package.json
 		'@guardian/browserslist-config',

--- a/support-frontend/stories/productPage/PageTitle.stories.tsx
+++ b/support-frontend/stories/productPage/PageTitle.stories.tsx
@@ -1,5 +1,5 @@
 import CentredContainer from 'components/containers/centredContainer';
-import PageTitle from 'components/page/pageTitle';
+import { PageTitle } from 'components/page/pageTitle';
 import { Hero } from './Hero.stories';
 
 export default {


### PR DESCRIPTION

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Changing the Knip config to not ignore unused exports if they're used within the same file. The main motivation for doing this is that there is a Knip [issue](https://github.com/webpro-nl/knip/issues/708) where combining `ignoreExportsUsedInFile: true` and `export { foo }` notation doesn't detect unused exports. This PR fixes the unnecessary `export` statements and removes the completely unused exports (and subsequent unused code)

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

