### PR TITLE
Only alarm on 500 responses

### DIFF
--- a/support-frontend/app/actions/CustomActionBuilders.scala
+++ b/support-frontend/app/actions/CustomActionBuilders.scala
@@ -67,15 +67,13 @@ class CustomActionBuilders(
       AwsCloudWatchMetricPut(AwsCloudWatchMetricPut.client)(cloudwatchEvent)
     }
 
-    private def isNon200Result(result: Result) = result.header.status.toString.head != '2'
-
     private def maybePushAlarmMetric(result: Result) = {
       val ignoreList = Set(
         emailProviderRejectedCode,
         invalidEmailAddressCode,
         recaptchaFailedCode,
       )
-      if (isNon200Result(result)) {
+      if (result.header.status == 500) {
         if (!ignoreList.contains(result.header.reasonPhrase.getOrElse(""))) {
           logger.error(
             scrub"pushing alarm metric - non 2xx response. Http code: ${result.header.status}, reason: ${result.header.reasonPhrase}",


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We have some code which triggers an alarm every time we return a non 200 response from the `CreateSubscriptionController` class, however there are some non 200 responses which we do not want to alarm on like 400 errors.

This PR changes the behaviour to only alarm on a 500 error ie. an internal server error where our code has behaved in an unexpected way.