### PR TITLE
Update browserslist packages

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -120,7 +120,7 @@
 		"@babel/preset-react": "^7.23.3",
 		"@babel/preset-typescript": "^7.26.0",
 		"@emotion/eslint-plugin": "^11.11.0",
-		"@guardian/browserslist-config": "^6.1.1",
+		"@guardian/browserslist-config": "^6.1.2",
 		"@guardian/eslint-config": "8.0.1",
 		"@guardian/eslint-config-typescript": "10.0.1",
 		"@guardian/prettier": "^2.1.5",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1784,10 +1784,10 @@
     aria-hidden "^1.1.3"
     tabbable "^6.0.1"
 
-"@guardian/browserslist-config@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-6.1.1.tgz#acca57ca0666490ca2dd67522a9fbaf5c7ef4b4d"
-  integrity sha512-62fVcqE5opXxN1bgm5lF6ykPrKM2/U8WdGH7gcrFGV6f5VVz+oFloMX+C2Svj19fdmXpfHj6+I1AmJbqSAX5CQ==
+"@guardian/browserslist-config@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-6.1.2.tgz#ba6ed8bb005d6143702a1e9f5c9fa40b39e21f6d"
+  integrity sha512-3SWaa6759XJVyYX3b4NERv7juqzX4Qt5VigxaQAp1gnFOPZMkjKmEZrDW1s3Ty2bSs6MAMrUovIgcDCqfRX71w==
 
 "@guardian/eslint-config-typescript@10.0.1":
   version "10.0.1"

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -4348,15 +4348,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001565:
-  version "1.0.30001628"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001628.tgz"
-  integrity sha512-S3BnR4Kh26TBxbi5t5kpbcUlLJb9lhtDXISDPwOfI+JoC+ik0QksvkZtUVyikw3hjnkgkMPSJ8oIM9yMm9vflA==
-
-caniuse-lite@^1.0.30001669:
-  version "1.0.30001677"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz#27c2e2c637e007cfa864a16f7dfe7cde66b38b5f"
-  integrity sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001565, caniuse-lite@^1.0.30001669:
+  version "1.0.30001695"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz"
+  integrity sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
## What are you doing in this PR?

This updates the `@guardian/browserslist` package version and also the `caniuse-lite` db which contains browser stats. These are used in combination with `preset-env` to determine the code to be generated by babel. When I ran the upgrade I saw the following log line: `No target browser changes`. So I don't think this actually changes anything regarding the browsers we're targeting.

Update: I actually don't think we use caniuse-lite at all since `@guardian/browserslist-config` contains its own stats pulled from our GA data. We can see that this PR doesn't change any bundle sizes at all, so I think that confirms this upgrade is essentially a no-op.

## Why are you doing this?

We see the following warnings in local dev and CI:

```
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
