### PR TITLE
Create knip production mode specific config

### DIFF
--- a/support-frontend/knip.config.js
+++ b/support-frontend/knip.config.js
@@ -9,6 +9,7 @@ module.exports = {
 	entry: [...flattenedEntryPoints, 'scripts/build-ssr-content.tsx!'],
 	project: ['**/*.{js,jsx,ts,tsx,scss}!'],
 	ignoreExportsUsedInFile: false,
+	ignore: ['**/knip.*.js'],
 	ignoreDependencies: [
 		// used in package.json
 		'@guardian/browserslist-config',

--- a/support-frontend/knip.production.config.js
+++ b/support-frontend/knip.production.config.js
@@ -1,0 +1,5 @@
+const normalConfig = require('./knip.config');
+
+module.exports = Object.assign({}, normalConfig, {
+	ignoreExportsUsedInFile: true,
+});

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -19,6 +19,7 @@
 		"test": "NODE_ENV=test echo 'Running TS tests' && jest",
 		"test-watch": "NODE_ENV=test echo 'Running TS tests in watch mode' && jest --watch",
 		"knip": "knip --include files,exports,nsExports,types,nsTypes,dependencies",
+		"knip:production": "yarn knip --production --config knip.production.config.js",
 		"jest-update-snapshot": "echo 'Updating TS tests' && jest -u",
 		"prepare": "cd .. && husky install ./support-frontend/.husky",
 		"prettier:check": "prettier --check ./assets",


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Creating a production mode config file for knip and a new script to run it in production mode with that config.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

## Why are you doing this?

Production mode is a useful feature because it identifies code only used in tests and not by production code. However in #6721 it became a lot noisier because `ignoreExportsUsedInFile` was set to false. I've set this to true in the new config

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Run `yarn knip --production` and compare to `yarn knip:production`. 

There are much fewer errors in the latter, most of which are mocks and are easier to ignore

## Screenshots
 `yarn knip --production`
 
<img width="1281" alt="image" src="https://github.com/user-attachments/assets/bba55b6d-ec85-4718-9ef9-cfb4b7f593ab" />

 `yarn knip:production`
 
 
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/bacea1e5-7389-4128-b837-85500633906d" />
