### PR TITLE
Make HEAD requests to the metric-push-api

### DIFF
--- a/support-frontend/assets/helpers/rendering/render.ts
+++ b/support-frontend/assets/helpers/rendering/render.ts
@@ -13,6 +13,7 @@ const safeFetch = (url: string, opts?: Record<string, string>) => {
 const logRenderingException = (e: Error): void => {
 	safeFetch(window.guardian.settings.metricUrl, {
 		mode: 'no-cors',
+		method: 'HEAD',
 	}); // ignore result, fire and forget
 
 	logException(


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

When we call the metric-push-api, use a HEAD request.
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

This API now accepts HEAD requests instead of GET requests. See also guardian/support-service-lambdas#2652.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

I've tested locally by forcing an error and can see the metric-push-api invoked as expected.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
