### PR TITLE
Lighthouse - remove third party resource count

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -8,10 +8,6 @@
         "resource-summary:document:size": [
           "error",
           { "maxNumericValue": 22000 }
-        ],
-        "resource-summary:third-party:count": [
-          "error",
-          { "maxNumericValue": 30 }
         ]
       }
     }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Removing the assertion of third party resource count from our lighthouse CI action, after refactoring the router in #6733 it's been bumped up to 33. But this doesn't seem like a metric worth tracking

## Screenshots
Example of what these are from the generated report
<img width="816" alt="image" src="https://github.com/user-attachments/assets/98b8aa95-faf9-48db-82f1-19bf55212ed9" />
