### PR TITLE
Revert "Make HEAD requests to the metric-push-api"

### DIFF
--- a/support-frontend/assets/helpers/rendering/render.ts
+++ b/support-frontend/assets/helpers/rendering/render.ts
@@ -13,7 +13,6 @@ const safeFetch = (url: string, opts?: Record<string, string>) => {
 const logRenderingException = (e: Error): void => {
 	safeFetch(window.guardian.settings.metricUrl, {
 		mode: 'no-cors',
-		method: 'HEAD',
 	}); // ignore result, fire and forget
 
 	logException(


### PR DESCRIPTION
Reverts guardian/support-frontend#6732.

The alarm this was supposed to help quieten down has been noisier than ever overnight, so revert this change.

See also guardian/support-service-lambdas#2653.