### PR TITLE
Make tramlines reach the footer on tall screens

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutLayout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutLayout.tsx
@@ -25,6 +25,7 @@ const secureTransactionIndicator = css`
 `;
 
 const darkBackgroundContainerMobile = css`
+	display: flex;
 	background-color: ${palette.neutral[97]};
 	${until.tablet} {
 		background-color: ${palette.brand[400]};

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/contributionsOnlyLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/contributionsOnlyLanding.tsx
@@ -24,6 +24,7 @@ import { getGeoIdConfig } from 'pages/geoIdConfig';
 import { AmountsCard } from '../components/amountsCard';
 
 const recurringContainer = css`
+	display: flex;
 	background-color: ${palette.brand[400]};
 	border-bottom: 1px solid ${palette.brand[600]};
 	> div {
@@ -178,9 +179,16 @@ export function ContributionsOnlyLanding({
 		<PageScaffold
 			header={<Header></Header>}
 			footer={
-				<FooterWithContents>
-					<FooterLinks links={links}></FooterLinks>
-				</FooterWithContents>
+				<>
+					<Container
+						sideBorders
+						borderColor={palette.brand[600]}
+						cssOverrides={disclaimerContainer}
+					></Container>
+					<FooterWithContents>
+						<FooterLinks links={links}></FooterLinks>
+					</FooterWithContents>
+				</>
 			}
 		>
 			<Container
@@ -215,11 +223,6 @@ export function ContributionsOnlyLanding({
 					/>
 				</div>
 			</Container>
-			<Container
-				sideBorders
-				borderColor={palette.brand[600]}
-				cssOverrides={disclaimerContainer}
-			></Container>
 		</PageScaffold>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -536,9 +536,75 @@ export function ThreeTierLanding({
 				</>
 			}
 			footer={
-				<FooterWithContents>
-					<FooterLinks links={links}></FooterLinks>
-				</FooterWithContents>
+				<>
+					{countryGroupId === UnitedStates && (
+						<Container
+							sideBorders
+							borderColor="rgba(170, 170, 180, 0.5)"
+							cssOverrides={supportAnotherWayContainer}
+						>
+							<div css={supportAnotherWay}>
+								<h4>Support another way</h4>
+								<p>
+									If you are interested in contributing through a donor-advised
+									fund, foundation or retirement account, or by mailing a check,{' '}
+									<br />
+									please visit our{' '}
+									<a href="https://manage.theguardian.com/help-centre/article/contribute-another-way?INTCMP=gdnwb_copts_support_contributions_referral">
+										help page
+									</a>{' '}
+									to learn how.
+								</p>
+							</div>
+						</Container>
+					)}
+					<Container
+						sideBorders
+						borderColor="rgba(170, 170, 180, 0.5)"
+						cssOverrides={disclaimerContainer}
+					>
+						<ThreeTierTsAndCs
+							tsAndCsContent={[
+								{
+									title: tier1Card.productDescription.label,
+									planCost: getPlanCost(tier1Card.price, contributionType),
+								},
+								{
+									title: tier2Card.productDescription.label,
+									planCost: getPlanCost(
+										tier2Card.price,
+										contributionType,
+										promotionTier2,
+									),
+									starts: promotionTier2?.starts
+										? new Date(promotionTier2.starts)
+										: undefined,
+									expires: promotionTier2?.expires
+										? new Date(promotionTier2.expires)
+										: undefined,
+								},
+								{
+									title: tier3Card.productDescription.label,
+									planCost: getPlanCost(
+										tier3Card.price,
+										contributionType,
+										promotionTier3,
+									),
+									starts: promotionTier3?.starts
+										? new Date(promotionTier3.starts)
+										: undefined,
+									expires: promotionTier3?.expires
+										? new Date(promotionTier3.expires)
+										: undefined,
+								},
+							]}
+							currency={currencies[currencyId].glyph}
+						></ThreeTierTsAndCs>
+					</Container>
+					<FooterWithContents>
+						<FooterLinks links={links}></FooterLinks>
+					</FooterWithContents>
+				</>
 			}
 		>
 			<Container
@@ -632,70 +698,6 @@ export function ThreeTierLanding({
 					/>
 				</Container>
 			)}
-			{countryGroupId === UnitedStates && (
-				<Container
-					sideBorders
-					borderColor="rgba(170, 170, 180, 0.5)"
-					cssOverrides={supportAnotherWayContainer}
-				>
-					<div css={supportAnotherWay}>
-						<h4>Support another way</h4>
-						<p>
-							If you are interested in contributing through a donor-advised
-							fund, foundation or retirement account, or by mailing a check,{' '}
-							<br />
-							please visit our{' '}
-							<a href="https://manage.theguardian.com/help-centre/article/contribute-another-way?INTCMP=gdnwb_copts_support_contributions_referral">
-								help page
-							</a>{' '}
-							to learn how.
-						</p>
-					</div>
-				</Container>
-			)}
-			<Container
-				sideBorders
-				borderColor="rgba(170, 170, 180, 0.5)"
-				cssOverrides={disclaimerContainer}
-			>
-				<ThreeTierTsAndCs
-					tsAndCsContent={[
-						{
-							title: tier1Card.productDescription.label,
-							planCost: getPlanCost(tier1Card.price, contributionType),
-						},
-						{
-							title: tier2Card.productDescription.label,
-							planCost: getPlanCost(
-								tier2Card.price,
-								contributionType,
-								promotionTier2,
-							),
-							starts: promotionTier2?.starts
-								? new Date(promotionTier2.starts)
-								: undefined,
-							expires: promotionTier2?.expires
-								? new Date(promotionTier2.expires)
-								: undefined,
-						},
-						{
-							title: tier3Card.productDescription.label,
-							planCost: getPlanCost(
-								tier3Card.price,
-								contributionType,
-								promotionTier3,
-							),
-							starts: promotionTier3?.starts
-								? new Date(promotionTier3.starts)
-								: undefined,
-							expires: promotionTier3?.expires
-								? new Date(promotionTier3.expires)
-								: undefined,
-						},
-					]}
-					currency={currencies[currencyId].glyph}
-				></ThreeTierTsAndCs>
-			</Container>
 		</PageScaffold>
 	);
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Updating the three tier landing, generic checkout and contributions only landing page to make the tramlines (side borders) go all the way down the page at tall screen sizes.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/qYg9D559/1361-support-site-layout-issue-detached-footer)

## Why are you doing this?
We noticed while building the new contributions only page that the side borders don't hit the bottom if the screen is very tall or there isn't enough vertical content.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
Zoom out in your browser, visit the three tier landing `/uk/contribute`, generic checkout and contributions only landing page (`/int/contribute?country=`) and see that the side borders reach the footer.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Screenshots

###Three Tier Landing
Before 
![image](https://github.com/user-attachments/assets/431ca4e1-50ea-492d-a6ef-4882694ae504)

After
![image](https://github.com/user-attachments/assets/92b11f73-91fd-46c3-8df0-804bc35ecc69)

###Generic checkout
Before
![image](https://github.com/user-attachments/assets/6be8e533-157f-43dd-82fc-1e247bc7ae19)

After
![image](https://github.com/user-attachments/assets/481afd77-6968-4988-ba5a-4ce26aaeebfb)

###Contributions only
Before
![image](https://github.com/user-attachments/assets/cf4fad4b-9425-4090-9e44-3c48ec6c3343)

After
![image](https://github.com/user-attachments/assets/199b825c-b94d-4d4d-9a24-131e0c2c4298)
