### PR TITLE
Add A/B test for confirm email form field

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -109,4 +109,25 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeContributionsOnlyCountries: true,
 	},
+	confirmEmail: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		isActive: true,
+		referrerControlled: false, // ab-test name not needed to be in paramURL
+		seed: 5,
+		targetPage: pageUrlRegexes.contributions.genericCheckoutOnly,
+		excludeContributionsOnlyCountries: false,
+	},
 };

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
@@ -14,6 +14,9 @@ type PersonalDetailsFieldsProps = {
 	email: string;
 	setEmail: (value: string) => void;
 	isEmailAddressReadOnly: boolean;
+	requireConfirmedEmail: boolean;
+	confirmedEmail: string;
+	setConfirmedEmail: (value: string) => void;
 };
 
 export function PersonalDetailsFields({
@@ -25,10 +28,19 @@ export function PersonalDetailsFields({
 	email,
 	setEmail,
 	isEmailAddressReadOnly,
+	requireConfirmedEmail,
+	confirmedEmail,
+	setConfirmedEmail,
 }: PersonalDetailsFieldsProps) {
 	const [firstNameError, setFirstNameError] = useState<string>();
 	const [lastNameError, setLastNameError] = useState<string>();
 	const [emailError, setEmailError] = useState<string>();
+
+	const emailAddressDoesNotMatch =
+		confirmedEmail.length && email !== confirmedEmail;
+	const confirmedEmailError = emailAddressDoesNotMatch
+		? 'The email addresses do not match.'
+		: undefined;
 
 	return (
 		<>
@@ -66,6 +78,25 @@ export function PersonalDetailsFields({
 					}}
 				/>
 			</div>
+			{requireConfirmedEmail && !isEmailAddressReadOnly && (
+				<div>
+					<TextInput
+						id="confirm-email"
+						data-qm-masking="blocklist"
+						label="Confirm email address"
+						value={confirmedEmail}
+						type="email"
+						autoComplete="email"
+						onChange={(event) => {
+							setConfirmedEmail(event.currentTarget.value);
+						}}
+						name="confirm-email"
+						required
+						maxLength={80}
+						error={confirmedEmailError}
+					/>
+				</div>
+			)}
 			{children}
 			<div>
 				<TextInput

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -243,6 +243,8 @@ export function CheckoutComponent({
 		abParticipations.newspaperArchiveBenefit ?? '',
 	);
 
+	const requireConfirmedEmail = abParticipations.confirmEmail === 'variant';
+
 	const productDescription = showNewspaperArchiveBenefit
 		? productCatalogDescriptionNewBenefits(countryGroupId)[productKey]
 		: productCatalogDescription[productKey];
@@ -363,6 +365,7 @@ export function CheckoutComponent({
 	const [firstName, setFirstName] = useState(user?.firstName ?? '');
 	const [lastName, setLastName] = useState(user?.lastName ?? '');
 	const [email, setEmail] = useState(user?.email ?? '');
+	const [confirmedEmail, setConfirmedEmail] = useState('');
 
 	/** Delivery and billing addresses */
 	const [deliveryPostcode, setDeliveryPostcode] = useState('');
@@ -420,6 +423,15 @@ export function CheckoutComponent({
 
 	const formOnSubmit = async (formData: FormData) => {
 		setIsProcessingPayment(true);
+
+		/**  This validation has to happen on submit,
+		 *   as we cannot check it with form validation rules
+		 */
+		if (requireConfirmedEmail && email !== confirmedEmail) {
+			setIsProcessingPayment(false);
+			return;
+		}
+
 		/**
 		 * The validation for this is currently happening on the client side form validation
 		 * So we'll assume strings are not null.
@@ -926,6 +938,11 @@ export function CheckoutComponent({
 								setLastName={(lastName) => setLastName(lastName)}
 								email={email}
 								setEmail={(email) => setEmail(email)}
+								requireConfirmedEmail={requireConfirmedEmail}
+								confirmedEmail={confirmedEmail}
+								setConfirmedEmail={(confirmedEmail) =>
+									setConfirmedEmail(confirmedEmail)
+								}
 							>
 								<Signout isSignedIn={isSignedIn} />
 							</PersonalDetailsFields>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Adding a form field to the generic checkout for a user to confirm their email address. 

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/mCYE3GTi/1373-add-confirm-email-field-across-products-generic-checkout-a-b-test)

## Why are you doing this?
This feature is present on the old subscription checkout, and should stop cases where a user might have made a mistake and tied their subscription to the wrong email address. We want to test if the additional friction of having to confirm the email will harm the CVR.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

### Signed out

Go to `https://support.thegulocal.com/uk/checkout?product=Contribution&ratePlan=Monthly&contribution=3#ab-confirmEmail=variant`. See the confirm email field. Enter an email address in the email field. Then enter a different email in the confirm email field. See error message and cannot submit the form. Make the two fields match. Can submit the form.

### Signed in
Go to `https://support.thegulocal.com/uk/checkout?product=Contribution&ratePlan=Monthly&contribution=3#ab-confirmEmail=variant`. Do not see the confirm email field.

### E2E

We need an exception to stop this affecting our playwright e2e tests.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Screenshots
### Signed out
![image](https://github.com/user-attachments/assets/4c166b81-475d-4e90-8234-282f8ee22c0e)

### Signed in
![image](https://github.com/user-attachments/assets/adc905d5-2b6d-4174-bd96-3b7bad8e65d0)
