### PR TITLE
Log the endpoint if we get an error back from `/guest`

### DIFF
--- a/support-frontend/app/services/HttpIdentityService.scala
+++ b/support-frontend/app/services/HttpIdentityService.scala
@@ -226,7 +226,7 @@ class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient:
         )
         .map(response => UserDetails(response.guestRegistrationRequest.userId, email, "new"))
     }
-  }
+  }.leftMap(e => e.setEndpoint(GuestEndpoint))
 
   private def uriWithoutQuery(uri: URI) = uri.toString.takeWhile(_ != '?')
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Occassionally we see errors which we're pretty sure are coming from the /guest endpoint, but when we log the error the endpoint isn't specified. I think that's because the IdentityError instance doesn't have the endpoint set on it in some cases. This PR ensures we're doing that.

Related to: [**Trello Card**](https://trello.com/c/2Utb3wDH/1225-500-errors-from-identity)

Before: `ServerError(Error calling Identity: Email in use: This email has already been taken)`

After: `ServerError(Identity error calling /guest: Email in use; This email has already been taken)`

## Why are you doing this?

This removes some ambiguity when reading the error message in the logs.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Tested locally by forcing an error and saw the correct message get logged.

Smoke tests run fine against local app.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
