### PR TITLE
Don't alarm on "Email in use" response from Identity `/guest` endpoint

### DIFF
--- a/support-frontend/app/actions/CustomActionBuilders.scala
+++ b/support-frontend/app/actions/CustomActionBuilders.scala
@@ -72,6 +72,7 @@ class CustomActionBuilders(
         emailProviderRejectedCode,
         invalidEmailAddressCode,
         recaptchaFailedCode,
+        emailAddressAlreadyTakenCode,
       )
       if (result.header.status == 500) {
         if (!ignoreList.contains(result.header.reasonPhrase.getOrElse(""))) {

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -233,10 +233,14 @@ class CreateSubscriptionController(
     )
   }
 
-  private def mapIdentityErrorToCreateSubscriptionError(identityError: IdentityError) =
+  private def mapIdentityErrorToCreateSubscriptionError(identityError: IdentityError): CreateSubscriptionError =
     identityError match {
       case EmailProviderRejected(_) => RequestValidationError(emailProviderRejectedCode)
       case InvalidEmailAddress(_) => RequestValidationError(invalidEmailAddressCode)
+      // We're mapping this to a ServerError because it shouldn't ever happen, but sometimes does. Even though we
+      // asked identity (in getOrCreateIdentityUser) whether the user exists first, sometimes we get an answer of no
+      // back but then attempting to create returns this error.
+      case EmailAddressAlreadyTaken(_) => ServerError(emailAddressAlreadyTakenCode)
       case OtherIdentityError(message, description, endpoint) =>
         endpoint match {
           case Some(GuestEndpoint) => ServerError(s"Identity error calling /guest: $message; $description")
@@ -344,6 +348,14 @@ class CreateSubscriptionController(
                   reasonPhrase = Some(err.message),
                 ),
                 body = writeable.toEntity(err.message),
+              )
+            case ServerError(code) if code == emailAddressAlreadyTakenCode =>
+              Result(
+                header = new ResponseHeader(
+                  status = INTERNAL_SERVER_ERROR,
+                  reasonPhrase = Some(emailAddressAlreadyTakenCode),
+                ),
+                body = writeable.toEntity(emailAddressAlreadyTakenCode),
               )
             case _: ServerError =>
               InternalServerError

--- a/support-frontend/app/models/identity/responses/IdentityErrorResponse.scala
+++ b/support-frontend/app/models/identity/responses/IdentityErrorResponse.scala
@@ -28,6 +28,7 @@ object IdentityErrorResponse {
   implicit val reads: Reads[IdentityErrorResponse] = Json.reads[IdentityErrorResponse]
   val emailProviderRejectedCode = "email_provider_rejected"
   val invalidEmailAddressCode = "invalid_email_address"
+  val emailAddressAlreadyTakenCode = "email_address_already_taken"
 
   sealed trait IdentityError {
     def endpoint: Option[IdentityEndpoint]
@@ -45,6 +46,9 @@ object IdentityErrorResponse {
 
   /** The email address is invalid. */
   case class InvalidEmailAddress(endpoint: Option[IdentityEndpoint]) extends IdentityError
+
+  /** The email address is already associated with an existing account. */
+  case class EmailAddressAlreadyTaken(endpoint: Option[IdentityEndpoint]) extends IdentityError
 
   /** Some other error occurred. */
   case class OtherIdentityError(message: String, description: String, endpoint: Option[IdentityEndpoint])
@@ -65,6 +69,8 @@ object IdentityErrorResponse {
         EmailProviderRejected(endpoint = None)
       } else if (message == "Invalid emailAddress:" && description == "Please enter a valid email address") {
         InvalidEmailAddress(endpoint = None)
+      } else if (message == "Email in use" && description == "This email has already been taken") {
+        EmailAddressAlreadyTaken(endpoint = None)
       } else {
         OtherIdentityError(message, description, endpoint = None)
       }

--- a/support-frontend/app/models/identity/responses/IdentityErrorResponse.scala
+++ b/support-frontend/app/models/identity/responses/IdentityErrorResponse.scala
@@ -36,6 +36,7 @@ object IdentityErrorResponse {
       this match {
         case EmailProviderRejected(_) => EmailProviderRejected(Some(e))
         case InvalidEmailAddress(_) => InvalidEmailAddress(Some(e))
+        case EmailAddressAlreadyTaken(_) => EmailAddressAlreadyTaken(Some(e))
         case OtherIdentityError(m, d, _endpoint) => OtherIdentityError(m, d, endpoint = Some(e))
       }
     }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Don't alarm on `Email in use` response from Identity `/guest` endpoint.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

Sometimes `POST /guest` returns `Email in use` even though we already checked whether the user existed using the `GET /user` endpoint. According to identity occasionally users get into a weird state and this is a result of that. I think this should still result in a 500 (it's not related to something the user has done) but we don't want to alarm on it.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

I've tested locally by forcing the error, in the logs I see:

```
not pushing alarm metric for 500 Some(email_address_already_taken) as it is in our ignore list
```

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
