### PR TITLE
Remove digisub gift references from client side

### DIFF
--- a/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
@@ -21,9 +21,6 @@ import { _, init as abInit, getAmountsTestVariant } from '../abtest';
 import type { Audience, Participations, Test, Variant } from '../abtest';
 
 const { targetPageMatches } = _;
-const { subsDigiSubPages, digiSub } = pageUrlRegexes.subscriptions;
-const { nonGiftLandingNotAusNotUS, nonGiftLandingAndCheckoutWithGuest } =
-	digiSub;
 const { allLandingPagesAndThankyouPages, genericCheckoutOnly } =
 	pageUrlRegexes.contributions;
 
@@ -581,65 +578,7 @@ describe('init', () => {
 });
 
 it('targetPage matching', () => {
-	expect(targetPageMatches('/uk/subscribe/paper', subsDigiSubPages)).toEqual(
-		false,
-	);
-	expect(
-		targetPageMatches('/uk/subscribe/digital/checkout', subsDigiSubPages),
-	).toEqual(false);
-	expect(targetPageMatches('/us/subscribe', subsDigiSubPages)).toEqual(true);
-	expect(targetPageMatches('/us/subscribe/digital', subsDigiSubPages)).toEqual(
-		true,
-	);
-	const withAcquisitionParams =
-		'/uk/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B"componentType"%3A"ACQUISITIONS_HEADER"%2C"componentId"%3A"header_support_subscribe"%2C"source"%3A"GUARDIAN_WEB"%2C"referrerPageviewId"%3A"k8heft91k5c3tnnnmwjd"%2C"referrerUrl"%3A"https%3A%2F%2Fwww.theguardian.com%2Fuk"%7D';
-	expect(targetPageMatches(withAcquisitionParams, subsDigiSubPages)).toEqual(
-		true,
-	);
-	expect(
-		targetPageMatches('/us/subscribe/digital?test=blah', subsDigiSubPages),
-	).toEqual(true);
 	// Test nonGiftLandingAndCheckout regex
-	expect(
-		targetPageMatches(
-			'/uk/subscribe/digital',
-			nonGiftLandingAndCheckoutWithGuest,
-		),
-	).toEqual(true);
-	expect(
-		targetPageMatches(
-			'/subscribe/digital/checkout',
-			nonGiftLandingAndCheckoutWithGuest,
-		),
-	).toEqual(true);
-	expect(
-		targetPageMatches(
-			'/subscribe/digital/checkout/guest',
-			nonGiftLandingAndCheckoutWithGuest,
-		),
-	).toEqual(true);
-	expect(
-		targetPageMatches(
-			'/uk/subscribe/digital/gift',
-			nonGiftLandingAndCheckoutWithGuest,
-		),
-	).toEqual(false);
-	// Test nonGiftLandingNotAusNotUS regex
-	expect(
-		targetPageMatches('/uk/subscribe/digital', nonGiftLandingNotAusNotUS),
-	).toEqual(true);
-	expect(
-		targetPageMatches('/subscribe/digital/checkout', nonGiftLandingNotAusNotUS),
-	).toEqual(true);
-	expect(
-		targetPageMatches('/us/subscribe/digital', nonGiftLandingNotAusNotUS),
-	).toEqual(false);
-	expect(
-		targetPageMatches('/au/subscribe/digital', nonGiftLandingNotAusNotUS),
-	).toEqual(false);
-	expect(
-		targetPageMatches('/uk/subscribe/digital/gift', nonGiftLandingNotAusNotUS),
-	).toEqual(false);
 	expect(
 		targetPageMatches(
 			'/subscribe/weekly/checkout',

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -17,23 +17,6 @@ export const pageUrlRegexes = {
 		genericCheckoutOnly: '(uk|us|au|ca|eu|nz|int)/checkout|thank-you(/.*)?$',
 	},
 	subscriptions: {
-		subsDigiSubPages: '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)',
-		digiSubLandingPages:
-			'(/??/subscribe/digital/gift(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)',
-		digiSubLandingPagesNotAus:
-			'(/(uk|us|ca|eu|nz|int)/subscribe/digital(\\?.*)?$)',
-		digiSub: {
-			// Requires /subscribe/digital, allows /checkout and/or /gift, allows any query string
-			allLandingAndCheckout:
-				/\/subscribe\/digital(\/checkout)?(\/gift)?(\?.*)?$/,
-			// Requires /subscribe/digital and /gift, allows /checkout before /gift, allows any query string
-			giftLandingAndCheckout: /\/subscribe\/digital(\/checkout)?\/gift(\?.*)?$/,
-			// Requires /subscribe/digital, allows /checkout, allows any query string
-			nonGiftLandingAndCheckoutWithGuest:
-				/\/subscribe\/digital(\/checkout|\/checkout\/guest)?(\?.*)?$/,
-			nonGiftLandingNotAusNotUS:
-				/((uk|ca|eu|nz|int)\/subscribe\/digital(?!\/gift).?(\\?.*)?$)|(\/subscribe\/digital\/checkout?(\\?.*)?$)/,
-		},
 		paper: {
 			// Requires /subscribe/paper, allows /checkout or /checkout/guest, allows any query string
 			paperLandingWithGuestCheckout:

--- a/support-frontend/assets/helpers/subscriptionsForms/formActionCreators.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/formActionCreators.ts
@@ -28,7 +28,6 @@ import { getDeliveryAgentsThunk } from 'helpers/redux/checkout/addressMeta/thunk
 import {
 	setEmail as setEmailGift,
 	setFirstName as setFirstNameGift,
-	setGiftDeliveryDate,
 	setGiftMessage,
 	setLastName as setLastNameGift,
 	setTitle as setTitleGift,
@@ -83,7 +82,6 @@ const formActionCreators = {
 	setGiftStatus: setOrderIsAGift,
 	setDeliveryInstructions,
 	setGiftMessage,
-	setDigitalGiftDeliveryDate: setGiftDeliveryDate,
 	setAddDigitalSubscription: setAddDigital,
 	setCsrUsername: (username: string): Action => ({
 		type: 'SET_CSR_USERNAME',

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -41,7 +41,6 @@ enum SendEventSubscriptionCheckoutStart {
 	DigiSub = 75,
 	PaperSub = 76,
 	GuardianWeeklySub = 77,
-	DigiSubGift = 78,
 	GuardianWeeklySubGift = 79,
 }
 
@@ -49,7 +48,6 @@ enum SendEventSubscriptionCheckoutConversion {
 	DigiSub = 31,
 	PaperSub = 67,
 	GuardianWeeklySub = 68,
-	DigiSubGift = 69,
 	GuardianWeeklySubGift = 70,
 }
 
@@ -82,13 +80,8 @@ type SendEventId =
 
 // ---- sendEvent logic ---- //
 
-const {
-	DigiSub,
-	PaperSub,
-	GuardianWeeklySub,
-	DigiSubGift,
-	GuardianWeeklySubGift,
-} = SendEventSubscriptionCheckoutStart;
+const { DigiSub, PaperSub, GuardianWeeklySub, GuardianWeeklySubGift } =
+	SendEventSubscriptionCheckoutStart;
 
 const { SingleContribution, RecurringContribution } =
 	SendEventContributionAmountUpdate;
@@ -97,7 +90,6 @@ const cartValueEventIds: SendEventId[] = [
 	DigiSub,
 	PaperSub,
 	GuardianWeeklySub,
-	DigiSubGift,
 	GuardianWeeklySubGift,
 	SingleContribution,
 	RecurringContribution,
@@ -228,15 +220,10 @@ function productToCheckoutEvents(
 	| undefined {
 	switch (product) {
 		case 'DigitalPack':
-			return orderIsAGift
-				? checkoutEvents(
-						SendEventSubscriptionCheckoutStart.DigiSubGift,
-						SendEventSubscriptionCheckoutConversion.DigiSubGift,
-				  )
-				: checkoutEvents(
-						SendEventSubscriptionCheckoutStart.DigiSub,
-						SendEventSubscriptionCheckoutConversion.DigiSub,
-				  );
+			return checkoutEvents(
+				SendEventSubscriptionCheckoutStart.DigiSub,
+				SendEventSubscriptionCheckoutConversion.DigiSub,
+			);
 		case 'GuardianWeekly':
 			return orderIsAGift
 				? checkoutEvents(

--- a/support-frontend/assets/helpers/urls/routes.ts
+++ b/support-frontend/assets/helpers/urls/routes.ts
@@ -30,7 +30,6 @@ const routes = {
 	subscriptionCreate: '/subscribe/create',
 	subscriptionsLanding: '/subscribe',
 	digitalSubscriptionLanding: '/subscribe/digitaledition',
-	digitalSubscriptionLandingGift: '/subscribe/digital/gift',
 	paperSubscriptionLanding: '/subscribe/paper',
 	paperSubscriptionProductChoices: '/subscribe/paper#HomeDelivery',
 	paperSubscriptionDeliveryProductChoices:
@@ -81,14 +80,9 @@ function paperSubsUrl(
 	return baseURL;
 }
 
-function digitalSubscriptionLanding(
-	countryGroupId: CountryGroupId,
-	gift: boolean,
-) {
+function digitalSubscriptionLanding(countryGroupId: CountryGroupId) {
 	return `${getOrigin()}/${countryPath(countryGroupId)}${
-		gift
-			? routes.digitalSubscriptionLandingGift
-			: routes.digitalSubscriptionLanding
+		routes.digitalSubscriptionLanding
 	}`;
 }
 

--- a/support-frontend/assets/pages/promotion-terms/DigitalPackTerms.tsx
+++ b/support-frontend/assets/pages/promotion-terms/DigitalPackTerms.tsx
@@ -22,7 +22,7 @@ export default function DigitalPackTerms(props: PropTypes) {
 		'By entering the promotion you are accepting these terms and conditions.',
 		<div>
 			To enter the promotion, you must: (i) either go to{' '}
-			<a href={digitalSubscriptionLanding(props.countryGroupId, false)}>
+			<a href={digitalSubscriptionLanding(props.countryGroupId)}>
 				support.theguardian.com
 			</a>{' '}
 			or call +44 (0) 330 333 6767 and quote promotion code {props.promoCode}{' '}

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
@@ -73,7 +73,7 @@ const digital = (
 	buttons: [
 		{
 			ctaButtonText: 'Find out more',
-			link: digitalSubscriptionLanding(countryGroupId, false),
+			link: digitalSubscriptionLanding(countryGroupId),
 			analyticsTracking: sendTrackingEventsOnClick({
 				id: 'digipack_cta',
 				product: 'DigitalPack',


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Removing any references to digisub gifting from the client side after it was removed from the server (#6736)

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/xP95HBiR/1400-remove-digi-pack-gift-code-client-side)

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
- Run through E2E tests
- Check digisub routes (`/subscribe/digital` redirects to `/contribute` through fastly)


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
