### PR TITLE
Add a higher threshold alarm which we can use for known checkout failure reasons

### DIFF
--- a/cdk/lib/__snapshots__/frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/frontend.test.ts.snap
@@ -43,6 +43,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
       "GuAlarm",
       "GuAlarm",
       "GuAlarm",
+      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -1340,6 +1341,64 @@ exports[`The Frontend stack matches the snapshot 1`] = `
           },
         ],
         "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ServerSideHighThresholdCreateFailureAlarm1DE4A5A9": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Impact - Someone pressed buy on a recurring product but received an error. This has happened multiple times for a known reason.. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
+        "AlarmName": "Support-frontend create recurring product call failed multiple times for a known reason",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "EvaluationPeriods": 60,
+        "MetricName": "ServerSideHighThresholdCreateFailure",
+        "Namespace": "support-frontend",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 10,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",

--- a/cdk/lib/__snapshots__/frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/frontend.test.ts.snap
@@ -1369,6 +1369,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
         "AlarmDescription": "Impact - Someone pressed buy on a recurring product but received an error. This has happened multiple times for a known reason.. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
         "AlarmName": "Support-frontend create recurring product call failed multiple times for a known reason",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 10,
         "Dimensions": [
           {
             "Name": "Stage",
@@ -1398,7 +1399,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
             "Value": "PROD",
           },
         ],
-        "Threshold": 10,
+        "Threshold": 1,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -374,7 +374,7 @@ export class Frontend extends GuStack {
         metricName: "ServerSideHighThresholdCreateFailure",
         namespace: "support-frontend",
         dimensionsMap: {
-          Stage: "PROD",
+          Stage: this.stage,
         },
         statistic: "Sum",
         period: Duration.minutes(1),

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -331,6 +331,32 @@ export class Frontend extends GuStack {
         snsTopicName: `alarms-handler-topic-${this.stage}`,
       });
 
+      new GuAlarm(this, "ServerSideHighThresholdCreateFailureAlarm", {
+        app,
+        alarmName: alarmName(
+          "support-frontend create recurring product call failed multiple times for a known reason"
+        ),
+        alarmDescription: alarmDescription(
+          "Someone pressed buy on a recurring product but received an error. This has happened multiple times for a known reason."
+        ),
+        actionsEnabled: shouldCreateAlarms,
+        threshold: 10,
+        evaluationPeriods: 60,
+        comparisonOperator:
+          ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        metric: new Metric({
+          metricName: "ServerSideHighThresholdCreateFailure",
+          namespace: "support-frontend",
+          dimensionsMap: {
+            Stage: "PROD",
+          },
+          statistic: "Sum",
+          period: Duration.minutes(1),
+        }),
+        treatMissingData: TreatMissingData.NOT_BREACHING,
+        snsTopicName: `alarms-handler-topic-${this.stage}`,
+      });
+
       new GuAlarm(this, "GetDeliveryAgentsFailure", {
         app,
         alarmName: alarmName("support-frontend GetDeliveryAgentsFailure"),

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -354,33 +354,33 @@ export class Frontend extends GuStack {
         treatMissingData: TreatMissingData.NOT_BREACHING,
         snsTopicName: `alarms-handler-topic-${this.stage}`,
       });
-    }
 
-    new GuAlarm(this, "ServerSideHighThresholdCreateFailureAlarm", {
-      app,
-      alarmName: alarmName(
-        "support-frontend create recurring product call failed multiple times for a known reason"
-      ),
-      alarmDescription: alarmDescription(
-        "Someone pressed buy on a recurring product but received an error. This has happened multiple times for a known reason."
-      ),
-      actionsEnabled: shouldCreateAlarms,
-      threshold: 1,
-      evaluationPeriods: 60,
-      datapointsToAlarm: 10,
-      comparisonOperator:
-        ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-      metric: new Metric({
-        metricName: "ServerSideHighThresholdCreateFailure",
-        namespace: "support-frontend",
-        dimensionsMap: {
-          Stage: this.stage,
-        },
-        statistic: "Sum",
-        period: Duration.minutes(1),
-      }),
-      treatMissingData: TreatMissingData.NOT_BREACHING,
-      snsTopicName: `alarms-handler-topic-${this.stage}`,
-    });
+      new GuAlarm(this, "ServerSideHighThresholdCreateFailureAlarm", {
+        app,
+        alarmName: alarmName(
+          "support-frontend create recurring product call failed multiple times for a known reason"
+        ),
+        alarmDescription: alarmDescription(
+          "Someone pressed buy on a recurring product but received an error. This has happened multiple times for a known reason."
+        ),
+        actionsEnabled: shouldCreateAlarms,
+        threshold: 1,
+        evaluationPeriods: 60,
+        datapointsToAlarm: 10,
+        comparisonOperator:
+          ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        metric: new Metric({
+          metricName: "ServerSideHighThresholdCreateFailure",
+          namespace: "support-frontend",
+          dimensionsMap: {
+            Stage: this.stage,
+          },
+          statistic: "Sum",
+          period: Duration.minutes(1),
+        }),
+        treatMissingData: TreatMissingData.NOT_BREACHING,
+        snsTopicName: `alarms-handler-topic-${this.stage}`,
+      });
+    }
   }
 }

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -340,8 +340,9 @@ export class Frontend extends GuStack {
           "Someone pressed buy on a recurring product but received an error. This has happened multiple times for a known reason."
         ),
         actionsEnabled: shouldCreateAlarms,
-        threshold: 10,
+        threshold: 1,
         evaluationPeriods: 60,
+        datapointsToAlarm: 10,
         comparisonOperator:
           ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
         metric: new Metric({

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -331,33 +331,6 @@ export class Frontend extends GuStack {
         snsTopicName: `alarms-handler-topic-${this.stage}`,
       });
 
-      new GuAlarm(this, "ServerSideHighThresholdCreateFailureAlarm", {
-        app,
-        alarmName: alarmName(
-          "support-frontend create recurring product call failed multiple times for a known reason"
-        ),
-        alarmDescription: alarmDescription(
-          "Someone pressed buy on a recurring product but received an error. This has happened multiple times for a known reason."
-        ),
-        actionsEnabled: shouldCreateAlarms,
-        threshold: 1,
-        evaluationPeriods: 60,
-        datapointsToAlarm: 10,
-        comparisonOperator:
-          ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-        metric: new Metric({
-          metricName: "ServerSideHighThresholdCreateFailure",
-          namespace: "support-frontend",
-          dimensionsMap: {
-            Stage: "PROD",
-          },
-          statistic: "Sum",
-          period: Duration.minutes(1),
-        }),
-        treatMissingData: TreatMissingData.NOT_BREACHING,
-        snsTopicName: `alarms-handler-topic-${this.stage}`,
-      });
-
       new GuAlarm(this, "GetDeliveryAgentsFailure", {
         app,
         alarmName: alarmName("support-frontend GetDeliveryAgentsFailure"),
@@ -382,5 +355,32 @@ export class Frontend extends GuStack {
         snsTopicName: `alarms-handler-topic-${this.stage}`,
       });
     }
+
+    new GuAlarm(this, "ServerSideHighThresholdCreateFailureAlarm", {
+      app,
+      alarmName: alarmName(
+        "support-frontend create recurring product call failed multiple times for a known reason"
+      ),
+      alarmDescription: alarmDescription(
+        "Someone pressed buy on a recurring product but received an error. This has happened multiple times for a known reason."
+      ),
+      actionsEnabled: shouldCreateAlarms,
+      threshold: 1,
+      evaluationPeriods: 60,
+      datapointsToAlarm: 10,
+      comparisonOperator:
+        ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      metric: new Metric({
+        metricName: "ServerSideHighThresholdCreateFailure",
+        namespace: "support-frontend",
+        dimensionsMap: {
+          Stage: "PROD",
+        },
+        statistic: "Sum",
+        period: Duration.minutes(1),
+      }),
+      treatMissingData: TreatMissingData.NOT_BREACHING,
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
+    });
   }
 }

--- a/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
+++ b/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
@@ -47,6 +47,14 @@ object AwsCloudWatchMetricSetup {
       ),
     )
 
+  def serverSideHighThresholdCreateFailure(stage: Stage): MetricRequest =
+    getMetricRequest(
+      MetricName("ServerSideHighThresholdCreateFailure"),
+      Map(
+        MetricDimensionName("Stage") -> MetricDimensionValue(stage.toString),
+      ),
+    )
+
   def defaultPromotionsLoadingFailure(stage: Stage): MetricRequest =
     getMetricRequest(
       MetricName("DefaultPromotionsLoadingFailure"),


### PR DESCRIPTION
## What are you doing in this PR?

This PR adds a new higher threshold alarm/metric.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/2Utb3wDH/1225-500-errors-from-identity)

## Why are you doing this?

In #6745 we stopped alarming on the "email already taken" error from identity. It's a known issue and we don't want to spend time investigating every time it happens. However, we would like to know if it starts occurring at a higher volume. This PR adds the concept of a higher threshold alarm/metric which we can use to cover this case. The alarm will trigger if 10 or more minutes in the last hour have errors.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Forcing the "email already taken" error locally I see the following in the logs: 

```
pushing higher threshold alarm metric for 500 Some(email_address_already_taken)
```

I could also see the new metric in Cloudwatch:

<img width="517" alt="Screenshot 2025-01-30 at 13 04 24" src="https://github.com/user-attachments/assets/037347eb-17cb-452c-8ef4-a592030c144b" />

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
