### PR TITLE
Confirm email - use pattern validation

### DIFF
--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -58,7 +58,8 @@ export const testCheckout = (testDetails: TestDetails) => {
 		context,
 		baseURL,
 	}) => {
-		const url = `/${internationalisationId.toLowerCase()}/checkout?product=${product}&ratePlan=${ratePlan}`;
+		// Temporary opt out of this test
+		const url = `/${internationalisationId.toLowerCase()}/checkout?product=${product}&ratePlan=${ratePlan}#ab-confirmEmail=control`;
 		const page = await context.newPage();
 		await setupPage(page, context, baseURL, url);
 

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -109,4 +109,25 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeContributionsOnlyCountries: true,
 	},
+	confirmEmail: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		isActive: true,
+		referrerControlled: false, // ab-test name not needed to be in paramURL
+		seed: 5,
+		targetPage: pageUrlRegexes.contributions.genericCheckoutOnly,
+		excludeContributionsOnlyCountries: false,
+	},
 };

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
@@ -14,6 +14,9 @@ type PersonalDetailsFieldsProps = {
 	email: string;
 	setEmail: (value: string) => void;
 	isEmailAddressReadOnly: boolean;
+	requireConfirmedEmail: boolean;
+	confirmedEmail: string;
+	setConfirmedEmail: (value: string) => void;
 };
 
 export function PersonalDetailsFields({
@@ -25,10 +28,19 @@ export function PersonalDetailsFields({
 	email,
 	setEmail,
 	isEmailAddressReadOnly,
+	requireConfirmedEmail,
+	confirmedEmail,
+	setConfirmedEmail,
 }: PersonalDetailsFieldsProps) {
 	const [firstNameError, setFirstNameError] = useState<string>();
 	const [lastNameError, setLastNameError] = useState<string>();
 	const [emailError, setEmailError] = useState<string>();
+
+	const emailAddressDoesNotMatch =
+		confirmedEmail.length && email !== confirmedEmail;
+	const confirmedEmailError = emailAddressDoesNotMatch
+		? 'The email addresses do not match.'
+		: undefined;
 
 	return (
 		<>
@@ -66,6 +78,25 @@ export function PersonalDetailsFields({
 					}}
 				/>
 			</div>
+			{requireConfirmedEmail && !isEmailAddressReadOnly && (
+				<div>
+					<TextInput
+						id="confirm-email"
+						data-qm-masking="blocklist"
+						label="Confirm email address"
+						value={confirmedEmail}
+						type="email"
+						autoComplete="email"
+						onChange={(event) => {
+							setConfirmedEmail(event.currentTarget.value);
+						}}
+						name="confirm-email"
+						required
+						maxLength={80}
+						error={confirmedEmailError}
+					/>
+				</div>
+			)}
 			{children}
 			<div>
 				<TextInput

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
@@ -1,6 +1,6 @@
 import { TextInput } from '@guardian/source/react-components';
 import escapeStringRegexp from 'escape-string-regexp';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import {
 	doesNotContainExtendedEmojiOrLeadingSpace,
 	preventDefaultValidityMessage,
@@ -38,8 +38,6 @@ export function PersonalDetailsFields({
 	const [emailError, setEmailError] = useState<string>();
 	const [confirmedEmailError, setConfirmedEmailError] = useState<string>();
 
-	const confirmEmailRef = useRef<HTMLDivElement>(null);
-
 	return (
 		<>
 			<div>
@@ -55,9 +53,6 @@ export function PersonalDetailsFields({
 					}}
 					onBlur={(event) => {
 						event.target.checkValidity();
-						if (confirmedEmail.length > 0) {
-							confirmEmailRef.current?.querySelector('input')?.checkValidity();
-						}
 					}}
 					readOnly={isEmailAddressReadOnly}
 					name="email"
@@ -80,7 +75,7 @@ export function PersonalDetailsFields({
 				/>
 			</div>
 			{requireConfirmedEmail && !isEmailAddressReadOnly && (
-				<div ref={confirmEmailRef}>
+				<div>
 					<TextInput
 						id="confirm-email"
 						data-qm-masking="blocklist"

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
@@ -1,5 +1,5 @@
 import { TextInput } from '@guardian/source/react-components';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
 	doesNotContainExtendedEmojiOrLeadingSpace,
 	preventDefaultValidityMessage,
@@ -35,12 +35,18 @@ export function PersonalDetailsFields({
 	const [firstNameError, setFirstNameError] = useState<string>();
 	const [lastNameError, setLastNameError] = useState<string>();
 	const [emailError, setEmailError] = useState<string>();
+	const [confirmedEmailError, setConfirmedEmailError] = useState<string>();
 
-	const emailAddressDoesNotMatch =
-		confirmedEmail.length && email !== confirmedEmail;
-	const confirmedEmailError = emailAddressDoesNotMatch
-		? 'The email addresses do not match.'
-		: undefined;
+	useEffect(() => {
+		const emailAddressDoesNotMatch =
+			confirmedEmail.length && email !== confirmedEmail;
+
+		setConfirmedEmailError(
+			emailAddressDoesNotMatch
+				? 'The email addresses do not match.'
+				: undefined,
+		);
+	}, [email, confirmedEmail]);
 
 	return (
 		<>
@@ -94,6 +100,17 @@ export function PersonalDetailsFields({
 						required
 						maxLength={80}
 						error={confirmedEmailError}
+						onInvalid={(event) => {
+							preventDefaultValidityMessage(event.currentTarget);
+							const validityState = event.currentTarget.validity;
+							if (validityState.valid) {
+								setConfirmedEmailError(undefined);
+							} else {
+								if (validityState.valueMissing) {
+									setConfirmedEmailError('Please confirm your email address.');
+								}
+							}
+						}}
 					/>
 				</div>
 			)}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
@@ -55,7 +55,9 @@ export function PersonalDetailsFields({
 					}}
 					onBlur={(event) => {
 						event.target.checkValidity();
-						confirmEmailRef.current?.querySelector('input')?.checkValidity();
+						if (email.length > 0) {
+							confirmEmailRef.current?.querySelector('input')?.checkValidity();
+						}
 					}}
 					readOnly={isEmailAddressReadOnly}
 					name="email"
@@ -105,8 +107,10 @@ export function PersonalDetailsFields({
 							} else {
 								if (validityState.valueMissing) {
 									setConfirmedEmailError('Please confirm your email address.');
-								} else {
+								} else if (validityState.patternMismatch) {
 									setConfirmedEmailError('The email addresses do not match.');
+								} else {
+									setConfirmedEmailError('Please enter a valid email address.');
 								}
 							}
 						}}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
@@ -55,7 +55,7 @@ export function PersonalDetailsFields({
 					}}
 					onBlur={(event) => {
 						event.target.checkValidity();
-						if (email.length > 0) {
+						if (confirmedEmail.length > 0) {
 							confirmEmailRef.current?.querySelector('input')?.checkValidity();
 						}
 					}}

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -248,7 +248,7 @@ export function CheckoutComponent({
 		abParticipations.newspaperArchiveBenefit ?? '',
 	);
 
-	const requireConfirmedEmail = abParticipations.confirmEmail === 'variant';
+	const inConfirmEmailVariant = abParticipations.confirmEmail === 'variant';
 
 	const productDescription = showNewspaperArchiveBenefit
 		? productCatalogDescriptionNewBenefits(countryGroupId)[productKey]
@@ -429,10 +429,15 @@ export function CheckoutComponent({
 	const formOnSubmit = async (formData: FormData) => {
 		setIsProcessingPayment(true);
 
+		const requireConfirmedEmail =
+			inConfirmEmailVariant &&
+			!isSignedIn &&
+			paymentMethod !== 'StripeExpressCheckoutElement';
+
 		/**  This validation has to happen on submit,
 		 *   as we cannot check it with form validation rules
 		 */
-		if (requireConfirmedEmail && !isSignedIn && email !== confirmedEmail) {
+		if (requireConfirmedEmail && email !== confirmedEmail) {
 			setIsProcessingPayment(false);
 			return;
 		}
@@ -946,7 +951,7 @@ export function CheckoutComponent({
 								setLastName={(lastName) => setLastName(lastName)}
 								email={email}
 								setEmail={(email) => setEmail(email)}
-								requireConfirmedEmail={requireConfirmedEmail}
+								requireConfirmedEmail={inConfirmEmailVariant}
 								confirmedEmail={confirmedEmail}
 								setConfirmedEmail={(confirmedEmail) =>
 									setConfirmedEmail(confirmedEmail)

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -243,7 +243,8 @@ export function CheckoutComponent({
 		abParticipations.newspaperArchiveBenefit ?? '',
 	);
 
-	const requireConfirmedEmail = abParticipations.confirmEmail === 'variant';
+	const requireConfirmedEmail =
+		abParticipations.confirmEmail === 'variant' && !isSignedIn;
 
 	const productDescription = showNewspaperArchiveBenefit
 		? productCatalogDescriptionNewBenefits(countryGroupId)[productKey]

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -243,6 +243,8 @@ export function CheckoutComponent({
 		abParticipations.newspaperArchiveBenefit ?? '',
 	);
 
+	const requireConfirmedEmail = abParticipations.confirmEmail === 'variant';
+
 	const productDescription = showNewspaperArchiveBenefit
 		? productCatalogDescriptionNewBenefits(countryGroupId)[productKey]
 		: productCatalogDescription[productKey];
@@ -363,6 +365,7 @@ export function CheckoutComponent({
 	const [firstName, setFirstName] = useState(user?.firstName ?? '');
 	const [lastName, setLastName] = useState(user?.lastName ?? '');
 	const [email, setEmail] = useState(user?.email ?? '');
+	const [confirmedEmail, setConfirmedEmail] = useState('');
 
 	/** Delivery and billing addresses */
 	const [deliveryPostcode, setDeliveryPostcode] = useState('');
@@ -420,6 +423,15 @@ export function CheckoutComponent({
 
 	const formOnSubmit = async (formData: FormData) => {
 		setIsProcessingPayment(true);
+
+		/**  This validation has to happen on submit,
+		 *   as we cannot check it with form validation rules
+		 */
+		if (requireConfirmedEmail && email !== confirmedEmail) {
+			setIsProcessingPayment(false);
+			return;
+		}
+
 		/**
 		 * The validation for this is currently happening on the client side form validation
 		 * So we'll assume strings are not null.
@@ -926,6 +938,11 @@ export function CheckoutComponent({
 								setLastName={(lastName) => setLastName(lastName)}
 								email={email}
 								setEmail={(email) => setEmail(email)}
+								requireConfirmedEmail={requireConfirmedEmail}
+								confirmedEmail={confirmedEmail}
+								setConfirmedEmail={(confirmedEmail) =>
+									setConfirmedEmail(confirmedEmail)
+								}
 							>
 								<Signout isSignedIn={isSignedIn} />
 							</PersonalDetailsFields>

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -243,8 +243,7 @@ export function CheckoutComponent({
 		abParticipations.newspaperArchiveBenefit ?? '',
 	);
 
-	const requireConfirmedEmail =
-		abParticipations.confirmEmail === 'variant' && !isSignedIn;
+	const requireConfirmedEmail = abParticipations.confirmEmail === 'variant';
 
 	const productDescription = showNewspaperArchiveBenefit
 		? productCatalogDescriptionNewBenefits(countryGroupId)[productKey]
@@ -428,7 +427,7 @@ export function CheckoutComponent({
 		/**  This validation has to happen on submit,
 		 *   as we cannot check it with form validation rules
 		 */
-		if (requireConfirmedEmail && email !== confirmedEmail) {
+		if (requireConfirmedEmail && !isSignedIn && email !== confirmedEmail) {
 			setIsProcessingPayment(false);
 			return;
 		}

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -429,19 +429,6 @@ export function CheckoutComponent({
 	const formOnSubmit = async (formData: FormData) => {
 		setIsProcessingPayment(true);
 
-		const requireConfirmedEmail =
-			inConfirmEmailVariant &&
-			!isSignedIn &&
-			paymentMethod !== 'StripeExpressCheckoutElement';
-
-		/**  This validation has to happen on submit,
-		 *   as we cannot check it with form validation rules
-		 */
-		if (requireConfirmedEmail && email !== confirmedEmail) {
-			setIsProcessingPayment(false);
-			return;
-		}
-
 		/**
 		 * The validation for this is currently happening on the client side form validation
 		 * So we'll assume strings are not null.
@@ -884,6 +871,8 @@ export function CheckoutComponent({
 
 										event.billingDetails?.email &&
 											setEmail(event.billingDetails.email);
+										event.billingDetails?.email &&
+											setConfirmedEmail(event.billingDetails.email);
 
 										setPaymentMethod('StripeExpressCheckoutElement');
 										setStripeExpressCheckoutPaymentType(

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -575,10 +575,6 @@ export function CheckoutComponent({
 			labels: ['generic-checkout'],
 		};
 
-		if (stripeExpressCheckoutPaymentType === 'link') {
-			referrerAcquisitionData.labels.push('express-checkout-link');
-		}
-
 		if (paymentMethod && paymentFields) {
 			/** TODO
 			 * - add debugInfo

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -97,6 +97,7 @@
 		"@types/uuid": "^9.0.2",
 		"classnames": "^2.5.1",
 		"dompurify": "^3.2.0",
+		"escape-string-regexp": "5.0.0",
 		"framer-motion": "^1.11.1",
 		"lodash.debounce": "^4.0.6",
 		"mockdate": "^3.0.5",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -5700,6 +5700,11 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
+escape-string-regexp@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
+
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Implement the confirm email field but using HTML form validation - a pattern regex field that updates based on whatever is in the email field. 

This PR also enables it as an A/B test

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/mCYE3GTi/1373-add-confirm-email-field-across-products-generic-checkout-a-b-test)

## Why are you doing this?

This is a branch off of #6742 but using a different mechanism.

Comparison of this approach (HTML validation) vs the other approach (validate in JS)

Pros: 

- Fits with our other validation of the form
- Doesn't require a check based on the sign-in status in the form's submit function

Cons:

- Adds an additional dependency (we wanted to use [RegExp.escape](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape) but it has limited availability)
- ~Slightly clunky useRef~

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

See #6742
