### PR TITLE
Move AB test types

### DIFF
--- a/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
@@ -18,7 +18,7 @@ import {
 	UnitedStates,
 } from '../../internationalisation/countryGroup';
 import { _, init as abInit, getAmountsTestVariant } from '../abtest';
-import type { Audience, Participations, Test, Variant } from '../abtest';
+import type { Audience, Participations, Test, Variant } from '../models';
 
 const { targetPageMatches } = _;
 const { allLandingPagesAndThankyouPages, genericCheckoutOnly } =

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -13,83 +13,18 @@ import type {
 } from '../contributions';
 import { tests } from './abtestDefinitions';
 import { getFallbackAmounts } from './helpers';
-
-// ----- Types ----- //
-
-const breakpoints = {
-	mobile: 320,
-	mobileMedium: 375,
-	mobileLandscape: 480,
-	phablet: 660,
-	tablet: 740,
-	desktop: 980,
-	leftCol: 1140,
-	wide: 1300,
-};
-
-type Breakpoint = keyof typeof breakpoints;
-
-type BreakpointRange = {
-	minWidth?: Breakpoint;
-	maxWidth?: Breakpoint;
-};
-
-export type Participations = Record<string, string | undefined>;
+import type {
+	AcquisitionABTest,
+	Audience,
+	Participations,
+	Test,
+	Tests,
+} from './models';
+import { breakpoints } from './models';
 
 export const testIsActive = (
 	value: [string, string | undefined],
 ): value is [string, string] => value[1] !== undefined;
-
-export type Audience = {
-	offset: number;
-	size: number;
-	breakpoint?: BreakpointRange;
-};
-
-type AudienceType = IsoCountry | CountryGroupId | 'ALL' | 'CONTRIBUTIONS_ONLY';
-
-type Audiences = {
-	[key in AudienceType]?: Audience;
-};
-
-type AcquisitionABTest = {
-	name: string;
-	variant: string;
-	testType?: string;
-};
-
-export type Variant = {
-	id: string;
-};
-
-export type Test = {
-	variants: Variant[];
-	audiences: Audiences;
-	isActive: boolean;
-	canRun?: () => boolean;
-	// Indicates whether the A/B test is controlled by the referrer (acquisition channel)
-	// e.g. Test of a banner design change on dotcom
-	// If true the A/B test participation info should be passed through in the acquisition data
-	// query parameter.
-	// In particular this allows 3rd party tests to be identified and tracked in support-frontend
-	// without too much "magic" involving the shared mvtId.
-	referrerControlled: boolean;
-	// If another test participation is referrerControlled, exclude this test
-	excludeIfInReferrerControlledTest?: boolean;
-	seed: number;
-	// An optional regex that will be tested against the path of the current page
-	// before activating this test eg. '/(uk|us|au|ca|nz)/subscribe$'
-	targetPage?: string | RegExp;
-	// Persist this test participation across more pages using this regex
-	persistPage?: string | RegExp;
-	omitCountries?: IsoCountry[];
-	// Some users will see a version of the checkout that only offers
-	// the option to make contributions. We won't want to include these
-	// users in some AB tests
-	excludeContributionsOnlyCountries: boolean;
-};
-
-export type Tests = Record<string, Test>;
 
 // ----- Init ----- //
 

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -1,4 +1,4 @@
-import type { Tests } from './abtest';
+import type { Tests } from './models';
 // ----- Tests ----- //
 // Note: When setting up a test to run on the contributions thank you page
 // you should always target both the landing page *and* the thank you page.

--- a/support-frontend/assets/helpers/abTests/models.ts
+++ b/support-frontend/assets/helpers/abTests/models.ts
@@ -1,0 +1,82 @@
+import type { IsoCountry } from '../internationalisation/country';
+import type { CountryGroupId } from '../internationalisation/countryGroup';
+
+export const breakpoints = {
+	mobile: 320,
+	mobileMedium: 375,
+	mobileLandscape: 480,
+	phablet: 660,
+	tablet: 740,
+	desktop: 980,
+	leftCol: 1140,
+	wide: 1300,
+};
+
+type Breakpoint = keyof typeof breakpoints;
+
+type BreakpointRange = {
+	minWidth?: Breakpoint;
+	maxWidth?: Breakpoint;
+};
+
+type Audience = {
+	offset: number;
+	size: number;
+	breakpoint?: BreakpointRange;
+};
+
+type AudienceType = IsoCountry | CountryGroupId | 'ALL' | 'CONTRIBUTIONS_ONLY';
+
+type Audiences = {
+	[key in AudienceType]?: Audience;
+};
+
+type AcquisitionABTest = {
+	name: string;
+	variant: string;
+	testType?: string;
+};
+
+type Variant = {
+	id: string;
+};
+
+type Test = {
+	variants: Variant[];
+	audiences: Audiences;
+	isActive: boolean;
+	canRun?: () => boolean;
+	// Indicates whether the A/B test is controlled by the referrer (acquisition channel)
+	// e.g. Test of a banner design change on dotcom
+	// If true the A/B test participation info should be passed through in the acquisition data
+	// query parameter.
+	// In particular this allows 3rd party tests to be identified and tracked in support-frontend
+	// without too much "magic" involving the shared mvtId.
+	referrerControlled: boolean;
+	// If another test participation is referrerControlled, exclude this test
+	excludeIfInReferrerControlledTest?: boolean;
+	seed: number;
+	// An optional regex that will be tested against the path of the current page
+	// before activating this test eg. '/(uk|us|au|ca|nz)/subscribe$'
+	targetPage?: string | RegExp;
+	// Persist this test participation across more pages using this regex
+	persistPage?: string | RegExp;
+	omitCountries?: IsoCountry[];
+	// Some users will see a version of the checkout that only offers
+	// the option to make contributions. We won't want to include these
+	// users in some AB tests
+	excludeContributionsOnlyCountries: boolean;
+};
+
+type Tests = Record<string, Test>;
+
+type Participations = Record<string, string | undefined>;
+
+export type {
+	AcquisitionABTest,
+	Audience,
+	Participations,
+	Test,
+	Tests,
+	Variant,
+};

--- a/support-frontend/assets/helpers/page/analyticsAndConsent.ts
+++ b/support-frontend/assets/helpers/page/analyticsAndConsent.ts
@@ -3,13 +3,13 @@
 import type { ConsentState } from '@guardian/libs';
 import { cmp, getCookie, onConsent } from '@guardian/libs';
 import ophan from 'ophan';
-import type { Participations } from 'helpers/abTests/abtest';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import * as googleTagManager from 'helpers/tracking/googleTagManager';
 import { init as initQuantumMetric } from 'helpers/tracking/quantumMetric';
 import { isPostDeployUser } from 'helpers/user/user';
 import { init as initLogger } from 'helpers/utilities/logger';
+import type { Participations } from '../abTests/models';
 import {
 	setReferrerDataInLocalStorage,
 	trackAbTests,

--- a/support-frontend/assets/helpers/page/analyticsAndConsent.ts
+++ b/support-frontend/assets/helpers/page/analyticsAndConsent.ts
@@ -3,13 +3,13 @@
 import type { ConsentState } from '@guardian/libs';
 import { cmp, getCookie, onConsent } from '@guardian/libs';
 import ophan from 'ophan';
+import type { Participations } from 'helpers/abTests/models';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import * as googleTagManager from 'helpers/tracking/googleTagManager';
 import { init as initQuantumMetric } from 'helpers/tracking/quantumMetric';
 import { isPostDeployUser } from 'helpers/user/user';
 import { init as initLogger } from 'helpers/utilities/logger';
-import type { Participations } from '../abTests/models';
 import {
 	setReferrerDataInLocalStorage,
 	trackAbTests,

--- a/support-frontend/assets/helpers/page/page.ts
+++ b/support-frontend/assets/helpers/page/page.ts
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 import * as abTest from 'helpers/abTests/abtest';
 import { getAmountsTestVariant } from 'helpers/abTests/abtest';
+import type { Participations } from 'helpers/abTests/models';
 import { Country } from 'helpers/internationalisation/classes/country';
 import { CountryGroup } from 'helpers/internationalisation/classes/countryGroup';
 import type { IsoCountry } from 'helpers/internationalisation/country';
@@ -11,7 +12,6 @@ import {
 	sendConsentToOphan,
 } from 'helpers/page/analyticsAndConsent';
 import { getReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
-import type { Participations } from '../abTests/models';
 import { getSettings } from '../globalsAndSwitches/globals';
 
 function setUpTrackingAndConsents(participations: Participations): void {

--- a/support-frontend/assets/helpers/page/page.ts
+++ b/support-frontend/assets/helpers/page/page.ts
@@ -1,5 +1,4 @@
 // ----- Imports ----- //
-import type { Participations } from 'helpers/abTests/abtest';
 import * as abTest from 'helpers/abTests/abtest';
 import { getAmountsTestVariant } from 'helpers/abTests/abtest';
 import { Country } from 'helpers/internationalisation/classes/country';
@@ -12,6 +11,7 @@ import {
 	sendConsentToOphan,
 } from 'helpers/page/analyticsAndConsent';
 import { getReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import type { Participations } from '../abTests/models';
 import { getSettings } from '../globalsAndSwitches/globals';
 
 function setUpTrackingAndConsents(participations: Participations): void {

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -1,6 +1,6 @@
 import type { ActiveProductKey } from '@guardian/support-service-lambdas/modules/product-catalog/src/productCatalog';
 import { activeTypeObject } from '@guardian/support-service-lambdas/modules/product-catalog/src/typeObject';
-import type { Participations } from './abTests/abtest';
+import type { Participations } from './abTests/models';
 import { newspaperCountries } from './internationalisation/country';
 import type {
 	CountryGroupId,

--- a/support-frontend/assets/helpers/redux/commonState/state.ts
+++ b/support-frontend/assets/helpers/redux/commonState/state.ts
@@ -1,4 +1,3 @@
-import type { Participations } from 'helpers/abTests/abtest';
 import { getFallbackAmounts } from 'helpers/abTests/helpers';
 import type { SelectedAmountsVariant } from 'helpers/contributions';
 import { getSettings } from 'helpers/globalsAndSwitches/globals';
@@ -13,6 +12,7 @@ import type {
 	Campaign,
 	ReferrerAcquisitionData,
 } from 'helpers/tracking/acquisitions';
+import type { Participations } from '../../abTests/models';
 
 export type Internationalisation = {
 	currencyId: IsoCurrency;

--- a/support-frontend/assets/helpers/redux/commonState/state.ts
+++ b/support-frontend/assets/helpers/redux/commonState/state.ts
@@ -1,4 +1,5 @@
 import { getFallbackAmounts } from 'helpers/abTests/helpers';
+import type { Participations } from 'helpers/abTests/models';
 import type { SelectedAmountsVariant } from 'helpers/contributions';
 import { getSettings } from 'helpers/globalsAndSwitches/globals';
 import type { Settings } from 'helpers/globalsAndSwitches/settings';
@@ -12,7 +13,6 @@ import type {
 	Campaign,
 	ReferrerAcquisitionData,
 } from 'helpers/tracking/acquisitions';
-import type { Participations } from '../../abTests/models';
 
 export type Internationalisation = {
 	currencyId: IsoCurrency;

--- a/support-frontend/assets/helpers/redux/utils/setup.ts
+++ b/support-frontend/assets/helpers/redux/utils/setup.ts
@@ -1,5 +1,6 @@
 import * as abTest from 'helpers/abTests/abtest';
 import { getAmountsTestVariant } from 'helpers/abTests/abtest';
+import type { Participations } from 'helpers/abTests/models';
 import { getSettings } from 'helpers/globalsAndSwitches/globals';
 import type { Settings } from 'helpers/globalsAndSwitches/settings';
 import { Country } from 'helpers/internationalisation/classes/country';
@@ -14,7 +15,6 @@ import {
 	getReferrerAcquisitionData,
 } from 'helpers/tracking/acquisitions';
 import { getAllQueryParamsWithExclusions } from 'helpers/urls/url';
-import type { Participations } from '../../abTests/models';
 import type { SelectedAmountsVariant } from '../../contributions';
 import type { CommonState, Internationalisation } from '../commonState/state';
 

--- a/support-frontend/assets/helpers/redux/utils/setup.ts
+++ b/support-frontend/assets/helpers/redux/utils/setup.ts
@@ -1,4 +1,3 @@
-import type { Participations } from 'helpers/abTests/abtest';
 import * as abTest from 'helpers/abTests/abtest';
 import { getAmountsTestVariant } from 'helpers/abTests/abtest';
 import { getSettings } from 'helpers/globalsAndSwitches/globals';
@@ -15,6 +14,7 @@ import {
 	getReferrerAcquisitionData,
 } from 'helpers/tracking/acquisitions';
 import { getAllQueryParamsWithExclusions } from 'helpers/urls/url';
+import type { Participations } from '../../abTests/models';
 import type { SelectedAmountsVariant } from '../../contributions';
 import type { CommonState, Internationalisation } from '../commonState/state';
 

--- a/support-frontend/assets/helpers/tracking/__tests__/ophanTest.ts
+++ b/support-frontend/assets/helpers/tracking/__tests__/ophanTest.ts
@@ -1,4 +1,4 @@
-import type { Participations } from '../../abTests/abtest';
+import type { Participations } from '../../abTests/models';
 import type { OphanABPayload } from '../trackingOphan';
 import { buildOphanPayload } from '../trackingOphan';
 

--- a/support-frontend/assets/helpers/tracking/acquisitions.ts
+++ b/support-frontend/assets/helpers/tracking/acquisitions.ts
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
 import { viewId } from 'ophan';
-import { type Participations, testIsActive } from 'helpers/abTests/abtest';
+import { testIsActive } from 'helpers/abTests/abtest';
 import { get as getCookie } from 'helpers/storage/cookie';
 import * as storage from 'helpers/storage/storage';
 import {
@@ -10,6 +10,7 @@ import {
 	getQueryParameter,
 } from 'helpers/urls/url';
 import { deserialiseJsonObject } from 'helpers/utilities/utilities';
+import type { Participations } from '../abTests/models';
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/helpers/tracking/acquisitions.ts
+++ b/support-frontend/assets/helpers/tracking/acquisitions.ts
@@ -2,6 +2,7 @@
 
 import { viewId } from 'ophan';
 import { testIsActive } from 'helpers/abTests/abtest';
+import { type Participations } from 'helpers/abTests/models';
 import { get as getCookie } from 'helpers/storage/cookie';
 import * as storage from 'helpers/storage/storage';
 import {
@@ -10,7 +11,6 @@ import {
 	getQueryParameter,
 } from 'helpers/urls/url';
 import { deserialiseJsonObject } from 'helpers/utilities/utilities';
-import type { Participations } from '../abTests/models';
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -1,5 +1,6 @@
 import { loadScript } from '@guardian/libs';
 import { viewId } from 'ophan';
+import type { Participations } from 'helpers/abTests/models';
 import type { ContributionType } from 'helpers/contributions';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
@@ -8,7 +9,6 @@ import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import type { SubscriptionProduct } from 'helpers/productPrice/subscriptions';
 import { logException } from 'helpers/utilities/logger';
-import type { Participations } from '../abTests/models';
 import type { ReferrerAcquisitionData } from './acquisitions';
 import {
 	canRunQuantumMetric,

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -1,6 +1,5 @@
 import { loadScript } from '@guardian/libs';
 import { viewId } from 'ophan';
-import type { Participations } from 'helpers/abTests/abtest';
 import type { ContributionType } from 'helpers/contributions';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
@@ -9,6 +8,7 @@ import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import type { SubscriptionProduct } from 'helpers/productPrice/subscriptions';
 import { logException } from 'helpers/utilities/logger';
+import type { Participations } from '../abTests/models';
 import type { ReferrerAcquisitionData } from './acquisitions';
 import {
 	canRunQuantumMetric,

--- a/support-frontend/assets/helpers/tracking/trackingOphan.ts
+++ b/support-frontend/assets/helpers/tracking/trackingOphan.ts
@@ -1,9 +1,9 @@
 // ----- Imports ----- //
 import * as ophan from 'ophan';
 import { testIsActive } from 'helpers/abTests/abtest';
+import type { Participations } from 'helpers/abTests/models';
 import { getLocal, setLocal } from 'helpers/storage/storage';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
-import type { Participations } from '../abTests/models';
 
 // ----- Types ----- //
 // These are to match Thrift definitions which can be found here:

--- a/support-frontend/assets/helpers/tracking/trackingOphan.ts
+++ b/support-frontend/assets/helpers/tracking/trackingOphan.ts
@@ -1,8 +1,9 @@
 // ----- Imports ----- //
 import * as ophan from 'ophan';
-import { type Participations, testIsActive } from 'helpers/abTests/abtest';
+import { testIsActive } from 'helpers/abTests/abtest';
 import { getLocal, setLocal } from 'helpers/storage/storage';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import type { Participations } from '../abTests/models';
 
 // ----- Types ----- //
 // These are to match Thrift definitions which can be found here:

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -14,7 +14,7 @@ import { sendEventCheckoutValue } from 'helpers/tracking/quantumMetric';
 import { logException } from 'helpers/utilities/logger';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
-import type { Participations } from '../../helpers/abTests/abtest';
+import type { Participations } from '../../helpers/abTests/models';
 import { CheckoutComponent } from './components/checkoutComponent';
 
 type Props = {

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -41,6 +41,7 @@ import { AddressFields } from 'components/subscriptionCheckouts/address/addressF
 import type { PostcodeFinderResult } from 'components/subscriptionCheckouts/address/postcodeLookup';
 import { findAddressesForPostcode } from 'components/subscriptionCheckouts/address/postcodeLookup';
 import { getAmountsTestVariant } from 'helpers/abTests/abtest';
+import type { Participations } from 'helpers/abTests/models';
 import { isContributionsOnlyCountry } from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import {
@@ -95,7 +96,6 @@ import {
 	PaymentTsAndCs,
 	SummaryTsAndCs,
 } from 'pages/supporter-plus-landing/components/paymentTsAndCs';
-import type { Participations } from '../../../helpers/abTests/models';
 import {
 	formatMachineDate,
 	formatUserDate,

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -40,7 +40,6 @@ import { StripeCardForm } from 'components/stripeCardForm/stripeCardForm';
 import { AddressFields } from 'components/subscriptionCheckouts/address/addressFields';
 import type { PostcodeFinderResult } from 'components/subscriptionCheckouts/address/postcodeLookup';
 import { findAddressesForPostcode } from 'components/subscriptionCheckouts/address/postcodeLookup';
-import type { Participations } from 'helpers/abTests/abtest';
 import { getAmountsTestVariant } from 'helpers/abTests/abtest';
 import { isContributionsOnlyCountry } from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
@@ -96,6 +95,7 @@ import {
 	PaymentTsAndCs,
 	SummaryTsAndCs,
 } from 'pages/supporter-plus-landing/components/paymentTsAndCs';
+import type { Participations } from '../../../helpers/abTests/models';
 import {
 	formatMachineDate,
 	formatUserDate,

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -33,7 +33,6 @@ import { Recaptcha } from 'components/recaptcha/recaptcha';
 import { SecureTransactionIndicator } from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import Signout from 'components/signout/signout';
 import { StripeCardForm } from 'components/stripeCardForm/stripeCardForm';
-import type { Participations } from 'helpers/abTests/abtest';
 import { getAmountsTestVariant } from 'helpers/abTests/abtest';
 import { config } from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
@@ -81,6 +80,7 @@ import { FinePrint } from 'pages/supporter-plus-landing/components/finePrint';
 import { GuardianTsAndCs } from 'pages/supporter-plus-landing/components/guardianTsAndCs';
 import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsMessage';
 import { TsAndCsFooterLinks } from 'pages/supporter-plus-landing/components/paymentTsAndCs';
+import type { Participations } from '../../../helpers/abTests/models';
 import { setThankYouOrder } from '../checkout/helpers/sessionStorage';
 import {
 	doesNotContainExtendedEmojiOrLeadingSpace,

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -34,6 +34,7 @@ import { SecureTransactionIndicator } from 'components/secureTransactionIndicato
 import Signout from 'components/signout/signout';
 import { StripeCardForm } from 'components/stripeCardForm/stripeCardForm';
 import { getAmountsTestVariant } from 'helpers/abTests/abtest';
+import type { Participations } from 'helpers/abTests/models';
 import { config } from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import { appropriateErrorMessage } from 'helpers/forms/errorReasons';
@@ -80,7 +81,6 @@ import { FinePrint } from 'pages/supporter-plus-landing/components/finePrint';
 import { GuardianTsAndCs } from 'pages/supporter-plus-landing/components/guardianTsAndCs';
 import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsMessage';
 import { TsAndCsFooterLinks } from 'pages/supporter-plus-landing/components/paymentTsAndCs';
-import type { Participations } from '../../../helpers/abTests/models';
 import { setThankYouOrder } from '../checkout/helpers/sessionStorage';
 import {
 	doesNotContainExtendedEmojiOrLeadingSpace,

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -7,7 +7,6 @@ import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
 import type { ThankYouModuleType } from 'components/thankYou/thankYouModule';
 import { getThankYouModuleData } from 'components/thankYou/thankYouModuleData';
-import type { Participations } from 'helpers/abTests/abtest';
 import type { ContributionType } from 'helpers/contributions';
 import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import { Country } from 'helpers/internationalisation/classes/country';
@@ -35,6 +34,7 @@ import ThankYouFooter from 'pages/supporter-plus-thank-you/components/thankYouFo
 import ThankYouHeader from 'pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader';
 import { getGuardianAdLiteDate } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
 import { ThankYouModules } from '../../../components/thankYou/thankyouModules';
+import type { Participations } from '../../../helpers/abTests/models';
 import {
 	getReturnAddress,
 	getThankYouOrder,

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -7,6 +7,7 @@ import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
 import type { ThankYouModuleType } from 'components/thankYou/thankYouModule';
 import { getThankYouModuleData } from 'components/thankYou/thankYouModuleData';
+import type { Participations } from 'helpers/abTests/models';
 import type { ContributionType } from 'helpers/contributions';
 import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import { Country } from 'helpers/internationalisation/classes/country';
@@ -34,7 +35,6 @@ import ThankYouFooter from 'pages/supporter-plus-thank-you/components/thankYouFo
 import ThankYouHeader from 'pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader';
 import { getGuardianAdLiteDate } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
 import { ThankYouModules } from '../../../components/thankYou/thankyouModules';
-import type { Participations } from '../../../helpers/abTests/models';
 import {
 	getReturnAddress,
 	getThankYouOrder,

--- a/support-frontend/assets/pages/[countryGroupId]/landingPage.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/landingPage.tsx
@@ -1,11 +1,11 @@
 import { getAmountsTestVariant } from 'helpers/abTests/abtest';
+import type { Participations } from 'helpers/abTests/models';
 import { Country } from 'helpers/internationalisation/classes/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
 import { threeTierCheckoutEnabled } from 'pages/supporter-plus-landing/setup/threeTierChecks';
 import { ContributionsOnlyLanding } from 'pages/supporter-plus-landing/twoStepPages/contributionsOnlyLanding';
 import { ThreeTierLanding } from 'pages/supporter-plus-landing/twoStepPages/threeTierLanding';
-import type { Participations } from '../../helpers/abTests/models';
 
 type Props = {
 	geoId: GeoId;

--- a/support-frontend/assets/pages/[countryGroupId]/landingPage.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/landingPage.tsx
@@ -1,13 +1,11 @@
-import {
-	getAmountsTestVariant,
-	type Participations,
-} from 'helpers/abTests/abtest';
+import { getAmountsTestVariant } from 'helpers/abTests/abtest';
 import { Country } from 'helpers/internationalisation/classes/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
 import { threeTierCheckoutEnabled } from 'pages/supporter-plus-landing/setup/threeTierChecks';
 import { ContributionsOnlyLanding } from 'pages/supporter-plus-landing/twoStepPages/contributionsOnlyLanding';
 import { ThreeTierLanding } from 'pages/supporter-plus-landing/twoStepPages/threeTierLanding';
+import type { Participations } from '../../helpers/abTests/models';
 
 type Props = {
 	geoId: GeoId;

--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -6,7 +6,7 @@ import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import { Country } from 'helpers/internationalisation/classes/country';
 import * as cookie from 'helpers/storage/cookie';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
-import type { Participations } from '../../helpers/abTests/abtest';
+import type { Participations } from '../../helpers/abTests/models';
 import { OneTimeCheckoutComponent } from './components/oneTimeCheckoutComponent';
 
 const countryId = Country.detect();

--- a/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
@@ -8,7 +8,7 @@ import type { UserType } from 'helpers/redux/checkout/personalDetails/state';
 import { logException } from 'helpers/utilities/logger';
 import { roundToDecimalPlaces } from 'helpers/utilities/utilities';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
-import type { Participations } from '../../helpers/abTests/abtest';
+import type { Participations } from '../../helpers/abTests/models';
 import { setOneOffContributionCookie } from '../../helpers/storage/contributionsCookies';
 import { ThankYouComponent } from './components/thankYouComponent';
 

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingProps.ts
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingProps.ts
@@ -1,10 +1,10 @@
-import type { Participations } from 'helpers/abTests/abtest';
 import {
 	getProductPrices,
 	getPromotionCopy,
 } from 'helpers/globalsAndSwitches/globals';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import type { PromotionCopy } from 'helpers/productPrice/promotions';
+import type { Participations } from '../../helpers/abTests/models';
 
 export type PaperLandingPropTypes = {
 	productPrices: ProductPrices | null | undefined;

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingProps.ts
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingProps.ts
@@ -1,10 +1,10 @@
+import type { Participations } from 'helpers/abTests/models';
 import {
 	getProductPrices,
 	getPromotionCopy,
 } from 'helpers/globalsAndSwitches/globals';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import type { PromotionCopy } from 'helpers/productPrice/promotions';
-import type { Participations } from '../../helpers/abTests/models';
 
 export type PaperLandingPropTypes = {
 	productPrices: ProductPrices | null | undefined;

--- a/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsProduct.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsProduct.tsx
@@ -1,9 +1,9 @@
 import cx from 'classnames';
 import type { ReactNode } from 'react';
 import SubscriptionsProductDescription from 'components/subscriptionsProductDescription/subscriptionsProductDescription';
+import type { Participations } from 'helpers/abTests/models';
 import 'helpers/types/option';
 import type { ProductButton } from 'pages/subscriptions-landing/copy/subscriptionCopy';
-import type { Participations } from '../../../helpers/abTests/models';
 
 type PropTypes = {
 	title: string;

--- a/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsProduct.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsProduct.tsx
@@ -1,9 +1,9 @@
 import cx from 'classnames';
 import type { ReactNode } from 'react';
 import SubscriptionsProductDescription from 'components/subscriptionsProductDescription/subscriptionsProductDescription';
-import type { Participations } from 'helpers/abTests/abtest';
 import 'helpers/types/option';
 import type { ProductButton } from 'pages/subscriptions-landing/copy/subscriptionCopy';
+import type { Participations } from '../../../helpers/abTests/models';
 
 type PropTypes = {
 	title: string;

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
@@ -4,6 +4,7 @@ import DigitalPackshotHero from 'components/packshots/digital-packshot-hero';
 import GuardianWeeklyPackShotHero from 'components/packshots/guardian-weekly-packshot-hero';
 import PaperPackshot from 'components/packshots/paper-packshot';
 // images
+import type { Participations } from 'helpers/abTests/models';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 import { currencies, detect } from 'helpers/internationalisation/currency';
@@ -22,7 +23,6 @@ import {
 	guardianWeeklyLanding,
 	paperSubsUrl,
 } from 'helpers/urls/routes';
-import type { Participations } from '../../../helpers/abTests/models';
 import type { PriceCopy, PricingCopy } from '../subscriptionsLandingProps';
 
 // types

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
@@ -4,7 +4,6 @@ import DigitalPackshotHero from 'components/packshots/digital-packshot-hero';
 import GuardianWeeklyPackShotHero from 'components/packshots/guardian-weekly-packshot-hero';
 import PaperPackshot from 'components/packshots/paper-packshot';
 // images
-import type { Participations } from 'helpers/abTests/abtest';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 import { currencies, detect } from 'helpers/internationalisation/currency';
@@ -23,6 +22,7 @@ import {
 	guardianWeeklyLanding,
 	paperSubsUrl,
 } from 'helpers/urls/routes';
+import type { Participations } from '../../../helpers/abTests/models';
 import type { PriceCopy, PricingCopy } from '../subscriptionsLandingProps';
 
 // types

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLandingProps.ts
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLandingProps.ts
@@ -1,11 +1,11 @@
 // ----- Imports ----- //
-import type { Participations } from 'helpers/abTests/abtest';
 import { getGlobal } from 'helpers/globalsAndSwitches/globals';
 import { CountryGroup } from 'helpers/internationalisation/classes/countryGroup';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { SubscriptionProduct } from 'helpers/productPrice/subscriptions';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import { getReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import type { Participations } from '../../helpers/abTests/models';
 
 export type PriceCopy = {
 	price: number;

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLandingProps.ts
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLandingProps.ts
@@ -1,11 +1,11 @@
 // ----- Imports ----- //
+import type { Participations } from 'helpers/abTests/models';
 import { getGlobal } from 'helpers/globalsAndSwitches/globals';
 import { CountryGroup } from 'helpers/internationalisation/classes/countryGroup';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { SubscriptionProduct } from 'helpers/productPrice/subscriptions';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import { getReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
-import type { Participations } from '../../helpers/abTests/models';
 
 export type PriceCopy = {
 	price: number;

--- a/support-frontend/assets/pages/subscriptions-redemption/api.ts
+++ b/support-frontend/assets/pages/subscriptions-redemption/api.ts
@@ -1,4 +1,3 @@
-import type { Participations } from 'helpers/abTests/abtest';
 import { fetchJson } from 'helpers/async/fetch';
 import { appropriateErrorMessage } from 'helpers/forms/errorReasons';
 import { postRegularPaymentRequest } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
@@ -27,6 +26,7 @@ import type { Option } from 'helpers/types/option';
 import { routes } from 'helpers/urls/routes';
 import { getOrigin } from 'helpers/urls/url';
 import type { Stage } from 'pages/subscriptions-redemption/subscriptionsRedemptionReducer';
+import type { Participations } from '../../helpers/abTests/models';
 
 type ValidationResult = {
 	valid: boolean;

--- a/support-frontend/assets/pages/subscriptions-redemption/api.ts
+++ b/support-frontend/assets/pages/subscriptions-redemption/api.ts
@@ -1,3 +1,4 @@
+import type { Participations } from 'helpers/abTests/models';
 import { fetchJson } from 'helpers/async/fetch';
 import { appropriateErrorMessage } from 'helpers/forms/errorReasons';
 import { postRegularPaymentRequest } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
@@ -26,7 +27,6 @@ import type { Option } from 'helpers/types/option';
 import { routes } from 'helpers/urls/routes';
 import { getOrigin } from 'helpers/urls/url';
 import type { Stage } from 'pages/subscriptions-redemption/subscriptionsRedemptionReducer';
-import type { Participations } from '../../helpers/abTests/models';
 
 type ValidationResult = {
 	valid: boolean;

--- a/support-frontend/assets/pages/subscriptions-redemption/thankYouContent.tsx
+++ b/support-frontend/assets/pages/subscriptions-redemption/thankYouContent.tsx
@@ -4,7 +4,7 @@ import Content from 'components/content/content';
 import HeadingBlock from 'components/headingBlock/headingBlock';
 import { HeroWrapper } from 'components/productPage/productPageHero/productPageHero';
 import Text, { LargeParagraph } from 'components/text/text';
-import type { Participations } from 'helpers/abTests/abtest';
+import type { Participations } from 'helpers/abTests/models';
 import type { PaymentMethod } from 'helpers/forms/paymentMethods';
 import { DirectDebit } from 'helpers/forms/paymentMethods';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -15,7 +15,6 @@ import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import type { Option } from 'helpers/types/option';
 import AppsSection from './components/thankYou/appsSection';
 import ThankYouHero from './components/thankYou/hero';
-import 'helpers/abTests/abtest';
 
 // ----- Types ----- //
 type PropTypes = {

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -13,7 +13,6 @@ import {
 	LinkButton,
 } from '@guardian/source/react-components';
 import { BenefitsCheckList } from 'components/checkoutBenefits/benefitsCheckList';
-import type { Participations } from 'helpers/abTests/abtest';
 import type { RegularContributionType } from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -29,6 +28,7 @@ import {
 } from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
+import type { Participations } from '../../../helpers/abTests/models';
 import { ThreeTierLozenge } from './threeTierLozenge';
 
 export type ThreeTierCardProps = {

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -13,6 +13,7 @@ import {
 	LinkButton,
 } from '@guardian/source/react-components';
 import { BenefitsCheckList } from 'components/checkoutBenefits/benefitsCheckList';
+import type { Participations } from 'helpers/abTests/models';
 import type { RegularContributionType } from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -28,7 +29,6 @@ import {
 } from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { recurringContributionPeriodMap } from 'helpers/utilities/timePeriods';
-import type { Participations } from '../../../helpers/abTests/models';
 import { ThreeTierLozenge } from './threeTierLozenge';
 
 export type ThreeTierCardProps = {

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/react';
 import { between, from, space } from '@guardian/source/foundations';
-import type { Participations } from 'helpers/abTests/abtest';
 import type { RegularContributionType } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { ProductDescription } from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
+import type { Participations } from '../../../helpers/abTests/models';
 import { ThreeTierCard } from './threeTierCard';
 
 export type ThreeTierCardsProps = {

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/react';
 import { between, from, space } from '@guardian/source/foundations';
+import type { Participations } from 'helpers/abTests/models';
 import type { RegularContributionType } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { ProductDescription } from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
-import type { Participations } from '../../../helpers/abTests/models';
 import { ThreeTierCard } from './threeTierCard';
 
 export type ThreeTierCardsProps = {

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierChecks.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierChecks.ts
@@ -1,6 +1,6 @@
-import type { Participations } from 'helpers/abTests/abtest';
 import type { SelectedAmountsVariant } from 'helpers/contributions';
 import { isContributionsOnlyCountry } from 'helpers/contributions';
+import type { Participations } from '../../../helpers/abTests/models';
 
 export const threeTierCheckoutEnabled = (
 	abParticipations: Participations,

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierChecks.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/threeTierChecks.ts
@@ -1,6 +1,6 @@
+import type { Participations } from 'helpers/abTests/models';
 import type { SelectedAmountsVariant } from 'helpers/contributions';
 import { isContributionsOnlyCountry } from 'helpers/contributions';
-import type { Participations } from '../../../helpers/abTests/models';
 
 export const threeTierCheckoutEnabled = (
 	abParticipations: Participations,

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -21,6 +21,7 @@ import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
 import { PaymentFrequencyButtons } from 'components/paymentFrequencyButtons/paymentFrequencyButtons';
 import { getAmountsTestVariant } from 'helpers/abTests/abtest';
+import type { Participations } from 'helpers/abTests/models';
 import {
 	countdownSwitchOn,
 	getCampaignSettings,
@@ -53,7 +54,6 @@ import type { Promotion } from 'helpers/productPrice/promotions';
 import { getPromotion } from 'helpers/productPrice/promotions';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
-import type { Participations } from '../../../helpers/abTests/models';
 import Countdown from '../components/countdown';
 import { LandingPageBanners } from '../components/landingPageBanners';
 import { OneOffCard } from '../components/oneOffCard';

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -20,7 +20,6 @@ import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countr
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
 import { PaymentFrequencyButtons } from 'components/paymentFrequencyButtons/paymentFrequencyButtons';
-import type { Participations } from 'helpers/abTests/abtest';
 import { getAmountsTestVariant } from 'helpers/abTests/abtest';
 import {
 	countdownSwitchOn,
@@ -54,6 +53,7 @@ import type { Promotion } from 'helpers/productPrice/promotions';
 import { getPromotion } from 'helpers/productPrice/promotions';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
+import type { Participations } from '../../../helpers/abTests/models';
 import Countdown from '../components/countdown';
 import { LandingPageBanners } from '../components/landingPageBanners';
 import { OneOffCard } from '../components/oneOffCard';

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingProps.ts
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingProps.ts
@@ -1,3 +1,4 @@
+import type { Participations } from 'helpers/abTests/models';
 import {
 	getGlobal,
 	getProductPrices,
@@ -9,7 +10,6 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import type { PromotionCopy } from 'helpers/productPrice/promotions';
-import type { Participations } from '../../helpers/abTests/models';
 
 export type WeeklyLandingPropTypes = {
 	countryId: IsoCountry;

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingProps.ts
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingProps.ts
@@ -1,4 +1,3 @@
-import type { Participations } from 'helpers/abTests/abtest';
 import {
 	getGlobal,
 	getProductPrices,
@@ -10,6 +9,7 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import type { PromotionCopy } from 'helpers/productPrice/promotions';
+import type { Participations } from '../../helpers/abTests/models';
 
 export type WeeklyLandingPropTypes = {
 	countryId: IsoCountry;

--- a/support-frontend/window.d.ts
+++ b/support-frontend/window.d.ts
@@ -1,5 +1,5 @@
 import type { ComponentType, React } from 'react';
-import type { Participations } from 'helpers/abTests/abtest';
+import type { Participations } from 'helpers/abTests/models';
 import type { Settings } from 'helpers/globalsAndSwitches/settings';
 import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';


### PR DESCRIPTION
Moves the types from `abTests/abtest.ts` into a separate `abTests/models.ts` file:
1. because `abtest.ts` is a very long file,
2. I want to avoid circular dependencies in some upcoming work on AB testing.