### PR TITLE
Guardian Ad-Lite: TsAndCs Url Update

### DIFF
--- a/support-frontend/assets/helpers/legal.ts
+++ b/support-frontend/assets/helpers/legal.ts
@@ -1,6 +1,5 @@
 // ----- Imports ----- //
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { getBaseDomain } from './urls/url';
 // ----- Terms & Conditions ----- //
 const defaultContributionTermsLink =
 	'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions';
@@ -35,7 +34,7 @@ const supporterPlusTermsLink =
 const tierThreeTermsLink =
 	'https://www.theguardian.com/info/article/2024/jul/19/digital-print-terms-and-conditions';
 // Placeholder, awaiting Ts&Cs location
-const guardianAdLiteTermsLink = `https://manage.${getBaseDomain()}/help-centre`;
+const guardianAdLiteTermsLink = `https://www.theguardian.com/guardian-ad-lite-tcs`;
 // ----- Exports ----- //
 export {
 	contributionsTermsLinks,

--- a/support-frontend/assets/helpers/legal.ts
+++ b/support-frontend/assets/helpers/legal.ts
@@ -33,7 +33,6 @@ const supporterPlusTermsLink =
 	'https://www.theguardian.com/info/2022/oct/28/the-guardian-supporter-plus-terms-and-conditions';
 const tierThreeTermsLink =
 	'https://www.theguardian.com/info/article/2024/jul/19/digital-print-terms-and-conditions';
-// Placeholder, awaiting Ts&Cs location
 const guardianAdLiteTermsLink = `https://www.theguardian.com/guardian-ad-lite-tcs`;
 // ----- Exports ----- //
 export {


### PR DESCRIPTION
## What are you doing in this PR?

Update to ad-lite terms -> `https://www.theguardian.com/guardian-ad-lite-tcs`

Affects:-
- LandingPage: 3rd Accordian Row
- Checkout: Ts&Cs Terms

NB: Currently 404'ing.

[**Trello Card**](https://trello.com/c/mskef35S/1309-add-correct-tcs-to-guardian-ad-lite-checkout-landing-page-faq)

## Screenshots

![image](https://github.com/user-attachments/assets/021839df-d06a-414d-905f-f47279b9cb1e)

