### PR TITLE
Add server side validation for billing address postcode

### DIFF
--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -15,6 +15,16 @@ import utils.CheckoutValidationRules._
 
 import scala.concurrent.{ExecutionContext, Future}
 
+object PreservableErrorMessages {
+  val invalidCharactersInBillingPostcodeError = "invalid_characters_in_billing_postcode"
+
+  val preservableErrorMessages = Set(
+    invalidCharactersInBillingPostcodeError,
+  )
+
+  def isMessagePreservable(message: String): Boolean = preservableErrorMessages.contains(message)
+}
+
 object CheckoutValidationRules {
 
   sealed trait Result {
@@ -102,6 +112,7 @@ object CheckoutValidationRules {
       case _: Contribution => PaidProductValidation.passes(createSupportWorkersRequest)
       case _: GuardianAdLite => PaidProductValidation.passes(createSupportWorkersRequest)
     }) match {
+      case Invalid(message) if PreservableErrorMessages.isMessagePreservable(message) => Invalid(message)
       case Invalid(message) =>
         Invalid(s"validation of the request body failed with $message - body was $createSupportWorkersRequest")
       case Valid => Valid
@@ -200,7 +211,8 @@ object PaidProductValidation {
       hasStateIfRequired(
         createSupportWorkersRequest.billingAddress.country,
         createSupportWorkersRequest.billingAddress.state,
-      )
+      ) and
+      hasValidBillingPostcodeCharacters(createSupportWorkersRequest.billingAddress.postCode)
 
   def noEmptyPaymentFields(paymentFields: PaymentFields): Result = paymentFields match {
     case directDebitDetails: DirectDebitPaymentFields =>
@@ -251,6 +263,13 @@ object AddressAndCurrencyValidationRules {
     }
     validPostCode
   }
+
+  def hasValidBillingPostcodeCharacters(postcodeFromRequest: Option[String]): Result =
+    postcodeFromRequest match {
+      case Some(postCode) if postCode.contains("@") =>
+        Invalid(PreservableErrorMessages.invalidCharactersInBillingPostcodeError)
+      case _ => Valid
+    }
 
   def hasPostcodeIfRequired(countryFromRequest: Country, postcodeFromRequest: Option[String]): Result =
     if (

--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -212,6 +212,7 @@ object PaidProductValidation {
         createSupportWorkersRequest.billingAddress.country,
         createSupportWorkersRequest.billingAddress.state,
       ) and
+      // For products which use this validation, we only collect postal/zip code in the US
       hasValidBillingPostcodeCharacters(createSupportWorkersRequest.billingAddress.postCode)
 
   def noEmptyPaymentFields(paymentFields: PaymentFields): Result = paymentFields match {

--- a/support-frontend/assets/helpers/forms/errorReasons.ts
+++ b/support-frontend/assets/helpers/forms/errorReasons.ts
@@ -19,6 +19,7 @@ const errorReasons = [
 	'invalid_email_address',
 	'recaptcha_validation_failed',
 	'guardian_ad_lite_purchase_not_allowed',
+	'invalid_characters_in_billing_postcode',
 	'unknown',
 ] as const;
 export function isErrorReason(value: string): value is ErrorReason {
@@ -77,6 +78,9 @@ function appropriateErrorMessage(errorReason: string): string {
 
 			case 'guardian_ad_lite_purchase_not_allowed':
 				return 'You already have Guardian Ad-Lite or can read the Guardian ad-free, please sign in';
+
+			case 'invalid_characters_in_billing_postcode':
+				return 'Please check your billing postcode to ensure it is valid';
 		}
 	}
 	return 'The transaction was temporarily declined. Please try entering your payment details again. Alternatively, try another payment method.';

--- a/support-frontend/assets/helpers/forms/errorReasons.ts
+++ b/support-frontend/assets/helpers/forms/errorReasons.ts
@@ -80,7 +80,8 @@ function appropriateErrorMessage(errorReason: string): string {
 				return 'You already have Guardian Ad-Lite or can read the Guardian ad-free, please sign in';
 
 			case 'invalid_characters_in_billing_postcode':
-				return 'Please check your billing postcode to ensure it is valid';
+				// Note, we're using ZIP code here as generally this error affects US users
+				return 'Please check your billing ZIP code to ensure it is correct';
 		}
 	}
 	return 'The transaction was temporarily declined. Please try entering your payment details again. Alternatively, try another payment method.';

--- a/support-frontend/assets/helpers/forms/errorReasons.ts
+++ b/support-frontend/assets/helpers/forms/errorReasons.ts
@@ -80,7 +80,10 @@ function appropriateErrorMessage(errorReason: string): string {
 				return 'You already have Guardian Ad-Lite or can read the Guardian ad-free, please sign in';
 
 			case 'invalid_characters_in_billing_postcode':
-				// Note, we're using ZIP code here as generally this error affects US users
+				// Note, we're using "ZIP code" here as generally this error
+				// affects US users only. For the products where we perform this
+				// validation rule, the only country we collect a ZIP/postal
+				// code is the US
 				return 'Please check your billing ZIP code to ensure it is correct';
 		}
 	}

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -28,7 +28,7 @@ import org.scalatest.matchers.should.Matchers
 import services.stepfunctions.CreateSupportWorkersRequest
 import services.stepfunctions.CreateSupportWorkersRequest.GiftRecipientRequest
 import utils.CheckoutValidationRules.{Invalid, Valid}
-import utils.TestData.monthlyDirectUSDProduct
+import utils.TestData.{monthlyDirectUSDProduct, validSupporterPlusRequest}
 
 import scala.concurrent.Future
 
@@ -393,6 +393,13 @@ class PaidProductValidationTest extends AnyFlatSpec with Matchers {
     PaidProductValidation.passes(requestSupporterPlus) shouldBe Valid
   }
 
+  it should "fail if the billing postcode field contains an email address" in {
+    val requestEmailInBillingPostcodeField = validSupporterPlusRequest.copy(
+      billingAddress = validSupporterPlusRequest.billingAddress.copy(postCode = Some("test@example.com")),
+      product = SupporterPlus(5, Currency.USD, Annual),
+    )
+    PaidProductValidation.passes(requestEmailInBillingPostcodeField) shouldBe an[Invalid]
+  }
 }
 class DigitalPackValidationTest extends AnyFlatSpec with Matchers {
 
@@ -755,6 +762,9 @@ object TestData {
     giftRecipient = None,
     deliveryInstructions = None,
     debugInfo = None,
+  )
+  val validSupporterPlusRequest = validDigitalPackRequest.copy(
+    product = SupporterPlus(50, Currency.USD, Monthly),
   )
 
   val someDateNextMonth = new LocalDate().plusMonths(1)


### PR DESCRIPTION
## What are you doing in this PR?

Add server side validation for billing address postcode.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/h2sFEVzL/1399-paypal-server-side-validation-placeholder)

## Why are you doing this?

We've had an ongoing issue where requests where the payment method is PayPal make it to support workers with an email address in the billing postcode field. We're not sure why this happens but are hoping some server side validation will prevent it and alert users that they need to fix something. It primarily seems to affect USD Supporter Plus and recurring contributions (we collect the postcode for these) so I've focused on fixing those cases, in the PaidProductValidation object used by both products.

I've introduced a concept of a preservable error message, i.e. something we can map to copy to show the user. It'd be nice to extend this but for now it's a one off for this field. As it stands, it's not perfect - if there are other validation errors we'll lose the message. I'd like to fix that in a future PR.

~~**Note: The error message copy needs updating.**~~ Copy has been updated.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Entering something which looks like an email address (contains an `@` character) triggers the validation:

<img width="627" alt="Screenshot 2025-02-06 at 09 32 31" src="https://github.com/user-attachments/assets/6daf7eb5-499f-4882-88b5-5787d0498c89" />

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
