### PR TITLE
Changes for copy in US landing page only

### DIFF
--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -104,6 +104,18 @@ const addFreeBenefit = {
 
 const newsletterBenefit = {
 	copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+	specificToRegions: [
+		'GBPCountries',
+		'EURCountries',
+		'AUDCountries',
+		'NZDCountries',
+		'Canada',
+		'International',
+	] as CountryGroupId[],
+};
+const newsletterBenefitUS = {
+	copy: 'Regular dispatches from the newsroom to see the impact of your support',
+	specificToRegions: ['UnitedStates'] as CountryGroupId[],
 };
 const fewerAsksBenefit = {
 	copy: 'Far fewer asks for support',
@@ -141,6 +153,7 @@ const supporterPlusBenefits = [
 	appBenefit,
 	addFreeBenefit,
 	newsletterBenefit,
+	newsletterBenefitUS,
 	fewerAsksBenefit,
 	partnerOffersBenefit,
 	feastBenefit,

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -44,6 +44,7 @@ import {
 	NZDCountries,
 	UnitedStates,
 } from 'helpers/internationalisation/countryGroup';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { currencies } from 'helpers/internationalisation/currency';
 import {
 	productCatalog,
@@ -342,13 +343,15 @@ export function ThreeTierLanding({
 		showCountdown: boolean,
 		currentCountdownSettings?: CountdownSetting,
 		campaignSettings?: CampaignSettings | null,
+		countryGroupId?: CountryGroupId,
 	) => {
 		if (showCountdown && currentCountdownSettings?.label.trim()) {
 			return currentCountdownSettings.label;
 		} else {
+			const firstWord = countryGroupId === UnitedStates ? 'Protect' : 'Support';
 			return (
 				<>
-					{campaignSettings?.copy.headingFragment ?? <>Support </>}
+					{campaignSettings?.copy.headingFragment ?? <>{firstWord} </>}
 					fearless, <br css={tabletLineBreak} />
 					independent journalism
 					{campaignSettings?.copy.punctuation ??
@@ -620,6 +623,7 @@ export function ThreeTierLanding({
 							showCountdown,
 							currentCountdownSettings,
 							campaignSettings,
+							countryGroupId,
 						)}
 					</h1>
 					{countryGroupId !== 'UnitedStates' && (


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

This PR is to change the copy on the landing page in the US only
 1. Update the benefit-  “Regular dispatches from the newsroom to see the impact of your support” [replacing Exclusive newsletter benefit on tier 2]
 2. Update the heading -“Protect” [replacing “Support” in the first line of text]



[**Trello Card**](https://trello.com/c/PqlPr88B/919-change-copy-in-us-landing-page-only)

## How to test

Test in CODE

## Screenshots

## Before Change (UK and US)
<img width="1170" alt="Screenshot 2025-02-06 at 11 45 34" src="https://github.com/user-attachments/assets/31fef829-b911-438f-add0-4976ee3cdd92" />


## After Change

## US 
![image](https://github.com/user-attachments/assets/3e8a485e-fe27-433f-999b-c5fde3ed5a63)


## UK 
<img width="1170" alt="image" src="https://github.com/user-attachments/assets/69ee492a-eebb-4d62-bfcf-0937c62578db" />

