### PR TITLE
Digital Editions: Ts&Cs align copy to original LandingPage

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/directDebit/directDebitTerms.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/directDebit/directDebitTerms.tsx
@@ -1,26 +1,21 @@
 import { css } from '@emotion/react';
-import { textSans12, textSans14 } from '@guardian/source/foundations';
+import { textSans14 } from '@guardian/source/foundations';
 
-const directDebitTerms = (isThreeTier?: true) => css`
-	${isThreeTier ? textSans12 : textSans14};
-
+const directDebitTerms = css`
+	${textSans14};
 	a,
 	a:visited {
-		color: ${isThreeTier ? '#606060' : 'inherit'};
+		color: inherit;
 	}
 	p {
 		margin-top: 10px;
-		color: ${isThreeTier ? '#606060' : 'inherit'};
+		color: inherit;
 	}
 `;
 
-interface DirectDebitTermsProps {
-	isThreeTier?: true;
-}
-
-function DirectDebitTerms({ isThreeTier }: DirectDebitTermsProps) {
+function DirectDebitTerms() {
 	return (
-		<div css={directDebitTerms(isThreeTier)}>
+		<div css={directDebitTerms}>
 			<p>
 				<strong>Payments by GoCardless</strong>
 				<br />

--- a/support-frontend/assets/components/subscriptionCheckouts/tierThreeTerms.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/tierThreeTerms.tsx
@@ -1,10 +1,6 @@
 import { css } from '@emotion/react';
 import { textSans12 } from '@guardian/source/foundations';
-import { FormSection } from 'components/checkoutForm/checkoutForm';
 import { StripeDisclaimer } from 'components/stripe/stripeDisclaimer';
-import DirectDebitTerms from 'components/subscriptionCheckouts/directDebit/directDebitTerms';
-import type { PaymentMethod } from 'helpers/forms/paymentMethods';
-import { DirectDebit } from 'helpers/forms/paymentMethods';
 import { privacyLink, tierThreeTermsLink } from 'helpers/legal';
 import { ManageMyAccountLink } from '../../pages/supporter-plus-landing/components/manageMyAccountLink';
 
@@ -29,52 +25,41 @@ const termsLink = (linkText: string, url: string) => (
 
 export default function TierThreeTerms(props: {
 	paymentFrequency: 'month' | 'year';
-	paymentMethod?: PaymentMethod;
 }): JSX.Element {
 	const paymentFrequencyName =
 		props.paymentFrequency === 'year' ? 'annual' : 'monthly';
 	const productName = 'Digital + print';
 
 	return (
-		<>
-			<FormSection>
-				<div css={tierThreeTerms}>
-					<p>
-						By signing up, you are taking out a {productName} subscription. Your{' '}
-						{productName} subscription will auto-renew each{' '}
-						{props.paymentFrequency} unless cancelled. Your first payment will
-						be taken on the publication date of your first Guardian Weekly
-						magazine (as shown in the checkout) but you will start to receive
-						your digital benefits when you sign up. Unless you cancel,
-						subsequent {paymentFrequencyName} payments will be taken on this
-						date using your chosen payment method. You can cancel your Digital +
-						print subscription at any time before your next renewal date. If you
-						cancel your {productName} subscription within 14 days of signing up,
-						your subscription will stop immediately and we will not take the
-						first payment from you. Cancellation of your subscription after 14
-						days will take effect at the end of your current{' '}
-						{paymentFrequencyName} payment period. To cancel go to&nbsp;
-						{ManageMyAccountLink} or see our {productName}{' '}
-						{termsLink('Terms', tierThreeTermsLink)}.
-					</p>
-					<p>
-						By proceeding, you are agreeing to the {productName}{' '}
-						{termsLink('Terms', tierThreeTermsLink)}.
-					</p>
-					<p>
-						To find out what personal data we collect and how we use it, please
-						visit our {termsLink('Privacy Policy', privacyLink)}.
-					</p>
-					<p>
-						<StripeDisclaimer />
-					</p>
-				</div>
-			</FormSection>
-			{props.paymentMethod === DirectDebit && (
-				<FormSection>
-					<DirectDebitTerms isThreeTier />
-				</FormSection>
-			)}
-		</>
+		<div css={tierThreeTerms}>
+			<p>
+				By signing up, you are taking out a {productName} subscription. Your{' '}
+				{productName} subscription will auto-renew each {props.paymentFrequency}{' '}
+				unless cancelled. Your first payment will be taken on the publication
+				date of your first Guardian Weekly magazine (as shown in the checkout)
+				but you will start to receive your digital benefits when you sign up.
+				Unless you cancel, subsequent {paymentFrequencyName} payments will be
+				taken on this date using your chosen payment method. You can cancel your
+				Digital + print subscription at any time before your next renewal date.
+				If you cancel your {productName} subscription within 14 days of signing
+				up, your subscription will stop immediately and we will not take the
+				first payment from you. Cancellation of your subscription after 14 days
+				will take effect at the end of your current {paymentFrequencyName}{' '}
+				payment period. To cancel go to&nbsp;
+				{ManageMyAccountLink} or see our {productName}{' '}
+				{termsLink('Terms', tierThreeTermsLink)}.
+			</p>
+			<p>
+				By proceeding, you are agreeing to the {productName}{' '}
+				{termsLink('Terms', tierThreeTermsLink)}.
+			</p>
+			<p>
+				To find out what personal data we collect and how we use it, please
+				visit our {termsLink('Privacy Policy', privacyLink)}.
+			</p>
+			<p>
+				<StripeDisclaimer />
+			</p>
+		</div>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
@@ -258,8 +258,8 @@ export function PaymentTsAndCs({
 					year unless you cancel. You can cancel at any time before your next
 					renewal date. Cancellation will take effect at the end of your current
 					subscription month. To cancel, go to{' '}
-					<a href="http://manage.theguardian.com/">Manage My Account</a> or see
-					our{' '}
+					<a href={'http://manage.theguardian.com/'}>Manage My Account</a> or
+					see our{' '}
 					<a href="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions">
 						Terms
 					</a>
@@ -298,6 +298,7 @@ export function SummaryTsAndCs({
 	productKey,
 	cssOverrides,
 }: SummaryTsAndCsProps): JSX.Element {
+	const inDigitalEdition = productKey === 'DigitalSubscription';
 	const inAdLite = productKey === 'GuardianAdLite';
 	const inDigitalPlusPrint = productKey === 'TierThree';
 	const inAllAccessDigital = productKey === 'SupporterPlus';
@@ -362,11 +363,15 @@ export function SummaryTsAndCs({
 	};
 
 	return (
-		<div css={[containerSummaryTsCs, cssOverrides]}>
-			{inSupport && copyTier1(contributionType)}
-			{inAllAccessDigital && copyTier2(contributionType, productKey)}
-			{inDigitalPlusPrint && copyTier3(contributionType, productKey, true)}
-			{inAdLite && copyTier3(contributionType, productKey, false)}
-		</div>
+		<>
+			{!inDigitalEdition && (
+				<div css={[containerSummaryTsCs, cssOverrides]}>
+					{inSupport && copyTier1(contributionType)}
+					{inAllAccessDigital && copyTier2(contributionType, productKey)}
+					{inDigitalPlusPrint && copyTier3(contributionType, productKey, true)}
+					{inAdLite && copyTier3(contributionType, productKey, false)}
+				</div>
+			)}
+		</>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
@@ -145,6 +145,7 @@ export function PaymentTsAndCs({
 	productKey,
 	promotion,
 }: PaymentTsAndCsProps): JSX.Element {
+	const inDigitalEdition = productKey === 'DigitalSubscription';
 	const inAdLite = productKey === 'GuardianAdLite';
 	const inAllAccessDigital =
 		productKey === 'SupporterPlus' && amountIsAboveThreshold;
@@ -152,7 +153,7 @@ export function PaymentTsAndCs({
 		productKey === 'TierThree' && amountIsAboveThreshold;
 	const inSupport =
 		productKey === 'Contribution' ||
-		!(inAllAccessDigital || inDigitalPlusPrint || inAdLite);
+		!(inAllAccessDigital || inDigitalPlusPrint || inAdLite || inDigitalEdition);
 
 	const frequencyPlural = (contributionType: ContributionType) =>
 		contributionType === 'MONTHLY' ? 'monthly' : 'annual';
@@ -247,6 +248,31 @@ export function PaymentTsAndCs({
 		);
 	};
 
+	const copyDigitalEdition = () => {
+		return (
+			<>
+				<div>
+					Payment taken after the first 14 day free trial. At the end of the
+					free trial period your subscription will auto-renew, and you will be
+					charged, each month at the full price of £14.99 per month or £149 per
+					year unless you cancel. You can cancel at any time before your next
+					renewal date. Cancellation will take effect at the end of your current
+					subscription month. To cancel, go to{' '}
+					<a href="http://manage.theguardian.com/">Manage My Account</a> or see
+					our{' '}
+					<a href="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions">
+						Terms
+					</a>
+					.
+				</div>
+				<TsAndCsFooterLinks
+					countryGroupId={countryGroupId}
+					amountIsAboveThreshold={amountIsAboveThreshold}
+				/>
+			</>
+		);
+	};
+
 	return (
 		<div css={container}>
 			<FinePrint mobileTheme={mobileTheme}>
@@ -259,6 +285,7 @@ export function PaymentTsAndCs({
 					copyAboveThreshold(contributionType, productKey, promotion)}
 				{inAdLite && copyAdLite(contributionType, productKey)}
 				{(inSupport || inAdLite) && copyBelowThreshold(countryGroupId)}
+				{inDigitalEdition && copyDigitalEdition()}
 			</FinePrint>
 		</div>
 	);


### PR DESCRIPTION
## What are you doing in this PR?

Copies the Ts&C's from the existing DigitalEdition LandingPage and places them in sam location on the new generic checkout when purchasing a DigitalSubscription.

Mis-matching Ts&Cs between the original DigitalEditionLandingPage and the generic checkout.
1. Align Ts&Cs
2. Remove un-required SummaryTsAndCs
3. Fixed format (half width) bug for TierThree TsAndCs

[**Trello Card**](https://trello.com/c/FXBoxx89/1415-dgital-edition-checkout-tscs)

## How to test

Original->
https://support.thegulocal.com/uk/subscribe/digitaledition
New->
https://support.thegulocal.com/uk/checkout?product=DigitalSubscription&ratePlan=Monthly
https://support.thegulocal.com/uk/checkout?product=DigitalSubscription&ratePlan=Annual


## Screenshots
|Original|New (Monthly)|New (Annual)|
|-----|-----|-----|
|![image](https://github.com/user-attachments/assets/3024b942-53ec-4afb-9866-8017c0040a4c)|![image](https://github.com/user-attachments/assets/a9c2462a-2312-44f7-8bdf-de42bff0f4af)|![image](https://github.com/user-attachments/assets/a3d1e194-4ae5-4481-8b55-0845eb1b44a1)|
