### PR TITLE
Add newsletter benefit to tier 1 in US

### DIFF
--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -357,7 +357,7 @@ export const productCatalogDescription: Record<
 	},
 	Contribution: {
 		label: 'Support',
-		benefits: [newsletterBenefit],
+		benefits: [newsletterBenefit, newsletterBenefitUS],
 		benefitsMissing: [
 			appBenefit,
 			addFreeBenefit,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This is to add back the newsletter benefit for US
“Regular dispatches from the newsroom to see the impact of your support”

[**Trello Card**](https://trello.com/c/60Qrx4aU/926-add-newsletter-benefit-back-in-to-tier-1-in-us)
This went missing following the change in the [PR](https://github.com/guardian/support-frontend/pull/6760)


## Screenshots

## Before
<img width="866" alt="image" src="https://github.com/user-attachments/assets/a9c2f8fa-78f7-480f-a59d-f4a6a23913d2" />

## After

<img width="866" alt="image" src="https://github.com/user-attachments/assets/93fbc878-1ce5-4dee-a816-2cda5effafb3" />
