### PR TITLE
Guardian Ad-Lite : LandingPage, display SignIn Copy when NOT Signed In

### DIFF
--- a/support-frontend/assets/components/stripe/stripeDisclaimer.tsx
+++ b/support-frontend/assets/components/stripe/stripeDisclaimer.tsx
@@ -14,11 +14,11 @@ export function StripeDisclaimer() {
 		<>
 			All card payments are powered by Stripe. Read the Stripe{' '}
 			<a href="https://stripe.com/privacy" target="_blank">
-				privacy policy
+				Privacy Policy
 			</a>{' '}
 			and{' '}
 			<a href="https://stripe.com/legal/end-users" target="_blank">
-				terms and conditions
+				Terms and conditions
 			</a>
 			.
 		</>

--- a/support-frontend/assets/components/stripe/stripeDisclaimer.tsx
+++ b/support-frontend/assets/components/stripe/stripeDisclaimer.tsx
@@ -14,11 +14,11 @@ export function StripeDisclaimer() {
 		<>
 			All card payments are powered by Stripe. Read the Stripe{' '}
 			<a href="https://stripe.com/privacy" target="_blank">
-				Privacy Policy
+				privacy policy
 			</a>{' '}
 			and{' '}
 			<a href="https://stripe.com/legal/end-users" target="_blank">
-				Terms and conditions
+				terms and conditions
 			</a>
 			.
 		</>

--- a/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/guardianAdLiteCards.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/guardianAdLiteCards.tsx
@@ -44,7 +44,7 @@ export function GuardianAdLiteCards({
 		<div
 			css={[
 				container(cardsContent.length),
-				!isSignedIn ? containerExpand : css``,
+				isSignedIn ? containerExpand : css``,
 			]}
 			role="tabpanel"
 			id={`monthly-tab`}

--- a/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/headerCards.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/headerCards.tsx
@@ -130,7 +130,7 @@ export function HeaderCards({
 					cardsContent={[card1, card2]}
 					isSignedIn={isSignedIn}
 				/>
-				{isSignedIn && (
+				{!isSignedIn && (
 					<div css={signIn}>
 						<p css={paragraph}>
 							If you already have Guardian Ad-Lite or another Guardian


### PR DESCRIPTION
## What are you doing in this PR?

It appears I have the Sign-In screen around the wrong way around

Change to ->
1. User is `NOT signedIn` SHOW SignIn option.
2. User is `signedIn` HIDE SignIn option.

[**Trello Card**](https://trello.com)

## Screenshots

NotSignedIn/SignedIn = regardless whether user has an ad-free account or not.

|Status|From (current CODE)|To (new DEV)|
|------------------|-----|-----|
|NotSignedIn|![image](https://github.com/user-attachments/assets/e3fc0260-830b-470e-8401-771ab14a489b)|![image](https://github.com/user-attachments/assets/2bac9794-a321-484a-8102-5e841a3e8fba)|
|SignedIn|![image](https://github.com/user-attachments/assets/00ac9ab4-64ae-4050-b49c-abc1cd95759f)|![image](https://github.com/user-attachments/assets/4d20bf0c-a7b7-4188-b004-d93969acbf6f)|