### PR TITLE
Force the recaptcha to re-initialise after a server side failure

### DIFF
--- a/support-frontend/assets/components/recaptcha/recaptcha.tsx
+++ b/support-frontend/assets/components/recaptcha/recaptcha.tsx
@@ -31,14 +31,14 @@ export type RecaptchaProps = {
 	id?: string;
 	onRecaptchaCompleted: (token: string) => void;
 	onRecaptchaExpired?: () => void;
-	attemptNumber: number;
+	attemptNumber?: number;
 };
 
 export function Recaptcha({
 	id = 'robot_checkbox',
 	onRecaptchaCompleted,
 	onRecaptchaExpired,
-	attemptNumber,
+	attemptNumber = 1,
 }: RecaptchaProps): JSX.Element {
 	useRecaptchaV2(id, attemptNumber, onRecaptchaCompleted, onRecaptchaExpired);
 

--- a/support-frontend/assets/components/recaptcha/recaptcha.tsx
+++ b/support-frontend/assets/components/recaptcha/recaptcha.tsx
@@ -31,14 +31,16 @@ export type RecaptchaProps = {
 	id?: string;
 	onRecaptchaCompleted: (token: string) => void;
 	onRecaptchaExpired?: () => void;
+	attemptNumber: number;
 };
 
 export function Recaptcha({
 	id = 'robot_checkbox',
 	onRecaptchaCompleted,
 	onRecaptchaExpired,
+	attemptNumber,
 }: RecaptchaProps): JSX.Element {
-	useRecaptchaV2(id, onRecaptchaCompleted, onRecaptchaExpired);
+	useRecaptchaV2(id, attemptNumber, onRecaptchaCompleted, onRecaptchaExpired);
 
 	return (
 		<>

--- a/support-frontend/assets/helpers/customHooks/useRecaptcha.ts
+++ b/support-frontend/assets/helpers/customHooks/useRecaptcha.ts
@@ -3,6 +3,7 @@ import { loadRecaptchaV2 } from 'helpers/forms/recaptcha';
 
 export function useRecaptchaV2(
 	placeholderId: string,
+	attemptNumber: number,
 	onCompletionCallback: (token: string) => void,
 	onExpireCallback?: () => void,
 ): void {
@@ -25,5 +26,5 @@ export function useRecaptchaV2(
 			};
 			void loadRecaptchaV2();
 		}
-	}, []);
+	}, [attemptNumber]);
 }

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -629,6 +629,8 @@ export function CheckoutComponent({
 					statusResponse,
 				);
 			} else {
+				setRecaptchaToken(undefined);
+				// This will trigger a new recaptcha token:
 				setAttemptNumber(attemptNumber + 1);
 
 				const errorReason = (await createResponse.text()) as ErrorReason;

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -328,6 +328,8 @@ export function CheckoutComponent({
 	const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>();
 	const [paymentMethodError, setPaymentMethodError] = useState<string>();
 
+	const [attemptNumber, setAttemptNumber] = useState<number>(1);
+
 	/** Payment methods: Stripe */
 	const stripe = useStripe();
 	const elements = useElements();
@@ -627,6 +629,8 @@ export function CheckoutComponent({
 					statusResponse,
 				);
 			} else {
+				setAttemptNumber(attemptNumber + 1);
+
 				const errorReason = (await createResponse.text()) as ErrorReason;
 				processPaymentResponse = {
 					status: 'failure',
@@ -1237,6 +1241,7 @@ export function CheckoutComponent({
 														errors={{}}
 														recaptcha={
 															<Recaptcha
+																attemptNumber={attemptNumber}
 																// We could change the parents type to Promise and use await here, but that has
 																// a lot of refactoring with not too much gain
 																onRecaptchaCompleted={(token) => {


### PR DESCRIPTION
## What are you doing in this PR?

Reinitialise the recaptcha each time server side validation fails. This causes a new Stripe payment intent to be created.


<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/YDTXTfHT/1420-fix-issue-with-server-side-validation-and-stripe-state)

## Why are you doing this?

Before this change, if the reader was paying with Stripe, and server side validation rejected the call to `/subscribe/create`, then even if the user then fixed the issue which caused the validation failure, future form submissions fail with the following error from Stripe: `You cannot confirm this SetupIntent because it has already succeeded.` ([setup_intent_unexpected_state]).

[setup_intent_unexpected_state]:
https://stripe.com/docs/error-codes/setup-intent-unexpected-state

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

On the generic checkout, submit the payment form with data which will cause server side validation to fail. Fix the issue and re-submit, the payment should now go through.

I've run the smoke test against my branch and all tests passed.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
