### PR TITLE
Guardian Ad-Lite : Enables the stripe express checkout (ApplePay & GooglePay in turn)

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -212,7 +212,12 @@ export function Checkout({ geoId, appConfig, abParticipations }: Props) {
 		 * Currently we're only using the stripe ExpressCheckoutElement on Contribution purchases
 		 * which then needs this configuration.
 		 */
-		if (productKey === 'Contribution' || productKey === 'SupporterPlus') {
+		if (
+			productKey === 'Contribution' ||
+			productKey === 'SupporterPlus' ||
+			productKey === 'GuardianAdLite' ||
+			productKey === 'DigitalSubscription'
+		) {
 			elementsOptions = {
 				mode: 'payment',
 				/**


### PR DESCRIPTION
## What are you doing in this PR?

- Enables the stripe express checkout (ApplePay & GooglePay in turn).
- Enable for Digital Editions too.

## How to test (code via IPhone or Google Wallet Enabled Chrome)
https://support.code.dev-theguardian.com/uk/checkout?product=GuardianAdLite&ratePlan=Monthly

## Screenshots
