### PR TITLE
Create Stripe setup intent on form submit, not on recaptcha check

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -1230,8 +1230,6 @@ export function CheckoutComponent({
 														errors={{}}
 														recaptcha={
 															<Recaptcha
-																// We could change the parents type to Promise and use await here, but that has
-																// a lot of refactoring with not too much gain
 																onRecaptchaCompleted={(token) => {
 																	setRecaptchaToken(token);
 																}}

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -332,7 +332,6 @@ export function CheckoutComponent({
 	const stripe = useStripe();
 	const elements = useElements();
 	const cardElement = elements?.getElement(CardNumberElement);
-	const [stripeClientSecret, setStripeClientSecret] = useState<string>();
 	const [
 		stripeExpressCheckoutPaymentType,
 		setStripeExpressCheckoutPaymentType,
@@ -346,13 +345,6 @@ export function CheckoutComponent({
 			formRef.current?.requestSubmit();
 		}
 	}, [stripeExpressCheckoutSuccessful]);
-
-	/**
-	 * flag that disables the submission of the form until the stripeClientSecret is
-	 * fetched from the Stripe API with using the reCaptcha token
-	 */
-	const [stripeClientSecretInProgress, setStripeClientSecretInProgress] =
-		useState(false);
 
 	/**
 	 * Payment method: PayPal
@@ -467,12 +459,13 @@ export function CheckoutComponent({
 
 		/** FormData: `paymentFields` */
 		let paymentFields: RegularPaymentFields | undefined = undefined;
-		if (
-			paymentMethod === 'Stripe' &&
-			stripe &&
-			cardElement &&
-			stripeClientSecret
-		) {
+		if (paymentMethod === 'Stripe' && stripe && cardElement && recaptchaToken) {
+			const stripeClientSecret = await stripeCreateSetupIntentRecaptcha(
+				isTestUser,
+				stripePublicKey,
+				recaptchaToken,
+			);
+
 			const stripeIntentResult = await stripe.confirmCardSetup(
 				stripeClientSecret,
 				{
@@ -1240,16 +1233,7 @@ export function CheckoutComponent({
 																// We could change the parents type to Promise and use await here, but that has
 																// a lot of refactoring with not too much gain
 																onRecaptchaCompleted={(token) => {
-																	setStripeClientSecretInProgress(true);
 																	setRecaptchaToken(token);
-																	void stripeCreateSetupIntentRecaptcha(
-																		isTestUser,
-																		stripePublicKey,
-																		token,
-																	).then((client_secret) => {
-																		setStripeClientSecret(client_secret);
-																		setStripeClientSecretInProgress(false);
-																	});
 																}}
 																onRecaptchaExpired={() => {
 																	setRecaptchaToken(undefined);
@@ -1331,24 +1315,21 @@ export function CheckoutComponent({
 						>
 							{paymentMethod !== 'PayPal' && (
 								<DefaultPaymentButton
-									isLoading={stripeClientSecretInProgress}
-									buttonText={
-										stripeClientSecretInProgress
-											? 'Validating reCAPTCHA...'
-											: `Pay ${simpleFormatAmount(currency, finalAmount)} per ${
-													ratePlanDescription.billingPeriod === 'Annual'
-														? 'year'
-														: ratePlanDescription.billingPeriod === 'Monthly'
-														? 'month'
-														: 'quarter'
-											  }`
-									}
+									buttonText={`Pay ${simpleFormatAmount(
+										currency,
+										finalAmount,
+									)} per ${
+										ratePlanDescription.billingPeriod === 'Annual'
+											? 'year'
+											: ratePlanDescription.billingPeriod === 'Monthly'
+											? 'month'
+											: 'quarter'
+									}`}
 									onClick={() => {
 										// no-op
 										// This isn't needed because we are now using the formOnSubmit handler
 									}}
 									type="submit"
-									disabled={stripeClientSecretInProgress}
 								/>
 							)}
 							{payPalLoaded && paymentMethod === 'PayPal' && (


### PR DESCRIPTION
## What are you doing in this PR?

Before this change, if the reader was paying with Stripe, and server side validation rejected the call to `/subscribe/create`, then even if the user fixed the issue which caused the validation failure, future form submissions (until the recaptcha expires) fail with the following error from Stripe: `You cannot confirm this SetupIntent because it has already succeeded` (`setup_intent_unexpected_state`).

This was happening because we were previously taking the recaptcha token, verifying it and retrieving a Stripe client secret all at the point where the recaptcha box was checked. This only happened once in the above scenario, and calling `stripe.confirmCardSetup` twice with the same client secret results in the above error.

Now, instead of getting the client secret (using the recaptcha token) when the recaptcha is checked, we use the recaptcha token from state to get the client secret at the point the form is submitted, so we get a new client secret each time to pass to `stripe.confirmCardSetup`.

Supersedes #6766.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/YDTXTfHT/1420-fix-issue-with-server-side-validation-and-stripe-state)

## Why are you doing this?

I noticed this issue while testing #6759, but I think it affects all Stripe payments on the generic checkout where server side validation prevents the purchase from going through.

## How to test

On the generic checkout, submit the payment form with data which will cause server side validation to fail. Fix the issue and re-submit, the payment should now go through.

I've run the smoke tests against my branch and they all passed.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
