### PR TITLE
GuardianAdLite: Stop SignedIn Ad-Free Users from re-purchasing Guardian Ad-Lite

### DIFF
--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -169,19 +169,13 @@ class CreateSubscriptionController(
   ): EitherT[Future, CreateSubscriptionError, Unit] = {
     request.body.product match {
       case GuardianAdLite(_) => {
-        if (userDetails.isSignedIn) {
-          // If the user is signed in, we'll assume they're eligible as they shouldn't have got
-          // to this point of the journey.
-          EitherT.rightT(())
-        } else {
-          for {
-            benefits <- userBenefitsApiServiceProvider
-              .forUser(testUsers.isTestUser(request))
-              .getUserBenefits(userDetails.userDetails.identityId)
-              .leftMap(_ => ServerError("Something went wrong calling the user benefits API"))
-            _ <- validateBenefitsForAdLitePurchase(benefits)
-          } yield ()
-        }
+        for {
+          benefits <- userBenefitsApiServiceProvider
+            .forUser(testUsers.isTestUser(request))
+            .getUserBenefits(userDetails.userDetails.identityId)
+            .leftMap(_ => ServerError("Something went wrong calling the user benefits API"))
+          _ <- validateBenefitsForAdLitePurchase(benefits)
+        } yield ()
       }
       case _ => EitherT.rightT(())
     }

--- a/support-frontend/assets/helpers/forms/errorReasons.ts
+++ b/support-frontend/assets/helpers/forms/errorReasons.ts
@@ -19,6 +19,7 @@ const errorReasons = [
 	'invalid_email_address',
 	'recaptcha_validation_failed',
 	'guardian_ad_lite_purchase_not_allowed',
+	'guardian_ad_lite_purchase_not_allowed_signed_in',
 	'invalid_characters_in_billing_postcode',
 	'unknown',
 ] as const;
@@ -78,6 +79,9 @@ function appropriateErrorMessage(errorReason: string): string {
 
 			case 'guardian_ad_lite_purchase_not_allowed':
 				return 'You already have Guardian Ad-Lite or can read the Guardian ad-free, please sign in';
+
+			case 'guardian_ad_lite_purchase_not_allowed_signed_in':
+				return 'You already have Guardian Ad-Lite or can read the Guardian ad-free';
 
 			case 'invalid_characters_in_billing_postcode':
 				// Note, we're using "ZIP code" here as generally this error


### PR DESCRIPTION
## What are you doing in this PR?

Stops SignedIn Ad-Free Users from re-purchasing Guardian Ad-Lite 
Different messages dependent on Sign-In status (see CODE screenshot's below)

[**Trello Card**](https://trello.com/c/gauWaokI/1424-on-the-guardian-ad-lite-checkout-check-for-adfree-or-rejecttracking-benefits-and-block-purchase-for-signed-in-users)

## How to test

1. Login through CODE [MMA](https://profile.code.dev-theguardian.com/signin?) (Ad-Lite or Ad-Free User)
2. Goto Guardian Ad-Lite [Checkout](https://support.code.dev-theguardian.com/uk/checkout?product=GuardianAdLite&ratePlan=Monthly),
3. Checkout (will get error message show below)
4. Sign-Out
5. Repeat Checkout with same email address (just not-signed in)

## Screenshots

|Not Signed-In|Sign-In|
|-----|-----|
|![image](https://github.com/user-attachments/assets/5fa60f34-e526-4a71-8526-f6571364cc66)|![image](https://github.com/user-attachments/assets/9f5f8ac6-b183-4701-85ca-f263b761ace0)|
