### PR TITLE
Adds back the abandon basket cookie to one time checkout

### DIFF
--- a/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
+++ b/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
@@ -1,13 +1,13 @@
 import { useEffect } from 'react';
 import type { InferInput } from 'valibot';
 import {
-  flatten,
-  literal,
-  number,
-  object,
-  safeParse,
-  string,
-  union,
+	flatten,
+	literal,
+	number,
+	object,
+	safeParse,
+	string,
+	union,
 } from 'valibot';
 import type { ActiveProductKey } from 'helpers/productCatalog';
 import * as cookie from 'helpers/storage/cookie';
@@ -17,10 +17,10 @@ const COOKIE_EXPIRY_DAYS = 3;
 const ABANDONED_BASKET_COOKIE_NAME = 'GU_CO_INCOMPLETE';
 
 const abandonedBasketSchema = object({
-  product: string(),
-  amount: union([number(), literal('other')]),
-  billingPeriod: string(),
-  region: string(),
+	product: string(),
+	amount: union([number(), literal('other')]),
+	billingPeriod: string(),
+	region: string(),
 });
 
 type AbandonedBasket = InferInput<typeof abandonedBasketSchema>;
@@ -40,7 +40,7 @@ export function useAbandonedBasketCookie(
 	};
 
 	useEffect(() => {
-		if (inAbandonedBasketVariant ) {
+		if (inAbandonedBasketVariant) {
 			cookie.set(
 				ABANDONED_BASKET_COOKIE_NAME,
 				JSON.stringify(abandonedBasket),
@@ -55,33 +55,33 @@ function parseAmount(amount: number): number | 'other' {
 }
 
 export function updateAbandonedBasketCookie(amount: string) {
-  const abandonedBasketCookie = cookie.get(ABANDONED_BASKET_COOKIE_NAME);
-  if (!abandonedBasketCookie) {
-    return;
-  }
+	const abandonedBasketCookie = cookie.get(ABANDONED_BASKET_COOKIE_NAME);
+	if (!abandonedBasketCookie) {
+		return;
+	}
 
-  const parsedCookie = safeParse(
-    abandonedBasketSchema,
-    JSON.parse(abandonedBasketCookie),
-  );
+	const parsedCookie = safeParse(
+		abandonedBasketSchema,
+		JSON.parse(abandonedBasketCookie),
+	);
 
-  if (parsedCookie.success) {
-    const newCookie: AbandonedBasket = {
-      ...parsedCookie.output,
-      amount: parseAmount(Number.parseFloat(amount)),
-    };
+	if (parsedCookie.success) {
+		const newCookie: AbandonedBasket = {
+			...parsedCookie.output,
+			amount: parseAmount(Number.parseFloat(amount)),
+		};
 
-    cookie.set(
-      ABANDONED_BASKET_COOKIE_NAME,
-      JSON.stringify(newCookie),
-      COOKIE_EXPIRY_DAYS,
-    );
-  } else {
-    logException(
-      `Failed to parse abandoned basket cookie. Error:
+		cookie.set(
+			ABANDONED_BASKET_COOKIE_NAME,
+			JSON.stringify(newCookie),
+			COOKIE_EXPIRY_DAYS,
+		);
+	} else {
+		logException(
+			`Failed to parse abandoned basket cookie. Error:
 			${JSON.stringify(flatten(parsedCookie.issues))}`,
-    );
-  }
+		);
+	}
 }
 
 export function deleteAbandonedBasketCookie() {

--- a/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
+++ b/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
@@ -1,9 +1,29 @@
 import { useEffect } from 'react';
+import type { InferInput } from 'valibot';
+import {
+  flatten,
+  literal,
+  number,
+  object,
+  safeParse,
+  string,
+  union,
+} from 'valibot';
 import type { ActiveProductKey } from 'helpers/productCatalog';
 import * as cookie from 'helpers/storage/cookie';
+import { logException } from 'helpers/utilities/logger';
 
 const COOKIE_EXPIRY_DAYS = 3;
 const ABANDONED_BASKET_COOKIE_NAME = 'GU_CO_INCOMPLETE';
+
+const abandonedBasketSchema = object({
+  product: string(),
+  amount: union([number(), literal('other')]),
+  billingPeriod: string(),
+  region: string(),
+});
+
+type AbandonedBasket = InferInput<typeof abandonedBasketSchema>;
 
 export function useAbandonedBasketCookie(
 	product: ActiveProductKey,
@@ -19,13 +39,8 @@ export function useAbandonedBasketCookie(
 		region,
 	};
 
-	// support-dotcom-components can only return a user to the checkout for these products
-	// don't drop the cookie if they came from a different checkout
-	const isSupportedProduct =
-		product === 'Contribution' || product === 'SupporterPlus';
-
 	useEffect(() => {
-		if (inAbandonedBasketVariant && isSupportedProduct) {
+		if (inAbandonedBasketVariant ) {
 			cookie.set(
 				ABANDONED_BASKET_COOKIE_NAME,
 				JSON.stringify(abandonedBasket),
@@ -37,6 +52,36 @@ export function useAbandonedBasketCookie(
 
 function parseAmount(amount: number): number | 'other' {
 	return isNaN(amount) ? 'other' : amount;
+}
+
+export function updateAbandonedBasketCookie(amount: string) {
+  const abandonedBasketCookie = cookie.get(ABANDONED_BASKET_COOKIE_NAME);
+  if (!abandonedBasketCookie) {
+    return;
+  }
+
+  const parsedCookie = safeParse(
+    abandonedBasketSchema,
+    JSON.parse(abandonedBasketCookie),
+  );
+
+  if (parsedCookie.success) {
+    const newCookie: AbandonedBasket = {
+      ...parsedCookie.output,
+      amount: parseAmount(Number.parseFloat(amount)),
+    };
+
+    cookie.set(
+      ABANDONED_BASKET_COOKIE_NAME,
+      JSON.stringify(newCookie),
+      COOKIE_EXPIRY_DAYS,
+    );
+  } else {
+    logException(
+      `Failed to parse abandoned basket cookie. Error:
+			${JSON.stringify(flatten(parsedCookie.issues))}`,
+    );
+  }
 }
 
 export function deleteAbandonedBasketCookie() {

--- a/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
+++ b/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts
@@ -39,8 +39,15 @@ export function useAbandonedBasketCookie(
 		region,
 	};
 
+	// support-dotcom-components can only return a user to the checkout for these products
+	// don't drop the cookie if they came from a different checkout
+	const isSupportedProduct =
+		product === 'Contribution' ||
+		product === 'SupporterPlus' ||
+		product === 'OneTimeContribution';
+
 	useEffect(() => {
-		if (inAbandonedBasketVariant) {
+		if (inAbandonedBasketVariant && isSupportedProduct) {
 			cookie.set(
 				ABANDONED_BASKET_COOKIE_NAME,
 				JSON.stringify(abandonedBasket),

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -82,7 +82,7 @@ import { GuardianTsAndCs } from 'pages/supporter-plus-landing/components/guardia
 import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsMessage';
 import { TsAndCsFooterLinks } from 'pages/supporter-plus-landing/components/paymentTsAndCs';
 import {countryGroups} from "../../../helpers/internationalisation/countryGroup";
-import {useAbandonedBasketCookie} from "../../../helpers/storage/abandonedBasketCookies";
+import {updateAbandonedBasketCookie, useAbandonedBasketCookie} from "../../../helpers/storage/abandonedBasketCookies";
 import { setThankYouOrder } from '../checkout/helpers/sessionStorage';
 import {
 	doesNotContainExtendedEmojiOrLeadingSpace,
@@ -572,6 +572,7 @@ export function OneTimeCheckoutComponent({
 								setSelectedPriceCard(
 									amount === 'other' ? amount : Number.parseFloat(amount),
 								);
+                updateAbandonedBasketCookie(amount);
 							}}
 							hideChooseYourAmount={hideChooseYourAmount}
 							otherAmountField={

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -81,8 +81,11 @@ import { FinePrint } from 'pages/supporter-plus-landing/components/finePrint';
 import { GuardianTsAndCs } from 'pages/supporter-plus-landing/components/guardianTsAndCs';
 import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsMessage';
 import { TsAndCsFooterLinks } from 'pages/supporter-plus-landing/components/paymentTsAndCs';
-import {countryGroups} from "../../../helpers/internationalisation/countryGroup";
-import {updateAbandonedBasketCookie, useAbandonedBasketCookie} from "../../../helpers/storage/abandonedBasketCookies";
+import { countryGroups } from '../../../helpers/internationalisation/countryGroup';
+import {
+	updateAbandonedBasketCookie,
+	useAbandonedBasketCookie,
+} from '../../../helpers/storage/abandonedBasketCookies';
 import { setThankYouOrder } from '../checkout/helpers/sessionStorage';
 import {
 	doesNotContainExtendedEmojiOrLeadingSpace,
@@ -534,15 +537,15 @@ export function OneTimeCheckoutComponent({
 		return;
 	}
 
-  const { supportInternationalisationId } = countryGroups[countryGroupId];
+	const { supportInternationalisationId } = countryGroups[countryGroupId];
 
-  useAbandonedBasketCookie(
-    'OneTimeContribution',
-    finalAmount ?? 0,
-    'ONE_OFF',
-    supportInternationalisationId,
-    abParticipations.abandonedBasket === 'variant',
-  );
+	useAbandonedBasketCookie(
+		'OneTimeContribution',
+		finalAmount ?? 0,
+		'ONE_OFF',
+		supportInternationalisationId,
+		abParticipations.abandonedBasket === 'variant',
+	);
 
 	const paymentButtonText = finalAmount
 		? paymentMethod === 'PayPal'
@@ -572,7 +575,7 @@ export function OneTimeCheckoutComponent({
 								setSelectedPriceCard(
 									amount === 'other' ? amount : Number.parseFloat(amount),
 								);
-                updateAbandonedBasketCookie(amount);
+								updateAbandonedBasketCookie(amount);
 							}}
 							hideChooseYourAmount={hideChooseYourAmount}
 							otherAmountField={

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -81,6 +81,8 @@ import { FinePrint } from 'pages/supporter-plus-landing/components/finePrint';
 import { GuardianTsAndCs } from 'pages/supporter-plus-landing/components/guardianTsAndCs';
 import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsMessage';
 import { TsAndCsFooterLinks } from 'pages/supporter-plus-landing/components/paymentTsAndCs';
+import {countryGroups} from "../../../helpers/internationalisation/countryGroup";
+import {useAbandonedBasketCookie} from "../../../helpers/storage/abandonedBasketCookies";
 import { setThankYouOrder } from '../checkout/helpers/sessionStorage';
 import {
 	doesNotContainExtendedEmojiOrLeadingSpace,
@@ -531,6 +533,16 @@ export function OneTimeCheckoutComponent({
 
 		return;
 	}
+
+  const { supportInternationalisationId } = countryGroups[countryGroupId];
+
+  useAbandonedBasketCookie(
+    'OneTimeContribution',
+    finalAmount ?? 0,
+    'ONE_OFF',
+    supportInternationalisationId,
+    abParticipations.abandonedBasket === 'variant',
+  );
 
 	const paymentButtonText = finalAmount
 		? paymentMethod === 'PayPal'


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Adds the abandon basket cookie back into the one time checkout

## Why are you doing this?
The abandon basket cookie was removed from the one time checkout during a refactor and this PR adds it back in. 

## How to test
One the time checkout, open the dev tools -> Application tab -> Cookies -> filter by GU_ and you should see....

![image](https://github.com/user-attachments/assets/1dbdb3cc-60e0-4e44-abf6-ec6b33c8b932)

when you change the amount on the choice card the cookie should update to reflect the selected amount, unless you select Other which just displays 'other'

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
