### PR TITLE
Pd/subscribe checkout image abtest

### DIFF
--- a/support-frontend/assets/components/orderSummary/orderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/orderSummary.tsx
@@ -27,7 +27,7 @@ function OrderSummary(props: PropTypes): JSX.Element {
 				</div>
 			</div>
 			<div css={styles.contentBlock}>
-				<div css={styles.imageContainer}>{props.image}</div>
+				{props.image && <div css={styles.imageContainer}>{props.image}</div>}
 				<div css={styles.mobileSummary}>
 					<h4>{props.mobileSummary.title}</h4>
 					<p>{props.mobileSummary.price}</p>

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -17,6 +17,7 @@ export const pageUrlRegexes = {
 		genericCheckoutOnly: '(uk|us|au|ca|eu|nz|int)/checkout|thank-you(/.*)?$',
 	},
 	subscriptions: {
+		all: '^(?!(?:/subscribe/paper(/delivery|/checkout|/checkout/guest)?(?.*)?$))(?:(/??/subscribe(?.*)?$|/??/subscribe/weekly(/checkout)?(?.*)?$))',
 		paper: {
 			// Requires /subscribe/paper, allows /checkout or /checkout/guest, allows any query string
 			paperLandingWithGuestCheckout:
@@ -139,5 +140,26 @@ export const tests: Tests = {
 			const productParam = urlSearchParams.get('product');
 			return !productParam || productParam === 'DigitalSubscription';
 		},
+	},
+	subscribeCheckoutImage: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 1,
+			},
+		},
+		isActive: false,
+		referrerControlled: false, // ab-test name not needed to be in paramURL
+		seed: 5,
+		targetPage: pageUrlRegexes.subscriptions.all,
+		excludeContributionsOnlyCountries: true,
 	},
 };

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -302,6 +302,7 @@ function PaperCheckoutForm(props: PropTypes) {
 				Collection,
 				getQueryParameter('promoCode'),
 			)}`}
+			participations={props.participations}
 		/>
 	);
 
@@ -324,6 +325,7 @@ function PaperCheckoutForm(props: PropTypes) {
 				getQueryParameter('promoCode'),
 			)}`}
 			startDate={formattedStartDate}
+			participations={props.participations}
 		/>
 	);
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperOrderSummary/paperOrderSummary.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperOrderSummary/paperOrderSummary.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import 'components/gridImage/gridImage';
 import OrderSummary from 'components/orderSummary/orderSummary';
 import OrderSummaryProduct from 'components/orderSummary/orderSummaryProduct';
+import type { Participations } from 'helpers/abTests/models';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { Collection } from 'helpers/productPrice/fulfilmentOptions';
 import type {
@@ -29,6 +30,7 @@ export type OrderSummaryProps = {
 	changeSubscription?: string | null;
 	startDate?: string;
 	total: ProductPrice;
+	participations: Participations;
 };
 
 function getMobileSummaryTitle(
@@ -56,6 +58,8 @@ const connector = connect(mapStateToProps);
 type PropTypes = ConnectedProps<typeof connector> & OrderSummaryProps;
 
 function PaperOrderSummary(props: PropTypes) {
+	const hideSummaryImage =
+		props.participations.subscribeCheckoutImage === 'variant';
 	const rawTotal = getPriceSummary(
 		showPrice(props.total, false),
 		props.billingPeriod,
@@ -128,7 +132,7 @@ function PaperOrderSummary(props: PropTypes) {
 
 	return (
 		<OrderSummary
-			image={props.image}
+			image={!hideSummaryImage ? props.image : null}
 			changeSubscription={props.changeSubscription}
 			total={total}
 			mobileSummary={mobileSummary}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
