### PR TITLE
More cookie changes

### DIFF
--- a/support-frontend/app/controllers/DiagnosticsController.scala
+++ b/support-frontend/app/controllers/DiagnosticsController.scala
@@ -2,28 +2,23 @@ package controllers
 
 import actions.CustomActionBuilders
 import play.api.mvc._
-import Results.Ok
+import play.api.mvc.Results.Ok
 
 class DiagnosticsController(
     actionRefiners: CustomActionBuilders,
 ) {
 
-  val relevantCookies = List(
-    "gu_user_features_expiry",
-    "gu_paying_member",
+  private val relevantCookies = List(
+    "gu_user_benefits_expiry",
     "GU_AF1",
     "gu_action_required_for",
-    "gu_digital_subscriber",
+    "gu_allow_reject_all",
     "gu_hide_support_messaging",
-    "gu_recurring_contributor",
-    "gu_one_off_contribution_date",
-    "gu.contributions.recurring.contrib-timestamp.Monthly",
-    "gu.contributions.recurring.contrib-timestamp.Annual",
     "gu.contributions.contrib-timestamp",
     "gu_article_count_opt_out",
     "GO_SO",
   )
-  val privateCookies = List(
+  private val privateCookies = List(
     "GU_U",
     "SC_GU_U",
   )
@@ -31,13 +26,12 @@ class DiagnosticsController(
   import actionRefiners._
   def cookies(): Action[AnyContent] = NoCacheAction() { request =>
     val humanReadableCookies =
-      "Please make sure you are logged in and have visited https://www.theguardian.com and seen the issue," +
-        " immediately before sending the information from this page" ::
+      "Please make sure you are logged in and have visited https://www.theguardian.com and seen the issue, immediately before sending the information from this page" ::
         request.cookies.collect {
           case cookie if relevantCookies.contains(cookie.name) =>
-            "* " + cookie.name + "\n  " + cookie.value
+            s"""* ${cookie.name}\n  ${cookie.value}"""
           case cookie if privateCookies.contains(cookie.name) =>
-            "* " + cookie.name + "\n  (private - length: " + cookie.value.length + ")"
+            s"""* ${cookie.name}\n  (private - length: ${cookie.value.length})"""
         }.toList
     Ok(humanReadableCookies.mkString("\n\n"))
   }

--- a/support-frontend/app/controllers/SubscriptionProductCookiesCreator.scala
+++ b/support-frontend/app/controllers/SubscriptionProductCookiesCreator.scala
@@ -30,8 +30,8 @@ case class SubscriptionProductCookiesCreator(domain: GuardianDomain) {
   private def allowRejectAllCookie(now: DateTime) =
     persistentCookieWithMaxAge("gu_allow_reject_all", now)
 
-  private def userFeaturesExpiryCookie(now: DateTime) =
-    persistentCookieWithMaxAge("gu_user_features_expiry", now)
+  private def userBenefitsExpiryCookie(now: DateTime) =
+    persistentCookieWithMaxAge("gu_user_benefits_expiry", now)
 
   def createCookiesForProduct(product: ProductType, now: DateTime): List[Cookie] = {
     // Setting the user benefits cookies used by frontend. See:
@@ -46,6 +46,6 @@ case class SubscriptionProductCookiesCreator(domain: GuardianDomain) {
       case _: GuardianAdLite => List(allowRejectAllCookie(now))
     }
 
-    userFeaturesExpiryCookie(now) :: productCookies
+    userBenefitsExpiryCookie(now) :: productCookies
   }
 }

--- a/support-frontend/assets/helpers/storage/contributionsCookies.ts
+++ b/support-frontend/assets/helpers/storage/contributionsCookies.ts
@@ -1,14 +1,14 @@
 import { set } from './cookie';
 
-const ONE_OFF_CONTRIBUTION_COOKIE_NAME = 'gu.contributions.contrib-timestamp';
-const ONE_OFF_CONTRIBUTION_COOKIE_NAME_DAYS_TO_LIVE = 90;
+const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
+const HIDE_SUPPORT_MESSAGING_DAYS_TO_LIVE = 90;
 
-export const setOneOffContributionCookie = (): void => {
+export const setHideSupportMessaginCookie = (): void => {
 	const currentTimeInEpochMilliseconds: number = Date.now();
 
 	set(
-		ONE_OFF_CONTRIBUTION_COOKIE_NAME,
+		HIDE_SUPPORT_MESSAGING_COOKIE,
 		currentTimeInEpochMilliseconds.toString(),
-		ONE_OFF_CONTRIBUTION_COOKIE_NAME_DAYS_TO_LIVE,
+		HIDE_SUPPORT_MESSAGING_DAYS_TO_LIVE,
 	);
 };

--- a/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
@@ -9,7 +9,7 @@ import { logException } from 'helpers/utilities/logger';
 import { roundToDecimalPlaces } from 'helpers/utilities/utilities';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
 import type { Participations } from '../../helpers/abTests/models';
-import { setOneOffContributionCookie } from '../../helpers/storage/contributionsCookies';
+import { setHideSupportMessaginCookie } from '../../helpers/storage/contributionsCookies';
 import { ThankYouComponent } from './components/thankYouComponent';
 
 type ThankYouProps = {
@@ -65,7 +65,7 @@ export function ThankYou({
 			finalAmount: finalAmount,
 		};
 
-		setOneOffContributionCookie();
+		setHideSupportMessaginCookie();
 	} else {
 		/** Recurring product must have product & ratePlan */
 		if (!product) {

--- a/support-frontend/test/controllers/SubscriptionProductCookiesCreatorTest.scala
+++ b/support-frontend/test/controllers/SubscriptionProductCookiesCreatorTest.scala
@@ -27,7 +27,7 @@ class SubscriptionProductCookiesCreatorTest extends AnyFlatSpec with Matchers {
 
     cookies should contain(expectedCookie("gu_allow_reject_all"))
     cookies should contain(
-      expectedCookie("gu_user_features_expiry"),
+      expectedCookie("gu_user_benefits_expiry"),
     ) // It should also contain the user features expiry cookie
   }
   it should "not set the hide support messaging cookie for Guardian Ad Lite because it is not a supporter product" in {
@@ -36,7 +36,7 @@ class SubscriptionProductCookiesCreatorTest extends AnyFlatSpec with Matchers {
 
     cookies should not contain expectedCookie("gu_hide_support_messaging")
     cookies should contain(
-      expectedCookie("gu_user_features_expiry"),
+      expectedCookie("gu_user_benefits_expiry"),
     ) // It should also contain the user features expiry cookie
   }
 
@@ -48,7 +48,7 @@ class SubscriptionProductCookiesCreatorTest extends AnyFlatSpec with Matchers {
     cookies should contain(expectedCookie("gu_hide_support_messaging"))
     cookies should contain(expectedCookie("gu_allow_reject_all"))
     cookies should contain(
-      expectedCookie("gu_user_features_expiry"),
+      expectedCookie("gu_user_benefits_expiry"),
     ) // It should also contain the user features expiry cookie
   }
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Some additional work on the cookies which support-frontend sets:
- Renames the gu_user_features_expiry to gu_user_benefits_expiry to match the same rename in DCR made [here](https://github.com/guardian/dotcom-rendering/pull/13277)
- Sets the gu_hide_support_messaging cookie on the succsessful completion of a one time contribution rather than the gu.contributions.contrib-timestamp cookie. This is to work with the new benefits mechanism introduced in the PR above
- Updates the DiagnosticController class which serves the /cookies page to only show currently relevant cookies