### PR TITLE
Digital Editions: Subscribe Landing Page ab-test simplification

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -131,13 +131,10 @@ export const tests: Tests = {
 		isActive: false,
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 7,
-		targetPage:
-			'(/uk/)(subscribe$|subscribe/digitaledition$|subscribe/digitaledition/thankyou$|checkout|thank-you)', // one-off test using canRun to exclude all products except DigitalSubscription
+		persistPage:
+			// uk will ensure we match the generic checkout
+			'(/uk/)(subscribe/digitaledition$|subscribe/digitaledition/thankyou$|checkout|thank-you)',
+		targetPage: '/subscribe$',
 		excludeContributionsOnlyCountries: true,
-		canRun: () => {
-			const urlSearchParams = new URLSearchParams(window.location.search);
-			const productParam = urlSearchParams.get('product');
-			return !productParam || productParam === 'DigitalSubscription';
-		},
 	},
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -133,7 +133,7 @@ export const tests: Tests = {
 		seed: 7,
 		persistPage:
 			// uk will ensure we match the generic checkout
-			'(/uk/)(subscribe/digitaledition$|subscribe/digitaledition/thankyou$|checkout|thank-you)',
+			'/uk/(subscribe/digitaledition$|subscribe/digitaledition/thankyou$|checkout|thank-you)',
 		targetPage: '/subscribe$',
 		excludeContributionsOnlyCountries: true,
 	},


### PR DESCRIPTION
## What are you doing in this PR?

ABTest: digitalEditionCheckout ->
- Remove non-required use of `canRun` 
- Replace with `persistsPage` instead.
