### PR TITLE
Digital Editions: Subscribe Landing Page digital edition mobile button spacing

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
@@ -524,7 +524,8 @@
 /****************** subscriptions__product-button ********************/
 
 .subscriptions__button-container,
-.subscriptions__button-container--feature {
+.subscriptions__button-container--feature,
+.subscriptions__button-container--feature--benefits {
 	display: block;
 
 	@include mq($from: phablet) {


### PR DESCRIPTION
## What are you doing in this PR?

Spacing bug in mobile, no margin-top between the dgital editions buttons

## Screenshots

|before|after|
|-----|-----|
|![image](https://github.com/user-attachments/assets/059e5b73-17ce-44c2-819b-c0ed801d39bc)|![image](https://github.com/user-attachments/assets/60f49fcc-0256-4935-b1d3-1ec705099c94)|