### PR TITLE
Revert "Set `aria-label` for checkout links on 3 tier landing page"

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
@@ -86,7 +86,6 @@ export function SupportOnce({
 					);
 				}}
 				data-qm-trackable="support-once-button"
-				aria-label="Support once"
 			>
 				Support now
 			</LinkButton>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -260,7 +260,6 @@ export function ThreeTierCard({
 					href={link}
 					cssOverrides={btnStyleOverrides}
 					data-qm-trackable={quantumMetricButtonRef}
-					aria-label={label}
 				>
 					{ctaCopy}
 				</LinkButton>


### PR DESCRIPTION
Reverts guardian/support-frontend#6776

Reverting this while I investigate a smoke test failure.