### PR TITLE
Set `aria-label` for checkout links on 3 tier landing page (attempt 2)

### DIFF
--- a/support-e2e/tests/smoke/promo-codes.test.ts
+++ b/support-e2e/tests/smoke/promo-codes.test.ts
@@ -20,6 +20,7 @@ import { setTestUserRequiredDetails } from '../utils/testUserDetails';
 		expectedCheckoutTotalText: 'Was £12, now £9.60/month',
 		expectedThankYouText:
 			/You'll pay £(\d|\.)+\/month for the first (\d|\.)+ months, then £(\d|\.)+\/month afterwards unless you cancel\./,
+		accessibleCtaText: 'All-access digital',
 	},
 	{
 		tier: 2,
@@ -31,6 +32,7 @@ import { setTestUserRequiredDetails } from '../utils/testUserDetails';
 		expectedCheckoutTotalText: /Was £(\d|\.)+, now £(\d|\.)+\/year/i,
 		expectedThankYouText:
 			/You'll pay £(\d|\.)+\/year for the first year, then £(\d|\.)+\/year afterwards unless you cancel\./i,
+		accessibleCtaText: 'All-access digital',
 	},
 ].forEach((testDetails) => {
 	test(`${testDetails.expectedCardHeading} ${testDetails.frequency} ${testDetails.promoCode}`, async ({
@@ -42,7 +44,6 @@ import { setTestUserRequiredDetails } from '../utils/testUserDetails';
 		const testFirstName = firstName();
 		const testLastName = lastName();
 		const testEmail = email();
-		const ctaCopy = 'Support';
 
 		await setupPage(
 			page,
@@ -60,8 +61,7 @@ import { setTestUserRequiredDetails } from '../utils/testUserDetails';
 			card.getByText(testDetails.expectedPromoText).first(),
 		).toBeVisible();
 		await page
-			.getByRole('link', { name: ctaCopy })
-			.nth(testDetails.tier - 1)
+			.getByRole('link', { name: testDetails.accessibleCtaText })
 			.click();
 
 		// Checkout

--- a/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
@@ -86,6 +86,7 @@ export function SupportOnce({
 					);
 				}}
 				data-qm-trackable="support-once-button"
+				aria-label="Support once"
 			>
 				Support now
 			</LinkButton>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -260,6 +260,7 @@ export function ThreeTierCard({
 					href={link}
 					cssOverrides={btnStyleOverrides}
 					data-qm-trackable={quantumMetricButtonRef}
+					aria-label={label}
 				>
 					{ctaCopy}
 				</LinkButton>


### PR DESCRIPTION

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This is a replay of #6776 which I reverted due to a smoke test failure. This version includes a small tweaks to the smoke tests and they now pass.


<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/Zvj6K3rU/614-add-3-tier-improve-subscribe-voiceover-accessibility)

## Why are you doing this?

The actual text on these links reads "Support" in every case, with the meaning coming from the context of the card. To make this clearer for screen readers set the aria-text to the product name/label.

Also add aria-label to the support once button.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
