### PR TITLE
Add a canonical link tag for the contributions landing page

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -345,9 +345,9 @@ class Application(
       priceSummaryServiceProvider.forUser(isTestUser).getPrices(TierThree, queryPromos)
 
     val productCatalog = cachedProductCatalogServiceProvider.fromStage(stage, isTestUser).get()
+    val canonicalLink = s"https://support.theguardian.com${buildCanonicalContributeLink(countryCode)}"
 
     views.html.contributions(
-      title = "Support the Guardian",
       id = s"contributions-landing-page-$countryCode",
       mainElement = mainElement,
       js = RefPath("[countryGroupId]/router.js"),
@@ -367,12 +367,12 @@ class Application(
       guestAccountCreationToken = guestAccountCreationToken,
       geoData = geoData,
       shareImageUrl = shareImageUrl(settings),
-      shareUrl = "https://support.theguardian.com/contribute",
       v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(isTestUser).v2PublicKey,
       serversideTests = serversideTests,
       allProductPrices = AllProductPrices(supporterPlusProductPrices, tierThreeProductPrices),
       productCatalog = productCatalog,
       noIndex = stage != PROD,
+      canonicalLink = canonicalLink,
     )
   }
 

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -10,7 +10,6 @@
 @import views.ViewHelpers.outputJson
 @import io.circe.JsonObject
 @(
-  title: String,
   id: String,
   mainElement: ReactDiv,
   js: RefPath,
@@ -23,15 +22,26 @@
   guestAccountCreationToken: Option[String],
   geoData: GeoData,
   shareImageUrl: String,
-  shareUrl: String,
   v2recaptchaConfigPublicKey: String,
   serversideTests: Map[String, Participation] = Map(),
   allProductPrices: AllProductPrices,
   productCatalog: JsonObject,
   noIndex: Boolean,
+  canonicalLink: String
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
-@main(title = title, mainJsBundle = js, description = description, mainElement = mainElement, mainStyleBundle = None, shareImageUrl = Some(shareImageUrl), shareUrl = Some(shareUrl), serversideTests = serversideTests, noindex = noIndex) {
+@main(
+  title = "Support the Guardian",
+  mainJsBundle = js,
+  description = description,
+  mainElement = mainElement,
+  mainStyleBundle = None,
+  shareImageUrl = Some(shareImageUrl),
+  shareUrl = Some(canonicalLink),
+  serversideTests = serversideTests,
+  noindex = noIndex,
+  canonicalLink = Some(canonicalLink)
+) {
   <script type="text/javascript">
     window.guardian = window.guardian || {};
     @idUser.map { user =>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We have an issue with Google failing to to index the US variant of the support checkout: [https://support.theguardian.com/us/contribute](https://support.theguardian.com/us/contribute "‌") .

All other regional variants of the `/contribute` route are indexed by Google eg. `uk/contribute` [https://search.google.com/search-console/inspect?resource\_id=sc-domain%3Asupport.theguardian.com&id=H5PfelVvg08EcNH\_uiooAA&hl=en-GB](https://search.google.com/search-console/inspect?resource_id=sc-domain%3Asupport.theguardian.com&id=H5PfelVvg08EcNH_uiooAA&hl=en-GB "‌"), however `us/contribute` cannot be indexed [https://search.google.com/search-console/inspect?resource_id=sc-domain%3Asupport.theguardian.com&id=7Zou81TL8dIg3wBxbshnhg&hl=en-GB](https://search.google.com/search-console/inspect?resource_id=sc-domain%3Asupport.theguardian.com&id=7Zou81TL8dIg3wBxbshnhg&hl=en-GB "‌"), because “Duplicate without user-selected canonical”.

Info on pages that Google couldn’t index because “Duplicate without user-selected canonical” is available here: [https://search.google.com/search-console/index/drilldown?resource\_id=sc-domain%3Asupport.theguardian.com&item\_key=CAMYDyAC&hl=en-GB](https://search.google.com/search-console/index/drilldown?resource_id=sc-domain%3Asupport.theguardian.com&item_key=CAMYDyAC&hl=en-GB "‌")

**Solution**

Google recommend setting a Canonical URL [https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-link-method](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-link-method "smartCard-inline") , we’re not currently doing this.

@:62d96a6a1d5eaf44c1569c7b and I agreed we should follow the recommendation and define the canonical URL in the HTML, as so  `<link rel="canonical" href="https://example.com/dresses/green-dresses" />`. The href should be the regional variant of the page so…

So in the US it’ll be “[https://support.theguardian.com/us/contribute](https://support.theguardian.com/us/contribute "‌")” for example.

[**Trello Card**](https://trello.com/c/BCvjNFt6/696-define-canonical-url-for-support-checkout-to-improve-google-indexing-performance)

## Screenshots
The contributions landing page now has a canonical link tag as shown in this screenshot
![Screenshot 2025-02-13 at 14 24 47](https://github.com/user-attachments/assets/ec7da1ca-08af-4061-b7ce-659c61b08c62)

