### PR TITLE
Landing Page: Support benefit updated for all regions except US

### DIFF
--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -103,7 +103,7 @@ const addFreeBenefit = {
 };
 
 const newsletterBenefit = {
-	copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+	copy: 'Give to the Guardian every month with Support',
 	specificToRegions: [
 		'GBPCountries',
 		'EURCountries',
@@ -112,6 +112,7 @@ const newsletterBenefit = {
 		'Canada',
 		'International',
 	] as CountryGroupId[],
+	hideBullet: true,
 };
 const newsletterBenefitUS = {
 	copy: 'Regular dispatches from the newsroom to see the impact of your support',

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -102,7 +102,7 @@ const addFreeBenefit = {
 	copy: 'Ad-free reading on all your devices',
 };
 
-const newsletterBenefit = {
+const supportBenefit = {
 	copy: 'Give to the Guardian every month with Support',
 	specificToRegions: [
 		'GBPCountries',
@@ -118,7 +118,7 @@ const newsletterBenefitUS = {
 	copy: 'Regular dispatches from the newsroom to see the impact of your support',
 	specificToRegions: ['UnitedStates'] as CountryGroupId[],
 };
-const newsletterBenefitAllAccessDigital = {
+const newsletterBenefit = {
 	copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
 	specificToRegions: [
 		'GBPCountries',
@@ -162,7 +162,7 @@ const feastBenefit = {
 const supporterPlusBenefits = [
 	appBenefit,
 	addFreeBenefit,
-	newsletterBenefitAllAccessDigital,
+	newsletterBenefit,
 	newsletterBenefitUS,
 	fewerAsksBenefit,
 	partnerOffersBenefit,
@@ -367,7 +367,7 @@ export const productCatalogDescription: Record<
 	},
 	Contribution: {
 		label: 'Support',
-		benefits: [newsletterBenefit, newsletterBenefitUS],
+		benefits: [supportBenefit, newsletterBenefitUS],
 		benefitsMissing: [
 			appBenefit,
 			addFreeBenefit,

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -123,6 +123,8 @@ const newsletterBenefit = {
 	specificToRegions: [
 		'GBPCountries',
 		'EURCountries',
+		'AUDCountries',
+		'NZDCountries',
 		'Canada',
 		'International',
 	] as CountryGroupId[],

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -118,6 +118,15 @@ const newsletterBenefitUS = {
 	copy: 'Regular dispatches from the newsroom to see the impact of your support',
 	specificToRegions: ['UnitedStates'] as CountryGroupId[],
 };
+const newsletterBenefitAllAccessDigital = {
+	copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+	specificToRegions: [
+		'GBPCountries',
+		'EURCountries',
+		'Canada',
+		'International',
+	] as CountryGroupId[],
+};
 const fewerAsksBenefit = {
 	copy: 'Far fewer asks for support',
 	tooltip: `You'll see far fewer financial support asks at the bottom of articles or in pop-up banners.`,
@@ -153,7 +162,7 @@ const feastBenefit = {
 const supporterPlusBenefits = [
 	appBenefit,
 	addFreeBenefit,
-	newsletterBenefit,
+	newsletterBenefitAllAccessDigital,
 	newsletterBenefitUS,
 	fewerAsksBenefit,
 	partnerOffersBenefit,


### PR DESCRIPTION
## What are you doing in this PR?

- Support Card benefits should now read `Give to the Guardian every month with Support` 
- Support Card has bullet hidden
- US specific copy and bullet remains unchanged.
- All-Access-Digital remains with `Exclusive newsletter for supporters, sent every week from the Guardian newsroom` benefit

[**Trello Card**](https://trello.com/c/V6mQcUiU/1409-remove-newsletter-benefit-from-tier-1-but-keep-in-s-for-tax-reasons-global-change-excluding-the-us)

## Screenshots

|before|after|
|-----|-----|
|![image](https://github.com/user-attachments/assets/679c3485-bf6b-440e-91c5-67c3aab349c5)|![image](https://github.com/user-attachments/assets/60ceb61d-921b-40d5-a264-a016dfcf6c87)|
