### PR TITLE
GuardianAdLite: Add Landing Page poster image

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/posterComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/posterComponent.tsx
@@ -81,7 +81,7 @@ const image = css`
 	}
 `;
 
-const posterImageUrl = `https://i.guim.co.uk/img/media/a3e6d39656007bf310093a2a934155abbfe10a49/0_0_794_794/794.png?width=500&quality=75&s=e74bca9368c32efdf60855a9ac714f17`;
+const posterImageUrl = `https://i.guim.co.uk/img/media/c64768218dc3fa9fe8294038e8f9e31920f9beaa/0_0_341_336/341.png?width=341&quality=75&s=dab7519a52c1eb0fc3442600a0572ceb`;
 
 export function PosterComponent(): JSX.Element {
 	return (


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Inserts (guim optimised) poster image onto Guardian Ad-Lite Landing Page

[**Trello Card**](https://trello.com/c/mocDMfVV/1405-guardian-ad-lite-landing-page-image-update)

## Screenshots

|before|after|
|-----|-----|
|![image](https://github.com/user-attachments/assets/468469cc-2af5-4066-b28b-09183b4ddbca)|![image](https://github.com/user-attachments/assets/442956d9-e0f1-4fb1-9b05-7c34bdcb0b11)|