### PR TITLE
round print saving vs retail % down

### DIFF
--- a/support-frontend/assets/helpers/productPrice/productPrices.test.ts
+++ b/support-frontend/assets/helpers/productPrice/productPrices.test.ts
@@ -3,6 +3,6 @@ import { getDiscountVsRetail } from './productPrices';
 describe('getDiscountVsRetail', () => {
 	it('calculates total discount vs retail', () => {
 		const discount = getDiscountVsRetail(48.79, 27, 20);
-		expect(discount).toEqual(42);
+		expect(discount).toEqual(41);
 	});
 });

--- a/support-frontend/assets/helpers/productPrice/productPrices.ts
+++ b/support-frontend/assets/helpers/productPrice/productPrices.ts
@@ -96,7 +96,12 @@ const getDiscountVsRetail = (
 	const onlinePrice = discountedPrice / (1 - discountedVsOnlinePerc / 100);
 	const retailPrice = onlinePrice / (1 - onlineVsRetailPerc / 100);
 	const totalSavingVsRetail = (1 - discountedPrice / retailPrice) * 100;
-	return Math.round(totalSavingVsRetail);
+	/**
+	 * We should never overstate a discount,
+	 * even by a fraction of a %. Therefore
+	 * we always round down to the nearest whole number.
+	 */
+	return Math.floor(totalSavingVsRetail);
 };
 
 export {


### PR DESCRIPTION
## What are you doing in this PR?

`getDiscountVsRetail` returns the "saving vs retail" % to show on a pricing card on the print subscriptions pages when a promotion is applied. Marketing have stated that we should never overstate a discount, even by a fraction of a %, so a saving vs retail of 5.75% should be advertised as 5%, not 6% as it is now. Therefore we always round down to the nearest whole number.

