### PR TITLE
Generic Checkout: Enables confirm email address 

### DIFF
--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -58,8 +58,7 @@ export const testCheckout = (testDetails: TestDetails) => {
 		context,
 		baseURL,
 	}) => {
-		// Temporary opt out of this test
-		const url = `/${internationalisationId.toLowerCase()}/checkout?product=${product}&ratePlan=${ratePlan}#ab-confirmEmail=control`;
+		const url = `/${internationalisationId.toLowerCase()}/checkout?product=${product}&ratePlan=${ratePlan}`;
 		const page = await context.newPage();
 		await setupPage(page, context, baseURL, url);
 

--- a/support-e2e/tests/utils/testUserDetails.ts
+++ b/support-e2e/tests/utils/testUserDetails.ts
@@ -7,7 +7,8 @@ export const setTestUserRequiredDetails = async (
 	firstName?: string,
 	lastName?: string,
 ) => {
-	await page.getByLabel('Email address').fill(email);
+	await page.getByLabel('Email address', { exact: true }).fill(email);
+	await page.getByLabel('Confirm email address', { exact: true }).fill(email);
 	if (firstName) {
 		await page.getByLabel('First name').fill(firstName);
 	}

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -92,27 +92,6 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeContributionsOnlyCountries: true,
 	},
-	confirmEmail: {
-		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'variant',
-			},
-		],
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		isActive: true,
-		referrerControlled: false, // ab-test name not needed to be in paramURL
-		seed: 5,
-		targetPage: pageUrlRegexes.contributions.genericCheckoutOnly,
-		excludeContributionsOnlyCountries: false,
-	},
 	digitalEditionCheckout: {
 		variants: [
 			{

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
@@ -15,7 +15,6 @@ type PersonalDetailsFieldsProps = {
 	email: string;
 	setEmail: (value: string) => void;
 	isEmailAddressReadOnly: boolean;
-	requireConfirmedEmail: boolean;
 	confirmedEmail: string;
 	setConfirmedEmail: (value: string) => void;
 };
@@ -29,7 +28,6 @@ export function PersonalDetailsFields({
 	email,
 	setEmail,
 	isEmailAddressReadOnly,
-	requireConfirmedEmail,
 	confirmedEmail,
 	setConfirmedEmail,
 }: PersonalDetailsFieldsProps) {
@@ -74,7 +72,7 @@ export function PersonalDetailsFields({
 					}}
 				/>
 			</div>
-			{requireConfirmedEmail && !isEmailAddressReadOnly && (
+			{!isEmailAddressReadOnly && (
 				<div>
 					<TextInput
 						id="confirm-email"

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -261,8 +261,6 @@ export function CheckoutComponent({
 		abParticipations.newspaperArchiveBenefit ?? '',
 	);
 
-	const inConfirmEmailVariant = abParticipations.confirmEmail === 'variant';
-
 	const productDescription = showNewspaperArchiveBenefit
 		? productCatalogDescriptionNewBenefits(countryGroupId)[productKey]
 		: productCatalogDescription[productKey];
@@ -937,7 +935,6 @@ export function CheckoutComponent({
 								setLastName={(lastName) => setLastName(lastName)}
 								email={email}
 								setEmail={(email) => setEmail(email)}
-								requireConfirmedEmail={inConfirmEmailVariant}
 								confirmedEmail={confirmedEmail}
 								setConfirmedEmail={(confirmedEmail) =>
 									setConfirmedEmail(confirmedEmail)


### PR DESCRIPTION
## What are you doing in this PR?

- Remove the abtest `ab-confirmEmail`
- Apply the `variant` to Production (confirm email applied)

[**Trello Card**](https://trello.com/c/yyvdWPKo/1418-end-confirm-email-a-b-test-and-keep-variant-with-confirmation-field)

## Screenshots

|from|to|
|-----|-----|
|![image](https://github.com/user-attachments/assets/65b62632-c5cd-4f8f-8299-107f3773db0e)|![image](https://github.com/user-attachments/assets/95d9173c-9011-4a1a-abd6-5e24c55234d1)|