### PR TITLE
One-Time-Checkout: check stripe elements available before enabling stripe express checkout

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -287,23 +287,26 @@ export function OneTimeCheckoutComponent({
 		coverTransactionCost,
 	);
 
+	const elements = useElements();
+	useEffect(() => {
+		if (finalAmount && elements) {
+			// valid elements and final amount, set amount, enable Express checkout
+			elements.update({ amount: finalAmount * 100 });
+			setStripeExpressCheckoutEnable(true);
+		} else {
+			// invalid elements and final amount, disable Express checkout
+			setStripeExpressCheckoutEnable(false);
+		}
+	}, [finalAmount, elements]);
 	useEffect(() => {
 		if (finalAmount) {
-			// valid final amount, set amount, enable Express checkout
-			elements?.update({ amount: finalAmount * 100 });
-			setStripeExpressCheckoutEnable(true);
-
-			// Track amount selection with QM
+			// Track valid final amount selection with QM
 			sendEventOneTimeCheckoutValue(finalAmount, currencyKey);
-		} else {
-			// invalid final amount, disable Express checkout
-			setStripeExpressCheckoutEnable(false);
 		}
 	}, [finalAmount]);
 
 	/** Payment methods: Stripe */
 	const stripe = useStripe();
-	const elements = useElements();
 	const cardElement = elements?.getElement(CardNumberElement);
 	const [
 		stripeExpressCheckoutPaymentType,
@@ -641,7 +644,6 @@ export function OneTimeCheckoutComponent({
 										const options = {
 											emailRequired: true,
 										};
-
 										// Track payment method selection with QM
 										sendEventPaymentMethodSelected(
 											'StripeExpressCheckoutElement',


### PR DESCRIPTION
## What are you doing in this PR?

SEVERITY 2 BUG

One-Time-Checkout ->
- ApplePay/GooglePay/PayPal amount on PriceCard not reflected in checkout
- StripeExpressCheckout, upon initial load, is defaulting to minimum amount not the PriceCard shown

Therefore, check stripe elements available before enabling stripe express checkout.  

[**Trello Card**](https://trello.com/c/q5Jt80mO/1443-severity-2-medium-bug-report-218-system-impacted-guardian-checkout-supporttheguardiancom-guardian-website)

## How to test

Checkout via any of three payment methods above without selecting a PriceCard and view amount on checkout screen.

## Screenshots

Before
|onetimecheckout|from|to|
|-----|-----|-----|
|![image](https://github.com/user-attachments/assets/8aa7baed-d650-432d-a6b3-91da1a31af0f)|![image](https://github.com/user-attachments/assets/03c05341-7d6f-4f95-9f4b-20317869fcff)|![image](https://github.com/user-attachments/assets/e701d725-147b-46cd-aca5-704bec8411a6)|


After
