### PR TITLE
Remove persisted A/B test participations on country group change

### DIFF
--- a/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx
+++ b/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx
@@ -8,6 +8,7 @@ import { useRef, useState } from 'react';
 import Dialog from 'components/dialog/dialog';
 import Menu, { LinkItem } from 'components/menu/menu';
 import SvgDropdownArrow from 'components/svgs/dropdownArrow';
+import { clearParticipationsFromSession } from 'helpers/abTests/abtest';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
 import { currencies } from 'helpers/internationalisation/currency';
@@ -123,6 +124,10 @@ function CountryGroupSwitcher({
 								})();
 
 								onCountryGroupSelect(countryGroupId);
+
+								if (countryGroupId !== selectedCountryGroup) {
+									clearParticipationsFromSession();
+								}
 							}}
 							isSelected={countryGroupId === selectedCountryGroup}
 						>

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -235,6 +235,10 @@ function getParticipationsFromSession(): Participations | undefined {
 	return undefined;
 }
 
+function clearParticipationsFromSession(): void {
+	storage.setSession('abParticipations', JSON.stringify({}));
+}
+
 function getServerSideParticipations(): Participations | null | undefined {
 	if (window.guardian.serversideTests) {
 		return window.guardian.serversideTests;
@@ -619,7 +623,7 @@ function targetPageMatches(
 	return locationPath.match(targetPage) != null;
 }
 
-export { init, getAmountsTestVariant };
+export { init, getAmountsTestVariant, clearParticipationsFromSession };
 
 // Exported for testing only
 export const _ = {


### PR DESCRIPTION
## What are you doing in this PR?

When the user changes their country group, clear any previously persisted A/B test participations. 

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/yWgx6fqN/1363-ab-test-allocation-issues-session-storage-country)

## Why are you doing this?

This is to prevent users being incorrectly attributed to an A/B test variant for a country they were previously in after changing their country code via the dropdown. We considered adding an extra layer to the persisted A/B tests to index by country but decided this was covering such an edge case that it'd be clearer just to delete all their participations.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Visit a page which puts you into a persisted test. See that it appears in session storage:

<img width="452" alt="Screenshot 2025-02-14 at 15 54 48" src="https://github.com/user-attachments/assets/a277f77c-aabb-477b-8645-1f810ea70793" />

No visit the 3 tier checkout and change your country group. See that the session storage item has been reset:

<img width="247" alt="Screenshot 2025-02-14 at 15 56 04" src="https://github.com/user-attachments/assets/9d7f6894-0930-42e0-806e-39872aeb8a50" />


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
