### PR TITLE
Upgrade the AWS SDK v2 version from 2.29.17 to 2.30.21

### DIFF
--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -3,7 +3,7 @@ object LibraryVersions {
 
   @deprecated("use awsClientVersion2")
   val awsClientVersion = "1.12.703"
-  val awsClientVersion2 = "2.29.17"
+  val awsClientVersion2 = "2.30.21"
 
   val catsVersion = "2.10.0"
   val jacksonVersion = "2.15.2"


### PR DESCRIPTION
## What are you doing in this PR?

Update the AWS SDK v2 version.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

This pulls in a newer version of io.netty:netty-handler which dependabot has reported a vulnerability for.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Verified that the smoke tests pass on this branch.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
