### PR TITLE
One-Time-Checkout: stripe express checkout valid default one-off card amount supply to one-time component checkout

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -289,19 +289,16 @@ export function OneTimeCheckoutComponent({
 
 	const elements = useElements();
 	useEffect(() => {
-		if (finalAmount && elements) {
-			// valid elements and final amount, set amount, enable Express checkout
-			elements.update({ amount: finalAmount * 100 });
-			setStripeExpressCheckoutEnable(true);
-		} else {
-			// invalid elements and final amount, disable Express checkout
-			setStripeExpressCheckoutEnable(false);
-		}
-	}, [finalAmount, elements]);
-	useEffect(() => {
 		if (finalAmount) {
-			// Track valid final amount selection with QM
+			// valid final amount, set amount, enable Express checkout
+			elements?.update({ amount: finalAmount * 100 });
+			setStripeExpressCheckoutEnable(true);
+
+			// Track amount selection with QM
 			sendEventOneTimeCheckoutValue(finalAmount, currencyKey);
+		} else {
+			// invalid final amount, disable Express checkout
+			setStripeExpressCheckoutEnable(false);
 		}
 	}, [finalAmount]);
 

--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -1,7 +1,8 @@
 import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
-import { config } from 'helpers/contributions';
+import { getAmountsTestVariant } from 'helpers/abTests/abtest';
 import { getStripeKey } from 'helpers/forms/stripe';
+import { getSettings } from 'helpers/globalsAndSwitches/globals';
 import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import { Country } from 'helpers/internationalisation/classes/country';
 import * as cookie from 'helpers/storage/cookie';
@@ -34,7 +35,15 @@ export function OneTimeCheckout({
 
 	const stripePromise = loadStripe(stripePublicKey);
 
-	const minAmount = config[countryGroupId]['ONE_OFF'].min;
+	const settings = getSettings();
+	const { selectedAmountsVariant } = getAmountsTestVariant(
+		countryId,
+		countryGroupId,
+		settings,
+	);
+	const { amountsCardData } = selectedAmountsVariant;
+	const { defaultAmount } = amountsCardData['ONE_OFF'];
+
 	const elementsOptions = {
 		mode: 'payment',
 		/**
@@ -42,7 +51,7 @@ export function OneTimeCheckout({
 		 * @see https://docs.stripe.com/api/charges/object
 		 * @see https://docs.stripe.com/currencies#zero-decimal
 		 */
-		amount: minAmount * 100,
+		amount: defaultAmount * 100,
 		currency: currencyKey.toLowerCase(),
 		paymentMethodCreation: 'manual',
 	} as const;


### PR DESCRIPTION
## What are you doing in this PR?

SEVERITY 2 BUG - ALTERNATIVE  CHANGE

One-Time-Checkout ->
- ApplePay/GooglePay/PayPal amount on PriceCard not reflected in checkout
- StripeExpressCheckout, upon initial load, is defaulting to minimum amount not the PriceCard shown

Therefore, check stripe elements available before enabling stripe express checkout.  

[**Trello Card**](https://trello.com/c/q5Jt80mO/1443-severity-2-medium-bug-report-218-system-impacted-guardian-checkout-supporttheguardiancom-guardian-website)

## How to test

Checkout via any of three payment methods above without selecting a PriceCard and view amount on checkout screen.

## Screenshots

Before
|onetimecheckout|from|to|
|-----|-----|-----|
|![image](https://github.com/user-attachments/assets/8aa7baed-d650-432d-a6b3-91da1a31af0f)|![image](https://github.com/user-attachments/assets/03c05341-7d6f-4f95-9f4b-20317869fcff)|![image](https://github.com/user-attachments/assets/e701d725-147b-46cd-aca5-704bec8411a6)|


After
