### PR TITLE
Playwright Tests: Confirm email address, not required for the One-Time-Checkout

### DIFF
--- a/support-e2e/tests/test/oneTimeCheckout.ts
+++ b/support-e2e/tests/test/oneTimeCheckout.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { email, firstName, lastName } from '../utils/users';
 import { setupPage } from '../utils/page';
-import { setTestUserRequiredDetailsNoEmailConfirmation } from '../utils/testUserDetails';
+import { setTestUserRequiredDetails } from '../utils/testUserDetails';
 import { fillInPayPalDetails } from '../utils/paypal';
 import {
 	fillInCardDetails,
@@ -31,7 +31,13 @@ export const testOneTimeCheckout = (testDetails: TestDetails) => {
 		const page = await context.newPage();
 		const testEmail = email();
 		await setupPage(page, context, baseURL, url);
-		await setTestUserRequiredDetailsNoEmailConfirmation(page, testEmail);
+		await setTestUserRequiredDetails(
+			page,
+			testEmail,
+			undefined,
+			undefined,
+			true,
+		);
 		await page.getByRole('radio', { name: paymentType }).check();
 
 		if (paymentType === 'Credit/Debit card') {

--- a/support-e2e/tests/test/oneTimeCheckout.ts
+++ b/support-e2e/tests/test/oneTimeCheckout.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { email, firstName, lastName } from '../utils/users';
 import { setupPage } from '../utils/page';
-import { setTestUserRequiredDetails } from '../utils/testUserDetails';
+import { setTestUserRequiredDetailsNoEmailConfirmation } from '../utils/testUserDetails';
 import { fillInPayPalDetails } from '../utils/paypal';
 import {
 	fillInCardDetails,
@@ -31,7 +31,7 @@ export const testOneTimeCheckout = (testDetails: TestDetails) => {
 		const page = await context.newPage();
 		const testEmail = email();
 		await setupPage(page, context, baseURL, url);
-		await setTestUserRequiredDetails(page, testEmail);
+		await setTestUserRequiredDetailsNoEmailConfirmation(page, testEmail);
 		await page.getByRole('radio', { name: paymentType }).check();
 
 		if (paymentType === 'Credit/Debit card') {

--- a/support-e2e/tests/utils/testUserDetails.ts
+++ b/support-e2e/tests/utils/testUserDetails.ts
@@ -1,15 +1,6 @@
 import { Page } from '@playwright/test';
 import { TestFields } from './userFields';
 
-export const setTestUserRequiredDetailsNoEmailConfirmation = async (
-	page: Page,
-	email: string,
-	firstName?: string,
-	lastName?: string,
-) => {
-	return setTestUserRequiredDetails(page, email, firstName, lastName, true);
-};
-
 export const setTestUserRequiredDetails = async (
 	page: Page,
 	email: string,

--- a/support-e2e/tests/utils/testUserDetails.ts
+++ b/support-e2e/tests/utils/testUserDetails.ts
@@ -1,14 +1,26 @@
 import { Page } from '@playwright/test';
 import { TestFields } from './userFields';
 
-export const setTestUserRequiredDetails = async (
+export const setTestUserRequiredDetailsNoEmailConfirmation = async (
 	page: Page,
 	email: string,
 	firstName?: string,
 	lastName?: string,
 ) => {
+	return setTestUserRequiredDetails(page, email, firstName, lastName, true);
+};
+
+export const setTestUserRequiredDetails = async (
+	page: Page,
+	email: string,
+	firstName?: string,
+	lastName?: string,
+	noEmailConfirmation?: boolean,
+) => {
 	await page.getByLabel('Email address', { exact: true }).fill(email);
-	await page.getByLabel('Confirm email address', { exact: true }).fill(email);
+	if (!noEmailConfirmation) {
+		await page.getByLabel('Confirm email address', { exact: true }).fill(email);
+	}
 	if (firstName) {
 		await page.getByLabel('First name').fill(firstName);
 	}


### PR DESCRIPTION
## What are you doing in this PR?

After enabling the [confirmEmail PR](https://github.com/guardian/support-frontend/pull/6784).

- Playwright tests for the `checkout` were correctd.
- This correction was in-advertantly applied to the `one-time-checkout` which, currently, has no `confirmEmail`

Thse tests are failing and requirement modification.

[**Trello Card**](https://trello.com/c/yyvdWPKo/1418-end-confirm-email-a-b-test-and-keep-variant-with-confirmation-field)

## How to test
`/support-e2e/yarn test-smoke-dev`
`/support-e2e/yarn test-cron-dev`

