### PR TITLE
Guardian Ad-Lite:  Apply CORP_FLAG param to AcceptAll LandingPage journey

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/guardianAdLiteLanding.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/guardianAdLiteLanding.tsx
@@ -34,12 +34,14 @@ export function GuardianAdLiteLanding({
 	 */
 	const urlSearchParams = new URLSearchParams(window.location.search);
 	const urlSearchParamsReturn = urlSearchParams.get('returnAddress');
-	/* CORP_FLAG is a shortened query parameter
-     appended to enable the CODE environment ConsentOrPay Banner
-     assuming they are not an ad-free reader (via cookie gu_allow_reject_all) */
-	const urlSearchParamsCorpFlag =
-		urlSearchParams.get('CORP_FLAG') === null ? '' : '?CORP_FLAG';
 	if (urlSearchParamsReturn) {
+		/* CORP_FLAG is a shortened query parameter
+		 * appended to enable the CODE environment ConsentOrPay Banner
+		 * assuming they are NOT an ad-free reader
+		 * (missing cookie gu_allow_reject_all)
+		 */
+		const urlSearchParamsCorpFlag =
+			urlSearchParams.get('CORP_FLAG') === null ? '' : '?CORP_FLAG';
 		setReturnAddress({
 			link: `${urlSearchParamsReturn}${urlSearchParamsCorpFlag}`,
 		});

--- a/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/guardianAdLiteLanding.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/guardianAdLiteLanding.tsx
@@ -34,8 +34,15 @@ export function GuardianAdLiteLanding({
 	 */
 	const urlSearchParams = new URLSearchParams(window.location.search);
 	const urlSearchParamsReturn = urlSearchParams.get('returnAddress');
+	/* CORP_FLAG is a shortened query parameter
+     appended to enable the CODE environment ConsentOrPay Banner
+     assuming they are not an ad-free reader (via cookie gu_allow_reject_all) */
+	const urlSearchParamsCorpFlag =
+		urlSearchParams.get('CORP_FLAG') === null ? '' : '?CORP_FLAG';
 	if (urlSearchParamsReturn) {
-		setReturnAddress({ link: urlSearchParamsReturn });
+		setReturnAddress({
+			link: `${urlSearchParamsReturn}${urlSearchParamsCorpFlag}`,
+		});
 	}
 	return (
 		<LandingPageLayout countrySwitcherProps={countrySwitcherProps}>


### PR DESCRIPTION
## What are you doing in this PR?

On `www.theguardian CODE` (only) an extra `CORP_FLAG` param Url  is applied and passed onto the Guardian Ad-Lite Landing Page.

We would like to return this back the preceding page when `Accept All (Go Back)` is pressed (or equivalent returns). This link is stored within Session Storage.

## Why are you doing this?

Without this param, `www.theguardian CODE` (only) will not display the  ConsentOrPay Banner.

[**Trello Card**](https://trello.com/c/9THWcrpe/1453-store-and-return-all-paramurls-on-the-ad-lite-landing-page)

## How to test

https://support.thegulocal.com/uk/guardian-ad-lite?returnAddress=https%3A%2F%2Fwww.theguardian.com%2Fus&CORP_FLAG
Should return via `Accept All (Go Back)` to https://www.theguardian.com/us?CORP_FLAG
