### PR TITLE
Subscribe: Landing Page update to Saturday as cheapest paper package

### DIFF
--- a/support-frontend/app/controllers/SubscriptionsController.scala
+++ b/support-frontend/app/controllers/SubscriptionsController.scala
@@ -65,7 +65,7 @@ class SubscriptionsController(
 
     val paperMap = if (countryGroup == CountryGroup.UK) {
       val paper = service.getPrices(Paper, Nil)(CountryGroup.UK)(HomeDelivery)(
-        Weekend,
+        Saturday,
       )(Monthly)(GBP)
       Map(Paper.toString -> pricingCopy(paper))
     } else


### PR DESCRIPTION
## What are you doing in this PR?

Cheapeast NewPaper Delivery advertised as £33.99.

Change to Staurday (currently) £20.99

[**Trello Card**](https://trello.com/c/WcSwWgt4/1425-update-subscribe-landing-page-to-reflect-cheapest-newspaper-product-wrong-price-atm)

![image](https://github.com/user-attachments/assets/25ea3a15-409b-4918-8ab5-9f6c2dc0a66d)
