### PR TITLE
Bump @guardian/libs to 21.3.0

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -82,7 +82,7 @@
 		"@emotion/react": "^11.11.1",
 		"@emotion/utils": "^1.1.0",
 		"@floating-ui/react": "^0.19.2",
-		"@guardian/libs": "^21.1.0",
+		"@guardian/libs": "^21.3.0",
 		"@guardian/pasteup": "1.0.0-alpha.7",
 		"@guardian/source": "8.0.0",
 		"@guardian/source-development-kitchen": "13.1.0",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1809,10 +1809,10 @@
     eslint-plugin-eslint-comments "3.2.0"
     eslint-plugin-import "2.29.1"
 
-"@guardian/libs@^21.1.0":
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-21.1.0.tgz#24450f6fd87363177fe96f516e255ad44120ed1c"
-  integrity sha512-M02tJniKcRDLYPIxJ/KYViLTjugjnzmNi/UTDKZm38xc6hjOPNnhFPBw59W2DlGENrMt58+m7qYAcdMmcEp+KQ==
+"@guardian/libs@^21.3.0":
+  version "21.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-21.3.0.tgz#57318ade3a1069d9b924988f3615d8d5fde03149"
+  integrity sha512-uFYUEkykB4w1X2299PnuaBDvjJIqnuJkZLKpqxCrUTahuarISe/0T14hNIs03inpruuxVdBBG6ecm9mEF9MqEQ==
 
 "@guardian/pasteup@1.0.0-alpha.7":
   version "1.0.0-alpha.7"


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
