### PR TITLE
update test user expiry to 2 days

### DIFF
--- a/support-frontend/app/controllers/TestUsersManagement.scala
+++ b/support-frontend/app/controllers/TestUsersManagement.scala
@@ -28,7 +28,7 @@ class TestUsersManagement(
         Cookie(
           "_test_username",
           testUser.token,
-          maxAge = Some(24 * 60 * 2),
+          maxAge = Some(2 * 24 * 60 * 60),// in seconds
           httpOnly = false,
           domain = Some(cookieDomain.value),
         ),


### PR DESCRIPTION
I noticed that there was a fix in https://github.com/guardian/support-frontend/pull/6556 to make the test users expire after 2 days.

However the [maxAge is defined in seconds](https://www.playframework.com/documentation/3.0.0/api/java/play/core/cookie/encoding/Cookie.html#maxAge()) rather than minutes, meaning that we only actually got 48 minutes of lifetime for the cookie.

This PR changes it so that we calculate the seconds instead of minutes when setting the maxAge.