### PR TITLE
Make the generic checkout work for Home Delivery and Subscription Card subscriptions

### DIFF
--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -16,10 +16,7 @@ import type { Country } from 'helpers/internationalisation/countries';
 import type { IsoCountry, UsState } from 'helpers/internationalisation/country';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import type {
-	ActivePaperProducts,
-	ProductOptions,
-} from 'helpers/productPrice/productOptions';
+import type { ProductOptions } from 'helpers/productPrice/productOptions';
 import type { ReaderType } from 'helpers/productPrice/readerType';
 import type {
 	DigitalPack,
@@ -84,12 +81,12 @@ type DigitalSubscription = {
 	readerType: ReaderType;
 	amount?: number;
 };
-export type PaperSubscription = {
+type PaperSubscription = {
 	productType: typeof Paper;
 	currency: string;
 	billingPeriod: BillingPeriod;
 	fulfilmentOptions: FulfilmentOptions;
-	productOptions: ActivePaperProducts;
+	productOptions: ProductOptions;
 	deliveryAgent?: number;
 };
 type GuardianWeeklySubscription = {

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -16,7 +16,10 @@ import type { Country } from 'helpers/internationalisation/countries';
 import type { IsoCountry, UsState } from 'helpers/internationalisation/country';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import type { ProductOptions } from 'helpers/productPrice/productOptions';
+import type {
+	ActivePaperProducts,
+	ProductOptions,
+} from 'helpers/productPrice/productOptions';
 import type { ReaderType } from 'helpers/productPrice/readerType';
 import type {
 	DigitalPack,
@@ -81,12 +84,12 @@ type DigitalSubscription = {
 	readerType: ReaderType;
 	amount?: number;
 };
-type PaperSubscription = {
+export type PaperSubscription = {
 	productType: typeof Paper;
 	currency: string;
 	billingPeriod: BillingPeriod;
 	fulfilmentOptions: FulfilmentOptions;
-	productOptions: ProductOptions;
+	productOptions: ActivePaperProducts;
 	deliveryAgent?: number;
 };
 type GuardianWeeklySubscription = {

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -349,6 +349,7 @@ export const productCatalogDescription: Record<
 	SubscriptionCard: {
 		label: 'Newspaper subscription',
 		benefits: [],
+		deliverableTo: newspaperCountries,
 		ratePlans: {
 			Sixday: {
 				billingPeriod: 'Monthly',

--- a/support-frontend/assets/helpers/productPrice/fulfilmentOptions.ts
+++ b/support-frontend/assets/helpers/productPrice/fulfilmentOptions.ts
@@ -1,4 +1,5 @@
 // Fulfilment options describe the various ways that a user can receive a product
+import type { ActiveProductKey } from '@guardian/support-service-lambdas/modules/product-catalog/src/productCatalog';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
 
@@ -38,7 +39,7 @@ const getWeeklyFulfilmentOption = (
 		: Domestic;
 
 export const getFulfilmentOptionFromProductKey = (
-	productKey: string,
+	productKey: ActiveProductKey,
 ): FulfilmentOptions => {
 	switch (productKey) {
 		case 'SupporterPlus':

--- a/support-frontend/assets/helpers/productPrice/fulfilmentOptions.ts
+++ b/support-frontend/assets/helpers/productPrice/fulfilmentOptions.ts
@@ -37,4 +37,28 @@ const getWeeklyFulfilmentOption = (
 		? RestOfWorld
 		: Domestic;
 
+export const getFulfilmentOptionFromProductKey = (
+	productKey: string,
+): FulfilmentOptions => {
+	switch (productKey) {
+		case 'SupporterPlus':
+		case 'Contribution':
+			return 'NoFulfilmentOptions';
+		case 'TierThree':
+		case 'GuardianWeeklyDomestic':
+			return 'Domestic';
+		case 'GuardianWeeklyRestOfWorld':
+			return 'RestOfWorld';
+		case 'SubscriptionCard':
+			return 'Collection';
+		case 'NationalDelivery':
+		case 'HomeDelivery':
+			return productKey;
+		default:
+			throw new Error(
+				`Fulfilment option not defined for product ${productKey}`,
+			);
+	}
+};
+
 export { getWeeklyFulfilmentOption };

--- a/support-frontend/assets/helpers/productPrice/productOptions.ts
+++ b/support-frontend/assets/helpers/productPrice/productOptions.ts
@@ -38,6 +38,14 @@ const ActivePaperProductTypes = [Everyday, Weekend, Saturday] as const;
 export type ActivePaperProductOptions =
 	(typeof ActivePaperProductTypes)[number];
 
+export const isActivePaperProductOption = (
+	productOption: ProductOptions,
+): productOption is ActivePaperProductOptions => {
+	return ActivePaperProductTypes.includes(
+		productOption as ActivePaperProductOptions,
+	);
+};
+
 const paperProductsWithDigital = {
 	Saturday: SaturdayPlus,
 	Sunday: SundayPlus,

--- a/support-frontend/assets/helpers/productPrice/productOptions.ts
+++ b/support-frontend/assets/helpers/productPrice/productOptions.ts
@@ -69,6 +69,37 @@ function productOptionIfDigiAddOnChanged(
 	return matchingProducLookup[selectedOption];
 }
 
+const getPaperProductOptions = (ratePlanKey: string): ProductOptions => {
+	switch (ratePlanKey) {
+		case 'Saturday':
+		case 'Sunday':
+		case 'Weekend':
+		case 'Sixday':
+		case 'Everyday':
+			return ratePlanKey;
+	}
+	throw new Error(
+		`Paper product option not defined for ratePlan ${ratePlanKey}`,
+	);
+};
+export const getProductOptionFromProductAndRatePlan = (
+	productKey: string,
+	ratePlanKey: string,
+): ProductOptions => {
+	switch (productKey) {
+		case 'TierThree':
+			return ratePlanKey.endsWith('V2')
+				? 'NewspaperArchive'
+				: 'NoProductOptions';
+		case 'SubscriptionCard':
+		case 'NationalDelivery':
+		case 'HomeDelivery':
+			return getPaperProductOptions(ratePlanKey);
+		default:
+			return 'NoProductOptions';
+	}
+};
+
 export {
 	NoProductOptions,
 	Saturday,

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -6,8 +6,11 @@ import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import { Country } from 'helpers/internationalisation/classes/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { isProductKey, productCatalog } from 'helpers/productCatalog';
-import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import { type ProductOptions } from 'helpers/productPrice/productOptions';
+import { getFulfilmentOptionFromProductKey } from 'helpers/productPrice/fulfilmentOptions';
+import {
+	getProductOptionFromProductAndRatePlan,
+	type ProductOptions,
+} from 'helpers/productPrice/productOptions';
 import { getPromotion } from 'helpers/productPrice/promotions';
 import * as cookie from 'helpers/storage/cookie';
 import { sendEventCheckoutValue } from 'helpers/tracking/quantumMetric';
@@ -26,7 +29,7 @@ type Props = {
 const countryId: IsoCountry = Country.detect();
 
 export function Checkout({ geoId, appConfig, abParticipations }: Props) {
-	const { currencyKey, countryGroupId } = getGeoIdConfig(geoId);
+	const { currencyKey } = getGeoIdConfig(geoId);
 	const urlSearchParams = new URLSearchParams(window.location.search);
 
 	/** 👇 a lot of this is copy/pasted into the thank you page */
@@ -131,33 +134,10 @@ export function Checkout({ geoId, appConfig, abParticipations }: Props) {
 				? appConfig.allProductPrices[productKey]
 				: undefined;
 
-		const getFulfilmentOptions = (productKey: string): FulfilmentOptions => {
-			switch (productKey) {
-				case 'SupporterPlus':
-				case 'Contribution':
-					return 'NoFulfilmentOptions';
-				case 'TierThree':
-					return countryGroupId === 'International'
-						? 'RestOfWorld'
-						: 'Domestic';
-				default:
-					// ToDo: define for every product here
-					return 'NoFulfilmentOptions';
-			}
-		};
-		const fulfilmentOption = getFulfilmentOptions(productKey);
-		const getProductOptions = (productKey: string): ProductOptions => {
-			switch (productKey) {
-				case 'TierThree':
-					return ratePlanKey.endsWith('V2')
-						? 'NewspaperArchive'
-						: 'NoProductOptions';
-				// TODO: define for newspaper
-				default:
-					return 'NoProductOptions';
-			}
-		};
-		const productOptions: ProductOptions = getProductOptions(productKey);
+		const fulfilmentOption = getFulfilmentOptionFromProductKey(productKey);
+
+		const productOptions: ProductOptions =
+			getProductOptionFromProductAndRatePlan(productKey, ratePlanKey);
 
 		promotion = productPrices
 			? getPromotion(

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/deliveryDates.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/deliveryDates.ts
@@ -14,29 +14,26 @@ export const getFirstDeliveryDateForProduct = (
 		case 'TierThree':
 			return formatMachineDate(getTierThreeDeliveryDate());
 		case 'NationalDelivery':
-		case 'HomeDelivery': {
-			if (productFields.productType !== 'Paper') {
-				throw new Error('Product fields are not of type PaperSubscription');
-			}
-			return formatMachineDate(
-				getHomeDeliveryDays(
-					Date.now(),
-					productFields.productOptions,
-				)[0] as Date,
-			);
-		}
+		case 'HomeDelivery':
 		case 'SubscriptionCard': {
 			if (
 				productFields.productType !== 'Paper' ||
 				!isActivePaperProductOption(productFields.productOptions)
 			) {
 				throw new Error(
-					'Product fields or product options are not of type PaperSubscription & ActivePaperProductOptions',
+					// 'Should not be possible'™
+					`Invalid product fields ${JSON.stringify(productFields)}`,
 				);
 			}
-			return formatMachineDate(
-				getPaymentStartDate(Date.now(), productFields.productOptions),
-			);
+			const firstDeliveryDate =
+				productKey === 'SubscriptionCard'
+					? getPaymentStartDate(Date.now(), productFields.productOptions)
+					: (getHomeDeliveryDays(
+							Date.now(),
+							productFields.productOptions,
+					  )[0] as Date);
+
+			return formatMachineDate(firstDeliveryDate);
 		}
 		default:
 			return null;

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/deliveryDates.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/deliveryDates.ts
@@ -1,0 +1,38 @@
+import type { ActiveProductKey } from '@guardian/support-service-lambdas/modules/product-catalog/src/productCatalog';
+import type { ProductFields } from '../../../../helpers/forms/paymentIntegrations/readerRevenueApis';
+import { formatMachineDate } from '../../../../helpers/utilities/dateConversions';
+import { getHomeDeliveryDays } from '../../../paper-subscription-checkout/helpers/homeDeliveryDays';
+import { getPaymentStartDate } from '../../../paper-subscription-checkout/helpers/subsCardDays';
+import { getTierThreeDeliveryDate } from '../../../weekly-subscription-checkout/helpers/deliveryDays';
+
+export const getFirstDeliveryDateForProduct = (
+	productKey: ActiveProductKey,
+	productFields: ProductFields,
+): string | null => {
+	switch (productKey) {
+		case 'TierThree':
+			return formatMachineDate(getTierThreeDeliveryDate());
+		case 'NationalDelivery':
+		case 'HomeDelivery': {
+			if (productFields.productType !== 'Paper') {
+				throw new Error('Product fields are not of type PaperSubscription');
+			}
+			return formatMachineDate(
+				getHomeDeliveryDays(
+					Date.now(),
+					productFields.productOptions,
+				)[0] as Date,
+			);
+		}
+		case 'SubscriptionCard': {
+			if (productFields.productType !== 'Paper') {
+				throw new Error('Product fields are not of type PaperSubscription');
+			}
+			return formatMachineDate(
+				getPaymentStartDate(Date.now(), productFields.productOptions),
+			);
+		}
+		default:
+			return null;
+	}
+};

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/deliveryDates.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/deliveryDates.ts
@@ -1,5 +1,6 @@
 import type { ActiveProductKey } from '@guardian/support-service-lambdas/modules/product-catalog/src/productCatalog';
 import type { ProductFields } from '../../../../helpers/forms/paymentIntegrations/readerRevenueApis';
+import { isActivePaperProductOption } from '../../../../helpers/productPrice/productOptions';
 import { formatMachineDate } from '../../../../helpers/utilities/dateConversions';
 import { getHomeDeliveryDays } from '../../../paper-subscription-checkout/helpers/homeDeliveryDays';
 import { getPaymentStartDate } from '../../../paper-subscription-checkout/helpers/subsCardDays';
@@ -25,8 +26,13 @@ export const getFirstDeliveryDateForProduct = (
 			);
 		}
 		case 'SubscriptionCard': {
-			if (productFields.productType !== 'Paper') {
-				throw new Error('Product fields are not of type PaperSubscription');
+			if (
+				productFields.productType !== 'Paper' ||
+				!isActivePaperProductOption(productFields.productOptions)
+			) {
+				throw new Error(
+					'Product fields or product options are not of type PaperSubscription & ActivePaperProductOptions',
+				);
 			}
 			return formatMachineDate(
 				getPaymentStartDate(Date.now(), productFields.productOptions),

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/getProductFields.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/getProductFields.ts
@@ -34,8 +34,8 @@ export const getProductFields = ({
 		billingPeriod: 'Monthly',
 	};
 
-	const fulfilmentOptions = getFulfilmentOptionFromProductKey(productKey);
-	const productOptions = getProductOptionFromProductAndRatePlan(
+	const fulfilmentOption = getFulfilmentOptionFromProductKey(productKey);
+	const productOption = getProductOptionFromProductAndRatePlan(
 		productKey,
 		ratePlanKey,
 	);
@@ -62,8 +62,8 @@ export const getProductFields = ({
 				productType: 'TierThree',
 				currency: currencyKey,
 				billingPeriod: ratePlanDescription.billingPeriod,
-				fulfilmentOptions,
-				productOptions,
+				fulfilmentOptions: fulfilmentOption,
+				productOptions: productOption,
 			};
 
 		case 'Contribution':
@@ -123,8 +123,8 @@ export const getProductFields = ({
 				productType: 'Paper',
 				currency: currencyKey,
 				billingPeriod: ratePlanDescription.billingPeriod,
-				fulfilmentOptions,
-				productOptions,
+				fulfilmentOptions: fulfilmentOption,
+				productOptions: productOption,
 			};
 
 		case 'GuardianPatron':

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/getProductFields.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/getProductFields.ts
@@ -4,8 +4,8 @@ import type {
 	ActiveProductKey,
 	ProductDescription,
 } from 'helpers/productCatalog';
-import { NoFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import { NoProductOptions } from 'helpers/productPrice/productOptions';
+import { getFulfilmentOptionFromProductKey } from 'helpers/productPrice/fulfilmentOptions';
+import { getProductOptionFromProductAndRatePlan } from 'helpers/productPrice/productOptions';
 import { logException } from 'helpers/utilities/logger';
 
 type GetProductFieldsParams = {
@@ -34,6 +34,11 @@ export const getProductFields = ({
 		billingPeriod: 'Monthly',
 	};
 
+	const fulfilmentOptions = getFulfilmentOptionFromProductKey(productKey);
+	const productOptions = getProductOptionFromProductAndRatePlan(
+		productKey,
+		ratePlanKey,
+	);
 	const unsupportedProductMessage = `Product not supported by generic checkout: ${productKey}`;
 
 	/**
@@ -57,21 +62,8 @@ export const getProductFields = ({
 				productType: 'TierThree',
 				currency: currencyKey,
 				billingPeriod: ratePlanDescription.billingPeriod,
-				fulfilmentOptions:
-					ratePlanKey === 'DomesticMonthly' ||
-					ratePlanKey === 'DomesticAnnual' ||
-					ratePlanKey === 'DomesticMonthlyV2' ||
-					ratePlanKey === 'DomesticAnnualV2'
-						? 'Domestic'
-						: ratePlanKey === 'RestOfWorldMonthly' ||
-						  ratePlanKey === 'RestOfWorldAnnual' ||
-						  ratePlanKey === 'RestOfWorldMonthlyV2' ||
-						  ratePlanKey === 'RestOfWorldAnnualV2'
-						? 'RestOfWorld'
-						: 'Domestic',
-				productOptions: ratePlanKey.endsWith('V2')
-					? 'NewspaperArchive'
-					: 'NoProductOptions',
+				fulfilmentOptions,
+				productOptions,
 			};
 
 		case 'Contribution':
@@ -131,8 +123,8 @@ export const getProductFields = ({
 				productType: 'Paper',
 				currency: currencyKey,
 				billingPeriod: ratePlanDescription.billingPeriod,
-				fulfilmentOptions: NoFulfilmentOptions,
-				productOptions: NoProductOptions,
+				fulfilmentOptions,
+				productOptions,
 			};
 
 		case 'GuardianPatron':

--- a/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
@@ -14,8 +14,7 @@ import {
 	getReferrerAcquisitionData,
 	getSupportAbTests,
 } from '../../../helpers/tracking/acquisitions';
-import { formatMachineDate } from '../../../helpers/utilities/dateConversions';
-import { getTierThreeDeliveryDate } from '../../weekly-subscription-checkout/helpers/deliveryDays';
+import { getFirstDeliveryDateForProduct } from '../checkout/helpers/deliveryDates';
 import type { FormPersonalFields } from '../checkout/helpers/formDataExtractors';
 import {
 	extractDeliverableAddressDataFromForm,
@@ -63,10 +62,10 @@ export const submitForm = async ({
 		labels: ['generic-checkout'], // Shall we get rid of this now?
 	};
 
-	const firstDeliveryDate =
-		productKey === 'TierThree'
-			? formatMachineDate(getTierThreeDeliveryDate())
-			: null;
+	const firstDeliveryDate = getFirstDeliveryDateForProduct(
+		productKey,
+		productFields,
+	);
 
 	const promoCode = promotion?.promoCode;
 	const appliedPromotion =

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -113,6 +113,11 @@ export function ThankYouComponent({
 		case 'DomesticMonthly':
 		case 'RestOfWorldMonthlyV2':
 		case 'DomesticMonthlyV2':
+		case 'Everyday':
+		case 'Sixday':
+		case 'Weekend':
+		case 'Saturday':
+		case 'Sunday':
 			contributionType = 'MONTHLY';
 			break;
 		case 'Annual':

--- a/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
@@ -132,9 +132,7 @@ export function ThankYou({
 						fulfilmentOption,
 				  )
 				: undefined;
-			const discountedPrice = promotion?.discountedPrice
-				? promotion.discountedPrice
-				: undefined;
+			const discountedPrice = promotion?.discountedPrice;
 			const price = discountedPrice ?? productPrice;
 
 			if (productKey === 'SupporterPlus') {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR makes the generic checkout work for home delivery and subscription card subs. It still will not work for national delivery subscriptions because those require a delivery agent to be selected but that work will follow in a separate PR.

[**Trello Card**](https://trello.com/c/VO1eUa15/1386-newspaper-products-create-payload)

## Why are you doing this?
We want to be able to sell newspaper products through the generic checkout so that we can decommission the old subs checkout and unify the codebase.

## How to test
Go to: 
https://support.thegulocal.com/uk/checkout?product=HomeDelivery&ratePlan=Everyday
or:
https://support.thegulocal.com/uk/checkout?product=SubscriptionCard&ratePlan=Saturday
You should be able to check out successfully.