### PR TITLE
Put a switch around Stripe Express on the one time checkout

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -146,6 +146,7 @@ type OneTimeCheckoutComponentProps = {
 	stripePublicKey: string;
 	countryId: IsoCountry;
 	abParticipations: Participations;
+	useStripeExpressCheckout: boolean;
 };
 
 function paymentMethodIsActive(paymentMethod: PaymentMethod) {
@@ -229,6 +230,7 @@ export function OneTimeCheckoutComponent({
 	stripePublicKey,
 	countryId,
 	abParticipations,
+	useStripeExpressCheckout,
 }: OneTimeCheckoutComponentProps) {
 	const { currency, currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 	const urlSearchParams = new URLSearchParams(window.location.search);
@@ -289,7 +291,7 @@ export function OneTimeCheckoutComponent({
 
 	const elements = useElements();
 	useEffect(() => {
-		if (finalAmount && elements) {
+		if (useStripeExpressCheckout && finalAmount && elements) {
 			// valid elements and final amount, set amount, enable Express checkout
 			elements.update({ amount: finalAmount * 100 });
 			setStripeExpressCheckoutEnable(true);
@@ -297,7 +299,8 @@ export function OneTimeCheckoutComponent({
 			// invalid elements and final amount, disable Express checkout
 			setStripeExpressCheckoutEnable(false);
 		}
-	}, [finalAmount, elements]);
+	}, [finalAmount, elements, useStripeExpressCheckout]);
+
 	useEffect(() => {
 		if (finalAmount) {
 			// Track valid final amount selection with QM
@@ -619,102 +622,106 @@ export function OneTimeCheckoutComponent({
 			>
 				<Box cssOverrides={shorterBoxMargin}>
 					<BoxContents>
-						<div
-							css={css`
-								/* Prevent content layout shift */
-								min-height: 8px;
-							`}
-						>
-							<ExpressCheckoutElement
-								onReady={({ availablePaymentMethods }) => {
-									/**
-									 * This is use to show UI needed besides this Element
-									 * i.e. The "or" divider
-									 */
-									if (
-										!!availablePaymentMethods?.applePay ||
-										!!availablePaymentMethods?.googlePay
-									) {
-										setStripeExpressCheckoutReady(true);
-									}
-								}}
-								onClick={({ resolve }) => {
-									/** @see https://docs.stripe.com/elements/express-checkout-element/accept-a-payment?locale=en-GB#handle-click-event */
-									if (stripeExpressCheckoutEnable) {
-										const options = {
-											emailRequired: true,
-										};
-										// Track payment method selection with QM
-										sendEventPaymentMethodSelected(
-											'StripeExpressCheckoutElement',
+						{useStripeExpressCheckout && (
+							<div
+								css={css`
+									/* Prevent content layout shift */
+									min-height: 8px;
+								`}
+							>
+								<ExpressCheckoutElement
+									onReady={({ availablePaymentMethods }) => {
+										/**
+										 * This is use to show UI needed besides this Element
+										 * i.e. The "or" divider
+										 */
+										if (
+											!!availablePaymentMethods?.applePay ||
+											!!availablePaymentMethods?.googlePay
+										) {
+											setStripeExpressCheckoutReady(true);
+										}
+									}}
+									onClick={({ resolve }) => {
+										/** @see https://docs.stripe.com/elements/express-checkout-element/accept-a-payment?locale=en-GB#handle-click-event */
+										if (stripeExpressCheckoutEnable) {
+											const options = {
+												emailRequired: true,
+											};
+											// Track payment method selection with QM
+											sendEventPaymentMethodSelected(
+												'StripeExpressCheckoutElement',
+											);
+
+											resolve(options);
+										}
+									}}
+									onConfirm={async (event) => {
+										if (!(stripe && elements)) {
+											console.error('Stripe not loaded');
+											return;
+										}
+
+										const { error: submitError } = await elements.submit();
+
+										if (submitError) {
+											setErrorMessage(submitError.message);
+											return;
+										}
+
+										// ->
+
+										setPaymentMethod('StripeExpressCheckoutElement');
+										setStripeExpressCheckoutPaymentType(
+											event.expressPaymentType,
 										);
+										event.billingDetails?.email &&
+											setEmail(event.billingDetails.email);
 
-										resolve(options);
-									}
-								}}
-								onConfirm={async (event) => {
-									if (!(stripe && elements)) {
-										console.error('Stripe not loaded');
-										return;
-									}
-
-									const { error: submitError } = await elements.submit();
-
-									if (submitError) {
-										setErrorMessage(submitError.message);
-										return;
-									}
-
-									// ->
-
-									setPaymentMethod('StripeExpressCheckoutElement');
-									setStripeExpressCheckoutPaymentType(event.expressPaymentType);
-									event.billingDetails?.email &&
-										setEmail(event.billingDetails.email);
-
-									/**
-									 * There is a useEffect that listens to this and submits the form
-									 * when true
-									 */
-									setStripeExpressCheckoutSuccessful(true);
-								}}
-								options={{
-									paymentMethods: {
-										applePay: 'auto',
-										googlePay: 'auto',
-										link: 'never',
-									},
-								}}
-							/>
-
-							{stripeExpressCheckoutReady && (
-								<Divider
-									displayText="or"
-									size="full"
-									cssOverrides={css`
-										::before {
-											margin-left: 0;
-										}
-										::after {
-											margin-right: 0;
-										}
-										margin: 0;
-										margin-top: 14px;
-										margin-bottom: 14px;
-										width: 100%;
-										@keyframes fadeIn {
-											0% {
-												opacity: 0;
-											}
-											100% {
-												opacity: 1;
-											}
-										}
-										animation: fadeIn 1s;
-									`}
+										/**
+										 * There is a useEffect that listens to this and submits the form
+										 * when true
+										 */
+										setStripeExpressCheckoutSuccessful(true);
+									}}
+									options={{
+										paymentMethods: {
+											applePay: 'auto',
+											googlePay: 'auto',
+											link: 'never',
+										},
+									}}
 								/>
-							)}
-						</div>
+
+								{stripeExpressCheckoutReady && (
+									<Divider
+										displayText="or"
+										size="full"
+										cssOverrides={css`
+											::before {
+												margin-left: 0;
+											}
+											::after {
+												margin-right: 0;
+											}
+											margin: 0;
+											margin-top: 14px;
+											margin-bottom: 14px;
+											width: 100%;
+											@keyframes fadeIn {
+												0% {
+													opacity: 0;
+												}
+												100% {
+													opacity: 1;
+												}
+											}
+											animation: fadeIn 1s;
+										`}
+									/>
+								)}
+							</div>
+						)}
 
 						<FormSection>
 							<Legend>1. Your details</Legend>

--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -17,6 +17,9 @@ type OneTimeCheckoutProps = {
 	abParticipations: Participations;
 };
 
+const stripeExpressCheckoutSwitch =
+	window.guardian.settings.switches.oneOffPaymentMethods.stripeExpressCheckout;
+
 export function OneTimeCheckout({
 	geoId,
 	appConfig,
@@ -55,6 +58,7 @@ export function OneTimeCheckout({
 				stripePublicKey={stripePublicKey}
 				countryId={countryId}
 				abParticipations={abParticipations}
+				useStripeExpressCheckout={stripeExpressCheckoutSwitch === 'On'}
 			/>
 		</Elements>
 	);


### PR DESCRIPTION
**TODO: Enable the switch in prod before merging** ✅ 

## What are you doing in this PR?

Adding support for a switch around Stripe Express (which powers Apple Pay and Google Pay) on the one time checkout.

[**Trello Card**](https://trello.com/c/lq9WEyx0/1444-one-time-payment-method-switches)

## Why are you doing this?

We recently discovered that although a switch exists in the RRCP it isn't respected in the one time checkout. So if we ever wanted to disable Stripe Express for any reason, the switch wouldn't have worked.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Deployed to CODE and toggled the switch in the CODE RRCP. When enabled the Apple Pay button is rendered on the one time checkout. When disabled, the Apple Pay button is not rendered (it takes a moment to take effect due to the polling mechanism on the backend).

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
