### PR TITLE
Fix warning from eslint

### DIFF
--- a/support-frontend/assets/helpers/utilities/utilities.ts
+++ b/support-frontend/assets/helpers/utilities/utilities.ts
@@ -1,4 +1,4 @@
-import DOMPurify from 'dompurify';
+import DomPurify from 'dompurify';
 import snarkdown from 'snarkdown';
 
 // A series of general purpose helper functions.
@@ -50,7 +50,7 @@ function deserialiseJsonObject(
 
 function getSanitisedHtml(markdownString: string): string {
 	// ensure we don't accidentally inject dangerous html into the page
-	return DOMPurify.sanitize(snarkdown(markdownString), {
+	return DomPurify.sanitize(snarkdown(markdownString), {
 		ALLOWED_TAGS: ['em', 'strong', 'ul', 'li', 'a', 'p'],
 	});
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Fix warning from eslint about the `DOMPurify` import.

Previously eslint was emitting a warning about the default import of `DOMPurify` (which is how the `DOMPurify` docs recommend using this import).

~It looks like we're getting the cjs version of the compiled JS, and this doesn't always play nicely with default imports. See https://www.typescriptlang.org/tsconfig/#esModuleInterop for more details.~ This didn't work (though it did fix the warning in VSCode!). Take the easy route and just rename the default import :-)

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
