### PR TITLE
Unify ActivePaperProducts and ActivePaperProductTypes

### DIFF
--- a/support-frontend/assets/helpers/productPrice/productOptions.ts
+++ b/support-frontend/assets/helpers/productPrice/productOptions.ts
@@ -33,21 +33,10 @@ export type PaperProductOptions =
 	| typeof Sixday
 	| typeof Everyday;
 
-const ActivePaperProductTypes: PaperProductOptions[] = [
-	Everyday,
-	Weekend,
-	Saturday,
-];
+const ActivePaperProductTypes = [Everyday, Weekend, Saturday] as const;
 
-export type ActivePaperProducts =
-	| typeof Sunday
-	| typeof SundayPlus
-	| typeof Weekend
-	| typeof WeekendPlus
-	| typeof Sixday
-	| typeof SixdayPlus
-	| typeof Everyday
-	| typeof EverydayPlus;
+export type ActivePaperProductOptions =
+	(typeof ActivePaperProductTypes)[number];
 
 const paperProductsWithDigital = {
 	Saturday: SaturdayPlus,

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -46,7 +46,7 @@ import {
 	Collection,
 	HomeDelivery,
 } from 'helpers/productPrice/fulfilmentOptions';
-import type { ActivePaperProducts } from 'helpers/productPrice/productOptions';
+import type { ActivePaperProductOptions } from 'helpers/productPrice/productOptions';
 import { showPrice } from 'helpers/productPrice/productPrices';
 import { Paper } from 'helpers/productPrice/subscriptions';
 import { setDeliveryAgent } from 'helpers/redux/checkout/addressMeta/actions';
@@ -236,7 +236,7 @@ function PaperCheckoutForm(props: PropTypes) {
 		const timeNow = Date.now();
 		const startDate = getPaymentStartDate(
 			timeNow,
-			props.productOption as ActivePaperProducts,
+			props.productOption as ActivePaperProductOptions,
 		);
 		formattedStartDate = getFormattedStartDate(startDate);
 		setSubsCardStartDateInState(props.setStartDate, startDate);

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperOrderSummary/paperOrderSummary.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperOrderSummary/paperOrderSummary.tsx
@@ -6,7 +6,7 @@ import OrderSummaryProduct from 'components/orderSummary/orderSummaryProduct';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { Collection } from 'helpers/productPrice/fulfilmentOptions';
 import type {
-	ActivePaperProducts,
+	ActivePaperProductOptions,
 	ProductOptions,
 } from 'helpers/productPrice/productOptions';
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
@@ -42,7 +42,7 @@ function mapStateToProps(state: SubscriptionsState) {
 	return {
 		fulfilmentOption: state.page.checkoutForm.product.fulfilmentOption,
 		productOption: state.page.checkoutForm.product
-			.productOption as ActivePaperProducts,
+			.productOption as ActivePaperProductOptions,
 		billingPeriod: state.page.checkoutForm.product.billingPeriod,
 		productPrices: state.page.checkoutForm.product.productPrices,
 		priceWithoutPromotions: selectPriceForProduct(state),

--- a/support-frontend/assets/pages/paper-subscription-checkout/helpers/__tests__/deliveryDays.test.ts
+++ b/support-frontend/assets/pages/paper-subscription-checkout/helpers/__tests__/deliveryDays.test.ts
@@ -2,8 +2,7 @@
 
 import {
 	Everyday,
-	Sixday,
-	Sunday,
+	Saturday,
 	Weekend,
 } from 'helpers/productPrice/productOptions';
 import {
@@ -179,12 +178,10 @@ describe('deliveryDays', () => {
 			const today = 1596727469480;
 			const day = getFormattedStartDate(getPaymentStartDate(today, Everyday));
 			expect(day).toBe('17 August 2020');
-			const day1 = getFormattedStartDate(getPaymentStartDate(today, Sixday));
-			expect(day1).toBe('17 August 2020');
 			const day2 = getFormattedStartDate(getPaymentStartDate(today, Weekend));
 			expect(day2).toBe('22 August 2020');
-			const day3 = getFormattedStartDate(getPaymentStartDate(today, Sunday));
-			expect(day3).toBe('23 August 2020');
+			const day3 = getFormattedStartDate(getPaymentStartDate(today, Saturday));
+			expect(day3).toBe('22 August 2020');
 		});
 	});
 });

--- a/support-frontend/assets/pages/paper-subscription-checkout/helpers/subsCardDays.ts
+++ b/support-frontend/assets/pages/paper-subscription-checkout/helpers/subsCardDays.ts
@@ -1,4 +1,4 @@
-import type { ActivePaperProducts } from 'helpers/productPrice/productOptions';
+import type { ActivePaperProductOptions } from 'helpers/productPrice/productOptions';
 import { formatMachineDate } from 'helpers/utilities/dateConversions';
 import type { DayOfWeekIndex } from './homeDeliveryDays';
 
@@ -113,7 +113,7 @@ const getFormattedStartDate = (startDate: Date): string => {
 
 const getPaymentStartDate = (
 	date: number,
-	productOption: ActivePaperProducts,
+	productOption: ActivePaperProductOptions,
 ): Date => {
 	const day = new Date(date).getDay() as DayOfWeekIndex;
 	const delay = additionalDays[day][productOption];


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Looking at the product options defined for newspaper we have a type `ActivePaperProducts` and a list of values `ActivePaperProductTypes`, however these are out of sync with each other.

This PR derives the type from the list so that they will always be in sync.