### PR TITLE
Make fulfilment options switch statement exhaustive

### DIFF
--- a/support-frontend/assets/helpers/productPrice/fulfilmentOptions.ts
+++ b/support-frontend/assets/helpers/productPrice/fulfilmentOptions.ts
@@ -43,7 +43,11 @@ export const getFulfilmentOptionFromProductKey = (
 ): FulfilmentOptions => {
 	switch (productKey) {
 		case 'SupporterPlus':
+		case 'GuardianAdLite':
 		case 'Contribution':
+		case 'OneTimeContribution':
+		case 'DigitalSubscription':
+		case 'GuardianPatron':
 			return 'NoFulfilmentOptions';
 		case 'TierThree':
 		case 'GuardianWeeklyDomestic':
@@ -55,10 +59,6 @@ export const getFulfilmentOptionFromProductKey = (
 		case 'NationalDelivery':
 		case 'HomeDelivery':
 			return productKey;
-		default:
-			throw new Error(
-				`Fulfilment option not defined for product ${productKey}`,
-			);
 	}
 };
 

--- a/support-frontend/assets/helpers/productPrice/productOptions.ts
+++ b/support-frontend/assets/helpers/productPrice/productOptions.ts
@@ -97,6 +97,15 @@ export const getProductOptionFromProductAndRatePlan = (
 	ratePlanKey: string,
 ): ProductOptions => {
 	switch (productKey) {
+		case 'SupporterPlus':
+		case 'GuardianAdLite':
+		case 'Contribution':
+		case 'OneTimeContribution':
+		case 'DigitalSubscription':
+		case 'GuardianPatron':
+		case 'GuardianWeeklyRestOfWorld':
+		case 'GuardianWeeklyDomestic':
+			return 'NoProductOptions';
 		case 'TierThree':
 			return ratePlanKey.endsWith('V2')
 				? 'NewspaperArchive'
@@ -105,8 +114,6 @@ export const getProductOptionFromProductAndRatePlan = (
 		case 'NationalDelivery':
 		case 'HomeDelivery':
 			return getPaperProductOptions(ratePlanKey);
-		default:
-			return 'NoProductOptions';
 	}
 };
 

--- a/support-frontend/assets/helpers/productPrice/productOptions.ts
+++ b/support-frontend/assets/helpers/productPrice/productOptions.ts
@@ -1,4 +1,6 @@
 // describes options relating to a product itself - only relevant for paper currently
+import type { ActiveProductKey } from '@guardian/support-service-lambdas/modules/product-catalog/src/productCatalog';
+
 const NoProductOptions = 'NoProductOptions';
 const Saturday = 'Saturday';
 const SaturdayPlus = 'SaturdayPlus';
@@ -91,7 +93,7 @@ const getPaperProductOptions = (ratePlanKey: string): ProductOptions => {
 	);
 };
 export const getProductOptionFromProductAndRatePlan = (
-	productKey: string,
+	productKey: ActiveProductKey,
 	ratePlanKey: string,
 ): ProductOptions => {
 	switch (productKey) {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

We were seeing errors in prod (via the smoke and cron playwright tests) because no fulfilment options were specified for GuardianAdLite. I've removed the default so that the type system can give us feedback on uncovered cases and done the same for product options.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
