### PR TITLE
GuardianAdLite: Add hi-res images for mobile and desktop breakpoints

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/posterComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/posterComponent.tsx
@@ -6,6 +6,7 @@ import {
 	palette,
 	space,
 	textEgyptian17,
+	until,
 } from '@guardian/source/foundations';
 import { Container } from 'components/layout/container';
 
@@ -73,6 +74,16 @@ const copy = css`
 const paragraph = css`
 	margin-bottom: ${space[3]}px;
 `;
+const displayMobile = css`
+	${from.desktop} {
+		display: none;
+	}
+`;
+const displayDesktop = css`
+	${until.desktop} {
+		display: none;
+	}
+`;
 const image = css`
 	width: 100%;
 	object-fit: contain;
@@ -81,7 +92,8 @@ const image = css`
 	}
 `;
 
-const posterImageUrl = `https://i.guim.co.uk/img/media/c64768218dc3fa9fe8294038e8f9e31920f9beaa/0_0_341_336/341.png?width=341&quality=75&s=dab7519a52c1eb0fc3442600a0572ceb`;
+const posterImageUrlMobile = `https://i.guim.co.uk/img/media/49109ff732b9fab51a496d015118504a07a7a69e/0_0_1396_1137/1396.png?width=1396&quality=75&s=ead4f371d212d1229c6bcce7fa936c2d`;
+const posterImageUrlDesktop = `https://i.guim.co.uk/img/media/5266c336f47108db31f68911d30f5259c8eed277/0_0_1424_1509/1424.png?width=1424&quality=75&s=485d4a200fc9428fc47c93e45f1bde2a`;
 
 export function PosterComponent(): JSX.Element {
 	return (
@@ -111,7 +123,8 @@ export function PosterComponent(): JSX.Element {
 							personalised advertising.
 						</p>
 					</div>
-					<img css={image} alt="" src={posterImageUrl} />
+					<img css={[displayMobile, image]} src={posterImageUrlMobile} />
+					<img css={[displayDesktop, image]} src={posterImageUrlDesktop} />
 				</div>
 			</div>
 		</Container>

--- a/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/posterComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/posterComponent.tsx
@@ -75,16 +75,17 @@ const paragraph = css`
 	margin-bottom: ${space[3]}px;
 `;
 const displayMobile = css`
-	${from.desktop} {
-		display: none;
+	${until.desktop} {
+		display: inherit;
 	}
 `;
 const displayDesktop = css`
-	${until.desktop} {
-		display: none;
+	${from.desktop} {
+		display: inherit;
 	}
 `;
 const image = css`
+	display: none;
 	width: 100%;
 	object-fit: contain;
 	${from.tablet} {


### PR DESCRIPTION
## What are you doing in this PR?

Updates the mobile and desktop breakpoints with hi-res (x4 png) images.

[**Trello Card**](https://trello.com/c/DqsPCOvA/1460-image-change-for-the-landing-page)

## Screenshots

|from|to|
|-----|-----|
|<img width="497" alt="image" src="https://github.com/user-attachments/assets/c83862b4-45e0-4007-8769-9dae1eb64833" />|<img width="497" alt="image" src="https://github.com/user-attachments/assets/5b1cf74d-c997-4856-aaf2-53f25f0e69e1" />|