### PR TITLE
Support National Delivery on the generic checkout

### DIFF
--- a/support-frontend/assets/helpers/redux/checkout/addressMeta/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/addressMeta/reducer.ts
@@ -1,6 +1,6 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
-import type { DeliveryAgentsResponse } from './state';
+import type { DeliveryAgentsResponse } from '../../../../pages/[countryGroupId]/checkout/helpers/getDeliveryAgents';
 import { initialState } from './state';
 import { getDeliveryAgentsThunk } from './thunks';
 

--- a/support-frontend/assets/helpers/redux/checkout/addressMeta/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/addressMeta/state.ts
@@ -1,3 +1,5 @@
+import type { DeliveryAgentsResponse } from '../../../../pages/[countryGroupId]/checkout/helpers/getDeliveryAgents';
+
 export type AddressMetaState = {
 	billingAddressMatchesDelivery: boolean;
 	deliveryInstructions?: string;
@@ -14,24 +16,4 @@ export type DeliveryAgentState = {
 export const initialState: AddressMetaState = {
 	billingAddressMatchesDelivery: true,
 	deliveryAgent: { isLoading: false, response: undefined },
-};
-
-export type DeliveryAgentsResponse = {
-	type:
-		| 'Covered'
-		| 'NotCovered'
-		| 'UnknownPostcode'
-		| 'ProblemWithInput'
-		| 'PaperRoundError';
-	agents?: DeliveryAgentOption[];
-};
-
-export type DeliveryAgentOption = {
-	agentId: number;
-	agentName: string;
-	deliveryMethod: string;
-	nbrDeliveryDays: number;
-	postcode: string;
-	refGroupId: number;
-	summary: string;
 };

--- a/support-frontend/assets/helpers/redux/checkout/addressMeta/thunks.ts
+++ b/support-frontend/assets/helpers/redux/checkout/addressMeta/thunks.ts
@@ -1,15 +1,8 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import type { DeliveryAgentsResponse } from './state';
+import type { DeliveryAgentsResponse } from '../../../../pages/[countryGroupId]/checkout/helpers/getDeliveryAgents';
+import { getDeliveryAgents } from '../../../../pages/[countryGroupId]/checkout/helpers/getDeliveryAgents';
 
 export const getDeliveryAgentsThunk = createAsyncThunk<
 	DeliveryAgentsResponse,
 	string
 >(`addressMeta/getDeliveryAgents`, getDeliveryAgents);
-
-async function getDeliveryAgents(
-	postcode: string,
-): Promise<DeliveryAgentsResponse> {
-	const agentsResponse = await fetch(`/delivery-agents/${postcode}`);
-	const response = (await agentsResponse.json()) as DeliveryAgentsResponse;
-	return response;
-}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/getDeliveryAgents.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/getDeliveryAgents.ts
@@ -1,0 +1,26 @@
+export type DeliveryAgentsResponse = {
+	type:
+		| 'Covered'
+		| 'NotCovered'
+		| 'UnknownPostcode'
+		| 'ProblemWithInput'
+		| 'PaperRoundError';
+	agents?: DeliveryAgentOption[];
+};
+export type DeliveryAgentOption = {
+	agentId: number;
+	agentName: string;
+	deliveryMethod: string;
+	nbrDeliveryDays: number;
+	postcode: string;
+	refGroupId: number;
+	summary: string;
+};
+
+export async function getDeliveryAgents(
+	postcode: string,
+): Promise<DeliveryAgentsResponse> {
+	const agentsResponse = await fetch(`/delivery-agents/${postcode}`);
+	const response = (await agentsResponse.json()) as DeliveryAgentsResponse;
+	return response;
+}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/getProductFields.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/getProductFields.ts
@@ -13,6 +13,7 @@ type GetProductFieldsParams = {
 		productKey: ActiveProductKey;
 		productDescription: ProductDescription;
 		ratePlanKey: string;
+		deliveryAgent: number | undefined;
 	};
 	financial: {
 		currencyKey: IsoCurrency;
@@ -26,7 +27,8 @@ export const getProductFields = ({
 	product,
 	financial,
 }: GetProductFieldsParams): RegularPaymentRequest['product'] => {
-	const { productKey, ratePlanKey, productDescription } = product;
+	const { productKey, ratePlanKey, productDescription, deliveryAgent } =
+		product;
 	const { currencyKey, finalAmount, originalAmount, contributionAmount } =
 		financial;
 
@@ -118,15 +120,20 @@ export const getProductFields = ({
 
 		case 'NationalDelivery':
 		case 'SubscriptionCard':
-		case 'HomeDelivery':
+		case 'HomeDelivery': {
+			const finalFulfilmentOption =
+				fulfilmentOption === 'HomeDelivery' && deliveryAgent
+					? 'NationalDelivery'
+					: fulfilmentOption;
 			return {
 				productType: 'Paper',
 				currency: currencyKey,
 				billingPeriod: ratePlanDescription.billingPeriod,
-				fulfilmentOptions: fulfilmentOption,
+				fulfilmentOptions: finalFulfilmentOption,
 				productOptions: productOption,
+				deliveryAgent,
 			};
-
+		}
 		case 'GuardianPatron':
 		case 'OneTimeContribution':
 			logException(unsupportedProductMessage);

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -324,9 +324,11 @@ export function CheckoutComponent({
 				setDeliveryPostcodeIsOutsideM25(false);
 			} else {
 				setDeliveryPostcodeIsOutsideM25(true);
-				void getDeliveryAgents(deliveryPostcode).then((agents) => {
-					setDeliveryAgents(agents);
-				});
+				void getDeliveryAgents(deliveryPostcode).then(
+					(agents: DeliveryAgentsResponse) => {
+						setDeliveryAgents(agents);
+					},
+				);
 			}
 		}
 	}, [deliveryPostcode]);
@@ -926,7 +928,7 @@ export function CheckoutComponent({
 						)}
 						{deliveryPostcodeIsOutsideM25 && (
 							<FormSection>
-								<Legend>Delivery Agent</Legend>
+								<Legend>3. Delivery Agent</Legend>
 								<DeliveryAgentsSelect
 									chosenDeliveryAgent={chosenDeliveryAgent}
 									deliveryAgentsResponse={deliveryAgents}
@@ -951,7 +953,12 @@ export function CheckoutComponent({
 
 						<FormSection>
 							<Legend>
-								{productDescription.deliverableTo ? '3' : '2'}. Payment method
+								{productDescription.deliverableTo
+									? deliveryPostcodeIsOutsideM25
+										? '4'
+										: '3'
+									: '2'}
+								. Payment method
 								<SecureTransactionIndicator
 									hideText={true}
 									cssOverrides={css``}

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -330,6 +330,9 @@ export function CheckoutComponent({
 					},
 				);
 			}
+		} else {
+			setDeliveryPostcodeIsOutsideM25(false);
+			setDeliveryAgents(undefined);
 		}
 	}, [deliveryPostcode]);
 

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -318,21 +318,26 @@ export function CheckoutComponent({
 	const [deliveryAddressErrors, setDeliveryAddressErrors] = useState<
 		AddressFormFieldError[]
 	>([]);
-	useEffect(() => {
-		if (isValidPostcode(deliveryPostcode)) {
-			if (postcodeIsWithinDeliveryArea(deliveryPostcode)) {
+
+	const fetchDeliveryAgentsForPostcodesOutsideTheM25 = async (
+		postcode: string,
+	) => {
+		if (isValidPostcode(postcode)) {
+			if (postcodeIsWithinDeliveryArea(postcode)) {
 				setDeliveryPostcodeIsOutsideM25(false);
 			} else {
 				setDeliveryPostcodeIsOutsideM25(true);
-				void getDeliveryAgents(deliveryPostcode).then(
-					(agents: DeliveryAgentsResponse) => {
-						setDeliveryAgents(agents);
-					},
-				);
+				const agents = await getDeliveryAgents(postcode);
+				setDeliveryAgents(agents);
 			}
 		} else {
 			setDeliveryPostcodeIsOutsideM25(false);
 			setDeliveryAgents(undefined);
+		}
+	};
+	useEffect(() => {
+		if (productKey === 'HomeDelivery') {
+			void fetchDeliveryAgentsForPostcodesOutsideTheM25(deliveryPostcode);
 		}
 	}, [deliveryPostcode]);
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
@@ -15,6 +15,7 @@ import type {
 	DeliveryAgentOption,
 	DeliveryAgentsResponse,
 } from '../../[countryGroupId]/checkout/helpers/getDeliveryAgents';
+import { CheckoutDivider } from '../../supporter-plus-landing/components/checkoutDivider';
 
 const marginBottom = css`
 	margin-bottom: ${space[6]}px;
@@ -42,56 +43,95 @@ export function DeliveryAgentsSelect(
 	props: DeliveryAgentsSelectProps,
 ): JSX.Element | null {
 	const postcodeError = firstError('postCode', props.deliveryAddressErrors);
+	if (postcodeError) {
+		return null;
+	}
 
-	if (props.deliveryAgentsResponse?.type === 'Covered' && !postcodeError) {
-		if (props.deliveryAgentsResponse.agents?.length === 1) {
-			if (!props.deliveryAgentsResponse.agents[0]) {
-				return null;
+	switch (props.deliveryAgentsResponse?.type) {
+		case 'Covered': {
+			if (props.deliveryAgentsResponse.agents?.length === 1) {
+				if (!props.deliveryAgentsResponse.agents[0]) {
+					return null;
+				}
+
+				return (
+					<SingleDeliveryProvider
+						singleDeliveryProvider={props.deliveryAgentsResponse.agents[0]}
+					/>
+				);
 			}
 
 			return (
-				<SingleDeliveryProvider
-					singleDeliveryProvider={props.deliveryAgentsResponse.agents[0]}
-				/>
+				<RadioGroup
+					label="Select delivery provider"
+					id="delivery-provider"
+					cssOverrides={marginBottom}
+					error={firstError('deliveryProvider', props.formErrors)}
+				>
+					<>
+						{props.deliveryAgentsResponse.agents?.map((agent) => (
+							<div
+								css={css`
+									border-bottom: 1px solid ${palette.neutral[86]};
+								`}
+								key={agent.agentId}
+							>
+								<Radio
+									value={agent.agentId}
+									checked={props.chosenDeliveryAgent === agent.agentId}
+									onChange={() => props.setDeliveryAgent(agent.agentId)}
+									label={
+										<>
+											{agent.agentName}{' '}
+											<GreenLabel deliveryMethod={agent.deliveryMethod} />
+										</>
+									}
+								/>
+								<DeliveryProviderSummary summary={agent.summary} />
+								<GreenDeliverySummary deliveryMethod={agent.deliveryMethod} />
+							</div>
+						))}
+					</>
+				</RadioGroup>
 			);
 		}
-
-		return (
-			<RadioGroup
-				label="Select delivery provider"
-				id="delivery-provider"
-				cssOverrides={marginBottom}
-				error={firstError('deliveryProvider', props.formErrors)}
-			>
-				<>
-					{props.deliveryAgentsResponse.agents?.map((agent) => (
-						<div
-							css={css`
-								border-bottom: 1px solid ${palette.neutral[86]};
-							`}
-							key={agent.agentId}
-						>
-							<Radio
-								value={agent.agentId}
-								checked={props.chosenDeliveryAgent === agent.agentId}
-								onChange={() => props.setDeliveryAgent(agent.agentId)}
-								label={
-									<>
-										{agent.agentName}{' '}
-										<GreenLabel deliveryMethod={agent.deliveryMethod} />
-									</>
-								}
-							/>
-							<DeliveryProviderSummary summary={agent.summary} />
-							<GreenDeliverySummary deliveryMethod={agent.deliveryMethod} />
-						</div>
-					))}
-				</>
-			</RadioGroup>
-		);
+		case 'UnknownPostcode':
+			return ErrorMessage(
+				'Unknown postcode',
+				'Please check that you have entered your postcode correctly',
+			);
+		case 'NotCovered':
+			return ErrorMessage(
+				'Not covered',
+				'Sorry, we do not deliver to this postcode. Please check that you have entered your postcode correctly or contact us for further assistance.',
+			);
+		default:
+			return ErrorMessage(
+				'Error fetching delivery agents',
+				'Sorry an error occurred fetching delivery agents, please try again later.',
+			);
 	}
 
 	return null;
+}
+
+function ErrorMessage(label: string, description: string) {
+	return (
+		<div css={marginBottom}>
+			<Label text={label}>
+				<div
+					css={css`
+						${textSans17};
+						margin-bottom: ${space[1]}px;
+					`}
+				>
+					{' '}
+					{description}
+				</div>
+			</Label>
+			<CheckoutDivider spacing="loose" />
+		</div>
+	);
 }
 
 function SingleDeliveryProvider({

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/deliveryAgentsSelect.tsx
@@ -9,12 +9,12 @@ import {
 } from '@guardian/source/foundations';
 import { Label, Radio, RadioGroup } from '@guardian/source/react-components';
 import type { ActionCreatorWithOptionalPayload } from '@reduxjs/toolkit';
+import type { FormError } from 'helpers/subscriptionsForms/validation';
+import { firstError } from 'helpers/subscriptionsForms/validation';
 import type {
 	DeliveryAgentOption,
 	DeliveryAgentsResponse,
-} from 'helpers/redux/checkout/addressMeta/state';
-import type { FormError } from 'helpers/subscriptionsForms/validation';
-import { firstError } from 'helpers/subscriptionsForms/validation';
+} from '../../[countryGroupId]/checkout/helpers/getDeliveryAgents';
 
 const marginBottom = css`
 	margin-bottom: ${space[6]}px;
@@ -28,10 +28,12 @@ type GreenDeliveryMethod = (typeof greenDeliveryMethods)[number];
 interface DeliveryAgentsSelectProps {
 	chosenDeliveryAgent?: number;
 	deliveryAgentsResponse?: DeliveryAgentsResponse;
-	setDeliveryAgent: ActionCreatorWithOptionalPayload<
-		number | undefined,
-		'addressMeta/setDeliveryAgent'
-	>;
+	setDeliveryAgent:
+		| ActionCreatorWithOptionalPayload<
+				number | undefined,
+				'addressMeta/setDeliveryAgent'
+		  >
+		| ((agent: number) => void);
 	formErrors: Array<FormError<string>>;
 	deliveryAddressErrors: Array<FormError<string>>;
 }

--- a/support-services/src/main/scala/com/gu/support/paperround/PaperRoundService.scala
+++ b/support-services/src/main/scala/com/gu/support/paperround/PaperRoundService.scala
@@ -1,18 +1,17 @@
 package com.gu.support.paperround
 
-import com.gu.okhttp.RequestRunners.{FutureHttpClient, futureRunner}
+import com.gu.okhttp.RequestRunners.{FutureHttpClient, configurableFutureRunner}
 import com.gu.rest.WebServiceHelper
 import com.gu.support.config.{PaperRoundConfig, PaperRoundConfigProvider}
-import com.gu.support.paperround.PaperRound
-import com.gu.support.paperround.{AgentsEndpoint, CoverageEndpoint, ChargeBandsEndpoint}
 import com.gu.support.touchpoint.{TouchpointService, TouchpointServiceProvider}
 
+import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 
 class PaperRoundServiceProvider(configProvider: PaperRoundConfigProvider)(implicit ec: ExecutionContext)
     extends TouchpointServiceProvider[PaperRoundService, PaperRoundConfig](configProvider) {
   override protected def createService(config: PaperRoundConfig) = {
-    new PaperRoundService(config, futureRunner)
+    new PaperRoundService(config, configurableFutureRunner(20.seconds))
   }
 }
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We want to make the generic checkout support National Delivery subscriptions. To do this we need to fetch a list of valid delivery agents for users whose postcode is not in our list of 'inside the M25' postcodes.
We also need to send a different `FulfilmentOptions` value through to the back end when creating the sub - `NationalDelivery` rather than `HomeDelivery`.

I've chosen to make this work without changing the productKey query string parameter as this would cause a full page refesh and be a worse user experience. Instead we send a different fulfilment option for postcodes that are outside the M25 and change the product key which is passed through to the thank you page.
