### PR TITLE
Bump @guardian/libs to 21.4.0

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -82,7 +82,7 @@
 		"@emotion/react": "^11.11.1",
 		"@emotion/utils": "^1.1.0",
 		"@floating-ui/react": "^0.19.2",
-		"@guardian/libs": "^21.1.0",
+		"@guardian/libs": "^21.4.0",
 		"@guardian/pasteup": "1.0.0-alpha.7",
 		"@guardian/source": "8.0.0",
 		"@guardian/source-development-kitchen": "13.1.0",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1809,10 +1809,10 @@
     eslint-plugin-eslint-comments "3.2.0"
     eslint-plugin-import "2.29.1"
 
-"@guardian/libs@^21.1.0":
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-21.1.0.tgz#24450f6fd87363177fe96f516e255ad44120ed1c"
-  integrity sha512-M02tJniKcRDLYPIxJ/KYViLTjugjnzmNi/UTDKZm38xc6hjOPNnhFPBw59W2DlGENrMt58+m7qYAcdMmcEp+KQ==
+"@guardian/libs@^21.4.0":
+  version "21.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-21.4.0.tgz#29da96012192e9930de54fbfdace8c3eabb31fe7"
+  integrity sha512-5EdlqalVRR+o+gRobHRbCQ+dWCY3as3nQlLGg1Fqu2cUSgCOVtMikPkQ/22JSobAOtPX1Sc+pCWunsQfWqbHmA==
 
 "@guardian/pasteup@1.0.0-alpha.7":
   version "1.0.0-alpha.7"


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Updating @guardian/libs version to latest.
Sending both propertyHref and propertyId to Sourcepoint.

## Why are you doing this?

To ensure correct property is selected by Sourcepoint