### PR TITLE
oneTimeCheckout: ApplePay email confirmation  correction

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -680,6 +680,8 @@ export function OneTimeCheckoutComponent({
 										);
 										event.billingDetails?.email &&
 											setEmail(event.billingDetails.email);
+										event.billingDetails?.email &&
+											setConfirmedEmail(event.billingDetails.email);
 
 										/**
 										 * There is a useEffect that listens to this and submits the form


### PR DESCRIPTION
## What are you doing in this PR?

re: [oneTimeCheckout PR](https://github.com/guardian/support-frontend/pull/6795/commits/59fdf84b47eae812f7bcdfc8f3799f955e0bcc44) 

ApplePay not checking out in variant as confirmEmail missing. 

[**Trello Card**](https://trello.com)

![image](https://github.com/user-attachments/assets/49067882-7842-498f-bf16-e43dc518e7d9)
