### PR TITLE
Make payment-success metric for Stripe more granular

### DIFF
--- a/support-payment-api/src/main/scala/backend/StripeBackend.scala
+++ b/support-payment-api/src/main/scala/backend/StripeBackend.scala
@@ -92,7 +92,8 @@ class StripeBackend(
         err
       })
       .semiflatMap { charge =>
-        cloudWatchService.recordPaymentSuccess(PaymentProvider.Stripe)
+        val paymentProvider = PaymentProvider.fromStripePaymentMethod(chargeData.paymentData.stripePaymentMethod)
+        cloudWatchService.recordPaymentSuccess(paymentProvider)
 
         getOrCreateIdentityIdFromEmail(chargeData.paymentData.email.value).map { identityUserDetails =>
           postPaymentTasks(
@@ -232,7 +233,8 @@ class StripeBackend(
       clientBrowserInfo: ClientBrowserInfo,
   ): Future[StripePaymentIntentsApiResponse.Success] = {
 
-    cloudWatchService.recordPaymentSuccess(PaymentProvider.Stripe)
+    val paymentProvider = PaymentProvider.fromStripePaymentMethod(request.paymentData.stripePaymentMethod)
+    cloudWatchService.recordPaymentSuccess(paymentProvider)
 
     getOrCreateIdentityIdFromEmail(request.paymentData.email.value).map { identityUserDetails =>
       paymentIntent.getCharges.getData.asScala.toList.headOption match {


### PR DESCRIPTION
## What are you doing in this PR?

The payment-api emits a payment-success metric from the StripeBackend. Before, the payment-provider dimension was always hard coded to Stripe. This change makes the payment-provider dimension more granular so we'll send one of:

* Stripe
* StripeApplePay
* StripePaymentRequestButton

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

Related to:
[**Trello Card**](https://trello.com/c/lq9WEyx0/1444-one-time-payment-method-switches)

## Why are you doing this?

The reason I want to do this is to have separate alarms for each of these when we go a period without any successful payments.
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

I deployed to CODE and made one time contributions with Stripe (card) and Apple Pay, I can see the granular metrics in the Cloudwatch UI:

![Screenshot 2025-03-07 at 17 21 06](https://github.com/user-attachments/assets/e4f5a1fd-210a-49b5-9865-d61d153e9388)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
