### PR TITLE
Guardian Ad-Lite: Container vertical spacing  adjustment

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/headerCards.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/headerCards.tsx
@@ -29,10 +29,12 @@ const containerCardsAndSignIn = css`
 		position: relative;
 		display: grid;
 		justify-content: center;
-		padding: 44px 10px 0px;
-		${from.mobileLandscape} {
-			padding-left: ${space[5]}px;
-			padding-right: ${space[5]}px;
+		padding: ${space[2]}px 10px 0px;
+		${from.tablet} {
+			padding-top: ${space[6]}px;
+		}
+		${from.desktop} {
+			padding: 42px ${space[5]}px 0px;
 		}
 	}
 `;


### PR DESCRIPTION
## What are you doing in this PR?

Small horizontal spacing adjustment to Guardian Ad-Lite Landing Page

<img width="590" alt="image" src="https://github.com/user-attachments/assets/69fc5f98-99bd-43a1-befb-38c46b35098a" />
