### PR TITLE
Pd/one time checkout email verification live

### DIFF
--- a/support-e2e/tests/test/oneTimeCheckout.ts
+++ b/support-e2e/tests/test/oneTimeCheckout.ts
@@ -28,7 +28,7 @@ export const testOneTimeCheckout = (testDetails: TestDetails) => {
 		baseURL,
 	}) => {
 		// Temporary, assumes confirm email required
-		const url = `/${internationalisationId}/one-time-checkout#ab-oneTimeConfirmEmail=variant`;
+		const url = `/${internationalisationId}/one-time-checkout`;
 		const page = await context.newPage();
 		const testEmail = email();
 		await setupPage(page, context, baseURL, url);

--- a/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/abtestTest.ts
@@ -21,11 +21,8 @@ import { _, init as abInit, getAmountsTestVariant } from '../abtest';
 import type { Audience, Participations, Test, Variant } from '../models';
 
 const { targetPageMatches } = _;
-const {
-	allLandingPagesAndThankyouPages,
-	genericCheckoutOnly,
-	oneTimeCheckoutOnly,
-} = pageUrlRegexes.contributions;
+const { allLandingPagesAndThankyouPages, genericCheckoutOnly } =
+	pageUrlRegexes.contributions;
 
 jest.mock('ophan', () => ({
 	record: () => null,
@@ -646,16 +643,6 @@ it('targetPage matching', () => {
 	).toEqual(true);
 	expect(targetPageMatches('/uk/thankyou', genericCheckoutOnly)).toEqual(false);
 	expect(targetPageMatches('/uk/thank-you', genericCheckoutOnly)).toEqual(
-		false,
-	);
-	expect(
-		targetPageMatches(
-			'/uk/thank-you?contribution=1&userType=current',
-			oneTimeCheckoutOnly,
-		),
-	).toEqual(true);
-	expect(targetPageMatches('/uk/thankyou', oneTimeCheckoutOnly)).toEqual(false);
-	expect(targetPageMatches('/uk/thank-you', oneTimeCheckoutOnly)).toEqual(
 		false,
 	);
 });

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -95,27 +95,6 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeContributionsOnlyCountries: true,
 	},
-	oneTimeConfirmEmail: {
-		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'variant',
-			},
-		],
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		isActive: true,
-		referrerControlled: false, // ab-test name not needed to be in paramURL
-		seed: 5,
-		targetPage: pageUrlRegexes.contributions.oneTimeCheckoutOnly,
-		excludeContributionsOnlyCountries: false,
-	},
 	digitalEditionCheckout: {
 		variants: [
 			{

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -16,8 +16,6 @@ export const pageUrlRegexes = {
 		usLandingPageOnly: '/us/contribute$',
 		genericCheckoutOnly:
 			'(uk|us|au|ca|eu|nz|int)/checkout|thank-you\\?product(.*)?$',
-		oneTimeCheckoutOnly:
-			'(uk|us|au|ca|eu|nz|int)/one-time-checkout|thank-you\\?contribution(.*)?$',
 	},
 	subscriptions: {
 		paper: {

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
@@ -16,7 +16,6 @@ type PersonalDetailsFieldsProps = {
 	isEmailAddressReadOnly: boolean;
 	confirmedEmail: string;
 	setConfirmedEmail: (value: string) => void;
-	requireConfirmedEmail: boolean;
 	isSignedIn: boolean;
 };
 
@@ -30,7 +29,6 @@ export function PersonalDetailsFields({
 	isEmailAddressReadOnly,
 	confirmedEmail,
 	setConfirmedEmail,
-	requireConfirmedEmail,
 	isSignedIn,
 }: PersonalDetailsFieldsProps) {
 	const [firstNameError, setFirstNameError] = useState<string>();
@@ -44,7 +42,6 @@ export function PersonalDetailsFields({
 				isEmailAddressReadOnly={isEmailAddressReadOnly}
 				confirmedEmail={confirmedEmail}
 				setConfirmedEmail={setConfirmedEmail}
-				requireConfirmedEmail={requireConfirmedEmail}
 				isSignedIn={isSignedIn}
 			/>
 			<div>

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
@@ -10,7 +10,6 @@ type PersonalEmailFieldsProps = {
 	isEmailAddressReadOnly: boolean;
 	confirmedEmail: string;
 	setConfirmedEmail: (value: string) => void;
-	requireConfirmedEmail: boolean;
 	isSignedIn: boolean;
 };
 
@@ -20,7 +19,6 @@ export function PersonalEmailFields({
 	isEmailAddressReadOnly,
 	confirmedEmail,
 	setConfirmedEmail,
-	requireConfirmedEmail,
 	isSignedIn,
 }: PersonalEmailFieldsProps) {
 	const [emailError, setEmailError] = useState<string>();
@@ -62,7 +60,7 @@ export function PersonalEmailFields({
 					}}
 				/>
 			</div>
-			{!isEmailAddressReadOnly && requireConfirmedEmail && (
+			{!isEmailAddressReadOnly && (
 				<div>
 					<TextInput
 						id="confirm-email"

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -666,7 +666,6 @@ export function CheckoutComponent({
 								setConfirmedEmail={(confirmedEmail) =>
 									setConfirmedEmail(confirmedEmail)
 								}
-								requireConfirmedEmail={true}
 								isSignedIn={isSignedIn}
 							/>
 

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -351,9 +351,6 @@ export function OneTimeCheckoutComponent({
 	const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('None');
 	const [paymentMethodError, setPaymentMethodError] = useState<string>();
 
-	const inOneTimeConfirmEmailVariant =
-		abParticipations.oneTimeConfirmEmail === 'variant';
-
 	const formRef = useRef<HTMLFormElement>(null);
 
 	const validate = (
@@ -739,7 +736,6 @@ export function OneTimeCheckoutComponent({
 									setConfirmedEmail(confirmedEmail)
 								}
 								isEmailAddressReadOnly={isSignedIn}
-								requireConfirmedEmail={inOneTimeConfirmEmailVariant}
 								isSignedIn={isSignedIn}
 							/>
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
