### PR TITLE
remove subscribeCheckoutImage AB test logic. Variant lost

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -139,27 +139,5 @@ export const tests: Tests = {
 			'/uk/(subscribe/digitaledition$|subscribe/digitaledition/thankyou$|checkout|thank-you)',
 		targetPage: '/subscribe$',
 		excludeContributionsOnlyCountries: true,
-	},
-	subscribeCheckoutImage: {
-		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'variant',
-			},
-		],
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		isActive: true,
-		referrerControlled: false, // ab-test name not needed to be in paramURL
-		seed: 5,
-		targetPage:
-			'(/subscribe/weekly/checkout$|/subscribe/weekly/checkout/gift$)', // weekly only test
-		excludeContributionsOnlyCountries: true,
-	},
+	}
 };

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.tsx
@@ -283,21 +283,16 @@ function PaperCheckoutForm(props: PropTypes) {
 		);
 	}, []);
 
-	const showSummaryImage =
-		props.participations.subscribeCheckoutImage !== 'variant';
-
 	const subsCardOrderSummary = (
 		<PaperOrderSummary
 			image={
-				showSummaryImage ? (
-					<GridImage
-						gridId="printCampaignDigitalVoucher"
-						srcSizes={[500]}
-						sizes="(max-width: 740px) 50vw, 696"
-						imgType="png"
-						altText=""
-					/>
-				) : undefined
+				<GridImage
+					gridId="printCampaignDigitalVoucher"
+					srcSizes={[500]}
+					sizes="(max-width: 740px) 50vw, 696"
+					imgType="png"
+					altText=""
+				/>
 			}
 			total={props.discountedPrice}
 			digiSubPrice={expandedPricingText}
@@ -313,15 +308,13 @@ function PaperCheckoutForm(props: PropTypes) {
 	const homeDeliveryOrderSummary = (
 		<PaperOrderSummary
 			image={
-				showSummaryImage ? (
-					<GridImage
-						gridId="printCampaignHDdigitalVoucher"
-						srcSizes={[500]}
-						sizes="(max-width: 740px) 50vw, 696"
-						imgType="png"
-						altText=""
-					/>
-				) : undefined
+				<GridImage
+					gridId="printCampaignHDdigitalVoucher"
+					srcSizes={[500]}
+					sizes="(max-width: 740px) 50vw, 696"
+					imgType="png"
+					altText=""
+				/>
 			}
 			total={props.discountedPrice}
 			digiSubPrice={expandedPricingText}

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.tsx
@@ -193,8 +193,6 @@ function WeeklyCheckoutForm(props: PropTypes) {
 		);
 	});
 
-	const showSummaryImage =
-		props.participations.subscribeCheckoutImage !== 'variant';
 	return (
 		<Content>
 			<Layout
@@ -202,15 +200,13 @@ function WeeklyCheckoutForm(props: PropTypes) {
 					<>
 						<Summary
 							image={
-								showSummaryImage ? (
-									<GridImage
-										gridId="checkoutPackshotWeekly"
-										srcSizes={[500]}
-										sizes="(max-width: 740px) 50vw, 548"
-										imgType="png"
-										altText=""
-									/>
-								) : undefined
+								<GridImage
+									gridId="checkoutPackshotWeekly"
+									srcSizes={[500]}
+									sizes="(max-width: 740px) 50vw, 548"
+									imgType="png"
+									altText=""
+								/>
 							}
 							title="Guardian Weekly"
 							description=""

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.tsx
@@ -182,24 +182,19 @@ function WeeklyCheckoutFormGifting(props: PropTypes): JSX.Element {
 		props.billingCountry,
 	);
 
-	const showSummaryImage =
-		props.participations.subscribeCheckoutImage !== 'variant';
-
 	return (
 		<Content>
 			<Layout
 				aside={
 					<Summary
 						image={
-							showSummaryImage ? (
-								<GridImage
-									gridId="checkoutPackshotWeeklyGifting"
-									srcSizes={[696, 500]}
-									sizes="(max-width: 740px) 50vw, 696"
-									imgType="png"
-									altText=""
-								/>
-							) : undefined
+							<GridImage
+								gridId="checkoutPackshotWeeklyGifting"
+								srcSizes={[696, 500]}
+								sizes="(max-width: 740px) 50vw, 696"
+								imgType="png"
+								altText=""
+							/>
 						}
 						title="Guardian Weekly"
 						description=""


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Clean up AB test for the subscribeCheckoutImage. Keep the control.
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[End subscribeCheckoutImage A/B test](https://trello.com/c/VhPMN5j8/1475-end-subscribecheckoutimage-a-b-test)

## Why are you doing this?
Test showed losses on the variant, we are keeping the image on checkout.
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
