### PR TITLE
Don't allow Saturday or Sunday rate plans for National Delivery

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -319,25 +319,37 @@ export function CheckoutComponent({
 		AddressFormFieldError[]
 	>([]);
 
-	const fetchDeliveryAgentsForPostcodesOutsideTheM25 = async (
-		postcode: string,
-	) => {
+	const fetchDeliveryAgentsIfRequired = async (postcode: string) => {
 		if (isValidPostcode(postcode)) {
 			if (postcodeIsWithinDeliveryArea(postcode)) {
+				// The user's postcode is inside the M25
 				setDeliveryPostcodeIsOutsideM25(false);
+			} else if (ratePlanKey === 'Saturday' || ratePlanKey === 'Sunday') {
+				// The user's postcode is outside the M25 but they have selected a
+				// Saturday or Sunday only rate plan which is not supported
+				setDeliveryAddressErrors((prevState) => [
+					...prevState,
+					{
+						field: 'postCode',
+						message:
+							'Saturday or Sunday delivery is available for Greater London only. Go back and select Weekend delivery option or choose a Digital Voucher.',
+					},
+				]);
 			} else {
+				// The users postcode is outside the M25 and they have selected a valid rate plan
 				setDeliveryPostcodeIsOutsideM25(true);
 				const agents = await getDeliveryAgents(postcode);
 				setDeliveryAgents(agents);
 			}
 		} else {
+			// The user's postcode is invalid
 			setDeliveryPostcodeIsOutsideM25(false);
 			setDeliveryAgents(undefined);
 		}
 	};
 	useEffect(() => {
 		if (productKey === 'HomeDelivery') {
-			void fetchDeliveryAgentsForPostcodesOutsideTheM25(deliveryPostcode);
+			void fetchDeliveryAgentsIfRequired(deliveryPostcode);
 		}
 	}, [deliveryPostcode]);
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR prevents users who live outside the M25 from purchasing a home delivery Saturday or Sunday only subscription through the generic checkout.

[**Trello Card**](https://trello.com/c/K7d35lpd/1457-saturday-national-delivery-validation)

## Why are you doing this?
This matches existing functionality on the old print checkout. It is not economical for us to fulfil single day subscriptions using PaperRound, hence the restriction.

## How to test
- Go to the checkout locally with the product set to HomeDelivery and the rate plan set to Saturday:
https://support.thegulocal.com/uk/checkout?product=HomeDelivery&ratePlan=Saturday
- Enter a postcode outside the M25, for example BS19GU, you should see the error message in the screenshot below.
- Change the postcode to one inside the M25, for example N19GU and there should be no error message.
## Screenshots
![Screenshot 2025-03-11 at 16 26 24](https://github.com/user-attachments/assets/9d0f17f3-ce1b-42c4-a63f-a2fbe90faf0d)

