### PR TITLE
Remove postcode error when postcode changes

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -342,7 +342,7 @@ export function CheckoutComponent({
 				setDeliveryAgents(agents);
 			}
 		} else {
-			// The user's postcode is invalid
+			// The postcode field does not contain a valid postcode, so reset to default state
 			setDeliveryPostcodeIsOutsideM25(false);
 			setDeliveryAgents(undefined);
 			setDeliveryAddressErrors((prevState) =>

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -345,6 +345,9 @@ export function CheckoutComponent({
 			// The user's postcode is invalid
 			setDeliveryPostcodeIsOutsideM25(false);
 			setDeliveryAgents(undefined);
+			setDeliveryAddressErrors((prevState) =>
+				prevState.filter((error) => error.field !== 'postCode'),
+			);
 		}
 	};
 	useEffect(() => {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
I missed pushing this commit to #6845
It just clears the error message related to single day home delivery plans for postcodes outside the M25 when the postcode is changed.