### PR TITLE
oneTimeCheckout: email confirmation remove (control)

### DIFF
--- a/support-e2e/tests/smoke/promo-codes.test.ts
+++ b/support-e2e/tests/smoke/promo-codes.test.ts
@@ -3,7 +3,7 @@ import { email, firstName, lastName } from '../utils/users';
 import { checkRecaptcha } from '../utils/recaptcha';
 import { fillInCardDetails } from '../utils/cardDetails';
 import { setupPage } from '../utils/page';
-import { setTestUserRequiredDetails } from '../utils/testUserDetails';
+import { setTestUserConfirmRequiredDetails } from '../utils/testUserDetails';
 
 /**
  * These tests are here to test that the promoCode values and associated copy
@@ -68,9 +68,8 @@ import { setTestUserRequiredDetails } from '../utils/testUserDetails';
 		await expect(
 			page.getByText(testDetails.expectedCheckoutTotalText).first(),
 		).toBeVisible();
-		await setTestUserRequiredDetails(
+		await setTestUserConfirmRequiredDetails(
 			page,
-			testEmail,
 			testEmail,
 			testFirstName,
 			testLastName,

--- a/support-e2e/tests/smoke/promo-codes.test.ts
+++ b/support-e2e/tests/smoke/promo-codes.test.ts
@@ -71,6 +71,7 @@ import { setTestUserRequiredDetails } from '../utils/testUserDetails';
 		await setTestUserRequiredDetails(
 			page,
 			testEmail,
+			testEmail,
 			testFirstName,
 			testLastName,
 		);

--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -24,10 +24,17 @@ const setUserDetailsForProduct = async (
 	product,
 	internationalisationId,
 ) => {
+	const testEmail = email();
 	switch (product) {
 		case 'SupporterPlus':
 		case 'GuardianAdLite':
-			await setTestUserRequiredDetails(page, email(), firstName(), lastName());
+			await setTestUserRequiredDetails(
+				page,
+				testEmail,
+				testEmail,
+				firstName(),
+				lastName(),
+			);
 
 			break;
 		case 'TierThree':

--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -3,7 +3,7 @@ import { email, firstName, lastName } from '../utils/users';
 import { setupPage } from '../utils/page';
 import {
 	setTestUserDetails,
-	setTestUserRequiredDetails,
+	setTestUserConfirmRequiredDetails,
 } from '../utils/testUserDetails';
 import { fillInPayPalDetails } from '../utils/paypal';
 import { fillInCardDetails } from '../utils/cardDetails';
@@ -24,14 +24,12 @@ const setUserDetailsForProduct = async (
 	product,
 	internationalisationId,
 ) => {
-	const testEmail = email();
 	switch (product) {
 		case 'SupporterPlus':
 		case 'GuardianAdLite':
-			await setTestUserRequiredDetails(
+			await setTestUserConfirmRequiredDetails(
 				page,
-				testEmail,
-				testEmail,
+				email(),
 				firstName(),
 				lastName(),
 			);

--- a/support-e2e/tests/test/oneTimeCheckout.ts
+++ b/support-e2e/tests/test/oneTimeCheckout.ts
@@ -28,7 +28,7 @@ export const testOneTimeCheckout = (testDetails: TestDetails) => {
 		baseURL,
 	}) => {
 		// Temporary, assumes confirm email required
-		const url = `/${internationalisationId}/one-time-checkout#ab-oneTimeConfirmEmail=control`;
+		const url = `/${internationalisationId}/one-time-checkout`;
 		const page = await context.newPage();
 		const testEmail = email();
 		await setupPage(page, context, baseURL, url);

--- a/support-e2e/tests/test/oneTimeCheckout.ts
+++ b/support-e2e/tests/test/oneTimeCheckout.ts
@@ -28,7 +28,7 @@ export const testOneTimeCheckout = (testDetails: TestDetails) => {
 		baseURL,
 	}) => {
 		// Temporary, assumes confirm email required
-		const url = `/${internationalisationId}/one-time-checkout#ab-oneTimeConfirmEmail=variant`;
+		const url = `/${internationalisationId}/one-time-checkout#ab-oneTimeConfirmEmail=control`;
 		const page = await context.newPage();
 		const testEmail = email();
 		await setupPage(page, context, baseURL, url);

--- a/support-e2e/tests/utils/testUserDetails.ts
+++ b/support-e2e/tests/utils/testUserDetails.ts
@@ -1,23 +1,31 @@
 import { Page } from '@playwright/test';
 import { TestFields } from './userFields';
 
+export const setTestUserConfirmRequiredDetails = async (
+	page: Page,
+	email: string,
+	firstName?: string,
+	lastName?: string,
+) => {
+	await setTestUserRequiredDetails(page, email, firstName, lastName);
+	await setTestConfirmEmail(page, email);
+};
 export const setTestUserRequiredDetails = async (
 	page: Page,
 	email: string,
-	confirmEmail?: string,
 	firstName?: string,
 	lastName?: string,
 ) => {
 	await page.getByLabel('Email address', { exact: true }).fill(email);
-	if (confirmEmail) {
-		await page.getByLabel('Confirm email address', { exact: true }).fill(email);
-	}
 	if (firstName) {
 		await page.getByLabel('First name').fill(firstName);
 	}
 	if (lastName) {
 		await page.getByLabel('Last name').fill(lastName);
 	}
+};
+const setTestConfirmEmail = async (page: Page, email: string) => {
+	await page.getByLabel('Confirm email address', { exact: true }).fill(email);
 };
 
 export const setTestUserDetails = async (
@@ -26,9 +34,8 @@ export const setTestUserDetails = async (
 	internationalisationId: string,
 	tier: number,
 ) => {
-	await setTestUserRequiredDetails(
+	await setTestUserConfirmRequiredDetails(
 		page,
-		testFields.email,
 		testFields.email,
 		testFields.firstName,
 		testFields.lastName,

--- a/support-e2e/tests/utils/testUserDetails.ts
+++ b/support-e2e/tests/utils/testUserDetails.ts
@@ -4,11 +4,14 @@ import { TestFields } from './userFields';
 export const setTestUserRequiredDetails = async (
 	page: Page,
 	email: string,
+	confirmEmail?: string,
 	firstName?: string,
 	lastName?: string,
 ) => {
 	await page.getByLabel('Email address', { exact: true }).fill(email);
-	await page.getByLabel('Confirm email address', { exact: true }).fill(email);
+	if (confirmEmail) {
+		await page.getByLabel('Confirm email address', { exact: true }).fill(email);
+	}
 	if (firstName) {
 		await page.getByLabel('First name').fill(firstName);
 	}
@@ -25,6 +28,7 @@ export const setTestUserDetails = async (
 ) => {
 	await setTestUserRequiredDetails(
 		page,
+		testFields.email,
 		testFields.email,
 		testFields.firstName,
 		testFields.lastName,

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -95,27 +95,6 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeContributionsOnlyCountries: true,
 	},
-	oneTimeConfirmEmail: {
-		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'variant',
-			},
-		],
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		isActive: true,
-		referrerControlled: false, // ab-test name not needed to be in paramURL
-		seed: 5,
-		targetPage: pageUrlRegexes.contributions.oneTimeCheckoutOnly,
-		excludeContributionsOnlyCountries: false,
-	},
 	digitalEditionCheckout: {
 		variants: [
 			{

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
@@ -30,7 +30,6 @@ export function PersonalDetailsFields({
 	isEmailAddressReadOnly,
 	confirmedEmail,
 	setConfirmedEmail,
-	requireConfirmedEmail,
 	isSignedIn,
 }: PersonalDetailsFieldsProps) {
 	const [firstNameError, setFirstNameError] = useState<string>();
@@ -44,7 +43,6 @@ export function PersonalDetailsFields({
 				isEmailAddressReadOnly={isEmailAddressReadOnly}
 				confirmedEmail={confirmedEmail}
 				setConfirmedEmail={setConfirmedEmail}
-				requireConfirmedEmail={requireConfirmedEmail}
 				isSignedIn={isSignedIn}
 			/>
 			<div>

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
@@ -16,7 +16,6 @@ type PersonalDetailsFieldsProps = {
 	isEmailAddressReadOnly: boolean;
 	confirmedEmail: string;
 	setConfirmedEmail: (value: string) => void;
-	requireConfirmedEmail: boolean;
 	isSignedIn: boolean;
 };
 

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
@@ -9,7 +9,6 @@ type PersonalEmailFieldsProps = {
 	setEmail: (value: string) => void;
 	isEmailAddressReadOnly: boolean;
 	isSignedIn: boolean;
-	requireConfirmedEmail?: boolean;
 	confirmedEmail?: string;
 	setConfirmedEmail?: (value: string) => void;
 };
@@ -19,7 +18,6 @@ export function PersonalEmailFields({
 	setEmail,
 	isEmailAddressReadOnly,
 	isSignedIn,
-	requireConfirmedEmail,
 	confirmedEmail,
 	setConfirmedEmail,
 }: PersonalEmailFieldsProps) {
@@ -62,50 +60,44 @@ export function PersonalEmailFields({
 					}}
 				/>
 			</div>
-			{!isEmailAddressReadOnly &&
-				requireConfirmedEmail &&
-				setConfirmedEmail && (
-					<div>
-						<TextInput
-							id="confirm-email"
-							data-qm-masking="blocklist"
-							label="Confirm email address"
-							value={confirmedEmail}
-							type="email"
-							autoComplete="email"
-							onChange={(event) => {
-								setConfirmedEmail(event.currentTarget.value);
-							}}
-							onBlur={(event) => {
-								event.target.checkValidity();
-							}}
-							name="confirm-email"
-							required
-							maxLength={80}
-							error={confirmedEmailError}
-							pattern={escapeStringRegexp(email)}
-							onInvalid={(event) => {
-								preventDefaultValidityMessage(event.currentTarget);
-								const validityState = event.currentTarget.validity;
-								if (validityState.valid) {
-									setConfirmedEmailError(undefined);
+			{!isEmailAddressReadOnly && setConfirmedEmail && (
+				<div>
+					<TextInput
+						id="confirm-email"
+						data-qm-masking="blocklist"
+						label="Confirm email address"
+						value={confirmedEmail}
+						type="email"
+						autoComplete="email"
+						onChange={(event) => {
+							setConfirmedEmail(event.currentTarget.value);
+						}}
+						onBlur={(event) => {
+							event.target.checkValidity();
+						}}
+						name="confirm-email"
+						required
+						maxLength={80}
+						error={confirmedEmailError}
+						pattern={escapeStringRegexp(email)}
+						onInvalid={(event) => {
+							preventDefaultValidityMessage(event.currentTarget);
+							const validityState = event.currentTarget.validity;
+							if (validityState.valid) {
+								setConfirmedEmailError(undefined);
+							} else {
+								if (validityState.valueMissing) {
+									setConfirmedEmailError('Please confirm your email address.');
+								} else if (validityState.patternMismatch) {
+									setConfirmedEmailError('The email addresses do not match.');
 								} else {
-									if (validityState.valueMissing) {
-										setConfirmedEmailError(
-											'Please confirm your email address.',
-										);
-									} else if (validityState.patternMismatch) {
-										setConfirmedEmailError('The email addresses do not match.');
-									} else {
-										setConfirmedEmailError(
-											'Please enter a valid email address.',
-										);
-									}
+									setConfirmedEmailError('Please enter a valid email address.');
 								}
-							}}
-						/>
-					</div>
-				)}
+							}
+						}}
+					/>
+				</div>
+			)}
 			<Signout isSignedIn={isSignedIn} />
 		</>
 	);

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
@@ -8,20 +8,20 @@ type PersonalEmailFieldsProps = {
 	email: string;
 	setEmail: (value: string) => void;
 	isEmailAddressReadOnly: boolean;
-	confirmedEmail: string;
-	setConfirmedEmail: (value: string) => void;
-	requireConfirmedEmail: boolean;
 	isSignedIn: boolean;
+	requireConfirmedEmail?: boolean;
+	confirmedEmail?: string;
+	setConfirmedEmail?: (value: string) => void;
 };
 
 export function PersonalEmailFields({
 	email,
 	setEmail,
 	isEmailAddressReadOnly,
+	isSignedIn,
+	requireConfirmedEmail,
 	confirmedEmail,
 	setConfirmedEmail,
-	requireConfirmedEmail,
-	isSignedIn,
 }: PersonalEmailFieldsProps) {
 	const [emailError, setEmailError] = useState<string>();
 	const [confirmedEmailError, setConfirmedEmailError] = useState<string>();
@@ -62,44 +62,50 @@ export function PersonalEmailFields({
 					}}
 				/>
 			</div>
-			{!isEmailAddressReadOnly && requireConfirmedEmail && (
-				<div>
-					<TextInput
-						id="confirm-email"
-						data-qm-masking="blocklist"
-						label="Confirm email address"
-						value={confirmedEmail}
-						type="email"
-						autoComplete="email"
-						onChange={(event) => {
-							setConfirmedEmail(event.currentTarget.value);
-						}}
-						onBlur={(event) => {
-							event.target.checkValidity();
-						}}
-						name="confirm-email"
-						required
-						maxLength={80}
-						error={confirmedEmailError}
-						pattern={escapeStringRegexp(email)}
-						onInvalid={(event) => {
-							preventDefaultValidityMessage(event.currentTarget);
-							const validityState = event.currentTarget.validity;
-							if (validityState.valid) {
-								setConfirmedEmailError(undefined);
-							} else {
-								if (validityState.valueMissing) {
-									setConfirmedEmailError('Please confirm your email address.');
-								} else if (validityState.patternMismatch) {
-									setConfirmedEmailError('The email addresses do not match.');
+			{!isEmailAddressReadOnly &&
+				requireConfirmedEmail &&
+				setConfirmedEmail && (
+					<div>
+						<TextInput
+							id="confirm-email"
+							data-qm-masking="blocklist"
+							label="Confirm email address"
+							value={confirmedEmail}
+							type="email"
+							autoComplete="email"
+							onChange={(event) => {
+								setConfirmedEmail(event.currentTarget.value);
+							}}
+							onBlur={(event) => {
+								event.target.checkValidity();
+							}}
+							name="confirm-email"
+							required
+							maxLength={80}
+							error={confirmedEmailError}
+							pattern={escapeStringRegexp(email)}
+							onInvalid={(event) => {
+								preventDefaultValidityMessage(event.currentTarget);
+								const validityState = event.currentTarget.validity;
+								if (validityState.valid) {
+									setConfirmedEmailError(undefined);
 								} else {
-									setConfirmedEmailError('Please enter a valid email address.');
+									if (validityState.valueMissing) {
+										setConfirmedEmailError(
+											'Please confirm your email address.',
+										);
+									} else if (validityState.patternMismatch) {
+										setConfirmedEmailError('The email addresses do not match.');
+									} else {
+										setConfirmedEmailError(
+											'Please enter a valid email address.',
+										);
+									}
 								}
-							}
-						}}
-					/>
-				</div>
-			)}
+							}}
+						/>
+					</div>
+				)}
 			<Signout isSignedIn={isSignedIn} />
 		</>
 	);

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
@@ -60,44 +60,50 @@ export function PersonalEmailFields({
 					}}
 				/>
 			</div>
-			{!isEmailAddressReadOnly && setConfirmedEmail && (
-				<div>
-					<TextInput
-						id="confirm-email"
-						data-qm-masking="blocklist"
-						label="Confirm email address"
-						value={confirmedEmail}
-						type="email"
-						autoComplete="email"
-						onChange={(event) => {
-							setConfirmedEmail(event.currentTarget.value);
-						}}
-						onBlur={(event) => {
-							event.target.checkValidity();
-						}}
-						name="confirm-email"
-						required
-						maxLength={80}
-						error={confirmedEmailError}
-						pattern={escapeStringRegexp(email)}
-						onInvalid={(event) => {
-							preventDefaultValidityMessage(event.currentTarget);
-							const validityState = event.currentTarget.validity;
-							if (validityState.valid) {
-								setConfirmedEmailError(undefined);
-							} else {
-								if (validityState.valueMissing) {
-									setConfirmedEmailError('Please confirm your email address.');
-								} else if (validityState.patternMismatch) {
-									setConfirmedEmailError('The email addresses do not match.');
+			{!isEmailAddressReadOnly &&
+				setConfirmedEmail &&
+				confirmedEmail !== undefined && (
+					<div>
+						<TextInput
+							id="confirm-email"
+							data-qm-masking="blocklist"
+							label="Confirm email address"
+							value={confirmedEmail}
+							type="email"
+							autoComplete="email"
+							onChange={(event) => {
+								setConfirmedEmail(event.currentTarget.value);
+							}}
+							onBlur={(event) => {
+								event.target.checkValidity();
+							}}
+							name="confirm-email"
+							required
+							maxLength={80}
+							error={confirmedEmailError}
+							pattern={escapeStringRegexp(email)}
+							onInvalid={(event) => {
+								preventDefaultValidityMessage(event.currentTarget);
+								const validityState = event.currentTarget.validity;
+								if (validityState.valid) {
+									setConfirmedEmailError(undefined);
 								} else {
-									setConfirmedEmailError('Please enter a valid email address.');
+									if (validityState.valueMissing) {
+										setConfirmedEmailError(
+											'Please confirm your email address.',
+										);
+									} else if (validityState.patternMismatch) {
+										setConfirmedEmailError('The email addresses do not match.');
+									} else {
+										setConfirmedEmailError(
+											'Please enter a valid email address.',
+										);
+									}
 								}
-							}
-						}}
-					/>
-				</div>
-			)}
+							}}
+						/>
+					</div>
+				)}
 			<Signout isSignedIn={isSignedIn} />
 		</>
 	);

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -725,7 +725,6 @@ export function CheckoutComponent({
 								setConfirmedEmail={(confirmedEmail) =>
 									setConfirmedEmail(confirmedEmail)
 								}
-								requireConfirmedEmail={true}
 								isSignedIn={isSignedIn}
 							/>
 

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -333,8 +333,6 @@ export function OneTimeCheckoutComponent({
 
 	/** Personal details **/
 	const [email, setEmail] = useState(user?.email ?? '');
-	const [confirmedEmail, setConfirmedEmail] = useState('');
-
 	const [billingPostcode, setBillingPostcode] = useState('');
 	const [billingPostcodeError, setBillingPostcodeError] = useState<string>();
 
@@ -677,8 +675,6 @@ export function OneTimeCheckoutComponent({
 										);
 										event.billingDetails?.email &&
 											setEmail(event.billingDetails.email);
-										event.billingDetails?.email &&
-											setConfirmedEmail(event.billingDetails.email);
 
 										/**
 										 * There is a useEffect that listens to this and submits the form
@@ -731,12 +727,7 @@ export function OneTimeCheckoutComponent({
 							<PersonalEmailFields
 								email={email}
 								setEmail={(email) => setEmail(email)}
-								confirmedEmail={confirmedEmail}
-								setConfirmedEmail={(confirmedEmail) =>
-									setConfirmedEmail(confirmedEmail)
-								}
 								isEmailAddressReadOnly={isSignedIn}
-								requireConfirmedEmail={false}
 								isSignedIn={isSignedIn}
 							/>
 

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -351,9 +351,6 @@ export function OneTimeCheckoutComponent({
 	const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('None');
 	const [paymentMethodError, setPaymentMethodError] = useState<string>();
 
-	const inOneTimeConfirmEmailVariant =
-		abParticipations.oneTimeConfirmEmail === 'variant';
-
 	const formRef = useRef<HTMLFormElement>(null);
 
 	const validate = (
@@ -739,7 +736,7 @@ export function OneTimeCheckoutComponent({
 									setConfirmedEmail(confirmedEmail)
 								}
 								isEmailAddressReadOnly={isSignedIn}
-								requireConfirmedEmail={inOneTimeConfirmEmailVariant}
+								requireConfirmedEmail={false}
 								isSignedIn={isSignedIn}
 							/>
 


### PR DESCRIPTION
## What are you doing in this PR?

- Makes the CONTROL live for this [PR](https://github.com/guardian/support-frontend/pull/6795)
- Remove AbTest

[**Trello Card**](https://trello.com/c/SizWySqG/1476-end-onetimeconfirmemail-a-b-test)

## Screenshots
|From|To|
|-----|-----|
|![image](https://github.com/user-attachments/assets/8d3dedc4-714b-4234-ab75-463fa948cc0c)|![image](https://github.com/user-attachments/assets/64373ac6-71f7-40b9-b69a-90c068186fb5)|

