### PR TITLE
Change a component to trigger a Storybook diff

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/guardianAdLiteCard.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/guardianAdLiteCard.tsx
@@ -8,7 +8,6 @@ import {
 	until,
 } from '@guardian/source/foundations';
 import { LinkButton, themeLinkBrand } from '@guardian/source/react-components';
-import { Divider } from '@guardian/source-development-kitchen/react-components';
 import { BenefitsCheckList } from 'components/checkoutBenefits/benefitsCheckList';
 import { type ProductDescription } from 'helpers/productCatalog';
 import { guardianAdLiteIconLeftSvg } from './guardianAdLiteIconLeftSvg';
@@ -71,13 +70,6 @@ const btnStyleOverrides = css`
 		margin-bottom: ${space[2]}px;
 	}
 `;
-const dividerCss = css`
-	width: 100%;
-	margin: ${space[4]}px 0;
-	${from.desktop} {
-		margin: ${space[6]}px 0;
-	}
-`;
 const checkmarkBenefitList = css`
 	text-align: left;
 	width: 100%;
@@ -111,7 +103,6 @@ export function GuardianAdLiteCard({
 					{ctaCopy}
 				</LinkButton>
 			</ThemeProvider>
-			<Divider cssOverrides={dividerCss} />
 			<BenefitsCheckList
 				benefitsCheckListData={benefits.map((benefit) => {
 					return {


### PR DESCRIPTION
I want to see if this is reported in CI.

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
