### PR TITLE
Add delivery instructions to generic checkout

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -5,6 +5,7 @@ import {
 	Label,
 	Radio,
 	RadioGroup,
+	TextArea,
 	TextInput,
 } from '@guardian/source/react-components';
 import {
@@ -368,6 +369,9 @@ export function CheckoutComponent({
 	const [lastName, setLastName] = useState(user?.lastName ?? '');
 	const [email, setEmail] = useState(user?.email ?? '');
 	const [confirmedEmail, setConfirmedEmail] = useState('');
+
+	/** Delivery Instructions */
+	const [deliveryInstructions, setDeliveryInstructions] = useState('');
 
 	/** Delivery and billing addresses */
 	const [deliveryPostcode, setDeliveryPostcode] = useState('');
@@ -898,6 +902,25 @@ export function CheckoutComponent({
 												},
 											);
 										}}
+									/>
+								</fieldset>
+								<fieldset
+									css={css`
+										margin-bottom: ${space[6]}px;
+									`}
+								>
+									<TextArea
+										id="deliveryInstructions"
+										data-qm-masking="blocklist"
+										name="deliveryInstructions"
+										label="Delivery instructions"
+										autoComplete="new-password" // Using "new-password" here because "off" isn't working in chrome
+										supporting="Please let us know any details to help us find your property (door colour, any access issues) and the best place to leave your newspaper. For example, 'Front door - red - on Crinan Street, put through letterbox'"
+										onChange={(event) => {
+											setDeliveryInstructions(event.target.value);
+										}}
+										value={deliveryInstructions}
+										optional
 									/>
 								</fieldset>
 

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -904,26 +904,27 @@ export function CheckoutComponent({
 										}}
 									/>
 								</fieldset>
-								<fieldset
-									css={css`
-										margin-bottom: ${space[6]}px;
-									`}
-								>
-									<TextArea
-										id="deliveryInstructions"
-										data-qm-masking="blocklist"
-										name="deliveryInstructions"
-										label="Delivery instructions"
-										autoComplete="new-password" // Using "new-password" here because "off" isn't working in chrome
-										supporting="Please let us know any details to help us find your property (door colour, any access issues) and the best place to leave your newspaper. For example, 'Front door - red - on Crinan Street, put through letterbox'"
-										onChange={(event) => {
-											setDeliveryInstructions(event.target.value);
-										}}
-										value={deliveryInstructions}
-										optional
-									/>
-								</fieldset>
-
+								{productKey === 'HomeDelivery' && (
+									<fieldset
+										css={css`
+											margin-bottom: ${space[6]}px;
+										`}
+									>
+										<TextArea
+											id="deliveryInstructions"
+											data-qm-masking="blocklist"
+											name="deliveryInstructions"
+											label="Delivery instructions"
+											autoComplete="new-password" // Using "new-password" here because "off" isn't working in chrome
+											supporting="Please let us know any details to help us find your property (door colour, any access issues) and the best place to leave your newspaper. For example, 'Front door - red - on Crinan Street, put through letterbox'"
+											onChange={(event) => {
+												setDeliveryInstructions(event.target.value);
+											}}
+											value={deliveryInstructions}
+											optional
+										/>
+									</fieldset>
+								)}
 								<fieldset
 									css={css`
 										margin-bottom: ${space[6]}px;

--- a/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
@@ -76,6 +76,7 @@ export const submitForm = async ({
 			  }
 			: undefined;
 	const supportAbTests = getSupportAbTests(abParticipations);
+	const deliveryInstructions = formData.get('deliveryInstructions') as string;
 
 	const createSupportWorkersRequest: RegularPaymentRequest = {
 		...personalData,
@@ -88,7 +89,7 @@ export const submitForm = async ({
 		referrerAcquisitionData,
 		product: productFields,
 		supportAbTests,
-		deliveryInstructions: formData.get('deliveryInstructions') as string,
+		deliveryInstructions,
 		debugInfo: '',
 	};
 

--- a/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
@@ -88,6 +88,7 @@ export const submitForm = async ({
 		referrerAcquisitionData,
 		product: productFields,
 		supportAbTests,
+		deliveryInstructions: formData.get('deliveryInstructions') as string,
 		debugInfo: '',
 	};
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Newspaper home delivery should have a 'delivery instructions' field on the checkout so that customers can give us more information about how to delivery their paper successfully.

This PR adds that field to the generic checkout, taking the design from the old newspaper checkout

![Screenshot 2025-03-18 at 10 22 48](https://github.com/user-attachments/assets/e3456968-f2f7-4767-bd41-f24984aecb9c)
