### PR TITLE
oneTimeCheckout: email confirmation optional field amendment (control) 

### DIFF
--- a/support-e2e/tests/smoke/promo-codes.test.ts
+++ b/support-e2e/tests/smoke/promo-codes.test.ts
@@ -71,9 +71,9 @@ import { setTestUserDetails } from '../utils/testUserDetails';
 		await setTestUserDetails(
 			page,
 			testEmail,
-			testEmail,
 			testFirstName,
 			testLastName,
+			true,
 		);
 		await page.getByRole('radio', { name: 'Credit/Debit card' }).check();
 		await fillInCardDetails(page);

--- a/support-e2e/tests/smoke/promo-codes.test.ts
+++ b/support-e2e/tests/smoke/promo-codes.test.ts
@@ -3,7 +3,7 @@ import { email, firstName, lastName } from '../utils/users';
 import { checkRecaptcha } from '../utils/recaptcha';
 import { fillInCardDetails } from '../utils/cardDetails';
 import { setupPage } from '../utils/page';
-import { setTestUserConfirmRequiredDetails } from '../utils/testUserDetails';
+import { setTestUserPersonalDetails } from '../utils/testUserDetails';
 
 /**
  * These tests are here to test that the promoCode values and associated copy
@@ -68,8 +68,9 @@ import { setTestUserConfirmRequiredDetails } from '../utils/testUserDetails';
 		await expect(
 			page.getByText(testDetails.expectedCheckoutTotalText).first(),
 		).toBeVisible();
-		await setTestUserConfirmRequiredDetails(
+		await setTestUserPersonalDetails(
 			page,
+			testEmail,
 			testEmail,
 			testFirstName,
 			testLastName,

--- a/support-e2e/tests/smoke/promo-codes.test.ts
+++ b/support-e2e/tests/smoke/promo-codes.test.ts
@@ -3,7 +3,7 @@ import { email, firstName, lastName } from '../utils/users';
 import { checkRecaptcha } from '../utils/recaptcha';
 import { fillInCardDetails } from '../utils/cardDetails';
 import { setupPage } from '../utils/page';
-import { setTestUserPersonalDetails } from '../utils/testUserDetails';
+import { setTestUserDetails } from '../utils/testUserDetails';
 
 /**
  * These tests are here to test that the promoCode values and associated copy
@@ -68,7 +68,7 @@ import { setTestUserPersonalDetails } from '../utils/testUserDetails';
 		await expect(
 			page.getByText(testDetails.expectedCheckoutTotalText).first(),
 		).toBeVisible();
-		await setTestUserPersonalDetails(
+		await setTestUserDetails(
 			page,
 			testEmail,
 			testEmail,

--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -1,14 +1,14 @@
 import { expect, Page, test } from '@playwright/test';
 import { email, firstName, lastName } from '../utils/users';
 import { setupPage } from '../utils/page';
-import {
-	setTestUserDetails,
-	setTestUserConfirmRequiredDetails,
-} from '../utils/testUserDetails';
 import { fillInPayPalDetails } from '../utils/paypal';
 import { fillInCardDetails } from '../utils/cardDetails';
 import { checkRecaptcha } from '../utils/recaptcha';
 import { TestFields, ukWithPostalAddressOnly } from '../utils/userFields';
+import {
+	setTestUserDetails,
+	setTestUserPersonalDetails,
+} from '../utils/testUserDetails';
 
 // TODO: it'd be great to make the types here more specific, possibly using the
 // shared types from the product catalog.
@@ -27,8 +27,9 @@ const setUserDetailsForProduct = async (
 	switch (product) {
 		case 'SupporterPlus':
 		case 'GuardianAdLite':
-			await setTestUserConfirmRequiredDetails(
+			await setTestUserPersonalDetails(
 				page,
+				email(),
 				email(),
 				firstName(),
 				lastName(),

--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -27,7 +27,7 @@ const setUserDetailsForProduct = async (
 	switch (product) {
 		case 'SupporterPlus':
 		case 'GuardianAdLite':
-			await setTestUserDetails(page, email(), email(), firstName(), lastName());
+			await setTestUserDetails(page, email(), firstName(), lastName(), true);
 
 			break;
 		case 'TierThree':

--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -6,8 +6,8 @@ import { fillInCardDetails } from '../utils/cardDetails';
 import { checkRecaptcha } from '../utils/recaptcha';
 import { TestFields, ukWithPostalAddressOnly } from '../utils/userFields';
 import {
+	setTestUserAddressDetails,
 	setTestUserDetails,
-	setTestUserPersonalDetails,
 } from '../utils/testUserDetails';
 
 // TODO: it'd be great to make the types here more specific, possibly using the
@@ -27,13 +27,7 @@ const setUserDetailsForProduct = async (
 	switch (product) {
 		case 'SupporterPlus':
 		case 'GuardianAdLite':
-			await setTestUserPersonalDetails(
-				page,
-				email(),
-				email(),
-				firstName(),
-				lastName(),
-			);
+			await setTestUserDetails(page, email(), email(), firstName(), lastName());
 
 			break;
 		case 'TierThree':
@@ -46,7 +40,12 @@ const setUserDetailsForProduct = async (
 					`Couldn't find user details for ${product} in ${internationalisationId}`,
 				);
 			}
-			await setTestUserDetails(page, userDetails, internationalisationId, 3);
+			await setTestUserAddressDetails(
+				page,
+				userDetails,
+				internationalisationId,
+				3,
+			);
 
 			break;
 		default:

--- a/support-e2e/tests/test/oneTimeCheckout.ts
+++ b/support-e2e/tests/test/oneTimeCheckout.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { email, firstName, lastName } from '../utils/users';
 import { setupPage } from '../utils/page';
-import { setTestUserPersonalDetails } from '../utils/testUserDetails';
+import { setTestUserDetails } from '../utils/testUserDetails';
 import { fillInPayPalDetails } from '../utils/paypal';
 import {
 	fillInCardDetails,
@@ -31,7 +31,7 @@ export const testOneTimeCheckout = (testDetails: TestDetails) => {
 		const url = `/${internationalisationId}/one-time-checkout`;
 		const page = await context.newPage();
 		await setupPage(page, context, baseURL, url);
-		await setTestUserPersonalDetails(page, email());
+		await setTestUserDetails(page, email());
 		await page.getByRole('radio', { name: paymentType }).check();
 
 		if (paymentType === 'Credit/Debit card') {

--- a/support-e2e/tests/test/oneTimeCheckout.ts
+++ b/support-e2e/tests/test/oneTimeCheckout.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { email, firstName, lastName } from '../utils/users';
 import { setupPage } from '../utils/page';
-import { setTestUserRequiredDetails } from '../utils/testUserDetails';
+import { setTestUserPersonalDetails } from '../utils/testUserDetails';
 import { fillInPayPalDetails } from '../utils/paypal';
 import {
 	fillInCardDetails,
@@ -30,9 +30,8 @@ export const testOneTimeCheckout = (testDetails: TestDetails) => {
 		// Temporary, assumes confirm email required
 		const url = `/${internationalisationId}/one-time-checkout`;
 		const page = await context.newPage();
-		const testEmail = email();
 		await setupPage(page, context, baseURL, url);
-		await setTestUserRequiredDetails(page, testEmail);
+		await setTestUserPersonalDetails(page, email());
 		await page.getByRole('radio', { name: paymentType }).check();
 
 		if (paymentType === 'Credit/Debit card') {

--- a/support-e2e/tests/utils/testUserDetails.ts
+++ b/support-e2e/tests/utils/testUserDetails.ts
@@ -1,7 +1,7 @@
 import { Page } from '@playwright/test';
 import { TestFields } from './userFields';
 
-export const setTestUserPersonalDetails = async (
+export const setTestUserDetails = async (
 	page: Page,
 	email: string,
 	confirmEmail?: string,
@@ -22,16 +22,16 @@ export const setTestUserPersonalDetails = async (
 	}
 };
 
-export const setTestUserDetails = async (
+export const setTestUserAddressDetails = async (
 	page: Page,
 	testFields: TestFields,
 	internationalisationId: string,
 	tier: number,
 ) => {
-	await setTestUserPersonalDetails(
+	await setTestUserDetails(
 		page,
 		testFields.email,
-		testFields.email,
+		testFields.email, // confirmEmail
 		testFields.firstName,
 		testFields.lastName,
 	);

--- a/support-e2e/tests/utils/testUserDetails.ts
+++ b/support-e2e/tests/utils/testUserDetails.ts
@@ -4,15 +4,13 @@ import { TestFields } from './userFields';
 export const setTestUserDetails = async (
 	page: Page,
 	email: string,
-	confirmEmail?: string,
 	firstName?: string,
 	lastName?: string,
+	confirmEmail?: boolean,
 ) => {
 	await page.getByLabel('Email address', { exact: true }).fill(email);
 	if (confirmEmail) {
-		await page
-			.getByLabel('Confirm email address', { exact: true })
-			.fill(confirmEmail);
+		await page.getByLabel('Confirm email address', { exact: true }).fill(email);
 	}
 	if (firstName) {
 		await page.getByLabel('First name').fill(firstName);
@@ -31,9 +29,9 @@ export const setTestUserAddressDetails = async (
 	await setTestUserDetails(
 		page,
 		testFields.email,
-		testFields.email, // confirmEmail
 		testFields.firstName,
 		testFields.lastName,
+		true, // confirmEmail required
 	);
 
 	if (testFields.addresses && testFields.addresses.length > 1) {

--- a/support-e2e/tests/utils/testUserDetails.ts
+++ b/support-e2e/tests/utils/testUserDetails.ts
@@ -1,31 +1,25 @@
 import { Page } from '@playwright/test';
 import { TestFields } from './userFields';
 
-export const setTestUserConfirmRequiredDetails = async (
+export const setTestUserPersonalDetails = async (
 	page: Page,
 	email: string,
-	firstName?: string,
-	lastName?: string,
-) => {
-	await setTestUserRequiredDetails(page, email, firstName, lastName);
-	await setTestConfirmEmail(page, email);
-};
-export const setTestUserRequiredDetails = async (
-	page: Page,
-	email: string,
+	confirmEmail?: string,
 	firstName?: string,
 	lastName?: string,
 ) => {
 	await page.getByLabel('Email address', { exact: true }).fill(email);
+	if (confirmEmail) {
+		await page
+			.getByLabel('Confirm email address', { exact: true })
+			.fill(confirmEmail);
+	}
 	if (firstName) {
 		await page.getByLabel('First name').fill(firstName);
 	}
 	if (lastName) {
 		await page.getByLabel('Last name').fill(lastName);
 	}
-};
-const setTestConfirmEmail = async (page: Page, email: string) => {
-	await page.getByLabel('Confirm email address', { exact: true }).fill(email);
 };
 
 export const setTestUserDetails = async (
@@ -34,8 +28,9 @@ export const setTestUserDetails = async (
 	internationalisationId: string,
 	tier: number,
 ) => {
-	await setTestUserConfirmRequiredDetails(
+	await setTestUserPersonalDetails(
 		page,
+		testFields.email,
 		testFields.email,
 		testFields.firstName,
 		testFields.lastName,


### PR DESCRIPTION
## What are you doing in this PR?

This is a further tidy-up to this [PR](https://github.com/guardian/support-frontend/pull/6851)


[**Trello Card**](https://trello.com/c/SizWySqG/1476-end-onetimeconfirmemail-a-b-test)

## Why are you doing this?

Refactored `setTestUserConfirmRequiredDetails` + `setTestUserConfirmRequiredDetails` to a single call with optional parameter as shown->

setTestUserDetails -
	page: Page,
	email: string,
	firstName?: string,
	lastName?: string,
	confirmEmail?: boolean,
)

Where confirmEmail is switch to display/hide the confirmEmail field for checkout/oneTimeCheckout respectively.