### PR TITLE
AB test for selling Newspaper on the generic checkout

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -26,6 +26,7 @@ import play.api.mvc._
 import services.pricing.{PriceSummaryServiceProvider, ProductPrices}
 import services.{CachedProductCatalogServiceProvider, PaymentAPIService, TestUserService}
 import utils.FastlyGEOIP._
+import utils.PaperValidation
 import views.EmptyDiv
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -533,6 +534,7 @@ class Application(
         productCatalog = productCatalog,
         allProductPrices = allProductPrices,
         user = request.user,
+        homeDeliveryPostcodes = Some(PaperValidation.M25_POSTCODE_PREFIXES),
       ),
     ).withSettingsSurrogateKey
   }

--- a/support-frontend/app/views/router.scala.html
+++ b/support-frontend/app/views/router.scala.html
@@ -17,7 +17,8 @@
   v2recaptchaConfigPublicKey: String,
   allProductPrices: AllProductPrices,
   productCatalog: JsonObject,
-  user: Option[User]
+  user: Option[User],
+  homeDeliveryPostcodes: Option[List[String]] = None,
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
 @main(
@@ -38,6 +39,12 @@
     window.guardian = window.guardian || {};
     window.guardian.allProductPrices = @Html(outputJson(allProductPrices))
   </script>
+
+  @homeDeliveryPostcodes.map { postcodes =>
+    <script type="text/javascript">
+      window.guardian.homeDeliveryPostcodes = @Html(outputJson(postcodes))
+    </script>
+  }
 
   @windowGuardianPaymentConfig(
     geoData = geoData,

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -137,8 +137,7 @@ export const tests: Tests = {
 		isActive: true,
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 9,
-		targetPage:
-			pageUrlRegexes.subscriptions.paper.paperLandingWithGuestCheckout,
+		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeContributionsOnlyCountries: true,
 	},
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -119,4 +119,26 @@ export const tests: Tests = {
 		targetPage: '/subscribe$',
 		excludeContributionsOnlyCountries: true,
 	},
+	newspaperGenericCheckout: {
+		variants: [
+			{
+				id: 'control',
+			},
+			{
+				id: 'variant',
+			},
+		],
+		audiences: {
+			ALL: {
+				offset: 0,
+				size: 0,
+			},
+		},
+		isActive: true,
+		referrerControlled: false, // ab-test name not needed to be in paramURL
+		seed: 9,
+		targetPage:
+			pageUrlRegexes.subscriptions.paper.paperLandingWithGuestCheckout,
+		excludeContributionsOnlyCountries: true,
+	},
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -132,7 +132,7 @@ export const tests: Tests = {
 		audiences: {
 			ALL: {
 				offset: 0,
-				size: 1,
+				size: 0,
 			},
 		},
 		isActive: true,

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -24,7 +24,7 @@ export const pageUrlRegexes = {
 			// Requires /subscribe/paper, allows /checkout or /checkout/guest, allows any query string
 			paperLandingWithGuestCheckout:
 				/\/subscribe\/paper(\/delivery|\/checkout|\/checkout\/guest)?(\?.*)?$/,
-			paperLandingAndGenericCheckout: /^\/uk\/subscribe\/paper?(\?.*)?$/,
+			paperLandingPage: /^\/uk\/subscribe\/paper?(\?.*)?$/,
 		},
 		subsWeeklyPages:
 			'(/??/subscribe(\\?.*)?$|/??/subscribe/weekly(\\/checkout)?(\\?.*)?$)',
@@ -138,8 +138,7 @@ export const tests: Tests = {
 		isActive: true,
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 9,
-		targetPage:
-			pageUrlRegexes.subscriptions.paper.paperLandingAndGenericCheckout,
+		targetPage: pageUrlRegexes.subscriptions.paper.paperLandingPage,
 		persistPage:
 			// match generic checkout & thank you page
 			'^/uk/(checkout|thank-you)',

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -24,6 +24,7 @@ export const pageUrlRegexes = {
 			// Requires /subscribe/paper, allows /checkout or /checkout/guest, allows any query string
 			paperLandingWithGuestCheckout:
 				/\/subscribe\/paper(\/delivery|\/checkout|\/checkout\/guest)?(\?.*)?$/,
+			paperLandingAndGenericCheckout: /^\/uk\/subscribe\/paper?(\?.*)?$/,
 		},
 		subsWeeklyPages:
 			'(/??/subscribe(\\?.*)?$|/??/subscribe/weekly(\\/checkout)?(\\?.*)?$)',
@@ -131,13 +132,17 @@ export const tests: Tests = {
 		audiences: {
 			ALL: {
 				offset: 0,
-				size: 0,
+				size: 1,
 			},
 		},
 		isActive: true,
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 9,
-		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
+		targetPage:
+			pageUrlRegexes.subscriptions.paper.paperLandingAndGenericCheckout,
+		persistPage:
+			// match generic checkout & thank you page
+			'^/uk/(checkout|thank-you)',
 		excludeContributionsOnlyCountries: true,
 	},
 };

--- a/support-frontend/assets/helpers/urls/routes.ts
+++ b/support-frontend/assets/helpers/urls/routes.ts
@@ -6,6 +6,7 @@ import type {
 } from 'helpers/productPrice/fulfilmentOptions';
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
 import type { Option } from 'helpers/types/option';
+import type { Participations } from '../abTests/models';
 import type { CountryGroupId } from '../internationalisation/countryGroup';
 import { countryGroups } from '../internationalisation/countryGroup';
 import {
@@ -108,8 +109,20 @@ const promotionTermsUrl = (promoCode: string) =>
 function paperCheckoutUrl(
 	fulfilmentOption: FulfilmentOptions,
 	productOptions: ProductOptions,
+	abParticipations: Participations,
 	promoCode?: Option<string>,
 ) {
+	if (abParticipations.newspaperGenericCheckout === 'variant') {
+		const url = `${getOrigin()}/uk/checkout`;
+		return addQueryParamsToURL(url, {
+			promoCode,
+			product:
+				fulfilmentOption === 'Collection'
+					? 'SubscriptionCard'
+					: fulfilmentOption,
+			ratePlan: productOptions,
+		});
+	}
 	const url = `${getOrigin()}/subscribe/paper/checkout`;
 	return addQueryParamsToURL(url, {
 		promoCode,

--- a/support-frontend/assets/pages/paper-subscription-landing/components/paperProductPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/paperProductPrices.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import type { Product } from 'components/product/productOption';
+import type { Participations } from 'helpers/abTests/models';
 import type {
 	FulfilmentOptions,
 	PaperFulfilmentOptions,
@@ -15,13 +16,13 @@ import {
 	getProductPrice,
 	showPrice,
 } from 'helpers/productPrice/productPrices';
-import { finalPrice, getAppliedPromo } from 'helpers/productPrice/promotions';
 import type { Promotion } from 'helpers/productPrice/promotions';
+import { finalPrice, getAppliedPromo } from 'helpers/productPrice/promotions';
+import type { TrackingProperties } from 'helpers/productPrice/subscriptions';
 import {
 	sendTrackingEventsOnClick,
 	sendTrackingEventsOnView,
 } from 'helpers/productPrice/subscriptions';
-import type { TrackingProperties } from 'helpers/productPrice/subscriptions';
 import { paperCheckoutUrl } from 'helpers/urls/routes';
 import { getTitle } from '../helpers/products';
 import { PaperPrices } from './content/paperPrices';
@@ -149,6 +150,7 @@ const copy: Record<
 const getPlans = (
 	fulfilmentOption: PaperFulfilmentOptions,
 	productPrices: ProductPrices,
+	abParticipations: Participations,
 ): Product[] =>
 	ActivePaperProductTypes.map((productOption) => {
 		const priceAfterPromosApplied = finalPrice(
@@ -176,7 +178,12 @@ const getPlans = (
 		return {
 			title: getTitle(productOption),
 			price: showPrice(priceAfterPromosApplied),
-			href: paperCheckoutUrl(fulfilmentOption, productOption, promoCode),
+			href: paperCheckoutUrl(
+				fulfilmentOption,
+				productOption,
+				abParticipations,
+				promoCode,
+			),
 			onClick: sendTrackingEventsOnClick(trackingProperties),
 			onView: sendTrackingEventsOnView(trackingProperties),
 			buttonCopy: 'Subscribe',
@@ -197,18 +204,20 @@ type PaperProductPricesProps = {
 	productPrices: ProductPrices | null | undefined;
 	tab: PaperFulfilmentOptions;
 	setTabAction: (arg0: PaperFulfilmentOptions) => void;
+	abParticipations: Participations;
 };
 
 function PaperProductPrices({
 	productPrices,
 	tab,
 	setTabAction,
+	abParticipations,
 }: PaperProductPricesProps): JSX.Element | null {
 	if (!productPrices) {
 		return null;
 	}
 
-	const products = getPlans(tab, productPrices);
+	const products = getPlans(tab, productPrices, abParticipations);
 	return (
 		<PaperPrices
 			activeTab={tab}

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
@@ -104,6 +104,7 @@ function PaperLandingPage({
 						productPrices={productPrices}
 						tab={selectedTab}
 						setTabAction={handleSetTabAction}
+						abParticipations={abParticipations}
 					/>
 				</CentredContainer>
 			</FullWidthContainer>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR sets up a 0% AB test on the newspaper landing page where the variant will send purchasers to the generic checkout rather than the old paper checkout.

## How to test
1. https://support.thegulocal.com/uk/subscribe/paper#ab-newspaperGenericCheckout=control
2. https://support.thegulocal.com/uk/subscribe/paper#ab-newspaperGenericCheckout=variant

