### PR TITLE
Add specific rate plan descriptions to newspaper order summary

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -142,7 +142,8 @@ const productStartDates = css`
 `;
 
 export type ContributionsOrderSummaryProps = {
-	description: string;
+	productDescription: string;
+	ratePlanDescription?: string;
 	amount: number;
 	promotion?: Promotion;
 	currency: Currency;
@@ -153,8 +154,6 @@ export type ContributionsOrderSummaryProps = {
 	headerButton?: React.ReactNode;
 	tsAndCs?: React.ReactNode;
 	tsAndCsTier3?: React.ReactNode;
-	heading?: string;
-	productDescription?: { description: string; frequency: string };
 };
 
 const visuallyHiddenCss = css`
@@ -162,7 +161,8 @@ const visuallyHiddenCss = css`
 `;
 
 export function ContributionsOrderSummary({
-	description,
+	productDescription,
+	ratePlanDescription,
 	amount,
 	promotion,
 	currency,
@@ -172,7 +172,6 @@ export function ContributionsOrderSummary({
 	headerButton,
 	tsAndCs,
 	tsAndCsTier3,
-	heading,
 	enableCheckList,
 }: ContributionsOrderSummaryProps): JSX.Element {
 	const [showCheckList, setCheckList] = useState(false);
@@ -195,13 +194,16 @@ export function ContributionsOrderSummary({
 	return (
 		<div css={componentStyles}>
 			<div css={[summaryRow, rowSpacing, headingRow]}>
-				<h2 css={headingCss}>{heading ?? 'Your subscription'}</h2>
+				<h2 css={headingCss}>Your subscription</h2>
 				{headerButton}
 			</div>
 			<hr css={hrCss} />
 			<div css={detailsSection}>
 				<div css={summaryRow}>
-					<p>{description}</p>
+					<p>
+						{ratePlanDescription && <div>{ratePlanDescription}</div>}
+						{productDescription}
+					</p>
 					{hasCheckList && (
 						<Button
 							priority="subdued"

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -34,6 +34,7 @@ export type ProductDescription = {
 		string,
 		{
 			billingPeriod: 'Annual' | 'Monthly' | 'Quarterly';
+			label?: string;
 		}
 	>;
 };
@@ -243,22 +244,6 @@ export const productCatalogDescription: Record<
 			},
 		},
 	},
-	NationalDelivery: {
-		label: 'National Delivery',
-		benefits: [],
-		deliverableTo: newspaperCountries,
-		ratePlans: {
-			Sixday: {
-				billingPeriod: 'Monthly',
-			},
-			Weekend: {
-				billingPeriod: 'Annual',
-			},
-			Everyday: {
-				billingPeriod: 'Monthly',
-			},
-		},
-	},
 	SupporterPlus: {
 		label: 'All-access digital',
 		benefits: supporterPlusBenefits,
@@ -316,24 +301,75 @@ export const productCatalogDescription: Record<
 		},
 	},
 	SubscriptionCard: {
-		label: 'Newspaper subscription',
+		label: 'Subscription card',
 		benefits: [],
 		deliverableTo: newspaperCountries,
 		ratePlans: {
-			Sixday: {
-				billingPeriod: 'Monthly',
-			},
 			Everyday: {
 				billingPeriod: 'Monthly',
+				label: 'Every day package',
+			},
+			Sixday: {
+				billingPeriod: 'Monthly',
+				label: 'Six day package',
 			},
 			Weekend: {
 				billingPeriod: 'Monthly',
-			},
-			Sunday: {
-				billingPeriod: 'Monthly',
+				label: 'Weekend package',
 			},
 			Saturday: {
 				billingPeriod: 'Monthly',
+				label: 'Saturday package',
+			},
+			Sunday: {
+				billingPeriod: 'Monthly',
+				label: 'The Observer package',
+			},
+		},
+	},
+	HomeDelivery: {
+		label: 'Home delivery',
+		benefits: [],
+		deliverableTo: newspaperCountries,
+		ratePlans: {
+			Everyday: {
+				billingPeriod: 'Monthly',
+				label: 'Every day package',
+			},
+			Sixday: {
+				billingPeriod: 'Monthly',
+				label: 'Six day package',
+			},
+			Weekend: {
+				billingPeriod: 'Monthly',
+				label: 'Weekend package',
+			},
+			Saturday: {
+				billingPeriod: 'Monthly',
+				label: 'Saturday package',
+			},
+			Sunday: {
+				billingPeriod: 'Monthly',
+				label: 'The Observer package',
+			},
+		},
+	},
+	NationalDelivery: {
+		label: 'National delivery',
+		benefits: [],
+		deliverableTo: newspaperCountries,
+		ratePlans: {
+			Everyday: {
+				billingPeriod: 'Monthly',
+				label: 'Every day package - The Guardian and The Observer',
+			},
+			Sixday: {
+				billingPeriod: 'Monthly',
+				label: 'Six day package - The Guardian',
+			},
+			Weekend: {
+				billingPeriod: 'Monthly',
+				label: 'Weekend package - The Guardian and The Observer',
 			},
 		},
 	},
@@ -346,28 +382,6 @@ export const productCatalogDescription: Record<
 			},
 			Annual: {
 				billingPeriod: 'Annual',
-			},
-		},
-	},
-	HomeDelivery: {
-		label: 'Home Delivery',
-		benefits: [],
-		deliverableTo: newspaperCountries,
-		ratePlans: {
-			Everyday: {
-				billingPeriod: 'Monthly',
-			},
-			Sunday: {
-				billingPeriod: 'Monthly',
-			},
-			Sixday: {
-				billingPeriod: 'Monthly',
-			},
-			Weekend: {
-				billingPeriod: 'Monthly',
-			},
-			Saturday: {
-				billingPeriod: 'Monthly',
 			},
 		},
 	},

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -569,7 +569,8 @@ export function CheckoutComponent({
 							</div>
 						)}
 					<ContributionsOrderSummary
-						description={productDescription.label}
+						productDescription={productDescription.label}
+						ratePlanDescription={ratePlanDescription.label}
 						paymentFrequency={
 							ratePlanDescription.billingPeriod === 'Annual'
 								? 'year'

--- a/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
@@ -75,7 +75,7 @@ Template.args = {} as ContributionsOrderSummaryProps;
 export const Default = Template.bind({});
 
 Default.args = {
-	description: 'Monthly support',
+	productDescription: 'Monthly support',
 	paymentFrequency: 'month',
 	enableCheckList: true,
 	amount: 10,
@@ -105,7 +105,7 @@ Default.args = {
 export const SingleContribution = Template.bind({});
 
 SingleContribution.args = {
-	description: 'One-off contribution',
+	productDescription: 'One-off contribution',
 	enableCheckList: false,
 	amount: 25,
 	currency: {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR adds a rate plan specific description to the order summary on the generic checkout. This is to support the purchase of newspaper products
[**Trello Card**](https://trello.com/c/ZzILpfBI/1518-update-order-summary-product-label-following-design-review)

## Why are you doing this?
The newspaper products have more purchase options than other products so in order to keep customers informed about what it is that they are buying, it is important to convey this purchase information on the checkout.

## How to test
https://support.thegulocal.com/uk/checkout?product=HomeDelivery&ratePlan=Saturday
## Screenshots
![Screenshot 2025-03-21 at 13 23 23](https://github.com/user-attachments/assets/80e37fe3-0469-4eef-853c-c32385abd30e)
![Screenshot 2025-03-21 at 13 22 53](https://github.com/user-attachments/assets/4b6c4d9e-cd13-41e9-aa6c-18fe9e1a9429)
![Screenshot 2025-03-21 at 13 22 39](https://github.com/user-attachments/assets/4f8e811e-b6ec-4d11-afe1-4991dfac17a2)
![Screenshot 2025-03-21 at 13 22 28](https://github.com/user-attachments/assets/134791d9-43cc-442f-bf40-c0ee9fff2a26)

