### PR TITLE
Payment provider can be undefined in acquisition events

### DIFF
--- a/support-lambdas/bigquery-acquisitions-publisher/typescript/acquisitions.ts
+++ b/support-lambdas/bigquery-acquisitions-publisher/typescript/acquisitions.ts
@@ -21,7 +21,7 @@ export type FactAcquisitionEventRow = {
 	referrer_url?: string | null;
 	ab_tests: { name: string; variant: string }[];
 	payment_frequency: PaymentFrequency;
-	payment_provider: PaymentProvider;
+	payment_provider?: PaymentProvider | null;
 	print_options?: { product: string; delivery_country_code: string } | null;
 	browser_id?: string | null;
 	identity_id?: string | null;

--- a/support-lambdas/bigquery-acquisitions-publisher/typescript/schemas.ts
+++ b/support-lambdas/bigquery-acquisitions-publisher/typescript/schemas.ts
@@ -335,7 +335,7 @@ export const AcquisitionProductSchema = z.object({
 	referrerUrl: z.string().nullish(),
 	abTests: z.object({ name: z.string(), variant: z.string() }).array(),
 	paymentFrequency: PaymentFrequencySchema,
-	paymentProvider: PaymentProviderSchema,
+	paymentProvider: PaymentProviderSchema.nullish(),
 	printOptions: PrintOptionsSchema,
 	browserId: z.string().nullish(),
 	identityId: z.string().nullish(),


### PR DESCRIPTION
## What are you doing in this PR?

Loosen schema so that payment provider can be undefined in acquisition events.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/iQqk6Nrl/1275-migrate-bigquery-acquisitions-publisher-to-typescript)

## Why are you doing this?

We've seen this in prod for Feast IAPs.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
