### PR TITLE
Extract `SubmitButton` component from generic `CheckoutComponent`

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/submitButton.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/submitButton.tsx
@@ -1,0 +1,137 @@
+import { DefaultPaymentButton } from 'components/paymentButton/defaultPaymentButton';
+import { PayPalButton } from 'components/payPalPaymentButton/payPalButton';
+import { simpleFormatAmount } from 'helpers/forms/checkouts';
+import type {
+	Currency,
+	IsoCurrency,
+} from 'helpers/internationalisation/currency';
+import { isProd } from 'helpers/urls/url';
+import {
+	paypalOneClickCheckout,
+	setupPayPalPayment,
+} from '../checkout/helpers/paypal';
+import type { PaymentMethod } from './paymentFields';
+
+type SubmitButtonProps = {
+	paymentMethod: PaymentMethod | undefined;
+	payPalLoaded: boolean;
+	payPalBAID: string;
+	setPayPalBAID: (baid: string) => void;
+	isTestUser: boolean;
+	finalAmount: number;
+	currencyKey: IsoCurrency;
+	ratePlanDescription: {
+		billingPeriod: 'Annual' | 'Monthly' | 'Quarterly';
+	};
+	csrf: string;
+	currency: Currency;
+	formRef: React.RefObject<HTMLFormElement>;
+};
+
+export function SubmitButton({
+	paymentMethod,
+	payPalLoaded,
+	payPalBAID,
+	setPayPalBAID,
+	formRef,
+	isTestUser,
+	finalAmount,
+	currencyKey,
+	ratePlanDescription,
+	csrf,
+	currency,
+}: SubmitButtonProps) {
+	switch (paymentMethod) {
+		case 'PayPal':
+			return payPalLoaded ? (
+				<>
+					<input type="hidden" name="payPalBAID" value={payPalBAID} />
+
+					<PayPalButton
+						env={isProd() && !isTestUser ? 'production' : 'sandbox'}
+						style={{
+							color: 'blue',
+							size: 'responsive',
+							label: 'pay',
+							tagline: false,
+							layout: 'horizontal',
+							fundingicons: false,
+						}}
+						commit={true}
+						validate={({ disable, enable }) => {
+							/** We run this initially to set the button to the correct state */
+							const valid = formRef.current?.checkValidity();
+							if (valid) {
+								enable();
+							} else {
+								disable();
+							}
+
+							/** And then run it on form change */
+							formRef.current?.addEventListener('change', (event) => {
+								const element = event.currentTarget as HTMLFormElement;
+								/* We call this twice because the first time does not
+                   not give us an accurate state of the form.
+                   This seems to be because we use `setCustomValidity` on the elements */
+								element.checkValidity();
+								const valid = element.checkValidity();
+
+								if (valid) {
+									enable();
+								} else {
+									disable();
+								}
+							});
+						}}
+						funding={{
+							disallowed: [window.paypal.FUNDING.CREDIT],
+						}}
+						onClick={() => {
+							// TODO - add tracking
+						}}
+						/** the order is Button.payment(opens PayPal window).then(Button.onAuthorize) */
+						payment={(resolve, reject) => {
+							setupPayPalPayment(
+								finalAmount,
+								currencyKey,
+								ratePlanDescription.billingPeriod,
+								csrf,
+							)
+								.then((token) => {
+									resolve(token);
+								})
+								.catch((error) => {
+									console.error(error);
+									reject(error as Error);
+								});
+						}}
+						onAuthorize={(payPalData: Record<string, unknown>) => {
+							void paypalOneClickCheckout(payPalData.paymentToken, csrf).then(
+								(baid) => {
+									// The state below has a useEffect that submits the form
+									setPayPalBAID(baid);
+								},
+							);
+						}}
+					/>
+				</>
+			) : null;
+		default:
+			return (
+				<DefaultPaymentButton
+					buttonText={`Pay ${simpleFormatAmount(currency, finalAmount)} per ${
+						ratePlanDescription.billingPeriod === 'Annual'
+							? 'year'
+							: ratePlanDescription.billingPeriod === 'Monthly'
+							? 'month'
+							: 'quarter'
+					}`}
+					onClick={() => {
+						// no-op
+						// This isn't needed because we are now using the formOnSubmit handler
+					}}
+					type="submit"
+				/>
+			);
+	}
+}


### PR DESCRIPTION
## What are you doing in this PR?

Extract `SubmitButton` component from generic `CheckoutComponent`.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

This will be easier to work with as we add a new CTA for Stripe Hosted Checkout.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

I've deployed to CODE and run the smoke and cron tests.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
