### PR TITLE
Update conditionals for checkout messages

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -535,8 +535,6 @@ export function CheckoutComponent({
 	const isAdLite = productKey === 'GuardianAdLite';
 	const isRecurringContribution = productKey === 'Contribution';
 
-	console.log('*** isRecurringContribution ***', isRecurringContribution);
-
 	const contributionType =
 		productFields.billingPeriod === 'Monthly'
 			? 'MONTHLY'

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -624,7 +624,7 @@ export function CheckoutComponent({
 				<Box
 					cssOverrides={[
 						shorterBoxMargin,
-						isAdLite || !isRecurringContribution ? lengthenBoxMargin : css``,
+						!isRecurringContribution ? lengthenBoxMargin : css``,
 					]}
 				>
 					<BoxContents>

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -534,7 +534,6 @@ export function CheckoutComponent({
 	);
 
 	const returnToLandingPage = `/${geoId}${productLanding(productKey)}`;
-	const isAdLite = productKey === 'GuardianAdLite';
 
 	const contributionType =
 		productFields.billingPeriod === 'Monthly'

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -74,8 +74,8 @@ import { isProd } from 'helpers/urls/url';
 import { logException } from 'helpers/utilities/logger';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
-import { CharitableDonationMessage } from 'pages/supporter-plus-landing/components/charitableDonationMessage';
 import { CheckoutDivider } from 'pages/supporter-plus-landing/components/checkoutDivider';
+import { ContributionCheckoutFinePrint } from 'pages/supporter-plus-landing/components/contributionCheckoutFinePrint';
 import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsMessage';
 import { PaymentTsAndCs } from 'pages/supporter-plus-landing/components/paymentTsAndCs';
 import { SummaryTsAndCs } from 'pages/supporter-plus-landing/components/summaryTsAndCs';
@@ -1305,7 +1305,7 @@ export function CheckoutComponent({
 						countryGroupId={countryGroupId}
 						mobileTheme={'light'}
 					/>
-					<CharitableDonationMessage mobileTheme={'light'} />
+					<ContributionCheckoutFinePrint mobileTheme={'light'} />
 				</>
 			)}
 			{isProcessingPayment && (

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -74,8 +74,8 @@ import { isProd } from 'helpers/urls/url';
 import { logException } from 'helpers/utilities/logger';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
+import { CharitableDonationMessage } from 'pages/supporter-plus-landing/components/charitableDonationMessage';
 import { CheckoutDivider } from 'pages/supporter-plus-landing/components/checkoutDivider';
-import { GuardianTsAndCs } from 'pages/supporter-plus-landing/components/guardianTsAndCs';
 import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsMessage';
 import { PaymentTsAndCs } from 'pages/supporter-plus-landing/components/paymentTsAndCs';
 import { SummaryTsAndCs } from 'pages/supporter-plus-landing/components/summaryTsAndCs';
@@ -199,7 +199,7 @@ export function CheckoutComponent({
 				abParticipations,
 				getSettings().landingPageTests,
 			);
-			if (productKey === 'Contribution') {
+			if (isRecurringContribution) {
 				// Also show SupporterPlus benefits greyed out
 				return [
 					...landingPageSettings.products.Contribution.benefits.map(
@@ -281,7 +281,7 @@ export function CheckoutComponent({
 	 *    If queryPrice above ratePlanPrice, in a upgrade to S+ country, invalid amount
 	 */
 	let isInvalidAmount = false;
-	if (productKey === 'Contribution') {
+	if (isRecurringContribution) {
 		const supporterPlusRatePlanPrice =
 			productCatalog.SupporterPlus?.ratePlans[ratePlanKey]?.pricing[
 				currencyKey
@@ -533,6 +533,9 @@ export function CheckoutComponent({
 
 	const returnToLandingPage = `/${geoId}${productLanding(productKey)}`;
 	const isAdLite = productKey === 'GuardianAdLite';
+	const isRecurringContribution = productKey === 'Contribution';
+
+	console.log('*** isRecurringContribution ***', isRecurringContribution);
 
 	const contributionType =
 		productFields.billingPeriod === 'Monthly'
@@ -622,7 +625,7 @@ export function CheckoutComponent({
 				<Box
 					cssOverrides={[
 						shorterBoxMargin,
-						isAdLite ? lengthenBoxMargin : css``,
+						isAdLite || !isRecurringContribution ? lengthenBoxMargin : css``,
 					]}
 				>
 					<BoxContents>
@@ -1298,16 +1301,13 @@ export function CheckoutComponent({
 					</BoxContents>
 				</Box>
 			</form>
-			{!isAdLite && (
+			{isRecurringContribution && (
 				<>
 					<PatronsMessage
 						countryGroupId={countryGroupId}
 						mobileTheme={'light'}
 					/>
-					<GuardianTsAndCs
-						mobileTheme={'light'}
-						displayPatronsCheckout={false}
-					/>
+					<CharitableDonationMessage mobileTheme={'light'} />
 				</>
 			)}
 			{isProcessingPayment && (

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -192,6 +192,8 @@ export function CheckoutComponent({
 		billingPeriod: 'Monthly',
 	};
 
+	const isRecurringContribution = productKey === 'Contribution';
+
 	const getBenefits = (): BenefitsCheckListData[] => {
 		// Three Tier products get their config from the Landing Page tool
 		if (['TierThree', 'SupporterPlus', 'Contribution'].includes(productKey)) {
@@ -533,7 +535,6 @@ export function CheckoutComponent({
 
 	const returnToLandingPage = `/${geoId}${productLanding(productKey)}`;
 	const isAdLite = productKey === 'GuardianAdLite';
-	const isRecurringContribution = productKey === 'Contribution';
 
 	const contributionType =
 		productFields.billingPeriod === 'Monthly'

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -74,10 +74,10 @@ import { payPalCancelUrl, payPalReturnUrl } from 'helpers/urls/routes';
 import { logException } from 'helpers/utilities/logger';
 import { roundToDecimalPlaces } from 'helpers/utilities/utilities';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
+import { CharitableDonationMessage } from 'pages/supporter-plus-landing/components/charitableDonationMessage';
 import { CheckoutDivider } from 'pages/supporter-plus-landing/components/checkoutDivider';
 import { CoverTransactionCost } from 'pages/supporter-plus-landing/components/coverTransactionCost';
 import { FinePrint } from 'pages/supporter-plus-landing/components/finePrint';
-import { GuardianTsAndCs } from 'pages/supporter-plus-landing/components/guardianTsAndCs';
 import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsMessage';
 import { FooterTsAndCs } from 'pages/supporter-plus-landing/components/paymentTsAndCs';
 import { countryGroups } from '../../../helpers/internationalisation/countryGroup';
@@ -886,7 +886,7 @@ export function OneTimeCheckoutComponent({
 				</Box>
 			</form>
 			<PatronsMessage countryGroupId={countryGroupId} mobileTheme={'light'} />
-			<GuardianTsAndCs mobileTheme={'light'} displayPatronsCheckout={false} />
+			<CharitableDonationMessage mobileTheme={'light'} />
 			{isProcessingPayment && (
 				<LoadingOverlay>
 					<p>Processing transaction</p>

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -74,8 +74,8 @@ import { payPalCancelUrl, payPalReturnUrl } from 'helpers/urls/routes';
 import { logException } from 'helpers/utilities/logger';
 import { roundToDecimalPlaces } from 'helpers/utilities/utilities';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
-import { CharitableDonationMessage } from 'pages/supporter-plus-landing/components/charitableDonationMessage';
 import { CheckoutDivider } from 'pages/supporter-plus-landing/components/checkoutDivider';
+import { ContributionCheckoutFinePrint } from 'pages/supporter-plus-landing/components/contributionCheckoutFinePrint';
 import { CoverTransactionCost } from 'pages/supporter-plus-landing/components/coverTransactionCost';
 import { FinePrint } from 'pages/supporter-plus-landing/components/finePrint';
 import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsMessage';
@@ -886,7 +886,7 @@ export function OneTimeCheckoutComponent({
 				</Box>
 			</form>
 			<PatronsMessage countryGroupId={countryGroupId} mobileTheme={'light'} />
-			<CharitableDonationMessage mobileTheme={'light'} />
+			<ContributionCheckoutFinePrint mobileTheme={'light'} />
 			{isProcessingPayment && (
 				<LoadingOverlay>
 					<p>Processing transaction</p>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/charitableDonationMessage.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/charitableDonationMessage.tsx
@@ -4,29 +4,24 @@ import { CheckoutDivider } from './checkoutDivider';
 import type { FinePrintTheme } from './finePrint';
 import { FinePrint } from './finePrint';
 
-const guardianTsAndCsStyles = (displayPatronsCheckout: boolean) => css`
+const charitableDonationMesageStyles = css`
 	margin-bottom: ${space[6]}px;
 	${from.tablet} {
 		margin-bottom: 64px;
 	}
-	${from.desktop} {
-		${displayPatronsCheckout ? 'margin-top: 100px;' : ''}
-	}
 `;
 
-export function GuardianTsAndCs({
+export function CharitableDonationMessage({
 	mobileTheme = 'dark',
-	displayPatronsCheckout = true,
 	spacing = 'tight',
 }: {
 	mobileTheme?: FinePrintTheme;
-	displayPatronsCheckout: boolean;
 	spacing?: 'tight' | 'loose';
 }): JSX.Element {
 	return (
 		<FinePrint
 			mobileTheme={mobileTheme}
-			cssOverrides={guardianTsAndCsStyles(displayPatronsCheckout)}
+			cssOverrides={charitableDonationMesageStyles}
 		>
 			<CheckoutDivider spacing={spacing} mobileTheme={'light'} />
 			<p>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/contributionCheckoutFinePrint.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/contributionCheckoutFinePrint.tsx
@@ -11,7 +11,7 @@ const charitableDonationMesageStyles = css`
 	}
 `;
 
-export function CharitableDonationMessage({
+export function ContributionCheckoutFinePrint({
 	mobileTheme = 'dark',
 	spacing = 'tight',
 }: {

--- a/support-frontend/assets/pages/supporter-plus-landing/components/contributionCheckoutFinePrint.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/contributionCheckoutFinePrint.tsx
@@ -4,7 +4,7 @@ import { CheckoutDivider } from './checkoutDivider';
 import type { FinePrintTheme } from './finePrint';
 import { FinePrint } from './finePrint';
 
-const charitableDonationMesageStyles = css`
+const checkoutFinePrintStyles = css`
 	margin-bottom: ${space[6]}px;
 	${from.tablet} {
 		margin-bottom: 64px;
@@ -19,10 +19,7 @@ export function ContributionCheckoutFinePrint({
 	spacing?: 'tight' | 'loose';
 }): JSX.Element {
 	return (
-		<FinePrint
-			mobileTheme={mobileTheme}
-			cssOverrides={charitableDonationMesageStyles}
-		>
+		<FinePrint mobileTheme={mobileTheme} cssOverrides={checkoutFinePrintStyles}>
 			<CheckoutDivider spacing={spacing} mobileTheme={'light'} />
 			<p>
 				The ultimate owner of the Guardian is The Scott Trust Limited, whose


### PR DESCRIPTION
## What are you doing in this PR?

There are 2 components on the generic checkout that need the conditions in which they're rendered updating 

1) The "Guardian Patrons" message and 
2) The "charitable donation" message that sits directly beneath it.

These components are currently conditionally rendered using these rules:

- We hide them both for the Ad-Lite product, eg. https://support.theguardian.com/uk/checkout?product=GuardianAdLite&ratePlan=Monthly
- We hide the "Guardian Patrons" container for all products in the US, eg. https://support.theguardian.com/us/checkout?product=Contribution&ratePlan=Monthly&contribution=5

<img width="637" alt="Screenshot 2025-03-24 at 15 21 01" src="https://github.com/user-attachments/assets/36df42ba-6d27-4507-902d-dded650a88b6" />


### Changes

Both messages are "support" orientated in the messaging, which isn't appropriate for non-Contributions product checkouts, in this PR I'm therefore making the following changes

- Rename `GuardianTsAndCs` to  `ContributionCheckoutFinePrint`, we have a few "T&Cs" components, I think the new name is clearer in conveying when and where this component is used.
-  Only show `ContributionCheckoutFinePrint` and `PatronsMessage` on the generic checkout if the product `isRecurringContribution`
