### PR TITLE
Checkout : Display default order summary  for non-Tier products

### DIFF
--- a/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.tsx
+++ b/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.tsx
@@ -100,7 +100,7 @@ export function OrderSummaryTsAndCs({
 			)}
 		</div>
 	);
-	const contributeAdLiteTsAndCs = (
+	const defaultOrderSummaryTsAndCs = (
 		<div css={containerSummaryTsCs}>
 			<p>Auto renews every {period} until you cancel.</p>
 			<p>
@@ -114,5 +114,5 @@ export function OrderSummaryTsAndCs({
 		SupporterPlus: tierThreeSupporterPlusTsAndCs,
 		TierThree: tierThreeSupporterPlusTsAndCs,
 	};
-	return orderSummaryTsAndCs[productKey] ?? contributeAdLiteTsAndCs;
+	return orderSummaryTsAndCs[productKey] ?? defaultOrderSummaryTsAndCs;
 }

--- a/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.tsx
+++ b/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.tsx
@@ -104,18 +104,15 @@ export function OrderSummaryTsAndCs({
 		<div css={containerSummaryTsCs}>
 			<p>Auto renews every {period} until you cancel.</p>
 			<p>
-				{['GuardianAdLite', 'DigitalSubscription'].includes(productKey)
-					? 'Cancel anytime.'
-					: 'Cancel or change your support anytime.'}
+				{['Contribution', 'OneTimeContribution'].includes(productKey)
+					? 'Cancel or change your support anytime.'
+					: 'Cancel anytime.'}
 			</p>
 		</div>
 	);
 	const orderSummaryTsAndCs: Partial<Record<ActiveProductKey, JSX.Element>> = {
-		GuardianAdLite: contributeAdLiteTsAndCs,
-		DigitalSubscription: contributeAdLiteTsAndCs,
-		Contribution: contributeAdLiteTsAndCs,
 		SupporterPlus: tierThreeSupporterPlusTsAndCs,
 		TierThree: tierThreeSupporterPlusTsAndCs,
 	};
-	return orderSummaryTsAndCs[productKey] ?? null;
+	return orderSummaryTsAndCs[productKey] ?? contributeAdLiteTsAndCs;
 }

--- a/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.tsx
+++ b/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.tsx
@@ -104,7 +104,7 @@ export function OrderSummaryTsAndCs({
 		<div css={containerSummaryTsCs}>
 			<p>Auto renews every {period} until you cancel.</p>
 			<p>
-				{productKey === 'GuardianAdLite'
+				{['GuardianAdLite', 'DigitalSubscription'].includes(productKey)
 					? 'Cancel anytime.'
 					: 'Cancel or change your support anytime.'}
 			</p>
@@ -112,6 +112,7 @@ export function OrderSummaryTsAndCs({
 	);
 	const orderSummaryTsAndCs: Partial<Record<ActiveProductKey, JSX.Element>> = {
 		GuardianAdLite: contributeAdLiteTsAndCs,
+		DigitalSubscription: contributeAdLiteTsAndCs,
 		Contribution: contributeAdLiteTsAndCs,
 		SupporterPlus: tierThreeSupporterPlusTsAndCs,
 		TierThree: tierThreeSupporterPlusTsAndCs,


### PR DESCRIPTION
## What are you doing in this PR?
Displays the following  DEFAULT summary for products that are NOT
-  Contributions
- S+
- TierThree

From (DS for example, )
![image](https://github.com/user-attachments/assets/71447df7-6327-46e7-8f89-5fdb00a3cc2e)

To
![image](https://github.com/user-attachments/assets/6d3a5204-1f23-4df7-8e45-8ab92ff5012e)
