### PR TITLE
Include source in fact_acquisition_event rows

### DIFF
--- a/support-lambdas/bigquery-acquisitions-publisher/typescript/acquisitions.test.ts
+++ b/support-lambdas/bigquery-acquisitions-publisher/typescript/acquisitions.test.ts
@@ -31,7 +31,7 @@ const baseAcquisitionProduct: AcquisitionProduct = {
 	product: 'CONTRIBUTION',
 	amount: 1.0,
 	currency: 'GBP',
-	source: null,
+	source: 'EMAIL',
 	platform: 'IOSNATIVEAPP',
 	labels: ['label'],
 };
@@ -72,6 +72,7 @@ describe('The transformAcquisitionProductForBigQuery function', () => {
 			payment_id: '123456789',
 			platform: 'IOS_NATIVE_APP',
 			labels: ['label'],
+			source: 'EMAIL',
 		};
 		expect(got).toEqual(expected);
 	});

--- a/support-lambdas/bigquery-acquisitions-publisher/typescript/acquisitions.ts
+++ b/support-lambdas/bigquery-acquisitions-publisher/typescript/acquisitions.ts
@@ -37,6 +37,7 @@ export type FactAcquisitionEventRow = {
 	payment_id?: string | null;
 	platform: string | null;
 	labels: string[];
+	source?: string | null;
 };
 
 const mapPlatformName = (name: string): string => {
@@ -99,5 +100,6 @@ export const transformAcquisitionProductForBigQuery = (
 		payment_id: acquisitionProduct.paymentId,
 		platform: mapPlatformName(acquisitionProduct.platform || 'SUPPORT'),
 		labels: acquisitionProduct.labels,
+		source: acquisitionProduct.source,
 	};
 };


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

When we migrated the bigquery-acquisitions-publisher lambda in #6787 to TypeScript the `source` field got omitted. This PR adds it back in.

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
