### PR TITLE
Fix 100% discounts on the generic checkout

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -207,6 +207,7 @@ export function Checkout({ geoId, appConfig, abParticipations }: Props) {
 		window.guardian.settings.switches.recurringPaymentMethods
 			.stripeExpressCheckout === 'On';
 
+	let elementsOptions = {};
 	let useStripeExpressCheckout = false;
 	if (stripeExpressCheckoutSwitch) {
 		/**
@@ -219,17 +220,17 @@ export function Checkout({ geoId, appConfig, abParticipations }: Props) {
 			productKey === 'GuardianAdLite' ||
 			productKey === 'DigitalSubscription'
 		) {
-			// elementsOptions = {
-			// 	mode: 'payment',
-			// 	/**
-			// 	 * Stripe amounts are in the "smallest currency unit"
-			// 	 * @see https://docs.stripe.com/api/charges/object
-			// 	 * @see https://docs.stripe.com/currencies#zero-decimal
-			// 	 */
-			// 	amount: payment.finalAmount * 100,
-			// 	currency: currencyKey.toLowerCase(),
-			// 	paymentMethodCreation: 'manual',
-			// } as const;
+			elementsOptions = {
+				mode: 'subscription',
+				/**
+				 * Stripe amounts are in the "smallest currency unit"
+				 * @see https://docs.stripe.com/api/charges/object
+				 * @see https://docs.stripe.com/currencies#zero-decimal
+				 */
+				amount: payment.finalAmount * 100,
+				currency: currencyKey.toLowerCase(),
+				paymentMethodCreation: 'manual',
+			} as const;
 			useStripeExpressCheckout = true;
 		}
 	}
@@ -254,7 +255,7 @@ export function Checkout({ geoId, appConfig, abParticipations }: Props) {
 	}, []);
 
 	return (
-		<Elements stripe={stripePromise} options={{}}>
+		<Elements stripe={stripePromise} options={elementsOptions}>
 			<CheckoutComponent
 				geoId={geoId}
 				appConfig={appConfig}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -110,7 +110,7 @@ export function Checkout({ geoId, appConfig, abParticipations }: Props) {
 
 	/**
 	 * - `originalAmount` the amount pre any discounts or contributions
-	 * - `discountredAmount` the amount with a discountApplied
+	 * - `discountedAmount` the amount with a discountApplied
 	 * - `finalAmount` is the amount a person will pay
 	 */
 	let payment: {
@@ -171,9 +171,8 @@ export function Checkout({ geoId, appConfig, abParticipations }: Props) {
 			billingPeriod,
 		);
 
-		const discountedPrice = promotion?.discountedPrice
-			? promotion.discountedPrice
-			: undefined;
+		const discountedPrice =
+			promotion !== undefined ? promotion.discountedPrice : undefined;
 
 		const price = discountedPrice ?? productPrice;
 
@@ -208,7 +207,6 @@ export function Checkout({ geoId, appConfig, abParticipations }: Props) {
 		window.guardian.settings.switches.recurringPaymentMethods
 			.stripeExpressCheckout === 'On';
 
-	let elementsOptions = {};
 	let useStripeExpressCheckout = false;
 	if (stripeExpressCheckoutSwitch) {
 		/**
@@ -221,17 +219,17 @@ export function Checkout({ geoId, appConfig, abParticipations }: Props) {
 			productKey === 'GuardianAdLite' ||
 			productKey === 'DigitalSubscription'
 		) {
-			elementsOptions = {
-				mode: 'payment',
-				/**
-				 * Stripe amounts are in the "smallest currency unit"
-				 * @see https://docs.stripe.com/api/charges/object
-				 * @see https://docs.stripe.com/currencies#zero-decimal
-				 */
-				amount: payment.finalAmount * 100,
-				currency: currencyKey.toLowerCase(),
-				paymentMethodCreation: 'manual',
-			} as const;
+			// elementsOptions = {
+			// 	mode: 'payment',
+			// 	/**
+			// 	 * Stripe amounts are in the "smallest currency unit"
+			// 	 * @see https://docs.stripe.com/api/charges/object
+			// 	 * @see https://docs.stripe.com/currencies#zero-decimal
+			// 	 */
+			// 	amount: payment.finalAmount * 100,
+			// 	currency: currencyKey.toLowerCase(),
+			// 	paymentMethodCreation: 'manual',
+			// } as const;
 			useStripeExpressCheckout = true;
 		}
 	}
@@ -256,7 +254,7 @@ export function Checkout({ geoId, appConfig, abParticipations }: Props) {
 	}, []);
 
 	return (
-		<Elements stripe={stripePromise} options={elementsOptions}>
+		<Elements stripe={stripePromise} options={{}}>
 			<CheckoutComponent
 				geoId={geoId}
 				appConfig={appConfig}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -229,7 +229,6 @@ export function Checkout({ geoId, appConfig, abParticipations }: Props) {
 				 */
 				amount: payment.finalAmount * 100,
 				currency: currencyKey.toLowerCase(),
-				paymentMethodCreation: 'manual',
 			} as const;
 			useStripeExpressCheckout = true;
 		}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Currently 100% discounts don't work correctly on the generic checkout - the order summary shows the correct price, but the CTA doesn't. This PR fixes that.

## Changes
- The reason for the issue was a falsy boolean where a zero price is equivalent to no discount. This has been changed to be more explicit
- After the first change, the CTA showed the correct amount but it was no longer possible to checkout out with Stripe, the fields on the form didn't appear:
![Screenshot 2025-03-27 at 15 17 08](https://github.com/user-attachments/assets/0b0f2c21-1490-4093-9607-cad749c6ca30)
This is because we pass the amount in to the Stripe Elements component and the minimum amount which it supports is $0.50.
- The fix to this issue is to change the `mode` setting of the Elements component from `payment` to `subscription`. As [the documentation](https://docs.stripe.com/js/elements_object/create_without_intent) says 'The minimum amount is 0.50 USD or [equivalent in charge currency](https://docs.stripe.com/currencies#minimum-and-maximum-charge-amounts). **If mode is subscription, the value supports 0 to account for coupons and free trials, but any amount above 0 is subject to the minimum.**'

##  Testing
I have tested:
- regular S+ checkout with no promotion and Stripe checkout payment method
- S+ checkout with 100% promotion and Stripe checkout payment method
- S+ checkout with 100% promotion and Google Pay

[**Trello Card**](https://trello.com/c/ksxvvod9/1542-fix-100-discounts-on-generic-checkout)