### PR TITLE
Lighthouse: Bump the resource-summary:document:size threshold

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -7,7 +7,7 @@
         "interactive": ["error", { "maxNumericValue": 9500 }],
         "resource-summary:document:size": [
           "error",
-          { "maxNumericValue": 23000 }
+          { "maxNumericValue": 25000 }
         ]
       }
     }


### PR DESCRIPTION
## What are you doing in this PR?

Bump the resource-summary:document:size threshold (lighthouse metric).


## Why are you doing this?

This lighthouse check is failing on every PR merge which is spamming the SR Dev chat channel. 

For now lets increase the threshold slightly so we stop spamming the chat channel.