### PR TITLE
Rename StripeServiceForCurrency to StripeServiceForAccount

### DIFF
--- a/support-workers/src/main/scala/com/gu/stripe/StripeService.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/StripeService.scala
@@ -21,16 +21,16 @@ class StripeService(val config: StripeConfig, client: FutureHttpClient, baseUrl:
   val wsUrl = baseUrl
   val httpClient: FutureHttpClient = client
 
-  def withPublicKey(stripePublicKey: StripePublicKey): StripeServiceForCurrency = {
+  def withPublicKey(stripePublicKey: StripePublicKey): StripeServiceForAccount = {
     val (stripeSecretKey, gateway) = config
       .forPublicKey(stripePublicKey)
       .getOrElse(throw StateNotValidException("not a known public key: " + stripePublicKey))
-    new StripeServiceForCurrency(this, stripeSecretKey, gateway)
+    new StripeServiceForAccount(this, stripeSecretKey, gateway)
   }
 
 }
 
-class StripeServiceForCurrency(
+class StripeServiceForAccount(
     stripeService: StripeService,
     stripeSecretKey: StripeSecretKey,
     val paymentIntentGateway: PaymentGateway,

--- a/support-workers/src/main/scala/com/gu/stripe/createCustomerFromPaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/createCustomerFromPaymentMethod.scala
@@ -14,7 +14,7 @@ object createCustomerFromPaymentMethod {
 
   case class Customer(id: String)
 
-  def apply(stripeService: StripeServiceForCurrency)(paymentMethod: PaymentMethodId): Future[Customer] =
+  def apply(stripeService: StripeServiceForAccount)(paymentMethod: PaymentMethodId): Future[Customer] =
     stripeService.postForm[Customer](
       "customers",
       Map(

--- a/support-workers/src/main/scala/com/gu/stripe/getPaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/getPaymentMethod.scala
@@ -22,7 +22,7 @@ object getPaymentMethod {
 
   case class StripeCard(brand: StripeBrand, last4: String, exp_month: Int, exp_year: Int, country: String)
 
-  def apply(stripeService: StripeServiceForCurrency)(paymentMethod: PaymentMethodId): Future[StripePaymentMethod] =
+  def apply(stripeService: StripeServiceForAccount)(paymentMethod: PaymentMethodId): Future[StripePaymentMethod] =
     stripeService.get[StripePaymentMethod](s"payment_methods/${paymentMethod.value}")
 
 }

--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
@@ -99,7 +99,7 @@ class CreatePaymentMethodSpec extends AsyncLambdaSpec with MockContext {
     val serviceProvider = mock[ServiceProvider]
     val services = mock[Services]
     val stripe = mock[StripeService]
-    val stripeWithCurrency = mock[StripeServiceForCurrency]
+    val stripeWithCurrency = mock[StripeServiceForAccount]
     val card1 = getPaymentMethod.StripeCard(StripeBrand.Visa, "1234", 1, 2099, "GB")
     val paymentMethod = getPaymentMethod.StripePaymentMethod(card1)
     when(stripeWithCurrency.getPaymentMethod).thenReturn(Function.const(Future(paymentMethod)) _)

--- a/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -3,7 +3,7 @@ package com.gu.zuora
 import com.gu.config.Configuration
 import com.gu.i18n.Currency.GBP
 import com.gu.i18n.{Country, Currency}
-import com.gu.stripe.StripeServiceForCurrency
+import com.gu.stripe.StripeServiceForAccount
 import com.gu.support.acquisitions.ReferrerAcquisitionData
 import com.gu.support.catalog
 import com.gu.support.catalog.{Everyday, HomeDelivery, NationalDelivery}


### PR DESCRIPTION
## What are you doing in this PR?

Following on from #6884, rename `StripeServiceForCurrency` to `StripeServiceForAccount` as it isn't really related to the currency any longer.