### PR TITLE
Persist and retrieve persisted form fields on checkout

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/__tests__/formDataExtractorsTest.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/__tests__/formDataExtractorsTest.ts
@@ -1,4 +1,5 @@
 import {
+	extractBillingAddressMatchesDeliveryFromForm,
 	extractDeliverableAddressDataFromForm,
 	extractNonDeliverableAddressDataFromForm,
 	extractPersonalDataFromForm,
@@ -107,5 +108,27 @@ describe('extractNonDeliverableAddressDataFromForm', () => {
 			country: 'UK',
 		});
 		expect(deliveryAddress).toBeUndefined();
+	});
+});
+
+describe('extractBillingAddressMatchesDeliveryFromForm', () => {
+	it('returns true if the checkbox is checked', () => {
+		const formData = new FormData();
+		formData.append('billingAddressMatchesDelivery', 'yes');
+
+		const billingAddressMatchesDelivery =
+			extractBillingAddressMatchesDeliveryFromForm(formData);
+
+		expect(billingAddressMatchesDelivery).toEqual(true);
+	});
+
+	it('returns false if the checkbox is not checked', () => {
+		// If unchecked this just won't appear in the form data
+		const formData = new FormData();
+
+		const billingAddressMatchesDelivery =
+			extractBillingAddressMatchesDeliveryFromForm(formData);
+
+		expect(billingAddressMatchesDelivery).toEqual(false);
 	});
 });

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -23,6 +23,7 @@ import type { Participations } from '../../helpers/abTests/models';
 import type { LandingPageVariant } from '../../helpers/globalsAndSwitches/landingPageSettings';
 import type { LegacyProductType } from '../../helpers/legacyTypeConversions';
 import { getLegacyProductType } from '../../helpers/legacyTypeConversions';
+import { getFormDetails } from './checkout/helpers/stripeCheckoutSession';
 import { CheckoutComponent } from './components/checkoutComponent';
 
 type Props = {
@@ -260,6 +261,11 @@ export function Checkout({
 		);
 	}, []);
 
+	const checkoutSessionId = window.location.hash;
+	const persistedFormData = checkoutSessionId
+		? getFormDetails(checkoutSessionId.substring(1))
+		: undefined;
+
 	return (
 		<Elements stripe={stripePromise} options={elementsOptions}>
 			<CheckoutComponent
@@ -279,6 +285,7 @@ export function Checkout({
 				forcedCountry={forcedCountry}
 				abParticipations={abParticipations}
 				landingPageSettings={landingPageSettings}
+				persistedFormFields={persistedFormData}
 			/>
 		</Elements>
 	);

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -261,10 +261,20 @@ export function Checkout({
 		);
 	}, []);
 
-	const maybeCheckoutSessionId = urlSearchParams.get('checkoutSessionId');
-	const persistedFormData = maybeCheckoutSessionId
-		? getFormDetails(maybeCheckoutSessionId)
-		: undefined;
+	const checkoutSessionIdUrlParam = 'checkoutSessionId';
+	const maybeCheckoutSessionId = urlSearchParams.get(checkoutSessionIdUrlParam);
+
+	let persistedFormData;
+	if (maybeCheckoutSessionId) {
+		persistedFormData = getFormDetails(maybeCheckoutSessionId);
+
+		// If there's no persisted data, remove the checkoutSessionId from the URL
+		if (!persistedFormData) {
+			const url = new URL(window.location.href);
+			url.searchParams.delete(checkoutSessionIdUrlParam);
+			window.location.href = url.toString();
+		}
+	}
 
 	return (
 		<Elements stripe={stripePromise} options={elementsOptions}>

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -261,9 +261,9 @@ export function Checkout({
 		);
 	}, []);
 
-	const checkoutSessionId = window.location.hash;
-	const persistedFormData = checkoutSessionId
-		? getFormDetails(checkoutSessionId.substring(1))
+	const maybeCheckoutSessionId = urlSearchParams.get('checkoutSessionId');
+	const persistedFormData = maybeCheckoutSessionId
+		? getFormDetails(maybeCheckoutSessionId)
 		: undefined;
 
 	return (

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/__tests__/stripeCheckoutSessionTest.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/__tests__/stripeCheckoutSessionTest.ts
@@ -1,0 +1,43 @@
+import { storage } from '@guardian/libs';
+import type { PersistableFormFields } from '../stripeCheckoutSession';
+import { persistFormDetails } from '../stripeCheckoutSession';
+
+describe('persistFormDetails', () => {
+	it('should persist the form fields in session storage', () => {
+		const formFields: PersistableFormFields = {
+			personalData: {
+				firstName: 'Jane',
+				lastName: 'Doe',
+				email: 'jane.doe@example.com',
+			},
+			addressFields: {
+				billingAddress: {
+					lineOne: '123 Main St',
+					lineTwo: 'Apt 1',
+					city: 'Anytown',
+					state: 'Example',
+					postCode: 'N1',
+					country: 'GB',
+				},
+				deliveryAddress: {
+					lineOne: '123 Main St',
+					lineTwo: 'Apt 1',
+					city: 'Anytown',
+					state: 'Example',
+					postCode: 'N1',
+					country: 'GB',
+				},
+			},
+		};
+
+		persistFormDetails('cs_test_abcdefghijk', formFields);
+
+		const persistedData = storage.session.get('checkoutSessionFormData');
+
+		expect(persistedData).toEqual({
+			formDetails: formFields,
+			version: 1,
+			checkoutSessionId: 'cs_test_abcdefghijk',
+		});
+	});
+});

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/__tests__/stripeCheckoutSessionTest.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/__tests__/stripeCheckoutSessionTest.ts
@@ -1,43 +1,74 @@
 import { storage } from '@guardian/libs';
 import type { PersistableFormFields } from '../stripeCheckoutSession';
-import { persistFormDetails } from '../stripeCheckoutSession';
+import { getFormDetails, persistFormDetails } from '../stripeCheckoutSession';
+
+const buildData = (): PersistableFormFields => {
+	return {
+		personalData: {
+			firstName: 'Jane',
+			lastName: 'Doe',
+			email: 'jane.doe@example.com',
+		},
+		addressFields: {
+			billingAddress: {
+				lineOne: '123 Main St',
+				lineTwo: 'Apt 1',
+				city: 'Anytown',
+				state: 'Example',
+				postCode: 'N1',
+				country: 'GB',
+			},
+			deliveryAddress: {
+				lineOne: '123 Main St',
+				lineTwo: 'Apt 1',
+				city: 'Anytown',
+				state: 'Example',
+				postCode: 'N1',
+				country: 'GB',
+			},
+		},
+	};
+};
 
 describe('persistFormDetails', () => {
 	it('should persist the form fields in session storage', () => {
-		const formFields: PersistableFormFields = {
-			personalData: {
-				firstName: 'Jane',
-				lastName: 'Doe',
-				email: 'jane.doe@example.com',
-			},
-			addressFields: {
-				billingAddress: {
-					lineOne: '123 Main St',
-					lineTwo: 'Apt 1',
-					city: 'Anytown',
-					state: 'Example',
-					postCode: 'N1',
-					country: 'GB',
-				},
-				deliveryAddress: {
-					lineOne: '123 Main St',
-					lineTwo: 'Apt 1',
-					city: 'Anytown',
-					state: 'Example',
-					postCode: 'N1',
-					country: 'GB',
-				},
-			},
-		};
+		const formFields = buildData();
 
 		persistFormDetails('cs_test_abcdefghijk', formFields);
 
 		const persistedData = storage.session.get('checkoutSessionFormData');
-
 		expect(persistedData).toEqual({
 			formDetails: formFields,
 			version: 1,
 			checkoutSessionId: 'cs_test_abcdefghijk',
 		});
+	});
+});
+
+describe('getFormDetails', () => {
+	it('returns the data', () => {
+		const formFields = buildData();
+		const checkoutSessionId = 'cs_test_abcdefghijk';
+		persistFormDetails(checkoutSessionId, formFields);
+
+		const persistedData = getFormDetails(checkoutSessionId);
+
+		expect(persistedData).toEqual(formFields);
+	});
+
+	it('returns undefined if the data is not valid according to the schema', () => {
+		storage.session.set('checkoutSessionFormData', { bad: 'data' });
+
+		const persistedData = getFormDetails('cs_test_abcdefghijk');
+
+		expect(persistedData).toBeUndefined();
+	});
+
+	it('returns undefined if the checkoutSessionId in the does not match the one specified', () => {
+		persistFormDetails('cs_test_abcdefghijk', buildData());
+
+		const persistedData = getFormDetails('cs_test_different_id');
+
+		expect(persistedData).toBeUndefined();
 	});
 });

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/__tests__/stripeCheckoutSessionTest.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/__tests__/stripeCheckoutSessionTest.ts
@@ -27,6 +27,7 @@ const buildData = (): PersistableFormFields => {
 				country: 'GB',
 			},
 		},
+		deliveryInstructions: 'Side entrance, please',
 	};
 };
 

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/__tests__/stripeCheckoutSessionTest.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/__tests__/stripeCheckoutSessionTest.ts
@@ -19,15 +19,16 @@ const buildData = (): PersistableFormFields => {
 				country: 'GB',
 			},
 			deliveryAddress: {
-				lineOne: '123 Main St',
-				lineTwo: 'Apt 1',
-				city: 'Anytown',
+				lineOne: 'Another St',
+				lineTwo: 'Apt 2',
+				city: 'Big City',
 				state: 'Example',
-				postCode: 'N1',
+				postCode: 'N2',
 				country: 'GB',
 			},
 		},
 		deliveryInstructions: 'Side entrance, please',
+		billingAddressMatchesDelivery: false,
 	};
 };
 

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/formDataExtractors.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/formDataExtractors.ts
@@ -14,7 +14,7 @@ export const extractPersonalDataFromForm = (
 	email: formData.get('email') as string,
 });
 
-export type FormAddressFields = {
+type FormAddressFields = {
 	billingAddress: {
 		lineOne?: string | null;
 		lineTwo?: string | null;

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/formDataExtractors.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/formDataExtractors.ts
@@ -14,7 +14,7 @@ export const extractPersonalDataFromForm = (
 	email: formData.get('email') as string,
 });
 
-type FormAddressFields = {
+export type FormAddressFields = {
 	deliveryAddress?: {
 		lineOne: string;
 		lineTwo: string;

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/formDataExtractors.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/formDataExtractors.ts
@@ -15,18 +15,18 @@ export const extractPersonalDataFromForm = (
 });
 
 export type FormAddressFields = {
-	deliveryAddress?: {
-		lineOne: string;
-		lineTwo: string;
-		city: string;
-		state: string;
-		postCode: string;
-		country: IsoCountry;
-	};
 	billingAddress: {
 		lineOne?: string;
 		lineTwo?: string;
 		city?: string;
+		state: string;
+		postCode: string;
+		country: IsoCountry;
+	};
+	deliveryAddress?: {
+		lineOne: string;
+		lineTwo: string;
+		city: string;
 		state: string;
 		postCode: string;
 		country: IsoCountry;

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/formDataExtractors.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/formDataExtractors.ts
@@ -16,19 +16,19 @@ export const extractPersonalDataFromForm = (
 
 export type FormAddressFields = {
 	billingAddress: {
-		lineOne?: string;
-		lineTwo?: string;
-		city?: string;
-		state: string;
-		postCode: string;
+		lineOne?: string | null;
+		lineTwo?: string | null;
+		city?: string | null;
+		state?: string | null;
+		postCode?: string | null;
 		country: IsoCountry;
 	};
 	deliveryAddress?: {
-		lineOne: string;
-		lineTwo: string;
-		city: string;
-		state: string;
-		postCode: string;
+		lineOne?: string | null;
+		lineTwo?: string | null;
+		city?: string | null;
+		state?: string | null;
+		postCode?: string | null;
 		country: IsoCountry;
 	};
 };

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/formDataExtractors.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/formDataExtractors.ts
@@ -45,10 +45,7 @@ export const extractDeliverableAddressDataFromForm = (
 		country: formData.get('delivery-country') as IsoCountry,
 	};
 
-	const billingAddressMatchesDelivery =
-		formData.get('billingAddressMatchesDelivery') === 'yes';
-
-	const billingAddress = !billingAddressMatchesDelivery
+	const billingAddress = !extractBillingAddressMatchesDeliveryFromForm(formData)
 		? {
 				lineOne: formData.get('billing-lineOne') as string,
 				lineTwo: formData.get('billing-lineTwo') as string,
@@ -75,3 +72,7 @@ export const extractNonDeliverableAddressDataFromForm = (
 	},
 	deliveryAddress: undefined,
 });
+
+export const extractBillingAddressMatchesDeliveryFromForm = (
+	formData: FormData,
+) => formData.get('billingAddressMatchesDelivery') === 'yes';

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
@@ -1,4 +1,5 @@
 import { storage } from '@guardian/libs';
+import type { InferInput } from 'valibot';
 import {
 	boolean,
 	nullish,
@@ -10,17 +11,6 @@ import {
 	string,
 } from 'valibot';
 import { isoCountries } from 'helpers/internationalisation/country';
-import type {
-	FormAddressFields,
-	FormPersonalFields,
-} from './formDataExtractors';
-
-export type PersistableFormFields = {
-	personalData: FormPersonalFields;
-	addressFields: FormAddressFields;
-	deliveryInstructions?: string;
-	billingAddressMatchesDelivery?: boolean;
-};
 
 const formDetailsSchema = object({
 	personalData: object({
@@ -51,6 +41,8 @@ const formDetailsSchema = object({
 	deliveryInstructions: optional(string()),
 	billingAddressMatchesDelivery: optional(boolean()),
 });
+
+export type PersistableFormFields = InferInput<typeof formDetailsSchema>;
 
 const schema = object({
 	formDetails: formDetailsSchema,

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
@@ -22,15 +22,23 @@ export type PersistableFormFields = {
 	billingAddressMatchesDelivery?: boolean;
 };
 
-const schema = object({
-	formDetails: object({
-		personalData: object({
-			firstName: string(),
-			lastName: string(),
-			email: string(),
+const formDetailsSchema = object({
+	personalData: object({
+		firstName: string(),
+		lastName: string(),
+		email: string(),
+	}),
+	addressFields: object({
+		billingAddress: object({
+			lineOne: nullish(string()),
+			lineTwo: nullish(string()),
+			city: nullish(string()),
+			state: nullish(string()),
+			postCode: nullish(string()),
+			country: picklist(isoCountries),
 		}),
-		addressFields: object({
-			billingAddress: object({
+		deliveryAddress: optional(
+			object({
 				lineOne: nullish(string()),
 				lineTwo: nullish(string()),
 				city: nullish(string()),
@@ -38,20 +46,14 @@ const schema = object({
 				postCode: nullish(string()),
 				country: picklist(isoCountries),
 			}),
-			deliveryAddress: optional(
-				object({
-					lineOne: nullish(string()),
-					lineTwo: nullish(string()),
-					city: nullish(string()),
-					state: nullish(string()),
-					postCode: nullish(string()),
-					country: picklist(isoCountries),
-				}),
-			),
-		}),
-		deliveryInstructions: optional(string()),
-		billingAddressMatchesDelivery: optional(boolean()),
+		),
 	}),
+	deliveryInstructions: optional(string()),
+	billingAddressMatchesDelivery: optional(boolean()),
+});
+
+const schema = object({
+	formDetails: formDetailsSchema,
 	version: number(),
 	checkoutSessionId: string(),
 });

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
@@ -1,0 +1,27 @@
+import { storage } from '@guardian/libs';
+import type {
+	FormAddressFields,
+	FormPersonalFields,
+} from './formDataExtractors';
+
+export type PersistableFormFields = {
+	personalData: FormPersonalFields;
+	addressFields: FormAddressFields;
+};
+
+const oneDayInMillis = 24 * 60 * 60 * 1000;
+
+export const persistFormDetails = (
+	checkoutSessionId: string,
+	formDetails: PersistableFormFields,
+): void => {
+	const dataToPersist = {
+		formDetails,
+		version: 1,
+		checkoutSessionId,
+	};
+
+	const expiry = Date.now() + oneDayInMillis;
+
+	storage.session.set('checkoutSessionFormData', dataToPersist, expiry);
+};

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
@@ -57,7 +57,6 @@ const oneDayInMillis = 24 * 60 * 60 * 1000;
 
 const KEY = 'checkoutSessionFormData';
 
-// TODO: persist delivery instructions
 export const persistFormDetails = (
 	checkoutSessionId: string,
 	formDetails: PersistableFormFields,

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
@@ -17,6 +17,7 @@ import type {
 export type PersistableFormFields = {
 	personalData: FormPersonalFields;
 	addressFields: FormAddressFields;
+	deliveryInstructions?: string;
 };
 
 const schema = object({
@@ -46,6 +47,7 @@ const schema = object({
 				}),
 			),
 		}),
+		deliveryInstructions: optional(string()),
 	}),
 	version: number(),
 	checkoutSessionId: string(),

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
@@ -1,5 +1,6 @@
 import { storage } from '@guardian/libs';
 import {
+	boolean,
 	nullish,
 	number,
 	object,
@@ -18,6 +19,7 @@ export type PersistableFormFields = {
 	personalData: FormPersonalFields;
 	addressFields: FormAddressFields;
 	deliveryInstructions?: string;
+	billingAddressMatchesDelivery?: boolean;
 };
 
 const schema = object({
@@ -48,6 +50,7 @@ const schema = object({
 			),
 		}),
 		deliveryInstructions: optional(string()),
+		billingAddressMatchesDelivery: optional(boolean()),
 	}),
 	version: number(),
 	checkoutSessionId: string(),

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
@@ -87,7 +87,3 @@ export const getFormDetails = (
 
 	return parsed.output.formDetails;
 };
-
-export const deleteFormDetails = (): void => {
-	storage.session.remove(KEY);
-};

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
@@ -54,6 +54,7 @@ const schema = object({
 const oneDayInMillis = 24 * 60 * 60 * 1000;
 
 const KEY = 'checkoutSessionFormData';
+
 // TODO: persist delivery instructions
 export const persistFormDetails = (
 	checkoutSessionId: string,

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
@@ -1,5 +1,13 @@
 import { storage } from '@guardian/libs';
-import { number, object, optional, picklist, safeParse, string } from 'valibot';
+import {
+	nullish,
+	number,
+	object,
+	optional,
+	picklist,
+	safeParse,
+	string,
+} from 'valibot';
 import { isoCountries } from 'helpers/internationalisation/country';
 import type {
 	FormAddressFields,
@@ -20,20 +28,20 @@ const schema = object({
 		}),
 		addressFields: object({
 			billingAddress: object({
-				lineOne: optional(string()),
-				lineTwo: optional(string()),
-				city: optional(string()),
-				state: string(),
-				postCode: string(),
+				lineOne: nullish(string()),
+				lineTwo: nullish(string()),
+				city: nullish(string()),
+				state: nullish(string()),
+				postCode: nullish(string()),
 				country: picklist(isoCountries),
 			}),
 			deliveryAddress: optional(
 				object({
-					lineOne: string(),
-					lineTwo: string(),
-					city: string(),
-					state: string(),
-					postCode: string(),
+					lineOne: nullish(string()),
+					lineTwo: nullish(string()),
+					city: nullish(string()),
+					state: nullish(string()),
+					postCode: nullish(string()),
 					country: picklist(isoCountries),
 				}),
 			),

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -88,6 +88,7 @@ import { PersonalDetailsFields } from '../checkout/components/PersonalDetailsFie
 import type { DeliveryAgentsResponse } from '../checkout/helpers/getDeliveryAgents';
 import { getDeliveryAgents } from '../checkout/helpers/getDeliveryAgents';
 import { getProductFields } from '../checkout/helpers/getProductFields';
+import type { PersistableFormFields } from '../checkout/helpers/stripeCheckoutSession';
 import {
 	doesNotContainExtendedEmojiOrLeadingSpace,
 	preventDefaultValidityMessage,
@@ -151,6 +152,7 @@ type CheckoutComponentProps = {
 	forcedCountry?: string;
 	abParticipations: Participations;
 	landingPageSettings: LandingPageVariant;
+	persistedFormFields?: PersistableFormFields;
 };
 
 const shouldUseStripeHostedCheckout = (
@@ -176,6 +178,7 @@ export function CheckoutComponent({
 	forcedCountry,
 	abParticipations,
 	landingPageSettings,
+	persistedFormFields,
 }: CheckoutComponentProps) {
 	const csrf = appConfig.csrf.token;
 	const user = appConfig.user;
@@ -366,25 +369,45 @@ export function CheckoutComponent({
 	const [recaptchaToken, setRecaptchaToken] = useState<string>();
 
 	/** Personal details */
-	const [firstName, setFirstName] = useState(user?.firstName ?? '');
-	const [lastName, setLastName] = useState(user?.lastName ?? '');
-	const [email, setEmail] = useState(user?.email ?? '');
-	const [confirmedEmail, setConfirmedEmail] = useState('');
+	const [firstName, setFirstName] = useState(
+		persistedFormFields?.personalData.firstName ?? user?.firstName ?? '',
+	);
+	const [lastName, setLastName] = useState(
+		persistedFormFields?.personalData.lastName ?? user?.lastName ?? '',
+	);
+	const [email, setEmail] = useState(
+		persistedFormFields?.personalData.email ?? user?.email ?? '',
+	);
+	const [confirmedEmail, setConfirmedEmail] = useState(
+		persistedFormFields?.personalData.email ?? '',
+	);
 
 	/** Delivery Instructions */
 	const [deliveryInstructions, setDeliveryInstructions] = useState('');
 
 	/** Delivery and billing addresses */
-	const [deliveryPostcode, setDeliveryPostcode] = useState('');
-	const [deliveryLineOne, setDeliveryLineOne] = useState('');
-	const [deliveryLineTwo, setDeliveryLineTwo] = useState('');
-	const [deliveryCity, setDeliveryCity] = useState('');
-	const [deliveryState, setDeliveryState] = useState('');
+	const [deliveryPostcode, setDeliveryPostcode] = useState(
+		persistedFormFields?.addressFields.deliveryAddress?.postCode ?? '',
+	);
+	const [deliveryLineOne, setDeliveryLineOne] = useState(
+		persistedFormFields?.addressFields.deliveryAddress?.lineOne ?? '',
+	);
+	const [deliveryLineTwo, setDeliveryLineTwo] = useState(
+		persistedFormFields?.addressFields.deliveryAddress?.lineTwo ?? '',
+	);
+	const [deliveryCity, setDeliveryCity] = useState(
+		persistedFormFields?.addressFields.deliveryAddress?.city ?? '',
+	);
+	const [deliveryState, setDeliveryState] = useState(
+		persistedFormFields?.addressFields.deliveryAddress?.state ?? '',
+	);
 	const [deliveryPostcodeStateResults, setDeliveryPostcodeStateResults] =
 		useState<PostcodeFinderResult[]>([]);
 	const [deliveryPostcodeStateLoading, setDeliveryPostcodeStateLoading] =
 		useState(false);
-	const [deliveryCountry, setDeliveryCountry] = useState(countryId);
+	const [deliveryCountry, setDeliveryCountry] = useState(
+		persistedFormFields?.addressFields.deliveryAddress?.country ?? countryId,
+	);
 	const [deliveryAddressErrors, setDeliveryAddressErrors] = useState<
 		AddressFormFieldError[]
 	>([]);

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -454,23 +454,35 @@ export function CheckoutComponent({
 	const [billingAddressMatchesDelivery, setBillingAddressMatchesDelivery] =
 		useState(persistedFormFields?.billingAddressMatchesDelivery ?? true);
 
-	const [billingPostcode, setBillingPostcode] = useState('');
+	const [billingPostcode, setBillingPostcode] = useState(
+		persistedFormFields?.addressFields.billingAddress.postCode ?? '',
+	);
 	const [billingPostcodeError, setBillingPostcodeError] = useState<string>();
-	const [billingLineOne, setBillingLineOne] = useState('');
-	const [billingLineTwo, setBillingLineTwo] = useState('');
-	const [billingCity, setBillingCity] = useState('');
+	const [billingLineOne, setBillingLineOne] = useState(
+		persistedFormFields?.addressFields.billingAddress.lineOne ?? '',
+	);
+	const [billingLineTwo, setBillingLineTwo] = useState(
+		persistedFormFields?.addressFields.billingAddress.lineTwo ?? '',
+	);
+	const [billingCity, setBillingCity] = useState(
+		persistedFormFields?.addressFields.billingAddress.city ?? '',
+	);
 	const [billingStateError, setBillingStateError] = useState<string>();
 	/**
 	 * BillingState selector initialised to undefined to hide
 	 * billingStateError message. formOnSubmit checks and converts to
 	 * empty string to display billingStateError message.
 	 */
-	const [billingState, setBillingState] = useState('');
+	const [billingState, setBillingState] = useState(
+		persistedFormFields?.addressFields.billingAddress.state ?? '',
+	);
 	const [billingPostcodeStateResults, setBillingPostcodeStateResults] =
 		useState<PostcodeFinderResult[]>([]);
 	const [billingPostcodeStateLoading, setBillingPostcodeStateLoading] =
 		useState(false);
-	const [billingCountry, setBillingCountry] = useState(countryId);
+	const [billingCountry, setBillingCountry] = useState(
+		persistedFormFields?.addressFields.billingAddress.country ?? countryId,
+	);
 	const [billingAddressErrors, setBillingAddressErrors] = useState<
 		AddressFormFieldError[]
 	>([]);

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -452,7 +452,7 @@ export function CheckoutComponent({
 	}, [deliveryPostcode]);
 
 	const [billingAddressMatchesDelivery, setBillingAddressMatchesDelivery] =
-		useState(true);
+		useState(persistedFormFields?.billingAddressMatchesDelivery ?? true);
 
 	const [billingPostcode, setBillingPostcode] = useState('');
 	const [billingPostcodeError, setBillingPostcodeError] = useState<string>();

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -383,7 +383,9 @@ export function CheckoutComponent({
 	);
 
 	/** Delivery Instructions */
-	const [deliveryInstructions, setDeliveryInstructions] = useState('');
+	const [deliveryInstructions, setDeliveryInstructions] = useState(
+		persistedFormFields?.deliveryInstructions ?? '',
+	);
 
 	/** Delivery and billing addresses */
 	const [deliveryPostcode, setDeliveryPostcode] = useState(

--- a/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
@@ -113,6 +113,7 @@ export const submitForm = async ({
 				billingAddress,
 				deliveryAddress,
 			},
+			deliveryInstructions,
 		});
 
 		return checkoutSession.url;


### PR DESCRIPTION
## What are you doing in this PR?

For the Stripe hosted checkout flow the checkout process looks like this:

```
+----------------------+     +------------------------+     +----------------------+
| Normal checkout form | --> | Stripe hosted checkout | --> | Back to support site |
+----------------------+     +------------------------+     +----------------------+
```

Validation of form fields etc takes place in the first step, before transferring to Stripe. When the user returns to our site, we don't want them to have to fill in their details again, but these details are needed to submit the create subscription request to support-workers. It's also possible that something may go wrong with the support-workers execution, in which case we'd want to place the user on the checkout form, with an error message, but their form fields still filled.

In this PR we persist the filled form fields to session storage under the key `checkoutSessionFormData`, with an expiration of 24 hours (managed by `@guardian/libs`). The reason we use 24 hours is to align with the expiration of the checkout session on Stripe's side. Since we're using session storage this data is tied to the current browser tab so the expiration will be the shorter of 24 hours and the lifespan of the current browser tab. After the user successfully returns from Stripe, we retrieve the details if there's a `checkoutSessionId` query string arg. If the checkout session ID doesn't match, the persisted form details aren't used. If there is a match, and the data is valid, we fill the form with the persisted details.

[**Trello Card**](https://trello.com/c/YU3EaFAw/1544-when-a-user-clicks-to-pay-by-credit-debit-card-on-the-generic-checkout-and-the-product-is-homedelivery-or-subscriptioncard-and-t)

## Why are you doing this?

Following on from #6863 this is the next step of implementing the complete flow.

## How to test

In CODE go to the Sunday HomeDelivery/Subs card checkout and pick debit/credit card payment option. After filling out the form with valid data and submitting you'll be transferred to Stripe to collect payment details. On success you will be taken back to the generic checkout with the form fields filled in to reflect the data you'd previously entered.

I've also run the smoke tests against this branch to ensure no existing flows are broken.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
