### PR TITLE
Connect Stripe hosted checkout frontend and backend changes

### DIFF
--- a/support-config/src/main/scala/com/gu/support/config/StripeConfig.scala
+++ b/support-config/src/main/scala/com/gu/support/config/StripeConfig.scala
@@ -21,30 +21,6 @@ case class StripeConfig(
 
   def forPublicKey(publicKey: StripePublicKey): Option[(StripeSecretKey, PaymentGateway)] =
     secretForPublic.get(publicKey)
-
-  // fallback for SupportWorkers (recurring products) which don't support a US Stripe account yet.
-  def forCurrency(maybeCurrency: Option[Currency]): StripeAccountConfig =
-    maybeCurrency match {
-      case Some(AUD) =>
-        logger.debug(s"StripeConfig: getting AU stripe account for AUD")
-        australiaAccount
-      case _ =>
-        logger.debug(s"StripeConfig: getting default stripe account for ${maybeCurrency.map(_.iso).mkString}")
-        defaultAccount
-    }
-
-  def forCountry(maybeCountry: Option[Country]): StripeAccountConfig =
-    maybeCountry match {
-      case Some(Country.Australia) =>
-        logger.debug(s"StripeConfig: getting AU stripe account for Australia")
-        australiaAccount
-      case Some(Country.US) =>
-        logger.debug(s"StripeConfig: getting US stripe account for United States")
-        unitedStatesAccount
-      case _ =>
-        logger.debug(s"StripeConfig: getting default stripe account for ${maybeCountry.map(_.name).mkString}")
-        defaultAccount
-    }
 }
 
 case class StripeAccountConfig(secretKey: StripeSecretKey, publicKey: StripePublicKey)

--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -51,7 +51,7 @@ object CheckoutValidationRules {
       if (switches.directDebit.contains(On)) Valid else Invalid("Invalid Payment Method")
     case _: StripePaymentFields =>
       if (switches.creditCard.contains(On)) Valid else Invalid("Invalid Payment Method")
-    case _: StripeHostedCheckoutPaymentFields =>
+    case _: StripeHostedPaymentFields =>
       if (switches.stripeHostedCheckout.contains(On)) Valid else Invalid("Invalid Payment Method")
     case _ => Invalid("Invalid Payment Method")
   }
@@ -66,7 +66,7 @@ object CheckoutValidationRules {
       if (switches.directDebit.contains(On)) Valid else Invalid("Invalid Payment Method")
     case _: SepaPaymentFields =>
       if (switches.sepa.contains(On)) Valid else Invalid("Invalid Payment Method")
-    case _: StripeHostedCheckoutPaymentFields =>
+    case _: StripeHostedPaymentFields =>
       if (switches.stripeHostedCheckout.contains(On)) Valid else Invalid("Invalid Payment Method")
     case s: StripePaymentFields =>
       s.stripePaymentType match {
@@ -229,7 +229,7 @@ object PaidProductValidation {
     case SepaPaymentFields(accountHolderName, iban, country, streetName) =>
       accountHolderName.nonEmpty.otherwise("sepa account holder name missing") and
         iban.nonEmpty.otherwise("sepa iban empty")
-    case _: StripeHostedCheckoutPaymentFields => Valid
+    case _: StripeHostedPaymentFields => Valid
   }
 
 }

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -131,8 +131,10 @@ type RegularSepaPaymentFields = {
 };
 type RegularStripeHostedCheckoutPaymentFields = {
 	paymentType: typeof StripeHostedCheckout;
+	checkoutSessionId?: string;
 };
 type GiftRedemption = {
+	paymentType: 'GiftRedemption';
 	redemptionCode: string;
 };
 export type RegularPaymentFields =

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -132,6 +132,7 @@ type RegularSepaPaymentFields = {
 type RegularStripeHostedCheckoutPaymentFields = {
 	paymentType: typeof StripeHostedCheckout;
 	checkoutSessionId?: string;
+	stripePublicKey: string;
 };
 type GiftRedemption = {
 	paymentType: 'GiftRedemption';

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -23,7 +23,7 @@ import type { Participations } from '../../helpers/abTests/models';
 import type { LandingPageVariant } from '../../helpers/globalsAndSwitches/landingPageSettings';
 import type { LegacyProductType } from '../../helpers/legacyTypeConversions';
 import { getLegacyProductType } from '../../helpers/legacyTypeConversions';
-import type { PersistableFormFields } from './checkout/helpers/stripeCheckoutSession';
+import type { CheckoutSession } from './checkout/helpers/stripeCheckoutSession';
 import { getFormDetails } from './checkout/helpers/stripeCheckoutSession';
 import { CheckoutComponent } from './components/checkoutComponent';
 
@@ -72,7 +72,7 @@ const getPromotionFromProductPrices = (
 
 const attemptToRetrievePersistedFormData = (
 	urlSearchParams: URLSearchParams,
-): PersistableFormFields | undefined => {
+): CheckoutSession | undefined => {
 	const checkoutSessionIdUrlParam = 'checkoutSessionId';
 	const maybeCheckoutSessionId = urlSearchParams.get(checkoutSessionIdUrlParam);
 
@@ -284,7 +284,7 @@ export function Checkout({
 		);
 	}, []);
 
-	const persistedFormData = attemptToRetrievePersistedFormData(urlSearchParams);
+	const checkoutSession = attemptToRetrievePersistedFormData(urlSearchParams);
 
 	return (
 		<Elements stripe={stripePromise} options={elementsOptions}>
@@ -305,7 +305,7 @@ export function Checkout({
 				forcedCountry={forcedCountry}
 				abParticipations={abParticipations}
 				landingPageSettings={landingPageSettings}
-				persistedFormFields={persistedFormData}
+				checkoutSession={checkoutSession}
 			/>
 		</Elements>
 	);

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/__tests__/stripeCheckoutSessionTest.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/__tests__/stripeCheckoutSessionTest.ts
@@ -55,7 +55,7 @@ describe('getFormDetails', () => {
 
 		const persistedData = getFormDetails(checkoutSessionId);
 
-		expect(persistedData).toEqual(formFields);
+		expect(persistedData?.formFields).toEqual(formFields);
 	});
 
 	it('returns undefined if the data is not valid according to the schema', () => {

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
@@ -44,6 +44,11 @@ const formDetailsSchema = object({
 
 export type PersistableFormFields = InferInput<typeof formDetailsSchema>;
 
+export type CheckoutSession = {
+	checkoutSessionId: string;
+	formFields: PersistableFormFields;
+};
+
 const schema = object({
 	formDetails: formDetailsSchema,
 	version: number(),
@@ -71,7 +76,7 @@ export const persistFormDetails = (
 
 export const getFormDetails = (
 	checkoutSessionId: string,
-): PersistableFormFields | undefined => {
+): CheckoutSession | undefined => {
 	const persistedData = storage.session.get(KEY);
 
 	const parsed = safeParse(schema, persistedData);
@@ -84,5 +89,5 @@ export const getFormDetails = (
 		return undefined;
 	}
 
-	return parsed.output.formDetails;
+	return { checkoutSessionId, formFields: parsed.output.formDetails };
 };

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -88,7 +88,7 @@ import { PersonalDetailsFields } from '../checkout/components/PersonalDetailsFie
 import type { DeliveryAgentsResponse } from '../checkout/helpers/getDeliveryAgents';
 import { getDeliveryAgents } from '../checkout/helpers/getDeliveryAgents';
 import { getProductFields } from '../checkout/helpers/getProductFields';
-import type { PersistableFormFields } from '../checkout/helpers/stripeCheckoutSession';
+import type { CheckoutSession } from '../checkout/helpers/stripeCheckoutSession';
 import {
 	doesNotContainExtendedEmojiOrLeadingSpace,
 	preventDefaultValidityMessage,
@@ -152,7 +152,7 @@ type CheckoutComponentProps = {
 	forcedCountry?: string;
 	abParticipations: Participations;
 	landingPageSettings: LandingPageVariant;
-	persistedFormFields?: PersistableFormFields;
+	checkoutSession?: CheckoutSession;
 };
 
 const shouldUseStripeHostedCheckout = (
@@ -178,7 +178,7 @@ export function CheckoutComponent({
 	forcedCountry,
 	abParticipations,
 	landingPageSettings,
-	persistedFormFields,
+	checkoutSession,
 }: CheckoutComponentProps) {
 	const csrf = appConfig.csrf.token;
 	const user = appConfig.user;
@@ -370,45 +370,46 @@ export function CheckoutComponent({
 
 	/** Personal details */
 	const [firstName, setFirstName] = useState(
-		persistedFormFields?.personalData.firstName ?? user?.firstName ?? '',
+		checkoutSession?.formFields.personalData.firstName ?? user?.firstName ?? '',
 	);
 	const [lastName, setLastName] = useState(
-		persistedFormFields?.personalData.lastName ?? user?.lastName ?? '',
+		checkoutSession?.formFields.personalData.lastName ?? user?.lastName ?? '',
 	);
 	const [email, setEmail] = useState(
-		persistedFormFields?.personalData.email ?? user?.email ?? '',
+		checkoutSession?.formFields.personalData.email ?? user?.email ?? '',
 	);
 	const [confirmedEmail, setConfirmedEmail] = useState(
-		persistedFormFields?.personalData.email ?? '',
+		checkoutSession?.formFields.personalData.email ?? '',
 	);
 
 	/** Delivery Instructions */
 	const [deliveryInstructions, setDeliveryInstructions] = useState(
-		persistedFormFields?.deliveryInstructions ?? '',
+		checkoutSession?.formFields.deliveryInstructions ?? '',
 	);
 
 	/** Delivery and billing addresses */
 	const [deliveryPostcode, setDeliveryPostcode] = useState(
-		persistedFormFields?.addressFields.deliveryAddress?.postCode ?? '',
+		checkoutSession?.formFields.addressFields.deliveryAddress?.postCode ?? '',
 	);
 	const [deliveryLineOne, setDeliveryLineOne] = useState(
-		persistedFormFields?.addressFields.deliveryAddress?.lineOne ?? '',
+		checkoutSession?.formFields.addressFields.deliveryAddress?.lineOne ?? '',
 	);
 	const [deliveryLineTwo, setDeliveryLineTwo] = useState(
-		persistedFormFields?.addressFields.deliveryAddress?.lineTwo ?? '',
+		checkoutSession?.formFields.addressFields.deliveryAddress?.lineTwo ?? '',
 	);
 	const [deliveryCity, setDeliveryCity] = useState(
-		persistedFormFields?.addressFields.deliveryAddress?.city ?? '',
+		checkoutSession?.formFields.addressFields.deliveryAddress?.city ?? '',
 	);
 	const [deliveryState, setDeliveryState] = useState(
-		persistedFormFields?.addressFields.deliveryAddress?.state ?? '',
+		checkoutSession?.formFields.addressFields.deliveryAddress?.state ?? '',
 	);
 	const [deliveryPostcodeStateResults, setDeliveryPostcodeStateResults] =
 		useState<PostcodeFinderResult[]>([]);
 	const [deliveryPostcodeStateLoading, setDeliveryPostcodeStateLoading] =
 		useState(false);
 	const [deliveryCountry, setDeliveryCountry] = useState(
-		persistedFormFields?.addressFields.deliveryAddress?.country ?? countryId,
+		checkoutSession?.formFields.addressFields.deliveryAddress?.country ??
+			countryId,
 	);
 	const [deliveryAddressErrors, setDeliveryAddressErrors] = useState<
 		AddressFormFieldError[]
@@ -452,20 +453,20 @@ export function CheckoutComponent({
 	}, [deliveryPostcode]);
 
 	const [billingAddressMatchesDelivery, setBillingAddressMatchesDelivery] =
-		useState(persistedFormFields?.billingAddressMatchesDelivery ?? true);
+		useState(checkoutSession?.formFields.billingAddressMatchesDelivery ?? true);
 
 	const [billingPostcode, setBillingPostcode] = useState(
-		persistedFormFields?.addressFields.billingAddress.postCode ?? '',
+		checkoutSession?.formFields.addressFields.billingAddress.postCode ?? '',
 	);
 	const [billingPostcodeError, setBillingPostcodeError] = useState<string>();
 	const [billingLineOne, setBillingLineOne] = useState(
-		persistedFormFields?.addressFields.billingAddress.lineOne ?? '',
+		checkoutSession?.formFields.addressFields.billingAddress.lineOne ?? '',
 	);
 	const [billingLineTwo, setBillingLineTwo] = useState(
-		persistedFormFields?.addressFields.billingAddress.lineTwo ?? '',
+		checkoutSession?.formFields.addressFields.billingAddress.lineTwo ?? '',
 	);
 	const [billingCity, setBillingCity] = useState(
-		persistedFormFields?.addressFields.billingAddress.city ?? '',
+		checkoutSession?.formFields.addressFields.billingAddress.city ?? '',
 	);
 	const [billingStateError, setBillingStateError] = useState<string>();
 	/**
@@ -474,14 +475,15 @@ export function CheckoutComponent({
 	 * empty string to display billingStateError message.
 	 */
 	const [billingState, setBillingState] = useState(
-		persistedFormFields?.addressFields.billingAddress.state ?? '',
+		checkoutSession?.formFields.addressFields.billingAddress.state ?? '',
 	);
 	const [billingPostcodeStateResults, setBillingPostcodeStateResults] =
 		useState<PostcodeFinderResult[]>([]);
 	const [billingPostcodeStateLoading, setBillingPostcodeStateLoading] =
 		useState(false);
 	const [billingCountry, setBillingCountry] = useState(
-		persistedFormFields?.addressFields.billingAddress.country ?? countryId,
+		checkoutSession?.formFields.addressFields.billingAddress.country ??
+			countryId,
 	);
 	const [billingAddressErrors, setBillingAddressErrors] = useState<
 		AddressFormFieldError[]
@@ -528,6 +530,7 @@ export function CheckoutComponent({
 				stripePublicKey,
 				recaptchaToken,
 				formData,
+				checkoutSession?.checkoutSessionId,
 			);
 			if (paymentFields === undefined) {
 				throw new Error('paymentFields is undefined');

--- a/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
@@ -97,7 +97,7 @@ export const submitForm = async ({
 
 	if (
 		paymentFields.paymentType === 'StripeHostedCheckout' &&
-		paymentFields.checkoutSessionId === undefined
+		!paymentFields.checkoutSessionId
 	) {
 		const checkoutSession = await createStripeCheckoutSession({
 			personalData,

--- a/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
@@ -95,7 +95,10 @@ export const submitForm = async ({
 		debugInfo: '',
 	};
 
-	if (paymentMethod === 'StripeHostedCheckout') {
+	if (
+		paymentFields.paymentType === 'StripeHostedCheckout' &&
+		paymentFields.checkoutSessionId === undefined
+	) {
 		const checkoutSession = await createStripeCheckoutSession({
 			personalData,
 			appliedPromotion,

--- a/support-frontend/assets/pages/[countryGroupId]/components/paymentFields.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/paymentFields.ts
@@ -145,6 +145,7 @@ export const getPaymentFieldsForPaymentMethod = async (
 	stripePublicKey: string,
 	recaptchaToken: string | undefined,
 	formData: FormData,
+	checkoutSessionId: string | undefined,
 ): Promise<RegularPaymentFields | undefined> => {
 	if (paymentMethod === 'Stripe') {
 		return getStripePaymentFields(
@@ -181,6 +182,7 @@ export const getPaymentFieldsForPaymentMethod = async (
 	if (paymentMethod === 'StripeHostedCheckout') {
 		return {
 			paymentType: StripeHostedCheckout,
+			checkoutSessionId,
 		};
 	}
 

--- a/support-frontend/assets/pages/[countryGroupId]/components/paymentFields.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/paymentFields.ts
@@ -182,7 +182,7 @@ export const getPaymentFieldsForPaymentMethod = async (
 	if (paymentMethod === 'StripeHostedCheckout') {
 		return {
 			paymentType: StripeHostedCheckout,
-			checkoutSessionId: checkoutSessionId ?? '',
+			checkoutSessionId: checkoutSessionId,
 			stripePublicKey,
 		};
 	}

--- a/support-frontend/assets/pages/[countryGroupId]/components/paymentFields.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/paymentFields.ts
@@ -182,7 +182,8 @@ export const getPaymentFieldsForPaymentMethod = async (
 	if (paymentMethod === 'StripeHostedCheckout') {
 		return {
 			paymentType: StripeHostedCheckout,
-			checkoutSessionId,
+			checkoutSessionId: checkoutSessionId ?? '',
+			stripePublicKey,
 		};
 	}
 

--- a/support-frontend/assets/pages/subscriptions-redemption/api.ts
+++ b/support-frontend/assets/pages/subscriptions-redemption/api.ts
@@ -197,6 +197,7 @@ function buildRegularPaymentRequest(
 		product,
 		firstDeliveryDate: null,
 		paymentFields: {
+			paymentType: 'GiftRedemption',
 			redemptionCode: userCode,
 		},
 		ophanIds: getOphanIds(),

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
@@ -127,7 +127,7 @@ object PaymentFields {
   implicit val stripePaymentMethodPaymentFieldsCodec: discriminatedType.VariantCodec[StripePaymentFields] =
     discriminatedType.variant[StripePaymentFields]("Stripe")
   implicit val stripeHostedPaymentFieldsCodec: discriminatedType.VariantCodec[StripeHostedPaymentFields] =
-    discriminatedType.variant[StripeHostedPaymentFields]("StripeHosted")
+    discriminatedType.variant[StripeHostedPaymentFields]("StripeHostedCheckout")
   implicit val directDebitPaymentFieldsCodec: discriminatedType.VariantCodec[DirectDebitPaymentFields] =
     discriminatedType.variant[DirectDebitPaymentFields]("DirectDebit")
   implicit val sepapaymentFieldsCodec: discriminatedType.VariantCodec[SepaPaymentFields] =

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
@@ -126,9 +126,8 @@ object PaymentFields {
     discriminatedType.variant[PayPalPaymentFields]("PayPal")
   implicit val stripePaymentMethodPaymentFieldsCodec: discriminatedType.VariantCodec[StripePaymentFields] =
     discriminatedType.variant[StripePaymentFields]("Stripe")
-  implicit val stripeHostedCheckoutPaymentFieldsCodec
-      : discriminatedType.VariantCodec[StripeHostedPaymentFields] =
-    discriminatedType.variant[StripeHostedPaymentFields]("StripeHostedCheckout")
+  implicit val stripeHostedPaymentFieldsCodec: discriminatedType.VariantCodec[StripeHostedPaymentFields] =
+    discriminatedType.variant[StripeHostedPaymentFields]("StripeHosted")
   implicit val directDebitPaymentFieldsCodec: discriminatedType.VariantCodec[DirectDebitPaymentFields] =
     discriminatedType.variant[DirectDebitPaymentFields]("DirectDebit")
   implicit val sepapaymentFieldsCodec: discriminatedType.VariantCodec[SepaPaymentFields] =
@@ -142,7 +141,7 @@ object PaymentFields {
       directDebitPaymentFieldsCodec,
       sepapaymentFieldsCodec,
       existingPaymentFieldsCodec,
-      stripeHostedCheckoutPaymentFieldsCodec,
+      stripeHostedPaymentFieldsCodec,
     ),
   )
 }

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
@@ -15,7 +15,7 @@ sealed trait PaymentFields {
 case class PayPalPaymentFields(baid: String) extends PaymentFields
 
 case class StripeHostedPaymentFields(
-    checkoutSessionId: String,
+    checkoutSessionId: Option[String],
     stripePublicKey: StripePublicKey,
 ) extends PaymentFields
 

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
@@ -14,6 +14,11 @@ sealed trait PaymentFields {
 
 case class PayPalPaymentFields(baid: String) extends PaymentFields
 
+case class StripeHostedPaymentFields(
+    checkoutSessionId: String,
+    stripePublicKey: StripePublicKey,
+) extends PaymentFields
+
 case class StripePaymentFields(
     paymentMethod: PaymentMethodId,
     stripePaymentType: Option[StripePaymentType],
@@ -111,9 +116,6 @@ case class SepaPaymentFields(
     streetName: Option[String],
 ) extends PaymentFields
 
-case class StripeHostedCheckoutPaymentFields(
-) extends PaymentFields
-
 case class ExistingPaymentFields(billingAccountId: String) extends PaymentFields
 
 object PaymentFields {
@@ -125,8 +127,8 @@ object PaymentFields {
   implicit val stripePaymentMethodPaymentFieldsCodec: discriminatedType.VariantCodec[StripePaymentFields] =
     discriminatedType.variant[StripePaymentFields]("Stripe")
   implicit val stripeHostedCheckoutPaymentFieldsCodec
-      : discriminatedType.VariantCodec[StripeHostedCheckoutPaymentFields] =
-    discriminatedType.variant[StripeHostedCheckoutPaymentFields]("StripeHostedCheckout")
+      : discriminatedType.VariantCodec[StripeHostedPaymentFields] =
+    discriminatedType.variant[StripeHostedPaymentFields]("StripeHostedCheckout")
   implicit val directDebitPaymentFieldsCodec: discriminatedType.VariantCodec[DirectDebitPaymentFields] =
     discriminatedType.variant[DirectDebitPaymentFields]("DirectDebit")
   implicit val sepapaymentFieldsCodec: discriminatedType.VariantCodec[SepaPaymentFields] =

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentProvider.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentProvider.scala
@@ -56,7 +56,7 @@ object PaymentProvider {
     case _: DirectDebitPaymentFields => DirectDebit
     case _: SepaPaymentFields => Sepa
     case _: ExistingPaymentFields => Existing
-    case _: StripeHostedCheckoutPaymentFields => StripeHostedCheckout
+    case _: StripeHostedPaymentFields => StripeHostedCheckout
   }
 
 }

--- a/support-workers/src/main/scala/com/gu/stripe/StripeService.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/StripeService.scala
@@ -58,4 +58,6 @@ class StripeServiceForAccount(
 
   val getPaymentMethod = com.gu.stripe.getPaymentMethod.apply(this) _
 
+  val retrieveCheckoutSession = com.gu.stripe.retrieveCheckoutSession.apply(this) _
+
 }

--- a/support-workers/src/main/scala/com/gu/stripe/StripeService.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/StripeService.scala
@@ -11,6 +11,7 @@ import com.gu.support.zuora.api.{PaymentGateway, StripeGatewayPaymentIntentsAUD,
 import com.typesafe.scalalogging.StrictLogging
 import io.circe.Decoder
 
+import scala.collection.immutable.Map.empty
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
@@ -38,8 +39,9 @@ class StripeServiceForAccount(
 
   def get[A](
       endpoint: String,
+      params: Map[String, String] = empty,
   )(implicit decoder: Decoder[A], errorDecoder: Decoder[StripeError], ctag: ClassTag[A]): Future[A] =
-    stripeService.get[A](endpoint, getHeaders())
+    stripeService.get[A](endpoint = endpoint, headers = getHeaders(), params = params)
 
   def postForm[A](
       endpoint: String,

--- a/support-workers/src/main/scala/com/gu/stripe/retrieveCheckoutSession.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/retrieveCheckoutSession.scala
@@ -1,0 +1,31 @@
+package com.gu.stripe
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+import scala.concurrent.Future
+
+case class CheckoutPaymentMethod(id: String)
+object CheckoutPaymentMethod {
+  implicit val decoder: Decoder[CheckoutPaymentMethod] = deriveDecoder
+}
+
+case class CheckoutSetupIntent(id: String, payment_method: CheckoutPaymentMethod)
+object CheckoutSetupIntent {
+  implicit val decoder: Decoder[CheckoutSetupIntent] = deriveDecoder
+}
+
+case class RetrieveCheckoutSessionResponseSuccess(setup_intent: CheckoutSetupIntent)
+object RetrieveCheckoutSessionResponseSuccess {
+  implicit val decoder: Decoder[RetrieveCheckoutSessionResponseSuccess] = deriveDecoder
+}
+
+object retrieveCheckoutSession {
+  def apply(
+      stripeService: StripeServiceForAccount,
+  )(checkoutSessionId: String): Future[RetrieveCheckoutSessionResponseSuccess] = {
+    stripeService.get[RetrieveCheckoutSessionResponseSuccess](
+      s"checkout/sessions/$checkoutSessionId?expand[]=setup_intent.payment_method",
+    )
+  }
+}

--- a/support-workers/src/main/scala/com/gu/stripe/retrieveCheckoutSession.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/retrieveCheckoutSession.scala
@@ -25,7 +25,8 @@ object retrieveCheckoutSession {
       stripeService: StripeServiceForAccount,
   )(checkoutSessionId: String): Future[RetrieveCheckoutSessionResponseSuccess] = {
     stripeService.get[RetrieveCheckoutSessionResponseSuccess](
-      s"checkout/sessions/$checkoutSessionId?expand[]=setup_intent.payment_method",
+      s"checkout/sessions/$checkoutSessionId",
+      Map("expand[]" -> "setup_intent.payment_method"),
     )
   }
 }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -92,8 +92,12 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
   private def createStripeHostedPaymentMethod(stripeHosted: StripeHostedPaymentFields, stripeService: StripeService) = {
     val stripeServiceForAccount = stripeService.withPublicKey(stripeHosted.stripePublicKey)
     for {
+      checkoutSessionId <- optionToFuture(
+        stripeHosted.checkoutSessionId,
+        "Missing checkout session id",
+      )
       paymentMethod <- stripeServiceForAccount
-        .retrieveCheckoutSession(stripeHosted.checkoutSessionId)
+        .retrieveCheckoutSession(checkoutSessionId)
         .map(_.setup_intent.payment_method)
       paymentMethodId <- optionToFuture(
         PaymentMethodId(paymentMethod.id),

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -60,8 +60,6 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
         createDirectDebitPaymentMethod(dd, user)
       case sepa: SepaPaymentFields =>
         createSepaPaymentMethod(sepa, user, ipAddress, userAgent)
-      case _: StripeHostedCheckoutPaymentFields =>
-        Future.failed(new RuntimeException("Stripe hosted checkout not implemented on the backend yet!"))
       case _: ExistingPaymentFields =>
         Future.failed(new RuntimeException("Existing payment methods should never make their way to this lambda"))
     }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -50,6 +50,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       userAgent: String,
   ): Future[PaymentMethod] =
     paymentFields match {
+      case stripeHosted: StripeHostedPaymentFields => ???
       case stripe: StripePaymentFields =>
         createStripePaymentMethod(stripe, services.stripeService)
       case paypal: PayPalPaymentFields =>

--- a/support-workers/src/test/scala/com.gu.config/PaymentConfigSpec.scala
+++ b/support-workers/src/test/scala/com.gu.config/PaymentConfigSpec.scala
@@ -2,6 +2,7 @@ package com.gu.config
 
 import com.gu.i18n.Currency.AUD
 import com.gu.support.config.Stages
+import com.gu.support.workers.StripePublicKey
 import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -12,13 +13,13 @@ class PaymentConfigSpec extends AnyFlatSpec with Matchers with LazyLogging {
     val config = Configuration.load()
     Configuration.stage should be(Stages.DEV)
 
-    val stripeDefault = config.stripeConfigProvider.get().forCurrency(None)
-    stripeDefault.publicKey.rawPublicKey should be("pk_test_Qm3CGRdrV4WfGYCpm0sftR0f")
-    stripeDefault.secretKey.secret.length should be > 0
+    val stripeDefault =
+      config.stripeConfigProvider.get().forPublicKey(StripePublicKey("pk_test_Qm3CGRdrV4WfGYCpm0sftR0f")).get
+    stripeDefault._1.secret.length should be > 0
 
-    val stripeAustralia = config.stripeConfigProvider.get().forCurrency(Some(AUD))
-    stripeAustralia.publicKey.rawPublicKey should be("pk_test_m0sjR1tGM22fpaz48csa49us")
-    stripeAustralia.secretKey.secret.length should be > 0
+    val stripeAustralia =
+      config.stripeConfigProvider.get().forPublicKey(StripePublicKey("pk_test_m0sjR1tGM22fpaz48csa49us")).get
+    stripeAustralia._1.secret.length should be > 0
 
     // This won't work on TeamCity unless we add the version into reference.conf in support-config
     // config.stripeConfigProvider.get().version should be(Some("2017-08-15"))


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Following on from #6863 and #6891 this PR adds code to connect the stripe hosted checkout to the backend and support-workers.

Now after the user returns from Stripe we can submit a request to the `/subscribe/create` endpoint containing the checkout session ID, which will be used in the support-workers execution to retrieve a setup intent and payment method.

## Why are you doing this?

Incrementally working toward the complete Stripe hosted checkout flow for Sunday newspaper subscriptions.

## How to test

Visit the generic checkout for Sunday HomeDelivery or SubscriptionCard and select Credit/Debit card as the payment method. Use test card details when transferred to Stripe. When you return back to the generic checkout select Credit/Debit card again and submit the form. This will create the support workers execution which should successfully complete.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
