### PR TITLE
Mj/add soft opt in consents to acquisiton event bus

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -97,13 +97,13 @@ new AcquisitionEventsApi(app, "Acquisition-Events-API-PROD", {
 new BigqueryAcquisitionsPublisher(app, "BigqueryAcquisitionsPublisher-CODE", {
   stack: "support",
   stage: "CODE",
-  softOptInConsentSetterQueueArn: "", // TODO: add Arn
+  softOptInConsentSetterQueueArn: "arn:aws:sqs:eu-west-1:865473395570:soft-opt-in-consent-setter-queue-CODE",
 });
 
 new BigqueryAcquisitionsPublisher(app, "BigqueryAcquisitionsPublisher-PROD", {
   stack: "support",
   stage: "PROD",
-  softOptInConsentSetterQueueArn: "", // TODO: add Arn
+  softOptInConsentSetterQueueArn: "arn:aws:sqs:eu-west-1:865473395570:soft-opt-in-consent-setter-queue-PROD",
 });
 
 new SupportWorkers(app, "SupportWorkers-CODE", {

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -97,11 +97,13 @@ new AcquisitionEventsApi(app, "Acquisition-Events-API-PROD", {
 new BigqueryAcquisitionsPublisher(app, "BigqueryAcquisitionsPublisher-CODE", {
   stack: "support",
   stage: "CODE",
+  softOptInConsentSetterQueueArn: "", // TODO: add Arn
 });
 
 new BigqueryAcquisitionsPublisher(app, "BigqueryAcquisitionsPublisher-PROD", {
   stack: "support",
   stage: "PROD",
+  softOptInConsentSetterQueueArn: "", // TODO: add Arn
 });
 
 new SupportWorkers(app, "SupportWorkers-CODE", {

--- a/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
+++ b/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
@@ -130,6 +130,14 @@ Logs: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#
           {
             "Arn": "arn:aws:sqs:eu-west-1:865473395570:soft-opt-in-consent-setter-queue-PROD",
             "Id": "Target0",
+            "InputTransformer": {
+              "InputPathsMap": {
+                "detail-ZuoraProductName": "$.detail.ZuoraProductName",
+                "detail-identityId": "$.detail.identityId",
+                "detail-zuoraSubscriptionNumber": "$.detail.zuoraSubscriptionNumber",
+              },
+              "InputTemplate": "{"subscriptionId":<detail-zuoraSubscriptionNumber>,"identityId":<detail-identityId>,"eventType":"Acquisition","productName":<detail-ZuoraProductName>,"previousProductName":null}",
+            },
           },
         ],
       },

--- a/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
+++ b/cdk/lib/__snapshots__/bigquery-acquisitions-publisher.test.ts.snap
@@ -111,6 +111,30 @@ Logs: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#
       },
       "Type": "AWS::Events::Rule",
     },
+    "SoftOptInToSQSRuleA7A6FB25": {
+      "Properties": {
+        "Description": "Send all events received via support-workers onto soft opt-in SQS queue",
+        "EventBusName": {
+          "Ref": "acquisitionsbusPROD768AFDE3",
+        },
+        "EventPattern": {
+          "region": [
+            "eu-west-1",
+          ],
+          "source": [
+            "support-workers.1",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": "arn:aws:sqs:eu-west-1:865473395570:soft-opt-in-consent-setter-queue-PROD",
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "acquisitionsbusPROD768AFDE3": {
       "Properties": {
         "Name": "acquisitions-bus-PROD",

--- a/cdk/lib/bigquery-acquisitions-publisher.test.ts
+++ b/cdk/lib/bigquery-acquisitions-publisher.test.ts
@@ -11,6 +11,7 @@ describe("The BigqueryAcquisitionsPublisher stack", () => {
       {
         stack: "support",
         stage: "PROD",
+        softOptInConsentSetterQueueArn: "arn:aws:sqs:eu-west-1:865473395570:soft-opt-in-consent-setter-queue-PROD",
       }
     );
 

--- a/cdk/lib/bigquery-acquisitions-publisher.ts
+++ b/cdk/lib/bigquery-acquisitions-publisher.ts
@@ -83,7 +83,7 @@ export class BigqueryAcquisitionsPublisher extends GuStack {
       description: "Send all events received via support-workers onto soft opt-in SQS queue",
       eventPattern: {
         region: ["eu-west-1"],
-        source: [""],
+        source: ["support-workers.1"],
       },
       eventBus: eventBus,
       targets: [new SqsQueue(softOptInConsentSetterQueue)],

--- a/cdk/lib/bigquery-acquisitions-publisher.ts
+++ b/cdk/lib/bigquery-acquisitions-publisher.ts
@@ -2,8 +2,8 @@ import { GuAlarm } from "@guardian/cdk/lib/constructs/cloudwatch";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack } from "@guardian/cdk/lib/constructs/core";
 import { GuLambdaFunction } from "@guardian/cdk/lib/constructs/lambda";
-import {App, aws_events} from "aws-cdk-lib";
-import { aws_sqs, Duration } from "aws-cdk-lib";
+import type {App} from "aws-cdk-lib";
+import { aws_events, aws_sqs, Duration } from "aws-cdk-lib";
 import {
   ComparisonOperator,
   TreatMissingData,
@@ -94,7 +94,7 @@ export class BigqueryAcquisitionsPublisher extends GuStack {
               subscriptionId: aws_events.EventField.fromPath('$.detail.zuoraSubscriptionNumber'),
               identityId: aws_events.EventField.fromPath('$.detail.identityId'),
               eventType: "Acquisition",
-              productName: aws_events.EventField.fromPath('$.detail.product'),
+              productName: aws_events.EventField.fromPath('$.detail.ZuoraProductName'),
               previousProductName: null
             }),
           },


### PR DESCRIPTION
## What are you doing in this PR?
This PR adds a new rule to the existing Acquisitions event bus, which keeps all remaining functionality unchanged, but also enqueues all events whose source is `support-workers.1` onto the `soft-opt-in-consent-setter-queue`.

This new rule also makes use of [input transformation](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-transform-target-input.html) to map values from the EventBridge acquisition event into the required SQS event shape for consumption by the `soft-opt-in-consents-setter-IAP` lambda.

For more context please see [this Trello card](https://trello.com/c/ZFfWib8T/740-soft-opt-in-pt2-add-consents-to-acquisition-event-bus).