### PR TITLE
Refactor landing page test participations

### DIFF
--- a/support-frontend/assets/helpers/abTests/__tests__/landingPageAbTests.spec.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/landingPageAbTests.spec.ts
@@ -23,7 +23,7 @@ const nonUsTest: LandingPageTest = {
 		{
 			name: 'CONTROL',
 			copy: {
-				heading: 'Support fearless, independent journalism',
+				heading: 'Support fearless, independent journalism!',
 				subheading:
 					"We're not owned by a billionaire or shareholders - our readers support us. Choose to join with one of the options below. <strong>Cancel anytime.</strong>",
 			},
@@ -39,7 +39,7 @@ const usTest: LandingPageTest = {
 		{
 			name: 'CONTROL',
 			copy: {
-				heading: 'Support fearless, independent journalism',
+				heading: 'Support fearless, independent journalism!',
 				subheading:
 					"We're not owned by a billionaire or profit-driven corporation: our fiercely independent journalism is funded by our readers. Monthly giving makes the most impact (and you can cancel anytime). Thank you.",
 			},
@@ -63,7 +63,10 @@ describe('getLandingPageParticipations', () => {
 			tests,
 			mvtId,
 		);
-		expect(result).toEqual({ [nonUsTest.name]: 'CONTROL' });
+		expect(result).toEqual({
+			variant: nonUsTest.variants[0],
+			participations: { [nonUsTest.name]: 'CONTROL' },
+		});
 	});
 
 	it('assigns a user to the US test on US landing page', () => {
@@ -73,7 +76,10 @@ describe('getLandingPageParticipations', () => {
 			tests,
 			mvtId,
 		);
-		expect(result).toEqual({ [usTest.name]: 'CONTROL' });
+		expect(result).toEqual({
+			variant: usTest.variants[0],
+			participations: { [usTest.name]: 'CONTROL' },
+		});
 	});
 
 	it('assigns a user to the UK test on a checkout page if it is in session storage', () => {
@@ -88,7 +94,10 @@ describe('getLandingPageParticipations', () => {
 			tests,
 			mvtId,
 		);
-		expect(result).toEqual({ [nonUsTest.name]: 'CONTROL' });
+		expect(result).toEqual({
+			variant: nonUsTest.variants[0],
+			participations: { [nonUsTest.name]: 'CONTROL' },
+		});
 	});
 
 	it('does not assign a user to the UK test on a checkout page if it is *not* in session storage', () => {
@@ -98,7 +107,7 @@ describe('getLandingPageParticipations', () => {
 			tests,
 			mvtId,
 		);
-		expect(result).toBeUndefined();
+		expect(result.participations).toEqual({});
 	});
 });
 
@@ -110,10 +119,7 @@ describe('getLandingPageVariant', () => {
 			[nonUsTest.name]: 'CONTROL',
 		};
 		const result = getLandingPageVariant(participations, tests);
-		expect(result).toEqual({
-			...nonUsTest.variants[0],
-			testName: nonUsTest.name,
-		});
+		expect(result).toEqual(nonUsTest.variants[0]);
 	});
 
 	it('falls back on default settings if no landing page test matches', () => {

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -20,6 +20,7 @@ import type {
 	Tests,
 } from './models';
 import { breakpoints } from './models';
+import { getMvtId } from './mvt';
 import {
 	getSessionParticipations,
 	PARTICIPATIONS_KEY,
@@ -73,27 +74,6 @@ function init({
 }
 
 // ----- Helpers ----- //
-
-const MVT_COOKIE = 'GU_mvt_id';
-const MVT_MAX = 1_000_000;
-
-// Attempts to retrieve the MVT id from a cookie, or sets it.
-function getMvtId(): number {
-	const mvtIdCookieValue = cookie.get(MVT_COOKIE);
-	let mvtId = Number(mvtIdCookieValue);
-
-	if (
-		Number.isNaN(mvtId) ||
-		mvtId >= MVT_MAX ||
-		mvtId < 0 ||
-		mvtIdCookieValue === null
-	) {
-		mvtId = Math.floor(Math.random() * MVT_MAX);
-		cookie.set(MVT_COOKIE, String(mvtId));
-	}
-
-	return mvtId;
-}
 
 function getParticipations(
 	abTests: Tests,

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -12,7 +12,6 @@ import type {
 } from '../contributions';
 import { tests } from './abtestDefinitions';
 import { getFallbackAmounts } from './helpers';
-import { getLandingPageParticipations } from './landingPageAbTests';
 import type {
 	AcquisitionABTest,
 	Audience,
@@ -52,7 +51,6 @@ function init({
 	mvt = getMvtId(),
 	acquisitionDataTests = getTestFromAcquisitionData() ?? [],
 	path = window.location.pathname,
-	settings,
 }: ABtestInitalizerData): Participations {
 	const sessionParticipations = getSessionParticipations(PARTICIPATIONS_KEY);
 	const participations = getParticipations(
@@ -66,19 +64,10 @@ function init({
 		sessionParticipations,
 	);
 
-	// A landing page test config may be passed through from the server, so we handle this separately
-	const landingPageParticipations = getLandingPageParticipations(
-		countryGroupId,
-		path,
-		settings.landingPageTests,
-		mvt,
-	);
-
 	const urlParticipations = getParticipationsFromUrl();
 	const serverSideParticipations = getServerSideParticipations();
 	return {
 		...participations,
-		...landingPageParticipations,
 		...serverSideParticipations,
 		...urlParticipations,
 	};

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -40,7 +40,6 @@ type ABtestInitalizerData = {
 	mvt?: number;
 	acquisitionDataTests?: AcquisitionABTest[];
 	path?: string;
-	settings: Settings;
 };
 
 function init({

--- a/support-frontend/assets/helpers/abTests/abtest.ts
+++ b/support-frontend/assets/helpers/abTests/abtest.ts
@@ -20,7 +20,7 @@ import type {
 	Tests,
 } from './models';
 import { breakpoints } from './models';
-import { getMvtId } from './mvt';
+import { getMvtId, MVT_MAX } from './mvt';
 import {
 	getSessionParticipations,
 	PARTICIPATIONS_KEY,

--- a/support-frontend/assets/helpers/abTests/landingPageAbTests.ts
+++ b/support-frontend/assets/helpers/abTests/landingPageAbTests.ts
@@ -13,8 +13,6 @@ import {
 	setSessionParticipations,
 } from './sessionStorage';
 
-export type LandingPageSelection = LandingPageVariant & { testName: string };
-
 // Fallback config in case there's an issue getting it from the server
 export const fallBackLandingPageSelection: LandingPageVariant = {
 	name: 'CONTROL',

--- a/support-frontend/assets/helpers/abTests/landingPageAbTests.ts
+++ b/support-frontend/assets/helpers/abTests/landingPageAbTests.ts
@@ -103,7 +103,7 @@ interface LandingPageParticipationsResult {
 export function getLandingPageParticipations(
 	countryGroupId: CountryGroupId = CountryGroup.detect(),
 	path: string = window.location.pathname,
-	tests: LandingPageTest[] = getSettings().landingPageTests,
+	tests: LandingPageTest[] = getSettings().landingPageTests ?? [],
 	mvtId: number = getMvtId(),
 ): LandingPageParticipationsResult {
 	// Is there already a participation in session storage?

--- a/support-frontend/assets/helpers/abTests/landingPageAbTests.ts
+++ b/support-frontend/assets/helpers/abTests/landingPageAbTests.ts
@@ -3,8 +3,10 @@ import type {
 	LandingPageTest,
 	LandingPageVariant,
 } from '../globalsAndSwitches/landingPageSettings';
+import { CountryGroup } from '../internationalisation/classes/countryGroup';
 import type { CountryGroupId } from '../internationalisation/countryGroup';
 import type { Participations } from './models';
+import { getMvtId } from './mvt';
 import {
 	getSessionParticipations,
 	LANDING_PAGE_PARTICIPATIONS_KEY,
@@ -14,8 +16,7 @@ import {
 export type LandingPageSelection = LandingPageVariant & { testName: string };
 
 // Fallback config in case there's an issue getting it from the server
-export const fallBackLandingPageSelection: LandingPageSelection = {
-	testName: 'FALLBACK_LANDING_PAGE',
+export const fallBackLandingPageSelection: LandingPageVariant = {
 	name: 'CONTROL',
 	copy: {
 		heading: 'Support fearless, independent journalism',
@@ -84,17 +85,40 @@ function randomNumber(mvtId: number, seed: string): number {
 
 const landingPageRegex = '^/.*/contribute(/.*)?$';
 function isLandingPage(path: string) {
-	return !!path && path.match(landingPageRegex);
+	return !!path && !!path.match(landingPageRegex);
 }
 
+/**
+ * getLandingPageParticipations will always return a landing page variant, regardless of which
+ * page the user is on. We sometimes need these settings on other pages as well.
+ *
+ * If the user is on the landing page, or session storage contains a landing page participation,
+ * then it will also return the participations data for tracking.
+ * Otherwise we assume the user has not arrived via the landing page, and the participations
+ * object will be empty because we do not need to track it.
+ */
+interface LandingPageParticipationsResult {
+	variant: LandingPageVariant;
+	participations: Participations;
+}
 export function getLandingPageParticipations(
-	countryGroupId: CountryGroupId,
-	path: string,
+	countryGroupId: CountryGroupId = CountryGroup.detect(),
+	path: string = window.location.pathname,
 	tests: LandingPageTest[] = [],
-	mvtId: number,
-): Participations | undefined {
-	if (isLandingPage(path)) {
-		// This is a landing page, assign user to a test + variant
+	mvtId: number = getMvtId(),
+): LandingPageParticipationsResult {
+	// Is there already a participation in session storage?
+	const sessionParticipations = getSessionParticipations(
+		LANDING_PAGE_PARTICIPATIONS_KEY,
+	);
+	if (sessionParticipations) {
+		const variant = getLandingPageVariant(sessionParticipations, tests);
+		return {
+			participations: sessionParticipations,
+			variant,
+		};
+	} else {
+		// No participation in session storage, assign user to a test + variant
 		const test = tests
 			.filter((test) => test.status == 'Live')
 			.find((test) => {
@@ -107,6 +131,9 @@ export function getLandingPageParticipations(
 					return targetedCountryGroups.includes(countryGroupId);
 				}
 			});
+
+		// Only track participation if user is on the landing page
+		const trackParticipation = isLandingPage(path);
 
 		if (test) {
 			const idx = randomNumber(mvtId, test.name) % test.variants.length;
@@ -122,14 +149,19 @@ export function getLandingPageParticipations(
 					LANDING_PAGE_PARTICIPATIONS_KEY,
 				);
 
-				return participations;
+				return {
+					participations: trackParticipation ? participations : {},
+					variant,
+				};
 			}
 		}
-		// No test assigned
-		return;
-	} else {
-		// This is not a landing page, but check if the session has a landing page test participation
-		return getSessionParticipations(LANDING_PAGE_PARTICIPATIONS_KEY);
+		// No test found, use the fallback
+		return {
+			participations: trackParticipation
+				? { FALLBACK_LANDING_PAGE: fallBackLandingPageSelection.name }
+				: ({} as Participations),
+			variant: fallBackLandingPageSelection,
+		};
 	}
 }
 
@@ -137,7 +169,7 @@ export function getLandingPageParticipations(
 export function getLandingPageVariant(
 	participations: Participations,
 	landingPageTests: LandingPageTest[] = [],
-): LandingPageSelection {
+): LandingPageVariant {
 	for (const test of landingPageTests) {
 		// Is the user in this test?
 		const variantName = participations[test.name];
@@ -146,10 +178,7 @@ export function getLandingPageVariant(
 				(variant) => variant.name === variantName,
 			);
 			if (variant) {
-				return {
-					testName: test.name,
-					...variant,
-				};
+				return variant;
 			}
 		}
 	}

--- a/support-frontend/assets/helpers/abTests/landingPageAbTests.ts
+++ b/support-frontend/assets/helpers/abTests/landingPageAbTests.ts
@@ -1,4 +1,5 @@
 import seedrandom from 'seedrandom';
+import { getSettings } from '../globalsAndSwitches/globals';
 import type {
 	LandingPageTest,
 	LandingPageVariant,
@@ -102,14 +103,17 @@ interface LandingPageParticipationsResult {
 export function getLandingPageParticipations(
 	countryGroupId: CountryGroupId = CountryGroup.detect(),
 	path: string = window.location.pathname,
-	tests: LandingPageTest[] = [],
+	tests: LandingPageTest[] = getSettings().landingPageTests,
 	mvtId: number = getMvtId(),
 ): LandingPageParticipationsResult {
 	// Is there already a participation in session storage?
 	const sessionParticipations = getSessionParticipations(
 		LANDING_PAGE_PARTICIPATIONS_KEY,
 	);
-	if (sessionParticipations) {
+	if (
+		sessionParticipations &&
+		Object.entries(sessionParticipations).length > 0
+	) {
 		const variant = getLandingPageVariant(sessionParticipations, tests);
 		return {
 			participations: sessionParticipations,

--- a/support-frontend/assets/helpers/abTests/mvt.ts
+++ b/support-frontend/assets/helpers/abTests/mvt.ts
@@ -1,0 +1,22 @@
+import * as cookie from '../storage/cookie';
+
+const MVT_COOKIE = 'GU_mvt_id';
+const MVT_MAX = 1_000_000;
+
+// Attempts to retrieve the MVT id from a cookie, or sets it.
+export function getMvtId(): number {
+	const mvtIdCookieValue = cookie.get(MVT_COOKIE);
+	let mvtId = Number(mvtIdCookieValue);
+
+	if (
+		Number.isNaN(mvtId) ||
+		mvtId >= MVT_MAX ||
+		mvtId < 0 ||
+		mvtIdCookieValue === null
+	) {
+		mvtId = Math.floor(Math.random() * MVT_MAX);
+		cookie.set(MVT_COOKIE, String(mvtId));
+	}
+
+	return mvtId;
+}

--- a/support-frontend/assets/helpers/abTests/mvt.ts
+++ b/support-frontend/assets/helpers/abTests/mvt.ts
@@ -1,7 +1,7 @@
 import * as cookie from '../storage/cookie';
 
 const MVT_COOKIE = 'GU_mvt_id';
-const MVT_MAX = 1_000_000;
+export const MVT_MAX = 1_000_000;
 
 // Attempts to retrieve the MVT id from a cookie, or sets it.
 export function getMvtId(): number {

--- a/support-frontend/assets/helpers/page/page.ts
+++ b/support-frontend/assets/helpers/page/page.ts
@@ -15,6 +15,7 @@ import { getReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import { getSettings } from '../globalsAndSwitches/globals';
 
 function setUpTrackingAndConsents(participations: Participations): void {
+	console.log({ participations });
 	const countryId: IsoCountry = Country.detect();
 	const acquisitionData = getReferrerAcquisitionData();
 
@@ -35,7 +36,6 @@ function getAbParticipations(): Participations {
 		selectedAmountsVariant,
 	};
 	const participations: Participations = abTest.init(abtestInitalizerData);
-	console.log({ participations });
 
 	return {
 		...participations,

--- a/support-frontend/assets/helpers/page/page.ts
+++ b/support-frontend/assets/helpers/page/page.ts
@@ -33,7 +33,6 @@ function getAbParticipations(): Participations {
 		countryId,
 		countryGroupId,
 		selectedAmountsVariant,
-		settings,
 	};
 	const participations: Participations = abTest.init(abtestInitalizerData);
 	console.log({ participations });

--- a/support-frontend/assets/helpers/redux/utils/setup.ts
+++ b/support-frontend/assets/helpers/redux/utils/setup.ts
@@ -61,7 +61,6 @@ export function getInitialState(): CommonState {
 		countryId,
 		countryGroupId,
 		selectedAmountsVariant,
-		settings,
 	};
 
 	const participations: Participations = abTest.init(abtestInitalizerData);

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -19,8 +19,8 @@ import { sendEventCheckoutValue } from 'helpers/tracking/quantumMetric';
 import { logException } from 'helpers/utilities/logger';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
-import type { LandingPageSelection } from '../../helpers/abTests/landingPageAbTests';
 import type { Participations } from '../../helpers/abTests/models';
+import type { LandingPageVariant } from '../../helpers/globalsAndSwitches/landingPageSettings';
 import type { LegacyProductType } from '../../helpers/legacyTypeConversions';
 import { getLegacyProductType } from '../../helpers/legacyTypeConversions';
 import { CheckoutComponent } from './components/checkoutComponent';
@@ -29,7 +29,7 @@ type Props = {
 	geoId: GeoId;
 	appConfig: AppConfig;
 	abParticipations: Participations;
-	landingPageSettings: LandingPageSelection;
+	landingPageSettings: LandingPageVariant;
 };
 
 const countryId: IsoCountry = Country.detect();

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -19,6 +19,7 @@ import { sendEventCheckoutValue } from 'helpers/tracking/quantumMetric';
 import { logException } from 'helpers/utilities/logger';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
+import type { LandingPageSelection } from '../../helpers/abTests/landingPageAbTests';
 import type { Participations } from '../../helpers/abTests/models';
 import type { LegacyProductType } from '../../helpers/legacyTypeConversions';
 import { getLegacyProductType } from '../../helpers/legacyTypeConversions';
@@ -28,6 +29,7 @@ type Props = {
 	geoId: GeoId;
 	appConfig: AppConfig;
 	abParticipations: Participations;
+	landingPageSettings: LandingPageSelection;
 };
 
 const countryId: IsoCountry = Country.detect();
@@ -66,7 +68,12 @@ const getPromotionFromProductPrices = (
 	);
 };
 
-export function Checkout({ geoId, appConfig, abParticipations }: Props) {
+export function Checkout({
+	geoId,
+	appConfig,
+	abParticipations,
+	landingPageSettings,
+}: Props) {
 	const { currencyKey } = getGeoIdConfig(geoId);
 	const urlSearchParams = new URLSearchParams(window.location.search);
 
@@ -273,6 +280,7 @@ export function Checkout({ geoId, appConfig, abParticipations }: Props) {
 				countryId={countryId}
 				forcedCountry={forcedCountry}
 				abParticipations={abParticipations}
+				landingPageSettings={landingPageSettings}
 			/>
 		</Elements>
 	);

--- a/support-frontend/assets/pages/[countryGroupId]/components/__tests__/thankYouComponent.test.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/__tests__/thankYouComponent.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { fallBackLandingPageSelection } from '../../../../helpers/abTests/landingPageAbTests';
 import {
 	type CheckoutComponentProps,
 	ThankYouComponent,
@@ -20,6 +21,7 @@ describe('thankYouComponent', () => {
 		},
 		identityUserType: 'new',
 		abParticipations: {},
+		landingPageSettings: fallBackLandingPageSelection,
 	};
 
 	it('should display the correct thankyou cards for One time contribution', () => {

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -49,7 +49,7 @@ import {
 	Stripe,
 	toPaymentMethodSwitchNaming,
 } from 'helpers/forms/paymentMethods';
-import { getSettings, isSwitchOn } from 'helpers/globalsAndSwitches/globals';
+import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
@@ -76,7 +76,7 @@ import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsM
 import { PaymentTsAndCs } from 'pages/supporter-plus-landing/components/paymentTsAndCs';
 import { SummaryTsAndCs } from 'pages/supporter-plus-landing/components/summaryTsAndCs';
 import type { BenefitsCheckListData } from '../../../components/checkoutBenefits/benefitsCheckList';
-import { getLandingPageVariant } from '../../../helpers/abTests/landingPageAbTests';
+import type { LandingPageSelection } from '../../../helpers/abTests/landingPageAbTests';
 import { postcodeIsWithinDeliveryArea } from '../../../helpers/forms/deliveryCheck';
 import { appropriateErrorMessage } from '../../../helpers/forms/errorReasons';
 import { isValidPostcode } from '../../../helpers/forms/formValidation';
@@ -149,6 +149,7 @@ type CheckoutComponentProps = {
 	countryId: IsoCountry;
 	forcedCountry?: string;
 	abParticipations: Participations;
+	landingPageSettings: LandingPageSelection;
 };
 
 export function CheckoutComponent({
@@ -166,6 +167,7 @@ export function CheckoutComponent({
 	countryId,
 	forcedCountry,
 	abParticipations,
+	landingPageSettings,
 }: CheckoutComponentProps) {
 	const csrf = appConfig.csrf.token;
 	const user = appConfig.user;
@@ -190,10 +192,6 @@ export function CheckoutComponent({
 	const getBenefits = (): BenefitsCheckListData[] => {
 		// Three Tier products get their config from the Landing Page tool
 		if (['TierThree', 'SupporterPlus', 'Contribution'].includes(productKey)) {
-			const landingPageSettings = getLandingPageVariant(
-				abParticipations,
-				getSettings().landingPageTests,
-			);
 			if (isRecurringContribution) {
 				// Also show SupporterPlus benefits greyed out
 				return [

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -76,10 +76,10 @@ import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsM
 import { PaymentTsAndCs } from 'pages/supporter-plus-landing/components/paymentTsAndCs';
 import { SummaryTsAndCs } from 'pages/supporter-plus-landing/components/summaryTsAndCs';
 import type { BenefitsCheckListData } from '../../../components/checkoutBenefits/benefitsCheckList';
-import type { LandingPageSelection } from '../../../helpers/abTests/landingPageAbTests';
 import { postcodeIsWithinDeliveryArea } from '../../../helpers/forms/deliveryCheck';
 import { appropriateErrorMessage } from '../../../helpers/forms/errorReasons';
 import { isValidPostcode } from '../../../helpers/forms/formValidation';
+import type { LandingPageVariant } from '../../../helpers/globalsAndSwitches/landingPageSettings';
 import { formatUserDate } from '../../../helpers/utilities/dateConversions';
 import { DeliveryAgentsSelect } from '../../paper-subscription-checkout/components/deliveryAgentsSelect';
 import { getTierThreeDeliveryDate } from '../../weekly-subscription-checkout/helpers/deliveryDays';
@@ -149,7 +149,7 @@ type CheckoutComponentProps = {
 	countryId: IsoCountry;
 	forcedCountry?: string;
 	abParticipations: Participations;
-	landingPageSettings: LandingPageSelection;
+	landingPageSettings: LandingPageVariant;
 };
 
 export function CheckoutComponent({

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -31,7 +31,7 @@ import ThankYouHeader from 'pages/supporter-plus-thank-you/components/thankYouHe
 import { getGuardianAdLiteDate } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
 import type { BenefitsCheckListData } from '../../../components/checkoutBenefits/benefitsCheckList';
 import { ThankYouModules } from '../../../components/thankYou/thankyouModules';
-import type { LandingPageSelection } from '../../../helpers/abTests/landingPageAbTests';
+import type { LandingPageVariant } from '../../../helpers/globalsAndSwitches/landingPageSettings';
 import {
 	getReturnAddress,
 	getThankYouOrder,
@@ -68,7 +68,7 @@ export type CheckoutComponentProps = {
 	promotion?: Promotion;
 	identityUserType: UserType;
 	abParticipations: Participations;
-	landingPageSettings: LandingPageSelection;
+	landingPageSettings: LandingPageVariant;
 };
 
 export function ThankYouComponent({

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -31,8 +31,7 @@ import ThankYouHeader from 'pages/supporter-plus-thank-you/components/thankYouHe
 import { getGuardianAdLiteDate } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
 import type { BenefitsCheckListData } from '../../../components/checkoutBenefits/benefitsCheckList';
 import { ThankYouModules } from '../../../components/thankYou/thankyouModules';
-import { getLandingPageVariant } from '../../../helpers/abTests/landingPageAbTests';
-import { getSettings } from '../../../helpers/globalsAndSwitches/globals';
+import type { LandingPageSelection } from '../../../helpers/abTests/landingPageAbTests';
 import {
 	getReturnAddress,
 	getThankYouOrder,
@@ -69,6 +68,7 @@ export type CheckoutComponentProps = {
 	promotion?: Promotion;
 	identityUserType: UserType;
 	abParticipations: Participations;
+	landingPageSettings: LandingPageSelection;
 };
 
 export function ThankYouComponent({
@@ -80,6 +80,7 @@ export function ThankYouComponent({
 	promotion,
 	identityUserType,
 	abParticipations,
+	landingPageSettings,
 }: CheckoutComponentProps) {
 	const countryId = Country.fromString(get('GU_country') ?? 'GB') ?? 'GB';
 	const user = getUser();
@@ -203,10 +204,6 @@ export function ThankYouComponent({
 	const getBenefits = (): BenefitsCheckListData[] => {
 		// Three Tier products get their config from the Landing Page tool
 		if (isTier) {
-			const landingPageSettings = getLandingPageVariant(
-				abParticipations,
-				getSettings().landingPageTests,
-			);
 			// Also show SupporterPlus benefits for TierThree
 			const tierThreeAdditionalBenefits =
 				productKey === 'TierThree'

--- a/support-frontend/assets/pages/[countryGroupId]/landingPage.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/landingPage.tsx
@@ -6,12 +6,12 @@ import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
 import { threeTierCheckoutEnabled } from 'pages/supporter-plus-landing/setup/threeTierChecks';
 import { ContributionsOnlyLanding } from 'pages/supporter-plus-landing/twoStepPages/contributionsOnlyLanding';
 import { ThreeTierLanding } from 'pages/supporter-plus-landing/twoStepPages/threeTierLanding';
-import type { LandingPageSelection } from '../../helpers/abTests/landingPageAbTests';
+import type { LandingPageVariant } from '../../helpers/globalsAndSwitches/landingPageSettings';
 
 type Props = {
 	geoId: GeoId;
 	abParticipations: Participations;
-	landingPageSettings: LandingPageSelection;
+	landingPageSettings: LandingPageVariant;
 };
 
 const countryId: IsoCountry = Country.detect();

--- a/support-frontend/assets/pages/[countryGroupId]/landingPage.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/landingPage.tsx
@@ -6,28 +6,27 @@ import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
 import { threeTierCheckoutEnabled } from 'pages/supporter-plus-landing/setup/threeTierChecks';
 import { ContributionsOnlyLanding } from 'pages/supporter-plus-landing/twoStepPages/contributionsOnlyLanding';
 import { ThreeTierLanding } from 'pages/supporter-plus-landing/twoStepPages/threeTierLanding';
-import { getLandingPageVariant } from '../../helpers/abTests/landingPageAbTests';
-import { getSettings } from '../../helpers/globalsAndSwitches/globals';
+import type { LandingPageSelection } from '../../helpers/abTests/landingPageAbTests';
 
 type Props = {
 	geoId: GeoId;
 	abParticipations: Participations;
+	landingPageSettings: LandingPageSelection;
 };
 
 const countryId: IsoCountry = Country.detect();
 
-export function LandingPage({ geoId, abParticipations }: Props) {
+export function LandingPage({
+	geoId,
+	abParticipations,
+	landingPageSettings,
+}: Props) {
 	const { countryGroupId } = getGeoIdConfig(geoId);
 
 	const { selectedAmountsVariant: amounts } = getAmountsTestVariant(
 		countryId,
 		countryGroupId,
 		window.guardian.settings,
-	);
-
-	const settings = getLandingPageVariant(
-		abParticipations,
-		getSettings().landingPageTests,
 	);
 
 	const inThreeTier = threeTierCheckoutEnabled(abParticipations, amounts);
@@ -37,7 +36,7 @@ export function LandingPage({ geoId, abParticipations }: Props) {
 			<ThreeTierLanding
 				geoId={geoId}
 				abParticipations={abParticipations}
-				settings={settings}
+				settings={landingPageSettings}
 			/>
 		);
 	} else {

--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -8,8 +8,13 @@ import {
 } from 'helpers/page/page';
 import { renderPage } from 'helpers/rendering/render';
 import { geoIds } from 'pages/geoIdConfig';
+import { getLandingPageParticipations } from '../../helpers/abTests/landingPageAbTests';
 
-const abParticipations = getAbParticipations();
+const landingPageParticipations = getLandingPageParticipations();
+const abParticipations = {
+	...getAbParticipations(),
+	...landingPageParticipations.participations,
+};
 setUpTrackingAndConsents(abParticipations);
 const appConfig = parseAppConfig(window.guardian);
 
@@ -51,7 +56,11 @@ const router = createBrowserRouter(
 			path: `/${geoId}/contribute/:campaignCode?`,
 			element: (
 				<Suspense fallback={<HoldingContent />}>
-					<LandingPage geoId={geoId} abParticipations={abParticipations} />
+					<LandingPage
+						geoId={geoId}
+						abParticipations={abParticipations}
+						landingPageSettings={landingPageParticipations.variant}
+					/>
 				</Suspense>
 			),
 		},
@@ -63,6 +72,7 @@ const router = createBrowserRouter(
 						geoId={geoId}
 						appConfig={appConfig}
 						abParticipations={abParticipations}
+						landingPageSettings={landingPageParticipations.variant}
 					/>
 				</Suspense>
 			),
@@ -87,6 +97,7 @@ const router = createBrowserRouter(
 						geoId={geoId}
 						appConfig={appConfig}
 						abParticipations={abParticipations}
+						landingPageSettings={landingPageParticipations.variant}
 					/>
 				</Suspense>
 			),

--- a/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
@@ -8,8 +8,8 @@ import type { UserType } from 'helpers/redux/checkout/personalDetails/state';
 import { logException } from 'helpers/utilities/logger';
 import { roundToDecimalPlaces } from 'helpers/utilities/utilities';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
-import type { LandingPageSelection } from '../../helpers/abTests/landingPageAbTests';
 import type { Participations } from '../../helpers/abTests/models';
+import type { LandingPageVariant } from '../../helpers/globalsAndSwitches/landingPageSettings';
 import { setHideSupportMessaginCookie } from '../../helpers/storage/contributionsCookies';
 import { ThankYouComponent } from './components/thankYouComponent';
 
@@ -17,7 +17,7 @@ type ThankYouProps = {
 	geoId: GeoId;
 	appConfig: AppConfig;
 	abParticipations: Participations;
-	landingPageSettings: LandingPageSelection;
+	landingPageSettings: LandingPageVariant;
 };
 
 export function ThankYou({

--- a/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
@@ -8,6 +8,7 @@ import type { UserType } from 'helpers/redux/checkout/personalDetails/state';
 import { logException } from 'helpers/utilities/logger';
 import { roundToDecimalPlaces } from 'helpers/utilities/utilities';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
+import type { LandingPageSelection } from '../../helpers/abTests/landingPageAbTests';
 import type { Participations } from '../../helpers/abTests/models';
 import { setHideSupportMessaginCookie } from '../../helpers/storage/contributionsCookies';
 import { ThankYouComponent } from './components/thankYouComponent';
@@ -16,12 +17,14 @@ type ThankYouProps = {
 	geoId: GeoId;
 	appConfig: AppConfig;
 	abParticipations: Participations;
+	landingPageSettings: LandingPageSelection;
 };
 
 export function ThankYou({
 	geoId,
 	appConfig,
 	abParticipations,
+	landingPageSettings,
 }: ThankYouProps) {
 	const countryId = Country.detect();
 	const { currencyKey, countryGroupId } = getGeoIdConfig(geoId);
@@ -165,6 +168,7 @@ export function ThankYou({
 			promotion={promotion}
 			identityUserType={userType}
 			abParticipations={abParticipations}
+			landingPageSettings={landingPageSettings}
 		/>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -48,7 +48,7 @@ import type { Promotion } from 'helpers/productPrice/promotions';
 import { getPromotion } from 'helpers/productPrice/promotions';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
-import type { LandingPageSelection } from '../../../helpers/abTests/landingPageAbTests';
+import type { LandingPageVariant } from '../../../helpers/globalsAndSwitches/landingPageSettings';
 import { getSanitisedHtml } from '../../../helpers/utilities/utilities';
 import Countdown from '../components/countdown';
 import { LandingPageBanners } from '../components/landingPageBanners';
@@ -253,7 +253,7 @@ function getPlanCost(
 
 type ThreeTierLandingProps = {
 	geoId: GeoId;
-	settings: LandingPageSelection;
+	settings: LandingPageVariant;
 	abParticipations: Participations;
 };
 export function ThreeTierLanding({


### PR DESCRIPTION
### Existing behaviour:
The AB tests [initialisation function](https://github.com/guardian/support-frontend/blob/main/support-frontend/assets/helpers/abTests/abtest.ts#L70) calls `getLandingPageParticipations`, which uses the settings from the landing page tool. If the user is on the landing page, or has a landing page participation in session storage, then it is added here to the set of test participations.
Later, we resolve the test participation to the actual landing page settings using `getLandingPageVariant`, for use in the components. The checkout and thankyou components also need these settings, as they may need the product benefits.

If a user arrives directly onto the checkout (not via the landing page) then the user is not put into a landing page test, and we use the `fallBackLandingPageSelection` settings. In this case we'd instead like to use the correct benefits settings from the landing page tool, even though we do not track the user as having been in the landing page test.

### New behaviour:
Move the call to `getLandingPageParticipations` out of the AB tests initialisation function.
Now we call it from the router.tsx.
`getLandingPageParticipations` now returns 2 fields:
```
interface LandingPageParticipationsResult {
	variant: LandingPageVariant;
	participations: Participations;
}
```
It will always return a variant, but only include the participation if the user is (or has been) on the landing page.
This way we ensure that the correct benefits copy is always available, but only track landing page test participation where appropriate.