### PR TITLE
Checkout Thankyou: Subscription Start Component paper date correction

### DIFF
--- a/support-frontend/assets/components/thankYou/guardianAdLite/whatNext.tsx
+++ b/support-frontend/assets/components/thankYou/guardianAdLite/whatNext.tsx
@@ -3,7 +3,7 @@ import BulletPointedList from '../utilityComponents/BulletPointedList';
 
 type WhatNextProps = {
 	amount: string;
-	startDate: string;
+	startDate?: string;
 	isSignedIn?: boolean;
 };
 
@@ -12,17 +12,24 @@ export function WhatNext({
 	startDate,
 	isSignedIn = false,
 }: WhatNextProps): JSX.Element {
-	const bulletItems = [
+	const bulletAllItems = [
 		'You will receive an email confirming the details of your subscription',
 		`Your payment of £${amount}/month will be taken on ${startDate}`,
-	];
-	const bulletPointSignedIn = bulletItems.concat([
 		'You can now start reading the Guardian website on all your devices without personalised advertising',
-	]);
+	];
+	const displayBulletItems: string[] = bulletAllItems.filter((item, index) => {
+		switch (index) {
+			case 0:
+				return item;
+			case 1:
+				return !!startDate;
+			case 2:
+				return isSignedIn;
+			default:
+				return false;
+		}
+	});
 	return (
-		<BulletPointedList
-			items={isSignedIn ? bulletPointSignedIn : bulletItems}
-			color={palette.neutral[7]}
-		/>
+		<BulletPointedList items={displayBulletItems} color={palette.neutral[7]} />
 	);
 }

--- a/support-frontend/assets/components/thankYou/subscriptionStart/subscriptionStartItems.tsx
+++ b/support-frontend/assets/components/thankYou/subscriptionStart/subscriptionStartItems.tsx
@@ -30,7 +30,7 @@ export const subscriptionStartHeader = 'When will your subscription start?';
 
 type SubscriptionStartProps = {
 	productKey: ActiveProductKey;
-	startDate: string;
+	startDate?: string;
 };
 export function SubscriptionStartItems({
 	productKey,
@@ -39,11 +39,13 @@ export function SubscriptionStartItems({
 	const paperCopy = (
 		<span css={[downloadCopy, subscriptionItems]}>
 			<div>
-				<p>
-					<span
-						css={boldText}
-					>{`You will receive your newspaper from ${startDate}`}</span>
-				</p>
+				{startDate && (
+					<p>
+						<span
+							css={boldText}
+						>{`You will receive your newspaper from ${startDate}`}</span>
+					</p>
+				)}
 				{productKey === 'SubscriptionCard' && (
 					<p css={paragraphSpacing}>
 						You will receive your Subscription Card in your subscriber pack in

--- a/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
@@ -113,7 +113,7 @@ export const getThankYouModuleData = (
 	csrf: CsrfState,
 	isOneOff: boolean,
 	amountIsAboveThreshold: boolean,
-	startDate: string,
+	startDate?: string,
 	email?: string,
 	campaignCode?: string,
 	isTier3?: boolean,

--- a/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
@@ -28,11 +28,6 @@ import {
 	OPHAN_COMPONENT_ID_SURVEY,
 } from 'helpers/thankYouPages/utils/ophan';
 import { manageSubsUrl } from 'helpers/urls/externalLinks';
-import {
-	formatMachineDate,
-	formatUserDate,
-} from 'helpers/utilities/dateConversions';
-import { getWeeklyDays } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
 import AppDownloadBadges, {
 	AppDownloadBadgesEditions,
 } from './appDownload/AppDownloadBadges';
@@ -118,6 +113,7 @@ export const getThankYouModuleData = (
 	csrf: CsrfState,
 	isOneOff: boolean,
 	amountIsAboveThreshold: boolean,
+	startDate: string,
 	email?: string,
 	campaignCode?: string,
 	isTier3?: boolean,
@@ -125,7 +121,6 @@ export const getThankYouModuleData = (
 	supportReminder?: ThankYouSupportReminderState,
 	feedbackSurveyHasBeenCompleted?: boolean,
 	finalAmount?: number,
-	startDate?: string,
 	returnAddress?: string,
 	isSignedIn?: boolean,
 ): Record<ThankYouModuleType, ThankYouModuleData> => {
@@ -137,15 +132,6 @@ export const getThankYouModuleData = (
 		useState<ThankYouSupportReminderState>(
 			supportReminder ?? defaultSupportReminder,
 		);
-
-	const days = getWeeklyDays();
-	const publicationStartDays = days.filter((day) => {
-		const invalidPublicationDates = ['-12-24', '-12-25', '-12-30'];
-		const date = formatMachineDate(day);
-		return !invalidPublicationDates.some((dateSuffix) =>
-			date.endsWith(dateSuffix),
-		);
-	});
 
 	const getFeedbackSurveyLink = (countryId: IsoCountry) => {
 		const surveyBasePath = 'https://guardiannewsandmedia.formstack.com/forms/';
@@ -256,14 +242,7 @@ export const getThankYouModuleData = (
 			icon: getThankYouModuleIcon('subscriptionStart'),
 			header: subscriptionStartHeader,
 			bodyCopy: (
-				<SubscriptionStartItems
-					productKey={productKey}
-					startDate={
-						publicationStartDays[0]
-							? formatUserDate(publicationStartDays[0])
-							: ''
-					}
-				/>
+				<SubscriptionStartItems productKey={productKey} startDate={startDate} />
 			),
 			ctas: null,
 		},
@@ -342,7 +321,7 @@ export const getThankYouModuleData = (
 			bodyCopy: (
 				<WhatNext
 					amount={(finalAmount ?? '').toString()}
-					startDate={startDate ?? ''}
+					startDate={startDate}
 					isSignedIn={isSignedIn}
 				/>
 			),

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -232,7 +232,7 @@ export function ThankYouComponent({
 		productKey,
 		ratePlanKey as ActivePaperProductOptions,
 	);
-	const startDate = deliveryDate ? formatUserDate(deliveryDate) : '';
+	const startDate = deliveryDate ? formatUserDate(deliveryDate) : undefined;
 
 	const thankYouModuleData = getThankYouModuleData(
 		productKey,

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -29,7 +29,7 @@ import { formatUserDate } from 'helpers/utilities/dateConversions';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
 import ThankYouFooter from 'pages/supporter-plus-thank-you/components/thankYouFooter';
 import ThankYouHeader from 'pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader';
-import { productDeliveryDate } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
+import { productDeliveryOrStartDate } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
 import type { BenefitsCheckListData } from '../../../components/checkoutBenefits/benefitsCheckList';
 import { ThankYouModules } from '../../../components/thankYou/thankyouModules';
 import type { LandingPageVariant } from '../../../helpers/globalsAndSwitches/landingPageSettings';
@@ -228,7 +228,7 @@ export function ThankYouComponent({
 
 	const benefitsChecklist = getBenefits();
 
-	const deliveryDate = productDeliveryDate(
+	const deliveryDate = productDeliveryOrStartDate(
 		productKey,
 		ratePlanKey as ActivePaperProductOptions,
 	);

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -11,6 +11,7 @@ import type { Participations } from 'helpers/abTests/models';
 import type { ContributionType } from 'helpers/contributions';
 import { Country } from 'helpers/internationalisation/classes/country';
 import type { ActiveProductKey } from 'helpers/productCatalog';
+import type { ActivePaperProductOptions } from 'helpers/productPrice/productOptions';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { type CsrfState } from 'helpers/redux/checkout/csrf/state';
 import type { UserType } from 'helpers/redux/checkout/personalDetails/state';
@@ -28,7 +29,7 @@ import { formatUserDate } from 'helpers/utilities/dateConversions';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
 import ThankYouFooter from 'pages/supporter-plus-thank-you/components/thankYouFooter';
 import ThankYouHeader from 'pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader';
-import { getGuardianAdLiteDate } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
+import { productDeliveryDate } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
 import type { BenefitsCheckListData } from '../../../components/checkoutBenefits/benefitsCheckList';
 import { ThankYouModules } from '../../../components/thankYou/thankyouModules';
 import type { LandingPageVariant } from '../../../helpers/globalsAndSwitches/landingPageSettings';
@@ -227,6 +228,12 @@ export function ThankYouComponent({
 
 	const benefitsChecklist = getBenefits();
 
+	const deliveryDate = productDeliveryDate(
+		productKey,
+		ratePlanKey as ActivePaperProductOptions,
+	);
+	const startDate = deliveryDate ? formatUserDate(deliveryDate) : '';
+
 	const thankYouModuleData = getThankYouModuleData(
 		productKey,
 		countryGroupId,
@@ -241,7 +248,7 @@ export function ThankYouComponent({
 		undefined,
 		undefined,
 		payment.finalAmount,
-		formatUserDate(getGuardianAdLiteDate()),
+		startDate,
 		getReturnAddress(), // Session storage returnAddress (from GuardianAdLiteLanding)
 		isSignedIn,
 	);

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -241,6 +241,7 @@ export function ThankYouComponent({
 		csrf,
 		isOneOff,
 		isSupporterPlus,
+		startDate,
 		undefined,
 		undefined,
 		isTier3,
@@ -248,7 +249,6 @@ export function ThankYouComponent({
 		undefined,
 		undefined,
 		payment.finalAmount,
-		startDate,
 		getReturnAddress(), // Session storage returnAddress (from GuardianAdLiteLanding)
 		isSignedIn,
 	);

--- a/support-frontend/assets/pages/digital-subscriber-thank-you/digitalSubscriptionThankYou.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-thank-you/digitalSubscriptionThankYou.tsx
@@ -83,7 +83,7 @@ export function DigitalSubscriptionThankYou(): JSX.Element {
 		csrf,
 		false,
 		amountIsAboveThreshold,
-		'',
+		undefined,
 		email,
 	);
 

--- a/support-frontend/assets/pages/digital-subscriber-thank-you/digitalSubscriptionThankYou.tsx
+++ b/support-frontend/assets/pages/digital-subscriber-thank-you/digitalSubscriptionThankYou.tsx
@@ -83,6 +83,7 @@ export function DigitalSubscriptionThankYou(): JSX.Element {
 		csrf,
 		false,
 		amountIsAboveThreshold,
+		'',
 		email,
 	);
 

--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.ts
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.ts
@@ -87,10 +87,6 @@ const productDeliveryOrStartDate = (
 					: productKey === 'HomeDelivery'
 					? getHomeDeliveryDays(Date.now(), paperProductOptions)[0]
 					: getVoucherDays(Date.now(), paperProductOptions)[0];
-			// paper home and voucher delivery date array empty check
-			if (paperDeliveryDate === undefined) {
-				return undefined;
-			}
 			return paperDeliveryDate;
 		}
 		case 'GuardianWeeklyDomestic':
@@ -103,10 +99,6 @@ const productDeliveryOrStartDate = (
 					date.endsWith(dateSuffix),
 				);
 			});
-			// guardian weekly delivery date array empty check
-			if (publicationStartDays[0] === undefined) {
-				return undefined;
-			}
 			return publicationStartDays[0];
 		}
 		default:

--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.ts
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.ts
@@ -68,7 +68,6 @@ const productDeliveryDate = (
 	productKey: ActiveProductKey,
 	paperProductOptions?: ActivePaperProductOptions,
 ): Date | undefined => {
-	console.log(paperProductOptions);
 	switch (productKey) {
 		case 'GuardianAdLite':
 			return addDays(new Date(), 15);

--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.ts
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.ts
@@ -64,7 +64,7 @@ function getTierThreeDeliveryDate(today?: number) {
 	return result;
 }
 
-const productDeliveryDate = (
+const productDeliveryOrStartDate = (
 	productKey: ActiveProductKey,
 	paperProductOptions?: ActivePaperProductOptions,
 ): Date | undefined => {
@@ -112,5 +112,5 @@ export {
 	getWeeklyDays,
 	addDays,
 	getTierThreeDeliveryDate,
-	productDeliveryDate,
+	productDeliveryOrStartDate,
 };

--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.ts
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.ts
@@ -8,6 +8,7 @@ import {
 import { formatMachineDate } from 'helpers/utilities/dateConversions';
 import { getHomeDeliveryDays } from 'pages/paper-subscription-checkout/helpers/homeDeliveryDays';
 import { getPaymentStartDate } from 'pages/paper-subscription-checkout/helpers/subsCardDays';
+import { getVoucherDays } from 'pages/paper-subscription-checkout/helpers/voucherDeliveryDays';
 
 const extraDelayCutoffWeekday = 3;
 const normalDelayWeeks = 1;
@@ -83,8 +84,10 @@ const productDeliveryOrStartDate = (
 			const paperDeliveryDate =
 				productKey === 'SubscriptionCard'
 					? getPaymentStartDate(Date.now(), paperProductOptions)
-					: getHomeDeliveryDays(Date.now(), paperProductOptions)[0];
-			// paper delivery date array empty check
+					: productKey === 'HomeDelivery'
+					? getHomeDeliveryDays(Date.now(), paperProductOptions)[0]
+					: getVoucherDays(Date.now(), paperProductOptions)[0];
+			// paper home and voucher delivery date array empty check
 			if (paperDeliveryDate === undefined) {
 				return undefined;
 			}

--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.ts
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.ts
@@ -76,15 +76,17 @@ const productDeliveryOrStartDate = (
 		case 'NationalDelivery':
 		case 'HomeDelivery':
 		case 'SubscriptionCard': {
+			// paper productOption undefined check
 			if (paperProductOptions === undefined) {
-				throw new Error(`ratePlan not found for ${productKey}`);
+				return undefined;
 			}
 			const paperDeliveryDate =
 				productKey === 'SubscriptionCard'
 					? getPaymentStartDate(Date.now(), paperProductOptions)
 					: getHomeDeliveryDays(Date.now(), paperProductOptions)[0];
+			// paper delivery date array empty check
 			if (paperDeliveryDate === undefined) {
-				throw new Error('delivery date not found for Home Delivery');
+				return undefined;
 			}
 			return paperDeliveryDate;
 		}
@@ -98,8 +100,9 @@ const productDeliveryOrStartDate = (
 					date.endsWith(dateSuffix),
 				);
 			});
+			// guardian weekly delivery date array empty check
 			if (publicationStartDays[0] === undefined) {
-				throw new Error('delivery date not found for Guardian Weekly');
+				return undefined;
 			}
 			return publicationStartDays[0];
 		}

--- a/support-frontend/stories/checkouts/thankYouModule.stories.tsx
+++ b/support-frontend/stories/checkouts/thankYouModule.stories.tsx
@@ -46,6 +46,7 @@ import type { ThankYouModuleProps } from 'components/thankYou/thankYouModule';
 import ThankYouModule from 'components/thankYou/thankYouModule';
 import { getThankYouModuleIcon } from 'components/thankYou/thankYouModuleIcons';
 import { SubscriptionStartItems } from 'components/thankYou/subscriptionStart/subscriptionStartItems';
+import { WhatNext } from 'components/thankYou/guardianAdLite/whatNext';
 
 const container = css`
 	padding: ${space[9]}px 0;
@@ -371,6 +372,39 @@ SubscriptionStartTierThree.args = {
 		/>
 	),
 	ctas: null,
+};
+
+export const WhatNextSignedOut = Template.bind({});
+WhatNextSignedOut.args = {
+	icon: getThankYouModuleIcon('whatNext'),
+	header: 'What next?',
+	bodyCopy: (
+		<WhatNext
+			amount={'12'}
+			startDate={'Friday, March 28, 2025'}
+			isSignedIn={true}
+		/>
+	),
+};
+
+export const WhatNextSignedIn = Template.bind({});
+WhatNextSignedIn.args = {
+	icon: getThankYouModuleIcon('whatNext'),
+	header: 'What next?',
+	bodyCopy: (
+		<WhatNext
+			amount={'12'}
+			startDate={'Friday, March 28, 2025'}
+			isSignedIn={false}
+		/>
+	),
+};
+
+export const WhatNextNoStartDate = Template.bind({});
+WhatNextNoStartDate.args = {
+	icon: getThankYouModuleIcon('whatNext'),
+	header: 'What next?',
+	bodyCopy: <WhatNext amount={'12'} isSignedIn={false} />,
 };
 
 SupportReminder.decorators = [


### PR DESCRIPTION
## What are you doing in this PR?

Thankyou component updates ->
- `SubscriptionStartItems` : Currently display's Weekly Start Date not Paper Start Date.
- `whatNext` : tidy to use new call from fix above.

[**Trello Card**](https://trello.com/c/CXqJlXXP/1549-ty-component-subscriptionstart-date-component-fix)

## How to test

1. Checkout via -> https://support.thegulocal.com/uk/checkout?product=NationalDelivery&ratePlan=Everyday&userType=current
2. Checkout via -> https://support.thegulocal.com/uk/checkout?product=HomelDelivery&ratePlan=Everyday&userType=current
3. Checkout via -> https://support.thegulocal.com/uk/checkout?product=SubscriptionCard&ratePlan=Everyday&userType=current

## Screenshots

|before|after|
|----|----|
|![image](https://github.com/user-attachments/assets/4940ef88-a41c-415b-bab4-dcb81da8f4fe)|![image](https://github.com/user-attachments/assets/cb0923b2-23f9-4b6d-98ea-1da888487880)|