### PR TITLE
Remove PayPal as payment option from Sunday only subs

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -153,12 +153,20 @@ type CheckoutComponentProps = {
 	landingPageSettings: LandingPageVariant;
 };
 
-const shouldUseStripeHostedCheckout = (
+const isSundayOnlyNewspaperSub = (
 	productKey: ProductKey,
 	ratePlanKey: string,
 ) =>
 	['HomeDelivery', 'SubscriptionCard'].includes(productKey) &&
 	ratePlanKey === 'Sunday';
+
+const shouldUseStripeHostedCheckout = (
+	productKey: ProductKey,
+	ratePlanKey: string,
+) => isSundayOnlyNewspaperSub(productKey, ratePlanKey);
+
+const shouldOfferPayPal = (productKey: ProductKey, ratePlanKey: string) =>
+	!isSundayOnlyNewspaperSub(productKey, ratePlanKey);
 
 export function CheckoutComponent({
 	geoId,
@@ -315,7 +323,7 @@ export function CheckoutComponent({
 		shouldUseStripeHostedCheckout(productKey, ratePlanKey)
 			? StripeHostedCheckout
 			: Stripe,
-		PayPal,
+		shouldOfferPayPal(productKey, ratePlanKey) && PayPal,
 	]
 		.filter(isPaymentMethod)
 		.filter(paymentMethodIsActive);


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Don't offer PayPal as a payment method on Sunday only subscriptions.

[**Trello Card**](https://trello.com/c/XFEN8o50/1506-remove-paypal-as-payment-method-for-sunday-only)

## Why are you doing this?

It removes some complexity if we don't offer PayPal as a payment option for Sunday only.

## How to test

On Sunday only checkouts, PayPal is not available (this is Sunday / SubscriptionCard):

<img width="606" alt="Screenshot 2025-04-02 at 14 57 38" src="https://github.com/user-attachments/assets/a83152e3-8015-4c25-8071-1ef482eef01b" />

For all other products, PayPal remains available:

<img width="604" alt="Screenshot 2025-04-02 at 14 58 09" src="https://github.com/user-attachments/assets/5f73baa3-534f-475a-b60d-13024476d02b" />

To ensure no existing products are affected, I ran the smoke and cron tests.