### PR TITLE
Use Tortoise Stripe account for Sunday newspaper payments

### DIFF
--- a/support-config/src/main/resources/touchpoint.CODE.conf
+++ b/support-config/src/main/resources/touchpoint.CODE.conf
@@ -10,6 +10,9 @@ touchpoint.backend.environments {
       default {
         api.key.public = "pk_test_Qm3CGRdrV4WfGYCpm0sftR0f"
       }
+      tortoiseMedia {
+        api.key.public = "pk_test_51R2EwSFNFWz7WMIhlRO95hCjJy6frZdqdOshm7L9ZPt8Pwgw9izuf6QV7VMSHiX2qOpKafDlzvnQPM4enjWxJlLM001gwbmifF"
+      }
     }
     oneOffStripe {
       AU {

--- a/support-config/src/main/resources/touchpoint.CODE.conf
+++ b/support-config/src/main/resources/touchpoint.CODE.conf
@@ -24,6 +24,9 @@ touchpoint.backend.environments {
       default {
         api.key.public = "pk_test_35RZz9AAyqErQshL410RDZMs"
       }
+      tortoiseMedia {
+        api.key.public = "pk_test_51R2EwSFNFWz7WMIhlRO95hCjJy6frZdqdOshm7L9ZPt8Pwgw9izuf6QV7VMSHiX2qOpKafDlzvnQPM4enjWxJlLM001gwbmifF"
+      }
     }
     paypal {
       user = ""

--- a/support-config/src/main/resources/touchpoint.PROD.conf
+++ b/support-config/src/main/resources/touchpoint.PROD.conf
@@ -10,6 +10,9 @@ touchpoint.backend.environments {
       default {
         api.key.public = "pk_live_2O6zPMHXNs2AGea4bAmq5R7Z"
       }
+      tortoiseMedia {
+        api.key.public = "pk_live_51R2EwSFNFWz7WMIhi8Xp3xQ9xMjGlaTQPrwrk0PikCdR4wLla5Y2tc6qIdTF5zgWW4oykETepTwCtN7iHQl0beDL00N8KPa4Jp"
+      }
     }
     oneOffStripe {
       AU {

--- a/support-config/src/main/resources/touchpoint.PROD.conf
+++ b/support-config/src/main/resources/touchpoint.PROD.conf
@@ -24,6 +24,9 @@ touchpoint.backend.environments {
       default {
         api.key.public = "pk_live_auSwLB4KBzbN3JOUVHvKMe6f"
       }
+      tortoiseMedia {
+        api.key.public = "pk_live_51R2EwSFNFWz7WMIhi8Xp3xQ9xMjGlaTQPrwrk0PikCdR4wLla5Y2tc6qIdTF5zgWW4oykETepTwCtN7iHQl0beDL00N8KPa4Jp"
+      }
     }
     paypal {
       user=""

--- a/support-config/src/main/scala/com/gu/support/config/StripeConfig.scala
+++ b/support-config/src/main/scala/com/gu/support/config/StripeConfig.scala
@@ -4,19 +4,26 @@ import com.gu.i18n.{Country, Currency}
 import com.gu.i18n.Currency.AUD
 import com.gu.monitoring.SafeLogging
 import com.gu.support.workers.{StripePublicKey, StripeSecretKey}
-import com.gu.support.zuora.api.{PaymentGateway, StripeGatewayPaymentIntentsAUD, StripeGatewayPaymentIntentsDefault}
+import com.gu.support.zuora.api.{
+  PaymentGateway,
+  StripeGatewayPaymentIntentsAUD,
+  StripeGatewayPaymentIntentsDefault,
+  StripeTortoiseMedia,
+}
 import com.typesafe.config.Config
 
 case class StripeConfig(
     defaultAccount: StripeAccountConfig,
     australiaAccount: StripeAccountConfig,
     unitedStatesAccount: StripeAccountConfig,
+    tortoiseMediaAccount: StripeAccountConfig,
     version: Option[String],
 ) extends SafeLogging {
   private val secretForPublic: Map[StripePublicKey, (StripeSecretKey, PaymentGateway)] = Map(
     defaultAccount.publicKey -> (defaultAccount.secretKey, StripeGatewayPaymentIntentsDefault),
     australiaAccount.publicKey -> (australiaAccount.secretKey, StripeGatewayPaymentIntentsAUD),
     unitedStatesAccount.publicKey -> (unitedStatesAccount.secretKey, StripeGatewayPaymentIntentsDefault), // US currently uses default account for recurring
+    tortoiseMediaAccount.publicKey -> (tortoiseMediaAccount.secretKey, StripeTortoiseMedia),
   )
 
   def forPublicKey(publicKey: StripePublicKey): Option[(StripeSecretKey, PaymentGateway)] =
@@ -31,6 +38,7 @@ class StripeConfigProvider(config: Config, defaultStage: Stage, prefix: String =
     accountFromConfig(config, prefix, "default"),
     accountFromConfig(config, prefix, Country.Australia.alpha2),
     accountFromConfig(config, prefix, Country.US.alpha2),
+    accountFromConfig(config, prefix, "tortoiseMedia"),
     version = stripeVersion(config),
   )
 

--- a/support-config/src/main/scala/com/gu/support/config/StripePublicConfig.scala
+++ b/support-config/src/main/scala/com/gu/support/config/StripePublicConfig.scala
@@ -8,6 +8,7 @@ case class StripePublicConfig(
     defaultAccount: StripePublicKey,
     australiaAccount: StripePublicKey,
     unitedStatesAccount: StripePublicKey,
+    tortoiseMediaAccount: StripePublicKey,
 )
 
 class StripePublicConfigProvider(config: Config, defaultStage: Stage, prefix: String = "stripe")
@@ -16,6 +17,7 @@ class StripePublicConfigProvider(config: Config, defaultStage: Stage, prefix: St
     accountFromConfig(config, prefix, "default"),
     accountFromConfig(config, prefix, Country.Australia.alpha2),
     accountFromConfig(config, prefix, Country.US.alpha2),
+    accountFromConfig(config, prefix, "tortoiseMedia"),
   )
 
   private def accountFromConfig(config: Config, prefix: String, country: String): StripePublicKey =

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -37,6 +37,7 @@ case class AppConfig private (
     stripeKeyDefaultCurrencies: AppConfig.StripeKeyConfig,
     stripeKeyAustralia: AppConfig.StripeKeyConfig,
     stripeKeyUnitedStates: AppConfig.StripeKeyConfig,
+    stripeKeyTortoiseMedia: AppConfig.StripeKeyConfig,
     payPalEnvironment: AppConfig.ConfigKeyValues,
     paymentApiUrl: String,
     paymentApiPayPalEndpoint: String,
@@ -129,6 +130,16 @@ object AppConfig extends InternationalisationCodecs {
           ),
         )
       },
+      stripeKeyTortoiseMedia = StripeKeyConfig(
+        ONE_OFF = ConfigKeyValues(
+          default = paymentMethodConfigs.oneOffDefaultStripeConfig.tortoiseMediaAccount.rawPublicKey,
+          test = paymentMethodConfigs.oneOffTestStripeConfig.tortoiseMediaAccount.rawPublicKey,
+        ),
+        REGULAR = ConfigKeyValues(
+          default = paymentMethodConfigs.regularDefaultStripeConfig.tortoiseMediaAccount.rawPublicKey,
+          test = paymentMethodConfigs.regularTestStripeConfig.tortoiseMediaAccount.rawPublicKey,
+        ),
+      ),
       ConfigKeyValues(
         default = paymentMethodConfigs.regularDefaultPayPalConfig.payPalEnvironment,
         test = paymentMethodConfigs.regularTestPayPalConfig.payPalEnvironment,

--- a/support-frontend/app/services/StripeCheckoutSessionService.scala
+++ b/support-frontend/app/services/StripeCheckoutSessionService.scala
@@ -71,7 +71,10 @@ class StripeCheckoutSessionService(
       .withBody(data)
       .execute()
       .attemptT
-      .leftMap(error => error.getMessage)
+      .leftMap(error => {
+        logger.warn(s"Error creating Stripe checkout session: ${error.getMessage}")
+        "Failed to create Stripe checkout session"
+      })
       .subflatMap(decodeResponse[CreateCheckoutSessionResponseSuccess])
   }
 

--- a/support-frontend/app/services/StripeCheckoutSessionService.scala
+++ b/support-frontend/app/services/StripeCheckoutSessionService.scala
@@ -32,10 +32,6 @@ case class CheckoutSetupIntent(id: String, payment_method: CheckoutPaymentMethod
 object CheckoutSetupIntent {
   implicit val decoder: Decoder[CheckoutSetupIntent] = deriveDecoder
 }
-case class RetrieveCheckoutSessionResponseSuccess(setup_intent: CheckoutSetupIntent)
-object RetrieveCheckoutSessionResponseSuccess {
-  implicit val decoder: Decoder[RetrieveCheckoutSessionResponseSuccess] = deriveDecoder
-}
 
 class StripeCheckoutSessionService(
     configProvider: StripeConfigProvider,

--- a/support-frontend/app/services/StripeCheckoutSessionService.scala
+++ b/support-frontend/app/services/StripeCheckoutSessionService.scala
@@ -5,6 +5,7 @@ import cats.implicits.{catsSyntaxApplicativeError, toBifunctorOps}
 import com.gu.i18n.Currency
 import com.gu.monitoring.SafeLogging
 import com.gu.support.config.StripeConfigProvider
+import com.gu.support.workers.StripePublicKey
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 import play.api.libs.ws.{WSAuthScheme, WSClient, WSResponse}
@@ -31,6 +32,10 @@ case class CheckoutSetupIntent(id: String, payment_method: CheckoutPaymentMethod
 object CheckoutSetupIntent {
   implicit val decoder: Decoder[CheckoutSetupIntent] = deriveDecoder
 }
+case class RetrieveCheckoutSessionResponseSuccess(setup_intent: CheckoutSetupIntent)
+object RetrieveCheckoutSessionResponseSuccess {
+  implicit val decoder: Decoder[RetrieveCheckoutSessionResponseSuccess] = deriveDecoder
+}
 
 class StripeCheckoutSessionService(
     configProvider: StripeConfigProvider,
@@ -40,12 +45,13 @@ class StripeCheckoutSessionService(
   val baseUrl: String = "https://api.stripe.com/v1"
 
   def createCheckoutSession(
+      stripePublicKey: StripePublicKey,
       email: String,
       currency: Currency,
       isTestUser: Boolean,
       successUrl: String,
   ): EitherT[Future, String, CreateCheckoutSessionResponseSuccess] = {
-    val privateKey = getPrivateKey(isTestUser)
+    val privateKey = getPrivateKey(stripePublicKey, isTestUser)
 
     // We use the default expiration of 24 hours
     val data = Map(
@@ -65,16 +71,16 @@ class StripeCheckoutSessionService(
       .withBody(data)
       .execute()
       .attemptT
-      .leftMap(error => {
-        logger.warn(s"Error creating Stripe checkout session: ${error.getMessage}")
-        "Failed to create Stripe checkout session"
-      })
+      .leftMap(error => error.getMessage)
       .subflatMap(decodeResponse[CreateCheckoutSessionResponseSuccess])
   }
 
-  private def getPrivateKey(isTestUser: Boolean): String = {
-    // TODO: take a public key and map to a secret key instead of hardcoding this
-    configProvider.get(isTestUser).defaultAccount.secretKey.secret
+  private def getPrivateKey(stripePublicKey: StripePublicKey, isTestUser: Boolean) = {
+    configProvider.get(isTestUser).forPublicKey(stripePublicKey) match {
+      case Some(config) => config._1.secret
+      case None =>
+        throw new RuntimeException(s"Stripe public key $stripePublicKey not found in config")
+    }
   }
 
   private def decodeResponse[A: Decoder](

--- a/support-frontend/app/views/windowGuardianPaymentConfig.scala.html
+++ b/support-frontend/app/views/windowGuardianPaymentConfig.scala.html
@@ -58,6 +58,17 @@
     REGULAR: window.guardian.stripeKeyDefaultCurrencies.REGULAR
   };
 
+  window.guardian.stripeKeyTortoiseMedia = {
+    ONE_OFF: {
+      default: "@paymentMethodConfigs.oneOffDefaultStripeConfig.tortoiseMediaAccount.rawPublicKey",
+      test: "@paymentMethodConfigs.oneOffTestStripeConfig.tortoiseMediaAccount.rawPublicKey"
+    },
+    REGULAR: {
+      default: "@paymentMethodConfigs.regularDefaultStripeConfig.tortoiseMediaAccount.rawPublicKey",
+      test: "@paymentMethodConfigs.regularTestStripeConfig.tortoiseMediaAccount.rawPublicKey"
+    }
+  }
+
   window.guardian.payPalEnvironment = {
     default: "@paymentMethodConfigs.regularDefaultPayPalConfig.payPalEnvironment",
     test: "@paymentMethodConfigs.regularTestPayPalConfig.payPalEnvironment"

--- a/support-frontend/app/views/windowGuardianPaymentConfig.scala.html
+++ b/support-frontend/app/views/windowGuardianPaymentConfig.scala.html
@@ -60,8 +60,8 @@
 
   window.guardian.stripeKeyTortoiseMedia = {
     ONE_OFF: {
-      default: "@paymentMethodConfigs.oneOffDefaultStripeConfig.tortoiseMediaAccount.rawPublicKey",
-      test: "@paymentMethodConfigs.oneOffTestStripeConfig.tortoiseMediaAccount.rawPublicKey"
+      default: "unused", // We will never need one-off payments for Tortoise Media
+      test: "unused"
     },
     REGULAR: {
       default: "@paymentMethodConfigs.regularDefaultStripeConfig.tortoiseMediaAccount.rawPublicKey",

--- a/support-frontend/assets/components/stripe/contributionsStripe.tsx
+++ b/support-frontend/assets/components/stripe/contributionsStripe.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import type { ContributionType } from 'helpers/contributions';
 import {
-	getStripeKey,
+	getStripeKeyForCountry,
 	stripeAccountForContributionType,
 } from 'helpers/forms/stripe';
 import {
@@ -38,7 +38,7 @@ export function ContributionsStripe({
 
 	useEffect(() => {
 		const stripeAccount = stripeAccountForContributionType[contributionType];
-		const publicKey = getStripeKey(
+		const publicKey = getStripeKeyForCountry(
 			stripeAccount,
 			countryId,
 			currencyId,

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.tsx
@@ -2,7 +2,7 @@ import { Elements } from '@stripe/react-stripe-js';
 import * as stripeJs from '@stripe/stripe-js';
 import { useEffect, useState } from 'react';
 import StripeForm from 'components/subscriptionCheckouts/stripeForm/stripeForm';
-import { getStripeKey } from 'helpers/forms/stripe';
+import { getStripeKeyForCountry } from 'helpers/forms/stripe';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CsrfState } from 'helpers/redux/checkout/csrf/state';
 import type { FormField } from 'helpers/subscriptionsForms/formFields';
@@ -26,7 +26,7 @@ function StripeProviderForCountry(props: PropTypes): JSX.Element {
 	const [stripeObject, setStripeObject] = useState<stripeJs.Stripe | null>(
 		null,
 	);
-	const stripeKey = getStripeKey(
+	const stripeKey = getStripeKeyForCountry(
 		'REGULAR',
 		props.country,
 		props.currency,

--- a/support-frontend/assets/helpers/forms/stripe.ts
+++ b/support-frontend/assets/helpers/forms/stripe.ts
@@ -1,3 +1,4 @@
+import type { ActiveProductKey } from '@guardian/support-service-lambdas/modules/product-catalog/src/productCatalog';
 import type { Stripe as StripeJs } from '@stripe/stripe-js';
 import { loadStripe } from '@stripe/stripe-js/pure';
 import { useEffect, useState } from 'react';
@@ -5,7 +6,7 @@ import type { ContributionType } from 'helpers/contributions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { IsoCurrency } from '../internationalisation/currency';
 
-export type StripeAccount = 'ONE_OFF' | 'REGULAR';
+export type StripeAccountType = 'ONE_OFF' | 'REGULAR';
 
 export type StripePaymentIntentResult = {
 	client_secret?: string;
@@ -13,7 +14,7 @@ export type StripePaymentIntentResult = {
 
 const stripeAccountForContributionType: Record<
 	ContributionType,
-	StripeAccount
+	StripeAccountType
 > = {
 	ONE_OFF: 'ONE_OFF',
 	MONTHLY: 'REGULAR',
@@ -21,7 +22,24 @@ const stripeAccountForContributionType: Record<
 };
 
 function getStripeKey(
-	stripeAccount: StripeAccount,
+	stripeAccountType: StripeAccountType,
+	country: IsoCountry,
+	currency: IsoCurrency,
+	isTestUser: boolean,
+	productKey: ActiveProductKey,
+	ratePlanKey: string,
+): string {
+	return (
+		getStripeKeyForProduct(
+			stripeAccountType,
+			productKey,
+			ratePlanKey,
+			isTestUser,
+		) ?? getStripeKeyForRegion(stripeAccountType, country, currency, isTestUser)
+	);
+}
+function getStripeKeyForRegion(
+	stripeAccountType: StripeAccountType,
 	country: IsoCountry,
 	currency: IsoCurrency,
 	isTestUser: boolean,
@@ -29,20 +47,38 @@ function getStripeKey(
 	let account;
 	switch (currency) {
 		case 'AUD': // need to match with how support-workers does it
-			account = window.guardian.stripeKeyAustralia[stripeAccount];
+			account = window.guardian.stripeKeyAustralia[stripeAccountType];
 			break;
 		case 'USD':
 			if (country === 'US') {
 				// this allows support of US only cards (for single)
-				account = window.guardian.stripeKeyUnitedStates[stripeAccount];
+				account = window.guardian.stripeKeyUnitedStates[stripeAccountType];
 			} else {
-				account = window.guardian.stripeKeyDefaultCurrencies[stripeAccount];
+				account = window.guardian.stripeKeyDefaultCurrencies[stripeAccountType];
 			}
 			break;
 		default:
-			account = window.guardian.stripeKeyDefaultCurrencies[stripeAccount];
+			account = window.guardian.stripeKeyDefaultCurrencies[stripeAccountType];
 	}
 	return isTestUser ? account.test : account.default;
+}
+
+function getStripeKeyForProduct(
+	stripeAccountType: StripeAccountType,
+	productKey: ActiveProductKey,
+	ratePlanKey: string,
+	isTestUser: boolean,
+) {
+	if (
+		(productKey === 'HomeDelivery' ||
+			productKey === 'NationalDelivery' ||
+			productKey === 'SubscriptionCard') &&
+		ratePlanKey === 'Sunday'
+	) {
+		const account = window.guardian.stripeKeyTortoiseMedia[stripeAccountType];
+		return isTestUser ? account.test : account.default;
+	}
+	return;
 }
 
 //  this is required as useStripeAccount is used in multiple components

--- a/support-frontend/assets/helpers/forms/stripe.ts
+++ b/support-frontend/assets/helpers/forms/stripe.ts
@@ -21,24 +21,7 @@ const stripeAccountForContributionType: Record<
 	ANNUAL: 'REGULAR',
 };
 
-function getStripeKey(
-	stripeAccountType: StripeAccountType,
-	country: IsoCountry,
-	currency: IsoCurrency,
-	isTestUser: boolean,
-	productKey: ActiveProductKey,
-	ratePlanKey: string,
-): string {
-	return (
-		getStripeKeyForProduct(
-			stripeAccountType,
-			productKey,
-			ratePlanKey,
-			isTestUser,
-		) ?? getStripeKeyForRegion(stripeAccountType, country, currency, isTestUser)
-	);
-}
-function getStripeKeyForRegion(
+function getStripeKeyForCountry(
 	stripeAccountType: StripeAccountType,
 	country: IsoCountry,
 	currency: IsoCurrency,
@@ -106,4 +89,8 @@ export function useStripeAccount(stripeKey: string): StripeJs | null {
 	return stripeSdk;
 }
 
-export { stripeAccountForContributionType, getStripeKey };
+export {
+	stripeAccountForContributionType,
+	getStripeKeyForCountry,
+	getStripeKeyForProduct,
+};

--- a/support-frontend/assets/helpers/globalsAndSwitches/window.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/window.ts
@@ -44,6 +44,10 @@ const PaymentConfigSchema = object({
 		ONE_OFF: object({ default: string(), test: string() }),
 		REGULAR: object({ default: string(), test: string() }),
 	}),
+	stripeKeyTortoiseMedia: object({
+		ONE_OFF: object({ default: string(), test: string() }),
+		REGULAR: object({ default: string(), test: string() }),
+	}),
 	payPalEnvironment: object({
 		default: string(),
 		test: string(),

--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentRequestButton/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentRequestButton/reducer.ts
@@ -1,6 +1,6 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
-import type { StripeAccount } from 'helpers/forms/stripe';
+import type { StripeAccountType } from 'helpers/forms/stripe';
 import { resetValidation, validateForm } from '../../checkoutActions';
 import type { PaymentRequestError } from './state';
 import { initialPaymentRequestButtonState } from './state';
@@ -9,16 +9,19 @@ export const paymentRequestButtonSlice = createSlice({
 	name: 'paymentRequestButton',
 	initialState: initialPaymentRequestButtonState,
 	reducers: {
-		clickPaymentRequestButton(state, action: PayloadAction<StripeAccount>) {
+		clickPaymentRequestButton(state, action: PayloadAction<StripeAccountType>) {
 			state[action.payload].buttonClicked = true;
 			if (state[action.payload].completed) {
 				state[action.payload].completed = false;
 			}
 		},
-		unClickPaymentRequestButton(state, action: PayloadAction<StripeAccount>) {
+		unClickPaymentRequestButton(
+			state,
+			action: PayloadAction<StripeAccountType>,
+		) {
 			state[action.payload].buttonClicked = false;
 		},
-		completePaymentRequest(state, action: PayloadAction<StripeAccount>) {
+		completePaymentRequest(state, action: PayloadAction<StripeAccountType>) {
 			state[action.payload].completed = true;
 		},
 		setPaymentRequestError(state, action: PayloadAction<PaymentRequestError>) {

--- a/support-frontend/assets/helpers/redux/checkout/payment/paymentRequestButton/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/paymentRequestButton/state.ts
@@ -1,5 +1,5 @@
 import type { ErrorReason } from 'helpers/forms/errorReasons';
-import type { StripeAccount } from 'helpers/forms/stripe';
+import type { StripeAccountType } from 'helpers/forms/stripe';
 
 type StripePaymentRequestButtonData = {
 	buttonClicked: boolean;
@@ -8,12 +8,12 @@ type StripePaymentRequestButtonData = {
 };
 
 export type PaymentRequestError = {
-	account: StripeAccount;
+	account: StripeAccountType;
 	error: ErrorReason;
 };
 
 export type PaymentRequestButtonState = Record<
-	StripeAccount,
+	StripeAccountType,
 	StripePaymentRequestButtonData
 >;
 

--- a/support-frontend/assets/helpers/redux/checkout/payment/stripeAccountDetails/reducer.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/stripeAccountDetails/reducer.ts
@@ -1,6 +1,6 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
-import type { StripeAccount } from 'helpers/forms/stripe';
+import type { StripeAccountType } from 'helpers/forms/stripe';
 import { initialState } from './state';
 
 export const stripeAccountDetailsSlice = createSlice({
@@ -10,7 +10,7 @@ export const stripeAccountDetailsSlice = createSlice({
 		setStripePublicKey(state, action: PayloadAction<string>) {
 			state.publicKey = action.payload;
 		},
-		setStripeAccountName(state, action: PayloadAction<StripeAccount>) {
+		setStripeAccountName(state, action: PayloadAction<StripeAccountType>) {
 			state.stripeAccount = action.payload;
 		},
 	},

--- a/support-frontend/assets/helpers/redux/checkout/payment/stripeAccountDetails/state.ts
+++ b/support-frontend/assets/helpers/redux/checkout/payment/stripeAccountDetails/state.ts
@@ -1,8 +1,8 @@
-import type { StripeAccount } from 'helpers/forms/stripe';
+import type { StripeAccountType } from 'helpers/forms/stripe';
 
 export type StripeAccountDetailsState = {
 	publicKey: string;
-	stripeAccount: StripeAccount;
+	stripeAccount: StripeAccountType;
 };
 
 export const initialState: StripeAccountDetailsState = {

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -231,6 +231,8 @@ export function Checkout({
 		countryId,
 		currencyKey,
 		isTestUser,
+		productKey,
+		ratePlanKey,
 	);
 	const stripePromise = loadStripe(stripePublicKey);
 

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -2,7 +2,10 @@ import type { ActiveProductKey } from '@guardian/support-service-lambdas/modules
 import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import { useEffect } from 'react';
-import { getStripeKey } from 'helpers/forms/stripe';
+import {
+	getStripeKeyForCountry,
+	getStripeKeyForProduct,
+} from 'helpers/forms/stripe';
 import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import { Country } from 'helpers/internationalisation/classes/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
@@ -226,14 +229,9 @@ export function Checkout({
 	}
 
 	const isTestUser = !!cookie.get('_test_username');
-	const stripePublicKey = getStripeKey(
-		'REGULAR',
-		countryId,
-		currencyKey,
-		isTestUser,
-		productKey,
-		ratePlanKey,
-	);
+	const stripePublicKey =
+		getStripeKeyForProduct('REGULAR', productKey, ratePlanKey, isTestUser) ??
+		getStripeKeyForCountry('REGULAR', countryId, currencyKey, isTestUser);
 	const stripePromise = loadStripe(stripePublicKey);
 
 	const stripeExpressCheckoutSwitch =

--- a/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/oneTimeCheckout.tsx
@@ -1,7 +1,7 @@
 import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import { config } from 'helpers/contributions';
-import { getStripeKey } from 'helpers/forms/stripe';
+import { getStripeKeyForCountry } from 'helpers/forms/stripe';
 import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import { Country } from 'helpers/internationalisation/classes/country';
 import * as cookie from 'helpers/storage/cookie';
@@ -28,7 +28,7 @@ export function OneTimeCheckout({
 	const { currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 	const isTestUser = !!cookie.get('_test_username');
 
-	const stripePublicKey = getStripeKey(
+	const stripePublicKey = getStripeKeyForCountry(
 		'ONE_OFF',
 		countryId,
 		currencyKey,

--- a/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
+++ b/support-frontend/assets/pages/supporter-plus-landing/setup/legacyActionCreators.ts
@@ -22,7 +22,7 @@ import {
 } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
 import { DirectDebit, Sepa, Stripe } from 'helpers/forms/paymentMethods';
 import {
-	getStripeKey,
+	getStripeKeyForCountry,
 	stripeAccountForContributionType,
 } from 'helpers/forms/stripe';
 import type {
@@ -99,7 +99,7 @@ const buildStripeChargeDataFromAuthorisation = (
 		state.page.checkoutForm.billingAddress.fields.postCode,
 	),
 	publicKey:
-		/* why don't we use state.page.checkoutForm.payment.stripeAccountDetails.publicKey ?*/ getStripeKey(
+		/* why don't we use state.page.checkoutForm.payment.stripeAccountDetails.publicKey ?*/ getStripeKeyForCountry(
 			stripeAccountForContributionType[getContributionType(state)],
 			state.common.internationalisation.countryId,
 			state.common.internationalisation.currencyId,

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -118,7 +118,9 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
       val stripe = mock[StripePublicConfigProvider]
       val stripeAccountConfig = StripePublicKey.get("pk_test_asdf")
       when(stripe.get(any[Boolean]))
-        .thenReturn(StripePublicConfig(stripeAccountConfig, stripeAccountConfig, stripeAccountConfig))
+        .thenReturn(
+          StripePublicConfig(stripeAccountConfig, stripeAccountConfig, stripeAccountConfig, stripeAccountConfig),
+        )
       val payPal = mock[PayPalConfigProvider]
       when(payPal.get(any[Boolean])).thenReturn(PayPalConfig("", "", "", "", "", ""))
       val recaptchaConfigProvider = mock[RecaptchaConfigProvider]

--- a/support-models/src/main/scala/com/gu/support/zuora/api/PaymentGateway.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/PaymentGateway.scala
@@ -29,6 +29,7 @@ object PaymentGateway {
     case ZuoraInstanceDirectDebitGateway.name => ZuoraInstanceDirectDebitGateway
     case StripeGatewayPaymentIntentsDefault.name => StripeGatewayPaymentIntentsDefault
     case StripeGatewayPaymentIntentsAUD.name => StripeGatewayPaymentIntentsAUD
+    case StripeTortoiseMedia.name => StripeTortoiseMedia
   }
 
   implicit val encoder: Encoder[PaymentGateway] = Encoder.encodeString.contramap[PaymentGateway](_.name)
@@ -52,6 +53,10 @@ case object StripeGatewayPaymentIntentsDefault extends PaymentGateway {
 
 case object StripeGatewayPaymentIntentsAUD extends PaymentGateway {
   val name = "Stripe PaymentIntents GNM Membership AUS"
+}
+
+case object StripeTortoiseMedia extends PaymentGateway {
+  val name = "Stripe - Observer - Tortoise Media"
 }
 
 case object PayPalGateway extends PaymentGateway {

--- a/support-workers/src/test/resources/reference.conf
+++ b/support-workers/src/test/resources/reference.conf
@@ -10,6 +10,9 @@ touchpoint.backend.environments {
       default {
         api.key.secret = "sk_test_key_default"
       }
+      tortoiseMedia {
+        api.key.secret = "sk_test_key_tortoise"
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR add key config and a new payment gateway for the Tortoise media Stripe account. This is so that we can process payment for Sunday only newspaper sales using their Stripe account not ours.

## Changes
- Add new Stripe public keys to the touchpoint.conf files which we can then use to look up the secret keys
- Create all the relevant secret keys in config - S3 for support-workers and parameter store for support-frontend
- Add a new payment gateway for the Tortoise media Stripe account
- Use the new config and Stripe account throughout the stack for Sunday only newspaper subscription. Blended subscriptions (those which contain both a Guardian and an Observer element) are unchanged.

[**Trello Card**](https://trello.com/c/P8mvEADx/1507-use-sunday-only-payment-gateway-support-workers)
