### PR TITLE
When the user returns from Stripe hosted checkout, immediately submit the checkout form

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -323,7 +323,9 @@ export function CheckoutComponent({
 		.filter(isPaymentMethod)
 		.filter(paymentMethodIsActive);
 
-	const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>();
+	const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | undefined>(
+		checkoutSession ? StripeHostedCheckout : undefined,
+	);
 	const [paymentMethodError, setPaymentMethodError] = useState<string>();
 
 	/** Payment methods: Stripe */
@@ -359,6 +361,16 @@ export function CheckoutComponent({
 			formRef.current?.requestSubmit();
 		}
 	}, [payPalBAID]);
+	/**
+	 * Checkout session ID forces formOnSubmit
+	 */
+	useEffect(() => {
+		if (checkoutSession?.checkoutSessionId) {
+			// TODO - this might not meet our browser compatibility requirements (Safari)
+			// see: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/requestSubmit#browser_compatibility
+			formRef.current?.requestSubmit();
+		}
+	}, [checkoutSession?.checkoutSessionId]);
 	useEffect(() => {
 		if (paymentMethod === 'PayPal' && !payPalLoaded) {
 			void loadPayPalRecurring().then(() => setPayPalLoaded(true));

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -363,6 +363,7 @@ export function CheckoutComponent({
 	}, [payPalBAID]);
 	/**
 	 * Checkout session ID forces formOnSubmit
+	 * This happens when the user returns from the Stripe hosted checkout with a checkout session ID in the URL
 	 */
 	useEffect(() => {
 		if (checkoutSession?.checkoutSessionId) {


### PR DESCRIPTION
## What are you doing in this PR?

Building on #6892, when the user returns from the Stripe hosted checkout with a checkoutSessionId in the query string, we want to immediately submit the checkout form to the server to trigger the support workers request.

[**Trello Card**](https://trello.com)

## Why are you doing this?

To provide a smooth user journey throughout the payment flow.

## How to test

Go through the Stripe hosted checkout flow for Sunday only. After completing payment details with Stripe, the user is returned to the generic checkout which is immediately in a processing state having automatically submitted the checkout form.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
