### PR TITLE
Use Bearer token for auth with Stripe when creating checkout session

### DIFF
--- a/support-frontend/app/services/StripeCheckoutSessionService.scala
+++ b/support-frontend/app/services/StripeCheckoutSessionService.scala
@@ -58,8 +58,7 @@ class StripeCheckoutSessionService(
 
     client
       .url(s"$baseUrl/checkout/sessions")
-      // Note: auth is done via basic auth. See https://docs.stripe.com/api/authentication
-      .withAuth(privateKey, "", WSAuthScheme.BASIC)
+      .withHttpHeaders("Authorization" -> s"Bearer $privateKey")
       .withMethod("POST")
       // https: //www.playframework.com/documentation/3.0.x/ScalaWS#Submitting-form-data
       .withBody(data)


### PR DESCRIPTION
## What are you doing in this PR?

In the StripeCheckoutSessionService switch from using basic auth to specifying a Bearer token.

## Why are you doing this?

Compared with using basic auth this is more expected and consistent with how we do auth in other places, including with Stripe.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

The Stripe hosted checkout flow continues to work as normal.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
