### PR TITLE
Checkout Thankyou: Subscription feedback hide when Observer signed in

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -321,7 +321,8 @@ export function ThankYouComponent({
 			isOneOff ||
 				(!(isTierThree && showNewspaperArchiveBenefit) &&
 					isSignedIn &&
-					!isGuardianAdLite),
+					!isGuardianAdLite &&
+					!observerPrint),
 			'feedback',
 		),
 		...maybeThankYouModule(isDigitalEdition, 'appDownloadEditions'),


### PR DESCRIPTION
## What are you doing in this PR?

re:https://github.com/guardian/support-frontend/pull/6888

Small Signed-In bugfix as shown below->

|before|after|
|---|---|
|![image](https://github.com/user-attachments/assets/6ee57e60-8663-4e95-8788-5624c8dbe234)|![image](https://github.com/user-attachments/assets/69d82114-cf7d-4905-8d02-47ff7219a0ff)|

[**Trello Card**](https://trello.com/c/AglZdDpe/1451-update-ty-page-for-sunday-only)

## How to test

Via CODE (checked-In), HomeDelivery/Sunday
https://profile.code.dev-theguardian.com/signin?
https://support.code.dev-theguardian.com/uk/checkout?product=HomeDelivery&ratePlan=Sunday
https://support.code.dev-theguardian.com/uk/thank-you?product=HomeDelivery&ratePlan=Sunday&userType=current
