### PR TITLE
Add Observer disclaimer to newspaper packages cards

### DIFF
--- a/support-frontend/assets/helpers/legal.ts
+++ b/support-frontend/assets/helpers/legal.ts
@@ -42,6 +42,10 @@ const guardianWeeklyTermsLink =
 	'https://www.theguardian.com/info/2014/jul/10/guardian-weekly-print-subscription-services-terms-conditions';
 const guardianWeeklyPromoTermsLink =
 	'https://support.thegulocal.com/p/10ANNUAL/terms';
+const observerLinks = {
+	TERMS: 'https://www.tortoisemedia.com/observer/terms',
+	PRIVACY: 'https://www.tortoisemedia.com/observer/privacy',
+};
 // ----- Exports ----- //
 export {
 	contributionsTermsLinks,
@@ -56,4 +60,5 @@ export {
 	digitalSubscriptionTermsLink,
 	guardianWeeklyTermsLink,
 	guardianWeeklyPromoTermsLink,
+	observerLinks,
 };

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
@@ -11,6 +11,7 @@ import FlexContainer from 'components/containers/flexContainer';
 import ProductInfoChip from 'components/product/productInfoChip';
 import type { Product } from 'components/product/productOption';
 import ProductOption from 'components/product/productOption';
+import { observerLinks } from 'helpers/legal';
 import {
 	Collection,
 	HomeDelivery,
@@ -110,8 +111,9 @@ export function PaperPrices({
 	const infoTextMessages = {
 		delivery: 'Delivery is included.',
 		cancel_subscripton: 'You can cancel your subscription at any time.',
-		sunday_subscription:
-			'Sunday only subscriptions for The Observer are offered by Tortoise Media Ltd. Tortoise Media\'s <a href="https://www.tortoisemedia.com/observer/terms">terms and conditions</a> and <a href="https://www.tortoisemedia.com/observer/privacy">privacy policy</a> will apply.',
+		sunday_subscription: `Sunday only subscriptions for The Observer are offered by Tortoise Media Ltd. \
+							  Tortoise Media's <a href="${observerLinks.TERMS}">terms and conditions</a> and \
+							   <a href="${observerLinks.PRIVACY}">privacy policy</a> will apply.`,
 	};
 
 	const infoText = [

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
@@ -92,6 +92,9 @@ const productOverrideWithLabel = css`
 
 const pricesInfo = css`
 	margin-top: ${space[6]}px;
+	a {
+		color: ${palette.brand[500]};
+	}
 `;
 const pricesTabs = css`
 	margin-bottom: 13px;
@@ -104,9 +107,18 @@ export function PaperPrices({
 	setTabAction,
 	products,
 }: PaperPricesPropTypes): JSX.Element {
-	const infoText = `${
-		activeTab === HomeDelivery ? 'Delivery is included. ' : ''
-	}You can cancel your subscription at any time`;
+	const infoTextMessages = {
+		delivery: 'Delivery is included.',
+		cancel_subscripton: 'You can cancel your subscription at any time.',
+		sunday_subscription:
+			'Sunday only subscriptions for The Observer are offered by Tortoise Media Ltd. Tortoise Media\'s <a href="https://www.tortoisemedia.com/observer/terms">terms and conditions</a> and <a href="https://www.tortoisemedia.com/observer/privacy">privacy policy</a> will apply.',
+	};
+
+	const infoText = [
+		activeTab === HomeDelivery ? infoTextMessages.delivery : '',
+		infoTextMessages.cancel_subscripton,
+		shouldShowObserverCard() ? infoTextMessages.sunday_subscription : '',
+	].join(' ');
 
 	return (
 		<section css={pricesSection}>
@@ -155,7 +167,9 @@ export function PaperPrices({
 				))}
 			</FlexContainer>
 			<div css={pricesInfo}>
-				<ProductInfoChip icon={<SvgInfoRound />}>{infoText}</ProductInfoChip>
+				<ProductInfoChip icon={<SvgInfoRound />}>
+					<p dangerouslySetInnerHTML={{ __html: infoText }}></p>
+				</ProductInfoChip>
 			</div>
 		</section>
 	);


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Adding a disclaimer for the Sunday only (Observer) on the newspaper page below the package cards.
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/LGmBdpgX/1437-wording-changes-to-blended-newspaper-product-cards-and-sunday-product-card-add-disclaimer-plus-update-privacy-policy-and-terms-a)

## Why are you doing this?
Sunday only (Observer) is sell via Tortoise Media and we need to add their disclaimer info.
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Locally by adding the `?enableObserver=true` query param.

eg. https://support.thegulocal.com/uk/subscribe/paper?enableObserver=true
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots

### Observer flag disabled

![Screenshot 2025-04-04 at 14 56 19](https://github.com/user-attachments/assets/331435fb-2d32-42a6-b21f-f8bc527ebf66)

### Observer Flag enabled

![image (44)](https://github.com/user-attachments/assets/46910dd8-0e32-4c84-8263-21ac1629eda8)

