### PR TITLE
Observer: Checkout Thankyou footer hidden for Observer only

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -355,7 +355,7 @@ export function ThankYouComponent({
 			header={<Header />}
 			footer={
 				<FooterWithContents>
-					<ThankYouFooter />
+					{<ThankYouFooter observerPrint={observerPrint} />}
 				</FooterWithContents>
 			}
 		>

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouFooter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouFooter.tsx
@@ -8,7 +8,7 @@ const footer = css`
 	margin-bottom: 28px;
 
 	${from.desktop} {
-		min-height: 20px;
+		min-height: ${space[5]}px;
 		margin-bottom: ${space[2]}px;
 	}
 `;

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouFooter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouFooter.tsx
@@ -8,7 +8,7 @@ const footer = css`
 	margin-bottom: 28px;
 
 	${from.desktop} {
-		min-height: 15px;
+		min-height: 20px;
 		margin-bottom: ${space[2]}px;
 	}
 `;

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouFooter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouFooter.tsx
@@ -8,6 +8,7 @@ const footer = css`
 	margin-bottom: 28px;
 
 	${from.desktop} {
+		min-height: 15px;
 		margin-bottom: ${space[2]}px;
 	}
 `;

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouFooter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouFooter.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { from, space, textSans15 } from '@guardian/source/foundations';
+import type { ObserverPrint } from 'pages/paper-subscription-landing/helpers/products';
 
 const footer = css`
 	${textSans15};
@@ -11,11 +12,15 @@ const footer = css`
 	}
 `;
 
-function ThankYouFooter(): JSX.Element {
+interface ThankYouFooterProps {
+	observerPrint?: ObserverPrint;
+}
+function ThankYouFooter({ observerPrint }: ThankYouFooterProps): JSX.Element {
 	return (
 		<div css={footer}>
-			If you have any questions about supporting the Guardian, please contact
-			our customer service team.
+			{!observerPrint
+				? 'If you have any questions about supporting the Guardian, please contact	our customer service team.'
+				: ''}
 		</div>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouFooter.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouFooter.tsx
@@ -13,10 +13,11 @@ const footer = css`
 	}
 `;
 
-interface ThankYouFooterProps {
+function ThankYouFooter({
+	observerPrint,
+}: {
 	observerPrint?: ObserverPrint;
-}
-function ThankYouFooter({ observerPrint }: ThankYouFooterProps): JSX.Element {
+}): JSX.Element {
 	return (
 		<div css={footer}>
 			{!observerPrint


### PR DESCRIPTION
## What are you doing in this PR?

re: https://github.com/guardian/support-frontend/pull/6888

Hide thankyou page footer copy only for Observer only 

![image](https://github.com/user-attachments/assets/9877314c-e237-4208-a576-c1028e451514)

[**Trello Card**](https://trello.com/c/AglZdDpe/1451-update-ty-page-for-sunday-only)

## How to test
https://support.code.dev-theguardian.com/uk/thank-you?product=HomeDelivery&ratePlan=Sunday&userType=current