### PR TITLE
Different email campaigns for Sunday only

### DIFF
--- a/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
@@ -1,7 +1,7 @@
 package com.gu.emailservices
 
 import com.gu.salesforce.Salesforce.SfContactId
-import com.gu.support.catalog.{HomeDelivery, NationalDelivery, Paper}
+import com.gu.support.catalog.{Collection, HomeDelivery, NationalDelivery, Paper, Sunday}
 import com.gu.support.config.TouchPointEnvironment
 import com.gu.support.paperround.AgentsEndpoint.AgentDetails
 import com.gu.support.workers.ProductTypeRatePlans.paperRatePlan
@@ -31,9 +31,11 @@ class PaperEmailFields(
       "delivery_agent_postcode" -> deliveryAgentDetails.map(_.postcode).getOrElse(""),
     )
 
-    val dataExtension: String = paper.product.fulfilmentOptions match {
-      case HomeDelivery => "paper-delivery"
-      case NationalDelivery => "paper-national-delivery"
+    val dataExtension: String = (paper.product.fulfilmentOptions, paper.product.productOptions) match {
+      case (HomeDelivery, Sunday) => "TBD"
+      case (Collection, Sunday) => "TBD"
+      case (HomeDelivery, _) => "paper-delivery"
+      case (NationalDelivery, _) => "paper-national-delivery"
       case _ => "paper-subscription-card"
     }
 

--- a/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
@@ -32,8 +32,8 @@ class PaperEmailFields(
     )
 
     val dataExtension: String = (paper.product.fulfilmentOptions, paper.product.productOptions) match {
-      case (HomeDelivery, Sunday) => "TBD"
-      case (Collection, Sunday) => "TBD"
+      case (HomeDelivery, Sunday) => "sunday-paper-delivery"
+      case (Collection, Sunday) => "sunday-paper-subscription-card"
       case (HomeDelivery, _) => "paper-delivery"
       case (NationalDelivery, _) => "paper-national-delivery"
       case _ => "paper-subscription-card"


### PR DESCRIPTION
## What are you doing in this PR?

This PR adds two new day zero/thank-you email mappings for Sunday only newspaper subscriptions (one for subscription card, one for home delivery - the two supported products on the support site).

[**Trello Card**](https://trello.com/c/kJ77lF1E/1452-trigger-new-day-0-email-for-sunday-only)

## Why are you doing this?

Customers taking out Observer only subs should receive separate email comms.

## How to test

Take out Sunday only sub in code and ensure correct email is received.