### PR TITLE
Add Tortoise Direct Debit Payment Gateway

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
@@ -69,7 +69,7 @@ case class DirectDebitPaymentMethod(
     StreetNumber: Option[String],
     BankTransferType: String = "DirectDebitUK",
     Type: String = "BankTransfer",
-    PaymentGateway: PaymentGateway = DirectDebitGateway,
+    PaymentGateway: PaymentGateway,
 ) extends PaymentMethod
 
 case class ClonedDirectDebitPaymentMethod(

--- a/support-models/src/main/scala/com/gu/support/zuora/api/PaymentGateway.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/PaymentGateway.scala
@@ -25,6 +25,7 @@ object PaymentGateway {
     case StripeGatewayAUD.name => StripeGatewayAUD
     case PayPalGateway.name => PayPalGateway
     case DirectDebitGateway.name => DirectDebitGateway
+    case DirectDebitTortoiseMediaGateway.name => DirectDebitTortoiseMediaGateway
     case SepaGateway.name => SepaGateway
     case ZuoraInstanceDirectDebitGateway.name => ZuoraInstanceDirectDebitGateway
     case StripeGatewayPaymentIntentsDefault.name => StripeGatewayPaymentIntentsDefault
@@ -65,6 +66,10 @@ case object PayPalGateway extends PaymentGateway {
 
 case object DirectDebitGateway extends PaymentGateway {
   val name = "GoCardless"
+}
+
+case object DirectDebitTortoiseMediaGateway extends PaymentGateway {
+  val name = "GoCardless - Observer - Tortoise Media"
 }
 
 case object SepaGateway extends PaymentGateway {

--- a/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
@@ -166,6 +166,7 @@ object Fixtures {
     State = None,
     StreetName = Some("easy street"),
     StreetNumber = None,
+    PaymentGateway = DirectDebitGateway,
   )
   val productRatePlanId = "12345"
   val productRatePlanChargeId = "67890"

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -258,9 +258,9 @@ object JsonFixtures {
       {
         "productType": "Paper",
         "currency": "GBP",
-        "billingPeriod" : "Monthly",
-        "fulfilmentOptions" : "HomeDelivery",
-        "productOptions" : "Sunday"
+        "billingPeriod": "Monthly",
+        "fulfilmentOptions": "HomeDelivery",
+        "productOptions": "Sunday"
       }
     """
 

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -5,7 +5,15 @@ import com.gu.i18n.Country.UK
 import com.gu.i18n.Currency.GBP
 import com.gu.salesforce.Fixtures.{emailAddress, idId}
 import com.gu.salesforce.Salesforce.SalesforceContactRecords
-import com.gu.support.catalog.{Domestic, Everyday, HomeDelivery, NationalDelivery, RestOfWorld}
+import com.gu.support.catalog.{
+  Domestic,
+  Everyday,
+  FulfilmentOptions,
+  HomeDelivery,
+  NationalDelivery,
+  RestOfWorld,
+  Sunday,
+}
 import com.gu.support.paperround.AgentId
 import com.gu.support.workers.encoding.Conversions.StringInputStreamConversions
 import com.gu.support.workers.states.{AnalyticsInfo, CreateZuoraSubscriptionProductState, CreateZuoraSubscriptionState}
@@ -18,15 +26,14 @@ import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.{
   SupporterPlusState,
   TierThreeState,
 }
-import com.gu.support.zuora.api.StripeGatewayDefault
-import com.gu.zuora.Fixtures.deliveryAgentId
+import com.gu.support.zuora.api.{DirectDebitTortoiseMediaGateway, StripeGatewayDefault}
+import com.gu.zuora.Fixtures.{deliveryAgentId, directDebitPaymentMethod}
 import io.circe.parser
 import io.circe.syntax._
 import org.joda.time.{DateTimeZone, LocalDate}
 
 import java.io.ByteArrayInputStream
 import java.util.UUID
-import com.gu.support.catalog.FulfilmentOptions
 
 //noinspection TypeAnnotation
 object JsonFixtures {
@@ -246,6 +253,17 @@ object JsonFixtures {
       }
     """
 
+  val sundayPaperJson =
+    """
+      {
+        "productType": "Paper",
+        "currency": "GBP",
+        "billingPeriod" : "Monthly",
+        "fulfilmentOptions" : "HomeDelivery",
+        "productOptions" : "Sunday"
+      }
+    """
+
   val weeklyJson = GuardianWeekly(GBP, Monthly, Domestic).asJson.spaces2
 
   val digitalPackProductJson =
@@ -295,7 +313,8 @@ object JsonFixtures {
         "paymentType": "DirectDebit",
         "accountHolderName": "$mickeyMouse",
         "sortCode": "111111",
-        "accountNumber": "99999999"
+        "accountNumber": "99999999",
+        "recaptchaToken": "recaptchaToken"
       }
     """
 
@@ -370,7 +389,23 @@ object JsonFixtures {
             "paymentProvider": "DirectDebit",
             "isGiftPurchase": false
           },
-          "paymentFields": $directDebitJson
+          "paymentFields": $directDebitJson,
+          "ipAddress": "127.0.0.1",
+          "userAgent": "Test"
+        }"""
+
+  val createDirectDebitObserverJson =
+    s"""{
+          $requestIdJson,
+          ${userJson()},
+          "product": $sundayPaperJson,
+          "analyticsInfo": {
+            "paymentProvider": "DirectDebit",
+            "isGiftPurchase": false
+          },
+          "paymentFields": $directDebitJson,
+          "ipAddress": "127.0.0.1",
+          "userAgent": "Test"
         }"""
 
   val createSalesForceContactJson =

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -21,7 +21,7 @@ import com.gu.support.workers.integration.util.EmailQueueName
 import com.gu.support.workers.integration.util.EmailQueueName.emailQueueName
 import com.gu.support.workers.lambdas.SendThankYouEmail
 import com.gu.support.workers.states.SendThankYouEmailState._
-import com.gu.support.zuora.api.ReaderType
+import com.gu.support.zuora.api.{DirectDebitGateway, ReaderType}
 import com.gu.test.tags.objects.IntegrationTest
 import com.gu.threadpools.CustomPool.executionContext
 import io.circe.Json
@@ -383,6 +383,7 @@ object TestData {
     State = None,
     StreetName = Some("streetname"),
     StreetNumber = Some("123"),
+    PaymentGateway = DirectDebitGateway,
   )
 
   val digitalPackEmailFields = new DigitalPackEmailFields(

--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
@@ -1,25 +1,25 @@
 package com.gu.support.workers.lambdas
 
-import java.io.ByteArrayOutputStream
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.config.Configuration
-import com.gu.i18n.Currency
-import com.gu.i18n.Currency.GBP
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.services.{ServiceProvider, Services}
-import com.gu.stripe.Stripe.StripeList
 import com.gu.stripe._
-import com.gu.support.workers.JsonFixtures.{validBaid, _}
+import com.gu.support.workers.JsonFixtures._
 import com.gu.support.workers._
 import com.gu.support.workers.encoding.Conversions.{FromOutputStream, StringInputStreamConversions}
 import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.exceptions.RetryNone
 import com.gu.support.workers.states.CreateSalesforceContactState
-import com.gu.support.zuora.api.{DirectDebitTortoiseMediaGateway, StripeGatewayPaymentIntentsDefault}
+import com.gu.support.zuora.api.{
+  DirectDebitGateway,
+  DirectDebitTortoiseMediaGateway,
+  StripeGatewayPaymentIntentsDefault,
+}
 import com.gu.test.tags.objects.IntegrationTest
 import org.mockito.ArgumentMatchers._
-import org.mockito.Mockito._
 
+import java.io.ByteArrayOutputStream
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
@@ -71,6 +71,29 @@ class CreatePaymentMethodSpec extends AsyncLambdaSpec with MockContext {
   }
 
   it should "retrieve a valid DirectDebitPaymentMethod when given valid DD fields" in {
+
+    val createPaymentMethod = new CreatePaymentMethod(mockServices)
+
+    val outStream = new ByteArrayOutputStream()
+
+    createPaymentMethod
+      .handleRequestFuture(wrapFixture(createDirectDebitDigitalPackJson), outStream, context)
+      .map { _ =>
+        // Check the output
+        val createSalesforceContactState = Encoding.in[CreateSalesforceContactState](outStream.toInputStream)
+
+        createSalesforceContactState.isSuccess should be(true)
+        createSalesforceContactState.get._1.paymentMethod match {
+          case dd: DirectDebitPaymentMethod =>
+            withClue("direct debit: " + dd) {
+              dd.PaymentGateway should be(DirectDebitGateway)
+            }
+          case _ => fail()
+        }
+      }
+  }
+
+  it should "use the Tortoise Media payment gateway for Observer DD subs" in {
 
     val createPaymentMethod = new CreatePaymentMethod(mockServices)
 

--- a/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -78,18 +78,20 @@ object Fixtures {
     StripePaymentType = Some(StripePaymentType.StripeCheckout),
   )
   val payPalPaymentMethod = PayPalReferenceTransaction(payPalBaid, "test@paypal.com")
-  val directDebitPaymentMethod = DirectDebitPaymentMethod(
-    "Barry",
-    "Humphreys",
-    "Barry Humphreys",
-    "200000",
-    "55779911",
-    City = Some("Edited city"),
-    PostalCode = Some("n19gu"),
-    State = Some("blah"),
-    StreetName = Some("easy street"),
-    StreetNumber = Some("123"),
-  )
+  def directDebitPaymentMethod(paymentGateway: PaymentGateway = DirectDebitGateway): DirectDebitPaymentMethod =
+    DirectDebitPaymentMethod(
+      "Barry",
+      "Humphreys",
+      "Barry Humphreys",
+      "200000",
+      "55779911",
+      City = Some("Edited city"),
+      PostalCode = Some("n19gu"),
+      State = Some("blah"),
+      StreetName = Some("easy street"),
+      StreetNumber = Some("123"),
+      PaymentGateway = paymentGateway,
+    )
 
   val config = Configuration.load().zuoraConfigProvider.get()
   val monthlySubscriptionData = SubscriptionData(
@@ -154,14 +156,14 @@ object Fixtures {
       ),
     )
 
-  def directDebitSubscriptionRequest: SubscribeRequest =
+  def directDebitSubscriptionRequest(paymentGateway: PaymentGateway): SubscribeRequest =
     SubscribeRequest(
       List(
         SubscribeItem(
-          account(paymentGateway = DirectDebitGateway),
+          account(paymentGateway = paymentGateway),
           contactDetails,
           None,
-          Some(directDebitPaymentMethod),
+          Some(directDebitPaymentMethod()),
           monthlySubscriptionData,
           SubscribeOptions(),
         ),
@@ -175,7 +177,7 @@ object Fixtures {
           account(paymentGateway = DirectDebitGateway),
           contactDetails,
           Some(differentContactDetails),
-          Some(directDebitPaymentMethod),
+          Some(directDebitPaymentMethod()),
           everydayPaperSubscriptionData,
           SubscribeOptions(),
         ),
@@ -189,7 +191,7 @@ object Fixtures {
           account(paymentGateway = DirectDebitGateway),
           contactDetails,
           Some(differentContactDetailsOutsideLondon),
-          Some(directDebitPaymentMethod),
+          Some(directDebitPaymentMethod()),
           everydayNationalDeliveryPaperSubscriptionData,
           SubscribeOptions(),
         ),

--- a/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
@@ -6,7 +6,13 @@ import com.gu.i18n.Currency.{AUD, EUR, GBP, USD}
 import com.gu.okhttp.RequestRunners
 import com.gu.support.workers.{GetSubscriptionWithCurrentRequestId, IdentityId}
 import com.gu.support.zuora.api.response.{ZuoraAccountNumber, ZuoraErrorResponse}
-import com.gu.support.zuora.api.{PreviewSubscribeRequest, StripeGatewayPaymentIntentsAUD, SubscribeRequest}
+import com.gu.support.zuora.api.{
+  DirectDebitGateway,
+  DirectDebitTortoiseMediaGateway,
+  PreviewSubscribeRequest,
+  StripeGatewayPaymentIntentsAUD,
+  SubscribeRequest,
+}
 import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.zuora.Fixtures._
 import org.joda.time.{DateTime, DateTimeZone}
@@ -129,7 +135,11 @@ class ZuoraITSpec extends AsyncFlatSpec with Matchers {
     Right(creditCardSubscriptionRequest(AUD, StripeGatewayPaymentIntentsAUD)),
   )
 
-  it should "work with Direct Debit" in doRequest(Right(directDebitSubscriptionRequest))
+  it should "work with Direct Debit" in doRequest(Right(directDebitSubscriptionRequest(DirectDebitGateway)))
+
+  it should "work with Direct Debit for an Observer subscription" in doRequest(
+    Right(directDebitSubscriptionRequest(DirectDebitTortoiseMediaGateway)),
+  )
 
   it should "work for a paper subscription" in doRequest(Right(directDebitSubscriptionRequestPaper))
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR configures support-frontend to use a different Zuora payment gateway for Observer (Sunday only) newspaper subscriptions. 
This is required as we now want to process Observer payments through Tortoise media's Go Cardless account, not GNMs.

~~Because of a difference in the way that GNM and Tortoise Media's Go Cardless accounts are configured, we need to pass an email address in the payment method object for the Tortoise account. This is not needed for our account and may be removed in future if the Tortoise account is updated to match the GNM one.~~ The Tortoise account has now been reconfigured to no longer require an email address so this additional code was removed from this PR.

[**Trello Card**](https://trello.com/c/lrrRQHUb/1551-use-different-gateway-for-gocardless-sunday-subs-in-support-workers)
