### PR TITLE
[Stripe hosted checkout] Allow persisted deliveryInstructions field to be null

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
@@ -38,7 +38,7 @@ const formDetailsSchema = object({
 			}),
 		),
 	}),
-	deliveryInstructions: optional(string()),
+	deliveryInstructions: nullish(string()),
 	billingAddressMatchesDelivery: optional(boolean()),
 });
 


### PR DESCRIPTION
## What are you doing in this PR?

Allow persisted `deliveryInstructions` field to be null (saved in session storage before transferring to Stripe and retrieved when the user comes back to the support site).

## Why are you doing this?

I noticed that when checking out an Observer subscription with SubscriptionCard that the persisted form details were failing to parse. This was because deliveryInstructions was set to null (it isn't offered on the form) rather than undefined. This small schema change means we're able to de-serialize the persisted json and complete the checkout flow.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
