### PR TITLE
Only show the 'processing payment' copy on actual checkout completion

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -23,7 +23,6 @@ import type { ExpressPaymentType } from '@stripe/stripe-js';
 import { useEffect, useRef, useState } from 'react';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import DirectDebitForm from 'components/directDebit/directDebitForm/directDebitForm';
-import { LoadingOverlay } from 'components/loadingOverlay/loadingOverlay';
 import { ContributionsOrderSummary } from 'components/orderSummary/contributionsOrderSummary';
 import {
 	OrderSummaryStartDate,
@@ -95,6 +94,7 @@ import {
 } from '../validation';
 import { BackButton } from './backButton';
 import { CheckoutLayout } from './checkoutLayout';
+import { CheckoutLoadingOverlay } from './checkoutLoadingOverlay';
 import {
 	FormSection,
 	Legend,
@@ -1279,12 +1279,10 @@ export function CheckoutComponent({
 					<ContributionCheckoutFinePrint mobileTheme={'light'} />
 				</>
 			)}
-			{isProcessingPayment && (
-				<LoadingOverlay>
-					<p>Processing transaction</p>
-					<p>Please wait</p>
-				</LoadingOverlay>
-			)}
+			<CheckoutLoadingOverlay
+				showOverlay={isProcessingPayment}
+				showCopy={!isSundayOnlyNewspaperSub(productKey, ratePlanKey)}
+			/>
 		</CheckoutLayout>
 	);
 }

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutLoadingOverlay.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutLoadingOverlay.tsx
@@ -1,0 +1,26 @@
+import { LoadingOverlay } from '../../../components/loadingOverlay/loadingOverlay';
+
+export type CheckoutLoadingOverlayProps = {
+	showOverlay: boolean;
+	showCopy: boolean;
+};
+export function CheckoutLoadingOverlay({
+	showOverlay,
+	showCopy,
+}: CheckoutLoadingOverlayProps) {
+	if (!showOverlay) {
+		return null;
+	}
+	const copy = showCopy ? (
+		<div>
+			<p>Processing transaction</p>
+			<p>Please wait</p>
+		</div>
+	) : null;
+
+	return (
+		<div className="checkoutLoadingOverlay">
+			<LoadingOverlay>{copy}</LoadingOverlay>
+		</div>
+	);
+}


### PR DESCRIPTION
Not when we are just going to the Stripe hosted payment page.

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
