### PR TITLE
FIX: Set chosen delivery agent for postcodes with only one possible agent

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -457,6 +457,9 @@ export function CheckoutComponent({
 				// The users postcode is outside the M25 and they have selected a valid rate plan
 				setDeliveryPostcodeIsOutsideM25(true);
 				const agents = await getDeliveryAgents(postcode);
+				if (agents.agents?.length === 1 && agents.agents[0]) {
+					setChosenDeliveryAgent(agents.agents[0].agentId);
+				}
 				setDeliveryAgents(agents);
 			}
 		} else {


### PR DESCRIPTION
## What are you doing in this PR?
We have a bug on the generic checkout for National Delivery where if a customer's postcode only has one available delivery agent, then that agent will not be set as the chosen agent, meaning it is impossible to complete the checkout.

This is because the code currently relies on the user clicking the checkbox for their chosen provider to set the correct state.

This PR fixes that.

[**Trello Card**](https://trello.com/c/p1Vr9yu6/1568-fix-national-delivery-single-provider-bug)
