### PR TITLE
Checkout design changes for Sunday only

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -13,6 +13,7 @@ import {
 	Button,
 	SvgChevronDownSingle,
 } from '@guardian/source/react-components';
+import type { ProductKey } from '@modules/product-catalog/productCatalog';
 import { useState } from 'react';
 import {
 	BenefitsCheckList,
@@ -21,6 +22,7 @@ import {
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import type { Currency } from 'helpers/internationalisation/currency';
 import type { Promotion } from 'helpers/productPrice/promotions';
+import { isSundayOnlyNewspaperSub } from 'pages/[countryGroupId]/helpers/isSundayOnlyNewspaperSub';
 
 const componentStyles = css`
 	${textSans17}
@@ -117,6 +119,15 @@ const detailsSection = css`
 	}
 `;
 
+const orderSummarySundayDetails = css`
+	${textSans14};
+	color: ${neutral[38]};
+	background-color: ${neutral[97]};
+	margin-top: ${space[6]}px;
+	padding: ${space[3]}px;
+	border-radius: ${space[3]}px;
+`;
+
 const termsAndConditions = css`
 	${textSans17};
 	color: ${neutral[0]};
@@ -126,7 +137,9 @@ const termsAndConditions = css`
 `;
 
 export type ContributionsOrderSummaryProps = {
+	productKey: ProductKey;
 	productDescription: string;
+	ratePlanKey: string;
 	ratePlanDescription?: string;
 	amount: number;
 	promotion?: Promotion;
@@ -146,7 +159,9 @@ const visuallyHiddenCss = css`
 `;
 
 export function ContributionsOrderSummary({
+	productKey,
 	productDescription,
+	ratePlanKey,
 	ratePlanDescription,
 	amount,
 	promotion,
@@ -160,6 +175,10 @@ export function ContributionsOrderSummary({
 	enableCheckList,
 }: ContributionsOrderSummaryProps): JSX.Element {
 	const [showCheckList, setCheckList] = useState(false);
+	const isSundayOnlyNewspaperSubscription = isSundayOnlyNewspaperSub(
+		productKey,
+		ratePlanKey,
+	);
 
 	const hasCheckList = enableCheckList && checkListData.length > 0;
 	const checkList = hasCheckList && (
@@ -189,7 +208,7 @@ export function ContributionsOrderSummary({
 						{ratePlanDescription && <div>{ratePlanDescription}</div>}
 						{productDescription}
 					</p>
-					{hasCheckList && (
+					{(hasCheckList || isSundayOnlyNewspaperSubscription) && (
 						<Button
 							priority="subdued"
 							aria-expanded={showCheckList ? 'true' : 'false'}
@@ -211,6 +230,13 @@ export function ContributionsOrderSummary({
 						<div css={checklistContainer}>{checkList}</div>
 						{startDateTierThree}
 					</>
+				)}
+				{isSundayOnlyNewspaperSubscription && showCheckList && (
+					<div css={orderSummarySundayDetails}>
+						{productKey === 'HomeDelivery'
+							? 'Print edition, delivered every Sunday and access to exclusive slow news digital newsletters, thought-provoking podcasts and Think-Ins, discussions with journalists.'
+							: 'Print edition every Sunday and access to exclusive slow news digital newsletters, thought-provoking podcasts and Think-Ins, discussions with journalists.'}
+					</div>
 				)}
 			</div>
 

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -340,7 +340,7 @@ export const productCatalogDescription: Record<
 			},
 			Sunday: {
 				billingPeriod: 'Monthly',
-				label: 'The Observer package',
+				label: 'The Observer',
 			},
 		},
 	},
@@ -369,7 +369,7 @@ export const productCatalogDescription: Record<
 			},
 			Sunday: {
 				billingPeriod: 'Monthly',
-				label: 'The Observer package',
+				label: 'The Observer',
 			},
 		},
 	},

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -88,6 +88,7 @@ import type { DeliveryAgentsResponse } from '../checkout/helpers/getDeliveryAgen
 import { getDeliveryAgents } from '../checkout/helpers/getDeliveryAgents';
 import { getProductFields } from '../checkout/helpers/getProductFields';
 import type { CheckoutSession } from '../checkout/helpers/stripeCheckoutSession';
+import { isSundayOnlyNewspaperSub } from '../helpers/isSundayOnlyNewspaperSub';
 import {
 	doesNotContainExtendedEmojiOrLeadingSpace,
 	preventDefaultValidityMessage,
@@ -143,13 +144,6 @@ type CheckoutComponentProps = {
 	landingPageSettings: LandingPageVariant;
 	checkoutSession?: CheckoutSession;
 };
-
-const isSundayOnlyNewspaperSub = (
-	productKey: ProductKey,
-	ratePlanKey: string,
-) =>
-	['HomeDelivery', 'SubscriptionCard'].includes(productKey) &&
-	ratePlanKey === 'Sunday';
 
 const getPaymentMethods = (
 	countryId: IsoCountry,
@@ -633,7 +627,9 @@ export function CheckoutComponent({
 							</div>
 						)}
 					<ContributionsOrderSummary
+						productKey={productKey}
 						productDescription={productDescription.label}
+						ratePlanKey={ratePlanKey}
 						ratePlanDescription={ratePlanDescription.label}
 						paymentFrequency={
 							ratePlanDescription.billingPeriod === 'Annual'
@@ -662,6 +658,7 @@ export function CheckoutComponent({
 						tsAndCs={
 							<OrderSummaryTsAndCs
 								productKey={productKey}
+								ratePlanKey={ratePlanKey}
 								contributionType={contributionType}
 								countryGroupId={countryGroupId}
 								thresholdAmount={thresholdAmount}
@@ -1240,6 +1237,7 @@ export function CheckoutComponent({
 						</FormSection>
 						<SummaryTsAndCs
 							productKey={productKey}
+							ratePlanKey={ratePlanKey}
 							contributionType={contributionType}
 							currency={currencyKey}
 							amount={originalAmount}
@@ -1276,6 +1274,7 @@ export function CheckoutComponent({
 						)}
 						<PaymentTsAndCs
 							productKey={productKey}
+							ratePlanKey={ratePlanKey}
 							contributionType={contributionType}
 							countryGroupId={countryGroupId}
 							promotion={promotion}

--- a/support-frontend/assets/pages/[countryGroupId]/helpers/isSundayOnlyNewspaperSub.test.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/helpers/isSundayOnlyNewspaperSub.test.tsx
@@ -1,0 +1,22 @@
+import type { ActiveProductKey } from 'helpers/productCatalog';
+import { isSundayOnlyNewspaperSub } from './isSundayOnlyNewspaperSub';
+
+describe('isSundayOnlyNewspaperSub', () => {
+	it.each`
+		productKey            | ratePlanKey   | expected
+		${'HomeDelivery'}     | ${'Sunday'}   | ${true}
+		${'HomeDelivery'}     | ${'Everyday'} | ${false}
+		${'SubscriptionCard'} | ${'Sunday'}   | ${true}
+		${'SupporterPlus'}    | ${'Sunday'}   | ${false}
+	`(
+		`should return $expected for productKey $productKey and ratePlanKey $ratePlanKey`,
+		({ productKey, ratePlanKey, expected }) => {
+			const isSundayOnlyNewspaperSubscription = isSundayOnlyNewspaperSub(
+				productKey as ActiveProductKey,
+				ratePlanKey as string,
+			);
+
+			expect(isSundayOnlyNewspaperSubscription).toEqual(expected);
+		},
+	);
+});

--- a/support-frontend/assets/pages/[countryGroupId]/helpers/isSundayOnlyNewspaperSub.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/helpers/isSundayOnlyNewspaperSub.ts
@@ -1,0 +1,8 @@
+import type { ProductKey } from '@modules/product-catalog/productCatalog';
+
+export const isSundayOnlyNewspaperSub = (
+	productKey: ProductKey,
+	ratePlanKey: string,
+): boolean =>
+	['HomeDelivery', 'SubscriptionCard'].includes(productKey) &&
+	ratePlanKey === 'Sunday';

--- a/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.tsx
@@ -12,6 +12,7 @@ import {
 	guardianAdLiteTermsLink,
 	guardianWeeklyPromoTermsLink,
 	guardianWeeklyTermsLink,
+	observerLinks,
 	paperTermsLink,
 	privacyLink,
 	supporterPlusTermsLink,
@@ -23,6 +24,7 @@ import {
 	productCatalogDescription,
 } from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
+import { isSundayOnlyNewspaperSub } from 'pages/[countryGroupId]/helpers/isSundayOnlyNewspaperSub';
 import { FinePrint } from './finePrint';
 import { ManageMyAccountLink } from './manageMyAccountLink';
 
@@ -111,6 +113,7 @@ export function FooterTsAndCs({
 
 export interface PaymentTsAndCsProps {
 	productKey: ActiveProductKey;
+	ratePlanKey: string;
 	contributionType: ContributionType;
 	countryGroupId: CountryGroupId;
 	promotion?: Promotion;
@@ -118,11 +121,31 @@ export interface PaymentTsAndCsProps {
 }
 export function PaymentTsAndCs({
 	productKey,
+	ratePlanKey,
 	contributionType,
 	countryGroupId,
 	promotion,
 	thresholdAmount = 0,
 }: PaymentTsAndCsProps): JSX.Element {
+	const isSundayOnlynewsletterSubscription = isSundayOnlyNewspaperSub(
+		productKey,
+		ratePlanKey,
+	);
+
+	if (isSundayOnlynewsletterSubscription) {
+		return (
+			<div css={container}>
+				The Observer is owned by Tortoise Media. By proceeding, you agree to
+				Tortoise Media’s {termsLink('Terms & Conditions', observerLinks.TERMS)}.
+				We will share your contact and subscription details with our fulfilment
+				partners to provide you with your subscription card. To find out more
+				about what personal data Tortoise Media will collect and how it will be
+				used, please visit Tortoise Media’s{' '}
+				{termsLink('Privacy Policy', observerLinks.PRIVACY)}.
+			</div>
+		);
+	}
+
 	const paperHomeDeliveryTsAndCs = `We will share your contact and subscription details with our fulfilment partners.`;
 	const paperNationalDeliverySubscriptionTsAndCs = `We will share your contact and subscription details with our fulfilment partners to provide you with your subscription card.`;
 	const guardianWeeklyPromo = (

--- a/support-frontend/assets/pages/supporter-plus-landing/components/summaryTsAndCs.test.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/summaryTsAndCs.test.tsx
@@ -29,6 +29,7 @@ describe('Summary Ts&Cs Snapshot comparison', () => {
 				<SummaryTsAndCs
 					contributionType={contributionType as ContributionType}
 					productKey={productKey as ActiveProductKey}
+					ratePlanKey=""
 					currency={'GBP'}
 					amount={0}
 				/>,

--- a/support-frontend/assets/pages/supporter-plus-landing/components/summaryTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/summaryTsAndCs.tsx
@@ -13,6 +13,7 @@ import {
 	getDateWithOrdinal,
 	getLongMonth,
 } from 'helpers/utilities/dateFormatting';
+import { isSundayOnlyNewspaperSub } from 'pages/[countryGroupId]/helpers/isSundayOnlyNewspaperSub';
 
 const containerSummaryTsCs = css`
 	margin-top: ${space[6]}px;
@@ -40,16 +41,33 @@ const getRenewalFrequency = (contributionType: ContributionType) => {
 
 export interface SummaryTsAndCsProps {
 	productKey: ActiveProductKey;
+	ratePlanKey: string;
 	contributionType: ContributionType;
 	currency: IsoCurrency;
 	amount: number;
 }
 export function SummaryTsAndCs({
 	productKey,
+	ratePlanKey,
 	contributionType,
 	currency,
 	amount,
 }: SummaryTsAndCsProps): JSX.Element | null {
+	const isSundayOnlynewsletterSubscription = isSundayOnlyNewspaperSub(
+		productKey,
+		ratePlanKey,
+	);
+
+	if (isSundayOnlynewsletterSubscription) {
+		return (
+			<div css={containerSummaryTsCs}>
+				The Observer subscription will auto renew each month. You will be
+				charged the subscription amounts using your chosen payment method at
+				each renewal, at the rate then in effect, unless you cancel.
+			</div>
+		);
+	}
+
 	const amountWithCurrency = formatAmount(
 		currencies[currency],
 		spokenCurrencies[currency],


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
- Adding a drop down with mode details for the observer in the order summary.
- Update the legal wording and links to Tortoise T&C and Privacy pages of the payment TsandCs
- update copy for the observer only on summary TsandCs

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/OfqjwywD/1436-implement-checkout-design-changes-for-sunday-only-including-legal-wording-tortoise-media-privacy-policy-tcs-url-links-on-sunday)

## Why are you doing this?
As part of the subscriber flow, the checkout must comply with the observer only sale from tortoise media.
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
### OrderSummary
![Screenshot 2025-04-09 at 10 07 44](https://github.com/user-attachments/assets/325af8e2-f3c4-482b-ad62-8be489dff716)

### Summary and Payment TsAndCs
![Screenshot 2025-04-09 at 10 07 52](https://github.com/user-attachments/assets/7afd5cf5-3002-4da3-bf50-370120aa0952)


