### PR TITLE
allow PROD to access CODE soft opt ins queue for test users

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -19,5 +19,6 @@ There are also some other commands defined in `package.json`, including:
 - `yarn lint --fix` attempt to autofix any linter errors
 - `yarn format` format the code using Prettier
 - `yarn watch` watch for changes and compile
+- `yarn test -u` to update the snapshots
 
 However, it's advised you configure your IDE to format on save to avoid horrible "correct linting" commits.

--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -1531,22 +1531,40 @@ exports[`The Payment API stack matches the snapshot 1`] = `
                 "sqs:SendMessage",
               ],
               "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:sqs:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":soft-opt-in-consent-setter-queue-PROD",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:sqs:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":soft-opt-in-consent-setter-queue-PROD",
+                    ],
                   ],
-                ],
-              },
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:sqs:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":soft-opt-in-consent-setter-queue-CODE",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -160,6 +160,7 @@ export class PaymentApi extends GuStack {
               this.stage === "PROD"
                 ? [
                     `arn:aws:sqs:${this.region}:${this.account}:soft-opt-in-consent-setter-queue-PROD`,
+                    `arn:aws:sqs:${this.region}:${this.account}:soft-opt-in-consent-setter-queue-CODE`,
                   ]
                 : [
                     `arn:aws:sqs:${this.region}:${this.account}:soft-opt-in-consent-setter-queue-CODE`,


### PR DESCRIPTION
We have noticed that test users throw an alarm for soft opt ins.  This is because PROD payment api  needs access to CODE soft opt ins queue because that's what test users write to.
There seems to be an automated test running during working hours that triggers this alarm (on paypal)

This was lost (presumably accidentally) during some work on Acquisitions event bus in 2023
https://github.com/guardian/support-frontend/pull/5287/files#diff-b6df073cd69dab873008f8d5446751972fbe3a60543c01dc9a2ccd2a7ababba9L145-L146
https://github.com/guardian/support-frontend/pull/5287

This PR adds the necesssary permission.