### PR TITLE
Add PlayWright tests for Home Delivery and National Delivery

### DIFF
--- a/support-e2e/tests/smoke/checkout.test.ts
+++ b/support-e2e/tests/smoke/checkout.test.ts
@@ -24,6 +24,26 @@ test.describe('Checkout', () => {
 			paymentType: 'Credit/Debit card',
 			internationalisationId: 'UK',
 		},
+		{
+			product: 'HomeDelivery',
+			ratePlan: 'Everyday',
+			paymentType: 'Credit/Debit card',
+			internationalisationId: 'UK',
+		},
+		{
+			product: 'NationalDelivery',
+			ratePlan: 'Weekend',
+			paymentType: 'Credit/Debit card',
+			internationalisationId: 'UK',
+			postCode: 'BN44 3QG', // This postcode only has one delivery agent
+		},
+		{
+			product: 'NationalDelivery',
+			ratePlan: 'Weekend',
+			paymentType: 'Credit/Debit card',
+			internationalisationId: 'UK',
+			postCode: 'BS6 6QY', // This postcode has multiple delivery agents
+		},
 	].forEach((testDetails) => {
 		testCheckout(testDetails);
 	});

--- a/support-e2e/tests/utils/userFields.ts
+++ b/support-e2e/tests/utils/userFields.ts
@@ -77,13 +77,13 @@ export const ukWithBillingAndPostalAddress: TestFieldsGenerator = () => ({
 	],
 });
 
-export const ukWithPostalAddressOnly: TestFieldsGenerator = () => ({
+export const ukWithPostalAddressOnly = (postCode: string = 'N1 9GU') => ({
 	email: email(),
 	firstName: firstName(),
 	lastName: lastName(),
 	addresses: [
 		{
-			postCode: 'N1 9GU',
+			postCode: postCode,
 			firstLine: '90 York Way',
 			city: 'London',
 		},


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR adds PlayWright checkout smoke tests for three scenarios
- A home delivery purchase
- A National delivery purchase where there is only one available delivery provider - in this case the user does not need to take an action to proceed
- A National delivery purchase where there is more than one delivery provider - in this case the user needs to select a provider before proceeding


[**Trello Card**](https://trello.com/c/Xh6K9Gdl/1534-expand-playwrite-tests-for-print-products)

## Why are you doing this?
To improve our smoke test coverage so that we can have greater certainty when making changs that no regressions have been introduced.
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
Get fresh Janus credentials for the membership account
```
cd support-e2e
yarn test-smoke-dev
```
Run these three tests:
![Screenshot 2025-04-10 at 11 38 56](https://github.com/user-attachments/assets/69a502d5-d822-4585-803f-db779baea690)
