### PR TITLE
Fail on any TRANSACTION_FAILED message from Zuora

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -67,9 +67,7 @@ class FailureHandler(emailService: EmailService) extends Handler[FailureHandlerS
         exitHandler(
           state,
           checkoutFailureReason,
-          if (message.contains("postal_code is required if any address fields are provided"))
-            updatedRequestInfo.copy(failed = true)
-          else updatedRequestInfo,
+          updatedRequestInfo.copy(failed = true),
         )
       case Some(se @ StripeError("card_error", _, _, _, _)) =>
         val checkoutFailureReason = toCheckoutFailureReason(se)


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We have noticed that some failures from Zuora are not being alarmed on. This is because if the FailureHandler doesn't requestInfo.failed = true in it's output JSON the failure will be silent and the alarm will not be triggered.

I think that any TRANSACTION_FAILED message should probably be alarmed on. I'm not sure why most weren't being, there's probably a reason lost in the mists of time somewhere, but let's make sure they are for now and we can take it from there.

[**Trello Card**](https://trello.com/c/zexoCkvb/1574-check-why-dd-support-workers-failures-are-not-alarming)
