### PR TITLE
Push the newspaperGenericCheckout variant live to all users

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -123,9 +123,6 @@ export const tests: Tests = {
 	newspaperGenericCheckout: {
 		variants: [
 			{
-				id: 'control',
-			},
-			{
 				id: 'variant',
 			},
 		],


### PR DESCRIPTION
## What are you doing in this PR?

The `variant` is performing consistently with the `control` so we'd like to send all traffic the `variant`.  This is the fastest way to do this, in a follow-up we'll: 

1. Redirect the old Newspaper checkout URLs to the new Newspaper URLs.
2. Remove the A/B test / set the variant as the default / remove the old Newspaper checkout code
