### PR TITLE
Warn when resource-summary:document:size exceeds budget in lighthouse tests

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -6,7 +6,7 @@
         "largest-contentful-paint": ["error", { "maxNumericValue": 7000 }],
         "interactive": ["error", { "maxNumericValue": 9500 }],
         "resource-summary:document:size": [
-          "error",
+          "warn",
           { "maxNumericValue": 26000 }
         ]
       }


### PR DESCRIPTION
## What are you doing in this PR?

Our lighthouse Github action tests `resource-summary:document:size` and errors if exceeds the desired budget, this metric was stable for some time but is now subject to change regularly now this page is tooled. We're getting a lot of noisy alarms related to this. 

In an attempt to reduce the noise I've switched the way we handle this to "warn" instead of "error", as documented here: https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/configuration.md#levels

According the docs this will mean the audit result will be checked, and the result will be printed to stderr, but failure will not result in a non-zero exit code.

I could've turned it to "off" instead of "warn", but I hope "warn" will allow us to continue collect the metric and possibly graph it in the future, which is something the team have discussed.
