### PR TITLE
Direct Debit Legał copy  for Sunday only

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
@@ -4,15 +4,10 @@ import {
 	TextInput,
 } from '@guardian/source/react-components';
 import type { ReactNode } from 'react';
-import DirectDebitGuarantee from 'components/directDebit/directDebitForm/directDebitGuarantee';
 import { ElementDecorator } from 'components/stripeCardForm/elementDecorator';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { contributionsEmail } from 'helpers/legal';
-import {
-	accountNumberSortCodeContainer,
-	legalNotice,
-	recaptcha,
-} from './directDebitFormStyles';
+import * as styles from './directDebitFormStyles';
+import LegalNotice from './legalNotice';
 import type { DirectDebitFormDisplayErrors } from './selectors';
 
 export type DirectDebitFormProps = {
@@ -61,7 +56,7 @@ export default function DirectDebitForm(
 				name="accountHolderName"
 			/>
 
-			<div css={accountNumberSortCodeContainer}>
+			<div css={styles.accountNumberSortCodeContainer}>
 				<div>
 					<TextInput
 						label="Sort code"
@@ -111,7 +106,7 @@ export default function DirectDebitForm(
 			/>
 
 			{props.recaptcha && (
-				<div css={recaptcha}>
+				<div css={styles.recaptcha}>
 					<ElementDecorator
 						id="robot-checkbox"
 						text="Security check"
@@ -125,72 +120,6 @@ export default function DirectDebitForm(
 				countryGroupId={props.countryGroupId}
 				isSundayOnly={props.isSundayOnly}
 			/>
-			<DirectDebitGuarantee />
-		</div>
-	);
-}
-
-function LegalNotice(props: {
-	countryGroupId: CountryGroupId;
-	isSundayOnly?: boolean;
-}) {
-	if (props.isSundayOnly) {
-		return (
-			<div css={legalNotice}>
-				<p>
-					<strong>Payments by GoCardless</strong>
-					<br />
-					Read the{' '}
-					<a href="https://gocardless.com/privacy">GoCardless privacy notice</a>
-				</p>
-				<p>
-					<strong>Advance notice</strong>
-					<br />
-					The details of your Direct Debit instruction including payment
-					schedule, due date, frequency and amount will be sent to you within
-					three working days. All the normal Direct Debit safeguards and
-					guarantees apply, protected by the Direct Debit guarantee.
-				</p>
-				<p>
-					Tel: 0330 333 6767 (within UK). Lines are open 8am-8pm on weekdays,
-					8am-6pm at weekends (GMT/BST){' '}
-				</p>
-			</div>
-		);
-	}
-
-	return (
-		<div css={legalNotice}>
-			<p>
-				<strong>Payments by GoCardless </strong>
-				<a
-					href="https://gocardless.com/legal/privacy/"
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					read the GoCardless privacy notice.
-				</a>
-			</p>
-			<p>
-				<strong>Advance notice</strong> The details of your Direct Debit
-				instruction including payment schedule, due date, frequency and amount
-				will be sent to you within three working days. All the normal Direct
-				Debit safeguards and guarantees apply.
-			</p>
-			<p>
-				<strong>Direct Debit</strong>
-				<address>
-					The Guardian, Mease Mill, Westminster Industrial Estate, Measham,
-					Swadlincote, DE12 7DS
-				</address>
-				<br />
-				Tel: 0330 333 6767 (within UK). Lines are open 8am-8pm on weekdays,
-				9am-6pm at weekends (GMT/BST)
-				<br />
-				<a href={contributionsEmail[props.countryGroupId]}>
-					{contributionsEmail[props.countryGroupId].replace('mailto:', '')}
-				</a>
-			</p>
 		</div>
 	);
 }

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
@@ -3,8 +3,7 @@ import {
 	InlineError,
 	TextInput,
 } from '@guardian/source/react-components';
-import * as React from 'react';
-import { useState } from 'react';
+import type { ReactNode } from 'react';
 import DirectDebitGuarantee from 'components/directDebit/directDebitForm/directDebitGuarantee';
 import { ElementDecorator } from 'components/stripeCardForm/elementDecorator';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -23,11 +22,12 @@ export type DirectDebitFormProps = {
 	accountHolderConfirmation: boolean;
 	sortCode: string;
 	recaptchaCompleted: boolean;
+	isSundayOnly: boolean;
 	updateAccountHolderName: (name: string) => void;
 	updateAccountNumber: (number: string) => void;
 	updateSortCode: (sortCode: string) => void;
 	updateAccountHolderConfirmation: (confirmation: boolean) => void;
-	recaptcha: React.ReactNode;
+	recaptcha: ReactNode;
 	formError: string;
 	errors: DirectDebitFormDisplayErrors;
 };
@@ -36,8 +36,6 @@ export type DirectDebitFormProps = {
 export default function DirectDebitForm(
 	props: DirectDebitFormProps,
 ): JSX.Element {
-	const [guaranteeOpen, setGuaranteeOpen] = useState(false);
-
 	return (
 		<div>
 			{props.formError && (
@@ -123,18 +121,44 @@ export default function DirectDebitForm(
 				</div>
 			)}
 
-			<LegalNotice countryGroupId={props.countryGroupId} />
-
-			<DirectDebitGuarantee
-				isDDGuaranteeOpen={guaranteeOpen}
-				openDirectDebitGuarantee={() => setGuaranteeOpen(true)}
-				closeDirectDebitGuarantee={() => setGuaranteeOpen(false)}
+			<LegalNotice
+				countryGroupId={props.countryGroupId}
+				isSundayOnly={props.isSundayOnly}
 			/>
+			<DirectDebitGuarantee />
 		</div>
 	);
 }
 
-function LegalNotice(props: { countryGroupId: CountryGroupId }) {
+function LegalNotice(props: {
+	countryGroupId: CountryGroupId;
+	isSundayOnly: boolean;
+}) {
+	if (props.isSundayOnly) {
+		return (
+			<div css={legalNotice}>
+				<p>
+					<strong>Payments by GoCardless</strong>
+					<br />
+					Read the{' '}
+					<a href="https://gocardless.com/privacy">GoCardless privacy notice</a>
+				</p>
+				<p>
+					<strong>Advance notice</strong>
+					<br />
+					The details of your Direct Debit instruction including payment
+					schedule, due date, frequency and amount will be sent to you within
+					three working days. All the normal Direct Debit safeguards and
+					guarantees apply, protected by the Direct Debit guarantee.
+				</p>
+				<p>
+					Tel: 0330 333 6767 (within UK). Lines are open 8am-8pm on weekdays,
+					8am-6pm at weekends (GMT/BST){' '}
+				</p>
+			</div>
+		);
+	}
+
 	return (
 		<div css={legalNotice}>
 			<p>

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.tsx
@@ -22,7 +22,6 @@ export type DirectDebitFormProps = {
 	accountHolderConfirmation: boolean;
 	sortCode: string;
 	recaptchaCompleted: boolean;
-	isSundayOnly: boolean;
 	updateAccountHolderName: (name: string) => void;
 	updateAccountNumber: (number: string) => void;
 	updateSortCode: (sortCode: string) => void;
@@ -30,6 +29,7 @@ export type DirectDebitFormProps = {
 	recaptcha: ReactNode;
 	formError: string;
 	errors: DirectDebitFormDisplayErrors;
+	isSundayOnly?: boolean;
 };
 
 // ----- Component ----- //
@@ -132,7 +132,7 @@ export default function DirectDebitForm(
 
 function LegalNotice(props: {
 	countryGroupId: CountryGroupId;
-	isSundayOnly: boolean;
+	isSundayOnly?: boolean;
 }) {
 	if (props.isSundayOnly) {
 		return (

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitFormStyles.ts
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitFormStyles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, palette, space, until } from '@guardian/source/foundations';
+import { from, space } from '@guardian/source/foundations';
 
 export const accountNumberSortCodeContainer = css`
 	display: flex;
@@ -22,60 +22,4 @@ export const recaptcha = css`
 	margin-bottom: ${space[1]}px;
 	// This is the set width of the recaptcha iframe, to fix the helper text below to the same size
 	max-width: 304px;
-`;
-
-export const legalNotice = css`
-	font-size: ${space[3]}px;
-	color: ${palette.neutral[46]};
-	margin-top: ${space[5]}px;
-	margin-bottom: ${space[3]}px;
-	display: inline-block;
-
-	a {
-		color: ${palette.neutral[46]};
-	}
-
-	strong {
-		font-weight: bold;
-	}
-
-	${until.tablet} {
-		p {
-			margin-bottom: ${space[1]}px;
-		}
-	}
-`;
-
-export const guarantee = css`
-	font-size: ${space[3]}px;
-	color: ${palette.neutral[46]};
-	margin-bottom: ${space[5]}px;
-	a {
-		color: ${palette.neutral[46]};
-	}
-`;
-
-export const guaranteeList = css`
-	list-style-type: disc;
-	padding-left: ${space[4]}px;
-	padding-top: ${space[2]}px;
-	visibility: collapse;
-	max-height: 0px;
-	transition: max-height 0.25s ease-in-out;
-`;
-
-export const guaranteeListOpen = css`
-	visibility: visible;
-	max-height: 100vh;
-`;
-
-export const guaranteeListOpenLink = css`
-	background: none;
-	outline: none;
-	color: inherit;
-	border: none;
-	padding: 0;
-	font: inherit;
-	text-decoration: underline;
-	cursor: pointer;
 `;

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitFormStyles.ts
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitFormStyles.ts
@@ -57,11 +57,16 @@ export const guarantee = css`
 
 export const guaranteeList = css`
 	list-style-type: disc;
-	margin-left: ${space[4]}px;
+	padding-left: ${space[4]}px;
+	padding-top: ${space[2]}px;
+	visibility: collapse;
+	max-height: 0px;
+	transition: max-height 0.25s ease-in-out;
 `;
 
-export const guaranteeListClosed = css`
-	display: none;
+export const guaranteeListOpen = css`
+	visibility: visible;
+	max-height: 100vh;
 `;
 
 export const guaranteeListOpenLink = css`

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitGuarantee.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitGuarantee.tsx
@@ -1,65 +1,57 @@
 // ----- Imports ----- //
 
 import { useState } from 'react';
-import {
-	guarantee,
-	guaranteeList,
-	guaranteeListOpen,
-	guaranteeListOpenLink,
-} from './directDebitFormStyles';
+import * as styles from './directDebitGuaranteeStyles';
 
-function DirectDebitGuarantee(): JSX.Element {
+function DirectDebitGuarantee({ preText }: { preText: string }): JSX.Element {
 	const [guaranteeOpen, setGuaranteeOpen] = useState(false);
 
-	const onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-		event.preventDefault();
-		return setGuaranteeOpen((state) => !state);
-	};
+	const onClick = () => setGuaranteeOpen((state) => !state);
 
 	return (
-		<div css={guarantee}>
+		<div css={styles.guarantee}>
 			<p>
-				<span>
-					Your payments are protected by the{' '}
-					<button css={guaranteeListOpenLink} onClick={onClick}>
-						Direct Debit guarantee
-					</button>
-					.
+				{preText}
+				<span css={styles.guaranteeListOpenLink} onClick={onClick}>
+					Direct Debit guarantee.
 				</span>
-				<div>
-					<ul css={[guaranteeList, guaranteeOpen && guaranteeListOpen]}>
-						<li>
-							The Guarantee is offered by all banks and building societies that
-							accept instructions to pay Direct Debits
-						</li>
-						<li>
-							If there are any changes to the amount, date or frequency of your
-							Direct Debit Guardian News & Media Ltd will notify you at least
-							three working days in advance of your account being debited or as
-							otherwise agreed.
-						</li>
-						<li>
-							If you ask Guardian News & Media Ltd to collect a payment,
-							confirmation of the amount and date will be given to you at the
-							time of the request.
-						</li>
-						<li>
-							If an error is made in the payment of your Direct Debit by
-							Guardian News & Media Ltd or your bank or building society, you
-							are entitled to a full and immediate refund of the amount paid
-							from your bank or building society.
-						</li>
-						<li>
-							If you receive a refund you are not entitled to, you must pay it
-							back when Guardian News & Media Ltd asks you to.
-						</li>
-						<li>
-							You can cancel a Direct Debit at any time by contacting your bank
-							or building society. Written confirmation may be required. Please
-							also notify us.
-						</li>
-					</ul>
-				</div>
+				<ul
+					css={[
+						styles.guaranteeList,
+						guaranteeOpen && styles.guaranteeListOpen,
+					]}
+				>
+					<li>
+						The Guarantee is offered by all banks and building societies that
+						accept instructions to pay Direct Debits
+					</li>
+					<li>
+						If there are any changes to the amount, date or frequency of your
+						Direct Debit Guardian News & Media Ltd will notify you at least
+						three working days in advance of your account being debited or as
+						otherwise agreed.
+					</li>
+					<li>
+						If you ask Guardian News & Media Ltd to collect a payment,
+						confirmation of the amount and date will be given to you at the time
+						of the request.
+					</li>
+					<li>
+						If an error is made in the payment of your Direct Debit by Guardian
+						News & Media Ltd or your bank or building society, you are entitled
+						to a full and immediate refund of the amount paid from your bank or
+						building society.
+					</li>
+					<li>
+						If you receive a refund you are not entitled to, you must pay it
+						back when Guardian News & Media Ltd asks you to.
+					</li>
+					<li>
+						You can cancel a Direct Debit at any time by contacting your bank or
+						building society. Written confirmation may be required. Please also
+						notify us.
+					</li>
+				</ul>
 			</p>
 		</div>
 	);

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitGuarantee.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitGuarantee.tsx
@@ -1,11 +1,12 @@
 // ----- Imports ----- //
 
 import { useState } from 'react';
+import type { MediaGroup } from 'helpers/legal';
 import * as styles from './directDebitGuaranteeStyles';
 
 type Props = {
 	preText: string;
-	mediaGroup: string;
+	mediaGroup: MediaGroup;
 };
 
 function DirectDebitGuarantee({ preText, mediaGroup }: Props): JSX.Element {

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitGuarantee.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitGuarantee.tsx
@@ -3,7 +3,12 @@
 import { useState } from 'react';
 import * as styles from './directDebitGuaranteeStyles';
 
-function DirectDebitGuarantee({ preText }: { preText: string }): JSX.Element {
+type Props = {
+	preText: string;
+	mediaGroup: string;
+};
+
+function DirectDebitGuarantee({ preText, mediaGroup }: Props): JSX.Element {
 	const [guaranteeOpen, setGuaranteeOpen] = useState(false);
 
 	const onClick = () => setGuaranteeOpen((state) => !state);
@@ -23,28 +28,27 @@ function DirectDebitGuarantee({ preText }: { preText: string }): JSX.Element {
 				>
 					<li>
 						The Guarantee is offered by all banks and building societies that
-						accept instructions to pay Direct Debits
+						accept instructions to pay Direct Debits.
 					</li>
 					<li>
 						If there are any changes to the amount, date or frequency of your
-						Direct Debit Guardian News & Media Ltd will notify you at least
-						three working days in advance of your account being debited or as
-						otherwise agreed.
+						Direct Debit {mediaGroup} will notify you at least three working
+						days in advance of your account being debited or as otherwise
+						agreed.
 					</li>
 					<li>
-						If you ask Guardian News & Media Ltd to collect a payment,
-						confirmation of the amount and date will be given to you at the time
-						of the request.
+						If you ask {mediaGroup} to collect a payment, confirmation of the
+						amount and date will be given to you at the time of the request.
 					</li>
 					<li>
-						If an error is made in the payment of your Direct Debit by Guardian
-						News & Media Ltd or your bank or building society, you are entitled
-						to a full and immediate refund of the amount paid from your bank or
+						If an error is made in the payment of your Direct Debit by
+						{mediaGroup} or your bank or building society, you are entitled to a
+						full and immediate refund of the amount paid from your bank or
 						building society.
 					</li>
 					<li>
 						If you receive a refund you are not entitled to, you must pay it
-						back when Guardian News & Media Ltd asks you to.
+						back when {mediaGroup} asks you to.
 					</li>
 					<li>
 						You can cancel a Direct Debit at any time by contacting your bank or

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitGuarantee.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitGuarantee.tsx
@@ -1,38 +1,33 @@
 // ----- Imports ----- //
+
+import { useState } from 'react';
 import {
 	guarantee,
 	guaranteeList,
-	guaranteeListClosed,
+	guaranteeListOpen,
 	guaranteeListOpenLink,
 } from './directDebitFormStyles';
 
-type PropTypes = {
-	isDDGuaranteeOpen: boolean;
-	openDirectDebitGuarantee: () => void;
-	closeDirectDebitGuarantee: () => void;
-};
+function DirectDebitGuarantee(): JSX.Element {
+	const [guaranteeOpen, setGuaranteeOpen] = useState(false);
 
-function DirectDebitGuarantee(props: PropTypes): JSX.Element {
-	const onClick = props.isDDGuaranteeOpen
-		? props.closeDirectDebitGuarantee
-		: props.openDirectDebitGuarantee;
+	const onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+		event.preventDefault();
+		return setGuaranteeOpen((state) => !state);
+	};
+
 	return (
 		<div css={guarantee}>
 			<p>
 				<span>
-					Your payments are protected by the&nbsp;
+					Your payments are protected by the{' '}
 					<button css={guaranteeListOpenLink} onClick={onClick}>
 						Direct Debit guarantee
 					</button>
 					.
 				</span>
 				<div>
-					<ul
-						css={[
-							guaranteeList,
-							!props.isDDGuaranteeOpen && guaranteeListClosed,
-						]}
-					>
+					<ul css={[guaranteeList, guaranteeOpen && guaranteeListOpen]}>
 						<li>
 							The Guarantee is offered by all banks and building societies that
 							accept instructions to pay Direct Debits

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitGuaranteeStyles.ts
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitGuaranteeStyles.ts
@@ -1,0 +1,37 @@
+import { css } from '@emotion/react';
+import { palette, space, textSans12 } from '@guardian/source/foundations';
+
+export const guarantee = css`
+	${textSans12}
+	color: ${palette.neutral[46]};
+	margin-bottom: ${space[1]}px;
+	a {
+		color: ${palette.neutral[46]};
+	}
+`;
+
+export const guaranteeList = css`
+	overflow: hidden;
+	list-style-type: disc;
+	padding-left: ${space[4]}px;
+	padding-top: ${space[2]}px;
+	visibility: collapse;
+	max-height: 0px;
+	transition: max-height 0.25s ease-in-out;
+`;
+
+export const guaranteeListOpen = css`
+	visibility: visible;
+	max-height: 100vh;
+`;
+
+export const guaranteeListOpenLink = css`
+	background: none;
+	outline: none;
+	color: inherit;
+	border: none;
+	padding: 0;
+	font: inherit;
+	text-decoration: underline;
+	cursor: pointer;
+`;

--- a/support-frontend/assets/components/directDebit/directDebitForm/legalNotice.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/legalNotice.tsx
@@ -1,0 +1,76 @@
+import DirectDebitGuarantee from 'components/directDebit/directDebitForm/directDebitGuarantee';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { contributionsEmail } from 'helpers/legal';
+import * as styles from './legalNoticeStyles';
+
+function LegalNotice(props: {
+	countryGroupId: CountryGroupId;
+	isSundayOnly?: boolean;
+}) {
+	if (props.isSundayOnly) {
+		return (
+			<div css={styles.legalNotice}>
+				<p>
+					<strong>Payments by GoCardless</strong>
+					<br />
+					Read the{' '}
+					<a href="https://gocardless.com/privacy">GoCardless privacy notice</a>
+				</p>
+				<p>
+					<strong>Advance notice</strong>
+					<br />
+					The details of your Direct Debit instruction including payment
+					schedule, due date, frequency and amount will be sent to you within
+					three working days.{' '}
+					<DirectDebitGuarantee
+						preText="All the normal Direct Debit safeguards and
+					guarantees apply, protected by the "
+					/>
+				</p>
+				<p>
+					Tel: 0330 333 6767 (within UK). Lines are open 8am-8pm on weekdays,
+					8am-6pm at weekends (GMT/BST){' '}
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div css={styles.legalNotice}>
+			<p>
+				<strong>Payments by GoCardless </strong>
+				<a
+					href="https://gocardless.com/legal/privacy/"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					read the GoCardless privacy notice.
+				</a>
+			</p>
+			<p>
+				<strong>Advance notice</strong> The details of your Direct Debit
+				instruction including payment schedule, due date, frequency and amount
+				will be sent to you within three working days. All the normal Direct
+				Debit safeguards and guarantees apply.
+			</p>
+			<p>
+				<strong>Direct Debit</strong>
+				<address>
+					The Guardian, Mease Mill, Westminster Industrial Estate, Measham,
+					Swadlincote, DE12 7DS
+				</address>
+				<br />
+				Tel: 0330 333 6767 (within UK). Lines are open 8am-8pm on weekdays,
+				9am-6pm at weekends (GMT/BST)
+				<br />
+				<a href={contributionsEmail[props.countryGroupId]}>
+					{contributionsEmail[props.countryGroupId].replace('mailto:', '')}
+				</a>
+			</p>
+			<br />
+			<DirectDebitGuarantee preText="Your payments are protected by the " />
+		</div>
+	);
+}
+
+export default LegalNotice;

--- a/support-frontend/assets/components/directDebit/directDebitForm/legalNotice.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/legalNotice.tsx
@@ -1,6 +1,6 @@
 import DirectDebitGuarantee from 'components/directDebit/directDebitForm/directDebitGuarantee';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { contributionsEmail } from 'helpers/legal';
+import { contributionsEmail, MediaGroup } from 'helpers/legal';
 import * as styles from './legalNoticeStyles';
 
 function LegalNotice(props: {
@@ -25,6 +25,7 @@ function LegalNotice(props: {
 					<DirectDebitGuarantee
 						preText="All the normal Direct Debit safeguards and
 					guarantees apply, protected by the "
+						mediaGroup={MediaGroup.TORTOISE}
 					/>
 				</p>
 				<p>
@@ -68,7 +69,10 @@ function LegalNotice(props: {
 				</a>
 			</p>
 			<br />
-			<DirectDebitGuarantee preText="Your payments are protected by the " />
+			<DirectDebitGuarantee
+				preText="Your payments are protected by the "
+				mediaGroup={MediaGroup.GUARDIAN}
+			/>
 		</div>
 	);
 }

--- a/support-frontend/assets/components/directDebit/directDebitForm/legalNotice.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/legalNotice.tsx
@@ -14,7 +14,13 @@ function LegalNotice(props: {
 					<strong>Payments by GoCardless</strong>
 					<br />
 					Read the{' '}
-					<a href="https://gocardless.com/privacy">GoCardless privacy notice</a>
+					<a
+						href="https://gocardless.com/privacy"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						GoCardless privacy notice
+					</a>
 				</p>
 				<p>
 					<strong>Advance notice</strong>
@@ -39,13 +45,15 @@ function LegalNotice(props: {
 	return (
 		<div css={styles.legalNotice}>
 			<p>
-				<strong>Payments by GoCardless </strong>
+				<strong>Payments by GoCardless</strong>
+				<br />
+				Read the{' '}
 				<a
-					href="https://gocardless.com/legal/privacy/"
+					href="https://gocardless.com/privacy"
 					target="_blank"
 					rel="noopener noreferrer"
 				>
-					read the GoCardless privacy notice.
+					GoCardless privacy notice
 				</a>
 			</p>
 			<p>

--- a/support-frontend/assets/components/directDebit/directDebitForm/legalNoticeStyles.ts
+++ b/support-frontend/assets/components/directDebit/directDebitForm/legalNoticeStyles.ts
@@ -1,0 +1,29 @@
+import { css } from '@emotion/react';
+import {
+	palette,
+	space,
+	textSans12,
+	until,
+} from '@guardian/source/foundations';
+
+export const legalNotice = css`
+	${textSans12}
+	color: ${palette.neutral[46]};
+	margin-top: ${space[5]}px;
+	margin-bottom: ${space[3]}px;
+	display: inline-block;
+
+	a {
+		color: ${palette.neutral[46]};
+	}
+
+	strong {
+		font-weight: bold;
+	}
+
+	${until.tablet} {
+		p {
+			margin-bottom: ${space[1]}px;
+		}
+	}
+`;

--- a/support-frontend/assets/helpers/legal.ts
+++ b/support-frontend/assets/helpers/legal.ts
@@ -46,6 +46,10 @@ const observerLinks = {
 	TERMS: 'https://www.tortoisemedia.com/observer/terms',
 	PRIVACY: 'https://www.tortoisemedia.com/observer/privacy',
 };
+enum MediaGroup {
+	GUARDIAN = 'Guardian News & Media Ltd',
+	TORTOISE = 'GC re Tortoise Media Ltd t/a The Observer',
+}
 // ----- Exports ----- //
 export {
 	contributionsTermsLinks,
@@ -61,4 +65,5 @@ export {
 	guardianWeeklyTermsLink,
 	guardianWeeklyPromoTermsLink,
 	observerLinks,
+	MediaGroup,
 };

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -194,16 +194,8 @@ export function CheckoutComponent({
 	const ratePlanDescription = productDescription.ratePlans[ratePlanKey] ?? {
 		billingPeriod: 'Monthly',
 	};
-
+	const isSundayOnly = isSundayOnlyNewspaperSub(productKey, ratePlanKey);
 	const isRecurringContribution = productKey === 'Contribution';
-
-	const isRedirectingToStripeHostedCheckout = (
-		productKey: ProductKey,
-		ratePlanKey: string,
-	) =>
-		isSundayOnlyNewspaperSub(productKey, ratePlanKey) &&
-		checkoutSession === undefined &&
-		paymentMethod === StripeHostedCheckout;
 
 	const getBenefits = (): BenefitsCheckListData[] => {
 		// Three Tier products get their config from the Landing Page tool
@@ -327,6 +319,11 @@ export function CheckoutComponent({
 		checkoutSession ? StripeHostedCheckout : undefined,
 	);
 	const [paymentMethodError, setPaymentMethodError] = useState<string>();
+
+	const isRedirectingToStripeHostedCheckout =
+		isSundayOnly &&
+		checkoutSession === undefined &&
+		paymentMethod === StripeHostedCheckout;
 
 	/** Payment methods: Stripe */
 	const stripe = useStripe();
@@ -1198,6 +1195,7 @@ export function CheckoutComponent({
 														}
 														sortCode={sortCode}
 														recaptchaCompleted={false}
+														isSundayOnly={isSundayOnly}
 														updateAccountHolderName={(name: string) => {
 															setAccountHolderName(name);
 														}}
@@ -1293,10 +1291,7 @@ export function CheckoutComponent({
 			)}
 			{isProcessingPayment && (
 				<CheckoutLoadingOverlay
-					hideProcessingMessage={isRedirectingToStripeHostedCheckout(
-						productKey,
-						ratePlanKey,
-					)}
+					hideProcessingMessage={isRedirectingToStripeHostedCheckout}
 				/>
 			)}
 		</CheckoutLayout>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Display different copy for the Direct Debit payment option on the checkout for the Sunday only.
Refactored Direct Debit guarantee component and move state management inside the component.
prevent form submission on user click in the direct debit guarantee button 

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?
Direct Debit is not managed by the guardian for the Sunday only.
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Go to the checkout page using the following params:
Product  = HomeDelivery
ratePlan  = Sunday 

eg https://support.thegulocal.com/uk/checkout?product=HomeDelivery&ratePlan=Sunday
## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots

### Sunday Only
| Collapsed    | Expanded |
| -------- | ------- |
| <img width="592" alt="Screenshot 2025-04-14 at 14 34 54" src="https://github.com/user-attachments/assets/209dfed9-f69e-4b35-93f4-875a7976098f" /> | <img width="590" alt="Screenshot 2025-04-15 at 10 17 20" src="https://github.com/user-attachments/assets/8ba1082f-d50b-4abd-8fe9-506c257780ac" /> |


### Everyday
| Collapsed    | Expanded |
| -------- | ------- |
| <img width="585" alt="Screenshot 2025-04-14 at 14 37 18" src="https://github.com/user-attachments/assets/149eb3f6-3edb-462f-9e68-912e2636d550" /> |  <img width="585" alt="Screenshot 2025-04-14 at 14 37 25" src="https://github.com/user-attachments/assets/ad477ad7-5e14-4a6f-9339-5bf844569dfe" />
|

