### PR TITLE
Track StripePaymentRequestButton metrics distinctly

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/PaymentProvider.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentProvider.scala
@@ -27,6 +27,7 @@ object PaymentProvider {
   val all = List(
     Stripe,
     StripeApplePay,
+    StripePaymentRequestButton,
     PayPal,
     DirectDebit,
     Sepa,
@@ -50,6 +51,7 @@ object PaymentProvider {
     case stripe: StripePaymentFields =>
       stripe.stripePaymentType match {
         case Some(StripePaymentType.StripeApplePay) => StripeApplePay
+        case Some(StripePaymentType.StripePaymentRequestButton) => StripePaymentRequestButton
         case _ => Stripe
       }
     case _: PayPalPaymentFields => PayPal


### PR DESCRIPTION
## What are you doing in this PR?

When recording Cloudwatch metrics for `PaymentSuccess` track `StripePaymentRequestButton` in the payment provider dimension distinctly.

## Why are you doing this?

It looks like StripePaymentRequestButton payments (any payments via Stripe Express which aren't Apple Pay) appear in the metrics with a PaymentProvider of Stripe. We'd like to alarm on these so first we need to track them distinctly.

## How to test