### PR TITLE
Change observer terms and privacy links urls and color

### DIFF
--- a/support-frontend/assets/helpers/legal.ts
+++ b/support-frontend/assets/helpers/legal.ts
@@ -43,8 +43,8 @@ const guardianWeeklyTermsLink =
 const guardianWeeklyPromoTermsLink =
 	'https://support.thegulocal.com/p/10ANNUAL/terms';
 const observerLinks = {
-	TERMS: 'https://www.tortoisemedia.com/observer/terms',
-	PRIVACY: 'https://www.tortoisemedia.com/observer/privacy',
+	TERMS: 'https://www.observer.co.uk/policy/terms',
+	PRIVACY: 'https://www.observer.co.uk/policy/privacy',
 };
 // ----- Exports ----- //
 export {

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/paperPrices.tsx
@@ -94,7 +94,7 @@ const productOverrideWithLabel = css`
 const pricesInfo = css`
 	margin-top: ${space[6]}px;
 	a {
-		color: ${palette.brand[500]};
+		color: ${palette.neutral[100]};
 	}
 `;
 const pricesTabs = css`


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Change observer terms and privacy links urls and color

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card for updating colour**](https://trello.com/c/lCatMwoH/1584-accessibility-change-link-colour-to-white-for-tcs-and-privacy-policy)
[**Trello Card for updating links**](https://trello.com/c/PRmL0dtu/1581-update-the-new-observer-tortoise-media-urls-for-privacy-policy-and-terms-and-conditions-to-their-post-completion-urls)

## Why are you doing this?

To match layout specs.
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
Locally
https://support.thegulocal.com/uk/subscribe/paper?enableObserver=true

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
<img width="1300" alt="Screenshot 2025-04-14 at 16 45 04" src="https://github.com/user-attachments/assets/86d5d35a-fda8-458c-ae83-ae77e4609c8d" />

