### PR TITLE
Provide a back button on Stripe hosted checkout

### DIFF
--- a/support-frontend/test/services/StripeCheckoutSessionServiceSpec.scala
+++ b/support-frontend/test/services/StripeCheckoutSessionServiceSpec.scala
@@ -39,4 +39,28 @@ class StripeCheckoutSessionServiceSpec extends AnyFlatSpec with Matchers {
 
     successUrl should be(None)
   }
+
+  "validateCancelUrl" should "return the referer if it's valid" in {
+    val referer = "https://support.theguardian.com/uk/checkout?product=HomeDelivery&ratePlan=Sunday"
+
+    val cancelUrl = StripeCheckoutSessionService.validateCancelUrl(referer)
+
+    cancelUrl should be(Some(referer))
+  }
+
+  it should "return None if the referer is not a valid domain" in {
+    val referer = "https://www.example.com?product=HomeDelivery&ratePlan=Sunday"
+
+    val cancelUrl = StripeCheckoutSessionService.validateCancelUrl(referer)
+
+    cancelUrl should be(None)
+  }
+
+  it should "return None for a non https referer" in {
+    val referer = "http://support.theguardian.com/uk/checkout?product=HomeDelivery&ratePlan=Sunday"
+
+    val cancelUrl = StripeCheckoutSessionService.validateCancelUrl(referer)
+
+    cancelUrl should be(None)
+  }
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

When the user is transferred to the Stripe hosted checkout, provide a back button by specifying a `cancel_url` when creating the Stripe checkout session. We use the referer, after validating that it's a sensible domain and https.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/I4Lql8UR/1585-add-back-url-link-to-stripe-hosted-checkout)

## Why are you doing this?

It's confusing to transfer the user to Stripe and not give them a route back to the support site.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Visit the generic checkout for HomeDelivery/SubscriptionCard for Sunday only. Fill in the form and select Credit/Debit Card as the payment method and click `Continue to Payment`. After transferring to Stripe, there should be a back CTA at the top right. Clicking this takes you back to the generic checkout with the same product options as before. Note the form itself will not be filled.

<img width="397" alt="Screenshot 2025-04-14 at 17 10 59" src="https://github.com/user-attachments/assets/53464111-ed71-4978-b1a5-9727c8ef3809" />
