### PR TITLE
Add alarms for period with no Stripe Apple Pay/Google Pay payments

### DIFF
--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -26,6 +26,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
       "GuAlarm",
       "GuAlarm",
       "GuAlarm",
+      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -1217,6 +1218,221 @@ exports[`The support-workers stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
+    "NoApplePayRecurringAlarmBF134839": {
+      "DependsOn": [
+        "SupportWorkersPROD",
+        "SupportWorkersRoleDefaultPolicyCB757939",
+        "SupportWorkersRole33385BA0",
+      ],
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
+        "AlarmName": "support-workers PROD No successful recurring Apple Pay payments in 8 hours.",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "EvaluationPeriods": 96,
+        "Metrics": [
+          {
+            "Expression": "SUM([FILL(m0,0),FILL(m1,0),FILL(m2,0),FILL(m3,0),FILL(m4,0),FILL(m5,0)])",
+            "Id": "expr_1",
+            "Label": "AllRecurringApplePayPayments",
+          },
+          {
+            "Id": "m0",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripeApplePay",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "Contribution",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripeApplePay",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "Paper",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripeApplePay",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "GuardianWeekly",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m3",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripeApplePay",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "SupporterPlus",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m4",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripeApplePay",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "TierThree",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m5",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripeApplePay",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "GuardianAdLite",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "NoGocardlessContributionsAlarmD9872C48": {
       "DependsOn": [
         "SupportWorkersPROD",
@@ -1334,6 +1550,221 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "Namespace": "support-frontend",
         "Period": 3600,
         "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "NoGooglePayRecurringAlarm3A098926": {
+      "DependsOn": [
+        "SupportWorkersPROD",
+        "SupportWorkersRoleDefaultPolicyCB757939",
+        "SupportWorkersRole33385BA0",
+      ],
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
+        "AlarmName": "support-workers PROD No successful recurring Google Pay payments in 15 hours.",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "EvaluationPeriods": 180,
+        "Metrics": [
+          {
+            "Expression": "SUM([FILL(m0,0),FILL(m1,0),FILL(m2,0),FILL(m3,0),FILL(m4,0),FILL(m5,0)])",
+            "Id": "expr_1",
+            "Label": "AllRecurringGooglePayPayments",
+          },
+          {
+            "Id": "m0",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripePaymentRequestButton",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "Contribution",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripePaymentRequestButton",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "Paper",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripePaymentRequestButton",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "GuardianWeekly",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m3",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripePaymentRequestButton",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "SupporterPlus",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m4",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripePaymentRequestButton",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "TierThree",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m5",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripePaymentRequestButton",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "GuardianAdLite",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -1681,117 +2112,6 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "Namespace": "support-frontend",
         "Period": 3600,
         "Statistic": "Sum",
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-frontend",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "Threshold": 0,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "NoStripeExpressRecurringAlarmCA3567A2": {
-      "DependsOn": [
-        "SupportWorkersPROD",
-        "SupportWorkersRoleDefaultPolicyCB757939",
-        "SupportWorkersRole33385BA0",
-      ],
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-PROD",
-              ],
-            ],
-          },
-        ],
-        "AlarmName": "support-workers PROD No successful recurring Stripe Express payments in 6 hours.",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "EvaluationPeriods": 72,
-        "Metrics": [
-          {
-            "Expression": "SUM([FILL(m1,0),FILL(m2,0)])",
-            "Id": "expr_1",
-            "Label": "AllRecurringStripeExpressPayments",
-          },
-          {
-            "Id": "m1",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "PaymentProvider",
-                    "Value": "StripeApplePay",
-                  },
-                  {
-                    "Name": "ProductType",
-                    "Value": "*",
-                  },
-                  {
-                    "Name": "Stage",
-                    "Value": "PROD",
-                  },
-                ],
-                "MetricName": "PaymentSuccess",
-                "Namespace": "support-frontend",
-              },
-              "Period": 300,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-          {
-            "Id": "m2",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "PaymentProvider",
-                    "Value": "StripePaymentRequestButton",
-                  },
-                  {
-                    "Name": "ProductType",
-                    "Value": "*",
-                  },
-                  {
-                    "Name": "Stage",
-                    "Value": "PROD",
-                  },
-                ],
-                "MetricName": "PaymentSuccess",
-                "Namespace": "support-frontend",
-              },
-              "Period": 300,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -25,6 +25,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
       "GuAlarm",
       "GuAlarm",
       "GuAlarm",
+      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -1680,6 +1681,117 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "Namespace": "support-frontend",
         "Period": 3600,
         "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "NoStripeExpressRecurringAlarmCA3567A2": {
+      "DependsOn": [
+        "SupportWorkersPROD",
+        "SupportWorkersRoleDefaultPolicyCB757939",
+        "SupportWorkersRole33385BA0",
+      ],
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
+        "AlarmName": "support-workers PROD No successful recurring Stripe Express payments in 6 hours.",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "EvaluationPeriods": 72,
+        "Metrics": [
+          {
+            "Expression": "SUM([FILL(m1,0),FILL(m2,0)])",
+            "Id": "expr_1",
+            "Label": "AllRecurringStripeExpressPayments",
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripeApplePay",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "*",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripePaymentRequestButton",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "*",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -27,15 +27,31 @@ import {
 } from "aws-cdk-lib/aws-stepfunctions";
 import { LambdaInvoke } from "aws-cdk-lib/aws-stepfunctions-tasks";
 
-type PaymentProvider = "Stripe" | "DirectDebit" | "PayPal" | "StripeApplePay" | "StripePaymentRequestButton";
+const Contribution = "Contribution";
+const Paper = "Paper";
+const GuardianWeekly = "GuardianWeekly";
+const SupporterPlus = "SupporterPlus";
+const TierThree = "TierThree";
+const GuardianAdLite = "GuardianAdLite";
 
 type ProductType =
-  | "Contribution"
-  | "Paper"
-  | "GuardianWeekly"
-  | "SupporterPlus"
-  | "TierThree"
-  | "GuardianAdLite";
+  | typeof Contribution
+  | typeof Paper
+  | typeof GuardianWeekly
+  | typeof SupporterPlus
+  | typeof TierThree
+  | typeof GuardianAdLite;
+
+const allProducts: ProductType[]  = [
+  Contribution,
+  Paper,
+  GuardianWeekly,
+  SupporterPlus,
+  TierThree,
+  GuardianAdLite,
+];
+
+type PaymentProvider = "Stripe" | "DirectDebit" | "PayPal" | "StripeApplePay" | "StripePaymentRequestButton";
 
 interface SupportWorkersProps extends GuStackProps {
   promotionsDynamoTables: string[];
@@ -420,37 +436,67 @@ export class SupportWorkers extends GuStack {
       threshold: 0,
     }).node.addDependency(stateMachine);
 
-    const stripeExpressMetricDuration = Duration.minutes(5);
-    const stripeExpressEvaluationPeriods = 72; // The number of 5 minute periods in 6 hours
-    const stripeExpressAlarmPeriod = Duration.minutes(
-      stripeExpressMetricDuration.toMinutes() * stripeExpressEvaluationPeriods
+    // Begin Apple Pay alarm
+    const applePayMetricDuration = Duration.minutes(5);
+    const applePayEvaluationPeriods = 96; // The number of 5 minute periods in 8 hours
+    const applePayAlarmPeriod = Duration.minutes(
+      applePayMetricDuration.toMinutes() * applePayEvaluationPeriods
     );
-    new GuAlarm(this, "NoStripeExpressRecurringAlarm", {
+    const applePayMetrics = Object.fromEntries(allProducts.map((product, idx) =>
+    [`m${idx}`, this.buildPaymentSuccessMetric(
+        "StripeApplePay",
+        product,
+        applePayMetricDuration
+      )]
+    ));
+    const applePayExpression = `SUM([${Object.keys(applePayMetrics).map(m => `FILL(${m},0)`).join(",")}])`;
+    new GuAlarm(this, "NoApplePayRecurringAlarm", {
       app,
       actionsEnabled: isProd,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `support-workers ${this.stage} No successful recurring Stripe Express payments in ${stripeExpressAlarmPeriod.toHumanString()}.`,
+      alarmName: `support-workers ${this.stage} No successful recurring Apple Pay payments in ${applePayAlarmPeriod.toHumanString()}.`,
       metric: new MathExpression({
-        expression: "SUM([FILL(m1,0),FILL(m2,0)])",
-        label: "AllRecurringStripeExpressPayments",
-        usingMetrics: {
-          m1: this.buildPaymentSuccessMetric(
-            "StripeApplePay",
-            "*",
-            stripeExpressMetricDuration,
-          ),
-          m2: this.buildPaymentSuccessMetric(
-            "StripePaymentRequestButton",
-            "*",
-            stripeExpressMetricDuration,
-          ),
-        },
+        expression: applePayExpression,
+        label: "AllRecurringApplePayPayments",
+        usingMetrics: applePayMetrics,
       }),
       comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
-      evaluationPeriods: stripeExpressEvaluationPeriods,
+      evaluationPeriods: applePayEvaluationPeriods,
       treatMissingData: TreatMissingData.BREACHING,
       threshold: 0,
     }).node.addDependency(stateMachine);
+    // End Apple Pay alarm
+
+    // Begin Google Pay alarm
+    const googlePayMetricDuration = Duration.minutes(5);
+    const googlePayEvaluationPeriods = 180; // The number of 5 minute periods in 15 hours
+    const googlePayAlarmPeriod = Duration.minutes(
+      googlePayMetricDuration.toMinutes() * googlePayEvaluationPeriods
+    );
+    const googlePayMetrics = Object.fromEntries(allProducts.map((product, idx) =>
+    [`m${idx}`, this.buildPaymentSuccessMetric(
+        "StripePaymentRequestButton",
+        product,
+        googlePayMetricDuration
+      )]
+    ));
+    const googlePayExpression = `SUM([${Object.keys(googlePayMetrics).map(m => `FILL(${m},0)`).join(",")}])`;
+    new GuAlarm(this, "NoGooglePayRecurringAlarm", {
+      app,
+      actionsEnabled: isProd,
+      snsTopicName: `alarms-handler-topic-${this.stage}`,
+      alarmName: `support-workers ${this.stage} No successful recurring Google Pay payments in ${googlePayAlarmPeriod.toHumanString()}.`,
+      metric: new MathExpression({
+        expression: googlePayExpression,
+        label: "AllRecurringGooglePayPayments",
+        usingMetrics: googlePayMetrics,
+      }),
+      comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
+      evaluationPeriods: googlePayEvaluationPeriods,
+      treatMissingData: TreatMissingData.BREACHING,
+      threshold: 0,
+    }).node.addDependency(stateMachine);
+    // End Google Pay alarm
 
     // This alarm is for the PaymentSuccess metric where
     // ProductType == Paper AND PaymentProvider in [Stripe, Gocardless, Paypal]

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -42,7 +42,7 @@ type ProductType =
   | typeof TierThree
   | typeof GuardianAdLite;
 
-const allProducts: ProductType[]  = [
+const allProducts: ProductType[] = [
   Contribution,
   Paper,
   GuardianWeekly,
@@ -51,7 +51,12 @@ const allProducts: ProductType[]  = [
   GuardianAdLite,
 ];
 
-type PaymentProvider = "Stripe" | "DirectDebit" | "PayPal" | "StripeApplePay" | "StripePaymentRequestButton";
+type PaymentProvider =
+  | "Stripe"
+  | "DirectDebit"
+  | "PayPal"
+  | "StripeApplePay"
+  | "StripePaymentRequestButton";
 
 interface SupportWorkersProps extends GuStackProps {
   promotionsDynamoTables: string[];
@@ -442,19 +447,26 @@ export class SupportWorkers extends GuStack {
     const applePayAlarmPeriod = Duration.minutes(
       applePayMetricDuration.toMinutes() * applePayEvaluationPeriods
     );
-    const applePayMetrics = Object.fromEntries(allProducts.map((product, idx) =>
-    [`m${idx}`, this.buildPaymentSuccessMetric(
-        "StripeApplePay",
-        product,
-        applePayMetricDuration
-      )]
-    ));
-    const applePayExpression = `SUM([${Object.keys(applePayMetrics).map(m => `FILL(${m},0)`).join(",")}])`;
+    const applePayMetrics = Object.fromEntries(
+      allProducts.map((product, idx) => [
+        `m${idx}`,
+        this.buildPaymentSuccessMetric(
+          "StripeApplePay",
+          product,
+          applePayMetricDuration
+        ),
+      ])
+    );
+    const applePayExpression = `SUM([${Object.keys(applePayMetrics)
+      .map((m) => `FILL(${m},0)`)
+      .join(",")}])`;
     new GuAlarm(this, "NoApplePayRecurringAlarm", {
       app,
       actionsEnabled: isProd,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `support-workers ${this.stage} No successful recurring Apple Pay payments in ${applePayAlarmPeriod.toHumanString()}.`,
+      alarmName: `support-workers ${
+        this.stage
+      } No successful recurring Apple Pay payments in ${applePayAlarmPeriod.toHumanString()}.`,
       metric: new MathExpression({
         expression: applePayExpression,
         label: "AllRecurringApplePayPayments",
@@ -473,19 +485,26 @@ export class SupportWorkers extends GuStack {
     const googlePayAlarmPeriod = Duration.minutes(
       googlePayMetricDuration.toMinutes() * googlePayEvaluationPeriods
     );
-    const googlePayMetrics = Object.fromEntries(allProducts.map((product, idx) =>
-    [`m${idx}`, this.buildPaymentSuccessMetric(
-        "StripePaymentRequestButton",
-        product,
-        googlePayMetricDuration
-      )]
-    ));
-    const googlePayExpression = `SUM([${Object.keys(googlePayMetrics).map(m => `FILL(${m},0)`).join(",")}])`;
+    const googlePayMetrics = Object.fromEntries(
+      allProducts.map((product, idx) => [
+        `m${idx}`,
+        this.buildPaymentSuccessMetric(
+          "StripePaymentRequestButton",
+          product,
+          googlePayMetricDuration
+        ),
+      ])
+    );
+    const googlePayExpression = `SUM([${Object.keys(googlePayMetrics)
+      .map((m) => `FILL(${m},0)`)
+      .join(",")}])`;
     new GuAlarm(this, "NoGooglePayRecurringAlarm", {
       app,
       actionsEnabled: isProd,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `support-workers ${this.stage} No successful recurring Google Pay payments in ${googlePayAlarmPeriod.toHumanString()}.`,
+      alarmName: `support-workers ${
+        this.stage
+      } No successful recurring Google Pay payments in ${googlePayAlarmPeriod.toHumanString()}.`,
       metric: new MathExpression({
         expression: googlePayExpression,
         label: "AllRecurringGooglePayPayments",

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -649,7 +649,7 @@ export class SupportWorkers extends GuStack {
   // End of an lite
   buildPaymentSuccessMetric = (
     paymentProvider: PaymentProvider,
-    productType: ProductType | '*',
+    productType: ProductType,
     period: Duration
   ) => {
     return new Metric({


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Adding two new Cloudwatch alarm for going a given period with no Stripe Apple Pay/Google Pay payments for any recurring product.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/hPyvKKvX/1582-alarms-to-monitor-payment-methods)

## Why are you doing this?

The Stripe Express integration was broken on the generic checkout for a period and this made us realise there wasn't an alarm to pro-actively alert us.

## How to test

I tested by deploying support-workers in CODE and tested the Apple Pay alarm. Initially it was in an alarm state. Then I put through an Apple Pay transaction (S+) and it changed to OK:

![Screenshot 2025-04-16 at 12 54 02](https://github.com/user-attachments/assets/7e1596b3-9320-4f68-8f88-4e5882f58581)
