### PR TITLE
Delete persisted form details just before thank you page

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
@@ -74,6 +74,10 @@ export const persistFormDetails = (
 	storage.session.set(KEY, dataToPersist, expiry);
 };
 
+export const deleteFormDetails = (): void => {
+	storage.session.remove(KEY);
+};
+
 export const getFormDetails = (
 	checkoutSessionId: string,
 ): CheckoutSession | undefined => {


### PR DESCRIPTION
## What are you doing in this PR?

When the user is checking out with Stripe hosted checkout we store their form fields in session storage (with a 24 hours expiry added by guardian/libs). But once we've retrieved them, submitted the support-workers request and transferred the user to the thank you page we won't ever use these details again. So remove them just before the thank you page (client side) redirect.

## Why are you doing this?

Although the form data is stored in session storage (so will be deleted when the browser tab is closed) and is wrapped in a 24 hour expiration applied by guardian/libs, we should proactively delete it if it's no longer needed.

## How to test

- [x] Stripe hosted checkout still works
- [x] Other checkouts unaffected

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
