### PR TITLE
Reintroduce the changes to fix 100% discounts

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -144,7 +144,7 @@ export function Checkout({
 
 	/**
 	 * - `originalAmount` the amount pre any discounts or contributions
-	 * - `discountredAmount` the amount with a discountApplied
+	 * - `discountedAmount` the amount with a discountApplied
 	 * - `finalAmount` is the amount a person will pay
 	 */
 	let payment: {
@@ -205,9 +205,7 @@ export function Checkout({
 			billingPeriod,
 		);
 
-		const discountedPrice = promotion?.discountedPrice
-			? promotion.discountedPrice
-			: undefined;
+		const discountedPrice = promotion?.discountedPrice ?? undefined;
 
 		const price = discountedPrice ?? productPrice;
 
@@ -243,8 +241,8 @@ export function Checkout({
 	let useStripeExpressCheckout = false;
 	if (stripeExpressCheckoutSwitch) {
 		/**
-		 * Currently we're only using the stripe ExpressCheckoutElement on Contribution purchases
-		 * which then needs this configuration.
+		 * Currently we're only using the stripe ExpressCheckoutElement (Google and Apple Pay) for some
+		 * product types - those which don't need an address. This requires some extra configuration.
 		 */
 		if (
 			productKey === 'Contribution' ||
@@ -253,7 +251,7 @@ export function Checkout({
 			productKey === 'DigitalSubscription'
 		) {
 			elementsOptions = {
-				mode: 'payment',
+				mode: 'subscription',
 				/**
 				 * Stripe amounts are in the "smallest currency unit"
 				 * @see https://docs.stripe.com/api/charges/object


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
https://github.com/guardian/support-frontend/pull/6885 introduced a fix for 100% discounts but it also broke checkouts via Apple and Google Pay by removing the `paymentMethodCreation: 'manual'` parameter from the Stripe configuration.
It was then reverted in #6934 when this was discovered.

This PR reintroduces the fix from that PR while leaving the `paymentMethodCreation` parameter in place so that GPay and Apple Pay work correctly.

[**Trello Card**](https://trello.com)
