### PR TITLE
Three new transaction declined messages to ignore

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -64,6 +64,7 @@ class FailureHandler(emailService: EmailService) extends Handler[FailureHandlerS
       "Transaction declined.402 - [card_error/card_declined/do_not_honor] Your card was declined.",
       "Transaction declined.402 - [card_error/card_declined/insufficient_funds] Your card has insufficient funds.",
       "Transaction declined.402 - [card_error/card_declined/try_again_later] Your card was declined.",
+      "Transaction declined.402 - [card_error/card_declined/transaction_not_allowed] Your card does not support this type of purchase.",
     )
 
     error.flatMap(extractUnderlyingError) match {

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -60,8 +60,11 @@ class FailureHandler(emailService: EmailService) extends Handler[FailureHandlerS
     logger.info(s"Attempting to handle error $error")
     val pattern =
       "No such token: (.*); a similar object exists in test mode, but a live mode key was used to make this request.".r
-    val cardDeclinedMessage =
-      "Transaction declined.402 - [card_error/card_declined/do_not_honor] Your card was declined."
+    val cardDeclinedMessages = List(
+      "Transaction declined.402 - [card_error/card_declined/do_not_honor] Your card was declined.",
+      "Transaction declined.402 - [card_error/card_declined/insufficient_funds] Your card has insufficient funds.",
+      "Transaction declined.402 - [card_error/card_declined/try_again_later] Your card was declined.",
+    )
 
     error.flatMap(extractUnderlyingError) match {
       case Some(ZuoraErrorResponse(_, List(ze @ ZuoraError("TRANSACTION_FAILED", message)))) =>
@@ -70,7 +73,7 @@ class FailureHandler(emailService: EmailService) extends Handler[FailureHandlerS
         exitHandler(
           state,
           checkoutFailureReason,
-          if (message.contains(cardDeclinedMessage))
+          if (cardDeclinedMessages.exists(messageToIgnore => message.contains(messageToIgnore)))
             updatedRequestInfo
           else
             updatedRequestInfo.copy(failed = true),


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
#6927 flipped the alarm behaviour for transaction failed error messages from Zuora so that we would alarm by default and only not do so for particular specified error messages.

This PR follows on from #6931 which added an exception to the alarm exclusion list by adding ~~two~~ three more error messages which it is safe to ignore.

[**Trello Card**](https://trello.com/c/lFopxdf3/1589-add-more-excluded-messages-to-zuora-transaction-failed-alarm)
