### PR TITLE
Add more transaction declined message to ignore + refactor

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/exceptions/CardDeclinedMessages.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/exceptions/CardDeclinedMessages.scala
@@ -1,0 +1,16 @@
+package com.gu.support.workers.exceptions
+
+object CardDeclinedMessages {
+  val errorMessages = List(
+    "Transaction declined.402 - [card_error/card_declined/do_not_honor] Your card was declined.",
+    "Transaction declined.402 - [card_error/card_declined/insufficient_funds] Your card has insufficient funds.",
+    "Transaction declined.402 - [card_error/card_declined/try_again_later] Your card was declined.",
+    "Transaction declined.402 - [card_error/card_declined/transaction_not_allowed] Your card does not support this type of purchase.",
+    "Transaction declined.402 - [card_error/card_declined/pickup_card] Your card was declined.",
+    "Transaction declined.10417 - Instruct the customer to retry the transaction using an alternative payment method from the customers PayPal wallet.",
+    "Transaction declined.validation_failed - account_number did not pass modulus check",
+  )
+  def alarmShouldBeSuppressedForErrorMessage(message: String): Boolean = {
+    errorMessages.exists(messageToIgnore => message.contains(messageToIgnore))
+  }
+}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR adds some more transaction declined messages which we don't want to alarm on and also refactors them into a separate object to reduce clutter in the FailureHandler class.

[**Trello Card**](https://trello.com/c/lFopxdf3/1589-add-more-excluded-messages-to-zuora-transaction-failed-alarm)
