### PR TITLE
Fix spaces in Direct debit guarantee items

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitGuarantee.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitGuarantee.tsx
@@ -32,24 +32,24 @@ function DirectDebitGuarantee({ preText, mediaGroup }: Props): JSX.Element {
 						accept instructions to pay Direct Debits.
 					</li>
 					<li>
-						If there are any changes to the amount, date or frequency of your
-						Direct Debit {mediaGroup} will notify you at least three working
+						{`If there are any changes to the amount, date or frequency of your
+						Direct Debit ${mediaGroup} will notify you at least three working
 						days in advance of your account being debited or as otherwise
-						agreed.
+						agreed.`}
 					</li>
 					<li>
-						If you ask {mediaGroup} to collect a payment, confirmation of the
-						amount and date will be given to you at the time of the request.
+						{`If you ask ${mediaGroup} to collect a payment, confirmation of the
+						amount and date will be given to you at the time of the request.`}
 					</li>
 					<li>
-						If an error is made in the payment of your Direct Debit by
-						{mediaGroup} or your bank or building society, you are entitled to a
+						{`If an error is made in the payment of your Direct Debit by 
+						${mediaGroup} or your bank or building society, you are entitled to a
 						full and immediate refund of the amount paid from your bank or
-						building society.
+						building society.`}
 					</li>
 					<li>
-						If you receive a refund you are not entitled to, you must pay it
-						back when {mediaGroup} asks you to.
+						{`If you receive a refund you are not entitled to, you must pay it
+						back when ${mediaGroup} asks you to.`}
 					</li>
 					<li>
 						You can cancel a Direct Debit at any time by contacting your bank or


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Prefer string interpolation when using variables in messages.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/38YBwQX1/1590-direct-debit-payment-section-direct-debit-guarantee-the-fourth-bullet-down-needs-a-gap-between-by-gc-currently-reads-as-bygc)

## Why are you doing this?
No space was being applied between items message and variables.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
1. Go to a checkout page (https://support.thegulocal.com/uk/checkout?product=HomeDelivery&ratePlan=Sunday)
2. select Direct Debit as a payment option
3. Click the direct debit guarantee to expand items
4. voilá

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
<img width="552" alt="Screenshot 2025-04-16 at 11 32 41" src="https://github.com/user-attachments/assets/2cda2814-6288-47f7-8a35-261e1a094956" />

