### PR TITLE
Include all payment methods in combined AdLite alarm

### DIFF
--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -1112,12 +1112,12 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "EvaluationPeriods": 144,
         "Metrics": [
           {
-            "Expression": "SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0)])",
+            "Expression": "SUM([FILL(m0,0),FILL(m1,0),FILL(m2,0),FILL(m3,0),FILL(m4,0)])",
             "Id": "expr_1",
             "Label": "AllGuardianAdLiteConversions",
           },
           {
-            "Id": "m1",
+            "Id": "m0",
             "MetricStat": {
               "Metric": {
                 "Dimensions": [
@@ -1143,7 +1143,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             "ReturnData": false,
           },
           {
-            "Id": "m2",
+            "Id": "m1",
             "MetricStat": {
               "Metric": {
                 "Dimensions": [
@@ -1169,13 +1169,65 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             "ReturnData": false,
           },
           {
-            "Id": "m3",
+            "Id": "m2",
             "MetricStat": {
               "Metric": {
                 "Dimensions": [
                   {
                     "Name": "PaymentProvider",
                     "Value": "PayPal",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "GuardianAdLite",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m3",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripeApplePay",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "GuardianAdLite",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m4",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripePaymentRequestButton",
                   },
                   {
                     "Name": "ProductType",

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -52,11 +52,11 @@ const allProducts: ProductType[] = [
 ];
 
 const PaymentProviders = {
-  Stripe: 'Stripe',
-  DirectDebit: 'DirectDebit',
-  PayPal: 'PayPal',
-  StripeApplePay: 'StripeApplePay',
-  StripePaymentRequestButton: 'StripePaymentRequestButton',
+  Stripe: "Stripe",
+  DirectDebit: "DirectDebit",
+  PayPal: "PayPal",
+  StripeApplePay: "StripeApplePay",
+  StripePaymentRequestButton: "StripePaymentRequestButton",
 } as const;
 
 type PaymentProvider = keyof typeof PaymentProviders;

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -51,26 +51,15 @@ const allProducts: ProductType[] = [
   GuardianAdLite,
 ];
 
-const Stripe = "Stripe";
-const DirectDebit = "DirectDebit";
-const PayPal = "PayPal";
-const StripeApplePay = "StripeApplePay";
-const StripePaymentRequestButton = "StripePaymentRequestButton";
+const PaymentProviders = {
+  Stripe: 'Stripe',
+  DirectDebit: 'DirectDebit',
+  PayPal: 'PayPal',
+  StripeApplePay: 'StripeApplePay',
+  StripePaymentRequestButton: 'StripePaymentRequestButton',
+} as const;
 
-type PaymentProvider =
-  | typeof Stripe
-  | typeof DirectDebit
-  | typeof PayPal
-  | typeof StripeApplePay
-  | typeof StripePaymentRequestButton;
-
-const allPaymentProviders: PaymentProvider[] = [
-  Stripe,
-  DirectDebit,
-  PayPal,
-  StripeApplePay,
-  StripePaymentRequestButton,
-];
+type PaymentProvider = keyof typeof PaymentProviders;
 
 interface SupportWorkersProps extends GuStackProps {
   promotionsDynamoTables: string[];
@@ -643,7 +632,7 @@ export class SupportWorkers extends GuStack {
       adLiteMetricDuration.toMinutes() * adLiteEvaluationPeriods
     );
     const adLiteMetrics = Object.fromEntries(
-      allPaymentProviders.map((paymentProvider, idx) => [
+      Object.values(PaymentProviders).map((paymentProvider, idx) => [
         `m${idx}`,
         this.buildPaymentSuccessMetric(
           paymentProvider,


### PR DESCRIPTION
## What are you doing in this PR?

Including Apple Pay and Google Pay in the combined Guardian Ad Lite alarm.

## Why are you doing this?

Previously we didn't include Apple Pay or Google Pay, so the alarm wasn't considering the full picture.