### PR TITLE
Observer:  Landing Page Cards & Checkout enabled in Production

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/helpers/shouldShowObserver.ts
+++ b/support-frontend/assets/pages/paper-subscription-landing/helpers/shouldShowObserver.ts
@@ -1,10 +1,10 @@
-import { isCode } from 'helpers/urls/url';
+import { isCode, isProd } from 'helpers/urls/url';
 
 const shouldShowObserverCard = () => {
 	const searchParams = new URLSearchParams(window.location.search);
 	const enableObserver = searchParams.get('enableObserver') === 'true';
 
-	return enableObserver || isCode();
+	return enableObserver || isCode() || isProd();
 };
 
 export default shouldShowObserverCard;


### PR DESCRIPTION
## What are you doing in this PR?

We need to enable observer on prod environment.
Ready for 22/4/25 go-live.

Note: we can remove the function  `shouldShowObserverCard` & associated `enableObserver` completely in a seperate PR after go-live would suggest. 

[**Trello Card**](https://trello.com/c/7Vu7ZLxa/1593-enable-observer-in-prod)

## Screenshots

|from|to|
|-----|-----|
|![image](https://github.com/user-attachments/assets/709f706f-6539-4873-ad3a-3d77b48ddbff)|![image](https://github.com/user-attachments/assets/bb4ff411-fe63-4744-b406-aa01900d960b)|