### PR TITLE
ThankYou page layout fixs

### DIFF
--- a/support-frontend/assets/components/thankYou/thankyouModules.tsx
+++ b/support-frontend/assets/components/thankYou/thankyouModules.tsx
@@ -13,6 +13,7 @@ type ThankYouModulesProps = {
 const mansory = css`
 	column-count: 1;
 	column-gap: ${space[4]}px;
+	margin-bottom: 184px;
 	> section {
 		break-inside: avoid;
 		margin-bottom: ${space[4]}px;
@@ -21,6 +22,10 @@ const mansory = css`
 	${from.desktop} {
 		column-count: 2;
 	}
+
+	${from.phablet} {
+		margin-bottom: 108px;
+	}
 `;
 
 function ThankYouModules({
@@ -28,15 +33,17 @@ function ThankYouModules({
 	thankYouModules,
 	thankYouModulesData,
 }: ThankYouModulesProps) {
-  return <div css={mansory}>
-		{thankYouModules.map((moduleType) => (
-			<ThankYouModule
-				moduleType={moduleType}
-				isSignedIn={isSignedIn}
-				{...thankYouModulesData[moduleType]}
-			/>
-		))}
-	</div>
+	return (
+		<div css={mansory}>
+			{thankYouModules.map((moduleType) => (
+				<ThankYouModule
+					moduleType={moduleType}
+					isSignedIn={isSignedIn}
+					{...thankYouModulesData[moduleType]}
+				/>
+			))}
+		</div>
+	);
 }
 
 export default ThankYouModules;

--- a/support-frontend/assets/components/thankYou/thankyouModules.tsx
+++ b/support-frontend/assets/components/thankYou/thankyouModules.tsx
@@ -1,69 +1,42 @@
 import { css } from '@emotion/react';
-import { between, from, space } from '@guardian/source/foundations';
-import { Column, Columns } from '@guardian/source/react-components';
+import { from, space } from '@guardian/source/foundations';
 import type { ThankYouModuleType } from 'components/thankYou/thankYouModule';
 import ThankYouModule from 'components/thankYou/thankYouModule';
 import type { ThankYouModuleData } from 'components/thankYou/thankYouModuleData';
 
-const columnContainer = css`
-	> *:not(:last-child) {
-		${from.tablet} {
-			margin-bottom: ${space[6]}px;
-		}
-
-		${from.desktop} {
-			margin-bottom: ${space[5]}px;
-		}
-	}
-`;
-
-const firstColumnContainer = css`
-	${between.tablet.and.desktop} {
-		margin-bottom: ${space[6]}px;
-	}
-`;
-
-interface ThankYouModulesProps {
+type ThankYouModulesProps = {
 	isSignedIn: boolean;
-	showNewspaperArchiveBenefit: boolean;
 	thankYouModules: ThankYouModuleType[];
 	thankYouModulesData: Record<ThankYouModuleType, ThankYouModuleData>;
-}
+};
 
-export function ThankYouModules({
+const mansory = css`
+	column-count: 1;
+	column-gap: ${space[4]}px;
+	> section {
+		break-inside: avoid;
+		margin-bottom: ${space[4]}px;
+	}
+
+	${from.desktop} {
+		column-count: 2;
+	}
+`;
+
+function ThankYouModules({
 	isSignedIn = false,
-	showNewspaperArchiveBenefit = false,
 	thankYouModules,
 	thankYouModulesData,
-}: ThankYouModulesProps): JSX.Element {
-	const maxModules = showNewspaperArchiveBenefit ? 5 : 6;
-	const numberOfModulesInFirstColumn =
-		thankYouModules.length >= maxModules ? 3 : 2;
-	const firstColumn = thankYouModules.slice(0, numberOfModulesInFirstColumn);
-	const secondColumn = thankYouModules.slice(numberOfModulesInFirstColumn);
-
-	return (
-		<>
-			<Columns collapseUntil="desktop">
-				<Column cssOverrides={[columnContainer, firstColumnContainer]}>
-					{firstColumn.map((moduleType) => (
-						<ThankYouModule
-							moduleType={moduleType}
-							isSignedIn={isSignedIn}
-							{...thankYouModulesData[moduleType]}
-						/>
-					))}
-				</Column>
-				<Column cssOverrides={columnContainer}>
-					{secondColumn.map((moduleType) => (
-						<ThankYouModule
-							moduleType={moduleType}
-							isSignedIn={isSignedIn}
-							{...thankYouModulesData[moduleType]}
-						/>
-					))}
-				</Column>
-			</Columns>
-		</>
-	);
+}: ThankYouModulesProps) {
+  return <div css={mansory}>
+		{thankYouModules.map((moduleType) => (
+			<ThankYouModule
+				moduleType={moduleType}
+				isSignedIn={isSignedIn}
+				{...thankYouModulesData[moduleType]}
+			/>
+		))}
+	</div>
 }
+
+export default ThankYouModules;

--- a/support-frontend/assets/components/thankYou/thankyouModules.tsx
+++ b/support-frontend/assets/components/thankYou/thankyouModules.tsx
@@ -13,6 +13,7 @@ type ThankYouModulesProps = {
 const mansory = css`
 	column-count: 1;
 	column-gap: ${space[4]}px;
+	margin-top: ${space[4]}px;
 	margin-bottom: 184px;
 	> section {
 		break-inside: avoid;

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -41,7 +41,7 @@ import ThankYouFooter from 'pages/supporter-plus-thank-you/components/thankYouFo
 import ThankYouHeader from 'pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader';
 import { productDeliveryOrStartDate } from 'pages/weekly-subscription-checkout/helpers/deliveryDays';
 import type { BenefitsCheckListData } from '../../../components/checkoutBenefits/benefitsCheckList';
-import { ThankYouModules } from '../../../components/thankYou/thankyouModules';
+import ThankYouModules from '../../../components/thankYou/thankyouModules';
 import type { LandingPageVariant } from '../../../helpers/globalsAndSwitches/landingPageSettings';
 import {
 	getReturnAddress,

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -48,7 +48,8 @@ import {
 	getThankYouOrder,
 } from '../checkout/helpers/sessionStorage';
 
-const checkoutContainer = css`
+const thankYouContainer = css`
+	position: relative;
 	${from.tablet} {
 		background-color: ${sport[800]};
 	}
@@ -62,7 +63,8 @@ const headerContainer = css`
 	}
 `;
 const buttonContainer = css`
-	padding: ${space[12]}px 0;
+	position: absolute;
+	bottom: ${space[8]}px;
 	& > a:first-child {
 		margin-right: ${space[3]}px;
 	}
@@ -359,7 +361,7 @@ export function ThankYouComponent({
 				</FooterWithContents>
 			}
 		>
-			<div css={checkoutContainer}>
+			<div css={thankYouContainer}>
 				<Container>
 					<div css={headerContainer}>
 						<ThankYouHeader
@@ -383,7 +385,6 @@ export function ThankYouComponent({
 
 					<ThankYouModules
 						isSignedIn={isSignedIn}
-						showNewspaperArchiveBenefit={showNewspaperArchiveBenefit}
 						thankYouModules={thankYouModules}
 						thankYouModulesData={thankYouModuleData}
 					/>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Move away from manual assigning thank you cards in the thank you page, and use css column count instead.
This will scale better and will reduce complexity.
Force page CTA's to sit at the bottom of the page.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/Wx8gPstv/1588-thank-you-page-items-alignment-and-cta-links)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
1. Go to the thankYou page (eg:  [TierThree for Domestic Monthly](https://support.thegulocal.com/uk/thank-you?product=TierThree&ratePlan=DomesticMonthly))
2. Add the sessionStorage values if you haven't: 
```
sessionStorage.setItem('thankYouOrder', JSON.stringify({"value":{"firstName":"John  Doe","email":"John.doe@theguardian.com","paymentMethod":"DirectDebit","status":"success"}}))
```
3. Change to any valid product/ratePlan Combination to test other scenarios


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
### HomeDelivery for Sunday
| Mobile    | Tablet | Desktop | 
| -------- | ------- | ------- |
| ![iPhone 12 Pro-1745246322034](https://github.com/user-attachments/assets/8124f24b-cd6d-4e89-995f-ab76fcbbaa4f) | ![iPad-1745246279624](https://github.com/user-attachments/assets/4de0a489-7d0a-445b-9a8a-4f8b70e1db24) | ![MacBook Pro-1745246277027](https://github.com/user-attachments/assets/77715529-195b-44f8-896d-e3f521d8dd28) |

### tierThree for DomesticMonthly
| Mobile    | Tablet | Desktop | 
| -------- | ------- | ------- |
| ![iPhone 12 Pro-1745246240592](https://github.com/user-attachments/assets/7e29b18e-1dec-46bc-8fc9-ebfb57c4ea8c) | ![iPad-1745246234848](https://github.com/user-attachments/assets/34419250-dfaa-4f1e-a8e2-24024ae4c372) |  ![MacBook Pro-1745246219589](https://github.com/user-attachments/assets/fd0d640f-a0d1-4fd1-aeeb-ea015217b532) |

