### PR TITLE
Add new card decline message which we shouldn't alarm on

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/exceptions/CardDeclinedMessages.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/exceptions/CardDeclinedMessages.scala
@@ -10,6 +10,7 @@ object CardDeclinedMessages {
     "Transaction declined.402 - [card_error/card_declined/generic_decline] Your card was declined.",
     "Transaction declined.402 - [card_error/incorrect_cvc/incorrect_cvc] Your card's security code is incorrect.",
     "Transaction declined.402 - [card_error/card_declined/card_velocity_exceeded] Your card was declined for making repeated attempts too frequently or exceeding its amount limit.",
+    "Transaction declined.402 - [card_error/card_declined/revocation_of_authorization] Your card was declined.",
     "Transaction declined.10417 - Instruct the customer to retry the transaction using an alternative payment method from the customers PayPal wallet.",
     "Transaction declined.validation_failed - account_number did not pass modulus check",
     "Transaction declined.validation_failed - account_number is the wrong length (should be 8 characters)",


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Following on from #6956 and others, this adds another card declined error which we don't want to alarm on.

[**Trello Card**](https://trello.com/c/lFopxdf3/1589-add-more-excluded-messages-to-zuora-transaction-failed-alarm)

## Why are you doing this?

These types of errors can be addressed by the user, so we don't want additional noise from alarming on them.