### PR TITLE
Fix observer image packshot for newsppaper

### DIFF
--- a/support-frontend/assets/components/packshots/guardian-weekly-packshot-hero.tsx
+++ b/support-frontend/assets/components/packshots/guardian-weekly-packshot-hero.tsx
@@ -1,29 +1,6 @@
 import GridPicture from 'components/gridPicture/gridPicture';
-import shouldShowObserverCard from 'pages/paper-subscription-landing/helpers/shouldShowObserver';
 
 function GuardianWeeklyPackShotHero(): JSX.Element {
-	if (shouldShowObserverCard()) {
-		return (
-			<div className="subscriptions-feature-packshot">
-				<GridPicture
-					sources={[
-						{
-							gridId: 'subscriptionGuardianWeeklyWithObserverHeroPackShot',
-							srcSizes: [500],
-							imgType: 'png',
-							sizes: '100vw',
-							media: '(max-width: 739px) 500px',
-						},
-					]}
-					fallback="subscriptionGuardianWeeklyWithObserverHeroPackShot"
-					fallbackSize={1000}
-					altText=""
-					fallbackImgType="png"
-				/>
-			</div>
-		);
-	}
-
 	return (
 		<div className="subscriptions-feature-packshot">
 			<GridPicture

--- a/support-frontend/assets/components/packshots/paper-packshot.tsx
+++ b/support-frontend/assets/components/packshots/paper-packshot.tsx
@@ -1,10 +1,15 @@
 import GridImage from 'components/gridImage/gridImage';
+import shouldShowObserverCard from 'pages/paper-subscription-landing/helpers/shouldShowObserver';
 
 function PaperPackshot() {
+	const gridId = shouldShowObserverCard()
+		? 'subscriptionPrintObserver'
+		: 'subscriptionPrint';
+
 	return (
 		<div className="subscriptions__paper-packshot">
 			<GridImage
-				gridId="subscriptionPrint"
+				gridId={gridId}
 				srcSizes={[500, 140]}
 				sizes="(max-width: 739px) 140px,
              (max-width: 979px) 500px,

--- a/support-frontend/assets/helpers/images/imageCatalogue.json
+++ b/support-frontend/assets/helpers/images/imageCatalogue.json
@@ -31,6 +31,7 @@
 	"subscriptionGuardianWeeklyPackShot": "e4ce5980efc3d43b00c2cbb6f193d4070d12a543/0_0_900_600",
 	"subscriptionGuardianWeeklyTablet": "e4ce5980efc3d43b00c2cbb6f193d4070d12a543/0_0_900_600",
 	"subscriptionPrint": "81d6bda5f74a84b952e7162d553ae71499c0c7ed/0_9_540_324",
+	"subscriptionPrintObserver": "da142c4e2f7cdaa105de46da1a35ae0f893c0ab6/0_0_500_300",
 	"supporterPlusLanding": "ee087a054ad8c6c04713e12cba93ef9ac246d35f/0_0_817_460",
 	"digitalEditionLanding": "3581b392c306308dc5770d26cff80fef71c9761a/0_0_1680_2080",
 	"supporterPlusLandingUnitedStates": "527b59919012a7666ccd067a3c82ad63682d2418/0_0_420_165",


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Swap observer sale packshot image from the guardian weekly to the newspaper weekly.
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?
Images are incorrect for the product.
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
### Old
<img width="1325" alt="Screenshot 2025-04-22 at 12 04 36" src="https://github.com/user-attachments/assets/f2471fbe-91fd-48bc-bd2a-340d69a54428" />

### New 
<img width="1312" alt="Screenshot 2025-04-22 at 12 04 51" src="https://github.com/user-attachments/assets/b0eb8441-0ec7-4fb6-b51c-81471fe18e49" />
