### PR TITLE
Observer: Subscription Landing Page Copy Observer removal

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.tsx
@@ -157,7 +157,7 @@ const guardianWeekly = (
 	title: 'Guardian Weekly',
 	subtitle: getDisplayPrice(countryGroupId, priceCopy.price),
 	description:
-		'Gain a deeper understanding of the issues that matter with the Guardian Weekly magazine. Every week, take your time over handpicked articles from the Guardian and Observer, delivered for free to wherever you are in the world.',
+		'Gain a deeper understanding of the issues that matter with the Guardian Weekly magazine. Every week, take your time over handpicked articles from the Guardian, delivered for free to wherever you are in the world.',
 	offer: getGuardianWeeklyOfferCopy(priceCopy.discountCopy),
 	buttons: [
 		{


### PR DESCRIPTION
## What are you doing in this PR?

Remove `and Observer` from the GuardianWeekly tab on the Subscriptions Landing Page only

## Screenshots
|from|to|
|----|----|
|![image](https://github.com/user-attachments/assets/8893448d-6b42-44c4-afc3-ddf2953e97b9)|![image](https://github.com/user-attachments/assets/8af8bbb1-2521-4d79-a33a-62b7d1600b44)|