### PR TITLE
Changes for getting tickerSettings from landing page tests

### DIFF
--- a/support-frontend/app/admin/settings/LandingPageTest.scala
+++ b/support-frontend/app/admin/settings/LandingPageTest.scala
@@ -53,6 +53,20 @@ case class Cta(
     copy: String,
 )
 
+case class TickerCopy(
+    countLabel: String,
+)
+object TickerCopy {
+  implicit val codec: Codec[TickerCopy] = deriveCodec
+}
+case class TickerSettings(
+    currencySymbol: String,
+    copy: TickerCopy,
+    name: String,
+)
+object TickerSettings {
+  implicit val tickerCodec: Codec[TickerSettings] = deriveCodec
+}
 case class Products(
     Contribution: LandingPageProductDescription,
     SupporterPlus: LandingPageProductDescription,
@@ -71,6 +85,7 @@ case class LandingPageVariant(
     name: String,
     copy: LandingPageCopy,
     products: Products,
+    tickerSettings: Option[TickerSettings],
 )
 
 object LandingPageVariant {

--- a/support-frontend/assets/helpers/campaigns/campaigns.tsx
+++ b/support-frontend/assets/helpers/campaigns/campaigns.tsx
@@ -1,4 +1,3 @@
-import type { TickerSettings } from '@guardian/source-development-kitchen/dist/react-components/ticker/Ticker';
 import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import type { CountryGroupId } from '../internationalisation/countryGroup';
 
@@ -24,10 +23,6 @@ interface CampaignCopy {
 	punctuation?: JSX.Element;
 }
 
-export type CampaignTickerSettings = Omit<TickerSettings, 'tickerData'> & {
-	id: string;
-};
-
 type CampaignSettings = {
 	isEligible: (
 		countryGroupId: CountryGroupId,
@@ -36,7 +31,6 @@ type CampaignSettings = {
 	enableSingleContributions: boolean;
 	countdownSettings?: CountdownSetting[];
 	copy: CampaignCopy;
-	tickerSettings?: CampaignTickerSettings;
 };
 
 const campaigns: Record<string, CampaignSettings> = {};

--- a/support-frontend/assets/helpers/globalsAndSwitches/landingPageSettings.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/landingPageSettings.ts
@@ -1,5 +1,21 @@
 import type { CountryGroupId } from '../internationalisation/countryGroup';
 
+enum TickerName {
+	US = 'US',
+	AU = 'AU',
+	GLOBAL = 'global',
+}
+
+interface TickerCopy {
+	countLabel: string;
+}
+
+export interface TickerSettings {
+	currencySymbol: string;
+	copy: TickerCopy;
+	name: TickerName;
+}
+
 interface ProductBenefit {
 	copy: string;
 	tooltip?: string;
@@ -35,6 +51,7 @@ export interface LandingPageVariant {
 	name: string;
 	copy: LandingPageCopy;
 	products: LandingPageProducts;
+	tickerSettings?: TickerSettings;
 }
 
 interface RegionTargeting {

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -626,8 +626,8 @@ export function ThreeTierLanding({
 						dangerouslySetInnerHTML={{ __html: sanitisedSubheading }}
 					/>
 
-					{campaignSettings?.tickerSettings && (
-						<TickerContainer tickerSettings={campaignSettings.tickerSettings} />
+					{settings.tickerSettings && (
+						<TickerContainer tickerSettings={settings.tickerSettings} />
 					)}
 					<PaymentFrequencyButtons
 						paymentFrequencies={paymentFrequencies.map(

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/tickerContainer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/tickerContainer.tsx
@@ -4,7 +4,7 @@ import type { TickerData } from '@guardian/source-development-kitchen/dist/react
 import { Ticker } from '@guardian/source-development-kitchen/react-components';
 import { useEffect, useState } from 'react';
 import { fetchJson } from '../../../helpers/async/fetch';
-import type { CampaignTickerSettings } from '../../../helpers/campaigns/campaigns';
+import type { TickerSettings } from '../../../helpers/globalsAndSwitches/landingPageSettings';
 import { isCodeOrProd } from '../../../helpers/urls/url';
 
 const containerStyle = css`
@@ -30,16 +30,23 @@ async function getInitialTickerValues(tickerId: string): Promise<TickerData> {
 }
 
 interface TickerContainerProps {
-	tickerSettings: CampaignTickerSettings;
+	tickerSettings: TickerSettings;
 }
 
 export function TickerContainer({
 	tickerSettings,
 }: TickerContainerProps): JSX.Element {
 	const [tickerData, setTickerData] = useState<TickerData | undefined>();
+	const tickerStylingSettings = {
+		headlineColour: '#000000',
+		totalColour: '#64B7C4',
+		goalColour: '#FFFFFF',
+		filledProgressColour: '#64B7C4',
+		progressBarBackgroundColour: 'rgba(100, 183, 196, 0.3)',
+	};
 
 	useEffect(() => {
-		void getInitialTickerValues(tickerSettings.id).then(setTickerData);
+		void getInitialTickerValues(tickerSettings.name).then(setTickerData);
 	}, []);
 
 	if (tickerData) {
@@ -48,19 +55,18 @@ export function TickerContainer({
 				<Ticker
 					currencySymbol={tickerSettings.currencySymbol}
 					copy={{
-						headline: tickerSettings.copy.headline,
+						headline: tickerSettings.copy.countLabel,
 					}}
 					tickerData={tickerData}
 					tickerStylingSettings={{
-						headlineColour: tickerSettings.tickerStylingSettings.headlineColour,
-						totalColour: tickerSettings.tickerStylingSettings.totalColour,
-						goalColour: tickerSettings.tickerStylingSettings.goalColour,
-						filledProgressColour:
-							tickerSettings.tickerStylingSettings.filledProgressColour,
+						headlineColour: tickerStylingSettings.headlineColour,
+						totalColour: tickerStylingSettings.totalColour,
+						goalColour: tickerStylingSettings.goalColour,
+						filledProgressColour: tickerStylingSettings.filledProgressColour,
 						progressBarBackgroundColour:
-							tickerSettings.tickerStylingSettings.progressBarBackgroundColour,
+							tickerStylingSettings.progressBarBackgroundColour,
 					}}
-					size={tickerSettings.size}
+					size={'large'}
 				/>
 			</div>
 		);

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/tickerContainer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/tickerContainer.tsx
@@ -38,7 +38,7 @@ export function TickerContainer({
 }: TickerContainerProps): JSX.Element {
 	const [tickerData, setTickerData] = useState<TickerData | undefined>();
 	const tickerStylingSettings = {
-		headlineColour: '#000000',
+		headlineColour: '#FFFFFF',
 		totalColour: '#64B7C4',
 		goalColour: '#FFFFFF',
 		filledProgressColour: '#64B7C4',

--- a/support-frontend/test/services/LandingPageTestServiceSpec.scala
+++ b/support-frontend/test/services/LandingPageTestServiceSpec.scala
@@ -11,6 +11,8 @@ import admin.settings.{
   Products,
   RegionTargeting,
   Status,
+  TickerCopy,
+  TickerSettings,
 }
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -175,6 +177,13 @@ class LandingPageTestServiceSpec extends AsyncFlatSpec with Matchers {
                   ),
                 ),
               ),
+              "tickerSettings" -> mapAttr(
+                Map(
+                  "currencySymbol" -> stringAttr("$"),
+                  "copy" -> mapAttr(Map("countLabel" -> stringAttr("test copy"))),
+                  "name" -> stringAttr("US"),
+                ),
+              ),
             ),
           ),
         ),
@@ -200,6 +209,15 @@ class LandingPageTestServiceSpec extends AsyncFlatSpec with Matchers {
               subheading = "test subheading",
             ),
             products = products,
+            tickerSettings = {
+              Some(
+                TickerSettings(
+                  currencySymbol = "$",
+                  copy = TickerCopy(countLabel = "test copy"),
+                  name = "US",
+                ),
+              )
+            },
           ),
         ),
       ),


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR has changes to use the tickerSetting from the Landing Page Tests 
The related support-admin -console changes are in the [ SAC PR](https://github.com/guardian/support-admin-console/pull/725) 

[**Trello Card**](https://trello.com/c/Jeyu43yW/1039-landing-page-tool-ticker-config)

## Why are you doing this?
This is  to support  Landing Page Tooling 

## How to test
Test in CODE 

## Screenshots


**For US/AU campaign that has a "Money" countType would should show the ticker with the currencySymbol**

<img width="1228" alt="image" src="https://github.com/user-attachments/assets/8fc93b00-52e8-4b2e-bdfe-eb3b4689c032" />

<img width="1228" alt="image" src="https://github.com/user-attachments/assets/48d46e68-54f8-472d-899d-58d691196fc7" />


<img width="1228" alt="image" src="https://github.com/user-attachments/assets/d7fac0e2-a4de-4712-b4ef-2996f4c9b07d" />


**For global  campaign that has a "SupporterCount" countType would just show the total and goal values**

<img width="1228" alt="image" src="https://github.com/user-attachments/assets/52107216-b0f4-4e80-98dc-37d69fd70a9f" />

<img width="1228" alt="image" src="https://github.com/user-attachments/assets/dd1dabd9-a01a-4ac5-8f8a-2a45a3ed1c9b" />

<img width="1228" alt="image" src="https://github.com/user-attachments/assets/3b5d94c0-c666-487d-8387-3818b517122f" />
