### PR TITLE
Thankyou safari fix

### DIFF
--- a/support-frontend/assets/components/thankYou/thankYouModule.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModule.tsx
@@ -24,6 +24,10 @@ const container = css`
 	padding-top: ${space[2]}px;
 	padding-bottom: ${space[5]}px;
 	border-bottom: 1px solid ${neutral[86]};
+	break-inside: avoid;
+	:not(:first-child) {
+		margin-top: ${space[4]}px;
+	}
 
 	${from.tablet} {
 		max-width: 620px;

--- a/support-frontend/assets/components/thankYou/thankyouModules.tsx
+++ b/support-frontend/assets/components/thankYou/thankyouModules.tsx
@@ -14,12 +14,8 @@ type ThankYouModulesProps = {
 const mansory = css`
 	column-count: 1;
 	column-gap: ${space[4]}px;
-	margin-top: ${space[4]}px;
 	margin-bottom: 184px;
-	> section {
-		break-inside: avoid;
-		margin-bottom: ${space[4]}px;
-	}
+	margin-top: ${space[4]}px;
 
 	${from.desktop} {
 		column-count: 2;

--- a/support-frontend/assets/components/thankYou/thankyouModules.tsx
+++ b/support-frontend/assets/components/thankYou/thankyouModules.tsx
@@ -5,7 +5,6 @@ import ThankYouModule from 'components/thankYou/thankYouModule';
 import type { ThankYouModuleData } from 'components/thankYou/thankYouModuleData';
 
 type ThankYouModulesProps = {
-type ThankYouModulesProps = {
 	isSignedIn: boolean;
 	thankYouModules: ThankYouModuleType[];
 	thankYouModulesData: Record<ThankYouModuleType, ThankYouModuleData>;

--- a/support-frontend/assets/components/thankYou/thankyouModules.tsx
+++ b/support-frontend/assets/components/thankYou/thankyouModules.tsx
@@ -5,6 +5,7 @@ import ThankYouModule from 'components/thankYou/thankYouModule';
 import type { ThankYouModuleData } from 'components/thankYou/thankYouModuleData';
 
 type ThankYouModulesProps = {
+type ThankYouModulesProps = {
 	isSignedIn: boolean;
 	thankYouModules: ThankYouModuleType[];
 	thankYouModulesData: Record<ThankYouModuleType, ThankYouModuleData>;


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Move styles to inner element.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?
Safari is the new internet explorer and was misbehaving due to bottom margin in the modules.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
### Broken (current)
<img width="1390" alt="Screenshot 2025-04-23 at 15 13 58" src="https://github.com/user-attachments/assets/7a5313c5-3d13-43d8-b55b-c8662ef72b7c" />

### Fixed (new)
<img width="1346" alt="Screenshot 2025-04-23 at 15 15 59" src="https://github.com/user-attachments/assets/791ec82a-ac27-4a06-a8e1-1df733a45a9c" />
