### PR TITLE
Re-instate playwright cron test failure alerts

### DIFF
--- a/.github/workflows/playwright-cron.yml
+++ b/.github/workflows/playwright-cron.yml
@@ -31,9 +31,9 @@ jobs:
         name: playwright-report
         path: support-e2e/playwright-report/
         retention-days: 30
-#    - name: Notify on Failure
-#      if: ${{ failure() }}
-#      run: |
-#        failedWorkflowRun="https://github.com/guardian/support-frontend/actions/runs/$GITHUB_RUN_ID"
-#        prTrigger="https://github.com/guardian/support-frontend/pull/${{ github.event.number }}"
-#        curl -X POST -H "Content-Type: application/json" "$GOOGLE_CHAT_WEB_HOOK" -d '{"text": "🚨 The Playwright cron tests for support-frontend have failed 🚨\n\n- <'"$failedWorkflowRun"'|You can see the reason for this failure on GitHub>. \n\n 📖 <https://github.com/guardian/support-frontend/wiki/Post-deployment-test-runbook|Check the runbook for a step by step guide>"}'
+    - name: Notify on Failure
+      if: ${{ failure() }}
+      run: |
+        failedWorkflowRun="https://github.com/guardian/support-frontend/actions/runs/$GITHUB_RUN_ID"
+        prTrigger="https://github.com/guardian/support-frontend/pull/${{ github.event.number }}"
+        curl -X POST -H "Content-Type: application/json" "$GOOGLE_CHAT_WEB_HOOK" -d '{"text": "🚨 The Playwright cron tests for support-frontend have failed 🚨\n\n- <'"$failedWorkflowRun"'|You can see the reason for this failure on GitHub>. \n\n 📖 <https://github.com/guardian/support-frontend/wiki/Post-deployment-test-runbook|Check the runbook for a step by step guide>"}'


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Re-instating playwright cron test failure alerts

## Why are you doing this?

The alerting part was commented out a few weeks ago (see #6909) due to flakiness, we think on the PayPal sandbox end. The tests have continued running and it looks like they've been much more reliable recently so let's turn the alerting back on so we find out about any genuine failures.
