### PR TITLE
Don't render the CMP banner in lighthouse tests

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -15,7 +15,7 @@ jobs:
         uses: treosh/lighthouse-ci-action@v12
         with:
           urls: |
-            https://support.theguardian.com/uk/contribute
+            https://support.theguardian.com/uk/contribute?_sp_targeting_params=framework:null
           configPath: ./lighthouserc.json
           uploadArtifacts: true # save results as an action artifacts
       - name: Notify on failure


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Hide the CMP banner when running lighthouse tests.

[**Trello Card**](https://trello.com/c/pFHFaLRq/1463-disable-cmp-from-lighthouse-tests)

## Why are you doing this?

We think loading the CMP banner affects metrics like largest-contentful-paint. This isn't something we can control so we want to remove this variability from our tests. Typically the user will have already interacted with the CMP before hitting the landing page.