### PR TITLE
Revert "Don't render the CMP banner in lighthouse tests"

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -15,7 +15,7 @@ jobs:
         uses: treosh/lighthouse-ci-action@v12
         with:
           urls: |
-            https://support.theguardian.com/uk/contribute?_sp_targeting_params=framework:null
+            https://support.theguardian.com/uk/contribute
           configPath: ./lighthouserc.json
           uploadArtifacts: true # save results as an action artifacts
       - name: Notify on failure


### PR DESCRIPTION
Reverts guardian/support-frontend#6976