### PR TITLE
Don't render the CMP in lighthouse tests

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -15,7 +15,7 @@ jobs:
         uses: treosh/lighthouse-ci-action@v12
         with:
           urls: |
-            https://support.theguardian.com/uk/contribute
+            https://support.theguardian.com/uk/contribute?${{ secrets.LIGHTHOUSE_QUERY_STRING }}
           configPath: ./lighthouserc.json
           uploadArtifacts: true # save results as an action artifacts
       - name: Notify on failure

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,10 +2,10 @@ name: Lighthouse CI
 on:
   workflow_dispatch:
   pull_request:
-    types: [labeled] # Only run when a PR is labeled with the 'Seen-on-PROD' label set by prout
+#    types: [labeled] # Only run when a PR is labeled with the 'Seen-on-PROD' label set by prout
 jobs:
   Lighthouse:
-    if: ${{ github.event.label.name == 'Seen-on-PROD' }}
+#    if: ${{ github.event.label.name == 'Seen-on-PROD' }}
     runs-on: ubuntu-latest
     env:
       GOOGLE_CHAT_WEB_HOOK: ${{ secrets.GOOGLE_CHAT_WEB_HOOK }}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Disabling the CMP in lighthouse tests.

[**Trello Card**](https://trello.com/c/pFHFaLRq/1463-disable-cmp-from-lighthouse-tests)

## Why are you doing this?

We think loading the CMP affects metrics like largest-contentful-paint. This isn't something we can control so we want to remove this variability from our tests. Typically the user will have already interacted with the CMP before hitting the landing page.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
