### PR TITLE
Add another two Stripe errors to the list we don't want to alarm on

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/exceptions/CardDeclinedMessages.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/exceptions/CardDeclinedMessages.scala
@@ -12,6 +12,8 @@ object CardDeclinedMessages {
     "Transaction declined.402 - [card_error/card_declined/card_velocity_exceeded] Your card was declined for making repeated attempts too frequently or exceeding its amount limit.",
     "Transaction declined.402 - [card_error/card_declined/revocation_of_authorization] Your card was declined.",
     "Transaction declined.402 - [card_error/authentication_required/authentication_required] Your card was declined. This transaction requires authentication.",
+    "Transaction declined.402 - [card_error/card_declined/fraudulent] Your card was declined.",
+    "Transaction declined.402 - [card_error/expired_card/expired_card] Your card has expired.",
     "Transaction declined.10417 - Instruct the customer to retry the transaction using an alternative payment method from the customers PayPal wallet.",
     "Transaction declined.validation_failed - account_number did not pass modulus check",
     "Transaction declined.validation_failed - account_number is the wrong length (should be 8 characters)",


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Following on from #6969, #6966 and others, add more Stripe errors to the list we don't want to alarm on.

[**Trello Card**](https://trello.com/c/lFopxdf3/1589-add-more-excluded-messages-to-zuora-transaction-failed-alarm)

## Why are you doing this?

These types of errors aren't anything we can do to fix. We should show informative messages to the user to allow them to fix themselves where possible.