### PR TITLE
Pass undefined for similarProductsConsent for products with no checkbox

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
@@ -82,8 +82,12 @@ export const submitForm = async ({
 			: undefined;
 	const supportAbTests = getSupportAbTests(abParticipations);
 	const deliveryInstructions = formData.get('deliveryInstructions') as string;
+
+	const similarProductsCheckbox = formData.get('similarProductsConsent');
 	const similarProductsConsent =
-		formData.get('similarProductsConsent') === 'on';
+		similarProductsCheckbox !== null
+			? similarProductsCheckbox === 'on'
+			: undefined;
 
 	const paymentRequest: RegularPaymentRequest = {
 		...personalData,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
I had an unpushed commit when I merged #6957!

Currently we will send similarProductsConsent = false from the client for products which do not have a consent checkbox (Guardian Ad-Lite & Observer). This should actually be undefined; this PR fixes that.