### PR TITLE
Ophan component event for the similar products checkbox

### DIFF
--- a/support-frontend/assets/helpers/tracking/behaviour.ts
+++ b/support-frontend/assets/helpers/tracking/behaviour.ts
@@ -34,13 +34,14 @@ const trackThankYouPageLoaded = (
 	}
 };
 
-const trackComponentClick = (componentId: string): void => {
+const trackComponentClick = (componentId: string, value?: string): void => {
 	trackComponentEvents({
 		component: {
 			componentType: 'ACQUISITIONS_OTHER',
 			id: componentId,
 		},
 		action: 'CLICK',
+		value,
 	});
 };
 

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
@@ -1,9 +1,10 @@
-import { Checkbox, TextInput } from '@guardian/source/react-components';
+import { TextInput } from '@guardian/source/react-components';
 import { useState } from 'react';
 import {
 	doesNotContainExtendedEmojiOrLeadingSpace,
 	preventDefaultValidityMessage,
 } from 'pages/[countryGroupId]/validation';
+import { SimilarProductsConsent } from '../../components/SimilarProductsConsent';
 import { PersonalEmailFields } from './PersonalEmailFields';
 
 type PersonalDetailsFieldsProps = {
@@ -46,13 +47,7 @@ export function PersonalDetailsFields({
 				setConfirmedEmail={setConfirmedEmail}
 				isSignedIn={isSignedIn}
 			/>
-			{showSimilarProductsConsent && (
-				<Checkbox
-					name="similarProductsConsent"
-					label="Receive information on our products and ways to support and enjoy our journalism. Untick to opt out."
-					checked={true}
-				/>
-			)}
+			{showSimilarProductsConsent && <SimilarProductsConsent />}
 			<div>
 				<TextInput
 					id="firstName"

--- a/support-frontend/assets/pages/[countryGroupId]/components/SimilarProductsConsent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/SimilarProductsConsent.tsx
@@ -1,0 +1,19 @@
+import { Checkbox } from '@guardian/source/react-components';
+import { trackComponentClick } from '../../../helpers/tracking/behaviour';
+
+export function SimilarProductsConsent() {
+	return (
+		<Checkbox
+			name="similarProductsConsent"
+			label="Receive information on our products and ways to support and enjoy our journalism. Untick to opt out."
+			checked={true}
+			onClick={(event) => {
+				const checked = event.currentTarget.checked;
+				trackComponentClick(
+					'similar-products-consent-checkbox',
+					checked.toString(),
+				);
+			}}
+		/>
+	);
+}

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -115,6 +115,7 @@ import {
 	PaymentMethodRadio,
 	PaymentMethodSelector,
 } from './paymentMethod';
+import { SimilarProductsConsent } from './SimilarProductsConsent';
 import { SubmitButton } from './submitButton';
 
 const countriesRequiringBillingState = ['US', 'CA', 'AU'];
@@ -1238,11 +1239,7 @@ export function CheckoutComponent({
 							`}
 						>
 							{abParticipations.similarProductsConsent === 'VariantB' && (
-								<Checkbox
-									name="similarProductsConsent"
-									label="Receive information on our products and ways to support and enjoy our journalism. Untick to opt out."
-									checked={true}
-								/>
+								<SimilarProductsConsent />
 							)}
 						</div>
 						<SummaryTsAndCs


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR adds an Ophan component event for when a user checks or unchecks the similar products consent checkbox. It records the new value of the checkbox, ie. when the checkbox is checked and the user clicks to uncheck it a `false` value is sent. 


[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
- Go to the generic checkout making sure that you are in an AB test variant which sees the checkbox eg. https://support.thegulocal.com/uk/checkout?product=SupporterPlus&ratePlan=Monthly#ab-similarProductsConsent=VariantB
- Open the network tab
- Uncheck the similar product consents checkbox
- Check that there is a new request in the network tab similar to: https://ophan.theguardian.com/img/2?viewId=ma2eewtv3cj00qe9yjy2&componentEvent={"component":{"componentType":"ACQUISITIONS_OTHER","id":"similar-products-consent-checkbox"},"action":"CLICK","value":"false"}
