### PR TITLE
Don't show the similar products consent checkbox for some products

### DIFF
--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -37,9 +37,15 @@ export type ProductDescription = {
 		{
 			billingPeriod: 'Annual' | 'Monthly' | 'Quarterly';
 			label?: string;
+			hideSimilarProductsConsent?: boolean;
 		}
 	>;
 };
+
+export const showSimilarProductsConsentForRatePlan = (
+	productDescription: ProductDescription,
+	ratePlanKey: string,
+) => !productDescription.ratePlans[ratePlanKey]?.hideSimilarProductsConsent;
 
 export function filterBenefitByRegion(
 	benefit: {
@@ -187,6 +193,7 @@ export const productCatalogDescription: Record<
 		ratePlans: {
 			Monthly: {
 				billingPeriod: 'Monthly',
+				hideSimilarProductsConsent: true,
 			},
 		},
 		benefits: guardianAdLiteBenefits,
@@ -341,6 +348,7 @@ export const productCatalogDescription: Record<
 			Sunday: {
 				billingPeriod: 'Monthly',
 				label: 'The Observer',
+				hideSimilarProductsConsent: true,
 			},
 		},
 	},
@@ -370,6 +378,7 @@ export const productCatalogDescription: Record<
 			Sunday: {
 				billingPeriod: 'Monthly',
 				label: 'The Observer',
+				hideSimilarProductsConsent: true,
 			},
 		},
 	},

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -61,6 +61,7 @@ import {
 	filterBenefitByRegion,
 	productCatalogDescription,
 	productCatalogDescriptionNewBenefits,
+	showSimilarProductsConsentForRatePlan,
 } from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import type { AddressFormFieldError } from 'helpers/redux/checkout/address/state';
@@ -852,7 +853,11 @@ export function CheckoutComponent({
 								}
 								isSignedIn={isSignedIn}
 								showSimilarProductsConsent={
-									abParticipations.similarProductsConsent === 'VariantA'
+									abParticipations.similarProductsConsent === 'VariantA' &&
+									showSimilarProductsConsentForRatePlan(
+										productDescription,
+										ratePlanKey,
+									)
 								}
 							/>
 
@@ -1255,9 +1260,11 @@ export function CheckoutComponent({
 								margin: ${space[6]}px 0;
 							`}
 						>
-							{abParticipations.similarProductsConsent === 'VariantB' && (
-								<SimilarProductsConsent />
-							)}
+							{abParticipations.similarProductsConsent === 'VariantB' &&
+								showSimilarProductsConsentForRatePlan(
+									productDescription,
+									ratePlanKey,
+								) && <SimilarProductsConsent />}
 						</div>
 						<SummaryTsAndCs
 							productKey={productKey}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Now that we are explicitly asking users to consent to 'Similar Guardian products' marketing by adding a checkbox to the checkout (see #6957), we need to make sure that we are not showing the checkbox for products where we do not want marketing consent - Guardian Ad-Lite and The Observer.

This PR adds a new boolean named `hideSimilarProductsConsent` onto the `ProductDescription.ratePlan` object in the product catalog. This has to be at the rate plan level rather than the product level because Observer is a rate plan of the home delivery and subscription card products, not a product in its own right.