### PR TITLE
Hosted checkout: verify that user entered form fields match the checkout session

### DIFF
--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -150,7 +150,7 @@ class CreateSubscriptionController(
 
     urls match {
       case Some((validSuccessUrl, validCancelUrl)) =>
-        val fieldsHash = FormFieldsHash.create(requestBody)
+        val fieldsHash = FormFieldsHash.createFromSupportWorkersRequest(requestBody)
         stripeCheckoutSessionService
           .createCheckoutSession(
             stripePublicKey,

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -18,7 +18,6 @@ import io.circe.Encoder
 import io.circe.generic.semiauto._
 import io.circe.syntax._
 import lib.PlayImplicits._
-import models.FormFieldsHash
 import models.identity.responses.IdentityErrorResponse._
 import org.apache.pekko.actor.{ActorSystem, Scheduler}
 import org.joda.time.DateTime
@@ -33,7 +32,6 @@ import services.{
   RecaptchaService,
   StripeCheckoutSessionService,
   TestUserService,
-  UserBenefitsApiService,
   UserBenefitsApiServiceProvider,
   UserBenefitsResponse,
   UserDetails,
@@ -134,6 +132,20 @@ class CreateSubscriptionController(
       }
     }
 
+  private def createFormFieldsHash(
+      requestBody: CreateSupportWorkersRequest,
+  ): String = {
+    FormFieldsHash.create(
+      email = requestBody.email,
+      firstName = requestBody.firstName,
+      lastName = requestBody.lastName,
+      telephoneNumber = requestBody.telephoneNumber,
+      billingAddress = requestBody.billingAddress,
+      deliveryAddress = requestBody.deliveryAddress,
+      deliveryInstructions = requestBody.deliveryInstructions,
+    )
+  }
+
   private def createCheckoutSession(
       stripePublicKey: StripePublicKey,
       email: String,
@@ -150,7 +162,7 @@ class CreateSubscriptionController(
 
     urls match {
       case Some((validSuccessUrl, validCancelUrl)) =>
-        val fieldsHash = FormFieldsHash.createFromSupportWorkersRequest(requestBody)
+        val fieldsHash = createFormFieldsHash(requestBody)
         stripeCheckoutSessionService
           .createCheckoutSession(
             stripePublicKey,

--- a/support-frontend/app/models/FormFieldsHash.scala
+++ b/support-frontend/app/models/FormFieldsHash.scala
@@ -1,0 +1,26 @@
+package models
+
+import services.stepfunctions.CreateSupportWorkersRequest
+import java.security.MessageDigest
+
+object FormFieldsHash {
+  def create(supportWorkersRequest: CreateSupportWorkersRequest) = {
+    val fields = List(
+      supportWorkersRequest.email,
+      supportWorkersRequest.firstName,
+      supportWorkersRequest.lastName,
+      supportWorkersRequest.telephoneNumber.getOrElse(""),
+      supportWorkersRequest.email,
+      supportWorkersRequest.telephoneNumber,
+      supportWorkersRequest.billingAddress.toString,
+      supportWorkersRequest.deliveryAddress.map(_.toString).getOrElse(""),
+      supportWorkersRequest.deliveryInstructions.getOrElse(""),
+    ).mkString("|")
+
+    MessageDigest
+      .getInstance("SHA-256")
+      .digest(fields.getBytes("UTF-8"))
+      .map("%02x".format(_))
+      .mkString
+  }
+}

--- a/support-frontend/app/models/FormFieldsHash.scala
+++ b/support-frontend/app/models/FormFieldsHash.scala
@@ -1,20 +1,40 @@
 package models
 
+import com.gu.support.workers.Address
 import services.stepfunctions.CreateSupportWorkersRequest
+
 import java.security.MessageDigest
 
 object FormFieldsHash {
-  def create(supportWorkersRequest: CreateSupportWorkersRequest) = {
+  def createFromSupportWorkersRequest(supportWorkersRequest: CreateSupportWorkersRequest): String = {
+    create(
+      email = supportWorkersRequest.email,
+      firstName = supportWorkersRequest.firstName,
+      lastName = supportWorkersRequest.lastName,
+      telephoneNumber = supportWorkersRequest.telephoneNumber,
+      billingAddress = supportWorkersRequest.billingAddress,
+      deliveryAddress = supportWorkersRequest.deliveryAddress,
+      deliveryInstructions = supportWorkersRequest.deliveryInstructions,
+    )
+  }
+
+  def create(
+      email: String,
+      firstName: String,
+      lastName: String,
+      telephoneNumber: Option[String],
+      billingAddress: Address,
+      deliveryAddress: Option[Address],
+      deliveryInstructions: Option[String],
+  ): String = {
     val fields = List(
-      supportWorkersRequest.email,
-      supportWorkersRequest.firstName,
-      supportWorkersRequest.lastName,
-      supportWorkersRequest.telephoneNumber.getOrElse(""),
-      supportWorkersRequest.email,
-      supportWorkersRequest.telephoneNumber,
-      supportWorkersRequest.billingAddress.toString,
-      supportWorkersRequest.deliveryAddress.map(_.toString).getOrElse(""),
-      supportWorkersRequest.deliveryInstructions.getOrElse(""),
+      email,
+      firstName,
+      lastName,
+      telephoneNumber.getOrElse(""),
+      billingAddress.toString,
+      deliveryAddress.map(_.toString).getOrElse(""),
+      deliveryInstructions.getOrElse(""),
     ).mkString("|")
 
     MessageDigest

--- a/support-frontend/app/services/StripeCheckoutSessionService.scala
+++ b/support-frontend/app/services/StripeCheckoutSessionService.scala
@@ -5,7 +5,7 @@ import cats.implicits.{catsSyntaxApplicativeError, toBifunctorOps}
 import com.gu.i18n.Currency
 import com.gu.monitoring.SafeLogging
 import com.gu.support.config.StripeConfigProvider
-import com.gu.support.workers.StripePublicKey
+import com.gu.support.workers.{FormFieldsHash, StripePublicKey}
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 import play.api.libs.ws.{WSAuthScheme, WSClient, WSResponse}
@@ -59,7 +59,7 @@ class StripeCheckoutSessionService(
       "currency" -> Seq(currency.iso.toLowerCase),
       "payment_method_types[]" -> Seq("card"),
       "customer_email" -> Seq(email),
-      "metadata[fields_hash]" -> Seq(fieldsHash),
+      s"metadata[${FormFieldsHash.fieldName}]" -> Seq(fieldsHash),
     )
 
     client

--- a/support-frontend/app/services/StripeCheckoutSessionService.scala
+++ b/support-frontend/app/services/StripeCheckoutSessionService.scala
@@ -47,6 +47,7 @@ class StripeCheckoutSessionService(
       isTestUser: Boolean,
       successUrl: String,
       cancelUrl: String,
+      fieldsHash: String,
   ): EitherT[Future, String, CreateCheckoutSessionResponseSuccess] = {
     val privateKey = getPrivateKey(stripePublicKey, isTestUser)
 
@@ -58,13 +59,14 @@ class StripeCheckoutSessionService(
       "currency" -> Seq(currency.iso.toLowerCase),
       "payment_method_types[]" -> Seq("card"),
       "customer_email" -> Seq(email),
+      "metadata[fields_hash]" -> Seq(fieldsHash),
     )
 
     client
       .url(s"$baseUrl/checkout/sessions")
       .withHttpHeaders("Authorization" -> s"Bearer $privateKey")
       .withMethod("POST")
-      // https: //www.playframework.com/documentation/3.0.x/ScalaWS#Submitting-form-data
+      // https://www.playframework.com/documentation/3.0.x/ScalaWS#Submitting-form-data
       .withBody(data)
       .execute()
       .attemptT

--- a/support-models/src/main/scala/com/gu/support/workers/FormFieldsHash.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/FormFieldsHash.scala
@@ -1,23 +1,8 @@
-package models
-
-import com.gu.support.workers.Address
-import services.stepfunctions.CreateSupportWorkersRequest
+package com.gu.support.workers
 
 import java.security.MessageDigest
 
 object FormFieldsHash {
-  def createFromSupportWorkersRequest(supportWorkersRequest: CreateSupportWorkersRequest): String = {
-    create(
-      email = supportWorkersRequest.email,
-      firstName = supportWorkersRequest.firstName,
-      lastName = supportWorkersRequest.lastName,
-      telephoneNumber = supportWorkersRequest.telephoneNumber,
-      billingAddress = supportWorkersRequest.billingAddress,
-      deliveryAddress = supportWorkersRequest.deliveryAddress,
-      deliveryInstructions = supportWorkersRequest.deliveryInstructions,
-    )
-  }
-
   def create(
       email: String,
       firstName: String,

--- a/support-models/src/main/scala/com/gu/support/workers/FormFieldsHash.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/FormFieldsHash.scala
@@ -3,6 +3,8 @@ package com.gu.support.workers
 import java.security.MessageDigest
 
 object FormFieldsHash {
+  val fieldName = "form_fields_hash"
+
   def create(
       email: String,
       firstName: String,

--- a/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
+++ b/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
@@ -79,6 +79,14 @@ object AwsCloudWatchMetricSetup {
       ),
     )
 
+  def stripeHostedFormFieldsHashMismatch(stage: Stage): MetricRequest =
+    getMetricRequest(
+      MetricName("StripeHostedFormFieldsHashMismatch"),
+      Map(
+        MetricDimensionName("Stage") -> MetricDimensionValue(stage.toString),
+      ),
+    )
+
   def getDeliveryAgentsSuccess(stage: Stage): MetricRequest =
     getMetricRequest(
       MetricName("GetDeliveryAgentsSuccess"),

--- a/support-workers/src/main/scala/com/gu/stripe/retrieveCheckoutSession.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/retrieveCheckoutSession.scala
@@ -15,7 +15,7 @@ object CheckoutSetupIntent {
   implicit val decoder: Decoder[CheckoutSetupIntent] = deriveDecoder
 }
 
-case class RetrieveCheckoutSessionResponseSuccess(setup_intent: CheckoutSetupIntent)
+case class RetrieveCheckoutSessionResponseSuccess(setup_intent: CheckoutSetupIntent, meta_data: Map[String, String])
 object RetrieveCheckoutSessionResponseSuccess {
   implicit val decoder: Decoder[RetrieveCheckoutSessionResponseSuccess] = deriveDecoder
 }

--- a/support-workers/src/main/scala/com/gu/stripe/retrieveCheckoutSession.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/retrieveCheckoutSession.scala
@@ -15,7 +15,7 @@ object CheckoutSetupIntent {
   implicit val decoder: Decoder[CheckoutSetupIntent] = deriveDecoder
 }
 
-case class RetrieveCheckoutSessionResponseSuccess(setup_intent: CheckoutSetupIntent, meta_data: Map[String, String])
+case class RetrieveCheckoutSessionResponseSuccess(setup_intent: CheckoutSetupIntent, metadata: Map[String, String])
 object RetrieveCheckoutSessionResponseSuccess {
   implicit val decoder: Decoder[RetrieveCheckoutSessionResponseSuccess] = deriveDecoder
 }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -107,7 +107,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       deliveryAddress = user.deliveryAddress,
       deliveryInstructions = user.deliveryInstructions,
     )
-    checkoutSession.meta_data.get("formFieldsHash") == Some(expectedFormFieldsHash)
+    checkoutSession.metadata.get("formFieldsHash") == Some(expectedFormFieldsHash)
   }
 
   private def createStripeHostedPaymentMethod(

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -107,6 +107,9 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       deliveryAddress = user.deliveryAddress,
       deliveryInstructions = user.deliveryInstructions,
     )
+    logger.info(
+      s"Comparing got: ${checkoutSession.metadata.get(FormFieldsHash.fieldName)} with expected: $expectedFormFieldsHash",
+    )
     checkoutSession.metadata.get(FormFieldsHash.fieldName) == Some(expectedFormFieldsHash)
   }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -107,7 +107,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       deliveryAddress = user.deliveryAddress,
       deliveryInstructions = user.deliveryInstructions,
     )
-    checkoutSession.metadata.get("formFieldsHash") == Some(expectedFormFieldsHash)
+    checkoutSession.metadata.get(FormFieldsHash.fieldName) == Some(expectedFormFieldsHash)
   }
 
   private def createStripeHostedPaymentMethod(

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -105,7 +105,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
     logger.info(
       s"Comparing got: ${checkoutSession.metadata.get(FormFieldsHash.fieldName)} with expected: $expectedFormFieldsHash",
     )
-    val hashesDidMatch = checkoutSession.metadata.get(FormFieldsHash.fieldName) == Some(s"${expectedFormFieldsHash}-x")
+    val hashesDidMatch = checkoutSession.metadata.get(FormFieldsHash.fieldName) == Some(expectedFormFieldsHash)
 
     if (!hashesDidMatch) {
       val cloudwatchEvent = stripeHostedFormFieldsHashMismatch(Configuration.stage)

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -105,7 +105,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
     logger.info(
       s"Comparing got: ${checkoutSession.metadata.get(FormFieldsHash.fieldName)} with expected: $expectedFormFieldsHash",
     )
-    val hashesDidMatch = checkoutSession.metadata.get(FormFieldsHash.fieldName) == Some(expectedFormFieldsHash)
+    val hashesDidMatch = checkoutSession.metadata.get(FormFieldsHash.fieldName) == Some(s"${expectedFormFieldsHash}-x")
 
     if (!hashesDidMatch) {
       val cloudwatchEvent = stripeHostedFormFieldsHashMismatch(Configuration.stage)


### PR DESCRIPTION
## What are you doing in this PR?

When the checkout session is created store the SHA256 hash of the user entered form fields in the `metadata` field. When retrieving the checkout session in support-workers, compare the hash with the hash of the form fields provided. If they don't match, ~~return an error~~ send a CloudWatch metric event.

[**Trello Card**](https://trello.com/c/88hS6qF5/1571-ensure-that-the-checkout-session-matches-the-form-fields-persisted-hash-these-and-add-the-hash-to-the-checkout-session-metadata)

## Why are you doing this?

There's no scenario where the form fields (which we stash in session storage) should change between redirecting the user to Stripe and coming back to the support site to complete the transaction, so let's make sure it doesn't. Before rolling this out in a way which actually prevents a purchase, let's emit a metric event so we can see if it ever happens first.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

I've verified that I can still put a Sunday only subscription through. I've also run the smoke tests against this branch.

I deliberately broke the hash check and can see the metric in CODE:

<img width="459" alt="Screenshot 2025-05-12 at 13 53 55" src="https://github.com/user-attachments/assets/2fff2c07-ec16-4d5a-acb2-e9748422a4e5" />
