### PR TITLE
Fix integration test alarms

### DIFF
--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -16,6 +16,9 @@ Mappings:
     Alarm:
       Process: See the wiki at https://github.com/guardian/support-frontend/wiki/Automated-IT-Tests
 
+Conditions:
+  IsProd: !Equals [!Ref Stage, PROD]
+
 Resources:
   LambdaFunction:
     Type: AWS::Serverless::Function
@@ -93,7 +96,7 @@ Resources:
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
-      ActionsEnabled: !Equals [ !Ref Stage, "PROD" ]
+      ActionsEnabled: !If [IsProd, true, false]
       AlarmName: !Join
         - ' '
         - - 'non urgent -'
@@ -130,7 +133,7 @@ Resources:
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
-      ActionsEnabled: !Equals [ !Ref Stage, "PROD" ]
+      ActionsEnabled: !If [IsProd, true, false]
       AlarmName: !Join
         - ' '
         - - 'non urgent -'

--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -16,9 +16,6 @@ Mappings:
     Alarm:
       Process: See the wiki at https://github.com/guardian/support-frontend/wiki/Automated-IT-Tests
 
-Conditions:
-  ProdOnlyResource: !Equals [!Ref Stage, PROD]
-
 Resources:
   LambdaFunction:
     Type: AWS::Serverless::Function
@@ -93,14 +90,15 @@ Resources:
 
   ITTestFailureAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: ProdOnlyResource
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
+      ActionsEnabled: !Equals [ !Ref Stage, "PROD" ]
       AlarmName: !Join
         - ' '
         - - 'non urgent -'
           - 'IT Tests are failing'
+          - !Ref Stage
       AlarmDescription: !Join
         - ' '
         - - 'Impact - There may be improperly tested code in PROD or CODE test data is broken.'
@@ -123,20 +121,21 @@ Resources:
             Unit: Count
       ComparisonOperator: GreaterThanThreshold
       Threshold: 0
-      EvaluationPeriods: 9
-      DatapointsToAlarm: 3
+      EvaluationPeriods: 25 # 25 = 6 hours in 15 minute intervals plus an extra 15 minutes buffer (these tests run every 6 hours)
+      DatapointsToAlarm: 1
       TreatMissingData: breaching
 
   ITTestNotRunningAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: ProdOnlyResource
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
+      ActionsEnabled: !Equals [ !Ref Stage, "PROD" ]
       AlarmName: !Join
         - ' '
         - - 'non urgent -'
           - 'IT Tests are not running'
+          - !Ref Stage
       AlarmDescription: !Join
         - ' '
         - - 'Impact - we are not aware of integration test pass/fail status'


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Fixing the support-workers integration tests alarm so that we're notified when integration tests are failing. Since we've been running them less frequently (see #5959) the alarm configuration means we've not been picking up failures.

I've also changed the alarm definitions so they're created in both CODE and PROD (though actions are only enabled in PROD). This makes it easier to test.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/bkG3KOja/1255-check-whether-support-integration-tests-are-running)

## Why are you doing this?

We want to know when integration tests are failing.

## How to test

Currently the integration tests are actually failing. So I've deployed the alarm changes to CODE and can now see that the alarm is correctly in an ALARM state:

<img width="1282" alt="Screenshot 2025-05-05 at 16 32 22" src="https://github.com/user-attachments/assets/253a4a57-61b5-468c-b6cd-368361a0fb86" />
