### PR TITLE
Use defaultChecked instead of checked prop in `SimilarProductsConsent.tsx`

### DIFF
--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -47,6 +47,18 @@ export const showSimilarProductsConsentForRatePlan = (
 	ratePlanKey: string,
 ) => !productDescription.ratePlans[ratePlanKey]?.hideSimilarProductsConsent;
 
+export const userShouldSeeConsentCheckbox = (
+	productDescription: ProductDescription,
+	ratePlanKey: string,
+	abParticipations: Participations,
+) => {
+	return (
+		['VariantA', 'VariantB'].includes(
+			abParticipations.similarProductsConsent ?? '',
+		) && showSimilarProductsConsentForRatePlan(productDescription, ratePlanKey)
+	);
+};
+
 export function filterBenefitByRegion(
 	benefit: {
 		specificToRegions?: CountryGroupId[];

--- a/support-frontend/assets/pages/[countryGroupId]/components/SimilarProductsConsent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/SimilarProductsConsent.tsx
@@ -6,7 +6,7 @@ export function SimilarProductsConsent() {
 		<Checkbox
 			name="similarProductsConsent"
 			label="Receive information on our products and ways to support and enjoy our journalism. Untick to opt out."
-			checked={true}
+			defaultChecked={true}
 			onClick={(event) => {
 				const checked = event.currentTarget.checked;
 				trackComponentClick(

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -60,6 +60,7 @@ import {
 	productCatalogDescription,
 	productCatalogDescriptionNewBenefits,
 	showSimilarProductsConsentForRatePlan,
+	userShouldSeeConsentCheckbox,
 } from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import type { AddressFormFieldError } from 'helpers/redux/checkout/address/state';
@@ -522,6 +523,11 @@ export function CheckoutComponent({
 				paymentFields,
 				productFields,
 				hasDeliveryAddress: !!productDescription.deliverableTo,
+				userWasShownCheckbox: userShouldSeeConsentCheckbox(
+					productDescription,
+					ratePlanKey,
+					abParticipations,
+				),
 				abParticipations,
 				promotion,
 				contributionAmount,

--- a/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
@@ -31,6 +31,24 @@ import { createSubscription } from './createSubscription';
 import type { PaymentMethod } from './paymentFields';
 import { FormSubmissionError } from './paymentFields';
 
+const getConsentValue = (
+	formData: FormData,
+	abParticipations: Participations,
+) => {
+	const similarProductsCheckbox = formData.get('similarProductsConsent');
+	if (similarProductsCheckbox) {
+		return similarProductsCheckbox === 'on';
+	}
+
+	if (
+		['VariantA', 'VariantB'].includes(
+			abParticipations.similarProductsConsent ?? '',
+		)
+	) {
+		return false;
+	}
+	return;
+};
 export const submitForm = async ({
 	geoId,
 	productKey,
@@ -72,6 +90,8 @@ export const submitForm = async ({
 		productFields,
 	);
 
+	const similarProductsConsent = getConsentValue(formData, abParticipations);
+
 	const promoCode = promotion?.promoCode;
 	const appliedPromotion =
 		promoCode !== undefined
@@ -82,12 +102,6 @@ export const submitForm = async ({
 			: undefined;
 	const supportAbTests = getSupportAbTests(abParticipations);
 	const deliveryInstructions = formData.get('deliveryInstructions') as string;
-
-	const similarProductsCheckbox = formData.get('similarProductsConsent');
-	const similarProductsConsent =
-		similarProductsCheckbox !== null
-			? similarProductsCheckbox === 'on'
-			: undefined;
 
 	const paymentRequest: RegularPaymentRequest = {
 		...personalData,

--- a/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
@@ -31,20 +31,12 @@ import { createSubscription } from './createSubscription';
 import type { PaymentMethod } from './paymentFields';
 import { FormSubmissionError } from './paymentFields';
 
-const getConsentValue = (
-	formData: FormData,
-	abParticipations: Participations,
-) => {
+const getConsentValue = (formData: FormData, userWasShownCheckbox: boolean) => {
 	const similarProductsCheckbox = formData.get('similarProductsConsent');
 	if (similarProductsCheckbox) {
 		return similarProductsCheckbox === 'on';
 	}
-
-	if (
-		['VariantA', 'VariantB'].includes(
-			abParticipations.similarProductsConsent ?? '',
-		)
-	) {
+	if (userWasShownCheckbox) {
 		return false;
 	}
 	return;
@@ -58,6 +50,7 @@ export const submitForm = async ({
 	paymentFields,
 	productFields,
 	hasDeliveryAddress,
+	userWasShownCheckbox,
 	abParticipations,
 	promotion,
 	contributionAmount,
@@ -70,6 +63,7 @@ export const submitForm = async ({
 	paymentFields: RegularPaymentFields;
 	productFields: ProductFields;
 	hasDeliveryAddress: boolean;
+	userWasShownCheckbox: boolean;
 	abParticipations: Participations;
 	promotion: Promotion | undefined;
 	contributionAmount: number | undefined;
@@ -90,7 +84,10 @@ export const submitForm = async ({
 		productFields,
 	);
 
-	const similarProductsConsent = getConsentValue(formData, abParticipations);
+	const similarProductsConsent = getConsentValue(
+		formData,
+		userWasShownCheckbox,
+	);
 
 	const promoCode = promotion?.promoCode;
 	const appliedPromotion =


### PR DESCRIPTION

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Update `SimilarProductsConsent` to specify `defaultChecked` instead of `checked`.

[**Trello Card**](https://trello.com)

## Why are you doing this?

Previously the checkbox reverted to a checked state any time the component re-rendered. This way we specify the initial state but let the browser handle the state going forward (this is an uncontrolled component).

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
