### PR TITLE
Another card declined error message to ignore

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/exceptions/CardDeclinedMessages.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/exceptions/CardDeclinedMessages.scala
@@ -14,6 +14,7 @@ object CardDeclinedMessages {
     "Transaction declined.402 - [card_error/authentication_required/authentication_required] Your card was declined. This transaction requires authentication.",
     "Transaction declined.402 - [card_error/card_declined/fraudulent] Your card was declined.",
     "Transaction declined.402 - [card_error/expired_card/expired_card] Your card has expired.",
+    "Transaction declined.402 - [card_error/processing_error/processing_error] An error occurred while processing your card. Try again in a little bit.",
     "Transaction declined.10417 - Instruct the customer to retry the transaction using an alternative payment method from the customers PayPal wallet.",
     "Transaction declined.validation_failed - account_number did not pass modulus check",
     "Transaction declined.validation_failed - account_number is the wrong length (should be 8 characters)",


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We have been adding card declined error messages to our list of errors not to alarm on for a while now. This is the latest one.