### PR TITLE
ActiveRatePlanKey Type Applied

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -21,6 +21,7 @@ import {
 } from 'components/checkoutBenefits/benefitsCheckList';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import type { Currency } from 'helpers/internationalisation/currency';
+import type { ActiveRatePlanKey } from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { isSundayOnlyNewspaperSub } from 'pages/[countryGroupId]/helpers/isSundayOnlyNewspaperSub';
 
@@ -139,7 +140,7 @@ const termsAndConditions = css`
 export type ContributionsOrderSummaryProps = {
 	productKey: ProductKey;
 	productDescription: string;
-	ratePlanKey: string;
+	ratePlanKey: ActiveRatePlanKey;
 	ratePlanDescription?: string;
 	amount: number;
 	promotion?: Promotion;

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
@@ -18,7 +18,10 @@ import {
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
-import type { ActiveProductKey } from 'helpers/productCatalog';
+import type {
+	ActiveProductKey,
+	ActiveRatePlanKey,
+} from 'helpers/productCatalog';
 import { internationaliseProductAndRatePlan } from 'helpers/productCatalog';
 import type {
 	AddressFieldsState,
@@ -231,7 +234,9 @@ export function AddressFields({ scope, countryGroupId, ...props }: PropTypes) {
 							const product = urlSearchParams.get(
 								'product',
 							) as ActiveProductKey;
-							const ratePlan = urlSearchParams.get('ratePlan') as string;
+							const ratePlan = urlSearchParams.get(
+								'ratePlan',
+							) as ActiveRatePlanKey;
 							const { productKey, ratePlanKey } =
 								internationaliseProductAndRatePlan(
 									selectedInternationalisationId,

--- a/support-frontend/assets/helpers/forms/stripe.ts
+++ b/support-frontend/assets/helpers/forms/stripe.ts
@@ -1,5 +1,6 @@
 import type { ActiveProductKey } from '@guardian/support-service-lambdas/modules/product-catalog/src/productCatalog';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { ActiveRatePlanKey } from 'helpers/productCatalog';
 import type { IsoCurrency } from '../internationalisation/currency';
 
 export type StripeAccountType = 'ONE_OFF' | 'REGULAR';
@@ -36,7 +37,7 @@ function getStripeKeyForCountry(
 function getStripeKeyForProduct(
 	stripeAccountType: StripeAccountType,
 	productKey: ActiveProductKey,
-	ratePlanKey: string,
+	ratePlanKey: ActiveRatePlanKey,
 	isTestUser: boolean,
 ) {
 	if (

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -13,6 +13,9 @@ import { gwDeliverableCountries } from './internationalisation/gwDeliverableCoun
 
 export type { ActiveProductKey };
 
+/*
+ * Ideally, would prefer to loop the ActiveProductKey's generating an ActiveRatePlanKey
+ */
 type OneTimeContributionRatePlanKey = ProductRatePlanKey<'OneTimeContribution'>;
 type GuardianAdLiteRatePlanKey = ProductRatePlanKey<'GuardianAdLite'>;
 type TierThreeRatePlanKey = ProductRatePlanKey<'TierThree'>;

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -70,12 +70,12 @@ export type ProductDescription = {
 
 export const showSimilarProductsConsentForRatePlan = (
 	productDescription: ProductDescription,
-	ratePlanKey: string,
+	ratePlanKey: ActiveRatePlanKey,
 ) => !productDescription.ratePlans[ratePlanKey]?.hideSimilarProductsConsent;
 
 export const userShouldSeeConsentCheckbox = (
 	productDescription: ProductDescription,
-	ratePlanKey: string,
+	ratePlanKey: ActiveRatePlanKey,
 	abParticipations: Participations,
 ) => {
 	return (
@@ -547,8 +547,8 @@ export function productCatalogGuardianAdLite(): Record<
 export function internationaliseProductAndRatePlan(
 	supportInternationalisationId: SupportInternationalisationId,
 	productKey: ActiveProductKey,
-	ratePlanKey: string,
-): { productKey: ActiveProductKey; ratePlanKey: string } {
+	ratePlanKey: ActiveRatePlanKey,
+): { productKey: ActiveProductKey; ratePlanKey: ActiveRatePlanKey } {
 	let productKeyToUse = productKey;
 	let ratePlanToUse = ratePlanKey;
 

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -1,4 +1,7 @@
-import type { ActiveProductKey } from '@guardian/support-service-lambdas/modules/product-catalog/src/productCatalog';
+import type {
+	ActiveProductKey,
+	ProductRatePlanKey,
+} from '@guardian/support-service-lambdas/modules/product-catalog/src/productCatalog';
 import { activeTypeObject } from '@guardian/support-service-lambdas/modules/product-catalog/src/typeObject';
 import type { Participations } from './abTests/models';
 import { newspaperCountries } from './internationalisation/country';
@@ -9,6 +12,29 @@ import type {
 import { gwDeliverableCountries } from './internationalisation/gwDeliverableCountries';
 
 export type { ActiveProductKey };
+
+type OneTimeContributionRatePlanKey = ProductRatePlanKey<'OneTimeContribution'>;
+type GuardianAdLiteRatePlanKey = ProductRatePlanKey<'GuardianAdLite'>;
+type TierThreeRatePlanKey = ProductRatePlanKey<'TierThree'>;
+type DigitalSubscriptioRatePlanKey = ProductRatePlanKey<'DigitalSubscription'>;
+type NationalDeliveryRatePlanKey = ProductRatePlanKey<'NationalDelivery'>;
+type SupporterPlusRatePlanKey = ProductRatePlanKey<'SupporterPlus'>;
+type GuardianWeeklyRestOfWorldRatePlanKey =
+	ProductRatePlanKey<'GuardianWeeklyRestOfWorld'>;
+type SubscriptionCardRatePlanKey = ProductRatePlanKey<'SubscriptionCard'>;
+type ContributionRatePlanKey = ProductRatePlanKey<'Contribution'>;
+type GuardianPatronRatePlanKey = ProductRatePlanKey<'GuardianPatron'>;
+export type ActiveRatePlanKey =
+	| OneTimeContributionRatePlanKey
+	| GuardianAdLiteRatePlanKey
+	| TierThreeRatePlanKey
+	| DigitalSubscriptioRatePlanKey
+	| NationalDeliveryRatePlanKey
+	| SupporterPlusRatePlanKey
+	| GuardianWeeklyRestOfWorldRatePlanKey
+	| SubscriptionCardRatePlanKey
+	| ContributionRatePlanKey
+	| GuardianPatronRatePlanKey;
 
 export const productCatalog = window.guardian.productCatalog;
 

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -19,7 +19,7 @@ export type { ActiveProductKey };
 type OneTimeContributionRatePlanKey = ProductRatePlanKey<'OneTimeContribution'>;
 type GuardianAdLiteRatePlanKey = ProductRatePlanKey<'GuardianAdLite'>;
 type TierThreeRatePlanKey = ProductRatePlanKey<'TierThree'>;
-type DigitalSubscriptioRatePlanKey = ProductRatePlanKey<'DigitalSubscription'>;
+type DigitalSubscriptionRatePlanKey = ProductRatePlanKey<'DigitalSubscription'>;
 type NationalDeliveryRatePlanKey = ProductRatePlanKey<'NationalDelivery'>;
 type SupporterPlusRatePlanKey = ProductRatePlanKey<'SupporterPlus'>;
 type GuardianWeeklyRestOfWorldRatePlanKey =
@@ -27,11 +27,16 @@ type GuardianWeeklyRestOfWorldRatePlanKey =
 type SubscriptionCardRatePlanKey = ProductRatePlanKey<'SubscriptionCard'>;
 type ContributionRatePlanKey = ProductRatePlanKey<'Contribution'>;
 type GuardianPatronRatePlanKey = ProductRatePlanKey<'GuardianPatron'>;
+/*
+ * Duplicate rate plans that cannot be unioned listed below ->
+ * GuardianWeeklyDomestic  = GuardianWeeklyRestOfWorld
+ * HomeDelivery = SubscriptionCardRatePlan
+ */
 export type ActiveRatePlanKey =
 	| OneTimeContributionRatePlanKey
 	| GuardianAdLiteRatePlanKey
 	| TierThreeRatePlanKey
-	| DigitalSubscriptioRatePlanKey
+	| DigitalSubscriptionRatePlanKey
 	| NationalDeliveryRatePlanKey
 	| SupporterPlusRatePlanKey
 	| GuardianWeeklyRestOfWorldRatePlanKey

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -21,28 +21,33 @@ type GuardianAdLiteRatePlanKey = ProductRatePlanKey<'GuardianAdLite'>;
 type TierThreeRatePlanKey = ProductRatePlanKey<'TierThree'>;
 type DigitalSubscriptionRatePlanKey = ProductRatePlanKey<'DigitalSubscription'>;
 type NationalDeliveryRatePlanKey = ProductRatePlanKey<'NationalDelivery'>;
+type HomeDeliveryRatePlanKey = ProductRatePlanKey<'HomeDelivery'>;
 type SupporterPlusRatePlanKey = ProductRatePlanKey<'SupporterPlus'>;
 type GuardianWeeklyRestOfWorldRatePlanKey =
 	ProductRatePlanKey<'GuardianWeeklyRestOfWorld'>;
+type GuardianWeeklyDomesticRatePlanKey =
+	ProductRatePlanKey<'GuardianWeeklyDomestic'>;
 type SubscriptionCardRatePlanKey = ProductRatePlanKey<'SubscriptionCard'>;
 type ContributionRatePlanKey = ProductRatePlanKey<'Contribution'>;
 type GuardianPatronRatePlanKey = ProductRatePlanKey<'GuardianPatron'>;
-/*
- * Duplicate rate plans that cannot be unioned listed below ->
- * GuardianWeeklyDomestic  = GuardianWeeklyRestOfWorld
- * HomeDelivery = SubscriptionCardRatePlan
- */
-export type ActiveRatePlanKey =
-	| OneTimeContributionRatePlanKey
-	| GuardianAdLiteRatePlanKey
-	| TierThreeRatePlanKey
-	| DigitalSubscriptionRatePlanKey
-	| NationalDeliveryRatePlanKey
-	| SupporterPlusRatePlanKey
-	| GuardianWeeklyRestOfWorldRatePlanKey
-	| SubscriptionCardRatePlanKey
-	| ContributionRatePlanKey
-	| GuardianPatronRatePlanKey;
+
+/* eslint-disable @typescript-eslint/no-duplicate-type-constituents -- HomeDelivery matches SubscriptionCard GuardianWeeklyDomestic matches GuardianWeeklyRestOfWorld */
+export type ActiveRatePlanKey = keyof {
+	[Key in
+		| OneTimeContributionRatePlanKey
+		| GuardianAdLiteRatePlanKey
+		| TierThreeRatePlanKey
+		| DigitalSubscriptionRatePlanKey
+		| NationalDeliveryRatePlanKey
+		| HomeDeliveryRatePlanKey
+		| SupporterPlusRatePlanKey
+		| GuardianWeeklyRestOfWorldRatePlanKey
+		| GuardianWeeklyDomesticRatePlanKey
+		| SubscriptionCardRatePlanKey
+		| ContributionRatePlanKey
+		| GuardianPatronRatePlanKey]: true;
+};
+/* eslint-enable @typescript-eslint/no-duplicate-type-constituents -- enabled */
 
 export const productCatalog = window.guardian.productCatalog;
 

--- a/support-frontend/assets/helpers/productPrice/productOptions.ts
+++ b/support-frontend/assets/helpers/productPrice/productOptions.ts
@@ -1,5 +1,6 @@
 // describes options relating to a product itself - only relevant for paper currently
 import type { ActiveProductKey } from '@guardian/support-service-lambdas/modules/product-catalog/src/productCatalog';
+import type { ActiveRatePlanKey } from 'helpers/productCatalog';
 
 const NoProductOptions = 'NoProductOptions';
 const Saturday = 'Saturday';
@@ -85,7 +86,9 @@ function productOptionIfDigiAddOnChanged(
 	return matchingProducLookup[selectedOption];
 }
 
-const getPaperProductOptions = (ratePlanKey: string): ProductOptions => {
+const getPaperProductOptions = (
+	ratePlanKey: ActiveRatePlanKey,
+): ProductOptions => {
 	switch (ratePlanKey) {
 		case 'Saturday':
 		case 'Sunday':
@@ -100,7 +103,7 @@ const getPaperProductOptions = (ratePlanKey: string): ProductOptions => {
 };
 export const getProductOptionFromProductAndRatePlan = (
 	productKey: ActiveProductKey,
-	ratePlanKey: string,
+	ratePlanKey: ActiveRatePlanKey,
 ): ProductOptions => {
 	switch (productKey) {
 		case 'SupporterPlus':

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -119,13 +119,7 @@ export function Checkout({
 		return <div>Product not found</div>;
 	}
 
-	/**
-	 * Get and validate ratePlan
-	 * TODO: This type should be more specific e.g. `ProductRatePlanKey<P>`.
-	 * Annoyingly the TypeScript for this is a little fiddly due to the
-	 * API being completely based on literals, so we've left it as `string`
-	 * although we do validate it is a valid ratePlan for this product
-	 */
+	/** Get and validate active ratePlan */
 	const ratePlanParam = urlSearchParams.get('ratePlan');
 	const ratePlanKey =
 		ratePlanParam && ratePlanParam in product.ratePlans

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -46,7 +46,7 @@ const countryId: IsoCountry = Country.detect();
 const getPromotionFromProductPrices = (
 	appConfig: AppConfig,
 	productKey: ActiveProductKey,
-	ratePlanKey: string,
+	ratePlanKey: ActiveRatePlanKey,
 	countryId: IsoCountry,
 	billingPeriod: BillingPeriod,
 ) => {

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -9,7 +9,11 @@ import {
 import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import { Country } from 'helpers/internationalisation/classes/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import { isProductKey, productCatalog } from 'helpers/productCatalog';
+import {
+	type ActiveRatePlanKey,
+	isProductKey,
+	productCatalog,
+} from 'helpers/productCatalog';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import { getFulfilmentOptionFromProductKey } from 'helpers/productPrice/fulfilmentOptions';
 import {
@@ -125,7 +129,7 @@ export function Checkout({
 	const ratePlanParam = urlSearchParams.get('ratePlan');
 	const ratePlanKey =
 		ratePlanParam && ratePlanParam in product.ratePlans
-			? ratePlanParam
+			? (ratePlanParam as ActiveRatePlanKey)
 			: undefined;
 	const ratePlan = ratePlanKey && product.ratePlans[ratePlanKey];
 	if (!ratePlan) {

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/getProductFields.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/getProductFields.ts
@@ -2,6 +2,7 @@ import type { RegularPaymentRequest } from 'helpers/forms/paymentIntegrations/re
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type {
 	ActiveProductKey,
+	ActiveRatePlanKey,
 	ProductDescription,
 } from 'helpers/productCatalog';
 import { getFulfilmentOptionFromProductKey } from 'helpers/productPrice/fulfilmentOptions';
@@ -12,7 +13,7 @@ type GetProductFieldsParams = {
 	product: {
 		productKey: ActiveProductKey;
 		productDescription: ProductDescription;
-		ratePlanKey: string;
+		ratePlanKey: ActiveRatePlanKey;
 		deliveryAgent: number | undefined;
 	};
 	financial: {

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -155,7 +155,7 @@ type CheckoutComponentProps = {
 const getPaymentMethods = (
 	countryId: IsoCountry,
 	productKey: ProductKey,
-	ratePlanKey: string,
+	ratePlanKey: ActiveRatePlanKey,
 ) => {
 	const maybeDirectDebit = countryId === 'GB' && DirectDebit;
 

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -57,6 +57,7 @@ import { countryGroups } from 'helpers/internationalisation/countryGroup';
 import { fromCountryGroupId } from 'helpers/internationalisation/currency';
 import {
 	type ActiveProductKey,
+	type ActiveRatePlanKey,
 	productCatalogDescription,
 	productCatalogDescriptionNewBenefits,
 	showSimilarProductsConsentForRatePlan,
@@ -137,7 +138,7 @@ type CheckoutComponentProps = {
 	stripePublicKey: string;
 	isTestUser: boolean;
 	productKey: ActiveProductKey;
-	ratePlanKey: string;
+	ratePlanKey: ActiveRatePlanKey;
 	originalAmount: number;
 	discountedAmount?: number;
 	contributionAmount?: number;

--- a/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
@@ -7,7 +7,10 @@ import type {
 	RegularPaymentFields,
 	RegularPaymentRequest,
 } from '../../../helpers/forms/paymentIntegrations/readerRevenueApis';
-import type { ActiveProductKey } from '../../../helpers/productCatalog';
+import type {
+	ActiveProductKey,
+	ActiveRatePlanKey,
+} from '../../../helpers/productCatalog';
 import type { UserType } from '../../../helpers/redux/checkout/personalDetails/state';
 import {
 	getOphanIds,
@@ -57,7 +60,7 @@ export const submitForm = async ({
 }: {
 	geoId: GeoId;
 	productKey: ActiveProductKey;
-	ratePlanKey: string;
+	ratePlanKey: ActiveRatePlanKey;
 	formData: FormData;
 	paymentMethod: PaymentMethod;
 	paymentFields: RegularPaymentFields;
@@ -168,7 +171,7 @@ const createStripeCheckoutSession = async ({
 	personalData: FormPersonalFields;
 	appliedPromotion?: { promoCode: string; countryGroupId: GeoId };
 	productKey: ActiveProductKey;
-	ratePlanKey: string;
+	ratePlanKey: ActiveRatePlanKey;
 	contributionAmount: number | undefined;
 	paymentMethod: PaymentMethod;
 	geoId: GeoId;
@@ -193,7 +196,7 @@ const processSubscription = async ({
 	personalData: FormPersonalFields;
 	appliedPromotion?: { promoCode: string; countryGroupId: GeoId };
 	productKey: ActiveProductKey;
-	ratePlanKey: string;
+	ratePlanKey: ActiveRatePlanKey;
 	contributionAmount: number | undefined;
 	paymentMethod: PaymentMethod;
 	geoId: GeoId;

--- a/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
@@ -235,7 +235,7 @@ const processSubscription = async ({
 
 const buildThankYouPageUrl = (
 	productKey: ActiveProductKey,
-	ratePlanKey: string,
+	ratePlanKey: ActiveRatePlanKey,
 	promoCode: string | undefined,
 	userType: UserType | undefined,
 	contributionAmount: number | undefined,

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -16,7 +16,10 @@ import { getThankYouModuleData } from 'components/thankYou/thankYouModuleData';
 import type { Participations } from 'helpers/abTests/models';
 import type { ContributionType } from 'helpers/contributions';
 import { Country } from 'helpers/internationalisation/classes/country';
-import type { ActiveProductKey } from 'helpers/productCatalog';
+import type {
+	ActiveProductKey,
+	ActiveRatePlanKey,
+} from 'helpers/productCatalog';
 import type { ActivePaperProductOptions } from 'helpers/productPrice/productOptions';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { type CsrfState } from 'helpers/redux/checkout/csrf/state';
@@ -91,7 +94,7 @@ export type CheckoutComponentProps = {
 		finalAmount: number;
 	};
 	productKey?: ActiveProductKey;
-	ratePlanKey?: string;
+	ratePlanKey?: ActiveRatePlanKey;
 	promotion?: Promotion;
 	identityUserType: UserType;
 	abParticipations: Participations;

--- a/support-frontend/assets/pages/[countryGroupId]/helpers/isSundayOnlyNewspaperSub.test.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/helpers/isSundayOnlyNewspaperSub.test.tsx
@@ -1,4 +1,7 @@
-import type { ActiveProductKey } from 'helpers/productCatalog';
+import type {
+	ActiveProductKey,
+	ActiveRatePlanKey,
+} from 'helpers/productCatalog';
 import { isSundayOnlyNewspaperSub } from './isSundayOnlyNewspaperSub';
 
 describe('isSundayOnlyNewspaperSub', () => {
@@ -13,7 +16,7 @@ describe('isSundayOnlyNewspaperSub', () => {
 		({ productKey, ratePlanKey, expected }) => {
 			const isSundayOnlyNewspaperSubscription = isSundayOnlyNewspaperSub(
 				productKey as ActiveProductKey,
-				ratePlanKey as string,
+				ratePlanKey as ActiveRatePlanKey,
 			);
 
 			expect(isSundayOnlyNewspaperSubscription).toEqual(expected);

--- a/support-frontend/assets/pages/[countryGroupId]/helpers/isSundayOnlyNewspaperSub.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/helpers/isSundayOnlyNewspaperSub.ts
@@ -1,8 +1,9 @@
 import type { ProductKey } from '@modules/product-catalog/productCatalog';
+import type { ActiveRatePlanKey } from 'helpers/productCatalog';
 
 export const isSundayOnlyNewspaperSub = (
 	productKey: ProductKey,
-	ratePlanKey: string,
+	ratePlanKey: ActiveRatePlanKey,
 ): boolean =>
 	['HomeDelivery', 'SubscriptionCard'].includes(productKey) &&
 	ratePlanKey === 'Sunday';

--- a/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
@@ -1,6 +1,10 @@
 import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import { Country } from 'helpers/internationalisation/classes/country';
-import { isProductKey, productCatalog } from 'helpers/productCatalog';
+import {
+	type ActiveRatePlanKey,
+	isProductKey,
+	productCatalog,
+} from 'helpers/productCatalog';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { getPromotion } from 'helpers/productPrice/promotions';
@@ -40,7 +44,7 @@ export function ThankYou({
 	const ratePlanParam = searchParams.get('ratePlan');
 	const ratePlanKey =
 		ratePlanParam && product && ratePlanParam in product.ratePlans
-			? ratePlanParam
+			? (ratePlanParam as ActiveRatePlanKey)
 			: undefined;
 	const ratePlan =
 		ratePlanKey && product ? product.ratePlans[ratePlanKey] : undefined;

--- a/support-frontend/assets/pages/supporter-plus-landing/components/summaryTsAndCs.test.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/summaryTsAndCs.test.tsx
@@ -1,5 +1,8 @@
 import { render } from '@testing-library/react';
-import type { ActiveProductKey } from 'helpers/productCatalog';
+import type {
+	ActiveProductKey,
+	ActiveRatePlanKey,
+} from 'helpers/productCatalog';
 import type { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import { SummaryTsAndCs } from './summaryTsAndCs';
 
@@ -29,7 +32,7 @@ describe('Summary Ts&Cs Snapshot comparison', () => {
 				<SummaryTsAndCs
 					billingPeriod={billingPeriod as BillingPeriod}
 					productKey={productKey as ActiveProductKey}
-					ratePlanKey=""
+					ratePlanKey={billingPeriod as ActiveRatePlanKey}
 					currency={'GBP'}
 					amount={0}
 				/>,

--- a/support-frontend/assets/pages/supporter-plus-landing/components/summaryTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/summaryTsAndCs.tsx
@@ -6,7 +6,10 @@ import {
 	currencies,
 	spokenCurrencies,
 } from 'helpers/internationalisation/currency';
-import type { ActiveProductKey } from 'helpers/productCatalog';
+import type {
+	ActiveProductKey,
+	ActiveRatePlanKey,
+} from 'helpers/productCatalog';
 import { productCatalogDescription } from 'helpers/productCatalog';
 import {
 	type BillingPeriod,
@@ -31,7 +34,7 @@ const containerSummaryTsCs = css`
 `;
 export interface SummaryTsAndCsProps {
 	productKey: ActiveProductKey;
-	ratePlanKey: string;
+	ratePlanKey: ActiveRatePlanKey;
 	billingPeriod: BillingPeriod;
 	currency: IsoCurrency;
 	amount: number;

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/heading.tsx
@@ -8,7 +8,10 @@ import {
 	currencies,
 	spokenCurrencies,
 } from 'helpers/internationalisation/currency';
-import type { ActiveProductKey } from 'helpers/productCatalog';
+import type {
+	ActiveProductKey,
+	ActiveRatePlanKey,
+} from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
 
 const supCss = css`
@@ -187,7 +190,7 @@ type HeadingProps = {
 	currency: IsoCurrency;
 	contributionType: ContributionType;
 	isObserverPrint: boolean;
-	ratePlanKey?: string;
+	ratePlanKey?: ActiveRatePlanKey;
 	paymentStatus?: PaymentStatus;
 	promotion?: Promotion;
 };

--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/thankYouHeader.tsx
@@ -3,7 +3,10 @@ import { from, space, textEgyptian15 } from '@guardian/source/foundations';
 import type { ContributionType } from 'helpers/contributions';
 import type { PaymentStatus } from 'helpers/forms/paymentMethods';
 import { type IsoCurrency } from 'helpers/internationalisation/currency';
-import type { ActiveProductKey } from 'helpers/productCatalog';
+import type {
+	ActiveProductKey,
+	ActiveRatePlanKey,
+} from 'helpers/productCatalog';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import type { UserType } from 'helpers/redux/checkout/personalDetails/state';
 import type { ObserverPrint } from 'pages/paper-subscription-landing/helpers/products';
@@ -43,7 +46,7 @@ type ThankYouHeaderProps = {
 	identityUserType: UserType;
 	observerPrint?: ObserverPrint;
 	startDate?: string;
-	ratePlanKey?: string;
+	ratePlanKey?: ActiveRatePlanKey;
 	paymentStatus?: PaymentStatus;
 	promotion?: Promotion;
 	showOffer?: boolean;

--- a/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
@@ -115,7 +115,7 @@ export const SingleContribution = Template.bind({});
 
 SingleContribution.args = {
 	productKey: 'Contribution',
-	ratePlanKey: '',
+	ratePlanKey: 'OneTime',
 	productDescription: 'One-off contribution',
 	enableCheckList: false,
 	amount: 25,
@@ -210,7 +210,7 @@ export const TierThree = Template.bind({});
 
 TierThree.args = {
 	productKey: 'TierThree',
-	ratePlanKey: 'Montly',
+	ratePlanKey: 'Monthly',
 	productDescription: 'Digital + print',
 	enableCheckList: true,
 	amount: 27,


### PR DESCRIPTION
## What are you doing in this PR?

Utilising `ProductRatePlanKey<P extends ProductKey> ` in support-service-lambdas (which we have as a dependency).

- Setup `ActiveRatePlan` within `ProductCatalog.ts`
- Replace `ratePlanKey : string` with `ratePlanKey : ActiveRatePlan` throughout (props/functions/tests)

[**Trello Card**](https://trello.com/c/Ilhra1GU/1496-activerateplankey-type-add)

## How to test / screenshots
This is a No-Op change.
