### PR TITLE
Simplify countdown

### DIFF
--- a/support-frontend/assets/helpers/globalsAndSwitches/landingPageSettings.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/landingPageSettings.ts
@@ -21,7 +21,7 @@ interface CountdownTheme {
 	backgroundColor: string;
 	foregroundColor: string;
 }
-interface CountdownSettings {
+export interface CountdownSettings {
 	overwriteHeadingLabel: string;
 	countdownStartTimestamp: string;
 	countdownDeadlineTimestamp: string;
@@ -29,7 +29,7 @@ interface CountdownSettings {
 	theme: CountdownTheme;
 }
 
-export type ParsedCountdownSettings = CountdownSettings & {
+type ParsedCountdownSettings = {
 	countdownStartInMillis: number;
 	countdownDeadlineInMillis: number;
 };
@@ -40,7 +40,6 @@ export const parseCountdownSettings = (
 	const { useLocalTime, countdownStartTimestamp, countdownDeadlineTimestamp } =
 		countdownSettings;
 	return {
-		...countdownSettings,
 		countdownStartInMillis: Date.parse(
 			useLocalTime ? countdownStartTimestamp : `${countdownStartTimestamp}Z`,
 		),

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -13,7 +13,7 @@ import {
 	FooterLinks,
 	FooterWithContents,
 } from '@guardian/source-development-kitchen/react-components';
-import { useEffect, useState } from 'preact/hooks';
+import { useState } from 'preact/hooks';
 import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countrySwitcherContainer';
@@ -47,11 +47,7 @@ import type { Promotion } from 'helpers/productPrice/promotions';
 import { getPromotion } from 'helpers/productPrice/promotions';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
-import type {
-	LandingPageVariant,
-	ParsedCountdownSettings,
-} from '../../../helpers/globalsAndSwitches/landingPageSettings';
-import { parseCountdownSettings } from '../../../helpers/globalsAndSwitches/landingPageSettings';
+import type { LandingPageVariant } from '../../../helpers/globalsAndSwitches/landingPageSettings';
 import { getSanitisedHtml } from '../../../helpers/utilities/utilities';
 import Countdown from '../components/countdown';
 import { LandingPageBanners } from '../components/landingPageBanners';
@@ -292,21 +288,11 @@ export function ThreeTierLanding({
 		urlSearchParamsPromoCode,
 	);
 
-	const getCountdownSettings = (
-		settings: LandingPageVariant,
-	): ParsedCountdownSettings | null => {
-		if (!settings.countdownSettings) {
-			return null;
-		}
-		if (!countdownSwitchOn()) {
-			return null;
-		}
-		return parseCountdownSettings(settings.countdownSettings);
-	};
-
-	const countdownSettings = getCountdownSettings(settings);
-
-	const now = Date.now();
+	const countdownSettings = countdownSwitchOn()
+		? settings.countdownSettings
+		: undefined;
+	// We override the heading when there's a live countdown
+	const [headingOverride, setHeadingOverride] = useState<string | undefined>();
 
 	const enableSingleContributionsTab =
 		campaignSettings?.enableSingleContributions ??
@@ -326,30 +312,6 @@ export function ThreeTierLanding({
 	const tierPlanPeriod = contributionType.toLowerCase();
 	const billingPeriod = (tierPlanPeriod[0]?.toUpperCase() +
 		tierPlanPeriod.slice(1)) as BillingPeriod;
-
-	// Handle which countdown to show (if any).
-	const [currentCountdownSettings, setCurrentCountdownSettings] =
-		useState<ParsedCountdownSettings>();
-	const [showCountdown, setShowCountdown] = useState<boolean>(false);
-	const shouldShowCountdown = () => {
-		if (!currentCountdownSettings) {
-			return false;
-		}
-		return countdownSwitchOn() && showCountdown && currentCountdownSettings;
-	};
-
-	useEffect(() => {
-		if (!countdownSettings) {
-			return undefined;
-		}
-		if (
-			countdownSettings.countdownStartInMillis < now &&
-			countdownSettings.countdownDeadlineInMillis > now
-		) {
-			setCurrentCountdownSettings(countdownSettings);
-			setShowCountdown(true);
-		}
-	}, []);
 
 	const paymentFrequencies: ContributionType[] = enableSingleContributionsTab
 		? ['ONE_OFF', 'MONTHLY', 'ANNUAL']
@@ -589,26 +551,23 @@ export function ThreeTierLanding({
 				cssOverrides={recurringContainer}
 			>
 				<div css={innerContentContainer}>
-					{countdownSwitchOn() && showCountdown && currentCountdownSettings && (
+					{countdownSettings && (
 						<Countdown
-							countdownCampaign={currentCountdownSettings}
-							showCountdown={showCountdown}
-							setShowCountdown={setShowCountdown}
+							countdownSettings={countdownSettings}
+							setHeadingOverride={setHeadingOverride}
 						/>
 					)}
 
-					{shouldShowCountdown() && (
+					{headingOverride && (
 						<h1 css={heading}>
 							<span
 								dangerouslySetInnerHTML={{
-									__html: currentCountdownSettings
-										? currentCountdownSettings.overwriteHeadingLabel
-										: sanitisedHeading,
+									__html: getSanitisedHtml(headingOverride),
 								}}
 							/>
 						</h1>
 					)}
-					{!shouldShowCountdown() && (
+					{!headingOverride && (
 						<h1 css={heading}>
 							<span dangerouslySetInnerHTML={{ __html: sanitisedHeading }} />
 						</h1>

--- a/support-frontend/stories/landingPage/Countdown.stories.tsx
+++ b/support-frontend/stories/landingPage/Countdown.stories.tsx
@@ -20,6 +20,10 @@ const millisecondsInMinute = 60 * millisecondsInSecond;
 const millisecondsInHour = 60 * millisecondsInMinute;
 const millisecondsInDay = 24 * millisecondsInHour;
 
+const buildTimestamp = (date: number): string =>
+	//remove the timezone
+	new Date(date).toISOString().slice(0, -1);
+
 function Template(args: CountdownProps) {
 	const contentContainer = css`
 		height: 500px;
@@ -38,112 +42,85 @@ Template.args = {} as CountdownProps;
 
 export const Default = Template.bind({});
 Default.args = {
-	countdownCampaign: {
+	countdownSettings: {
     overwriteHeadingLabel: 'default',
-    countdownStartTimestamp: (Date.now()- 1 * millisecondsInDay + 1 * millisecondsInHour).toString(),
-    countdownDeadlineTimestamp: (Date.now() +
+    countdownStartTimestamp: buildTimestamp(Date.now()- 1 * millisecondsInDay + 1 * millisecondsInHour),
+    countdownDeadlineTimestamp: buildTimestamp(Date.now() +
    (2 * millisecondsInDay +
     1 * millisecondsInHour +
     45 * millisecondsInMinute +
-    30 * millisecondsInSecond)).toString(),
-		countdownStartInMillis:
-			Date.now() - 1 * millisecondsInDay + 1 * millisecondsInHour,
-		countdownDeadlineInMillis:
-			Date.now() +
-			(2 * millisecondsInDay +
-				1 * millisecondsInHour +
-				45 * millisecondsInMinute +
-				30 * millisecondsInSecond),
-    useLocalTime: false,
+    30 * millisecondsInSecond)),
+    useLocalTime: true,
 		theme: {
 			backgroundColor: '#1e3e72',
 			foregroundColor: '#ffffff',
 		},
 	},
-	showCountdown: true,
-	setShowCountdown: () => {return true},
+	setHeadingOverride: () => {},
 };
 
 export const DeadlineNear = Template.bind({});
 DeadlineNear.args = {
-	countdownCampaign: {
+	countdownSettings: {
     overwriteHeadingLabel: 'deadline near',
-    countdownStartTimestamp: (Date.now() - 1 * millisecondsInDay).toString(),
-    countdownDeadlineTimestamp: (Date.now() + 5 * millisecondsInSecond).toString(),
-		countdownStartInMillis: Date.now() - 1 * millisecondsInDay,
-		countdownDeadlineInMillis: Date.now() + 5 * millisecondsInSecond,
-    useLocalTime: false,
+    countdownStartTimestamp: buildTimestamp(Date.now() - 1 * millisecondsInDay),
+    countdownDeadlineTimestamp: buildTimestamp(Date.now() + 5 * millisecondsInSecond),
+    useLocalTime: true,
 		theme: {
 			backgroundColor: '#1e3e72',
 			foregroundColor: '#ffffff',
 		},
 	},
-	showCountdown: false,
-	setShowCountdown: () => {return true},
+	setHeadingOverride: () => {},
 };
 
 export const DeadlinePassedHidden = Template.bind({});
 DeadlinePassedHidden.args = {
-	countdownCampaign: {
+	countdownSettings: {
     overwriteHeadingLabel: 'deadline passed',
-    countdownStartTimestamp: (Date.now() - 1 * millisecondsInDay).toString(),
-    countdownDeadlineTimestamp: (Date.now() - 5 * millisecondsInSecond).toString(),
-		countdownStartInMillis: Date.now() - 1 * millisecondsInDay,
-		countdownDeadlineInMillis: Date.now() - 5 * millisecondsInSecond,
-    useLocalTime: false,
+    countdownStartTimestamp: buildTimestamp(Date.now() - 1 * millisecondsInDay),
+    countdownDeadlineTimestamp: buildTimestamp(Date.now() - 5 * millisecondsInSecond),
+    useLocalTime: true,
 		theme: {
 			backgroundColor: '#1e3e72',
 			foregroundColor: '#ffffff',
 		},
 	},
-	showCountdown: false,
-	setShowCountdown: () => {return true},
+	setHeadingOverride: () => {},
 };
 
 export const NotYetAvailableHidden = Template.bind({});
 NotYetAvailableHidden.args = {
-	countdownCampaign: {
+	countdownSettings: {
     overwriteHeadingLabel: 'start date well in future',
-    countdownStartTimestamp: (Date.now() + 1 * millisecondsInDay).toString(),
-    countdownDeadlineTimestamp: (Date.now() + 5 * millisecondsInDay).toString(),
-		countdownStartInMillis: Date.now() + 1 * millisecondsInDay,
-		countdownDeadlineInMillis: Date.now() + 5 * millisecondsInDay,
-    useLocalTime: false,
+    countdownStartTimestamp: buildTimestamp(Date.now() + 1 * millisecondsInDay),
+    countdownDeadlineTimestamp: buildTimestamp(Date.now() + 5 * millisecondsInDay),
+    useLocalTime: true,
 		theme: {
 			backgroundColor: '#1e3e72',
 			foregroundColor: '#ffffff',
 		},
 	},
-	showCountdown: true,
-	setShowCountdown: () => {return true},
+	setHeadingOverride: () => {},
 };
 
 export const ThemedSubCampaign = Template.bind({});
 ThemedSubCampaign.args = {
-	countdownCampaign: {
+	countdownSettings: {
     overwriteHeadingLabel: 'change colour theme',
     countdownStartTimestamp:
-      (Date.now() - 1 * millisecondsInDay + 1 * millisecondsInHour).toString(),
+			buildTimestamp(Date.now() - 1 * millisecondsInDay + 1 * millisecondsInHour),
     countdownDeadlineTimestamp:
-      (Date.now() +
+			buildTimestamp(Date.now() +
       (2 * millisecondsInDay +
         1 * millisecondsInHour +
         45 * millisecondsInMinute +
-        30 * millisecondsInSecond)).toString(),
-		countdownStartInMillis:
-			Date.now() - 1 * millisecondsInDay + 1 * millisecondsInHour,
-		countdownDeadlineInMillis:
-			Date.now() +
-			(2 * millisecondsInDay +
-				1 * millisecondsInHour +
-				45 * millisecondsInMinute +
-				30 * millisecondsInSecond),
-    useLocalTime: false,
+        30 * millisecondsInSecond)),
+    useLocalTime: true,
 		theme: {
 			backgroundColor: '#ab0613',
 			foregroundColor: '#ffffff',
 		},
 	},
-	showCountdown: true,
-	setShowCountdown: () => {return true},
+	setHeadingOverride: () => {},
 };


### PR DESCRIPTION
Removes some of the complexity from the landing page countdown logic.
In particular, it removes much of the code from `ThreeTierLanding`, which largely duplicates the checks done inside the `Countdown` component.

- all timestamp parsing/checking happens inside the `Countdown` component
- the state used to decide whether to display the countdown is now inside the `Countdown` component
- a `setHeadingOverride` callback is used to set the heading in the `ThreeTierLanding` component
- the `Countdown` component now takes the same `CountdownSettings` model that RRCP publishes

One advantage is that the storybook stories no longer take a `showCountdown` boolean, and instead decide to render the countdown based on the actual timestamps.