### PR TITLE
If the form fields hash doesn't match, block the purchase

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -89,6 +89,9 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
     }
   }
 
+  private def booleanToFuture(boolean: Boolean, errorMessage: String) =
+    if (boolean) Future.successful(()) else Future.failed(new RuntimeException(errorMessage))
+
   private def doesCheckoutSessionFormFieldsHashMatch(
       user: User,
       checkoutSession: RetrieveCheckoutSessionResponseSuccess,
@@ -128,7 +131,10 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       )
       checkoutSession <- stripeServiceForAccount
         .retrieveCheckoutSession(checkoutSessionId)
-      _ = doesCheckoutSessionFormFieldsHashMatch(user, checkoutSession)
+      _ <- booleanToFuture(
+        doesCheckoutSessionFormFieldsHashMatch(user, checkoutSession),
+        "Checkout session formFields hash does not match",
+      )
       paymentMethodId <- optionToFuture(
         PaymentMethodId(checkoutSession.setup_intent.payment_method.id),
         "Invalid PaymentMethodId",


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Following on from #7002 which added logic to store the SHA256 hash of the user entered form fields in the `metadata` field when creating the checkout session. In the previous PR when retrieving the checkout session in support-workers, we compare the hash with the hash of the form fields provided and emit a Cloudwatch metric if they don't match. In this PR we block the purchase as something has gone wrong if the hashes don't match (this shouldn't ever happen).

We've been running the code for about a week and the metric (`StripeHostedFormFieldsHashMismatch`) hasn't in prod.

[**Trello Card**](https://trello.com/c/YBOW0lJa/1631-stripe-hosted-checkout-block-checkout-if-hashed-form-fields-dont-match)

## Why are you doing this?

There's no scenario where the form fields (which we stash in session storage) should change between redirecting the user to Stripe and coming back to the support site to complete the transaction, so let's make sure it doesn't.

## How to test