### PR TITLE
Handle discount rate plans when fetching contribution amount in ProcessSupporterProductDataLambda

### DIFF
--- a/supporter-product-data/src/main/scala/com/gu/model/zuora/response/MinimalZuoraSubscription.scala
+++ b/supporter-product-data/src/main/scala/com/gu/model/zuora/response/MinimalZuoraSubscription.scala
@@ -1,19 +1,13 @@
 package com.gu.model.zuora.response
 
-import com.gu.supporterdata.model.ContributionAmount
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 
-case class MinimalZuoraSubscription(ratePlans: List[RatePlan]) {
-  def contributionAmount = for {
-    ratePlans <- ratePlans.headOption
-    charges <- ratePlans.ratePlanCharges.headOption
-  } yield ContributionAmount(charges.price, charges.currency)
-}
+case class MinimalZuoraSubscription(ratePlans: List[RatePlan])
 
-case class RatePlan(ratePlanCharges: List[RatePlanCharge])
+case class RatePlan(id: String, ratePlanCharges: List[RatePlanCharge])
 
-case class RatePlanCharge(price: BigDecimal, currency: String)
+case class RatePlanCharge(price: Option[BigDecimal], currency: String)
 
 case class MinimalZuoraError(message: String) extends Throwable
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
I noticed that there were a lot of errors in the ProcessSupporterRatePlanItem lambda. This is the one which is responsible for syncing subscriptions between Zuora and the SupporterProductData Dynamo store which drives the user benefits api.

This PR fixes an error which is caused by the way we were trying to find out the contribution amount for recurring contribution records - we assumed that there would only be one rate plan on the subscription, and at one point that was true, but now we are using discounts for cancellation saves in MMA, and this means that the subscription will have two rate plans - one for the contribution and one for the discount.

The error was actually caused by trying to deserialise a discount rate plan which doesn't have a price to a case class model which insists that it does, so this PR makes the model more permissive and then takes account of that optionality when working out the contribution amount.