### PR TITLE
Handle errors from our backend after returning from the Stripe hosted checkout

### DIFF
--- a/support-frontend/app/services/StripeCheckoutSessionService.scala
+++ b/support-frontend/app/services/StripeCheckoutSessionService.scala
@@ -134,7 +134,13 @@ object StripeCheckoutSessionService {
       if (uri.getScheme != "https" || !ALLOWED_SUCCESS_DOMAINS.contains(uri.getHost)) {
         None
       } else {
-        Some(refererUrl)
+        val existingQueryArgs = uri.getQuery.split("&").toList
+        val newQuery =
+          if (existingQueryArgs.nonEmpty) {
+            existingQueryArgs.filterNot(_.startsWith("checkoutSessionId=")).mkString("&")
+          } else ""
+
+        Some(new java.net.URI(uri.getScheme, uri.getHost, uri.getPath, newQuery, uri.getFragment).toString)
       }
     } catch {
       case _: java.net.URISyntaxException => None

--- a/support-frontend/app/services/StripeCheckoutSessionService.scala
+++ b/support-frontend/app/services/StripeCheckoutSessionService.scala
@@ -106,10 +106,12 @@ object StripeCheckoutSessionService {
       if (uri.getScheme != "https" || !ALLOWED_SUCCESS_DOMAINS.contains(uri.getHost)) {
         None
       } else {
-        val existingQuery = uri.getQuery
+        val existingQueryArgs = uri.getQuery.split("&").toList
         val newQuery =
-          if (existingQuery != "") s"$existingQuery&__CHECKOUT_SESSION_ID_PLACEHOLDER__"
-          else "__CHECKOUT_SESSION_ID_PLACEHOLDER__"
+          if (existingQueryArgs.nonEmpty) {
+            val withExistingCheckoutSessionIdRemoved = existingQueryArgs.filterNot(_.startsWith("checkoutSessionId="))
+            s"${withExistingCheckoutSessionIdRemoved.mkString("&")}&__CHECKOUT_SESSION_ID_PLACEHOLDER__"
+          } else "__CHECKOUT_SESSION_ID_PLACEHOLDER__"
 
         val successUrlWithPlaceholder =
           new java.net.URI(uri.getScheme, uri.getHost, uri.getPath, newQuery, uri.getFragment).toString

--- a/support-frontend/app/services/StripeCheckoutSessionService.scala
+++ b/support-frontend/app/services/StripeCheckoutSessionService.scala
@@ -135,10 +135,7 @@ object StripeCheckoutSessionService {
         None
       } else {
         val existingQueryArgs = uri.getQuery.split("&").toList
-        val newQuery =
-          if (existingQueryArgs.nonEmpty) {
-            existingQueryArgs.filterNot(_.startsWith("checkoutSessionId=")).mkString("&")
-          } else ""
+        val newQuery = existingQueryArgs.filterNot(_.startsWith("checkoutSessionId=")).mkString("&")
 
         Some(new java.net.URI(uri.getScheme, uri.getHost, uri.getPath, newQuery, uri.getFragment).toString)
       }

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/hooks/useStateWithCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/hooks/useStateWithCheckoutSession.ts
@@ -1,0 +1,10 @@
+import { useState } from 'react';
+
+export function useStateWithCheckoutSession<T>(
+	checkoutSessionValue: T | undefined | null,
+	defaultValue: T,
+): [T, (value: T) => void] {
+	const [stateValue, setStateValue] = useState<T>(defaultValue);
+
+	return [checkoutSessionValue ?? stateValue, setStateValue];
+}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/hooks/useStripeHostedCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/hooks/useStripeHostedCheckoutSession.ts
@@ -13,9 +13,7 @@ export function useStripeHostedCheckoutSession(
 		if (checkoutSessionId) {
 			const persistedFormData = getFormDetails(checkoutSessionId);
 
-			console.log('getting data for checkout session', checkoutSessionId);
 			if (persistedFormData) {
-				console.log('found persisted form data', persistedFormData);
 				setCheckoutSession(persistedFormData);
 			} else {
 				setCheckoutSession(undefined);

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/hooks/useStripeHostedCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/hooks/useStripeHostedCheckoutSession.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import type { CheckoutSession } from '../helpers/stripeCheckoutSession';
+import { getFormDetails } from '../helpers/stripeCheckoutSession';
+
+export function useStripeHostedCheckoutSession(
+	checkoutSessionId: string | null,
+): [CheckoutSession | undefined, () => void] {
+	const [checkoutSession, setCheckoutSession] = useState<
+		CheckoutSession | undefined
+	>();
+
+	useEffect(() => {
+		if (checkoutSessionId) {
+			const persistedFormData = getFormDetails(checkoutSessionId);
+
+			console.log('getting data for checkout session', checkoutSessionId);
+			if (persistedFormData) {
+				console.log('found persisted form data', persistedFormData);
+				setCheckoutSession(persistedFormData);
+			} else {
+				setCheckoutSession(undefined);
+			}
+		} else {
+			setCheckoutSession(undefined);
+		}
+	}, [checkoutSessionId]);
+
+	return [checkoutSession, () => setCheckoutSession(undefined)];
+}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/hooks/useStripeHostedCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/hooks/useStripeHostedCheckoutSession.ts
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react';
 import type { CheckoutSession } from '../helpers/stripeCheckoutSession';
-import { getFormDetails } from '../helpers/stripeCheckoutSession';
+import {
+	deleteFormDetails,
+	getFormDetails,
+} from '../helpers/stripeCheckoutSession';
 
 export function useStripeHostedCheckoutSession(
 	checkoutSessionId: string | null,
@@ -23,5 +26,11 @@ export function useStripeHostedCheckoutSession(
 		}
 	}, [checkoutSessionId]);
 
-	return [checkoutSession, () => setCheckoutSession(undefined)];
+	return [
+		checkoutSession,
+		() => {
+			deleteFormDetails();
+			setCheckoutSession(undefined);
+		},
+	];
 }

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -500,12 +500,20 @@ export function CheckoutComponent({
 	/** General error that can occur via fetch validations */
 	const [errorMessage, setErrorMessage] = useState<string>();
 	const [errorContext, setErrorContext] = useState<string>();
+	const [postStripeCheckoutErrorMessage, setPostStripeCheckoutErrorMessage] =
+		useState<string>();
 
 	// If we get an error, and we've already got a checkout session, clear the checkout session
 	// so that the user restarts the checkout process
 	useEffect(() => {
 		if (errorMessage && checkoutSession) {
 			clearCheckoutSession();
+			// Clear the standard error message
+			setErrorMessage(undefined);
+			// Set a specific generic message which will appear at the top of the page
+			setPostStripeCheckoutErrorMessage(
+				'Please try submitting the form again.',
+			);
 		}
 	}, [errorMessage]);
 
@@ -821,6 +829,17 @@ export function CheckoutComponent({
 										`}
 									/>
 								)}
+							</div>
+						)}
+						{postStripeCheckoutErrorMessage && (
+							<div role="alert" data-qm-error>
+								<ErrorSummary
+									cssOverrides={css`
+										margin-bottom: ${space[6]}px;
+									`}
+									message={'Sorry, something went wrong'}
+									context={postStripeCheckoutErrorMessage}
+								/>
 							</div>
 						)}
 						<FormSection>

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -389,7 +389,7 @@ export function CheckoutComponent({
 	const [deliveryPostcodeStateLoading, setDeliveryPostcodeStateLoading] =
 		useState(false);
 	const [deliveryCountry, setDeliveryCountry] =
-		useStateWithCheckoutSession<string>(
+		useStateWithCheckoutSession<IsoCountry>(
 			checkoutSession?.formFields.addressFields.deliveryAddress?.country,
 			countryId,
 		);
@@ -478,7 +478,7 @@ export function CheckoutComponent({
 	const [billingPostcodeStateLoading, setBillingPostcodeStateLoading] =
 		useState(false);
 	const [billingCountry, setBillingCountry] =
-		useStateWithCheckoutSession<string>(
+		useStateWithCheckoutSession<IsoCountry>(
 			checkoutSession?.formFields.addressFields.billingAddress.country,
 			countryId,
 		);

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -97,6 +97,7 @@ import type { DeliveryAgentsResponse } from '../checkout/helpers/getDeliveryAgen
 import { getDeliveryAgents } from '../checkout/helpers/getDeliveryAgents';
 import { getProductFields } from '../checkout/helpers/getProductFields';
 import type { CheckoutSession } from '../checkout/helpers/stripeCheckoutSession';
+import { useStateWithCheckoutSession } from '../checkout/hooks/useStateWithCheckoutSession';
 import { isSundayOnlyNewspaperSub } from '../helpers/isSundayOnlyNewspaperSub';
 import {
 	doesNotContainExtendedEmojiOrLeadingSpace,
@@ -153,6 +154,7 @@ type CheckoutComponentProps = {
 	abParticipations: Participations;
 	landingPageSettings: LandingPageVariant;
 	checkoutSession?: CheckoutSession;
+	clearCheckoutSession: () => void;
 };
 
 const getPaymentMethods = (
@@ -186,10 +188,13 @@ export function CheckoutComponent({
 	abParticipations,
 	landingPageSettings,
 	checkoutSession,
+	clearCheckoutSession,
 }: CheckoutComponentProps) {
 	const csrf: CsrfState = appConfig.csrf;
 	const user = appConfig.user;
 	const isSignedIn = !!user?.email;
+
+	console.log('checkoutSession inner component', checkoutSession);
 
 	const productCatalog = appConfig.productCatalog;
 	const { currency, currencyKey, countryGroupId } = getGeoIdConfig(geoId);
@@ -268,9 +273,9 @@ export function CheckoutComponent({
 		.filter(isPaymentMethod)
 		.filter(paymentMethodIsActive);
 
-	const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | undefined>(
-		checkoutSession ? StripeHostedCheckout : undefined,
-	);
+	const [paymentMethod, setPaymentMethod] = useStateWithCheckoutSession<
+		PaymentMethod | undefined
+	>(checkoutSession ? StripeHostedCheckout : undefined, undefined);
 	const [paymentMethodError, setPaymentMethodError] = useState<string>();
 
 	const isRedirectingToStripeHostedCheckout =
@@ -332,48 +337,64 @@ export function CheckoutComponent({
 	const [recaptchaToken, setRecaptchaToken] = useState<string>();
 
 	/** Personal details */
-	const [firstName, setFirstName] = useState(
-		checkoutSession?.formFields.personalData.firstName ?? user?.firstName ?? '',
+	const [firstName, setFirstName] = useStateWithCheckoutSession<string>(
+		checkoutSession?.formFields.personalData.firstName,
+		user?.firstName ?? '',
 	);
-	const [lastName, setLastName] = useState(
-		checkoutSession?.formFields.personalData.lastName ?? user?.lastName ?? '',
+	const [lastName, setLastName] = useStateWithCheckoutSession<string>(
+		checkoutSession?.formFields.personalData.lastName,
+		user?.lastName ?? '',
 	);
-	const [email, setEmail] = useState(
-		checkoutSession?.formFields.personalData.email ?? user?.email ?? '',
+	const [email, setEmail] = useStateWithCheckoutSession<string>(
+		checkoutSession?.formFields.personalData.email,
+		user?.email ?? '',
 	);
-	const [confirmedEmail, setConfirmedEmail] = useState(
-		checkoutSession?.formFields.personalData.email ?? '',
-	);
+	const [confirmedEmail, setConfirmedEmail] =
+		useStateWithCheckoutSession<string>(
+			checkoutSession?.formFields.personalData.email,
+			'',
+		);
 
 	/** Delivery Instructions */
-	const [deliveryInstructions, setDeliveryInstructions] = useState(
-		checkoutSession?.formFields.deliveryInstructions ?? '',
-	);
+	const [deliveryInstructions, setDeliveryInstructions] =
+		useStateWithCheckoutSession<string>(
+			checkoutSession?.formFields.deliveryInstructions,
+			'',
+		);
 
 	/** Delivery and billing addresses */
-	const [deliveryPostcode, setDeliveryPostcode] = useState(
-		checkoutSession?.formFields.addressFields.deliveryAddress?.postCode ?? '',
+	const [deliveryPostcode, setDeliveryPostcode] =
+		useStateWithCheckoutSession<string>(
+			checkoutSession?.formFields.addressFields.deliveryAddress?.postCode,
+			'',
+		);
+	const [deliveryLineOne, setDeliveryLineOne] =
+		useStateWithCheckoutSession<string>(
+			checkoutSession?.formFields.addressFields.deliveryAddress?.lineOne,
+			'',
+		);
+	const [deliveryLineTwo, setDeliveryLineTwo] =
+		useStateWithCheckoutSession<string>(
+			checkoutSession?.formFields.addressFields.deliveryAddress?.lineTwo,
+			'',
+		);
+	const [deliveryCity, setDeliveryCity] = useStateWithCheckoutSession<string>(
+		checkoutSession?.formFields.addressFields.deliveryAddress?.city,
+		'',
 	);
-	const [deliveryLineOne, setDeliveryLineOne] = useState(
-		checkoutSession?.formFields.addressFields.deliveryAddress?.lineOne ?? '',
-	);
-	const [deliveryLineTwo, setDeliveryLineTwo] = useState(
-		checkoutSession?.formFields.addressFields.deliveryAddress?.lineTwo ?? '',
-	);
-	const [deliveryCity, setDeliveryCity] = useState(
-		checkoutSession?.formFields.addressFields.deliveryAddress?.city ?? '',
-	);
-	const [deliveryState, setDeliveryState] = useState(
-		checkoutSession?.formFields.addressFields.deliveryAddress?.state ?? '',
+	const [deliveryState, setDeliveryState] = useStateWithCheckoutSession<string>(
+		checkoutSession?.formFields.addressFields.deliveryAddress?.state,
+		'',
 	);
 	const [deliveryPostcodeStateResults, setDeliveryPostcodeStateResults] =
 		useState<PostcodeFinderResult[]>([]);
 	const [deliveryPostcodeStateLoading, setDeliveryPostcodeStateLoading] =
 		useState(false);
-	const [deliveryCountry, setDeliveryCountry] = useState(
-		checkoutSession?.formFields.addressFields.deliveryAddress?.country ??
+	const [deliveryCountry, setDeliveryCountry] =
+		useStateWithCheckoutSession<string>(
+			checkoutSession?.formFields.addressFields.deliveryAddress?.country,
 			countryId,
-	);
+		);
 	const [deliveryAddressErrors, setDeliveryAddressErrors] = useState<
 		AddressFormFieldError[]
 	>([]);
@@ -419,20 +440,30 @@ export function CheckoutComponent({
 	}, [deliveryPostcode]);
 
 	const [billingAddressMatchesDelivery, setBillingAddressMatchesDelivery] =
-		useState(checkoutSession?.formFields.billingAddressMatchesDelivery ?? true);
+		useStateWithCheckoutSession<boolean>(
+			checkoutSession?.formFields.billingAddressMatchesDelivery,
+			true,
+		);
 
-	const [billingPostcode, setBillingPostcode] = useState(
-		checkoutSession?.formFields.addressFields.billingAddress.postCode ?? '',
-	);
+	const [billingPostcode, setBillingPostcode] =
+		useStateWithCheckoutSession<string>(
+			checkoutSession?.formFields.addressFields.billingAddress.postCode,
+			'',
+		);
 	const [billingPostcodeError, setBillingPostcodeError] = useState<string>();
-	const [billingLineOne, setBillingLineOne] = useState(
-		checkoutSession?.formFields.addressFields.billingAddress.lineOne ?? '',
-	);
-	const [billingLineTwo, setBillingLineTwo] = useState(
-		checkoutSession?.formFields.addressFields.billingAddress.lineTwo ?? '',
-	);
-	const [billingCity, setBillingCity] = useState(
-		checkoutSession?.formFields.addressFields.billingAddress.city ?? '',
+	const [billingLineOne, setBillingLineOne] =
+		useStateWithCheckoutSession<string>(
+			checkoutSession?.formFields.addressFields.billingAddress.lineOne,
+			'',
+		);
+	const [billingLineTwo, setBillingLineTwo] =
+		useStateWithCheckoutSession<string>(
+			checkoutSession?.formFields.addressFields.billingAddress.lineTwo,
+			'',
+		);
+	const [billingCity, setBillingCity] = useStateWithCheckoutSession<string>(
+		checkoutSession?.formFields.addressFields.billingAddress.city,
+		'',
 	);
 	const [billingStateError, setBillingStateError] = useState<string>();
 	/**
@@ -440,17 +471,19 @@ export function CheckoutComponent({
 	 * billingStateError message. formOnSubmit checks and converts to
 	 * empty string to display billingStateError message.
 	 */
-	const [billingState, setBillingState] = useState(
-		checkoutSession?.formFields.addressFields.billingAddress.state ?? '',
+	const [billingState, setBillingState] = useStateWithCheckoutSession<string>(
+		checkoutSession?.formFields.addressFields.billingAddress.state,
+		'',
 	);
 	const [billingPostcodeStateResults, setBillingPostcodeStateResults] =
 		useState<PostcodeFinderResult[]>([]);
 	const [billingPostcodeStateLoading, setBillingPostcodeStateLoading] =
 		useState(false);
-	const [billingCountry, setBillingCountry] = useState(
-		checkoutSession?.formFields.addressFields.billingAddress.country ??
+	const [billingCountry, setBillingCountry] =
+		useStateWithCheckoutSession<string>(
+			checkoutSession?.formFields.addressFields.billingAddress.country,
 			countryId,
-	);
+		);
 	const [billingAddressErrors, setBillingAddressErrors] = useState<
 		AddressFormFieldError[]
 	>([]);
@@ -469,6 +502,14 @@ export function CheckoutComponent({
 	/** General error that can occur via fetch validations */
 	const [errorMessage, setErrorMessage] = useState<string>();
 	const [errorContext, setErrorContext] = useState<string>();
+
+	// If we get an error, and we've already got a checkout session, clear the checkout session
+	// so that the user restarts the checkout process
+	useEffect(() => {
+		if (errorMessage && checkoutSession) {
+			clearCheckoutSession();
+		}
+	}, [errorMessage]);
 
 	const { supportInternationalisationId } = countryGroups[countryGroupId];
 

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -194,8 +194,6 @@ export function CheckoutComponent({
 	const user = appConfig.user;
 	const isSignedIn = !!user?.email;
 
-	console.log('checkoutSession inner component', checkoutSession);
-
 	const productCatalog = appConfig.productCatalog;
 	const { currency, currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -487,6 +487,11 @@ export function CheckoutComponent({
 	>([]);
 
 	const formRef = useRef<HTMLFormElement>(null);
+	const scrollToViewRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		scrollToViewRef.current?.scrollIntoView({ behavior: 'smooth' });
+	}, [scrollToViewRef.current]);
 
 	/** Direct debit details */
 	const [accountHolderName, setAccountHolderName] = useState('');
@@ -832,7 +837,7 @@ export function CheckoutComponent({
 							</div>
 						)}
 						{postStripeCheckoutErrorMessage && (
-							<div role="alert" data-qm-error>
+							<div role="alert" data-qm-error ref={scrollToViewRef}>
 								<ErrorSummary
 									cssOverrides={css`
 										margin-bottom: ${space[6]}px;

--- a/support-frontend/test/services/StripeCheckoutSessionServiceSpec.scala
+++ b/support-frontend/test/services/StripeCheckoutSessionServiceSpec.scala
@@ -61,6 +61,19 @@ class StripeCheckoutSessionServiceSpec extends AnyFlatSpec with Matchers {
     cancelUrl should be(Some(referer))
   }
 
+  it should "remove any existing checkoutSessionId query parameter" in {
+    val referer =
+      "https://support.theguardian.com/uk/checkout?product=HomeDelivery&ratePlan=Sunday&checkoutSessionId=12345"
+
+    val successUrl = StripeCheckoutSessionService.validateCancelUrl(referer)
+
+    successUrl should be(
+      Some(
+        "https://support.theguardian.com/uk/checkout?product=HomeDelivery&ratePlan=Sunday",
+      ),
+    )
+  }
+
   it should "return None if the referer is not a valid domain" in {
     val referer = "https://www.example.com?product=HomeDelivery&ratePlan=Sunday"
 

--- a/support-frontend/test/services/StripeCheckoutSessionServiceSpec.scala
+++ b/support-frontend/test/services/StripeCheckoutSessionServiceSpec.scala
@@ -16,6 +16,19 @@ class StripeCheckoutSessionServiceSpec extends AnyFlatSpec with Matchers {
     )
   }
 
+  it should "remove any existing checkoutSessionId query parameter" in {
+    val referer =
+      "https://support.theguardian.com/uk/checkout?product=HomeDelivery&ratePlan=Sunday&checkoutSessionId=12345"
+
+    val successUrl = StripeCheckoutSessionService.buildSuccessUrl(referer)
+
+    successUrl should be(
+      Some(
+        "https://support.theguardian.com/uk/checkout?product=HomeDelivery&ratePlan=Sunday&checkoutSessionId={CHECKOUT_SESSION_ID}",
+      ),
+    )
+  }
+
   it should "return None for domains which aren't in the allow-list" in {
     val referer = "https://www.example.com/uk/checkout?product=HomeDelivery&ratePlan=Sunday"
 


### PR DESCRIPTION
## What are you doing in this PR?

If a user returns from the Stripe hosted checkout and receives an error from our backend, clear the form fields and start the checkout process over again.

As part of this I've migrated the checkout session retrieval logic to a custom hook which wraps useState and useEffect. The reason I'm doing this is so that we can manipulate/clear the checkout session state and cause a re-render as expected.

[**Trello Card**](https://trello.com/c/9YD5ZbkO/1647-handle-server-side-errors-when-user-returns-from-stripe-hosted-checkout)

TODO:

- [x] Show an error at the top of the page when the user returns to the checkout
- [x] Payment method selector should be returned to default state
- [x] No error at the bottom of the page (currently showing generic transaction declined message)
- [x] Ensure top error message appears in viewport

## Why are you doing this?

When a user returns from the Stripe hosted checkout to the generic checkout we automatically retrieve their form details and submit the form. It's theoretically possible (though we haven't seen it) that we may return an error from our backend at this point. If this happened the user would be left on the form with an error. Resubmitting at this stage will always just resubmit to the backend and use their Stripe hosted checkout details. Depending on the type of error this may not be sufficient to fix the problem. Because this is such an unlikely scenario, we decided the best thing to do is reset the form fields and effectively start over, which is what this PR adds.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

- [x] Smoke tests pass

Locally I can simulate this scenario by breaking the backend request after the user returns to our checkout. Screenshot of how this error state looks (generic error anchored to the top of the viewport/form fields cleared):

![Screenshot 2025-06-04 at 10 10 10](https://github.com/user-attachments/assets/54664388-3fc2-4a57-a67e-d52e95cb073c)


