### PR TITLE
Only send a percentage of traffic to QM

### DIFF
--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -96,7 +96,7 @@ const cartValueEventIds: SendEventId[] = [
 ];
 
 // We only want to send a sample percentage of our user traffic to Quantum Metric.
-export function userIsInSampledCohort(): boolean {
+function userIsInSampledCohort(): boolean {
 	const percentageOfUsersToSample = 50;
 	const divisor = 100 / percentageOfUsersToSample;
 

--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -8,6 +8,7 @@ import { BillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import type { SubscriptionProduct } from 'helpers/productPrice/subscriptions';
 import { logException } from 'helpers/utilities/logger';
+import { getMvtId } from '../abTests/mvt';
 import type { ReferrerAcquisitionData } from './acquisitions';
 import {
 	canRunQuantumMetric,
@@ -94,10 +95,19 @@ const cartValueEventIds: SendEventId[] = [
 	RecurringContribution,
 ];
 
+// We only want to send a sample percentage of our user traffic to Quantum Metric.
+export function userIsInSampledCohort(): boolean {
+	const percentageOfUsersToSample = 50;
+	const divisor = 100 / percentageOfUsersToSample;
+
+	const mvtId = getMvtId();
+	return mvtId % divisor === 0;
+}
+
 async function ifQmPermitted(callback: () => void) {
 	const canRun = await canRunQuantumMetric();
 
-	if (canRun) {
+	if (canRun && userIsInSampledCohort()) {
 		callback();
 	}
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We have a reduced allowance for the number of user interactions we can record in Quantum Metric. This PR introduces a sampling mechanism for users based on their MVT ID (stored in a cookie for all Guardian users).

Initially we are going to send 50% of the current traffic to QM to see how that affects reports. If everything is still working we will reduce it further to 10%.

[**Trello Card**](https://trello.com/c/RM5I9RgQ/1624-qm-with-the-new-contract-change-we-cant-use-qm-at-the-same-usage-as-before-can-we-instead-use-a-sample-and-see-if-that-is-benefi)

## How to test
- Go to the checkout https://support.thegulocal.com/uk/checkout?product=SupporterPlus&ratePlan=Monthly
- Set the value of your `GU_mvt_id` cookie to any even number
- Refresh the page and check your network tab, you should see requests to https://ingesteu.quantummetric.com
- Now set the value of `GU_mvt_id` to any odd number
- Refresh the page and check your network tab, you should see NO requests to https://ingesteu.quantummetric.com