### PR TITLE
Guardian Weekly Checkout: Correct and setup tests

### DIFF
--- a/support-e2e/tests/cron/checkout.test.ts
+++ b/support-e2e/tests/cron/checkout.test.ts
@@ -27,7 +27,7 @@ test.describe('Checkout', () => {
 		{
 			product: 'GuardianWeeklyDomestic',
 			ratePlan: 'Monthly',
-			paymentType: 'PayPal',
+			paymentType: 'Credit/Debit card',
 			internationalisationId: 'US',
 			postCode: '60601',
 		},
@@ -42,8 +42,8 @@ test.describe('Checkout', () => {
 			product: 'GuardianWeeklyDomestic',
 			ratePlan: 'Quarterly',
 			paymentType: 'PayPal',
-			internationalisationId: 'AU',
-			postCode: '2000',
+			internationalisationId: 'UK',
+			postCode: 'BN44 3QG',
 		},
 	].forEach((testDetails) => {
 		testCheckout(testDetails);

--- a/support-e2e/tests/cron/checkout.test.ts
+++ b/support-e2e/tests/cron/checkout.test.ts
@@ -24,6 +24,27 @@ test.describe('Checkout', () => {
 			paymentType: 'PayPal',
 			internationalisationId: 'UK',
 		},
+		{
+			product: 'GuardianWeeklyDomestic',
+			ratePlan: 'Monthly',
+			paymentType: 'PayPal',
+			internationalisationId: 'US',
+			postCode: '60601',
+		},
+		{
+			product: 'GuardianWeeklyRestOfWorld',
+			ratePlan: 'Annual',
+			paymentType: 'PayPal',
+			internationalisationId: 'INT',
+			postCode: '8001',
+		},
+		{
+			product: 'GuardianWeeklyDomestic',
+			ratePlan: 'Quarterly',
+			paymentType: 'PayPal',
+			internationalisationId: 'AU',
+			postCode: '2000',
+		},
 	].forEach((testDetails) => {
 		testCheckout(testDetails);
 	});

--- a/support-e2e/tests/smoke/checkout.test.ts
+++ b/support-e2e/tests/smoke/checkout.test.ts
@@ -44,6 +44,48 @@ test.describe('Checkout', () => {
 			internationalisationId: 'UK',
 			postCode: 'BS6 6QY', // This postcode has multiple delivery agents
 		},
+		{
+			product: 'GuardianWeeklyDomestic',
+			ratePlan: 'Monthly',
+			paymentType: 'Credit/Debit card',
+			internationalisationId: 'UK',
+			postCode: 'BS6 6QY',
+		},
+		{
+			product: 'GuardianWeeklyDomestic',
+			ratePlan: 'Annual',
+			paymentType: 'Credit/Debit card',
+			internationalisationId: 'UK',
+			postCode: 'BS6 6QY',
+		},
+		{
+			product: 'GuardianWeeklyDomestic',
+			ratePlan: 'Quarterly',
+			paymentType: 'Credit/Debit card',
+			internationalisationId: 'UK',
+			postCode: 'BN44 3QG',
+		},
+		{
+			product: 'GuardianWeeklyDomestic',
+			ratePlan: 'Monthly',
+			paymentType: 'Credit/Debit card',
+			internationalisationId: 'US',
+			postCode: '60601',
+		},
+		{
+			product: 'GuardianWeeklyRestOfWorld',
+			ratePlan: 'Annual',
+			paymentType: 'Credit/Debit card',
+			internationalisationId: 'INT',
+			postCode: '8001',
+		},
+		{
+			product: 'GuardianWeeklyDomestic',
+			ratePlan: 'Quarterly',
+			paymentType: 'Credit/Debit card',
+			internationalisationId: 'AU',
+			postCode: '2000',
+		},
 	].forEach((testDetails) => {
 		testCheckout(testDetails);
 	});

--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -4,7 +4,13 @@ import { setupPage } from '../utils/page';
 import { fillInPayPalDetails } from '../utils/paypal';
 import { fillInCardDetails } from '../utils/cardDetails';
 import { checkRecaptcha } from '../utils/recaptcha';
-import { TestFields, ukWithPostalAddressOnly } from '../utils/userFields';
+import {
+	ausWithFullAddress,
+	intWithPostalAddressOnly,
+	TestFields,
+	ukWithPostalAddressOnly,
+	usWithPostalAddressOnly,
+} from '../utils/userFields';
 import {
 	setTestUserAddressDetails,
 	setTestUserDetails,
@@ -32,19 +38,28 @@ const setUserDetailsForProduct = async (
 			await setTestUserDetails(page, email(), firstName(), lastName(), true);
 
 			break;
+		case 'GuardianWeeklyDomestic':
+		case 'GuardianWeeklyRestOfWorld':
 		case 'TierThree':
-			let userDetails: TestFields | undefined;
-			if (internationalisationId === 'UK') {
-				userDetails = ukWithPostalAddressOnly();
-			}
-			if (!userDetails) {
-				throw new Error(
-					`Couldn't find user details for ${product} in ${internationalisationId}`,
-				);
-			}
+			const userDetails = (): TestFields => {
+				switch (internationalisationId) {
+					case 'UK':
+						return ukWithPostalAddressOnly();
+					case 'US':
+						return usWithPostalAddressOnly();
+					case 'AU':
+						return ausWithFullAddress();
+					case 'INT':
+						return intWithPostalAddressOnly();
+					default:
+						throw new Error(
+							`Couldn't find user details for ${product} in ${internationalisationId}`,
+						);
+				}
+			};
 			await setTestUserAddressDetails(
 				page,
-				userDetails,
+				userDetails(),
 				internationalisationId,
 				3,
 			);
@@ -127,8 +142,12 @@ export const testCheckout = (testDetails: TestDetails) => {
 			postCode,
 		);
 
+		// State mandatory for AU and US
 		if (internationalisationId === 'AU') {
 			await page.getByLabel('State').selectOption({ label: 'New South Wales' });
+		}
+		if (internationalisationId === 'US') {
+			await page.getByLabel('State').selectOption({ label: 'Illinois' });
 		}
 
 		await page.getByRole('radio', { name: paymentType }).check();

--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -26,6 +26,26 @@ type TestDetails = {
 	postCode?: string;
 };
 
+const userDetails = (
+	product: string,
+	internationalisationId: string,
+): TestFields => {
+	switch (internationalisationId) {
+		case 'UK':
+			return ukWithPostalAddressOnly();
+		case 'US':
+			return usWithPostalAddressOnly();
+		case 'AU':
+			return ausWithFullAddress();
+		case 'INT':
+			return intWithPostalAddressOnly();
+		default:
+			throw new Error(
+				`Couldn't find user details for ${product} in ${internationalisationId}`,
+			);
+	}
+};
+
 const setUserDetailsForProduct = async (
 	page,
 	product,
@@ -41,25 +61,9 @@ const setUserDetailsForProduct = async (
 		case 'GuardianWeeklyDomestic':
 		case 'GuardianWeeklyRestOfWorld':
 		case 'TierThree':
-			const userDetails = (): TestFields => {
-				switch (internationalisationId) {
-					case 'UK':
-						return ukWithPostalAddressOnly();
-					case 'US':
-						return usWithPostalAddressOnly();
-					case 'AU':
-						return ausWithFullAddress();
-					case 'INT':
-						return intWithPostalAddressOnly();
-					default:
-						throw new Error(
-							`Couldn't find user details for ${product} in ${internationalisationId}`,
-						);
-				}
-			};
 			await setTestUserAddressDetails(
 				page,
-				userDetails(),
+				userDetails(product, internationalisationId),
 				internationalisationId,
 				3,
 			);

--- a/support-e2e/tests/utils/userFields.ts
+++ b/support-e2e/tests/utils/userFields.ts
@@ -90,6 +90,19 @@ export const ukWithPostalAddressOnly = (postCode: string = 'N1 9GU') => ({
 	],
 });
 
+export const intWithPostalAddressOnly = (postCode: string = '8001') => ({
+	email: email(),
+	firstName: firstName(),
+	lastName: lastName(),
+	addresses: [
+		{
+			postCode: postCode,
+			firstLine: '0C Heerengracht Street',
+			city: 'Cape Town',
+		},
+	],
+});
+
 export const usWithPostalAddressOnly: TestFieldsGenerator = () => ({
 	email: email(),
 	firstName: firstName(),

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/deliveryDates.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/deliveryDates.ts
@@ -12,6 +12,8 @@ export const getFirstDeliveryDateForProduct = (
 ): string | null => {
 	switch (productKey) {
 		case 'TierThree':
+		case 'GuardianWeeklyDomestic':
+		case 'GuardianWeeklyRestOfWorld':
 			return formatMachineDate(getTierThreeDeliveryDate());
 		case 'NationalDelivery':
 		case 'HomeDelivery':


### PR DESCRIPTION
## What are you doing in this PR?

Currently, checkout not going through, looks like not passing in first delivery date (from tier3 setup).
Add Playwright Checkout `Monthly`,`Annual`,`Quarterly` testing cases for 
- CreditCard
   1. UK
   2. US
   3. AU
   4. INT
- PayPal (smaller subset for speed)
   1. US
   2. UK
   3. INT
   
[**Trello Card**](https://trello.com/c/5IUkaPoD/1510-gw-test-generic-vs-old)

## Testing

From `./support-e2e/` folder ->
`pnpm test smoke-dev`
`pnpm test-cron-dev``

Example paths ->
https://support.thegulocal.com/us/checkout?product=GuardianWeeklyDomestic&ratePlan=Quarterly
https://support.thegulocal.com/int/checkout?product=GuardianWeeklyRestOfWorld&ratePlan=Annual

## Screenshots

|before|after|
|----|----|
|![image](https://github.com/user-attachments/assets/a669e875-1ff2-42ea-9f43-4686f9c8d28e)|![image](https://github.com/user-attachments/assets/e3eced51-cf74-486d-b86f-10335fdf5d90)|