### PR TITLE
Improve ticker animation

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -85,7 +85,7 @@
 		"@guardian/libs": "^22.0.0",
 		"@guardian/pasteup": "1.0.0-alpha.7",
 		"@guardian/source": "8.0.0",
-		"@guardian/source-development-kitchen": "18.1.0",
+		"@guardian/source-development-kitchen": "18.1.1",
 		"@guardian/support-service-lambdas": "guardian/support-service-lambdas#7c47d02f232c455163f12ab9fab25722d29af7ff",
 		"@guardian/tsconfig": "^0.2.0",
 		"@reduxjs/toolkit": "^1.9.4",

--- a/support-frontend/pnpm-lock.yaml
+++ b/support-frontend/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 8.0.0
         version: 8.0.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.5.4)
       '@guardian/source-development-kitchen':
-        specifier: 18.1.0
-        version: 18.1.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@guardian/libs@22.0.0(tslib@2.6.2)(typescript@5.5.4))(@guardian/source@8.0.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.5.4))(@types/react@18.2.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.5.4)
+        specifier: 18.1.1
+        version: 18.1.1(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@guardian/libs@22.0.0(tslib@2.6.2)(typescript@5.5.4))(@guardian/source@8.0.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.5.4))(@types/react@18.2.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.5.4)
       '@guardian/support-service-lambdas':
         specifier: guardian/support-service-lambdas#7c47d02f232c455163f12ab9fab25722d29af7ff
         version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/7c47d02f232c455163f12ab9fab25722d29af7ff
@@ -1439,8 +1439,8 @@ packages:
     peerDependencies:
       prettier: ^2.4.0
 
-  '@guardian/source-development-kitchen@18.1.0':
-    resolution: {integrity: sha512-1b/jBabT14GZ7um0ODlnguh9VmgxwPSM+wxGx2KYCpf9YEwWOI1GRbjcqjQG3FuGrB/wSgLi6jSk5+v7v5+P3A==}
+  '@guardian/source-development-kitchen@18.1.1':
+    resolution: {integrity: sha512-wuMULnVjValyEz6YjrOPt054tXJkutkAbPdeV/KQHoSCSjAJnd0Cp3SZeoVog77HE/iZ0mnKaiVkK+QXpRVtCQ==}
     peerDependencies:
       '@emotion/react': ^11.11.4
       '@guardian/libs': ^22.0.0
@@ -7985,7 +7985,7 @@ snapshots:
     dependencies:
       prettier: 2.8.8
 
-  '@guardian/source-development-kitchen@18.1.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@guardian/libs@22.0.0(tslib@2.6.2)(typescript@5.5.4))(@guardian/source@8.0.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.5.4))(@types/react@18.2.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.5.4)':
+  '@guardian/source-development-kitchen@18.1.1(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@guardian/libs@22.0.0(tslib@2.6.2)(typescript@5.5.4))(@guardian/source@8.0.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.5.4))(@types/react@18.2.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.5.4)':
     dependencies:
       '@guardian/libs': 22.0.0(tslib@2.6.2)(typescript@5.5.4)
       '@guardian/source': 8.0.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.5.4)


### PR DESCRIPTION
Improves the performance of the ticker animation. This component is used by the landing page.

See https://github.com/guardian/csnx/pull/2089 for details

Checked the ticker still works locally -
<img width="575" alt="Screenshot 2025-06-02 at 09 41 52" src="https://github.com/user-attachments/assets/3754ba25-aeff-48fc-a6c3-fae0bca58d82" />
