### PR TITLE
Fix the playwright install step

### DIFF
--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ./.github/actions/setup-node-and-install
 
       - name: Install Playwright Browsers
-        run: pnpm --filter support-e2e playwright install --with-deps
+        run: pnpm --filter support-e2e exec playwright install --with-deps
 
       - name: Run Playwright tests
         run: pnpm --filter support-e2e test-smoke


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
#7041 broke the playwright smoke test github action because the syntax of the command to install Playwright browsers wasn't correct. This PR fixes that.