### PR TITLE
Fix cron e2e tests setup

### DIFF
--- a/.github/workflows/playwright-cron.yml
+++ b/.github/workflows/playwright-cron.yml
@@ -18,7 +18,7 @@ jobs:
       uses: ./.github/actions/setup-node-and-install
 
     - name: Install Playwright Browsers
-      run: pnpm --filter support-e2e playwright install --with-deps
+      run: pnpm --filter support-e2e exec playwright install --with-deps
 
     - name: Run Playwright tests
       run: pnpm --filter support-e2e test-cron


### PR DESCRIPTION

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

The syntax for installing Playwright browsers wasn't quite right so fix it. This is the same change made in #7050 but for the cron tests.