### PR TITLE
Guardian Weekly : Generic Checkout AB-Test Enable

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -29,7 +29,7 @@ export const pageUrlRegexes = {
 		},
 		// Includes landing, original & generic checkout/thankyou pages
 		subsWeeklyPages:
-			'(/subscribe/weekly/checkout$)(/.*)?$|(?:/(uk|us|ca|eu|nz|int))(?:/(subscribe/weekly|checkout|one-time-checkout|contribute|thankyou|thank-you))(/.*)?$',
+			'(/subscribe/weekly/checkout$)(/.*)?$|(?:/(uk|us|ca|eu|nz|int))(?:/(subscribe/weekly|checkout|thankyou|thank-you))(/.*)?$',
 	},
 };
 

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -29,7 +29,7 @@ export const pageUrlRegexes = {
 		},
 		// Includes landing, original & generic checkout/thankyou pages
 		subsWeeklyPages:
-			'(/subscribe/weekly/checkout$)(/.*)?$|(?:/(uk|us|ca|eu|nz|int))(?:/(subscribe/weekly|checkout|thankyou|thank-you))(/.*)?$',
+			'(/subscribe/weekly/checkout)(/.*)?$|(?:/(uk|us|ca|eu|nz|int))(?:/(subscribe/weekly|checkout|thankyou|thank-you))(/.*)?$',
 	},
 };
 

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -27,8 +27,9 @@ export const pageUrlRegexes = {
 			paperLandingPage: /^\/uk\/subscribe\/paper?(\?.*)?$/,
 			weeklyLandingPage: /\/subscribe\/weekly\/checkout?(\?.*)?$/,
 		},
+		// Includes landing, original & generic checkout/thankyou pages
 		subsWeeklyPages:
-			'(/??/subscribe(\\?.*)?$|/??/subscribe/weekly(\\/checkout)?(\\?.*)?$)',
+			'(/subscribe/weekly/checkout$)(/.*)?$|(?:/(uk|us|ca|eu|nz|int))(?:/(subscribe/weekly|checkout|one-time-checkout|contribute|thankyou|thank-you))(/.*)?$',
 	},
 };
 
@@ -112,10 +113,10 @@ export const tests: Tests = {
 				size: 1,
 			},
 		},
-		isActive: false,
+		isActive: true,
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 9,
-		targetPage: pageUrlRegexes.subscriptions.paper.weeklyLandingPage,
+		targetPage: pageUrlRegexes.subscriptions.subsWeeklyPages,
 		persistPage:
 			// match generic checkout & thank you page
 			'^/uk/(checkout|thank-you)',


### PR DESCRIPTION
## What are you doing in this PR?

Enable `guardianWeeklyGenericCheckout` ab-test, set `control` and `variant` to cover 100% of audience.

Ensure these (non-gifting) GuardianWeekly paths are part of the test->
`.../<countryGroupId>/subscribe/weekly`
`.../<countryGroupId>/subscribe/weekly/checkout`
`.../subscribe/weekly/checkout`
`.../<countryGroupId>/thank-you`
`.../<countryGroupId>/thankyou`


[**Trello Card**](https://trello.com)

## Screenshots

Checkouts->
|control|variant|
|----|----|
|![image](https://github.com/user-attachments/assets/c07f5927-e16b-43a4-bc83-b318b548b290)|![image](https://github.com/user-attachments/assets/0e3ee185-c80e-434e-8bc3-50355988ec64)|
