### PR TITLE
Fix createPaymentMethod lambda access to param store

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -120,6 +120,9 @@ new SupportWorkers(app, "SupportWorkers-CODE", {
   eventBusArns: [
     "arn:aws:events:eu-west-1:865473395570:event-bus/acquisitions-bus-CODE",
   ],
+  parameterStorePaths: [
+    `arn:aws:ssm:eu-west-1:865473395570:parameter/CODE/support/support-workers/*`,
+  ],
 });
 
 new SupportWorkers(app, "SupportWorkers-PROD", {
@@ -141,5 +144,9 @@ new SupportWorkers(app, "SupportWorkers-PROD", {
   eventBusArns: [
     "arn:aws:events:eu-west-1:865473395570:event-bus/acquisitions-bus-CODE",
     "arn:aws:events:eu-west-1:865473395570:event-bus/acquisitions-bus-PROD",
+  ],
+  parameterStorePaths: [
+    `arn:aws:ssm:eu-west-1:865473395570:parameter/CODE/support/support-workers/*`,
+    `arn:aws:ssm:eu-west-1:865473395570:parameter/PROD/support/support-workers/*`,
   ],
 });

--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -189,38 +189,8 @@ exports[`The support-workers stack matches the snapshot 1`] = `
               "Action": "ssm:GetParameter",
               "Effect": "Allow",
               "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:aws:ssm:",
-                      {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":parameter/CODE/support/support-workers/*",
-                    ],
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:aws:ssm:",
-                      {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":parameter/PROD/support/support-workers/*",
-                    ],
-                  ],
-                },
+                "arn:aws:ssm:eu-west-1:865473395570:parameter/CODE/support/support-workers/*",
+                "arn:aws:ssm:eu-west-1:865473395570:parameter/PROD/support/support-workers/*",
               ],
             },
             {

--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -188,22 +188,40 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             {
               "Action": "ssm:GetParameter",
               "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/PROD/support/support-workers/*",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/CODE/support/support-workers/*",
+                    ],
                   ],
-                ],
-              },
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/PROD/support/support-workers/*",
+                    ],
+                  ],
+                },
+              ],
             },
             {
               "Action": [

--- a/cdk/lib/support-workers.test.ts
+++ b/cdk/lib/support-workers.test.ts
@@ -25,6 +25,10 @@ describe("The support-workers stack", () => {
         "arn:aws:events:eu-west-1:865473395570:event-bus/acquisitions-bus-CODE",
         "arn:aws:events:eu-west-1:865473395570:event-bus/acquisitions-bus-PROD",
       ],
+      parameterStorePaths: [
+        `arn:aws:ssm:eu-west-1:865473395570:parameter/CODE/support/support-workers/*`,
+        `arn:aws:ssm:eu-west-1:865473395570:parameter/PROD/support/support-workers/*`,
+      ],
     });
 
     const template = Template.fromStack(stack);

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -95,11 +95,18 @@ export class SupportWorkers extends GuStack {
         Fn.importValue(table)
       ),
     });
+    const parameterStoreResources =
+      this.stage === "CODE"
+        ? [
+            `arn:aws:ssm:${this.region}:${this.account}:parameter/CODE/${this.stack}/support-workers/*`,
+          ]
+        : [
+            `arn:aws:ssm:${this.region}:${this.account}:parameter/CODE/${this.stack}/support-workers/*`,
+            `arn:aws:ssm:${this.region}:${this.account}:parameter/PROD/${this.stack}/support-workers/*`,
+          ];
     const parameterStorePolicy = new PolicyStatement({
       actions: ["ssm:GetParameter"],
-      resources: [
-        `arn:aws:ssm:${this.region}:${this.account}:parameter/${this.stage}/${this.stack}/support-workers/*`,
-      ],
+      resources: parameterStoreResources,
     });
 
     // Lambdas

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -50,6 +50,7 @@ interface SupportWorkersProps extends GuStackProps {
   s3Files: string[];
   supporterProductDataTables: string[];
   eventBusArns: string[];
+  parameterStorePaths: string[];
 }
 
 export class SupportWorkers extends GuStack {
@@ -95,18 +96,9 @@ export class SupportWorkers extends GuStack {
         Fn.importValue(table)
       ),
     });
-    const parameterStoreResources =
-      this.stage === "CODE"
-        ? [
-            `arn:aws:ssm:${this.region}:${this.account}:parameter/CODE/${this.stack}/support-workers/*`,
-          ]
-        : [
-            `arn:aws:ssm:${this.region}:${this.account}:parameter/CODE/${this.stack}/support-workers/*`,
-            `arn:aws:ssm:${this.region}:${this.account}:parameter/PROD/${this.stack}/support-workers/*`,
-          ];
     const parameterStorePolicy = new PolicyStatement({
       actions: ["ssm:GetParameter"],
-      resources: parameterStoreResources,
+      resources: props.parameterStorePaths,
     });
 
     // Lambdas


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
The PROD version of the createPaymentMethod lambda needs access to the CODE parameter store values so that it can load config for test users. This PR gives it that access.