### PR TITLE
Reduce Quantum Metric sampling to 10%

### DIFF
--- a/support-frontend/assets/helpers/tracking/quantumMetric.ts
+++ b/support-frontend/assets/helpers/tracking/quantumMetric.ts
@@ -97,7 +97,7 @@ const cartValueEventIds: SendEventId[] = [
 
 // We only want to send a sample percentage of our user traffic to Quantum Metric.
 function userIsInSampledCohort(): boolean {
-	const percentageOfUsersToSample = 50;
+	const percentageOfUsersToSample = 10;
 	const divisor = 100 / percentageOfUsersToSample;
 
 	const mvtId = getMvtId();


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Following on from #7037 this PR reduces the proportion of events we send to Quantum Metric to 10%.

[**Trello Card**](https://trello.com/c/WUzy7xfG/1677-reduce-quantum-metrics-sampling-to-10)

## Why are you doing this?

We have a reduced allowance so need to fit within this.