### PR TITLE
Remove two redundant payment-api alarms

### DIFF
--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -52,8 +52,6 @@ exports[`The Payment API stack matches the snapshot 1`] = `
       "GuAlarm",
       "GuAlarm",
       "GuAlarm",
-      "GuAlarm",
-      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -1003,64 +1001,6 @@ exports[`The Payment API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "NoPaypalPaymentsInTwoHours247Alarm381FDFB1": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-PROD",
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "There have been no one-off contributions using paypal in the last 2 hours",
-        "AlarmName": "[CDK] payment-api PROD CP One-off contributions with PayPal might be down",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "Dimensions": [
-          {
-            "Name": "payment-provider",
-            "Value": "Paypal",
-          },
-        ],
-        "EvaluationPeriods": 12,
-        "MetricName": "payment-success",
-        "Namespace": "support-payment-api-PROD",
-        "Period": 600,
-        "Statistic": "Sum",
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-frontend",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "Threshold": 0,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "NoStripeExpressPaymentsInOneHourAlarmB7ED847E": {
       "Properties": {
         "ActionsEnabled": true,
@@ -1183,64 +1123,6 @@ exports[`The Payment API stack matches the snapshot 1`] = `
         "MetricName": "payment-success",
         "Namespace": "support-payment-api-PROD",
         "Period": 300,
-        "Statistic": "Sum",
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-frontend",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "Threshold": 0,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "NoStripePaymentsInThreeHours247AlarmF141CCFE": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":alarms-handler-topic-PROD",
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "There have been no one-off contributions using card payment in the last 3 hours",
-        "AlarmName": "[CDK] payment-api PROD CP One-off contributions with Card might be down",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "Dimensions": [
-          {
-            "Name": "payment-provider",
-            "Value": "Stripe",
-          },
-        ],
-        "EvaluationPeriods": 12,
-        "MetricName": "payment-success",
-        "Namespace": "support-payment-api-PROD",
-        "Period": 900,
         "Statistic": "Sum",
         "Tags": [
           {

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -277,50 +277,6 @@ export class PaymentApi extends GuStack {
       snsTopicName: `alarms-handler-topic-${this.stage}`,
     });
 
-    new GuAlarm(this, "NoPaypalPaymentsInTwoHours247Alarm", {
-      app,
-      alarmName: `[CDK] ${app} ${this.stage} CP One-off contributions with PayPal might be down`,
-      alarmDescription:
-        "There have been no one-off contributions using paypal in the last 2 hours",
-      actionsEnabled: props.stage === "PROD",
-      threshold: 0,
-      evaluationPeriods: 12,
-      comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
-      metric: new Metric({
-        metricName: "payment-success",
-        namespace: `support-payment-api-${this.stage}`,
-        dimensionsMap: {
-          "payment-provider": "Paypal",
-        },
-        statistic: "Sum",
-        period: Duration.seconds(600),
-      }),
-      treatMissingData: TreatMissingData.BREACHING,
-      snsTopicName: `alarms-handler-topic-${this.stage}`,
-    });
-
-    new GuAlarm(this, "NoStripePaymentsInThreeHours247Alarm", {
-      app,
-      alarmName: `[CDK] ${app} ${this.stage} CP One-off contributions with Card might be down`,
-      alarmDescription:
-        "There have been no one-off contributions using card payment in the last 3 hours",
-      actionsEnabled: props.stage === "PROD",
-      threshold: 0,
-      evaluationPeriods: 12,
-      comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
-      metric: new Metric({
-        metricName: "payment-success",
-        namespace: `support-payment-api-${this.stage}`,
-        dimensionsMap: {
-          "payment-provider": "Stripe",
-        },
-        statistic: "Sum",
-        period: Duration.seconds(900),
-      }),
-      treatMissingData: TreatMissingData.BREACHING,
-      snsTopicName: `alarms-handler-topic-${this.stage}`,
-    });
-
     new GuAlarm(this, "NoPaypalPaymentsInOneHourAlarm", {
       app,
       alarmName: `[CDK] ${app} ${this.stage} No successful paypal payments via payment-api for an hour`,


### PR DESCRIPTION
## What are you doing in this PR?

Removing two payment-api alarms which I think are already covered by other alarms with a lower threshold:

`NoPaypalPaymentsInTwoHours247Alarm` is covered by `NoPaypalPaymentsInOneHourAlarm`.
`NoStripePaymentsInThreeHours247Alarm` is covered by `NoStripePaymentsInOneHourAlarm`.

## Why are you doing this?

I don't think there's a reason to have these - they all go to the same channel so it'll be the same people looking at these as those with a lower threshold.