### PR TITLE
Extract this sale ID and pass as transaction ID

### DIFF
--- a/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
+++ b/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala
@@ -45,6 +45,7 @@ case class AcquisitionDataRow(
     state: Option[String],
     email: Option[String],
     similarProductsConsent: Option[Boolean],
+    paypalTransactionId: Option[String],
 )
 
 object AcquisitionDataRow {


### PR DESCRIPTION
## What are you doing in this PR?

When a user makes a single contribution with PayPal, extract an additional ID field from the payment object we get back from PayPal and add it to the acquisition event under `paypalTransactionId`. Later, this will be used to populate a field in Salesforce.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/2XxPTiyE/1543-severity-2-medium-bug-report-229-system-impacted-salesforce-paypal-payment-id-issue)

## Why are you doing this?

Currently CSRs find it impossible to find a transaction in PayPal if the PayPal email address doesn't match the identity account email address. This is becuase the payment ID field on the acquisition event, which is surfaced in Salesforce, cannot be used to search transactions in PayPal (or rather it can be used, but doesn't match anything useful).