### PR TITLE
Increase threshold of payment-api paypal alarm

### DIFF
--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -965,7 +965,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "[CDK] payment-api PROD No successful paypal payments via payment-api for 1 hour",
+        "AlarmName": "[CDK] payment-api PROD No successful paypal payments via payment-api for 1 hour 30 minutes",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -973,7 +973,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             "Value": "Paypal",
           },
         ],
-        "EvaluationPeriods": 12,
+        "EvaluationPeriods": 18,
         "MetricName": "payment-success",
         "Namespace": "support-payment-api-PROD",
         "Period": 300,

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -278,7 +278,7 @@ export class PaymentApi extends GuStack {
     });
 
     const paypalMetricDuration = Duration.minutes(5);
-    const paypalEvaluationPeriods = 12; // The number of 5 minute periods in 1 hour
+    const paypalEvaluationPeriods = 18; // The number of 5 minute periods in 90 minutes
     const paypalAlarmPeriod = Duration.minutes(
       paypalMetricDuration.toMinutes() * paypalEvaluationPeriods
     );


### PR DESCRIPTION
## What are you doing in this PR?

This PR slightly increases the threshold of the payment-api PayPal period alarm.

I've also refactored the alarm slightly to derive the description from the parameters, so it's impossible for the description to get out of sync.

## Why are you doing this?

This alarm has fired occassionally recently, so make it a little less sensitive.