### PR TITLE
Increase threshold payment api stripe express alarm

### DIFF
--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -1022,9 +1022,9 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "[CDK] payment-api PROD No successful stripe express payments via payment-api for an hour",
+        "AlarmName": "[CDK] payment-api PROD No successful stripe express payments via payment-api for 1 hour 30 minutes",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "EvaluationPeriods": 12,
+        "EvaluationPeriods": 18,
         "Metrics": [
           {
             "Expression": "SUM(METRICS())",

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -323,7 +323,7 @@ export class PaymentApi extends GuStack {
     });
 
     const stripeExpressMetricDuration = Duration.minutes(5);
-    const stripeExpressEvaluationPeriods = 12; // The number of 5 minute periods in 1 hour
+    const stripeExpressEvaluationPeriods = 18; // The number of 5 minute periods in 90 minutes
     const stripeExpressAlarmPeriod = Duration.minutes(
       stripeExpressMetricDuration.toMinutes() * stripeExpressEvaluationPeriods
     );


### PR DESCRIPTION
## What are you doing in this PR?

Following on from #7075 this PR slightly increases the threshold of the payment-api Stripe Express period alarm.

I've also refactored the alarm slightly to derive the description from the parameters, so it's impossible for the description to get out of sync.

## Why are you doing this?

This alarm has fired occassionally recently, so make it a little less sensitive.