### PR TITLE
Make generic checkout the only checkout for GW

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -98,28 +98,4 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeContributionsOnlyCountries: true,
 	},
-	guardianWeeklyGenericCheckout: {
-		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'variant',
-			},
-		],
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		isActive: true,
-		referrerControlled: false, // ab-test name not needed to be in paramURL
-		seed: 9,
-		targetPage: pageUrlRegexes.subscriptions.subsWeeklyPages,
-		persistPage:
-			// match generic checkout & thank you page
-			'^/uk/(checkout|thank-you)',
-		excludeContributionsOnlyCountries: true,
-	},
 };

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
@@ -52,15 +52,12 @@ const countryPath = (countryGroupId: CountryGroupId) =>
 const getCheckoutUrl = (
 	countryId: IsoCountry,
 	billingPeriod: RecurringBillingPeriod,
-	abParticipations: Participations,
+	_abParticipations: Participations, // This is not used right now but will be when we're testing gifting so I'm leaving it here
 	orderIsGift: boolean,
 	promotion?: Promotion,
 ): string => {
 	// Gifting will be supported last
-	if (
-		abParticipations.guardianWeeklyGenericCheckout === 'variant' &&
-		!orderIsGift
-	) {
+	if (!orderIsGift) {
 		const countryGroupId = CountryGroup.fromCountry(countryId) ?? GBPCountries;
 		const productGuardianWeekly = internationaliseProduct(
 			countryGroups[countryGroupId].supportInternationalisationId,
@@ -76,8 +73,7 @@ const getCheckoutUrl = (
 
 	const promoCode = getQueryParameter(promoQueryParam);
 	const promoQuery = promoCode ? `&${promoQueryParam}=${promoCode}` : '';
-	const gift = orderIsGift ? '/gift' : '';
-	return `${getOrigin()}/subscribe/weekly/checkout${gift}?period=${billingPeriod.toString()}${promoQuery}`;
+	return `${getOrigin()}/subscribe/weekly/checkout/gift?period=${billingPeriod.toString()}${promoQuery}`;
 };
 
 const getCurrencySymbol = (currencyId: IsoCurrency): string =>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We have been running an AB test between the generic checkout and the old Guardian Weekly checkout for over a week now and there is no difference in performance so we are switching to using the generic checkout exclusively and removing the old checkout.

This PR just switches all traffic to the generic checkout, there will be a follow up PR to remove old code.