### PR TITLE
Exclude commons-beanutils to fix vulnerability

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -7,7 +7,6 @@ packageSummary := "Support Play APP"
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.2",
   "com.gu" %% "simple-configuration-ssm" % "1.7.0",
-  "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
   "org.mockito" % "mockito-core" % "2.28.2" % Test,
   "io.sentry" % "sentry-logback" % "6.29.0",
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsClientVersion,
@@ -49,6 +48,7 @@ excludeDependencies ++= Seq(
   // it. The vulnerability is fixed in v3 onwards, but the lib was renamed so I don't think we can force a newer version
   // by specifying is in the dependencies.
   ExclusionRule("net.sourceforge.htmlunit", "htmlunit"),
+  ExclusionRule("commons-beanutils", "commons-beanutils"), // Also exclude commons-beanutils due to a vulnerability
 )
 
 ThisBuild / libraryDependencySchemes ++= Seq(

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -75,6 +75,7 @@ excludeDependencies ++= Seq(
 
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
 dependencyOverrides += "commons-io" % "commons-io" % "2.14.0" % Test
+dependencyOverrides += "commons-beanutils" % "commons-beanutils" % "1.11.0" % Test
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -71,11 +71,11 @@ excludeDependencies ++= Seq(
   // don't need it. The vulnerability is fixed in v3 onwards, but the lib was renamed so I don't think we can force a
   // newer version by specifying it in the dependencies.
   ExclusionRule("net.sourceforge.htmlunit", "htmlunit"),
+  ExclusionRule("commons-beanutils", "commons-beanutils"), // Also exclude commons-beanutils due to a vulnerability
 )
 
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
 dependencyOverrides += "commons-io" % "commons-io" % "2.14.0" % Test
-dependencyOverrides += "commons-beanutils" % "commons-beanutils" % "1.11.0" % Test
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Fixes https://github.com/guardian/support-frontend/security/dependabot/220

commons-beanutils is brought into the project via play-test which is in turn included by the play-framework plugin but we don't use it in any of our tests so I am using an exclusion rule to remove it from the dependency tree.