### PR TITLE
Remove valibot

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,9 +255,6 @@ importers:
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
-      valibot:
-        specifier: ^0.31.0
-        version: 0.31.1
       zod:
         specifier: ^3.22.4
         version: 3.25.30
@@ -7910,9 +7907,6 @@ packages:
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
-
-  valibot@0.31.1:
-    resolution: {integrity: sha512-2YYIhPrnVSz/gfT2/iXVTrSj92HwchCt9Cga/6hX4B26iCz9zkIsGTS0HjDYTZfTi1Un0X6aRvhBi1cfqs/i0Q==}
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -17756,8 +17750,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
-
-  valibot@0.31.1: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/support-frontend/assets/helpers/globalsAndSwitches/window.test.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/window.test.ts
@@ -1,5 +1,4 @@
 import { expect } from '@storybook/test';
-import { safeParse } from 'valibot';
 import { ProductPricesSchema } from './window';
 
 test('ProductPricesSchema', () => {
@@ -1793,9 +1792,9 @@ test('ProductPricesSchema', () => {
 			},
 		},
 	};
-	const result = safeParse(ProductPricesSchema, allProductPrices);
+	const result = ProductPricesSchema.safeParse(allProductPrices);
 	if (result.success) {
-		const allProductPrices = result.output.allProductPrices;
+		const allProductPrices = result.data.allProductPrices;
 		expect(allProductPrices.Contribution).toBeUndefined;
 		expect(allProductPrices.SupporterPlus).toBeDefined;
 	}

--- a/support-frontend/assets/helpers/globalsAndSwitches/window.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/window.ts
@@ -1,74 +1,59 @@
 import { isoCountries } from '@modules/internationalisation/country';
-import type { InferOutput } from 'valibot';
-import {
-	array,
-	boolean,
-	intersect,
-	literal,
-	looseObject,
-	number,
-	object,
-	optional,
-	picklist,
-	record,
-	safeParse,
-	string,
-	union,
-} from 'valibot';
+import { z } from 'zod';
 import type { LegacyProductType } from 'helpers/legacyTypeConversions';
 import { legacyProductTypes } from 'helpers/legacyTypeConversions';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 
 /**
- * This file is used to validate data that get's injected from
+ * This file is used to validate data that gets injected from
  * the Play controllers onto the `window.guardian` object of the page.
  *
  * It will only error in NODE_ENV === 'development'.
  */
-const PaymentConfigSchema = object({
-	geoip: optional(
-		object({
-			countryCode: string(),
-			stateCode: optional(string()),
+const PaymentConfigSchema = z.object({
+	geoip: z.optional(
+		z.object({
+			countryCode: z.string(),
+			stateCode: z.optional(z.string()),
 		}),
 	),
-	stripeKeyDefaultCurrencies: object({
-		ONE_OFF: object({ default: string(), test: string() }),
-		REGULAR: object({ default: string(), test: string() }),
+	stripeKeyDefaultCurrencies: z.object({
+		ONE_OFF: z.object({ default: z.string(), test: z.string() }),
+		REGULAR: z.object({ default: z.string(), test: z.string() }),
 	}),
-	stripeKeyAustralia: object({
-		ONE_OFF: object({ default: string(), test: string() }),
-		REGULAR: object({ default: string(), test: string() }),
+	stripeKeyAustralia: z.object({
+		ONE_OFF: z.object({ default: z.string(), test: z.string() }),
+		REGULAR: z.object({ default: z.string(), test: z.string() }),
 	}),
-	stripeKeyUnitedStates: object({
-		ONE_OFF: object({ default: string(), test: string() }),
-		REGULAR: object({ default: string(), test: string() }),
+	stripeKeyUnitedStates: z.object({
+		ONE_OFF: z.object({ default: z.string(), test: z.string() }),
+		REGULAR: z.object({ default: z.string(), test: z.string() }),
 	}),
-	stripeKeyTortoiseMedia: object({
-		ONE_OFF: object({ default: string(), test: string() }),
-		REGULAR: object({ default: string(), test: string() }),
+	stripeKeyTortoiseMedia: z.object({
+		ONE_OFF: z.object({ default: z.string(), test: z.string() }),
+		REGULAR: z.object({ default: z.string(), test: z.string() }),
 	}),
-	payPalEnvironment: object({
-		default: string(),
-		test: string(),
+	payPalEnvironment: z.object({
+		default: z.string(),
+		test: z.string(),
 	}),
-	mdapiUrl: string(),
-	paymentApiPayPalEndpoint: string(),
-	paymentApiUrl: string(),
-	csrf: object({ token: string() }),
-	guestAccountCreationToken: optional(string()),
-	recaptchaEnabled: boolean(),
-	v2recaptchaPublicKey: string(),
-	user: optional(
-		object({
-			id: string(),
-			email: optional(string()),
-			firstName: optional(string()),
-			lastName: optional(string()),
+	mdapiUrl: z.string(),
+	paymentApiPayPalEndpoint: z.string(),
+	paymentApiUrl: z.string(),
+	csrf: z.object({ token: z.string() }),
+	guestAccountCreationToken: z.optional(z.string()),
+	recaptchaEnabled: z.boolean(),
+	v2recaptchaPublicKey: z.string(),
+	user: z.optional(
+		z.object({
+			id: z.string(),
+			email: z.optional(z.string()),
+			firstName: z.optional(z.string()),
+			lastName: z.optional(z.string()),
 		}),
 	),
-	serversideTests: optional(object({})),
-	settings: object({
+	serversideTests: z.optional(z.object({})),
+	settings: z.object({
 		/**
 		 * These keys are generated in Switches.scala
 		 * @see {@link file://./../../../app/admin/settings/Switches.scala}
@@ -76,35 +61,41 @@ const PaymentConfigSchema = object({
 		 * And added to the `window.guardian` object in settingsScript.scala.html
 		 * @see {@link file://./../../../app/views/settingsScript.scala.html}
 		 */
-		switches: object({
-			oneOffPaymentMethods: record(string(), optional(picklist(['On', 'Off']))),
-			recurringPaymentMethods: record(
-				string(),
-				optional(picklist(['On', 'Off'])),
+		switches: z.object({
+			oneOffPaymentMethods: z.record(
+				z.string(),
+				z.optional(z.enum(['On', 'Off'])),
 			),
-			subscriptionsPaymentMethods: record(
-				string(),
-				optional(picklist(['On', 'Off'])),
+			recurringPaymentMethods: z.record(
+				z.string(),
+				z.optional(z.enum(['On', 'Off'])),
 			),
-			subscriptionsSwitches: record(
-				string(),
-				optional(picklist(['On', 'Off'])),
+			subscriptionsPaymentMethods: z.record(
+				z.string(),
+				z.optional(z.enum(['On', 'Off'])),
 			),
-			featureSwitches: record(string(), optional(picklist(['On', 'Off']))),
-			campaignSwitches: record(string(), optional(picklist(['On', 'Off']))),
-			recaptchaSwitches: record(string(), optional(picklist(['On', 'Off']))),
+			subscriptionsSwitches: z.record(
+				z.string(),
+				z.optional(z.enum(['On', 'Off'])),
+			),
+			featureSwitches: z.record(z.string(), z.optional(z.enum(['On', 'Off']))),
+			campaignSwitches: z.record(z.string(), z.optional(z.enum(['On', 'Off']))),
+			recaptchaSwitches: z.record(
+				z.string(),
+				z.optional(z.enum(['On', 'Off'])),
+			),
 		}),
-		amounts: array(
-			object({
-				testName: string(),
-				liveTestName: optional(string()),
-				isLive: boolean(),
-				order: number(),
-				seed: number(),
-				targeting: union([
-					object({
-						targetingType: literal('Region'),
-						region: picklist([
+		amounts: z.array(
+			z.object({
+				testName: z.string(),
+				liveTestName: z.optional(z.string()),
+				isLive: z.boolean(),
+				order: z.number(),
+				seed: z.number(),
+				targeting: z.union([
+					z.object({
+						targetingType: z.literal('Region'),
+						region: z.enum([
 							'GBPCountries',
 							'UnitedStates',
 							'AUDCountries',
@@ -114,104 +105,104 @@ const PaymentConfigSchema = object({
 							'International',
 						]),
 					}),
-					object({
-						targetingType: literal('Country'),
-						countries: array(picklist(isoCountries)),
+					z.object({
+						targetingType: z.literal('Country'),
+						countries: z.array(z.enum(isoCountries)),
 					}),
 				]),
-				variants: array(
-					object({
-						amountsCardData: object({
-							ANNUAL: object({
-								amounts: array(number()),
-								defaultAmount: number(),
-								hideChooseYourAmount: boolean(),
+				variants: z.array(
+					z.object({
+						amountsCardData: z.object({
+							ANNUAL: z.object({
+								amounts: z.array(z.number()),
+								defaultAmount: z.number(),
+								hideChooseYourAmount: z.boolean(),
 							}),
-							MONTHLY: object({
-								amounts: array(number()),
-								defaultAmount: number(),
-								hideChooseYourAmount: boolean(),
+							MONTHLY: z.object({
+								amounts: z.array(z.number()),
+								defaultAmount: z.number(),
+								hideChooseYourAmount: z.boolean(),
 							}),
-							ONE_OFF: object({
-								amounts: array(number()),
-								defaultAmount: number(),
-								hideChooseYourAmount: boolean(),
+							ONE_OFF: z.object({
+								amounts: z.array(z.number()),
+								defaultAmount: z.number(),
+								hideChooseYourAmount: z.boolean(),
 							}),
 						}),
-						defaultContributionType: picklist(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
-						displayContributionType: array(
-							picklist(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
+						defaultContributionType: z.enum(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
+						displayContributionType: z.array(
+							z.enum(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
 						),
-						variantName: string(),
+						variantName: z.string(),
 					}),
 				),
 			}),
 		),
-		contributionTypes: object({
-			AUDCountries: array(
-				object({
-					contributionType: picklist(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
-					isDefault: optional(boolean()),
+		contributionTypes: z.object({
+			AUDCountries: z.array(
+				z.object({
+					contributionType: z.enum(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
+					isDefault: z.optional(z.boolean()),
 				}),
 			),
-			Canada: array(
-				object({
-					contributionType: picklist(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
-					isDefault: optional(boolean()),
+			Canada: z.array(
+				z.object({
+					contributionType: z.enum(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
+					isDefault: z.optional(z.boolean()),
 				}),
 			),
-			EURCountries: array(
-				object({
-					contributionType: picklist(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
-					isDefault: optional(boolean()),
+			EURCountries: z.array(
+				z.object({
+					contributionType: z.enum(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
+					isDefault: z.optional(z.boolean()),
 				}),
 			),
-			GBPCountries: array(
-				object({
-					contributionType: picklist(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
-					isDefault: optional(boolean()),
+			GBPCountries: z.array(
+				z.object({
+					contributionType: z.enum(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
+					isDefault: z.optional(z.boolean()),
 				}),
 			),
-			International: array(
-				object({
-					contributionType: picklist(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
-					isDefault: optional(boolean()),
+			International: z.array(
+				z.object({
+					contributionType: z.enum(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
+					isDefault: z.optional(z.boolean()),
 				}),
 			),
-			NZDCountries: array(
-				object({
-					contributionType: picklist(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
-					isDefault: optional(boolean()),
+			NZDCountries: z.array(
+				z.object({
+					contributionType: z.enum(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
+					isDefault: z.optional(z.boolean()),
 				}),
 			),
-			UnitedStates: array(
-				object({
-					contributionType: picklist(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
-					isDefault: optional(boolean()),
+			UnitedStates: z.array(
+				z.object({
+					contributionType: z.enum(['ONE_OFF', 'MONTHLY', 'ANNUAL']),
+					isDefault: z.optional(z.boolean()),
 				}),
 			),
 		}),
-		metricUrl: string(),
+		metricUrl: z.string(),
 	}),
 });
 
-const ProductCatalogSchema = object({
-	productCatalog: record(
-		string(),
-		object({
-			ratePlans: record(
-				string(),
-				object({
-					id: string(),
-					pricing: record(string(), number()),
-					charges: record(
-						string(),
-						object({
-							id: string(),
+const ProductCatalogSchema = z.object({
+	productCatalog: z.record(
+		z.string(),
+		z.object({
+			ratePlans: z.record(
+				z.string(),
+				z.object({
+					id: z.string(),
+					pricing: z.record(z.string(), z.number()),
+					charges: z.record(
+						z.string(),
+						z.object({
+							id: z.string(),
 						}),
 					),
-					billingPeriod: optional(
-						picklist(['Quarter', 'Month', 'Annual', 'OneTime']),
+					billingPeriod: z.optional(
+						z.enum(['Quarter', 'Month', 'Annual', 'OneTime']),
 					),
 				}),
 			),
@@ -220,6 +211,7 @@ const ProductCatalogSchema = object({
 });
 
 /**
+ * TODO: try making this schema stricter no that we are no using valibot
  * We parse productPrices through as a looseObject (no validation)
  * and then type it on the InferOutput using the existing types.
  *
@@ -228,40 +220,37 @@ const ProductCatalogSchema = object({
  * when creating the valibot schema we get this error
  * `Type instantiation is excessively deep and possibly infinite.`
  */
-export const ProductPricesSchema = object({
-	allProductPrices: record(
-		picklist(legacyProductTypes),
-		optional(looseObject({})),
+export const ProductPricesSchema = z.object({
+	allProductPrices: z.record(
+		z.enum(legacyProductTypes),
+		z.record(z.any()).optional(),
 	),
 });
 
-const AppConfigSchema = intersect([
-	PaymentConfigSchema,
-	ProductCatalogSchema,
-	ProductPricesSchema,
-]);
+const AppConfigSchema =
+	PaymentConfigSchema.merge(ProductCatalogSchema).merge(ProductPricesSchema);
 
-export type AppConfig = InferOutput<typeof AppConfigSchema> & {
+export type AppConfig = z.infer<typeof AppConfigSchema> & {
 	allProductPrices: Partial<Record<LegacyProductType, ProductPrices>>;
 };
 
 export const parseAppConfig = (obj: unknown): AppConfig => {
-	const appConfig = safeParse(AppConfigSchema, obj);
+	const appConfig = AppConfigSchema.safeParse(obj);
 	if (appConfig.success) {
-		return appConfig.output as AppConfig;
+		return appConfig.data as AppConfig;
 	} else {
 		// We allow parsing errors through on PROD as they might not be breaking changes
 		// but we should be aware of them.
 		if (process.env.NODE_ENV === 'development') {
-			console.error(appConfig.issues);
+			console.error(appConfig.error);
 			throw new SyntaxError(
 				'Failed to parse window.guardian value with issues: ',
-				{ cause: appConfig.issues },
+				{ cause: appConfig.error },
 			);
 		} else {
 			console.error(
 				'Failed to parse window.guardian value with issues: ',
-				appConfig.issues,
+				appConfig.error,
 			);
 		}
 	}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
@@ -1,58 +1,48 @@
 import { storage } from '@guardian/libs';
 import { isoCountries } from '@modules/internationalisation/country';
-import type { InferInput } from 'valibot';
-import {
-	boolean,
-	nullish,
-	number,
-	object,
-	optional,
-	picklist,
-	safeParse,
-	string,
-} from 'valibot';
+import { z } from 'zod';
 
-const formDetailsSchema = object({
-	personalData: object({
-		firstName: string(),
-		lastName: string(),
-		email: string(),
+const formDetailsSchema = z.object({
+	personalData: z.object({
+		firstName: z.string(),
+		lastName: z.string(),
+		email: z.string(),
 	}),
-	addressFields: object({
-		billingAddress: object({
-			lineOne: nullish(string()),
-			lineTwo: nullish(string()),
-			city: nullish(string()),
-			state: nullish(string()),
-			postCode: nullish(string()),
-			country: picklist(isoCountries),
+	addressFields: z.object({
+		billingAddress: z.object({
+			lineOne: z.string().nullish(),
+			lineTwo: z.string().nullish(),
+			city: z.string().nullish(),
+			state: z.string().nullish(),
+			postCode: z.string().nullish(),
+			country: z.enum(isoCountries),
 		}),
-		deliveryAddress: optional(
-			object({
-				lineOne: nullish(string()),
-				lineTwo: nullish(string()),
-				city: nullish(string()),
-				state: nullish(string()),
-				postCode: nullish(string()),
-				country: picklist(isoCountries),
-			}),
-		),
+		deliveryAddress: z
+			.object({
+				lineOne: z.string().nullish(),
+				lineTwo: z.string().nullish(),
+				city: z.string().nullish(),
+				state: z.string().nullish(),
+				postCode: z.string().nullish(),
+				country: z.enum(isoCountries),
+			})
+			.optional(),
 	}),
-	deliveryInstructions: nullish(string()),
-	billingAddressMatchesDelivery: optional(boolean()),
+	deliveryInstructions: z.string().nullish(),
+	billingAddressMatchesDelivery: z.oboolean(),
 });
 
-export type PersistableFormFields = InferInput<typeof formDetailsSchema>;
+export type PersistableFormFields = z.infer<typeof formDetailsSchema>;
 
 export type CheckoutSession = {
 	checkoutSessionId: string;
 	formFields: PersistableFormFields;
 };
 
-const schema = object({
+const schema = z.object({
 	formDetails: formDetailsSchema,
-	version: number(),
-	checkoutSessionId: string(),
+	version: z.number(),
+	checkoutSessionId: z.string(),
 });
 
 const oneDayInMillis = 24 * 60 * 60 * 1000;
@@ -83,15 +73,15 @@ export const getFormDetails = (
 ): CheckoutSession | undefined => {
 	const persistedData = storage.session.get(KEY);
 
-	const parsed = safeParse(schema, persistedData);
+	const parsed = schema.safeParse(persistedData);
 
 	if (!parsed.success) {
 		return undefined;
 	}
 
-	if (parsed.output.checkoutSessionId != checkoutSessionId) {
+	if (parsed.data.checkoutSessionId != checkoutSessionId) {
 		return undefined;
 	}
 
-	return { checkoutSessionId, formFields: parsed.output.formDetails };
+	return { checkoutSessionId, formFields: parsed.data.formDetails };
 };

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -43,7 +43,7 @@
 			".+\\.(js|jsx|ts|tsx)$": "./node_modules/babel-jest"
 		},
 		"transformIgnorePatterns": [
-			"/node_modules/\\.pnpm/(?!@guardian|valibot)",
+			"/node_modules/\\.pnpm/(?!@guardian)",
 			"^.+\\.module\\.(css|sass|scss)$"
 		],
 		"moduleFileExtensions": [
@@ -112,7 +112,6 @@
 		"snarkdown": "^2.0.0",
 		"tsx": "^4.19.2",
 		"uuid": "^9.0.0",
-		"valibot": "^0.31.0",
 		"zod": "^3.22.4"
 	},
 	"devDependencies": {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Currently we have a mix of Valibot and Zod schemas in support-frontend. We have decided to standardise on Zod for now, mostly because it is more of a standard across our code bases (support-service-lambdas uses it extensively for example).

This PR removes Valibot and migrates the schemas which used it to Zod.