### PR TITLE
Full typing for the ProductPricesSchema

### DIFF
--- a/support-frontend/assets/helpers/productPrice/productOptions.ts
+++ b/support-frontend/assets/helpers/productPrice/productOptions.ts
@@ -154,6 +154,7 @@ export {
 	SixdayPlus,
 	Everyday,
 	EverydayPlus,
+	NewspaperArchive,
 	ActivePaperProductTypes,
 	paperProductsWithDigital,
 	paperProductsWithoutDigital,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR follows on from #7087 and adds full typing for the allProductPrices object on window.guardian - previously this was only quite loosely typed as an object due to some issue with Valibot.

There are a number of new schemas which can be shared with support-workers but I am going to move those to the `modules` folder in a follow up PR because it will be very noisy as I'll also move the types those schemas validate at the same time.
