### PR TITLE
Make missing Stripe card payment fields on the checkout more obvious to the user

### DIFF
--- a/support-frontend/assets/components/stripeCardForm/elementDecorator.tsx
+++ b/support-frontend/assets/components/stripeCardForm/elementDecorator.tsx
@@ -72,6 +72,10 @@ const mobileCreditDebitIcons = css`
 	}
 `;
 
+const stripeFieldsContainer = css`
+	flex: 1;
+`;
+
 type ElementRenderProps = {
 	id: string;
 	options: StripeCardElementOptions;
@@ -103,31 +107,33 @@ export function ElementDecorator({
 	const [isFocused, setIsFocused] = useState<boolean>(false);
 
 	return (
-		<Label
-			{...labelProps}
-			htmlFor={id}
-			cssOverrides={stripeElementStyles(isFocused, error)}
-		>
-			{error && (
-				<div css={inlineMessageMargin}>
-					<InlineError id={descriptionId(id)}>{error}</InlineError>
-				</div>
-			)}
-			{renderElement({
-				id,
-				options: {
-					style: {
-						base: { ...baseStyles },
+		<div css={stripeFieldsContainer}>
+			<Label
+				{...labelProps}
+				htmlFor={id}
+				cssOverrides={stripeElementStyles(isFocused, error)}
+			>
+				{error && (
+					<div css={inlineMessageMargin}>
+						<InlineError id={descriptionId(id)}>{error}</InlineError>
+					</div>
+				)}
+				{renderElement({
+					id,
+					options: {
+						style: {
+							base: { ...baseStyles },
+						},
 					},
-				},
-				onFocus: () => setIsFocused(true),
-				onBlur: () => setIsFocused(false),
-			})}
-			{id === 'card-number' && (
-				<p css={mobileCreditDebitIcons}>
-					<BrandedIcons />
-				</p>
-			)}
-		</Label>
+					onFocus: () => setIsFocused(true),
+					onBlur: () => setIsFocused(false),
+				})}
+				{id === 'card-number' && (
+					<p css={mobileCreditDebitIcons}>
+						<BrandedIcons />
+					</p>
+				)}
+			</Label>
+		</div>
 	);
 }

--- a/support-frontend/assets/components/stripeCardForm/elementDecorator.tsx
+++ b/support-frontend/assets/components/stripeCardForm/elementDecorator.tsx
@@ -41,12 +41,10 @@ These styles applied to the .StripeElement container that wraps each iframe make
 like our own inputs from Source.
 */
 const stripeElementStyles = (isFocused: boolean, error?: string) => css`
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
+	display: block;
+	flex-grow: 1;
 	// credit card icons positioned absolutely on mobile breakpoints
 	position: relative;
-	height: 100%;
 
 	& > div:first-child {
 		margin-bottom: ${space[1]}px;
@@ -72,10 +70,6 @@ const mobileCreditDebitIcons = css`
 	@media (min-width: 355px) {
 		display: none;
 	}
-`;
-
-const stripeFieldsContainer = css`
-	flex: 1;
 `;
 
 type ElementRenderProps = {
@@ -109,33 +103,31 @@ export function ElementDecorator({
 	const [isFocused, setIsFocused] = useState<boolean>(false);
 
 	return (
-		<div css={stripeFieldsContainer}>
-			<Label
-				{...labelProps}
-				htmlFor={id}
-				cssOverrides={stripeElementStyles(isFocused, error)}
-			>
-				{error && (
-					<div css={inlineMessageMargin}>
-						<InlineError id={descriptionId(id)}>{error}</InlineError>
-					</div>
-				)}
-				{renderElement({
-					id,
-					options: {
-						style: {
-							base: { ...baseStyles },
-						},
+		<Label
+			{...labelProps}
+			htmlFor={id}
+			cssOverrides={stripeElementStyles(isFocused, error)}
+		>
+			{error && (
+				<div css={inlineMessageMargin}>
+					<InlineError id={descriptionId(id)}>{error}</InlineError>
+				</div>
+			)}
+			{renderElement({
+				id,
+				options: {
+					style: {
+						base: { ...baseStyles },
 					},
-					onFocus: () => setIsFocused(true),
-					onBlur: () => setIsFocused(false),
-				})}
-				{id === 'card-number' && (
-					<p css={mobileCreditDebitIcons}>
-						<BrandedIcons />
-					</p>
-				)}
-			</Label>
-		</div>
+				},
+				onFocus: () => setIsFocused(true),
+				onBlur: () => setIsFocused(false),
+			})}
+			{id === 'card-number' && (
+				<p css={mobileCreditDebitIcons}>
+					<BrandedIcons />
+				</p>
+			)}
+		</Label>
 	);
 }

--- a/support-frontend/assets/components/stripeCardForm/elementDecorator.tsx
+++ b/support-frontend/assets/components/stripeCardForm/elementDecorator.tsx
@@ -41,10 +41,12 @@ These styles applied to the .StripeElement container that wraps each iframe make
 like our own inputs from Source.
 */
 const stripeElementStyles = (isFocused: boolean, error?: string) => css`
-	display: block;
-	flex-grow: 1;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
 	// credit card icons positioned absolutely on mobile breakpoints
 	position: relative;
+	height: 100%;
 
 	& > div:first-child {
 		margin-bottom: ${space[1]}px;
@@ -70,6 +72,10 @@ const mobileCreditDebitIcons = css`
 	@media (min-width: 355px) {
 		display: none;
 	}
+`;
+
+const stripeFieldsContainer = css`
+	flex: 1;
 `;
 
 type ElementRenderProps = {
@@ -103,31 +109,33 @@ export function ElementDecorator({
 	const [isFocused, setIsFocused] = useState<boolean>(false);
 
 	return (
-		<Label
-			{...labelProps}
-			htmlFor={id}
-			cssOverrides={stripeElementStyles(isFocused, error)}
-		>
-			{error && (
-				<div css={inlineMessageMargin}>
-					<InlineError id={descriptionId(id)}>{error}</InlineError>
-				</div>
-			)}
-			{renderElement({
-				id,
-				options: {
-					style: {
-						base: { ...baseStyles },
+		<div css={stripeFieldsContainer}>
+			<Label
+				{...labelProps}
+				htmlFor={id}
+				cssOverrides={stripeElementStyles(isFocused, error)}
+			>
+				{error && (
+					<div css={inlineMessageMargin}>
+						<InlineError id={descriptionId(id)}>{error}</InlineError>
+					</div>
+				)}
+				{renderElement({
+					id,
+					options: {
+						style: {
+							base: { ...baseStyles },
+						},
 					},
-				},
-				onFocus: () => setIsFocused(true),
-				onBlur: () => setIsFocused(false),
-			})}
-			{id === 'card-number' && (
-				<p css={mobileCreditDebitIcons}>
-					<BrandedIcons />
-				</p>
-			)}
-		</Label>
+					onFocus: () => setIsFocused(true),
+					onBlur: () => setIsFocused(false),
+				})}
+				{id === 'card-number' && (
+					<p css={mobileCreditDebitIcons}>
+						<BrandedIcons />
+					</p>
+				)}
+			</Label>
+		</div>
 	);
 }

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -295,14 +295,12 @@ export function CheckoutComponent({
 	const [stripeFieldError, setStripeFieldError] = useState<{
 		[key in StripeField]?: string;
 	}>({});
+
 	useEffect(() => {
-		if (
-			paymentMethodError ??
-			Object.values(stripeFieldError).some((error) => !!error)
-		) {
+		if (paymentMethodError) {
 			paymentMethodRef.current?.scrollIntoView({ behavior: 'smooth' });
 		}
-	}, [paymentMethodError, ...Object.values(stripeFieldError)]);
+	}, [paymentMethodError]);
 
 	const isRedirectingToStripeHostedCheckout =
 		isSundayOnly &&
@@ -586,31 +584,24 @@ export function CheckoutComponent({
 		}
 
 		if (paymentMethod === 'Stripe') {
-			stripeFieldsAreEmpty.cardNumber &&
-				setStripeFieldError((previousState) => ({
-					...previousState,
+			const newStripeFieldError = {
+				...(stripeFieldsAreEmpty.cardNumber && {
 					cardNumber: 'Please enter card number',
-				}));
-			stripeFieldsAreEmpty.expiry &&
-				setStripeFieldError((previousState) => ({
-					...previousState,
+				}),
+				...(stripeFieldsAreEmpty.expiry && {
 					expiry: 'Please enter expiry',
-				}));
-			stripeFieldsAreEmpty.cvc &&
-				setStripeFieldError((previousState) => ({
-					...previousState,
+				}),
+				...(stripeFieldsAreEmpty.cvc && {
 					cvc: 'Please enter CVC',
-				}));
-			// Recaptcha works slightly differently because we own the state
-			if (!recaptchaToken) {
-				setStripeFieldError((previousState) => ({
-					...previousState,
-					recaptcha: 'Please complete security check',
-				}));
-			}
+				}),
+				// Recaptcha works slightly differently because we own the state
+				...(!recaptchaToken && { recaptcha: 'Please complete security check' }),
+			};
 
 			// Don't go any further if there are errors for any Stripe fields
-			if (Object.values(stripeFieldError).some((value) => value)) {
+			if (Object.values(newStripeFieldError).some((value) => value)) {
+				setStripeFieldError(newStripeFieldError);
+				paymentMethodRef.current?.scrollIntoView({ behavior: 'smooth' });
 				return;
 			}
 		}

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -481,10 +481,15 @@ export function CheckoutComponent({
 			cvc: true,
 		});
 		setStripeFieldError({});
-		// Should we unset recaptcha token here?
-		// Should we reset the recaptcha error when the recaptcha token changes?
-		// Maybe questions for Helene.
 	}, [paymentMethod]);
+
+	// Reset recaptcha error when recaptcha token changes
+	useEffect(() => {
+		setStripeFieldError((previousState) => ({
+			...previousState,
+			recaptcha: undefined,
+		}));
+	}, [recaptchaToken]);
 
 	const [billingAddressMatchesDelivery, setBillingAddressMatchesDelivery] =
 		useStateWithCheckoutSession<boolean>(

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -295,10 +295,13 @@ export function CheckoutComponent({
 		[key in StripeField]?: string;
 	}>({});
 	useEffect(() => {
-		if (paymentMethodError) {
+		if (
+			paymentMethodError ??
+			Object.values(stripeFieldError).some((error) => !!error)
+		) {
 			paymentMethodRef.current?.scrollIntoView({ behavior: 'smooth' });
 		}
-	}, [paymentMethodError]);
+	}, [paymentMethodError, ...Object.values(stripeFieldError)]);
 
 	const isRedirectingToStripeHostedCheckout =
 		isSundayOnly &&

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -287,15 +287,12 @@ export function CheckoutComponent({
 		PaymentMethod | undefined
 	>(checkoutSession ? StripeHostedCheckout : undefined, undefined);
 	const [paymentMethodError, setPaymentMethodError] = useState<string>();
+	type StripeField = 'cardNumber' | 'expiry' | 'cvc';
 	const [stripeFieldsAreEmpty, setStripeFieldsAreEmpty] = useState<{
-		cardNumber: boolean;
-		expiry: boolean;
-		cvc: boolean;
-	}>({ expiry: true, cardNumber: true, cvc: true });
+		[key in StripeField]: boolean;
+	}>({ cardNumber: true, expiry: true, cvc: true });
 	const [stripeFieldError, setStripeFieldError] = useState<{
-		cardNumber?: string;
-		expiry?: string;
-		cvc?: string;
+		[key in StripeField]?: string;
 	}>({});
 	useEffect(() => {
 		if (paymentMethodError) {

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -584,23 +584,23 @@ export function CheckoutComponent({
 			stripeFieldsAreEmpty.cardNumber &&
 				setStripeFieldError((previousState) => ({
 					...previousState,
-					cardNumber: 'Please enter your card number',
+					cardNumber: 'Please enter card number',
 				}));
 			stripeFieldsAreEmpty.expiry &&
 				setStripeFieldError((previousState) => ({
 					...previousState,
-					expiry: 'Please enter your card expiration date',
+					expiry: 'Please enter expiry',
 				}));
 			stripeFieldsAreEmpty.cvc &&
 				setStripeFieldError((previousState) => ({
 					...previousState,
-					cvc: 'Please enter your card CVC number',
+					cvc: 'Please enter CVC',
 				}));
 			// Recaptcha works slightly differently because we own the state
 			if (!recaptchaToken) {
 				setStripeFieldError((previousState) => ({
 					...previousState,
-					recaptcha: 'Please complete the security check',
+					recaptcha: 'Please complete security check',
 				}));
 			}
 

--- a/support-frontend/assets/pages/[countryGroupId]/components/paymentFields.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/paymentFields.ts
@@ -68,7 +68,6 @@ const getStripePaymentFields = async (
 				'There was an issue with your card details.',
 				appropriateErrorMessage(stripeIntentResult.error.decline_code ?? ''),
 			);
-			console.error(stripeIntentResult.error);
 		} else if (stripeIntentResult.setupIntent.payment_method) {
 			return {
 				paymentType: 'Stripe',

--- a/support-frontend/assets/pages/[countryGroupId]/helpers/maybeArrayWrap.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/helpers/maybeArrayWrap.ts
@@ -1,6 +1,4 @@
-export const maybeArrayWrap = <T>(
-	value: T | undefined,
-): T[] | undefined => {
+export const maybeArrayWrap = <T>(value: T | undefined): T[] | undefined => {
 	if (value === undefined) {
 		return undefined;
 	}

--- a/support-frontend/assets/pages/[countryGroupId]/helpers/maybeArrayWrap.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/helpers/maybeArrayWrap.ts
@@ -1,0 +1,9 @@
+export const maybeArrayWrap = <T>(
+	value: T | undefined,
+): T[] | undefined => {
+	if (value === undefined) {
+		return undefined;
+	}
+
+	return [value];
+};


### PR DESCRIPTION
## What are you doing in this PR?

When a user selects the Credit/Debit card payment method and submits the form without entering one or more of the required card fields, show specific errors next to the field and scroll to them.

[**Trello Card**](https://trello.com/c/sXWIyRpu/1676-handle-missing-payment-fields-on-the-generic-checkout)

## Why are you doing this?

Currently if the user performs the actions above, it's not very clear what's gone wrong. A very generic error message is show below the pay/submit button and we don't make it clear what the user can do to fix things. There's no indication of the actual problem:

<img width="618" alt="Screenshot 2025-07-01 at 12 37 48" src="https://github.com/user-attachments/assets/35a3c268-44f8-48f9-9590-b5e9e435e390" />

Currently this causes an exception which is reported to Sentry. The volumes of this error suggests this situation is actually happening to users.

Now, when this happens we'll show an error message next to the relevant field(s) and scroll the viewport to the payment section of the form to make sure these errors are visible. See screenshots below.

Note: This PR contains a small styling change to ensure the expiry and cvc fields are always equal width. Without this an error on only one of the fields rendered next to each other (expiry/CVC) sometimes causes the other field to be weirdly narrow. Originally I included another change to ensure they are always vertically aligned with each other but this created a detachment from the label which we felt could be confusing for users so I rolled this back.

## How to test

* Visit the generic checkout
* Fill in personal details (email etc)
* Select Credit/Debit card but leave fields blank
* Submit the form
* See new contextual inline errors

## How can we measure success?

I'd expect the Sentry error mentioned above to decrease in volume.

## Screenshots

All fields missing:

<img width="582" alt="Screenshot 2025-07-01 at 12 19 38" src="https://github.com/user-attachments/assets/38847a98-7251-4c08-8dd9-e5eaa112a5a2" />

Some fields missing:

![Screenshot 2025-07-02 at 11 27 34](https://github.com/user-attachments/assets/9f8d9cd3-3fab-4212-a3d6-27a878ee1bcf)

