### PR TITLE
Use correct GoCardless payment gateway for Sunday paper subs

### DIFF
--- a/support-workers/src/typescript/lambdas/createPaymentMethodLambda.ts
+++ b/support-workers/src/typescript/lambdas/createPaymentMethodLambda.ts
@@ -12,6 +12,7 @@ import type {
 	PayPalPaymentMethod,
 	StripePaymentMethod,
 } from '../model/paymentMethod';
+import { ProductType } from '../model/productType';
 import { stageFromEnvironment } from '../model/stage';
 import type {
 	CreatePaymentMethodState,
@@ -52,6 +53,7 @@ export const handler = async (
 			await createPaymentMethod(
 				createPaymentMethodState.paymentFields,
 				createPaymentMethodState.user,
+				createPaymentMethodState.product,
 			),
 		);
 	} catch (error) {
@@ -62,6 +64,7 @@ export const handler = async (
 export function createPaymentMethod(
 	paymentFields: PaymentFields,
 	user: User,
+	productType: ProductType,
 ): Promise<PaymentMethod> {
 	switch (paymentFields.paymentType) {
 		case 'Stripe':
@@ -71,7 +74,7 @@ export function createPaymentMethod(
 		case 'PayPal':
 			return createPayPalPaymentMethod(user.isTestUser, paymentFields);
 		case 'DirectDebit':
-			return createDirectDebitPaymentMethod(user, paymentFields);
+			return createDirectDebitPaymentMethod(user, paymentFields, productType);
 		case 'Existing':
 			return Promise.reject(
 				new Error(
@@ -217,15 +220,24 @@ async function createPayPalPaymentMethod(
 export function createDirectDebitPaymentMethod(
 	user: User,
 	dd: DirectDebitPaymentFields,
+	productType: ProductType,
 ): Promise<DirectDebitPaymentMethod> {
 	const addressLine = combinedAddressLine(
 		user.billingAddress.lineOne,
 		user.billingAddress.lineTwo,
 	);
 
+	const shouldUseTortoiseMediaGateway =
+		productType.productType === 'Paper' &&
+		productType.productOptions === 'Sunday';
+	const guardianGateway = 'GoCardless';
+	const tortoiseMediaGateway = 'GoCardless - Observer - Tortoise Media';
+
 	return Promise.resolve({
 		Type: 'BankTransfer',
-		PaymentGateway: 'GoCardless',
+		PaymentGateway: shouldUseTortoiseMediaGateway
+			? tortoiseMediaGateway
+			: guardianGateway,
 		BankTransferType: 'DirectDebitUK',
 		FirstName: user.firstName,
 		LastName: user.lastName,

--- a/support-workers/src/typescript/lambdas/createPaymentMethodLambda.ts
+++ b/support-workers/src/typescript/lambdas/createPaymentMethodLambda.ts
@@ -12,7 +12,7 @@ import type {
 	PayPalPaymentMethod,
 	StripePaymentMethod,
 } from '../model/paymentMethod';
-import { ProductType } from '../model/productType';
+import type { ProductType } from '../model/productType';
 import { stageFromEnvironment } from '../model/stage';
 import type {
 	CreatePaymentMethodState,

--- a/support-workers/src/typescript/model/paymentMethod.ts
+++ b/support-workers/src/typescript/model/paymentMethod.ts
@@ -36,6 +36,10 @@ const stripePaymentMethodSchema = z.object({
 });
 export type StripePaymentMethod = z.infer<typeof stripePaymentMethodSchema>;
 
+export const directDebitPaymentGatewaySchema = z.union([
+	z.literal('GoCardless'),
+	z.literal('GoCardless - Observer - Tortoise Media'),
+]);
 const directDebitPaymentMethodSchema = z.object({
 	FirstName: z.string(),
 	LastName: z.string(),
@@ -50,7 +54,7 @@ const directDebitPaymentMethodSchema = z.object({
 	StreetNumber: z.string().nullable(),
 	BankTransferType: z.literal('DirectDebitUK'),
 	Type: z.literal('BankTransfer'),
-	PaymentGateway: z.literal('GoCardless'),
+	PaymentGateway: directDebitPaymentGatewaySchema,
 });
 export type DirectDebitPaymentMethod = z.infer<
 	typeof directDebitPaymentMethodSchema

--- a/support-workers/src/typescript/model/productType.ts
+++ b/support-workers/src/typescript/model/productType.ts
@@ -57,3 +57,4 @@ export const productTypeSchema = z.discriminatedUnion('productType', [
 	digitalPackProductSchema,
 	guardianAdLiteProductSchema,
 ]);
+export type ProductType = z.infer<typeof productTypeSchema>;


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Consider the product when specifying the direct debit (GoCardless) payment gateway.

## Why are you doing this?

Since the create payment method lambda was migrated to TypeScript (#7017) we lost some functionality around GoCardless payment gateways. For Sunday paper subs we want to use a different payment gateway.

In the Scala version of this lambda we set the GoCardless payment gateway depending on the product (see #6913 for the original change), so implement the same logic here.

## How to test

I'd like to follow up with adding some unit tests around this, but to get things moving I'll test in CODE and check the payment gateway in Zuora.

## How can we measure success?

Sunday Paper subs should be created with the correct direct debit payment gateway.