### PR TITLE
Add tests for the CreatePaymentMethod lambda handler

### DIFF
--- a/support-workers/package.json
+++ b/support-workers/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest --group=-integration",
+    "test": "STAGE=CODE jest --group=-integration",
     "it-test": "jest --group=integration",
     "lint:check": "eslint src/typescript/**/*.ts",
     "lint:fix": "eslint --fix src/typescript/**/*.ts",

--- a/support-workers/src/typescript/lambdas/createPaymentMethodLambda.ts
+++ b/support-workers/src/typescript/lambdas/createPaymentMethodLambda.ts
@@ -6,6 +6,10 @@ import type {
 	StripeHostedPaymentFields,
 	StripePaymentFields,
 } from '../model/paymentFields';
+import {
+	guardianDirectDebitGateway,
+	tortoiseMediaDirectDebitGateway,
+} from '../model/paymentGateway';
 import type {
 	DirectDebitPaymentMethod,
 	PaymentMethod,
@@ -230,14 +234,12 @@ export function createDirectDebitPaymentMethod(
 	const shouldUseTortoiseMediaGateway =
 		productType.productType === 'Paper' &&
 		productType.productOptions === 'Sunday';
-	const guardianGateway = 'GoCardless';
-	const tortoiseMediaGateway = 'GoCardless - Observer - Tortoise Media';
 
 	return Promise.resolve({
 		Type: 'BankTransfer',
 		PaymentGateway: shouldUseTortoiseMediaGateway
-			? tortoiseMediaGateway
-			: guardianGateway,
+			? tortoiseMediaDirectDebitGateway
+			: guardianDirectDebitGateway,
 		BankTransferType: 'DirectDebitUK',
 		FirstName: user.firstName,
 		LastName: user.lastName,

--- a/support-workers/src/typescript/model/paymentGateway.ts
+++ b/support-workers/src/typescript/model/paymentGateway.ts
@@ -1,0 +1,3 @@
+export const guardianDirectDebitGateway = 'GoCardless';
+export const tortoiseMediaDirectDebitGateway =
+	'GoCardless - Observer - Tortoise Media';

--- a/support-workers/src/typescript/model/paymentMethod.ts
+++ b/support-workers/src/typescript/model/paymentMethod.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { countrySchema } from './address';
 import { stripePaymentTypeSchema } from './paymentFields';
+import {
+	guardianDirectDebitGateway,
+	tortoiseMediaDirectDebitGateway,
+} from './paymentGateway';
 // Payment methods are the activated payment details which are passed into Zuora as opposed to
 // payment fields which are the details entered by the user into the checkout
 
@@ -37,8 +41,8 @@ const stripePaymentMethodSchema = z.object({
 export type StripePaymentMethod = z.infer<typeof stripePaymentMethodSchema>;
 
 export const directDebitPaymentGatewaySchema = z.union([
-	z.literal('GoCardless'),
-	z.literal('GoCardless - Observer - Tortoise Media'),
+	z.literal(guardianDirectDebitGateway),
+	z.literal(tortoiseMediaDirectDebitGateway),
 ]);
 const directDebitPaymentMethodSchema = z.object({
 	FirstName: z.string(),

--- a/support-workers/src/typescript/test/createPaymentMethodLambda.test.ts
+++ b/support-workers/src/typescript/test/createPaymentMethodLambda.test.ts
@@ -1,0 +1,57 @@
+import { handler } from '../lambdas/createPaymentMethodLambda';
+import createPaymentDirectDebitPaper from './fixtures/createPaymentMethod/paperDirectDebit.json';
+import {
+	CreatePaymentMethodState,
+	createPaymentMethodStateSchema,
+} from '../model/stateSchemas';
+import { fulfilmentOptionsSchema } from '@modules/product/schemas';
+import { BillingPeriod } from '@modules/product/billingPeriod';
+
+const wrapPayload = (payload: CreatePaymentMethodState) => ({
+	state: payload,
+	error: null,
+	requestInfo: {
+		testUser: false,
+		failed: false,
+		messages: [],
+		accountExists: true,
+	},
+});
+
+describe('handler', () => {
+	describe('Direct Debit', () => {
+		it('uses the GoCardless payment gateway for a non-Sunday newspaper subscription', async () => {
+			const payload: CreatePaymentMethodState =
+				createPaymentMethodStateSchema.parse(createPaymentDirectDebitPaper);
+			payload.product = {
+				productType: 'Paper',
+				currency: 'GBP',
+				billingPeriod: BillingPeriod.Monthly,
+				fulfilmentOptions: 'HomeDelivery',
+				productOptions: 'Everyday',
+			};
+
+			const result = await handler(wrapPayload(payload));
+
+			expect(result.state.paymentMethod.PaymentGateway).toBe('GoCardless');
+		});
+
+		it('uses the Tortoise payment gateway for a Sunday newspaper subscription', async () => {
+			const payload: CreatePaymentMethodState =
+				createPaymentMethodStateSchema.parse(createPaymentDirectDebitPaper);
+			payload.product = {
+				productType: 'Paper',
+				currency: 'GBP',
+				billingPeriod: BillingPeriod.Monthly,
+				fulfilmentOptions: 'HomeDelivery',
+				productOptions: 'Sunday',
+			};
+
+			const result = await handler(wrapPayload(payload));
+
+			expect(result.state.paymentMethod.PaymentGateway).toBe(
+				'GoCardless - Observer - Tortoise Media',
+			);
+		});
+	});
+});

--- a/support-workers/src/typescript/test/createPaymentMethodLambda.test.ts
+++ b/support-workers/src/typescript/test/createPaymentMethodLambda.test.ts
@@ -1,5 +1,9 @@
 import { BillingPeriod } from '@modules/product/billingPeriod';
 import { handler } from '../lambdas/createPaymentMethodLambda';
+import {
+	guardianDirectDebitGateway,
+	tortoiseMediaDirectDebitGateway,
+} from '../model/paymentGateway';
 import type { CreatePaymentMethodState } from '../model/stateSchemas';
 import { createPaymentMethodStateSchema } from '../model/stateSchemas';
 import createPaymentDirectDebitPaper from './fixtures/createPaymentMethod/paperDirectDebit.json';
@@ -30,7 +34,9 @@ describe('handler', () => {
 
 			const result = await handler(wrapPayload(payload));
 
-			expect(result.state.paymentMethod.PaymentGateway).toBe('GoCardless');
+			expect(result.state.paymentMethod.PaymentGateway).toBe(
+				guardianDirectDebitGateway,
+			);
 		});
 
 		it('uses the Tortoise payment gateway for a Sunday newspaper subscription', async () => {
@@ -47,7 +53,7 @@ describe('handler', () => {
 			const result = await handler(wrapPayload(payload));
 
 			expect(result.state.paymentMethod.PaymentGateway).toBe(
-				'GoCardless - Observer - Tortoise Media',
+				tortoiseMediaDirectDebitGateway,
 			);
 		});
 	});

--- a/support-workers/src/typescript/test/createPaymentMethodLambda.test.ts
+++ b/support-workers/src/typescript/test/createPaymentMethodLambda.test.ts
@@ -1,11 +1,8 @@
-import { handler } from '../lambdas/createPaymentMethodLambda';
-import createPaymentDirectDebitPaper from './fixtures/createPaymentMethod/paperDirectDebit.json';
-import {
-	CreatePaymentMethodState,
-	createPaymentMethodStateSchema,
-} from '../model/stateSchemas';
-import { fulfilmentOptionsSchema } from '@modules/product/schemas';
 import { BillingPeriod } from '@modules/product/billingPeriod';
+import { handler } from '../lambdas/createPaymentMethodLambda';
+import type { CreatePaymentMethodState } from '../model/stateSchemas';
+import { createPaymentMethodStateSchema } from '../model/stateSchemas';
+import createPaymentDirectDebitPaper from './fixtures/createPaymentMethod/paperDirectDebit.json';
 
 const wrapPayload = (payload: CreatePaymentMethodState) => ({
 	state: payload,


### PR DESCRIPTION
## What are you doing in this PR?

Building on top of #7104 add some tests for the lambda handler, specifically testing the thing which #7104 touches (which Direct Debit payment gateway to use).

## Why are you doing this?

Build confidence in the code by increasing test coverage, and make it easier to add to these tests in future.

## How to test

`pnpm --filter support-workers test`