### PR TITLE
Remove temporary Wazuh security group

### DIFF
--- a/cdk/lib/__snapshots__/frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/frontend.test.ts.snap
@@ -1808,40 +1808,6 @@ exports[`The Frontend stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "WazuhSecurityGroup": {
-      "Properties": {
-        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-frontend",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
     "supportPRODfrontend47D51027": {
       "DependsOn": [
         "InstanceRoleFrontend9A970131",

--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -1687,40 +1687,6 @@ exports[`The Payment API stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
-    "WazuhSecurityGroup": {
-      "Properties": {
-        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-frontend",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
     "supportPRODpaymentapiF3F3A4D6": {
       "DependsOn": [
         "InstanceRolePaymentapi2FA25312",

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -20,7 +20,6 @@ import {
   InstanceClass,
   InstanceSize,
   InstanceType,
-  SecurityGroup,
   UserData,
 } from "aws-cdk-lib/aws-ec2";
 import { SslPolicy } from "aws-cdk-lib/aws-elasticloadbalancingv2";
@@ -154,18 +153,6 @@ export class Frontend extends GuStack {
       },
       scaling,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
-    });
-
-    // A temporary security group with a fixed logical ID, replicating the one removed from GuCDK v61.5.0.
-    const tempSecurityGroup = new SecurityGroup(this, "WazuhSecurityGroup", {
-      vpc: ec2App.vpc,
-      // Must keep the same description, else CloudFormation will try to replace the security group
-      // See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-securitygroup.html#cfn-ec2-securitygroup-groupdescription.
-      description: "Allow outbound traffic from wazuh agent to manager",
-    });
-    this.overrideLogicalId(tempSecurityGroup, {
-      logicalId: "WazuhSecurityGroup",
-      reason: "Part one of updating to GuCDK 61.5.0+ whilst using Riff-Raff's ASG deployment type",
     });
 
     (ec2App.listener.node.defaultChild as CfnListener).sslPolicy =

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -21,7 +21,6 @@ import {
   InstanceClass,
   InstanceSize,
   InstanceType,
-  SecurityGroup,
   UserData,
 } from "aws-cdk-lib/aws-ec2";
 import {
@@ -209,18 +208,6 @@ export class PaymentApi extends GuStack {
           }),
         ],
       },
-    });
-
-    // A temporary security group with a fixed logical ID, replicating the one removed from GuCDK v61.5.0.
-    const tempSecurityGroup = new SecurityGroup(this, "WazuhSecurityGroup", {
-      vpc: playApp.vpc,
-      // Must keep the same description, else CloudFormation will try to replace the security group
-      // See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-securitygroup.html#cfn-ec2-securitygroup-groupdescription.
-      description: "Allow outbound traffic from wazuh agent to manager",
-    });
-    this.overrideLogicalId(tempSecurityGroup, {
-      logicalId: "WazuhSecurityGroup",
-      reason: "Part one of updating to GuCDK 61.5.0+ whilst using Riff-Raff's ASG deployment type",
     });
 
     // Rule to only allow known http methods


### PR DESCRIPTION
## What are you doing in this PR?

Removing temporary security group added in #7103.

## Why are you doing this?

Wazuh is deprecated, and from gu/cdk v61.5.0 the security group is no longer created, but this must [happen in 2 steps](https://github.com/guardian/cdk/blob/main/CHANGELOG.md#6150). So in #7103 we created it, but detached from the ASG. Now it can be removed completely.

## How to test

Deployed to CODE (payment-api and support-frontend) and everything seems fine.