### PR TITLE
WIP: Fix jackson-core vulnerability in stripe-patrons-data and supporter-product-data

### DIFF
--- a/stripe-patrons-data/build.sbt
+++ b/stripe-patrons-data/build.sbt
@@ -10,6 +10,7 @@ scalacOptions ++= Seq(
 
 libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "dynamodb" % awsClientVersion2,
+  "software.amazon.awssdk" % "ssm" % awsClientVersion2,
   "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.5",

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/services/ConfigService.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/services/ConfigService.scala
@@ -1,8 +1,7 @@
 package com.gu.patrons.services
 
-import com.amazonaws.services.simplesystemsmanagement.model.Parameter
-import com.gu.supporterdata.model.Stage
 import com.typesafe.scalalogging.StrictLogging
+import software.amazon.awssdk.services.ssm.model.Parameter
 
 trait ConfigService extends StrictLogging {
 
@@ -15,7 +14,7 @@ trait ConfigService extends StrictLogging {
 
   protected def findParameterValue(name: String, params: List[Parameter]) =
     params
-      .find(_.getName.split('/').last == name)
-      .map(_.getValue)
+      .find(_.name.split('/').last == name)
+      .map(_.value)
 
 }

--- a/stripe-patrons-data/src/main/scala/com/gu/patrons/services/ParameterStoreService.scala
+++ b/stripe-patrons-data/src/main/scala/com/gu/patrons/services/ParameterStoreService.scala
@@ -1,86 +1,34 @@
 package com.gu.patrons.services
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{
-  AWSCredentialsProviderChain,
-  EC2ContainerCredentialsProviderWrapper,
-  EnvironmentVariableCredentialsProvider,
-  InstanceProfileCredentialsProvider,
-}
-import com.amazonaws.regions.Regions
-import com.amazonaws.services.simplesystemsmanagement.model.{
-  GetParameterRequest,
-  GetParametersByPathRequest,
-  ParameterType,
-  PutParameterRequest,
-}
-import com.amazonaws.services.simplesystemsmanagement.{
-  AWSSimpleSystemsManagementAsync,
-  AWSSimpleSystemsManagementAsyncClientBuilder,
-}
-import com.gu.aws.ProfileName
-import com.gu.patrons.AwsAsync
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.ssm.SsmClient
+import software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest
+import com.gu.aws.CredentialsProvider
 import com.gu.supporterdata.model.Stage
 
-import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
-class ParameterStoreService(client: AWSSimpleSystemsManagementAsync, stage: Stage) {
+class ParameterStoreService(client: SsmClient, stage: Stage) {
   val configRoot = s"/$stage/support/stripe-patrons-data"
 
-  def getParametersByPath(path: String)(implicit executionContext: ExecutionContext) = {
-    val request: GetParametersByPathRequest = new GetParametersByPathRequest()
-      .withPath(s"$configRoot/$path/")
-      .withRecursive(false)
-      .withWithDecryption(true)
-
-    AwsAsync(client.getParametersByPathAsync, request).map(_.getParameters.asScala.toList)
-  }
-
   def getParametersByPathSync(path: String) = {
-    val request: GetParametersByPathRequest = new GetParametersByPathRequest()
-      .withPath(s"$configRoot/$path/")
-      .withRecursive(false)
-      .withWithDecryption(true)
+    val request: GetParametersByPathRequest = GetParametersByPathRequest
+      .builder()
+      .path(s"$configRoot/$path/")
+      .recursive(false)
+      .withDecryption(true)
+      .build()
 
-    client.getParametersByPath(request).getParameters.asScala.toList
+    client.getParametersByPath(request).parameters().asScala.toList
   }
-
-  def getParameter(name: String)(implicit executionContext: ExecutionContext) = {
-    val request = new GetParameterRequest()
-      .withName(s"$configRoot/$name")
-      .withWithDecryption(true)
-
-    AwsAsync(client.getParameterAsync, request).map(_.getParameter.getValue)
-  }
-
-  def putParameter(name: String, value: String, parameterType: ParameterType = ParameterType.String) = {
-
-    val putParameterRequest = new PutParameterRequest()
-      .withName(s"$configRoot/$name")
-      .withType(parameterType)
-      .withValue(value)
-      .withOverwrite(true)
-
-    AwsAsync(client.putParameterAsync, putParameterRequest)
-  }
-
 }
 
 object ParameterStoreService {
 
-  // please update to AWS SDK 2 and use com.gu.aws.CredentialsProvider
-  lazy val CredentialsProviderDEPRECATEDV1 = new AWSCredentialsProviderChain(
-    new ProfileCredentialsProvider(ProfileName),
-    new InstanceProfileCredentialsProvider(false),
-    new EnvironmentVariableCredentialsProvider(),
-    new EC2ContainerCredentialsProviderWrapper(), // for use with lambda snapstart
-  )
-
-  lazy val client = AWSSimpleSystemsManagementAsyncClientBuilder
-    .standard()
-    .withRegion(Regions.EU_WEST_1)
-    .withCredentials(CredentialsProviderDEPRECATEDV1)
+  val client = SsmClient
+    .builder()
+    .credentialsProvider(CredentialsProvider)
+    .region(Region.EU_WEST_1)
     .build()
 
   def apply(stage: Stage) = new ParameterStoreService(client, stage)


### PR DESCRIPTION
## What are you doing in this PR?

Fixes a vulnerablility reported by dependabot for jackson-core. The vulnerability affects projects which use jackson-core < 2.15.0. Most of our projects use a later version but not stripe-patrons-data or supporter-product-data. 

[**Trello Card**](https://trello.com)

## Why are you doing this?

To remove a vulnerable version of jackson-core from the project.