### PR TITLE
Make dependabot run against the root pnpm workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,23 +6,14 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/support-frontend"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/support-workers/cloud-formation/src"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: 'npm'
-    directory: '/cdk'
+    directory: "/"
     # The version of @aws-cdk/* libraries must match those from @guardian/cdk.
     # We'd never be able to update them here independently, so just ignore them.
     ignore:
       - dependency-name: "aws-cdk"
       - dependency-name: "@aws-cdk/*"
-    # The cdk directory does not run in a PROD environment, only CI, so we can afford to use old versions of libraries for a short time. Run Dependabot once a month to reduce the frequency of PRs.
     schedule:
-      interval: 'monthly'
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -27,12 +27,10 @@ jobs:
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-node-and-install
 
-      - name: Test - support-frontend
-        run: pnpm --filter support-frontend test
+      - name: Test all workspaces
+        run: pnpm test
 
       - name: Install & test - CDK
         run: ./script/ci
         working-directory: cdk
 
-      - name: Test - bigquery-acquisitions-publisher
-        run: pnpm --filter bigquery-acquisitions-publisher test

--- a/modules/package.json
+++ b/modules/package.json
@@ -2,8 +2,6 @@
   "name": "modules",
   "version": "1.0.0",
   "scripts": {
-    "test": "jest --group=-integration",
-    "it-test": "jest --group=integration",
     "lint:check": "eslint **/*.ts",
     "lint:fix": "eslint --fix **/*.ts",
     "check-formatting": "prettier --check **.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "license": "Apache-2.0",
   "scripts": {
-    "prepare": "husky"
+    "prepare": "husky",
+    "test": "pnpm --stream -r run test"
   },
   "devDependencies": {
     "husky": "^9.0.11"


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR configures dependabot to run against the root of the pnpm workspace rather than on individual projects. 

This is because the root is now where the pnpm-lock.yml file lives, and should hopefully fix the issue of dependabot PRs not updating the lockfile.