### PR TITLE
Prevent flash of checkout without overlay before redirect to thank you page

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -617,11 +617,12 @@ export function CheckoutComponent({
 					`An error occurred in checkoutComponent.tsx while trying to submit the form: ${errorMessage}`,
 				);
 			}
-			// This state update is in the catch block because it has the effect of
-			// removing the processing overlay. Previously it was outside of the catch
-			// and this had the effect of removing the overlay even in the case where
-			// the submitForm was successful which meant there was a flash of the
-			// checkout with no overlap before the redirect to the thank you page.
+			// This state update is in the catch block because it has the effect
+			// of removing the processing overlay. If it was outside of the
+			// try/catch then in the case where the submitForm is successful the
+			// overlay would be removed before the redirect has completed
+			// resulting in a flash of the checkout with no overlay before the
+			// redirect to the thank you page.
 			setIsProcessingPayment(false);
 		}
 	};

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -617,8 +617,13 @@ export function CheckoutComponent({
 					`An error occurred in checkoutComponent.tsx while trying to submit the form: ${errorMessage}`,
 				);
 			}
+			// This state update is in the catch block because it has the effect of
+			// removing the processing overlay. Previously it was outside of the catch
+			// and this had the effect of removing the overlay even in the case where
+			// the submitForm was successful which meant there was a flash of the
+			// checkout with no overlap before the redirect to the thank you page.
+			setIsProcessingPayment(false);
 		}
-		setIsProcessingPayment(false);
 	};
 
 	useAbandonedBasketCookie(


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

In the checkoutComponent move the `setIsProcessingPayment(false)` call to catch block of the form submit handler because it has the effect of removing the processing overlay. Previously it was below/outside of the catch and this had the effect of removing the overlay even in the case where the submitForm was successful which meant there was a flash of the checkout with no overlap before the redirect to the thank you page. There's no need to remove the overlay unless we're dropping the user back on the checkout with errors in case something went wrong.

## Why are you doing this?

Prevent the flash of checkout without overlay when payment is successful before the (client side) redirect to the thank you page.

## How to test

Put through a transaction and watch the redirect to the thank you page.