### PR TITLE
Update smoke tests to use newspaper plus rate plans

### DIFF
--- a/support-e2e/tests/smoke/checkout.test.ts
+++ b/support-e2e/tests/smoke/checkout.test.ts
@@ -26,20 +26,20 @@ test.describe('Checkout', () => {
 		},
 		{
 			product: 'HomeDelivery',
-			ratePlan: 'Everyday',
+			ratePlan: 'EverydayPlus',
 			paymentType: 'Credit/Debit card',
 			internationalisationId: 'UK',
 		},
 		{
 			product: 'NationalDelivery',
-			ratePlan: 'Weekend',
+			ratePlan: 'WeekendPlus',
 			paymentType: 'Credit/Debit card',
 			internationalisationId: 'UK',
 			postCode: 'BN44 3QG', // This postcode only has one delivery agent
 		},
 		{
 			product: 'NationalDelivery',
-			ratePlan: 'Weekend',
+			ratePlan: 'WeekendPlus',
 			paymentType: 'Credit/Debit card',
 			internationalisationId: 'UK',
 			postCode: 'BS6 6QY', // This postcode has multiple delivery agents


### PR DESCRIPTION
## What are you doing in this PR?

In the Playwright smoke tests for newspaper subscriptions switch to the new "*Plus" rate plans.

## Why are you doing this?

These are the rate plans we're actively selling now (since #7097) so it makes sense to test against these.