### PR TITLE
Show error if recaptcha not checked for DirectDebit

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -295,6 +295,9 @@ export function CheckoutComponent({
 	const [stripeFieldError, setStripeFieldError] = useState<{
 		[key in StripeField]?: string;
 	}>({});
+	const [directDebitFieldError, setDirectDebitFieldError] = useState<{
+		recaptcha?: string;
+	}>({});
 
 	useEffect(() => {
 		if (paymentMethodError) {
@@ -479,11 +482,16 @@ export function CheckoutComponent({
 			cvc: true,
 		});
 		setStripeFieldError({});
+		setDirectDebitFieldError({});
 	}, [paymentMethod]);
 
 	// Reset recaptcha error when recaptcha token changes
 	useEffect(() => {
 		setStripeFieldError((previousState) => ({
+			...previousState,
+			recaptcha: undefined,
+		}));
+		setDirectDebitFieldError((previousState) => ({
 			...previousState,
 			recaptcha: undefined,
 		}));
@@ -601,6 +609,19 @@ export function CheckoutComponent({
 			// Don't go any further if there are errors for any Stripe fields
 			if (Object.values(newStripeFieldError).some((value) => value)) {
 				setStripeFieldError(newStripeFieldError);
+				paymentMethodRef.current?.scrollIntoView({ behavior: 'smooth' });
+				return;
+			}
+		}
+
+		if (paymentMethod === 'DirectDebit') {
+			const newDirectDebitFieldError = {
+				...(!recaptchaToken && { recaptcha: 'Please complete security check' }),
+			};
+
+			// Don't go any further if there are errors for any Stripe fields
+			if (Object.values(newDirectDebitFieldError).some((value) => value)) {
+				setDirectDebitFieldError(newDirectDebitFieldError);
 				paymentMethodRef.current?.scrollIntoView({ behavior: 'smooth' });
 				return;
 			}
@@ -1384,7 +1405,11 @@ export function CheckoutComponent({
 															/>
 														}
 														formError={''}
-														errors={{}}
+														errors={{
+															recaptcha: maybeArrayWrap(
+																directDebitFieldError.recaptcha,
+															),
+														}}
 													/>
 												</div>
 											)}


### PR DESCRIPTION


<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Before this change if the user tried to pay with Direct Debit but didn't check the recaptcha the form submit would fail and we'd render a very generic error below the submit button, which isn't helpful to the user.

Now when this happens an error is shown by the recaptcha and the viewport is scrolled to the payment section of the form.

Note: Currently there's an inconsistency in the UI when other Direct Debit fields are missed. We use native HTML validation. We'd like to move to the approach we use for Stripe (where the native validation isn't possible as we don't own the form fields). We hope to address this in a future PR.

[**Trello Card**](https://trello.com/c/sXWIyRpu/1676-handle-missing-payment-fields-on-the-generic-checkout)

## Why are you doing this?

Before this change if the user tried to pay with Direct Debit but didn't check the recaptcha the form submit would fail and we'd render a very generic error below the submit button, which isn't helpful to the user and may prevent them from completing the checkout process.

## How to test

On this branch:

* Go to the generic checkout
* Enter personal details
* Select Direct Debit
* Fill in all the fields but don't check the recaptcha
* Submit the form
* Observe the new error message.

## How can we measure success?

Currently this causes an exception which is reported to Sentry. The volumes of this error suggests this situation is actually happening to users. I'd expect instances of this error to reduce.

## Screenshots

Before:

<img width="611" alt="Screenshot 2025-07-03 at 12 12 48" src="https://github.com/user-attachments/assets/d4eb3403-a092-43b3-a57e-42e3ff032a07" />

After:

<img width="564" alt="Screenshot 2025-07-03 at 12 08 22" src="https://github.com/user-attachments/assets/029ff972-dced-4cef-a40f-8ecc913bec2a" />

