### PR TITLE
Extract Ad-Lite e2e tests out to start from landing page

### DIFF
--- a/support-e2e/tests/smoke/ad-lite.test.ts
+++ b/support-e2e/tests/smoke/ad-lite.test.ts
@@ -1,0 +1,13 @@
+import test from '@playwright/test';
+import { testAdLiteCheckout } from '../test/adLiteCheckout';
+import type { TestDetails } from '../test/adLiteCheckout';
+
+const tests: TestDetails[] = [
+	{
+		paymentType: 'Credit/Debit card',
+		ratePlan: 'Monthly',
+	},
+];
+
+test.describe('Ad Lite Checkout', () =>
+	tests.map((testDetails) => testAdLiteCheckout(testDetails)));

--- a/support-e2e/tests/smoke/checkout.test.ts
+++ b/support-e2e/tests/smoke/checkout.test.ts
@@ -7,12 +7,6 @@ afterEachTasks(test);
 test.describe('Checkout', () => {
 	[
 		{
-			product: 'GuardianAdLite',
-			ratePlan: 'Monthly',
-			paymentType: 'Credit/Debit card',
-			internationalisationId: 'UK',
-		},
-		{
 			product: 'SupporterPlus',
 			ratePlan: 'Annual',
 			paymentType: 'Credit/Debit card',

--- a/support-e2e/tests/test/adLiteCheckout.ts
+++ b/support-e2e/tests/test/adLiteCheckout.ts
@@ -1,0 +1,33 @@
+import test, { expect } from '@playwright/test';
+import { setupPage } from '../utils/page';
+import { completeCheckout } from './checkout';
+
+export type TestDetails = {
+	paymentType: string;
+	ratePlan: string;
+};
+
+export const testAdLiteCheckout = (testDetails: TestDetails) =>
+	test(`Ad-Lite - ${testDetails.paymentType}`, async ({ context, baseURL }) => {
+		const landingPageUrl = '/uk/guardian-ad-lite';
+		const page = await context.newPage();
+		await setupPage(page, context, baseURL, landingPageUrl);
+
+		// Click through to the checkout
+		const purchaseButton = await page.getByText('Get Guardian Ad-Lite');
+		await purchaseButton.click();
+
+		// Wait for the checkout page to load
+		await expect(
+			page.getByRole('heading', { name: 'Your subscription' }),
+		).toBeVisible({
+			timeout: 100000,
+		});
+
+		await completeCheckout(page, {
+			product: 'GuardianAdLite',
+			ratePlan: testDetails.ratePlan,
+			paymentType: testDetails.paymentType,
+			internationalisationId: 'UK',
+		});
+	});

--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -178,7 +178,6 @@ export const completeCheckout = async (page, testDetails: TestDetails) => {
 			fillInPayPalDetails(popupPage);
 			break;
 		case 'Credit/Debit card':
-		default:
 			await fillInCardDetails(page);
 			await checkRecaptcha(page);
 			await page

--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -139,54 +139,60 @@ export const testCheckout = (testDetails: TestDetails) => {
 		const page = await context.newPage();
 		await setupPage(page, context, baseURL, url);
 
-		await setUserDetailsForProduct(
-			page,
-			product,
-			internationalisationId,
-			postCode,
-		);
+		await completeCheckout(page, testDetails);
+	});
+};
 
-		// State mandatory for AU and US
-		if (internationalisationId === 'AU') {
-			await page.getByLabel('State').selectOption({ label: 'New South Wales' });
-		}
-		if (internationalisationId === 'US') {
-			await page.getByLabel('State').selectOption({ label: 'Illinois' });
-		}
+export const completeCheckout = async (page, testDetails: TestDetails) => {
+	const { product, internationalisationId, postCode, paymentType } =
+		testDetails;
+	await setUserDetailsForProduct(
+		page,
+		product,
+		internationalisationId,
+		postCode,
+	);
 
-		await page.getByRole('radio', { name: paymentType }).check();
-		switch (paymentType) {
-			case 'PayPal':
-				const popupPagePromise = page.waitForEvent('popup');
-				await page
-					.locator("iframe[name^='xcomponent__ppbutton']")
-					.scrollIntoViewIfNeeded();
-				await page
-					.frameLocator("iframe[name^='xcomponent__ppbutton']")
-					// this class gets added to the iframe body after the JavaScript has finished executing
-					.locator('body.dom-ready')
-					.locator('[role="button"]:has-text("Pay with")')
-					.click({ delay: 2000 });
-				const popupPage = await popupPagePromise;
-				fillInPayPalDetails(popupPage);
-				break;
-			case 'Credit/Debit card':
-			default:
-				await fillInCardDetails(page);
-				break;
-		}
+	// State mandatory for AU and US
+	if (internationalisationId === 'AU') {
+		await page.getByLabel('State').selectOption({ label: 'New South Wales' });
+	}
+	if (internationalisationId === 'US') {
+		await page.getByLabel('State').selectOption({ label: 'Illinois' });
+	}
 
-		if (paymentType === 'Credit/Debit card') {
-			await checkRecaptcha(page);
+	await page.getByRole('radio', { name: paymentType }).check();
+	switch (paymentType) {
+		case 'PayPal':
+			const popupPagePromise = page.waitForEvent('popup');
 			await page
-				.getByRole('button', {
-					name: `Pay`,
-				})
-				.click();
-		}
+				.locator("iframe[name^='xcomponent__ppbutton']")
+				.scrollIntoViewIfNeeded();
+			await page
+				.frameLocator("iframe[name^='xcomponent__ppbutton']")
+				// this class gets added to the iframe body after the JavaScript has finished executing
+				.locator('body.dom-ready')
+				.locator('[role="button"]:has-text("Pay with")')
+				.click({ delay: 2000 });
+			const popupPage = await popupPagePromise;
+			fillInPayPalDetails(popupPage);
+			break;
+		case 'Credit/Debit card':
+		default:
+			await fillInCardDetails(page);
+			break;
+	}
 
-		await expect(page.getByRole('heading', { name: 'Thank you' })).toBeVisible({
-			timeout: 600000,
-		});
+	if (paymentType === 'Credit/Debit card') {
+		await checkRecaptcha(page);
+		await page
+			.getByRole('button', {
+				name: `Pay`,
+			})
+			.click();
+	}
+
+	await expect(page.getByRole('heading', { name: 'Thank you' })).toBeVisible({
+		timeout: 600000,
 	});
 };

--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -180,16 +180,13 @@ export const completeCheckout = async (page, testDetails: TestDetails) => {
 		case 'Credit/Debit card':
 		default:
 			await fillInCardDetails(page);
+			await checkRecaptcha(page);
+			await page
+				.getByRole('button', {
+					name: `Pay`,
+				})
+				.click();
 			break;
-	}
-
-	if (paymentType === 'Credit/Debit card') {
-		await checkRecaptcha(page);
-		await page
-			.getByRole('button', {
-				name: `Pay`,
-			})
-			.click();
 	}
 
 	await expect(page.getByRole('heading', { name: 'Thank you' })).toBeVisible({


### PR DESCRIPTION
## What are you doing in this PR?

Extracting Ad-Lite e2e tests out to start from landing page instead of the going directly to the checkout.

This establishes a new pattern where checkout tests start on the landing page for the relevant product. Eventually this will be applied to all the current tests defined in `checkout.test.ts`, which will be grouped by the landing page. I've extracted a method `completeCheckout` which can be used to fill in the checkout and submit. This is shared by the new tests which start on the landing page and the existing checkout tests.


<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/lnE2F0us/1690-update-playwright-e2e-tests-to-begin-checkout-flows-on-the-relevant-landing-page)

## Why are you doing this?

We'd like to start tests on the landing page as this is closer to how real users will interact with the site.