### PR TITLE
Add /UTS to the student landing page path

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -59,19 +59,8 @@ const StudentLandingPage = lazy(() => {
 	});
 });
 
-const router = createBrowserRouter(
-	geoIds.flatMap((geoId) => [
-		{
-			path: `/${geoId}/student`,
-			element: (
-				<Suspense fallback={<HoldingContent />}>
-					<StudentLandingPage
-						geoId={geoId}
-						landingPageVariant={landingPageParticipations.variant}
-					/>
-				</Suspense>
-			),
-		},
+const router = createBrowserRouter([
+	...geoIds.flatMap((geoId) => [
 		{
 			path: `/${geoId}/contribute/:campaignCode?`,
 			element: (
@@ -131,7 +120,18 @@ const router = createBrowserRouter(
 			),
 		},
 	]),
-);
+	{
+		path: '/au/student/UTS',
+		element: (
+			<Suspense fallback={<HoldingContent />}>
+				<StudentLandingPage
+					geoId={'au'}
+					landingPageVariant={landingPageParticipations.variant}
+				/>
+			</Suspense>
+		),
+	},
+]);
 
 function Router() {
 	return (

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -79,14 +79,7 @@ GET  /contribute/:campaignCode                                     controllers.A
 GET  /$country<(uk|us|au|eu|int|nz|ca)>/contribute                 controllers.Application.contributionsLanding(country: String, campaignCode = "")
 GET  /$country<(uk|us|au|eu|int|nz|ca)>/contribute/:campaignCode   controllers.Application.contributionsLanding(country: String, campaignCode: String)
 
-GET  /student                                                      controllers.Application.studentGeoRedirect()
-GET  /uk/student                                                   controllers.Application.contributeGeoRedirect(campaignCode = "")
-GET  /us/student                                                   controllers.Application.contributeGeoRedirect(campaignCode = "")
-GET  /eu/student                                                   controllers.Application.contributeGeoRedirect(campaignCode = "")
-GET  /int/student                                                  controllers.Application.contributeGeoRedirect(campaignCode = "")
-GET  /nz/student                                                   controllers.Application.contributeGeoRedirect(campaignCode = "")
-GET  /ca/student                                                   controllers.Application.contributeGeoRedirect(campaignCode = "")
-GET  /au/student                                                   controllers.Application.studentLanding(country = "au", campaignCode = "")
+GET  /au/student/UTS                                               controllers.Application.studentLanding(country = "au", campaignCode = "")
 
 GET  /aus-2020-map                                                 controllers.Application.ausMomentMap()
 GET  /aus-map                                                      controllers.Application.ausMomentMap()


### PR DESCRIPTION
## What are you doing in this PR?

Adds /UTS to the student landing page path.

Previously for non au region paths we redirected to the 3 tier landing page. This was kind of a placeholder until we broadened the student landing page to other regions. Now that the university is part of the URL I think that changes things, and that visiting /student/UTS when not in Australia doesn't really make sense (and won't in future). So I've removed the other regions and the non-region path from the routes completely. Interested in thoughts on this.

## Why are you doing this?

Feedback from MRR.