### PR TITLE
Fix newspaper redesign cards benefits list

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/helpers/getPlans.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/helpers/getPlans.tsx
@@ -205,52 +205,51 @@ export const getPlans = (
 	ActivePaperProductTypes.filter(
 		(productOption) =>
 			productOption.endsWith('Plus') || productOption === 'Sunday',
-	) //Don't show Plus options on the landing page for now
-		.map((productOption) => {
-			const priceAfterPromosApplied = finalPrice(
-				productPrices,
-				'GB',
-				BillingPeriod.Monthly,
+	).map((productOption) => {
+		const priceAfterPromosApplied = finalPrice(
+			productPrices,
+			'GB',
+			BillingPeriod.Monthly,
+			fulfilmentOption,
+			productOption,
+		);
+		const promotion = getAppliedPromo(priceAfterPromosApplied.promotions);
+		const promoCode = promotion ? promotion.promoCode : null;
+		const trackingProperties: TrackingProperties = {
+			id: `subscribe_now_cta-${[productOption, fulfilmentOption].join()}`,
+			product: 'Paper',
+			componentType: 'ACQUISITIONS_BUTTON',
+		};
+		const nonDiscountedPrice = getProductPrice(
+			productPrices,
+			'GB',
+			BillingPeriod.Monthly,
+			fulfilmentOption,
+			productOption,
+		);
+		const label =
+			productOption === 'Everyday' || productOption === 'EverydayPlus'
+				? 'Best deal'
+				: '';
+		const productLabel = getProductLabel(productOption);
+		return {
+			title: getTitle(productOption),
+			price: showPrice(priceAfterPromosApplied),
+			href: paperCheckoutUrl(fulfilmentOption, productOption, promoCode),
+			onClick: sendTrackingEventsOnClick(trackingProperties),
+			onView: sendTrackingEventsOnView(trackingProperties),
+			buttonCopy: 'Subscribe',
+			priceCopy: getPriceCopyString(
+				nonDiscountedPrice,
+				copy[fulfilmentOption][productOption],
+			),
+			planData: getPlanData(productOption),
+			offerCopy: getOfferText(priceAfterPromosApplied, promotion),
+			label,
+			productLabel,
+			unavailableOutsideLondon: getUnavailableOutsideLondon(
 				fulfilmentOption,
 				productOption,
-			);
-			const promotion = getAppliedPromo(priceAfterPromosApplied.promotions);
-			const promoCode = promotion ? promotion.promoCode : null;
-			const trackingProperties: TrackingProperties = {
-				id: `subscribe_now_cta-${[productOption, fulfilmentOption].join()}`,
-				product: 'Paper',
-				componentType: 'ACQUISITIONS_BUTTON',
-			};
-			const nonDiscountedPrice = getProductPrice(
-				productPrices,
-				'GB',
-				BillingPeriod.Monthly,
-				fulfilmentOption,
-				productOption,
-			);
-			const label =
-				productOption === 'Everyday' || productOption === 'EverydayPlus'
-					? 'Best deal'
-					: '';
-			const productLabel = getProductLabel(productOption);
-			return {
-				title: getTitle(productOption),
-				price: showPrice(priceAfterPromosApplied),
-				href: paperCheckoutUrl(fulfilmentOption, productOption, promoCode),
-				onClick: sendTrackingEventsOnClick(trackingProperties),
-				onView: sendTrackingEventsOnView(trackingProperties),
-				buttonCopy: 'Subscribe',
-				priceCopy: getPriceCopyString(
-					nonDiscountedPrice,
-					copy[fulfilmentOption][productOption],
-				),
-				planData: getPlanData(productOption),
-				offerCopy: getOfferText(priceAfterPromosApplied, promotion),
-				label,
-				productLabel,
-				unavailableOutsideLondon: getUnavailableOutsideLondon(
-					fulfilmentOption,
-					productOption,
-				),
-			};
-		});
+			),
+		};
+	});

--- a/support-frontend/assets/pages/paper-subscription-landing/planData.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/planData.tsx
@@ -31,8 +31,8 @@ const baseDigitalRewards = [
 	'Far fewer asks for support',
 ];
 
-const planData: Record<PaperProductOptions, PlanData> = {
-	Everyday: {
+const planData: Partial<Record<PaperProductOptions, PlanData>> = {
+	EverydayPlus: {
 		description: (
 			<>
 				<strong>Home delivery</strong> of <strong>the Guardian</strong> from
@@ -52,7 +52,7 @@ const planData: Record<PaperProductOptions, PlanData> = {
 			items: baseDigitalRewards,
 		},
 	},
-	Sixday: {
+	SixdayPlus: {
 		description: (
 			<>
 				<strong>Home delivery</strong> of <strong>the Guardian</strong> plus
@@ -68,7 +68,7 @@ const planData: Record<PaperProductOptions, PlanData> = {
 			items: baseDigitalRewards,
 		},
 	},
-	Weekend: {
+	WeekendPlus: {
 		description: (
 			<>
 				<strong>Home delivery</strong> of the Saturday editions of{' '}
@@ -88,7 +88,7 @@ const planData: Record<PaperProductOptions, PlanData> = {
 			items: baseDigitalRewards,
 		},
 	},
-	Saturday: {
+	SaturdayPlus: {
 		description: (
 			<>
 				<strong>Home delivery</strong> of <strong>the Guardian</strong> on
@@ -120,50 +120,6 @@ const planData: Record<PaperProductOptions, PlanData> = {
 				</>
 			),
 			items: ['The Observer and all its supplements, delivered on Sundays  '],
-		},
-	},
-	SaturdayPlus: {
-		description: <></>,
-		benefits: {
-			label: <></>,
-			items: [],
-		},
-		digitalRewards: {
-			label: <></>,
-			items: [],
-		},
-	},
-	WeekendPlus: {
-		description: <></>,
-		benefits: {
-			label: <></>,
-			items: [],
-		},
-		digitalRewards: {
-			label: <></>,
-			items: [],
-		},
-	},
-	SixdayPlus: {
-		description: <></>,
-		benefits: {
-			label: <></>,
-			items: [],
-		},
-		digitalRewards: {
-			label: <></>,
-			items: [],
-		},
-	},
-	EverydayPlus: {
-		description: <></>,
-		benefits: {
-			label: <></>,
-			items: [],
-		},
-		digitalRewards: {
-			label: <></>,
-			items: [],
 		},
 	},
 };


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
update the plans data with the correct active ratePlans for the newspaper products.
Updated the Type to make use of  Typescript `Partial`, so we don't have to maintain  unused ratePlans in the data.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?
We went live with the Plus ratePlans and the plans data which is not live stayed stale with the old ratePlans.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
### Broken
![Screenshot 2025-07-07 at 15 17 26](https://github.com/user-attachments/assets/62bf0a47-3649-4605-ab19-dee92bf29469)

### Fixed
![Screenshot 2025-07-07 at 15 17 01](https://github.com/user-attachments/assets/997430b7-5cb4-4d5c-ba05-974b0b91d4d7)


