### PR TITLE
Disable back button for student offer

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -202,6 +202,9 @@ export function CheckoutComponent({
 	const user = appConfig.user;
 	const isSignedIn = !!user?.email;
 
+	const urlParams = new URLSearchParams(window.location.search);
+	const showBackButton = urlParams.get('backButton') !== 'false';
+
 	const productCatalog = appConfig.productCatalog;
 	const { currency, currencyKey, countryGroupId } = getGeoIdConfig(geoId);
 
@@ -780,10 +783,12 @@ export function CheckoutComponent({
 							/>
 						}
 						headerButton={
-							<BackButton
-								path={`/${geoId}${productDescription.landingPagePath}`}
-								buttonText={'Change'}
-							/>
+							showBackButton && (
+								<BackButton
+									path={`/${geoId}${productDescription.landingPagePath}`}
+									buttonText={'Change'}
+								/>
+							)
 						}
 					/>
 				</BoxContents>

--- a/support-frontend/assets/pages/[countryGroupId]/student/helpers/getProductContents.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/student/helpers/getProductContents.ts
@@ -15,6 +15,7 @@ export default function getProductContents(geoId: GeoId): CardContent {
 	const urlSearchParams = new URLSearchParams({
 		product: 'SupporterPlus',
 		ratePlan: 'Annual',
+		backButton: 'false',
 	});
 
 	const promotion = getPromotion(


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Disable back button on the checkout order summary using a query param.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

There is no point to having the back navigations because there aren't any other options to choose from on the student page.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
