### PR TITLE
fetch benefits from the pageSettings variant

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -65,7 +65,10 @@ const router = createBrowserRouter(
 			path: `/${geoId}/student`,
 			element: (
 				<Suspense fallback={<HoldingContent />}>
-					<StudentLandingPage geoId={geoId} />
+					<StudentLandingPage
+						geoId={geoId}
+						landingPageVariant={landingPageParticipations.variant}
+					/>
 				</Suspense>
 			),
 		},

--- a/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.tsx
@@ -4,6 +4,7 @@ import {
 } from '@guardian/source-development-kitchen/react-components';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
+import type { LandingPageVariant } from 'helpers/globalsAndSwitches/landingPageSettings';
 import { type GeoId } from 'pages/geoIdConfig';
 import { AccordionFAQ } from '../components/accordionFAQ';
 import StudentHeader from './components/StudentHeader';
@@ -11,7 +12,13 @@ import { StudentTsAndCs } from './components/studentTsAndCs';
 import { getStudentFAQs } from './helpers/studentFAQs';
 import { getStudentTsAndCs } from './helpers/studentTsAndCsCopy';
 
-export function StudentLandingPage({ geoId }: { geoId: GeoId }) {
+export function StudentLandingPage({
+	geoId,
+	landingPageVariant,
+}: {
+	geoId: GeoId;
+	landingPageVariant: LandingPageVariant;
+}) {
 	const faqItems = getStudentFAQs(geoId);
 	const tsAndCsItem = getStudentTsAndCs(geoId);
 	return (
@@ -23,7 +30,7 @@ export function StudentLandingPage({ geoId }: { geoId: GeoId }) {
 				</FooterWithContents>
 			}
 		>
-			<StudentHeader geoId={geoId} />
+			<StudentHeader geoId={geoId} landingPageVariant={landingPageVariant} />
 			{faqItems && <AccordionFAQ faqItems={faqItems} />}
 			{tsAndCsItem && <StudentTsAndCs tsAndCsItem={tsAndCsItem} />}
 		</PageScaffold>

--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
@@ -1,5 +1,6 @@
 import { BillingPeriod } from '@modules/product/billingPeriod';
 import { Container } from 'components/layout/container';
+import type { LandingPageVariant } from 'helpers/globalsAndSwitches/landingPageSettings';
 import type { GeoId } from 'pages/geoIdConfig';
 import getProductContents from '../helpers/getProductContents';
 import LogoUTS from '../logos/uts';
@@ -13,8 +14,14 @@ import {
 } from './StudentHeaderStyles';
 import StudentProductCard from './StudentProductCard';
 
-export default function StudentHeader({ geoId }: { geoId: GeoId }) {
-	const productContent = getProductContents(geoId);
+export default function StudentHeader({
+	geoId,
+	landingPageVariant,
+}: {
+	geoId: GeoId;
+	landingPageVariant: LandingPageVariant;
+}) {
+	const productContent = getProductContents(geoId, landingPageVariant);
 	return (
 		<Container
 			sideBorders

--- a/support-frontend/assets/pages/[countryGroupId]/student/helpers/getProductContents.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/student/helpers/getProductContents.ts
@@ -1,12 +1,16 @@
 import type { IsoCountry } from '@modules/internationalisation/country';
 import { BillingPeriod } from '@modules/product/billingPeriod';
+import type { LandingPageVariant } from 'helpers/globalsAndSwitches/landingPageSettings';
 import { productCatalog } from 'helpers/productCatalog';
 import { getPromotion } from 'helpers/productPrice/promotions';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
 import type { CardContent } from 'pages/supporter-plus-landing/components/threeTierCard';
 
-export default function getProductContents(geoId: GeoId): CardContent {
+export default function getProductContents(
+	geoId: GeoId,
+	landingPageVariant: LandingPageVariant,
+): CardContent {
 	const { currencyKey } = getGeoIdConfig(geoId);
 	const tier2Pricing = productCatalog.SupporterPlus?.ratePlans[
 		BillingPeriod.Annual
@@ -22,36 +26,20 @@ export default function getProductContents(geoId: GeoId): CardContent {
 		geoId.toLocaleUpperCase() as IsoCountry,
 		BillingPeriod.Annual,
 	);
-	const benefits = [
-		{
-			copy: 'Unlimited access to the Guardian app',
-		},
-		{
-			copy: 'Unlimited access to the Guardian Feast app',
-		},
-		{
-			copy: 'Ad-free reading on all your devices',
-		},
-		{
-			copy: 'Exclusive supporter newsletter',
-		},
-		{
-			copy: 'Far fewer asks for support',
-		},
-	];
 
 	if (promotion) {
 		urlSearchParams.set('promoCode', promotion.promoCode);
 	}
 	const chekoutUrl = `checkout?${urlSearchParams.toString()}`;
+
 	return {
 		product: 'SupporterPlus',
 		price: tier2Pricing,
 		link: chekoutUrl,
 		promotion,
 		isUserSelected: false,
+		...landingPageVariant.products.SupporterPlus,
 		title: 'All-access digital',
-		benefits,
 		cta: {
 			copy: 'Sign up for free',
 		},


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Fetch benefits list rom the pageSettings variant.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?
For the Benefits list we want to mimic what's being displayed on the Australian  page for the supporter plus Product.
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
