### PR TITLE
Three tier product e2e smoke tests start on the three tier landing page

### DIFF
--- a/support-e2e/tests/smoke/checkout.test.ts
+++ b/support-e2e/tests/smoke/checkout.test.ts
@@ -7,18 +7,6 @@ afterEachTasks(test);
 test.describe('Checkout', () => {
 	[
 		{
-			product: 'SupporterPlus',
-			ratePlan: 'Annual',
-			paymentType: 'Credit/Debit card',
-			internationalisationId: 'EU',
-		},
-		{
-			product: 'TierThree',
-			ratePlan: 'DomesticMonthly',
-			paymentType: 'Credit/Debit card',
-			internationalisationId: 'UK',
-		},
-		{
 			product: 'HomeDelivery',
 			ratePlan: 'EverydayPlus',
 			paymentType: 'Credit/Debit card',

--- a/support-e2e/tests/smoke/three-tier.test.ts
+++ b/support-e2e/tests/smoke/three-tier.test.ts
@@ -1,0 +1,23 @@
+import test from '@playwright/test';
+import { testThreeTierCheckout } from '../test/threeTierCheckout';
+import type { TestDetails } from '../test/threeTierCheckout';
+
+const tests: TestDetails[] = [
+	{
+		productLabel: 'All-access digital',
+		product: 'SupporterPlus',
+		billingFrequency: 'Annual',
+		paymentType: 'Credit/Debit card',
+		internationalisationId: 'EU',
+	},
+	{
+		productLabel: 'Digital + print',
+		product: 'TierThree',
+		billingFrequency: 'Monthly',
+		paymentType: 'Credit/Debit card',
+		internationalisationId: 'UK',
+	},
+];
+
+test.describe('Three Tier Checkout', () =>
+	tests.map((testDetails) => testThreeTierCheckout(testDetails)));

--- a/support-e2e/tests/test/adLiteCheckout.ts
+++ b/support-e2e/tests/test/adLiteCheckout.ts
@@ -1,6 +1,6 @@
 import test, { expect } from '@playwright/test';
 import { setupPage } from '../utils/page';
-import { completeCheckout } from './checkout';
+import { completeGenericCheckout } from '../utils/completeGenericCheckout';
 
 export type TestDetails = {
 	paymentType: string;
@@ -24,9 +24,8 @@ export const testAdLiteCheckout = (testDetails: TestDetails) =>
 			timeout: 100000,
 		});
 
-		await completeCheckout(page, {
+		await completeGenericCheckout(page, {
 			product: 'GuardianAdLite',
-			ratePlan: testDetails.ratePlan,
 			paymentType: testDetails.paymentType,
 			internationalisationId: 'UK',
 		});

--- a/support-e2e/tests/test/checkout.ts
+++ b/support-e2e/tests/test/checkout.ts
@@ -1,20 +1,6 @@
-import { expect, Page, test } from '@playwright/test';
-import { email, firstName, lastName } from '../utils/users';
+import { test } from '@playwright/test';
 import { setupPage } from '../utils/page';
-import { fillInPayPalDetails } from '../utils/paypal';
-import { fillInCardDetails } from '../utils/cardDetails';
-import { checkRecaptcha } from '../utils/recaptcha';
-import {
-	ausWithFullAddress,
-	intWithPostalAddressOnly,
-	TestFields,
-	ukWithPostalAddressOnly,
-	usWithPostalAddressOnly,
-} from '../utils/userFields';
-import {
-	setTestUserAddressDetails,
-	setTestUserDetails,
-} from '../utils/testUserDetails';
+import { completeGenericCheckout } from '../utils/completeGenericCheckout';
 
 // TODO: it'd be great to make the types here more specific, possibly using the
 // shared types from the product catalog.
@@ -24,105 +10,6 @@ type TestDetails = {
 	paymentType: string;
 	internationalisationId: string;
 	postCode?: string;
-};
-
-const userDetails = (
-	product: string,
-	internationalisationId: string,
-): TestFields => {
-	switch (internationalisationId) {
-		case 'UK':
-			return ukWithPostalAddressOnly();
-		case 'US':
-			return usWithPostalAddressOnly();
-		case 'AU':
-			return ausWithFullAddress();
-		case 'INT':
-			return intWithPostalAddressOnly();
-		default:
-			throw new Error(
-				`Couldn't find user details for ${product} in ${internationalisationId}`,
-			);
-	}
-};
-
-const setUserDetailsForProduct = async (
-	page,
-	product,
-	internationalisationId,
-	postCode,
-) => {
-	switch (product) {
-		case 'SupporterPlus':
-		case 'GuardianAdLite':
-			await setTestUserDetails(page, email(), firstName(), lastName(), true);
-
-			break;
-		case 'GuardianWeeklyDomestic':
-		case 'GuardianWeeklyRestOfWorld':
-		case 'TierThree':
-			await setTestUserAddressDetails(
-				page,
-				userDetails(product, internationalisationId),
-				internationalisationId,
-				3,
-			);
-
-			break;
-		case 'HomeDelivery':
-			if (internationalisationId !== 'UK') {
-				throw new Error(
-					`Home delivery is only available in the UK, but got ${internationalisationId}`,
-				);
-			}
-
-			await setTestUserAddressDetails(
-				page,
-				ukWithPostalAddressOnly(),
-				internationalisationId,
-				3,
-			);
-
-			break;
-		case 'NationalDelivery':
-			if (internationalisationId !== 'UK') {
-				throw new Error(
-					`National delivery is only available in the UK, but got ${internationalisationId}`,
-				);
-			}
-
-			await setTestUserAddressDetails(
-				page,
-				ukWithPostalAddressOnly(postCode),
-				internationalisationId,
-				3,
-			);
-			await selectDeliveryAgent(page);
-
-			break;
-		default:
-			throw new Error(
-				`I don't know how to fill in user details for ${product}`,
-			);
-	}
-};
-
-const selectDeliveryAgent = async (page: Page) => {
-	// Depending on whether there are one or multiple delivery agents we need to do different things here.
-	// If there are multiple delivery agents, we need to select one of them, if there is only one we do not.
-	const deliveryAgentLabel = page.locator(
-		'div:text-matches("Delivery provider|Select delivery provider")', // This will match both labels
-	);
-	await deliveryAgentLabel.waitFor({ state: 'visible' });
-
-	const deliveryAgentRadioButton = page.locator(
-		'fieldSet#delivery-provider input[type="radio"]',
-	);
-
-	if ((await deliveryAgentRadioButton.count()) > 0) {
-		// If there are multiple delivery agents, select the first one
-		await deliveryAgentRadioButton.first().check();
-	}
 };
 
 export const testCheckout = (testDetails: TestDetails) => {
@@ -139,56 +26,6 @@ export const testCheckout = (testDetails: TestDetails) => {
 		const page = await context.newPage();
 		await setupPage(page, context, baseURL, url);
 
-		await completeCheckout(page, testDetails);
-	});
-};
-
-export const completeCheckout = async (page, testDetails: TestDetails) => {
-	const { product, internationalisationId, postCode, paymentType } =
-		testDetails;
-	await setUserDetailsForProduct(
-		page,
-		product,
-		internationalisationId,
-		postCode,
-	);
-
-	// State mandatory for AU and US
-	if (internationalisationId === 'AU') {
-		await page.getByLabel('State').selectOption({ label: 'New South Wales' });
-	}
-	if (internationalisationId === 'US') {
-		await page.getByLabel('State').selectOption({ label: 'Illinois' });
-	}
-
-	await page.getByRole('radio', { name: paymentType }).check();
-	switch (paymentType) {
-		case 'PayPal':
-			const popupPagePromise = page.waitForEvent('popup');
-			await page
-				.locator("iframe[name^='xcomponent__ppbutton']")
-				.scrollIntoViewIfNeeded();
-			await page
-				.frameLocator("iframe[name^='xcomponent__ppbutton']")
-				// this class gets added to the iframe body after the JavaScript has finished executing
-				.locator('body.dom-ready')
-				.locator('[role="button"]:has-text("Pay with")')
-				.click({ delay: 2000 });
-			const popupPage = await popupPagePromise;
-			fillInPayPalDetails(popupPage);
-			break;
-		case 'Credit/Debit card':
-			await fillInCardDetails(page);
-			await checkRecaptcha(page);
-			await page
-				.getByRole('button', {
-					name: `Pay`,
-				})
-				.click();
-			break;
-	}
-
-	await expect(page.getByRole('heading', { name: 'Thank you' })).toBeVisible({
-		timeout: 600000,
+		await completeGenericCheckout(page, testDetails);
 	});
 };

--- a/support-e2e/tests/test/threeTierCheckout.ts
+++ b/support-e2e/tests/test/threeTierCheckout.ts
@@ -1,0 +1,48 @@
+import test, { expect } from '@playwright/test';
+import { setupPage } from '../utils/page';
+import { completeGenericCheckout } from '../utils/completeGenericCheckout';
+
+export type TestDetails = {
+	productLabel: string;
+	paymentType: string;
+	product: string;
+	billingFrequency: string;
+	internationalisationId: string;
+};
+
+export const testThreeTierCheckout = (testDetails: TestDetails) => {
+	const {
+		billingFrequency,
+		product,
+		paymentType,
+		internationalisationId,
+		productLabel,
+	} = testDetails;
+	test(`Three Tier - ${product} - ${billingFrequency} - ${paymentType} - ${internationalisationId}`, async ({
+		context,
+		baseURL,
+	}) => {
+		const landingPageUrl = `/${internationalisationId.toLowerCase()}/contribute`;
+		const page = await context.newPage();
+		await setupPage(page, context, baseURL, landingPageUrl);
+
+		// Select the billing frequency
+		await page.getByRole('tab', { name: billingFrequency }).click();
+
+		// Click through to the checkout (we use the aria-label to target the link)
+		await page.getByLabel(productLabel, { exact: true }).click();
+
+		// Wait for the checkout page to load
+		await expect(
+			page.getByRole('heading', { name: 'Your subscription' }),
+		).toBeVisible({
+			timeout: 100000,
+		});
+
+		await completeGenericCheckout(page, {
+			product,
+			paymentType,
+			internationalisationId,
+		});
+	});
+};

--- a/support-e2e/tests/utils/completeGenericCheckout.ts
+++ b/support-e2e/tests/utils/completeGenericCheckout.ts
@@ -1,0 +1,175 @@
+import { Page, expect } from '@playwright/test';
+import { fillInCardDetails } from './cardDetails';
+import { fillInPayPalDetails } from './paypal';
+import { checkRecaptcha } from './recaptcha';
+import {
+	setTestUserAddressDetails,
+	setTestUserDetails,
+} from './testUserDetails';
+import {
+	TestFields,
+	ukWithPostalAddressOnly,
+	usWithPostalAddressOnly,
+	ausWithFullAddress,
+	intWithPostalAddressOnly,
+} from './userFields';
+import { email, firstName, lastName } from './users';
+
+const selectDeliveryAgent = async (page: Page) => {
+	// Depending on whether there are one or multiple delivery agents we need to do different things here.
+	// If there are multiple delivery agents, we need to select one of them, if there is only one we do not.
+	const deliveryAgentLabel = page.locator(
+		'div:text-matches("Delivery provider|Select delivery provider")', // This will match both labels
+	);
+	await deliveryAgentLabel.waitFor({ state: 'visible' });
+
+	const deliveryAgentRadioButton = page.locator(
+		'fieldSet#delivery-provider input[type="radio"]',
+	);
+
+	if ((await deliveryAgentRadioButton.count()) > 0) {
+		// If there are multiple delivery agents, select the first one
+		await deliveryAgentRadioButton.first().check();
+	}
+};
+
+const userDetails = (
+	product: string,
+	internationalisationId: string,
+): TestFields => {
+	switch (internationalisationId) {
+		case 'UK':
+			return ukWithPostalAddressOnly();
+		case 'US':
+			return usWithPostalAddressOnly();
+		case 'AU':
+			return ausWithFullAddress();
+		case 'INT':
+			return intWithPostalAddressOnly();
+		default:
+			throw new Error(
+				`Couldn't find user details for ${product} in ${internationalisationId}`,
+			);
+	}
+};
+
+const setUserDetailsForProduct = async (
+	page,
+	product,
+	internationalisationId,
+	postCode,
+) => {
+	switch (product) {
+		case 'SupporterPlus':
+		case 'GuardianAdLite':
+			await setTestUserDetails(page, email(), firstName(), lastName(), true);
+
+			break;
+		case 'GuardianWeeklyDomestic':
+		case 'GuardianWeeklyRestOfWorld':
+		case 'TierThree':
+			await setTestUserAddressDetails(
+				page,
+				userDetails(product, internationalisationId),
+				internationalisationId,
+				3,
+			);
+
+			break;
+		case 'HomeDelivery':
+			if (internationalisationId !== 'UK') {
+				throw new Error(
+					`Home delivery is only available in the UK, but got ${internationalisationId}`,
+				);
+			}
+
+			await setTestUserAddressDetails(
+				page,
+				ukWithPostalAddressOnly(),
+				internationalisationId,
+				3,
+			);
+
+			break;
+		case 'NationalDelivery':
+			if (internationalisationId !== 'UK') {
+				throw new Error(
+					`National delivery is only available in the UK, but got ${internationalisationId}`,
+				);
+			}
+
+			await setTestUserAddressDetails(
+				page,
+				ukWithPostalAddressOnly(postCode),
+				internationalisationId,
+				3,
+			);
+			await selectDeliveryAgent(page);
+
+			break;
+		default:
+			throw new Error(
+				`I don't know how to fill in user details for ${product}`,
+			);
+	}
+};
+
+type TestDetails = {
+	product: string;
+	paymentType: string;
+	internationalisationId: string;
+	postCode?: string;
+};
+
+export const completeGenericCheckout = async (
+	page,
+	testDetails: TestDetails,
+) => {
+	const { product, internationalisationId, postCode, paymentType } =
+		testDetails;
+	await setUserDetailsForProduct(
+		page,
+		product,
+		internationalisationId,
+		postCode,
+	);
+
+	// State mandatory for AU and US
+	if (internationalisationId === 'AU') {
+		await page.getByLabel('State').selectOption({ label: 'New South Wales' });
+	}
+	if (internationalisationId === 'US') {
+		await page.getByLabel('State').selectOption({ label: 'Illinois' });
+	}
+
+	await page.getByRole('radio', { name: paymentType }).check();
+	switch (paymentType) {
+		case 'PayPal':
+			const popupPagePromise = page.waitForEvent('popup');
+			await page
+				.locator("iframe[name^='xcomponent__ppbutton']")
+				.scrollIntoViewIfNeeded();
+			await page
+				.frameLocator("iframe[name^='xcomponent__ppbutton']")
+				// this class gets added to the iframe body after the JavaScript has finished executing
+				.locator('body.dom-ready')
+				.locator('[role="button"]:has-text("Pay with")')
+				.click({ delay: 2000 });
+			const popupPage = await popupPagePromise;
+			fillInPayPalDetails(popupPage);
+			break;
+		case 'Credit/Debit card':
+			await fillInCardDetails(page);
+			await checkRecaptcha(page);
+			await page
+				.getByRole('button', {
+					name: `Pay`,
+				})
+				.click();
+			break;
+	}
+
+	await expect(page.getByRole('heading', { name: 'Thank you' })).toBeVisible({
+		timeout: 600000,
+	});
+};


### PR DESCRIPTION
## What are you doing in this PR?

Following on from #7126, move the e2e smoke tests for 3 tier products out to a separate test file which start on the 3 tier landing page.

[**Trello Card**](https://trello.com/c/lnE2F0us/1690-update-playwright-e2e-tests-to-begin-checkout-flows-on-the-relevant-landing-page)

## Why are you doing this?

This more closely reflects the journey that real users take, and will surface any issues navigating from the landing page to chckout.

## How to test

Run the new tests via the Playwright UI:

<img width="632" alt="Screenshot 2025-07-08 at 11 09 43" src="https://github.com/user-attachments/assets/09ae9c3f-2949-454c-af5b-3383151282c9" />