### PR TITLE
Fix issue with new Direct Debit icon vertical alignment

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { space } from '@guardian/source/foundations';
+import { size, space } from '@guardian/source/foundations';
 import {
 	Checkbox,
 	Label,
@@ -1249,7 +1249,13 @@ export function CheckoutComponent({
 													label={
 														<>
 															{label}
-															<div>{icon}</div>
+															<div
+																css={css`
+																	max-height: ${size.xsmall}px;
+																`}
+															>
+																{icon}
+															</div>
 														</>
 													}
 													name="paymentMethod"


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Fix the vertical alignment within the Direct Debit payment method radio on the generic checkout.

Before:

![Screenshot 2025-07-09 at 10 23 50](https://github.com/user-attachments/assets/7bf3ed79-c789-4e2e-972c-2b17824cc7a7)

After:

![Screenshot 2025-07-09 at 10 23 23](https://github.com/user-attachments/assets/56a0dc04-42a8-4754-b4e0-128586fb484d)

And on mobile:

![Screenshot 2025-07-09 at 11 37 40](https://github.com/user-attachments/assets/8474a8f0-435b-4406-b9c1-5dfc9f3a405c)


[**Trello Card**](https://trello.com/c/xikkkGLc/1715-fix-alignment-of-direct-debit-payment-method-selector)

## Why are you doing this?

In #7077 the source library was updated and this brought in a new Direct Debit icon. This new icon slightly broke the alignment of the radio button component. Here we limit the height of the SVG icon by specifying a height for the SVG container.