### PR TITLE
Begin newspaper e2e smoke tests on the landing page

### DIFF
--- a/support-e2e/tests/smoke/checkout.test.ts
+++ b/support-e2e/tests/smoke/checkout.test.ts
@@ -7,26 +7,6 @@ afterEachTasks(test);
 test.describe('Checkout', () => {
 	[
 		{
-			product: 'HomeDelivery',
-			ratePlan: 'EverydayPlus',
-			paymentType: 'Credit/Debit card',
-			internationalisationId: 'UK',
-		},
-		{
-			product: 'NationalDelivery',
-			ratePlan: 'WeekendPlus',
-			paymentType: 'Credit/Debit card',
-			internationalisationId: 'UK',
-			postCode: 'BN44 3QG', // This postcode only has one delivery agent
-		},
-		{
-			product: 'NationalDelivery',
-			ratePlan: 'WeekendPlus',
-			paymentType: 'Credit/Debit card',
-			internationalisationId: 'UK',
-			postCode: 'BS6 6QY', // This postcode has multiple delivery agents
-		},
-		{
 			product: 'GuardianWeeklyDomestic',
 			ratePlan: 'Monthly',
 			paymentType: 'Credit/Debit card',

--- a/support-e2e/tests/smoke/newspaper.test.ts
+++ b/support-e2e/tests/smoke/newspaper.test.ts
@@ -1,0 +1,32 @@
+import test from '@playwright/test';
+import { testNewspaperCheckout } from '../test/newspaperCheckout';
+import type { TestDetails } from '../test/newspaperCheckout';
+
+const tests: TestDetails[] = [
+	{
+		productLabel: 'Home Delivery',
+		product: 'HomeDelivery',
+		ratePlanLabel: 'Every day',
+		paymentType: 'Credit/Debit card',
+		internationalisationId: 'UK',
+	},
+	{
+		productLabel: 'Home Delivery',
+		product: 'NationalDelivery',
+		ratePlanLabel: 'Weekend',
+		paymentType: 'Credit/Debit card',
+		internationalisationId: 'UK',
+		postCode: 'BN44 3QG', // This postcode only has one delivery agent
+	},
+	{
+		productLabel: 'Home Delivery',
+		product: 'NationalDelivery',
+		ratePlanLabel: 'Weekend',
+		paymentType: 'Credit/Debit card',
+		internationalisationId: 'UK',
+		postCode: 'BS6 6QY', // This postcode has multiple delivery agents
+	},
+];
+
+test.describe('Newspaper Checkout', () =>
+	tests.map((testDetails) => testNewspaperCheckout(testDetails)));

--- a/support-e2e/tests/test/newspaperCheckout.ts
+++ b/support-e2e/tests/test/newspaperCheckout.ts
@@ -1,0 +1,54 @@
+import test, { expect } from '@playwright/test';
+import { setupPage } from '../utils/page';
+import { completeGenericCheckout } from '../utils/completeGenericCheckout';
+
+export type TestDetails = {
+	product: string;
+	productLabel: string;
+	ratePlanLabel: string;
+	paymentType: string;
+	internationalisationId: string;
+	postCode?: string;
+};
+
+export const testNewspaperCheckout = (testDetails: TestDetails) => {
+	const {
+		product,
+		productLabel,
+		paymentType,
+		internationalisationId,
+		postCode,
+		ratePlanLabel,
+	} = testDetails;
+
+	test(`Newspaper - ${product} - ${paymentType} - ${internationalisationId} ${postCode ? `- ${postCode}` : ''}`, async ({
+		context,
+		baseURL,
+	}) => {
+		const landingPageUrl = `/${internationalisationId.toLowerCase()}/subscribe/paper`;
+		const page = await context.newPage();
+		await setupPage(page, context, baseURL, landingPageUrl);
+
+		// Select the product (Home Delivery or Subscription Card)
+		await page.getByRole('tab', { name: productLabel }).click();
+
+		// // Click through to the checkout (we use the aria-label to target the link)
+		await page
+			.getByLabel(`${ratePlanLabel}- Subscribe`, { exact: true })
+			.click();
+
+		// Wait for the checkout page to load
+		await expect(
+			page.getByRole('heading', { name: 'Your subscription' }),
+		).toBeVisible({
+			timeout: 100000,
+		});
+
+		await completeGenericCheckout(page, {
+			product,
+			paymentType,
+			internationalisationId,
+			postCode,
+		});
+	});
+};

--- a/support-e2e/tests/test/newspaperCheckout.ts
+++ b/support-e2e/tests/test/newspaperCheckout.ts
@@ -32,7 +32,7 @@ export const testNewspaperCheckout = (testDetails: TestDetails) => {
 		// Select the product (Home Delivery or Subscription Card)
 		await page.getByRole('tab', { name: productLabel }).click();
 
-		// // Click through to the checkout (we use the aria-label to target the link)
+		// Click through to the checkout (we use the aria-label to target the link)
 		await page
 			.getByLabel(`${ratePlanLabel}- Subscribe`, { exact: true })
 			.click();


### PR DESCRIPTION
## What are you doing in this PR?

Begin the newspaper checkout smoke tests on the newspaper landing page.

[**Trello Card**](https://trello.com/c/lnE2F0us/1690-update-playwright-e2e-tests-to-begin-checkout-flows-on-the-relevant-landing-page)

## Why are you doing this?

This is closer to the real user experience. See also #7134 #7126.