### PR TITLE
Migrate the CreateSalesforceContact Lambda to Typescript

### DIFF
--- a/.github/workflows/support-workers-build.yml
+++ b/.github/workflows/support-workers-build.yml
@@ -85,7 +85,6 @@ jobs:
                 type: aws-lambda
                 parameters:
                   functionNames:
-                    - "-CreateSalesforceContactLambda-"
                     - "-CreateZuoraSubscriptionLambda-"
                     - "-SendThankYouEmailLambda-"
                     - "-UpdateSupporterProductDataLambda-"
@@ -98,6 +97,7 @@ jobs:
                 type: aws-lambda
                 parameters:
                   functionNames:
+                    - "-CreateSalesforceContactLambda-"
                     - "-CreatePaymentMethodLambda-"
                   fileName: support-workers.zip
                 dependencies: [cfn]

--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -302,11 +302,11 @@ exports[`The support-workers stack matches the snapshot 1`] = `
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "support/PROD/support-workers-scala/support-workers.jar",
+          "S3Key": "support/PROD/support-workers-typescript/support-workers.zip",
         },
         "Environment": {
           "Variables": {
-            "APP": "support-workers-scala",
+            "APP": "support-workers-typescript",
             "EMAIL_QUEUE_NAME": {
               "Fn::ImportValue": "comms-PROD-EmailQueueName",
             },
@@ -318,7 +318,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
           },
         },
         "FunctionName": "support-CreateSalesforceContactLambda-PROD",
-        "Handler": "com.gu.support.workers.lambdas.CreateSalesforceContact::handleRequest",
+        "Handler": "createSalesforceContactLambda.handler",
         "LoggingConfig": {
           "LogFormat": "JSON",
         },
@@ -329,11 +329,11 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "java21",
+        "Runtime": "nodejs22.x",
         "Tags": [
           {
             "Key": "App",
-            "Value": "support-workers-scala",
+            "Value": "support-workers-typescript",
           },
           {
             "Key": "gu:cdk:version",
@@ -387,7 +387,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "Tags": [
           {
             "Key": "App",
-            "Value": "support-workers-scala",
+            "Value": "support-workers-typescript",
           },
           {
             "Key": "gu:cdk:version",
@@ -433,6 +433,14 @@ exports[`The support-workers stack matches the snapshot 1`] = `
               "Resource": "*",
             },
             {
+              "Action": "ssm:GetParameter",
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:ssm:eu-west-1:865473395570:parameter/CODE/support/support-workers/*",
+                "arn:aws:ssm:eu-west-1:865473395570:parameter/PROD/support/support-workers/*",
+              ],
+            },
+            {
               "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
@@ -467,7 +475,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/support/PROD/support-workers-scala/support-workers.jar",
+                      "/support/PROD/support-workers-typescript/support-workers.zip",
                     ],
                   ],
                 },
@@ -488,7 +496,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/PROD/support/support-workers-scala",
+                    ":parameter/PROD/support/support-workers-typescript",
                   ],
                 ],
               },
@@ -511,7 +519,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/PROD/support/support-workers-scala/*",
+                    ":parameter/PROD/support/support-workers-typescript/*",
                   ],
                 ],
               },
@@ -3580,7 +3588,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"CreateSalesforceContact":{"Next":"CreateZuoraSubscription","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["com.gu.support.workers.exceptions.RetryNone"],"MaxAttempts":0},{"ErrorEquals":["com.gu.support.workers.exceptions.RetryLimited"],"IntervalSeconds":1,"MaxAttempts":5,"BackoffRate":10},{"ErrorEquals":["com.gu.support.workers.exceptions.RetryUnlimited"],"IntervalSeconds":1,"MaxAttempts":999999,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":3,"MaxAttempts":999999,"BackoffRate":2}],"Catch":[{"ErrorEquals":["States.TaskFailed"],"ResultPath":"$.error","Next":"FailureHandler"}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"CreateSalesforceContact":{"Next":"CreateZuoraSubscription","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["RetryNone"],"MaxAttempts":0},{"ErrorEquals":["RetryLimited"],"IntervalSeconds":1,"MaxAttempts":5,"BackoffRate":10},{"ErrorEquals":["RetryUnlimited"],"IntervalSeconds":1,"MaxAttempts":999999,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":3,"MaxAttempts":999999,"BackoffRate":2}],"Catch":[{"ErrorEquals":["States.TaskFailed"],"ResultPath":"$.error","Next":"FailureHandler"}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -249,7 +249,7 @@ export class SupportWorkers extends GuStack {
       "CreatePaymentMethod"
     ).addCatch(failureHandler, catchProps);
 
-    const createSalesforceContactLambda = createScalaLambda(
+    const createSalesforceContactLambda = createTypescriptLambda(
       "CreateSalesforceContact"
     ).addCatch(failureHandler, catchProps);
 

--- a/modules/internationalisation/country.ts
+++ b/modules/internationalisation/country.ts
@@ -592,6 +592,9 @@ const countries: Record<IsoCountry, string> = {
 	JE: 'Jersey',
 	SH: 'Saint Helena',
 };
+export function getCountryNameByIsoCode(code: IsoCountry) {
+	return countries[code] || null;
+}
 // ----- Types ----- //
 export type UsState = keyof typeof usStates;
 export type CaState = keyof typeof caStates;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -549,6 +549,9 @@ importers:
       '@aws-sdk/credential-provider-node':
         specifier: 'catalog:'
         version: 3.699.0(@aws-sdk/client-sso-oidc@3.817.0)(@aws-sdk/client-sts@3.817.0)
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.13
       stripe:
         specifier: ^17.4.0
         version: 17.7.0

--- a/support-workers/deploy-to-code.sh
+++ b/support-workers/deploy-to-code.sh
@@ -2,6 +2,7 @@ S3_BUCKET="membership-dist"
 S3_KEY="support/CODE/support-workers-typescript/support-workers.zip"
 LAMBDA_FUNCTIONS=(
   "CreatePaymentMethodLambda"
+  "CreateSalesforceContactLambda"
 )
 echo "Uploading target/typescript/support-workers.zip to S3 (to update the zipfile before upload use the yarn deploy-to-code command)"
 aws s3 cp target/typescript/support-workers.zip s3://$S3_BUCKET/$S3_KEY --profile membership

--- a/support-workers/package.json
+++ b/support-workers/package.json
@@ -27,7 +27,8 @@
     "@aws-sdk/client-ssm": "catalog:",
     "@aws-sdk/credential-provider-node": "catalog:",
     "stripe": "^17.4.0",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "dayjs": "^1.11.13"
   },
   "devDependencies": {
     "@guardian/eslint-config-typescript": "catalog:",

--- a/support-workers/src/typescript/lambdas/createSalesforceContactLambda.ts
+++ b/support-workers/src/typescript/lambdas/createSalesforceContactLambda.ts
@@ -37,7 +37,10 @@ export const handler = async (
 			createSalesforceContactState.user,
 			createSalesforceContactState.giftRecipient,
 		);
-		return createNextState(createSalesforceContactState, contactRecords);
+		return {
+			...state,
+			state: createNextState(createSalesforceContactState, contactRecords),
+		};
 	} catch (error) {
 		throw asRetryError(error);
 	}
@@ -51,6 +54,7 @@ const createNextState = (
 		case 'Contribution':
 			return {
 				productSpecificState: {
+					productType: 'Contribution',
 					product: state.product,
 					paymentMethod: state.paymentMethod,
 					salesForceContact: contactRecords.buyer,
@@ -61,6 +65,7 @@ const createNextState = (
 		case 'SupporterPlus':
 			return {
 				productSpecificState: {
+					productType: 'SupporterPlus',
 					billingCountry: user.billingAddress.country,
 					product: state.product,
 					paymentMethod: state.paymentMethod,
@@ -73,6 +78,7 @@ const createNextState = (
 		case 'TierThree':
 			return {
 				productSpecificState: {
+					productType: 'TierThree',
 					user: state.user,
 					product: state.product,
 					paymentMethod: state.paymentMethod,
@@ -89,6 +95,7 @@ const createNextState = (
 		case 'GuardianAdLite':
 			return {
 				productSpecificState: {
+					productType: 'GuardianAdLite',
 					product: state.product,
 					paymentMethod: state.paymentMethod,
 					salesForceContact: contactRecords.buyer,
@@ -98,6 +105,7 @@ const createNextState = (
 		case 'GuardianWeekly':
 			return {
 				productSpecificState: {
+					productType: 'GuardianWeekly',
 					user: state.user,
 					giftRecipient: state.giftRecipient,
 					product: state.product,
@@ -115,6 +123,7 @@ const createNextState = (
 		case 'Paper':
 			return {
 				productSpecificState: {
+					productType: 'Paper',
 					user: state.user,
 					product: state.product,
 					paymentMethod: state.paymentMethod,
@@ -131,6 +140,7 @@ const createNextState = (
 		case 'DigitalPack':
 			return {
 				productSpecificState: {
+					productType: 'DigitalSubscription',
 					billingCountry: user.billingAddress.country,
 					product: state.product,
 					paymentMethod: state.paymentMethod,

--- a/support-workers/src/typescript/lambdas/createSalesforceContactLambda.ts
+++ b/support-workers/src/typescript/lambdas/createSalesforceContactLambda.ts
@@ -1,0 +1,144 @@
+import type { CreateZuoraSubscriptionState } from '../model/createZuoraSubscriptionState';
+import { stageFromEnvironment } from '../model/stage';
+import type {
+	CreateSalesforceContactState,
+	WrappedState,
+} from '../model/stateSchemas';
+import {
+	createSalesforceContactStateSchema,
+	wrapperSchemaForState,
+} from '../model/stateSchemas';
+import { ServiceProvider } from '../services/config';
+import type { SalesforceContactRecords } from '../services/salesforce';
+import { SalesforceService } from '../services/salesforce';
+import { getSalesforceConfig } from '../services/salesforceClient';
+import { user } from '../test/fixtures/salesforceFixtures';
+import { asRetryError } from '../util/errorHandler';
+import { getIfDefined } from '../util/nullAndUndefined';
+
+const stage = stageFromEnvironment();
+const salesforceServiceProvider = new ServiceProvider(stage, async (stage) => {
+	const config = await getSalesforceConfig(stage);
+	return new SalesforceService(config);
+});
+
+export const handler = async (
+	state: WrappedState<CreateSalesforceContactState>,
+) => {
+	try {
+		console.info(`Input is ${JSON.stringify(state)}`);
+		const createSalesforceContactState = wrapperSchemaForState(
+			createSalesforceContactStateSchema,
+		).parse(state).state;
+		const serviceForUser = await salesforceServiceProvider.getServiceForUser(
+			state.state.user.isTestUser,
+		);
+		const contactRecords = await serviceForUser.createContactRecords(
+			createSalesforceContactState.user,
+			createSalesforceContactState.giftRecipient,
+		);
+		return createNextState(createSalesforceContactState, contactRecords);
+	} catch (error) {
+		throw asRetryError(error);
+	}
+};
+
+const createNextState = (
+	state: CreateSalesforceContactState,
+	contactRecords: SalesforceContactRecords,
+): CreateZuoraSubscriptionState => {
+	switch (state.product.productType) {
+		case 'Contribution':
+			return {
+				productSpecificState: {
+					product: state.product,
+					paymentMethod: state.paymentMethod,
+					salesForceContact: contactRecords.buyer,
+					similarProductsConsent: state.similarProductsConsent,
+				},
+				...state,
+			};
+		case 'SupporterPlus':
+			return {
+				productSpecificState: {
+					billingCountry: user.billingAddress.country,
+					product: state.product,
+					paymentMethod: state.paymentMethod,
+					appliedPromotion: state.appliedPromotion,
+					salesForceContact: contactRecords.buyer,
+					similarProductsConsent: state.similarProductsConsent,
+				},
+				...state,
+			};
+		case 'TierThree':
+			return {
+				productSpecificState: {
+					user: state.user,
+					product: state.product,
+					paymentMethod: state.paymentMethod,
+					firstDeliveryDate: getIfDefined(
+						state.firstDeliveryDate,
+						'First delivery date is required for Tier Three products',
+					),
+					appliedPromotion: state.appliedPromotion,
+					salesForceContact: contactRecords.buyer,
+					similarProductsConsent: state.similarProductsConsent,
+				},
+				...state,
+			};
+		case 'GuardianAdLite':
+			return {
+				productSpecificState: {
+					product: state.product,
+					paymentMethod: state.paymentMethod,
+					salesForceContact: contactRecords.buyer,
+				},
+				...state,
+			};
+		case 'GuardianWeekly':
+			return {
+				productSpecificState: {
+					user: state.user,
+					giftRecipient: state.giftRecipient,
+					product: state.product,
+					paymentMethod: state.paymentMethod,
+					firstDeliveryDate: getIfDefined(
+						state.firstDeliveryDate,
+						'First delivery date is required for Guardian Weekly products',
+					),
+					appliedPromotion: state.appliedPromotion,
+					salesforceContacts: contactRecords,
+					similarProductsConsent: state.similarProductsConsent,
+				},
+				...state,
+			};
+		case 'Paper':
+			return {
+				productSpecificState: {
+					user: state.user,
+					product: state.product,
+					paymentMethod: state.paymentMethod,
+					firstDeliveryDate: getIfDefined(
+						state.firstDeliveryDate,
+						'First delivery date is required for Paper products',
+					),
+					appliedPromotion: state.appliedPromotion,
+					salesForceContact: contactRecords.buyer,
+					similarProductsConsent: state.similarProductsConsent,
+				},
+				...state,
+			};
+		case 'DigitalPack':
+			return {
+				productSpecificState: {
+					billingCountry: user.billingAddress.country,
+					product: state.product,
+					paymentMethod: state.paymentMethod,
+					appliedPromotion: state.appliedPromotion,
+					salesForceContact: contactRecords.buyer,
+					similarProductsConsent: state.similarProductsConsent,
+				},
+				...state,
+			};
+	}
+};

--- a/support-workers/src/typescript/model/address.ts
+++ b/support-workers/src/typescript/model/address.ts
@@ -5,12 +5,14 @@ export const countrySchema = z.enum(isoCountries);
 
 export const addressSchema = z.object({
 	lineOne: z.string().nullable(),
-	lineTwo: z.string().nullable(),
+	lineTwo: z.string().nullish(),
 	city: z.string().nullable(),
 	state: z.string().nullable(),
 	postCode: z.string().nullable(),
 	country: countrySchema,
 });
+
+type Address = z.infer<typeof addressSchema>;
 
 type AddressLine = {
 	streetNumber?: string;
@@ -19,7 +21,7 @@ type AddressLine = {
 
 export function combinedAddressLine(
 	addressLine1: string | null,
-	addressLine2: string | null,
+	addressLine2?: string | null,
 ): AddressLine | undefined {
 	const singleAddressLine = (addressLine: string): AddressLine => {
 		const pattern = /([0-9]+) (.+)/;
@@ -80,6 +82,17 @@ export function combinedAddressLine(
 		}
 	}
 	return undefined;
+}
+
+export function getAddressLine(address: Address): string | null {
+	const combinedAddressLineResult = combinedAddressLine(
+		address.lineOne,
+		address.lineTwo,
+	);
+	if (combinedAddressLineResult) {
+		return asFormattedString(combinedAddressLineResult);
+	}
+	return null;
 }
 
 export function truncateForZuoraStreetNameLimit(

--- a/support-workers/src/typescript/model/createZuoraSubscriptionState.ts
+++ b/support-workers/src/typescript/model/createZuoraSubscriptionState.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod';
+import {
+	salesforceContactRecordSchema,
+	salesforceContactRecordsSchema,
+} from '../services/salesforce';
+import { countrySchema } from './address';
+import { paymentMethodSchema } from './paymentMethod';
+import {
+	contributionProductSchema,
+	digitalPackProductSchema,
+	guardianAdLiteProductSchema,
+	guardianWeeklyProductSchema,
+	paperProductSchema,
+	productTypeSchema,
+	supporterPlusProductSchema,
+	tierThreeProductSchema,
+} from './productType';
+import {
+	acquisitionDataSchema,
+	analyticsInfoSchema,
+	appliedPromotionSchema,
+	giftRecipientSchema,
+	userSchema,
+} from './stateSchemas';
+
+export const contributionStateSchema = z.object({
+	product: contributionProductSchema,
+	paymentMethod: paymentMethodSchema,
+	salesForceContact: salesforceContactRecordSchema,
+	similarProductsConsent: z.boolean().nullable(),
+});
+export type ContributionState = z.infer<typeof contributionStateSchema>;
+
+export const supporterPlusStateSchema = z.object({
+	billingCountry: countrySchema,
+	product: supporterPlusProductSchema,
+	paymentMethod: paymentMethodSchema,
+	appliedPromotion: appliedPromotionSchema.nullable(),
+	salesForceContact: salesforceContactRecordSchema,
+	similarProductsConsent: z.boolean().nullable(),
+});
+export type SupporterPlusState = z.infer<typeof supporterPlusStateSchema>;
+
+export const tierThreeStateSchema = z.object({
+	user: userSchema,
+	product: tierThreeProductSchema,
+	paymentMethod: paymentMethodSchema,
+	firstDeliveryDate: z.string(),
+	appliedPromotion: appliedPromotionSchema.nullable(),
+	salesForceContact: salesforceContactRecordSchema,
+	similarProductsConsent: z.boolean().nullable(),
+});
+export type TierThreeState = z.infer<typeof tierThreeStateSchema>;
+
+export const guardianAdLiteStateSchema = z.object({
+	product: guardianAdLiteProductSchema,
+	paymentMethod: paymentMethodSchema,
+	salesForceContact: salesforceContactRecordSchema,
+});
+export type GuardianAdLiteState = z.infer<typeof guardianAdLiteStateSchema>;
+
+export const digitalSubscriptionStateSchema = z.object({
+	billingCountry: countrySchema,
+	product: digitalPackProductSchema,
+	paymentMethod: paymentMethodSchema,
+	appliedPromotion: appliedPromotionSchema.nullable(),
+	salesForceContact: salesforceContactRecordSchema,
+	similarProductsConsent: z.boolean().nullable(),
+});
+export type DigitalSubscriptionState = z.infer<
+	typeof digitalSubscriptionStateSchema
+>;
+
+export const paperStateSchema = z.object({
+	user: userSchema,
+	product: paperProductSchema,
+	paymentMethod: paymentMethodSchema,
+	firstDeliveryDate: z.string(),
+	appliedPromotion: appliedPromotionSchema.nullable(),
+	salesForceContact: salesforceContactRecordSchema,
+	similarProductsConsent: z.boolean().nullable(),
+});
+export type PaperState = z.infer<typeof paperStateSchema>;
+
+export const guardianWeeklyStateSchema = z.object({
+	user: userSchema,
+	giftRecipient: giftRecipientSchema.nullable(),
+	product: guardianWeeklyProductSchema,
+	paymentMethod: paymentMethodSchema,
+	firstDeliveryDate: z.string(),
+	appliedPromotion: appliedPromotionSchema.nullable(),
+	salesforceContacts: salesforceContactRecordsSchema,
+	similarProductsConsent: z.boolean().nullable(),
+});
+export type GuardianWeeklyState = z.infer<typeof guardianWeeklyStateSchema>;
+
+export const createZuoraSubscriptionProductStateSchema = z.discriminatedUnion(
+	'product',
+	[
+		contributionStateSchema,
+		supporterPlusStateSchema,
+		tierThreeStateSchema,
+		guardianAdLiteStateSchema,
+		digitalSubscriptionStateSchema,
+		paperStateSchema,
+		guardianWeeklyStateSchema,
+	],
+);
+
+export const createZuoraSubscriptionStateSchema = z.object({
+	productSpecificState: createZuoraSubscriptionProductStateSchema,
+	requestId: z.string(),
+	user: userSchema,
+	product: productTypeSchema,
+	analyticsInfo: analyticsInfoSchema,
+	firstDeliveryDate: z.string().nullable(),
+	appliedPromotion: appliedPromotionSchema.nullable(),
+	csrUsername: z.string().nullable(),
+	salesforceCaseId: z.string().nullable(),
+	acquisitionData: acquisitionDataSchema.nullable(),
+});
+
+export type CreateZuoraSubscriptionState = z.infer<
+	typeof createZuoraSubscriptionStateSchema
+>;

--- a/support-workers/src/typescript/model/createZuoraSubscriptionState.ts
+++ b/support-workers/src/typescript/model/createZuoraSubscriptionState.ts
@@ -24,6 +24,7 @@ import {
 } from './stateSchemas';
 
 export const contributionStateSchema = z.object({
+	productType: z.literal('Contribution'),
 	product: contributionProductSchema,
 	paymentMethod: paymentMethodSchema,
 	salesForceContact: salesforceContactRecordSchema,
@@ -32,6 +33,7 @@ export const contributionStateSchema = z.object({
 export type ContributionState = z.infer<typeof contributionStateSchema>;
 
 export const supporterPlusStateSchema = z.object({
+	productType: z.literal('SupporterPlus'),
 	billingCountry: countrySchema,
 	product: supporterPlusProductSchema,
 	paymentMethod: paymentMethodSchema,
@@ -42,6 +44,7 @@ export const supporterPlusStateSchema = z.object({
 export type SupporterPlusState = z.infer<typeof supporterPlusStateSchema>;
 
 export const tierThreeStateSchema = z.object({
+	productType: z.literal('TierThree'),
 	user: userSchema,
 	product: tierThreeProductSchema,
 	paymentMethod: paymentMethodSchema,
@@ -53,6 +56,7 @@ export const tierThreeStateSchema = z.object({
 export type TierThreeState = z.infer<typeof tierThreeStateSchema>;
 
 export const guardianAdLiteStateSchema = z.object({
+	productType: z.literal('GuardianAdLite'),
 	product: guardianAdLiteProductSchema,
 	paymentMethod: paymentMethodSchema,
 	salesForceContact: salesforceContactRecordSchema,
@@ -60,6 +64,7 @@ export const guardianAdLiteStateSchema = z.object({
 export type GuardianAdLiteState = z.infer<typeof guardianAdLiteStateSchema>;
 
 export const digitalSubscriptionStateSchema = z.object({
+	productType: z.literal('DigitalSubscription'),
 	billingCountry: countrySchema,
 	product: digitalPackProductSchema,
 	paymentMethod: paymentMethodSchema,
@@ -72,6 +77,7 @@ export type DigitalSubscriptionState = z.infer<
 >;
 
 export const paperStateSchema = z.object({
+	productType: z.literal('Paper'),
 	user: userSchema,
 	product: paperProductSchema,
 	paymentMethod: paymentMethodSchema,
@@ -83,6 +89,7 @@ export const paperStateSchema = z.object({
 export type PaperState = z.infer<typeof paperStateSchema>;
 
 export const guardianWeeklyStateSchema = z.object({
+	productType: z.literal('GuardianWeekly'),
 	user: userSchema,
 	giftRecipient: giftRecipientSchema.nullable(),
 	product: guardianWeeklyProductSchema,
@@ -95,7 +102,7 @@ export const guardianWeeklyStateSchema = z.object({
 export type GuardianWeeklyState = z.infer<typeof guardianWeeklyStateSchema>;
 
 export const createZuoraSubscriptionProductStateSchema = z.discriminatedUnion(
-	'product',
+	'productType',
 	[
 		contributionStateSchema,
 		supporterPlusStateSchema,

--- a/support-workers/src/typescript/model/stateSchemas.ts
+++ b/support-workers/src/typescript/model/stateSchemas.ts
@@ -84,7 +84,7 @@ export type GiftRecipient = z.infer<typeof giftRecipientSchema>;
 
 export const appliedPromotionSchema = z.object({
 	promoCode: z.string(),
-	countryGroupId: z.string(), //TODO: build a schema for this or take it from the frontend
+	countryGroupId: z.string(),
 });
 
 const baseStateSchema = z.object({

--- a/support-workers/src/typescript/model/stateSchemas.ts
+++ b/support-workers/src/typescript/model/stateSchemas.ts
@@ -15,6 +15,8 @@ export const titleSchema = z.union([
 	z.literal('Rev'),
 ]);
 
+export type Title = z.infer<typeof titleSchema>;
+
 export const userSchema = z.object({
 	id: z.string(),
 	primaryEmailAddress: z.string(),
@@ -23,9 +25,9 @@ export const userSchema = z.object({
 	lastName: z.string(),
 	billingAddress: addressSchema,
 	deliveryAddress: addressSchema.nullable(),
-	telephoneNumber: z.string().nullable(),
+	telephoneNumber: z.string().nullish(),
 	isTestUser: z.boolean(),
-	deliveryInstructions: z.string().nullable(),
+	deliveryInstructions: z.string().nullish(),
 });
 export type User = z.infer<typeof userSchema>;
 
@@ -65,7 +67,7 @@ const referrerAcquisitionDataSchema = z.object({
 	labels: z.array(z.string()).nullable(),
 });
 
-const acquisitionDataSchema = z.object({
+export const acquisitionDataSchema = z.object({
 	ophanIds: ophanIdsSchema,
 	referrerAcquisitionData: referrerAcquisitionDataSchema,
 	supportAbTests: z.array(abTestSchema),
@@ -78,6 +80,13 @@ export const giftRecipientSchema = z.object({
 	email: z.string().nullable(),
 });
 
+export type GiftRecipient = z.infer<typeof giftRecipientSchema>;
+
+export const appliedPromotionSchema = z.object({
+	promoCode: z.string(),
+	countryGroupId: z.string(), //TODO: build a schema for this or take it from the frontend
+});
+
 const baseStateSchema = z.object({
 	requestId: z.string(),
 	user: userSchema,
@@ -87,12 +96,7 @@ const baseStateSchema = z.object({
 	//TODO: This should probably be a date but the scala lambdas struggle to deserialise the default date representation
 	// so leave it as a string until all the lambdas are Typescript
 	firstDeliveryDate: z.string().nullable(),
-	appliedPromotion: z
-		.object({
-			promoCode: z.string(),
-			countryGroupId: z.string(), //TODO: build a schema for this or take it from the frontend
-		})
-		.nullable(),
+	appliedPromotion: appliedPromotionSchema.nullable(),
 	csrUsername: z.string().nullable(),
 	salesforceCaseId: z.string().nullable(),
 	acquisitionData: acquisitionDataSchema.nullable(),

--- a/support-workers/src/typescript/model/stateSchemas.ts
+++ b/support-workers/src/typescript/model/stateSchemas.ts
@@ -125,6 +125,15 @@ export type CreateSalesforceContactState = z.infer<
 	typeof createSalesforceContactStateSchema
 >;
 
+const requestInfoSchema = z.object({
+	testUser: z.boolean(),
+	failed: z.boolean(),
+	messages: z.array(z.string()),
+	accountExists: z.boolean(),
+});
+
+export type RequestInfo = z.infer<typeof requestInfoSchema>;
+
 export type LambdaState =
 	| CreatePaymentMethodState
 	| CreateSalesforceContactState;
@@ -154,11 +163,18 @@ export function wrapperSchemaForState<SchemaType extends z.ZodTypeAny>(
 				Cause: z.string(),
 			})
 			.nullable(),
-		requestInfo: z.object({
-			testUser: z.boolean(),
-			failed: z.boolean(),
-			messages: z.array(z.string()),
-			accountExists: z.boolean(),
-		}),
+		requestInfo: requestInfoSchema,
 	});
+}
+
+export function wrapState<S extends LambdaState>(
+	state: S,
+	error: { Error: string; Cause: string } | null = null,
+	requestInfo: RequestInfo,
+): WrappedState<S> {
+	return {
+		state,
+		error,
+		requestInfo,
+	};
 }

--- a/support-workers/src/typescript/services/salesforce.ts
+++ b/support-workers/src/typescript/services/salesforce.ts
@@ -42,7 +42,7 @@ export const salesforceContactRecordSchema = z.object({
 });
 type SalesforceContactRecord = z.infer<typeof salesforceContactRecordSchema>;
 
-class SalesforceError extends Error {
+export class SalesforceError extends Error {
 	constructor({ errorCode, message }: { errorCode: string; message: string }) {
 		super(message);
 		this.name = errorCode;
@@ -65,7 +65,7 @@ const upsertResponseSchema = z.discriminatedUnion('Success', [
 	failedUpsertResponseSchema,
 ]);
 
-type UpsertResponse = z.infer<typeof upsertResponseSchema>;
+export type UpsertResponse = z.infer<typeof upsertResponseSchema>;
 
 export const salesforceContactRecordsSchema = z.object({
 	buyer: salesforceContactRecordSchema,
@@ -75,7 +75,7 @@ export type SalesforceContactRecords = z.infer<
 	typeof salesforceContactRecordsSchema
 >;
 
-const salesforceErrorCodes = {
+export const salesforceErrorCodes = {
 	expiredAuthenticationCode: 'INVALID_SESSION_ID',
 	rateLimitExceeded: 'REQUEST_LIMIT_EXCEEDED',
 	readOnlyMaintenance: 'INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE',
@@ -118,6 +118,10 @@ export class SalesforceService {
 			upsertResponseSchema,
 		);
 
+		return SalesforceService.parseResponseToResult(response);
+	};
+
+	static parseResponseToResult(response: UpsertResponse) {
 		if (response.Success) {
 			return response;
 		} else {
@@ -133,7 +137,7 @@ export class SalesforceService {
 					'Salesforce `Success` returned as `false` with no error message',
 			});
 		}
-	};
+	}
 
 	private maybeAddGiftRecipient(
 		contactRecord: SalesforceContactRecord,

--- a/support-workers/src/typescript/services/salesforce.ts
+++ b/support-workers/src/typescript/services/salesforce.ts
@@ -1,0 +1,204 @@
+import { getCountryNameByIsoCode } from '@modules/internationalisation/country';
+import { z } from 'zod';
+import { getAddressLine } from '../model/address';
+import type { GiftRecipient, Title, User } from '../model/stateSchemas';
+import type { SalesforceConfig } from './salesforceClient';
+import { SalesforceClient } from './salesforceClient';
+
+export type ContactRecordRequest = {
+	IdentityID__c: string;
+	Email: string;
+	Salutation?: Title | null;
+	FirstName: string;
+	LastName: string;
+	OtherStreet: string | null;
+	OtherCity: string | null;
+	OtherState: string | null;
+	OtherPostalCode: string | null;
+	OtherCountry: string | null;
+	Phone?: string | null;
+	MailingStreet: string | null;
+	MailingCity: string | null;
+	MailingState: string | null;
+	MailingPostalCode: string | null;
+	MailingCountry: string | null;
+};
+export type DeliveryContactRecordRequest = {
+	AccountId: string;
+	Email: string | null;
+	Salutation?: Title | null;
+	FirstName: string;
+	LastName: string;
+	MailingStreet: string | null;
+	MailingCity: string | null;
+	MailingState: string | null;
+	MailingPostalCode: string | null;
+	MailingCountry: string | null;
+	RecordTypeId: '01220000000VB50AAG';
+};
+export const salesforceContactRecordSchema = z.object({
+	Id: z.string(),
+	AccountId: z.string(),
+});
+type SalesforceContactRecord = z.infer<typeof salesforceContactRecordSchema>;
+
+class SalesforceError extends Error {
+	constructor({ errorCode, message }: { errorCode: string; message: string }) {
+		super(message);
+		this.name = errorCode;
+	}
+}
+
+export const successfulUpsertResponseSchema = z.object({
+	Success: z.literal(true),
+	ContactRecord: salesforceContactRecordSchema,
+});
+
+type SuccessfulUpsertResponse = z.infer<typeof successfulUpsertResponseSchema>;
+
+const failedUpsertResponseSchema = z.object({
+	Success: z.literal(false),
+	ErrorString: z.string(),
+});
+const upsertResponseSchema = z.discriminatedUnion('Success', [
+	successfulUpsertResponseSchema,
+	failedUpsertResponseSchema,
+]);
+
+type UpsertResponse = z.infer<typeof upsertResponseSchema>;
+
+export const salesforceContactRecordsSchema = z.object({
+	buyer: salesforceContactRecordSchema,
+	giftRecipient: salesforceContactRecordSchema.nullable(),
+});
+export type SalesforceContactRecords = z.infer<
+	typeof salesforceContactRecordsSchema
+>;
+
+const salesforceErrorCodes = {
+	expiredAuthenticationCode: 'INVALID_SESSION_ID',
+	rateLimitExceeded: 'REQUEST_LIMIT_EXCEEDED',
+	readOnlyMaintenance: 'INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE',
+};
+
+export class SalesforceService {
+	private upsertEndpoint = 'services/apexrest/RegisterCustomer/v1/';
+	private client: SalesforceClient;
+
+	constructor(config: SalesforceConfig) {
+		this.client = new SalesforceClient(config);
+	}
+
+	createContactRecords = async (
+		user: User,
+		giftRecipient: GiftRecipient | null,
+	): Promise<SalesforceContactRecords> => {
+		const upsertResponse = await this.upsert(
+			createContactRecordRequest(user, giftRecipient),
+		);
+		const recipientUpsertResponse = await this.maybeAddGiftRecipient(
+			upsertResponse.ContactRecord,
+			giftRecipient,
+			user,
+		);
+		return {
+			buyer: upsertResponse.ContactRecord,
+			giftRecipient: recipientUpsertResponse?.ContactRecord ?? null,
+		};
+	};
+
+	upsert = async (
+		contact: ContactRecordRequest | DeliveryContactRecordRequest,
+	): Promise<SuccessfulUpsertResponse> => {
+		const response: UpsertResponse = await this.client.post(
+			this.upsertEndpoint,
+			JSON.stringify({
+				newContact: contact,
+			}),
+			upsertResponseSchema,
+		);
+
+		if (response.Success) {
+			return response;
+		} else {
+			const errorCode = response.ErrorString.includes(
+				salesforceErrorCodes.readOnlyMaintenance,
+			)
+				? salesforceErrorCodes.readOnlyMaintenance
+				: 'UNKNOWN_ERROR';
+			throw new SalesforceError({
+				errorCode,
+				message:
+					response.ErrorString ||
+					'Salesforce `Success` returned as `false` with no error message',
+			});
+		}
+	};
+
+	private maybeAddGiftRecipient(
+		contactRecord: SalesforceContactRecord,
+		giftRecipient: GiftRecipient | null,
+		user: User,
+	): Promise<SuccessfulUpsertResponse> | null {
+		if (giftRecipient?.firstName && giftRecipient.lastName) {
+			const giftRecipientContact: DeliveryContactRecordRequest = {
+				AccountId: contactRecord.AccountId,
+				Email: giftRecipient.email,
+				Salutation: giftRecipient.title,
+				FirstName: giftRecipient.firstName,
+				LastName: giftRecipient.lastName,
+				MailingStreet: user.deliveryAddress
+					? getAddressLine(user.deliveryAddress)
+					: null,
+				MailingCity: user.deliveryAddress?.city ?? null,
+				MailingState: user.deliveryAddress?.state ?? null,
+				MailingPostalCode: user.deliveryAddress?.postCode ?? null,
+				MailingCountry: user.deliveryAddress
+					? getCountryNameByIsoCode(user.deliveryAddress.country)
+					: null,
+				RecordTypeId: '01220000000VB50AAG',
+			};
+			return this.upsert(giftRecipientContact);
+		}
+		return null;
+	}
+}
+
+export const createContactRecordRequest = (
+	user: User,
+	giftRecipient: GiftRecipient | null,
+): ContactRecordRequest => {
+	const contact = {
+		IdentityID__c: user.id,
+		Email: user.primaryEmailAddress,
+		Salutation: user.title,
+		FirstName: user.firstName,
+		LastName: user.lastName,
+		OtherStreet: getAddressLine(user.billingAddress),
+		OtherCity: user.billingAddress.city,
+		OtherState: user.billingAddress.state,
+		OtherPostalCode: user.billingAddress.postCode,
+		OtherCountry: getCountryNameByIsoCode(user.billingAddress.country),
+		Phone: user.telephoneNumber,
+		MailingStreet: null,
+		MailingCity: null,
+		MailingState: null,
+		MailingPostalCode: null,
+		MailingCountry: null,
+	};
+	if (giftRecipient ?? !user.deliveryAddress) {
+		// If there is a gift recipient then we don't want to update the
+		// delivery address. This is because the user may already have another
+		// non-gift delivery product which must still be delivered to their
+		// original delivery address.
+		return contact;
+	}
+	return {
+		...contact,
+		MailingStreet: getAddressLine(user.deliveryAddress),
+		MailingCity: user.deliveryAddress.city,
+		MailingState: user.deliveryAddress.state,
+		MailingPostalCode: user.deliveryAddress.postCode,
+		MailingCountry: getCountryNameByIsoCode(user.deliveryAddress.country),
+	};
+};

--- a/support-workers/src/typescript/services/salesforceClient.ts
+++ b/support-workers/src/typescript/services/salesforceClient.ts
@@ -1,0 +1,119 @@
+import dayjs from 'dayjs';
+import { z } from 'zod';
+import type { Stage } from '../model/stage';
+import { getIfDefined } from '../util/nullAndUndefined';
+import { getConfig } from './config';
+
+export const salesforceConfigSchema = z.object({
+	url: z.string(),
+	consumer: z.object({
+		key: z.string(),
+		secret: z.string(),
+	}),
+	api: z.object({
+		username: z.string(),
+		password: z.string(),
+		token: z.string(),
+	}),
+});
+
+const authTokenSchema = z.object({
+	access_token: z.string(),
+	instance_url: z.string(),
+	issued_at: z.string(),
+});
+
+export type SalesforceConfig = z.infer<typeof salesforceConfigSchema>;
+
+export const getSalesforceConfig = async (
+	stage: Stage,
+): Promise<SalesforceConfig> => {
+	return getConfig(stage, 'salesforce-config', salesforceConfigSchema);
+};
+
+export class SalesforceClient {
+	constructor(config: SalesforceConfig) {
+		this.authService = new AuthService(config);
+	}
+	private authService: AuthService;
+
+	post = async <I, O, T extends z.ZodType<O, z.ZodTypeDef, I>>(
+		path: string,
+		body: string,
+		schema: T,
+	): Promise<O> => {
+		const auth = await this.authService.getAuthentication();
+		const url = `${auth.instance_url}/${path}`;
+		const response = await fetch(url, {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${auth.access_token}`,
+				'Content-Type': 'application/json',
+			},
+			body,
+		});
+		if (response.ok) {
+			return schema.parse(await response.json());
+		}
+		throw new Error(`Failed to post to Salesforce: ${await response.text()}`);
+	};
+}
+
+type Authentication = {
+	access_token: string;
+	instance_url: string;
+	issued_at: string;
+};
+
+export class AuthService {
+	private expiryTimeMinutes = 15;
+	private auth: Authentication | undefined;
+	constructor(private config: SalesforceConfig) {
+		this.config = config;
+	}
+
+	authIsValid() {
+		return (
+			this.auth &&
+			dayjs(Number(this.auth.issued_at))
+				.add(this.expiryTimeMinutes, 'minutes')
+				.isAfter(dayjs())
+		);
+	}
+
+	async getAuthentication() {
+		if (!this.authIsValid()) {
+			console.log('Auth token is invalid or expired, fetching a new one');
+			this.auth = await this.fetchAuthToken();
+		}
+		return getIfDefined(this.auth, 'No valid Salesforce authentication found');
+	}
+
+	private async fetchAuthToken(): Promise<Authentication> {
+		console.log(`Trying to authenticate with Salesforce`);
+		const authUrl = this.config.url + '/services/oauth2/token';
+		const response = await fetch(authUrl, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				client_id: this.config.consumer.key,
+				client_secret: this.config.consumer.secret,
+				username: this.config.api.username,
+				password: `${this.config.api.password}${this.config.api.token}`,
+				grant_type: 'password',
+			}),
+		});
+
+		if (!response.ok) {
+			throw new Error(
+				`Failed to authenticate with Salesforce: ${response.statusText}`,
+			);
+		}
+
+		this.auth = authTokenSchema.parse(await response.json());
+		console.log('Authenticated with Salesforce successfully');
+		return this.auth;
+	}
+}

--- a/support-workers/src/typescript/test/errorHandler.test.ts
+++ b/support-workers/src/typescript/test/errorHandler.test.ts
@@ -2,7 +2,7 @@ import { SalesforceError, salesforceErrorCodes } from '../services/salesforce';
 import { asRetryError } from '../util/errorHandler';
 
 describe('errorHandler', () => {
-	test('should throw a the correct retry error for Salesforce errors', () => {
+	test('should throw a retry unlimited error during readonly mode', () => {
 		const errorMessage =
 			'Failed Upsert of new Contact: Upsert failed. First exception on row 0; first error: INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE, Updates can’t be made during maintenance. Try again when maintenance is complete: []';
 		const salesforceError: SalesforceError = new SalesforceError({

--- a/support-workers/src/typescript/test/errorHandler.test.ts
+++ b/support-workers/src/typescript/test/errorHandler.test.ts
@@ -1,0 +1,26 @@
+import { SalesforceError, salesforceErrorCodes } from '../services/salesforce';
+import { asRetryError } from '../util/errorHandler';
+
+describe('errorHandler', () => {
+	test('should throw a the correct retry error for Salesforce errors', () => {
+		const errorMessage =
+			'Failed Upsert of new Contact: Upsert failed. First exception on row 0; first error: INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE, Updates can’t be made during maintenance. Try again when maintenance is complete: []';
+		const salesforceError: SalesforceError = new SalesforceError({
+			errorCode: salesforceErrorCodes.readOnlyMaintenance,
+			message: errorMessage,
+		});
+		const retryError = asRetryError(salesforceError);
+		expect(retryError.name).toEqual('RetryUnlimited');
+		expect(retryError.message).toEqual(errorMessage);
+	});
+	test('should throw a retry none error for generic errors', () => {
+		const errorMessage = 'Something went wrong';
+		const genericError = new SalesforceError({
+			errorCode: 'UNKNOWN_ERROR',
+			message: errorMessage,
+		});
+		const retryError = asRetryError(genericError);
+		expect(retryError.name).toEqual('RetryNone');
+		expect(retryError.message).toEqual(errorMessage);
+	});
+});

--- a/support-workers/src/typescript/test/fixtures/createSalesforceContact/gwGiftDirectDebit.json
+++ b/support-workers/src/typescript/test/fixtures/createSalesforceContact/gwGiftDirectDebit.json
@@ -3,35 +3,35 @@
     "requestId": "531f493c-c880-fb83-0000-00000000111b",
     "user": {
       "id": "21841796",
-      "primaryEmailAddress": "rupert.bates@gmail.com",
+      "primaryEmailAddress": "Test.User@gmail.com",
       "title": null,
-      "firstName": "Rupert",
-      "lastName": "Bates",
+      "firstName": "Test",
+      "lastName": "User",
       "billingAddress": {
-        "lineOne": "8 Trelawney Road",
+        "lineOne": "York Place",
         "lineTwo": null,
-        "city": "Bristol",
+        "city": "London",
         "state": "",
-        "postCode": "BS6 6EA",
+        "postCode": "N19GU",
         "country": "GB"
       },
       "deliveryAddress": {
-        "lineOne": "8 Trelawney Road",
+        "lineOne": "York Place",
         "lineTwo": null,
-        "city": "Bristol",
+        "city": "London",
         "state": "",
-        "postCode": "BS6 6EA",
+        "postCode": "N19GU",
         "country": "GB"
       },
-      "telephoneNumber": "+447972212521",
+      "telephoneNumber": "+4411111111111",
       "isTestUser": false,
       "deliveryInstructions": null
     },
     "giftRecipient": {
       "title": null,
-      "firstName": "Rupert",
-      "lastName": "Bates",
-      "email": "rupert.bates@gmail.com"
+      "firstName": "Test",
+      "lastName": "User",
+      "email": "Test.User@gmail.com"
     },
     "product": {
       "currency": "GBP",
@@ -83,14 +83,14 @@
       "Type": "BankTransfer",
       "PaymentGateway": "GoCardless",
       "BankTransferType": "DirectDebitUK",
-      "FirstName": "Rupert",
-      "LastName": "Bates",
+      "FirstName": "Test",
+      "LastName": "User",
       "BankTransferAccountName": "RB",
       "BankCode": "200000",
       "BankTransferAccountNumber": "55779911",
       "Country": "GB",
-      "City": "Bristol",
-      "PostalCode": "BS6 6EA",
+      "City": "London",
+      "PostalCode": "N19GU",
       "State": "",
       "StreetName": "Trelawney Road",
       "StreetNumber": "8"

--- a/support-workers/src/typescript/test/fixtures/createSalesforceContact/gwGiftDirectDebit.json
+++ b/support-workers/src/typescript/test/fixtures/createSalesforceContact/gwGiftDirectDebit.json
@@ -1,0 +1,106 @@
+{
+  "state": {
+    "requestId": "531f493c-c880-fb83-0000-00000000111b",
+    "user": {
+      "id": "21841796",
+      "primaryEmailAddress": "rupert.bates@gmail.com",
+      "title": null,
+      "firstName": "Rupert",
+      "lastName": "Bates",
+      "billingAddress": {
+        "lineOne": "8 Trelawney Road",
+        "lineTwo": null,
+        "city": "Bristol",
+        "state": "",
+        "postCode": "BS6 6EA",
+        "country": "GB"
+      },
+      "deliveryAddress": {
+        "lineOne": "8 Trelawney Road",
+        "lineTwo": null,
+        "city": "Bristol",
+        "state": "",
+        "postCode": "BS6 6EA",
+        "country": "GB"
+      },
+      "telephoneNumber": "+447972212521",
+      "isTestUser": false,
+      "deliveryInstructions": null
+    },
+    "giftRecipient": {
+      "title": null,
+      "firstName": "Rupert",
+      "lastName": "Bates",
+      "email": "rupert.bates@gmail.com"
+    },
+    "product": {
+      "currency": "GBP",
+      "billingPeriod": "Quarterly",
+      "fulfilmentOptions": "Domestic",
+      "productType": "GuardianWeekly"
+    },
+    "analyticsInfo": {
+      "isGiftPurchase": true,
+      "paymentProvider": "DirectDebit"
+    },
+    "paymentFields": {
+      "accountHolderName": "RB",
+      "sortCode": "200000",
+      "accountNumber": "55779911",
+      "recaptchaToken": "03AFcWeA7yDAPAWz2F28cZRoK5B0Guxe98-DPZ-umjdJahSjb2biO0eb_asDvNDDHkOwysL1ALlmCc3tHzVi2EFqCTw-koYnQw6Zs8xYJT4wWoY6Z2_Pafp1096XkIFWRSqYHanugwLaBLoKeloVX78a3hV6LDGUL9msZPEr5a3kiy-Q-sf68_-0qSvCzE3AYU-tbq9PQgU23ZhI-oTZJJCt8IQKUp5FeJJ37PoZ3iimu1TkXnMHDv1YIpLhieGrAogUT5NhkIuVVntSVHg0SQzWRPud5eTOmIT4cYSm4_9dnoBySAXUAoohNRIt0vg02Fz0-BFzm12vQhLHSqEcho3BP-cTKp5ed7XW03s2dcNHplBhMTuolmnpAraQ8RnQan15kbgoXncQD46OmrxeMTNlMGb0EQyuiuRm4BDgXQF-EX94nyU6vz5swcNdB8-dEZPBkiFgF0fqn1iW3q4WRzlCveEDNJlr3iPFCmUVtOdAqsPzNqTUdHQxE2LxlEKTSxItJXw0x2wLKMp0_J0MupzpbO6ItuFwfdp-ew1fJIeXg6hPwgDONPBKlA70bF-WoZUiKquK8jrrajJNNKZa2thybK8ho_HXj0mhB6ViwVxL1U3KiFbuFqyTWp1u2mjm9HIoi51S81jqH3ljn7V8Zb0bHALR3ixinMSpplkMFvonZDcY2WVMR6pfC9zLF_QwKN_d9tc1MUDrFIA2PH1FBOasjYtoSoGCS9gz4yuk-H8UeuU5tQ3OBZKFiT9F31Nw590TtYoXHCC_PgC4YFQ4UdVJycJB-87u_GAeYYLcB3y5yQbkZoBUzQ5OxYL8SVd3ywk9vepVk7cnr86w1yHbA3i8TdhcX78mcwTli8yGL5pxJLQVOkMr6L_s3Ce7VsormEgB8DL_9EtSwhGpzoGvyqn-k1h5fAmC2qN5ES5gPGwjwJm-v8P35brdIRE5vletLj--cKpukEAezyTMx9VXn8roOVk-D4v4T1AjMj-X3VTN9dJO1d1lMTsu8Qa6HlAIlHw_AG70AM5OTMKtU0yVt8H1ZoLyeVBaak2Trg8KHF6j80d94kO3Gy5VAZoVYk_H1ZUeNAplNXbyi9BH6us1SD0zdafbC8lW57xujdKnnzVDZ_EQpdpMdqT49wTBeU--7tdTS3ivv6rpebRMHG1P5cG7c1XU3MOLQS15YK81hBc13JaGpTaKgquntFs6mGby_7R2BDD29N-rf4GK7twHevpET1aXa_1AvO5pH85_Il6BlEOUxcW8kcWF8qBpiNuxeY3ESELqbgoFmX5TYX30bTVGP8NH0YLNu5S-1mtHJ4WcaeLA4xyfMK80_YLhmV3fanmWJQ0o_8reCUmPRu6G11R2HyfxqcqB3S1sIGw_Tb6uqojcz5YxABTw7TLkrYoNSJKjS9Jy_SftD9OlFPHKaUjrdaW-Vpk6DlTYVJmstOBsywKL73wY_ngTwKAfPlv-MND_nKtwgwBZgkpzXYHmqJ5d2TZTI0fzNlZt8wQ_OU80UDLkb6eFDvyD6M2Zs2nyjf3LKt_3ZBF1B5w33sM5TfjOQhDU82LJIqHGoqK8likZsNSo2dM2JTPlo",
+      "paymentType": "DirectDebit"
+    },
+    "firstDeliveryDate": "2025-07-25",
+    "appliedPromotion": null,
+    "csrUsername": null,
+    "salesforceCaseId": null,
+    "acquisitionData": {
+      "ophanIds": {
+        "pageviewId": "mcywaoxrovvvh02sdtuf",
+        "browserId": null
+      },
+      "referrerAcquisitionData": {
+        "campaignCode": null,
+        "referrerPageviewId": "",
+        "referrerUrl": null,
+        "componentId": null,
+        "componentType": null,
+        "source": null,
+        "abTests": null,
+        "queryParameters": [],
+        "hostname": "support.code.dev-theguardian.com",
+        "gaClientId": null,
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:140.0) Gecko/20100101 Firefox/140.0",
+        "ipAddress": "10.248.135.28",
+        "labels": null
+      },
+      "supportAbTests": []
+    },
+    "ipAddress": "86.154.28.44",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:140.0) Gecko/20100101 Firefox/140.0",
+    "similarProductsConsent": null,
+    "paymentMethod": {
+      "Type": "BankTransfer",
+      "PaymentGateway": "GoCardless",
+      "BankTransferType": "DirectDebitUK",
+      "FirstName": "Rupert",
+      "LastName": "Bates",
+      "BankTransferAccountName": "RB",
+      "BankCode": "200000",
+      "BankTransferAccountNumber": "55779911",
+      "Country": "GB",
+      "City": "Bristol",
+      "PostalCode": "BS6 6EA",
+      "State": "",
+      "StreetName": "Trelawney Road",
+      "StreetNumber": "8"
+    }
+  },
+  "error": null,
+  "requestInfo": {
+    "testUser": false,
+    "failed": false,
+    "messages": [],
+    "accountExists": false
+  }
+}

--- a/support-workers/src/typescript/test/fixtures/salesforceFixtures.ts
+++ b/support-workers/src/typescript/test/fixtures/salesforceFixtures.ts
@@ -1,0 +1,54 @@
+import { ContactRecordRequest } from '../../services/salesforce';
+import { Title } from '../../model/stateSchemas';
+import { IsoCountry } from '@modules/internationalisation/country';
+
+export const idId = '9999999';
+export const salesforceId = '003UD00000VZnteYAD';
+export const salesforceAccountId = '001UD00000Gk8XeYAJ';
+export const emailAddress = 'integration-test@thegulocal.com';
+export const telephoneNumber = '0123456789';
+export const title: Title = 'Mrs';
+export const name = 'integration-test';
+export const street = '123 trash alley';
+export const city = 'London';
+export const postCode = 'n1 9gu';
+export const uk: IsoCountry = 'GB';
+export const state = 'CA';
+export const customer: ContactRecordRequest = {
+	IdentityID__c: idId,
+	Email: emailAddress,
+	Salutation: title,
+	FirstName: name,
+	LastName: name,
+	OtherStreet: null,
+	OtherCity: null,
+	OtherState: null,
+	OtherPostalCode: null,
+	OtherCountry: uk,
+	MailingStreet: null,
+	MailingCity: null,
+	MailingState: null,
+	MailingPostalCode: null,
+	MailingCountry: null,
+	Phone: null,
+};
+
+const address = {
+	lineOne: street,
+	city,
+	state,
+	postCode,
+	country: uk,
+};
+export const user = {
+	id: idId,
+	firstName: name,
+	lastName: name,
+	title,
+	primaryEmailAddress: emailAddress,
+	telephoneNumber,
+	billingAddress: address,
+	deliveryAddress: address,
+	isTestUser: false,
+	deliveryInstructions: null,
+};

--- a/support-workers/src/typescript/test/salesforce.it.test.ts
+++ b/support-workers/src/typescript/test/salesforce.it.test.ts
@@ -135,6 +135,7 @@ describe('CreateSalesforceContatctLambda', () => {
 		);
 
 		expect(result.state.product.productType).toBe('Contribution');
+		// Need to check type here because Typescript can't infer it from the preceding check
 		if (result.state.productSpecificState.productType === 'Contribution') {
 			expect(result.state.productSpecificState.salesForceContact.Id).toBe(
 				'003UD00000bt0YfYAI',

--- a/support-workers/src/typescript/test/salesforce.test.ts
+++ b/support-workers/src/typescript/test/salesforce.test.ts
@@ -1,0 +1,17 @@
+import { createContactRecordRequest } from '../services/salesforce';
+import { emailAddress, street, user } from './fixtures/salesforceFixtures';
+
+describe('SalesforceService', () => {
+	test('getNewContact should only include delivery fields for purchases without a gift recipient', () => {
+		const newContactNoGift = createContactRecordRequest(user, null);
+		expect(newContactNoGift.MailingStreet).toBe(street);
+
+		const newContactWithGift = createContactRecordRequest(user, {
+			email: emailAddress,
+			title: 'Ms',
+			firstName: 'Jane',
+			lastName: 'Doe',
+		});
+		expect(newContactWithGift.MailingStreet).toBeNull();
+	});
+});

--- a/support-workers/src/typescript/test/salesforce.test.ts
+++ b/support-workers/src/typescript/test/salesforce.test.ts
@@ -1,4 +1,9 @@
-import { createContactRecordRequest } from '../services/salesforce';
+import {
+	createContactRecordRequest,
+	SalesforceError,
+	salesforceErrorCodes,
+	SalesforceService,
+} from '../services/salesforce';
 import { emailAddress, street, user } from './fixtures/salesforceFixtures';
 
 describe('SalesforceService', () => {
@@ -13,5 +18,36 @@ describe('SalesforceService', () => {
 			lastName: 'Doe',
 		});
 		expect(newContactWithGift.MailingStreet).toBeNull();
+	});
+	test('it should throw an INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE error when appropriate', () => {
+		const errorString =
+			'Failed Upsert of new Contact: Upsert failed. First exception on row 0; first error: INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE, Updates can’t be made during maintenance. Try again when maintenance is complete: []';
+
+		expect(() =>
+			SalesforceService.parseResponseToResult({
+				Success: false,
+				ErrorString: errorString,
+			}),
+		).toThrow(
+			new SalesforceError({
+				errorCode: salesforceErrorCodes.readOnlyMaintenance,
+				message: errorString,
+			}),
+		);
+	});
+	test('it should throw an UNKNOWN_ERROR error for all other exceptions', () => {
+		const errorString = 'Things have gone awry';
+
+		expect(() =>
+			SalesforceService.parseResponseToResult({
+				Success: false,
+				ErrorString: errorString,
+			}),
+		).toThrow(
+			new SalesforceError({
+				errorCode: 'UNKNOWN_ERROR',
+				message: errorString,
+			}),
+		);
 	});
 });

--- a/support-workers/src/typescript/test/salesforceClientIntegration.test.ts
+++ b/support-workers/src/typescript/test/salesforceClientIntegration.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @group integration
+ */
+
+import type { DeliveryContactRecordRequest } from '../services/salesforce';
+import { SalesforceService } from '../services/salesforce';
+import type { SalesforceConfig } from '../services/salesforceClient';
+import { AuthService, getSalesforceConfig } from '../services/salesforceClient';
+import {
+	city,
+	customer,
+	emailAddress,
+	postCode,
+	salesforceAccountId,
+	salesforceId,
+	state,
+	street,
+	telephoneNumber,
+	title,
+	uk,
+} from './fixtures/salesforceFixtures';
+
+describe('AuthService', () => {
+	test('should be able to retrieve an auth token', async () => {
+		const config = await getSalesforceConfig('CODE');
+		const authService = new AuthService(config);
+		const authentication = await authService.getAuthentication();
+		expect(authentication.access_token.length).toBeGreaterThan(0);
+	});
+	test('should reuse that auth token if it is still valid', async () => {
+		const config = await getSalesforceConfig('CODE');
+		const authService = new AuthService(config);
+		const firstAuth = await authService.getAuthentication();
+		const secondAuth = await authService.getAuthentication();
+		expect(firstAuth).toEqual(secondAuth);
+	});
+});
+
+describe('SalesforceService', () => {
+	let config: SalesforceConfig;
+	let salesforceService: SalesforceService;
+
+	beforeAll(async () => {
+		config = await getSalesforceConfig('CODE');
+		salesforceService = new SalesforceService(config);
+	});
+
+	test('should be able to upsert a customer', async () => {
+		const result = await salesforceService.upsert(customer);
+		expect(result).toEqual({
+			Success: true,
+			ContactRecord: {
+				Id: salesforceId,
+				AccountId: salesforceAccountId,
+			},
+		});
+	});
+
+	test('should be able to upsert a customer that has optional fields', async () => {
+		const result = await salesforceService.upsert({
+			...customer,
+			OtherStreet: street,
+			OtherCity: city,
+			OtherPostalCode: postCode,
+			OtherCountry: uk,
+			MailingStreet: street,
+			MailingCity: city,
+			MailingPostalCode: postCode,
+			Phone: telephoneNumber,
+		});
+		expect(result).toEqual({
+			Success: true,
+			ContactRecord: {
+				Id: salesforceId,
+				AccountId: salesforceAccountId,
+			},
+		});
+	});
+
+	test('it should be able to add a related contact record', async () => {
+		const name = 'integration-test-recipient';
+		const upsertData: DeliveryContactRecordRequest = {
+			AccountId: salesforceAccountId,
+			Email: emailAddress,
+			Salutation: title,
+			FirstName: name,
+			LastName: name,
+			MailingStreet: street,
+			MailingCity: city,
+			MailingState: state,
+			MailingPostalCode: postCode,
+			MailingCountry: uk,
+			RecordTypeId: '01220000000VB50AAG',
+		};
+		const result = await salesforceService.upsert(upsertData);
+		expect(result).toEqual({
+			Success: true,
+			ContactRecord: {
+				Id: expect.stringMatching('[0-9A-Z]+') as string,
+				AccountId: salesforceAccountId,
+			},
+		});
+	});
+});


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR follows on from https://github.com/guardian/support-frontend/pull/7017 and is the next step in moving support-workers from Scala to Typescript.

This is a simpler lambda than the CreatePaymentMethod lambda and most of the schemas and model classes were already in place so this PR is smaller than previous ones. 

TODO:
- [x] Check error handling, particularly readonly mode

[**Trello Card**](https://trello.com/c/UPZDpNiB/1745-createsalesforcecontact-lambda)

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

- Deploy this branch of support-workers to CODE
- Run smoke tests against CODE
- All the resulting support-workers executions should succeed
