### PR TITLE
Fix formatting of zero amounts in day zero email

### DIFF
--- a/support-workers/src/main/scala/com/gu/emailservices/SubscriptionEmailFieldHelpers.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/SubscriptionEmailFieldHelpers.scala
@@ -13,7 +13,7 @@ object SubscriptionEmailFieldHelpers {
 
   implicit def localDateOrdering: Ordering[LocalDate] = Ordering.fromLessThan(_ isBefore _)
 
-  val formatter = new DecimalFormat("#.00")
+  val formatter = new DecimalFormat("0.00")
 
   def formatPrice(price: Double): String = formatter.format(price)
 

--- a/support-workers/src/test/scala/com/gu/emailservices/SubscriptionEmailFieldHelpersSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/SubscriptionEmailFieldHelpersSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.emailservices
 
-import com.gu.i18n.Currency.{EUR, GBP, USD}
+import com.gu.i18n.Currency.{AUD, EUR, GBP, USD}
 import com.gu.support.workers._
 import org.joda.time.LocalDate
 import org.scalatest.flatspec.AnyFlatSpec
@@ -69,5 +69,23 @@ class SubscriptionEmailFieldHelpersSpec extends AnyFlatSpec with Matchers {
       payments(firstDiscountedPayment, List(3)) ++ payments(firstFullPricePayment, List(3, 6))
     val expected = "£30.00 every quarter for 2 quarters, then £37.50 every quarter"
     assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Quarterly, GBP) == expected)
+  }
+
+  "describe" should "correctly format zero amounts with multiple zero amounts in the payment schedule" in {
+    val zeroPayment = Payment(referenceDate, 0.00)
+    val schedule: List[Payment] = payments(zeroPayment, List(10))
+
+    val got = SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Monthly, AUD)
+
+    assert(got == "$0.00 every month")
+  }
+
+  "describe" should "correctly format zero amounts with a single zero amount in the payment schedule" in {
+    val zeroPayment = Payment(referenceDate, 0.00)
+    val schedule: List[Payment] = List(zeroPayment)
+
+    val got = SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Monthly, AUD)
+
+    assert(got == "$0.00 for the first month")
   }
 }


### PR DESCRIPTION
## What are you doing in this PR?

While e2e testing the student Aus offer that the subscription amount was badly formatted in the day zero email:

We were showing: "$.00 every month"

But it should be "$0.00 every month"

This PR makes that change. I've added some tests for zero amounts and verified that the existing tests continue to pass.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/sLPngorh/1743-fix-payment-formatting-in-day-zero-email-for-aus-student-offer)

## Why are you doing this?

The zero amount looks broken in the email:

<img width="512" height="293" alt="dayzeroausoffer" src="https://github.com/user-attachments/assets/40397e38-9251-4f2b-8c76-190d311dd7c0" />

## How to test

Take out the student offer and inspect the email.

In CODE with a zero amount:

<img width="469" height="233" alt="Screenshot 2025-07-11 at 10 51 16" src="https://github.com/user-attachments/assets/bb257da2-f3fa-4549-be1b-5f58ae850b33" />

and verifying that a non-zero amount is unaffected:

<img width="508" height="229" alt="Screenshot 2025-07-11 at 10 45 32" src="https://github.com/user-attachments/assets/03f627f5-d9c7-4c83-9666-ff9add40a66f" />
