### PR TITLE
Test whether we can use undefined in place of null in support-workers…

### DIFF
--- a/support-workers/src/typescript/model/stateSchemas.ts
+++ b/support-workers/src/typescript/model/stateSchemas.ts
@@ -81,7 +81,7 @@ export const giftRecipientSchema = z.object({
 const baseStateSchema = z.object({
 	requestId: z.string(),
 	user: userSchema,
-	giftRecipient: giftRecipientSchema.nullable(),
+	giftRecipient: giftRecipientSchema.optional(),
 	product: productTypeSchema,
 	analyticsInfo: analyticsInfoSchema,
 	//TODO: This should probably be a date but the scala lambdas struggle to deserialise the default date representation


### PR DESCRIPTION
… state schemas

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
