### PR TITLE
add UTS student smoke test for promos

### DIFF
--- a/support-e2e/tests/smoke/student.test.ts
+++ b/support-e2e/tests/smoke/student.test.ts
@@ -13,6 +13,8 @@ import { setTestUserDetails } from '../utils/testUserDetails';
 		expectedPromoText: '$0/month for two years, then $20/month',
 		expectedCheckoutTotalText: 'Was $20, now $0/month',
 		accessibleCtaText: 'Sign up for free',
+		expectedThankYouText:
+			"You'll pay $0/month for the first 24 months, then $20/month afterwards unless you cancel",
 	},
 ].forEach((testDetails) => {
 	test(`${testDetails.expectedCardHeading} ${testDetails.frequency} ${testDetails.promoCode} Promo`, async ({
@@ -55,6 +57,7 @@ import { setTestUserDetails } from '../utils/testUserDetails';
 			testLastName,
 			true,
 		);
+		await page.getByLabel('State').selectOption({ label: 'New South Wales' });
 		await page.getByRole('radio', { name: 'Credit/Debit card' }).check();
 		await fillInCardDetails(page);
 		await checkRecaptcha(page);
@@ -63,5 +66,14 @@ import { setTestUserDetails } from '../utils/testUserDetails';
 				name: `Pay`,
 			})
 			.click();
+
+		// Thank you
+		await expect(page.getByRole('heading', { name: 'Thank you' })).toBeVisible({
+			timeout: 600000,
+		});
+
+		await expect(
+			page.getByText(testDetails.expectedThankYouText).first(),
+		).toBeVisible({ timeout: 600000 });
 	});
 });


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Add UTS student smoke test for promos. 

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/GvuziiX7/1718-aus-landing-page-e2e-testing)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
