### PR TITLE
Avoid race condition when updating error state object

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -1311,44 +1311,44 @@ export function CheckoutComponent({
 														onCardNumberChange={(
 															event: StripeCardNumberElementChangeEvent,
 														) => {
-															setStripeFieldsAreEmpty({
-																...stripeFieldsAreEmpty,
+															setStripeFieldsAreEmpty((prevState) => ({
+																...prevState,
 																cardNumber: event.empty,
-															});
+															}));
 
 															// Clear errors when the field changes, we'll (re) show errors, if any, on submit
-															setStripeFieldError({
-																...stripeFieldError,
+															setStripeFieldError((prevState) => ({
+																...prevState,
 																cardNumber: undefined,
-															});
+															}));
 														}}
 														onExpiryChange={(
 															event: StripeCardExpiryElementChangeEvent,
 														) => {
-															setStripeFieldsAreEmpty({
-																...stripeFieldsAreEmpty,
+															setStripeFieldsAreEmpty((prevState) => ({
+																...prevState,
 																expiry: event.empty,
-															});
+															}));
 
 															// Clear errors when the field changes, we'll (re) show errors, if any, on submit
-															setStripeFieldError({
-																...stripeFieldError,
+															setStripeFieldError((prevState) => ({
+																...prevState,
 																expiry: undefined,
-															});
+															}));
 														}}
 														onCvcChange={(
 															event: StripeCardCvcElementChangeEvent,
 														) => {
-															setStripeFieldsAreEmpty({
-																...stripeFieldsAreEmpty,
+															setStripeFieldsAreEmpty((prevState) => ({
+																...prevState,
 																cvc: event.empty,
-															});
+															}));
 
 															// Clear errors when the field changes, we'll (re) show errors, if any, on submit
-															setStripeFieldError({
-																...stripeFieldError,
+															setStripeFieldError((prevState) => ({
+																...prevState,
 																cvc: undefined,
-															});
+															}));
 														}}
 														errors={{
 															cardNumber: maybeArrayWrap(


### PR DESCRIPTION
When autofilling a credit card we observed that occassionally on Chrome an error would show next to one of the card fields preventing the form from submitting. I think that was because the call to update the empty field state was overwriting a previous call from another field. Using the callback version of the set state prevents this.

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
