### PR TITLE
FIX: add promotion terms and condition for newspaper products

### DIFF
--- a/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.tsx
+++ b/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.tsx
@@ -88,20 +88,20 @@ export function OrderSummaryTsAndCs({
 }: OrderSummaryTsAndCsProps): JSX.Element | null {
 	const billingPeriod = ratePlanToBillingPeriod(ratePlanKey);
 	const periodNoun = getBillingPeriodNoun(billingPeriod);
+	const promoMessage = productLegal(
+		countryGroupId,
+		billingPeriod,
+		'/',
+		thresholdAmount,
+		promotion,
+	);
 	const tierThreeSupporterPlusTsAndCs = (
 		<div css={containerSummaryTsCs}>
 			{promotion && (
 				<p>
-					You’ll pay{' '}
-					{productLegal(
-						countryGroupId,
-						billingPeriod,
-						'/',
-						thresholdAmount,
-						promotion,
-					)}{' '}
-					afterwards unless you cancel. Offer only available to new subscribers
-					who do not have an existing subscription with the Guardian.
+					You’ll pay {promoMessage} afterwards unless you cancel. Offer only
+					available to new subscribers who do not have an existing subscription
+					with the Guardian.
 				</p>
 			)}
 			{productKey === 'SupporterPlus' && (
@@ -120,6 +120,7 @@ export function OrderSummaryTsAndCs({
 	);
 	const defaultOrderSummaryTsAndCs = (
 		<div css={containerSummaryTsCs}>
+			{promotion && <p>You’ll pay {promoMessage}.</p>}
 			<p>Auto renews every {periodNoun} until you cancel.</p>
 			<p>
 				{['Contribution', 'OneTimeContribution'].includes(productKey)

--- a/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.tsx
+++ b/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.tsx
@@ -88,13 +88,14 @@ export function OrderSummaryTsAndCs({
 }: OrderSummaryTsAndCsProps): JSX.Element | null {
 	const billingPeriod = ratePlanToBillingPeriod(ratePlanKey);
 	const periodNoun = getBillingPeriodNoun(billingPeriod);
+
 	const promoMessage = productLegal(
 		countryGroupId,
 		billingPeriod,
 		'/',
 		thresholdAmount,
 		promotion,
-	);
+	); // promoMessage expected to be a string like: "£10.49/month for the first 6 months, then £20.99/month"
 	const tierThreeSupporterPlusTsAndCs = (
 		<div css={containerSummaryTsCs}>
 			{promotion && (

--- a/support-frontend/assets/helpers/supporterPlus/benefitsThreshold.ts
+++ b/support-frontend/assets/helpers/supporterPlus/benefitsThreshold.ts
@@ -15,17 +15,16 @@ export function getLowerProductBenefitThreshold(
 	product: ActiveProductKey,
 	ratePlan: ActiveRatePlanKey,
 ): number {
-	const ratePlanTier3 =
-		countryGroupId === 'International'
-			? billingPeriod === BillingPeriod.Annual
-				? 'RestOfWorldAnnual'
-				: 'RestOfWorldMonthly'
-			: billingPeriod === BillingPeriod.Annual
-			? 'DomesticAnnual'
-			: 'DomesticMonthly';
-	const ratePlanRegularContribution = getBillingPeriodTitle(billingPeriod);
-
 	if (product === 'TierThree') {
+		const ratePlanTier3 =
+			countryGroupId === 'International'
+				? billingPeriod === BillingPeriod.Annual
+					? 'RestOfWorldAnnual'
+					: 'RestOfWorldMonthly'
+				: billingPeriod === BillingPeriod.Annual
+				? 'DomesticAnnual'
+				: 'DomesticMonthly';
+
 		return (
 			productCatalog[product]?.ratePlans[ratePlanTier3]?.pricing[currencyId] ??
 			0
@@ -38,6 +37,7 @@ export function getLowerProductBenefitThreshold(
 		);
 	}
 
+	const ratePlanRegularContribution = getBillingPeriodTitle(billingPeriod);
 	return (
 		productCatalog[product]?.ratePlans[ratePlanRegularContribution]?.pricing[
 			currencyId

--- a/support-frontend/assets/helpers/supporterPlus/benefitsThreshold.ts
+++ b/support-frontend/assets/helpers/supporterPlus/benefitsThreshold.ts
@@ -1,7 +1,10 @@
 import type { CountryGroupId } from '@modules/internationalisation/countryGroup';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { BillingPeriod } from '@modules/product/billingPeriod';
-import type { ActiveProductKey } from 'helpers/productCatalog';
+import type {
+	ActiveProductKey,
+	ActiveRatePlanKey,
+} from 'helpers/productCatalog';
 import { productCatalog } from 'helpers/productCatalog';
 import { getBillingPeriodTitle } from 'helpers/productPrice/billingPeriods';
 
@@ -10,6 +13,7 @@ export function getLowerProductBenefitThreshold(
 	currencyId: IsoCurrency,
 	countryGroupId: CountryGroupId,
 	product: ActiveProductKey,
+	ratePlan: ActiveRatePlanKey,
 ): number {
 	const ratePlanTier3 =
 		countryGroupId === 'International'
@@ -20,7 +24,23 @@ export function getLowerProductBenefitThreshold(
 			? 'DomesticAnnual'
 			: 'DomesticMonthly';
 	const ratePlanRegularContribution = getBillingPeriodTitle(billingPeriod);
-	const ratePlan =
-		product === 'TierThree' ? ratePlanTier3 : ratePlanRegularContribution;
-	return productCatalog[product]?.ratePlans[ratePlan]?.pricing[currencyId] ?? 0;
+
+	if (product === 'TierThree') {
+		return (
+			productCatalog[product]?.ratePlans[ratePlanTier3]?.pricing[currencyId] ??
+			0
+		);
+	}
+
+	if (product === 'HomeDelivery' || product === 'SubscriptionCard') {
+		return (
+			productCatalog[product]?.ratePlans[ratePlan]?.pricing[currencyId] ?? 0
+		);
+	}
+
+	return (
+		productCatalog[product]?.ratePlans[ratePlanRegularContribution]?.pricing[
+			currencyId
+		] ?? 0
+	);
 }

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
@@ -721,6 +721,7 @@ export function CheckoutComponent({
 		fromCountryGroupId(countryGroupId),
 		countryGroupId,
 		productKey,
+		ratePlanKey,
 	);
 
 	return (


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Add Promotion message to the order summary Terms and Conditions.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/1kuP0IIQ/1753-newspaper-promos-wording-not-appearing-checkout)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
