### PR TITLE
Remove `readerType` from DigitalPack ProductType

### DIFF
--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -247,7 +247,6 @@ class PaymentSwitchValidationTest extends AnyFlatSpec with Matchers {
       product = DigitalPack(
         GBP,
         Monthly,
-        Direct,
       ),
       paymentFields = DirectDebitPaymentFields("", "", "", ""),
       switches = TestData.buildSwitches(
@@ -276,7 +275,6 @@ class PaymentSwitchValidationTest extends AnyFlatSpec with Matchers {
       product = DigitalPack(
         GBP,
         Monthly,
-        Direct,
       ),
       paymentFields = StripePaymentFields(
         paymentMethod = PaymentMethodId("testId").get,
@@ -520,7 +518,6 @@ class PaymentSwitchValidationTest extends AnyFlatSpec with Matchers {
       product = DigitalPack(
         GBP,
         Monthly,
-        Direct,
       ),
       paymentFields = DirectDebitPaymentFields("", "", "", ""),
       switches = TestData.buildSwitches(
@@ -549,7 +546,6 @@ class PaymentSwitchValidationTest extends AnyFlatSpec with Matchers {
       product = DigitalPack(
         GBP,
         Monthly,
-        Direct,
       ),
       paymentFields = StripePaymentFields(
         paymentMethod = PaymentMethodId("testId").get,

--- a/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
@@ -27,9 +27,7 @@ object ProductTypeRatePlans {
   ): Option[ProductRatePlan[catalog.DigitalPack.type]] =
     catalog.DigitalPack.ratePlans
       .getOrElse(environment, Nil)
-      .find(productRatePlan =>
-        productRatePlan.billingPeriod == product.billingPeriod && productRatePlan.readerType == product.readerType,
-      )
+      .find(productRatePlan => productRatePlan.billingPeriod == product.billingPeriod)
 
   def supporterPlusRatePlan(
       product: SupporterPlus,

--- a/support-models/src/main/scala/com/gu/support/workers/Products.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/Products.scala
@@ -57,9 +57,8 @@ case class SupporterPlus(
 case class DigitalPack(
     currency: Currency,
     billingPeriod: BillingPeriod,
-    readerType: ReaderType = Direct,
 ) extends ProductType {
-  override def describe: String = s"$billingPeriod-DigitalPack-$currency-$readerType"
+  override def describe: String = s"$billingPeriod-DigitalPack-$currency"
 }
 
 case class Paper(

--- a/support-models/src/test/scala/com/gu/support/workers/SendThankYouEmailStateSerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/SendThankYouEmailStateSerialisationSpec.scala
@@ -38,7 +38,7 @@ object ProductTypeCreatedTestData {
 
   val digitalSubscriptionCreated = SendThankYouEmailDigitalSubscriptionState(
     user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),
-    DigitalPack(GBP, Monthly, ReaderType.Direct),
+    DigitalPack(GBP, Monthly),
     PayPalReferenceTransaction("baid", "email@emaail.com"),
     PaymentSchedule(List(Payment(new LocalDate(2020, 6, 16), 1.49))),
     None,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -60,7 +60,7 @@ class NextState(state: CreateSalesforceContactState) {
         toNextTierThree(salesforceContactRecords, product, purchase)
       case (product: GuardianAdLite, purchase) =>
         toNextGuardianAdLite(salesforceContactRecords, product, purchase)
-      case (product: DigitalPack, purchase) if product.readerType == ReaderType.Direct =>
+      case (product: DigitalPack, purchase) =>
         toNextDSDirect(salesforceContactRecords.buyer, product, purchase)
       case (product: Paper, purchase) =>
         toNextPaper(salesforceContactRecords.buyer, product, purchase)

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilder.scala
@@ -32,7 +32,7 @@ class DigitalSubscriptionBuilder(
       productRatePlanId = productRatePlanId,
       contractEffectiveDate = todaysDate,
       contractAcceptanceDate = contractAcceptanceDate,
-      readerType = ReaderType.impliedBySomeAppliedPromotion(state.appliedPromotion) getOrElse state.product.readerType,
+      readerType = ReaderType.Direct,
       initialTermPeriodType = Month,
       csrUsername = csrUsername,
       salesforceCaseId = salesforceCaseId,

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
@@ -91,46 +91,6 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
     )
   }
 
-  "SubscriptionData for a Monthly subscription with a Patron PromoCode" should "be correct" in {
-    val aPromotion = mock[Promotion]
-    val pwc = PromotionWithCode("FOOPATRON", aPromotion)
-
-    when(promotionService.findPromotion(ArgumentMatchers.eq("FOOPATRON"))).thenReturn(Right(pwc))
-
-    when(
-      promotionService.applyPromotion(
-        ArgumentMatchers.eq(pwc),
-        ArgumentMatchers.eq(UK),
-        ArgumentMatchers.eq("2c92c0f84bbfec8b014bc655f4852d9d"),
-        any(),
-        ArgumentMatchers.eq(false),
-      ),
-    ).thenAnswer { i =>
-      {
-        val sd = i.getArgument[SubscriptionData](3)
-        val patchedSubscription = sd.subscription.copy(promoCode = Some(pwc.promoCode))
-        Right(sd.copy(subscription = patchedSubscription))
-      }
-    }
-
-    monthlyPatron.subscriptionData shouldBe SubscriptionData(
-      List(RatePlanData(RatePlan("2c92c0f84bbfec8b014bc655f4852d9d"), List(), List())),
-      Subscription(
-        contractAcceptanceDate = saleDate.plusDays(16),
-        contractEffectiveDate = saleDate,
-        termStartDate = saleDate,
-        createdRequestId = "f7651338-5d94-4f57-85fd-262030de9ad5",
-        autoRenew = true,
-        initialTermPeriodType = Month,
-        initialTerm = 12,
-        renewalTerm = 12,
-        termType = "TERMED",
-        readerType = ReaderType.Patron,
-        promoCode = Some("FOOPATRON"),
-      ),
-    )
-  }
-
   lazy val promotionService = mock[PromotionService]
   lazy val saleDate = new LocalDate(2020, 6, 5)
 

--- a/support-workers/src/typescript/model/productType.ts
+++ b/support-workers/src/typescript/model/productType.ts
@@ -41,7 +41,6 @@ export const guardianWeeklyProductSchema = z.object({
 export const digitalPackProductSchema = z.object({
 	currency: isoCurrencySchema,
 	billingPeriod: recurringBillingPeriodSchema,
-	readerType: z.string(), //TODO this can be removed now that digital subscription gifts are no longer supported but we'll need to remove it from the scala code as well
 	productType: z.literal('DigitalPack'),
 });
 export const guardianAdLiteProductSchema = z.object({


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
I have started to look at using the product catalog throughout the whole support-frontend stack, getting rid of the mapping to the old way of doing things that happens when the form is submitted. 

As preparation for this I am trying to remove any bits of complexity  which are no longer needed, and one of these is the `readerType` field on the DigitalPack product type. This used to be used to differentiate between gift, corporate and regular digital subscriptions, but we no longer sell gift or corporate, so it is just clutter now.