### PR TITLE
Lighthouse: lcp and fcp metrics update from 99th percentile over 30days from grafana

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -2,13 +2,10 @@
   "ci": {
     "assert": {
       "assertions": {
-        "first-contentful-paint": ["error", { "maxNumericValue": 3000 }],
-        "largest-contentful-paint": ["error", { "maxNumericValue": 7000 }],
+        "first-contentful-paint": ["error", { "maxNumericValue": 4000 }],
+        "largest-contentful-paint": ["error", { "maxNumericValue": 10000 }],
         "interactive": ["error", { "maxNumericValue": 9500 }],
-        "resource-summary:document:size": [
-          "warn",
-          { "maxNumericValue": 26000 }
-        ]
+        "resource-summary:document:size": ["warn", { "maxNumericValue": 26000 }]
       }
     }
   }


### PR DESCRIPTION
## What are you doing?
Update paint metrics using the 99th percentile over 30days from [grafana support site metrics](https://metrics.gutools.co.uk/d/aepxbypfcitxcb/support-site-core-web-vitals?orgId=1&from=now-14d&to=now&timezone=utc&refresh=1d)

- first-contentful-paint metrics  : 4000msecs
- largest-contentful-paint : 10000msecs 

|fcp|lcp|
|----|-----|
|<img width="584" height="303" alt="image" src="https://github.com/user-attachments/assets/541acf5c-eb70-4e48-9b23-6c9de46bd65f" />|<img width="577" height="288" alt="image" src="https://github.com/user-attachments/assets/0c0bd90c-e3c5-49e4-b408-5bb6405648a1" />|

## Why are you doing this?
To dampen down the false-positive lighthouse alarms, over this threshold we deem to be genuine.
<img width="577" height="170" alt="image" src="https://github.com/user-attachments/assets/ed8d221c-56d0-49e5-ab25-f678d7f59503" />

Later we may develop introduce metric alarms in  [grafana support site metrics](https://metrics.gutools.co.uk/d/aepxbypfcitxcb/support-site-core-web-vitals?orgId=1&from=now-14d&to=now&timezone=utc&refresh=1d)
