### PR TITLE
split checkout form from summary

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -30,7 +30,9 @@ import { getLegacyProductType } from '../../helpers/legacyTypeConversions';
 import { getFulfilmentOptionFromProductKey } from '../../helpers/productCatalogToFulfilmentOption';
 import { getProductOptionFromProductAndRatePlan } from '../../helpers/productCatalogToProductOption';
 import { useStripeHostedCheckoutSession } from './checkout/hooks/useStripeHostedCheckoutSession';
-import { CheckoutComponent } from './components/checkoutComponent';
+import CheckoutForm from './components/checkoutForm';
+import { CheckoutLayout } from './components/checkoutLayout';
+import CheckoutSummary from './components/checkoutSummary';
 
 type Props = {
 	geoId: GeoId;
@@ -257,26 +259,49 @@ export function Checkout({
 
 	return (
 		<Elements stripe={stripePromise} options={elementsOptions}>
-			<CheckoutComponent
-				geoId={geoId}
-				appConfig={appConfig}
-				stripePublicKey={stripePublicKey}
-				isTestUser={isTestUser}
-				productKey={productKey}
-				ratePlanKey={ratePlanKey}
-				promotion={promotion}
-				originalAmount={payment.originalAmount}
-				discountedAmount={payment.discountedAmount}
-				contributionAmount={payment.contributionAmount}
-				finalAmount={payment.finalAmount}
-				useStripeExpressCheckout={useStripeExpressCheckout}
-				countryId={countryId}
-				forcedCountry={forcedCountry}
-				abParticipations={abParticipations}
-				landingPageSettings={landingPageSettings}
-				checkoutSession={checkoutSession}
-				clearCheckoutSession={clearCheckoutSession}
-			/>
+			<CheckoutLayout>
+				<CheckoutSummary
+					geoId={geoId}
+					appConfig={appConfig}
+					stripePublicKey={stripePublicKey}
+					isTestUser={isTestUser}
+					productKey={productKey}
+					ratePlanKey={ratePlanKey}
+					promotion={promotion}
+					originalAmount={payment.originalAmount}
+					discountedAmount={payment.discountedAmount}
+					contributionAmount={payment.contributionAmount}
+					finalAmount={payment.finalAmount}
+					useStripeExpressCheckout={useStripeExpressCheckout}
+					countryId={countryId}
+					forcedCountry={forcedCountry}
+					abParticipations={abParticipations}
+					landingPageSettings={landingPageSettings}
+					checkoutSession={checkoutSession}
+					clearCheckoutSession={clearCheckoutSession}
+				/>
+
+				<CheckoutForm
+					geoId={geoId}
+					appConfig={appConfig}
+					stripePublicKey={stripePublicKey}
+					isTestUser={isTestUser}
+					productKey={productKey}
+					ratePlanKey={ratePlanKey}
+					promotion={promotion}
+					originalAmount={payment.originalAmount}
+					discountedAmount={payment.discountedAmount}
+					contributionAmount={payment.contributionAmount}
+					finalAmount={payment.finalAmount}
+					useStripeExpressCheckout={useStripeExpressCheckout}
+					countryId={countryId}
+					forcedCountry={forcedCountry}
+					abParticipations={abParticipations}
+					landingPageSettings={landingPageSettings}
+					checkoutSession={checkoutSession}
+					clearCheckoutSession={clearCheckoutSession}
+				/>
+			</CheckoutLayout>
 		</Elements>
 	);
 }

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -15,7 +15,6 @@ import {
 import type { IsoCountry } from '@modules/internationalisation/country';
 import { countryGroups } from '@modules/internationalisation/countryGroup';
 import { BillingPeriod } from '@modules/product/billingPeriod';
-import type { PaperProductOptions } from '@modules/product/productOptions';
 import type { ProductKey } from '@modules/product-catalog/productCatalog';
 import {
 	ExpressCheckoutElement,
@@ -72,8 +71,6 @@ import { sendEventPaymentMethodSelected } from 'helpers/tracking/quantumMetric';
 import { logException } from 'helpers/utilities/logger';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
-import { displayPaperProductTabs } from 'pages/paper-subscription-landing/helpers/displayPaperProductTabs';
-import { getPaperRatePlanBenefits } from 'pages/paper-subscription-landing/planData';
 import { CheckoutDivider } from 'pages/supporter-plus-landing/components/checkoutDivider';
 import { ContributionCheckoutFinePrint } from 'pages/supporter-plus-landing/components/contributionCheckoutFinePrint';
 import { PatronsMessage } from 'pages/supporter-plus-landing/components/patronsMessage';
@@ -204,8 +201,6 @@ export default function CheckoutForm({
 		['GuardianWeeklyDomestic', 'GuardianWeeklyRestOfWorld'].includes(
 			productKey,
 		) && ['OneYearGift', 'ThreeMonthGift'].includes(ratePlanKey);
-	const isPaper = ['HomeDelivery', 'SubscriptionCard'].includes(productKey);
-	const showPaperProductTabs = isPaper && displayPaperProductTabs();
 
 	/** Delivery agent for National Delivery product */
 	const [deliveryPostcodeIsOutsideM25, setDeliveryPostcodeIsOutsideM25] =
@@ -706,82 +701,8 @@ export default function CheckoutForm({
 		ratePlanKey,
 	);
 
-	const paperPlusDigitalBenefits = showPaperProductTabs
-		? getPaperRatePlanBenefits(ratePlanKey as PaperProductOptions)
-		: undefined;
-	const benefitsCheckListData =
-		paperPlusDigitalBenefits ??
-		getBenefitsChecklistFromLandingPageTool(productKey, landingPageSettings) ??
-		getBenefitsChecklistFromProductDescription(
-			productDescription,
-			countryGroupId,
-			abParticipations,
-		);
-
 	return (
-<<<<<<< HEAD:support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
-		<CheckoutLayout>
-			<Box cssOverrides={shorterBoxMargin}>
-				<BoxContents>
-					{forcedCountry &&
-						productDescription.deliverableTo?.[forcedCountry] && (
-							<div role="alert">
-								<InfoSummary
-									cssOverrides={css`
-										margin-bottom: ${space[6]}px;
-									`}
-									message={`You've changed your delivery country to ${productDescription.deliverableTo[forcedCountry]}.`}
-									context={`Your subscription price has been updated to reflect the rates in your new location.`}
-								/>
-							</div>
-						)}
-					<ContributionsOrderSummary
-						productKey={productKey}
-						productDescription={productDescription.label}
-						ratePlanKey={ratePlanKey}
-						ratePlanDescription={ratePlanDescription.label}
-						paymentFrequency={getBillingPeriodNoun(
-							ratePlanDescription.billingPeriod,
-						)}
-						amount={originalAmount}
-						promotion={promotion}
-						currency={currency}
-						checkListData={benefitsCheckListData}
-						onCheckListToggle={(isOpen) => {
-							trackComponentClick(
-								`contribution-order-summary-${isOpen ? 'opened' : 'closed'}`,
-							);
-						}}
-						enableCheckList={true}
-						startDate={
-							<OrderSummaryStartDate
-								productKey={productKey}
-								startDate={formatUserDate(getTierThreeDeliveryDate())}
-							/>
-						}
-						tsAndCs={
-							<OrderSummaryTsAndCs
-								productKey={productKey}
-								ratePlanKey={ratePlanKey}
-								countryGroupId={countryGroupId}
-								thresholdAmount={thresholdAmount}
-								promotion={promotion}
-							/>
-						}
-						headerButton={
-							showBackButton && (
-								<BackButton
-									path={`/${geoId}${productDescription.landingPagePath}`}
-									buttonText={'Change'}
-								/>
-							)
-						}
-					/>
-				</BoxContents>
-			</Box>
-=======
 		<>
->>>>>>> e52b4d8aa (split checkout form from summary):support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
 			<form
 				ref={formRef}
 				onSubmit={(event) => {

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -11,7 +11,6 @@ import {
 import {
 	Divider,
 	ErrorSummary,
-	InfoSummary,
 } from '@guardian/source-development-kitchen/react-components';
 import type { IsoCountry } from '@modules/internationalisation/country';
 import { countryGroups } from '@modules/internationalisation/countryGroup';
@@ -33,11 +32,6 @@ import { useEffect, useRef, useState } from 'react';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import DirectDebitForm from 'components/directDebit/directDebitForm/directDebitForm';
 import { checkAccount } from 'components/directDebit/helpers/ajax';
-import { ContributionsOrderSummary } from 'components/orderSummary/contributionsOrderSummary';
-import {
-	OrderSummaryStartDate,
-	OrderSummaryTsAndCs,
-} from 'components/orderSummary/orderSummaryTsAndCs';
 import { paymentMethodData } from 'components/paymentMethodSelector/paymentMethodData';
 import { StateSelect } from 'components/personalDetails/stateSelect';
 import { Recaptcha } from 'components/recaptcha/recaptcha';
@@ -69,13 +63,11 @@ import {
 	productCatalogDescriptionNewBenefits,
 	showSimilarProductsConsentForRatePlan,
 } from 'helpers/productCatalog';
-import { getBillingPeriodNoun } from 'helpers/productPrice/billingPeriods';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import type { AddressFormFieldError } from 'helpers/redux/checkout/address/state';
 import type { CsrfState } from 'helpers/redux/checkout/csrf/state';
 import { useAbandonedBasketCookie } from 'helpers/storage/abandonedBasketCookies';
 import { getLowerProductBenefitThreshold } from 'helpers/supporterPlus/benefitsThreshold';
-import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { sendEventPaymentMethodSelected } from 'helpers/tracking/quantumMetric';
 import { logException } from 'helpers/utilities/logger';
 import type { GeoId } from 'pages/geoIdConfig';
@@ -91,18 +83,10 @@ import { postcodeIsWithinDeliveryArea } from '../../../helpers/forms/deliveryChe
 import { appropriateErrorMessage } from '../../../helpers/forms/errorReasons';
 import { isValidPostcode } from '../../../helpers/forms/formValidation';
 import type { LandingPageVariant } from '../../../helpers/globalsAndSwitches/landingPageSettings';
-import { formatUserDate } from '../../../helpers/utilities/dateConversions';
 import { DeliveryAgentsSelect } from '../../paper-subscription-checkout/components/deliveryAgentsSelect';
-import {
-	getTierThreeDeliveryDate,
-	getWeeklyDays,
-} from '../../weekly-subscription-checkout/helpers/deliveryDays';
+import { getWeeklyDays } from '../../weekly-subscription-checkout/helpers/deliveryDays';
 import { PersonalDetailsFields } from '../checkout/components/PersonalDetailsFields';
 import { WeeklyDeliveryDates } from '../checkout/components/WeeklyDeliveryDates';
-import {
-	getBenefitsChecklistFromLandingPageTool,
-	getBenefitsChecklistFromProductDescription,
-} from '../checkout/helpers/benefitsChecklist';
 import type { DeliveryAgentsResponse } from '../checkout/helpers/getDeliveryAgents';
 import { getDeliveryAgents } from '../checkout/helpers/getDeliveryAgents';
 import { getProductFields } from '../checkout/helpers/getProductFields';
@@ -114,8 +98,6 @@ import {
 	doesNotContainExtendedEmojiOrLeadingSpace,
 	preventDefaultValidityMessage,
 } from '../validation';
-import { BackButton } from './backButton';
-import { CheckoutLayout } from './checkoutLayout';
 import { CheckoutLoadingOverlay } from './checkoutLoadingOverlay';
 import {
 	FormSection,
@@ -147,7 +129,7 @@ function paymentMethodIsActive(paymentMethod: LegacyPaymentMethod) {
 	);
 }
 
-type CheckoutComponentProps = {
+type CheckoutFormProps = {
 	geoId: GeoId;
 	appConfig: AppConfig;
 	stripePublicKey: string;
@@ -182,7 +164,7 @@ const getPaymentMethods = (
 	return [maybeDirectDebit, Stripe, PayPal];
 };
 
-export function CheckoutComponent({
+export default function CheckoutForm({
 	geoId,
 	appConfig,
 	stripePublicKey,
@@ -195,18 +177,13 @@ export function CheckoutComponent({
 	promotion,
 	useStripeExpressCheckout,
 	countryId,
-	forcedCountry,
 	abParticipations,
-	landingPageSettings,
 	checkoutSession,
 	clearCheckoutSession,
-}: CheckoutComponentProps) {
+}: CheckoutFormProps) {
 	const csrf: CsrfState = appConfig.csrf;
 	const user = appConfig.user;
 	const isSignedIn = !!user?.email;
-
-	const urlParams = new URLSearchParams(window.location.search);
-	const showBackButton = urlParams.get('backButton') !== 'false';
 
 	const productCatalog = appConfig.productCatalog;
 	const { currency, currencyKey, countryGroupId } = getGeoIdConfig(geoId);
@@ -742,6 +719,7 @@ export function CheckoutComponent({
 		);
 
 	return (
+<<<<<<< HEAD:support-frontend/assets/pages/[countryGroupId]/components/checkoutComponent.tsx
 		<CheckoutLayout>
 			<Box cssOverrides={shorterBoxMargin}>
 				<BoxContents>
@@ -801,6 +779,9 @@ export function CheckoutComponent({
 					/>
 				</BoxContents>
 			</Box>
+=======
+		<>
+>>>>>>> e52b4d8aa (split checkout form from summary):support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
 			<form
 				ref={formRef}
 				onSubmit={(event) => {
@@ -1508,6 +1489,6 @@ export function CheckoutComponent({
 					hideProcessingMessage={isRedirectingToStripeHostedCheckout}
 				/>
 			)}
-		</CheckoutLayout>
+		</>
 	);
 }

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
@@ -3,6 +3,7 @@ import { space } from '@guardian/source/foundations';
 import { InfoSummary } from '@guardian/source-development-kitchen/react-components';
 import type { IsoCountry } from '@modules/internationalisation/country';
 import { BillingPeriod } from '@modules/product/billingPeriod';
+import type { PaperProductOptions } from '@modules/product/productOptions';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { ContributionsOrderSummary } from 'components/orderSummary/contributionsOrderSummary';
 import {
@@ -25,9 +26,9 @@ import type { Promotion } from 'helpers/productPrice/promotions';
 import { getLowerProductBenefitThreshold } from 'helpers/supporterPlus/benefitsThreshold';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import type { GeoId } from 'pages/geoIdConfig';
+import { getGeoIdConfig } from 'pages/geoIdConfig';
 import { displayPaperProductTabs } from 'pages/paper-subscription-landing/helpers/displayPaperProductTabs';
 import { getPaperRatePlanBenefits } from 'pages/paper-subscription-landing/planData';
-import { getGeoIdConfig } from 'pages/geoIdConfig';
 import type { LandingPageVariant } from '../../../helpers/globalsAndSwitches/landingPageSettings';
 import { formatUserDate } from '../../../helpers/utilities/dateConversions';
 import { getTierThreeDeliveryDate } from '../../weekly-subscription-checkout/helpers/deliveryDays';
@@ -39,7 +40,6 @@ import { getProductFields } from '../checkout/helpers/getProductFields';
 import type { CheckoutSession } from '../checkout/helpers/stripeCheckoutSession';
 import { BackButton } from './backButton';
 import { shorterBoxMargin } from './form';
-import type { PaperProductOptions } from '@modules/product/productOptions';
 
 type CheckoutSummaryProps = {
 	geoId: GeoId;

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
@@ -1,0 +1,230 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/source/foundations';
+import { InfoSummary } from '@guardian/source-development-kitchen/react-components';
+import type { IsoCountry } from '@modules/internationalisation/country';
+import { BillingPeriod } from '@modules/product/billingPeriod';
+import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
+import { ContributionsOrderSummary } from 'components/orderSummary/contributionsOrderSummary';
+import {
+	OrderSummaryStartDate,
+	OrderSummaryTsAndCs,
+} from 'components/orderSummary/orderSummaryTsAndCs';
+import { getAmountsTestVariant } from 'helpers/abTests/abtest';
+import type { Participations } from 'helpers/abTests/models';
+import { isContributionsOnlyCountry } from 'helpers/contributions';
+import type { AppConfig } from 'helpers/globalsAndSwitches/window';
+import { fromCountryGroupId } from 'helpers/internationalisation/currency';
+import {
+	type ActiveProductKey,
+	type ActiveRatePlanKey,
+	productCatalogDescription,
+	productCatalogDescriptionNewBenefits,
+} from 'helpers/productCatalog';
+import { getBillingPeriodNoun } from 'helpers/productPrice/billingPeriods';
+import type { Promotion } from 'helpers/productPrice/promotions';
+import { getLowerProductBenefitThreshold } from 'helpers/supporterPlus/benefitsThreshold';
+import { trackComponentClick } from 'helpers/tracking/behaviour';
+import type { GeoId } from 'pages/geoIdConfig';
+import { displayPaperProductTabs } from 'pages/paper-subscription-landing/helpers/displayPaperProductTabs';
+import { getPaperRatePlanBenefits } from 'pages/paper-subscription-landing/planData';
+import { getGeoIdConfig } from 'pages/geoIdConfig';
+import type { LandingPageVariant } from '../../../helpers/globalsAndSwitches/landingPageSettings';
+import { formatUserDate } from '../../../helpers/utilities/dateConversions';
+import { getTierThreeDeliveryDate } from '../../weekly-subscription-checkout/helpers/deliveryDays';
+import {
+	getBenefitsChecklistFromLandingPageTool,
+	getBenefitsChecklistFromProductDescription,
+} from '../checkout/helpers/benefitsChecklist';
+import { getProductFields } from '../checkout/helpers/getProductFields';
+import type { CheckoutSession } from '../checkout/helpers/stripeCheckoutSession';
+import { BackButton } from './backButton';
+import { shorterBoxMargin } from './form';
+import type { PaperProductOptions } from '@modules/product/productOptions';
+
+type CheckoutSummaryProps = {
+	geoId: GeoId;
+	appConfig: AppConfig;
+	stripePublicKey: string;
+	isTestUser: boolean;
+	productKey: ActiveProductKey;
+	ratePlanKey: ActiveRatePlanKey;
+	originalAmount: number;
+	discountedAmount?: number;
+	contributionAmount?: number;
+	finalAmount: number;
+	promotion?: Promotion;
+	useStripeExpressCheckout: boolean;
+	countryId: IsoCountry;
+	forcedCountry?: string;
+	abParticipations: Participations;
+	landingPageSettings: LandingPageVariant;
+	checkoutSession?: CheckoutSession;
+	clearCheckoutSession: () => void;
+};
+
+export default function CheckoutComponent({
+	geoId,
+	appConfig,
+	productKey,
+	ratePlanKey,
+	originalAmount,
+	contributionAmount,
+	finalAmount,
+	promotion,
+	countryId,
+	forcedCountry,
+	abParticipations,
+	landingPageSettings,
+}: CheckoutSummaryProps) {
+	const urlParams = new URLSearchParams(window.location.search);
+	const showBackButton = urlParams.get('backButton') !== 'false';
+
+	const isPaper = ['HomeDelivery', 'SubscriptionCard'].includes(productKey);
+	const showPaperProductTabs = isPaper && displayPaperProductTabs();
+
+	const productCatalog = appConfig.productCatalog;
+	const { currency, currencyKey, countryGroupId } = getGeoIdConfig(geoId);
+
+	const showNewspaperArchiveBenefit = ['v1', 'v2', 'control'].includes(
+		abParticipations.newspaperArchiveBenefit ?? '',
+	);
+
+	const productDescription = showNewspaperArchiveBenefit
+		? productCatalogDescriptionNewBenefits(countryGroupId)[productKey]
+		: productCatalogDescription[productKey];
+	const ratePlanDescription = productDescription.ratePlans[ratePlanKey] ?? {
+		billingPeriod: BillingPeriod.Monthly,
+	};
+
+	const isRecurringContribution = productKey === 'Contribution';
+
+	const productFields = getProductFields({
+		product: {
+			productKey,
+			productDescription,
+			ratePlanKey,
+			deliveryAgent: undefined,
+		},
+		financial: {
+			currencyKey,
+			finalAmount,
+			originalAmount,
+			contributionAmount,
+		},
+	});
+
+	/**
+	 * Is It a Contribution? URL queryPrice supplied?
+	 *    If queryPrice above ratePlanPrice, in a upgrade to S+ country, invalid amount
+	 */
+	let isInvalidAmount = false;
+	if (isRecurringContribution) {
+		const supporterPlusRatePlanPrice =
+			productCatalog.SupporterPlus?.ratePlans[ratePlanKey]?.pricing[
+				currencyKey
+			];
+
+		const { selectedAmountsVariant } = getAmountsTestVariant(
+			countryId,
+			countryGroupId,
+			appConfig.settings,
+		);
+		if (originalAmount < 1) {
+			isInvalidAmount = true;
+		}
+		if (!isContributionsOnlyCountry(selectedAmountsVariant)) {
+			if (originalAmount >= (supporterPlusRatePlanPrice ?? 0)) {
+				isInvalidAmount = true;
+			}
+		}
+	}
+
+	if (isInvalidAmount) {
+		return <div>Invalid Amount {originalAmount}</div>;
+	}
+
+	const billingPeriod = productFields.billingPeriod;
+	/*
+  TODO :  Passed down because minimum product prices are unavailable in the paymentTsAndCs story
+          We should revisit this and see if we can remove this prop, pushing it lower down the tree
+  */
+	const thresholdAmount = getLowerProductBenefitThreshold(
+		billingPeriod,
+		fromCountryGroupId(countryGroupId),
+		countryGroupId,
+		productKey,
+		ratePlanKey,
+	);
+
+	const paperPlusDigitalBenefits = showPaperProductTabs
+		? getPaperRatePlanBenefits(ratePlanKey as PaperProductOptions)
+		: undefined;
+	const benefitsCheckListData =
+		paperPlusDigitalBenefits ??
+		getBenefitsChecklistFromLandingPageTool(productKey, landingPageSettings) ??
+		getBenefitsChecklistFromProductDescription(
+			productDescription,
+			countryGroupId,
+			abParticipations,
+		);
+
+	return (
+		<Box cssOverrides={shorterBoxMargin}>
+			<BoxContents>
+				{forcedCountry && productDescription.deliverableTo?.[forcedCountry] && (
+					<div role="alert">
+						<InfoSummary
+							cssOverrides={css`
+								margin-bottom: ${space[6]}px;
+							`}
+							message={`You've changed your delivery country to ${productDescription.deliverableTo[forcedCountry]}.`}
+							context={`Your subscription price has been updated to reflect the rates in your new location.`}
+						/>
+					</div>
+				)}
+				<ContributionsOrderSummary
+					productKey={productKey}
+					productDescription={productDescription.label}
+					ratePlanKey={ratePlanKey}
+					ratePlanDescription={ratePlanDescription.label}
+					paymentFrequency={getBillingPeriodNoun(
+						ratePlanDescription.billingPeriod,
+					)}
+					amount={originalAmount}
+					promotion={promotion}
+					currency={currency}
+					checkListData={benefitsCheckListData}
+					onCheckListToggle={(isOpen) => {
+						trackComponentClick(
+							`contribution-order-summary-${isOpen ? 'opened' : 'closed'}`,
+						);
+					}}
+					enableCheckList={true}
+					startDate={
+						<OrderSummaryStartDate
+							productKey={productKey}
+							startDate={formatUserDate(getTierThreeDeliveryDate())}
+						/>
+					}
+					tsAndCs={
+						<OrderSummaryTsAndCs
+							productKey={productKey}
+							ratePlanKey={ratePlanKey}
+							countryGroupId={countryGroupId}
+							thresholdAmount={thresholdAmount}
+							promotion={promotion}
+						/>
+					}
+					headerButton={
+						showBackButton && (
+							<BackButton
+								path={`/${geoId}${productDescription.landingPagePath}`}
+								buttonText={'Change'}
+							/>
+						)
+					}
+				/>
+			</BoxContents>
+		</Box>
+	);
+}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Declutter order summary from the check form.
- Remove orderSummary logic from `checkoutComponent.tsx` into `checkoutSummary.tsx`.
- Rename `checkoutComponent.tsx` to `checkoutForm.tsx`
- import both from `checkout.tsx` module.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?
The checkout component is doing to much, and following the single responsibility principle they should be diferent components.
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
