### PR TITLE
Update form-data NPM package from 4.0.2 to 4.0.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5035,8 +5035,8 @@ packages:
     resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
     engines: {node: '>= 0.12'}
 
-  form-data@4.0.2:
-    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
   formatly@0.2.3:
@@ -14508,11 +14508,12 @@ snapshots:
       mime-types: 2.1.35
       safe-buffer: 5.2.1
 
-  form-data@4.0.2:
+  form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
 
   formatly@0.2.3:
@@ -15694,7 +15695,7 @@ snapshots:
       decimal.js: 10.5.0
       domexception: 4.0.0
       escodegen: 2.1.0
-      form-data: 4.0.2
+      form-data: 4.0.4
       html-encoding-sniffer: 3.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1


### PR DESCRIPTION
## What are you doing in this PR?

This fixes a dependabot vulnerability (see also #7170).

There were two places where 4.0.2 existed in the lockfile (both as dev dependencies, brought in by jsdom):

In support-frontend:

```
devDependencies:
jest-environment-jsdom 29.7.0
└─┬ jsdom 20.0.3
  └── form-data 4.0.2
jest-environment-jsdom-global 4.0.0
└─┬ jest-environment-jsdom 29.7.0 peer
  └─┬ jsdom 20.0.3
    └── form-data 4.0.2
```

In bigquery-acquisitions-publisher:
```
devDependencies:
vitest 3.1.4
└─┬ jsdom 20.0.3 peer
  └── form-data 4.0.2
```

In both cases it was being brought in as a transative dependency of jsdom, which species a version range of `^4.0.0`. So the non-vulnerable version 4.0.4 fits this range. Unfortunately using `pnpm update form-data` resulted in lots of unrelated changes so I resorted to updating the lockfile manually to resolve jsdom's form-data version to 4.0.4 and deleting the 4.0.2 resolution. Running pnpm install then reports this as broken and fixes, picking up the desired 4.0.4.

## Why are you doing this?

Fix a vulnerability reported by dependabot.

## How to test

Since in both cases this is a dev dependencies, I think CI being green is a good indicator.

Just to be cautious I deployed support-frontend to CODE and ran the smoke tests.

## How can we measure success?

The vulnerability disappears from dependabot.