### PR TITLE
Remove accountExists boolean from TS requestInfo schema

### DIFF
--- a/support-workers/src/typescript/model/stateSchemas.ts
+++ b/support-workers/src/typescript/model/stateSchemas.ts
@@ -129,7 +129,6 @@ const requestInfoSchema = z.object({
 	testUser: z.boolean(),
 	failed: z.boolean(),
 	messages: z.array(z.string()),
-	accountExists: z.boolean(),
 });
 
 export type RequestInfo = z.infer<typeof requestInfoSchema>;
@@ -144,12 +143,7 @@ export type WrappedState<InputState> = {
 		Error: string;
 		Cause: string;
 	} | null;
-	requestInfo: {
-		testUser: boolean;
-		failed: boolean;
-		messages: string[];
-		accountExists: boolean;
-	};
+	requestInfo: RequestInfo;
 };
 
 export function wrapperSchemaForState<SchemaType extends z.ZodTypeAny>(

--- a/support-workers/src/typescript/test/salesforce.it.test.ts
+++ b/support-workers/src/typescript/test/salesforce.it.test.ts
@@ -130,7 +130,6 @@ describe('CreateSalesforceContatctLambda', () => {
 				testUser: false,
 				failed: false,
 				messages: [],
-				accountExists: false,
 			}),
 		);
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
#7168 removed the accountExists boolean from the Scala models, but did not remove it from the Typescript one. This caused failures when support-frontend stopped sending this field.