### PR TITLE
Scroll to Errors for PayPal click

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -161,7 +161,7 @@ const getPaymentMethods = (
 	return [maybeDirectDebit, Stripe, PayPal];
 };
 
-export default function CheckoutForm({
+export function CheckoutComponent({
 	geoId,
 	appConfig,
 	stripePublicKey,

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -161,7 +161,7 @@ const getPaymentMethods = (
 	return [maybeDirectDebit, Stripe, PayPal];
 };
 
-export function CheckoutComponent({
+export default function CheckoutForm({
 	geoId,
 	appConfig,
 	stripePublicKey,

--- a/support-frontend/assets/pages/[countryGroupId]/components/submitButton.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/submitButton.tsx
@@ -57,6 +57,8 @@ export function SubmitButton({
 						}}
 						commit={true}
 						validate={({ disable, enable }) => {
+							/** We run this so the form validation happens and focus on errors */
+							formRef.current?.requestSubmit();
 							/** We run this initially to set the button to the correct state */
 							const valid = formRef.current?.checkValidity();
 							if (valid) {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Run form submission on Paypal click in order to mimic the other payment methods error focus.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/9FL7KWx9/1714-generic-checkout-clicking-paypal-cta-with-unfilled-personal-details-doesnt-scroll-to-errors)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
