### PR TITLE
Revert "Fix jackson-core vulnerability in supporter-product-data"

### DIFF
--- a/supporter-product-data/build.sbt
+++ b/supporter-product-data/build.sbt
@@ -6,9 +6,10 @@ version := "0.1-SNAPSHOT"
 
 libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "dynamodb" % awsClientVersion2,
-  "software.amazon.awssdk" % "ssm" % awsClientVersion2,
-  "software.amazon.awssdk" % "s3" % awsClientVersion2,
-  "software.amazon.awssdk" % "sqs" % awsClientVersion2,
+  "com.amazonaws" % "aws-java-sdk-ssm" % awsClientVersion,
+  "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
+  "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion,
+  "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsClientVersion,
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/supporter-product-data/src/main/scala/com/gu/AWSAsyncHandler.scala
+++ b/supporter-product-data/src/main/scala/com/gu/AWSAsyncHandler.scala
@@ -1,55 +1,50 @@
 package com.gu
 
+import com.amazonaws.handlers.AsyncHandler
+import com.amazonaws.{AmazonServiceException, AmazonWebServiceRequest}
 import com.typesafe.scalalogging.LazyLogging
-import software.amazon.awssdk.awscore.AwsRequest
-import software.amazon.awssdk.awscore.exception.AwsServiceException
 
-import java.util.concurrent.CompletableFuture
+import java.util.concurrent.{Future => JFuture}
 import scala.concurrent.{Future, Promise}
 
-class AwsAsyncHandler[Request <: AwsRequest, Response](
-    f: (Request) => CompletableFuture[Response],
+class AwsAsyncHandler[Request <: AmazonWebServiceRequest, Response](
+    f: (Request, AsyncHandler[Request, Response]) => JFuture[Response],
     request: Request,
-    promise: Promise[Response] = Promise[Response](),
-) extends LazyLogging {
-  val result: CompletableFuture[Response] = f(request)
+) extends AsyncHandler[Request, Response]
+    with LazyLogging {
+  f(request, this)
 
-  result
-    .thenAccept((response: Response) => {
-      logger.debug(s"Successful result from AwsAsyncHandler")
+  private val promise = Promise[Response]()
 
-      promise.success(response)
-    })
-    .exceptionally((exception: Throwable) => {
-      logger.warn("Failure from AwsAsyncHandler", exception)
+  override def onError(exception: Exception): Unit = {
+    logger.warn("Failure from AWSAsyncHandler", exception)
+    exception match {
+      case e: AmazonServiceException =>
+        if (e.getErrorCode == "ThrottlingException") {
+          logger.warn(
+            "A rate limiting exception was thrown, we may need to adjust the rate limiting in ClientWrapper.scala",
+          )
+          Thread.sleep(1000) // Wait for a second and retry
+          f(request, this)
+        } else {
+          promise.failure(exception)
+        }
+      case _ => promise.failure(exception)
+    }
+  }
 
-      exception match {
-        case e: AwsServiceException =>
-          if (e.awsErrorDetails.errorCode == "ThrottlingException") {
-            logger.warn(
-              "A rate limiting exception was thrown, we may need to adjust the rate limiting in ClientWrapper.scala",
-            )
-            Thread.sleep(1000) // Wait for a second and retry
-            // Pass the promise from this instance down, so that it can be completed/failed later
-            new AwsAsyncHandler(f, request, promise)
-          } else {
-            promise.failure(exception)
-          }
-        case _ => promise.failure(exception)
-      }
-
-      promise.failure(exception)
-
-      null
-    })
+  override def onSuccess(request: Request, result: Response): Unit = {
+    logger.debug(s"Successful result from AWS AsyncHandler")
+    promise.success(result)
+  }
 
   def future: Future[Response] = promise.future
 }
 
 object AwsAsync {
 
-  def apply[Request <: AwsRequest, Response](
-      f: (Request) => CompletableFuture[Response],
+  def apply[Request <: AmazonWebServiceRequest, Response](
+      f: (Request, AsyncHandler[Request, Response]) => JFuture[Response],
       request: Request,
   ): Future[Response] = {
     val handler = new AwsAsyncHandler[Request, Response](f, request)

--- a/supporter-product-data/src/main/scala/com/gu/lambdas/AddSupporterRatePlanItemToQueueLambda.scala
+++ b/supporter-product-data/src/main/scala/com/gu/lambdas/AddSupporterRatePlanItemToQueueLambda.scala
@@ -41,7 +41,7 @@ object AddSupporterRatePlanItemToQueueLambda extends StrictLogging {
     logger.info(s"Starting to add subscriptions to queue for ${state.recordCount} records from ${state.filename}")
 
     val s3Object = S3Service.streamFromS3(stage, state.filename)
-    val csvReader = s3Object.asCsvReader[SupporterRatePlanItem](rfc.withHeader)
+    val csvReader = s3Object.getObjectContent.asCsvReader[SupporterRatePlanItem](rfc.withHeader)
     val sqsService = SqsService(stage)
     val alarmService = AlarmService(stage)
 

--- a/supporter-product-data/src/main/scala/com/gu/lambdas/FetchResultsLambda.scala
+++ b/supporter-product-data/src/main/scala/com/gu/lambdas/FetchResultsLambda.scala
@@ -41,14 +41,8 @@ object FetchResultsLambda extends StrictLogging {
         fileResponse.isSuccessful,
         s"File download for job with id $jobId failed with http code ${fileResponse.code}",
       )
-      contentLength = fileResponse.body.contentLength
-      _ = assert(
-        contentLength > 0,
-        s"Content length of the file for job with id $jobId is not > 0",
-      )
-      byteStream = fileResponse.body.byteStream
-      _ = S3Service.streamToS3(stage, filename, byteStream, contentLength)
-      _ = byteStream.close()
+      val contentLength = if (fileResponse.body.contentLength >= 0) Some(fileResponse.body.contentLength) else None
+      _ = S3Service.streamToS3(stage, filename, fileResponse.body.byteStream, contentLength)
     } yield {
       logger.info(s"Successfully wrote file $filename to S3 with ${batch.recordCount} records for jobId $jobId")
       if (batch.recordCount == 0)

--- a/supporter-product-data/src/main/scala/com/gu/services/ConfigService.scala
+++ b/supporter-product-data/src/main/scala/com/gu/services/ConfigService.scala
@@ -1,6 +1,6 @@
 package com.gu.services
 
-import software.amazon.awssdk.services.ssm.model.Parameter
+import com.amazonaws.services.simplesystemsmanagement.model.Parameter
 import com.gu.conf.ZuoraQuerierConfig
 import com.gu.monitoring.SafeLogger
 import com.gu.supporterdata.model.Stage.{CODE, PROD}
@@ -80,8 +80,8 @@ class ConfigService(stage: Stage) extends StrictLogging {
 
   private def findParameterValue(name: String, params: List[Parameter]) =
     params
-      .find(_.name.split('/').last == name)
-      .map(_.value)
+      .find(_.getName.split('/').last == name)
+      .map(_.getValue)
 
   def putLastSuccessfulQueryTime(time: ZonedDateTime) = {
     val timeAsString = time.format(DateTimeFormatter.ISO_DATE_TIME)

--- a/supporter-product-data/src/main/scala/com/gu/services/DiscountService.scala
+++ b/supporter-product-data/src/main/scala/com/gu/services/DiscountService.scala
@@ -30,7 +30,7 @@ class S3CatalogLoader(stage: Stage) extends CatalogLoader with LazyLogging {
     logger.info(s"Attempting to load catalog from $bucket/$key")
 
     Try(
-      S3Service.getAsString(bucket, key),
+      S3Service.s3Client.getObjectAsString(bucket, key),
     )
   }
 }

--- a/supporter-product-data/src/main/scala/com/gu/services/ParameterStoreService.scala
+++ b/supporter-product-data/src/main/scala/com/gu/services/ParameterStoreService.scala
@@ -1,70 +1,76 @@
 package com.gu.services
 
-import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.ssm.{SsmAsyncClient, SsmClient}
-import software.amazon.awssdk.services.ssm.model.{
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.auth.{
+  AWSCredentialsProviderChain,
+  EC2ContainerCredentialsProviderWrapper,
+  EnvironmentVariableCredentialsProvider,
+  InstanceProfileCredentialsProvider,
+}
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.simplesystemsmanagement.model.{
   GetParameterRequest,
   GetParametersByPathRequest,
   ParameterType,
   PutParameterRequest,
 }
-import com.gu.aws.CredentialsProvider
+import com.amazonaws.services.simplesystemsmanagement.{
+  AWSSimpleSystemsManagementAsync,
+  AWSSimpleSystemsManagementAsyncClientBuilder,
+}
 import com.gu.AwsAsync
+import com.gu.aws.ProfileName
 import com.gu.supporterdata.model.Stage
 
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
-class ParameterStoreService(client: SsmClient, asyncClient: SsmAsyncClient, stage: Stage) {
+class ParameterStoreService(client: AWSSimpleSystemsManagementAsync, stage: Stage) {
   val configRoot = s"/supporter-product-data/${stage.value}"
 
   def getParametersByPath(path: String)(implicit executionContext: ExecutionContext) = {
-    val request: GetParametersByPathRequest = GetParametersByPathRequest
-      .builder()
-      .path(s"$configRoot/$path/")
-      .recursive(false)
-      .withDecryption(true)
-      .build()
-
-    client.getParametersByPath(request).parameters().asScala.toList
+    val request: GetParametersByPathRequest = new GetParametersByPathRequest()
+      .withPath(s"$configRoot/$path/")
+      .withRecursive(false)
+      .withWithDecryption(true)
+    client.getParametersByPath(request).getParameters.asScala.toList
   }
 
   def getParameter(name: String)(implicit executionContext: ExecutionContext) = {
-    val request = GetParameterRequest
-      .builder()
-      .name(s"$configRoot/$name")
-      .withDecryption(true)
-      .build()
+    val request = new GetParameterRequest()
+      .withName(s"$configRoot/$name")
+      .withWithDecryption(true)
 
-    AwsAsync((request: GetParameterRequest) => asyncClient.getParameter(request), request).map(_.parameter().value())
+    AwsAsync(client.getParameterAsync, request).map(_.getParameter.getValue)
   }
 
-  def putParameter(name: String, value: String) = {
-    val putParameterRequest = PutParameterRequest
-      .builder()
-      .name(s"$configRoot/$name")
-      .`type`(ParameterType.STRING)
-      .value(value)
-      .overwrite(true)
-      .build()
+  def putParameter(name: String, value: String, parameterType: ParameterType = ParameterType.String) = {
 
-    AwsAsync((request: PutParameterRequest) => asyncClient.putParameter(request), putParameterRequest)
+    val putParameterRequest = new PutParameterRequest()
+      .withName(s"$configRoot/$name")
+      .withType(parameterType)
+      .withValue(value)
+      .withOverwrite(true)
+
+    AwsAsync(client.putParameterAsync, putParameterRequest)
   }
 
 }
 
 object ParameterStoreService {
-  lazy val client: SsmClient = SsmClient
-    .builder()
-    .credentialsProvider(CredentialsProvider)
-    .region(Region.EU_WEST_1)
+  // please update to AWS SDK 2 and use com.gu.aws.CredentialsProvider
+  lazy val CredentialsProviderDEPRECATEDV1 = new AWSCredentialsProviderChain(
+    new ProfileCredentialsProvider(ProfileName),
+    new InstanceProfileCredentialsProvider(false),
+    new EnvironmentVariableCredentialsProvider(),
+    new EC2ContainerCredentialsProviderWrapper(), // for use with lambda snapstart
+  )
+
+  lazy val client = AWSSimpleSystemsManagementAsyncClientBuilder
+    .standard()
+    .withRegion(Regions.EU_WEST_1)
+    .withCredentials(CredentialsProviderDEPRECATEDV1)
     .build()
 
-  lazy val asyncClient: SsmAsyncClient = SsmAsyncClient
-    .builder()
-    .credentialsProvider(CredentialsProvider)
-    .region(Region.EU_WEST_1)
-    .build()
-
-  def apply(stage: Stage) = new ParameterStoreService(client, asyncClient, stage)
+  def apply(stage: Stage) = new ParameterStoreService(client, stage)
 }

--- a/supporter-product-data/src/main/scala/com/gu/services/SqsService.scala
+++ b/supporter-product-data/src/main/scala/com/gu/services/SqsService.scala
@@ -1,18 +1,14 @@
 package com.gu.services
 
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder
+import com.amazonaws.services.sqs.model.{SendMessageBatchRequest, SendMessageBatchRequestEntry}
 import com.gu.monitoring.SafeLogging
+import com.gu.services.ParameterStoreService.CredentialsProviderDEPRECATEDV1
 import com.gu.supporterdata.model.{ContributionAmount, Stage, SupporterRatePlanItem}
-import com.gu.aws.CredentialsProvider
 import io.circe.Encoder
 import io.circe.generic.semiauto.deriveEncoder
 import io.circe.syntax.EncoderOps
-import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.sqs.model.{
-  GetQueueUrlRequest,
-  SendMessageBatchRequest,
-  SendMessageBatchRequestEntry,
-}
-import software.amazon.awssdk.services.sqs.SqsClient
 
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
@@ -22,44 +18,31 @@ class SqsService(queueName: String, alarmService: AlarmService)(implicit val exe
     extends SafeLogging {
   implicit val encoder: Encoder[SupporterRatePlanItem] = deriveEncoder
   implicit val contributionAmountEncoder: Encoder[ContributionAmount] = deriveEncoder
-  private val sqsClient = SqsClient
-    .builder()
-    .region(Region.EU_WEST_1)
-    .credentialsProvider(CredentialsProvider)
+  private val sqsClient = AmazonSQSAsyncClientBuilder.standard
+    .withCredentials(CredentialsProviderDEPRECATEDV1)
+    .withRegion(Regions.EU_WEST_1)
     .build()
 
-  private val getQueueUrlRequest = GetQueueUrlRequest
-    .builder()
-    .queueName(queueName)
-    .build()
-  private val queueUrl = sqsClient.getQueueUrl(getQueueUrlRequest).queueUrl
+  private val queueUrl = sqsClient.getQueueUrl(queueName).getQueueUrl
 
   def sendBatch(supporterRatePlanItems: List[(SupporterRatePlanItem, Int)]) = {
     logger.info(s"Sending message batch with ${supporterRatePlanItems.length} items to SQS queue $queueUrl")
 
     val batchRequestEntries = supporterRatePlanItems.map { case (item, index) =>
-      SendMessageBatchRequestEntry
-        .builder()
-        .id(index.toString)
-        .messageBody(item.asJson.noSpaces)
-        .build()
+      new SendMessageBatchRequestEntry(index.toString, item.asJson.noSpaces)
     }
 
-    val batchRequest = SendMessageBatchRequest
-      .builder()
-      .queueUrl(queueUrl)
-      .entries(batchRequestEntries.asJava)
-      .build()
+    val batchRequest = new SendMessageBatchRequest(queueUrl, batchRequestEntries.asJava)
     sqsClient.sendMessageBatch(batchRequest)
 
     Try(sqsClient.sendMessageBatch(batchRequest)) match {
       case Success(batchResult) =>
-        val failures = batchResult.failed.asScala.toList
+        val failures = batchResult.getFailed.asScala.toList
         if (failures.nonEmpty) {
           failures.foreach { error =>
-            val failedItem = supporterRatePlanItems(error.id.toInt)
+            val failedItem = supporterRatePlanItems(error.getId.toInt)
             logger.error(
-              scrub"Error writing to the queue\nFor item with body: ${failedItem.asJson}\nError message: ${error.message}",
+              scrub"Error writing to the queue\nFor item with body: ${failedItem.asJson}\nError message: ${error.getMessage}",
             )
           }
           alarmService.triggerSQSWriteAlarm

--- a/supporter-product-data/src/test/scala/com/gu/lambdas/AddSupporterRatePlanItemToQueueIntegrationTest.scala
+++ b/supporter-product-data/src/test/scala/com/gu/lambdas/AddSupporterRatePlanItemToQueueIntegrationTest.scala
@@ -1,0 +1,30 @@
+package com.gu.lambdas
+
+import com.gu.model.states.AddSupporterRatePlanItemToQueueState
+import com.gu.supporterdata.model.Stage.CODE
+import com.gu.test.tags.annotations.IntegrationTest
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.ZonedDateTime
+
+@IntegrationTest
+class AddSupporterRatePlanItemToQueueIntegrationTest extends AsyncFlatSpec with Matchers {
+
+  "AddSupporterRatePlanItemToQueueLambda" should "process records correctly" in {
+    val csvFilename = "test-fixture.csv"
+    AddSupporterRatePlanItemToQueueLambda.addToQueue(
+      CODE,
+      AddSupporterRatePlanItemToQueueState(
+        csvFilename,
+        248,
+        0,
+        ZonedDateTime.parse("2023-01-11T21:59:53.743208-08:00[America/Los_Angeles]"),
+      ),
+      new TimeOutCheck {
+        override def timeRemainingMillis: Int = 1000 * 60 * 5
+      },
+    )
+  }.map(outState => outState.processedCount shouldBe 9)
+
+}

--- a/supporter-product-data/src/test/scala/com/gu/services/S3ServiceSpec.scala
+++ b/supporter-product-data/src/test/scala/com/gu/services/S3ServiceSpec.scala
@@ -17,12 +17,7 @@ class S3ServiceSpec extends AsyncFlatSpec with Matchers {
     val stream = new ByteArrayInputStream(initialString.getBytes())
     val filename = s"test-file-${UUID.randomUUID().toString}"
     S3Service
-      .streamToS3(CODE, filename, stream, initialString.length)
-
-    val byteArray =
-      S3Service.streamFromS3(CODE, filename).readAllBytes()
-    val string = new String(byteArray, "UTF-8")
-
-    string shouldBe initialString
+      .streamToS3(CODE, filename, stream, Some(initialString.length))
+    Source.fromInputStream(S3Service.streamFromS3(CODE, filename).getObjectContent).mkString shouldBe initialString
   }
 }


### PR DESCRIPTION
Reverts guardian/support-frontend#7160.

Since merging to prod the numbers of records processed look strangely low so I'm going to revert this for now while I investigate.