### PR TITLE
Add deliveryAgent to CreateSalesforceContact state

### DIFF
--- a/support-workers/src/typescript/model/productType.ts
+++ b/support-workers/src/typescript/model/productType.ts
@@ -31,6 +31,7 @@ export const paperProductSchema = z.object({
 	fulfilmentOptions: fulfilmentOptionsSchema,
 	productOptions: productOptionsSchema,
 	productType: z.literal('Paper'),
+	deliveryAgent: z.number().nullish(),
 });
 export const guardianWeeklyProductSchema = z.object({
 	currency: isoCurrencySchema,


### PR DESCRIPTION
## What are you doing in this PR?

Add `deliveryAgent` field to CreateSalesforceContact state. It's an optional field because it's only there for national delivery paper subscriptions (not home delivery or subs card).

## Why are you doing this?

We lost this field in the migration from TypeScript to Scala and it means that some national delivery subscriptions haven't been able to be fulfilled. I don't think this field is actually used by the CreateSalesforceContact lambda but it's used by the CreateZuoraSubscription lambda so we need to pass it through.

## How to test

I've deployed to CODE and taken out a national delivery subscription, and can see this value make to to the CreateZuoraSubscription lambda (and can see it set in Zuora). For non national delivery paper subs the field is set to null which mirrors the old Scala behaviour.