### PR TITLE
Playwright: Digital Subscription Tests - UK-Only

### DIFF
--- a/support-e2e/tests/cron/digital-subscription.test.ts
+++ b/support-e2e/tests/cron/digital-subscription.test.ts
@@ -7,7 +7,7 @@ const tests = [
 		product: 'DigitalSubscription',
 		billingFrequency: 'Monthly',
 		paymentType: 'PayPal',
-		internationalisationId: 'EU',
+		internationalisationId: 'UK',
 	},
 ];
 

--- a/support-e2e/tests/smoke/digital-subscription.test.ts
+++ b/support-e2e/tests/smoke/digital-subscription.test.ts
@@ -14,7 +14,7 @@ const tests = [
 		product: 'DigitalSubscription',
 		billingFrequency: 'Annual',
 		paymentType: 'Credit/Debit card',
-		internationalisationId: 'US',
+		internationalisationId: 'UK',
 	},
 ];
 


### PR DESCRIPTION
## What are you doing in this PR?

An amendment to [Playwright: Digital Subscription Tests PR](https://github.com/guardian/support-frontend/pull/7182)

Orignallly added a US/EU tests to the DigitalEdition product.

Unlike dev, the prod route from the [us/eu subscription landing page](https://support.theguardian.com/us/subscribe) is redirected (via fastly)
 
Currenty, our test needs to start from [subscription landing page](https://support.theguardian.com/uk/subscribe). Therfore neds to be uk-only dues to fastly redirect setup. 

Think makes sense to :-
1. correct this out initally for cron and smoke tests (this PR).
2. possibly look to not start from the landing page for non-uk digital edition product (future PR)
