### PR TITLE
Migrate away from deprecated ThemeProvider

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/components/form.tsx
@@ -1,11 +1,11 @@
 // ----- Imports ----- //
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import {
 	Button,
-	buttonThemeReaderRevenueBrand,
 	Checkbox,
 	SvgArrowRightStraight,
 	TextInput,
+	themeButtonReaderRevenueBrand,
 } from '@guardian/source/react-components';
 import * as React from 'react';
 import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';
@@ -136,17 +136,16 @@ function Form(props: PropTypes): JSX.Element {
 				/>
 			</div>
 
-			<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-				<Button
-					id="qa-direct-debit-submit"
-					onClick={props.onSubmit}
-					priority="primary"
-					icon={<SvgArrowRightStraight />}
-					iconSide="right"
-				>
-					Confirm
-				</Button>
-			</ThemeProvider>
+			<Button
+				id="qa-direct-debit-submit"
+				onClick={props.onSubmit}
+				priority="primary"
+				icon={<SvgArrowRightStraight />}
+				iconSide="right"
+				theme={themeButtonReaderRevenueBrand}
+			>
+				Confirm
+			</Button>
 			{props.accountErrorsLength > 0 && (
 				<ErrorSummary errors={[...props.accountErrors]} />
 			)}

--- a/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/components/playback.tsx
+++ b/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/components/playback.tsx
@@ -1,5 +1,5 @@
 // ----- Imports ----- //
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import {
 	space,
 	textSans15,
@@ -8,9 +8,9 @@ import {
 } from '@guardian/source/foundations';
 import {
 	Button,
-	buttonThemeReaderRevenueBrand,
-	buttonThemeReaderRevenueBrandAlt,
 	SvgArrowRightStraight,
+	themeButtonReaderRevenueBrand,
+	themeButtonReaderRevenueBrandAlt,
 } from '@guardian/source/react-components';
 import { useEffect, useRef } from 'react';
 import * as React from 'react';
@@ -116,19 +116,21 @@ function Playback(props: {
 			</div>
 
 			<div css={ctaContainer} ref={subscribeButtonRef} tabIndex={-1}>
-				<ThemeProvider theme={buttonThemeReaderRevenueBrandAlt}>
-					<Button onClick={props.editDirectDebitClicked}>Edit</Button>
-				</ThemeProvider>
-				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-					<Button
-						id="qa-submit-button-2"
-						onClick={props.onSubmit}
-						icon={<SvgArrowRightStraight />}
-						iconSide="right"
-					>
-						{props.buttonText}
-					</Button>
-				</ThemeProvider>
+				<Button
+					onClick={props.editDirectDebitClicked}
+					theme={themeButtonReaderRevenueBrandAlt}
+				>
+					Edit
+				</Button>
+				<Button
+					id="qa-submit-button-2"
+					onClick={props.onSubmit}
+					icon={<SvgArrowRightStraight />}
+					iconSide="right"
+					theme={themeButtonReaderRevenueBrand}
+				>
+					{props.buttonText}
+				</Button>
 			</div>
 
 			{props.allErrors.length > 0 && (

--- a/support-frontend/assets/components/footerCompliant/Footer.tsx
+++ b/support-frontend/assets/components/footerCompliant/Footer.tsx
@@ -1,10 +1,9 @@
 // ----- Imports ----- //
-import { ThemeProvider } from '@emotion/react';
 import { cmp } from '@guardian/libs';
 import {
 	ButtonLink,
 	Link,
-	linkThemeBrand,
+	themeLinkBrand,
 } from '@guardian/source/react-components';
 import type { ReactNode } from 'react';
 import { Children } from 'react';
@@ -38,68 +37,75 @@ function Footer({
 
 	return (
 		<footer id="qa-footer" css={componentFooter} role="contentinfo">
-			<ThemeProvider theme={linkThemeBrand}>
-				{Children.count(children) > 0 && (
-					<FooterContent
-						appearance={{
-							border: true,
-							paddingTop: true,
-							centred,
-						}}
-					>
-						<div>
-							<Rows>{children}</Rows>
-						</div>
-					</FooterContent>
-				)}
+			{Children.count(children) > 0 && (
 				<FooterContent
 					appearance={{
 						border: true,
+						paddingTop: true,
 						centred,
 					}}
 				>
-					<ul css={linksList}>
-						<li css={link}>
-							<Link href="https://manage.theguardian.com/help-centre">
-								Help Centre
-							</Link>
-						</li>
-						<li css={link}>
-							<Link href="https://www.theguardian.com/help/contact-us">
-								Contact us
-							</Link>
-						</li>
-						<li css={link}>
-							<Link
-								subdued
-								href="https://www.theguardian.com/help/privacy-policy"
-							>
-								Privacy Policy
-							</Link>
-						</li>
-						<li css={link}>
-							<ButtonLink onClick={showPrivacyManager}>
-								Privacy Settings
-							</ButtonLink>
-						</li>
-						{termsConditionsLink && (
-							<li css={link}>
-								<Link href={termsConditionsLink}>Terms & Conditions</Link>
-							</li>
-						)}
-					</ul>
-				</FooterContent>
-				<FooterContent
-					appearance={{
-						centred,
-					}}
-				>
-					<div css={backToTopLink}>
-						<BackToTop />
+					<div>
+						<Rows>{children}</Rows>
 					</div>
-					<span css={copyright}>{copyrightNotice}</span>
 				</FooterContent>
-			</ThemeProvider>
+			)}
+			<FooterContent
+				appearance={{
+					border: true,
+					centred,
+				}}
+			>
+				<ul css={linksList}>
+					<li css={link}>
+						<Link
+							href="https://manage.theguardian.com/help-centre"
+							theme={themeLinkBrand}
+						>
+							Help Centre
+						</Link>
+					</li>
+					<li css={link}>
+						<Link
+							href="https://www.theguardian.com/help/contact-us"
+							theme={themeLinkBrand}
+						>
+							Contact us
+						</Link>
+					</li>
+					<li css={link}>
+						<Link
+							subdued
+							href="https://www.theguardian.com/help/privacy-policy"
+							theme={themeLinkBrand}
+						>
+							Privacy Policy
+						</Link>
+					</li>
+					<li css={link}>
+						<ButtonLink onClick={showPrivacyManager} theme={themeLinkBrand}>
+							Privacy Settings
+						</ButtonLink>
+					</li>
+					{termsConditionsLink && (
+						<li css={link}>
+							<Link href={termsConditionsLink} theme={themeLinkBrand}>
+								Terms & Conditions
+							</Link>
+						</li>
+					)}
+				</ul>
+			</FooterContent>
+			<FooterContent
+				appearance={{
+					centred,
+				}}
+			>
+				<div css={backToTopLink}>
+					<BackToTop />
+				</div>
+				<span css={copyright}>{copyrightNotice}</span>
+			</FooterContent>
 		</footer>
 	);
 }

--- a/support-frontend/assets/components/paymentButton/defaultPaymentButton.tsx
+++ b/support-frontend/assets/components/paymentButton/defaultPaymentButton.tsx
@@ -1,9 +1,9 @@
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import { neutral } from '@guardian/source/foundations';
 import type { ButtonProps } from '@guardian/source/react-components';
 import {
 	Button,
-	buttonThemeReaderRevenueBrand,
+	themeButtonReaderRevenueBrand,
 } from '@guardian/source/react-components';
 
 const buttonOverrides = css`
@@ -26,15 +26,14 @@ export function DefaultPaymentButton({
 	...buttonProps
 }: DefaultPaymentButtonProps): JSX.Element {
 	return (
-		<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-			<Button
-				id={id}
-				cssOverrides={buttonOverrides}
-				isLoading={false}
-				{...buttonProps}
-			>
-				{buttonText}
-			</Button>
-		</ThemeProvider>
+		<Button
+			id={id}
+			cssOverrides={buttonOverrides}
+			isLoading={false}
+			{...buttonProps}
+			theme={themeButtonReaderRevenueBrand}
+		>
+			{buttonText}
+		</Button>
 	);
 }

--- a/support-frontend/assets/components/product/productOption.tsx
+++ b/support-frontend/assets/components/product/productOption.tsx
@@ -1,10 +1,10 @@
 import type { SerializedStyles } from '@emotion/react';
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import { until } from '@guardian/source/foundations';
 import {
-	buttonThemeReaderRevenue,
 	LinkButton,
 	SvgInfoRound,
+	themeButtonReaderRevenue,
 } from '@guardian/source/react-components';
 import { BillingPeriod } from '@modules/product/billingPeriod';
 import type { ReactNode } from 'react';
@@ -150,16 +150,15 @@ function ProductOption(props: Product): JSX.Element {
 				</p>
 			</div>
 			<div css={buttonDiv}>
-				<ThemeProvider theme={buttonThemeReaderRevenue}>
-					<LinkButton
-						cssOverrides={button}
-						href={props.href}
-						onClick={props.onClick}
-						aria-label={`${props.title}- ${props.buttonCopy}`}
-					>
-						{props.buttonCopy}
-					</LinkButton>
-				</ThemeProvider>
+				<LinkButton
+					cssOverrides={button}
+					href={props.href}
+					onClick={props.onClick}
+					aria-label={`${props.title}- ${props.buttonCopy}`}
+					theme={themeButtonReaderRevenue}
+				>
+					{props.buttonCopy}
+				</LinkButton>
 			</div>
 		</div>
 	);

--- a/support-frontend/assets/components/subscriptionCheckouts/address/postcodeFinder.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/postcodeFinder.tsx
@@ -1,11 +1,11 @@
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import { space } from '@guardian/source/foundations';
 import {
 	Button,
-	buttonThemeReaderRevenueBrandAlt,
 	Option,
 	Select,
 	TextInput,
+	themeButtonReaderRevenueBrandAlt,
 } from '@guardian/source/react-components';
 import React from 'react';
 import type { PostcodeFinderResult } from 'components/subscriptionCheckouts/address/postcodeLookup';
@@ -70,11 +70,14 @@ export function PostcodeFinder({
 
 				{!isLoading && (
 					<div css={styles.buttonContainer}>
-						<ThemeProvider theme={buttonThemeReaderRevenueBrandAlt}>
-							<Button priority="tertiary" type="button" onClick={handleSubmit}>
-								Find address
-							</Button>
-						</ThemeProvider>
+						<Button
+							priority="tertiary"
+							type="button"
+							onClick={handleSubmit}
+							theme={themeButtonReaderRevenueBrandAlt}
+						>
+							Find address
+						</Button>
 					</div>
 				)}
 			</div>

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetails.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetails.tsx
@@ -1,9 +1,9 @@
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import { space, textSans17 } from '@guardian/source/foundations';
 import {
 	Button,
-	buttonThemeReaderRevenueBrandAlt,
 	TextInput,
+	themeButtonReaderRevenueBrandAlt,
 } from '@guardian/source/react-components';
 import React from 'react';
 import CheckoutExpander from 'components/checkoutExpander/checkoutExpander';
@@ -54,18 +54,17 @@ function SignedInEmailFooter(props: SignedInEmailFooterTypes) {
 			</CheckoutExpander>
 			<CheckoutExpander copy="Not you?">
 				<p css={paragraphWithButton}>
-					<ThemeProvider theme={buttonThemeReaderRevenueBrandAlt}>
-						<Button
-							type="button"
-							data-testid="sign-out"
-							onClick={(e) => props.handleSignOut(e)}
-							priority="tertiary"
-							size="small"
-						>
-							Sign out
-						</Button>{' '}
-						and create a new account.
-					</ThemeProvider>
+					<Button
+						type="button"
+						data-testid="sign-out"
+						onClick={(e) => props.handleSignOut(e)}
+						priority="tertiary"
+						size="small"
+						theme={themeButtonReaderRevenueBrandAlt}
+					>
+						Sign out
+					</Button>{' '}
+					and create a new account.
 				</p>
 			</CheckoutExpander>
 		</div>

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.tsx
@@ -1,9 +1,9 @@
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import { space } from '@guardian/source/foundations';
 import {
 	Button,
-	buttonThemeReaderRevenue,
 	SvgArrowRightStraight,
+	themeButtonReaderRevenue,
 } from '@guardian/source/react-components';
 import * as stripeJs from '@stripe/react-stripe-js';
 import { CardNumberElement } from '@stripe/react-stripe-js';
@@ -441,18 +441,17 @@ function StripeForm(props: StripeFormPropTypes): JSX.Element {
 						/>
 					) : null}
 					<div className="component-stripe-submit-button">
-						<ThemeProvider theme={buttonThemeReaderRevenue}>
-							<Button
-								id="qa-stripe-submit-button"
-								onClick={requestSCAPaymentMethod}
-								priority="primary"
-								icon={<SvgArrowRightStraight />}
-								iconSide="right"
-								disabled={disableButton}
-							>
-								{props.buttonText}
-							</Button>
-						</ThemeProvider>
+						<Button
+							id="qa-stripe-submit-button"
+							onClick={requestSCAPaymentMethod}
+							priority="primary"
+							icon={<SvgArrowRightStraight />}
+							iconSide="right"
+							disabled={disableButton}
+							theme={themeButtonReaderRevenue}
+						>
+							{props.buttonText}
+						</Button>
 					</div>
 					{errors.length > 0 && <ErrorSummary errors={errors} />}
 				</fieldset>

--- a/support-frontend/assets/components/subscriptionCheckouts/thankYou/returnSection.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/thankYou/returnSection.tsx
@@ -1,10 +1,10 @@
 // ----- Imports ----- //
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import { from, space } from '@guardian/source/foundations';
 import {
-	buttonThemeReaderRevenue,
 	LinkButton,
 	SvgArrowRightStraight,
+	themeButtonReaderRevenue,
 } from '@guardian/source/react-components';
 import Content, { Divider, NarrowContent } from 'components/content/content';
 import type { SubscriptionProduct } from 'helpers/productPrice/subscriptions';
@@ -26,24 +26,23 @@ function ReturnSection(props: PropTypes) {
 			<Divider />
 			<NarrowContent>
 				<div className="thank-you-stage__ctas">
-					<ThemeProvider theme={buttonThemeReaderRevenue}>
-						<LinkButton
-							cssOverrides={buttonStyles}
-							priority="tertiary"
-							aria-label="Return to the Guardian home page"
-							href="https://theguardian.com"
-							icon={<SvgArrowRightStraight />}
-							iconSide="right"
-							nudgeIcon
-							onClick={sendTrackingEventsOnClick({
-								id: 'checkout_return_home',
-								product: props.subscriptionProduct,
-								componentType: 'ACQUISITIONS_BUTTON',
-							})}
-						>
-							Return to the Guardian
-						</LinkButton>
-					</ThemeProvider>
+					<LinkButton
+						cssOverrides={buttonStyles}
+						priority="tertiary"
+						aria-label="Return to the Guardian home page"
+						href="https://theguardian.com"
+						icon={<SvgArrowRightStraight />}
+						iconSide="right"
+						nudgeIcon
+						onClick={sendTrackingEventsOnClick({
+							id: 'checkout_return_home',
+							product: props.subscriptionProduct,
+							componentType: 'ACQUISITIONS_BUTTON',
+						})}
+						theme={themeButtonReaderRevenue}
+					>
+						Return to the Guardian
+					</LinkButton>
 				</div>
 			</NarrowContent>
 		</Content>

--- a/support-frontend/assets/components/test-user-banner/thankYouUserTypeSelector.tsx
+++ b/support-frontend/assets/components/test-user-banner/thankYouUserTypeSelector.tsx
@@ -1,8 +1,8 @@
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import {
 	Radio,
 	RadioGroup,
-	radioThemeBrand,
+	themeRadioBrand,
 } from '@guardian/source/react-components';
 import { useEffect, useState } from 'react';
 import type { UserType } from 'helpers/redux/checkout/personalDetails/state';
@@ -23,27 +23,26 @@ export function ThankYouUserTypeSelector(): JSX.Element {
 	}, [selectedUserType]);
 
 	return (
-		<ThemeProvider theme={radioThemeBrand}>
-			<RadioGroup
-				error=""
-				label="Select a user account type:"
-				name="thankYouUserTypeSelector"
-				orientation="horizontal"
-				cssOverrides={selectorStyles}
-			>
-				<Radio
-					// the default user type response from identity as a test user is "new"
-					defaultChecked
-					label="New"
-					value="new"
-					onChange={() => setSelectedUserType('new')}
-				/>
-				<Radio
-					label="Existing"
-					value="current"
-					onChange={() => setSelectedUserType('current')}
-				/>
-			</RadioGroup>
-		</ThemeProvider>
+		<RadioGroup
+			error=""
+			label="Select a user account type:"
+			name="thankYouUserTypeSelector"
+			orientation="horizontal"
+			cssOverrides={selectorStyles}
+			theme={themeRadioBrand}
+		>
+			<Radio
+				// the default user type response from identity as a test user is "new"
+				defaultChecked
+				label="New"
+				value="new"
+				onChange={() => setSelectedUserType('new')}
+			/>
+			<Radio
+				label="Existing"
+				value="current"
+				onChange={() => setSelectedUserType('current')}
+			/>
+		</RadioGroup>
 	);
 }

--- a/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/guardianAdLiteCard.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/components/guardianAdLiteCard.tsx
@@ -1,4 +1,4 @@
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import {
 	from,
 	headlineBold20,
@@ -102,15 +102,14 @@ export function GuardianAdLiteCard({
 				<div css={svgCss}>{icon}</div>
 				<h2 css={titleCss(cardIndex)}>{label}</h2>
 			</div>
-			<ThemeProvider theme={themeLinkBrand}>
-				<LinkButton
-					href={link}
-					cssOverrides={btnStyleOverrides}
-					data-qm-trackable={quantumMetricButtonRef}
-				>
-					{ctaCopy}
-				</LinkButton>
-			</ThemeProvider>
+			<LinkButton
+				href={link}
+				cssOverrides={btnStyleOverrides}
+				data-qm-trackable={quantumMetricButtonRef}
+				theme={themeLinkBrand}
+			>
+				{ctaCopy}
+			</LinkButton>
 			<Divider cssOverrides={dividerCss} />
 			<BenefitsCheckList
 				benefitsCheckListData={benefits.map((benefit) => {

--- a/support-frontend/assets/pages/aus-moment-map/components/header.tsx
+++ b/support-frontend/assets/pages/aus-moment-map/components/header.tsx
@@ -1,7 +1,6 @@
-import { ThemeProvider } from '@emotion/react';
 import {
-	buttonThemeBrand,
 	LinkButton,
+	themeButtonBrand,
 } from '@guardian/source/react-components';
 import { contributeUrl } from '../utils';
 
@@ -61,18 +60,17 @@ export function Header(): JSX.Element {
 		<div id="header-wrapper">
 			<div>
 				<div id="header">Join the fight for progress</div>
-				<ThemeProvider theme={buttonThemeBrand}>
-					<LinkButton
-						priority="tertiary"
-						size="small"
-						href={contributeUrl('AUSELECTION2022_SUPPORTERMAP_header')}
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						<span className="header-cta-text-full">Support the Guardian</span>
-						<span className="header-cta-text-short">Support us</span>
-					</LinkButton>
-				</ThemeProvider>
+				<LinkButton
+					priority="tertiary"
+					size="small"
+					href={contributeUrl('AUSELECTION2022_SUPPORTERMAP_header')}
+					target="_blank"
+					rel="noopener noreferrer"
+					theme={themeButtonBrand}
+				>
+					<span className="header-cta-text-full">Support the Guardian</span>
+					<span className="header-cta-text-short">Support us</span>
+				</LinkButton>
 			</div>
 			<a className="logo" href="https://www.theguardian.com/au">
 				<GuardianLogoSvg />

--- a/support-frontend/assets/pages/aus-moment-map/components/testimonialsContainer.tsx
+++ b/support-frontend/assets/pages/aus-moment-map/components/testimonialsContainer.tsx
@@ -1,8 +1,7 @@
-import { ThemeProvider } from '@emotion/react';
 import {
 	Button,
-	buttonThemeBrandAlt,
 	LinkButton,
+	themeButtonBrandAlt,
 } from '@guardian/source/react-components';
 import type { AuState } from '@modules/internationalisation/country';
 import { auStates } from '@modules/internationalisation/country';
@@ -28,18 +27,17 @@ function TestimonialCtaPrimary() {
 				we&apos;ll only publish your message if you give us permission to.
 			</p>
 
-			<ThemeProvider theme={buttonThemeBrandAlt}>
-				<LinkButton
-					className="testimonial-cta-primary-link-button"
-					priority="primary"
-					size="small"
-					href="https://guardiannewsandmedia.formstack.com/forms/australia_2022"
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					Send a message
-				</LinkButton>
-			</ThemeProvider>
+			<LinkButton
+				className="testimonial-cta-primary-link-button"
+				priority="primary"
+				size="small"
+				href="https://guardiannewsandmedia.formstack.com/forms/australia_2022"
+				target="_blank"
+				rel="noopener noreferrer"
+				theme={themeButtonBrandAlt}
+			>
+				Send a message
+			</LinkButton>
 		</div>
 	);
 }
@@ -53,18 +51,17 @@ function TestimonialCtaSecondary() {
 				</span>
 			</h3>
 
-			<ThemeProvider theme={buttonThemeBrandAlt}>
-				<LinkButton
-					className="testimonial-cta-primary-link-button"
-					priority="primary"
-					size="small"
-					href={contributeUrl('Aus_Moment_2021_map_inline')}
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					Support the Guardian
-				</LinkButton>
-			</ThemeProvider>
+			<LinkButton
+				className="testimonial-cta-primary-link-button"
+				priority="primary"
+				size="small"
+				href={contributeUrl('Aus_Moment_2021_map_inline')}
+				target="_blank"
+				rel="noopener noreferrer"
+				theme={themeButtonBrandAlt}
+			>
+				Support the Guardian
+			</LinkButton>
 		</div>
 	);
 }

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/PaperHero.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/PaperHero.tsx
@@ -1,9 +1,8 @@
 // ----- Imports ----- //
-import { ThemeProvider } from '@emotion/react';
 import {
-	buttonThemeBrand,
 	LinkButton,
 	SvgArrowDownStraight,
+	themeButtonBrand,
 } from '@guardian/source/react-components';
 import CentredContainer from 'components/containers/centredContainer';
 import GridImage from 'components/gridImage/gridImage';
@@ -54,21 +53,20 @@ export function PaperHero({
 					<section css={heroCopy}>
 						<h2 css={heroTitle}>{title}</h2>
 						<p css={heroParagraph}>{body}</p>
-						<ThemeProvider theme={buttonThemeBrand}>
-							<LinkButton
-								onClick={sendTrackingEventsOnClick({
-									id: 'options_cta_click',
-									product: 'Paper',
-									componentType: 'ACQUISITIONS_BUTTON',
-								})}
-								priority="tertiary"
-								iconSide="right"
-								icon={<SvgArrowDownStraight />}
-								href="#HomeDelivery"
-							>
-								See pricing options
-							</LinkButton>
-						</ThemeProvider>
+						<LinkButton
+							onClick={sendTrackingEventsOnClick({
+								id: 'options_cta_click',
+								product: 'Paper',
+								componentType: 'ACQUISITIONS_BUTTON',
+							})}
+							priority="tertiary"
+							iconSide="right"
+							icon={<SvgArrowDownStraight />}
+							href="#HomeDelivery"
+							theme={themeButtonBrand}
+						>
+							See pricing options
+						</LinkButton>
 					</section>
 				</Hero>
 			</CentredContainer>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/amountsCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/amountsCard.tsx
@@ -1,4 +1,4 @@
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import {
 	from,
 	headlineBold24,
@@ -8,8 +8,8 @@ import {
 	until,
 } from '@guardian/source/foundations';
 import {
-	buttonThemeReaderRevenueBrand,
 	LinkButton,
+	themeButtonReaderRevenueBrand,
 } from '@guardian/source/react-components';
 import type { CountryGroupId } from '@modules/internationalisation/countryGroup';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
@@ -126,21 +126,20 @@ export function AmountsCard({
 				/>
 			</div>
 			<div css={buttonContainer}>
-				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-					<LinkButton
-						href={checkoutLink}
-						cssOverrides={btnStyleOverrides}
-						onClick={() => {
-							trackComponentClick(
-								`npf-contribution-amount-toggle-${countryGroupId}-${billingPeriodToContributionType(
-									billingPeriod,
-								)}`,
-							);
-						}}
-					>
-						Continue to checkout
-					</LinkButton>
-				</ThemeProvider>
+				<LinkButton
+					href={checkoutLink}
+					cssOverrides={btnStyleOverrides}
+					onClick={() => {
+						trackComponentClick(
+							`npf-contribution-amount-toggle-${countryGroupId}-${billingPeriodToContributionType(
+								billingPeriod,
+							)}`,
+						);
+					}}
+					theme={themeButtonReaderRevenueBrand}
+				>
+					Continue to checkout
+				</LinkButton>
 				<PaymentCards />
 			</div>
 		</section>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/oneOffCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/oneOffCard.tsx
@@ -1,4 +1,4 @@
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import {
 	from,
 	headlineBold24,
@@ -8,8 +8,8 @@ import {
 	until,
 } from '@guardian/source/foundations';
 import {
-	buttonThemeReaderRevenueBrand,
 	LinkButton,
+	themeButtonReaderRevenueBrand,
 } from '@guardian/source/react-components';
 import type { CountryGroupId } from '@modules/internationalisation/countryGroup';
 import { countryGroups } from '@modules/internationalisation/countryGroup';
@@ -123,23 +123,22 @@ export function OneOffCard({
 				/>
 			</div>
 			<div css={buttonContainer}>
-				<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-					<LinkButton
-						href={`/${
-							countryGroups[countryGroupId].supportInternationalisationId
-						}/contribute/checkout?selected-contribution-type=one_off&selected-amount=${
-							selectedAmount === 'other' ? otherAmount : selectedAmount
-						}`}
-						cssOverrides={btnStyleOverrides}
-						onClick={() => {
-							trackComponentClick(
-								`npf-contribution-amount-toggle-${countryGroupId}-ONE_OFF`,
-							);
-						}}
-					>
-						Continue to checkout
-					</LinkButton>
-				</ThemeProvider>
+				<LinkButton
+					href={`/${
+						countryGroups[countryGroupId].supportInternationalisationId
+					}/contribute/checkout?selected-contribution-type=one_off&selected-amount=${
+						selectedAmount === 'other' ? otherAmount : selectedAmount
+					}`}
+					cssOverrides={btnStyleOverrides}
+					onClick={() => {
+						trackComponentClick(
+							`npf-contribution-amount-toggle-${countryGroupId}-ONE_OFF`,
+						);
+					}}
+					theme={themeButtonReaderRevenueBrand}
+				>
+					Continue to checkout
+				</LinkButton>
 				<PaymentCards />
 			</div>
 		</section>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -1,4 +1,4 @@
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import {
 	from,
 	palette,
@@ -9,8 +9,8 @@ import {
 	until,
 } from '@guardian/source/foundations';
 import {
-	buttonThemeReaderRevenueBrand,
 	LinkButton,
+	themeButtonReaderRevenueBrand,
 } from '@guardian/source/react-components';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { BillingPeriod } from '@modules/product/billingPeriod';
@@ -240,16 +240,15 @@ export function ThreeTierCard({
 				)}
 				{!promotion && `${formattedPrice}/${periodNoun}`}
 			</p>
-			<ThemeProvider theme={buttonThemeReaderRevenueBrand}>
-				<LinkButton
-					href={link}
-					cssOverrides={btnStyleOverrides}
-					data-qm-trackable={quantumMetricButtonRef}
-					aria-label={title}
-				>
-					{cta.copy}
-				</LinkButton>
-			</ThemeProvider>
+			<LinkButton
+				href={link}
+				cssOverrides={btnStyleOverrides}
+				data-qm-trackable={quantumMetricButtonRef}
+				aria-label={title}
+				theme={themeButtonReaderRevenueBrand}
+			>
+				{cta.copy}
+			</LinkButton>
 
 			{product === 'TierThree' && (
 				<div css={benefitsPrefixCss}>

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
@@ -1,4 +1,4 @@
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import {
 	from,
 	headlineBold24,
@@ -128,11 +128,13 @@ function Prices({ orderIsAGift, products }: PropTypes): JSX.Element {
 					{!orderIsAGift && 'You can cancel your subscription at any time'}
 				</ProductInfoChip>
 				<ProductInfoChip>
-					<ThemeProvider theme={themeLinkBrand}>
-						<Link href={termsConditionsLink} cssOverrides={termsLink}>
-							Click here to see full Terms and Conditions
-						</Link>
-					</ThemeProvider>
+					<Link
+						href={termsConditionsLink}
+						cssOverrides={termsLink}
+						theme={themeLinkBrand}
+					>
+						Click here to see full Terms and Conditions
+					</Link>
 				</ProductInfoChip>
 			</div>
 		</section>

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
@@ -3,6 +3,7 @@ import {
 	from,
 	headlineBold24,
 	neutral,
+	palette,
 	space,
 	textEgyptian17,
 	textSans12,
@@ -84,6 +85,7 @@ const pricesInfo = css`
 
 const termsLink = css`
 	${textSans12};
+	color: ${palette.brand[500]};
 	margin-left: ${space[9]}px;
 	margin-top: -12px;
 `;

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import {
 	brandAlt,
 	from,
@@ -11,9 +11,9 @@ import {
 	textEgyptian17,
 } from '@guardian/source/foundations';
 import {
-	buttonThemeDefault,
 	LinkButton,
 	SvgArrowDownStraight,
+	themeButton,
 } from '@guardian/source/react-components';
 import type { CountryGroupId } from '@modules/internationalisation/countryGroup';
 import { GBPCountries } from '@modules/internationalisation/countryGroup';
@@ -175,22 +175,21 @@ export function WeeklyHero({
 					<section css={styles.weeklyHeroCopy}>
 						<h2 css={styles.weeklyHeroTitle}>{title}</h2>
 						<p css={styles.weeklyHeroParagraph}>{copy}</p>
-						<ThemeProvider theme={buttonThemeDefault}>
-							<LinkButton
-								onClick={sendTrackingEventsOnClick({
-									id: 'options_cta_click',
-									product: 'GuardianWeekly',
-									componentType: 'ACQUISITIONS_BUTTON',
-								})}
-								priority="tertiary"
-								iconSide="right"
-								icon={<SvgArrowDownStraight />}
-								cssOverrides={linkButtonColour}
-								href="#subscribe"
-							>
-								See pricing options
-							</LinkButton>
-						</ThemeProvider>
+						<LinkButton
+							onClick={sendTrackingEventsOnClick({
+								id: 'options_cta_click',
+								product: 'GuardianWeekly',
+								componentType: 'ACQUISITIONS_BUTTON',
+							})}
+							priority="tertiary"
+							iconSide="right"
+							icon={<SvgArrowDownStraight />}
+							cssOverrides={linkButtonColour}
+							href="#subscribe"
+							theme={themeButton}
+						>
+							See pricing options
+						</LinkButton>
 					</section>
 				</Hero>
 			</CentredContainer>


### PR DESCRIPTION
## What are you doing in this PR?

Migrating away from `ThemeProvider`, passing the theme directly to the relevant source component.

[**Trello Card**](https://trello.com/c/GDnEbUWn/1709-move-away-from-themeprovider-for-source-components)

## Why are you doing this?

Using `ThemeProvider` with source components is deprecated.

## How to test

Chromatic is happy. Manually inspecting revealed one small diff, which I've left a comment for.