### PR TITLE
Fix `/p/<promo code>` endpoint

### DIFF
--- a/support-frontend/app/controllers/Promotions.scala
+++ b/support-frontend/app/controllers/Promotions.scala
@@ -38,7 +38,7 @@ class Promotions(
       val productLandingPage = promotionTerms.product match {
         case GuardianWeekly => routes.WeeklySubscriptionController.weeklyGeoRedirect(promotionTerms.isGift).url
         case DigitalPack => routes.Application.geoRedirectToPath("subscribe/digitaledition").url
-        case Paper => routes.Application.geoRedirectToPath("uk/subscribe/paper").url
+        case Paper => routes.PaperSubscriptionController.paper().url
         case _ => routes.Application.contributeGeoRedirect("").url
       }
       val queryString = {


### PR DESCRIPTION
## What are you doing in this PR?

Before this was erroring when the promo code specified in the URL path was for a newspaper product. The reverse route lookup was failing, I think because uk/subscribe/paper is not a geo aware path, it only exists for uk.

I've tested locally and now visiting `/p/<promo code>` redirects to `/uk/subscribe/paper?promoCode=<promo code>`, which I think is the expected behaviour.

## Why are you doing this?

We noticed this issue as we had a spike of 500s for this endpoint.

## How to test

I've tested locally by visiting the endpoint with a newspaper promo code in the path.
