### PR TITLE
Improved validation for Paper subscriptions in support-workers

### DIFF
--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/PaperSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/PaperSubscriptionBuilderSpec.scala
@@ -1,12 +1,19 @@
 package com.gu.zuora.subscriptionBuilders
 
 import com.gu.i18n.Currency.GBP
-import com.gu.support.catalog.{EverydayPlus, NationalDelivery}
+import com.gu.support.catalog.{EverydayPlus, HomeDelivery, NationalDelivery, Sunday}
 import com.gu.support.config.TouchPointEnvironments.CODE
 import com.gu.support.promotions.PromotionService
-import com.gu.support.workers.JsonFixtures.{salesforceContact, stripePaymentMethodObj, user, userJsonWithDeliveryAddressOutsideLondon}
-import com.gu.support.workers.{Paper, User}
+import com.gu.support.workers.JsonFixtures.{
+  salesforceContact,
+  stripePaymentMethodObj,
+  userJsonWithDeliveryAddress,
+  userJsonWithDeliveryAddressOutsideLondon,
+}
+import com.gu.support.workers.{DirectDebitPaymentMethod, Paper}
+import com.gu.support.workers.exceptions.BadRequestException
 import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.PaperState
+import com.gu.zuora.Fixtures.directDebitPaymentMethod
 import org.joda.time.LocalDate
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
@@ -14,16 +21,15 @@ import org.scalatestplus.mockito.MockitoSugar.mock
 
 import java.util.UUID
 
-
 class PaperSubscriptionBuilderSpec extends AnyFlatSpec with Matchers {
   "National Delivery subscriptions" must "have a delivery agent" in {
-    assertThrows[IllegalArgumentException] {
+    assertThrows[BadRequestException] {
       val product = Paper(
         fulfilmentOptions = NationalDelivery,
         productOptions = EverydayPlus,
         deliveryAgent = None,
       )
-      val userObject  = userJsonWithDeliveryAddressOutsideLondon
+      val userObject = userJsonWithDeliveryAddressOutsideLondon
       val state = PaperState(
         product = product,
         firstDeliveryDate = LocalDate.now(),
@@ -39,6 +45,47 @@ class PaperSubscriptionBuilderSpec extends AnyFlatSpec with Matchers {
         new SubscribeItemBuilder(UUID.randomUUID(), userObject, GBP),
       ).build(
         state,
+        csrUsername = None,
+        salesforceCaseId = None,
+      )
+    }
+  }
+  "Sunday subscriptions" must "use the Tortoise payment gateways" in {
+    val userObject = userJsonWithDeliveryAddress
+    val builder = new PaperSubscriptionBuilder(
+      mock[PromotionService],
+      CODE,
+      new SubscribeItemBuilder(UUID.randomUUID(), userObject, GBP),
+    )
+    val product = Paper(
+      fulfilmentOptions = HomeDelivery,
+      productOptions = Sunday,
+      deliveryAgent = None,
+    )
+    val stripeState = PaperState(
+      product = product,
+      firstDeliveryDate = LocalDate.now(),
+      appliedPromotion = None,
+      user = userObject,
+      paymentMethod = stripePaymentMethodObj,
+      salesForceContact = salesforceContact,
+      similarProductsConsent = None,
+    )
+    val directDebitState = stripeState.copy(
+      paymentMethod = directDebitPaymentMethod(),
+    )
+
+    assertThrows[BadRequestException] {
+      builder.build(
+        stripeState,
+        csrUsername = None,
+        salesforceCaseId = None,
+      )
+    }
+
+    assertThrows[BadRequestException] {
+      builder.build(
+        directDebitState,
         csrUsername = None,
         salesforceCaseId = None,
       )

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/PaperSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/PaperSubscriptionBuilderSpec.scala
@@ -10,9 +10,10 @@ import com.gu.support.workers.JsonFixtures.{
   userJsonWithDeliveryAddress,
   userJsonWithDeliveryAddressOutsideLondon,
 }
-import com.gu.support.workers.{DirectDebitPaymentMethod, Paper}
+import com.gu.support.workers.Paper
 import com.gu.support.workers.exceptions.BadRequestException
 import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.PaperState
+import com.gu.support.zuora.api.{DirectDebitTortoiseMediaGateway, StripeTortoiseMedia}
 import com.gu.zuora.Fixtures.directDebitPaymentMethod
 import org.joda.time.LocalDate
 import org.scalatest.flatspec.AnyFlatSpec
@@ -23,40 +24,43 @@ import java.util.UUID
 
 class PaperSubscriptionBuilderSpec extends AnyFlatSpec with Matchers {
   "National Delivery subscriptions" must "have a delivery agent" in {
+    val product = Paper(
+      fulfilmentOptions = NationalDelivery,
+      productOptions = EverydayPlus,
+      deliveryAgent = None,
+    )
+    val userObject = userJsonWithDeliveryAddressOutsideLondon
+    val state = PaperState(
+      product = product,
+      firstDeliveryDate = LocalDate.now(),
+      appliedPromotion = None,
+      user = userObject,
+      paymentMethod = stripePaymentMethodObj,
+      salesForceContact = salesforceContact,
+      similarProductsConsent = None,
+    )
+    val builder = new PaperSubscriptionBuilder(
+      mock[PromotionService],
+      CODE,
+      new SubscribeItemBuilder(UUID.randomUUID(), userObject, GBP),
+    )
+
     assertThrows[BadRequestException] {
-      val product = Paper(
-        fulfilmentOptions = NationalDelivery,
-        productOptions = EverydayPlus,
-        deliveryAgent = None,
-      )
-      val userObject = userJsonWithDeliveryAddressOutsideLondon
-      val state = PaperState(
-        product = product,
-        firstDeliveryDate = LocalDate.now(),
-        appliedPromotion = None,
-        user = userObject,
-        paymentMethod = stripePaymentMethodObj,
-        salesForceContact = salesforceContact,
-        similarProductsConsent = None,
-      )
-      new PaperSubscriptionBuilder(
-        mock[PromotionService],
-        CODE,
-        new SubscribeItemBuilder(UUID.randomUUID(), userObject, GBP),
-      ).build(
+      builder.build(
         state,
         csrUsername = None,
         salesforceCaseId = None,
       )
     }
   }
+  private val userObject = userJsonWithDeliveryAddress
+  private val builder = new PaperSubscriptionBuilder(
+    mock[PromotionService],
+    CODE,
+    new SubscribeItemBuilder(UUID.randomUUID(), userObject, GBP),
+  )
+
   "Sunday subscriptions" must "use the Tortoise payment gateways" in {
-    val userObject = userJsonWithDeliveryAddress
-    val builder = new PaperSubscriptionBuilder(
-      mock[PromotionService],
-      CODE,
-      new SubscribeItemBuilder(UUID.randomUUID(), userObject, GBP),
-    )
     val product = Paper(
       fulfilmentOptions = HomeDelivery,
       productOptions = Sunday,
@@ -90,5 +94,71 @@ class PaperSubscriptionBuilderSpec extends AnyFlatSpec with Matchers {
         salesforceCaseId = None,
       )
     }
+  }
+  "Other subscriptions" must "not use the Tortoise payment gateways" in {
+    val product = Paper(
+      fulfilmentOptions = HomeDelivery,
+      productOptions = EverydayPlus,
+      deliveryAgent = None,
+    )
+    val stripeState = PaperState(
+      product = product,
+      firstDeliveryDate = LocalDate.now(),
+      appliedPromotion = None,
+      user = userObject,
+      paymentMethod = stripePaymentMethodObj.copy(PaymentGateway = StripeTortoiseMedia),
+      salesForceContact = salesforceContact,
+      similarProductsConsent = None,
+    )
+    val directDebitState = stripeState.copy(
+      paymentMethod = directDebitPaymentMethod().copy(PaymentGateway = DirectDebitTortoiseMediaGateway),
+    )
+
+    assertThrows[BadRequestException] {
+      builder.build(
+        stripeState,
+        csrUsername = None,
+        salesforceCaseId = None,
+      )
+    }
+
+    assertThrows[BadRequestException] {
+      builder.build(
+        directDebitState,
+        csrUsername = None,
+        salesforceCaseId = None,
+      )
+    }
+  }
+  "Correctly configured subscriptions" must "not throw an exception" in {
+    val product = Paper(
+      fulfilmentOptions = HomeDelivery,
+      productOptions = EverydayPlus,
+      deliveryAgent = None,
+    )
+    val stripeState = PaperState(
+      product = product,
+      firstDeliveryDate = LocalDate.now(),
+      appliedPromotion = None,
+      user = userObject,
+      paymentMethod = stripePaymentMethodObj,
+      salesForceContact = salesforceContact,
+      similarProductsConsent = None,
+    )
+    val directDebitState = stripeState.copy(
+      paymentMethod = directDebitPaymentMethod(),
+    )
+
+    builder.build(
+      stripeState,
+      csrUsername = None,
+      salesforceCaseId = None,
+    )
+
+    builder.build(
+      directDebitState,
+      csrUsername = None,
+      salesforceCaseId = None,
+    )
   }
 }

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/PaperSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/PaperSubscriptionBuilderSpec.scala
@@ -1,0 +1,47 @@
+package com.gu.zuora.subscriptionBuilders
+
+import com.gu.i18n.Currency.GBP
+import com.gu.support.catalog.{EverydayPlus, NationalDelivery}
+import com.gu.support.config.TouchPointEnvironments.CODE
+import com.gu.support.promotions.PromotionService
+import com.gu.support.workers.JsonFixtures.{salesforceContact, stripePaymentMethodObj, user, userJsonWithDeliveryAddressOutsideLondon}
+import com.gu.support.workers.{Paper, User}
+import com.gu.support.workers.states.CreateZuoraSubscriptionProductState.PaperState
+import org.joda.time.LocalDate
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar.mock
+
+import java.util.UUID
+
+
+class PaperSubscriptionBuilderSpec extends AnyFlatSpec with Matchers {
+  "National Delivery subscriptions" must "have a delivery agent" in {
+    assertThrows[IllegalArgumentException] {
+      val product = Paper(
+        fulfilmentOptions = NationalDelivery,
+        productOptions = EverydayPlus,
+        deliveryAgent = None,
+      )
+      val userObject  = userJsonWithDeliveryAddressOutsideLondon
+      val state = PaperState(
+        product = product,
+        firstDeliveryDate = LocalDate.now(),
+        appliedPromotion = None,
+        user = userObject,
+        paymentMethod = stripePaymentMethodObj,
+        salesForceContact = salesforceContact,
+        similarProductsConsent = None,
+      )
+      new PaperSubscriptionBuilder(
+        mock[PromotionService],
+        CODE,
+        new SubscribeItemBuilder(UUID.randomUUID(), userObject, GBP),
+      ).build(
+        state,
+        csrUsername = None,
+        salesforceCaseId = None,
+      )
+    }
+  }
+}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We have had two incidents over the last month or two; in the first Observer subscriptions were being created with the wrong payment gateway and in the second National Delivery subscriptions were created with no delivery agent id set, meaning that their papers could not be delivered successfully.

In both cases we should have prevented creation of these subs and triggered an alarm to alert us to the invalid state. This is what this PR puts in place.
