### PR TITLE
Make the events E2E test work for all environments

### DIFF
--- a/support-e2e/tests/smoke/ticket-tailor.test.ts
+++ b/support-e2e/tests/smoke/ticket-tailor.test.ts
@@ -1,5 +1,29 @@
 import { test, expect } from '@playwright/test';
 
+const isProd = (baseURL: string): boolean => {
+	return baseURL.includes('support.theguardian.com');
+};
+
+const eventIdFromBaseURL = (baseURL: string): string => {
+	const prodE2EEventId = '1428771';
+	const codeE2EEventId = '1354460';
+	if (isProd(baseURL)) {
+		return prodE2EEventId;
+	} else {
+		return codeE2EEventId;
+	}
+};
+
+const iframeSrcFromBaseUrl = (baseURL: string): string => {
+	const prodIframeSrc = 'https://tickets.theguardian.live';
+	const codeIframeSrc = 'https://www.tickettailor.com';
+	if (isProd(baseURL)) {
+		return prodIframeSrc;
+	} else {
+		return codeIframeSrc;
+	}
+};
+
 test('Ticket Tailor iframe loads correctly', async ({
 	page,
 	context,
@@ -23,11 +47,11 @@ test('Ticket Tailor iframe loads correctly', async ({
 	});
 
 	// Navigate to the page containing the iframe
-	await page.goto('https://support.theguardian.com/uk/events/1428771');
+	await page.goto(`${baseURL}/uk/events/${eventIdFromBaseURL(baseURL)}`);
 
 	// Wait for the iframe to be present in the DOM
 	const iframe = await page.waitForSelector(
-		'iframe[src*="https://tickets.theguardian.live"]',
+		`iframe[src*="${iframeSrcFromBaseUrl(baseURL)}"]`,
 	);
 
 	// Check if the iframe is visible


### PR DESCRIPTION
## What are you doing in this PR?

Previously the Ticket Tailor/events E2E tests always called prod. Now it called the environment you're running the tests for, just like the other tests.

I'd hoped I could configure the event ID and iframe directly in the Playwright config but unfortunately there doesn't seem to be a way of adding arbitrary content in a TypeScript safe way, so I'm instead deriving the values from the base URL.

## Why are you doing this?

This will help give us confidence that any changes we've made locally (or in CODE) haven't affected the events page. Previously this wasn't the case as the test always ran against prod.

## How to test

I've run the E2E tests against:

* local
* code
* prod