### PR TITLE
Fix unintended submission of PayPal checkout without BAID

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/submitButton.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/submitButton.tsx
@@ -57,8 +57,6 @@ export function SubmitButton({
 						}}
 						commit={true}
 						validate={({ disable, enable }) => {
-							/** We run this so the form validation happens and focus on errors */
-							formRef.current?.requestSubmit();
 							/** We run this initially to set the button to the correct state */
 							const valid = formRef.current?.checkValidity();
 							if (valid) {
@@ -88,6 +86,16 @@ export function SubmitButton({
 						}}
 						onClick={() => {
 							// TODO - add tracking
+
+							// The button won't actually submit if the form
+							// isn't valid but we can check here and if invalid
+							// the browser will scroll the user to the first
+							// error if necessary
+							const valid = formRef.current?.checkValidity();
+							if (!valid) {
+								/** We run this so the form validation happens and focus on errors */
+								formRef.current?.requestSubmit();
+							}
 						}}
 						/** the order is Button.payment(opens PayPal window).then(Button.onAuthorize) */
 						payment={(resolve, reject) => {


### PR DESCRIPTION
## What are you doing in this PR?

Working on functionality to scroll to form fields with errors when attempting to click the PayPal submit button on the generic checkout.

## Why are you doing this?

In #7173 a change was made to programatically submit the checkout form in the validate callback in order to get the form validation to kick in and scroll the user to the relevant form field errors. It looks like this had an unintended side effect of actually submitting to the backend in the case that the fields were all valid. However since the user hasn't yet auth'd with PayPal there's no BAID so the backend correctly rejects the request. This PR changes things to only scroll to the errors on attempting to submit the form, and only if we know that there are errors.

## How to test

* Leave one or more required form fields blank on the generic checkout (e.g. email, name)
* Select PayPal as the payment method
* Observe no paymentField errors in the console
* Click the `PayPal` submit button.
* See form field errors in the viewport
* Fix form field errors
* Click the `PayPal` submit button (again)
* Successfully complete the checkout flow

## How can we measure success?

Instances of the error `processPaymentResponse error: validation of the request body failed with paypal BAID missing` should disappear from the support-frontend server logs.