### PR TITLE
Prevent invalid email confirmation validation error when using autofill

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
@@ -75,7 +75,15 @@ export function PersonalEmailFields({
 								setConfirmedEmail(event.currentTarget.value);
 							}}
 							onBlur={(event) => {
-								event.target.checkValidity();
+								// Delay to allow the state to update before checking validity.
+								// When using auto-fill we sometimes see the validity check for
+								// equality with the email field fail. I think this is happening
+								// because the state hasn't yet updated. Delaying this slightly
+								// seems to fix the issue. It doesn't seem super elegant but I'm
+								// not sure of a better way to handle this.
+								setTimeout(() => {
+									event.target.checkValidity();
+								}, 100);
 							}}
 							name="confirm-email"
 							required

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
@@ -83,7 +83,7 @@ export function PersonalEmailFields({
 								// not sure of a better way to handle this.
 								setTimeout(() => {
 									event.target.checkValidity();
-								}, 100);
+								}, 50);
 							}}
 							name="confirm-email"
 							required


### PR DESCRIPTION
## What are you doing in this PR?

Add a short delay before checking the validity of the email confirmation field.

## Why are you doing this?

When using browser auto-fill we sometimes see the validity check for the email confirmation field being equal to the email field fail (seems to be Firefox specific). I think this is happening because the state hasn't updated by the time we trigger the check on blur. Delaying this slightly seems to fix the issue. It isn't super elegant but I'm not sure of a better way to handle this.

Previously it was possible to end up in situations like this:

<img width="597" height="248" alt="Screenshot 2025-08-06 at 14 22 59" src="https://github.com/user-attachments/assets/a03de961-7ecf-4d06-817e-af8eccaebc07" />

## How to test

Use browser autofill and verify that the email confirmation confirmation field has no unexpected errors.

More generally run the smoke tests to ensure no regressions.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->