### PR TITLE
Enable routing for global student page

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -119,6 +119,18 @@ const router = createBrowserRouter([
 				</Suspense>
 			),
 		},
+		{
+			path: `/${geoId}/student`,
+			element: (
+				<Suspense fallback={<HoldingContent />}>
+					<StudentLandingPage
+						geoId={geoId}
+						landingPageVariant={landingPageParticipations.variant}
+						global
+					/>
+				</Suspense>
+			),
+		},
 	]),
 	{
 		path: '/au/student/UTS',

--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -126,7 +126,6 @@ const router = createBrowserRouter([
 					<StudentLandingPage
 						geoId={geoId}
 						landingPageVariant={landingPageParticipations.variant}
-						global
 					/>
 				</Suspense>
 			),

--- a/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.test.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { getLandingPageParticipations } from 'helpers/abTests/landingPageAbTests';
+import { StudentLandingPage } from './StudentLandingPage';
+
+jest.mock('./components/StudentHeader');
+
+describe('StudentLandingPage', () => {
+	const landingPageParticipations = getLandingPageParticipations();
+
+	it('should display country switcher for global student page', () => {
+		render(
+			<StudentLandingPage
+				geoId="uk"
+				landingPageVariant={landingPageParticipations.variant}
+				global
+			/>,
+		);
+
+		const countrySwitcherhButton = screen.getByLabelText('Select a country');
+
+		expect(countrySwitcherhButton).toBeInTheDocument();
+	});
+
+	it('should not display country switcher for australian student page', () => {
+		render(
+			<StudentLandingPage
+				geoId="au"
+				landingPageVariant={landingPageParticipations.variant}
+			/>,
+		);
+
+		const countrySwitcherhButton = screen.queryByLabelText('Select a country');
+
+		expect(countrySwitcherhButton).not.toBeInTheDocument();
+	});
+});

--- a/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.test.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.test.tsx
@@ -12,7 +12,6 @@ describe('StudentLandingPage', () => {
 			<StudentLandingPage
 				geoId="uk"
 				landingPageVariant={landingPageParticipations.variant}
-				global
 			/>,
 		);
 

--- a/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.tsx
@@ -2,10 +2,20 @@ import {
 	FooterLinks,
 	FooterWithContents,
 } from '@guardian/source-development-kitchen/react-components';
+import {
+	Canada,
+	GBPCountries,
+	UnitedStates,
+} from '@modules/internationalisation/countryGroup';
+import type {
+	CountryGroupSwitcherProps,
+} from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countrySwitcherContainer';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
 import type { LandingPageVariant } from 'helpers/globalsAndSwitches/landingPageSettings';
-import { type GeoId } from 'pages/geoIdConfig';
+import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
 import { AccordionFAQ } from '../components/accordionFAQ';
 import StudentHeader from './components/StudentHeader';
 import { StudentTsAndCs } from './components/studentTsAndCs';
@@ -15,15 +25,35 @@ import { getStudentTsAndCs } from './helpers/studentTsAndCsCopy';
 export function StudentLandingPage({
 	geoId,
 	landingPageVariant,
+	global = false,
 }: {
 	geoId: GeoId;
 	landingPageVariant: LandingPageVariant;
+	global?: boolean;
 }) {
 	const faqItems = getStudentFAQs(geoId);
 	const tsAndCsItem = getStudentTsAndCs(geoId);
+
+	const { countryGroupId } = getGeoIdConfig(geoId);
+	const countrySwitcherProps: CountryGroupSwitcherProps = {
+		countryGroupIds: [GBPCountries, UnitedStates, Canada],
+		selectedCountryGroup: countryGroupId,
+		subPath: '/student',
+	};
+	const enableCountrySwitcher =
+		global && countrySwitcherProps.countryGroupIds.length > 1;
+
 	return (
 		<PageScaffold
-			header={<Header />}
+			header={
+				<Header>
+					{enableCountrySwitcher && (
+						<CountrySwitcherContainer>
+							<CountryGroupSwitcher {...countrySwitcherProps} />
+						</CountrySwitcherContainer>
+					)}
+				</Header>
+			}
 			footer={
 				<FooterWithContents>
 					<FooterLinks />

--- a/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.tsx
@@ -7,9 +7,7 @@ import {
 	GBPCountries,
 	UnitedStates,
 } from '@modules/internationalisation/countryGroup';
-import type {
-	CountryGroupSwitcherProps,
-} from 'components/countryGroupSwitcher/countryGroupSwitcher';
+import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countrySwitcherContainer';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';

--- a/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.tsx
@@ -36,14 +36,14 @@ export function StudentLandingPage({
 		selectedCountryGroup: countryGroupId,
 		subPath: '/student',
 	};
-	const enableCountrySwitcher =
+	const showCountrySwitcher =
 		geoId !== 'au' && countrySwitcherProps.countryGroupIds.length > 1;
 
 	return (
 		<PageScaffold
 			header={
 				<Header>
-					{enableCountrySwitcher && (
+					{showCountrySwitcher && (
 						<CountrySwitcherContainer>
 							<CountryGroupSwitcher {...countrySwitcherProps} />
 						</CountrySwitcherContainer>

--- a/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.tsx
@@ -23,11 +23,9 @@ import { getStudentTsAndCs } from './helpers/studentTsAndCsCopy';
 export function StudentLandingPage({
 	geoId,
 	landingPageVariant,
-	global = false,
 }: {
 	geoId: GeoId;
 	landingPageVariant: LandingPageVariant;
-	global?: boolean;
 }) {
 	const faqItems = getStudentFAQs(geoId);
 	const tsAndCsItem = getStudentTsAndCs(geoId);
@@ -39,7 +37,7 @@ export function StudentLandingPage({
 		subPath: '/student',
 	};
 	const enableCountrySwitcher =
-		global && countrySwitcherProps.countryGroupIds.length > 1;
+		geoId !== 'au' && countrySwitcherProps.countryGroupIds.length > 1;
 
 	return (
 		<PageScaffold

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -80,6 +80,7 @@ GET  /$country<(uk|us|au|eu|int|nz|ca)>/contribute                 controllers.A
 GET  /$country<(uk|us|au|eu|int|nz|ca)>/contribute/:campaignCode   controllers.Application.contributionsLanding(country: String, campaignCode: String)
 
 GET  /au/student/UTS                                               controllers.Application.studentLanding(country = "au", campaignCode = "")
+GET  /$country<(uk|us|ca)>/student                                 controllers.Application.studentLanding(country: String, campaignCode = "")
 
 GET  /aus-2020-map                                                 controllers.Application.ausMomentMap()
 GET  /aus-map                                                      controllers.Application.ausMomentMap()


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This pr enables `uk`, `us`, and `ca` country ids to list of  available countries that render student landing page.
Add country Switcher to global student page.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/C7yTVxHV/1796-global-student-page-enable-routing)

## Why are you doing this?
Beginning of development for the global student page.
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
Go any any of the urls:
- https://support.thegulocal.com/uk/student
- https://support.thegulocal.com/ca/student
- https://support.thegulocal.com/us/student

Any other regions should 404 eg: 
- https://support.thegulocal.com/eu/student

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
<img width="1347" height="851" alt="Screenshot 2025-08-11 at 16 24 09" src="https://github.com/user-attachments/assets/8b14abc1-490a-43e8-bdeb-7e1b28f7dcfa" />

