### PR TITLE
Updating wording about what Observer subscribers get access to

### DIFF
--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -235,8 +235,8 @@ export function ContributionsOrderSummary({
 				{isSundayOnlyNewspaperSubscription && showCheckList && (
 					<div css={orderSummarySundayDetails}>
 						{productKey === 'HomeDelivery'
-							? 'Print edition, delivered every Sunday and access to exclusive slow news digital newsletters, thought-provoking podcasts and Think-Ins, discussions with journalists.'
-							: 'Print edition every Sunday and access to exclusive slow news digital newsletters, thought-provoking podcasts and Think-Ins, discussions with journalists.'}
+							? 'Print edition, delivered every Sunday. All Observer readers also gain free access to the Observer digital newsletters and thought-provoking podcasts, and book tickets to Observer events.'
+							: 'Print edition every Sunday. All readers can also gain free access to the Observer digital newsletters and thought-provoking podcasts, and book tickets to Observer events.'}
 					</div>
 				)}
 			</div>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Updating wording at Tortoise Media's request about what Observer subscribers get access to

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->
<img width="1554" height="424" alt="Screenshot 2025-08-05 at 11 51 30" src="https://github.com/user-attachments/assets/6703c3a8-ae87-4e58-89bd-babc96474164" />


## Why are you doing this?
One of several [requests](https://docs.google.com/document/d/1TPhNbmvF-8CIKUWMzMEOx52HM9r5ODeW4yO_z5qRoHc/edit?tab=t.0) from Tortoise Media.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

- [x] Deployed to CODE

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Screenshots

Before:

Home Delivery:
<img width="985" height="568" alt="Screenshot 2025-08-13 at 09 36 54" src="https://github.com/user-attachments/assets/7be77b34-eab2-4ffe-8a7c-23a3b04f3e66" />

Subs card:
<img width="1013" height="570" alt="Screenshot 2025-08-12 at 17 22 54" src="https://github.com/user-attachments/assets/9366be45-e428-4b14-9a1e-1a71df0746b1" />


After:

Home Delivery:

<img width="983" height="586" alt="Screenshot 2025-08-13 at 09 37 57" src="https://github.com/user-attachments/assets/bb4e1e1e-b174-44ef-8cdd-1ca2a1941f39" />

Subs card:
<img width="980" height="571" alt="Screenshot 2025-08-13 at 09 35 14" src="https://github.com/user-attachments/assets/8fcb153b-3fe1-44ba-9029-b1d739cd29c1" />


