### PR TITLE
Add GuardianWeeklyGift product prices to allProductPrices object

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -12,6 +12,7 @@ import com.gu.support.catalog.{DigitalPack, GuardianWeekly, Paper, SupporterPlus
 import com.gu.support.config.Stages.PROD
 import com.gu.support.config._
 import com.gu.support.encoding.InternationalisationCodecs
+import com.gu.support.zuora.api.ReaderType.Gift
 import com.typesafe.scalalogging.StrictLogging
 import config.{RecaptchaConfigProvider, StringsConfig}
 import controllers.AppConfig.CsrfToken
@@ -196,6 +197,7 @@ case class AllProductPrices(
     TierThree: ProductPrices,
     Paper: ProductPrices,
     GuardianWeekly: ProductPrices,
+    GuardianWeeklyGift: ProductPrices,
     DigitalPack: ProductPrices,
 )
 
@@ -237,6 +239,7 @@ class Application(
       TierThree = priceSummaryServiceProvider.forUser(isTestUser).getPrices(TierThree, queryPromos),
       Paper = priceSummaryServiceProvider.forUser(isTestUser).getPrices(Paper, queryPromos),
       GuardianWeekly = priceSummaryServiceProvider.forUser(isTestUser).getPrices(GuardianWeekly, queryPromos),
+      GuardianWeeklyGift = priceSummaryServiceProvider.forUser(isTestUser).getPrices(GuardianWeekly, queryPromos, Gift),
       DigitalPack = priceSummaryServiceProvider.forUser(isTestUser).getPrices(DigitalPack, queryPromos),
     )
   }

--- a/support-frontend/assets/helpers/globalsAndSwitches/window.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/window.ts
@@ -245,9 +245,10 @@ const promotionSchema = z.object({
 	starts: dateTimeSchema,
 	expires: dateTimeSchema.optional(),
 });
+
 export const ProductPricesSchema = z.object({
 	allProductPrices: z.record(
-		z.enum(legacyProductTypes),
+		z.enum([...legacyProductTypes, 'GuardianWeeklyGift']),
 		optional(
 			z.record(
 				countryKeySchema,
@@ -279,7 +280,9 @@ const AppConfigSchema =
 	PaymentConfigSchema.merge(ProductCatalogSchema).merge(ProductPricesSchema);
 
 export type AppConfig = z.infer<typeof AppConfigSchema> & {
-	allProductPrices: Partial<Record<LegacyProductType, ProductPrices>>;
+	allProductPrices: Partial<
+		Record<LegacyProductType | 'GuardianWeeklyGift', ProductPrices>
+	>;
 };
 
 export const parseAppConfig = (obj: unknown): AppConfig => {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
To be able to present correct pricing and promotion information for Guardian Weekly gifts on the generic checkout we need to add product prices to the window.guardian.allProductPrices object.

This PR does that by adding a new top level object with allProductPrices named `GuardianWeeklyGift`. This is a slight hack because previously all the other top level objects were valid product types whereas this is just a variation on Guardian Weekly, but it is by far the most straightforward way to get the information to the page and this area is likely to be reworked quite soon to use the product catalog instead.

_The new object:_
<img width="537" height="228" alt="Screenshot 2025-08-14 at 11 42 26" src="https://github.com/user-attachments/assets/25f6ae34-7de1-471a-b2a4-75a52a5516b3" />


## [Trello Card](https://trello.com/c/wgr0tPOx/1815-guardian-weekly-guardianallproductprices-billingperiod-support-for-gifting-rateplans)