### PR TITLE
Add Student Offer link to 3 Tier landing page

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import {
 	between,
 	from,
+	headlineMedium24,
 	headlineMedium34,
 	palette,
 	space,
@@ -21,13 +22,13 @@ const container = css`
 
 const heading = css`
 	color: ${palette.neutral[7]};
-	${headlineMedium34}
+	${headlineMedium24}
+	${from.desktop} {
+		${headlineMedium34}
+	}
 	${between.tablet.and.desktop} {
 		margin: 0 auto;
 		max-width: 340px;
-	}
-	${from.desktop} {
-		font-size: 2.125rem;
 	}
 `;
 

--- a/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
@@ -63,6 +63,34 @@ const btnStyleOverrides = css`
 	}
 `;
 
+const dividerContainer = css`
+	text-align: center;
+	margin-bottom: ${space[8]}px;
+`;
+
+const dividerCopy = css`
+	${textSans17};
+	color: ${palette.neutral[38]};
+	display: flex;
+	align-items: center;
+
+	:before,
+	:after {
+		content: '';
+		height: 1px;
+		background-color: ${palette.neutral[86]};
+		flex-grow: 2;
+	}
+
+	:before {
+		margin-right: ${space[2]}px;
+	}
+
+	:after {
+		margin-left: ${space[2]}px;
+	}
+`;
+
 interface StudentOfferProps {
 	currencyKey: IsoCurrency;
 	countryGroupId: CountryGroupId;
@@ -85,23 +113,28 @@ export function StudentOffer({
 	}
 
 	return (
-		<div css={container}>
-			<h2 css={heading}>Student subscription</h2>
-			<p css={standFirst}>
-				Keep up to date on the latest news with an{' '}
-				<span css={boldCopy}>All&#x2011;access&nbsp;digital</span> subscription
-				for just {currencyGlyph}
-				{price}&nbsp;a&nbsp;year.
-			</p>
-			<LinkButton
-				href={`/${countryGroups[countryGroupId].supportInternationalisationId}/student`}
-				priority="tertiary"
-				size="default"
-				cssOverrides={btnStyleOverrides}
-				aria-label="Find out more"
-			>
-				Find out more
-			</LinkButton>
-		</div>
+		<>
+			<div css={dividerContainer}>
+				<p css={dividerCopy}>More subscription options</p>
+			</div>
+			<div css={container}>
+				<h2 css={heading}>Student subscription</h2>
+				<p css={standFirst}>
+					Keep up to date on the latest news with an{' '}
+					<span css={boldCopy}>All&#x2011;access&nbsp;digital</span>{' '}
+					subscription for just {currencyGlyph}
+					{price}&nbsp;a&nbsp;year.
+				</p>
+				<LinkButton
+					href={`/${countryGroups[countryGroupId].supportInternationalisationId}/student`}
+					priority="tertiary"
+					size="default"
+					cssOverrides={btnStyleOverrides}
+					aria-label="Find out more"
+				>
+					Find out more
+				</LinkButton>
+			</div>
+		</>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
@@ -64,8 +64,11 @@ const btnStyleOverrides = css`
 `;
 
 const dividerContainer = css`
-	text-align: center;
-	margin-bottom: ${space[8]}px;
+	margin: 0 auto ${space[8]}px auto;
+
+	${from.desktop} {
+		max-width: 940px;
+	}
 `;
 
 const dividerCopy = css`

--- a/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
@@ -43,7 +43,7 @@ const standFirst = css`
 		max-width: 340px;
 	}
 	${from.desktop} {
-		max-width: 500px;
+		max-width: 422px;
 	}
 `;
 

--- a/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
@@ -1,0 +1,92 @@
+import { css } from '@emotion/react';
+import {
+	between,
+	from,
+	headlineBold24,
+	palette,
+	space,
+	textSans17,
+} from '@guardian/source/foundations';
+import { LinkButton } from '@guardian/source/react-components';
+import {
+	type CountryGroupId,
+	countryGroups,
+} from '@modules/internationalisation/countryGroup';
+
+const container = css`
+	text-align: center;
+`;
+
+const heading = css`
+	color: ${palette.neutral[7]};
+	${headlineBold24}
+	${between.tablet.and.desktop} {
+		margin: 0 auto;
+		max-width: 340px;
+	}
+	${from.desktop} {
+		font-size: 2.125rem;
+	}
+`;
+
+const standFirst = css`
+	color: ${palette.neutral[10]};
+	${textSans17};
+	line-height: 1.35;
+	padding-top: ${space[1]}px;
+	${from.tablet} {
+		padding-top: ${space[2]}px;
+		margin: 0 auto;
+		max-width: 340px;
+	}
+	${from.desktop} {
+		max-width: 422px;
+	}
+`;
+
+const boldCopy = css`
+	font-weight: bold;
+`;
+
+const btnStyleOverrides = css`
+	width: 100%;
+	justify-content: center;
+	margin-top: ${space[6]}px;
+	${from.tablet} {
+		max-width: 340px;
+	}
+	${from.desktop} {
+		max-width: 275px;
+	}
+`;
+
+interface StudentOfferProps {
+	currency: string;
+	countryGroupId: CountryGroupId;
+}
+
+export function StudentOffer({
+	currency,
+	countryGroupId,
+}: StudentOfferProps): JSX.Element {
+	return (
+		<div css={container}>
+			<h2 css={heading}>Student subscription</h2>
+			<p css={standFirst}>
+				Keep up to date on the latest news with an{' '}
+				<span css={boldCopy}>All&#x2011;access&nbsp;digital</span> subscription
+				for just {currency}
+				TBD&nbsp;a&nbsp;year.
+			</p>
+			<LinkButton
+				href={`/${countryGroups[countryGroupId].supportInternationalisationId}/one-time-checkout`}
+				priority="tertiary"
+				size="default"
+				cssOverrides={btnStyleOverrides}
+				aria-label="Find out more"
+			>
+				Find out more
+			</LinkButton>
+		</div>
+	);
+}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
@@ -41,7 +41,7 @@ const standFirst = css`
 		max-width: 340px;
 	}
 	${from.desktop} {
-		max-width: 422px;
+		max-width: 500px;
 	}
 `;
 

--- a/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
@@ -80,7 +80,7 @@ export function StudentOffer({
 				TBD&nbsp;a&nbsp;year.
 			</p>
 			<LinkButton
-				href={`/${countryGroups[countryGroupId].supportInternationalisationId}/one-time-checkout`}
+				href={`/${countryGroups[countryGroupId].supportInternationalisationId}/student`}
 				priority="tertiary"
 				size="default"
 				cssOverrides={btnStyleOverrides}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
@@ -8,10 +8,11 @@ import {
 	textSans17,
 } from '@guardian/source/foundations';
 import { LinkButton } from '@guardian/source/react-components';
-import {
-	type CountryGroupId,
-	countryGroups,
-} from '@modules/internationalisation/countryGroup';
+import type { CountryGroupId } from '@modules/internationalisation/countryGroup';
+import { countryGroups } from '@modules/internationalisation/countryGroup';
+import type { IsoCurrency } from '@modules/internationalisation/currency';
+import { currencies } from 'helpers/internationalisation/currency';
+import { productCatalog } from 'helpers/productCatalog';
 
 const container = css`
 	text-align: center;
@@ -62,22 +63,34 @@ const btnStyleOverrides = css`
 `;
 
 interface StudentOfferProps {
-	currency: string;
+	currencyKey: IsoCurrency;
 	countryGroupId: CountryGroupId;
 }
 
 export function StudentOffer({
-	currency,
+	currencyKey,
 	countryGroupId,
 }: StudentOfferProps): JSX.Element {
+	const price =
+		productCatalog.SupporterPlus?.ratePlans['OneYearStudent']?.pricing[
+			currencyKey
+		];
+	const currencyGlyph = currencies[currencyKey].glyph;
+
+	// We don't expect this to happen, but don't render the copy with a missing
+	// price if it ever does.
+	if (!price) {
+		return <></>;
+	}
+
 	return (
 		<div css={container}>
 			<h2 css={heading}>Student subscription</h2>
 			<p css={standFirst}>
 				Keep up to date on the latest news with an{' '}
 				<span css={boldCopy}>All&#x2011;access&nbsp;digital</span> subscription
-				for just {currency}
-				TBD&nbsp;a&nbsp;year.
+				for just {currencyGlyph}
+				{price}&nbsp;a&nbsp;year.
 			</p>
 			<LinkButton
 				href={`/${countryGroups[countryGroupId].supportInternationalisationId}/student`}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
@@ -15,6 +15,7 @@ import {
 
 const container = css`
 	text-align: center;
+	margin-bottom: ${space[4]}px;
 `;
 
 const heading = css`

--- a/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import {
 	between,
 	from,
-	headlineBold24,
+	headlineMedium34,
 	palette,
 	space,
 	textSans17,
@@ -20,7 +20,7 @@ const container = css`
 
 const heading = css`
 	color: ${palette.neutral[7]};
-	${headlineBold24}
+	${headlineMedium34}
 	${between.tablet.and.desktop} {
 		margin: 0 auto;
 		max-width: 340px;
@@ -31,7 +31,7 @@ const heading = css`
 `;
 
 const standFirst = css`
-	color: ${palette.neutral[10]};
+	color: ${palette.neutral[7]};
 	${textSans17};
 	line-height: 1.35;
 	padding-top: ${space[1]}px;

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -50,6 +50,7 @@ import { getSanitisedHtml } from '../../../helpers/utilities/utilities';
 import Countdown from '../components/countdown';
 import { LandingPageBanners } from '../components/landingPageBanners';
 import { OneOffCard } from '../components/oneOffCard';
+import { StudentOffer } from '../components/studentOffer';
 import { SupportOnce } from '../components/supportOnce';
 import type { CardContent } from '../components/threeTierCard';
 import { ThreeTierCards } from '../components/threeTierCards';
@@ -80,7 +81,7 @@ const recurringContainer = css`
 	}
 `;
 
-const oneTimeContainer = css`
+const lightContainer = css`
 	display: flex;
 	background-color: ${palette.neutral[97]};
 	> div {
@@ -611,7 +612,7 @@ export function ThreeTierLanding({
 				<Container
 					sideBorders
 					borderColor="rgba(170, 170, 180, 0.5)"
-					cssOverrides={oneTimeContainer}
+					cssOverrides={lightContainer}
 				>
 					<SupportOnce
 						currency={currencies[currencyId].glyph}
@@ -619,6 +620,16 @@ export function ThreeTierLanding({
 					/>
 				</Container>
 			)}
+			<Container
+				sideBorders
+				borderColor="rgba(170, 170, 180, 0.5)"
+				cssOverrides={lightContainer}
+			>
+				<StudentOffer
+					currency={currencies[currencyId].glyph}
+					countryGroupId={countryGroupId}
+				/>
+			</Container>
 		</PageScaffold>
 	);
 }

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -85,7 +85,11 @@ const lightContainer = css`
 	display: flex;
 	background-color: ${palette.neutral[97]};
 	> div {
-		padding: ${space[5]}px 72px;
+		padding: ${space[5]}px;
+
+		${from.tablet} {
+			padding: ${space[5]}px 72px;
+		}
 	}
 `;
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -631,7 +631,7 @@ export function ThreeTierLanding({
 					cssOverrides={lightContainer}
 				>
 					<StudentOffer
-						currency={currencies[currencyId].glyph}
+						currencyKey={currencyId}
 						countryGroupId={countryGroupId}
 					/>
 				</Container>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -292,6 +292,10 @@ export function ThreeTierLanding({
 		campaignSettings?.enableSingleContributions ??
 		urlSearchParams.has('enableOneTime');
 
+	const enableStudentOffer =
+		['uk', 'us', 'ca'].includes(geoId) &&
+		urlSearchParams.has('enableStudentOffer');
+
 	const getInitialContributionType = () => {
 		if (enableSingleContributionsTab && urlSearchParamsOneTime) {
 			return 'ONE_OFF';
@@ -620,16 +624,18 @@ export function ThreeTierLanding({
 					/>
 				</Container>
 			)}
-			<Container
-				sideBorders
-				borderColor="rgba(170, 170, 180, 0.5)"
-				cssOverrides={lightContainer}
-			>
-				<StudentOffer
-					currency={currencies[currencyId].glyph}
-					countryGroupId={countryGroupId}
-				/>
-			</Container>
+			{enableStudentOffer && (
+				<Container
+					sideBorders
+					borderColor="rgba(170, 170, 180, 0.5)"
+					cssOverrides={lightContainer}
+				>
+					<StudentOffer
+						currency={currencies[currencyId].glyph}
+						countryGroupId={countryGroupId}
+					/>
+				</Container>
+			)}
 		</PageScaffold>
 	);
 }


### PR DESCRIPTION
## What are you doing in this PR?

This PR adds a new section to the 3 tier landing page, under the `Support us just once` section, with a link to the student offer landing page. It's only ever displayed in uk, us and ca, and currently a query string arg is needed to show it at all (we don't want it to be visible in prod yet).

[**Trello Card**](https://trello.com/c/o2O49aP9/1769-tier3-landing-page-add-student-link-container)

## Why are you doing this?

Signposting the new student offer.

## How to test

Visit the 3 tier landing page with a region code of `uk`, `us` or `ca` and add `enableStudentOffer` as a query string arg (no value needed).

## Screenshots

### Mobile

<img width="499" height="804" alt="Screenshot 2025-08-19 at 09 41 09" src="https://github.com/user-attachments/assets/6315b4c5-dd21-45a7-8c0e-5c6ab32791ff" />

### Desktop

<img width="1400" height="733" alt="Screenshot 2025-08-19 at 09 41 24" src="https://github.com/user-attachments/assets/d36fbe9c-d29a-401e-8ab4-6944899cc9d3" />
