### PR TITLE
Add note to PR template to label PRs appropriately

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->
+
 <!-- all sections optional, delete any you don't need -->
 ## What are you doing in this PR?
 


### PR DESCRIPTION
## What are you doing in this PR?

Adding a note to the PR template to remind PR-raisers to label their PR appropriately.

## Why are you doing this?

DevX would like to track the kinds of changes made on repos and this will assist that.
