### PR TITLE
WIP: Remove Aus/UTS specific pieces from global student landing page

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -51,11 +51,18 @@ const LandingPage = lazy(() => {
 		},
 	);
 });
-const StudentLandingPage = lazy(() => {
+const StudentLandingPageUTSContainer = lazy(() => {
 	return import(
-		/* webpackChunkName: "StudentLandingPageContainer" */ './student/StudentLandingPageContainer'
+		/* webpackChunkName: "StudentLandingPageUTSContainer" */ './student/StudentLandingPageUTSContainer'
 	).then((mod) => {
-		return { default: mod.StudentLandingPageContainer };
+		return { default: mod.StudentLandingPageUTSContainer };
+	});
+});
+const StudentLandingPageGlobalContainer = lazy(() => {
+	return import(
+		/* webpackChunkName: "StudentLandingPageGlobalContainer" */ './student/StudentLandingPageGlobalContainer'
+	).then((mod) => {
+		return { default: mod.StudentLandingPageGlobalContainer };
 	});
 });
 
@@ -123,10 +130,8 @@ const router = createBrowserRouter([
 			path: `/${geoId}/student`,
 			element: (
 				<Suspense fallback={<HoldingContent />}>
-					<StudentLandingPage
+					<StudentLandingPageGlobalContainer
 						geoId={geoId}
-						productKey="SupporterPlus"
-						ratePlanKey="OneYearStudent"
 						landingPageVariant={landingPageParticipations.variant}
 					/>
 				</Suspense>
@@ -137,10 +142,7 @@ const router = createBrowserRouter([
 		path: '/au/student/UTS',
 		element: (
 			<Suspense fallback={<HoldingContent />}>
-				<StudentLandingPage
-					geoId={'au'}
-					productKey="SupporterPlus"
-					ratePlanKey="Monthly"
+				<StudentLandingPageUTSContainer
 					landingPageVariant={landingPageParticipations.variant}
 				/>
 			</Suspense>

--- a/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.tsx
@@ -20,10 +20,12 @@ import type {
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
 import { AccordionFAQ } from '../components/accordionFAQ';
 import StudentHeader from './components/StudentHeader';
+import { universityBadge } from './components/StudentHeaderStyles';
 import { StudentTsAndCs } from './components/studentTsAndCs';
 import type { StudentDiscount } from './helpers/discountDetails';
 import { getStudentFAQs } from './helpers/studentFAQs';
 import { getStudentTsAndCs } from './helpers/studentTsAndCsCopy';
+import LogoUTS from './logos/uts';
 
 type StudentLandingPageProps = {
 	geoId: GeoId;
@@ -75,6 +77,12 @@ export function StudentLandingPage({
 				ratePlanKey={ratePlanKey}
 				landingPageVariant={landingPageVariant}
 				studentDiscount={studentDiscount}
+				headingCopy="Subscribe to fearless, independent and inspiring journalism"
+				universityBadge={
+					<p css={universityBadge}>
+						<LogoUTS /> <span>Special offer for UTS students</span>
+					</p>
+				}
 			/>
 			{faqItems && <AccordionFAQ faqItems={faqItems} />}
 			{tsAndCsItem && <StudentTsAndCs tsAndCsItem={tsAndCsItem} />}

--- a/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.tsx
@@ -12,36 +12,18 @@ import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSw
 import { CountrySwitcherContainer } from 'components/headers/simpleHeader/countrySwitcherContainer';
 import { Header } from 'components/headers/simpleHeader/simpleHeader';
 import { PageScaffold } from 'components/page/pageScaffold';
-import type { LandingPageVariant } from 'helpers/globalsAndSwitches/landingPageSettings';
-import type {
-	ActiveProductKey,
-	ActiveRatePlanKey,
-} from 'helpers/productCatalog';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
 import { AccordionFAQ } from '../components/accordionFAQ';
-import StudentHeader from './components/StudentHeader';
-import { universityBadge } from './components/StudentHeaderStyles';
 import { StudentTsAndCs } from './components/studentTsAndCs';
-import type { StudentDiscount } from './helpers/discountDetails';
 import { getStudentFAQs } from './helpers/studentFAQs';
 import { getStudentTsAndCs } from './helpers/studentTsAndCsCopy';
-import LogoUTS from './logos/uts';
 
 type StudentLandingPageProps = {
 	geoId: GeoId;
-	productKey: ActiveProductKey;
-	ratePlanKey: ActiveRatePlanKey;
-	landingPageVariant: LandingPageVariant;
-	studentDiscount: StudentDiscount;
+	header: React.ReactNode;
 };
 
-export function StudentLandingPage({
-	geoId,
-	productKey,
-	ratePlanKey,
-	landingPageVariant,
-	studentDiscount,
-}: StudentLandingPageProps) {
+export function StudentLandingPage({ geoId, header }: StudentLandingPageProps) {
 	const faqItems = getStudentFAQs(geoId);
 	const tsAndCsItem = getStudentTsAndCs(geoId);
 
@@ -71,32 +53,7 @@ export function StudentLandingPage({
 				</FooterWithContents>
 			}
 		>
-			<StudentHeader
-				geoId={geoId}
-				productKey={productKey}
-				ratePlanKey={ratePlanKey}
-				landingPageVariant={landingPageVariant}
-				studentDiscount={studentDiscount}
-				headingCopy="Subscribe to fearless, independent and inspiring journalism"
-				subheading={
-					<>
-						For a limited time, students with a valid UTS email address can
-						unlock the premium experience of Guardian journalism, including
-						unmetered app access
-						{studentDiscount.promoDuration && (
-							<>
-								, <strong>free for {studentDiscount.promoDuration}</strong>
-							</>
-						)}
-						.
-					</>
-				}
-				universityBadge={
-					<p css={universityBadge}>
-						<LogoUTS /> <span>Special offer for UTS students</span>
-					</p>
-				}
-			/>
+			{header}
 			{faqItems && <AccordionFAQ faqItems={faqItems} />}
 			{tsAndCsItem && <StudentTsAndCs tsAndCsItem={tsAndCsItem} />}
 		</PageScaffold>

--- a/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPage.tsx
@@ -78,6 +78,19 @@ export function StudentLandingPage({
 				landingPageVariant={landingPageVariant}
 				studentDiscount={studentDiscount}
 				headingCopy="Subscribe to fearless, independent and inspiring journalism"
+				subheading={
+					<>
+						For a limited time, students with a valid UTS email address can
+						unlock the premium experience of Guardian journalism, including
+						unmetered app access
+						{studentDiscount.promoDuration && (
+							<>
+								, <strong>free for {studentDiscount.promoDuration}</strong>
+							</>
+						)}
+						.
+					</>
+				}
 				universityBadge={
 					<p css={universityBadge}>
 						<LogoUTS /> <span>Special offer for UTS students</span>

--- a/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPageGlobal.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPageGlobal.tsx
@@ -1,0 +1,40 @@
+import type { LandingPageVariant } from 'helpers/globalsAndSwitches/landingPageSettings';
+import {
+	type ActiveProductKey,
+	type ActiveRatePlanKey,
+} from 'helpers/productCatalog';
+import { type GeoId } from 'pages/geoIdConfig';
+import StudentHeader from './components/StudentHeader';
+import type { StudentDiscount } from './helpers/discountDetails';
+import { StudentLandingPage } from './StudentLandingPage';
+
+export function StudentLandingPageGlobal({
+	geoId,
+	landingPageVariant,
+	productKey,
+	ratePlanKey,
+	studentDiscount,
+}: {
+	geoId: GeoId;
+	landingPageVariant: LandingPageVariant;
+	productKey: ActiveProductKey;
+	ratePlanKey: ActiveRatePlanKey;
+	studentDiscount: StudentDiscount;
+}) {
+	return (
+		<StudentLandingPage
+			geoId={geoId}
+			header={
+				<StudentHeader
+					geoId={geoId}
+					productKey={productKey}
+					ratePlanKey={ratePlanKey}
+					landingPageVariant={landingPageVariant}
+					studentDiscount={studentDiscount}
+					headingCopy={`No owner. No agenda. No more than ${studentDiscount.discountPriceWithCurrency} a year for students`}
+					subheadingCopy="Now more than ever, independent journalism matters. Get fact-based reporting you can trust and unlimited access to the Guardian apps &mdash; without breaking your budget."
+				/>
+			}
+		/>
+	);
+}

--- a/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPageGlobalContainer.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPageGlobalContainer.tsx
@@ -4,9 +4,8 @@ import {
 	type ActiveRatePlanKey,
 } from 'helpers/productCatalog';
 import { type GeoId } from 'pages/geoIdConfig';
-import StudentHeader from './components/StudentHeader';
 import { getStudentDiscount } from './helpers/discountDetails';
-import { StudentLandingPage } from './StudentLandingPage';
+import { StudentLandingPageGlobal } from './StudentLandingPageGlobal';
 
 export function StudentLandingPageGlobalContainer({
 	geoId,
@@ -28,19 +27,12 @@ export function StudentLandingPageGlobalContainer({
 	return (
 		<>
 			{studentDiscount && (
-				<StudentLandingPage
+				<StudentLandingPageGlobal
 					geoId={geoId}
-					header={
-						<StudentHeader
-							geoId={geoId}
-							productKey={productKey}
-							ratePlanKey={ratePlanKey}
-							landingPageVariant={landingPageVariant}
-							studentDiscount={studentDiscount}
-							headingCopy={`No owner. No agenda. No more than ${studentDiscount.discountPriceWithCurrency} a year for students`}
-							subheadingCopy="Now more than ever, independent journalism matters. Get fact-based reporting you can trust and unlimited access to the Guardian apps &mdash; without breaking your budget."
-						/>
-					}
+					productKey={productKey}
+					ratePlanKey={ratePlanKey}
+					landingPageVariant={landingPageVariant}
+					studentDiscount={studentDiscount}
 				/>
 			)}
 		</>

--- a/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPageGlobalContainer.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPageGlobalContainer.tsx
@@ -1,0 +1,48 @@
+import type { LandingPageVariant } from 'helpers/globalsAndSwitches/landingPageSettings';
+import {
+	type ActiveProductKey,
+	type ActiveRatePlanKey,
+} from 'helpers/productCatalog';
+import { type GeoId } from 'pages/geoIdConfig';
+import StudentHeader from './components/StudentHeader';
+import { getStudentDiscount } from './helpers/discountDetails';
+import { StudentLandingPage } from './StudentLandingPage';
+
+export function StudentLandingPageGlobalContainer({
+	geoId,
+	landingPageVariant,
+}: {
+	geoId: GeoId;
+	landingPageVariant: LandingPageVariant;
+}) {
+	const productKey: ActiveProductKey = 'SupporterPlus';
+	const ratePlanKey: ActiveRatePlanKey = 'OneYearStudent';
+
+	const studentDiscount = getStudentDiscount(
+		geoId,
+		ratePlanKey,
+		productKey,
+		undefined, // Promo code not needed here - discount is applied by the rate plan
+	);
+
+	return (
+		<>
+			{studentDiscount && (
+				<StudentLandingPage
+					geoId={geoId}
+					header={
+						<StudentHeader
+							geoId={geoId}
+							productKey={productKey}
+							ratePlanKey={ratePlanKey}
+							landingPageVariant={landingPageVariant}
+							studentDiscount={studentDiscount}
+							headingCopy={`No owner. No agenda. No more than ${studentDiscount.discountPriceWithCurrency} a year for students`}
+							subheadingCopy="Now more than ever, independent journalism matters. Get fact-based reporting you can trust and unlimited access to the Guardian apps &mdash; without breaking your budget."
+						/>
+					}
+				/>
+			)}
+		</>
+	);
+}

--- a/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPageUTS.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPageUTS.tsx
@@ -1,0 +1,59 @@
+import type { LandingPageVariant } from 'helpers/globalsAndSwitches/landingPageSettings';
+import type {
+	ActiveProductKey,
+	ActiveRatePlanKey,
+} from 'helpers/productCatalog';
+import { type GeoId } from 'pages/geoIdConfig';
+import StudentHeader from './components/StudentHeader';
+import { universityBadge } from './components/StudentHeaderStyles';
+import type { StudentDiscount } from './helpers/discountDetails';
+import LogoUTS from './logos/uts';
+import { StudentLandingPage } from './StudentLandingPage';
+
+export function StudentLandingPageUTS({
+	landingPageVariant,
+	geoId,
+	productKey,
+	ratePlanKey,
+	studentDiscount,
+}: {
+	landingPageVariant: LandingPageVariant;
+	geoId: GeoId;
+	productKey: ActiveProductKey;
+	ratePlanKey: ActiveRatePlanKey;
+	studentDiscount: StudentDiscount;
+}) {
+	return (
+		<StudentLandingPage
+			geoId={geoId}
+			header={
+				<StudentHeader
+					geoId={geoId}
+					productKey={productKey}
+					ratePlanKey={ratePlanKey}
+					landingPageVariant={landingPageVariant}
+					studentDiscount={studentDiscount}
+					headingCopy="Subscribe to fearless, independent and inspiring journalism"
+					subheadingCopy={
+						<>
+							For a limited time, students with a valid UTS email address can
+							unlock the premium experience of Guardian journalism, including
+							unmetered app access
+							{studentDiscount.promoDuration && (
+								<>
+									, <strong>free for {studentDiscount.promoDuration}</strong>
+								</>
+							)}
+							.
+						</>
+					}
+					universityBadge={
+						<p css={universityBadge}>
+							<LogoUTS /> <span>Special offer for UTS students</span>
+						</p>
+					}
+				/>
+			}
+		/>
+	);
+}

--- a/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPageUTSContainer.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPageUTSContainer.tsx
@@ -9,20 +9,21 @@ import { ratePlanToBillingPeriod } from 'helpers/productPrice/billingPeriods';
 import { allProductPrices } from 'helpers/productPrice/productPrices';
 import { getPromotion } from 'helpers/productPrice/promotions';
 import { type GeoId } from 'pages/geoIdConfig';
+import StudentHeader from './components/StudentHeader';
+import { universityBadge } from './components/StudentHeaderStyles';
 import { getStudentDiscount } from './helpers/discountDetails';
+import LogoUTS from './logos/uts';
 import { StudentLandingPage } from './StudentLandingPage';
 
-export function StudentLandingPageContainer({
-	geoId,
-	productKey,
-	ratePlanKey,
+export function StudentLandingPageUTSContainer({
 	landingPageVariant,
 }: {
-	geoId: GeoId;
-	productKey: ActiveProductKey;
-	ratePlanKey: ActiveRatePlanKey;
 	landingPageVariant: LandingPageVariant;
 }) {
+	const geoId: GeoId = 'au';
+	const productKey: ActiveProductKey = 'SupporterPlus';
+	const ratePlanKey: ActiveRatePlanKey = 'Monthly';
+
 	/**
 	 * Non-AU Students have ratePlanKey as OneYearStudent
 	 * AU Students have ratePlanKey as Monthly, productKey as SupporterPlus and promoCode UTS_STUDENT
@@ -45,10 +46,35 @@ export function StudentLandingPageContainer({
 			{studentDiscount && (
 				<StudentLandingPage
 					geoId={geoId}
-					productKey={productKey}
-					ratePlanKey={ratePlanKey}
-					landingPageVariant={landingPageVariant}
-					studentDiscount={studentDiscount}
+					header={
+						<StudentHeader
+							geoId={geoId}
+							productKey={productKey}
+							ratePlanKey={ratePlanKey}
+							landingPageVariant={landingPageVariant}
+							studentDiscount={studentDiscount}
+							headingCopy="Subscribe to fearless, independent and inspiring journalism"
+							subheadingCopy={
+								<>
+									For a limited time, students with a valid UTS email address
+									can unlock the premium experience of Guardian journalism,
+									including unmetered app access
+									{studentDiscount.promoDuration && (
+										<>
+											,{' '}
+											<strong>free for {studentDiscount.promoDuration}</strong>
+										</>
+									)}
+									.
+								</>
+							}
+							universityBadge={
+								<p css={universityBadge}>
+									<LogoUTS /> <span>Special offer for UTS students</span>
+								</p>
+							}
+						/>
+					}
 				/>
 			)}
 		</>

--- a/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPageUTSContainer.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/StudentLandingPageUTSContainer.tsx
@@ -9,11 +9,8 @@ import { ratePlanToBillingPeriod } from 'helpers/productPrice/billingPeriods';
 import { allProductPrices } from 'helpers/productPrice/productPrices';
 import { getPromotion } from 'helpers/productPrice/promotions';
 import { type GeoId } from 'pages/geoIdConfig';
-import StudentHeader from './components/StudentHeader';
-import { universityBadge } from './components/StudentHeaderStyles';
 import { getStudentDiscount } from './helpers/discountDetails';
-import LogoUTS from './logos/uts';
-import { StudentLandingPage } from './StudentLandingPage';
+import { StudentLandingPageUTS } from './StudentLandingPageUTS';
 
 export function StudentLandingPageUTSContainer({
 	landingPageVariant,
@@ -24,10 +21,6 @@ export function StudentLandingPageUTSContainer({
 	const productKey: ActiveProductKey = 'SupporterPlus';
 	const ratePlanKey: ActiveRatePlanKey = 'Monthly';
 
-	/**
-	 * Non-AU Students have ratePlanKey as OneYearStudent
-	 * AU Students have ratePlanKey as Monthly, productKey as SupporterPlus and promoCode UTS_STUDENT
-	 */
 	const countryId: IsoCountry = Country.detect();
 	const promotionSupporterPlus = getPromotion(
 		allProductPrices.SupporterPlus,
@@ -44,37 +37,12 @@ export function StudentLandingPageUTSContainer({
 	return (
 		<>
 			{studentDiscount && (
-				<StudentLandingPage
+				<StudentLandingPageUTS
 					geoId={geoId}
-					header={
-						<StudentHeader
-							geoId={geoId}
-							productKey={productKey}
-							ratePlanKey={ratePlanKey}
-							landingPageVariant={landingPageVariant}
-							studentDiscount={studentDiscount}
-							headingCopy="Subscribe to fearless, independent and inspiring journalism"
-							subheadingCopy={
-								<>
-									For a limited time, students with a valid UTS email address
-									can unlock the premium experience of Guardian journalism,
-									including unmetered app access
-									{studentDiscount.promoDuration && (
-										<>
-											,{' '}
-											<strong>free for {studentDiscount.promoDuration}</strong>
-										</>
-									)}
-									.
-								</>
-							}
-							universityBadge={
-								<p css={universityBadge}>
-									<LogoUTS /> <span>Special offer for UTS students</span>
-								</p>
-							}
-						/>
-					}
+					landingPageVariant={landingPageVariant}
+					productKey={productKey}
+					ratePlanKey={ratePlanKey}
+					studentDiscount={studentDiscount}
 				/>
 			)}
 		</>

--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.test.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.test.tsx
@@ -55,6 +55,7 @@ describe('<StudentHeader />', () => {
 				ratePlanKey={ratePlanKey}
 				landingPageVariant={landingPageVariant}
 				studentDiscount={auStudentDiscount}
+				headingCopy="Subscribe to fearless, independent and inspiring journalism"
 			/>,
 		);
 		expect(
@@ -70,6 +71,7 @@ describe('<StudentHeader />', () => {
 				ratePlanKey={ratePlanKey}
 				landingPageVariant={landingPageVariant}
 				studentDiscount={auStudentDiscount}
+				headingCopy="Subscribe to fearless, independent and inspiring journalism"
 			/>,
 		);
 		expect(screen.getByTestId('cta-button')).toHaveTextContent(
@@ -85,6 +87,7 @@ describe('<StudentHeader />', () => {
 				ratePlanKey={ratePlanKey}
 				landingPageVariant={landingPageVariant}
 				studentDiscount={oneYearStudentDiscount}
+				headingCopy="Subscribe to fearless, independent and inspiring journalism"
 			/>,
 		);
 		expect(screen.getByTestId('cta-button')).toHaveTextContent('Subscribe');
@@ -98,6 +101,7 @@ describe('<StudentHeader />', () => {
 				ratePlanKey={ratePlanKey}
 				landingPageVariant={landingPageVariant}
 				studentDiscount={auStudentDiscount}
+				headingCopy="Subscribe to fearless, independent and inspiring journalism"
 			/>,
 		);
 		expect(

--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
@@ -25,6 +25,7 @@ interface StudentHeaderProps {
 	landingPageVariant: LandingPageVariant;
 	studentDiscount: StudentDiscount;
 	headingCopy: string;
+	subheading: React.ReactNode;
 	universityBadge?: React.ReactNode;
 }
 
@@ -37,7 +38,7 @@ export default function StudentHeader({
 	headingCopy,
 	universityBadge,
 }: StudentHeaderProps) {
-	const { amount, promoDuration, promoCode, discountSummary } = studentDiscount;
+	const { amount, promoCode, discountSummary } = studentDiscount;
 	const { benefits } = landingPageVariant.products.SupporterPlus;
 	const checkoutUrl = buildCheckoutUrl(
 		geoId,
@@ -58,17 +59,7 @@ export default function StudentHeader({
 			{universityBadge}
 			<div css={headingWrapper}>
 				<h1 css={heading}>{headingCopy}</h1>
-				<p css={subHeading}>
-					For a limited time, students with a valid UTS email address can unlock
-					the premium experience of Guardian journalism, including unmetered app
-					access
-					{promoDuration && (
-						<>
-							, <strong>free for {promoDuration}</strong>
-						</>
-					)}
-					.
-				</p>
+				<p css={subHeading}></p>
 			</div>
 			<div css={cardContainer}>
 				<StudentProductCard

--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
@@ -8,17 +8,25 @@ import type {
 import type { GeoId } from 'pages/geoIdConfig';
 import buildCheckoutUrl from '../helpers/buildCheckoutUrl';
 import type { StudentDiscount } from '../helpers/discountDetails';
-import LogoUTS from '../logos/uts';
 import {
 	cardContainer,
 	containerCardsAndSignIn,
 	heading,
 	headingWrapper,
 	subHeading,
-	universityBadge,
 } from './StudentHeaderStyles';
 import StudentPrice from './StudentPrice';
 import StudentProductCard from './StudentProductCard';
+
+interface StudentHeaderProps {
+	geoId: GeoId;
+	productKey: ActiveProductKey;
+	ratePlanKey: ActiveRatePlanKey;
+	landingPageVariant: LandingPageVariant;
+	studentDiscount: StudentDiscount;
+	headingCopy: string;
+	universityBadge?: React.ReactNode;
+}
 
 export default function StudentHeader({
 	geoId,
@@ -26,13 +34,9 @@ export default function StudentHeader({
 	ratePlanKey,
 	landingPageVariant,
 	studentDiscount,
-}: {
-	geoId: GeoId;
-	productKey: ActiveProductKey;
-	ratePlanKey: ActiveRatePlanKey;
-	landingPageVariant: LandingPageVariant;
-	studentDiscount: StudentDiscount;
-}) {
+	headingCopy,
+	universityBadge,
+}: StudentHeaderProps) {
 	const { amount, promoDuration, promoCode, discountSummary } = studentDiscount;
 	const { benefits } = landingPageVariant.products.SupporterPlus;
 	const checkoutUrl = buildCheckoutUrl(
@@ -51,13 +55,9 @@ export default function StudentHeader({
 			borderColor="rgba(170, 170, 180, 0.5)"
 			cssOverrides={containerCardsAndSignIn}
 		>
-			<p css={universityBadge}>
-				<LogoUTS /> <span>Special offer for UTS students</span>
-			</p>
+			{universityBadge}
 			<div css={headingWrapper}>
-				<h1 css={heading}>
-					Subscribe to fearless, independent and inspiring journalism
-				</h1>
+				<h1 css={heading}>{headingCopy}</h1>
 				<p css={subHeading}>
 					For a limited time, students with a valid UTS email address can unlock
 					the premium experience of Guardian journalism, including unmetered app

--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
@@ -25,7 +25,7 @@ interface StudentHeaderProps {
 	landingPageVariant: LandingPageVariant;
 	studentDiscount: StudentDiscount;
 	headingCopy: string;
-	subheading: React.ReactNode;
+	subheadingCopy: React.ReactNode;
 	universityBadge?: React.ReactNode;
 }
 
@@ -36,6 +36,7 @@ export default function StudentHeader({
 	landingPageVariant,
 	studentDiscount,
 	headingCopy,
+	subheadingCopy,
 	universityBadge,
 }: StudentHeaderProps) {
 	const { amount, promoCode, discountSummary } = studentDiscount;
@@ -59,7 +60,7 @@ export default function StudentHeader({
 			{universityBadge}
 			<div css={headingWrapper}>
 				<h1 css={heading}>{headingCopy}</h1>
-				<p css={subHeading}></p>
+				<p css={subHeading}>{subheadingCopy}</p>
 			</div>
 			<div css={cardContainer}>
 				<StudentProductCard


### PR DESCRIPTION
## What are you doing in this PR?

The current implementation of the global student landing page re-uses components from the UTS/Aus student landing page, which has copy and the image hardcoded. This PR changes the components to be flexible and usable in both contexts (global and UTS student offer).

[**Trello Card**](https://trello.com/c/e4S1aQvX/1797-global-student-page-hide-aus-institute-specific-logo)

## Why are you doing this?

This is a stepping stone to launching the global student offer, which requires its own distinct copy etc.

## How to test

Visit the global student landing page and compare with the Aus/UTS specific version.

## Screenshots

<img width="1037" height="341" alt="Screenshot 2025-08-25 at 10 48 09" src="https://github.com/user-attachments/assets/1911977f-cb99-47c0-9855-83bdb1806b2e" />
