### PR TITLE
Add toggleable "Not a student?" signposting to landing page

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
@@ -28,6 +28,7 @@ interface StudentHeaderProps {
 	headingCopy: string;
 	subheadingCopy: React.ReactNode;
 	universityBadge?: JSX.Element;
+	includeThreeTierLink?: boolean;
 }
 
 export default function StudentHeader({
@@ -39,6 +40,7 @@ export default function StudentHeader({
 	headingCopy,
 	subheadingCopy,
 	universityBadge,
+	includeThreeTierLink = false,
 }: StudentHeaderProps) {
 	const { amount, promoCode, discountSummary } = studentDiscount;
 	const { benefits } = landingPageVariant.products.SupporterPlus;
@@ -100,15 +102,17 @@ export default function StudentHeader({
 					altText=""
 				/>
 			</div>
-			<div css={notAStudentContainer}>
-				<p>
-					<span>Not a student?</span>{' '}
-					<span>
-						Explore our other{' '}
-						<a href={`/${geoId}/contribute`}>support options</a>
-					</span>
-				</p>
-			</div>
+			{includeThreeTierLink && (
+				<div css={notAStudentContainer}>
+					<p>
+						<span>Not a student?</span>{' '}
+						<span>
+							Explore our other{' '}
+							<a href={`/${geoId}/contribute`}>support options</a>
+						</span>
+					</p>
+				</div>
+			)}
 		</Container>
 	);
 }

--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
@@ -13,6 +13,7 @@ import {
 	containerCardsAndSignIn,
 	heading,
 	headingWrapper,
+	notAStudentContainer,
 	subHeading,
 } from './StudentHeaderStyles';
 import StudentPrice from './StudentPrice';
@@ -98,6 +99,15 @@ export default function StudentHeader({
 					fallbackSize={574}
 					altText=""
 				/>
+			</div>
+			<div css={notAStudentContainer}>
+				<p>
+					<span>Not a student?</span>{' '}
+					<span>
+						Explore our other{' '}
+						<a href={`/${geoId}/contribute`}>support options</a>
+					</span>
+				</p>
 			</div>
 		</Container>
 	);

--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeaderStyles.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeaderStyles.tsx
@@ -69,7 +69,7 @@ export const cardContainer = css`
 	display: flex;
 	flex-direction: column-reverse;
 	align-self: center;
-	padding: ${space[6]}px 0 ${space[3]}px;
+	padding: ${space[6]}px 0 ${space[6]}px;
 
 	picture {
 		display: flex;
@@ -86,11 +86,29 @@ export const cardContainer = css`
 
 	${from.tablet} {
 		flex-direction: row;
-		padding: ${space[9]}px 0 ${space[8]}px;
+		padding: ${space[9]}px 0 ${space[6]}px;
 	}
 
 	${from.desktop} {
 		flex-direction: row;
-		padding: ${space[12]}px 0 ${space[9]}px;
+		padding: ${space[12]}px 0 ${space[6]}px;
+	}
+`;
+
+export const notAStudentContainer = css`
+	${textSans17}
+	margin: 0 auto ${space[6]}px;
+	color: ${palette.neutral[100]};
+	text-align: center;
+
+	// This causes the text to break in the right place on small screens, but
+	// doesn't affect things on larger screens.
+	span {
+		display: inline-block;
+	}
+
+	a {
+		${textSansBold17}
+		color: ${palette.neutral[100]};
 	}
 `;

--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentLandingPageGlobal.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentLandingPageGlobal.tsx
@@ -33,6 +33,7 @@ export function StudentLandingPageGlobal({
 					studentDiscount={studentDiscount}
 					headingCopy={`No owner. No agenda. No more than ${studentDiscount.discountPriceWithCurrency} a year for students`}
 					subheadingCopy="Now more than ever, independent journalism matters. Get fact-based reporting you can trust and unlimited access to the Guardian apps &mdash; without breaking your budget."
+					includeThreeTierLink={true}
 				/>
 			}
 		/>


### PR DESCRIPTION
## What are you doing in this PR?

Add toggleable "Not a student?" signposting to the landing page with a link to the 3 tier landing page.

Note: This is controllable with a prop on the `StudentHeader` component which defaults to `false`. After #7224 is merged we can override this by passing `true` from the global student landing page component.

[**Trello Card**](https://trello.com/c/Tvk2HjkK/1801-global-student-page-create-not-a-student-return-link)

## Why are you doing this?

To give users an onwards journey from the student landing page if the student offer isn't for them.

## Screenshots

<img width="1092" height="224" alt="Screenshot 2025-08-25 at 12 31 00" src="https://github.com/user-attachments/assets/27711a96-3336-4b68-9107-35248dec187d" />

<img width="399" height="139" alt="Screenshot 2025-08-25 at 12 31 20" src="https://github.com/user-attachments/assets/c4b5fa7e-29f2-4da9-9034-9e89ea2dadd6" />
