### PR TITLE
Update AWS SDK v2 libs to v2.32.29

### DIFF
--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -3,7 +3,7 @@ object LibraryVersions {
 
   @deprecated("use awsClientVersion2")
   val awsClientVersion = "1.12.703"
-  val awsClientVersion2 = "2.30.21"
+  val awsClientVersion2 = "2.32.29"
 
   val catsVersion = "2.10.0"
   val jacksonVersion = "2.15.2"


### PR DESCRIPTION
## What are you doing in this PR?

Update AWS SDK v2 libs to v2.32.29 in the aws module.

[**Trello Card**](https://trello.com/c/JiNV3XWA/1828-fix-high-severity-vulnerability-on-support-frontend-netty)

## Why are you doing this?

This fixes a vulnerability reported by Dependabot for
`io.netty:netty-codec-http2` across a number of sub-projects because it's a transitive dependency of some AWS SDK v2 libs.

## How to test

TBD.

## How can we measure success?

The Dependabot alert will be closed.