### PR TITLE
Removing the noisy logging when we retrieve epic tests

### DIFF
--- a/support-frontend/app/services/LandingPageTestService.scala
+++ b/support-frontend/app/services/LandingPageTestService.scala
@@ -129,7 +129,6 @@ class LandingPageTestServiceImpl(stage: Stage)(implicit val ec: ExecutionContext
   system.scheduler.scheduleAtFixedRate(0.minute, 1.minute)(() => {
     fetchLandingPageTests()
       .map { tests =>
-        logger.info(s"Got landing page tests: ${tests}")
         cachedTests.set(tests)
       }
       .recover { case NonFatal(error) =>


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We noticed that the support-frontend logs are full of logging related to epic tests which are running on the site. This is very noisy as these tests contain a lot of information and are refeshed every minute. 

This PR changes the logging so that we will only log if there is a failure, not on success.