### PR TITLE
Return correct output state from CreateZuoraSubscriptionTSLambda

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ catalogs:
       specifier: ^2.1.5
       version: 2.1.5
     '@guardian/support-service-lambdas':
-      specifier: guardian/support-service-lambdas#26dc841334ed11918467d3201c2de3d08ed9558c
+      specifier: guardian/support-service-lambdas#a359b7b9d829c09d8ea37577d6416fd58dd6844a
       version: 1.0.0
     '@types/jest':
       specifier: ^29.5.12
@@ -128,7 +128,7 @@ importers:
         version: 2.1.5(prettier@2.8.8)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/26dc841334ed11918467d3201c2de3d08ed9558c
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/a359b7b9d829c09d8ea37577d6416fd58dd6844a
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.0
@@ -201,7 +201,7 @@ importers:
         version: 18.1.1(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@guardian/libs@22.5.0(tslib@2.8.1)(typescript@5.5.4))(@guardian/source@10.2.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/26dc841334ed11918467d3201c2de3d08ed9558c
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/a359b7b9d829c09d8ea37577d6416fd58dd6844a
       '@guardian/tsconfig':
         specifier: ^0.2.0
         version: 0.2.0
@@ -563,7 +563,7 @@ importers:
         version: 3.699.0(@aws-sdk/client-sso-oidc@3.817.0)(@aws-sdk/client-sts@3.817.0)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/26dc841334ed11918467d3201c2de3d08ed9558c
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/a359b7b9d829c09d8ea37577d6416fd58dd6844a
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -2105,8 +2105,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/26dc841334ed11918467d3201c2de3d08ed9558c':
-    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/26dc841334ed11918467d3201c2de3d08ed9558c}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/a359b7b9d829c09d8ea37577d6416fd58dd6844a':
+    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/a359b7b9d829c09d8ea37577d6416fd58dd6844a}
     version: 1.0.0
 
   '@guardian/tsconfig@0.2.0':
@@ -11601,7 +11601,7 @@ snapshots:
       react: 18.2.0
       typescript: 5.5.4
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/26dc841334ed11918467d3201c2de3d08ed9558c': {}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/a359b7b9d829c09d8ea37577d6416fd58dd6844a': {}
 
   '@guardian/tsconfig@0.2.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,4 +21,4 @@ catalog:
   "@aws-sdk/credential-provider-node": 3.699.0
   "@guardian/eslint-config-typescript": 12.0.0
   "@guardian/prettier": ^2.1.5
-  "@guardian/support-service-lambdas": "guardian/support-service-lambdas#26dc841334ed11918467d3201c2de3d08ed9558c"
+  "@guardian/support-service-lambdas": "guardian/support-service-lambdas#a359b7b9d829c09d8ea37577d6416fd58dd6844a"

--- a/support-workers/src/typescript/lambdas/createZuoraSubscriptionTSLambda.ts
+++ b/support-workers/src/typescript/lambdas/createZuoraSubscriptionTSLambda.ts
@@ -77,7 +77,6 @@ export const handler = async (
 		);
 
 		// TODO:
-		//  Output state
 		//  Prevent duplicates (Idempotency key?)
 		//  Apply promotion if present
 		//  Validate paper payment gateway? Might be done already by schema

--- a/support-workers/src/typescript/lambdas/createZuoraSubscriptionTSLambda.ts
+++ b/support-workers/src/typescript/lambdas/createZuoraSubscriptionTSLambda.ts
@@ -1,20 +1,40 @@
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { getProductCatalogFromApi } from '@modules/product-catalog/api';
-import {
-	createSubscription,
-	type CreateSubscriptionInputFields,
+import { createSubscription } from '@modules/zuora/createSubscription/createSubscription';
+import type {
+	CreateSubscriptionInputFields,
+	CreateSubscriptionResponse,
 } from '@modules/zuora/createSubscription/createSubscription';
+import { previewCreateSubscription } from '@modules/zuora/createSubscription/previewCreateSubscription';
+import type {
+	PreviewCreateSubscriptionInputFields,
+	PreviewCreateSubscriptionResponse,
+} from '@modules/zuora/createSubscription/previewCreateSubscription';
 import type { Contact } from '@modules/zuora/orders/newAccount';
 import type { PaymentMethod as ZuoraPaymentMethod } from '@modules/zuora/orders/paymentMethods';
+import { zuoraDateFormat } from '@modules/zuora/utils/common';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
+import dayjs from 'dayjs';
 import type { Address } from '../model/address';
 import type { CreateZuoraSubscriptionState } from '../model/createZuoraSubscriptionState';
 import type { PaymentMethod } from '../model/paymentMethod';
+import type { PaymentSchedule } from '../model/paymentSchedule';
+import { buildPaymentSchedule } from '../model/paymentSchedule';
+import type {
+	SendAcquisitionEventState,
+	SendThankYouEmailState,
+} from '../model/sendAcquisitionEventState';
+import { sendThankYouEmailStateSchema } from '../model/sendAcquisitionEventState';
 import { stageFromEnvironment } from '../model/stage';
 import type { WrappedState } from '../model/stateSchemas';
 import { ServiceProvider } from '../services/config';
 import { asRetryError } from '../util/errorHandler';
 import { getIfDefined } from '../util/nullAndUndefined';
+
+// Ensure that any Date objects are serialised in the format expected by Zuora
+Date.prototype.toJSON = function () {
+	return zuoraDateFormat(dayjs(this));
+};
 
 const stage = stageFromEnvironment();
 
@@ -57,9 +77,10 @@ export const handler = async (
 		);
 
 		// TODO:
+		//  Output state
+		//  Prevent duplicates (Idempotency key?)
 		//  Apply promotion if present
 		//  Validate paper payment gateway? Might be done already by schema
-		//  Output state
 		//  CSR mode is NOT needed
 
 		const inputFields: CreateSubscriptionInputFields<ZuoraPaymentMethod> = {
@@ -81,17 +102,32 @@ export const handler = async (
 		const productCatalog = await productCatalogProvider.getServiceForUser(
 			createZuoraSubscriptionState.user.isTestUser,
 		);
-		const result = await createSubscription(
+		const createSubscriptionResult = await createSubscription(
 			zuoraClient,
 			productCatalog,
 			inputFields,
 		);
 
-		// TODO: return the correct state
-		return Promise.resolve({
-			state: result,
-		});
+		const previewInputFields: PreviewCreateSubscriptionInputFields = {
+			accountNumber: createSubscriptionResult.accountNumber,
+			currency: currency,
+			productPurchase: productInformation,
+		};
+
+		const previewInvoices = await previewCreateSubscription(
+			zuoraClient,
+			productCatalog,
+			previewInputFields,
+		);
+
+		return buildOutputState(
+			state,
+			createZuoraSubscriptionState,
+			createSubscriptionResult,
+			previewInvoices,
+		);
 	} catch (error) {
+		// TODO: correct error handling
 		throw asRetryError(error);
 	}
 };
@@ -141,4 +177,75 @@ const buildContact = (
 		address2: address.lineTwo ?? undefined,
 		postalCode: address.postCode ?? undefined,
 	};
+};
+
+export const buildOutputState = (
+	wrappedState: WrappedState<CreateZuoraSubscriptionState>,
+	createZuoraSubscriptionState: CreateZuoraSubscriptionState,
+	createZuoraSubscriptionResult: CreateSubscriptionResponse,
+	previewInvoices: PreviewCreateSubscriptionResponse,
+): WrappedState<SendAcquisitionEventState> => {
+	const subscriptionNumber = getIfDefined(
+		createZuoraSubscriptionResult.subscriptionNumbers[0],
+		'No subscription number returned from Zuora createSubscription call',
+	);
+	const paymentSchedule = buildPaymentSchedule(
+		getIfDefined(
+			previewInvoices.previewResult.invoices[0]?.invoiceItems,
+			`Unable to build payment schedule for subscription ${subscriptionNumber} with state ${JSON.stringify(
+				createZuoraSubscriptionState,
+			)}. Preview invoices: ${JSON.stringify(previewInvoices)}`,
+		),
+	);
+
+	// TODO: this needs extensive testing for all products
+	return {
+		state: {
+			sendThankYouEmailState: buildSendThankYouEmailState(
+				createZuoraSubscriptionState,
+				createZuoraSubscriptionResult,
+				paymentSchedule,
+				subscriptionNumber,
+			),
+			requestId: createZuoraSubscriptionState.requestId,
+			analyticsInfo: createZuoraSubscriptionState.analyticsInfo,
+			acquisitionData: createZuoraSubscriptionState.acquisitionData,
+		},
+		requestInfo: wrappedState.requestInfo,
+		error: wrappedState.error,
+	};
+};
+const buildSendThankYouEmailState = (
+	state: CreateZuoraSubscriptionState,
+	createZuoraSubscriptionResult: CreateSubscriptionResponse,
+	paymentSchedule: PaymentSchedule,
+	subscriptionNumber: string,
+): SendThankYouEmailState => {
+	const { similarProductsConsent, firstDeliveryDate } = {
+		similarProductsConsent: undefined,
+		firstDeliveryDate: undefined,
+		...state.productSpecificState.productInformation,
+	};
+
+	const { giftRecipient, appliedPromotion } = {
+		giftRecipient: undefined,
+		appliedPromotion: undefined,
+		...state.productSpecificState,
+	};
+
+	return sendThankYouEmailStateSchema.parse({
+		productType: state.product.productType,
+		user: state.user,
+		product: state.product,
+		productInformation:
+			state.productSpecificState.productInformation ?? undefined,
+		paymentMethod: state.productSpecificState.paymentMethod,
+		accountNumber: createZuoraSubscriptionResult.accountNumber,
+		subscriptionNumber: subscriptionNumber,
+		paymentSchedule: paymentSchedule,
+		firstDeliveryDate: firstDeliveryDate,
+		giftRecipient: giftRecipient,
+		similarProductsConsent: similarProductsConsent,
+		promoCode: appliedPromotion?.promoCode ?? undefined,
+	});
 };

--- a/support-workers/src/typescript/model/paymentSchedule.ts
+++ b/support-workers/src/typescript/model/paymentSchedule.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+export type InvoiceItem = {
+	serviceStartDate: Date;
+	amountWithoutTax: number;
+	taxAmount: number;
+};
+
+const paymentSchema = z.object({
+	date: z.date(),
+	amount: z.number(),
+});
+export type Payment = z.infer<typeof paymentSchema>;
+
+export const paymentScheduleSchema = z.object({
+	payments: z.array(paymentSchema),
+});
+export type PaymentSchedule = z.infer<typeof paymentScheduleSchema>;
+
+const round = (amount: number): number => Math.round(amount * 100) / 100;
+
+export const buildPaymentSchedule = (
+	invoiceItems: InvoiceItem[],
+): PaymentSchedule => {
+	if (invoiceItems.length == 0) {
+		throw new Error('No invoice items provided to buildPaymentSchedule');
+	}
+	const paymentMap = new Map<string, number>();
+
+	for (const charge of invoiceItems) {
+		const dateKey = charge.serviceStartDate.toISOString();
+		const currentAmount = paymentMap.get(dateKey) ?? 0;
+		paymentMap.set(
+			dateKey,
+			currentAmount + charge.amountWithoutTax + charge.taxAmount,
+		);
+	}
+
+	const payments: Payment[] = [];
+	for (const [dateKey, amount] of paymentMap) {
+		payments.push({
+			date: new Date(dateKey),
+			amount: round(amount),
+		});
+	}
+
+	payments.sort((a, b) => a.date.getTime() - b.date.getTime());
+	return { payments };
+};

--- a/support-workers/src/typescript/model/sendAcquisitionEventState.ts
+++ b/support-workers/src/typescript/model/sendAcquisitionEventState.ts
@@ -1,0 +1,119 @@
+import { productPurchaseSchema } from '@modules/product-catalog/productPurchaseSchema';
+import { z } from 'zod';
+import { paymentMethodSchema } from './paymentMethod';
+import { paymentScheduleSchema } from './paymentSchedule';
+import { productTypeSchema } from './productType';
+import {
+	acquisitionDataSchema,
+	analyticsInfoSchema,
+	giftRecipientSchema,
+	userSchema,
+} from './stateSchemas';
+
+export const sendThankYouEmailStateSchema = z.union([
+	z.object({
+		productType: z.literal('Contribution'),
+		user: userSchema,
+		product: productTypeSchema,
+		productInformation: productPurchaseSchema,
+		paymentMethod: paymentMethodSchema,
+		accountNumber: z.string(),
+		subscriptionNumber: z.string(),
+		similarProductsConsent: z.boolean().optional(),
+	}),
+
+	z.object({
+		productType: z.literal('SupporterPlus'),
+		user: userSchema,
+		product: productTypeSchema,
+		productInformation: productPurchaseSchema,
+		paymentMethod: paymentMethodSchema,
+		paymentSchedule: paymentScheduleSchema,
+		promoCode: z.string().optional(),
+		accountNumber: z.string(),
+		subscriptionNumber: z.string(),
+		similarProductsConsent: z.boolean().optional(),
+	}),
+
+	z.object({
+		productType: z.literal('TierThree'),
+		user: userSchema,
+		product: productTypeSchema,
+		productInformation: productPurchaseSchema,
+		paymentMethod: paymentMethodSchema,
+		paymentSchedule: paymentScheduleSchema,
+		promoCode: z.string().optional(),
+		accountNumber: z.string(),
+		subscriptionNumber: z.string(),
+		firstDeliveryDate: z.string(),
+		similarProductsConsent: z.boolean().optional(),
+	}),
+
+	z.object({
+		productType: z.literal('GuardianAdLite'),
+		user: userSchema,
+		product: productTypeSchema,
+		productInformation: productPurchaseSchema,
+		paymentMethod: paymentMethodSchema,
+		paymentSchedule: paymentScheduleSchema,
+		accountNumber: z.string(),
+		subscriptionNumber: z.string(),
+	}),
+
+	z.object({
+		productType: z.literal('DigitalPack'),
+		user: userSchema,
+		product: productTypeSchema,
+		productInformation: productPurchaseSchema,
+		paymentMethod: paymentMethodSchema,
+		paymentSchedule: paymentScheduleSchema,
+		promoCode: z.string().optional(),
+		accountNumber: z.string(),
+		subscriptionNumber: z.string(),
+		similarProductsConsent: z.boolean().optional(),
+	}),
+
+	z.object({
+		productType: z.literal('Paper'),
+		user: userSchema,
+		product: productTypeSchema,
+		productInformation: productPurchaseSchema,
+		paymentMethod: paymentMethodSchema,
+		paymentSchedule: paymentScheduleSchema,
+		promoCode: z.string().optional(),
+		accountNumber: z.string(),
+		subscriptionNumber: z.string(),
+		firstDeliveryDate: z.string(),
+		similarProductsConsent: z.boolean().optional(),
+	}),
+
+	z.object({
+		productType: z.literal('GuardianWeekly'),
+		user: userSchema,
+		product: productTypeSchema,
+		productInformation: productPurchaseSchema.optional(),
+		giftRecipient: giftRecipientSchema.optional(),
+		paymentMethod: paymentMethodSchema,
+		paymentSchedule: paymentScheduleSchema,
+		promoCode: z.string().optional(),
+		accountNumber: z.string(),
+		subscriptionNumber: z.string(),
+		firstDeliveryDate: z.string(),
+		similarProductsConsent: z.boolean().optional(),
+	}),
+]);
+
+export type SendThankYouEmailState = z.infer<
+	typeof sendThankYouEmailStateSchema
+>;
+
+export const sendAcquisitionEventStateSchema = z.object({
+	requestId: z.string(),
+	sendThankYouEmailState: sendThankYouEmailStateSchema,
+	analyticsInfo: analyticsInfoSchema,
+	acquisitionData: acquisitionDataSchema.nullish(),
+});
+
+export type SendAcquisitionEventState = z.infer<
+	typeof sendAcquisitionEventStateSchema
+>;

--- a/support-workers/src/typescript/test/paymentSchedule.test.ts
+++ b/support-workers/src/typescript/test/paymentSchedule.test.ts
@@ -1,0 +1,166 @@
+import type { InvoiceItem } from '../model/paymentSchedule';
+import { buildPaymentSchedule } from '../model/paymentSchedule';
+
+describe('buildPaymentSchedule', () => {
+	test('should throw if we have no invoice items', () => {
+		expect(() => buildPaymentSchedule([])).toThrow(
+			'No invoice items provided to buildPaymentSchedule',
+		);
+	});
+
+	test('should create payment for single invoice item', () => {
+		const invoiceItems: InvoiceItem[] = [
+			{
+				serviceStartDate: new Date('2025-01-01'),
+				amountWithoutTax: 10.0,
+				taxAmount: 2.0,
+			},
+		];
+
+		const result = buildPaymentSchedule(invoiceItems);
+
+		expect(result).toEqual({
+			payments: [
+				{
+					date: new Date('2025-01-01'),
+					amount: 12.0,
+				},
+			],
+		});
+	});
+
+	test('should combine multiple invoice items with same date', () => {
+		const invoiceItems: InvoiceItem[] = [
+			{
+				serviceStartDate: new Date('2025-01-01'),
+				amountWithoutTax: 10.0,
+				taxAmount: 2.0,
+			},
+			{
+				serviceStartDate: new Date('2025-01-01'),
+				amountWithoutTax: 5.0,
+				taxAmount: 1.0,
+			},
+		];
+
+		const result = buildPaymentSchedule(invoiceItems);
+
+		expect(result).toEqual({
+			payments: [
+				{
+					date: new Date('2025-01-01'),
+					amount: 18.0,
+				},
+			],
+		});
+	});
+
+	test('should create separate payments for different dates', () => {
+		const invoiceItems: InvoiceItem[] = [
+			{
+				serviceStartDate: new Date('2025-01-01'),
+				amountWithoutTax: 10.0,
+				taxAmount: 2.0,
+			},
+			{
+				serviceStartDate: new Date('2025-02-01'),
+				amountWithoutTax: 15.0,
+				taxAmount: 3.0,
+			},
+		];
+
+		const result = buildPaymentSchedule(invoiceItems);
+
+		expect(result).toEqual({
+			payments: [
+				{
+					date: new Date('2025-01-01'),
+					amount: 12.0,
+				},
+				{
+					date: new Date('2025-02-01'),
+					amount: 18.0,
+				},
+			],
+		});
+	});
+
+	test('should sort payments by date ascending', () => {
+		const invoiceItems: InvoiceItem[] = [
+			{
+				serviceStartDate: new Date('2025-03-01'),
+				amountWithoutTax: 20.0,
+				taxAmount: 4.0,
+			},
+			{
+				serviceStartDate: new Date('2025-01-01'),
+				amountWithoutTax: 10.0,
+				taxAmount: 2.0,
+			},
+			{
+				serviceStartDate: new Date('2025-02-01'),
+				amountWithoutTax: 15.0,
+				taxAmount: 3.0,
+			},
+		];
+
+		const result = buildPaymentSchedule(invoiceItems);
+
+		expect(result.payments).toEqual([
+			{
+				date: new Date('2025-01-01'),
+				amount: 12.0,
+			},
+			{
+				date: new Date('2025-02-01'),
+				amount: 18.0,
+			},
+			{
+				date: new Date('2025-03-01'),
+				amount: 24.0,
+			},
+		]);
+	});
+
+	test('should round amounts to 2 decimal places', () => {
+		const invoiceItems: InvoiceItem[] = [
+			{
+				serviceStartDate: new Date('2025-01-01'),
+				amountWithoutTax: 10.333,
+				taxAmount: 2.666,
+			},
+		];
+
+		const result = buildPaymentSchedule(invoiceItems);
+
+		expect(result).toEqual({
+			payments: [
+				{
+					date: new Date('2025-01-01'),
+					amount: 13.0,
+				},
+			],
+		});
+	});
+
+	test('should handle zero amounts', () => {
+		const invoiceItems: InvoiceItem[] = [
+			{
+				serviceStartDate: new Date('2025-01-01'),
+				amountWithoutTax: 0,
+				taxAmount: 0,
+			},
+		];
+
+		const result = buildPaymentSchedule(invoiceItems);
+
+		expect(result).toEqual({
+			payments: [
+				{
+					date: new Date('2025-01-01'),
+					amount: 0,
+				},
+			],
+		});
+	});
+});

--- a/support-workers/src/typescript/test/zuoraDateReplacer.test.ts
+++ b/support-workers/src/typescript/test/zuoraDateReplacer.test.ts
@@ -1,0 +1,35 @@
+import { zuoraDateReplacer } from '../util/zuoraDateReplacer';
+
+describe('zuoraDateReplacer', () => {
+	const realDate = new Date('2025-09-01T12:25:09Z');
+
+	it('replaces Date objects with formatted string', () => {
+		const obj = { date: realDate };
+		const result = JSON.stringify(obj, zuoraDateReplacer);
+		expect(result).toEqual('{"date":"2025-09-01"}');
+	});
+
+	it('leaves non-Date values unchanged', () => {
+		const obj = { num: 42, str: 'test', bool: true, nil: null };
+		const result = JSON.stringify(obj, zuoraDateReplacer);
+		expect(result).toBe(JSON.stringify(obj));
+	});
+
+	it('replaces nested Date objects', () => {
+		const obj = { nested: { date: realDate } };
+		const result = JSON.stringify(obj, zuoraDateReplacer);
+		expect(result).toEqual('{"nested":{"date":"2025-09-01"}}');
+	});
+
+	it('handles arrays with Date objects', () => {
+		const obj = { dates: [realDate, 'not a date', 123] };
+		const result = JSON.stringify(obj, zuoraDateReplacer);
+		expect(result).toEqual('{"dates":["2025-09-01","not a date",123]}');
+	});
+
+	it('ignores invalid date strings', () => {
+		const obj = { invalidDate: '2025-13-01T12:00:00Z' }; // Invalid month
+		const result = JSON.stringify(obj, zuoraDateReplacer);
+		expect(result).toEqual('{"invalidDate":"2025-13-01T12:00:00Z"}');
+	});
+});

--- a/support-workers/src/typescript/util/zuoraDateReplacer.ts
+++ b/support-workers/src/typescript/util/zuoraDateReplacer.ts
@@ -1,0 +1,14 @@
+import { zuoraDateFormat } from '@modules/zuora/utils/common';
+import dayjs from 'dayjs';
+
+const isoDateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+
+export function zuoraDateReplacer(key: string, value: unknown): unknown {
+	if (typeof value === 'string' && isoDateRegex.test(value)) {
+		const date = new Date(value);
+		if (!isNaN(date.getTime())) {
+			return zuoraDateFormat(dayjs(date));
+		}
+	}
+	return value;
+}


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR is the next step in the work to move the CreateZuoraSubscription lambda in the support-workers step function to a new Typescript implementation. The benefits of this are:
- Migrating from Scala to Typescript is a strategic goal for us to increase our ability to find developers to work on our codebase
- Moving from Zuora's deprecated subscribe and amend API to their newer Orders API
- Start using the product catalog to define which subscriptions we create rather than the old deprecated model

Note that at this stage there is still no traffic going to the new lambda, it is all being routed to the old one as described in this PR https://github.com/guardian/support-frontend/pull/7175

[**Trello Card for the Epic**](https://trello.com/c/346hWkLe/1804-build-and-release-typescript-createzuorasubscription-lambda)
[**Trello Card for this piece of work**](https://trello.com/c/PDP1MTX6/1850-create-output-for-sendthankyouemail-lambda)
