### PR TITLE
Error handling for CreateZuoraSubscription lambda

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ catalogs:
       specifier: ^2.1.5
       version: 2.1.5
     '@guardian/support-service-lambdas':
-      specifier: guardian/support-service-lambdas#a359b7b9d829c09d8ea37577d6416fd58dd6844a
+      specifier: guardian/support-service-lambdas#49cf4074e202fd884c80fe66ab9d2fb15ead9711
       version: 1.0.0
     '@types/jest':
       specifier: ^29.5.12
@@ -128,7 +128,7 @@ importers:
         version: 2.1.5(prettier@2.8.8)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/a359b7b9d829c09d8ea37577d6416fd58dd6844a
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/49cf4074e202fd884c80fe66ab9d2fb15ead9711
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.0
@@ -201,7 +201,7 @@ importers:
         version: 18.1.1(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@guardian/libs@22.5.0(tslib@2.8.1)(typescript@5.5.4))(@guardian/source@10.2.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/a359b7b9d829c09d8ea37577d6416fd58dd6844a
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/49cf4074e202fd884c80fe66ab9d2fb15ead9711
       '@guardian/tsconfig':
         specifier: ^0.2.0
         version: 0.2.0
@@ -563,7 +563,7 @@ importers:
         version: 3.699.0(@aws-sdk/client-sso-oidc@3.817.0)(@aws-sdk/client-sts@3.817.0)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/a359b7b9d829c09d8ea37577d6416fd58dd6844a
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/49cf4074e202fd884c80fe66ab9d2fb15ead9711
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -2105,8 +2105,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/a359b7b9d829c09d8ea37577d6416fd58dd6844a':
-    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/a359b7b9d829c09d8ea37577d6416fd58dd6844a}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/49cf4074e202fd884c80fe66ab9d2fb15ead9711':
+    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/49cf4074e202fd884c80fe66ab9d2fb15ead9711}
     version: 1.0.0
 
   '@guardian/tsconfig@0.2.0':
@@ -11601,7 +11601,7 @@ snapshots:
       react: 18.2.0
       typescript: 5.5.4
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/a359b7b9d829c09d8ea37577d6416fd58dd6844a': {}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/49cf4074e202fd884c80fe66ab9d2fb15ead9711': {}
 
   '@guardian/tsconfig@0.2.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,4 +21,4 @@ catalog:
   "@aws-sdk/credential-provider-node": 3.699.0
   "@guardian/eslint-config-typescript": 12.0.0
   "@guardian/prettier": ^2.1.5
-  "@guardian/support-service-lambdas": "guardian/support-service-lambdas#a359b7b9d829c09d8ea37577d6416fd58dd6844a"
+  "@guardian/support-service-lambdas": "guardian/support-service-lambdas#49cf4074e202fd884c80fe66ab9d2fb15ead9711"

--- a/support-workers/jest.config.js
+++ b/support-workers/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	runner: 'groups',
 	testPathIgnorePatterns: ['/node_modules/', 'target'],
 	transformIgnorePatterns: ['/node_modules/\\.pnpm/(?!@guardian)'],
+	setupFilesAfterEnv: ['<rootDir>/src/typescript/test/test-setup.ts'],
 	moduleNameMapper: {
 		// Modules directory in support-frontend
 		'@modules/(product|internationalisation)/(.*)$':

--- a/support-workers/src/main/scala/com/gu/support/workers/exceptions/CardDeclinedMessages.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/exceptions/CardDeclinedMessages.scala
@@ -20,6 +20,7 @@ object CardDeclinedMessages {
     "Transaction declined.validation_failed - account_number did not pass modulus check",
     "Transaction declined.validation_failed - account_number is the wrong length (should be 8 characters)",
     "Transaction declined.validation_failed - account_number does not match sort code",
+    // This list should be kept in sync with the list in src/typescript/errors/zuoraErrors.ts
   )
   def alarmShouldBeSuppressedForErrorMessage(message: String): Boolean = {
     errorMessages.exists(messageToIgnore => message.contains(messageToIgnore))

--- a/support-workers/src/typescript/errors/errorHandler.ts
+++ b/support-workers/src/typescript/errors/errorHandler.ts
@@ -1,20 +1,8 @@
+import { ZuoraError } from '@modules/zuora/errors/zuoraError';
 import Stripe from 'stripe';
 import { SalesforceError, salesforceErrorCodes } from '../services/salesforce';
-
-export class RetryError extends Error {
-	constructor(errorType: string, message: string) {
-		super(message);
-		this.name = errorType; // This is what the step function retry policy uses
-	}
-}
-
-const retryNone = (message: string) => new RetryError('RetryNone', message);
-
-const retryLimited = (message: string) =>
-	new RetryError('RetryLimited', message);
-
-const retryUnlimited = (message: string) =>
-	new RetryError('RetryUnlimited', message);
+import { retryLimited, retryNone, retryUnlimited } from './retryError';
+import { mapZuoraError } from './zuoraErrors';
 
 export const asRetryError = (error: unknown) => {
 	if (error instanceof Stripe.errors.StripeError) {
@@ -22,6 +10,9 @@ export const asRetryError = (error: unknown) => {
 	}
 	if (error instanceof SalesforceError) {
 		return mapSalesforceError(error);
+	}
+	if (error instanceof ZuoraError) {
+		return mapZuoraError(error);
 	}
 	if (error instanceof Error) {
 		return retryLimited(error.message);

--- a/support-workers/src/typescript/errors/retryError.ts
+++ b/support-workers/src/typescript/errors/retryError.ts
@@ -1,0 +1,19 @@
+export enum RetryErrorType {
+	RetryNone = 'RetryNone',
+	RetryLimited = 'RetryLimited',
+	RetryUnlimited = 'RetryUnlimited',
+}
+
+export class RetryError extends Error {
+	constructor(errorType: string, message: string) {
+		super(message);
+		this.name = errorType; // This is what the step function retry policy uses
+	}
+}
+
+export const retryNone = (message: string) =>
+	new RetryError(RetryErrorType.RetryNone, message);
+export const retryLimited = (message: string) =>
+	new RetryError(RetryErrorType.RetryLimited, message);
+export const retryUnlimited = (message: string) =>
+	new RetryError(RetryErrorType.RetryUnlimited, message);

--- a/support-workers/src/typescript/errors/zuoraErrors.ts
+++ b/support-workers/src/typescript/errors/zuoraErrors.ts
@@ -1,0 +1,35 @@
+import type { ZuoraError } from '@guardian/support-service-lambdas/modules/zuora/src/errors/zuoraError';
+import { retryLimited, retryNone } from './retryError';
+
+const transactionDeclinedMessages = [
+	'Transaction declined.402 - [card_error/card_declined/do_not_honor] Your card was declined.',
+	'Transaction declined.402 - [card_error/card_declined/insufficient_funds] Your card has insufficient funds.',
+	'Transaction declined.402 - [card_error/card_declined/try_again_later] Your card was declined.',
+	'Transaction declined.402 - [card_error/card_declined/transaction_not_allowed] Your card does not support this type of purchase.',
+	'Transaction declined.402 - [card_error/card_declined/pickup_card] Your card was declined.',
+	'Transaction declined.402 - [card_error/card_declined/generic_decline] Your card was declined.',
+	"Transaction declined.402 - [card_error/incorrect_cvc/incorrect_cvc] Your card's security code is incorrect.",
+	'Transaction declined.402 - [card_error/card_declined/card_velocity_exceeded] Your card was declined for making repeated attempts too frequently or exceeding its amount limit.',
+	'Transaction declined.402 - [card_error/card_declined/revocation_of_authorization] Your card was declined.',
+	'Transaction declined.402 - [card_error/card_declined/revocation_of_all_authorizations] Your card was declined.',
+	'Transaction declined.402 - [card_error/authentication_required/authentication_required] Your card was declined. This transaction requires authentication.',
+	'Transaction declined.402 - [card_error/card_declined/fraudulent] Your card was declined.',
+	'Transaction declined.402 - [card_error/expired_card/expired_card] Your card has expired.',
+	'Transaction declined.402 - [card_error/processing_error/processing_error] An error occurred while processing your card. Try again in a little bit.',
+	'Transaction declined.10417 - Instruct the customer to retry the transaction using an alternative payment method from the customers PayPal wallet.',
+	'Transaction declined.validation_failed - account_number did not pass modulus check',
+	'Transaction declined.validation_failed - account_number is the wrong length (should be 8 characters)',
+	'Transaction declined.validation_failed - account_number does not match sort code',
+];
+
+const isTransactionDeclinedError = (error: ZuoraError) =>
+	error.zuoraErrorDetails.find((detail) =>
+		transactionDeclinedMessages.includes(detail.message),
+	);
+
+export function mapZuoraError(error: ZuoraError) {
+	if (isTransactionDeclinedError(error)) {
+		return retryNone('Transaction declined');
+	}
+	return retryLimited(`${error.message}`);
+}

--- a/support-workers/src/typescript/errors/zuoraErrors.ts
+++ b/support-workers/src/typescript/errors/zuoraErrors.ts
@@ -20,6 +20,7 @@ const transactionDeclinedMessages = [
 	'Transaction declined.validation_failed - account_number did not pass modulus check',
 	'Transaction declined.validation_failed - account_number is the wrong length (should be 8 characters)',
 	'Transaction declined.validation_failed - account_number does not match sort code',
+	// This list should be kept in sync with the list in src/main/scala/com/gu/support/workers/exceptions/CardDeclinedMessages.scala
 ];
 
 const isTransactionDeclinedError = (error: ZuoraError) =>

--- a/support-workers/src/typescript/lambdas/createPaymentMethodLambda.ts
+++ b/support-workers/src/typescript/lambdas/createPaymentMethodLambda.ts
@@ -1,3 +1,4 @@
+import { asRetryError } from '../errors/errorHandler';
 import { combinedAddressLine } from '../model/address';
 import type {
 	DirectDebitPaymentFields,
@@ -31,7 +32,6 @@ import {
 import { ServiceProvider } from '../services/config';
 import { getPayPalConfig, PayPalService } from '../services/payPal';
 import { getStripeConfig, StripeService } from '../services/stripe';
-import { asRetryError } from '../util/errorHandler';
 import { getIfDefined } from '../util/nullAndUndefined';
 
 const stage = stageFromEnvironment();

--- a/support-workers/src/typescript/lambdas/createSalesforceContactLambda.ts
+++ b/support-workers/src/typescript/lambdas/createSalesforceContactLambda.ts
@@ -1,3 +1,4 @@
+import { asRetryError } from '../errors/errorHandler';
 import type { CreateZuoraSubscriptionState } from '../model/createZuoraSubscriptionState';
 import { stageFromEnvironment } from '../model/stage';
 import type {
@@ -13,7 +14,6 @@ import type { SalesforceContactRecord } from '../services/salesforce';
 import { SalesforceService } from '../services/salesforce';
 import { getSalesforceConfig } from '../services/salesforceClient';
 import { user } from '../test/fixtures/salesforceFixtures';
-import { asRetryError } from '../util/errorHandler';
 import { getIfDefined } from '../util/nullAndUndefined';
 
 const stage = stageFromEnvironment();

--- a/support-workers/src/typescript/lambdas/createZuoraSubscriptionTSLambda.ts
+++ b/support-workers/src/typescript/lambdas/createZuoraSubscriptionTSLambda.ts
@@ -13,6 +13,7 @@ import { previewCreateSubscription } from '@modules/zuora/createSubscription/pre
 import type { Contact } from '@modules/zuora/orders/newAccount';
 import type { PaymentMethod as ZuoraPaymentMethod } from '@modules/zuora/orders/paymentMethods';
 import { ZuoraClient } from '@modules/zuora/zuoraClient';
+import { asRetryError } from '../errors/errorHandler';
 import type { Address } from '../model/address';
 import type { CreateZuoraSubscriptionState } from '../model/createZuoraSubscriptionState';
 import type { PaymentMethod } from '../model/paymentMethod';
@@ -26,7 +27,6 @@ import { sendThankYouEmailStateSchema } from '../model/sendAcquisitionEventState
 import { stageFromEnvironment } from '../model/stage';
 import type { WrappedState } from '../model/stateSchemas';
 import { ServiceProvider } from '../services/config';
-import { asRetryError } from '../util/errorHandler';
 import { getIfDefined } from '../util/nullAndUndefined';
 import { zuoraDateReplacer } from '../util/zuoraDateReplacer';
 
@@ -123,7 +123,6 @@ export const handler = async (
 			zuoraDateReplacer,
 		);
 	} catch (error) {
-		// TODO: correct error handling
 		throw asRetryError(error);
 	}
 };

--- a/support-workers/src/typescript/test/createPaymentMethodLambda.test.ts
+++ b/support-workers/src/typescript/test/createPaymentMethodLambda.test.ts
@@ -19,10 +19,6 @@ const wrapPayload = (payload: CreatePaymentMethodState) => ({
 	},
 });
 
-jest.mock('../model/stage', () => ({
-	stageFromEnvironment: jest.fn().mockReturnValue('CODE'),
-}));
-
 describe('handler', () => {
 	describe('Direct Debit', () => {
 		it('uses the GoCardless payment gateway for a non-Sunday newspaper subscription', async () => {

--- a/support-workers/src/typescript/test/createZuoraSubscriptionLambda.it.test.ts
+++ b/support-workers/src/typescript/test/createZuoraSubscriptionLambda.it.test.ts
@@ -1,0 +1,21 @@
+import { RetryError, RetryErrorType } from '../errors/retryError';
+import { handler } from '../lambdas/createZuoraSubscriptionTSLambda';
+import type { CreateZuoraSubscriptionState } from '../model/createZuoraSubscriptionState';
+import type { WrappedState } from '../model/stateSchemas';
+import json from './fixtures/createZuoraSubscription/transactionDeclinedInput.json';
+
+describe('createZuoraSubscriptionLambda integration', () => {
+	test('we handle a transaction declined error from Stripe appropriately', async () => {
+		try {
+			await handler(json as WrappedState<CreateZuoraSubscriptionState>);
+			fail('Expected handler to throw');
+		} catch (error) {
+			if (error instanceof RetryError) {
+				expect(error.name).toBe(RetryErrorType.RetryNone);
+				expect(error.message).toContain('Transaction declined');
+			} else {
+				fail('Error is not an instance of RetryError');
+			}
+		}
+	}, 20000);
+});

--- a/support-workers/src/typescript/test/createZuoraSubscriptionLambda.it.test.ts
+++ b/support-workers/src/typescript/test/createZuoraSubscriptionLambda.it.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @group integration
+ */
+
 import { RetryError, RetryErrorType } from '../errors/retryError';
 import { handler } from '../lambdas/createZuoraSubscriptionTSLambda';
 import type { CreateZuoraSubscriptionState } from '../model/createZuoraSubscriptionState';

--- a/support-workers/src/typescript/test/createZuoraSubscriptionLambda.it.test.ts
+++ b/support-workers/src/typescript/test/createZuoraSubscriptionLambda.it.test.ts
@@ -8,18 +8,24 @@ import type { CreateZuoraSubscriptionState } from '../model/createZuoraSubscript
 import type { WrappedState } from '../model/stateSchemas';
 import json from './fixtures/createZuoraSubscription/transactionDeclinedInput.json';
 
+const testTimeout = 20000;
+
 describe('createZuoraSubscriptionLambda integration', () => {
-	test('we handle a transaction declined error from Stripe appropriately', async () => {
-		try {
-			await handler(json as WrappedState<CreateZuoraSubscriptionState>);
-			fail('Expected handler to throw');
-		} catch (error) {
-			if (error instanceof RetryError) {
-				expect(error.name).toBe(RetryErrorType.RetryNone);
-				expect(error.message).toContain('Transaction declined');
-			} else {
-				fail('Error is not an instance of RetryError');
+	test(
+		'we handle a transaction declined error from Stripe appropriately',
+		async () => {
+			try {
+				await handler(json as WrappedState<CreateZuoraSubscriptionState>);
+				fail('Expected handler to throw');
+			} catch (error) {
+				if (error instanceof RetryError) {
+					expect(error.name).toBe(RetryErrorType.RetryNone);
+					expect(error.message).toContain('Transaction declined');
+				} else {
+					fail('Error is not an instance of RetryError');
+				}
 			}
-		}
-	}, 20000);
+		},
+		testTimeout,
+	);
 });

--- a/support-workers/src/typescript/test/errorHandler.test.ts
+++ b/support-workers/src/typescript/test/errorHandler.test.ts
@@ -1,5 +1,5 @@
+import { asRetryError } from '../errors/errorHandler';
 import { SalesforceError, salesforceErrorCodes } from '../services/salesforce';
-import { asRetryError } from '../util/errorHandler';
 
 describe('errorHandler', () => {
 	test('should throw a retry unlimited error during readonly mode', () => {

--- a/support-workers/src/typescript/test/fixtures/createZuoraSubscription/transactionDeclinedInput.json
+++ b/support-workers/src/typescript/test/fixtures/createZuoraSubscription/transactionDeclinedInput.json
@@ -1,0 +1,136 @@
+{
+  "state": {
+    "productSpecificState": {
+      "productType": "SupporterPlus",
+      "billingCountry": "GB",
+      "product": {
+        "amount": 12,
+        "currency": "GBP",
+        "billingPeriod": "Monthly",
+        "productType": "SupporterPlus"
+      },
+      "productInformation": {
+        "product": "SupporterPlus",
+        "ratePlan": "Monthly",
+        "amount": 12
+      },
+      "paymentMethod": {
+        "TokenId": "pm_0S1SrNItVxyc3Q6ntB3yRwJ9",
+        "SecondTokenId": "cus_SxNccaDzSlgCsG",
+        "PaymentGateway": "Stripe PaymentIntents GNM Membership",
+        "Type": "CreditCardReferenceTransaction",
+        "StripePaymentType": "StripeCheckout"
+      },
+      "appliedPromotion": null,
+      "salesForceContact": {
+        "Id": "0039E00001Lin87QAB",
+        "AccountId": "0019E00001ct6lUQAQ"
+      },
+      "similarProductsConsent": true
+    },
+    "requestId": "32630b4c-d9ff-617d-0000-000000001789",
+    "user": {
+      "id": "21841796",
+      "primaryEmailAddress": "test@test.com",
+      "title": null,
+      "firstName": "test",
+      "lastName": "test",
+      "billingAddress": {
+        "lineOne": null,
+        "lineTwo": null,
+        "city": null,
+        "state": null,
+        "postCode": null,
+        "country": "GB"
+      },
+      "deliveryAddress": null,
+      "telephoneNumber": null,
+      "isTestUser": false,
+      "deliveryInstructions": null
+    },
+    "giftRecipient": null,
+    "product": {
+      "amount": 12,
+      "currency": "GBP",
+      "billingPeriod": "Monthly",
+      "productType": "SupporterPlus"
+    },
+    "productInformation": {
+      "product": "SupporterPlus",
+      "ratePlan": "Monthly",
+      "amount": 12
+    },
+    "analyticsInfo": {
+      "isGiftPurchase": false,
+      "paymentProvider": "Stripe"
+    },
+    "firstDeliveryDate": null,
+    "appliedPromotion": null,
+    "csrUsername": null,
+    "salesforceCaseId": null,
+    "acquisitionData": {
+      "ophanIds": {
+        "pageviewId": "mewwgcj5tcojm96n8108",
+        "browserId": null
+      },
+      "referrerAcquisitionData": {
+        "campaignCode": null,
+        "referrerPageviewId": "",
+        "referrerUrl": null,
+        "componentId": null,
+        "componentType": null,
+        "source": null,
+        "abTests": null,
+        "queryParameters": [
+          {
+            "name": "product",
+            "value": "Contribution"
+          },
+          {
+            "name": "ratePlan",
+            "value": "Monthly"
+          },
+          {
+            "name": "userType",
+            "value": "current"
+          },
+          {
+            "name": "contribution",
+            "value": "5"
+          }
+        ],
+        "hostname": "support.code.dev-theguardian.com",
+        "gaClientId": null,
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:142.0) Gecko/20100101 Firefox/142.0",
+        "ipAddress": "10.248.135.161",
+        "labels": [
+          "generic-checkout"
+        ]
+      },
+      "supportAbTests": [
+        {
+          "name": "abandonedBasket",
+          "variant": "control"
+        },
+        {
+          "name": "LP_COUNTDOWN",
+          "variant": "CONTROL"
+        }
+      ]
+    },
+    "similarProductsConsent": true,
+    "paymentMethod": {
+      "TokenId": "pm_0S1SrNItVxyc3Q6ntB3yRwJ9",
+      "SecondTokenId": "cus_SxNccaDzSlgCsG",
+      "PaymentGateway": "Stripe PaymentIntents GNM Membership",
+      "Type": "CreditCardReferenceTransaction",
+      "StripePaymentType": "StripeCheckout"
+    }
+  },
+  "error": null,
+  "requestInfo": {
+    "testUser": false,
+    "failed": false,
+    "messages": []
+  }
+}

--- a/support-workers/src/typescript/test/getZuoraPaymentMethod.test.ts
+++ b/support-workers/src/typescript/test/getZuoraPaymentMethod.test.ts
@@ -1,10 +1,6 @@
 import { getZuoraPaymentMethod } from '../lambdas/createZuoraSubscriptionTSLambda';
 import type { PaymentMethod } from '../model/paymentMethod';
 
-jest.mock('../model/stage', () => ({
-	stageFromEnvironment: jest.fn().mockReturnValue('CODE'),
-}));
-
 describe('getZuoraPaymentMethod', () => {
 	test('should map CreditCardReferenceTransaction correctly', () => {
 		const paymentMethod = {

--- a/support-workers/src/typescript/test/salesforce.it.test.ts
+++ b/support-workers/src/typescript/test/salesforce.it.test.ts
@@ -115,10 +115,6 @@ describe('SalesforceService', () => {
 	});
 });
 
-jest.mock('../model/stage', () => ({
-	stageFromEnvironment: jest.fn().mockReturnValue('CODE'),
-}));
-
 describe('CreateSalesforceContatctLambda', () => {
 	test('CreateSalesforceContact lambda should upsert a SalesforceContactRecord', async () => {
 		const inputState: CreateSalesforceContactState =

--- a/support-workers/src/typescript/test/test-setup.ts
+++ b/support-workers/src/typescript/test/test-setup.ts
@@ -1,0 +1,3 @@
+jest.mock('../model/stage', () => ({
+	stageFromEnvironment: jest.fn().mockReturnValue('CODE'),
+}));


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR follows on from #7230 and is the next step in the work to move the CreateZuoraSubscription lambda in the support-workers step function to a new Typescript implementation. The benefits of this are:
- Migrating from Scala to Typescript is a strategic goal for us to increase our ability to find developers to work on our codebase
- Moving from Zuora's deprecated subscribe and amend API to their newer Orders API
- Start using the product catalog to define which subscriptions we create rather than the old deprecated model

Specifically in this PR we add the error handling to the CreateZuoraSubscription Typescript lambda to match the Scala version.

Note that at this stage there is still no traffic going to the new lambda, it is all being routed to the old one as described in this PR https://github.com/guardian/support-frontend/pull/7175

[**Trello Card for the Epic**](https://trello.com/c/346hWkLe/1804-build-and-release-typescript-createzuorasubscription-lambda)
[**Trello Card for this piece of work**](https://trello.com/c/8c2uAKgx/1845-complete-error-handling-for-createzuorasubscription-lambda)
