### PR TITLE
Fix the current date to August 29th

### DIFF
--- a/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.test.tsx
+++ b/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.test.tsx
@@ -7,6 +7,15 @@ import type {
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { OrderSummaryTsAndCs } from './orderSummaryTsAndCs';
 
+// Mock the date - some of the Ts&Cs include calculated dates
+beforeAll(() => {
+	jest.useFakeTimers().setSystemTime(new Date('2025-08-29'));
+});
+
+afterAll(() => {
+	jest.useRealTimers();
+});
+
 describe('orderSummaryTs&Cs Snapshot comparison', () => {
 	const promotionTierThreeUnitedStatesMonthly: Promotion = {
 		name: '$8 off for 12 months',


### PR DESCRIPTION
## What are you doing in this PR?

Mocking the current date in the Ts and Cs snapshot tests to give consistent copy.

## Why are you doing this?

This keeps the snapshots consistent - the first delivery date is relative and is included in the Ts and Cs copy. If we don't do this we'll have to keep updating the date in the snapshots. I think this was introduced when #7229 was merged.