### PR TITLE
Add UK specific hardcoded student benefit

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
@@ -1,6 +1,9 @@
 import GridPicture from 'components/gridPicture/gridPicture';
 import { Container } from 'components/layout/container';
-import type { LandingPageVariant } from 'helpers/globalsAndSwitches/landingPageSettings';
+import type {
+	LandingPageVariant,
+	ProductBenefit,
+} from 'helpers/globalsAndSwitches/landingPageSettings';
 import type {
 	ActiveProductKey,
 	ActiveRatePlanKey,
@@ -31,6 +34,13 @@ interface StudentHeaderProps {
 	includeThreeTierLink?: boolean;
 }
 
+const ukSpecificAdditionalBenefit: ProductBenefit = {
+	copy: 'Student-focused newsletter, curated by our journalists',
+	label: {
+		copy: 'Limited series',
+	},
+};
+
 export default function StudentHeader({
 	geoId,
 	productKey,
@@ -43,13 +53,21 @@ export default function StudentHeader({
 	includeThreeTierLink = false,
 }: StudentHeaderProps) {
 	const { amount, promoCode, discountSummary } = studentDiscount;
-	const { benefits } = landingPageVariant.products.SupporterPlus;
 	const checkoutUrl = buildCheckoutUrl(
 		geoId,
 		productKey,
 		ratePlanKey,
 		promoCode,
 	);
+
+	// In the UK on this page only, add an additional benefit to the list
+	const { benefits: configuredBenefits } =
+		landingPageVariant.products.SupporterPlus;
+
+	const benefits =
+		geoId === 'uk'
+			? [ukSpecificAdditionalBenefit, ...configuredBenefits]
+			: configuredBenefits;
 
 	const ctaLabel = amount === 0 ? 'Sign up for free' : 'Subscribe';
 


### PR DESCRIPTION
## What are you doing in this PR?

In the UK, on the global student landing page only, add a hardcoded benefit to the beginning of the list of configured benefits from the RRCP.

[**Trello Card**](https://trello.com/c/xIskruDc/1799-global-student-page-add-uk-specific-benefit)

**Note: does not include the tooltip as we don't have the copy yet.**

## Why are you doing this?

It's part of the designs.

## How to test

Browse the site. The additional benefit is visible on the UK student landing page, but not on any other student landing page or the 3 tier landing page.

## Images

<img width="387" height="492" alt="Screenshot 2025-09-02 at 08 30 40" src="https://github.com/user-attachments/assets/127c39b8-1ba9-44c0-a5b8-b6a5952535ca" />
