### PR TITLE
Update global student offer FAQs

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/student/helpers/studentFAQs.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/helpers/studentFAQs.tsx
@@ -11,6 +11,7 @@ const supporterPlusBodyAccess: JSX.Element = (
 		logging into your Guardian account.
 	</p>
 );
+
 const supporterPlusBodyManage: JSX.Element = (
 	<p>
 		To manage your subscription, go to Manage my account, and for further
@@ -18,30 +19,24 @@ const supporterPlusBodyManage: JSX.Element = (
 		<a href={supporterPlusTermsLink}>Terms & Conditions</a>
 	</p>
 );
+
 const supporterPlusBodyContact: JSX.Element = (
 	<p>
 		For any queries, including subscription-related queries, visit our{' '}
 		<a href={helpCentreUrl}>Help centre</a>
 	</p>
 );
-const otherSupporterPlusFAQ: FAQItem[] = [
+
+const otherSupporterPlusFAQ: (regionName: string) => FAQItem[] = (
+	regionName,
+) => [
 	{
 		title: 'Who is eligible for this discount?',
 		body: (
 			<p>
-				Current students at [university/college] who register and verify through
-				Student Beans, are eligible for this discount.
-			</p>
-		),
-	},
-	{
-		title: 'What is included in my All-access subscription?',
-		body: (
-			<p>
-				Your All-access digital subscription entitles you to all the benefits
-				listed above, including: unlimited access to the Guardian news app and
-				Guardian Feast app, ad-free reading on all your devices, exclusive
-				newsletter for supporters and far fewer asks for support.
+				You must be 16+ and a verified fulltime student in {regionName}. You
+				will need a valid Student Beans account to complete the verification and
+				access this offer.
 			</p>
 		),
 	},
@@ -58,7 +53,8 @@ const otherSupporterPlusFAQ: FAQItem[] = [
 		body: supporterPlusBodyContact,
 	},
 ];
-const auSupporterPlusFAQ: FAQItem[] = [
+
+const auSupporterPlusFAQ: (regionName: string) => FAQItem[] = () => [
 	{
 		title: 'Who is eligible for this discount?',
 		body: (
@@ -68,12 +64,12 @@ const auSupporterPlusFAQ: FAQItem[] = [
 				University of Technology Sydney (UTS). Redemption of the offer is
 				conditional upon registration using a valid and active UTS email
 				address. Your email address may be subjected to an internal verification
-				process to confirm your eligibility as a UTS student – you may refer to
-				the Guardian’s <a href={privacyLink}>privacy policy</a> which explains
-				how personal information is handled by the Guardian. The Guardian
-				reserves the right to cancel, suspend, or revoke any subscription
-				claimed through this offer if it is reasonably suspected or determined
-				that the subscriber does not meet the eligibility criteria.
+				process to confirm your eligibility as a UTS student &mdash; you may
+				refer to the Guardian&apos;s <a href={privacyLink}>privacy policy</a>{' '}
+				which explains how personal information is handled by the Guardian. The
+				Guardian reserves the right to cancel, suspend, or revoke any
+				subscription claimed through this offer if it is reasonably suspected or
+				determined that the subscriber does not meet the eligibility criteria.
 			</p>
 		),
 	},
@@ -104,14 +100,39 @@ const auSupporterPlusFAQ: FAQItem[] = [
 		body: supporterPlusBodyContact,
 	},
 ];
-const studentFAQs: Partial<Record<CountryGroupId, FAQItem[]>> = {
-	GBPCountries: otherSupporterPlusFAQ,
-	UnitedStates: otherSupporterPlusFAQ,
-	Canada: otherSupporterPlusFAQ,
-	AUDCountries: auSupporterPlusFAQ,
+
+interface StudentFAQsConfig {
+	getCopy: (regionName: string) => FAQItem[];
+	regionName: string;
+}
+
+const studentFAQsConfig: Partial<Record<CountryGroupId, StudentFAQsConfig>> = {
+	GBPCountries: {
+		getCopy: otherSupporterPlusFAQ,
+		regionName: 'the UK',
+	},
+	UnitedStates: {
+		getCopy: otherSupporterPlusFAQ,
+		regionName: 'the USA',
+	},
+	Canada: {
+		getCopy: otherSupporterPlusFAQ,
+		regionName: 'Canada',
+	},
+	AUDCountries: {
+		getCopy: auSupporterPlusFAQ,
+		// Not actually used
+		regionName: 'Australia',
+	},
 };
 
 export function getStudentFAQs(geoId: GeoId): FAQItem[] | undefined {
 	const { countryGroupId } = getGeoIdConfig(geoId);
-	return studentFAQs[countryGroupId];
+	const faqConfig = studentFAQsConfig[countryGroupId];
+
+	if (faqConfig) {
+		return faqConfig.getCopy(faqConfig.regionName);
+	}
+
+	return undefined;
 }


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Updating the FAQs section on the global student offer landing page.

I've had to refactor things a little bit to support interpolating the country/region name into the copy.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/HVHzu85S/1802-global-student-page-studentfaq-accordian-copy)

## Why are you doing this?

To reflect the updated copy in the doc.

## How to test

Visit the global student offer landing page for us, uk, canada. Check the FAQs against the doc.

## Screenshots

<img width="963" height="449" alt="Screenshot 2025-09-02 at 11 35 39" src="https://github.com/user-attachments/assets/681bc99b-7dff-406e-9def-42aa71276c3f" />

