### PR TITLE
Split the global student landing page headline

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
@@ -28,7 +28,7 @@ interface StudentHeaderProps {
 	ratePlanKey: ActiveRatePlanKey;
 	landingPageVariant: LandingPageVariant;
 	studentDiscount: StudentDiscount;
-	headingCopy: string;
+	headingCopy: React.ReactNode;
 	subheadingCopy: React.ReactNode;
 	universityBadge?: JSX.Element;
 	includeThreeTierLink?: boolean;

--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentLandingPageGlobal.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentLandingPageGlobal.tsx
@@ -32,7 +32,15 @@ export function StudentLandingPageGlobal({
 					ratePlanKey={ratePlanKey}
 					landingPageVariant={landingPageVariant}
 					studentDiscount={studentDiscount}
-					headingCopy={`No owner. No agenda. No more than ${studentDiscount.discountPriceWithCurrency} a year for students`}
+					headingCopy={
+						<>
+							<p>No owner. No agenda.</p>
+							<p>
+								No more than {studentDiscount.discountPriceWithCurrency} a year
+								for students
+							</p>
+						</>
+					}
 					subheadingCopy="Now more than ever, independent journalism matters. Get fact-based reporting you can trust and unlimited access to the Guardian apps &mdash; without breaking your budget."
 					includeThreeTierLink={true}
 				/>


### PR DESCRIPTION
## What are you doing in this PR?

Format the global student landing page headline copy to add a line break in the middle.

## Why are you doing this?

The copy which starts "No more than..." should always begin on a new line.

## Screenshots

### Before

<img width="782" height="183" alt="Screenshot 2025-09-03 at 11 07 08" src="https://github.com/user-attachments/assets/4a75413c-cc44-48aa-afd8-cb3f79c0ffd8" />

### After

<img width="802" height="189" alt="Screenshot 2025-09-03 at 11 06 50" src="https://github.com/user-attachments/assets/4b5e4570-f5e9-4e3a-afa8-e9476acfb1ea" />
