### PR TITLE
Global Student Page: Ts&Cs copy on Landing page

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/student/helpers/studentTsAndCsCopy.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/helpers/studentTsAndCsCopy.tsx
@@ -21,6 +21,27 @@ const studentTsAndCs: Partial<Record<CountryGroupId, JSX.Element>> = {
 			that the subscriber does not meet the eligibility criteria.
 		</div>
 	),
+	UnitedStates: (
+		<>
+			Access to this offer is strictly limited to verified full time students
+			16+ in the USA. You must have a Student Beans account to access this
+			offer. Subscription is for 1 year and does not auto renew.
+		</>
+	),
+	GBPCountries: (
+		<>
+			Access to this offer is strictly limited to verified full time students
+			16+ in the UK. You must have a Student Beans account to access this offer.
+			Subscription is for 1 year and does not auto renew.
+		</>
+	),
+	Canada: (
+		<>
+			Access to this offer is strictly limited to verified full time students
+			16+ in Canada. You must have a Student Beans account to access this offer.
+			Subscription is for 1 year and does not auto renew.
+		</>
+	),
 };
 
 export function getStudentTsAndCs(geoId: GeoId): JSX.Element | undefined {


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Add region specific copy for terms and conditions.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/zEt4ow2a/1803-global-student-page-tscs-copy-on-lp)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

use one of the region specific student pages
| Region| url |
| --- | --- | 
| US | https://support.thegulocal.com/us/student |
| UK | https://support.thegulocal.com/uk/student |
| Canada | https://support.thegulocal.com/ca/student |

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
### US
<img width="1319" height="118" alt="Screenshot 2025-09-03 at 11 44 54" src="https://github.com/user-attachments/assets/f77544e7-02b6-40a6-a649-c2447feb5b21" />

### UK
<img width="1326" height="121" alt="Screenshot 2025-09-03 at 11 44 42" src="https://github.com/user-attachments/assets/19d2cde7-ceb5-45bb-9d72-c34bd501f96c" />

### Canada
<img width="1318" height="120" alt="Screenshot 2025-09-03 at 11 45 10" src="https://github.com/user-attachments/assets/00c0a6cb-fe69-4cb5-8386-b3562e748f73" />
