### PR TITLE
Don't trigger the create recurring product fail alarm for test users in prod

### DIFF
--- a/support-frontend/app/actions/CustomActionBuilders.scala
+++ b/support-frontend/app/actions/CustomActionBuilders.scala
@@ -110,7 +110,7 @@ class CustomActionBuilders(
     }
 
     def apply(requestHeader: RequestHeader): Accumulator[ByteString, Result] = {
-      val isTestUser = testUsersService.isTestUser(requestHeader)
+      lazy val isTestUser = testUsersService.isTestUser(requestHeader)
       val accumulator = chainedAction.apply(requestHeader)
       val loggedAccumulator = accumulator.through(Flow.fromFunction { (byteString: ByteString) =>
         logger.info("incoming POST: " + byteString.utf8String)

--- a/support-frontend/app/wiring/ActionBuilders.scala
+++ b/support-frontend/app/wiring/ActionBuilders.scala
@@ -17,5 +17,6 @@ trait ActionBuilders {
     csrfConfig = csrfConfig,
     stage = appConfig.stage,
     featureSwitches = allSettingsProvider.getAllSettings().switches.featureSwitches,
+    testUsersService = testUsers,
   )
 }

--- a/support-frontend/test/actions/ActionRefinerTest.scala
+++ b/support-frontend/test/actions/ActionRefinerTest.scala
@@ -31,6 +31,8 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
       enableCampaignCountdown = Some(On),
     )
 
+  val testUsersService = TestUserService("secret")
+
   trait Mocks {
     val asyncAuthenticationService = mock[AsyncAuthenticationService]
     val userFromAuthCookiesOrAuthServerActionBuilder = mock[UserFromAuthCookiesOrAuthServerActionBuilder]
@@ -50,7 +52,8 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
           csrfCheck,
           csrfConfig,
           stage,
-          featureSwitches,
+          featureSwitches = featureSwitches,
+          testUsersService = testUsersService,
         )
       val result = actionRefiner.PrivateAction(Ok("")).apply(FakeRequest())
       header("Cache-Control", result) mustBe Some("no-cache, private")
@@ -75,7 +78,8 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
         csrfCheck,
         csrfConfig,
         stage,
-        featureSwitches,
+        featureSwitches = featureSwitches,
+        testUsersService = testUsersService,
       )
 
       val result = actionRefiner
@@ -101,7 +105,8 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
         checkToken = csrfCheck,
         csrfConfig = csrfConfig,
         stage = stage,
-        featureSwitches,
+        featureSwitches = featureSwitches,
+        testUsersService = testUsersService,
       )
 
       val result = actionRefiner
@@ -127,7 +132,8 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
         checkToken = csrfCheck,
         csrfConfig = csrfConfig,
         stage = stage,
-        featureSwitches,
+        featureSwitches = featureSwitches,
+        testUsersService = testUsersService,
       )
       val result = actionRefiner.MaybeAuthenticatedAction(Ok("authentication-test")).apply(fakeRequest)
       header("Cache-Control", result) mustBe Some("no-cache, private")
@@ -144,7 +150,8 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
         checkToken = csrfCheck,
         csrfConfig = csrfConfig,
         stage = stage,
-        featureSwitches,
+        featureSwitches = featureSwitches,
+        testUsersService = testUsersService,
       )
       val result = actionRefiner.MaybeAuthenticatedAction(Ok("authentication-test")).apply(fakeRequest)
       header("Cache-Control", result) mustBe Some("no-cache, private")

--- a/support-frontend/test/controllers/ApplicationTest.scala
+++ b/support-frontend/test/controllers/ApplicationTest.scala
@@ -53,6 +53,7 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
     csrfConfig = csrfConfig,
     stage = stage,
     featureSwitches = FeatureSwitches(Some(On), Some(On), Some(On), Some(On)),
+    testUsersService = TestUserService("secret"),
   )
 
   val priceSummaryServiceProvider = {

--- a/support-frontend/test/controllers/SiteMapTest.scala
+++ b/support-frontend/test/controllers/SiteMapTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{status, stubControllerComponents}
-import services.AsyncAuthenticationService
+import services.{AsyncAuthenticationService, TestUserService}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -31,6 +31,7 @@ class SiteMapTest extends AnyWordSpec with Matchers with TestCSRFComponents {
     csrfConfig = csrfConfig,
     stage = stage,
     featureSwitches = FeatureSwitches(Some(On), Some(On), Some(On), Some(On)),
+    testUsersService = TestUserService("secret"),
   )
 
   "GET /sitemap.xml" should {

--- a/support-frontend/test/fixtures/DisplayFormMocks.scala
+++ b/support-frontend/test/fixtures/DisplayFormMocks.scala
@@ -48,6 +48,7 @@ trait DisplayFormMocks extends TestCSRFComponents {
     csrfConfig = csrfConfig,
     stage = stage,
     featureSwitches = FeatureSwitches(Some(On), Some(On), Some(Off), Some(On)),
+    testUsersService = testUsers,
   )
 
 }


### PR DESCRIPTION
## What are you doing in this PR?

When the current user is a test user, emit the `ServerSideCreateFailure` metric with a stage of CODE rather than PROD. 

[**Trello Card**](https://trello.com/c/0FJuz17y/1857-dont-trigger-support-frontend-create-recurring-product-call-failed-alarm-for-test-users)

## Why are you doing this?

This change means the prod alarm won't be triggered by test users which is the behaviour we want. In prod test users use CODE APIs. We don't want a CODE API call failing to trigger this alarm.

## How to test

I've verified this change by breaking one of the server side API calls (delivery coverage) to trigger the `ServerSideCreateFailure` to be emitted. In CODE a stage of CODE is used in both cases. In Dev when you're a test user a stage of CODE is user, when not a test user a stage of DEV is used. This shows that the distinction between test users and non test users is being made correctly. (Yes, it's slightly odd for the stage to be CODE when acting as a test user in DEV, but it's quite an unlikely scenario and it's useful to be able to see the distinction).

## How can we measure success?

Less time spent investigating alarms triggered by CODE services failing.

## Have we considered potential risks?

The only risk I can see is somehow mis-identifying test users and silencing real alerts in PROD, but I think the testing I've done has mitigated this.