### PR TITLE
Custom top up amounts for one time off contributions

### DIFF
--- a/support-frontend/assets/helpers/utilities/__tests__/parseCustomAmounts.test.ts
+++ b/support-frontend/assets/helpers/utilities/__tests__/parseCustomAmounts.test.ts
@@ -1,0 +1,53 @@
+import { parseCustomAmounts } from '../utilities';
+
+describe('parseCustomAmounts', () => {
+	test('should parse valid comma-separated amounts', () => {
+		const result = parseCustomAmounts('15,30,75');
+		expect(result).toEqual([15, 30, 75]);
+	});
+
+	test('should filter out invalid amounts (NaN, negative, zero, infinite)', () => {
+		const result = parseCustomAmounts('10,invalid,20,-5,0,30,Infinity,NaN');
+		expect(result).toEqual([10, 20, 30]);
+	});
+
+	test('should remove duplicate amounts', () => {
+		const result = parseCustomAmounts('25,50,25,100,50,25,100');
+		expect(result).toEqual([25, 50, 100]);
+	});
+
+	test('should handle decimal values correctly', () => {
+		const result = parseCustomAmounts('12.50,25.75,50.25');
+		expect(result).toEqual([12.5, 25.75, 50.25]);
+	});
+
+	test('should trim whitespace from amounts', () => {
+		const result = parseCustomAmounts(' 15 , 30 , 75 ');
+		expect(result).toEqual([15, 30, 75]);
+	});
+
+	test('should return empty array when all amounts are invalid', () => {
+		const result = parseCustomAmounts('invalid,NaN,-5,0,-10,abc');
+		expect(result).toEqual([]);
+	});
+
+	test('should return empty array for empty string', () => {
+		const result = parseCustomAmounts('');
+		expect(result).toEqual([]);
+	});
+
+	test('should handle single valid amount', () => {
+		const result = parseCustomAmounts('42');
+		expect(result).toEqual([42]);
+	});
+
+	test('should handle single invalid amount', () => {
+		const result = parseCustomAmounts('invalid');
+		expect(result).toEqual([]);
+	});
+
+	test('should handle mixed valid and invalid amounts with duplicates', () => {
+		const result = parseCustomAmounts('5.5,invalid,5.5,10,abc,-1,10,0,15.75');
+		expect(result).toEqual([5.5, 10, 15.75]);
+	});
+});

--- a/support-frontend/assets/helpers/utilities/utilities.ts
+++ b/support-frontend/assets/helpers/utilities/utilities.ts
@@ -55,6 +55,16 @@ function getSanitisedHtml(markdownString: string): string {
 	});
 }
 
+// Parses a comma-separated string of amounts and returns an array of valid, unique numbers.
+// Filters out invalid values (NaN, negative, zero, infinite) and removes duplicates.
+function parseCustomAmounts(customAmountsParam: string): number[] {
+	return customAmountsParam
+		.split(',')
+		.map((amount) => parseFloat(amount.trim()))
+		.filter((amount) => !isNaN(amount) && isFinite(amount) && amount > 0)
+		.filter((amount, index, array) => array.indexOf(amount) === index);
+}
+
 // ----- Exports ----- //
 export {
 	ascending,
@@ -63,4 +73,5 @@ export {
 	classNameWithModifiers,
 	hiddenIf,
 	deserialiseJsonObject,
+	parseCustomAmounts,
 };

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.test.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.test.tsx
@@ -85,6 +85,9 @@ function deepCopySelectedAmountsVariant(
 }
 
 describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
+	// Note: The parseCustomAmounts function is thoroughly tested in its own test file
+	// These tests focus on how the component integrates custom amounts from URL parameters
+	
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockLocation.search = '';
@@ -95,7 +98,7 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 		});
 	});
 
-	test('should create custom amounts data when custom amounts parameter is provided', () => {
+	test('should process custom amounts from URL parameter and override default amounts', () => {
 		// Set up URL with custom amounts parameter
 		mockLocation.search = '?amounts=15,30,75';
 
@@ -120,19 +123,17 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 		}
 
 		const { amountsCardData } = selectedAmountsVariant;
-		const { amounts, defaultAmount, hideChooseYourAmount } =
+		const { amounts, defaultAmount } =
 			customAmountsData ?? amountsCardData['ONE_OFF'];
 
 		// Verify the custom amounts data was created correctly
 		expect(customAmountsData).toBeDefined();
 		expect(customAmountsData?.amounts).toEqual([15, 30, 75]);
 		expect(customAmountsData?.defaultAmount).toBe(30); // amounts[1]
-		expect(customAmountsData?.hideChooseYourAmount).toBe(false);
 
 		// Verify the final destructured values
 		expect(amounts).toEqual([15, 30, 75]);
 		expect(defaultAmount).toBe(30);
-		expect(hideChooseYourAmount).toBe(false);
 
 		// Verify original variant data remains unchanged
 		expect(selectedAmountsVariant.amountsCardData['MONTHLY'].amounts).toEqual([
@@ -143,59 +144,7 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 		]);
 	});
 
-	test('should filter out invalid amounts and keep only valid ones', () => {
-		mockLocation.search = '?amounts=10,invalid,20,-5,0,30,Infinity,NaN';
-
-		const urlSearchParams = new URLSearchParams(mockLocation.search);
-		const customAmountsParam = urlSearchParams.get('amounts');
-
-		let customAmountsData;
-		if (customAmountsParam) {
-			const amounts = parseCustomAmounts(customAmountsParam);
-			customAmountsData = {
-				amounts,
-				defaultAmount: amounts[1] ?? 0,
-				hideChooseYourAmount: false,
-			};
-		}
-
-		const { amountsCardData } = mockSelectedAmountsVariant;
-		const { amounts, defaultAmount, hideChooseYourAmount } =
-			customAmountsData ?? amountsCardData['ONE_OFF'];
-
-		// Should only include valid positive finite amounts
-		expect(amounts).toEqual([10, 20, 30]);
-		expect(defaultAmount).toBe(20); // amounts[1]
-		expect(hideChooseYourAmount).toBe(false);
-	});
-
-	test('should remove duplicate amounts', () => {
-		mockLocation.search = '?amounts=25,50,25,100,50,25,100';
-
-		const urlSearchParams = new URLSearchParams(mockLocation.search);
-		const customAmountsParam = urlSearchParams.get('amounts');
-
-		let customAmountsData;
-		if (customAmountsParam) {
-			const amounts = parseCustomAmounts(customAmountsParam);
-			customAmountsData = {
-				amounts,
-				defaultAmount: amounts[1] ?? 0,
-				hideChooseYourAmount: false,
-			};
-		}
-
-		const { amountsCardData } = mockSelectedAmountsVariant;
-		const { amounts, defaultAmount, hideChooseYourAmount } =
-			customAmountsData ?? amountsCardData['ONE_OFF'];
-
-		// Should remove duplicates and keep first occurrence
-		expect(amounts).toEqual([25, 50, 100]);
-		expect(defaultAmount).toBe(50); // amounts[1]
-		expect(hideChooseYourAmount).toBe(false);
-	});
-
-	test('should handle decimal values correctly', () => {
+	test('should preserve decimal precision in custom amounts', () => {
 		mockLocation.search = '?amounts=12.50,25.75,50.25';
 
 		const urlSearchParams = new URLSearchParams(mockLocation.search);
@@ -212,79 +161,12 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 		}
 
 		const { amountsCardData } = mockSelectedAmountsVariant;
-		const { amounts, defaultAmount, hideChooseYourAmount } =
+		const { amounts, defaultAmount } =
 			customAmountsData ?? amountsCardData['ONE_OFF'];
 
 		// Should handle decimal values correctly (parseFloat handles trailing zeros)
 		expect(amounts).toEqual([12.5, 25.75, 50.25]);
 		expect(defaultAmount).toBe(25.75); // amounts[1]
-		expect(hideChooseYourAmount).toBe(false);
-	});
-
-	test('should trim whitespace from amounts', () => {
-		mockLocation.search = '?amounts= 15 , 30 , 75 ';
-
-		const urlSearchParams = new URLSearchParams(mockLocation.search);
-		const customAmountsParam = urlSearchParams.get('amounts');
-
-		let customAmountsData;
-		if (customAmountsParam) {
-			const amounts = parseCustomAmounts(customAmountsParam);
-			customAmountsData = {
-				amounts,
-				defaultAmount: amounts[1] ?? 0,
-				hideChooseYourAmount: false,
-			};
-		}
-
-		const { amountsCardData } = mockSelectedAmountsVariant;
-		const { amounts, defaultAmount, hideChooseYourAmount } =
-			customAmountsData ?? amountsCardData['ONE_OFF'];
-
-		// Should handle whitespace correctly
-		expect(amounts).toEqual([15, 30, 75]);
-		expect(defaultAmount).toBe(30); // amounts[1]
-		expect(hideChooseYourAmount).toBe(false);
-	});
-
-	test('should not create custom amounts data when custom amounts parameter is empty', () => {
-		mockLocation.search = '?amounts=';
-
-		const urlSearchParams = new URLSearchParams(mockLocation.search);
-		const customAmountsParam = urlSearchParams.get('amounts');
-
-		const selectedAmountsVariant = deepCopySelectedAmountsVariant(
-			mockSelectedAmountsVariant,
-		);
-
-		let customAmountsData;
-		if (customAmountsParam) {
-			const amounts = parseCustomAmounts(customAmountsParam);
-			customAmountsData = {
-				amounts,
-				defaultAmount: amounts[1] ?? 0,
-				hideChooseYourAmount: false,
-			};
-		}
-
-		const { amountsCardData } = selectedAmountsVariant;
-		const { amounts, defaultAmount, hideChooseYourAmount } =
-			customAmountsData ?? amountsCardData['ONE_OFF'];
-
-		// Should not create custom amounts data when parameter is empty
-		expect(customAmountsData).toBeUndefined();
-
-		// Should use original amountsCardData values
-		expect(amounts).toEqual(
-			mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].amounts,
-		);
-		expect(defaultAmount).toBe(
-			mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].defaultAmount,
-		);
-		expect(hideChooseYourAmount).toBe(
-			mockSelectedAmountsVariant.amountsCardData['ONE_OFF']
-				.hideChooseYourAmount,
-		);
 	});
 
 	test('should not create custom amounts data when no custom amounts parameter is provided', () => {
@@ -308,7 +190,7 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 		}
 
 		const { amountsCardData } = selectedAmountsVariant;
-		const { amounts, defaultAmount, hideChooseYourAmount } =
+		const { amounts, defaultAmount } =
 			customAmountsData ?? amountsCardData['ONE_OFF'];
 
 		// Should not create custom amounts data when no parameter
@@ -322,88 +204,6 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 		expect(defaultAmount).toBe(
 			mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].defaultAmount,
 		);
-		expect(hideChooseYourAmount).toBe(
-			mockSelectedAmountsVariant.amountsCardData['ONE_OFF']
-				.hideChooseYourAmount,
-		);
-	});
-
-	test('should set amounts to empty array when all custom amounts are invalid', () => {
-		mockLocation.search = '?amounts=invalid,NaN,-5,0,-10,abc';
-
-		const urlSearchParams = new URLSearchParams(mockLocation.search);
-		const customAmountsParam = urlSearchParams.get('amounts');
-
-		let customAmountsData;
-		if (customAmountsParam) {
-			const amounts = parseCustomAmounts(customAmountsParam);
-			customAmountsData = {
-				amounts,
-				defaultAmount: amounts[1] ?? 0,
-				hideChooseYourAmount: false,
-			};
-		}
-
-		const { amountsCardData } = mockSelectedAmountsVariant;
-		const { amounts, defaultAmount, hideChooseYourAmount } =
-			customAmountsData ?? amountsCardData['ONE_OFF'];
-
-		// Should result in empty array when all amounts are invalid
-		expect(amounts).toEqual([]);
-		expect(defaultAmount).toBe(0); // amounts[1] ?? 0 when amounts[1] is undefined
-		expect(hideChooseYourAmount).toBe(false);
-	});
-
-	test('should handle single custom amount and set defaultAmount to 0', () => {
-		mockLocation.search = '?amounts=25';
-
-		const urlSearchParams = new URLSearchParams(mockLocation.search);
-		const customAmountsParam = urlSearchParams.get('amounts');
-
-		let customAmountsData;
-		if (customAmountsParam) {
-			const amounts = parseCustomAmounts(customAmountsParam);
-			customAmountsData = {
-				amounts,
-				defaultAmount: amounts[1] ?? 0,
-				hideChooseYourAmount: false,
-			};
-		}
-
-		const { amountsCardData } = mockSelectedAmountsVariant;
-		const { amounts, defaultAmount, hideChooseYourAmount } =
-			customAmountsData ?? amountsCardData['ONE_OFF'];
-
-		// Should have single amount and defaultAmount should be 0 (amounts[1] is undefined)
-		expect(amounts).toEqual([25]);
-		expect(defaultAmount).toBe(0); // amounts[1] ?? 0 when amounts[1] is undefined
-		expect(hideChooseYourAmount).toBe(false);
-	});
-
-	test('should handle two custom amounts and set defaultAmount to second amount', () => {
-		mockLocation.search = '?amounts=25,50';
-
-		const urlSearchParams = new URLSearchParams(mockLocation.search);
-		const customAmountsParam = urlSearchParams.get('amounts');
-
-		let customAmountsData;
-		if (customAmountsParam) {
-			const amounts = parseCustomAmounts(customAmountsParam);
-			customAmountsData = {
-				amounts,
-				defaultAmount: amounts[1] ?? 0,
-				hideChooseYourAmount: false,
-			};
-		}
-
-		const { amountsCardData } = mockSelectedAmountsVariant;
-		const { amounts, defaultAmount, hideChooseYourAmount } =
-			customAmountsData ?? amountsCardData['ONE_OFF'];
-
-		// Should have two amounts and defaultAmount should be second amount
-		expect(amounts).toEqual([25, 50]);
-		expect(defaultAmount).toBe(50); // amounts[1]
-		expect(hideChooseYourAmount).toBe(false);
 	});
 
 	describe('URLSearchParams behavior', () => {

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.test.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.test.tsx
@@ -51,12 +51,12 @@ const mockSelectedAmountsVariant = {
 describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 	// Note: The parseCustomAmounts function is thoroughly tested in its own test file
 	// These tests focus on how the component integrates custom amounts from URL parameters
-	
+
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockLocation.search = '';
 
-		(mockGetAmountsTestVariant).mockReturnValue({
+		mockGetAmountsTestVariant.mockReturnValue({
 			selectedAmountsVariant: mockSelectedAmountsVariant,
 			amountsParticipation: undefined,
 		});
@@ -188,7 +188,8 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 		}
 
 		const { amountsCardData } = mockSelectedAmountsVariant;
-		const { amounts, defaultAmount } = customAmountsData ?? amountsCardData['ONE_OFF'];
+		const { amounts, defaultAmount } =
+			customAmountsData ?? amountsCardData['ONE_OFF'];
 
 		// Verify that custom amounts override the fallback amounts
 		expect(amounts).toEqual([15, 30, 75]);

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.test.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.test.tsx
@@ -53,7 +53,9 @@ const mockSelectedAmountsVariant = {
 } satisfies SelectedAmountsVariant;
 
 // Helper function to create a deep copy with proper typing
-function deepCopySelectedAmountsVariant(variant: SelectedAmountsVariant): SelectedAmountsVariant {
+function deepCopySelectedAmountsVariant(
+	variant: SelectedAmountsVariant,
+): SelectedAmountsVariant {
 	return {
 		testName: variant.testName,
 		variantName: variant.variantName,
@@ -63,17 +65,20 @@ function deepCopySelectedAmountsVariant(variant: SelectedAmountsVariant): Select
 			ONE_OFF: {
 				amounts: [...variant.amountsCardData.ONE_OFF.amounts],
 				defaultAmount: variant.amountsCardData.ONE_OFF.defaultAmount,
-				hideChooseYourAmount: variant.amountsCardData.ONE_OFF.hideChooseYourAmount,
+				hideChooseYourAmount:
+					variant.amountsCardData.ONE_OFF.hideChooseYourAmount,
 			},
 			MONTHLY: {
 				amounts: [...variant.amountsCardData.MONTHLY.amounts],
 				defaultAmount: variant.amountsCardData.MONTHLY.defaultAmount,
-				hideChooseYourAmount: variant.amountsCardData.MONTHLY.hideChooseYourAmount,
+				hideChooseYourAmount:
+					variant.amountsCardData.MONTHLY.hideChooseYourAmount,
 			},
 			ANNUAL: {
 				amounts: [...variant.amountsCardData.ANNUAL.amounts],
 				defaultAmount: variant.amountsCardData.ANNUAL.defaultAmount,
-				hideChooseYourAmount: variant.amountsCardData.ANNUAL.hideChooseYourAmount,
+				hideChooseYourAmount:
+					variant.amountsCardData.ANNUAL.hideChooseYourAmount,
 			},
 		},
 	};
@@ -83,7 +88,7 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockLocation.search = '';
-		
+
 		(getAmountsTestVariant as jest.Mock).mockReturnValue({
 			selectedAmountsVariant: mockSelectedAmountsVariant,
 			amountsParticipation: undefined,
@@ -93,159 +98,207 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 	test('should modify amounts variant when custom amounts parameter is provided', () => {
 		// Set up URL with custom amounts parameter
 		mockLocation.search = '?amounts=15,30,75';
-		
+
 		// Simulate the URLSearchParams logic from the component
 		const urlSearchParams = new URLSearchParams(mockLocation.search);
 		const customAmountsParam = urlSearchParams.get('amounts');
-		
+
 		// Create a copy of the mock to simulate the component behavior
-		const selectedAmountsVariant = deepCopySelectedAmountsVariant(mockSelectedAmountsVariant);
-		
+		const selectedAmountsVariant = deepCopySelectedAmountsVariant(
+			mockSelectedAmountsVariant,
+		);
+
 		// This is the exact logic from the component (lines 267-273)
 		if (customAmountsParam) {
-			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
+				parseCustomAmounts(customAmountsParam);
 		}
-		
+
 		// Verify the amounts were modified correctly
-		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([15, 30, 75]);
+		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([
+			15, 30, 75,
+		]);
 		// Verify other contribution types remain unchanged
-		expect(selectedAmountsVariant.amountsCardData['MONTHLY'].amounts).toEqual([5, 10, 20]);
-		expect(selectedAmountsVariant.amountsCardData['ANNUAL'].amounts).toEqual([60, 100, 250, 500]);
+		expect(selectedAmountsVariant.amountsCardData['MONTHLY'].amounts).toEqual([
+			5, 10, 20,
+		]);
+		expect(selectedAmountsVariant.amountsCardData['ANNUAL'].amounts).toEqual([
+			60, 100, 250, 500,
+		]);
 	});
 
 	test('should filter out invalid amounts and keep only valid ones', () => {
 		mockLocation.search = '?amounts=10,invalid,20,-5,0,30,Infinity,NaN';
-		
+
 		const urlSearchParams = new URLSearchParams(mockLocation.search);
 		const customAmountsParam = urlSearchParams.get('amounts');
-		const selectedAmountsVariant = deepCopySelectedAmountsVariant(mockSelectedAmountsVariant);
-		
+		const selectedAmountsVariant = deepCopySelectedAmountsVariant(
+			mockSelectedAmountsVariant,
+		);
+
 		if (customAmountsParam) {
-			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
+				parseCustomAmounts(customAmountsParam);
 		}
-		
+
 		// Should only include valid positive finite amounts
-		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([10, 20, 30]);
+		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([
+			10, 20, 30,
+		]);
 	});
 
 	test('should remove duplicate amounts', () => {
 		mockLocation.search = '?amounts=25,50,25,100,50,25,100';
-		
+
 		const urlSearchParams = new URLSearchParams(mockLocation.search);
 		const customAmountsParam = urlSearchParams.get('amounts');
-		const selectedAmountsVariant = deepCopySelectedAmountsVariant(mockSelectedAmountsVariant);
-		
+		const selectedAmountsVariant = deepCopySelectedAmountsVariant(
+			mockSelectedAmountsVariant,
+		);
+
 		if (customAmountsParam) {
-			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
+				parseCustomAmounts(customAmountsParam);
 		}
-		
+
 		// Should remove duplicates and keep first occurrence
-		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([25, 50, 100]);
+		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([
+			25, 50, 100,
+		]);
 	});
 
 	test('should handle decimal values correctly', () => {
 		mockLocation.search = '?amounts=12.50,25.75,50.25';
-		
+
 		const urlSearchParams = new URLSearchParams(mockLocation.search);
 		const customAmountsParam = urlSearchParams.get('amounts');
-		const selectedAmountsVariant = deepCopySelectedAmountsVariant(mockSelectedAmountsVariant);
-		
+		const selectedAmountsVariant = deepCopySelectedAmountsVariant(
+			mockSelectedAmountsVariant,
+		);
+
 		if (customAmountsParam) {
-			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
+				parseCustomAmounts(customAmountsParam);
 		}
-		
+
 		// Should handle decimal values correctly (parseFloat handles trailing zeros)
-		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([12.5, 25.75, 50.25]);
+		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([
+			12.5, 25.75, 50.25,
+		]);
 	});
 
 	test('should trim whitespace from amounts', () => {
 		mockLocation.search = '?amounts= 15 , 30 , 75 ';
-		
+
 		const urlSearchParams = new URLSearchParams(mockLocation.search);
 		const customAmountsParam = urlSearchParams.get('amounts');
-		const selectedAmountsVariant = deepCopySelectedAmountsVariant(mockSelectedAmountsVariant);
-		
+		const selectedAmountsVariant = deepCopySelectedAmountsVariant(
+			mockSelectedAmountsVariant,
+		);
+
 		if (customAmountsParam) {
-			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
+				parseCustomAmounts(customAmountsParam);
 		}
-		
+
 		// Should handle whitespace correctly
-		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([15, 30, 75]);
+		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([
+			15, 30, 75,
+		]);
 	});
 
 	test('should not modify amounts when custom amounts parameter is empty', () => {
 		mockLocation.search = '?amounts=';
-		
+
 		const urlSearchParams = new URLSearchParams(mockLocation.search);
 		const customAmountsParam = urlSearchParams.get('amounts');
-		const selectedAmountsVariant = deepCopySelectedAmountsVariant(mockSelectedAmountsVariant);
-		const originalAmounts = [...selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts];
-		
+		const selectedAmountsVariant = deepCopySelectedAmountsVariant(
+			mockSelectedAmountsVariant,
+		);
+		const originalAmounts = [
+			...selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts,
+		];
+
 		if (customAmountsParam) {
-			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
+				parseCustomAmounts(customAmountsParam);
 		}
-		
+
 		// Should keep original amounts when parameter is empty
-		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual(originalAmounts);
+		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual(
+			originalAmounts,
+		);
 	});
 
 	test('should not modify amounts when no custom amounts parameter is provided', () => {
 		mockLocation.search = '';
-		
+
 		const urlSearchParams = new URLSearchParams(mockLocation.search);
 		const customAmountsParam = urlSearchParams.get('amounts');
-		const selectedAmountsVariant = deepCopySelectedAmountsVariant(mockSelectedAmountsVariant);
-		const originalAmounts = [...selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts];
-		
+		const selectedAmountsVariant = deepCopySelectedAmountsVariant(
+			mockSelectedAmountsVariant,
+		);
+		const originalAmounts = [
+			...selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts,
+		];
+
 		if (customAmountsParam) {
-			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
+				parseCustomAmounts(customAmountsParam);
 		}
-		
+
 		// Should keep original amounts when no parameter
-		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual(originalAmounts);
+		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual(
+			originalAmounts,
+		);
 		expect(customAmountsParam).toBeNull();
 	});
 
 	test('should set amounts to empty array when all custom amounts are invalid', () => {
 		mockLocation.search = '?amounts=invalid,NaN,-5,0,-10,abc';
-		
+
 		const urlSearchParams = new URLSearchParams(mockLocation.search);
 		const customAmountsParam = urlSearchParams.get('amounts');
-		const selectedAmountsVariant = deepCopySelectedAmountsVariant(mockSelectedAmountsVariant);
-		
+		const selectedAmountsVariant = deepCopySelectedAmountsVariant(
+			mockSelectedAmountsVariant,
+		);
+
 		if (customAmountsParam) {
-			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
+				parseCustomAmounts(customAmountsParam);
 		}
-		
+
 		// Should result in empty array when all amounts are invalid
-		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([]);
+		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual(
+			[],
+		);
 	});
 
 	describe('URLSearchParams behavior', () => {
 		test('should correctly extract amounts parameter from URL', () => {
 			mockLocation.search = '?amounts=15,30,75&other=param';
-			
+
 			const urlSearchParams = new URLSearchParams(mockLocation.search);
 			const customAmountsParam = urlSearchParams.get('amounts');
-			
+
 			expect(customAmountsParam).toBe('15,30,75');
 		});
 
 		test('should return null when amounts parameter is not present', () => {
 			mockLocation.search = '?other=param';
-			
+
 			const urlSearchParams = new URLSearchParams(mockLocation.search);
 			const customAmountsParam = urlSearchParams.get('amounts');
-			
+
 			expect(customAmountsParam).toBeNull();
 		});
 
 		test('should return empty string when amounts parameter is empty', () => {
 			mockLocation.search = '?amounts=&other=param';
-			
+
 			const urlSearchParams = new URLSearchParams(mockLocation.search);
 			const customAmountsParam = urlSearchParams.get('amounts');
-			
+
 			expect(customAmountsParam).toBe('');
 		});
 	});

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.test.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.test.tsx
@@ -273,11 +273,18 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 
 		// Should not create custom amounts data when parameter is empty
 		expect(customAmountsData).toBeUndefined();
-		
+
 		// Should use original amountsCardData values
-		expect(amounts).toEqual(mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].amounts);
-		expect(defaultAmount).toBe(mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].defaultAmount);
-		expect(hideChooseYourAmount).toBe(mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].hideChooseYourAmount);
+		expect(amounts).toEqual(
+			mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].amounts,
+		);
+		expect(defaultAmount).toBe(
+			mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].defaultAmount,
+		);
+		expect(hideChooseYourAmount).toBe(
+			mockSelectedAmountsVariant.amountsCardData['ONE_OFF']
+				.hideChooseYourAmount,
+		);
 	});
 
 	test('should not create custom amounts data when no custom amounts parameter is provided', () => {
@@ -307,11 +314,18 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 		// Should not create custom amounts data when no parameter
 		expect(customAmountsData).toBeUndefined();
 		expect(customAmountsParam).toBeNull();
-		
+
 		// Should use original amountsCardData values
-		expect(amounts).toEqual(mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].amounts);
-		expect(defaultAmount).toBe(mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].defaultAmount);
-		expect(hideChooseYourAmount).toBe(mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].hideChooseYourAmount);
+		expect(amounts).toEqual(
+			mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].amounts,
+		);
+		expect(defaultAmount).toBe(
+			mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].defaultAmount,
+		);
+		expect(hideChooseYourAmount).toBe(
+			mockSelectedAmountsVariant.amountsCardData['ONE_OFF']
+				.hideChooseYourAmount,
+		);
 	});
 
 	test('should set amounts to empty array when all custom amounts are invalid', () => {

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.test.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.test.tsx
@@ -1,0 +1,252 @@
+import '@testing-library/jest-dom';
+import { getAmountsTestVariant } from '../../../helpers/abTests/abtest';
+import type { SelectedAmountsVariant } from '../../../helpers/contributions';
+import { parseCustomAmounts } from '../../../helpers/utilities/utilities';
+
+// Mock the getAmountsTestVariant function
+jest.mock('../../../helpers/abTests/abtest', () => ({
+	getAmountsTestVariant: jest.fn(),
+}));
+
+// Mock the geoIdConfig
+jest.mock('../../geoIdConfig', () => ({
+	getGeoIdConfig: jest.fn(() => ({
+		currency: { glyph: '£', isPaddedGlyph: false, isSuffixGlyph: false },
+		currencyKey: 'GBP',
+		countryGroupId: 'GBPCountries',
+	})),
+}));
+
+// Mock window.location
+const mockLocation = {
+	search: '',
+	pathname: '/uk/one-time-checkout',
+};
+
+Object.defineProperty(window, 'location', {
+	value: mockLocation,
+	writable: true,
+});
+
+const mockSelectedAmountsVariant = {
+	testName: 'FALLBACK_AMOUNTS__GBPCountries',
+	variantName: 'CONTROL',
+	defaultContributionType: 'MONTHLY',
+	displayContributionType: ['ONE_OFF', 'MONTHLY', 'ANNUAL'],
+	amountsCardData: {
+		ONE_OFF: {
+			amounts: [25, 50, 100, 250],
+			defaultAmount: 50,
+			hideChooseYourAmount: false,
+		},
+		MONTHLY: {
+			amounts: [5, 10, 20],
+			defaultAmount: 10,
+			hideChooseYourAmount: false,
+		},
+		ANNUAL: {
+			amounts: [60, 100, 250, 500],
+			defaultAmount: 60,
+			hideChooseYourAmount: false,
+		},
+	},
+} satisfies SelectedAmountsVariant;
+
+// Helper function to create a deep copy with proper typing
+function deepCopySelectedAmountsVariant(variant: SelectedAmountsVariant): SelectedAmountsVariant {
+	return {
+		testName: variant.testName,
+		variantName: variant.variantName,
+		defaultContributionType: variant.defaultContributionType,
+		displayContributionType: [...variant.displayContributionType],
+		amountsCardData: {
+			ONE_OFF: {
+				amounts: [...variant.amountsCardData.ONE_OFF.amounts],
+				defaultAmount: variant.amountsCardData.ONE_OFF.defaultAmount,
+				hideChooseYourAmount: variant.amountsCardData.ONE_OFF.hideChooseYourAmount,
+			},
+			MONTHLY: {
+				amounts: [...variant.amountsCardData.MONTHLY.amounts],
+				defaultAmount: variant.amountsCardData.MONTHLY.defaultAmount,
+				hideChooseYourAmount: variant.amountsCardData.MONTHLY.hideChooseYourAmount,
+			},
+			ANNUAL: {
+				amounts: [...variant.amountsCardData.ANNUAL.amounts],
+				defaultAmount: variant.amountsCardData.ANNUAL.defaultAmount,
+				hideChooseYourAmount: variant.amountsCardData.ANNUAL.hideChooseYourAmount,
+			},
+		},
+	};
+}
+
+describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockLocation.search = '';
+		
+		(getAmountsTestVariant as jest.Mock).mockReturnValue({
+			selectedAmountsVariant: mockSelectedAmountsVariant,
+			amountsParticipation: undefined,
+		});
+	});
+
+	test('should modify amounts variant when custom amounts parameter is provided', () => {
+		// Set up URL with custom amounts parameter
+		mockLocation.search = '?amounts=15,30,75';
+		
+		// Simulate the URLSearchParams logic from the component
+		const urlSearchParams = new URLSearchParams(mockLocation.search);
+		const customAmountsParam = urlSearchParams.get('amounts');
+		
+		// Create a copy of the mock to simulate the component behavior
+		const selectedAmountsVariant = deepCopySelectedAmountsVariant(mockSelectedAmountsVariant);
+		
+		// This is the exact logic from the component (lines 267-273)
+		if (customAmountsParam) {
+			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+		}
+		
+		// Verify the amounts were modified correctly
+		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([15, 30, 75]);
+		// Verify other contribution types remain unchanged
+		expect(selectedAmountsVariant.amountsCardData['MONTHLY'].amounts).toEqual([5, 10, 20]);
+		expect(selectedAmountsVariant.amountsCardData['ANNUAL'].amounts).toEqual([60, 100, 250, 500]);
+	});
+
+	test('should filter out invalid amounts and keep only valid ones', () => {
+		mockLocation.search = '?amounts=10,invalid,20,-5,0,30,Infinity,NaN';
+		
+		const urlSearchParams = new URLSearchParams(mockLocation.search);
+		const customAmountsParam = urlSearchParams.get('amounts');
+		const selectedAmountsVariant = deepCopySelectedAmountsVariant(mockSelectedAmountsVariant);
+		
+		if (customAmountsParam) {
+			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+		}
+		
+		// Should only include valid positive finite amounts
+		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([10, 20, 30]);
+	});
+
+	test('should remove duplicate amounts', () => {
+		mockLocation.search = '?amounts=25,50,25,100,50,25,100';
+		
+		const urlSearchParams = new URLSearchParams(mockLocation.search);
+		const customAmountsParam = urlSearchParams.get('amounts');
+		const selectedAmountsVariant = deepCopySelectedAmountsVariant(mockSelectedAmountsVariant);
+		
+		if (customAmountsParam) {
+			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+		}
+		
+		// Should remove duplicates and keep first occurrence
+		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([25, 50, 100]);
+	});
+
+	test('should handle decimal values correctly', () => {
+		mockLocation.search = '?amounts=12.50,25.75,50.25';
+		
+		const urlSearchParams = new URLSearchParams(mockLocation.search);
+		const customAmountsParam = urlSearchParams.get('amounts');
+		const selectedAmountsVariant = deepCopySelectedAmountsVariant(mockSelectedAmountsVariant);
+		
+		if (customAmountsParam) {
+			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+		}
+		
+		// Should handle decimal values correctly (parseFloat handles trailing zeros)
+		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([12.5, 25.75, 50.25]);
+	});
+
+	test('should trim whitespace from amounts', () => {
+		mockLocation.search = '?amounts= 15 , 30 , 75 ';
+		
+		const urlSearchParams = new URLSearchParams(mockLocation.search);
+		const customAmountsParam = urlSearchParams.get('amounts');
+		const selectedAmountsVariant = deepCopySelectedAmountsVariant(mockSelectedAmountsVariant);
+		
+		if (customAmountsParam) {
+			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+		}
+		
+		// Should handle whitespace correctly
+		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([15, 30, 75]);
+	});
+
+	test('should not modify amounts when custom amounts parameter is empty', () => {
+		mockLocation.search = '?amounts=';
+		
+		const urlSearchParams = new URLSearchParams(mockLocation.search);
+		const customAmountsParam = urlSearchParams.get('amounts');
+		const selectedAmountsVariant = deepCopySelectedAmountsVariant(mockSelectedAmountsVariant);
+		const originalAmounts = [...selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts];
+		
+		if (customAmountsParam) {
+			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+		}
+		
+		// Should keep original amounts when parameter is empty
+		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual(originalAmounts);
+	});
+
+	test('should not modify amounts when no custom amounts parameter is provided', () => {
+		mockLocation.search = '';
+		
+		const urlSearchParams = new URLSearchParams(mockLocation.search);
+		const customAmountsParam = urlSearchParams.get('amounts');
+		const selectedAmountsVariant = deepCopySelectedAmountsVariant(mockSelectedAmountsVariant);
+		const originalAmounts = [...selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts];
+		
+		if (customAmountsParam) {
+			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+		}
+		
+		// Should keep original amounts when no parameter
+		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual(originalAmounts);
+		expect(customAmountsParam).toBeNull();
+	});
+
+	test('should set amounts to empty array when all custom amounts are invalid', () => {
+		mockLocation.search = '?amounts=invalid,NaN,-5,0,-10,abc';
+		
+		const urlSearchParams = new URLSearchParams(mockLocation.search);
+		const customAmountsParam = urlSearchParams.get('amounts');
+		const selectedAmountsVariant = deepCopySelectedAmountsVariant(mockSelectedAmountsVariant);
+		
+		if (customAmountsParam) {
+			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+		}
+		
+		// Should result in empty array when all amounts are invalid
+		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([]);
+	});
+
+	describe('URLSearchParams behavior', () => {
+		test('should correctly extract amounts parameter from URL', () => {
+			mockLocation.search = '?amounts=15,30,75&other=param';
+			
+			const urlSearchParams = new URLSearchParams(mockLocation.search);
+			const customAmountsParam = urlSearchParams.get('amounts');
+			
+			expect(customAmountsParam).toBe('15,30,75');
+		});
+
+		test('should return null when amounts parameter is not present', () => {
+			mockLocation.search = '?other=param';
+			
+			const urlSearchParams = new URLSearchParams(mockLocation.search);
+			const customAmountsParam = urlSearchParams.get('amounts');
+			
+			expect(customAmountsParam).toBeNull();
+		});
+
+		test('should return empty string when amounts parameter is empty', () => {
+			mockLocation.search = '?amounts=&other=param';
+			
+			const urlSearchParams = new URLSearchParams(mockLocation.search);
+			const customAmountsParam = urlSearchParams.get('amounts');
+			
+			expect(customAmountsParam).toBe('');
+		});
+	});
+});

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.test.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.test.tsx
@@ -95,7 +95,7 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 		});
 	});
 
-	test('should modify amounts variant when custom amounts parameter is provided', () => {
+	test('should create custom amounts data when custom amounts parameter is provided', () => {
 		// Set up URL with custom amounts parameter
 		mockLocation.search = '?amounts=15,30,75';
 
@@ -108,17 +108,33 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 			mockSelectedAmountsVariant,
 		);
 
-		// This is the exact logic from the component (lines 267-273)
+		// This is the exact logic from the component
+		let customAmountsData;
 		if (customAmountsParam) {
-			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
-				parseCustomAmounts(customAmountsParam);
+			const amounts = parseCustomAmounts(customAmountsParam);
+			customAmountsData = {
+				amounts,
+				defaultAmount: amounts[1] ?? 0,
+				hideChooseYourAmount: false,
+			};
 		}
 
-		// Verify the amounts were modified correctly
-		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([
-			15, 30, 75,
-		]);
-		// Verify other contribution types remain unchanged
+		const { amountsCardData } = selectedAmountsVariant;
+		const { amounts, defaultAmount, hideChooseYourAmount } =
+			customAmountsData ?? amountsCardData['ONE_OFF'];
+
+		// Verify the custom amounts data was created correctly
+		expect(customAmountsData).toBeDefined();
+		expect(customAmountsData?.amounts).toEqual([15, 30, 75]);
+		expect(customAmountsData?.defaultAmount).toBe(30); // amounts[1]
+		expect(customAmountsData?.hideChooseYourAmount).toBe(false);
+
+		// Verify the final destructured values
+		expect(amounts).toEqual([15, 30, 75]);
+		expect(defaultAmount).toBe(30);
+		expect(hideChooseYourAmount).toBe(false);
+
+		// Verify original variant data remains unchanged
 		expect(selectedAmountsVariant.amountsCardData['MONTHLY'].amounts).toEqual([
 			5, 10, 20,
 		]);
@@ -132,19 +148,25 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 
 		const urlSearchParams = new URLSearchParams(mockLocation.search);
 		const customAmountsParam = urlSearchParams.get('amounts');
-		const selectedAmountsVariant = deepCopySelectedAmountsVariant(
-			mockSelectedAmountsVariant,
-		);
 
+		let customAmountsData;
 		if (customAmountsParam) {
-			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
-				parseCustomAmounts(customAmountsParam);
+			const amounts = parseCustomAmounts(customAmountsParam);
+			customAmountsData = {
+				amounts,
+				defaultAmount: amounts[1] ?? 0,
+				hideChooseYourAmount: false,
+			};
 		}
 
+		const { amountsCardData } = mockSelectedAmountsVariant;
+		const { amounts, defaultAmount, hideChooseYourAmount } =
+			customAmountsData ?? amountsCardData['ONE_OFF'];
+
 		// Should only include valid positive finite amounts
-		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([
-			10, 20, 30,
-		]);
+		expect(amounts).toEqual([10, 20, 30]);
+		expect(defaultAmount).toBe(20); // amounts[1]
+		expect(hideChooseYourAmount).toBe(false);
 	});
 
 	test('should remove duplicate amounts', () => {
@@ -152,19 +174,25 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 
 		const urlSearchParams = new URLSearchParams(mockLocation.search);
 		const customAmountsParam = urlSearchParams.get('amounts');
-		const selectedAmountsVariant = deepCopySelectedAmountsVariant(
-			mockSelectedAmountsVariant,
-		);
 
+		let customAmountsData;
 		if (customAmountsParam) {
-			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
-				parseCustomAmounts(customAmountsParam);
+			const amounts = parseCustomAmounts(customAmountsParam);
+			customAmountsData = {
+				amounts,
+				defaultAmount: amounts[1] ?? 0,
+				hideChooseYourAmount: false,
+			};
 		}
 
+		const { amountsCardData } = mockSelectedAmountsVariant;
+		const { amounts, defaultAmount, hideChooseYourAmount } =
+			customAmountsData ?? amountsCardData['ONE_OFF'];
+
 		// Should remove duplicates and keep first occurrence
-		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([
-			25, 50, 100,
-		]);
+		expect(amounts).toEqual([25, 50, 100]);
+		expect(defaultAmount).toBe(50); // amounts[1]
+		expect(hideChooseYourAmount).toBe(false);
 	});
 
 	test('should handle decimal values correctly', () => {
@@ -172,19 +200,25 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 
 		const urlSearchParams = new URLSearchParams(mockLocation.search);
 		const customAmountsParam = urlSearchParams.get('amounts');
-		const selectedAmountsVariant = deepCopySelectedAmountsVariant(
-			mockSelectedAmountsVariant,
-		);
 
+		let customAmountsData;
 		if (customAmountsParam) {
-			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
-				parseCustomAmounts(customAmountsParam);
+			const amounts = parseCustomAmounts(customAmountsParam);
+			customAmountsData = {
+				amounts,
+				defaultAmount: amounts[1] ?? 0,
+				hideChooseYourAmount: false,
+			};
 		}
 
+		const { amountsCardData } = mockSelectedAmountsVariant;
+		const { amounts, defaultAmount, hideChooseYourAmount } =
+			customAmountsData ?? amountsCardData['ONE_OFF'];
+
 		// Should handle decimal values correctly (parseFloat handles trailing zeros)
-		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([
-			12.5, 25.75, 50.25,
-		]);
+		expect(amounts).toEqual([12.5, 25.75, 50.25]);
+		expect(defaultAmount).toBe(25.75); // amounts[1]
+		expect(hideChooseYourAmount).toBe(false);
 	});
 
 	test('should trim whitespace from amounts', () => {
@@ -192,66 +226,92 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 
 		const urlSearchParams = new URLSearchParams(mockLocation.search);
 		const customAmountsParam = urlSearchParams.get('amounts');
-		const selectedAmountsVariant = deepCopySelectedAmountsVariant(
-			mockSelectedAmountsVariant,
-		);
 
+		let customAmountsData;
 		if (customAmountsParam) {
-			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
-				parseCustomAmounts(customAmountsParam);
+			const amounts = parseCustomAmounts(customAmountsParam);
+			customAmountsData = {
+				amounts,
+				defaultAmount: amounts[1] ?? 0,
+				hideChooseYourAmount: false,
+			};
 		}
 
+		const { amountsCardData } = mockSelectedAmountsVariant;
+		const { amounts, defaultAmount, hideChooseYourAmount } =
+			customAmountsData ?? amountsCardData['ONE_OFF'];
+
 		// Should handle whitespace correctly
-		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual([
-			15, 30, 75,
-		]);
+		expect(amounts).toEqual([15, 30, 75]);
+		expect(defaultAmount).toBe(30); // amounts[1]
+		expect(hideChooseYourAmount).toBe(false);
 	});
 
-	test('should not modify amounts when custom amounts parameter is empty', () => {
+	test('should not create custom amounts data when custom amounts parameter is empty', () => {
 		mockLocation.search = '?amounts=';
 
 		const urlSearchParams = new URLSearchParams(mockLocation.search);
 		const customAmountsParam = urlSearchParams.get('amounts');
+
 		const selectedAmountsVariant = deepCopySelectedAmountsVariant(
 			mockSelectedAmountsVariant,
 		);
-		const originalAmounts = [
-			...selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts,
-		];
 
+		let customAmountsData;
 		if (customAmountsParam) {
-			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
-				parseCustomAmounts(customAmountsParam);
+			const amounts = parseCustomAmounts(customAmountsParam);
+			customAmountsData = {
+				amounts,
+				defaultAmount: amounts[1] ?? 0,
+				hideChooseYourAmount: false,
+			};
 		}
 
-		// Should keep original amounts when parameter is empty
-		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual(
-			originalAmounts,
-		);
+		const { amountsCardData } = selectedAmountsVariant;
+		const { amounts, defaultAmount, hideChooseYourAmount } =
+			customAmountsData ?? amountsCardData['ONE_OFF'];
+
+		// Should not create custom amounts data when parameter is empty
+		expect(customAmountsData).toBeUndefined();
+		
+		// Should use original amountsCardData values
+		expect(amounts).toEqual(mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].amounts);
+		expect(defaultAmount).toBe(mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].defaultAmount);
+		expect(hideChooseYourAmount).toBe(mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].hideChooseYourAmount);
 	});
 
-	test('should not modify amounts when no custom amounts parameter is provided', () => {
+	test('should not create custom amounts data when no custom amounts parameter is provided', () => {
 		mockLocation.search = '';
 
 		const urlSearchParams = new URLSearchParams(mockLocation.search);
 		const customAmountsParam = urlSearchParams.get('amounts');
+
 		const selectedAmountsVariant = deepCopySelectedAmountsVariant(
 			mockSelectedAmountsVariant,
 		);
-		const originalAmounts = [
-			...selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts,
-		];
 
+		let customAmountsData;
 		if (customAmountsParam) {
-			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
-				parseCustomAmounts(customAmountsParam);
+			const amounts = parseCustomAmounts(customAmountsParam);
+			customAmountsData = {
+				amounts,
+				defaultAmount: amounts[1] ?? 0,
+				hideChooseYourAmount: false,
+			};
 		}
 
-		// Should keep original amounts when no parameter
-		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual(
-			originalAmounts,
-		);
+		const { amountsCardData } = selectedAmountsVariant;
+		const { amounts, defaultAmount, hideChooseYourAmount } =
+			customAmountsData ?? amountsCardData['ONE_OFF'];
+
+		// Should not create custom amounts data when no parameter
+		expect(customAmountsData).toBeUndefined();
 		expect(customAmountsParam).toBeNull();
+		
+		// Should use original amountsCardData values
+		expect(amounts).toEqual(mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].amounts);
+		expect(defaultAmount).toBe(mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].defaultAmount);
+		expect(hideChooseYourAmount).toBe(mockSelectedAmountsVariant.amountsCardData['ONE_OFF'].hideChooseYourAmount);
 	});
 
 	test('should set amounts to empty array when all custom amounts are invalid', () => {
@@ -259,19 +319,77 @@ describe('OneTimeCheckoutComponent - Custom Amounts URL Processing', () => {
 
 		const urlSearchParams = new URLSearchParams(mockLocation.search);
 		const customAmountsParam = urlSearchParams.get('amounts');
-		const selectedAmountsVariant = deepCopySelectedAmountsVariant(
-			mockSelectedAmountsVariant,
-		);
 
+		let customAmountsData;
 		if (customAmountsParam) {
-			selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
-				parseCustomAmounts(customAmountsParam);
+			const amounts = parseCustomAmounts(customAmountsParam);
+			customAmountsData = {
+				amounts,
+				defaultAmount: amounts[1] ?? 0,
+				hideChooseYourAmount: false,
+			};
 		}
 
+		const { amountsCardData } = mockSelectedAmountsVariant;
+		const { amounts, defaultAmount, hideChooseYourAmount } =
+			customAmountsData ?? amountsCardData['ONE_OFF'];
+
 		// Should result in empty array when all amounts are invalid
-		expect(selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts).toEqual(
-			[],
-		);
+		expect(amounts).toEqual([]);
+		expect(defaultAmount).toBe(0); // amounts[1] ?? 0 when amounts[1] is undefined
+		expect(hideChooseYourAmount).toBe(false);
+	});
+
+	test('should handle single custom amount and set defaultAmount to 0', () => {
+		mockLocation.search = '?amounts=25';
+
+		const urlSearchParams = new URLSearchParams(mockLocation.search);
+		const customAmountsParam = urlSearchParams.get('amounts');
+
+		let customAmountsData;
+		if (customAmountsParam) {
+			const amounts = parseCustomAmounts(customAmountsParam);
+			customAmountsData = {
+				amounts,
+				defaultAmount: amounts[1] ?? 0,
+				hideChooseYourAmount: false,
+			};
+		}
+
+		const { amountsCardData } = mockSelectedAmountsVariant;
+		const { amounts, defaultAmount, hideChooseYourAmount } =
+			customAmountsData ?? amountsCardData['ONE_OFF'];
+
+		// Should have single amount and defaultAmount should be 0 (amounts[1] is undefined)
+		expect(amounts).toEqual([25]);
+		expect(defaultAmount).toBe(0); // amounts[1] ?? 0 when amounts[1] is undefined
+		expect(hideChooseYourAmount).toBe(false);
+	});
+
+	test('should handle two custom amounts and set defaultAmount to second amount', () => {
+		mockLocation.search = '?amounts=25,50';
+
+		const urlSearchParams = new URLSearchParams(mockLocation.search);
+		const customAmountsParam = urlSearchParams.get('amounts');
+
+		let customAmountsData;
+		if (customAmountsParam) {
+			const amounts = parseCustomAmounts(customAmountsParam);
+			customAmountsData = {
+				amounts,
+				defaultAmount: amounts[1] ?? 0,
+				hideChooseYourAmount: false,
+			};
+		}
+
+		const { amountsCardData } = mockSelectedAmountsVariant;
+		const { amounts, defaultAmount, hideChooseYourAmount } =
+			customAmountsData ?? amountsCardData['ONE_OFF'];
+
+		// Should have two amounts and defaultAmount should be second amount
+		expect(amounts).toEqual([25, 50]);
+		expect(defaultAmount).toBe(50); // amounts[1]
+		expect(hideChooseYourAmount).toBe(false);
 	});
 
 	describe('URLSearchParams behavior', () => {

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -267,7 +267,7 @@ export function OneTimeCheckoutComponent({
 	if (customAmountsParam) {
 		// Let's hijack the ab test variant if we have a custom amounts query param.
 		// This was designed for the marketing team being able to calculate and provide their own
-		// suggested amounts for top-up campaigns etc.
+		// suggested amounts for top-up campaigns, etc.
 		selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
 	}
 

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -74,7 +74,7 @@ import {
 } from 'helpers/tracking/quantumMetric';
 import { payPalCancelUrl, payPalReturnUrl } from 'helpers/urls/routes';
 import { logException } from 'helpers/utilities/logger';
-import { roundToDecimalPlaces } from 'helpers/utilities/utilities';
+import { parseCustomAmounts, roundToDecimalPlaces } from 'helpers/utilities/utilities';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
 import { CheckoutDivider } from 'pages/supporter-plus-landing/components/checkoutDivider';
 import { ContributionCheckoutFinePrint } from 'pages/supporter-plus-landing/components/contributionCheckoutFinePrint';
@@ -268,7 +268,7 @@ export function OneTimeCheckoutComponent({
 		// Let's hijack the ab test variant if we have a custom amounts query param.
 		// This was designed for the marketing team being able to calculate and provide their own
 		// suggested amounts for top-up campaigns etc.
-		selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = customAmountsParam.split(',').map(amount => parseFloat(amount)).filter(amount => !isNaN(amount));
+		selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
 	}
 
 	const { amountsCardData } = selectedAmountsVariant;

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -267,17 +267,15 @@ export function OneTimeCheckoutComponent({
 	);
 
 	const customAmountsParam = urlSearchParams.get('amounts');
-	if (customAmountsParam) {
-		// Let's hijack the ab test variant if we have a custom amounts query param.
-		// This was designed for the marketing team being able to calculate and provide their own
-		// suggested amounts for top-up campaigns, etc.
-		selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
-			parseCustomAmounts(customAmountsParam);
-	}
+	const customAmountsData = customAmountsParam ? {
+		amounts: parseCustomAmounts(customAmountsParam),
+		defaultAmount: 0,
+		hideChooseYourAmount: false,
+	} : null;
 
 	const { amountsCardData } = selectedAmountsVariant;
 	const { amounts, defaultAmount, hideChooseYourAmount } =
-		amountsCardData['ONE_OFF'];
+		customAmountsData ?? amountsCardData['ONE_OFF'];
 
 	const { preSelectedPriceCard, preSelectedOtherAmount } = getPreSelectedAmount(
 		preSelectedAmountParam,

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -74,7 +74,10 @@ import {
 } from 'helpers/tracking/quantumMetric';
 import { payPalCancelUrl, payPalReturnUrl } from 'helpers/urls/routes';
 import { logException } from 'helpers/utilities/logger';
-import { parseCustomAmounts, roundToDecimalPlaces } from 'helpers/utilities/utilities';
+import {
+	parseCustomAmounts,
+	roundToDecimalPlaces,
+} from 'helpers/utilities/utilities';
 import { type GeoId, getGeoIdConfig } from 'pages/geoIdConfig';
 import { CheckoutDivider } from 'pages/supporter-plus-landing/components/checkoutDivider';
 import { ContributionCheckoutFinePrint } from 'pages/supporter-plus-landing/components/contributionCheckoutFinePrint';
@@ -268,7 +271,8 @@ export function OneTimeCheckoutComponent({
 		// Let's hijack the ab test variant if we have a custom amounts query param.
 		// This was designed for the marketing team being able to calculate and provide their own
 		// suggested amounts for top-up campaigns, etc.
-		selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = parseCustomAmounts(customAmountsParam);
+		selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts =
+			parseCustomAmounts(customAmountsParam);
 	}
 
 	const { amountsCardData } = selectedAmountsVariant;

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -266,12 +266,16 @@ export function OneTimeCheckoutComponent({
 		settings,
 	);
 
+	let customAmountsData;
 	const customAmountsParam = urlSearchParams.get('amounts');
-	const customAmountsData = customAmountsParam ? {
-		amounts: parseCustomAmounts(customAmountsParam),
-		defaultAmount: 0,
-		hideChooseYourAmount: false,
-	} : null;
+	if (customAmountsParam) {
+		const amounts = parseCustomAmounts(customAmountsParam);
+		customAmountsData = {
+			amounts,
+			defaultAmount: amounts[1] ?? 0,
+			hideChooseYourAmount: false,
+		};
+	}
 
 	const { amountsCardData } = selectedAmountsVariant;
 	const { amounts, defaultAmount, hideChooseYourAmount } =

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -263,6 +263,14 @@ export function OneTimeCheckoutComponent({
 		settings,
 	);
 
+	const customAmountsParam = urlSearchParams.get('amounts');
+	if (customAmountsParam) {
+		// Let's hijack the ab test variant if we have a custom amounts query param.
+		// This was designed for the marketing team being able to calculate and provide their own
+		// suggested amounts for top-up campaigns etc.
+		selectedAmountsVariant.amountsCardData['ONE_OFF'].amounts = customAmountsParam.split(',').map(amount => parseFloat(amount)).filter(amount => !isNaN(amount));
+	}
+
 	const { amountsCardData } = selectedAmountsVariant;
 	const { amounts, defaultAmount, hideChooseYourAmount } =
 		amountsCardData['ONE_OFF'];
@@ -620,12 +628,14 @@ export function OneTimeCheckoutComponent({
 									maxAmount={maxAmount}
 									selectedAmount={selectedPriceCard}
 									otherAmount={otherAmount}
-									onBlur={(event) => {
+									onBlur={(event: React.FocusEvent<HTMLInputElement>) => {
 										event.target.checkValidity(); // loose focus, onInvalid check fired
 									}}
-									onOtherAmountChange={setOtherAmount}
+									onOtherAmountChange={
+										setOtherAmount as (value: string) => void
+									}
 									errors={[otherAmountError ?? '']}
-									onInvalid={(event) => {
+									onInvalid={(event: React.FormEvent<HTMLInputElement>) => {
 										validate(
 											event,
 											setOtherAmountError,


### PR DESCRIPTION
## What are you doing in this PR?

This PR adds support for custom contribution amounts via URL query parameters for one-time contributions. When the `amounts` URL parameter is provided (e.g., `?amounts=15,30,75`), it overrides the default A/B test variant amounts with the custom values specified by the marketing team.

The feature includes:
- A new `parseCustomAmounts` utility function that safely parses comma-separated amount strings
- URL parameter processing in `OneTimeCheckoutComponent` to extract and apply custom amounts
- Robust input validation that filters out invalid values (NaN, negative, zero, infinite)
- Deduplication of amount values
- Comprehensive test coverage for both the utility function and component integration

**Trello Card**: [Custom top-up amounts for one-time contributions](https://trello.com/c/BrPJ7nL7/915-contribution-topups-on-braze)

## Why are you doing this?

The marketing team needs the ability to provide custom suggested amounts for top-up campaigns and other marketing initiatives without requiring code deployments or A/B test configuration changes. This allows for more agile campaign management and testing of different amount strategies.

Previously, changing suggested amounts required either:
1. Creating new A/B test variants (time-consuming)
2. Code changes and deployments (slow and heavyweight)

This feature enables marketing campaigns to dynamically set contribution amounts via URL parameters, making campaign optimization much more flexible and responsive.

## How to test

**On any environment:**

1. **Default behavior (no custom amounts):** 
   - Visit `/uk/contribute/one-time-checkout`
   - Verify default amounts are displayed (e.g., £25, £50, £100, £250)

2. **Custom amounts via URL parameter:**
   - Visit `/uk/contribute/one-time-checkout?amounts=15,30,75`
   - Verify custom amounts (£15, £30, £75) are displayed instead of defaults
   - Verify you can select these amounts and complete a contribution

3. **Invalid amounts handling:**
   - Visit `/uk/contribute/one-time-checkout?amounts=10,invalid,20,-5,0,30`
   - Verify only valid amounts (£10, £20, £30) are displayed
   - Invalid values should be filtered out silently

4. **Duplicate removal:**
   - Visit `/uk/contribute/one-time-checkout?amounts=25,50,25,100,50`
   - Verify duplicates are removed (£25, £50, £100)

5. **Decimal values:**
   - Visit `/uk/contribute/one-time-checkout?amounts=12.50,25.75,50.25`
   - Verify decimal amounts work correctly

## How can we measure success?

- Marketing team can create campaigns with custom amounts without engineering involvement
- Faster iteration on amount optimization for campaigns
- No errors in production when invalid amounts are provided (robust input validation)
- Campaign performance can be measured through existing contribution tracking (no additional metrics needed)

## Have we considered potential risks?

**Potential risks and mitigations:**

1. **Invalid input causing errors:** 
   - ✅ Mitigated by robust input validation in `parseCustomAmounts`
   - Invalid values are filtered out, empty arrays handled gracefully

2. **Marketing team providing inappropriate amounts:**
   - ⚠️ Consider adding reasonable min/max bounds to prevent extreme values
   - Could add validation against existing min/max contribution limits

3. **URL parameter manipulation by users:**
   - ✅ Low risk - users can already choose custom amounts via "Other" option
   - No security implications as amounts are validated server-side during payment

4. **Performance impact:**
   - ✅ Minimal - only processes URL parameters client-side, no additional API calls

5. **A/B test data integrity:**
   - ⚠️ Custom amounts bypass A/B testing - ensure marketing team understands this
   - Consider tracking when custom amounts are used for analytics

## Accessibility test checklist

- ✅ [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader) - No changes to existing components
- ✅ [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard) - No changes to existing components  
- ✅ [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast) - No UI changes
- ✅ [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour) - No UI changes

## Screenshots

No UI changes - the feature dynamically replaces the default amount buttons with custom amounts when the URL parameter is present. The visual appearance remains identical, only the suggested amounts change.

---

This PR provides a clean, well-tested solution for marketing team flexibility while maintaining robust input validation and existing user experience.