### PR TITLE
Different hero images on global student landing page

### DIFF
--- a/support-frontend/assets/helpers/images/imageCatalogue.json
+++ b/support-frontend/assets/helpers/images/imageCatalogue.json
@@ -45,5 +45,8 @@
 	"AuStudentLandingHeroTablet": "14e65d1ade49300434e31603dd5b43e25e98e6c2/0_0_1396_1632",
 	"AuStudentLandingHeroMobile": "811f456e9786d119d766e55f2df821c056d415b0/0_0_2588_1276",
 	"globalStudentLandingBrand": "537be33f8613e9f504bb83db6f3678c5e99fe13a/0_0_3000_3000",
-	"globalStudentLandingBrandTitle": "c46a25f3bc0188c28acf6aa5e0c392b8b5b34e8d/0_0_1125_264"
+	"globalStudentLandingBrandTitle": "c46a25f3bc0188c28acf6aa5e0c392b8b5b34e8d/0_0_1125_264",
+	"globalStudentLandingHeroDesktop": "21d4315c7d57a26a5e68d19fd221e3f0fc8fe0d5/0_0_2296_1704",
+	"globalStudentLandingHeroTablet": "f16486a6c2c64c88383ad028d6e1991a154e2ffe/0_0_1408_1704",
+	"globalStudentLandingHeroMobile": "811f456e9786d119d766e55f2df821c056d415b0/0_0_2588_1276"
 }

--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.test.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.test.tsx
@@ -46,6 +46,7 @@ describe('<StudentHeader />', () => {
 				studentDiscount={oneYearStudentDiscount}
 				headingCopy="Example heading"
 				subheadingCopy="Example subheading"
+				heroImagePrefix="globalStudentLandingHero"
 			/>,
 		);
 		expect(screen.getByTestId('cta-button')).toHaveTextContent('Subscribe');
@@ -61,6 +62,7 @@ describe('<StudentHeader />', () => {
 				studentDiscount={utsStudentDiscount}
 				headingCopy="Example heading"
 				subheadingCopy="Example subheading"
+				heroImagePrefix="globalStudentLandingHero"
 			/>,
 		);
 		expect(screen.getByTestId('cta-button')).toHaveTextContent(
@@ -78,6 +80,7 @@ describe('<StudentHeader />', () => {
 				studentDiscount={utsStudentDiscount}
 				headingCopy="Example heading"
 				subheadingCopy="Example subheading"
+				heroImagePrefix="globalStudentLandingHero"
 			/>,
 		);
 		expect(

--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
@@ -32,6 +32,7 @@ interface StudentHeaderProps {
 	subheadingCopy: React.ReactNode;
 	universityBadge?: JSX.Element;
 	includeThreeTierLink?: boolean;
+	heroImagePrefix: string;
 }
 
 const ukSpecificAdditionalBenefit: ProductBenefit = {
@@ -51,6 +52,7 @@ export default function StudentHeader({
 	subheadingCopy,
 	universityBadge,
 	includeThreeTierLink = false,
+	heroImagePrefix,
 }: StudentHeaderProps) {
 	const { amount, promoCode, discountSummary } = studentDiscount;
 	const checkoutUrl = buildCheckoutUrl(
@@ -94,28 +96,28 @@ export default function StudentHeader({
 				<GridPicture
 					sources={[
 						{
-							gridId: 'AuStudentLandingHeroMobile',
+							gridId: `${heroImagePrefix}Mobile`,
 							srcSizes: [2000, 1000, 500],
 							sizes: '350px',
 							imgType: 'jpg',
 							media: '(max-width: 739px)',
 						},
 						{
-							gridId: 'AuStudentLandingHeroTablet',
+							gridId: `${heroImagePrefix}Tablet`,
 							srcSizes: [1396, 855, 428],
 							sizes: '350px',
 							imgType: 'jpg',
 							media: '(max-width: 979px)',
 						},
 						{
-							gridId: 'AuStudentLandingHeroDesktop',
+							gridId: `${heroImagePrefix}Desktop`,
 							srcSizes: [2000, 1000, 500],
 							sizes: '574px',
 							imgType: 'jpg',
 							media: '(min-width: 980px)',
 						},
 					]}
-					fallback="AuStudentLandingHeroDesktop"
+					fallback={`${heroImagePrefix}Desktop`}
 					fallbackSize={574}
 					altText=""
 				/>

--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentLandingPageGlobal.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentLandingPageGlobal.tsx
@@ -43,6 +43,7 @@ export function StudentLandingPageGlobal({
 					}
 					subheadingCopy="Now more than ever, independent journalism matters. Get fact-based reporting you can trust and unlimited access to the Guardian apps &mdash; without breaking your budget."
 					includeThreeTierLink={true}
+					heroImagePrefix="globalStudentLandingHero"
 				/>
 			}
 			brandAwareness={<StudentBrandAwareness />}

--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentLandingPageUTS.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentLandingPageUTS.tsx
@@ -52,6 +52,7 @@ export function StudentLandingPageUTS({
 							<LogoUTS /> <span>Special offer for UTS students</span>
 						</p>
 					}
+					heroImagePrefix="AuStudentLandingHero"
 				/>
 			}
 		/>


### PR DESCRIPTION
## What are you doing in this PR?

Updating the hero image(s) on the global student offer landing page. Until now we've just been re-using the same images as the Aus/UTS landing page.

**Note: I need a higher res version of the table image before this can be merged**

[**Trello Card**](https://trello.com/c/P2fRFN5K/1798-global-student-page-image-updates-excl-aus)

## Why are you doing this?

Following the designs in Figma - before this PR the images are Aus centric (the headlines visible etc).

## How to test

Visit the global student landing page and see (slightly) different images compared with Aus.

## Screenshots

### Desktop

<img width="1042" height="567" alt="Screenshot 2025-09-04 at 13 10 24" src="https://github.com/user-attachments/assets/33e95535-0025-48ca-bb05-cfc7b3656047" />

### Tablet

<img width="770" height="522" alt="Screenshot 2025-09-04 at 13 10 37" src="https://github.com/user-attachments/assets/296bf42b-1ba1-494b-bd64-e2e5fe82a48a" />

### Mobile

Coming soon.
