### PR TITLE
On the new newspaper plus landing page, collection should be the default tab

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperProductTabs.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperProductTabs.tsx
@@ -47,7 +47,7 @@ function NewspaperProductTabs({
 	isPaperProductTest: boolean;
 }) {
 	const fulfilment =
-		window.location.hash === `#${Collection}` ? Collection : HomeDelivery;
+		window.location.hash === `#${HomeDelivery}` ? HomeDelivery : Collection;
 
 	const [selectedTab, setSelectedTab] =
 		useState<PaperFulfilmentOptions>(fulfilment);


### PR DESCRIPTION

## What are you doing in this PR?

Updating the new newspaper plus landing page to make Collection the default fulfillment tab, not HomeDelivery.

[**Trello Card**](https://trello.com/c/SyLWVrA6/1862-print-design-feedback-on-landing-page)

## Why are you doing this?

Design feedback. Current default of HomeDelivery does not match what's in Figma.

## How to test

Visit the new landing page and see that the Collection tab is selected by default.