### PR TITLE
Newspaper Plus landing page card description copy

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/benefitsChecklist.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/benefitsChecklist.ts
@@ -23,7 +23,9 @@ export const getPaperPlusDigitalBenefits = (
 	ratePlanKey: ActiveRatePlanKey,
 	productKey: ActiveProductKey,
 ): BenefitsCheckListData[] | undefined => {
-	if (!isPaperProductTest) {return undefined;}
+	if (!isPaperProductTest) {
+		return undefined;
+	}
 
 	switch (productKey) {
 		case 'HomeDelivery':

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/benefitsChecklist.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/benefitsChecklist.ts
@@ -1,7 +1,9 @@
 import { css } from '@emotion/react';
 import { palette } from '@guardian/source/foundations';
 import type { CountryGroupId } from '@modules/internationalisation/countryGroup';
+import type { PaperProductOptions } from '@modules/product/productOptions';
 import type { ProductKey } from '@modules/product-catalog/productCatalog';
+import { getPlanBenefitData } from 'pages/paper-subscription-landing/planData';
 import type { BenefitsCheckListData } from '../../../../components/checkoutBenefits/benefitsCheckList';
 import type { Participations } from '../../../../helpers/abTests/models';
 import type { LandingPageVariant } from '../../../../helpers/globalsAndSwitches/landingPageSettings';
@@ -10,9 +12,34 @@ import {
 	filterBenefitByRegion,
 } from '../../../../helpers/productCatalog';
 import type {
+	ActiveProductKey,
+	ActiveRatePlanKey,
 	ProductBenefit,
 	ProductDescription,
 } from '../../../../helpers/productCatalog';
+
+export const getPaperPlusDigitalBenefits = (
+	isPaperProductTest: boolean,
+	ratePlanKey: ActiveRatePlanKey,
+	productKey: ActiveProductKey,
+): BenefitsCheckListData[] | undefined => {
+	if (!isPaperProductTest) {return undefined;}
+
+	switch (productKey) {
+		case 'HomeDelivery':
+			return getPlanBenefitData(
+				ratePlanKey as PaperProductOptions,
+				'HomeDelivery',
+			);
+		case 'SubscriptionCard':
+			return getPlanBenefitData(
+				ratePlanKey as PaperProductOptions,
+				'Collection',
+			);
+		default:
+			return undefined;
+	}
+};
 
 const benefitsAsChecklist = ({
 	checked,

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
@@ -3,7 +3,6 @@ import { space } from '@guardian/source/foundations';
 import { InfoSummary } from '@guardian/source-development-kitchen/react-components';
 import type { IsoCountry } from '@modules/internationalisation/country';
 import { BillingPeriod } from '@modules/product/billingPeriod';
-import type { PaperProductOptions } from '@modules/product/productOptions';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { ContributionsOrderSummary } from 'components/orderSummary/contributionsOrderSummary';
 import {
@@ -25,12 +24,12 @@ import type { Promotion } from 'helpers/productPrice/promotions';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import type { GeoId } from 'pages/geoIdConfig';
 import { getGeoIdConfig } from 'pages/geoIdConfig';
-import { getPlanBenefitData } from 'pages/paper-subscription-landing/planData';
 import type { LandingPageVariant } from '../../../helpers/globalsAndSwitches/landingPageSettings';
 import { formatUserDate } from '../../../helpers/utilities/dateConversions';
 import {
 	getBenefitsChecklistFromLandingPageTool,
 	getBenefitsChecklistFromProductDescription,
+	getPaperPlusDigitalBenefits,
 } from '../checkout/helpers/benefitsChecklist';
 import type { StudentDiscount } from '../student/helpers/discountDetails';
 import { BackButton } from './backButton';
@@ -116,11 +115,8 @@ export default function CheckoutSummary({
 		return <div>Invalid Amount {originalAmount}</div>;
 	}
 
-	const paperPlusDigitalBenefits = isPaperProductTest
-		? getPlanBenefitData(ratePlanKey as PaperProductOptions)
-		: undefined;
 	const benefitsCheckListData =
-		paperPlusDigitalBenefits ??
+		getPaperPlusDigitalBenefits(isPaperProductTest, ratePlanKey, productKey) ??
 		getBenefitsChecklistFromLandingPageTool(productKey, landingPageSettings) ??
 		getBenefitsChecklistFromProductDescription(
 			productDescription,

--- a/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperRatePlanCard.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperRatePlanCard.tsx
@@ -110,8 +110,8 @@ function NewspaperRatePlanCard({
 				</LinkButton>
 			</div>
 
-			<p css={cardOffer}>{offerCopy}</p>
-			<p css={planDescription}>{planData?.description}</p>
+			<p css={cardOffer}>cardOffer: {offerCopy}</p>
+			<p css={planDescription}>planDescription: {planData?.description}</p>
 
 			{windowWidthIsGreaterThan('tablet') ? (
 				renderPlanDetails()

--- a/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperRatePlanCard.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperRatePlanCard.tsx
@@ -110,8 +110,8 @@ function NewspaperRatePlanCard({
 				</LinkButton>
 			</div>
 
-			<p css={cardOffer}>cardOffer: {offerCopy}</p>
-			<p css={planDescription}>planDescription: {planData?.description}</p>
+			<p css={cardOffer}>{offerCopy}</p>
+			<p css={planDescription}>{planData?.description}</p>
 
 			{windowWidthIsGreaterThan('tablet') ? (
 				renderPlanDetails()

--- a/support-frontend/assets/pages/paper-subscription-landing/planData.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/planData.tsx
@@ -124,7 +124,7 @@ const planDescriptions: Record<
 		EverydayPlus: (
 			<>
 				Collect the Guardian and all its supplements{' '}
-				<strong>Monday to Saturday</strong>and the Observer on{' '}
+				<strong>Monday to Saturday</strong> and the Observer on{' '}
 				<strong>Sunday</strong> in store with a subscription card
 			</>
 		),

--- a/support-frontend/assets/pages/paper-subscription-landing/planData.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/planData.tsx
@@ -201,12 +201,11 @@ export default function getPlanData(
 		return undefined;
 	}
 
-	const paperPlan = {
+	return {
 		description,
 		benefits,
-		digitalBenefits: digitalBenefitsMap[ratePlanKey],
+		digitalRewards: digitalBenefitsMap[ratePlanKey],
 	};
-	return paperPlan;
 }
 
 export function getPlanBenefitData(

--- a/support-frontend/assets/pages/paper-subscription-landing/planData.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/planData.tsx
@@ -7,16 +7,15 @@ const benefitStyle = css`
 	display: inline-block;
 `;
 
+interface Benefits {
+	label: JSX.Element;
+	items: JSX.Element[];
+}
+
 export type PlanData = {
 	description: JSX.Element;
-	benefits: {
-		label: JSX.Element;
-		items: JSX.Element[];
-	};
-	digitalRewards?: {
-		label: JSX.Element;
-		items: JSX.Element[];
-	};
+	benefits: Benefits;
+	digitalRewards?: Benefits;
 };
 
 const benefitsHomeDeliveryLabel = (
@@ -70,110 +69,151 @@ const benefitObserverSunday = (
 	</span>
 );
 
-const planData: Partial<Record<PaperProductOptions, PlanData>> = {
+const getBenefitsMap = (
+	fulfilmentOption: PaperFulfilmentOptions,
+): Partial<Record<PaperProductOptions, Benefits>> => ({
 	EverydayPlus: {
-		description: (
-			<>
-				<strong>Home delivery</strong> of <strong>the Guardian</strong> from
-				Monday to Saturday and <strong>the Observer</strong> on Sundays plus
-				exclusive <strong>digital rewards</strong>
-			</>
-		),
-		benefits: {
-			label: <></>,
-			items: [benefitGuardianSixDay, benefitObserverSunday],
-		},
-		digitalRewards: {
-			label: digitalRewardsLabel,
-			items: baseDigitalRewards,
-		},
+		label: benefitsLabel[fulfilmentOption],
+		items: [benefitGuardianSixDay, benefitObserverSunday],
 	},
 	SixdayPlus: {
-		description: (
-			<>
-				<strong>Home delivery</strong> of <strong>the Guardian</strong> plus
-				exclusive <strong>digital rewards</strong>
-			</>
-		),
-		benefits: {
-			label: <></>,
-			items: [benefitGuardianSixDay],
-		},
-		digitalRewards: {
-			label: digitalRewardsLabel,
-			items: baseDigitalRewards,
-		},
+		label: benefitsLabel[fulfilmentOption],
+		items: [benefitGuardianSixDay],
 	},
 	WeekendPlus: {
-		description: (
-			<>
-				<strong>Home delivery</strong> of the Saturday editions of{' '}
-				<strong>the Guardian</strong> and <strong>the Observer</strong> on
-				Sundays plus exclusive <strong>digital rewards</strong>
-			</>
-		),
-		benefits: {
-			label: <></>,
-			items: [benefitGuardianSaturday, benefitObserverSunday],
-		},
-		digitalRewards: {
-			label: digitalRewardsLabel,
-			items: baseDigitalRewards,
-		},
+		label: benefitsLabel[fulfilmentOption],
+		items: [benefitGuardianSaturday, benefitObserverSunday],
 	},
 	SaturdayPlus: {
-		description: (
-			<>
-				<strong>Home delivery</strong> of <strong>the Guardian</strong> on
-				Saturdays plus exclusive <strong>digital rewards</strong>
-			</>
-		),
-		benefits: {
-			label: <></>,
-			items: [benefitGuardianSaturday],
-		},
-		digitalRewards: {
-			label: digitalRewardsLabel,
-			items: baseDigitalRewards,
-		},
+		label: benefitsLabel[fulfilmentOption],
+		items: [benefitGuardianSaturday],
 	},
 	Sunday: {
-		description: (
+		label: benefitsLabel[fulfilmentOption],
+		items: [benefitObserverSunday],
+	},
+});
+
+const digitalBenefitsMap: Partial<
+	Record<PaperProductOptions, Benefits | undefined>
+> = {
+	EverydayPlus: {
+		label: digitalRewardsLabel,
+		items: baseDigitalRewards,
+	},
+	SixdayPlus: {
+		label: digitalRewardsLabel,
+		items: baseDigitalRewards,
+	},
+	WeekendPlus: {
+		label: digitalRewardsLabel,
+		items: baseDigitalRewards,
+	},
+	SaturdayPlus: {
+		label: digitalRewardsLabel,
+		items: baseDigitalRewards,
+	},
+	Sunday: undefined, // Has no digital benefits
+};
+
+const planDescriptions: Record<
+	PaperFulfilmentOptions,
+	Partial<Record<PaperProductOptions, JSX.Element>>
+> = {
+	Collection: {
+		EverydayPlus: (
 			<>
-				<strong>Home delivery</strong> of <strong>the Observer</strong> on every
-				Sunday
+				Collect the Guardian and all its supplements{' '}
+				<strong>Monday to Saturday</strong>and the Observer on{' '}
+				<strong>Sunday</strong> in store with a subscription card
 			</>
 		),
-		benefits: {
-			label: <></>,
-			items: [benefitObserverSunday],
-		},
+		SixdayPlus: (
+			<>
+				Collect the Guardian and all its supplements{' '}
+				<strong>Monday to Saturday</strong> in store with a subscription card
+			</>
+		),
+		WeekendPlus: (
+			<>
+				Collect the Guardian and all its supplements on{' '}
+				<strong>Saturday</strong> and the Observer on <strong>Sunday</strong> in
+				store with a subscription card
+			</>
+		),
+		SaturdayPlus: (
+			<>
+				Collect the Guardian and all its supplements on{' '}
+				<strong>Saturday</strong> in store with a subscription card
+			</>
+		),
+		Sunday: (
+			<>
+				Collect the Observer on <strong>Sunday</strong> in store with a
+				subscription card
+			</>
+		),
+	},
+	HomeDelivery: {
+		EverydayPlus: (
+			<>
+				The Guardian and all its supplements <strong>Monday to Saturday</strong>{' '}
+				and the Observer on Sunday delivered to your door
+			</>
+		),
+		SixdayPlus: (
+			<>
+				The Guardian and all its supplements <strong>Monday to Saturday</strong>{' '}
+				delivered to your door
+			</>
+		),
+		WeekendPlus: (
+			<>
+				The Guardian and all its supplements on <strong>Saturday</strong> and
+				the Observer on <strong>Sunday</strong> delivered to your door
+			</>
+		),
+		SaturdayPlus: (
+			<>
+				The Guardian and all its supplements on <strong>Saturday</strong>{' '}
+				delivered to your door
+			</>
+		),
+		Sunday: (
+			<>
+				The Observer on <strong>Sunday</strong> delivered to your door
+			</>
+		),
 	},
 };
 
 export default function getPlanData(
 	ratePlanKey: PaperProductOptions,
-	fulfillmentOption?: PaperFulfilmentOptions,
+	fulfillmentOption: PaperFulfilmentOptions,
 ): PlanData | undefined {
-	const validPaperPlan = planData[ratePlanKey];
-	if (!validPaperPlan) {
+	const description = planDescriptions[fulfillmentOption][ratePlanKey];
+	if (!description) {
+		return undefined;
+	}
+
+	const benefits = getBenefitsMap(fulfillmentOption)[ratePlanKey];
+	if (!benefits) {
 		return undefined;
 	}
 
 	const paperPlan = {
-		...validPaperPlan,
-		benefits: {
-			label: fulfillmentOption ? benefitsLabel[fulfillmentOption] : <></>,
-			items: validPaperPlan.benefits.items,
-		},
+		description,
+		benefits,
+		digitalBenefits: digitalBenefitsMap[ratePlanKey],
 	};
 	return paperPlan;
 }
 
 export function getPlanBenefitData(
 	ratePlanKey: PaperProductOptions,
+	fulfillmentOption: PaperFulfilmentOptions,
 ): BenefitsCheckListData[] | undefined {
-	const ratePlanData = getPlanData(ratePlanKey);
+	const ratePlanData = getPlanData(ratePlanKey, fulfillmentOption);
 	if (!ratePlanData) {
 		return undefined;
 	}


### PR DESCRIPTION
## What are you doing in this PR?

Update the description copy shown on the product cards on the new paper plus landing page. Note: this description is only shown at mobile width.

[**Trello Card**](https://trello.com/c/SyLWVrA6/1862-print-design-feedback-on-landing-page)

## Why are you doing this?

The copy is out of date vs the Figma. The copy was not varied between home delivery and collection but it needs to, some refactoring was required to support this.

## How to test

Visit the new paper plus landing page at mobile width. Toggle between collection and home delivery to see the description copy.

## Screenshots

Just as an example, here's how six day now looks for collection and home delivery:

<img width="325" height="335" alt="Screenshot 2025-09-05 at 15 52 04" src="https://github.com/user-attachments/assets/cd14c490-703b-4600-a167-38d2cc4bf35d" />

<img width="321" height="315" alt="Screenshot 2025-09-05 at 15 52 17" src="https://github.com/user-attachments/assets/ce31a21c-33c7-4621-b6ce-b46b27b91ce0" />

