### PR TITLE
Reset carousel scroll position when the tab changes

### DIFF
--- a/support-frontend/assets/components/product/Carousel.tsx
+++ b/support-frontend/assets/components/product/Carousel.tsx
@@ -58,6 +58,19 @@ export default function Carousel({ items }: { items: ReactNode[] }) {
 		};
 	}, []);
 
+	useEffect(
+		function resetScroll() {
+			const container = containerRef.current;
+			if (!container) {
+				return;
+			}
+
+			container.scrollTo({ left: 0, behavior: 'instant' });
+			updateScrollButtons();
+		},
+		[items],
+	);
+
 	return (
 		<div css={carouselWrapper}>
 			<button


### PR DESCRIPTION
Design feedback. The items change when the tab changes, so this is what the useEffect is based on.

<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
