### PR TITLE
Fix thank you page title for Guardian paper products

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/GuardianPrintHeading.tsx
+++ b/support-frontend/assets/pages/supporter-plus-thank-you/components/thankYouHeader/GuardianPrintHeading.tsx
@@ -55,6 +55,7 @@ export default function GuardianPrintHeading({
 	const maybeRatePlanDetails =
 		productCatalogDescription[productKey].ratePlans[ratePlanKey];
 	const maybeRatePlanDisplayName = maybeRatePlanDetails?.label;
+	// This will be something like "Six day package"
 	const ratePlanDisplayName =
 		maybeRatePlanDisplayName ?? `${ratePlanKey} package`;
 


### PR DESCRIPTION
## What are you doing in this PR?

Updating the thank you page title for Guardian paper products.

[**Trello Card**](https://trello.com/c/F8SoJUoe/1863-print-thank-you-page-design-feedback)

## Why are you doing this?

The old logic took the rate plan and added a single exception where the Everyday rate plan was converted to Every day. All other rate plans were displayed as-is. The exception was no longer used since we're selling the Plus versions of the rate plans now. So you'd see copy like:

"You have now subscribed to the EverydayPlus package"

It was pointed out that we shouldn't be showing the Plus bit, and when the rate plan name is two words they should be displayed as such. E.g. Everyday -> Every day, Sixday -> Six day.

This mapping already exists in productCatalogDescription in productCatalog.ts and I think we should be using this. I've removed the work "package" from the template as it already appears in the product catalog data.

Note that the Observer uses different header copy on the thank you page, and this doesn't affect that.

## How to test

Purchase one of the following rate plans for HomeDelivery, National Delivery or SubscriptionCard and check the title on the thank you page:

* EverydayPlus
* WeekendPlus
* SixdayPlus
* SaturdayPlus

## Screenshots

### Before

<img width="808" height="155" alt="Screenshot 2025-09-08 at 16 43 10" src="https://github.com/user-attachments/assets/548791c7-6061-49b8-b63f-2d1a57b441b8" />

### After

<img width="826" height="157" alt="Screenshot 2025-09-08 at 16 42 58" src="https://github.com/user-attachments/assets/1582292b-6032-4d41-b4bc-4d15456954de" />
