### PR TITLE
Fix "Only available inside Greater London" label on paper landing page(s)

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/helpers/getPlans.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/helpers/getPlans.tsx
@@ -67,9 +67,10 @@ const getUnavailableOutsideLondon = (
 	fulfilmentOption: PaperFulfilmentOptions,
 	productOption: PaperProductOptions,
 ) =>
-	(fulfilmentOption === 'HomeDelivery' && productOption === 'Saturday') ||
-	productOption === 'Sunday' ||
-	productOption === 'SaturdayPlus';
+	fulfilmentOption === 'HomeDelivery' &&
+	(productOption === 'Saturday' ||
+		productOption === 'Sunday' ||
+		productOption === 'SaturdayPlus');
 
 // ---- Plans ----- //
 const copy: Record<


### PR DESCRIPTION
## What are you doing in this PR?

Remove the "Only available inside Greater London" label from subscription card product cards on the old and new newspaper landing pages.

[**Trello Card**](https://trello.com/c/Xysn3TpX/1875-only-available-inside-greater-london-should-be-removed-from-collect-in-store-product-cards-saturday-and-sunday-package)

## Why are you doing this?

Saturday and Sunday plans are only available in Greater London for home delivery, so we show a message about this on the product cards. However this restriction does not apple to subscription cards, but we were still showing the message "Only available inside Greater London" which isn't correct. This PR fixes that.

## How to test

Visit old and new landing pages and select Subscription Card. Neither Saturday or Sunday plans should have the "Only available inside Greater London" copy. Home Delivery should continue to show this message for Saturday and Sunday.

## Screenshots

Old landing page subs card:

<img width="1308" height="483" alt="Screenshot 2025-09-10 at 15 01 00" src="https://github.com/user-attachments/assets/afd16281-b8a5-4a31-9e07-51da33d403c3" />

Old landing page home delivery:

<img width="1312" height="508" alt="Screenshot 2025-09-10 at 15 00 51" src="https://github.com/user-attachments/assets/984265d2-1834-4a7f-b318-3d74c3b87483" />

The new landing page is affected in the same way but it's harder to screenshot both cards because of the carousel.
