### PR TITLE
Only install Chromium for playwright tests

### DIFF
--- a/.github/workflows/playwright-cron.yml
+++ b/.github/workflows/playwright-cron.yml
@@ -18,7 +18,7 @@ jobs:
       uses: ./.github/actions/setup-node-and-install
 
     - name: Install Playwright Browsers
-      run: pnpm --filter support-e2e exec playwright install chrome --with-deps
+      run: pnpm --filter support-e2e exec playwright install chromium --with-deps
 
     - name: Run Playwright tests
       run: pnpm --filter support-e2e test-cron


### PR DESCRIPTION
## What are you doing in this PR?

In the cron and smoke e2e test GHA setup, only install the `chromium` Playwright browser, because it's the only one we use.

## Why are you doing this?

It makes the setup more efficient and faster. The timings seem to vary a bit throughout the day, but this seems to have a good speed benefit and faster build checks is always nicer!

## How to test

I ran the cron e2e tests directly from this branch by invoking manually.

<img width="511" height="83" alt="Screenshot 2025-09-10 at 16 49 30" src="https://github.com/user-attachments/assets/36cc7ab8-5f63-4739-8308-6231a6abc1f6" />

This isn't very scientific, but contrast the timing with the previous two runs:

<img width="489" height="80" alt="Screenshot 2025-09-10 at 16 49 47" src="https://github.com/user-attachments/assets/e32111c3-895c-4470-a262-8d8b33b26950" />

<img width="491" height="79" alt="Screenshot 2025-09-10 at 16 50 00" src="https://github.com/user-attachments/assets/dca603c1-50d9-4371-b974-9b7dd0d01e25" />