### PR TITLE
make create subscription TS lambda use sandbox zuora for test users

### DIFF
--- a/support-workers/src/typescript/lambdas/createZuoraSubscriptionTSLambda.ts
+++ b/support-workers/src/typescript/lambdas/createZuoraSubscriptionTSLambda.ts
@@ -91,7 +91,9 @@ export const handler = async (
 			collectPayment: true,
 		};
 
-		const zuoraClient = await zuoraServiceProvider.getServiceForUser(false);
+		const zuoraClient = await zuoraServiceProvider.getServiceForUser(
+			createZuoraSubscriptionState.user.isTestUser,
+		);
 		const productCatalog = await productCatalogProvider.getServiceForUser(
 			createZuoraSubscriptionState.user.isTestUser,
 		);


### PR DESCRIPTION
I noticed that test users are not working in PROD for student plan (which uses the new TS lambda).

We were getting an error when creating the sub
OK: 58560020: This currency in the RatePlan is not active. RatePlan Id: 71a10c6269b981784c9817e1887c0000; Currency: GBP.

It looks like just an omission that it was hard coded to be test user = false

This PR makes it use the sandbox zuora for test users using the isTestUser field from the state.