### PR TITLE
Support workers secrets manager permissions

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -123,6 +123,9 @@ new SupportWorkers(app, "SupportWorkers-CODE", {
   parameterStorePaths: [
     `arn:aws:ssm:eu-west-1:865473395570:parameter/CODE/support/support-workers/*`,
   ],
+  secretsManagerPaths: [
+    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Zuora-OAuth/SupportServiceLambdas-*",
+  ],
 });
 
 new SupportWorkers(app, "SupportWorkers-PROD", {
@@ -148,5 +151,9 @@ new SupportWorkers(app, "SupportWorkers-PROD", {
   parameterStorePaths: [
     `arn:aws:ssm:eu-west-1:865473395570:parameter/CODE/support/support-workers/*`,
     `arn:aws:ssm:eu-west-1:865473395570:parameter/PROD/support/support-workers/*`,
+  ],
+  secretsManagerPaths: [
+    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Zuora-OAuth/SupportServiceLambdas-*",
+    "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Zuora-OAuth/SupportServiceLambdas-*",
   ],
 });

--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -955,22 +955,10 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             {
               "Action": "secretsmanager:GetSecretValue",
               "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:secretsmanager:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":secret:PROD/Zuora-OAuth/SupportServiceLambdas-*",
-                  ],
-                ],
-              },
+              "Resource": [
+                "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Zuora-OAuth/SupportServiceLambdas-*",
+                "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Zuora-OAuth/SupportServiceLambdas-*",
+              ],
             },
             {
               "Action": [

--- a/cdk/lib/support-workers.test.ts
+++ b/cdk/lib/support-workers.test.ts
@@ -29,6 +29,10 @@ describe("The support-workers stack", () => {
         `arn:aws:ssm:eu-west-1:865473395570:parameter/CODE/support/support-workers/*`,
         `arn:aws:ssm:eu-west-1:865473395570:parameter/PROD/support/support-workers/*`,
       ],
+      secretsManagerPaths: [
+        "arn:aws:secretsmanager:eu-west-1:865473395570:secret:CODE/Zuora-OAuth/SupportServiceLambdas-*",
+        "arn:aws:secretsmanager:eu-west-1:865473395570:secret:PROD/Zuora-OAuth/SupportServiceLambdas-*",
+      ],
     });
 
     const template = Template.fromStack(stack);

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -51,6 +51,7 @@ interface SupportWorkersProps extends GuStackProps {
   supporterProductDataTables: string[];
   eventBusArns: string[];
   parameterStorePaths: string[];
+  secretsManagerPaths: string[];
 }
 
 export class SupportWorkers extends GuStack {
@@ -103,9 +104,7 @@ export class SupportWorkers extends GuStack {
     const secretsManagerPolicy = new PolicyStatement({
       effect: Effect.ALLOW,
       actions: ["secretsmanager:GetSecretValue"],
-      resources: [
-        `arn:aws:secretsmanager:${this.region}:${this.account}:secret:${this.stage}/Zuora-OAuth/SupportServiceLambdas-*`,
-      ],
+      resources: props.secretsManagerPaths,
     });
 
     // Lambdas


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
The PROD version of support-workers needs to be able to access the CODE version of secrets-manager to support test users.