### PR TITLE
Enable ALB access logs for support-frontend (CODE only)

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -24,6 +24,7 @@ new Frontend(app, "Frontend-PROD", {
     maximumInstances: 6,
   },
   shouldCreateAlarms: true,
+  shouldEnableAlbAccessLogs: false,
 });
 
 new Frontend(app, "Frontend-CODE", {
@@ -39,6 +40,7 @@ new Frontend(app, "Frontend-CODE", {
     maximumInstances: 2,
   },
   shouldCreateAlarms: false,
+  shouldEnableAlbAccessLogs: true,
 });
 
 new StripePatronsData(app, "StripePatronsData-CODE", {

--- a/cdk/lib/__snapshots__/frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/frontend.test.ts.snap
@@ -166,11 +166,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -290,11 +286,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -420,11 +412,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -510,11 +498,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -635,11 +619,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:kinesis:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:kinesis:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -692,11 +672,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -856,11 +832,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -1068,11 +1040,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -1142,11 +1110,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -1165,11 +1129,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -1243,11 +1203,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -1317,11 +1273,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -1350,11 +1302,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -1408,11 +1356,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -1524,11 +1468,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -1697,11 +1637,7 @@ exports[`The Frontend stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -1902,23 +1838,12 @@ exports[`The Frontend stack matches the snapshot 1`] = `
             },
           ],
           "UserData": {
-            "Fn::Base64": {
-              "Fn::Join": [
-                "",
-                [
-                  "#!/bin/bash
+            "Fn::Base64": "#!/bin/bash
 #!/bin/bash -ev
     mkdir /etc/gu
-    aws --region ",
-                  {
-                    "Ref": "AWS::Region",
-                  },
-                  " s3 cp s3://membership-dist/support/PROD/frontend/support-frontend_1.0-SNAPSHOT_all.deb /tmp
+    aws --region eu-west-1 s3 cp s3://membership-dist/support/PROD/frontend/support-frontend_1.0-SNAPSHOT_all.deb /tmp
     dpkg -i /tmp/support-frontend_1.0-SNAPSHOT_all.deb
     /opt/cloudwatch-logs/configure-logs application support PROD frontend /var/log/support-frontend/application.log '%Y-%m-%dT%H:%M:%S,%f%z'",
-                ],
-              ],
-            },
           },
         },
         "TagSpecifications": [

--- a/cdk/lib/frontend.test.ts
+++ b/cdk/lib/frontend.test.ts
@@ -17,6 +17,7 @@ describe("The Frontend stack", () => {
         maximumInstances: 6,
       },
       shouldCreateAlarms: true,
+      shouldEnableAlbAccessLogs: false,
     });
 
     const template = Template.fromStack(stack);

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -44,7 +44,12 @@ export class Frontend extends GuStack {
       shouldEnableAlbAccessLogs,
     } = props;
 
-    super(scope, id, props);
+    super(scope, id, {
+      ...props,
+      // Required for ALB logging
+      env: { region: 'eu-west-1' },
+    }
+    );
 
     const app = "frontend";
 

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -31,6 +31,7 @@ interface FrontendProps extends GuStackProps {
   domainName: string;
   scaling: GuAsgCapacity;
   shouldCreateAlarms: boolean;
+  shouldEnableAlbAccessLogs: boolean;
 }
 
 export class Frontend extends GuStack {
@@ -40,6 +41,7 @@ export class Frontend extends GuStack {
       domainName,
       scaling,
       shouldCreateAlarms,
+      shouldEnableAlbAccessLogs,
     } = props;
 
     super(scope, id, props);
@@ -153,6 +155,10 @@ export class Frontend extends GuStack {
       },
       scaling,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
+      accessLogging: {
+        enabled: shouldEnableAlbAccessLogs,
+        prefix: `application-load-balancer/${this.stage}/${this.stack}/${app}`,
+      },
     });
 
     (ec2App.listener.node.defaultChild as CfnListener).sslPolicy =


### PR DESCRIPTION
## What are you doing in this PR?

Enabling access logs from the Application Load Balancer for support-frontend (only CODE for now).

This depends on work done in guardian/aws-account-setup#414 which will ensure these logs go to the right bucket with the correct retention policy, access etc.

## Why are you doing this?

Combined with the PR mentioned above, this will unlock better insights into issues and usage by enabling querying access logs with Athena.

## How to test

Deploy to CODE and inspect access logs. Ensure there are no issues.