### PR TITLE
Add tooltip copy for UK student newsletter benefit

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
@@ -40,6 +40,8 @@ const ukSpecificAdditionalBenefit: ProductBenefit = {
 	label: {
 		copy: 'Limited series',
 	},
+	tooltip:
+		'Each week, hear from our journalists about topics that matter to you — including AI, politics, climate and more.',
 };
 
 export default function StudentHeader({


### PR DESCRIPTION
## What are you doing in this PR?

In #7241 a hardcoded UK specific benefit was added to the product card on the student landing page. This PR adds a tooltip, now that the copy is available.

[**Trello Card**](https://trello.com/c/T3x0g6aT/1860-add-tooltip-copy-for-global-student-offer-uk-page-newsletter-benefit)

## Why are you doing this?

It's part of the design.

## Screenshots

<img width="517" height="527" alt="Screenshot 2025-09-12 at 14 52 34" src="https://github.com/user-attachments/assets/844f7760-4cf2-445c-9f36-6117cdb309f6" />
