### PR TITLE
Display UK student specific benefit on checkout page

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
@@ -31,6 +31,7 @@ import {
 	getBenefitsChecklistFromProductDescription,
 	getPaperPlusDigitalBenefits,
 } from '../checkout/helpers/benefitsChecklist';
+import { ukSpecificAdditionalBenefit } from '../student/components/StudentHeader';
 import type { StudentDiscount } from '../student/helpers/discountDetails';
 import { BackButton } from './backButton';
 import { shorterBoxMargin } from './form';
@@ -123,6 +124,14 @@ export default function CheckoutSummary({
 			countryGroupId,
 			abParticipations,
 		);
+
+	if (ratePlanKey === 'OneYearStudent') {
+		benefitsCheckListData.unshift({
+			isChecked: true,
+			text: ukSpecificAdditionalBenefit.copy,
+		});
+	}
+
 	return (
 		<Box cssOverrides={shorterBoxMargin}>
 			<BoxContents>

--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentHeader.tsx
@@ -35,7 +35,7 @@ interface StudentHeaderProps {
 	heroImagePrefix: string;
 }
 
-const ukSpecificAdditionalBenefit: ProductBenefit = {
+export const ukSpecificAdditionalBenefit: ProductBenefit = {
 	copy: 'Student-focused newsletter, curated by our journalists',
 	label: {
 		copy: 'Limited series',


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
show student benefit on checkout summary for oneYearStudent rateplan.
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/w9PT3U8i/1876-add-uk-specific-newsletter-benefit-to-student-offer-uk-checkout-page-benefits-listing)

## Why are you doing this?
Benefist list must match the one from the Student landing page for consistency.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
<img width="646" height="501" alt="Screenshot 2025-09-15 at 10 08 48" src="https://github.com/user-attachments/assets/46f86637-f89a-4ca2-9403-2ab48b718ad8" />
