### PR TITLE
Skip non-Au student offer Playwright tests while we fix them

### DIFF
--- a/support-e2e/tests/smoke/student-non-au.test.ts
+++ b/support-e2e/tests/smoke/student-non-au.test.ts
@@ -40,7 +40,7 @@ import { fillInDirectDebitDetails } from '../utils/directDebitDetails';
 		accessibleCtaText: 'Subscribe',
 	},
 ].forEach((testDetails) => {
-	test(`${testDetails.expectedCardHeading} ${testDetails.country}`, async ({
+	test.skip(`${testDetails.expectedCardHeading} ${testDetails.country}`, async ({
 		context,
 		baseURL,
 	}) => {


### PR DESCRIPTION
## What are you doing in this PR?

Skip non-Au student offer Playwright tests while we fix them.

## Why are you doing this?

In #7285 we updated the journey to take users via Student beans for verification. This has broken the e2e Playwright tests. Skip these while we update the tests to reflect this.