### PR TITLE
Update top pill bg colour on student product card

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/student/components/StudentProductCardStyles.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/components/StudentProductCardStyles.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import {
 	from,
 	neutral,
-	news,
 	palette,
 	space,
 	textSans12,
@@ -77,7 +76,7 @@ export const pill = css`
 	white-space: nowrap;
 	padding: ${space[1]}px ${space[4]}px;
 	border-radius: ${space[1]}px;
-	background-color: ${news[400]};
+	background-color: ${palette.brand[500]};
 	color: ${palette.neutral[100]};
 	${textSansBold15};
 `;


### PR DESCRIPTION
## What are you doing in this PR?

Update the top pill bg colour on student product card.

[**Trello Card**](https://trello.com/c/fnxbfoLG/1892-student-offer-pill-colour-needs-correcting-for-global-pages-only-aus-should-stay-as-red)

## Why are you doing this?

The top pill (with the text "Student offer") should be blue, not red, on both the global student landing page and the Aus/UTS landing page to match Figma.

## How to test

Visit the global student landing page or the Aus/UTS landing page and see the updated product card.

## Screenshots

### Global

<img width="455" height="144" alt="Screenshot 2025-09-16 at 09 58 36" src="https://github.com/user-attachments/assets/d9710e1b-3bd2-4b42-a8ee-45ca4d701cd8" />

### Aus/UTS

<img width="427" height="159" alt="Screenshot 2025-09-16 at 09 58 54" src="https://github.com/user-attachments/assets/365782da-c0a7-421c-b9cc-f960ec8661c6" />
