### PR TITLE
Only add tab anchor to URL when the user selects a tab

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperProductTabs.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperProductTabs.tsx
@@ -73,7 +73,6 @@ function NewspaperProductTabs({
 				isPaperProductTest,
 			),
 		);
-		windowSetHashProperty(selectedTab);
 	}, [selectedTab]);
 
 	const handleTabChange = (tabId: PaperFulfilmentOptions) => {
@@ -83,6 +82,7 @@ function NewspaperProductTabs({
 			product: 'Paper',
 			componentType: 'ACQUISITIONS_BUTTON',
 		})();
+		windowSetHashProperty(tabId);
 	};
 
 	const tabItems = Object.entries(tabs).map(([fulfilment, tab]) => {


### PR DESCRIPTION
## What are you doing in this PR?

On the new print+ landing page, only add the tab anchor parameter to the URL when the user actively selects a tab, not by default when the page loads.

## Why are you doing this?

Previously when `windowSetHashProperty` was called from the `useEffect` this ran whenver the tab was changed but also on the initial render. This had the effect of adding and scrolling to the tab section whenever the user lands on the page. Instead, do this when a user actively selects a tab.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Navigate to the print+ landing page. The browser should not scroll to the tab section by default. When selecting a different tab, the anchor is added to the URL.

## Screenshots


https://github.com/user-attachments/assets/f37a4e4c-ee2e-4e67-ab8d-f06ca0d15829

