### PR TITLE
Add SSM param containing ALB ARN for support-frontend

### DIFF
--- a/cdk/lib/__snapshots__/frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/frontend.test.ts.snap
@@ -91,6 +91,25 @@ exports[`The Frontend stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "AlbSsmParam485C1D52": {
+      "Properties": {
+        "DataType": "text",
+        "Description": "The ARN of the ALB for support-PROD-frontend. This parameter is created via CDK.",
+        "Name": "/infosec/waf/services/PROD/frontend-alb-arn",
+        "Tags": {
+          "Stack": "support",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/support-frontend",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": {
+          "Ref": "LoadBalancerFrontendD42F8E66",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
     "AutoScalingGroupFrontendASG567FDA1B": {
       "Properties": {
         "HealthCheckGracePeriod": 120,


### PR DESCRIPTION
## What are you doing in this PR?

Add SSM param (via CDK) containing the ALB ARN for support-frontend.

## Why are you doing this?

This is used by https://github.com/guardian/waf, which we'd like to enable, initially in CODE.