### PR TITLE
NewPaper Plus Digital: SummaryTsAndCs Paper Copy Fix

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -1110,7 +1110,6 @@ export default function CheckoutForm({
 							ratePlanDescription={ratePlanDescription.label}
 							currency={currencyKey}
 							amount={originalAmount}
-							isPaperProductTest={isPaperProductTest}
 						/>
 						<div
 							css={css`

--- a/support-frontend/assets/pages/supporter-plus-landing/components/summaryTsAndCs.test.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/summaryTsAndCs.test.tsx
@@ -48,11 +48,6 @@ describe('Summary Ts&Cs Snapshot comparison', () => {
 					}
 					currency={'GBP'}
 					amount={0}
-					isPaperProductTest={
-						!!['WeekendPlus', 'SixdayPlus'].includes(
-							activeRatePlanKey as ActiveRatePlanKey,
-						)
-					}
 				/>,
 			);
 			expect(container.textContent).toMatchSnapshot();

--- a/support-frontend/assets/pages/supporter-plus-landing/components/summaryTsAndCs.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/summaryTsAndCs.tsx
@@ -20,7 +20,10 @@ import {
 	getDateWithOrdinal,
 	getLongMonth,
 } from 'helpers/utilities/dateFormatting';
-import { isSundayOnlyNewspaperSub } from 'pages/[countryGroupId]/helpers/isSundayOnlyNewspaperSub';
+import {
+	isPaperPlusSub,
+	isSundayOnlyNewspaperSub,
+} from 'pages/[countryGroupId]/helpers/isSundayOnlyNewspaperSub';
 
 const containerSummaryTsCs = css`
 	margin-top: ${space[6]}px;
@@ -39,7 +42,6 @@ export interface SummaryTsAndCsProps {
 	ratePlanDescription?: string;
 	currency: IsoCurrency;
 	amount: number;
-	isPaperProductTest?: boolean;
 }
 export function SummaryTsAndCs({
 	productKey,
@@ -47,7 +49,6 @@ export function SummaryTsAndCs({
 	ratePlanDescription,
 	currency,
 	amount,
-	isPaperProductTest = false,
 }: SummaryTsAndCsProps): JSX.Element | null {
 	const billingPeriod = ratePlanToBillingPeriod(ratePlanKey);
 	const periodNoun = getBillingPeriodNoun(billingPeriod);
@@ -63,9 +64,13 @@ export function SummaryTsAndCs({
 		productKey,
 		ratePlanKey,
 	);
+	const isPaperSundayOrPlus =
+		isSundayOnlyNewsletterSubscription ||
+		isPaperPlusSub(productKey, ratePlanKey);
+
 	const rateDescriptor = ratePlanDescription ?? ratePlanKey;
 
-	if (isSundayOnlyNewsletterSubscription || isPaperProductTest) {
+	if (isPaperSundayOrPlus) {
 		return (
 			<div css={containerSummaryTsCs}>
 				The {isSundayOnlyNewsletterSubscription ? 'Observer' : rateDescriptor}{' '}

--- a/support-frontend/stories/checkouts/SummaryTsAndCs.stories.tsx
+++ b/support-frontend/stories/checkouts/SummaryTsAndCs.stories.tsx
@@ -35,9 +35,9 @@ Contribution.args = {
 export const SupporterPlus = Template.bind({});
 SupporterPlus.args = {
 	productKey: 'SupporterPlus',
-	ratePlanKey: 'Monthly',
+	ratePlanKey: 'Annual',
 	currency: 'GBP',
-	amount: 12,
+	amount: 120,
 };
 
 export const TierThree = Template.bind({});

--- a/support-frontend/stories/checkouts/SummaryTsAndCs.stories.tsx
+++ b/support-frontend/stories/checkouts/SummaryTsAndCs.stories.tsx
@@ -55,7 +55,6 @@ HomeDeliverySunday.args = {
 	ratePlanDescription: 'The Observer',
 	currency: 'GBP',
 	amount: 27.99,
-	isPaperProductTest: true,
 };
 
 export const SubscriptionCardWeekendPaperProduct = Template.bind({});
@@ -65,7 +64,6 @@ SubscriptionCardWeekendPaperProduct.args = {
 	ratePlanDescription: 'Weekend package',
 	currency: 'GBP',
 	amount: 27.99,
-	isPaperProductTest: true,
 };
 
 export const HomeDeliverySixdayPaperProduct = Template.bind({});
@@ -75,5 +73,4 @@ HomeDeliverySixdayPaperProduct.args = {
 	ratePlanDescription: 'Six day package',
 	currency: 'GBP',
 	amount: 73.99,
-	isPaperProductTest: true,
 };


### PR DESCRIPTION
## What are you doing in this PR?

SummaryTsAndCs appears to be displaying Paper copy for all products since the `inPaperProducts` switch went live yesterday.

## How to test

Old: https://support.theguardian.com/uk/checkout?product=SupporterPlus&ratePlan=Annual
vs
New: https://support.thegulocal.com/uk/checkout?product=SupporterPlus&ratePlan=Annual

## Screenshots

|old|new|
|----|----|
|<img width="695" height="555" alt="image" src="https://github.com/user-attachments/assets/7a17cc48-ea1f-4527-9612-e095c7c4b94d" />|<img width="695" height="555" alt="image" src="https://github.com/user-attachments/assets/81bbab8d-8746-45ef-b491-70d9f4d57a9c" />|