### PR TITLE
Maintenance/fix salesforce address overwrite bug

### DIFF
--- a/support-workers/src/typescript/services/salesforce.ts
+++ b/support-workers/src/typescript/services/salesforce.ts
@@ -17,11 +17,11 @@ export type ContactRecordRequest = {
 	OtherPostalCode: string | null;
 	OtherCountry: string | null;
 	Phone?: string | null;
-	MailingStreet: string | null;
-	MailingCity: string | null;
-	MailingState: string | null;
-	MailingPostalCode: string | null;
-	MailingCountry: string | null;
+	MailingStreet?: string | null;
+	MailingCity?: string | null;
+	MailingState?: string | null;
+	MailingPostalCode?: string | null;
+	MailingCountry?: string | null;
 };
 
 export type DeliveryContactRecordRequest = {
@@ -176,11 +176,6 @@ export const createContactRecordRequest = (
 		OtherPostalCode: user.billingAddress.postCode,
 		OtherCountry: getCountryNameByIsoCode(user.billingAddress.country),
 		Phone: user.telephoneNumber,
-		MailingStreet: null,
-		MailingCity: null,
-		MailingState: null,
-		MailingPostalCode: null,
-		MailingCountry: null,
 	};
 	if (giftRecipient ?? !user.deliveryAddress) {
 		// If there is a gift recipient then we don't want to update the

--- a/support-workers/src/typescript/services/salesforce.ts
+++ b/support-workers/src/typescript/services/salesforce.ts
@@ -23,6 +23,7 @@ export type ContactRecordRequest = {
 	MailingPostalCode: string | null;
 	MailingCountry: string | null;
 };
+
 export type DeliveryContactRecordRequest = {
 	AccountId: string;
 	Email: string | null;


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/dfupSnCe/621-createsalesforcecontactlambda-difference-between-scala-and-ts)

# What are you doing in this PR?
Fixing a bug in a lambda that is overwriting values in address fields on a Salesforce Contact when it shouldn't be.

## Context
A new typescript lambda has been replicated from a scala lamba as part of a movement towards using typescript rather than scala. The behaviour in the new lambda is mostly the same, but a bug has been introduced where the populated address fields on a contact record for a print subscriber will be overwritten with null values if that subscriber then takes out a digital product.

_Salesforce Contact address fields after taking out GW_
<img width="676" height="400" alt="Screenshot 2025-09-17 at 14 59 47" src="https://github.com/user-attachments/assets/0b0b6426-2e5a-4ef8-98d7-0e6dfb0d134c" />

_Salesforce Contact address fields after then taking out Supporter Plus_
<img width="616" height="294" alt="Screenshot 2025-09-17 at 15 00 51" src="https://github.com/user-attachments/assets/9eaa7b4f-98db-4c18-ad39-078604da9adf" />

## Root cause
Mailing address fields, with values of null, were being included in the json body for the calllout to Salesforce to update the records with the new subscription details. These nulls were overwriting the values in the address fields in the matching contact.

## Fix
Update mailing address fields on ContactRecordRequest type to optional, so that we can add them only when creating a  standard contact in salesforce that has no associated gift recipient

## Testing
- create a GW sub using the [front end](https://support.code.dev-theguardian.com/uk/subscribe/weekly#subscribe)
- verify the contact gets created in Salesforce
- using the same email address for the GW sub, create a digital subscription (e.g. All-access digital) using the [front end](https://support.code.dev-theguardian.com/uk/contribute) 
- verify the sub is created in Salesforce
- on the contact that the address fields have not been overwritten with null values

### Notes
The [initial approach](https://github.com/guardian/support-frontend/pull/7270) to fixing this bug sought to also add improvements to salesforce.ts module by improving the type definitions in line with the Salesforce data model, as well as the maintainability (readability, understandability, testability) of the code. After a discussion with the Platform Team about the best approach to this, we decided that, in-line with the single-responsibility principle for PRs, we would release the lowest risk fix first, and raise a separate PR for the proposed improvements to the code.