### PR TITLE
Add missing fullstops to FAQ copy

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/student/helpers/studentFAQs.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/student/helpers/studentFAQs.tsx
@@ -16,14 +16,14 @@ const supporterPlusBodyManage: JSX.Element = (
 	<p>
 		To manage your subscription, go to Manage my account, and for further
 		information on your All-access digital subscription, see our{' '}
-		<a href={supporterPlusTermsLink}>Terms & Conditions</a>
+		<a href={supporterPlusTermsLink}>Terms & Conditions</a>.
 	</p>
 );
 
 const supporterPlusBodyContact: JSX.Element = (
 	<p>
 		For any queries, including subscription-related queries, visit our{' '}
-		<a href={helpCentreUrl}>Help centre</a>
+		<a href={helpCentreUrl}>Help centre</a>.
 	</p>
 );
 


### PR DESCRIPTION
## What are you doing in this PR?

Tiny copy change to add fullstops to the end of a couple of FAQs on the student landing page.

[**Trello Card**](https://trello.com/c/KBVBDOPm/1896-missing-in-the-faqs-on-student-page)

## Why are you doing this?

Spotted during e2e testing.

## Screenshots

<img width="920" height="238" alt="Screenshot 2025-09-17 at 16 35 09" src="https://github.com/user-attachments/assets/80b62951-60fe-4c10-9214-ebea37e787e4" />
