### PR TITLE
Rename `SupportInternationalisationId` to `SupportRegionId`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ catalogs:
       specifier: ^2.1.5
       version: 2.1.5
     '@guardian/support-service-lambdas':
-      specifier: guardian/support-service-lambdas#1dc9d6e8f9541b79eed2521760ed9922e4091b80
+      specifier: guardian/support-service-lambdas#5f7a766e3c128f11a0fae14542571f18f97dd35a
       version: 1.0.0
     '@types/jest':
       specifier: ^29.5.12
@@ -128,7 +128,7 @@ importers:
         version: 2.1.5(prettier@2.8.8)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1dc9d6e8f9541b79eed2521760ed9922e4091b80
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/5f7a766e3c128f11a0fae14542571f18f97dd35a
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.0
@@ -201,7 +201,7 @@ importers:
         version: 18.1.1(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@guardian/libs@25.3.0(@guardian/ophan-tracker-js@2.5.0)(tslib@2.8.1)(typescript@5.5.4))(@guardian/source@10.2.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1dc9d6e8f9541b79eed2521760ed9922e4091b80
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/5f7a766e3c128f11a0fae14542571f18f97dd35a
       '@guardian/tsconfig':
         specifier: ^0.2.0
         version: 0.2.0
@@ -563,7 +563,7 @@ importers:
         version: 3.699.0(@aws-sdk/client-sso-oidc@3.817.0)(@aws-sdk/client-sts@3.817.0)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1dc9d6e8f9541b79eed2521760ed9922e4091b80
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/5f7a766e3c128f11a0fae14542571f18f97dd35a
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -2110,8 +2110,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1dc9d6e8f9541b79eed2521760ed9922e4091b80':
-    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1dc9d6e8f9541b79eed2521760ed9922e4091b80}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/5f7a766e3c128f11a0fae14542571f18f97dd35a':
+    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/5f7a766e3c128f11a0fae14542571f18f97dd35a}
     version: 1.0.0
 
   '@guardian/tsconfig@0.2.0':
@@ -11618,7 +11618,7 @@ snapshots:
       react: 18.2.0
       typescript: 5.5.4
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1dc9d6e8f9541b79eed2521760ed9922e4091b80': {}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/5f7a766e3c128f11a0fae14542571f18f97dd35a': {}
 
   '@guardian/tsconfig@0.2.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ catalogs:
       specifier: ^2.1.5
       version: 2.1.5
     '@guardian/support-service-lambdas':
-      specifier: guardian/support-service-lambdas#5f7a766e3c128f11a0fae14542571f18f97dd35a
+      specifier: guardian/support-service-lambdas#6b5fec3ae8337c9786aca65a09398a07e69aa99a
       version: 1.0.0
     '@types/jest':
       specifier: ^29.5.12
@@ -128,7 +128,7 @@ importers:
         version: 2.1.5(prettier@2.8.8)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/5f7a766e3c128f11a0fae14542571f18f97dd35a
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/6b5fec3ae8337c9786aca65a09398a07e69aa99a
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.0
@@ -201,7 +201,7 @@ importers:
         version: 18.1.1(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@guardian/libs@25.3.0(@guardian/ophan-tracker-js@2.5.0)(tslib@2.8.1)(typescript@5.5.4))(@guardian/source@10.2.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/5f7a766e3c128f11a0fae14542571f18f97dd35a
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/6b5fec3ae8337c9786aca65a09398a07e69aa99a
       '@guardian/tsconfig':
         specifier: ^0.2.0
         version: 0.2.0
@@ -563,7 +563,7 @@ importers:
         version: 3.699.0(@aws-sdk/client-sso-oidc@3.817.0)(@aws-sdk/client-sts@3.817.0)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/5f7a766e3c128f11a0fae14542571f18f97dd35a
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/6b5fec3ae8337c9786aca65a09398a07e69aa99a
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -2110,8 +2110,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/5f7a766e3c128f11a0fae14542571f18f97dd35a':
-    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/5f7a766e3c128f11a0fae14542571f18f97dd35a}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/6b5fec3ae8337c9786aca65a09398a07e69aa99a':
+    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/6b5fec3ae8337c9786aca65a09398a07e69aa99a}
     version: 1.0.0
 
   '@guardian/tsconfig@0.2.0':
@@ -11618,7 +11618,7 @@ snapshots:
       react: 18.2.0
       typescript: 5.5.4
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/5f7a766e3c128f11a0fae14542571f18f97dd35a': {}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/6b5fec3ae8337c9786aca65a09398a07e69aa99a': {}
 
   '@guardian/tsconfig@0.2.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,4 +21,4 @@ catalog:
   "@aws-sdk/credential-provider-node": 3.699.0
   "@guardian/eslint-config-typescript": 12.0.0
   "@guardian/prettier": ^2.1.5
-  "@guardian/support-service-lambdas": "guardian/support-service-lambdas#5f7a766e3c128f11a0fae14542571f18f97dd35a"
+  "@guardian/support-service-lambdas": "guardian/support-service-lambdas#6b5fec3ae8337c9786aca65a09398a07e69aa99a"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,4 +21,4 @@ catalog:
   "@aws-sdk/credential-provider-node": 3.699.0
   "@guardian/eslint-config-typescript": 12.0.0
   "@guardian/prettier": ^2.1.5
-  "@guardian/support-service-lambdas": "guardian/support-service-lambdas#1dc9d6e8f9541b79eed2521760ed9922e4091b80"
+  "@guardian/support-service-lambdas": "guardian/support-service-lambdas#5f7a766e3c128f11a0fae14542571f18f97dd35a"

--- a/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx
+++ b/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.tsx
@@ -116,7 +116,7 @@ function CountryGroupSwitcher({
 				>
 					{countryGroupIds.map((countryGroupId: CountryGroupId) => (
 						<LinkItem
-							href={`/${countryGroups[countryGroupId].supportInternationalisationId}${subPath}${window.location.search}`}
+							href={`/${countryGroups[countryGroupId].supportRegionId}${subPath}${window.location.search}`}
 							onClick={() => {
 								sendTrackingEventsOnClick({
 									id: `toggle_country: ${countryGroupId}`,

--- a/support-frontend/assets/components/headers/links/links.tsx
+++ b/support-frontend/assets/components/headers/links/links.tsx
@@ -77,7 +77,7 @@ function internationalisationID(
 ): string | null {
 	if (countryGroupId != null) {
 		const group = countryGroups[countryGroupId];
-		return group.supportInternationalisationId;
+		return group.supportRegionId;
 	}
 
 	return null;

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.tsx
@@ -221,7 +221,7 @@ export function AddressFields({ scope, countryGroupId, ...props }: PropTypes) {
 								pathname.split('/')[1] ?? '';
 							const selectedInternationalisationId =
 								countryGroups[selectedCountryGroup as CountryGroupId]
-									.supportInternationalisationId;
+									.supportRegionId;
 							const redirectPathname = pathname.replace(
 								currentInternationalisationId,
 								selectedInternationalisationId,

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -3,7 +3,7 @@ import type {
 	IsoCountry,
 	UsState,
 } from '@modules/internationalisation/country';
-import type { SupportInternationalisationId } from '@modules/internationalisation/countryGroup';
+import type { SupportRegionId } from '@modules/internationalisation/countryGroup';
 import type { BillingPeriod } from '@modules/product/billingPeriod';
 import type { FulfilmentOptions } from '@modules/product/fulfilmentOptions';
 import type { ProductOptions } from '@modules/product/productOptions';
@@ -161,7 +161,7 @@ export type GiftRecipientType = {
 };
 type AppliedPromotion = {
 	promoCode: string;
-	countryGroupId: SupportInternationalisationId; // There is a bit of naming mismatch between the front and back end
+	countryGroupId: SupportRegionId; // There is a bit of naming mismatch between the front and back end
 };
 // The model that is sent to support-workers
 export type RegularPaymentRequest = {

--- a/support-frontend/assets/helpers/internationalisation/Readme.md
+++ b/support-frontend/assets/helpers/internationalisation/Readme.md
@@ -1,22 +1,16 @@
-# Internationalisation Helper
+# Internationalisation Helper Functions
 
-The internationalisation helper is formed by:
+The internationalisation helper functions uses three main types:
 
 - CountryGroup
 - Country
 - Currency
-
-These three values are stored in the common state.
+  The base types are defined in the [`internationalisation`](https://github.com/guardian/support-service-lambdas/tree/main/modules/internationalisation) module in support-service-lambdas.
 
 ## Country Group
 
-The `CountryGroup` is the data structure which is defined to apply business requirements to the country and currency.
-We would like to group countries according different requirements and assign to all the countries of that group the
-same currency. Additionally, this structure should match the `CountryGroup` case class defined in
-[`support-internationalisation`](https://github.com/guardian/support-internationalisation) project.
-
-For example the decision of having a landing page for a certain country or group of country should be modeled using
-country groups.
+The `CountryGroup` defines a grouping of countries with a single currency.
+This is used throughout the site to provide region specific versions of pages such as the three tier landing page or the checkout.
 
 `CountryGroup` is defined as follows:
 
@@ -27,14 +21,14 @@ type CountryGroup = {
   name: string,
   currency: IsoCurrency,
   countries: IsoCountry[],
-  supportInternationalizationId: SupportInternationalizationId,
+  supportRegionId: SupportRegionId,
 };
 ```
 
 - **name**: Business name for a certain group of countries.
 - **currency**: The currency shared by all the countries of a certain group.
 - **countries**: The countries which shape a group.
-- **supportInternationalizationId**: The id of support-internationalization that match with this group.
+- **supportRegionId**: The id of the support region that matches with this group.
 
 ## Country
 

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -1,7 +1,7 @@
 import { newspaperCountries } from '@modules/internationalisation/country';
-import type {
-	CountryGroupId,
-	SupportInternationalisationId,
+import {
+	type CountryGroupId,
+	SupportRegionId,
 } from '@modules/internationalisation/countryGroup';
 import { gwDeliverableCountries } from '@modules/internationalisation/gwDeliverableCountries';
 import type { RecurringBillingPeriod } from '@modules/product/billingPeriod';
@@ -538,7 +538,7 @@ export function productCatalogGuardianAdLite(): Record<
  * @see: https://knowledgecenter.zuora.com/Zuora_Billing/Build_products_and_prices/Attribute-based_pricing/AA_Overview_of_Attribute-based_Pricing
  * */
 export function internationaliseProductAndRatePlan(
-	supportInternationalisationId: SupportInternationalisationId,
+	supportRegionId: SupportRegionId,
 	productKey: ActiveProductKey,
 	ratePlanKey: ActiveRatePlanKey,
 ): {
@@ -546,12 +546,9 @@ export function internationaliseProductAndRatePlan(
 	ratePlanKey: ActiveRatePlanKey;
 } {
 	return {
-		productKey: internationaliseProduct(
-			supportInternationalisationId,
-			productKey,
-		),
+		productKey: internationaliseProduct(supportRegionId, productKey),
 		ratePlanKey: internationaliseRatePlan(
-			supportInternationalisationId,
+			supportRegionId,
 			productKey,
 			ratePlanKey,
 		),
@@ -559,14 +556,14 @@ export function internationaliseProductAndRatePlan(
 }
 
 export function internationaliseProduct(
-	supportInternationalisationId: SupportInternationalisationId,
+	supportRegionId: SupportRegionId,
 	productKey: ActiveProductKey,
 ): ActiveProductKey {
 	if (
 		productKey === 'GuardianWeeklyDomestic' ||
 		productKey === 'GuardianWeeklyRestOfWorld'
 	) {
-		if (supportInternationalisationId === 'int') {
+		if (supportRegionId === SupportRegionId.INT) {
 			return 'GuardianWeeklyRestOfWorld';
 		} else {
 			return 'GuardianWeeklyDomestic';
@@ -576,12 +573,12 @@ export function internationaliseProduct(
 }
 
 function internationaliseRatePlan(
-	supportInternationalisationId: SupportInternationalisationId,
+	supportRegionId: SupportRegionId,
 	productKey: ActiveProductKey,
 	ratePlanKey: ActiveRatePlanKey,
 ): ActiveRatePlanKey {
 	if (productKey === 'TierThree') {
-		if (supportInternationalisationId === 'int') {
+		if (supportRegionId === SupportRegionId.INT) {
 			if (ratePlanKey === 'DomesticAnnual') {
 				return 'RestOfWorldAnnual';
 			}

--- a/support-frontend/assets/helpers/productPrice/__tests__/productPricesTests.ts
+++ b/support-frontend/assets/helpers/productPrice/__tests__/productPricesTests.ts
@@ -219,14 +219,14 @@ describe('getCountryGroup', () => {
 			countries: ['GB', 'FK', 'GI', 'GG', 'IM', 'JE', 'SH'],
 			currency: 'GBP',
 			name: 'United Kingdom',
-			supportInternationalisationId: 'uk',
+			supportRegionId: 'uk',
 		});
 
 		expect(getCountryGroup('CA')).toEqual({
 			countries: ['CA'],
 			currency: 'CAD',
 			name: 'Canada',
-			supportInternationalisationId: 'ca',
+			supportRegionId: 'ca',
 		});
 	});
 });

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.ts
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.ts
@@ -1,4 +1,4 @@
-import type { SupportInternationalisationId } from '@modules/internationalisation/countryGroup';
+import type { SupportRegionId } from '@modules/internationalisation/countryGroup';
 import { countryGroups } from '@modules/internationalisation/countryGroup';
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { BillingPeriod } from '@modules/product/billingPeriod';
@@ -134,14 +134,14 @@ const getPaperFulfilmentOption = (
 };
 
 const getAppliedPromotion = (
-	supportInternationalisationId: SupportInternationalisationId,
+	supportRegionId: SupportRegionId,
 	promotions?: Promotion[],
 ) => {
 	const promotion = getAppliedPromo(promotions);
 	return promotion?.promoCode !== undefined
 		? {
 				promoCode: promotion.promoCode,
-				countryGroupId: supportInternationalisationId,
+				countryGroupId: supportRegionId,
 		  }
 		: undefined;
 };
@@ -205,7 +205,7 @@ function buildRegularPaymentRequest(
 	const giftRecipient = getGiftRecipient(state.page.checkoutForm.gifting);
 	const appliedPromotion = getAppliedPromotion(
 		countryGroups[state.common.internationalisation.countryGroupId]
-			.supportInternationalisationId,
+			.supportRegionId,
 		promotions,
 	);
 

--- a/support-frontend/assets/helpers/urls/externalLinks.ts
+++ b/support-frontend/assets/helpers/urls/externalLinks.ts
@@ -35,7 +35,7 @@ function getPatronsLink(
 function convertCountryGroupIdToAppStoreCountryCode(cgId: CountryGroupId) {
 	const groupFromId = countryGroups[cgId];
 
-	switch (groupFromId.supportInternationalisationId.toLowerCase()) {
+	switch (groupFromId.supportRegionId.toLowerCase()) {
 		case 'uk':
 			return 'gb';
 
@@ -46,7 +46,7 @@ function convertCountryGroupIdToAppStoreCountryCode(cgId: CountryGroupId) {
 			return 'us';
 
 		default:
-			return groupFromId.supportInternationalisationId.toLowerCase();
+			return groupFromId.supportRegionId.toLowerCase();
 	}
 }
 

--- a/support-frontend/assets/helpers/urls/routes.ts
+++ b/support-frontend/assets/helpers/urls/routes.ts
@@ -59,7 +59,7 @@ const createRecurringReminderEndpoint = isProd()
 	: 'https://support.code.dev-theguardian.com/reminders/create/recurring';
 
 const countryPath = (countryGroupId: CountryGroupId) =>
-	countryGroups[countryGroupId].supportInternationalisationId;
+	countryGroups[countryGroupId].supportRegionId;
 
 function postcodeLookupUrl(postcode: string): string {
 	return `${getOrigin() + routes.postcodeLookup}/${postcode}`;

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -527,7 +527,7 @@ export default function CheckoutForm({
 		}
 	}, [errorMessage]);
 
-	const { supportInternationalisationId } = countryGroups[countryGroupId];
+	const { supportRegionId } = countryGroups[countryGroupId];
 
 	const onFormSubmit = async (formData: FormData) => {
 		if (paymentMethod === undefined) {
@@ -648,7 +648,7 @@ export default function CheckoutForm({
 		productKey,
 		originalAmount,
 		ratePlanDescription.billingPeriod,
-		supportInternationalisationId,
+		supportRegionId,
 		abParticipations.abandonedBasket === 'variant',
 	);
 

--- a/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
@@ -1,3 +1,4 @@
+import type { SupportRegionId } from '@modules/internationalisation/countryGroup';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import type { GeoId } from 'pages/geoIdConfig';
 import type { Participations } from '../../../helpers/abTests/models';
@@ -85,7 +86,7 @@ export const submitForm = async ({
 		promoCode !== undefined
 			? {
 					promoCode,
-					countryGroupId: geoId,
+					countryGroupId: geoId as SupportRegionId, // TODO: remove GeoId type as it is a duplicate of SupportRegionId
 			  }
 			: undefined;
 	const supportAbTests = getSupportAbTests(abParticipations);

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -587,13 +587,13 @@ export function OneTimeCheckoutComponent({
 		return;
 	}
 
-	const { supportInternationalisationId } = countryGroups[countryGroupId];
+	const { supportRegionId } = countryGroups[countryGroupId];
 
 	useAbandonedBasketCookie(
 		'OneTimeContribution',
 		finalAmount ?? 0,
 		'ONE_OFF',
-		supportInternationalisationId,
+		supportRegionId,
 		abParticipations.abandonedBasket === 'variant',
 	);
 

--- a/support-frontend/assets/pages/supporter-plus-landing/components/oneOffCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/oneOffCard.tsx
@@ -125,7 +125,7 @@ export function OneOffCard({
 			<div css={buttonContainer}>
 				<LinkButton
 					href={`/${
-						countryGroups[countryGroupId].supportInternationalisationId
+						countryGroups[countryGroupId].supportRegionId
 					}/contribute/checkout?selected-contribution-type=one_off&selected-amount=${
 						selectedAmount === 'other' ? otherAmount : selectedAmount
 					}`}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/studentOffer.tsx
@@ -129,7 +129,7 @@ export function StudentOffer({
 					{price}&nbsp;a&nbsp;year.
 				</p>
 				<LinkButton
-					href={`/${countryGroups[countryGroupId].supportInternationalisationId}/student`}
+					href={`/${countryGroups[countryGroupId].supportRegionId}/student`}
 					priority="tertiary"
 					size="default"
 					cssOverrides={btnStyleOverrides}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/supportOnce.tsx
@@ -75,7 +75,7 @@ export function SupportOnce({
 				{currency}1 or more.
 			</p>
 			<LinkButton
-				href={`/${countryGroups[countryGroupId].supportInternationalisationId}/one-time-checkout`}
+				href={`/${countryGroups[countryGroupId].supportRegionId}/one-time-checkout`}
 				iconSide="left"
 				priority="primary"
 				size="default"

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.tsx
@@ -47,7 +47,7 @@ import { getWeeklyFulfilmentOption } from '../../../helpers/productCatalogToFulf
 import Prices from './content/prices';
 
 const countryPath = (countryGroupId: CountryGroupId) =>
-	countryGroups[countryGroupId].supportInternationalisationId;
+	countryGroups[countryGroupId].supportRegionId;
 
 const getCheckoutUrl = (
 	countryId: IsoCountry,
@@ -62,7 +62,7 @@ const getCheckoutUrl = (
 	) {
 		const countryGroupId = CountryGroup.fromCountry(countryId) ?? GBPCountries;
 		const productGuardianWeekly = internationaliseProduct(
-			countryGroups[countryGroupId].supportInternationalisationId,
+			countryGroups[countryGroupId].supportRegionId,
 			'GuardianWeeklyDomestic',
 		);
 		const url = `${getOrigin()}/${countryPath(countryGroupId)}/checkout`;


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
https://github.com/guardian/support-service-lambdas/pull/3072 renamed the `SupportInternationalisationId` type to `SupportRegionId` for the following reasons:
- It makes more sense to talk about a support region than a 'support internationalisation'
- It is more concise - quite a lot shorter to type
- There is no spelling ambiguity (internationalization vs internationalisation)

This PR updates support-frontend to use the renamed type.

Next step after this is to remove the `GeoId` type which is an exact duplicate of SupportRegionId.