### PR TITLE
Remove feature flag around 3 tier LP student link

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -298,9 +298,7 @@ export function ThreeTierLanding({
 		campaignSettings?.enableSingleContributions ??
 		urlSearchParams.has('enableOneTime');
 
-	const enableStudentOffer =
-		['uk', 'us', 'ca'].includes(supportRegionId) &&
-		urlSearchParams.has('enableStudentOffer');
+	const enableStudentOffer = ['uk', 'us', 'ca'].includes(supportRegionId);
 
 	const getInitialContributionType = () => {
 		if (enableSingleContributionsTab && urlSearchParamsOneTime) {


### PR DESCRIPTION
## What are you doing in this PR?

Previously we only ever showed the student offer link on the 3 tier landing page if you were in one of the regions where the offer is available (UK, US, Canada) AND if a specific query string arg was present. This PR removes the requirement for the query string arg to be present.

[**Trello Card**](https://trello.com/c/YhqoCXAe/1871-remove-feature-flag-around-student-link-on-the-3-tier-landing-page)

## Why are you doing this?

To support the global student offer launch.

## How to test

Visit the 3 tier LP in UK, US or Canada and see the link below the 3 tier cards (under "More subscription options").