### PR TITLE
Enable OK actions for product acquisition alarms

### DIFF
--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -1535,6 +1535,24 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             "ReturnData": false,
           },
         ],
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -1750,6 +1768,24 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             "ReturnData": false,
           },
         ],
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -1818,6 +1854,24 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "EvaluationPeriods": 18,
         "MetricName": "PaymentSuccess",
         "Namespace": "support-frontend",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
         "Period": 3600,
         "Statistic": "Sum",
         "Tags": [
@@ -1888,6 +1942,24 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "EvaluationPeriods": 18,
         "MetricName": "PaymentSuccess",
         "Namespace": "support-frontend",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
         "Period": 3600,
         "Statistic": "Sum",
         "Tags": [
@@ -2105,6 +2177,24 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             "ReturnData": false,
           },
         ],
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -2242,6 +2332,24 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             "ReturnData": false,
           },
         ],
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -2310,6 +2418,24 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "EvaluationPeriods": 4,
         "MetricName": "PaymentSuccess",
         "Namespace": "support-frontend",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
         "Period": 3600,
         "Statistic": "Sum",
         "Tags": [
@@ -2380,6 +2506,24 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "EvaluationPeriods": 6,
         "MetricName": "PaymentSuccess",
         "Namespace": "support-frontend",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
         "Period": 3600,
         "Statistic": "Sum",
         "Tags": [
@@ -2450,6 +2594,24 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "EvaluationPeriods": 8,
         "MetricName": "PaymentSuccess",
         "Namespace": "support-frontend",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
         "Period": 3600,
         "Statistic": "Sum",
         "Tags": [
@@ -2520,6 +2682,24 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "EvaluationPeriods": 12,
         "MetricName": "PaymentSuccess",
         "Namespace": "support-frontend",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
         "Period": 3600,
         "Statistic": "Sum",
         "Tags": [
@@ -2590,6 +2770,24 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "EvaluationPeriods": 3,
         "MetricName": "PaymentSuccess",
         "Namespace": "support-frontend",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
         "Period": 3600,
         "Statistic": "Sum",
         "Tags": [
@@ -2660,6 +2858,24 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "EvaluationPeriods": 24,
         "MetricName": "PaymentSuccess",
         "Namespace": "support-frontend",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
         "Period": 3600,
         "Statistic": "Sum",
         "Tags": [
@@ -2730,6 +2946,24 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "EvaluationPeriods": 24,
         "MetricName": "PaymentSuccess",
         "Namespace": "support-frontend",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
         "Period": 3600,
         "Statistic": "Sum",
         "Tags": [
@@ -2800,6 +3034,24 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "EvaluationPeriods": 3,
         "MetricName": "PaymentSuccess",
         "Namespace": "support-frontend",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
         "Period": 3600,
         "Statistic": "Sum",
         "Tags": [
@@ -2939,6 +3191,24 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             "ReturnData": false,
           },
         ],
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -3074,6 +3344,24 @@ exports[`The support-workers stack matches the snapshot 1`] = `
               "Stat": "Sum",
             },
             "ReturnData": false,
+          },
+        ],
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
           },
         ],
         "Tags": [

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -52,9 +52,8 @@ export class Frontend extends GuStack {
     super(scope, id, {
       ...props,
       // Required for ALB logging
-      env: { region: 'eu-west-1' },
-    }
-    );
+      env: { region: "eu-west-1" },
+    });
 
     const app = "frontend";
 

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -426,6 +426,7 @@ export class SupportWorkers extends GuStack {
         new GuAlarm(this, `No${paymentProvider}ContributionsAlarm`, {
           app,
           actionsEnabled: isProd,
+          okAction: true,
           snsTopicName: `alarms-handler-topic-${this.stage}`,
           alarmName: `support-workers ${this.stage} No successful recurring ${paymentProvider} contributions recently.`,
           metric: this.buildPaymentSuccessMetric(
@@ -480,6 +481,7 @@ export class SupportWorkers extends GuStack {
         new GuAlarm(this, `No${paymentProvider}SupporterPlusAlarm`, {
           app,
           actionsEnabled: isProd,
+          okAction: true,
           snsTopicName: `alarms-handler-topic-${this.stage}`,
           alarmName: `support-workers ${this.stage} No successful ${paymentProvider} supporter plus subscriptions recently.`,
           metric: this.buildPaymentSuccessMetric(
@@ -519,6 +521,7 @@ export class SupportWorkers extends GuStack {
     new GuAlarm(this, "NoApplePayRecurringAlarm", {
       app,
       actionsEnabled: isProd,
+      okAction: true,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
       alarmName: `support-workers ${
         this.stage
@@ -557,6 +560,7 @@ export class SupportWorkers extends GuStack {
     new GuAlarm(this, "NoGooglePayRecurringAlarm", {
       app,
       actionsEnabled: isProd,
+      okAction: true,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
       alarmName: `support-workers ${
         this.stage
@@ -578,6 +582,7 @@ export class SupportWorkers extends GuStack {
     new GuAlarm(this, "NoPaperAcquisitionInOneDayAlarm", {
       app,
       actionsEnabled: isProd,
+      okAction: true,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
       alarmName: `URGENT 9-5 - ${this.stage} support-workers No successful paper checkouts in 24h.`,
       metric: new MathExpression({
@@ -610,6 +615,7 @@ export class SupportWorkers extends GuStack {
     new GuAlarm(this, "NoWeeklyAcquisitionInOneDayAlarm", {
       app,
       actionsEnabled: isProd,
+      okAction: true,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
       alarmName: `URGENT 9-5 - ${this.stage} support-workers No successful guardian weekly checkouts in 8h.`,
       metric: new MathExpression({
@@ -647,6 +653,7 @@ export class SupportWorkers extends GuStack {
     new GuAlarm(this, `NoTierThreeAcquisitionInPeriodAlarm`, {
       app,
       actionsEnabled: isProd,
+      okAction: true,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
       alarmName: `URGENT 9-5 - ${
         this.stage
@@ -700,6 +707,7 @@ export class SupportWorkers extends GuStack {
     new GuAlarm(this, `NoAdLiteAcquisitionInPeriodAlarm`, {
       app,
       actionsEnabled: isProd,
+      okAction: true,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
       alarmName: `URGENT 9-5 - ${
         this.stage


### PR DESCRIPTION
## What are you doing in this PR?

Enabling OK actions for product acquisition Cloudwatch alarms.

## Why are you doing this?

These are the alarms which are of the format "No successful x in y hours" which we have for most product/payment method combinations. Usually if one goes off the first thing to check is whether it's back to OK already (for example if we see one of these overnight or over the weekend). This will surface that information in the alarms channel.

## How to test

Hard to test in CODE because actions aren't enabled. Once this is out I'll manually trigger the alarm (and then put it back to OK). We should see both of these show up in the alarms channel.

## How can we measure success?

Reduced time spent investigating these alarms.