### PR TITLE
Tw/generic checkout field limits

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalDetailsFields.tsx
@@ -33,8 +33,8 @@ type PersonalDetailsFieldsProps = {
 	setEmail: (value: string) => void;
 	confirmedEmail?: string;
 	setConfirmedEmail?: (value: string) => void;
-	phoneNumber?: string;
-	setPhoneNumber?: (value: string) => void;
+	phoneNumber: string;
+	setPhoneNumber: (value: string) => void;
 	billingStatePostcode?: BillingStatePostcode;
 	hasDeliveryAddress?: boolean;
 	isEmailAddressReadOnly?: boolean;
@@ -86,10 +86,12 @@ export function PersonalDetailsFields({
 					setLastName={setLastName}
 				/>
 				{isWeeklyGift && personalEmailFields}
-				<PersonalPhoneField
-					phoneNumber={phoneNumber}
-					setPhoneNumber={setPhoneNumber}
-				/>
+				{isWeeklyGift && (
+					<PersonalPhoneField
+						phoneNumber={phoneNumber}
+						setPhoneNumber={setPhoneNumber}
+					/>
+				)}
 				{/**
 				 * We require state for non-deliverable products as we use different taxes
 				 * within those regions upstream For deliverable products we take the

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalFields.tsx
@@ -44,7 +44,7 @@ export function PersonalFields({
 						event.target.checkValidity();
 					}}
 					required
-					maxLength={40}
+					maxLength={30}
 					error={firstNameError}
 					pattern={doesNotContainExtendedEmojiOrLeadingSpace}
 					onInvalid={(event) => {

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalPhoneField.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalPhoneField.tsx
@@ -8,8 +8,8 @@ import {
 } from 'pages/[countryGroupId]/validation';
 
 type PersonalPhoneFieldProps = {
-	phoneNumber?: string;
-	setPhoneNumber?: (value: string) => void;
+	phoneNumber: string;
+	setPhoneNumber: (value: string) => void;
 };
 
 const phoneStyle = css`
@@ -26,35 +26,33 @@ export function PersonalPhoneField({
 	const [telephoneError, setTelephoneError] = useState<string>();
 	return (
 		<>
-			{setPhoneNumber && (
-				<fieldset css={phoneStyle}>
-					<TextInput
-						id="telephone"
-						data-qm-masking="blocklist"
-						label="Telephone"
-						name="telephone"
-						value={phoneNumber}
-						onChange={(event) => {
-							setPhoneNumber(event.target.value);
-						}}
-						onBlur={(event) => {
-							event.target.checkValidity();
-						}}
-						optional
-						error={telephoneError}
-						pattern={doesNotContainExtendedEmojiOrLeadingSpace} // We intentionally use a minimally restrictive pattern here to allow users to enter additional details beyond digits. This matches the original checkout's behavior.
-						onInvalid={(event) => {
-							preventDefaultValidityMessage(event.currentTarget);
-							const validityState = event.currentTarget.validity;
-							if (validityState.valid) {
-								setTelephoneError(undefined);
-							} else {
-								setTelephoneError('Please enter valid telephone details.');
-							}
-						}}
-					/>
-				</fieldset>
-			)}
+			<fieldset css={phoneStyle}>
+				<TextInput
+					id="telephone"
+					data-qm-masking="blocklist"
+					label="Telephone"
+					name="telephone"
+					value={phoneNumber}
+					onChange={(event) => {
+						setPhoneNumber(event.target.value);
+					}}
+					onBlur={(event) => {
+						event.target.checkValidity();
+					}}
+					optional
+					error={telephoneError}
+					pattern={doesNotContainExtendedEmojiOrLeadingSpace} // We intentionally use a minimally restrictive pattern here to allow users to enter additional details beyond digits. This matches the original checkout's behavior.
+					onInvalid={(event) => {
+						preventDefaultValidityMessage(event.currentTarget);
+						const validityState = event.currentTarget.validity;
+						if (validityState.valid) {
+							setTelephoneError(undefined);
+						} else {
+							setTelephoneError('Please enter valid telephone details.');
+						}
+					}}
+				/>
+			</fieldset>
 		</>
 	);
 }

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalPhoneField.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalPhoneField.tsx
@@ -33,6 +33,7 @@ export function PersonalPhoneField({
 					label="Telephone"
 					name="telephone"
 					value={phoneNumber}
+					maxLength={40}
 					onChange={(event) => {
 						setPhoneNumber(event.target.value);
 					}}

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -877,8 +877,8 @@ export default function CheckoutForm({
 							setEmail={setEmail}
 							confirmedEmail={confirmedEmail}
 							setConfirmedEmail={setConfirmedEmail}
-							phoneNumber={isWeeklyGift ? phoneNumber : undefined}
-							setPhoneNumber={isWeeklyGift ? setPhoneNumber : undefined}
+							phoneNumber={phoneNumber}
+							setPhoneNumber={setPhoneNumber}
 							billingStatePostcode={billingStatePostcode}
 							hasDeliveryAddress={hasDeliveryAddress}
 							isEmailAddressReadOnly={isSignedIn}


### PR DESCRIPTION
## What are you doing in this PR?

Adding length validation limits to a couple of fields on the generic checkout (first name and phone number). There are limits elsewhere in the backend systems which we should reflect here.

Also includes a tiny refactoring around the phone number form field which is only used on the GW gifting checkout.

[**Trello Card**](https://trello.com/c/WjztmI4g/1894-align-checkout-field-length-validation-between-support-frontend-zuora-and-salesforce)

## Why are you doing this?

We've recently experienced a couple of failed support workers executions where fields were too long for either GoCardless/Zuora and Salesforce. In these cases the feedback on the checkout wouldn't have been clear to the user. Instead we'll enforce these limits on the checkout.

## How to test

Attempt to add too many characters to these fields on the checkout and see that it's not possible.

## How can we measure success?

We should no longer see failed support workers executions due to field length limits being exceeded.