### PR TITLE
Only install Chromium for playwright smoke tests

### DIFF
--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ./.github/actions/setup-node-and-install
 
       - name: Install Playwright Browsers
-        run: pnpm --filter support-e2e exec playwright install --with-deps
+        run: pnpm --filter support-e2e exec playwright install chromium --with-deps
 
       - name: Run Playwright tests
         run: pnpm --filter support-e2e test-smoke


### PR DESCRIPTION
## What are you doing in this PR?

Only install Chromium for playwright smoke tests. I made this change in #7274 but only for the playwright cron tests.

## Why are you doing this?

It makes the build more efficient as we don't install browsers we don't need.