### PR TITLE
Update support-frontend to use catalog version of @types/node

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,8 +357,8 @@ importers:
         specifier: ^4.0.9
         version: 4.0.9
       '@types/node':
-        specifier: ^22.10.1
-        version: 22.15.29
+        specifier: 'catalog:'
+        version: 20.19.0
       '@types/react':
         specifier: 18.2.0
         version: 18.2.0
@@ -427,7 +427,7 @@ importers:
         version: 9.0.21
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.15.29)(babel-plugin-macros@3.1.0)
+        version: 29.7.0(@types/node@20.19.0)(babel-plugin-macros@3.1.0)
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -439,7 +439,7 @@ importers:
         version: 3.1.0
       knip:
         specifier: ^5.40.0
-        version: 5.58.1(@types/node@22.15.29)(typescript@5.5.4)
+        version: 5.58.1(@types/node@20.19.0)(typescript@5.5.4)
       lint-staged:
         specifier: ^15.3.0
         version: 15.5.2
@@ -17110,25 +17110,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.15.29)(babel-plugin-macros@3.1.0):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.15.29)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.15.29)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@22.15.29)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3))
@@ -17466,18 +17447,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.15.29)(babel-plugin-macros@3.1.0):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.15.29)(babel-plugin-macros@3.1.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest@29.7.0(@types/node@22.15.29)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.3.3))
@@ -17612,10 +17581,10 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  knip@5.58.1(@types/node@22.15.29)(typescript@5.5.4):
+  knip@5.58.1(@types/node@20.19.0)(typescript@5.5.4):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
-      '@types/node': 22.15.29
+      '@types/node': 20.19.0
       fast-glob: 3.3.3
       formatly: 0.2.3
       jiti: 2.4.2

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -8,7 +8,7 @@
 		"validate": "echo 'Validating TS' && npm-run-all 'lint:fix' && pnpm tsc && pnpm knip",
 		"typecheck": "tsc --noEmit",
 		"lint:nibble": "eslint-nibble ./assets --ext .ts,.tsx",
-    "lint:check": "NODE_OPTIONS=\"--max-old-space-size=28192\" eslint ./assets --ext .ts --ext .tsx",
+		"lint:check": "NODE_OPTIONS=\"--max-old-space-size=28192\" eslint ./assets --ext .ts --ext .tsx",
 		"lint:fix": "eslint --fix ./assets --ext .ts --ext .tsx",
 		"build-dev": "webpack --config webpack.dev.js",
 		"build-ssr": "tsx ./scripts/build-ssr-content.tsx",
@@ -65,10 +65,10 @@
 			"ophan(.*)": "<rootDir>/node_modules/ophan-tracker-js/build/ophan.support",
 			"\\.(css|less|sass|scss)$": "<rootDir>/assets/__mocks__/styleMock.ts",
 			"\\.(svg|png|jpg)$": "<rootDir>/assets/__mocks__/imageMock.ts",
-      "@modules/product-catalog/(.*)$": "@guardian/support-service-lambdas/modules/product-catalog/src/$1",
-      "@modules/internationalisation/(.*)$": "@guardian/support-service-lambdas/modules/internationalisation/src/$1",
-      "@modules/(.*)$": "<rootDir>/../modules/$1"
-    },
+			"@modules/product-catalog/(.*)$": "@guardian/support-service-lambdas/modules/product-catalog/src/$1",
+			"@modules/internationalisation/(.*)$": "@guardian/support-service-lambdas/modules/internationalisation/src/$1",
+			"@modules/(.*)$": "<rootDir>/../modules/$1"
+		},
 		"setupFilesAfterEnv": [
 			"./jestSetup"
 		],
@@ -130,7 +130,7 @@
 		"@emotion/eslint-plugin": "^11.11.0",
 		"@guardian/browserslist-config": "^6.1.2",
 		"@guardian/prettier": "^2.1.5",
-    "@guardian/eslint-config-typescript": "10.0.1",
+		"@guardian/eslint-config-typescript": "10.0.1",
 		"@storybook/addon-a11y": "^8.4.2",
 		"@storybook/addon-essentials": "^8.4.5",
 		"@storybook/addon-interactions": "^8.4.2",
@@ -145,7 +145,7 @@
 		"@types/jest": "^29.5.14",
 		"@types/jsdom": "^21.1.6",
 		"@types/lodash.debounce": "^4.0.9",
-		"@types/node": "^22.10.1",
+		"@types/node": "catalog:",
 		"@types/react": "18.2.0",
 		"@types/react-dom": "18.2.0",
 		"autoprefixer": "^10.4.21",


### PR DESCRIPTION
The version of Node is set centrally and should be reflected in the version of @types/node.

<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
