### PR TITLE
Adding profile.theguardian to the default-src csp directive to allow us 

### DIFF
--- a/support-frontend/conf/CODE.public.conf
+++ b/support-frontend/conf/CODE.public.conf
@@ -100,6 +100,9 @@ _src=${_src} "https://cdn.tickettailor.com/js/widgets/min/widget.css"
 # Used for collecting Core Web Vitals
 _src=${_src} "https://feast-events.guardianapis.com/web-vitals"
 
+# This is required for the iframe to load the sign in page for the Supporter Onboarding journey
+_src=${_src} "https://profile.code.dev-theguardian.com/"
+
 play.filters.csp.directives {
   default-src=${_src}
   frame-ancestors="https://theguardian.newspapers.com https://gnmtouchpoint--dev1--c.cs88.visual.force.com https://gnmtouchpoint--dev1.lightning.force.com https://m.code.dev-theguardian.com https://gnmtouchpoint--dev1--c.sandbox.vf.force.com https://gnmtouchpoint--dev1.sandbox.lightning.force.com"

--- a/support-frontend/conf/DEV.public.conf
+++ b/support-frontend/conf/DEV.public.conf
@@ -103,6 +103,9 @@ _src=${_src} "https://cdn.tickettailor.com/js/widgets/min/widget.css"
 # Used for collecting Core Web Vitals
 _src=${_src} "https://feast-events.guardianapis.com/web-vitals"
 
+# This is required for the iframe to load the sign in page for the Supporter Onboarding journey
+_src=${_src} "https://profile.thegulocal.com"
+
 
 play.filters.csp.directives {
   default-src=${_src}

--- a/support-frontend/conf/PROD.public.conf
+++ b/support-frontend/conf/PROD.public.conf
@@ -97,6 +97,9 @@ _src=${_src} "https://cdn.tickettailor.com/js/widgets/min/widget.css"
 # Used for collecting Core Web Vitals
 _src=${_src} "https://feast-events.guardianapis.com/web-vitals"
 
+# This is required for the iframe to load the sign in page for the Supporter Onboarding journey
+_src=${_src} "https://profile.theguardian.com/"
+
 play.filters.csp.directives {
   default-src=${_src}
   frame-ancestors="https://theguardian.newspapers.com https://gnmtouchpoint--c.eu31.visual.force.com https://gnmtouchpoint.lightning.force.com https://www.theguardian.com https://gnmtouchpoint--c.vf.force.com"


### PR DESCRIPTION
## What are you doing in this PR?
As part of the support onboarding journey we want to encourage users to register or sign in after they have made a purchase. 

To do this we want to iframe in the signin journey into the thankyou page. 

We need to add profile.theguardian.com (more specifically the correct profile domains for the particular stage that support and profile are running on) into the default-src CSP directive to allow iframing from the correct domain.

## Screenshots
<img width="692" height="560" alt="Screenshot 2025-09-23 at 15 44 53" src="https://github.com/user-attachments/assets/0903e668-3876-42bc-b6e1-4dcd48f95808" />

