### PR TITLE
Fix missing billing country on digital only subs

### DIFF
--- a/support-workers/src/typescript/services/salesforce.ts
+++ b/support-workers/src/typescript/services/salesforce.ts
@@ -184,6 +184,12 @@ export const createContactRecordRequest = (
 		...(user.billingAddress.postCode
 			? { OtherPostalCode: user.billingAddress.postCode }
 			: {}),
+		...(user.billingAddress.city
+			? { OtherCity: user.billingAddress.city }
+			: {}),
+		...(user.billingAddress.lineOne
+			? { OtherStreet: getAddressLine(user.billingAddress) }
+			: {}),
 	};
 	if (giftRecipient ?? !user.deliveryAddress) {
 		// If there is a gift recipient then we don't want to update the
@@ -194,8 +200,6 @@ export const createContactRecordRequest = (
 	}
 	return {
 		...contact,
-		OtherStreet: getAddressLine(user.billingAddress),
-		OtherCity: user.billingAddress.city,
 		MailingStreet: getAddressLine(user.deliveryAddress),
 		MailingCity: user.deliveryAddress.city,
 		MailingState: user.deliveryAddress.state,

--- a/support-workers/src/typescript/services/salesforce.ts
+++ b/support-workers/src/typescript/services/salesforce.ts
@@ -15,7 +15,7 @@ export type ContactRecordRequest = {
 	OtherCity?: string | null;
 	OtherState?: string | null;
 	OtherPostalCode?: string | null;
-	OtherCountry?: string | null;
+	OtherCountry: string | null;
 	Phone?: string | null;
 	MailingStreet?: string | null;
 	MailingCity?: string | null;
@@ -88,9 +88,15 @@ export class SalesforceService {
 		user: User,
 		giftRecipient: GiftRecipient | null,
 	): Promise<SalesforceContactRecord> => {
-		const buyerResponse = await this.upsert(
-			createContactRecordRequest(user, giftRecipient),
+		console.log('UUU SalesforceService: Creating contact records');
+		console.log('UUU user:', user);
+		const contactRecordRequest = createContactRecordRequest(
+			user,
+			giftRecipient,
 		);
+		console.log('UUU contactRecordRequest:', contactRecordRequest);
+		// First upsert the buyer contact record
+		const buyerResponse = await this.upsert(contactRecordRequest);
 		const giftRecipientResponse = await this.maybeAddGiftRecipient(
 			buyerResponse.ContactRecord,
 			giftRecipient,
@@ -171,6 +177,7 @@ export const createContactRecordRequest = (
 		FirstName: user.firstName,
 		LastName: user.lastName,
 		Phone: user.telephoneNumber,
+		OtherCountry: getCountryNameByIsoCode(user.billingAddress.country),
 	};
 	if (giftRecipient ?? !user.deliveryAddress) {
 		// If there is a gift recipient then we don't want to update the
@@ -185,7 +192,6 @@ export const createContactRecordRequest = (
 		OtherCity: user.billingAddress.city,
 		OtherState: user.billingAddress.state,
 		OtherPostalCode: user.billingAddress.postCode,
-		OtherCountry: getCountryNameByIsoCode(user.billingAddress.country),
 		MailingStreet: getAddressLine(user.deliveryAddress),
 		MailingCity: user.deliveryAddress.city,
 		MailingState: user.deliveryAddress.state,

--- a/support-workers/src/typescript/services/salesforce.ts
+++ b/support-workers/src/typescript/services/salesforce.ts
@@ -88,13 +88,11 @@ export class SalesforceService {
 		user: User,
 		giftRecipient: GiftRecipient | null,
 	): Promise<SalesforceContactRecord> => {
-		console.log('UUU SalesforceService: Creating contact records');
-		console.log('UUU user:', user);
+		console.log('SalesforceService: Creating contact records');
 		const contactRecordRequest = createContactRecordRequest(
 			user,
 			giftRecipient,
 		);
-		console.log('UUU contactRecordRequest:', contactRecordRequest);
 		// First upsert the buyer contact record
 		const buyerResponse = await this.upsert(contactRecordRequest);
 		const giftRecipientResponse = await this.maybeAddGiftRecipient(

--- a/support-workers/src/typescript/services/salesforce.ts
+++ b/support-workers/src/typescript/services/salesforce.ts
@@ -178,6 +178,12 @@ export const createContactRecordRequest = (
 		LastName: user.lastName,
 		Phone: user.telephoneNumber,
 		OtherCountry: getCountryNameByIsoCode(user.billingAddress.country),
+		...(user.billingAddress.state
+			? { OtherState: user.billingAddress.state }
+			: {}),
+		...(user.billingAddress.postCode
+			? { OtherPostalCode: user.billingAddress.postCode }
+			: {}),
 	};
 	if (giftRecipient ?? !user.deliveryAddress) {
 		// If there is a gift recipient then we don't want to update the
@@ -190,8 +196,6 @@ export const createContactRecordRequest = (
 		...contact,
 		OtherStreet: getAddressLine(user.billingAddress),
 		OtherCity: user.billingAddress.city,
-		OtherState: user.billingAddress.state,
-		OtherPostalCode: user.billingAddress.postCode,
 		MailingStreet: getAddressLine(user.deliveryAddress),
 		MailingCity: user.deliveryAddress.city,
 		MailingState: user.deliveryAddress.state,

--- a/support-workers/src/typescript/test/salesforce.test.ts
+++ b/support-workers/src/typescript/test/salesforce.test.ts
@@ -1,69 +1,54 @@
 import {
-	// createContactRecordRequest,
+	createContactRecordRequest,
 	SalesforceError,
 	salesforceErrorCodes,
 	SalesforceService,
 } from '../services/salesforce';
-// import { emailAddress, street, user } from './fixtures/salesforceFixtures';
+import { emailAddress, street, user } from './fixtures/salesforceFixtures';
 
 describe('SalesforceService', () => {
-	// test('createContactRecordRequest should only include address fields for purchases without a gift recipient', () => {
-	// 	const newContactNoGift = createContactRecordRequest(user, null);
-	// 	expect(newContactNoGift.MailingStreet).toBe(street);
-	// 	expect(newContactNoGift.OtherStreet).toBe(street);
+	test('createContactRecordRequest should only include mailing address fields for purchases without a gift recipient', () => {
+		const newContactNoGift = createContactRecordRequest(user, null);
+		expect(newContactNoGift.MailingStreet).toBe(street);
+		expect(newContactNoGift.OtherStreet).toBe(street);
 
-	// 	const newContactWithGift = createContactRecordRequest(user, {
-	// 		email: emailAddress,
-	// 		title: 'Ms',
-	// 		firstName: 'Jane',
-	// 		lastName: 'Doe',
-	// 	});
-	// 	expect('MailingStreet' in newContactWithGift).toBe(false);
-	// 	expect('MailingCity' in newContactWithGift).toBe(false);
-	// 	expect('MailingState' in newContactWithGift).toBe(false);
-	// 	expect('MailingPostalCode' in newContactWithGift).toBe(false);
-	// 	expect('MailingCountry' in newContactWithGift).toBe(false);
-	// 	expect('OtherStreet' in newContactWithGift).toBe(false);
-	// 	expect('OtherCity' in newContactWithGift).toBe(false);
-	// 	expect('OtherState' in newContactWithGift).toBe(false);
-	// 	expect('OtherPostalCode' in newContactWithGift).toBe(false);
-	// 	expect('OtherCountry' in newContactWithGift).toBe(false);
-	// });
+		const newContactWithGift = createContactRecordRequest(user, {
+			email: emailAddress,
+			title: 'Ms',
+			firstName: 'Jane',
+			lastName: 'Doe',
+		});
+		expect('MailingStreet' in newContactWithGift).toBe(false);
+		expect('MailingCity' in newContactWithGift).toBe(false);
+		expect('MailingState' in newContactWithGift).toBe(false);
+		expect('MailingPostalCode' in newContactWithGift).toBe(false);
+		expect('MailingCountry' in newContactWithGift).toBe(false);
+	});
 
-	// test('createContactRecordRequest should not include address fields for purchases when user delivery address is null', () => {
-	// 	const userWithoutDeliveryAddress = {
-	// 		...user,
-	// 		deliveryAddress: null,
-	// 	};
-	// 	const newContact = createContactRecordRequest(
-	// 		userWithoutDeliveryAddress,
-	// 		null,
-	// 	);
-	// 	expect('MailingStreet' in newContact).toBe(false);
-	// 	expect('MailingCity' in newContact).toBe(false);
-	// 	expect('MailingState' in newContact).toBe(false);
-	// 	expect('MailingPostalCode' in newContact).toBe(false);
-	// 	expect('MailingCountry' in newContact).toBe(false);
-	// 	expect('OtherStreet' in newContact).toBe(false);
-	// 	expect('OtherCity' in newContact).toBe(false);
-	// 	expect('OtherState' in newContact).toBe(false);
-	// 	expect('OtherPostalCode' in newContact).toBe(false);
-	// 	expect('OtherCountry' in newContact).toBe(false);
-	// });
+	test('createContactRecordRequest should not include mailing address fields for purchases when user delivery address is null', () => {
+		const userWithoutDeliveryAddress = {
+			...user,
+			deliveryAddress: null,
+		};
+		const newContact = createContactRecordRequest(
+			userWithoutDeliveryAddress,
+			null,
+		);
+		expect('MailingStreet' in newContact).toBe(false);
+		expect('MailingCity' in newContact).toBe(false);
+		expect('MailingState' in newContact).toBe(false);
+		expect('MailingPostalCode' in newContact).toBe(false);
+		expect('MailingCountry' in newContact).toBe(false);
+	});
 
-	// test('createContactRecordRequest should include address fields for purchases when user delivery address is populated and there is no giftRecipient', () => {
-	// 	const newContact = createContactRecordRequest(user, null);
-	// 	expect(newContact.MailingStreet).toBe(street);
-	// 	expect(newContact.MailingCity).toBe(user.deliveryAddress.city);
-	// 	expect(newContact.MailingState).toBe(user.deliveryAddress.state);
-	// 	expect(newContact.MailingPostalCode).toBe(user.deliveryAddress.postCode);
-	// 	expect(newContact.MailingCountry).toBe('United Kingdom');
-	// 	expect(newContact.OtherStreet).toBe(street);
-	// 	expect(newContact.OtherCity).toBe(user.deliveryAddress.city);
-	// 	expect(newContact.OtherState).toBe(user.deliveryAddress.state);
-	// 	expect(newContact.OtherPostalCode).toBe(user.deliveryAddress.postCode);
-	// 	expect(newContact.OtherCountry).toBe('United Kingdom');
-	// });
+	test('createContactRecordRequest should include mailing address fields for purchases when user delivery address is populated and there is no giftRecipient', () => {
+		const newContact = createContactRecordRequest(user, null);
+		expect(newContact.MailingStreet).toBe(street);
+		expect(newContact.MailingCity).toBe(user.deliveryAddress.city);
+		expect(newContact.MailingState).toBe(user.deliveryAddress.state);
+		expect(newContact.MailingPostalCode).toBe(user.deliveryAddress.postCode);
+		expect(newContact.MailingCountry).toBe('United Kingdom');
+	});
 
 	test('it should throw an INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE error when appropriate', () => {
 		const errorString =

--- a/support-workers/src/typescript/test/salesforce.test.ts
+++ b/support-workers/src/typescript/test/salesforce.test.ts
@@ -50,6 +50,62 @@ describe('SalesforceService', () => {
 		expect(newContact.MailingCountry).toBe('United Kingdom');
 	});
 
+	test('createContactRecordRequest should include billingCountry', () => {
+		const newContact = createContactRecordRequest(user, null);
+		expect(newContact.OtherCountry).toBe('United Kingdom');
+	});
+
+	test('createContactRecordRequest should include billingState and billingPostalCode when provided', () => {
+		const newContact = createContactRecordRequest(user, null);
+		expect(newContact.OtherState).toBe(user.billingAddress.state);
+		expect(newContact.OtherPostalCode).toBe(user.billingAddress.postCode);
+	});
+
+	test('createContactRecordRequest should not include billingState when state is null', () => {
+		const userWithoutBillingState = {
+			...user,
+			billingAddress: {
+				...user.billingAddress,
+				state: null,
+			},
+		};
+		const newContact = createContactRecordRequest(
+			userWithoutBillingState,
+			null,
+		);
+		expect('OtherState' in newContact).toBe(false);
+	});
+
+	test('createContactRecordRequest should not include billingPostalCode when postCode is null', () => {
+		const userWithoutBillingPostalCode = {
+			...user,
+			billingAddress: {
+				...user.billingAddress,
+				postCode: null,
+			},
+		};
+		const newContact = createContactRecordRequest(
+			userWithoutBillingPostalCode,
+			null,
+		);
+		expect('OtherPostalCode' in newContact).toBe(false);
+	});
+
+	test('createContactRecordRequest should not include billingPostalCode when postCode is empty string', () => {
+		const userWithoutBillingPostalCode = {
+			...user,
+			billingAddress: {
+				...user.billingAddress,
+				postCode: '',
+			},
+		};
+		const newContact = createContactRecordRequest(
+			userWithoutBillingPostalCode,
+			null,
+		);
+		expect('OtherPostalCode' in newContact).toBe(false);
+	});
+
 	test('it should throw an INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE error when appropriate', () => {
 		const errorString =
 			'Failed Upsert of new Contact: Upsert failed. First exception on row 0; first error: INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE, Updates can’t be made during maintenance. Try again when maintenance is complete: []';

--- a/support-workers/src/typescript/test/salesforce.test.ts
+++ b/support-workers/src/typescript/test/salesforce.test.ts
@@ -1,69 +1,69 @@
 import {
-	createContactRecordRequest,
+	// createContactRecordRequest,
 	SalesforceError,
 	salesforceErrorCodes,
 	SalesforceService,
 } from '../services/salesforce';
-import { emailAddress, street, user } from './fixtures/salesforceFixtures';
+// import { emailAddress, street, user } from './fixtures/salesforceFixtures';
 
 describe('SalesforceService', () => {
-	test('createContactRecordRequest should only include address fields for purchases without a gift recipient', () => {
-		const newContactNoGift = createContactRecordRequest(user, null);
-		expect(newContactNoGift.MailingStreet).toBe(street);
-		expect(newContactNoGift.OtherStreet).toBe(street);
+	// test('createContactRecordRequest should only include address fields for purchases without a gift recipient', () => {
+	// 	const newContactNoGift = createContactRecordRequest(user, null);
+	// 	expect(newContactNoGift.MailingStreet).toBe(street);
+	// 	expect(newContactNoGift.OtherStreet).toBe(street);
 
-		const newContactWithGift = createContactRecordRequest(user, {
-			email: emailAddress,
-			title: 'Ms',
-			firstName: 'Jane',
-			lastName: 'Doe',
-		});
-		expect('MailingStreet' in newContactWithGift).toBe(false);
-		expect('MailingCity' in newContactWithGift).toBe(false);
-		expect('MailingState' in newContactWithGift).toBe(false);
-		expect('MailingPostalCode' in newContactWithGift).toBe(false);
-		expect('MailingCountry' in newContactWithGift).toBe(false);
-		expect('OtherStreet' in newContactWithGift).toBe(false);
-		expect('OtherCity' in newContactWithGift).toBe(false);
-		expect('OtherState' in newContactWithGift).toBe(false);
-		expect('OtherPostalCode' in newContactWithGift).toBe(false);
-		expect('OtherCountry' in newContactWithGift).toBe(false);
-	});
+	// 	const newContactWithGift = createContactRecordRequest(user, {
+	// 		email: emailAddress,
+	// 		title: 'Ms',
+	// 		firstName: 'Jane',
+	// 		lastName: 'Doe',
+	// 	});
+	// 	expect('MailingStreet' in newContactWithGift).toBe(false);
+	// 	expect('MailingCity' in newContactWithGift).toBe(false);
+	// 	expect('MailingState' in newContactWithGift).toBe(false);
+	// 	expect('MailingPostalCode' in newContactWithGift).toBe(false);
+	// 	expect('MailingCountry' in newContactWithGift).toBe(false);
+	// 	expect('OtherStreet' in newContactWithGift).toBe(false);
+	// 	expect('OtherCity' in newContactWithGift).toBe(false);
+	// 	expect('OtherState' in newContactWithGift).toBe(false);
+	// 	expect('OtherPostalCode' in newContactWithGift).toBe(false);
+	// 	expect('OtherCountry' in newContactWithGift).toBe(false);
+	// });
 
-	test('createContactRecordRequest should not include address fields for purchases when user delivery address is null', () => {
-		const userWithoutDeliveryAddress = {
-			...user,
-			deliveryAddress: null,
-		};
-		const newContact = createContactRecordRequest(
-			userWithoutDeliveryAddress,
-			null,
-		);
-		expect('MailingStreet' in newContact).toBe(false);
-		expect('MailingCity' in newContact).toBe(false);
-		expect('MailingState' in newContact).toBe(false);
-		expect('MailingPostalCode' in newContact).toBe(false);
-		expect('MailingCountry' in newContact).toBe(false);
-		expect('OtherStreet' in newContact).toBe(false);
-		expect('OtherCity' in newContact).toBe(false);
-		expect('OtherState' in newContact).toBe(false);
-		expect('OtherPostalCode' in newContact).toBe(false);
-		expect('OtherCountry' in newContact).toBe(false);
-	});
+	// test('createContactRecordRequest should not include address fields for purchases when user delivery address is null', () => {
+	// 	const userWithoutDeliveryAddress = {
+	// 		...user,
+	// 		deliveryAddress: null,
+	// 	};
+	// 	const newContact = createContactRecordRequest(
+	// 		userWithoutDeliveryAddress,
+	// 		null,
+	// 	);
+	// 	expect('MailingStreet' in newContact).toBe(false);
+	// 	expect('MailingCity' in newContact).toBe(false);
+	// 	expect('MailingState' in newContact).toBe(false);
+	// 	expect('MailingPostalCode' in newContact).toBe(false);
+	// 	expect('MailingCountry' in newContact).toBe(false);
+	// 	expect('OtherStreet' in newContact).toBe(false);
+	// 	expect('OtherCity' in newContact).toBe(false);
+	// 	expect('OtherState' in newContact).toBe(false);
+	// 	expect('OtherPostalCode' in newContact).toBe(false);
+	// 	expect('OtherCountry' in newContact).toBe(false);
+	// });
 
-	test('createContactRecordRequest should include address fields for purchases when user delivery address is populated and there is no giftRecipient', () => {
-		const newContact = createContactRecordRequest(user, null);
-		expect(newContact.MailingStreet).toBe(street);
-		expect(newContact.MailingCity).toBe(user.deliveryAddress.city);
-		expect(newContact.MailingState).toBe(user.deliveryAddress.state);
-		expect(newContact.MailingPostalCode).toBe(user.deliveryAddress.postCode);
-		expect(newContact.MailingCountry).toBe('United Kingdom');
-		expect(newContact.OtherStreet).toBe(street);
-		expect(newContact.OtherCity).toBe(user.deliveryAddress.city);
-		expect(newContact.OtherState).toBe(user.deliveryAddress.state);
-		expect(newContact.OtherPostalCode).toBe(user.deliveryAddress.postCode);
-		expect(newContact.OtherCountry).toBe('United Kingdom');
-	});
+	// test('createContactRecordRequest should include address fields for purchases when user delivery address is populated and there is no giftRecipient', () => {
+	// 	const newContact = createContactRecordRequest(user, null);
+	// 	expect(newContact.MailingStreet).toBe(street);
+	// 	expect(newContact.MailingCity).toBe(user.deliveryAddress.city);
+	// 	expect(newContact.MailingState).toBe(user.deliveryAddress.state);
+	// 	expect(newContact.MailingPostalCode).toBe(user.deliveryAddress.postCode);
+	// 	expect(newContact.MailingCountry).toBe('United Kingdom');
+	// 	expect(newContact.OtherStreet).toBe(street);
+	// 	expect(newContact.OtherCity).toBe(user.deliveryAddress.city);
+	// 	expect(newContact.OtherState).toBe(user.deliveryAddress.state);
+	// 	expect(newContact.OtherPostalCode).toBe(user.deliveryAddress.postCode);
+	// 	expect(newContact.OtherCountry).toBe('United Kingdom');
+	// });
 
 	test('it should throw an INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE error when appropriate', () => {
 		const errorString =


### PR DESCRIPTION
## What are you doing in this PR?
Fix a bug introduced in #7302. Billing address fields for digital only subscriptions should be saved to relevant Salesforce contacts created or updated during the acquisition process. #7302 introduced a bug which stopped this from happening. 

_Address fields not being saved:_
<img width="700" height="215" alt="image" src="https://github.com/user-attachments/assets/5c815351-89c3-44ca-aafb-019ae9a5d479" />

_Should be:_
<img width="700" height="215" alt="Screenshot 2025-09-24 at 12 03 12" src="https://github.com/user-attachments/assets/295caee5-3ca9-4418-848f-b93dc70ab046" />

Note the data was still saved to Zuora as expected.

[**Trello Card**](https://trello.com/c/dFGa0J5v/636-fix-ensure-billing-country-fields-are-written-to-salesforce-on-digital-only-acquisition)

## Why are you doing this?
It is important that Billing address fields in Salesforce match those in Zuora, so that our CSRs have accurate information for resolving customer issues.

## Root Cause
Billing address fields were only being saved to Salesforce when there was no associated gift recipient and there were delivery details provided from the user object.

## Fix
On the Salesforce contact, OtherCountry should always be populated and OtherState and OtherPostalCode should be populated when they are present and have values in the user object.

## How to test

---

**Verify Billing address fields are captured in Salesforce when product is digital only and state and zip are provided by customer**
 
- Create a digital only sub from [US endpoint](https://support.code.dev-theguardian.com/us/contribute)
- include a value for zip code (state is mandatory)

<img width="470" height="328" alt="Screenshot 2025-09-24 at 12 00 10" src="https://github.com/user-attachments/assets/7a5a448a-0f20-4e5d-8718-4dca5c0be740" />

- Verify in salesforce that country, state and zip code are populated on the contact:

<img width="700" height="215" alt="Screenshot 2025-09-24 at 12 03 12" src="https://github.com/user-attachments/assets/295caee5-3ca9-4418-848f-b93dc70ab046" />

---

**Verify Billing address fields are captured in Salesforce when product is digital only and state is provided by customer but zip is not**

- Create a digital only sub from [US endpoint](https://support.code.dev-theguardian.com/us/contribute)
- do not include a value for zip code (state is mandatory)
- Verify in salesforce that country, state are populated on the contact, and that post code is empty

---

**Verify Billing address fields are captured in Salesforce when product is digital only and neither state nor post code are provided by customer**

- Create a digital only sub from [UK endpoint](https://support.code.dev-theguardian.com/uk/contribute)
- There is no option to fill in post code or state (or in fact any billing address data)
- Verify in salesforce that country is populated on the contact (post code and state should be empty)

---

**Verify Mailing address fields are not overwritten with nulls when a customer purchases a print subscription followed by a digital only subscription (objective of the PR that introduced the bug)**
- Create a print sub from [UK endpoint](https://support.code.dev-theguardian.com/uk/subscribe/weekly#subscribe)
- Verify in salesforce mailing address fields are populated
- Create a digital only sub from [UK endpoint](https://support.code.dev-theguardian.com/uk/contribute)
- There is no option to fill in post code or state (or in fact any billing address data)
- Verify in salesforce that mailing address fields and billing address fields have not been overwritten with null values
<img width="1022" height="289" alt="Screenshot 2025-09-24 at 12 24 48" src="https://github.com/user-attachments/assets/b3c61af8-b8f0-4310-928a-5131ca7debc1" />

---
