### PR TITLE
Support fractional savings vs retail amounts

### DIFF
--- a/support-frontend/app/services/pricing/PriceSummary.scala
+++ b/support-frontend/app/services/pricing/PriceSummary.scala
@@ -6,7 +6,7 @@ import org.joda.time.DateTime
 
 case class PriceSummary(
     price: BigDecimal,
-    savingVsRetail: Option[Int],
+    savingVsRetail: Option[Float],
     currency: Currency,
     fixedTerm: Boolean,
     promotions: List[PromotionSummary],

--- a/support-frontend/app/services/pricing/PriceSummaryService.scala
+++ b/support-frontend/app/services/pricing/PriceSummaryService.scala
@@ -72,7 +72,7 @@ class PriceSummaryService(
       countryGroup: CountryGroup,
       productRatePlan: ProductRatePlan[Product],
       price: Price,
-      saving: Option[Int],
+      saving: Option[Float],
   ): (Currency, PriceSummary) = {
 
     val promotionSummaries: List[PromotionSummary] = for {

--- a/support-frontend/assets/helpers/productPrice/productPrices.test.ts
+++ b/support-frontend/assets/helpers/productPrice/productPrices.test.ts
@@ -5,4 +5,8 @@ describe('getDiscountVsRetail', () => {
 		const discount = getDiscountVsRetail(48.79, 27, 20);
 		expect(discount).toEqual(41);
 	});
+	it('works with fractional online vs retail savings percentages', () => {
+		const discount = getDiscountVsRetail(48.14, 29.18, 22.34);
+		expect(discount).toEqual(45);
+	});
 });

--- a/support-frontend/assets/pages/paper-subscription-landing/helpers/getPlans.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/helpers/getPlans.tsx
@@ -57,7 +57,7 @@ const getOfferText = (price: ProductPrice, promo?: Promotion) => {
 	}
 
 	if (price.savingVsRetail && price.savingVsRetail > 0) {
-		return `Save ${price.savingVsRetail}% on retail price`;
+		return `Save ${Math.floor(price.savingVsRetail)}% on retail price`;
 	}
 
 	return '';

--- a/support-models/src/main/scala/com/gu/support/catalog/Catalog.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Catalog.scala
@@ -50,7 +50,7 @@ object Catalog {
       val ratePlanCharges = productRatePlan.productRatePlanCharges.flatMap(_.pricing)
       val priceListSum = sumPriceLists(ratePlanCharges)
       val id = productRatePlan.id
-      val saving = productRatePlan.Saving__c.map(_.toInt)
+      val saving = productRatePlan.Saving__c.map(_.toFloat)
       Pricelist(id, saving, priceListSum)
     }
 

--- a/support-models/src/main/scala/com/gu/support/catalog/Pricelist.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Pricelist.scala
@@ -1,6 +1,6 @@
 package com.gu.support.catalog
 
-case class Pricelist(productRatePlanId: ProductRatePlanId, savingVsRetail: Option[Int], prices: List[Price])
+case class Pricelist(productRatePlanId: ProductRatePlanId, savingVsRetail: Option[Float], prices: List[Price])
 
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec._


### PR DESCRIPTION
## What are you doing in this PR?
On the newspaper landing page, we show the discount amount given by promotions as the discount vs the _retail_ price of the newspaper (not the subscription price it sells for on the website). 

This is different to all other products and we work it out by taking the savings vs retail amount stored in Zuora and doing a calculation with the discount amount. Unfortunately until now this calculation has not been completely accurate as we were storing a rounded amount for the saving value. 

This PR changes that so that we store the full fractional amount of the saving in Zuora, meaning that the 'discount vs retail' amount is correct. This also means that we need to round down the amount before we display it to end users.


[**Trello Card**](https://trello.com/c/w8qXiXpB/1921-fix-discount-vs-retail-amount)

## TODO
- [ ] Update all the savings amounts to match the values in column G of [this spreadsheet](https://docs.google.com/spreadsheets/d/1d2_pLCY1_fJB3tukgutpth2ACHHWJDtnt1OZEK-j0oM/edit?gid=575283476#gid=575283476)
