### PR TITLE
PremiumDigital: Remove Ab test and create feature flag

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -75,30 +75,6 @@ export const tests: Tests = {
 		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
 		excludeContributionsOnlyCountries: true,
 	},
-	newspaperArchiveBenefit: {
-		variants: [
-			{
-				id: 'control',
-			},
-			{
-				id: 'v1',
-			},
-			{
-				id: 'v2',
-			},
-		],
-		audiences: {
-			ALL: {
-				offset: 0,
-				size: 1,
-			},
-		},
-		isActive: false,
-		referrerControlled: false, // ab-test name not needed to be in paramURL
-		seed: 2,
-		targetPage: pageUrlRegexes.contributions.allLandingPagesAndThankyouPages,
-		excludeContributionsOnlyCountries: true,
-	},
 	guardianWeeklyGiftGenericCheckout: {
 		variants: [
 			{

--- a/support-frontend/assets/helpers/featureFlags.ts
+++ b/support-frontend/assets/helpers/featureFlags.ts
@@ -6,6 +6,6 @@ export function getFeatureFlags(): FeatureFlag {
 	const urlParams = new URLSearchParams(window.location.search);
 
 	return {
-		enablePremiumDigital: urlParams.has('premiumDigital'),
+		enablePremiumDigital: urlParams.has('enablePremiumDigital'),
 	};
 }

--- a/support-frontend/assets/helpers/featureFlags.ts
+++ b/support-frontend/assets/helpers/featureFlags.ts
@@ -1,0 +1,11 @@
+type FeatureFlag = {
+	enablePremiumDigital: boolean;
+};
+
+export function getFeatureFlags(): FeatureFlag {
+	const urlParams = new URLSearchParams(window.location.search);
+
+	return {
+		enablePremiumDigital: urlParams.has('premiumDigital'),
+	};
+}

--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -322,18 +322,6 @@ export const productCatalogDescription: Record<
 			RestOfWorldAnnual: {
 				billingPeriod: BillingPeriod.Annual,
 			},
-			DomesticMonthlyV2: {
-				billingPeriod: BillingPeriod.Monthly,
-			},
-			DomesticAnnualV2: {
-				billingPeriod: BillingPeriod.Annual,
-			},
-			RestOfWorldMonthlyV2: {
-				billingPeriod: BillingPeriod.Monthly,
-			},
-			RestOfWorldAnnualV2: {
-				billingPeriod: BillingPeriod.Annual,
-			},
 		},
 	},
 	DigitalSubscription: {

--- a/support-frontend/assets/helpers/productPrice/billingPeriods.ts
+++ b/support-frontend/assets/helpers/productPrice/billingPeriods.ts
@@ -67,8 +67,6 @@ export function ratePlanToBillingPeriod(
 		case 'Annual':
 		case 'RestOfWorldAnnual':
 		case 'DomesticAnnual':
-		case 'RestOfWorldAnnualV2':
-		case 'DomesticAnnualV2':
 		case 'OneYearGift':
 		case 'OneYearStudent':
 		case 'V1DeprecatedAnnual':
@@ -79,8 +77,6 @@ export function ratePlanToBillingPeriod(
 		case 'Monthly':
 		case 'RestOfWorldMonthly':
 		case 'DomesticMonthly':
-		case 'RestOfWorldMonthlyV2':
-		case 'DomesticMonthlyV2':
 		case 'Everyday':
 		case 'Sixday':
 		case 'Weekend':

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -31,6 +31,7 @@ import { StripeCardForm } from 'components/stripeCardForm/stripeCardForm';
 import { getAmountsTestVariant } from 'helpers/abTests/abtest';
 import type { Participations } from 'helpers/abTests/models';
 import { isContributionsOnlyCountry } from 'helpers/contributions';
+import { getFeatureFlags } from 'helpers/featureFlags';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import { loadPayPalRecurring } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 import {
@@ -196,11 +197,9 @@ export default function CheckoutForm({
 	const { currency, currencyKey, countryGroupId } =
 		getSupportRegionIdConfig(supportRegionId);
 
-	const showNewspaperArchiveBenefit = ['v1', 'v2', 'control'].includes(
-		abParticipations.newspaperArchiveBenefit ?? '',
-	);
+	const { enablePremiumDigital } = getFeatureFlags();
 
-	const productDescription = showNewspaperArchiveBenefit
+	const productDescription = enablePremiumDigital
 		? productCatalogDescriptionNewBenefits(countryGroupId)[productKey]
 		: productCatalogDescription[productKey];
 	const hasDeliveryAddress = !!productDescription.deliverableTo;

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
@@ -14,6 +14,7 @@ import {
 import { getAmountsTestVariant } from 'helpers/abTests/abtest';
 import type { Participations } from 'helpers/abTests/models';
 import { isContributionsOnlyCountry } from 'helpers/contributions';
+import { getFeatureFlags } from 'helpers/featureFlags';
 import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import {
 	type ActiveProductKey,
@@ -75,11 +76,9 @@ export default function CheckoutSummary({
 	const { currency, currencyKey, countryGroupId } =
 		getSupportRegionIdConfig(supportRegionId);
 
-	const showNewspaperArchiveBenefit = ['v1', 'v2', 'control'].includes(
-		abParticipations.newspaperArchiveBenefit ?? '',
-	);
+	const { enablePremiumDigital } = getFeatureFlags();
 
-	const productDescription = showNewspaperArchiveBenefit
+	const productDescription = enablePremiumDigital
 		? productCatalogDescriptionNewBenefits(countryGroupId)[productKey]
 		: productCatalogDescription[productKey];
 	const ratePlanDescription = productDescription.ratePlans[ratePlanKey] ?? {

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -16,6 +16,7 @@ import { PageScaffold } from 'components/page/pageScaffold';
 import type { ThankYouModuleType } from 'components/thankYou/thankYouModule';
 import { getThankYouModuleData } from 'components/thankYou/thankYouModuleData';
 import type { Participations } from 'helpers/abTests/models';
+import { getFeatureFlags } from 'helpers/featureFlags';
 import { Country } from 'helpers/internationalisation/classes/country';
 import type {
 	ActiveProductKey,
@@ -59,7 +60,6 @@ import {
 	getReturnAddress,
 	getThankYouOrder,
 } from '../checkout/helpers/sessionStorage';
-import { getFeatureFlags } from 'helpers/featureFlags';
 
 const thankYouContainer = css`
 	position: relative;

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -59,6 +59,7 @@ import {
 	getReturnAddress,
 	getThankYouOrder,
 } from '../checkout/helpers/sessionStorage';
+import { getFeatureFlags } from 'helpers/featureFlags';
 
 const thankYouContainer = css`
 	position: relative;
@@ -115,7 +116,6 @@ export function ThankYouComponent({
 	ratePlanKey = 'OneTime',
 	promotion,
 	identityUserType,
-	abParticipations,
 	landingPageSettings,
 }: CheckoutComponentProps) {
 	const countryId = Country.fromString(get('GU_country') ?? 'GB') ?? 'GB';
@@ -219,9 +219,7 @@ export function ThankYouComponent({
 	const isTierThree = productKey === 'TierThree';
 	const isNationalDelivery = productKey === 'NationalDelivery';
 	const validEmail = order.email !== '';
-	const showNewspaperArchiveBenefit = ['v1', 'v2', 'control'].includes(
-		abParticipations.newspaperArchiveBenefit ?? '',
-	);
+	const { enablePremiumDigital } = getFeatureFlags();
 
 	// Clarify Guardian Ad-lite thankyou page states
 	const signedInUser = isSignedIn;
@@ -292,7 +290,7 @@ export function ThankYouComponent({
 		...maybeThankYouModule(userNotSignedIn && !isGuardianAdLite, 'signIn'), // Sign in to access your benefits
 		...maybeThankYouModule(isTierThree, 'benefits'),
 		...maybeThankYouModule(
-			isTierThree && showNewspaperArchiveBenefit,
+			isTierThree && enablePremiumDigital,
 			'newspaperArchiveBenefit',
 		),
 		...maybeThankYouModule(
@@ -307,7 +305,7 @@ export function ThankYouComponent({
 		...maybeThankYouModule(isOneOff && validEmail, 'supportReminder'),
 		...maybeThankYouModule(
 			isOneOff ||
-				(!(isTierThree && showNewspaperArchiveBenefit) &&
+				(!(isTierThree && enablePremiumDigital) &&
 					isSignedIn &&
 					!isGuardianAdLite &&
 					!observerPrint &&

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -50,7 +50,6 @@ import type { LandingPageVariant } from '../../../helpers/globalsAndSwitches/lan
 import { getSanitisedHtml } from '../../../helpers/utilities/utilities';
 import { getSupportRegionIdConfig } from '../../supportRegionConfig';
 import Countdown from '../components/countdown';
-import { LandingPageBanners } from '../components/landingPageBanners';
 import { OneOffCard } from '../components/oneOffCard';
 import { StudentOffer } from '../components/studentOffer';
 import { SupportOnce } from '../components/supportOnce';
@@ -265,10 +264,6 @@ export function ThreeTierLanding({
 	const urlSearchParamsOneTime = urlSearchParams.has('oneTime');
 	const urlSearchParamsPromoCode = urlSearchParams.get('promoCode');
 	const { enablePremiumDigital } = getFeatureFlags();
-	console.log(
-		'🚀 ~ ThreeTierLanding ~ enablePremiumDigital:',
-		enablePremiumDigital,
-	);
 
 	const { currencyKey: currencyId, countryGroupId } =
 		getSupportRegionIdConfig(supportRegionId);
@@ -610,7 +605,6 @@ export function ThreeTierLanding({
 							billingPeriod={billingPeriod}
 						/>
 					)}
-					{enablePremiumDigital && <LandingPageBanners />}
 				</div>
 			</Container>
 			{!enableSingleContributionsTab && (

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -38,6 +38,7 @@ import {
 	getCampaignSettings,
 } from 'helpers/campaigns/campaigns';
 import type { ContributionType } from 'helpers/contributions';
+import { getFeatureFlags } from 'helpers/featureFlags';
 import { Country } from 'helpers/internationalisation/classes/country';
 import { currencies } from 'helpers/internationalisation/currency';
 import { productCatalog } from 'helpers/productCatalog';
@@ -257,13 +258,17 @@ type ThreeTierLandingProps = {
 export function ThreeTierLanding({
 	supportRegionId,
 	settings,
-	abParticipations,
 }: ThreeTierLandingProps): JSX.Element {
 	const urlSearchParams = new URLSearchParams(window.location.search);
 	const urlSearchParamsProduct = urlSearchParams.get('product');
 	const urlSearchParamsRatePlan = urlSearchParams.get('ratePlan');
 	const urlSearchParamsOneTime = urlSearchParams.has('oneTime');
 	const urlSearchParamsPromoCode = urlSearchParams.get('promoCode');
+	const { enablePremiumDigital } = getFeatureFlags();
+	console.log(
+		'🚀 ~ ThreeTierLanding ~ enablePremiumDigital:',
+		enablePremiumDigital,
+	);
 
 	const { currencyKey: currencyId, countryGroupId } =
 		getSupportRegionIdConfig(supportRegionId);
@@ -423,9 +428,7 @@ export function ThreeTierLanding({
 				? 'DomesticAnnual'
 				: 'DomesticMonthly';
 
-		return abParticipations.newspaperArchiveBenefit === undefined
-			? ratePlanKey
-			: `${ratePlanKey}V2`;
+		return enablePremiumDigital ? `${ratePlanKey}V2` : ratePlanKey;
 	};
 
 	const tier3RatePlan = getTier3RatePlan();
@@ -441,10 +444,7 @@ export function ThreeTierLanding({
 		countryId,
 		billingPeriod,
 		countryGroupId === 'International' ? 'RestOfWorld' : 'Domestic',
-
-		abParticipations.newspaperArchiveBenefit === undefined
-			? 'NoProductOptions'
-			: 'NewspaperArchive',
+		enablePremiumDigital ? 'NewspaperArchive' : 'NoProductOptions',
 	);
 	if (tier3Promotion) {
 		tier3UrlParams.set('promoCode', tier3Promotion.promoCode);
@@ -459,9 +459,6 @@ export function ThreeTierLanding({
 			isCardUserSelected(tier3Pricing, tier3Promotion?.discount?.amount),
 		...settings.products.TierThree,
 	};
-
-	const showNewspaperArchiveBanner =
-		abParticipations.newspaperArchiveBenefit === 'v2';
 
 	const sanitisedHeading = getSanitisedHtml(settings.copy.heading);
 	const sanitisedSubheading = getSanitisedHtml(settings.copy.subheading);
@@ -613,7 +610,7 @@ export function ThreeTierLanding({
 							billingPeriod={billingPeriod}
 						/>
 					)}
-					{showNewspaperArchiveBanner && <LandingPageBanners />}
+					{enablePremiumDigital && <LandingPageBanners />}
 				</div>
 			</Container>
 			{!enableSingleContributionsTab && (

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -423,7 +423,7 @@ export function ThreeTierLanding({
 				? 'DomesticAnnual'
 				: 'DomesticMonthly';
 
-		return enablePremiumDigital ? `${ratePlanKey}V2` : ratePlanKey;
+		return ratePlanKey;
 	};
 
 	const tier3RatePlan = getTier3RatePlan();


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Remove ab test definition for the `newspaperArchiveBenefit` and use a url  based feature flag to control the functionality.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/fYIcX0Dk/1918-setup-feature-flag-remove-abtest-newspaperarchivebenefit)

## Why are you doing this?
Since newspaper archive benefit will be part of the new Premium digital product, we need a way to control all related features.
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
1. visit `https://support.thegulocal.com/uk/contribute`
2. add `?enablePremiumDigital` to the url


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots


