### PR TITLE
Show saving vs retail amount if the promotion means there is one

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/helpers/getPlans.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/helpers/getPlans.tsx
@@ -43,10 +43,10 @@ const getPriceCopyString = (
 };
 
 const getOfferText = (price: ProductPrice, promo?: Promotion) => {
-	if (promo && price.savingVsRetail && promo.discount?.amount) {
+	if (promo?.discount?.amount) {
 		const discount = getDiscountVsRetail(
 			price.price,
-			price.savingVsRetail,
+			price.savingVsRetail ?? 0,
 			promo.discount.amount,
 		);
 		if (discount > 0) {


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Follows on from #7330 
The Saturday and Sunday newspaper home delivery rate plans do not show a 'savings vs retail' amount on the landing page because the cost of delivery actually makes them more expensive than purchasing from a newsagent. However when they are discounted they can work out cheaper than retail. 

Currently we are not showing the 'discount vs retail' amount even when there is one, this PR changes that/