### PR TITLE
Upgrade S3 to v2 in payment-api

### DIFF
--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -12,8 +12,7 @@ addCompilerPlugin("org.typelevel" % "kind-projector_2.13.4" % "0.13.2")
 
 libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "ssm" % awsClientVersion2,
-  "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion,
-  "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
+  "software.amazon.awssdk" % "s3" % awsClientVersion2,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion,

--- a/support-payment-api/src/main/scala/MyApplicationLoader.scala
+++ b/support-payment-api/src/main/scala/MyApplicationLoader.scala
@@ -5,7 +5,6 @@ import backend._
 import com.amazon.pay.impl.ipn.NotificationFactory
 import com.amazon.pay.response.ipn.model.Notification
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync
-import com.amazonaws.services.s3.AmazonS3
 import com.typesafe.scalalogging.StrictLogging
 import conf.{ConfigLoader, PlayConfigUpdater}
 import model.{AppThreadPools, AppThreadPoolsProvider, RequestEnvironments}
@@ -16,6 +15,7 @@ import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.AhcWSComponents
 import router.Routes
 import services.CloudWatchService
+import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.ssm.SsmClient
 import util.RequestBasedProvider
 
@@ -65,7 +65,7 @@ class MyComponents(context: Context)
   override val threadPools: AppThreadPools = AppThreadPools.load(executionContext, actorSystem).valueOr(throw _)
 
   implicit val _wsClient: WSClient = wsClient
-  implicit val s3Client: AmazonS3 = AWSClientBuilder.buildS3Client()
+  implicit val s3Client: S3Client = AWSClientBuilder.buildS3Client()
   private implicit val system: ActorSystem = ActorSystem()
 
   override lazy val httpErrorHandler = new ErrorHandler(environment, configuration, sourceMapper, Some(router))

--- a/support-payment-api/src/main/scala/aws/AWSClientBuilder.scala
+++ b/support-payment-api/src/main/scala/aws/AWSClientBuilder.scala
@@ -4,11 +4,11 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudwatch.{AmazonCloudWatchAsync, AmazonCloudWatchAsyncClientBuilder}
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.amazonaws.services.sqs.{AmazonSQSAsync, AmazonSQSAsyncClientBuilder}
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.ssm.SsmClient
 import com.gu.aws.CredentialsProvider
+import software.amazon.awssdk.services.s3.S3Client
 
 object AWSClientBuilder {
 
@@ -41,9 +41,10 @@ object AWSClientBuilder {
       .withRegion(Regions.EU_WEST_1)
       .build()
 
-  def buildS3Client(): AmazonS3 = AmazonS3ClientBuilder
-    .standard()
-    .withRegion(Regions.EU_WEST_1)
-    .withCredentials(credentialsProvider)
-    .build()
+  def buildS3Client(): S3Client =
+    S3Client
+      .builder()
+      .region(Region.EU_WEST_1)
+      .credentialsProvider(CredentialsProvider)
+      .build()
 }

--- a/support-payment-api/src/main/scala/backend/PaypalBackend.scala
+++ b/support-payment-api/src/main/scala/backend/PaypalBackend.scala
@@ -7,7 +7,6 @@ import cats.syntax.apply._
 import cats.syntax.either._
 import cats.syntax.validated._
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync
-import com.amazonaws.services.s3.AmazonS3
 import com.gu.support.acquisitions.eventbridge.AcquisitionsEventBusService
 import com.gu.support.acquisitions.eventbridge.AcquisitionsEventBusService.Sources
 import com.gu.support.config.Stages.{CODE, PROD}
@@ -25,6 +24,7 @@ import model.paypal._
 import org.apache.pekko.http.scaladsl.model.Uri
 import play.api.libs.ws.WSClient
 import services._
+import software.amazon.awssdk.services.s3.S3Client
 import util.EnvironmentBasedBuilder
 
 import scala.concurrent.Future
@@ -270,7 +270,7 @@ object PaypalBackend {
       paypalThreadPool: PaypalThreadPool,
       sqsThreadPool: SQSThreadPool,
       wsClient: WSClient,
-      awsClient: AmazonS3,
+      s3Client: S3Client,
       system: ActorSystem,
   ) extends EnvironmentBasedBuilder[PaypalBackend] {
 
@@ -292,7 +292,7 @@ object PaypalBackend {
         .andThen(EmailService.fromEmailConfig): InitializationResult[EmailService],
       new CloudWatchService(cloudWatchAsyncClient, env).valid: InitializationResult[CloudWatchService],
       new SupporterProductDataService(env).valid: InitializationResult[SupporterProductDataService],
-      new SwitchService(env)(awsClient, system, paypalThreadPool).valid: InitializationResult[SwitchService],
+      new SwitchService(env)(s3Client, system, paypalThreadPool).valid: InitializationResult[SwitchService],
     ).mapN(PaypalBackend.apply)
   }
 }

--- a/support-payment-api/src/main/scala/backend/StripeBackend.scala
+++ b/support-payment-api/src/main/scala/backend/StripeBackend.scala
@@ -6,7 +6,6 @@ import cats.instances.future._
 import cats.syntax.apply._
 import cats.syntax.validated._
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync
-import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.support.acquisitions.eventbridge.AcquisitionsEventBusService
 import com.gu.support.acquisitions.eventbridge.AcquisitionsEventBusService.Sources
@@ -25,6 +24,7 @@ import model.stripe.StripePaymentMethod.{StripeApplePay, StripeCheckout, StripeP
 import model.stripe._
 import play.api.libs.ws.WSClient
 import services._
+import software.amazon.awssdk.services.s3.S3Client
 import util.EnvironmentBasedBuilder
 
 import scala.concurrent.Future
@@ -325,7 +325,7 @@ object StripeBackend {
       supporterProductDataService: SupporterProductDataService,
       switchService: SwitchService,
       environment: Environment,
-  )(implicit pool: DefaultThreadPool, WSClient: WSClient, awsClient: AmazonS3): StripeBackend = {
+  )(implicit pool: DefaultThreadPool, WSClient: WSClient, awsClient: S3Client): StripeBackend = {
     new StripeBackend(
       stripeService,
       databaseService,
@@ -345,7 +345,7 @@ object StripeBackend {
       stripeThreadPool: StripeThreadPool,
       sqsThreadPool: SQSThreadPool,
       wsClient: WSClient,
-      awsClient: AmazonS3,
+      s3Client: S3Client,
       system: ActorSystem,
   ) extends EnvironmentBasedBuilder[StripeBackend] {
 
@@ -370,7 +370,7 @@ object StripeBackend {
         .andThen(RecaptchaService.fromRecaptchaConfig): InitializationResult[RecaptchaService],
       new CloudWatchService(cloudWatchAsyncClient, env).valid: InitializationResult[CloudWatchService],
       new SupporterProductDataService(env).valid: InitializationResult[SupporterProductDataService],
-      new SwitchService(env)(awsClient, system, stripeThreadPool).valid: InitializationResult[SwitchService],
+      new SwitchService(env)(s3Client, system, stripeThreadPool).valid: InitializationResult[SwitchService],
       env.valid: InitializationResult[Environment],
     ).mapN(StripeBackend.apply)
   }

--- a/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
@@ -4,7 +4,6 @@ import org.apache.pekko.actor.ActorSystem
 import backend.BackendError.SoftOptInsServiceError
 import cats.data.EitherT
 import cats.implicits._
-import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.support.acquisitions.eventbridge.AcquisitionsEventBusService
 import com.stripe.model.Charge.PaymentMethodDetails
@@ -27,6 +26,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.ws.WSClient
 import services.SwitchState.{Off, On}
 import services._
+import software.amazon.awssdk.services.s3.S3Client
 import util.FutureEitherValues
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -187,7 +187,7 @@ class StripeBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
   val mockSwitchService: SwitchService = mock[SwitchService]
   implicit val mockWsClient: WSClient = mock[WSClient]
   implicit val mockActorSystem: ActorSystem = mock[ActorSystem]
-  implicit val mockS3Client: AmazonS3 = mock[AmazonS3]
+  implicit val mockS3Client: S3Client = mock[S3Client]
 
   // happens on instantiation of StripeBackend
   when(mockSwitchService.allSwitches).thenReturn(switchServiceOnResponse)


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Follows on from https://github.com/guardian/support-frontend/pull/7336 This PR upgrades S3 to the V2 SDK in payment-api
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/gVQ076wZ/1859-migrate-remaining-aws-sdk-v1-libraries-in-support-frontend-to-v2)
