### PR TITLE
Upgrade SQS to v2 in payment-api

### DIFF
--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -13,9 +13,8 @@ addCompilerPlugin("org.typelevel" % "kind-projector_2.13.4" % "0.13.2")
 libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "ssm" % awsClientVersion2,
   "software.amazon.awssdk" % "s3" % awsClientVersion2,
-  "com.amazonaws" % "aws-java-sdk-ec2" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
-  "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion,
+  "software.amazon.awssdk" % "sqs" % awsClientVersion2,
   "com.amazon.pay" % "amazon-pay-java-sdk" % "3.6.2",
   "com.beachape" %% "enumeratum" % "1.7.3",
   "com.beachape" %% "enumeratum-circe" % "1.7.3",

--- a/support-payment-api/src/main/scala/aws/AWSClientBuilder.scala
+++ b/support-payment-api/src/main/scala/aws/AWSClientBuilder.scala
@@ -4,11 +4,11 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudwatch.{AmazonCloudWatchAsync, AmazonCloudWatchAsyncClientBuilder}
-import com.amazonaws.services.sqs.{AmazonSQSAsync, AmazonSQSAsyncClientBuilder}
-import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.ssm.SsmClient
 import com.gu.aws.CredentialsProvider
+import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.ssm.SsmClient
 
 object AWSClientBuilder {
 
@@ -27,11 +27,11 @@ object AWSClientBuilder {
       .credentialsProvider(CredentialsProvider)
       .build()
 
-  def buildAmazonSQSAsyncClient(): AmazonSQSAsync =
-    AmazonSQSAsyncClientBuilder
-      .standard()
-      .withCredentials(credentialsProvider)
-      .withRegion(Regions.EU_WEST_1)
+  def buildAmazonSQSAsyncClient(): SqsAsyncClient =
+    SqsAsyncClient
+      .builder()
+      .credentialsProvider(CredentialsProvider)
+      .region(Region.EU_WEST_1)
       .build()
 
   def buildCloudWatchAsyncClient(): AmazonCloudWatchAsync =

--- a/support-payment-api/src/main/scala/backend/StripeBackend.scala
+++ b/support-payment-api/src/main/scala/backend/StripeBackend.scala
@@ -1,12 +1,10 @@
 package backend
 
-import org.apache.pekko.actor.ActorSystem
 import cats.data.EitherT
 import cats.instances.future._
 import cats.syntax.apply._
 import cats.syntax.validated._
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync
-import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.support.acquisitions.eventbridge.AcquisitionsEventBusService
 import com.gu.support.acquisitions.eventbridge.AcquisitionsEventBusService.Sources
 import com.gu.support.config.Stages.{CODE, PROD}
@@ -22,9 +20,11 @@ import model.email.ContributorRow
 import model.stripe.StripeApiError.{recaptchaErrorText, stripeDisabledErrorText}
 import model.stripe.StripePaymentMethod.{StripeApplePay, StripeCheckout, StripePaymentRequestButton}
 import model.stripe._
+import org.apache.pekko.actor.ActorSystem
 import play.api.libs.ws.WSClient
 import services._
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse
 import util.EnvironmentBasedBuilder
 
 import scala.concurrent.Future
@@ -298,7 +298,7 @@ class StripeBackend(
       email: String,
       data: StripeRequest,
       identityId: String,
-  ): EitherT[Future, BackendError, SendMessageResult] = {
+  ): EitherT[Future, BackendError, SendMessageResponse] = {
     val contributorRow = ContributorRow(
       email,
       data.paymentData.currency.toString,

--- a/support-payment-api/src/main/scala/services/EmailService.scala
+++ b/support-payment-api/src/main/scala/services/EmailService.scala
@@ -2,30 +2,34 @@ package services
 
 import aws.AWSClientBuilder
 import cats.data.{EitherT, Validated}
-import com.amazonaws.services.sqs.AmazonSQSAsync
-import com.amazonaws.services.sqs.model.{SendMessageRequest, _}
 import com.typesafe.scalalogging.StrictLogging
 import conf.EmailConfig
 import model.email.ContributorRow
 import model.{DefaultThreadPool, InitializationError, InitializationResult}
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.model.{GetQueueUrlRequest, SendMessageRequest, SendMessageResponse}
 
 import scala.concurrent.Future
 
-class EmailService(sqsClient: AmazonSQSAsync, queueName: String)(implicit pool: DefaultThreadPool)
+class EmailService(sqsClient: SqsAsyncClient, queueName: String)(implicit pool: DefaultThreadPool)
     extends StrictLogging {
 
-  val thankYouQueueUrl = sqsClient.getQueueUrl(queueName).getQueueUrl
+  val request = GetQueueUrlRequest.builder().queueName(queueName).build()
+  val thankYouQueueUrl = sqsClient.getQueueUrl(request).get().queueUrl()
 
   /*
    * No need to provide an AsyncHandler as the process is fire and forget and it's not required any action if the message
    * cannot be process by the subscriber.
    */
-  def sendThankYouEmail(contributorRow: ContributorRow): EitherT[Future, EmailService.Error, SendMessageResult] = {
+  def sendThankYouEmail(contributorRow: ContributorRow): EitherT[Future, EmailService.Error, SendMessageResponse] = {
+    val messageRequest = SendMessageRequest
+      .builder()
+      .queueUrl(thankYouQueueUrl)
+      .messageBody(contributorRow.toJsonContributorRowSqsMessage)
+      .build()
 
     EitherT(Future {
-      sqsClient
-        .sendMessageAsync(new SendMessageRequest(thankYouQueueUrl, contributorRow.toJsonContributorRowSqsMessage))
-        .get
+      sqsClient.sendMessage(messageRequest).get
     }.map(Right.apply).recover {
       case err: Throwable => Left(EmailService.Error(err))
       case _ => Left(EmailService.Error(new Exception("Unknown error while sending message to SQS.")))

--- a/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/PaypalBackendSpec.scala
@@ -3,7 +3,6 @@ package backend
 import backend.BackendError.SoftOptInsServiceError
 import cats.data.EitherT
 import cats.implicits._
-import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.support.acquisitions.eventbridge.AcquisitionsEventBusService
 import com.paypal.api.payments.{Amount, Payer, PayerInfo, Payment}
 import model.UserType.Current
@@ -18,6 +17,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import services.SwitchState.{Off, On}
 import services._
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse
 import util.FutureEitherValues
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -110,7 +110,7 @@ class PaypalBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
     EitherT.right(Future.successful(IdentityUserDetails("1", Current)))
   val identityResponseError: EitherT[Future, IdentityClient.ContextualError, IdentityUserDetails] =
     EitherT.left(Future.successful(identityError))
-  val emailResponseError: EitherT[Future, EmailService.Error, SendMessageResult] =
+  val emailResponseError: EitherT[Future, EmailService.Error, SendMessageResponse] =
     EitherT.left(Future.successful(emailError))
   val switchServiceOnResponse: EitherT[Future, Nothing, Switches] =
     EitherT.right(

--- a/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
+++ b/support-payment-api/src/test/scala/backend/StripeBackendSpec.scala
@@ -4,7 +4,6 @@ import org.apache.pekko.actor.ActorSystem
 import backend.BackendError.SoftOptInsServiceError
 import cats.data.EitherT
 import cats.implicits._
-import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.support.acquisitions.eventbridge.AcquisitionsEventBusService
 import com.stripe.model.Charge.PaymentMethodDetails
 import com.stripe.model.{Charge, ChargeCollection, Event, PaymentIntent}
@@ -27,6 +26,7 @@ import play.api.libs.ws.WSClient
 import services.SwitchState.{Off, On}
 import services._
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse
 import util.FutureEitherValues
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -128,9 +128,9 @@ class StripeBackendFixture(implicit ec: ExecutionContext) extends MockitoSugar {
   val acquisitionsEventBusErrorMessage = "an event bus error"
   val acquisitionsEventBusResponseError: Future[Either[String, Unit]] =
     Future.successful(Left(acquisitionsEventBusErrorMessage))
-  val emailResponseError: EitherT[Future, EmailService.Error, SendMessageResult] =
+  val emailResponseError: EitherT[Future, EmailService.Error, SendMessageResponse] =
     EitherT.left(Future.successful(emailError))
-  val emailServiceErrorResponse: EitherT[Future, EmailService.Error, SendMessageResult] =
+  val emailServiceErrorResponse: EitherT[Future, EmailService.Error, SendMessageResponse] =
     EitherT.left(Future.successful(EmailService.Error(new Exception("email service failure"))))
   val recaptchaServiceErrorResponse: EitherT[Future, StripeApiError, RecaptchaResponse] =
     EitherT.left(Future.successful(stripeApiError))

--- a/support-payment-api/src/test/scala/services/EmailServiceSpec.scala
+++ b/support-payment-api/src/test/scala/services/EmailServiceSpec.scala
@@ -1,23 +1,26 @@
 package services
 
-import com.amazonaws.services.sqs.AmazonSQSAsync
-import com.amazonaws.services.sqs.model.{GetQueueUrlResult, SendMessageResult}
 import com.paypal.api.payments.{Amount, Payer, PayerInfo, Payment}
-import model.{DefaultThreadPool, PaymentProvider}
-import org.mockito.Mockito._
-import org.mockito.ArgumentMatchers.any
-import org.scalatest.concurrent.ScalaFutures
-import java.util.concurrent.CompletableFuture
-
 import model.email.ContributorRow
+import model.{DefaultThreadPool, PaymentProvider}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito._
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.model.{
+  GetQueueUrlRequest,
+  GetQueueUrlResponse,
+  SendMessageRequest,
+  SendMessageResponse,
+}
 
+import java.util.concurrent.CompletableFuture
 import scala.compat.java8.FutureConverters._
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
-import scala.concurrent.ExecutionContext
 
 class EmailServiceSpec extends AnyFlatSpec with Matchers with MockitoSugar with ScalaFutures {
 
@@ -25,10 +28,10 @@ class EmailServiceSpec extends AnyFlatSpec with Matchers with MockitoSugar with 
 
   trait EmailServiceTestFixture {
     implicit val executionContextTest: DefaultThreadPool = DefaultThreadPool(ExecutionContext.global)
-    val sqsClient = mock[AmazonSQSAsync]
-    val getQueueUrlResult = mock[GetQueueUrlResult]
-    when(getQueueUrlResult.getQueueUrl()).thenReturn("test-queue-name")
-    when(sqsClient.getQueueUrl("test-queue-name")).thenReturn(getQueueUrlResult)
+    val sqsClient = mock[SqsAsyncClient]
+    val getQueueUrlResponse = GetQueueUrlResponse.builder().queueUrl("test-queue-name").build()
+    when(sqsClient.getQueueUrl(any[GetQueueUrlRequest]()))
+      .thenReturn(Future.successful(getQueueUrlResponse).toJava.toCompletableFuture)
     val emailService = new EmailService(sqsClient, "test-queue-name")
   }
 
@@ -50,16 +53,16 @@ class EmailServiceSpec extends AnyFlatSpec with Matchers with MockitoSugar with 
     when(payment.getTransactions).thenReturn(transactions)
     when(payment.getCreateTime).thenReturn("01-01-2018T12:12:12")
 
-    val scalaFuture = Future.successful(new SendMessageResult)
-    val javaFuture: CompletableFuture[SendMessageResult] = scalaFuture.toJava.toCompletableFuture
+    val scalaFuture = Future.successful(SendMessageResponse.builder().build())
+    val javaFuture: CompletableFuture[SendMessageResponse] = scalaFuture.toJava.toCompletableFuture
 
-    when(sqsClient.sendMessageAsync(any())).thenReturn(javaFuture)
+    when(sqsClient.sendMessage(any[SendMessageRequest]())).thenReturn(javaFuture)
 
     val emailResult = emailService.sendThankYouEmail(
       ContributorRow("email@email.com", "GBP", "1", PaymentProvider.Paypal, None, BigDecimal(2)),
     )
     whenReady(emailResult.value) { result =>
-      result mustBe Right(new SendMessageResult)
+      result mustBe Right(SendMessageResponse.builder().build())
     }
   }
 
@@ -84,10 +87,10 @@ class EmailServiceSpec extends AnyFlatSpec with Matchers with MockitoSugar with 
     val errorString = "Any sqs client error"
     val exception = new Exception(errorString)
     val emailError = EmailService.Error(exception)
-    val scalaFuture = Future.failed[SendMessageResult](exception)
-    val javaFuture: CompletableFuture[SendMessageResult] = scalaFuture.toJava.toCompletableFuture
+    val scalaFuture = Future.failed[SendMessageResponse](exception)
+    val javaFuture: CompletableFuture[SendMessageResponse] = scalaFuture.toJava.toCompletableFuture
 
-    when(sqsClient.sendMessageAsync(any())).thenReturn(javaFuture)
+    when(sqsClient.sendMessage(any[SendMessageRequest]())).thenReturn(javaFuture)
 
     whenReady(
       emailService


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Follows on from #7337 this PR upgrades the AWS SQS SDK to version 2

[**Trello Card**](https://trello.com/c/gVQ076wZ/1859-migrate-remaining-aws-sdk-v1-libraries-in-support-frontend-to-v2)
