### PR TITLE
Fix thank you page support reminder for OneTime contributions

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -218,7 +218,8 @@ export function ThankYouComponent({
 	const isSupporterPlus = productKey === 'SupporterPlus';
 	const isTierThree = productKey === 'TierThree';
 	const isNationalDelivery = productKey === 'NationalDelivery';
-	const validEmail = order.email !== '';
+	const { email } = order;
+	const validEmail = email !== '';
 	const { enablePremiumDigital } = getFeatureFlags();
 
 	// Clarify Guardian Ad-lite thankyou page states
@@ -267,7 +268,7 @@ export function ThankYouComponent({
 		isSupporterPlus,
 		isTierThree,
 		startDate,
-		undefined,
+		email,
 		undefined,
 		benefitsChecklist,
 		undefined,


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Pass email from local storage order to the thankYouModuleData for the support Reminder module
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?
SupportReminder module needs the email to be present in order to create a reminder. we were passing nothing. 
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
