### PR TITLE
Premium Digital: Newspaper archive ThankYou module  updates

### DIFF
--- a/support-frontend/assets/components/thankYou/newspaperArchive/newspaperArchiveImage.tsx
+++ b/support-frontend/assets/components/thankYou/newspaperArchive/newspaperArchiveImage.tsx
@@ -28,7 +28,6 @@ const desktopImg = css`
 	margin-left: auto;
 	margin-top: -${space[2]}px; // padding-top over-run
 	margin-bottom: -${space[5]}px; // padding-bottom over-run
-	overflow: hidden;
 
 	& img {
 		width: 100%;

--- a/support-frontend/assets/components/thankYou/newspaperArchive/newspaperArchiveImage.tsx
+++ b/support-frontend/assets/components/thankYou/newspaperArchive/newspaperArchiveImage.tsx
@@ -28,6 +28,7 @@ const desktopImg = css`
 	margin-left: auto;
 	margin-top: -${space[2]}px; // padding-top over-run
 	margin-bottom: -${space[5]}px; // padding-bottom over-run
+	overflow: hidden;
 
 	& img {
 		width: 100%;

--- a/support-frontend/assets/components/thankYou/thankYouModule.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModule.tsx
@@ -167,6 +167,7 @@ const imgContainer = css`
 	grid-area: img;
 	align-self: flex-end;
 `;
+
 const sizeImgContainer = css`
 	margin-top: ${space[2]}px;
 	${until.tablet} {
@@ -195,7 +196,9 @@ const paddingRightApps = css`
 	}
 `;
 
-const imageryPadding = css`
+const imageryStyle = css`
+	overflow: hidden;
+
 	${until.tablet} {
 		padding-bottom: 0;
 	}
@@ -302,7 +305,7 @@ function ThankYouModule({
 
 	return (
 		<section
-			css={[container, maybePaddingRight, hasImagery && imageryPadding]}
+			css={[container, maybePaddingRight, hasImagery && imageryStyle]}
 			data-testid={`${TEST_ID_PREFIX}-${moduleType}`}
 		>
 			<div css={gridContainer}>

--- a/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
+++ b/support-frontend/assets/components/thankYou/thankYouModuleData.tsx
@@ -239,9 +239,10 @@ export const getThankYouModuleData = (
 			header: 'The Guardian newspaper archive',
 			bodyCopy: (
 				<>
-					Sign in to start exploring more than 200 years of world history with
-					our newspaper archive. View digital reproductions of every front page,
-					article and advertisement as it was printed in the Guardian from 1821.
+					Sign in and start exploring more than 200 years of world history with
+					our newspapers archive. View digital reproductions of every front
+					page, article and advertisement printed in the Guardian from 1821 and
+					in the Observer from 1791.
 				</>
 			),
 			ctas: null,

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -310,7 +310,7 @@ export function ThankYouComponent({
 		),
 		...maybeThankYouModule(isDigitalEdition, 'appDownloadEditions'),
 		...maybeThankYouModule(
-			isTierThree && enablePremiumDigital,
+			isDigitalEdition && enablePremiumDigital,
 			'newspaperArchiveBenefit',
 		),
 		...maybeThankYouModule(countryId === 'AU', 'ausMap'),

--- a/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/thankYouComponent.tsx
@@ -290,10 +290,6 @@ export function ThankYouComponent({
 		...maybeThankYouModule(userNotSignedIn && !isGuardianAdLite, 'signIn'), // Sign in to access your benefits
 		...maybeThankYouModule(isTierThree, 'benefits'),
 		...maybeThankYouModule(
-			isTierThree && enablePremiumDigital,
-			'newspaperArchiveBenefit',
-		),
-		...maybeThankYouModule(
 			isTierThree || isNationalDelivery,
 			'subscriptionStart',
 		),
@@ -313,6 +309,10 @@ export function ThankYouComponent({
 			'feedback',
 		),
 		...maybeThankYouModule(isDigitalEdition, 'appDownloadEditions'),
+		...maybeThankYouModule(
+			isTierThree && enablePremiumDigital,
+			'newspaperArchiveBenefit',
+		),
 		...maybeThankYouModule(countryId === 'AU', 'ausMap'),
 		...maybeThankYouModule(
 			!isTierThree && !isGuardianAdLite && !isPrint,


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
A few changes on for the newspaper archive thank you module:
- change order to last position
- update copy
- Fix bleeding images in leftCol screen size
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com/c/fuqLTW5B/1916-thankyou-display-newspaper-archive-component)

## Why are you doing this?
Newspaper Archive benefit is part of the Premium Digital product 

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
1. go to a [DigitalSubscription Thank You page](https://support.thegulocal.com/uk/thank-you?product=DigitalSubscription&ratePlan=Monthly&enablePremiumDigital)
2. open the console and run the following command.
```
sessionStorage.setItem('thankYouOrder', JSON.stringify({"value":{"firstName":"John","email":"testing@theguardian.com","paymentMethod":"DirectDebit","status":"success"}}))
```
3. Refresh the page


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
### Mobile
![iPhone 12 Pro-1759247053152](https://github.com/user-attachments/assets/a1f43205-2583-4d72-b690-4ed8e28d71d9)

### Tablet
![iPad-1759247051594](https://github.com/user-attachments/assets/8329c996-7d4f-4c9c-8032-28826e859a35)

### Desktop
![MacBook Pro-1759247049941](https://github.com/user-attachments/assets/4f2e2203-0c15-4e20-a59c-8f680835d84e)
