### PR TITLE
Copy changes for Guardian Ad-Lite

### DIFF
--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -231,7 +231,7 @@ const supporterPlusBenefits = [
 
 const guardianAdLiteBenefits = [
 	{
-		copy: 'A Guardian Ad-Lite subscription enables you to read the Guardian website without personalised advertising.',
+		copy: 'A Guardian Ad-Lite subscription enables you to read the Guardian website without personalised advertising (except for when we host third party content, like videos).',
 	},
 	{
 		copy: 'You will still see non-personalised advertising.',

--- a/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/helpers/adLiteFAQs.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/guardianAdLiteLanding/helpers/adLiteFAQs.tsx
@@ -9,9 +9,10 @@ export const adLiteFAQs: FAQItem[] = [
 			<>
 				<p>
 					A Guardian Ad-Lite subscription enables you to read the Guardian
-					website without personalised advertising. You will still see
-					advertising but it will be delivered without the use of personalised
-					advertising cookies or similar technologies.
+					website without personalised advertising (except for when we host
+					third party content, like videos). You will still see advertising but
+					it will be delivered without the use of personalised advertising
+					cookies or similar technologies.
 				</p>
 				<p>
 					A Guardian Ad-Lite subscription does not entitle you to the additional


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR updates copy on the Guardian Ad-Lite landing page to add the qualification '(except for when we host third party content, like videos)' wherever personalised advertising is mentioned.

[**Trello Card**](https://trello.com/c/G8Y8rHGW/1842-update-wording-on-the-landing-page-uk-eu)

## Screenshots
First bullet point has the phrase added:
<img width="491" height="471" alt="Screenshot 2025-10-03 at 14 49 48" src="https://github.com/user-attachments/assets/3fe6bc25-684c-4570-8314-bcf440ae884a" />
This carries through to the checkout:
<img width="671" height="314" alt="Screenshot 2025-10-03 at 14 50 14" src="https://github.com/user-attachments/assets/807d8518-786e-4dd0-90fb-4ab4cdcc8e31" />
First FAQ point is also updated:
<img width="671" height="314" alt="Screenshot 2025-10-03 at 14 50 02" src="https://github.com/user-attachments/assets/523867cc-7e50-4a71-90e7-7d0003b698cb" />


## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
