### PR TITLE
Guardian Weekly Gift: Enable Test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -90,7 +90,7 @@ export const tests: Tests = {
 				size: 1,
 			},
 		},
-		isActive: false,
+		isActive: true,
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 9,
 		targetPage: pageUrlRegexes.subscriptions.subsWeeklyGiftPages,


### PR DESCRIPTION
## What are you doing in this PR?
Enables ab-test `guardianWeeklyGiftGenericCheckout`
[**Trello Card**](https://trello.com/c/QsGOhnyf/1923-launch-gw-gifting-a-b-test)

## Why are you doing this / Screenshots?
Sets the following test live ->
|old|new|
|----|----|
|<img width="590" height="1333" alt="image" src="https://github.com/user-attachments/assets/dce7fc92-5d06-4cb1-950f-b0623205db81" />|<img width="518" height="1333" alt="image" src="https://github.com/user-attachments/assets/6484d820-58f7-4c9b-ac9b-077ea415ae38" />|

## How to test
old: https://support.thegulocal.com/subscribe/weekly/checkout/gift?period=Quarterly
new: https://support.thegulocal.com/uk/checkout?product=GuardianWeeklyDomestic&ratePlan=ThreeMonthGift

## How can we measure success?
TODO
