### PR TITLE
Make contribution amount optional on checkout

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -146,19 +146,14 @@ export function Checkout({
 
 	let promotion;
 	if (productKey === 'Contribution') {
-		/**
-		 * Contributions are dynamic amounts, often selected from the `amounts` from RRCP
-		 * @see https://support.gutools.co.uk/amounts
-		 */
-		if (!contributionAmount) {
-			logException('Contribution not specified');
-			return <div>Contribution not specified</div>;
-		}
+		// Use the amount from the url if provided, otherwise use the product catalog amount
+		const amount =
+			contributionAmount ?? (ratePlan.pricing[currencyKey] as number);
 
 		payment = {
-			contributionAmount,
-			originalAmount: contributionAmount,
-			finalAmount: contributionAmount,
+			contributionAmount: amount,
+			originalAmount: amount,
+			finalAmount: amount,
 		};
 	} else {
 		const productPrice =


### PR DESCRIPTION
The recurring contribution checkout requires a contribution amount, e.g.
`/checkout?product=Contribution&ratePlan=Monthly&contribution=4`
If the `contribution` param isn't supplied then there's an error -
<img width="176" height="37" alt="Screenshot 2025-10-07 at 11 04 39" src="https://github.com/user-attachments/assets/790448b7-fcb6-49fb-b724-e08f3a2fa810" />


We want to link direct to checkout from the choice cards (in epic + banner). Currently the DCR page doesn't know about the contribution amount. We always use the amount from the product catalog, so we can just fall back on this value if the url doesn't specify an amount.

This PR makes it possible to visit e.g.
`/checkout?product=Contribution&ratePlan=Monthly`
and it will choose the contribution amount from the product catalog instead of showing an error.