### PR TITLE
Adding /favicon.ico to the list of exclusions to the Observer Archive redirect

### DIFF
--- a/support-frontend/conf/fastly-snippets/observerarchive-redirect-recv.vcl
+++ b/support-frontend/conf/fastly-snippets/observerarchive-redirect-recv.vcl
@@ -3,6 +3,8 @@ if (req.http.host ~ "^observer\." &&
     (req.method == "GET" || req.method == "HEAD") &&
     !req.url ~ "^/uk/checkout" &&
     !req.url ~ "^/uk/thank-you" &&
-    !req.url ~ "^/assets/") {
+    !req.url ~ "^/assets/" &&
+    !req.url ~ "^/favicon.ico"
+  ) {
   error 802 "redirect";
 }


### PR DESCRIPTION
## What are you doing in this PR?
Adding /favicon.ico to the list of exclusions to the Observer Archive redirect.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

## [Trello Card](https://trello.com)
https://trello.com/c/VpzTq7pQ/1941-move-observertheguardiancom-domain-from-the-www-fastly-service-to-the-support-fastly-service

## Why are you doing this?
Because the favicon should display rather than redirect.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
- [x] Visit https://observer.code.dev-theguardian.com/favicon.ico and confirm it shows or downloads the icon and does not redirect anywhere.

## How to verify post-merging
- [ ] Visit https://observer.theguardian.com/favicon.ico and confirm it shows or downloads the icon and does not redirect anywhere.