### PR TITLE
feat: checkout displays GuardianWeekly/TierThree dates using weeklyDe…

### DIFF
--- a/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.tsx
+++ b/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.tsx
@@ -87,6 +87,7 @@ export interface OrderSummaryTsAndCsProps {
 	countryGroupId: CountryGroupId;
 	promotion?: Promotion;
 	thresholdAmount?: number;
+	deliveryDate?: Date;
 }
 export function OrderSummaryTsAndCs({
 	productKey,
@@ -95,6 +96,7 @@ export function OrderSummaryTsAndCs({
 	countryGroupId,
 	promotion,
 	thresholdAmount = 0,
+	deliveryDate,
 }: OrderSummaryTsAndCsProps): JSX.Element | null {
 	const billingPeriod = ratePlanToBillingPeriod(ratePlanKey);
 	const periodNoun = getBillingPeriodNoun(billingPeriod);
@@ -110,11 +112,13 @@ export function OrderSummaryTsAndCs({
 		thresholdAmount,
 		promotion,
 	); // promoMessage expected to be a string like: "£10.49/month for the first 6 months, then £20.99/month"
-	const deliveryDate = productDeliveryOrStartDate(
-		productKey,
-		ratePlanKey as ActivePaperProductOptions,
-	);
-	const deliveryStartDate = deliveryDate ? formatUserDate(deliveryDate) : '';
+	const deliveryStart =
+		deliveryDate ??
+		productDeliveryOrStartDate(
+			productKey,
+			ratePlanKey as ActivePaperProductOptions,
+		);
+	const deliveryStartDate = deliveryStart ? formatUserDate(deliveryStart) : '';
 	const rateDescriptor = ratePlanDescription
 		? ratePlanDescription
 				.replace(/^The\s+/i, '') // Remove "The" at the start, case-insensitive, with following space

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
@@ -25,7 +25,10 @@ import { getBillingPeriodNoun } from 'helpers/productPrice/billingPeriods';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { parameteriseUrl } from 'helpers/urls/routes';
-import { isGuardianWeeklyGiftProduct } from 'pages/supporter-plus-thank-you/components/thankYouHeader/utils/productMatchers';
+import {
+	isGuardianWeeklyGiftProduct,
+	isGuardianWeeklyOrTierThreeProduct,
+} from 'pages/supporter-plus-thank-you/components/thankYouHeader/utils/productMatchers';
 import type { LandingPageVariant } from '../../../helpers/globalsAndSwitches/landingPageSettings';
 import { formatUserDate } from '../../../helpers/utilities/dateConversions';
 import { getSupportRegionIdConfig } from '../../supportRegionConfig';
@@ -208,6 +211,11 @@ export default function CheckoutSummary({
 							countryGroupId={countryGroupId}
 							thresholdAmount={thresholdAmount}
 							promotion={promotion}
+							deliveryDate={
+								isGuardianWeeklyOrTierThreeProduct(productKey)
+									? weeklyDeliveryDate
+									: undefined
+							}
 						/>
 					}
 					headerButton={


### PR DESCRIPTION
…liveryDate state

<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
