### PR TITLE
GuardianWeekly: WeeklyGift Billing Address test amendment

### DIFF
--- a/support-e2e/tests/utils/testUserDetails.ts
+++ b/support-e2e/tests/utils/testUserDetails.ts
@@ -87,7 +87,8 @@ export const setTestUserDetails = async (
 	ratePlan: string,
 ) => {
 	const stateLabel = internationalisationId === 'CA' ? 'Province' : 'State';
-	if (['3MonthGift', 'OneYearGift'].includes(ratePlan)) {
+	const isWeeklyGift = ['3MonthGift', 'OneYearGift'].includes(ratePlan);
+	if (isWeeklyGift) {
 		await setGiftingCoreDetails(
 			page,
 			testFields.email,
@@ -115,7 +116,7 @@ export const setTestUserDetails = async (
 		if (testFields.addresses.length > 1) {
 			await page
 				.getByRole('checkbox', {
-					name: 'Billing address same as delivery address',
+					name: `Billing address same as ${isWeeklyGift ? `recipient's` : 'delivery'} address`,
 				})
 				.uncheck();
 		}


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Trello Card**](https://trello.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
