### PR TITLE
Feature switch local overrides

### DIFF
--- a/support-frontend/assets/helpers/globalsAndSwitches/globals.test.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/globals.test.ts
@@ -148,8 +148,8 @@ describe('getGlobal', () => {
 describe('isSwitchOn', () => {
 	beforeEach(() => {
 		sessionStorage.clear();
-		// @ts-expect-error -- incomplete type
 		window.guardian = {
+			// @ts-expect-error -- incomplete type
 			settings: {
 				switches: {
 					...emptySwitches,

--- a/support-frontend/assets/helpers/globalsAndSwitches/globals.test.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/globals.test.ts
@@ -3,6 +3,7 @@ import {
 	emptyConfiguredRegionAmounts,
 	emptySwitches,
 	getGlobal,
+	isSwitchOn,
 } from './globals';
 
 const getSpecifiedRegionAmountsFromGlobal = (
@@ -141,5 +142,50 @@ describe('getGlobal', () => {
 		expect(
 			getGlobal('settings.switches.experiments.myLovelyExperiment'),
 		).toBeNull();
+	});
+});
+
+describe('isSwitchOn', () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+		window.guardian = {
+			// @ts-expect-error -- incomplete type
+			settings: {
+				switches: {
+					...emptySwitches,
+					featureSwitches: {
+						myFeature: 'On',
+						myDisabledFeature: 'Off',
+					},
+				},
+			},
+		};
+	});
+
+	it('falls back to the global setting and returns true if no override is present in session storage', () => {
+		expect(isSwitchOn('featureSwitches.myFeature')).toBe(true);
+	});
+
+	it('returns true when the session storage override is "On"', () => {
+		sessionStorage.setItem('myFeature', 'On');
+		expect(isSwitchOn('featureSwitches.myFeature')).toBe(true);
+	});
+
+	it('returns false when the session storage override is "Off" for myFeature', () => {
+		sessionStorage.setItem('myFeature', 'Off');
+		expect(isSwitchOn('featureSwitches.myFeature')).toBe(false);
+	});
+
+	it('falls back to the global setting and returns false if no override is present in session storage', () => {
+		expect(isSwitchOn('featureSwitches.myDisabledFeature')).toBe(false);
+	});
+
+	it('returns true when the session storage override is "On" for myDisabledFeature', () => {
+		sessionStorage.setItem('myDisabledFeature', 'On');
+		expect(isSwitchOn('featureSwitches.myDisabledFeature')).toBe(true);
+	});
+
+	it('returns false when neither session storage nor globals have a value for the switch', () => {
+		expect(isSwitchOn('featureSwitches.nonExistentFeature')).toBe(false);
 	});
 });

--- a/support-frontend/assets/helpers/globalsAndSwitches/globals.test.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/globals.test.ts
@@ -1,3 +1,4 @@
+import { storage } from '@guardian/libs';
 import type { AmountsTest, AmountsTests } from 'helpers/contributions';
 import {
 	emptyConfiguredRegionAmounts,
@@ -147,7 +148,7 @@ describe('getGlobal', () => {
 
 describe('isSwitchOn', () => {
 	beforeEach(() => {
-		sessionStorage.clear();
+		storage.session.clear();
 		window.guardian = {
 			// @ts-expect-error -- incomplete type
 			settings: {
@@ -167,12 +168,12 @@ describe('isSwitchOn', () => {
 	});
 
 	it('returns true when the session storage override is "On"', () => {
-		sessionStorage.setItem('myFeature', 'On');
+		storage.session.set('myFeature', 'On');
 		expect(isSwitchOn('featureSwitches.myFeature')).toBe(true);
 	});
 
 	it('returns false when the session storage override is "Off" for myFeature', () => {
-		sessionStorage.setItem('myFeature', 'Off');
+		storage.session.set('myFeature', 'Off');
 		expect(isSwitchOn('featureSwitches.myFeature')).toBe(false);
 	});
 
@@ -181,7 +182,7 @@ describe('isSwitchOn', () => {
 	});
 
 	it('returns true when the session storage override is "On" for myDisabledFeature', () => {
-		sessionStorage.setItem('myDisabledFeature', 'On');
+		storage.session.set('myDisabledFeature', 'On');
 		expect(isSwitchOn('featureSwitches.myDisabledFeature')).toBe(true);
 	});
 

--- a/support-frontend/assets/helpers/globalsAndSwitches/globals.test.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/globals.test.ts
@@ -148,8 +148,8 @@ describe('getGlobal', () => {
 describe('isSwitchOn', () => {
 	beforeEach(() => {
 		sessionStorage.clear();
+		// @ts-expect-error -- incomplete type
 		window.guardian = {
-			// @ts-expect-error -- incomplete type
 			settings: {
 				switches: {
 					...emptySwitches,

--- a/support-frontend/assets/helpers/globalsAndSwitches/globals.test.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/globals.test.ts
@@ -158,6 +158,9 @@ describe('isSwitchOn', () => {
 						myFeature: 'On',
 						myDisabledFeature: 'Off',
 					},
+					subscriptionsSwitches: {
+						useDotcomContactPage: 'On',
+					},
 				},
 			},
 		};
@@ -184,6 +187,11 @@ describe('isSwitchOn', () => {
 	it('returns true when the session storage override is "On" for myDisabledFeature', () => {
 		storage.session.set('myDisabledFeature', 'On');
 		expect(isSwitchOn('featureSwitches.myDisabledFeature')).toBe(true);
+	});
+
+	it('ignores session storage overrides for non-featureSwitches groups', () => {
+		sessionStorage.setItem('useDotcomContactPage', 'Off');
+		expect(isSwitchOn('subscriptionsSwitches.useDotcomContactPage')).toBe(true);
 	});
 
 	it('returns false when neither session storage nor globals have a value for the switch', () => {

--- a/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
@@ -157,14 +157,11 @@ const getPromotionCopy = (): PromotionCopy | null =>
 	getGlobal<PromotionCopy>('promotionCopy');
 
 const isSwitchOn = (switchName: string): boolean => {
-	let sw;
+	const sw =
+		getLocal<Status>(switchName) ??
+		getGlobal<Status>(`settings.switches.${switchName}`);
 
-	sw = getLocal<Status>(switchName);
-
-	if (!sw) {
-		sw = getGlobal<Status>(`settings.switches.${switchName}`);
-	}
-	return !!(sw && sw === 'On');
+	return sw === 'On';
 };
 
 export {

--- a/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
@@ -28,7 +28,7 @@ function getGlobal<T>(path = ''): T | null {
 }
 
 function getLocal<T>(path = ''): T | null {
-	// feature flags path is n the format 'featureSwitches.featureFlagName' and we want to
+	// feature flags path is in the format 'featureSwitches.featureFlagName' and we want to
 	// extract the 'featureFlagName' part to check if there is an override in sessionStorage
 
 	const [flag] = path.split('.').slice(-1);

--- a/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
@@ -46,7 +46,10 @@ function getLocal<T>(path = ''): T | null {
 
 		return null;
 	} catch (e) {
-		console.error('Failed to read overrides:', e);
+		console.error(
+			`Failed to read overrides for flag "${flag}" from path "${path}":`,
+			e,
+		);
 		return null;
 	}
 }

--- a/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
@@ -28,15 +28,13 @@ function getGlobal<T>(path = ''): T | null {
 }
 
 function getLocal<T>(path = ''): T | null {
+	// feature flags path is n the format 'featureSwitches.featureFlagName' and we want to
+	// extract the 'featureFlagName' part to check if there is an override in sessionStorage
+
+	const [flag] = path.split('.').slice(-1);
+
 	try {
-		const localSwitches = sessionStorage.getItem('switches');
-		const parsedSwitches = localSwitches ? JSON.parse(localSwitches) : {};
-		const value = path.split('.').reduce((config, key) => {
-			if (isRecord(config)) {
-				return config[key];
-			}
-			return config;
-		}, parsedSwitches);
+		const value = flag && sessionStorage.getItem(flag);
 		if (value) {
 			return value as T;
 		}

--- a/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
@@ -1,3 +1,4 @@
+import { storage } from '@guardian/libs';
 import type { CountryGroupId } from '@modules/internationalisation/countryGroup';
 import type { Settings, Status } from 'helpers/globalsAndSwitches/settings';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
@@ -34,7 +35,7 @@ function getLocal<T>(path = ''): T | null {
 	const [flag] = path.split('.').slice(-1);
 
 	try {
-		const value = flag && sessionStorage.getItem(flag);
+		const value = flag && storage.session.get(flag);
 		if (value) {
 			return value as T;
 		}

--- a/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
@@ -162,8 +162,7 @@ const isSwitchOn = (switchName: string): boolean => {
 		: null;
 
 	const sw =
-		localOverride ??
-		getGlobal<Status>(`settings.switches.${switchName}`);
+		localOverride ?? getGlobal<Status>(`settings.switches.${switchName}`);
 
 	return sw === 'On';
 };

--- a/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
@@ -157,8 +157,12 @@ const getPromotionCopy = (): PromotionCopy | null =>
 	getGlobal<PromotionCopy>('promotionCopy');
 
 const isSwitchOn = (switchName: string): boolean => {
+	const localOverride = switchName.startsWith('featureSwitches.')
+		? getLocal<Status>(switchName)
+		: null;
+
 	const sw =
-		getLocal<Status>(switchName) ??
+		localOverride ??
 		getGlobal<Status>(`settings.switches.${switchName}`);
 
 	return sw === 'On';

--- a/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
@@ -32,6 +32,10 @@ function getLocal<T>(path = ''): T | null {
 	// feature flags path is in the format 'featureSwitches.featureFlagName' and we want to
 	// extract the 'featureFlagName' part to check if there is an override in sessionStorage
 
+	if (!storage.session.isAvailable()) {
+		return null;
+	}
+
 	const [flag] = path.split('.').slice(-1);
 
 	try {

--- a/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/globals.ts
@@ -27,6 +27,27 @@ function getGlobal<T>(path = ''): T | null {
 	return null;
 }
 
+function getLocal<T>(path = ''): T | null {
+	try {
+		const localSwitches = sessionStorage.getItem('switches');
+		const parsedSwitches = localSwitches ? JSON.parse(localSwitches) : {};
+		const value = path.split('.').reduce((config, key) => {
+			if (isRecord(config)) {
+				return config[key];
+			}
+			return config;
+		}, parsedSwitches);
+		if (value) {
+			return value as T;
+		}
+
+		return null;
+	} catch (e) {
+		console.error('Failed to read overrides:', e);
+		return null;
+	}
+}
+
 const emptyAmountsTestVariants: AmountsVariant[] = [
 	{
 		variantName: 'CONTROL',
@@ -138,7 +159,13 @@ const getPromotionCopy = (): PromotionCopy | null =>
 	getGlobal<PromotionCopy>('promotionCopy');
 
 const isSwitchOn = (switchName: string): boolean => {
-	const sw = getGlobal<Status>(`settings.switches.${switchName}`);
+	let sw;
+
+	sw = getLocal<Status>(switchName);
+
+	if (!sw) {
+		sw = getGlobal<Status>(`settings.switches.${switchName}`);
+	}
 	return !!(sw && sw === 'On');
 };
 


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Lookup for a session storage feature flag override before reading from the global object (aka `windows.guardian.settings.swtiches`).
To keep things simple, we will storage overrides as simple key/value entries instead of mimicking the entire featureSwitches object.
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[Build local override logic for feature switches](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1213748188214735?focus=true)

## Why are you doing this?
This allows features to be tested before turning them on for all envs without the need to carry feature flag as url params.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

1. Go to a [supporterPlus thank-you page](https://support.thegulocal.com/uk/thank-you?product=SupporterPlus&ratePlan=Annual&userType=current&step=summary)
2. Open the console and paste the following snippet
```
sessionStorage.setItem('thankYouOrder', JSON.stringify({"value":{"firstName":"john","email":"testing@theguardian.com","paymentMethod":"DirectDebit","status":"success"}}))
```
3. Turn off the `enableThankYouOnboarding` flag by running the following snippet in the console
```
sessionStorage.setItem('enableThankYouOnboarding', 'Off')
```
4. Refresh the page and see old ThankYou page.
5. Set the flag to "On" by using the `sessionStorage.setItem .setItem` function or delete it from sessionStorage
6. Refresh the page and see new ThankYou onboarding page

## Screenshots
| No Override or enableThankYouOnboarding: On | enableThankYouOnboarding: Off |
| --- | --- |
| <img width="1401" height="1141" alt="Screenshot 2026-04-15 at 15 00 26" src="https://github.com/user-attachments/assets/097e75a7-9c08-433f-8d7b-0ae0c872fe0c" />|<img width="1408" height="1097" alt="Screenshot 2026-04-15 at 15 00 39" src="https://github.com/user-attachments/assets/aa4a2bd0-ab05-4c3a-acbc-343ddd98df84" />|