### PR TITLE
Add an additional transaction declined error to ignore

### DIFF
--- a/support-workers/src/typescript/errors/zuoraErrors.ts
+++ b/support-workers/src/typescript/errors/zuoraErrors.ts
@@ -18,6 +18,7 @@ const transactionDeclinedMessages = [
 	'Transaction declined.402 - [card_error/card_declined/revocation_of_all_authorizations] Your card was declined.',
 	'Transaction declined.402 - [card_error/authentication_required/authentication_required] Your card was declined. This transaction requires authentication.',
 	'Transaction declined.402 - [card_error/card_declined/fraudulent] Your card was declined.',
+	'Transaction declined.402 - [card_error/card_declined/reenter_transaction] Your card was declined.',
 	'Transaction declined.402 - [card_error/expired_card/expired_card] Your card has expired.',
 	'Transaction declined.402 - [card_error/processing_error/processing_error] An error occurred while processing your card. Try again in a little bit.',
 	'Transaction declined.10417 - Instruct the customer to retry the transaction using an alternative payment method from the customers PayPal wallet.',


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR adds a new Stripe transaction declined error into the list of errors that we will not alarm on - 'Transaction declined.402 - [card_error/card_declined/reenter_transaction] Your card was declined.'

We saw this error in a failed execution on Mar 29, 2026, 20:28:38.346