### PR TITLE
Newspaper April Campaign terms and conditions 

### DIFF
--- a/support-frontend/assets/components/product/productOption.tsx
+++ b/support-frontend/assets/components/product/productOption.tsx
@@ -10,6 +10,7 @@ import { BillingPeriod } from '@modules/product/billingPeriod';
 import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 import { useHasBeenSeen } from 'helpers/customHooks/useHasBeenSeen';
+import type { Promotion } from 'helpers/productPrice/promotions';
 import {
 	Channel,
 	type ProductLabelProps,
@@ -60,6 +61,7 @@ export type Product = {
 	unavailableOutsideLondon?: boolean;
 	planData?: PlanData;
 	children?: ReactNode;
+	promotion?: Promotion;
 };
 
 function ProductOption(props: Product): JSX.Element {

--- a/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperProductTabs.test.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperProductTabs.test.tsx
@@ -1,8 +1,17 @@
 import { render, screen } from '@testing-library/react';
+import { PromoTermsProvider } from 'contexts/PromoTermsContext';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import * as subscriptionsModule from 'helpers/productPrice/subscriptions';
 import { getPlans } from '../helpers/getPlans';
 import NewspaperProductTabs from './NewspaperProductTabs';
+
+function renderWithPromoTermsProvider(productPrices: ProductPrices) {
+	return render(
+		<PromoTermsProvider>
+			<NewspaperProductTabs productPrices={productPrices} />
+		</PromoTermsProvider>,
+	);
+}
 
 jest.mock('../helpers/getPlans');
 jest.mock('pages/aus-moment-map/hooks/useWindowWidth', () => ({
@@ -24,7 +33,7 @@ describe('NewspaperProductTabs', () => {
 	});
 
 	it('should set the collect in store as the initial active tab', () => {
-		render(<NewspaperProductTabs productPrices={productPrices} />);
+		renderWithPromoTermsProvider(productPrices);
 
 		const tab = screen.getByRole('tab', { selected: true });
 
@@ -45,7 +54,7 @@ describe('NewspaperProductTabs', () => {
 			);
 
 			// Act
-			render(<NewspaperProductTabs productPrices={productPrices} />);
+			renderWithPromoTermsProvider(productPrices);
 
 			screen
 				.getByRole('tab', {

--- a/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperProductTabs.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperProductTabs.tsx
@@ -113,7 +113,6 @@ function NewspaperProductTabs({
 					paperFulfilment={selectedTab}
 					productPrices={productPrices}
 					activePaperProducts={ActivePaperProductTypes}
-					paperPromotions={promotions}
 				/>
 			</CentredContainer>
 		</FullWidthContainer>

--- a/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperProductTabs.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperProductTabs.tsx
@@ -6,6 +6,7 @@ import CentredContainer from 'components/containers/centredContainer';
 import FullWidthContainer from 'components/containers/fullWidthContainer';
 import Carousel from 'components/product/Carousel';
 import Tabs, { type TabProps } from 'components/tabs/tabs';
+import { usePromoTerms } from 'contexts/PromoTermsContext';
 import { ActivePaperProductTypes } from 'helpers/productCatalogToProductOption';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { sendTrackingEventsOnClick } from 'helpers/productPrice/subscriptions';
@@ -51,6 +52,7 @@ function NewspaperProductTabs({
 		useState<PaperFulfilmentOptions>(paperFulfilment);
 
 	const { windowWidthIsGreaterThan } = useWindowWidth();
+	const { setPromoTerms } = usePromoTerms();
 
 	const promotions = useMemo(
 		() =>
@@ -76,6 +78,8 @@ function NewspaperProductTabs({
 			componentType: 'ACQUISITIONS_BUTTON',
 		})();
 		windowSetHashProperty(tabId);
+		// clean promo terms when switching tabs, as they are specific to each tab's offers
+		setPromoTerms(null);
 	};
 
 	const tabItems = Object.entries(tabs).map(([fulfilment, tab]) => {

--- a/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperRatePlanCard.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperRatePlanCard.tsx
@@ -5,12 +5,14 @@ import {
 	themeButtonReaderRevenueBrand,
 } from '@guardian/source/react-components';
 import { useEffect } from 'react';
+import { usePromoTerms } from 'contexts/PromoTermsContext';
 import { useHasBeenSeen } from 'helpers/customHooks/useHasBeenSeen';
 import { useWindowWidth } from 'pages/aus-moment-map/hooks/useWindowWidth';
 import { Channel } from 'pages/paper-subscription-landing/helpers/products';
 import BenefitsList from '../../../components/product/BenefitsList';
 import Collapsible from '../../../components/product/Collapsible';
 import { type Product } from '../../../components/product/productOption';
+import getNewspaperPromoTerms from '../helpers/getNewspaperPromoTerms';
 import {
 	badge,
 	badgeObserver,
@@ -36,6 +38,7 @@ function NewspaperRatePlanCard({
 	savingsText,
 	planData,
 	offerCopy,
+	promotion,
 	buttonCopy,
 	href,
 	onClick,
@@ -44,6 +47,7 @@ function NewspaperRatePlanCard({
 	productLabel,
 	unavailableOutsideLondon,
 }: Product) {
+	console.log('🚀 ~ NewspaperRatePlanCard ~ promotion:', promotion);
 	const [hasBeenSeen, setElementToObserve] = useHasBeenSeen({
 		threshold: 0.5,
 		debounce: true,
@@ -59,10 +63,16 @@ function NewspaperRatePlanCard({
 	 * true.
 	 * */
 	useEffect(() => {
-		if (hasBeenSeen) {
-			onView();
-		}
+		hasBeenSeen && onView();
 	}, [hasBeenSeen]);
+
+	useEffect(() => {
+		const { setPromoTerms } = usePromoTerms();
+		if (promotion?.expires) {
+			const promoTerms = getNewspaperPromoTerms(promotion);
+			setPromoTerms(promoTerms);
+		}
+	}, [promotion]);
 
 	const isObserverChannel = productLabel?.channel === Channel.Observer;
 

--- a/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperRatePlanCard.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperRatePlanCard.tsx
@@ -54,6 +54,7 @@ function NewspaperRatePlanCard({
 
 	const { windowWidthIsGreaterThan } = useWindowWidth();
 	const { setPromoTerms } = usePromoTerms();
+	const isObserver = productLabel?.channel === Channel.Observer;
 
 	/**
 	 * The first time this runs hasBeenSeen
@@ -67,11 +68,9 @@ function NewspaperRatePlanCard({
 	}, [hasBeenSeen]);
 
 	useEffect(() => {
-		if (promotion?.expires) {
+		if (promotion?.expires && !isObserver) {
 			const promoTerms = getNewspaperPromoTerms(promotion);
 			setPromoTerms(promoTerms);
-		} else {
-			setPromoTerms(null);
 		}
 	}, [promotion]);
 
@@ -153,7 +152,7 @@ function NewspaperRatePlanCard({
 				>
 					{buttonCopy}
 				</LinkButton>
-				<p css={cardOffer}>{offerCopy}</p>
+				{offerCopy && <p css={cardOffer}>{offerCopy}</p>}
 			</div>
 
 			<p css={planDescription}>{planData?.description}</p>

--- a/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperRatePlanCard.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperRatePlanCard.tsx
@@ -47,7 +47,6 @@ function NewspaperRatePlanCard({
 	productLabel,
 	unavailableOutsideLondon,
 }: Product) {
-	console.log('🚀 ~ NewspaperRatePlanCard ~ promotion:', promotion);
 	const [hasBeenSeen, setElementToObserve] = useHasBeenSeen({
 		threshold: 0.5,
 		debounce: true,

--- a/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperRatePlanCard.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/NewspaperRatePlanCard.tsx
@@ -53,6 +53,7 @@ function NewspaperRatePlanCard({
 	});
 
 	const { windowWidthIsGreaterThan } = useWindowWidth();
+	const { setPromoTerms } = usePromoTerms();
 
 	/**
 	 * The first time this runs hasBeenSeen
@@ -66,10 +67,11 @@ function NewspaperRatePlanCard({
 	}, [hasBeenSeen]);
 
 	useEffect(() => {
-		const { setPromoTerms } = usePromoTerms();
 		if (promotion?.expires) {
 			const promoTerms = getNewspaperPromoTerms(promotion);
 			setPromoTerms(promoTerms);
+		} else {
+			setPromoTerms(null);
 		}
 	}, [promotion]);
 

--- a/support-frontend/assets/pages/paper-subscription-landing/components/PaperLandingTsAndCs.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/PaperLandingTsAndCs.tsx
@@ -5,10 +5,7 @@ import { observerLinks } from 'helpers/legal';
 import type { ActivePaperProductOptions } from 'helpers/productCatalogToProductOption';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import type { PaperPromotion } from '../helpers/getPromotions';
-import {
-	productExpiryAdjust,
-	productInfoWrapper,
-} from './PaperLandingTsAndCsStyles';
+import { productInfoWrapper } from './PaperLandingTsAndCsStyles';
 import PaperPromotionExpiries from './PaperPromotionExpiries';
 
 type PaperLandingTsAndCsProps = {
@@ -19,21 +16,10 @@ type PaperLandingTsAndCsProps = {
 };
 export default function PaperLandingTsAndCs({
 	paperFulfilment,
-	paperPromotions,
 }: PaperLandingTsAndCsProps): JSX.Element {
-	const paperPromosWithExpiry = paperPromotions?.filter(
-		(paperPromotion) => paperPromotion.expires,
-	);
-	const paperPromoContainsExpiry =
-		paperPromosWithExpiry && paperPromosWithExpiry.length > 0;
 	return (
 		<>
-			<div
-				css={[
-					productInfoWrapper,
-					paperPromoContainsExpiry ? productExpiryAdjust : null,
-				]}
-			>
+			<div css={productInfoWrapper}>
 				<SvgInfoRound size="medium" />
 				<p>
 					{paperFulfilment === HomeDelivery && 'Delivery is included. '}
@@ -44,9 +30,8 @@ export default function PaperLandingTsAndCs({
 					<a href={observerLinks.PRIVACY}>privacy policy</a> will apply.
 				</p>
 			</div>
-			{paperPromosWithExpiry && paperPromoContainsExpiry && (
-				<PaperPromotionExpiries paperPromotions={paperPromosWithExpiry} />
-			)}
+
+			<PaperPromotionExpiries />
 		</>
 	);
 }

--- a/support-frontend/assets/pages/paper-subscription-landing/components/PaperLandingTsAndCsStyles.ts
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/PaperLandingTsAndCsStyles.ts
@@ -42,10 +42,3 @@ export const productInfoWrapper = css`
 		padding: ${space[4]}px 0 ${space[8]}px;
 	}
 `;
-
-export const productExpiryAdjust = css`
-	border-bottom: none;
-	${from.tablet} {
-		padding-bottom: ${space[2]}px;
-	}
-`;

--- a/support-frontend/assets/pages/paper-subscription-landing/components/PaperPromotionExpiries.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/PaperPromotionExpiries.tsx
@@ -1,31 +1,11 @@
-import { getDateString } from 'helpers/utilities/dateFormatting';
-import type { PaperPromotion } from '../helpers/getPromotions';
-import { getTitle } from '../helpers/products';
+import { usePromoTerms } from 'contexts/PromoTermsContext';
 import { promotionContainer } from './PaperPromotionExpiriesStyles';
 
-function getPromotionProductsAndExpiry(paperPromotion: PaperPromotion): string {
-	const products = paperPromotion.activePaperProducts
-		.map((paperProduct) => getTitle(paperProduct))
-		.join(', ');
-	const offerExpiry = paperPromotion.expires
-		? ` offer ends ${getDateString(new Date(paperPromotion.expires))}. `
-		: '';
-	return `${products}${offerExpiry}`;
-}
-
-type PaperPromoExpiriesProps = {
-	paperPromotions: PaperPromotion[];
-};
-export default function PaperPromotionExpiries({
-	paperPromotions,
-}: PaperPromoExpiriesProps): JSX.Element {
+export default function PaperPromotionExpiries(): JSX.Element {
+	const { promoTerms } = usePromoTerms();
 	return (
 		<div css={promotionContainer}>
-			{paperPromotions.map((paperPromotion, index) => (
-				<p>{`${'*'.repeat(index + 1)} ${getPromotionProductsAndExpiry(
-					paperPromotion,
-				)}`}</p>
-			))}
+			<p>{promoTerms}</p>
 		</div>
 	);
 }

--- a/support-frontend/assets/pages/paper-subscription-landing/components/PaperPromotionExpiries.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/PaperPromotionExpiries.tsx
@@ -1,8 +1,12 @@
 import { usePromoTerms } from 'contexts/PromoTermsContext';
 import { promotionContainer } from './PaperPromotionExpiriesStyles';
 
-export default function PaperPromotionExpiries(): JSX.Element {
+export default function PaperPromotionExpiries(): JSX.Element | null {
 	const { promoTerms } = usePromoTerms();
+	if (!promoTerms) {
+		return null;
+	}
+
 	return (
 		<div css={promotionContainer}>
 			<p>{promoTerms}</p>

--- a/support-frontend/assets/pages/paper-subscription-landing/helpers/getNewspaperPromoTerms.ts
+++ b/support-frontend/assets/pages/paper-subscription-landing/helpers/getNewspaperPromoTerms.ts
@@ -1,0 +1,13 @@
+import { getDateString } from 'helpers/utilities/dateFormatting';
+import type { PaperPromotion } from './getPromotions';
+
+export default function getNewspaperPromoTerms(
+	promotion: PaperPromotion,
+): string {
+	if (!promotion.expires) {
+		return '';
+	}
+	return `* Retail saving shown is the retail saving during the first six months. Offer ends ${getDateString(
+		new Date(promotion.expires),
+	)}`;
+}

--- a/support-frontend/assets/pages/paper-subscription-landing/helpers/getNewspaperPromoTerms.ts
+++ b/support-frontend/assets/pages/paper-subscription-landing/helpers/getNewspaperPromoTerms.ts
@@ -1,13 +1,28 @@
+import type { Promotion } from 'helpers/productPrice/promotions';
 import { getDateString } from 'helpers/utilities/dateFormatting';
-import type { PaperPromotion } from './getPromotions';
 
-export default function getNewspaperPromoTerms(
-	promotion: PaperPromotion,
-): string {
-	if (!promotion.expires) {
+const numberString = [
+	'zero',
+	'one',
+	'two',
+	'three',
+	'four',
+	'five',
+	'six',
+	'seven',
+	'eight',
+	'nine',
+	'ten',
+	'eleven',
+	'twelve',
+];
+
+export default function getNewspaperPromoTerms(promotion: Promotion): string {
+	const { durationMonths } = promotion.discount ?? {};
+	if (!promotion.expires || !durationMonths) {
 		return '';
 	}
-	return `* Retail saving shown is the retail saving during the first six months. Offer ends ${getDateString(
-		new Date(promotion.expires),
-	)}`;
+	return `* Retail saving shown is the retail saving during the first ${
+		numberString[durationMonths]
+	} months. Offer ends ${getDateString(new Date(promotion.expires))}.`;
 }

--- a/support-frontend/assets/pages/paper-subscription-landing/helpers/getPlans.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/helpers/getPlans.tsx
@@ -57,7 +57,7 @@ const getOfferText = (
 	if (promo?.discount?.amount && promotionIndex !== undefined) {
 		return discountSummaryCopy(
 			getCurrencyInfo(price.currency),
-			promotionIndex + 1, // if promotionIndex is 0, we want to show one "*"
+			1, // if promotionIndex is 0, we want to show one "*"
 			price.price,
 			promo,
 			BillingPeriod.Monthly,
@@ -286,6 +286,7 @@ export const getPlans = (
 				savingsText,
 				showLabel,
 				productLabel,
+				promotion,
 				unavailableOutsideLondon: getUnavailableOutsideLondon(
 					fulfilmentOption,
 					productOption,

--- a/support-frontend/assets/pages/paper-subscription-landing/helpers/getPlans.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/helpers/getPlans.tsx
@@ -57,7 +57,7 @@ const getOfferText = (
 	if (promo?.discount?.amount && promotionIndex !== undefined) {
 		return discountSummaryCopy(
 			getCurrencyInfo(price.currency),
-			1,
+			promotionIndex >= 0 ? 1 : 0, // if promotionIndex is 0 or higher, we want to show one "*",
 			price.price,
 			promo,
 			BillingPeriod.Monthly,

--- a/support-frontend/assets/pages/paper-subscription-landing/helpers/getPlans.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/helpers/getPlans.tsx
@@ -57,7 +57,7 @@ const getOfferText = (
 	if (promo?.discount?.amount && promotionIndex !== undefined) {
 		return discountSummaryCopy(
 			getCurrencyInfo(price.currency),
-			1, // if promotionIndex is 0, we want to show one "*"
+			1,
 			price.price,
 			promo,
 			BillingPeriod.Monthly,

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.tsx
@@ -3,6 +3,7 @@ import { ClientSideErrorHandler } from 'components/ClientSideError';
 import Footer from 'components/footerCompliant/Footer';
 import Header from 'components/headers/header/header';
 import { PageScaffold } from 'components/page/pageScaffold';
+import { PromoTermsProvider } from 'contexts/PromoTermsContext';
 import {
 	getAbParticipations,
 	setUpTrackingAndConsents,
@@ -55,6 +56,8 @@ const abParticipations = getAbParticipations();
 setUpTrackingAndConsents(abParticipations);
 renderPage(
 	<ClientSideErrorHandler>
-		<PaperLandingPage {...paperLandingProps(abParticipations)} />
+		<PromoTermsProvider>
+			<PaperLandingPage {...paperLandingProps(abParticipations)} />
+		</PromoTermsProvider>
 	</ClientSideErrorHandler>,
 );

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/WeeklyRatePlanCard.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/WeeklyRatePlanCard.tsx
@@ -70,6 +70,7 @@ function WeeklyRatePlanCard({
 			setPromoTerms(promoTerms);
 		}
 	}, [isPriorityPromo, billingPeriod, discountedPrice]);
+
 	return (
 		<div
 			ref={setElementToObserve}

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/WeeklyRatePlanCard.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/WeeklyRatePlanCard.tsx
@@ -37,6 +37,7 @@ function WeeklyRatePlanCard({
 	priorityPromotionExists,
 	buttonCopy,
 }: Product & { priorityPromotionExists: boolean }) {
+	const { setPromoTerms } = usePromoTerms();
 	const [hasBeenSeen, setElementToObserve] = useHasBeenSeen({
 		threshold: 0.5,
 		debounce: true,
@@ -60,7 +61,6 @@ function WeeklyRatePlanCard({
 	}, [hasBeenSeen]);
 
 	useEffect(() => {
-		const { setPromoTerms } = usePromoTerms();
 		if (isPriorityPromo && billingPeriod && discountedPrice) {
 			const promoTerms = getWeeklyPromoTerms(
 				billingPeriod,

--- a/support-frontend/stories/landingPage/NewspaperRatePlanCard.stories.tsx
+++ b/support-frontend/stories/landingPage/NewspaperRatePlanCard.stories.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { palette, space } from '@guardian/source/foundations';
 import type { Product } from 'components/product/productOption';
+import { PromoTermsProvider } from 'contexts/PromoTermsContext';
 import NewspaperRatePlanCard from 'pages/paper-subscription-landing/components/NewspaperRatePlanCard';
 import { Channel } from 'pages/paper-subscription-landing/helpers/products';
 
@@ -21,7 +22,9 @@ function Template(args: Product) {
 
 	return (
 		<div css={innerContentContainer}>
-			<NewspaperRatePlanCard {...args} />
+			<PromoTermsProvider>
+				<NewspaperRatePlanCard {...args} />
+			</PromoTermsProvider>
 		</div>
 	);
 }

--- a/support-frontend/stories/pages/PaperSubscriptionLandingPage.stories.tsx
+++ b/support-frontend/stories/pages/PaperSubscriptionLandingPage.stories.tsx
@@ -1,6 +1,7 @@
 import type { PaperFulfilmentOptions } from '@modules/product/fulfilmentOptions';
 import { Collection, HomeDelivery } from '@modules/product/fulfilmentOptions';
 import type { StoryObj } from '@storybook/preact-vite';
+import { PromoTermsProvider } from 'contexts/PromoTermsContext';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { PaperLandingPage } from 'pages/paper-subscription-landing/paperSubscriptionLandingPage';
 import type { PaperLandingPropTypes } from 'pages/paper-subscription-landing/paperSubscriptionLandingProps';
@@ -175,11 +176,19 @@ const collectionArgs = {
 };
 
 export const NewspaperHomeDelivery: Story = {
-	render: (args: PaperLandingPropTypes) => <PaperLandingPage {...args} />,
+	render: (args: PaperLandingPropTypes) => (
+		<PromoTermsProvider>
+			<PaperLandingPage {...args} />
+		</PromoTermsProvider>
+	),
 	args: homeDeliveryArgs,
 };
 
 export const NewspaperCollection: Story = {
-	render: (args: PaperLandingPropTypes) => <PaperLandingPage {...args} />,
+	render: (args: PaperLandingPropTypes) => (
+		<PromoTermsProvider>
+			<PaperLandingPage {...args} />
+		</PromoTermsProvider>
+	),
 	args: collectionArgs,
 };


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Use existing PromoTermsProvider to set correct terms for the newspaper promotions.
Asterisks are hardcoded to 1 for newspaper promos.
Add function to generate terms and condition for newspaper from the end date and duration in months. 


<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[Newspaper landing page : update the promo wording - signed off ready for Devs](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1213706508421513?focus=true)

## Why are you doing this?
Needed for the April marketing campaign.
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
1. with promo codes:
https://support.thegulocal.com/uk/subscribe/paper?promoCode=EVERYDAY40&promoCode=SATURDAY30
2. without promo code:
https://support.thegulocal.com/uk/subscribe/paper

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
### With Promo Codes
<img width="1305" height="1179" alt="Screenshot 2026-04-07 at 16 54 15" src="https://github.com/user-attachments/assets/c62c8a54-757a-437f-bac4-743789b56373" />

### With Default Observer Promo Code
<img width="1349" height="1023" alt="Screenshot 2026-04-13 at 12 46 07" src="https://github.com/user-attachments/assets/47dfe910-8bc3-4a50-ae5c-13424f1185d6" />
