### PR TITLE
Improve HeroContainer Storybook story 

### DIFF
--- a/support-frontend/stories/productPage/Hero.stories.tsx
+++ b/support-frontend/stories/productPage/Hero.stories.tsx
@@ -3,9 +3,127 @@ import CentredContainer from 'components/containers/centredContainer';
 import GridPicture from 'components/gridPicture/gridPicture';
 import HeroContainer from 'components/hero/HeroContainer';
 
+// ---------------------------------------------------------------------------
+// Shared slot fixtures — reused across stories to keep each story concise
+// ---------------------------------------------------------------------------
+
+/**
+ * Responsive placeholder image used in all HeroContainer stories.
+ * In a real page, replace these gridIds with actual asset identifiers
+ * and tune `srcSizes`/`sizes` to match your layout's image dimensions.
+ *
+ * For full `GridPicture` prop documentation and source/breakpoint examples,
+ * see the **Grid Images/GridPicture** story in Storybook
+ * (stories/images/GridPicture.stories.tsx).
+ */
+function SampleImage(): JSX.Element {
+	return (
+		<GridPicture
+			sources={[
+				{
+					gridId: 'placeholder_16x9',
+					srcSizes: [962, 500],
+					sizes: '240px',
+					imgType: 'jpg',
+					media: '(max-width: 739px)',
+				},
+				{
+					gridId: 'placeholder_1x1',
+					srcSizes: [802, 500],
+					sizes: '200px',
+					imgType: 'jpg',
+					media: '(max-width: 979px)',
+				},
+				{
+					gridId: 'placeholder_4x3',
+					srcSizes: [962, 500],
+					sizes: '240px',
+					imgType: 'jpg',
+					media: '(min-width: 980px)',
+				},
+			]}
+			fallback="placeholder_4x3"
+			fallbackSize={240}
+			altText=""
+		/>
+	);
+}
+
+function SampleContent(): JSX.Element {
+	return (
+		<section>
+			<h1>Support independent journalism</h1>
+			<p>
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id
+				justo at est elementum egestas rhoncus eu nulla. Proin pellentesque
+				massa at metus condimentum, a aliquam erat condimentum. Vivamus quis
+				rutrum nulla. Curabitur ut ullamcorper magna, eu ornare nunc.
+			</p>
+		</section>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Story metadata
+// ---------------------------------------------------------------------------
+
 export default {
 	title: 'LandingPage/HeroContainer',
 	component: HeroContainer,
+	/**
+	 * `parameters.docs.description.component` renders as the component overview
+	 * at the top of the auto-generated Docs page.  Use it to explain the
+	 * component's purpose, key props, and usage guidelines.
+	 */
+	parameters: {
+		docs: {
+			description: {
+				component: `
+\`HeroContainer\` provides a two-column landing-page hero layout with a
+**content slot** (headings, body copy, CTAs) and an **image slot**.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| \`contentSlot\` | \`ReactNode\` | — | Text, headings, and call-to-action elements |
+| \`imageSlot\` | \`ReactNode\` | — | An image or illustration |
+| \`heroDirection\` | \`'default' \\| 'reverse'\` | \`'default'\` | \`'default'\` puts the image on the right; \`'reverse'\` puts it on the left |
+| \`imagePosition\` | \`'float' \\| 'bottom'\` | \`'float'\` | \`'float'\` vertically centres the image; \`'bottom'\` pins it to the bottom edge |
+| \`cssOverrides\` | \`SerializedStyles\` | — | Emotion CSS to override the container's default background/text colours |
+
+## Usage
+
+\`\`\`tsx
+import { css } from '@emotion/react';
+import HeroContainer from 'components/hero/HeroContainer';
+
+<HeroContainer
+  heroDirection="default"
+  imagePosition="float"
+  contentSlot={<YourContent />}
+  imageSlot={<YourImage />}
+  cssOverrides={css\`
+    background-color: #052962;
+    color: #fff;
+  \`}
+/>
+\`\`\`
+
+## Layout behaviour
+
+- On **mobile** the image always stacks *above* the content regardless of \`heroDirection\`
+  (the container uses \`flex-direction: column-reverse\`).
+- On **tablet and above** the two columns sit side by side; the image column is
+  45 % wide on tablet and 40 % on desktop.
+- Use \`imagePosition="bottom"\` for illustrations that look grounded rather than floating.
+- The default background is \`neutral[97]\` (light grey). Pass \`cssOverrides\` to apply
+  brand colours — see the *Dark* and *Light* stories below for examples.
+- It's common to serve a different image depending on the breakpoint.  For a responsive image solution, consider passing a \`GridPicture\` directly as the \`imageSlot\`, mirroring the pattern used in the **Grid Images/GridPicture** story in Storybook (stories/images/GridPicture.stories.tsx). 
+				`,
+			},
+		},
+	},
 	decorators: [
 		(Story: React.FC): JSX.Element => (
 			<div
@@ -25,20 +143,22 @@ export default {
 		heroDirection: {
 			control: 'radio',
 			options: ['default', 'reverse'],
-			description: 'Reverse the hero direction (image on the left)',
+			description:
+				'Controls which side the image appears on (tablet and above)',
 		},
 		imagePosition: {
 			control: 'radio',
 			options: ['float', 'bottom'],
-			description: 'Position of the image slot',
+			description:
+				'`float` vertically centres the image; `bottom` pins it to the bottom edge',
 		},
 		backgroundColor: {
 			control: 'color',
-			description: 'Hero background colour',
+			description: 'Hero background colour (applied via cssOverrides)',
 		},
 		color: {
 			control: 'color',
-			description: 'Hero text colour',
+			description: 'Hero text colour (applied via cssOverrides)',
 		},
 	},
 	args: {
@@ -49,6 +169,15 @@ export default {
 	},
 };
 
+// ---------------------------------------------------------------------------
+// Interactive / playground story
+// ---------------------------------------------------------------------------
+
+/**
+ * Use the **Controls** panel to experiment with every prop combination in real
+ * time.  This is the best starting point when integrating the component into a
+ * new page.
+ */
 export function Hero({
 	heroDirection,
 	imagePosition,
@@ -60,6 +189,91 @@ export function Hero({
 	backgroundColor: string;
 	color: string;
 }): JSX.Element {
+	return (
+		<HeroContainer
+			imageSlot={<SampleImage />}
+			contentSlot={<SampleContent />}
+			heroDirection={heroDirection}
+			imagePosition={imagePosition}
+			cssOverrides={css`
+				background-color: ${backgroundColor};
+				color: ${color};
+			`}
+		/>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Named variant stories
+// Each story documents a specific, intentional use-case.  Use these as
+// reference implementations when building a new landing page.
+// ---------------------------------------------------------------------------
+
+/**
+ * The default configuration: image on the right, vertically centred,
+ * with Guardian dark-blue branding.
+ */
+export function Default(): JSX.Element {
+	return (
+		<HeroContainer
+			imageSlot={<SampleImage />}
+			contentSlot={<SampleContent />}
+			cssOverrides={css`
+				background-color: #052962;
+				color: #fff;
+			`}
+		/>
+	);
+}
+
+/**
+ * Set \`heroDirection="reverse"\` to move the image to the **left** on tablet
+ * and above.  Useful when the design calls for alternating hero rows.
+ */
+export function Reversed(): JSX.Element {
+	return (
+		<HeroContainer
+			imageSlot={<SampleImage />}
+			contentSlot={<SampleContent />}
+			heroDirection="reverse"
+			cssOverrides={css`
+				background-color: #052962;
+				color: #fff;
+			`}
+		/>
+	);
+}
+
+/**
+ * \`imagePosition="bottom"\` pins the image to the bottom of its column,
+ * which works well for illustrations that have a natural "standing" pose
+ * (e.g. characters or objects that should appear grounded).
+ */
+export function ImageAtBottom(): JSX.Element {
+	return (
+		<HeroContainer
+			imageSlot={<SampleImage />}
+			contentSlot={<SampleContent />}
+			imagePosition="bottom"
+			cssOverrides={css`
+				background-color: #052962;
+				color: #fff;
+			`}
+		/>
+	);
+}
+
+/**
+ * Example of passing a `GridPicture` directly as the `imageSlot`, mirroring
+ * the pattern used in the **Grid Images/GridPicture** story.
+ * See stories/images/GridPicture.stories.tsx for more `GridPicture` examples.
+ *
+ * For the current breakpoints/sizes used in this story, the image will switch between
+ * the 16:9, 1:1, and 4:3 placeholders as the viewport width increases.
+ *
+ * click show code to view the full `GridPicture` configuration used in this example.
+ */
+export function WithGridPictureImageSlot(): JSX.Element {
 	return (
 		<HeroContainer
 			imageSlot={
@@ -92,26 +306,77 @@ export function Hero({
 					altText=""
 				/>
 			}
-			contentSlot={
-				<section>
-					<h1>some title</h1>
-					<p>
-						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id
-						justo at est elementum egestas rhoncus eu nulla. Proin pellentesque
-						massa at metus condimentum, a aliquam erat condimentum. Vivamus quis
-						rutrum nulla. Curabitur ut ullamcorper magna, eu ornare nunc. Lorem
-						ipsum dolor sit amet, consectetur adipiscing elit. Quisque id justo
-						at est elementum egestas rhoncus eu nulla. Proin pellentesque massa
-						at metus condimentum, a aliquam erat condimentum. Vivamus quis
-						rutrum nulla. Curabitur ut ullamcorper magna, eu ornare nunc.
-					</p>
-				</section>
-			}
-			heroDirection={heroDirection}
-			imagePosition={imagePosition}
+			contentSlot={<SampleContent />}
 			cssOverrides={css`
-				background-color: ${backgroundColor};
-				color: ${color};
+				background-color: #052962;
+				color: #fff;
+			`}
+		/>
+	);
+}
+
+WithGridPictureImageSlot.parameters = {
+	docs: {
+		source: {
+			code: `
+import { css } from '@emotion/react';
+import GridPicture from 'components/gridPicture/gridPicture';
+import HeroContainer from 'components/hero/HeroContainer';
+
+<HeroContainer
+  contentSlot={<YourContent />}
+  imageSlot={
+  <GridPicture
+		sources={[
+			{
+				gridId: 'placeholder_16x9',
+				srcSizes: [962, 500],
+				sizes: '240px',
+				imgType: 'jpg',
+				media: '(max-width: 739px)',
+			},
+			{
+				gridId: 'placeholder_1x1',
+				srcSizes: [802, 500],
+				sizes: '200px',
+				imgType: 'jpg',
+				media: '(max-width: 979px)',
+			},
+			{
+				gridId: 'placeholder_4x3',
+				srcSizes: [962, 500],
+				sizes: '240px',
+				imgType: 'jpg',
+				media: '(min-width: 980px)',
+			},
+		]}
+		fallback="placeholder_4x3"
+		fallbackSize={240}
+		altText=""
+	/>
+  }
+  cssOverrides={css\`
+    background-color: #052962;
+    color: #fff;
+  \`}
+/>
+			`.trim(),
+		},
+	},
+};
+
+/**
+ * Light-theme variant.  Override the container colours via \`cssOverrides\`
+ * whenever the page palette differs from the dark Guardian blue default.
+ */
+export function LightTheme(): JSX.Element {
+	return (
+		<HeroContainer
+			imageSlot={<SampleImage />}
+			contentSlot={<SampleContent />}
+			cssOverrides={css`
+				background-color: #f6f6f6;
+				color: #121212;
 			`}
 		/>
 	);


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->
<!-- Label: Maintenance -->

## What are you doing in this PR?

Improves the `HeroContainer` Storybook story (`stories/productPage/Hero.stories.tsx`) with proper usage documentation and additional variant stories.

Changes include:
- Added a `parameters.docs.description.component` block to the story metadata with a prop table, a copy-paste usage example, and layout behaviour notes (mobile stacking, column widths, `imagePosition` semantics)
- Extracted shared `SampleImage` and `SampleContent` fixture components so each story stays concise and the `GridPicture` config isn't repeated
- Added a cross-reference comment on `SampleImage` pointing to the **Grid Images/GridPicture** story for further `GridPicture` documentation
- Added named variant stories documenting specific use-cases: `Default`, `Reversed`, `ImageAtBottom`, `WithGridPictureImageSlot`, and `LightTheme`
- Added a `WithGridPictureImageSlot` story with an explicit `docs.source.code` override providing a clean, copy-paste-ready `GridPicture` + `HeroContainer` example
- Improved `argTypes` descriptions to be more precise

## Why are you doing this?

`HeroContainer` had a single undocumented playground story. Anyone wanting to use the component had to read the source to understand available props, layout behaviour, and how to wire up a responsive image. This brings the story up to the team's Storybook best practices — a Docs page overview, per-story JSDoc, and concrete variant examples to copy from.

## How to test

Open Storybook and navigate to **LandingPage > HeroContainer**:
- The **Docs** tab should show a component overview with a prop table, usage snippet, and layout behaviour notes
- The sidebar should list: `Hero` (playground), `Default`, `Reversed`, `Image At Bottom`, `With Grid Picture Image Slot`, `Light Theme`
- Each story should render without errors and match its description
- On `WithGridPictureImageSlot`, clicking **Show code** should display the formatted `GridPicture` example, not the raw story source

## Screenshots

<img width="1112" height="1116" alt="Screenshot 2026-04-14 at 16 43 21" src="https://github.com/user-attachments/assets/2edd7169-aeef-4e88-800b-9df14b6021b2" />
