### PR TITLE
Fix payment method name on thank you page for PayPal Complete Payments

### DIFF
--- a/support-frontend/assets/components/onboarding/sections/summary.tsx
+++ b/support-frontend/assets/components/onboarding/sections/summary.tsx
@@ -244,7 +244,9 @@ function OnboardingSummary({
 	}
 
 	const isDirectDebit = order?.paymentMethod === 'DirectDebit';
-	const isPaypal = order?.paymentMethod === 'PayPal';
+	const isPaypal =
+		order?.paymentMethod === 'PayPal' ||
+		order?.paymentMethod === 'PayPalCompletePayments';
 	const isStripeCard =
 		order?.paymentMethod === 'Stripe' ||
 		order?.paymentMethod === 'StripeExpressCheckoutElement' ||


### PR DESCRIPTION

## What are you doing in this PR?

Fix payment method name on thank you page for PayPal Complete Payments.

## Why are you doing this?

On the new onboarding/thank you page the payment method name for the new PayPal method (PayPalCompletePayments) was rendering as "Your selected payment method" instead of "PayPal". This fixes the page to correctly render as "PayPal".

## How to test

Opt into the inactive AB test for PayPal Complete payments and go through the checkout flow with PayPal.

## Screenshots

### Before

<img width="578" height="198" alt="Screenshot 2026-04-15 at 09 45 05" src="https://github.com/user-attachments/assets/92184f30-81a5-49dd-9461-8d6629659714" />

### After

<img width="580" height="181" alt="Screenshot 2026-04-15 at 10 20 51" src="https://github.com/user-attachments/assets/42b6df17-1f32-4086-b9e7-52b32952d29e" />
