### PR TITLE
Force the version of  org.codehaus.plexus:plexus-utils to 3.6.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,8 @@ inThisBuild(
   Seq(
     organization := "com.gu",
     scalaVersion := "2.13.18",
+    // Force plexus-utils to 3.6.1 to avoid CVE in the version pulled in transitively by Play
+    dependencyOverrides += "org.codehaus.plexus" % "plexus-utils" % "3.6.1",
     // https://www.scala-sbt.org/1.x/docs/Cached-Resolution.html
     updateOptions := updateOptions.value.withCachedResolution(true),
     assembly / assemblyMergeStrategy := {


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Fix this CVE https://github.com/guardian/support-frontend/security/dependabot/346 by forcing the version of  `org.codehaus.plexus:plexus-utils` used by the project from 3.5.1 to 3.6.1.

This dependency is pulled in by the Play framework plugin and only exists in the test scope, you can check which version is being used by running `sbt Test/dependencyTree | grep org.codehaus.plexus:plexus-utils`

Output will look like this:
```
sbt Test/dependencyTree | grep org.codehaus.plexus:plexus-utils
[info]   | | | +-org.codehaus.plexus:plexus-utils:3.6.1
[info]   | | | +-org.codehaus.plexus:plexus-utils:3.6.1
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213941242990795