### PR TITLE
Adds and uses new switch for tooled student landing page

### DIFF
--- a/support-frontend/app/admin/settings/Switches.scala
+++ b/support-frontend/app/admin/settings/Switches.scala
@@ -28,6 +28,7 @@ case class FeatureSwitches(
     enableThankYouOnboarding: Option[SwitchState],
     enableCheckoutNudge: Option[SwitchState],
     enableMParticle: Option[SwitchState],
+    enableTooledStudentLandingPage: Option[SwitchState],
 )
 
 object FeatureSwitches {

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -368,7 +368,10 @@ class Application(
         if variant.institution.acronym.equalsIgnoreCase(institution)
       } yield variant
 
-    if (institutionList.size == 1) {
+    val isSwitchedOn =
+      settingsProvider.getAllSettings().switches.featureSwitches.enableTooledStudentLandingPage.exists(_.isOn)
+
+    if (institutionList.size == 1 && isSwitchedOn) {
       Ok(
         contributionsPlusStudentHtml(
           countryCode,

--- a/support-frontend/assets/pages/[countryGroupId]/router.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/router.tsx
@@ -10,6 +10,7 @@ import { GuardianHoldingContent } from 'components/serverSideRendered/guardianHo
 import { ObserverHoldingContent } from 'components/serverSideRendered/observerHoldingContent';
 import { getStudentLandingPageTestConfig } from 'helpers/abTests/studentLandingPageAbTests';
 import { WithCoreWebVitals } from 'helpers/coreWebVitals/withCoreWebVitals';
+import { isSwitchOn } from 'helpers/globalsAndSwitches/globals';
 import type { LandingPageVariant } from 'helpers/globalsAndSwitches/landingPageSettings';
 import { isObserverSubdomain } from 'helpers/globalsAndSwitches/observer';
 import type { OneTimeCheckoutVariant } from 'helpers/globalsAndSwitches/oneTimeCheckoutSettings';
@@ -213,7 +214,10 @@ const router = createBrowserRouter([
 						return {
 							Component: function StudentRoute() {
 								const { landing, studentLanding } = useRootLoaderData();
-								if (!studentLanding.variant) {
+								const isSwitchedOn = isSwitchOn(
+									'featureSwitches.enableTooledStudentLandingPage',
+								);
+								if (!studentLanding.variant || !isSwitchedOn) {
 									return null;
 								}
 								return (

--- a/support-frontend/test/actions/ActionRefinerTest.scala
+++ b/support-frontend/test/actions/ActionRefinerTest.scala
@@ -32,6 +32,7 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
       enableThankYouOnboarding = Some(On),
       enableCheckoutNudge = Some(On),
       enableMParticle = Some(On),
+      enableTooledStudentLandingPage = Some(On),
     )
 
   val testUsersService = TestUserService("secret")

--- a/support-frontend/test/admin/settings/SwitchesSpec.scala
+++ b/support-frontend/test/admin/settings/SwitchesSpec.scala
@@ -112,6 +112,11 @@ class SwitchesSpec extends AnyWordSpec with Matchers {
           |        "description" : "Enable mparticle",
           |        "state" : "On"
           |      }
+          |      },
+          |      "enableTooledStudentLandingPage" : {
+          |        "description" : "Enable tooled student landing page",
+          |        "state" : "On"
+          |      }
           |    }
           |  },
           |  "campaignSwitches" : {

--- a/support-frontend/test/admin/settings/SwitchesSpec.scala
+++ b/support-frontend/test/admin/settings/SwitchesSpec.scala
@@ -111,7 +111,6 @@ class SwitchesSpec extends AnyWordSpec with Matchers {
           |      "enableMParticle" : {
           |        "description" : "Enable mparticle",
           |        "state" : "On"
-          |      }
           |      },
           |      "enableTooledStudentLandingPage" : {
           |        "description" : "Enable tooled student landing page",

--- a/support-frontend/test/admin/settings/SwitchesSpec.scala
+++ b/support-frontend/test/admin/settings/SwitchesSpec.scala
@@ -161,7 +161,8 @@ class SwitchesSpec extends AnyWordSpec with Matchers {
             stripeHostedCheckout = Some(Off),
           ),
           subscriptionsSwitches = SubscriptionsSwitches(Some(On), Some(On), Some(On)),
-          featureSwitches = FeatureSwitches(Some(On), Some(On), Some(Off), Some(On), Some(Off), Some(On), Some(On)),
+          featureSwitches =
+            FeatureSwitches(Some(On), Some(On), Some(Off), Some(On), Some(Off), Some(On), Some(On), Some(On)),
           campaignSwitches = CampaignSwitches(Some(Off), Some(Off)),
           recaptchaSwitches = RecaptchaSwitches(Some(On), Some(On)),
         ),

--- a/support-frontend/test/controllers/ApplicationTest.scala
+++ b/support-frontend/test/controllers/ApplicationTest.scala
@@ -54,7 +54,7 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
     checkToken = csrfCheck,
     csrfConfig = csrfConfig,
     stage = stage,
-    featureSwitches = FeatureSwitches(Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On)),
+    featureSwitches = FeatureSwitches(Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On)),
     testUsersService = TestUserService("secret"),
   )
 

--- a/support-frontend/test/controllers/SiteMapTest.scala
+++ b/support-frontend/test/controllers/SiteMapTest.scala
@@ -30,7 +30,7 @@ class SiteMapTest extends AnyWordSpec with Matchers with TestCSRFComponents {
     checkToken = csrfCheck,
     csrfConfig = csrfConfig,
     stage = stage,
-    featureSwitches = FeatureSwitches(Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On)),
+    featureSwitches = FeatureSwitches(Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On)),
     testUsersService = TestUserService("secret"),
   )
 

--- a/support-frontend/test/fixtures/DisplayFormMocks.scala
+++ b/support-frontend/test/fixtures/DisplayFormMocks.scala
@@ -47,7 +47,7 @@ trait DisplayFormMocks extends TestCSRFComponents {
     checkToken = csrfCheck,
     csrfConfig = csrfConfig,
     stage = stage,
-    featureSwitches = FeatureSwitches(Some(On), Some(On), Some(Off), Some(On), Some(On), Some(On), Some(On)),
+    featureSwitches = FeatureSwitches(Some(On), Some(On), Some(Off), Some(On), Some(On), Some(On), Some(On), Some(On)),
     testUsersService = testUsers,
   )
 

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -814,7 +814,7 @@ object TestData {
     OneOffPaymentMethodSwitches(Some(On), Some(On), Some(On)),
     recurringPaymentMethodSwitches,
     SubscriptionsSwitches(Some(On), Some(On), Some(On)),
-    FeatureSwitches(Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On)),
+    FeatureSwitches(Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On)),
     CampaignSwitches(Some(On), Some(On)),
     RecaptchaSwitches(Some(On), Some(On)),
   )


### PR DESCRIPTION
## What are you doing in this PR?

In order to quickly hide all the tooled student landing pages in case of emergency, this adds a switch and will ensure that none of the tooled landing pages are shown. 

A specific tooled student landing page for a given institution can be hidden by reverting it to draft in RRCP.

NOTE: this does not affect student beans or the existing UTS landing page.

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1214114506388104?focus=true)

## How to test

Deploy to CODE, in the CODE RRCP Switches page, switch off the Enable the tooled student landing page. 
This should result in a 404 page instead of the expected tooled student landing page.

