### PR TITLE
Increase StripeHosted Checkout (Observer) alarm period

### DIFF
--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -2186,41 +2186,23 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         ],
         "AlarmName": "URGENT 9-5 - PROD support-workers No successful Paper StripeHostedCheckout (Observer) checkouts in 2 days.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "EvaluationPeriods": 48,
-        "Metrics": [
+        "Dimensions": [
           {
-            "Expression": "SUM([FILL(m1,0)])",
-            "Id": "expr_1",
-            "Label": "AllStripeHostedCheckoutPaperConversions",
-            "ReturnData": true,
+            "Name": "PaymentProvider",
+            "Value": "StripeHostedCheckout",
           },
           {
-            "Id": "m1",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "PaymentProvider",
-                    "Value": "StripeHostedCheckout",
-                  },
-                  {
-                    "Name": "ProductType",
-                    "Value": "Paper",
-                  },
-                  {
-                    "Name": "Stage",
-                    "Value": "PROD",
-                  },
-                ],
-                "MetricName": "PaymentSuccess",
-                "Namespace": "support-frontend",
-              },
-              "Period": 300,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
+            "Name": "ProductType",
+            "Value": "Paper",
+          },
+          {
+            "Name": "Stage",
+            "Value": "PROD",
           },
         ],
+        "EvaluationPeriods": 48,
+        "MetricName": "PaymentSuccess",
+        "Namespace": "support-frontend",
         "OKActions": [
           {
             "Fn::Join": [
@@ -2239,6 +2221,8 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             ],
           },
         ],
+        "Period": 3600,
+        "Statistic": "Sum",
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -2184,9 +2184,9 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "URGENT 9-5 - PROD support-workers No successful Paper StripeHostedCheckout (Observer) checkouts in 24h.",
+        "AlarmName": "URGENT 9-5 - PROD support-workers No successful Paper StripeHostedCheckout (Observer) checkouts in 2 days.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "EvaluationPeriods": 288,
+        "EvaluationPeriods": 576,
         "Metrics": [
           {
             "Expression": "SUM([FILL(m1,0)])",

--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -2186,7 +2186,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         ],
         "AlarmName": "URGENT 9-5 - PROD support-workers No successful Paper StripeHostedCheckout (Observer) checkouts in 2 days.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "EvaluationPeriods": 576,
+        "EvaluationPeriods": 48,
         "Metrics": [
           {
             "Expression": "SUM([FILL(m1,0)])",

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -604,7 +604,7 @@ export class SupportWorkers extends GuStack {
       metric: this.buildPaymentSuccessMetric(
         PaymentProviders.StripeHostedCheckout,
         ProductTypes.Paper,
-        Duration.hours(1)
+        stripeHostedMetricDuration
       ),
       comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
       evaluationPeriods: stripeHostedEvaluationPeriods,

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -598,18 +598,14 @@ export class SupportWorkers extends GuStack {
       actionsEnabled: isProd,
       okAction: true,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `URGENT 9-5 - ${this.stage} support-workers No successful Paper StripeHostedCheckout (Observer) checkouts in ${stripeHostedAlarmPeriod.toHumanString()}.`,
-      metric: new MathExpression({
-        expression: "SUM([FILL(m1,0)])",
-        label: "AllStripeHostedCheckoutPaperConversions",
-        usingMetrics: {
-          m1: this.buildPaymentSuccessMetric(
-            PaymentProviders.StripeHostedCheckout,
-            ProductTypes.Paper,
-            stripeHostedMetricDuration,
-          ),
-        },
-      }),
+      alarmName: `URGENT 9-5 - ${
+        this.stage
+      } support-workers No successful Paper StripeHostedCheckout (Observer) checkouts in ${stripeHostedAlarmPeriod.toHumanString()}.`,
+      metric: this.buildPaymentSuccessMetric(
+        PaymentProviders.StripeHostedCheckout,
+        ProductTypes.Paper,
+        Duration.hours(1)
+      ),
       comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
       evaluationPeriods: stripeHostedEvaluationPeriods,
       treatMissingData: TreatMissingData.BREACHING,

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -588,8 +588,8 @@ export class SupportWorkers extends GuStack {
     }).node.addDependency(stateMachine);
 
     // Paper StripeHostedCheckout (Observer) alarm
-    const stripeHostedMetricDuration = Duration.minutes(5);
-    const stripeHostedEvaluationPeriods = 576; // The number of 5 minute periods in 15 hours
+    const stripeHostedMetricDuration = Duration.hours(1);
+    const stripeHostedEvaluationPeriods = 48; // The number of 1 hour periods in 2 days
     const stripeHostedAlarmPeriod = Duration.minutes(
       stripeHostedMetricDuration.toMinutes() * stripeHostedEvaluationPeriods
     );

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -588,12 +588,17 @@ export class SupportWorkers extends GuStack {
     }).node.addDependency(stateMachine);
 
     // Paper StripeHostedCheckout (Observer) alarm
+    const stripeHostedMetricDuration = Duration.minutes(5);
+    const stripeHostedEvaluationPeriods = 576; // The number of 5 minute periods in 15 hours
+    const stripeHostedAlarmPeriod = Duration.minutes(
+      stripeHostedMetricDuration.toMinutes() * stripeHostedEvaluationPeriods
+    );
     new GuAlarm(this, "NoPaperStripeHostedAcquisitionInPeriodAlarm", {
       app,
       actionsEnabled: isProd,
       okAction: true,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `URGENT 9-5 - ${this.stage} support-workers No successful Paper StripeHostedCheckout (Observer) checkouts in 24h.`,
+      alarmName: `URGENT 9-5 - ${this.stage} support-workers No successful Paper StripeHostedCheckout (Observer) checkouts in ${stripeHostedAlarmPeriod.toHumanString()}.`,
       metric: new MathExpression({
         expression: "SUM([FILL(m1,0)])",
         label: "AllStripeHostedCheckoutPaperConversions",
@@ -601,12 +606,12 @@ export class SupportWorkers extends GuStack {
           m1: this.buildPaymentSuccessMetric(
             PaymentProviders.StripeHostedCheckout,
             ProductTypes.Paper,
-            Duration.seconds(300)
+            stripeHostedMetricDuration,
           ),
         },
       }),
       comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
-      evaluationPeriods: 288,
+      evaluationPeriods: stripeHostedEvaluationPeriods,
       treatMissingData: TreatMissingData.BREACHING,
       threshold: 0,
     }).node.addDependency(stateMachine);


### PR DESCRIPTION
## What are you doing in this PR?

Update StripeHostedCheckout alarm threshold to 2 days. The period needed to be updated to 1 hour (this is a requirement for alarms with a threshold > 1 day).

Also refactor the alarm definition a bit to derive the description from the configuration.

## Why are you doing this?

We've had some false positive alarms from this recently.

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

Deploy to CODE and verify the alarm definition in the Cloudwatch UI.