### PR TITLE
Copy changes on Guardian Weekly gifting landing page

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
@@ -9,7 +9,7 @@ import {
 import FlexContainer from 'components/containers/flexContainer';
 import type { Product } from 'components/product/productOption';
 import ProductOption from 'components/product/productOption';
-import { WeeklyPriceInfo } from '../weeklyPriceInfo';
+import { WeeklyGiftPriceInfo } from '../weeklyGiftPriceInfo';
 
 const pricesSection = css`
 	padding: 0 ${space[3]}px ${space[12]}px;
@@ -90,7 +90,7 @@ function Prices({ products }: { products: Product[] }): JSX.Element {
 					/>
 				))}
 			</FlexContainer>
-			<WeeklyPriceInfo isGift={true} showGift={true} />
+			<WeeklyGiftPriceInfo />
 		</section>
 	);
 }

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
@@ -6,6 +6,7 @@ import {
 	space,
 	textEgyptian17,
 } from '@guardian/source/foundations';
+import type { CountryGroupId } from '@modules/internationalisation/countryGroup';
 import FlexContainer from 'components/containers/flexContainer';
 import type { Product } from 'components/product/productOption';
 import ProductOption from 'components/product/productOption';
@@ -66,7 +67,13 @@ const pricesSubHeadline = css`
 	padding-bottom: ${space[2]}px;
 `;
 
-function Prices({ products }: { products: Product[] }): JSX.Element {
+function Prices({
+	products,
+	countryGroupId,
+}: {
+	products: Product[];
+	countryGroupId: CountryGroupId;
+}): JSX.Element {
 	return (
 		<section css={pricesSection} id="subscribe">
 			<h2 css={pricesHeadline}>Subscribe to the Guardian Weekly today</h2>
@@ -90,7 +97,7 @@ function Prices({ products }: { products: Product[] }): JSX.Element {
 					/>
 				))}
 			</FlexContainer>
-			<WeeklyGiftPriceInfo />
+			<WeeklyGiftPriceInfo countryGroupId={countryGroupId} />
 		</section>
 	);
 }

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/weeklyGiftBenefits.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/weeklyGiftBenefits.tsx
@@ -14,8 +14,7 @@ function WeeklyGiftBenefits() {
 							<List
 								items={[
 									{
-										content:
-											'The Guardian Weekly delivered, wherever they are in the world',
+										content: 'The Guardian Weekly delivered to their door',
 									},
 									{
 										content:

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyGiftPriceInfo.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyGiftPriceInfo.tsx
@@ -10,6 +10,8 @@ import {
 	SvgInfoRound,
 	themeLinkBrand,
 } from '@guardian/source/react-components';
+import type { CountryGroupId } from '@modules/internationalisation/countryGroup';
+import { GBPCountries } from '@modules/internationalisation/countryGroup';
 import ProductInfoChip from 'components/product/productInfoChip';
 import { guardianWeeklyTermsLink } from 'helpers/legal';
 
@@ -30,13 +32,21 @@ const termsLinkStyle = css`
 	margin-top: -12px;
 `;
 
-export function WeeklyGiftPriceInfo(): JSX.Element {
+type WeeklyGiftPriceInfoProps = {
+	countryGroupId: CountryGroupId;
+};
+
+export function WeeklyGiftPriceInfo({
+	countryGroupId,
+}: WeeklyGiftPriceInfoProps): JSX.Element {
 	const deliveryCostInfo = (
 		<div>
-			Delivery cost included. Price may vary if the recipient's delivery address
-			is in a different country to you.
+			Delivery cost included. Prices shown are for{' '}
+			{countryGroupId === GBPCountries ? 'UK' : 'local'} delivery. Price may
+			vary if the recipient's delivery address is in a different country to you.
 		</div>
 	);
+
 	return (
 		<div css={pricesInfo}>
 			<ProductInfoChip icon={<SvgInfoRound />}>

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyGiftPriceInfo.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyGiftPriceInfo.tsx
@@ -1,0 +1,56 @@
+import { css } from '@emotion/react';
+import {
+	neutral,
+	palette,
+	space,
+	textSans12,
+} from '@guardian/source/foundations';
+import {
+	Link,
+	SvgInfoRound,
+	themeLinkBrand,
+} from '@guardian/source/react-components';
+import ProductInfoChip from 'components/product/productInfoChip';
+import { guardianWeeklyTermsLink } from 'helpers/legal';
+
+const pricesInfo = css`
+	margin-top: ${space[6]}px;
+	& a {
+		color: ${neutral[100]};
+		:visited {
+			color: ${neutral[100]};
+		}
+	}
+`;
+
+const termsLinkStyle = css`
+	${textSans12};
+	color: ${palette.neutral[100]};
+	margin-left: ${space[9]}px;
+	margin-top: -12px;
+`;
+
+export function WeeklyGiftPriceInfo(): JSX.Element {
+	const deliveryCostInfo = (
+		<div>
+			Delivery cost included. Price may vary if the recipient's delivery address
+			is in a different country to you.
+		</div>
+	);
+	return (
+		<div css={pricesInfo}>
+			<ProductInfoChip icon={<SvgInfoRound />}>
+				{deliveryCostInfo}
+			</ProductInfoChip>
+			<ProductInfoChip>
+				<Link
+					href={guardianWeeklyTermsLink}
+					cssOverrides={termsLinkStyle}
+					theme={themeLinkBrand}
+				>
+					Click here to see full Terms and Conditions
+				</Link>
+			</ProductInfoChip>
+		</div>
+	);
+}

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyGiftProductPrices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyGiftProductPrices.tsx
@@ -1,4 +1,5 @@
 import type { IsoCountry } from '@modules/internationalisation/country';
+import type { CountryGroupId } from '@modules/internationalisation/countryGroup';
 import { weeklyGiftBillingPeriods } from 'helpers/productPrice/billingPeriods';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { getWeeklyProducts } from '../helpers/getWeeklyProducts';
@@ -6,9 +7,11 @@ import Prices from './content/prices';
 
 function WeeklyGiftProductPrices({
 	countryId,
+	countryGroupId,
 	productPrices,
 }: {
 	countryId: IsoCountry;
+	countryGroupId: CountryGroupId;
 	productPrices: ProductPrices;
 }): JSX.Element | null {
 	const products = getWeeklyProducts({
@@ -17,7 +20,7 @@ function WeeklyGiftProductPrices({
 		billingPeriods: weeklyGiftBillingPeriods,
 		isGift: true,
 	});
-	return <Prices products={products} />;
+	return <Prices countryGroupId={countryGroupId} products={products} />;
 }
 
 export default WeeklyGiftProductPrices;

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyPriceInfo.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyPriceInfo.tsx
@@ -1,21 +1,18 @@
 import { css } from '@emotion/react';
-import {
-	neutral,
-	palette,
-	space,
-	textSans12,
-} from '@guardian/source/foundations';
-import {
-	Link,
-	SvgGift,
-	SvgInfoRound,
-	themeLinkBrand,
-} from '@guardian/source/react-components';
+import { neutral, space, textSans12 } from '@guardian/source/foundations';
+import { SvgInfoRound } from '@guardian/source/react-components';
 import ProductInfoChip from 'components/product/productInfoChip';
-import { guardianWeeklyTermsLink } from 'helpers/legal';
 
 const pricesInfo = css`
 	margin-top: ${space[6]}px;
+	color: ${neutral[100]};
+
+	div {
+		${textSans12};
+		font-size: 15px;
+	}
+	margin-top: ${space[4]}px;
+
 	& a {
 		color: ${neutral[100]};
 		:visited {
@@ -23,58 +20,18 @@ const pricesInfo = css`
 		}
 	}
 `;
-const pricesInfoWeeklyDigital = css`
-	color: ${neutral[100]};
-	div {
-		${textSans12};
-		font-size: 15px;
-	}
-	margin-top: ${space[4]}px;
-`;
-const termsLinkStyle = css`
-	${textSans12};
-	color: ${palette.neutral[100]};
-	margin-left: ${space[9]}px;
-	margin-top: -12px;
-`;
 
-type WeeklyPriceInfoProps = {
-	isGift?: boolean;
-	showGift?: boolean;
-};
-export function WeeklyPriceInfo({
-	isGift,
-	showGift,
-}: WeeklyPriceInfoProps): JSX.Element {
+export function WeeklyPriceInfo(): JSX.Element {
 	const deliveryCostInfo = (
 		<div>
-			Delivery cost included.{' '}
-			{isGift
-				? "Price may vary if the recipient's delivery address is in a different country to you."
-				: 'You can cancel your subscription at any time.'}
+			Delivery cost included. You can cancel your subscription at any time.
 		</div>
 	);
 	return (
-		<div css={[pricesInfo, !showGift && pricesInfoWeeklyDigital]}>
-			{!isGift && showGift && (
-				<ProductInfoChip icon={<SvgGift />}>
-					Gifting is available
-				</ProductInfoChip>
-			)}
+		<div css={pricesInfo}>
 			<ProductInfoChip icon={<SvgInfoRound />}>
 				{deliveryCostInfo}
 			</ProductInfoChip>
-			{showGift && (
-				<ProductInfoChip>
-					<Link
-						href={guardianWeeklyTermsLink}
-						cssOverrides={termsLinkStyle}
-						theme={themeLinkBrand}
-					>
-						Click here to see full Terms and Conditions
-					</Link>
-				</ProductInfoChip>
-			)}
 		</div>
 	);
 }

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyPriceInfo.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyPriceInfo.tsx
@@ -49,7 +49,9 @@ export function WeeklyPriceInfo({
 	const deliveryCostInfo = (
 		<div>
 			Delivery cost included.{' '}
-			{!isGift && 'You can cancel your subscription at any time.'}
+			{isGift
+				? "Price may vary if the recipient's delivery address is in a different country to you."
+				: 'You can cancel your subscription at any time.'}
 		</div>
 	);
 	return (

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyPriceInfo.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyPriceInfo.tsx
@@ -4,20 +4,12 @@ import { SvgInfoRound } from '@guardian/source/react-components';
 import ProductInfoChip from 'components/product/productInfoChip';
 
 const pricesInfo = css`
-	margin-top: ${space[6]}px;
+	margin-top: ${space[4]}px;
 	color: ${neutral[100]};
 
 	div {
 		${textSans12};
 		font-size: 15px;
-	}
-	margin-top: ${space[4]}px;
-
-	& a {
-		color: ${neutral[100]};
-		:visited {
-			color: ${neutral[100]};
-		}
 	}
 `;
 

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.tsx
@@ -141,6 +141,7 @@ export function WeeklyLandingPage({
 						<FullWidthContainer theme="dark" hasOverlap>
 							<CentredContainer>
 								<WeeklyGiftProductPrices
+									countryGroupId={countryGroupId}
 									countryId={countryId}
 									productPrices={productPrices}
 								/>


### PR DESCRIPTION

## What are you doing in this PR?

Making some copy changes on the Guardian Weekly gifting landing page requested by Julia H.

I've refactored `WeeklyPriceInfo` to extract a new component for gifting. Previously this component handled gifting and non gifting but they're showing quite different things now (especially now that for gifting we need to support region) so I don't think the complexity is worth it.

## Why are you doing this?

Making the copy more accurate.