### PR TITLE
Use Mise/`.tool-versions` to manage Java versions and switch to guardian/setup-scala

### DIFF
--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -44,14 +44,8 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
-      - uses: sbt/setup-sbt@v1
-
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: "21"
-          distribution: "corretto"
-          cache: sbt
+      - name: Setup Scala
+        uses: guardian/setup-scala@v1
 
       - name: Build and upload to RiffRaff
         run: |

--- a/.github/workflows/stripe-patrons-data.yml
+++ b/.github/workflows/stripe-patrons-data.yml
@@ -33,14 +33,8 @@ jobs:
         run: ./script/ci
         working-directory: cdk
 
-      - uses: sbt/setup-sbt@v1
-
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: "corretto"
-          java-version: "21"
-          cache: sbt
+      - name: Setup Scala
+        uses: guardian/setup-scala@v1
 
       - name: Build
         run: |

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -50,14 +50,8 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
-      - uses: sbt/setup-sbt@v1
-
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: "21"
-          distribution: "corretto"
-          cache: sbt
+      - name: Setup Scala
+        uses: guardian/setup-scala@v1
 
       - name: Build, test, and upload to RiffRaff
         run: |

--- a/.github/workflows/support-lambdas-build.yml
+++ b/.github/workflows/support-lambdas-build.yml
@@ -42,14 +42,8 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
-      - uses: sbt/setup-sbt@v1
-
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: "21"
-          distribution: "corretto"
-          cache: sbt
+      - name: Setup Scala
+        uses: guardian/setup-scala@v1
 
       - name: Build and upload to RiffRaff
         run: |

--- a/.github/workflows/supporter-product-data.yml
+++ b/.github/workflows/supporter-product-data.yml
@@ -36,16 +36,11 @@ jobs:
 
       - uses: sbt/setup-sbt@v1
 
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: "21"
-          distribution: "corretto"
-          cache: sbt
+      - name: Setup Scala
+        uses: guardian/setup-scala@v1
 
       - name: Build and upload supporter-product-data to RiffRaff
         run: |
           export LAST_TEAMCITY_BUILD=6000
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
           sbt "project supporter-product-data" riffRaffUpload
-

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,0 @@
-# Enable auto-env through the sdkman_auto_env config
-# Add key=value pairs of SDKs to use below
-java=11.0.16-amzn

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-21


### PR DESCRIPTION
## What are you doing in this PR?

Making the management of Java versions more consistent across the project by adding a `.tool-versions` file to the repo and recommending Mise to manage Java versions locally.

If we go with this approach I'll update the setup instructions in the wiki as a follow up task.

## Why are you doing this?

Currently the Java version is duplicated in a few places:
* different GHA workflows use the setup-java action and specify the version as a param
* there is an out of data `.sdkmanrc` file in the root of the repo

This PR moves us towards having a single canonical Java version specified in the `.tool-versions` file in the root of the repo which is used everywhere: local development and GHA workflows which build deployable artifacts.

## How to test

- [x] Build passes
- [x] Smoke tests 
- [x] Workflow logs report correct Java version (corretto 21)
- [x] Using Mise locally picks up version of Java in `.tool-versions` file