### PR TITLE
Use unique test name as path instead of institution acronym

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -364,8 +364,8 @@ class Application(
       for {
         test <- studentTests
         if getCountryGroup(test.countryGroupId).id.equalsIgnoreCase(countryCode)
+        if test.name.equalsIgnoreCase(institution)
         variant <- test.variants
-        if variant.institution.acronym.equalsIgnoreCase(institution)
       } yield variant
 
     val isSwitchedOn =

--- a/support-frontend/assets/helpers/abTests/studentLandingPageAbTests.ts
+++ b/support-frontend/assets/helpers/abTests/studentLandingPageAbTests.ts
@@ -42,8 +42,7 @@ const filterTestsByURL = (
 		const regionMatches =
 			countryGroups[test.countryGroupId].supportRegionId ===
 			urlCountryGroup.supportRegionId;
-		const institutionMatches =
-			test.name.trim() === urlInstitution;
+		const institutionMatches = test.name.trim() === urlInstitution;
 		return regionMatches && institutionMatches;
 	});
 };

--- a/support-frontend/assets/helpers/abTests/studentLandingPageAbTests.ts
+++ b/support-frontend/assets/helpers/abTests/studentLandingPageAbTests.ts
@@ -43,7 +43,7 @@ const filterTestsByURL = (
 			countryGroups[test.countryGroupId].supportRegionId ===
 			urlCountryGroup.supportRegionId;
 		const institutionMatches =
-			test.variants[0]?.institution.acronym.trim() === urlInstitution;
+			test.name.trim() === urlInstitution;
 		return regionMatches && institutionMatches;
 	});
 };


### PR DESCRIPTION
## What are you doing in this PR?

This PR changes the test filtering to check for the test name rather than the test variant's institution acronym. 

Note: we will update the User Guide to recommend that the created test name is simple and user-friendly to act as a path in the URL being sent to students.

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1214306171064755?focus=true)

## Why are you doing this?

There are several instances where the same University acronym is used across several Universities in the same region. For example UoL can mean University of London, Leicester, Liverpool or Lincoln.

There is, therefore a risk that more than one offer could be created with the same acronym in the same region and therefore a risk of clashes with the link sent to students. The system would not know which University's details to display and would therefore return a 404 NOT FOUND error.

## How to test

Deploy to CODE.  Create a test in RRCP after this RRCP [PR](https://github.com/guardian/support-admin-console/pull/1124) has been merged which will build the path with the test name.

## Screenshots

This demonstrates that the path is now picking up the name of the test. 

<img width="1483" height="815" alt="Screenshot 2026-04-27 at 16 35 30" src="https://github.com/user-attachments/assets/f8b5ae4e-a486-46ce-a326-fda999462301" />
