### PR TITLE
Tiny follow up fix to GW gift landing page wording

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyGiftPriceInfo.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyGiftPriceInfo.tsx
@@ -43,7 +43,7 @@ export function WeeklyGiftPriceInfo({
 		<div>
 			Delivery cost included. Prices shown are for{' '}
 			{countryGroupId === GBPCountries ? 'UK' : 'local'} delivery. Price may
-			vary if the recipient's delivery address is in a different country to you.
+			vary if the recipient is in another country.
 		</div>
 	);
 


### PR DESCRIPTION
## What are you doing in this PR?

Tiny follow up wording change after #7935.

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1214266587346368)

## Why are you doing this?

This matches what's in the copy doc.