### PR TITLE
BAU vs Promotion weekly gifting savings message

### DIFF
--- a/support-frontend/assets/components/product/productOption.tsx
+++ b/support-frontend/assets/components/product/productOption.tsx
@@ -25,9 +25,9 @@ import {
 	productOptionInfo,
 	productOptionLabel,
 	productOptionLabelObserver,
-	productOptionOfferCopy,
 	productOptionPrice,
 	productOptionPriceCopy,
+	productOptionSavingsText,
 	productOptionTitle,
 	productOptionTitleHeading,
 	productOptionUnderline,
@@ -141,8 +141,8 @@ function ProductOption(props: Product): JSX.Element {
 				{props.children && props.children}
 			</div>
 			<div css={productOptionVerticalLine}>
-				<p css={[productOptionOfferCopy, productOptionUnderline]}>
-					{props.offerCopy}
+				<p css={[productOptionSavingsText, productOptionUnderline]}>
+					{props.savingsText}
 					{props.unavailableOutsideLondon && (
 						<div css={productOptionInfo}>
 							<SvgInfoRound />
@@ -176,7 +176,6 @@ function ProductOption(props: Product): JSX.Element {
 ProductOption.defaultProps = {
 	children: null,
 	label: '',
-	offerCopy: '',
 	cssOverrides: '',
 	billingPeriod: BillingPeriod.Monthly,
 };

--- a/support-frontend/assets/components/product/productOptionStyles.tsx
+++ b/support-frontend/assets/components/product/productOptionStyles.tsx
@@ -105,7 +105,7 @@ export const productOptionLabelObserver = css`
 	background: #963c00;
 `;
 
-export const productOptionOfferCopy = css`
+export const productOptionSavingsText = css`
 	${textSans17};
 	${from.tablet} {
 		height: 100%;

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/prices.tsx
@@ -77,16 +77,7 @@ function Prices({ products }: { products: Product[] }): JSX.Element {
 						cssOverrides={
 							product.showLabel ? productOverrideWithLabel : productOverride
 						}
-						title={product.title}
-						price={product.price}
-						offerCopy={product.offerCopy}
-						priceCopy={product.priceCopy}
-						buttonCopy={product.buttonCopy}
-						href={product.href}
-						onClick={product.onClick}
-						onView={product.onView}
-						showLabel={product.showLabel}
-						isSpecialOffer={product.isSpecialOffer}
+						{...product}
 					/>
 				))}
 			</FlexContainer>

--- a/support-frontend/assets/pages/weekly-subscription-landing/helpers/getSavingsText.test.ts
+++ b/support-frontend/assets/pages/weekly-subscription-landing/helpers/getSavingsText.test.ts
@@ -1,0 +1,123 @@
+import { BillingPeriod } from '@modules/product/billingPeriod';
+import type { ProductPrice } from 'helpers/productPrice/productPrices';
+import type { Promotion } from 'helpers/productPrice/promotions';
+import {
+	getWeeklyGiftSavingsText,
+	getWeeklySavingsText,
+} from './getSavingsText';
+
+const makeProductPrice = (price: number): ProductPrice => ({
+	price,
+	currency: 'GBP',
+	fixedTerm: false,
+});
+
+const makePromotion = (overrides: Partial<Promotion> = {}): Promotion => ({
+	name: 'Test Promo',
+	description: 'Test promo description',
+	promoCode: 'TESTPROMO',
+	...overrides,
+});
+
+describe('getWeeklySavingsText', () => {
+	it('returns null when there is no promotion', () => {
+		expect(getWeeklySavingsText(undefined)).toBeNull();
+	});
+
+	it('returns null when durationMonths is missing', () => {
+		const promotion = makePromotion({
+			discount: { amount: 25, durationMonths: undefined },
+		});
+		expect(getWeeklySavingsText(promotion)).toBeNull();
+	});
+
+	it('returns savings text for a 12-month discount', () => {
+		const promotion = makePromotion({
+			discount: { amount: 50, durationMonths: 12 },
+		});
+		expect(getWeeklySavingsText(promotion)).toBe('Save 50% for the first year');
+	});
+});
+
+describe('getWeeklyGiftSavingsText', () => {
+	describe('when a promotion is present', () => {
+		it('returns the roundel text from the promotion landing page', () => {
+			const promotion = makePromotion({
+				landingPage: { roundel: 'Custom roundel text' },
+			});
+			expect(
+				getWeeklyGiftSavingsText(BillingPeriod.Annual, promotion, {}),
+			).toBe('Custom roundel text');
+		});
+
+		it('returns null when promotion has no landingPage roundel', () => {
+			const promotion = makePromotion({ landingPage: undefined });
+			expect(
+				getWeeklyGiftSavingsText(BillingPeriod.Annual, promotion, {}),
+			).toBeNull();
+		});
+	});
+
+	describe('when business as usual for Annual weekly gifting', () => {
+		it('returns null for Quarterly billing period', () => {
+			const allPrices = {
+				[BillingPeriod.Quarterly]: makeProductPrice(50),
+				[BillingPeriod.Annual]: makeProductPrice(160),
+			};
+			expect(
+				getWeeklyGiftSavingsText(BillingPeriod.Quarterly, undefined, allPrices),
+			).toBeNull();
+		});
+
+		it('returns null when Annual price is missing', () => {
+			const allPrices = {
+				[BillingPeriod.Quarterly]: makeProductPrice(50),
+			};
+			expect(
+				getWeeklyGiftSavingsText(BillingPeriod.Annual, undefined, allPrices),
+			).toBeNull();
+		});
+
+		it('returns null when Quarterly price is missing', () => {
+			const allPrices = {
+				[BillingPeriod.Annual]: makeProductPrice(190),
+			};
+			expect(
+				getWeeklyGiftSavingsText(BillingPeriod.Annual, undefined, allPrices),
+			).toBeNull();
+		});
+
+		it('returns null when no saving', () => {
+			// 50 * 4 - 200 = 0, savingsPercentage = 0
+			const allPrices = {
+				[BillingPeriod.Quarterly]: makeProductPrice(50),
+				[BillingPeriod.Annual]: makeProductPrice(200),
+			};
+			expect(
+				getWeeklyGiftSavingsText(BillingPeriod.Annual, undefined, allPrices),
+			).toBeNull();
+		});
+
+		it('returns savings text with correct percentage', () => {
+			// 50 * 4 - 190 = 10, savingsPercentage = round(10/50 * 100) = 20
+			const allPrices = {
+				[BillingPeriod.Quarterly]: makeProductPrice(50),
+				[BillingPeriod.Annual]: makeProductPrice(190),
+			};
+			expect(
+				getWeeklyGiftSavingsText(BillingPeriod.Annual, undefined, allPrices),
+			).toBe('Save an extra 20% on a 12 month gift subscription');
+		});
+
+		it('rounds the savings percentage to the nearest integer', () => {
+			// 45 * 4 - 152 = 28, savingsPercentage = round(28/45 * 100) = round(62.2) = 62
+			const allPrices = {
+				[BillingPeriod.Quarterly]: makeProductPrice(45),
+				[BillingPeriod.Annual]: makeProductPrice(152),
+			};
+			expect(
+				getWeeklyGiftSavingsText(BillingPeriod.Annual, undefined, allPrices),
+			).toBe('Save an extra 62% on a 12 month gift subscription');
+		});
+	});
+});

--- a/support-frontend/assets/pages/weekly-subscription-landing/helpers/getSavingsText.test.ts
+++ b/support-frontend/assets/pages/weekly-subscription-landing/helpers/getSavingsText.test.ts
@@ -102,11 +102,11 @@ describe('getWeeklyGiftSavingsText', () => {
 			// 50 * 4 - 190 = 10, savingsPercentage = round(10/50 * 100) = 20
 			const allPrices = {
 				[BillingPeriod.Quarterly]: makeProductPrice(50),
-				[BillingPeriod.Annual]: makeProductPrice(190),
+				[BillingPeriod.Annual]: makeProductPrice(150),
 			};
 			expect(
 				getWeeklyGiftSavingsText(BillingPeriod.Annual, undefined, allPrices),
-			).toBe('Save an extra 20% on a 12 month gift subscription');
+			).toBe('Save an extra 25% on a 12 month gift subscription');
 		});
 
 		it('rounds the savings percentage to the nearest integer', () => {
@@ -117,7 +117,7 @@ describe('getWeeklyGiftSavingsText', () => {
 			};
 			expect(
 				getWeeklyGiftSavingsText(BillingPeriod.Annual, undefined, allPrices),
-			).toBe('Save an extra 62% on a 12 month gift subscription');
+			).toBe('Save an extra 16% on a 12 month gift subscription');
 		});
 	});
 });

--- a/support-frontend/assets/pages/weekly-subscription-landing/helpers/getSavingsText.test.ts
+++ b/support-frontend/assets/pages/weekly-subscription-landing/helpers/getSavingsText.test.ts
@@ -99,7 +99,7 @@ describe('getWeeklyGiftSavingsText', () => {
 		});
 
 		it('returns savings text with correct percentage', () => {
-			// 50 * 4 - 190 = 10, savingsPercentage = round(10/50 * 100) = 20
+			// ((50 * 4) - 150) = 50, savingsPercentage = round(50/(50 * 4) * 100) = 25
 			const allPrices = {
 				[BillingPeriod.Quarterly]: makeProductPrice(50),
 				[BillingPeriod.Annual]: makeProductPrice(150),
@@ -110,7 +110,7 @@ describe('getWeeklyGiftSavingsText', () => {
 		});
 
 		it('rounds the savings percentage to the nearest integer', () => {
-			// 45 * 4 - 152 = 28, savingsPercentage = round(28/45 * 100) = round(62.2) = 62
+			// ((45 * 4) - 152) = 28, savingsPercentage = round(28/(45 * 4) * 100) = 15.556 = 16
 			const allPrices = {
 				[BillingPeriod.Quarterly]: makeProductPrice(45),
 				[BillingPeriod.Annual]: makeProductPrice(152),

--- a/support-frontend/assets/pages/weekly-subscription-landing/helpers/getSavingsText.ts
+++ b/support-frontend/assets/pages/weekly-subscription-landing/helpers/getSavingsText.ts
@@ -36,10 +36,9 @@ export function getWeeklyGiftSavingsText(
 		if (!annualPrice || !quarterlyPrice) {
 			return null;
 		}
-
-		const savingsVsQuarterly = quarterlyPrice * 4 - annualPrice;
+		const quarterlyCostForYear = quarterlyPrice * 4;
 		const savingsPercentage = Math.round(
-			(savingsVsQuarterly / quarterlyPrice) * 100,
+			((quarterlyCostForYear - annualPrice) / quarterlyCostForYear) * 100,
 		);
 
 		if (savingsPercentage > 0) {

--- a/support-frontend/assets/pages/weekly-subscription-landing/helpers/getSavingsText.ts
+++ b/support-frontend/assets/pages/weekly-subscription-landing/helpers/getSavingsText.ts
@@ -38,15 +38,13 @@ export function getWeeklyGiftSavingsText(
 		}
 
 		const savingsVsQuarterly = quarterlyPrice * 4 - annualPrice;
+		const savingsPercentage = Math.round(
+			(savingsVsQuarterly / quarterlyPrice) * 100,
+		);
 
-		if (savingsVsQuarterly <= 0) {
-			return null;
+		if (savingsPercentage > 0) {
+			return `Save an extra ${savingsPercentage}% on a 12 month gift subscription`;
 		}
-
-		const savingsPercentage = savingsVsQuarterly
-			? Math.round((savingsVsQuarterly / quarterlyPrice) * 100)
-			: null;
-		return `Save an extra ${savingsPercentage}% on a 12 month gift subscription`;
 	}
 
 	return null;

--- a/support-frontend/assets/pages/weekly-subscription-landing/helpers/getSavingsText.ts
+++ b/support-frontend/assets/pages/weekly-subscription-landing/helpers/getSavingsText.ts
@@ -1,0 +1,53 @@
+import type { RecurringBillingPeriod } from '@modules/product/billingPeriod';
+import { BillingPeriod } from '@modules/product/billingPeriod';
+import type { ProductPrice } from 'helpers/productPrice/productPrices';
+import type { Promotion } from 'helpers/productPrice/promotions';
+import { getDiscountDuration } from 'pages/[countryGroupId]/student/helpers/discountDetails';
+
+export function getWeeklySavingsText(
+	promotion: Promotion | undefined,
+): string | null {
+	const durationInMonths = promotion?.discount?.durationMonths;
+
+	if (!durationInMonths) {
+		return null;
+	}
+
+	return `Save ${promotion.discount?.amount}% for ${getDiscountDuration({
+		durationInMonths,
+	})}`;
+}
+
+export function getWeeklyGiftSavingsText(
+	billingPeriod: RecurringBillingPeriod,
+	promotion: Promotion | undefined,
+	allPrices: Partial<Record<RecurringBillingPeriod, ProductPrice>>,
+): string | null {
+	if (promotion) {
+		return promotion.landingPage?.roundel ?? null;
+	}
+
+	// BAU for Annual weekly gifting
+	// The goal in here is to display the savings compared to the Quarlerly price
+	if (billingPeriod === BillingPeriod.Annual) {
+		const annualPrice = allPrices[BillingPeriod.Annual]?.price;
+		const quarterlyPrice = allPrices[BillingPeriod.Quarterly]?.price;
+
+		if (!annualPrice || !quarterlyPrice) {
+			return null;
+		}
+
+		const savingsVsQuarterly = quarterlyPrice * 4 - annualPrice;
+
+		if (savingsVsQuarterly <= 0) {
+			return null;
+		}
+
+		const savingsPercentage = savingsVsQuarterly
+			? Math.round((savingsVsQuarterly / quarterlyPrice) * 100)
+			: null;
+		return `Save an extra ${savingsPercentage}% on a 12 month gift subscription`;
+	}
+
+	return null;
+}

--- a/support-frontend/assets/pages/weekly-subscription-landing/helpers/getWeeklyProducts.tsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/helpers/getWeeklyProducts.tsx
@@ -36,10 +36,11 @@ import {
 } from 'helpers/productPrice/subscriptions';
 import type { OphanComponentType } from 'helpers/tracking/trackingOphan';
 import { addQueryParamsToURL, getOrigin } from 'helpers/urls/url';
+import { getDiscountSummary } from 'pages/[countryGroupId]/student/helpers/discountDetails';
 import {
-	getDiscountDuration,
-	getDiscountSummary,
-} from 'pages/[countryGroupId]/student/helpers/discountDetails';
+	getWeeklyGiftSavingsText,
+	getWeeklySavingsText,
+} from './getSavingsText';
 
 function getWeeklyRatePlan(
 	billingPeriod: RecurringBillingPeriod,
@@ -104,15 +105,26 @@ export const getWeeklyProducts = ({
 	productPrices: ProductPrices;
 	billingPeriods: RecurringBillingPeriod[];
 	isGift?: boolean;
-}): Product[] =>
-	billingPeriods.map((billingPeriod) => {
-		const productPrice = getProductPrice(
-			productPrices,
-			countryId,
+}): Product[] => {
+	// Pre-compute prices for all billing periods
+	const priceByBillingPeriod = Object.fromEntries(
+		billingPeriods.map((billingPeriod) => [
 			billingPeriod,
-			getWeeklyFulfilmentOption(countryId),
-			isGift ? 'NoProductOptions' : 'PlusDigital',
-		);
+			getProductPrice(
+				productPrices,
+				countryId,
+				billingPeriod,
+				getWeeklyFulfilmentOption(countryId),
+				isGift ? 'NoProductOptions' : 'PlusDigital',
+			),
+		]),
+	) as Partial<Record<RecurringBillingPeriod, ProductPrice>>;
+
+	return billingPeriods.map((billingPeriod) => {
+		const productPrice = priceByBillingPeriod[billingPeriod];
+		if (!productPrice) {
+			throw new Error(`No price found for billing period ${billingPeriod}`);
+		}
 		const promotion = getAppliedPromo(productPrice.promotions);
 		const trackingProperties = {
 			id: `subscribe_now_cta_gift-${billingPeriod}`,
@@ -128,9 +140,6 @@ export const getWeeklyProducts = ({
 			displayPrice,
 		);
 
-		const offerCopy = isGift
-			? promotion?.landingPage?.roundel ?? ''
-			: undefined;
 		const priceCopy = isGift
 			? getSimplifiedPriceDescription(productPrice, billingPeriod)
 			: '';
@@ -154,12 +163,10 @@ export const getWeeklyProducts = ({
 						shortFormat: true,
 				  })
 				: undefined;
-		const savingsText =
-			!isGift && promotion?.discount?.amount && durationInMonths
-				? `Save ${promotion.discount.amount}% for ${getDiscountDuration({
-						durationInMonths,
-				  })}`
-				: undefined;
+
+		const savingsText = isGift
+			? getWeeklyGiftSavingsText(billingPeriod, promotion, priceByBillingPeriod)
+			: getWeeklySavingsText(promotion);
 
 		const augmentedPromotion = promotion && getAugmentedPromotion(promotion);
 		return {
@@ -179,7 +186,6 @@ export const getWeeklyProducts = ({
 			billingPeriod: isGift ? undefined : billingPeriod,
 			discountedPrice: discountPriceWithCurrency,
 			discountSummary,
-			offerCopy,
 			savingsText,
 			hasPromotion: !isGift && !!promotion,
 			isPriorityPromo: isGift ? undefined : augmentedPromotion?.hasPriority,
@@ -187,6 +193,7 @@ export const getWeeklyProducts = ({
 			isSpecialOffer,
 		};
 	});
+};
 
 const getAugmentedPromotion = (promotion: Promotion): Promotion => {
 	// TODO: This is a temporary function to augment the promotion with additional properties until we have the ability to add custom copy for specific promotions in the promo tool.

--- a/support-frontend/stories/product/ProductOption.stories.tsx
+++ b/support-frontend/stories/product/ProductOption.stories.tsx
@@ -9,7 +9,7 @@ export default {
 	argTypes: {
 		title: { type: 'text' },
 		price: { type: 'text' },
-		offerCopy: { type: 'text' },
+		savingsText: { type: 'text' },
 		priceCopy: { type: 'text' },
 		buttonCopy: { type: 'text' },
 		showLabel: { type: 'boolean' },
@@ -47,7 +47,7 @@ function Template(args: Product) {
 		<ProductOptionComponent
 			title={args.title}
 			price={args.price}
-			offerCopy={args.offerCopy}
+			savingsText={args.savingsText}
 			priceCopy={args.priceCopy}
 			buttonCopy={args.buttonCopy}
 			showLabel={args.showLabel}
@@ -67,7 +67,7 @@ export const ProductOption = Template.bind({});
 ProductOption.args = {
 	title: '6 for 6',
 	price: '£6',
-	offerCopy: '£6 for the first 6 issues',
+	savingsText: '£6 for the first 6 issues',
 	priceCopy: 'then £37.50 per quarter',
 	buttonCopy: 'Subscribe now',
 	label: 'Best deal',
@@ -78,7 +78,7 @@ export const SpecialOfferProductOption = Template.bind({});
 SpecialOfferProductOption.args = {
 	title: '12 for 12',
 	price: '£12',
-	offerCopy: '£12 for the first 6 issues',
+	savingsText: '£12 for the first 6 issues',
 	priceCopy: 'then £13.50 per month',
 	buttonCopy: 'Subscribe now',
 	label: 'Special offer',
@@ -90,7 +90,7 @@ export const ProductOptionWithProductLabel = Template.bind({});
 ProductOptionWithProductLabel.args = {
 	title: '6 for 6',
 	price: '£6',
-	offerCopy: '£6 for the first 6 issues',
+	savingsText: '£6 for the first 6 issues',
 	priceCopy: 'then £37.50 per quarter',
 	buttonCopy: 'Subscribe now',
 	label: 'Best deal',


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

1. New getSavingsText.ts helper module:
- getWeeklySavingsText -  for non-gift subscriptions; formats a savings string from a promotion's discount amount and duration
- getWeeklyGiftSavingsText — for gift subscriptions; computes the annual saving percentage by comparing the annual price against 4× the quarterly price, falling back to null if no saving exists or prices are unavailable; also defers to a promotion's `landingPage.roundel` when a promo is active

2. In order to compare rate plans prices we are now pre computing prices for all billing periods ahead of iteration on `getWeeklyProducts`.
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[BAU vs Promo saving message](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1214305915373497?focus=true)

## Why are you doing this?
Anual price will be set to the current promotion price (£158.40) as a BAU, and we want to preserve the current saving message, and make it cope with  future changes.

<!--
Remember, PRs are documentation for future contributors.
-->


## Screenshots
### Current Behaviour (with promotion)
<img width="1909" height="460" alt="Screenshot 2026-04-28 at 14 53 33" src="https://github.com/user-attachments/assets/7d06564b-3cd9-4dff-b27c-b9b56a77604e" />

### Current Behaviour (no promotion)
<img width="1635" height="463" alt="Screenshot 2026-04-28 at 15 01 09" src="https://github.com/user-attachments/assets/953de2b8-e73d-43ef-ad0e-288c340f1f01" />

### Future Behaviour (new price)
<img width="1858" height="529" alt="Screenshot 2026-04-28 at 15 19 48" src="https://github.com/user-attachments/assets/347a569d-ad11-46e1-9476-a16c4ce739b6" />

