### PR TITLE
Update mparticle alarm trigger

### DIFF
--- a/cdk/lib/__snapshots__/frontend.test.ts.snap
+++ b/cdk/lib/__snapshots__/frontend.test.ts.snap
@@ -1204,13 +1204,14 @@ exports[`The Frontend stack matches the snapshot 1`] = `
         "AlarmDescription": "Impact - support-frontend failed to use the mparticle API because no valid oauth token was available. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit",
         "AlarmName": "Support-frontend MParticleTokenError",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 2,
         "Dimensions": [
           {
             "Name": "Stage",
             "Value": "PROD",
           },
         ],
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 2,
         "MetricName": "MParticleTokenError",
         "Namespace": "support-frontend",
         "Period": 60,

--- a/cdk/lib/frontend.ts
+++ b/cdk/lib/frontend.ts
@@ -497,7 +497,8 @@ export class Frontend extends GuStack {
         ),
         actionsEnabled: shouldCreateAlarms,
         threshold: 1,
-        evaluationPeriods: 1,
+        evaluationPeriods: 2,
+        datapointsToAlarm: 2,
         comparisonOperator:
           ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
         metric: new Metric({


### PR DESCRIPTION
We had an instance of the `MParticleTokenError` alarm today, after a single failure to use the mparticle API.

It was caused by the server not having any valid mparticle tokens. Normally the server maintains 3 tokens (because sometimes tokens do just stop working). The fact that only one request failed this way tells us that we did get a working token soon after.

This PR updates the alarm to only fire if there are any errors for 2 consecutive minutes.
This means in future we will not receive an alarm for such a short lived issue.