### PR TITLE
Build deployable artifact for support-backend

### DIFF
--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -47,8 +47,8 @@ jobs:
         run: |
           pnpm --filter support-backend test
           pnpm --filter support-backend build
-          pnpm --filter ../support-backend  --prod deploy --legacy ../support-backend/target_node_modules
-          pushd ../support-backend
+          pnpm --filter support-backend  --prod deploy --legacy ../support-backend/target_node_modules
+          pushd support-backend
           mv target_node_modules/node_modules ./target/
           tar -czf support-backend.tar.gz target
           popd

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           pnpm --filter support-backend test
           pnpm --filter support-backend build
-          pnpm --filter support-backend  --prod deploy --legacy ../support-backend/target_node_modules
+          pnpm --filter support-backend build-prod-node-modules
           pushd support-backend
           mv target_node_modules/node_modules ./target/
           tar -czf support-backend.tar.gz target

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -47,8 +47,8 @@ jobs:
         run: |
           pnpm --filter support-backend test
           pnpm --filter support-backend build
-          pnpm --filter=support-backend --prod deploy --legacy support-backend/target_node_modules
-          pushd support-backend
+          pnpm --filter ../support-backend  --prod deploy --legacy ../support-backend/target_node_modules
+          pushd ../support-backend
           mv target_node_modules/node_modules ./target/
           tar -czf support-backend.tar.gz target
           popd

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -43,6 +43,16 @@ jobs:
         run: ./script/ci
         working-directory: cdk
 
+      - name: TypeScript support-backend test and build
+        run: |
+          pnpm --filter support-backend test
+          pnpm --filter support-backend build
+          pnpm --filter=support-backend --prod deploy --legacy support-backend/target_node_modules
+          pushd support-backend
+          mv target_node_modules/node_modules ./target/
+          tar -czf support-backend.tar.gz target
+          popd
+
       # Required by sbt riffRaffUpload
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,9 +159,6 @@ importers:
 
   support-backend:
     dependencies:
-      '@guardian/support-service-lambdas':
-        specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/4b496e4b2c38743a45fc4535ca1da83476bb473a
       express:
         specifier: ^5.2.1
         version: 5.2.1

--- a/support-backend/.gitignore
+++ b/support-backend/.gitignore
@@ -1,0 +1,2 @@
+support-backend.tar.gz
+target_node_modules/

--- a/support-backend/package.json
+++ b/support-backend/package.json
@@ -13,7 +13,9 @@
     "fix": "pnpm fix-formatting && pnpm lint:fix",
     "prebuild": "rm -rf target",
     "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "predeploy-to-prod": "rm -rf target_node_modules",
+    "deploy-to-prod": "pnpm deploy --legacy target_node_modules"
   },
   "keywords": [],
   "author": "",

--- a/support-backend/package.json
+++ b/support-backend/package.json
@@ -14,8 +14,8 @@
     "prebuild": "rm -rf target",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "predeploy-to-prod": "rm -rf target_node_modules",
-    "deploy-to-prod": "pnpm deploy --legacy target_node_modules"
+    "prebuild-prod-node-modules": "rm -rf target_node_modules",
+    "build-prod-node-modules": "pnpm --filter . deploy --prod --legacy target_node_modules"
   },
   "keywords": [],
   "author": "",

--- a/support-backend/package.json
+++ b/support-backend/package.json
@@ -20,7 +20,6 @@
   "license": "ISC",
   "packageManager": "pnpm@10.28.2",
   "dependencies": {
-    "@guardian/support-service-lambdas": "catalog:",
     "express": "^5.2.1"
   },
   "devDependencies": {

--- a/support-backend/package.json
+++ b/support-backend/package.json
@@ -11,8 +11,9 @@
     "check-formatting": "prettier --check **.ts",
     "fix-formatting": "prettier --write **.ts",
     "fix": "pnpm fix-formatting && pnpm lint:fix",
-    "build": "tsc --noEmit",
-    "clean-target": "rm -rf target && mkdir -p target"
+    "prebuild": "rm -rf target",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/support-backend/tsconfig.json
+++ b/support-backend/tsconfig.json
@@ -1,9 +1,10 @@
 {
 	"extends": "../tsconfig.json",
+	"files": ["./src/server.ts"],
 	"compilerOptions": {
-	  "types": ["node", "jest"],
-	  "resolveJsonModule": true,
-	  "noEmit": true,
-    "outDir": "target"
+		"types": ["node", "jest"],
+		"resolveJsonModule": true,
+		"rootDir": "src",
+		"outDir":	"./target"
 	}
 }

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -77,7 +77,7 @@ riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffArtifactResources += (file("cdk/cdk.out/Frontend-PROD.template.json"), "cfn/Frontend-PROD.template.json")
 riffRaffArtifactResources += (file("cdk/cdk.out/Frontend-CODE.template.json"), "cfn/Frontend-CODE.template.json")
 riffRaffArtifactResources ++= getFiles(file("support-frontend/public/compiled-assets"), "assets-static")
-riffRaffArtifactResources ++= getFiles(file("support-backend/support-backend.tar.gz"), "support-backend.tar.gz")
+riffRaffArtifactResources ++= getFiles(file("support-backend/support-backend.tar.gz"), "backend/support-backend.tar.gz")
 
 def getFiles(rootFile: File, deployName: String): Seq[(File, String)] = {
   def getFiles0(f: File): Seq[(File, String)] = {

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -77,6 +77,7 @@ riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffArtifactResources += (file("cdk/cdk.out/Frontend-PROD.template.json"), "cfn/Frontend-PROD.template.json")
 riffRaffArtifactResources += (file("cdk/cdk.out/Frontend-CODE.template.json"), "cfn/Frontend-CODE.template.json")
 riffRaffArtifactResources ++= getFiles(file("support-frontend/public/compiled-assets"), "assets-static")
+riffRaffArtifactResources ++= getFiles(file("support-backend/support-backend.tar.gz"), "support-backend.tar.gz")
 
 def getFiles(rootFile: File, deployName: String): Seq[(File, String)] = {
   def getFiles0(f: File): Seq[(File, String)] = {


### PR DESCRIPTION
## What are you doing in this PR?

This PR adds a new step to the support-frontend-build GH workflow to create a deployable artifact for the new support-backend Express app. The artifact is a .tar.gz archive which contains the transpiled application JS and the production node_modules needed to run the app. This artifact is then uploaded to Riff Raff (but is not deployable yet, that's coming in #7953).

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1213569470208973)

## Why are you doing this?

Working towards a deployable TS backend.

## How to test

* The new build step is successful ✅ 
* Repeating `.github/workflows/support-frontend-build.yml` steps locally results in tar.gz file which can be extracted and run with node ✅ 