### PR TITLE
Checkout: Recaptcha terms removal

### DIFF
--- a/support-frontend/assets/components/recaptcha/recaptcha.tsx
+++ b/support-frontend/assets/components/recaptcha/recaptcha.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { palette, textSans12, until } from '@guardian/source/foundations';
+import { until } from '@guardian/source/foundations';
 import { useRecaptchaV2 } from 'helpers/customHooks/useRecaptcha';
 
 const container = css`
@@ -15,18 +15,6 @@ const container = css`
 	}
 `;
 
-const terms = css`
-	color: ${palette.neutral[46]};
-	${textSans12};
-
-	margin-top: 5px;
-
-	a {
-		color: ${palette.brand[500]};
-		text-decoration: none;
-	}
-`;
-
 type RecaptchaProps = {
 	id?: string;
 	onRecaptchaCompleted: (token: string) => void;
@@ -39,30 +27,9 @@ export function Recaptcha({
 	onRecaptchaExpired,
 }: RecaptchaProps): JSX.Element {
 	useRecaptchaV2(id, onRecaptchaCompleted, onRecaptchaExpired);
-
 	return (
 		<>
 			<div id={id} css={container} />
-			<p css={terms}>
-				By ticking this box, you agree to let Google perform a security check to
-				confirm you are a human. Please refer to their{' '}
-				<a
-					target="_blank"
-					rel="noopener noreferrer"
-					href="https://policies.google.com/terms"
-				>
-					terms
-				</a>{' '}
-				and{' '}
-				<a
-					target="_blank"
-					rel="noopener noreferrer"
-					href="https://policies.google.com/privacy"
-				>
-					privacy
-				</a>{' '}
-				policies.
-			</p>
 		</>
 	);
 }


### PR DESCRIPTION
## What are you doing in this PR?
- Remove the  recaptcha T&Cs language that is currently on checkout.
- Applies to `checkout` and `oneTimeCheckout`

## Why are you doing this?
Google is now a data processor rather than data controller for this data use so the relevant T&Cs are now in the Guardian privacy policy.

## How to test
_{Select Credit Card}_
https://support.thegulocal.com/uk/checkout?product=SupporterPlus&ratePlan=Monthly
https://support.thegulocal.com/uk/one-time-checkout

## Screenshots
|before|after|
|----|----|
|<img width="598" height="559" alt="image" src="https://github.com/user-attachments/assets/8df5cc2a-fdb2-41ed-b84c-6b864a4220ce" />|<img width="598" height="518" alt="image" src="https://github.com/user-attachments/assets/d19268c0-360a-4cce-9f72-3b2180c9f876" />|


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214100217153534