### PR TITLE
Use guardian/setup-scala in SBT dependency graph workflow

### DIFF
--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
       - sbt-dependency-graph-228eca55167613ca
-  workflow_dispatch: 
+  workflow_dispatch:
 jobs:
   dependency-graph:
     runs-on: ubuntu-latest
@@ -12,15 +12,8 @@ jobs:
       - name: Checkout branch
         id: checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4.2.1
-      - name: Install Java
-        id: java
-        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.4.0
-        with:
-          distribution: corretto
-          java-version: 17
-      - name: Install sbt
-        id: sbt
-        uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
+      - name: Setup Scala
+        uses: guardian/setup-scala@v1
       - name: Submit dependencies
         id: submit
         uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0


### PR DESCRIPTION
## What are you doing in this PR?

Updating the SBT dependency graph workflow to use `guardian/setup-scala`. 

## Why are you doing this?

This is the only remaining usage of `actions/setup-java` and `sbt/setup-sbt` in the repo after #7936.

## How to test

Run the workflow directly from this branch.