### PR TITLE
Exclude oneYearStudent rate plan from promotions logic

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -66,6 +66,12 @@ const getPromotionFromProductPrices = (
 	 * Get any promotions.
 	 * These come from the productPrices object for the particular product on window.guardian.
 	 */
+
+	// exclude one year student promotion as it's mapped to the annual billing period and we don't to apply regualr annual promotions to it
+	if (productKey === 'SupporterPlus' && ratePlanKey === 'OneYearStudent') {
+		return undefined;
+	}
+
 	const productPriceKey: LegacyProductType = getLegacyProductType(
 		productKey,
 		ratePlanKey,


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Early return from computing promotions for supporterPlus with oneYearStudent Rate plan.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Asana Card**](https://app.asana.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->
Promotions are only mapped via billing period and student offer is being caught in the Annual mapping thus returning any promotion for that rate plan.



## Screenshots
| Before | After |
|---|---|
|<img width="1150" height="892" alt="Screenshot 2026-05-05 at 14 57 40" src="https://github.com/user-attachments/assets/1b1bcad5-6b41-4490-af9c-76bc9de76897" />|<img width="1159" height="930" alt="Screenshot 2026-05-05 at 14 56 31" src="https://github.com/user-attachments/assets/ae564490-b112-4ff9-a567-a593186c144e" />|