### PR TITLE
Add standard Guardian prettier config for support-backend

### DIFF
--- a/support-backend/.prettierrc.js
+++ b/support-backend/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+	...require('@guardian/prettier'),
+};

--- a/support-backend/src/server.ts
+++ b/support-backend/src/server.ts
@@ -1,16 +1,14 @@
-import express from "express";
+import express from 'express';
 
 const app = express();
 
 const PORT = process.env.PORT ?? 3000;
 
-app.get("/healthcheck-express", (req, res) => {
-  console.log(
-    `HealthCheck processed from port: ${req.socket.localPort}`
-  );
-  res.json({ status: "OK" });
+app.get('/healthcheck-express', (req, res) => {
+	console.log(`HealthCheck processed from port: ${req.socket.localPort}`);
+	res.json({ status: 'OK' });
 });
 
 app.listen(PORT, () => {
-  console.log(`Server is running on port ${PORT}`);
+	console.log(`Server is running on port ${PORT}`);
 });

--- a/support-backend/src/test/sample.test.ts
+++ b/support-backend/src/test/sample.test.ts
@@ -1,10 +1,10 @@
-describe("sample", () => {
-  it("false", () => {
-    const result = false;
-    expect(result).toEqual(false);
-  });
-  it("true", () => {
-    const result = true;
-    expect(result).toEqual(true);
-  });
+describe('sample', () => {
+	it('false', () => {
+		const result = false;
+		expect(result).toEqual(false);
+	});
+	it('true', () => {
+		const result = true;
+		expect(result).toEqual(true);
+	});
 });

--- a/support-backend/tsconfig.json
+++ b/support-backend/tsconfig.json
@@ -5,6 +5,6 @@
 		"types": ["node", "jest"],
 		"resolveJsonModule": true,
 		"rootDir": "src",
-		"outDir":	"./target"
+		"outDir": "./target"
 	}
 }


### PR DESCRIPTION
## What are you doing in this PR?

Add standard Guardian prettier config to the `support-backend` workspace and format existing files according to the config.

## Why are you doing this?

To ensure consistent formatting.