### PR TITLE
Choice cards accessibility tweaks

### DIFF
--- a/support-e2e/tests/cron/three-tier.test.ts
+++ b/support-e2e/tests/cron/three-tier.test.ts
@@ -45,7 +45,7 @@ test.describe('Three Tier Checkout', () =>
 					await page.getByRole('tab', { name: billingFrequency }).click();
 
 					// 2. Click through to the checkout (we use the aria-label to target the link)
-					await page.getByLabel(productLabel, { exact: true }).click();
+					await page.getByRole('link', { name: productLabel, exact: false }).click();
 				},
 			);
 		});

--- a/support-e2e/tests/smoke/three-tier.test.ts
+++ b/support-e2e/tests/smoke/three-tier.test.ts
@@ -59,7 +59,7 @@ test.describe('Three Tier Checkout', () =>
 					await page.getByRole('tab', { name: billingFrequency }).click();
 
 					// 2. Click through to the checkout (we use the aria-label to target the link)
-					await page.getByLabel(productLabel, { exact: true }).click();
+					await page.getByRole('link', { name: productLabel, exact: false }).click();
 				},
 			);
 		});

--- a/support-frontend/assets/components/checkoutBenefits/benefitsCheckList.tsx
+++ b/support-frontend/assets/components/checkoutBenefits/benefitsCheckList.tsx
@@ -108,12 +108,17 @@ function ChecklistItemIcon({
 	style: CheckListStyle;
 }): JSX.Element {
 	const styleSize = style === 'standard' ? 'small' : 'xsmall';
+	const statusLabel = checked ? 'Included' : 'Not included';
 	return style === 'bullet' ? (
 		<BulletSvg />
-	) : checked ? (
-		<SvgTickRound isAnnouncedByScreenReader size={styleSize} />
 	) : (
-		<SvgCrossRoundFilled isAnnouncedByScreenReader size={styleSize} />
+		<span role="img" aria-label={statusLabel}>
+			{checked ? (
+				<SvgTickRound size={styleSize} />
+			) : (
+				<SvgCrossRoundFilled size={styleSize} />
+			)}
+		</span>
 	);
 }
 

--- a/support-frontend/assets/components/tooltip/Tooltip.tsx
+++ b/support-frontend/assets/components/tooltip/Tooltip.tsx
@@ -20,7 +20,7 @@ import {
 	visuallyHidden,
 } from '@guardian/source/foundations';
 import { Button, SvgCross } from '@guardian/source/react-components';
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { InfoRound } from './InfoRound';
 
 const buttonAndTooltipContainer = css`
@@ -191,6 +191,7 @@ export default function Tooltip({
 	desktopOnly,
 }: TooltipProps): JSX.Element {
 	const [open, setOpen] = useState(false);
+	const tooltipId = useId();
 
 	const { x, y, refs, strategy, context } = useFloating({
 		open,
@@ -231,6 +232,9 @@ export default function Tooltip({
 			<div css={buttonAndTooltipContainer}>
 				<div>
 					<Button
+						aria-controls={tooltipId}
+						aria-describedby={open ? tooltipId : undefined}
+						aria-expanded={open}
 						hideLabel
 						icon={<InfoRound />}
 						priority="tertiary"
@@ -241,7 +245,9 @@ export default function Tooltip({
 				</div>
 				<FloatingPortal>
 					<div
-						role="status"
+						id={tooltipId}
+						role="tooltip"
+						aria-hidden={!open}
 						css={[tooltipContainer, tooltipContainerDisplay(open, desktopOnly)]}
 						ref={refs.setFloating}
 						style={{

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -195,6 +195,11 @@ export function ThreeTierCard({
 	const currency = getCurrencyInfo(currencyId);
 	const periodNoun = getBillingPeriodNoun(billingPeriod);
 	const formattedPrice = simpleFormatAmount(currency, price);
+	const ariaLabelPrice = simpleFormatAmount(
+		currency,
+		promotion?.discountedPrice ?? price,
+	);
+	const linkAriaLabel = `${title}, ${ariaLabelPrice} per ${periodNoun}`;
 	const quantumMetricButtonRef = `tier-${cardTier}-button`;
 	const pillCopy = promotion?.landingPage?.roundel ?? cardContent.label?.copy;
 	const inAdditionToAllAccessDigital = product === 'DigitalSubscription';
@@ -257,7 +262,7 @@ export function ThreeTierCard({
 				href={link}
 				cssOverrides={btnStyleOverrides}
 				data-qm-trackable={quantumMetricButtonRef}
-				aria-label={title}
+				aria-label={linkAriaLabel}
 				theme={themeButtonReaderRevenueBrand}
 			>
 				{cta.copy}


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1214813992929289)

## Why are you doing this?
Some accessibility features are not working the best way for screen readers and can be improved.
In this PR three accessibility issues are addressed:
- In choice cards "Support" button aria-label text now includes the price and rate plan of the product to make it more clear which choice card is selected
- More information tooltip content in Choice cards' benefits is now readable with the screen reader
- Icons aria-label text now conveys more relevant information about included and not included benefits in Checkout page summary
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
Deployed to CODE environment and verified with screen reader
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
