### PR TITLE
fix three-tier e2e tests to target the correct element

### DIFF
--- a/support-e2e/tests/cron/three-tier.test.ts
+++ b/support-e2e/tests/cron/three-tier.test.ts
@@ -45,7 +45,9 @@ test.describe('Three Tier Checkout', () =>
 					await page.getByRole('tab', { name: billingFrequency }).click();
 
 					// 2. Click through to the checkout (we use the aria-label to target the link)
-					await page.getByRole('link', { name: productLabel, exact: false }).click();
+					await page
+						.getByRole('link', { name: new RegExp(`^${productLabel},`) })
+						.click();
 				},
 			);
 		});

--- a/support-e2e/tests/smoke/three-tier.test.ts
+++ b/support-e2e/tests/smoke/three-tier.test.ts
@@ -59,7 +59,9 @@ test.describe('Three Tier Checkout', () =>
 					await page.getByRole('tab', { name: billingFrequency }).click();
 
 					// 2. Click through to the checkout (we use the aria-label to target the link)
-					await page.getByRole('link', { name: productLabel, exact: false }).click();
+					await page
+						.getByRole('link', { name: new RegExp(`^${productLabel},`) })
+						.click();
 				},
 			);
 		});


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR fixes e2e tests after changes in this PR https://github.com/guardian/support-frontend/pull/7972
Two elements where targeted by these query: await page.getByRole('link', { name: productLabel, exact: false }).click(); so it is updated to use regex with "productLabel" + "," to target the correct element
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Asana Card**](https://app.asana.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
