### PR TITLE
Fix jest types for all workspaces by adding to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
 	"devDependencies": {
 		"@guardian/eslint-config": "^11.0.0",
 		"@guardian/prettier": "catalog:",
-		"prettier": "catalog:",
+		"@types/jest": "catalog:",
 		"eslint": "^9.38.0",
-		"husky": "^9.0.11"
+		"husky": "^9.0.11",
+		"prettier": "catalog:"
 	},
 	"pnpm": {
 		"overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@guardian/prettier':
         specifier: 'catalog:'
         version: 2.1.5(prettier@2.8.8)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 29.5.14
       eslint:
         specifier: ^9.38.0
         version: 9.38.0(jiti@2.4.2)


### PR DESCRIPTION
## What are you doing in this PR?

This fixes an issue in VSCode where types for jest methods (describe, it, expect etc) cannot be found resulting in errors shown in the IDE.

After experimenting with different fixes, adding @types/jest as a dev dependency to the root package.json seems to work. I think this is related to the fact that this is a workspaces project and VSCode is getting confused somehow.

## Why are you doing this?

It's distracting to have errors in the IDE and it means you can't click through to type definitions for Jest methods.

## Screenshots

### Before

<img width="637" height="149" alt="Screenshot 2026-05-19 at 11 58 20" src="https://github.com/user-attachments/assets/923a278e-6884-46f1-a203-971703962d36" />

### After

<img width="624" height="148" alt="Screenshot 2026-05-19 at 11 59 23" src="https://github.com/user-attachments/assets/b1703ff9-e555-43f7-90e6-e19c21629a86" />


