### PR TITLE
Increase no weekly acquisitions alarm period to 12 hours

### DIFF
--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -2950,7 +2950,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "NoWeeklyAcquisitionInOneDayAlarm69C071FE": {
+    "NoWeeklyAcquisitionForPeriodAlarmD2778900": {
       "DependsOn": [
         "SupportWorkersPROD",
         "SupportWorkersRoleDefaultPolicyCB757939",
@@ -2976,9 +2976,9 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "URGENT 9-5 - PROD support-workers No successful guardian weekly checkouts in 8h.",
+        "AlarmName": "URGENT 9-5 - PROD support-workers No successful guardian weekly checkouts in 12 hours.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "EvaluationPeriods": 96,
+        "EvaluationPeriods": 144,
         "Metrics": [
           {
             "Expression": "SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0)])",

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -610,16 +610,23 @@ export class SupportWorkers extends GuStack {
       threshold: 0,
     }).node.addDependency(stateMachine);
 
-    new GuAlarm(this, "NoWeeklyAcquisitionInOneDayAlarm", {
+    // Guardian Weekly alarm for all payment providers combined (Stripe, Gocardless, Paypal)
+    const weeklyMetricDuration = Duration.minutes(5);
+    const weeklyEvaluationPeriods = 144; // The number of 5 minute periods in 12 hours
+    const weeklyAlarmPeriod = Duration.minutes(
+      weeklyMetricDuration.toMinutes() * weeklyEvaluationPeriods
+    );
+
+    new GuAlarm(this, "NoWeeklyAcquisitionForPeriodAlarm", {
       app,
       actionsEnabled: isProd,
       okAction: true,
       snsTopicName: `alarms-handler-topic-${this.stage}`,
-      alarmName: `URGENT 9-5 - ${this.stage} support-workers No successful guardian weekly checkouts in 8h.`,
+      alarmName: `URGENT 9-5 - ${this.stage} support-workers No successful guardian weekly checkouts in ${weeklyAlarmPeriod.toHumanString()}.`,
       metric: new MathExpression({
         label: "AllWeeklyConversions",
         expression: "SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0)])",
-        period: Duration.minutes(5),
+        period: weeklyMetricDuration,
         usingMetrics: {
           m1: this.buildPaymentSuccessMetric(
             PaymentProviders.Stripe,
@@ -636,7 +643,7 @@ export class SupportWorkers extends GuStack {
         },
       }),
       comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
-      evaluationPeriods: 96,
+      evaluationPeriods: weeklyEvaluationPeriods,
       treatMissingData: TreatMissingData.BREACHING,
       threshold: 0,
     }).node.addDependency(stateMachine);


### PR DESCRIPTION
…o noisy.

<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
increase weekly alarm threshold to 12 hours.
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Asana Card**](https://app.asana.com)

## Why are you doing this?
Alarms channel is being too noisy
<!--
Remember, PRs are documentation for future contributors.
-->
