### PR TITLE
Ensure a separate PayPal payment token per purchase

### DIFF
--- a/support-frontend/app/services/PayPalCompletePaymentsService.scala
+++ b/support-frontend/app/services/PayPalCompletePaymentsService.scala
@@ -30,6 +30,7 @@ case class PayPalPaymentSource(
     customer_type: String,
     description: String,
     experience_context: ExperienceContext,
+    permit_multiple_payment_tokens: Boolean,
 )
 object PayPalPaymentSource {
   implicit val codec: Codec[PayPalPaymentSource] = deriveCodec
@@ -130,6 +131,9 @@ class PayPalCompletePaymentsService(config: PayPalCompletePaymentsConfig, client
             cancel_url = cancelUrl,
             shipping_preference = "NO_SHIPPING",
           ),
+          // We want a separate payment token per purchase. This way subscriptions can be
+          // cancelled in a granular way on the PayPal side.
+          permit_multiple_payment_tokens = true,
         ),
       ),
     )


### PR DESCRIPTION
## What are you doing in this PR?

Ensure we get a separate PayPal payment token per purchase.

## Why are you doing this?

So that it's possible to cancel subscriptions in a granular way from the PayPal side. Sometimes we see payments grouped under a single payment token, though it's unclear exactly what the rules are.

https://developer.paypal.com/docs/api/payment-tokens/v3/#setup-tokens_create!ct=application/json&path=payment_source/paypal/permit_multiple_payment_tokens&t=request

## How to test

1. Opt into the `ab-paypalMigrationRecurring` AB test on the checkout and select the variant.
2. Go through the PayPal flow for any recurring product.
3. Repeat 1 & 2.
4. Inspect the payment tokens for each purchase in Zuora and verify that they are different.