### PR TITLE
Make support-backend logs available in Cloudwatch

### DIFF
--- a/cdk/lib/__snapshots__/backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/backend.test.ts.snap
@@ -883,9 +883,9 @@ mkdir /var/log/support-backend
 chown -R support-backend:support /var/log/support-backend
 
 cd target
-/usr/local/node/pm2 start --uid support-backend --gid support --output ~/.pm2/logs/application.log --error ~/.pm2/logs/application.log server.js
+/usr/local/node/pm2 start --uid support-backend --gid support --output /var/log/application.log --error /var/log/application.log server.js
 
-/opt/cloudwatch-logs/configure-logs application support PROD support-backend ~/.pm2/logs/application.log",
+/opt/cloudwatch-logs/configure-logs application support PROD support-backend /var/log/application.log",
                 ],
               ],
             },

--- a/cdk/lib/__snapshots__/backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/backend.test.ts.snap
@@ -883,9 +883,9 @@ mkdir /var/log/support-backend
 chown -R support-backend:support /var/log/support-backend
 
 cd target
-/usr/local/node/pm2 start --uid support-backend --gid support --output /var/log/application.log --error /var/log/application.log server.js
+/usr/local/node/pm2 start --uid support-backend --gid support --output /var/log/support-backend/application.log --error /var/log/support-backend/application.log server.js
 
-/opt/cloudwatch-logs/configure-logs application support PROD support-backend /var/log/application.log",
+/opt/cloudwatch-logs/configure-logs application support PROD support-backend /var/log/support-backend/application.log",
                 ],
               ],
             },

--- a/cdk/lib/__snapshots__/backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/backend.test.ts.snap
@@ -883,7 +883,9 @@ mkdir /var/log/support-backend
 chown -R support-backend:support /var/log/support-backend
 
 cd target
-/usr/local/node/pm2 start --uid support-backend --gid support server.js",
+/usr/local/node/pm2 start --uid support-backend --gid support --output ~/.pm2/logs/application.log --error ~/.pm2/logs/application.log server.js
+
+/opt/cloudwatch-logs/configure-logs application support PROD support-backend ~/.pm2/logs/application.log",
                 ],
               ],
             },

--- a/cdk/lib/backend.ts
+++ b/cdk/lib/backend.ts
@@ -60,7 +60,11 @@ mkdir /var/log/${app}
 chown -R ${app}:support /var/log/${app}
 
 cd target
-/usr/local/node/pm2 start --uid ${app} --gid support server.js`);
+/usr/local/node/pm2 start --uid ${app} --gid support --output ~/.pm2/logs/application.log --error ~/.pm2/logs/application.log server.js
+
+/opt/cloudwatch-logs/configure-logs application ${this.stack} ${
+			this.stage
+		} ${app} ~/.pm2/logs/application.log`);
 
 		const policies = [
 			new GuAllowPolicy(this, 'SSMGet', {

--- a/cdk/lib/backend.ts
+++ b/cdk/lib/backend.ts
@@ -60,11 +60,11 @@ mkdir /var/log/${app}
 chown -R ${app}:support /var/log/${app}
 
 cd target
-/usr/local/node/pm2 start --uid ${app} --gid support --output /var/log/application.log --error /var/log/application.log server.js
+/usr/local/node/pm2 start --uid ${app} --gid support --output /var/log/${app}/application.log --error /var/log/${app}/application.log server.js
 
 /opt/cloudwatch-logs/configure-logs application ${this.stack} ${
 			this.stage
-		} ${app} /var/log/application.log`);
+		} ${app} /var/log/${app}/application.log`);
 
 		const policies = [
 			new GuAllowPolicy(this, 'SSMGet', {

--- a/cdk/lib/backend.ts
+++ b/cdk/lib/backend.ts
@@ -60,11 +60,11 @@ mkdir /var/log/${app}
 chown -R ${app}:support /var/log/${app}
 
 cd target
-/usr/local/node/pm2 start --uid ${app} --gid support --output ~/.pm2/logs/application.log --error ~/.pm2/logs/application.log server.js
+/usr/local/node/pm2 start --uid ${app} --gid support --output /var/log/application.log --error /var/log/application.log server.js
 
 /opt/cloudwatch-logs/configure-logs application ${this.stack} ${
 			this.stage
-		} ${app} ~/.pm2/logs/application.log`);
+		} ${app} /var/log/application.log`);
 
 		const policies = [
 			new GuAllowPolicy(this, 'SSMGet', {

--- a/support-backend/src/server.ts
+++ b/support-backend/src/server.ts
@@ -5,7 +5,6 @@ const app = express();
 const PORT = process.env.PORT ?? 3000;
 
 app.get('/healthcheck-express', (req, res) => {
-	console.log(`HealthCheck processed from port: ${req.socket.localPort}`);
 	res.json({ status: 'OK' });
 });
 


### PR DESCRIPTION
## What are you doing in this PR?

Making Node logs for the new support backend available in Cloudwatch.

This includes a change to make pm2 log message and errors to the same file, so that the Cloudwatch agent can pick them up from a single place.

TODO: Perform log rotation on the file system. This could be done in a follow up PR as we're logging very little at this point.

## Why are you doing this?

We currently have no way to easily interrogate these logs, making it hard to troubleshoot issues.