### PR TITLE
Add logging to support-workers

### DIFF
--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -3626,6 +3626,33 @@ exports[`The support-workers stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
+    "SupportWorkersLogGroup3988AB33": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/states/support-workers-PROD",
+        "RetentionInDays": 14,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
     "SupportWorkersPROD": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
@@ -3717,6 +3744,22 @@ exports[`The support-workers stack matches the snapshot 1`] = `
               "","Payload.$":"$"}},"SucceedOrFailChoice":{"Type":"Choice","Choices":[{"Variable":"$.requestInfo.testUser","BooleanEquals":true,"Next":"CheckoutFailure"},{"Variable":"$.requestInfo.failed","BooleanEquals":true,"Next":"FailState"}],"Default":"CheckoutFailure"},"CheckoutFailure":{"Type":"Pass","End":true},"FailState":{"Type":"Fail"}},"TimeoutSeconds":86400}",
             ],
           ],
+        },
+        "LoggingConfiguration": {
+          "Destinations": [
+            {
+              "CloudWatchLogsLogGroup": {
+                "LogGroupArn": {
+                  "Fn::GetAtt": [
+                    "SupportWorkersLogGroup3988AB33",
+                    "Arn",
+                  ],
+                },
+              },
+            },
+          ],
+          "IncludeExecutionData": true,
+          "Level": "ALL",
         },
         "RoleArn": {
           "Fn::GetAtt": [
@@ -3967,6 +4010,33 @@ exports[`The support-workers stack matches the snapshot 1`] = `
                   ],
                 },
               ],
+            },
+            {
+              "Action": [
+                "logs:CreateLogDelivery",
+                "logs:GetLogDelivery",
+                "logs:UpdateLogDelivery",
+                "logs:DeleteLogDelivery",
+                "logs:ListLogDeliveries",
+                "logs:PutResourcePolicy",
+                "logs:DescribeResourcePolicies",
+                "logs:DescribeLogGroups",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "SupportWorkersLogGroup3988AB33",
+                  "Arn",
+                ],
+              },
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -285,14 +285,10 @@ export class SupportWorkers extends GuStack {
 			.next(createSalesforceContactLambda)
 			.next(createZuoraSubscriptionTS.next(parallelSteps));
 
-		const stateMachineLogGroup = new LogGroup(
-			this,
-			'SupportWorkersLogGroup',
-			{
-				logGroupName: `/aws/states/support-workers-${this.stage}`,
-				retention: RetentionDays.TWO_WEEKS,
-			},
-		);
+		const stateMachineLogGroup = new LogGroup(this, 'SupportWorkersLogGroup', {
+			logGroupName: `/aws/states/support-workers-${this.stage}`,
+			retention: RetentionDays.TWO_WEEKS,
+		});
 
 		const stateMachine = new StateMachine(this, 'SupportWorkers', {
 			stateMachineName: `${app}-${this.stage}`, // Used by support-frontend to find the state machine

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -16,12 +16,14 @@ import {
 	WebIdentityPrincipal,
 } from 'aws-cdk-lib/aws-iam';
 import { Architecture, LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import {
 	Choice,
 	Condition,
 	DefinitionBody,
 	Errors,
 	Fail,
+	LogLevel,
 	Parallel,
 	Pass,
 	StateMachine,
@@ -283,16 +285,32 @@ export class SupportWorkers extends GuStack {
 			.next(createSalesforceContactLambda)
 			.next(createZuoraSubscriptionTS.next(parallelSteps));
 
+		const stateMachineLogGroup = new LogGroup(
+			this,
+			'SupportWorkersLogGroup',
+			{
+				logGroupName: `/aws/states/support-workers-${this.stage}`,
+				retention: RetentionDays.TWO_WEEKS,
+			},
+		);
+
 		const stateMachine = new StateMachine(this, 'SupportWorkers', {
 			stateMachineName: `${app}-${this.stage}`, // Used by support-frontend to find the state machine
 			timeout: Duration.hours(24),
 			definitionBody: DefinitionBody.fromChainable(allSteps),
+			logs: {
+				destination: stateMachineLogGroup,
+				level: LogLevel.ALL,
+				includeExecutionData: true,
+			},
 		});
 
 		this.overrideLogicalId(stateMachine, {
 			logicalId: `SupportWorkers${this.stage}`,
 			reason: 'Moving existing step function to CDK',
 		});
+
+		stateMachineLogGroup.grantWrite(stateMachine);
 
 		// Alarms
 		const isProd = this.stage === 'PROD';


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

I noticed that we can log step function executions to CloudWatch, this will make it easier to search the request bodies of executions. 

Currently I have set up logging to log all execution data with a retention period of 2 weeks. If we think this is too much data then we could change the logging level to error although I think this negates the point of adding logs because failed executions are easy to find anyway.