### PR TITLE
Fix tracking of url-forced tests

### DIFF
--- a/support-frontend/assets/helpers/abTests/__tests__/pageParticipations.spec.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/pageParticipations.spec.ts
@@ -150,6 +150,24 @@ describe('getPageParticipations', () => {
 			);
 		});
 
+		it('stores forced participation in session storage', async () => {
+			const variant = createTestVariant('control', 'control-value');
+			const test = createPageTest('test-1', [variant]);
+			const config = createConfig([test]);
+
+			mockLocation('/test/page', '?force-test=test-1:control');
+			mockGetParticipationFromQueryString.mockReturnValue({
+				'test-1': 'control',
+			});
+
+			await getPageParticipations(config);
+
+			expect(mockSetSessionParticipations).toHaveBeenCalledWith(
+				{ 'test-1': 'control' },
+				'landingPageParticipations',
+			);
+		});
+
 		it('returns undefined variant when forced participation test not found', async () => {
 			const test = createPageTest('test-1', [
 				createTestVariant('control', 'control-value'),

--- a/support-frontend/assets/helpers/abTests/pageParticipations.ts
+++ b/support-frontend/assets/helpers/abTests/pageParticipations.ts
@@ -114,6 +114,7 @@ export async function getPageParticipations<Variant>(
 	);
 	if (urlParticipations) {
 		const variant = getVariant(urlParticipations, tests);
+		setSessionParticipations(urlParticipations, sessionStorageKey);
 		return { participations: urlParticipations, variant };
 	}
 


### PR DESCRIPTION
Sometimes we force the landing page test from the url, e.g. if a banner choice card needs to put the user into a particular landing page experience then it uses the `force-landing-page` parameter.
The logic for using the test participation from the url doesn't add the participation to session storage. This means that on subsequent page views the user drops out of the test.
This PR fixes that