### PR TITLE
Remove aws-actions/configure-aws-credentials usage

### DIFF
--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -36,19 +36,25 @@ jobs:
       - name: Build CFN from CDK
         run: ./script/ci
         working-directory: cdk
-
-      # Required by sbt riffRaffUpload
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
-
       - name: Setup Scala
         uses: guardian/setup-scala@v1
 
-      - name: Build and upload to RiffRaff
-        run: |
-          export LAST_TEAMCITY_BUILD=6000
-          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt "project support-payment-api" clean riffRaffUpload
+      - name: Build deb package
+        run: sbt "project support-payment-api" clean debian:packageBin
+
+
+      - name: Upload to Riff-Raff
+        uses: guardian/actions-riff-raff@v4.3.2
+        with:
+          projectName: support:payment-api-mono
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          buildNumberOffset: 6000
+          commentingEnabled: 'false'
+          configPath: ./support-payment-api/src/main/resources/riff-raff.yaml
+          contentDirectories: |
+            payment-api:
+              - support-payment-api/target/payment-api_0.1_all.deb
+            cfn:
+              - cdk/cdk.out/Payment-API-CODE.template.json
+              - cdk/cdk.out/Payment-API-PROD.template.json

--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -36,12 +36,12 @@ jobs:
       - name: Build CFN from CDK
         run: ./script/ci
         working-directory: cdk
+
       - name: Setup Scala
         uses: guardian/setup-scala@v1
 
       - name: Build deb package
         run: sbt "project support-payment-api" clean debian:packageBin
-
 
       - name: Upload to Riff-Raff
         uses: guardian/actions-riff-raff@v4.3.2

--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -41,7 +41,7 @@ jobs:
         uses: guardian/setup-scala@v1
 
       - name: Build deb package
-        run: sbt "project support-payment-api" clean debian:packageBin
+        run: sbt "project support-payment-api" clean test debian:packageBin
 
       - name: Upload to Riff-Raff
         uses: guardian/actions-riff-raff@v4.3.2

--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -44,7 +44,7 @@ jobs:
         run: sbt "project support-payment-api" clean test debian:packageBin
 
       - name: Upload to Riff-Raff
-        uses: guardian/actions-riff-raff@v4.3.2
+        uses: guardian/actions-riff-raff@v4
         with:
           projectName: support:payment-api-mono
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -53,18 +53,32 @@ jobs:
           tar -czf support-backend.tar.gz target
           popd
 
-      # Required by sbt riffRaffUpload
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
-
       - name: Setup Scala
         uses: guardian/setup-scala@v1
 
-      - name: Build, test, and upload to RiffRaff
+      - name: Build, test, and package
         run: |
-          export LAST_TEAMCITY_BUILD=10000
-          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt "project support-frontend" test riffRaffUpload
+          sbt "project support-frontend" clean test debian:packageBin
+
+      - name: Upload to Riff-Raff
+        uses: guardian/actions-riff-raff@v4.3.2
+        with:
+          projectName: support:frontend-mono
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          buildNumberOffset: 10000
+          commentingEnabled: 'false'
+          configPath: ./support-frontend/conf/riff-raff.yaml
+          contentDirectories: |
+            frontend:
+              - support-frontend/target/support-frontend_1.0-SNAPSHOT_all.deb
+            support-backend:
+              - ./support-backend/support-backend.tar.gz
+            cfn-backend:
+              - ./cdk/cdk.out/Backend-CODE.template.json
+              - ./cdk/cdk.out/Backend-PROD.template.json
+            cfn-frontend:
+              - ./cdk/cdk.out/Frontend-CODE.template.json
+              - ./cdk/cdk.out/Frontend-PROD.template.json
+            assets-static:
+              - ./support-frontend/public/compiled-assets

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -57,11 +57,10 @@ jobs:
         uses: guardian/setup-scala@v1
 
       - name: Build, test, and package
-        run: |
-          sbt "project support-frontend" clean test debian:packageBin
+        run: sbt "project support-frontend" clean test debian:packageBin
 
       - name: Upload to Riff-Raff
-        uses: guardian/actions-riff-raff@v4.3.2
+        uses: guardian/actions-riff-raff@v4
         with:
           projectName: support:frontend-mono
           githubToken: ${{ secrets.GITHUB_TOKEN }}
@@ -73,12 +72,12 @@ jobs:
             frontend:
               - support-frontend/target/support-frontend_1.0-SNAPSHOT_all.deb
             support-backend:
-              - ./support-backend/support-backend.tar.gz
+              - support-backend/support-backend.tar.gz
             cfn-backend:
-              - ./cdk/cdk.out/Backend-CODE.template.json
-              - ./cdk/cdk.out/Backend-PROD.template.json
+              - cdk/cdk.out/Backend-CODE.template.json
+              - cdk/cdk.out/Backend-PROD.template.json
             cfn-frontend:
-              - ./cdk/cdk.out/Frontend-CODE.template.json
-              - ./cdk/cdk.out/Frontend-PROD.template.json
+              - cdk/cdk.out/Frontend-CODE.template.json
+              - cdk/cdk.out/Frontend-PROD.template.json
             assets-static:
-              - ./support-frontend/public/compiled-assets
+              - support-frontend/public/compiled-assets

--- a/.github/workflows/support-lambdas-build.yml
+++ b/.github/workflows/support-lambdas-build.yml
@@ -53,10 +53,10 @@ jobs:
           commentingEnabled: "false"
           contentDirectories: |
             acquisition-events-api:
-              - ./support-lambdas/acquisition-events-api/target/scala-2.13/acquisition-events-api.jar
+              - support-lambdas/acquisition-events-api/target/scala-2.13/acquisition-events-api.jar
             cfn:
-              - ./cdk/cdk.out/Acquisition-Events-API-CODE.template.json
-              - ./cdk/cdk.out/Acquisition-Events-API-PROD.template.json
+              - cdk/cdk.out/Acquisition-Events-API-CODE.template.json
+              - cdk/cdk.out/Acquisition-Events-API-PROD.template.json
 
       - name: Upload Stripe Intent to Riff-Raff
         uses: guardian/actions-riff-raff@v4
@@ -69,9 +69,9 @@ jobs:
           commentingEnabled: "false"
           contentDirectories: |
             stripe-intent:
-              - ./support-lambdas/stripe-intent/target/scala-2.13/stripe-intent.jar
+              - support-lambdas/stripe-intent/target/scala-2.13/stripe-intent.jar
             cfn:
-              - ./support-lambdas/stripe-intent/cfn.yaml
+              - support-lambdas/stripe-intent/cfn.yaml
 
   support_lambdas_typescripts_bigquery_acquisition_publisher:
     if: >-

--- a/.github/workflows/support-lambdas-build.yml
+++ b/.github/workflows/support-lambdas-build.yml
@@ -42,14 +42,14 @@ jobs:
         run: |
           sbt "project support-lambdas" clean assembly
 
-      - name: Upload to Riff-Raff
+      - name: Upload Acquisition Events API to Riff-Raff
         uses: guardian/actions-riff-raff@v4
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           projectName: "support:lambdas:acquisition-events-api"
           buildNumberOffset: 15000
-          configPath: "support-lambdas/riff-raff.yaml"
+          configPath: ./support-lambdas/acquisition-events-api/riff-raff.yaml
           commentingEnabled: "false"
           contentDirectories: |
             acquisition-events-api:
@@ -57,6 +57,21 @@ jobs:
             cfn:
               - ./cdk/cdk.out/Acquisition-Events-API-CODE.template.json
               - ./cdk/cdk.out/Acquisition-Events-API-PROD.template.json
+
+      - name: Upload Stripe Intent to Riff-Raff
+        uses: guardian/actions-riff-raff@v4
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          projectName: "support:lambdas:Stripe Intent"
+          buildNumberOffset: 15000
+          configPath: ./support-lambdas/stripe-intent/riff-raff.yaml
+          commentingEnabled: "false"
+          contentDirectories: |
+            stripe-intent:
+              - ./support-lambdas/stripe-intent/target/scala-2.13/stripe-intent.jar
+            cfn:
+              - ./support-lambdas/stripe-intent/cfn.yaml
 
   support_lambdas_typescripts_bigquery_acquisition_publisher:
     if: >-

--- a/.github/workflows/support-lambdas-build.yml
+++ b/.github/workflows/support-lambdas-build.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build jar
         run: |
-          sbt "project support-lambdas" clean assembly
+          sbt "project support-lambdas" clean test assembly
 
       - name: Upload Acquisition Events API to Riff-Raff
         uses: guardian/actions-riff-raff@v4

--- a/.github/workflows/support-lambdas-build.yml
+++ b/.github/workflows/support-lambdas-build.yml
@@ -35,21 +35,28 @@ jobs:
         run: ./script/ci
         working-directory: cdk
 
-      # Required by sbt riffRaffUpload
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
-
       - name: Setup Scala
         uses: guardian/setup-scala@v1
 
-      - name: Build and upload to RiffRaff
+      - name: Build jar
         run: |
-          export LAST_TEAMCITY_BUILD=15000
-          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt "project support-lambdas" riffRaffUpload
+          sbt "project support-lambdas" clean assembly
+
+      - name: Upload to Riff-Raff
+        uses: guardian/actions-riff-raff@v4
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          projectName: "support:lambdas:acquisition-events-api"
+          buildNumberOffset: 15000
+          configPath: "support-lambdas/riff-raff.yaml"
+          commentingEnabled: "false"
+          contentDirectories: |
+            acquisition-events-api:
+              - ./support-lambdas/acquisition-events-api/target/scala-2.13/acquisition-events-api.jar
+            cfn:
+              - ./cdk/cdk.out/Acquisition-Events-API-CODE.template.json
+              - ./cdk/cdk.out/Acquisition-Events-API-PROD.template.json
 
   support_lambdas_typescripts_bigquery_acquisition_publisher:
     if: >-
@@ -85,12 +92,6 @@ jobs:
 
       - run: zip -qr index.zip ./*.js
         working-directory: support-lambdas/bigquery-acquisitions-publisher/target/typescript
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
 
       - name: Upload to Riff-Raff
         uses: guardian/actions-riff-raff@v4

--- a/.github/workflows/supporter-product-data.yml
+++ b/.github/workflows/supporter-product-data.yml
@@ -24,23 +24,29 @@ jobs:
     steps:
       - name: Env
         run: env
+
       - name: Checkout repo
         uses: actions/checkout@v6
-
-      # Required by sbt riffRaffUpload
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
 
       - uses: sbt/setup-sbt@v1
 
       - name: Setup Scala
         uses: guardian/setup-scala@v1
 
-      - name: Build and upload supporter-product-data to RiffRaff
-        run: |
-          export LAST_TEAMCITY_BUILD=6000
-          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt "project supporter-product-data" riffRaffUpload
+      - name: Build jar
+        run:   sbt "project supporter-product-data" clean assembly
+
+      - name: Upload to Riff-Raff
+        uses: guardian/actions-riff-raff@v4.3.2
+        with:
+          projectName: support:supporter-product-data
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          buildNumberOffset: 6000
+          commentingEnabled: 'false'
+          configPath: ./supporter-product-data/riff-raff.yaml
+          contentDirectories: |
+            cfn:
+              - ./supporter-product-data/cloudformation/cfn.yaml
+            supporter-product-data:
+              - supporter-product-data/target/scala-2.13/supporter-product-data.jar

--- a/.github/workflows/supporter-product-data.yml
+++ b/.github/workflows/supporter-product-data.yml
@@ -37,7 +37,7 @@ jobs:
         run:  sbt "project supporter-product-data" clean test assembly
 
       - name: Upload to Riff-Raff
-        uses: guardian/actions-riff-raff@v4.3.2
+        uses: guardian/actions-riff-raff@v4
         with:
           projectName: support:supporter-product-data
           githubToken: ${{ secrets.GITHUB_TOKEN }}
@@ -47,6 +47,6 @@ jobs:
           configPath: ./supporter-product-data/riff-raff.yaml
           contentDirectories: |
             cfn:
-              - ./supporter-product-data/cloudformation/cfn.yaml
+              - supporter-product-data/cloudformation/cfn.yaml
             supporter-product-data:
               - supporter-product-data/target/scala-2.13/supporter-product-data.jar

--- a/.github/workflows/supporter-product-data.yml
+++ b/.github/workflows/supporter-product-data.yml
@@ -34,7 +34,7 @@ jobs:
         uses: guardian/setup-scala@v1
 
       - name: Build jar
-        run:   sbt "project supporter-product-data" clean assembly
+        run:  sbt "project supporter-product-data" clean assembly
 
       - name: Upload to Riff-Raff
         uses: guardian/actions-riff-raff@v4.3.2

--- a/.github/workflows/supporter-product-data.yml
+++ b/.github/workflows/supporter-product-data.yml
@@ -34,7 +34,7 @@ jobs:
         uses: guardian/setup-scala@v1
 
       - name: Build jar
-        run:  sbt "project supporter-product-data" clean assembly
+        run:  sbt "project supporter-product-data" clean test assembly
 
       - name: Upload to Riff-Raff
         uses: guardian/actions-riff-raff@v4.3.2

--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,7 @@ lazy val root = (project in file("."))
   )
 
 lazy val `support-frontend` = (project in file("support-frontend"))
-  .enablePlugins(PlayScala, BuildInfoPlugin, RiffRaffArtifact, JDebPackaging)
+  .enablePlugins(PlayScala, BuildInfoPlugin, JDebPackaging)
   .disablePlugins(ReleasePlugin, SbtPgp, Sonatype)
   .configs(IntegrationTest)
   .settings(
@@ -145,7 +145,6 @@ lazy val `support-frontend` = (project in file("support-frontend"))
   )
 
 lazy val `supporter-product-data` = (project in file("supporter-product-data"))
-  .enablePlugins(RiffRaffArtifact)
   .disablePlugins(ReleasePlugin, SbtPgp, Sonatype)
   .configs(IntegrationTest)
   .settings(
@@ -164,7 +163,6 @@ lazy val `supporter-product-data-dynamo` = (project in file("support-modules/sup
   )
 
 lazy val `stripe-patrons-data` = (project in file("stripe-patrons-data"))
-  .enablePlugins(RiffRaffArtifact)
   .disablePlugins(ReleasePlugin, SbtPgp, Sonatype)
   .configs(IntegrationTest)
   .settings(
@@ -176,7 +174,7 @@ lazy val `stripe-patrons-data` = (project in file("stripe-patrons-data"))
   .aggregate(`module-rest`, `module-aws`, `supporter-product-data-dynamo`)
 
 lazy val `support-payment-api` = (project in file("support-payment-api"))
-  .enablePlugins(RiffRaffArtifact, SystemdPlugin, PlayService, RoutesCompiler, JDebPackaging, BuildInfoPlugin)
+  .enablePlugins(SystemdPlugin, PlayService, RoutesCompiler, JDebPackaging, BuildInfoPlugin)
   .disablePlugins(ReleasePlugin, SbtPgp, Sonatype)
   .settings(
     buildInfoKeys := BuildInfoSettings.buildInfoKeys,
@@ -277,7 +275,6 @@ lazy val `support-internationalisation` = (project in file("support-internationa
   )
 
 lazy val `stripe-intent` = (project in file("support-lambdas/stripe-intent"))
-  .enablePlugins(RiffRaffArtifact)
   .disablePlugins(ReleasePlugin, SbtPgp, Sonatype)
   .configs(IntegrationTest)
   .settings(
@@ -289,7 +286,6 @@ lazy val `stripe-intent` = (project in file("support-lambdas/stripe-intent"))
   .aggregate(`module-rest`, `support-config`, `module-aws`)
 
 lazy val `acquisition-events-api` = (project in file("support-lambdas/acquisition-events-api"))
-  .enablePlugins(RiffRaffArtifact)
   .disablePlugins(ReleasePlugin, SbtPgp, Sonatype)
   .settings(
     scalafmtSettings,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,8 +22,6 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.5")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
-
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 //Fix for sbt-native-packager 1.9.11 upgrade errors
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always

--- a/stripe-patrons-data/build.sbt
+++ b/stripe-patrons-data/build.sbt
@@ -1,5 +1,4 @@
 import LibraryVersions.{awsClientVersion2, circeVersion}
-import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport.riffRaffManifestProjectName
 import sbt.Keys.libraryDependencies
 
 version := "0.1-SNAPSHOT"
@@ -19,16 +18,6 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser" % circeVersion,
 )
 
-riffRaffPackageType := assembly.value
-riffRaffManifestProjectName := s"support:stripe-patrons-data"
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffArtifactResources += (
-  file("cdk/cdk.out/StripePatronsData-PROD.template.json"), "cfn/StripePatronsData-PROD.template.json"
-)
-riffRaffArtifactResources += (
-  file("cdk/cdk.out/StripePatronsData-CODE.template.json"), "cfn/StripePatronsData-CODE.template.json"
-)
 // We use the buildNumber to set the lambda fileName, because lambda versioning requires a new fileName each time
 val buildNumber = sys.env.getOrElse("GITHUB_RUN_NUMBER", "DEV")
 assemblyJarName := s"${name.value}-$buildNumber.jar"

--- a/stripe-patrons-data/project/plugins.sbt
+++ b/stripe-patrons-data/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.3")

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -68,30 +68,6 @@ packageSummary := "Support Frontend Play App"
 packageDescription := """Frontend for the new supporter platform"""
 maintainer := "Membership <membership.dev@theguardian.com>"
 
-riffRaffPackageType := (Debian / packageBin).value
-riffRaffManifestProjectName := "support:frontend-mono"
-riffRaffPackageName := "frontend"
-riffRaffAwsCredentialsProfile := Some("membership") // needed when running locally
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffArtifactResources += (file(
-  "cdk/cdk.out/Frontend-PROD.template.json",
-), "cfn-frontend/Frontend-PROD.template.json")
-riffRaffArtifactResources += (file(
-  "cdk/cdk.out/Frontend-CODE.template.json",
-), "cfn-frontend/Frontend-CODE.template.json")
-riffRaffArtifactResources += (file(
-  "cdk/cdk.out/Backend-PROD.template.json",
-), "cfn-backend/Backend-PROD.template.json")
-riffRaffArtifactResources += (file(
-  "cdk/cdk.out/Backend-CODE.template.json",
-), "cfn-backend/Backend-CODE.template.json")
-riffRaffArtifactResources ++= getFiles(file("support-frontend/public/compiled-assets"), "assets-static")
-riffRaffArtifactResources ++= getFiles(
-  file("support-backend/support-backend.tar.gz"),
-  "support-backend/support-backend.tar.gz",
-)
-
 def getFiles(rootFile: File, deployName: String): Seq[(File, String)] = {
   def getFiles0(f: File): Seq[(File, String)] = {
     f match {

--- a/support-lambdas/acquisition-events-api/build.sbt
+++ b/support-lambdas/acquisition-events-api/build.sbt
@@ -10,13 +10,3 @@ libraryDependencies ++= Seq(
 )
 
 assemblyJarName := s"${name.value}.jar"
-riffRaffPackageType := assembly.value
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffManifestProjectName := s"support:lambdas:${name.value}"
-riffRaffArtifactResources += (file(
-  "cdk/cdk.out/Acquisition-Events-API-PROD.template.json",
-), "cfn/Acquisition-Events-API-PROD.template.json")
-riffRaffArtifactResources += (file(
-  "cdk/cdk.out/Acquisition-Events-API-CODE.template.json",
-), "cfn/Acquisition-Events-API-CODE.template.json")

--- a/support-lambdas/stripe-intent/build.sbt
+++ b/support-lambdas/stripe-intent/build.sbt
@@ -4,11 +4,6 @@ name := "stripe-intent"
 description := "Returns a stripe setup intent token so we can get authorisation of a recurring payment on the client side"
 
 assemblyJarName := "stripe-intent.jar"
-riffRaffPackageType := assembly.value
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffManifestProjectName := "support:lambdas:Stripe Intent"
-riffRaffArtifactResources += (file("support-lambdas/stripe-intent/cfn.yaml"), "cfn/cfn.yaml")
 
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core",

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -81,10 +81,3 @@ Debian / packageName := name.value
 packageSummary := "Payment API Play App"
 packageDescription := """API for reader revenue payments"""
 maintainer := "Reader Revenue <reader.revenue.dev@theguardian.com>"
-
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffManifestProjectName := "support:payment-api-mono"
-riffRaffPackageType := (Debian / packageBin).value
-riffRaffArtifactResources += (file("cdk/cdk.out/Payment-API-PROD.template.json"), "cfn/Payment-API-PROD.template.json")
-riffRaffArtifactResources += (file("cdk/cdk.out/Payment-API-CODE.template.json"), "cfn/Payment-API-CODE.template.json")

--- a/supporter-product-data/build.sbt
+++ b/supporter-product-data/build.sbt
@@ -1,5 +1,4 @@
 import LibraryVersions.{awsClientVersion2, circeVersion}
-import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport.riffRaffManifestProjectName
 import sbt.Keys.libraryDependencies
 
 version := "0.1-SNAPSHOT"
@@ -19,11 +18,6 @@ libraryDependencies ++= Seq(
   "com.jayway.jsonpath" % "json-path" % "2.8.0",
 )
 
-riffRaffPackageType := assembly.value
-riffRaffManifestProjectName := s"support:supporter-product-data"
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffArtifactResources += (file("supporter-product-data/cloudformation/cfn.yaml"), "cfn/cfn.yaml")
 assemblyJarName := s"${name.value}.jar"
 
 lazy val deployToCode =

--- a/supporter-product-data/project/plugins.sbt
+++ b/supporter-product-data/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.3")


### PR DESCRIPTION
Removes workflow steps using aws-actions/configure-aws-credentials.

# Implementation

This requires removing `sbt riffRaffUpload` and replacing with an explicit build and a list of files to upload for each sub-project.  Each should then be checked to confirm the set of files created is identical (small changes to deb/tarballs may be caused by different zipping algorithms).

# Sub-Projects affected

## support:payment-api-mono
branch: https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=support%3Apayment-api-mono&id=23096
main: https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=support%3Apayment-api-mono&id=23080

## support:frontend-mono
branch: https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=support%3Afrontend-mono&id=27261

main: https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=support%3Afrontend-mono&id=27242

## support:lambdas:acquisition-events-api
branch: https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=support%3Alambdas%3Aacquisition-events-api&id=30169

main: https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=support%3Alambdas%3Aacquisition-events-api&id=30152

## support:supporter-product-data
branch: https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=support%3Asupporter-product-data&id=20827
main: https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=support%3Asupporter-product-data&id=20808

## support:lambdas:Stripe Intent
(note the space!)
branch: https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=support%3Alambdas%3AStripe+Intent&id=30169
main: https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=support%3Alambdas%3AStripe+Intent&id=30152