### PR TITLE
Updated benefits copies for the Feast and Guardian apps in the onboarding pages

### DIFF
--- a/support-frontend/assets/components/onboarding/appBadgesDownload/badgesDownload.tsx
+++ b/support-frontend/assets/components/onboarding/appBadgesDownload/badgesDownload.tsx
@@ -111,7 +111,7 @@ export function OnboardingAppBadgesDownload({
 					<div css={separator} />
 					<div css={qrContainer}>
 						{qrCode}
-						<p>Scan to get the App</p>
+						<p>Scan to get the app</p>
 					</div>
 				</>
 			) : null}

--- a/support-frontend/assets/components/onboarding/sections/appsDiscovery.tsx
+++ b/support-frontend/assets/components/onboarding/sections/appsDiscovery.tsx
@@ -22,26 +22,25 @@ import {
 const GUARDIAN_APP_BENEFITS = [
 	{
 		title: 'Home',
-		description: 'Choose the sections that matter to you.',
+		description: 'Stay connected with the latest live events.',
 	},
 	{
 		title: 'My Guardian',
 		description:
-			'Personalise your feed, listen to articles, or save them for later.',
+			'Follow topics, save articles for later and view your reading history.',
 	},
 	{
 		title: 'Podcasts',
-		description: 'All your favourites in one place.',
+		description: 'Play all our latest episodes from one place.',
 	},
 	{
 		title: 'Puzzles',
-		description:
-			'Upgrade your downtime with daily word, number and quiz puzzles.',
+		description: 'Play our daily word, logic and quiz games.',
 	},
 	{
 		title: 'Settings',
 		description:
-			'Customise your experience with stories for offline reading, dark mode and notifications.',
+			'Set up your live events feed, notifications, offline reading and more.',
 	},
 	{
 		title: 'Ad-free reading',
@@ -135,9 +134,13 @@ export function OnboardingAppsDiscovery({
 					</h1>
 					<p css={descriptions}>
 						{isGuardianApp
-							? 'Get the stuff you want, when you want it — news, sport, podcasts, puzzles and more.'
+							? 'Get the stuff you want, when you want it - news, sport, podcasts, puzzles and more.'
 							: 'Rated 4 out of 5 stars by our Feast community.'}
 					</p>
+
+					{!hasAppDownloaded && (
+						<OnboardingAppBadgesDownload onboardingStep={onboardingStep} />
+					)}
 
 					<div css={separator}></div>
 					<ul>
@@ -157,10 +160,6 @@ export function OnboardingAppsDiscovery({
 							</li>
 						))}
 					</ul>
-
-					{!hasAppDownloaded && (
-						<OnboardingAppBadgesDownload onboardingStep={onboardingStep} />
-					)}
 
 					<Stack
 						space={0}

--- a/support-frontend/assets/components/onboarding/sections/appsDiscovery.tsx
+++ b/support-frontend/assets/components/onboarding/sections/appsDiscovery.tsx
@@ -72,7 +72,7 @@ const FEAST_APP_BENEFITS = [
 		title: 'Shopping list',
 		description: 'Add recipe ingredients and tick them off as you shop.',
 	},
-];
+] as const;
 
 const FEAST_APP_UNITS_BENEFIT = {
 	title: 'Recipes',
@@ -80,7 +80,7 @@ const FEAST_APP_UNITS_BENEFIT = {
 };
 
 const FEAST_APP_BENEFITS_US = [
-	...FEAST_APP_BENEFITS.slice(0, 1),
+	FEAST_APP_BENEFITS[0],
 	FEAST_APP_UNITS_BENEFIT,
 	...FEAST_APP_BENEFITS.slice(1),
 ];

--- a/support-frontend/assets/components/onboarding/sections/appsDiscovery.tsx
+++ b/support-frontend/assets/components/onboarding/sections/appsDiscovery.tsx
@@ -44,7 +44,7 @@ const GUARDIAN_APP_BENEFITS = [
 	},
 	{
 		title: 'Ad-free reading',
-		description: 'For an uninterrupted experience.',
+		description: 'Enjoy an uninterrupted experience.',
 	},
 ];
 
@@ -134,7 +134,7 @@ export function OnboardingAppsDiscovery({
 					</h1>
 					<p css={descriptions}>
 						{isGuardianApp
-							? 'Get the stuff you want, when you want it - news, sport, podcasts, puzzles and more.'
+							? 'News, sport, podcasts, puzzles and more.'
 							: 'Rated 4 out of 5 stars by our Feast community.'}
 					</p>
 

--- a/support-frontend/assets/components/onboarding/sections/appsDiscovery.tsx
+++ b/support-frontend/assets/components/onboarding/sections/appsDiscovery.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { palette, space } from '@guardian/source/foundations';
 import { Button, Stack, SvgTickRound } from '@guardian/source/react-components';
+import { SupportRegionId } from '@modules/internationalisation/countryGroup';
 import type { HandleStepNavigationFunction } from 'pages/[countryGroupId]/components/onboardingComponent';
 import { OnboardingSteps } from 'pages/[countryGroupId]/components/onboardingSteps';
 import { useWindowWidth } from 'pages/aus-moment-map/hooks/useWindowWidth';
@@ -52,7 +53,7 @@ const FEAST_APP_BENEFITS = [
 	{
 		title: 'Home',
 		description:
-			'Choose from over 7,000 curated recipes from our Guardian cooks.',
+			'Get inspired with over 7,000 recipes from our world-class cooks - and app exclusive recipes, just for you.',
 	},
 	{
 		title: 'Search',
@@ -61,8 +62,7 @@ const FEAST_APP_BENEFITS = [
 	},
 	{
 		title: 'My Feast',
-		description:
-			'Save your favourite recipes and curate your own recipe collections.',
+		description: 'Save your favourite recipes to your own curated collection.',
 	},
 	{
 		title: 'Cook mode',
@@ -71,20 +71,33 @@ const FEAST_APP_BENEFITS = [
 	},
 	{
 		title: 'Shopping list',
-		description: 'Add recipe ingredients to your weekly shop.',
+		description: 'Add recipe ingredients and tick them off as you shop.',
 	},
+];
+
+const FEAST_APP_UNITS_BENEFIT = {
+	title: 'Recipes',
+	description: 'Convert any recipe from metric to standard US units.',
+};
+
+const FEAST_APP_BENEFITS_US = [
+	...FEAST_APP_BENEFITS.slice(0, 1),
+	FEAST_APP_UNITS_BENEFIT,
+	...FEAST_APP_BENEFITS.slice(1),
 ];
 
 export function OnboardingAppsDiscovery({
 	hasMobileAppDownloaded,
 	hasFeastMobileAppDownloaded,
 	onboardingStep,
+	supporterRegion,
 	handleStepNavigation,
 }: {
 	hasMobileAppDownloaded: boolean;
 	hasFeastMobileAppDownloaded: boolean;
 	onboardingStep: OnboardingSteps;
 	handleStepNavigation: HandleStepNavigationFunction;
+	supporterRegion: SupportRegionId;
 }) {
 	const { windowWidthIsGreaterThan } = useWindowWidth();
 
@@ -93,9 +106,14 @@ export function OnboardingAppsDiscovery({
 		? hasMobileAppDownloaded
 		: hasFeastMobileAppDownloaded;
 
+	const FEAST_APP_BENEFITS_REGION =
+		supporterRegion === SupportRegionId.US
+			? FEAST_APP_BENEFITS_US
+			: FEAST_APP_BENEFITS;
+
 	const appBenefits = isGuardianApp
 		? GUARDIAN_APP_BENEFITS
-		: FEAST_APP_BENEFITS;
+		: FEAST_APP_BENEFITS_REGION;
 
 	const isTabledOrLarger = windowWidthIsGreaterThan('tablet');
 
@@ -118,12 +136,8 @@ export function OnboardingAppsDiscovery({
 					<p css={descriptions}>
 						{isGuardianApp
 							? 'Get the stuff you want, when you want it — news, sport, podcasts, puzzles and more.'
-							: 'Level up your cooking with more than 6,000 recipes and smart, exclusive cooking features.'}
+							: 'Rated 4 out of 5 stars by our Feast community.'}
 					</p>
-
-					{!hasAppDownloaded && (
-						<OnboardingAppBadgesDownload onboardingStep={onboardingStep} />
-					)}
 
 					<div css={separator}></div>
 					<ul>
@@ -143,6 +157,10 @@ export function OnboardingAppsDiscovery({
 							</li>
 						))}
 					</ul>
+
+					{!hasAppDownloaded && (
+						<OnboardingAppBadgesDownload onboardingStep={onboardingStep} />
+					)}
 
 					<Stack
 						space={0}

--- a/support-frontend/assets/pages/[countryGroupId]/components/onboardingComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/onboardingComponent.tsx
@@ -318,6 +318,7 @@ function OnboardingComponent({
 					hasMobileAppDownloaded={hasMobileAppDownloaded}
 					hasFeastMobileAppDownloaded={hasFeastMobileAppDownloaded}
 					onboardingStep={currentStep}
+					supporterRegion={supportRegionId}
 					handleStepNavigation={handleStepNavigation}
 				/>
 			)}

--- a/support-frontend/stories/onboarding/OnboardingAppsDiscovery.stories.tsx
+++ b/support-frontend/stories/onboarding/OnboardingAppsDiscovery.stories.tsx
@@ -23,6 +23,7 @@ const defaultArgs = {
 	handleStepNavigation: () => {},
 	hasMobileAppDownloaded: false,
 	hasFeastMobileAppDownloaded: false,
+	supporterRegion: 'uk' as const,
 };
 
 export const GuardianAppNotDownloaded = {
@@ -52,5 +53,13 @@ export const FeastAppAlreadyDownloaded = {
 		...defaultArgs,
 		onboardingStep: OnboardingSteps.FeastApp,
 		hasFeastMobileAppDownloaded: true,
+	},
+};
+
+export const FeastAppNotDownloadedUS = {
+	args: {
+		...defaultArgs,
+		onboardingStep: OnboardingSteps.FeastApp,
+		supporterRegion: 'us' as const,
 	},
 };


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Feast app and the Guardian app benefits copies are updated. Relevant 

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213134855566811/task/1215133636056367?focus=true)

## Why are you doing this?
Relevant documents on the onboarding copy changes for the [Feast app](https://docs.google.com/document/d/1ZYI0cxn6b1_KOu_zgQJFPjjcpJIauS4LLp-OimCuVfw/edit?tab=t.0) and the [Guardian app](https://docs.google.com/document/d/1L_hCcUHHv7lyBU0vMwAGhithyakfbnr9lrnStn4tl5k/edit?tab=t.0). 


<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
Tested the onboarding flow on CODE. 

## How can we measure success?
US-based users should see the metric-to-cups measurements feature on Feast app benefits. Updated benefit copy texts should be visible for the Guardian app and Feast app on the onboarding flow. 

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Screenshots
The Guardian app benefits copy
<img width="643" height="740" alt="image" src="https://github.com/user-attachments/assets/7ac3c28a-5979-420a-b247-f55e5e8f5748" />

Feast benefits copy (US)
<img width="631" height="761" alt="image" src="https://github.com/user-attachments/assets/82c82539-9dab-4053-aa72-27c4344f9fa3" />

Feast benefits copy (UK)
<img width="636" height="720" alt="image" src="https://github.com/user-attachments/assets/dc749aea-20a7-4c46-a942-23e43ad75ec8" />
