### PR TITLE
cache promotions to compute once per service instance

### DIFF
--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
@@ -13,6 +13,8 @@ class PromotionService(config: PromotionsConfig, maybeCollection: Option[Promoti
     with LazyLogging {
   private val promotionCollection = maybeCollection.getOrElse(new CachedDynamoPromotionCollection(config.tables))
   private def allPromotions = promotionCollection.all.toList
+  private lazy val promotionsByCode: Map[PromoCode, Promotion] =
+    allPromotions.iterator.map(promo => promo.promoCode -> promo).toMap
 
   def environment = if (config.tables.promotions.contains("PROD")) { "PROD" }
   else { "CODE" }
@@ -28,13 +30,8 @@ class PromotionService(config: PromotionsConfig, maybeCollection: Option[Promoti
 
   // promoCodes here is expected to be a small list of default promos plus one from the querystring
   def findPromotions(promoCodes: List[PromoCode]): List[PromotionWithCode] = {
-    val promosByCode: Map[PromoCode, Promotion] =
-      allPromotions
-        .map(promo => promo.promoCode -> promo)
-        .toMap
-
     promoCodes.flatMap { promoCode =>
-      promosByCode.get(promoCode).map(PromotionWithCode(promoCode, _))
+      promotionsByCode.get(promoCode).map(PromotionWithCode(promoCode, _))
     }
   }
 

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
@@ -13,8 +13,6 @@ class PromotionService(config: PromotionsConfig, maybeCollection: Option[Promoti
     with LazyLogging {
   private val promotionCollection = maybeCollection.getOrElse(new CachedDynamoPromotionCollection(config.tables))
   private def allPromotions = promotionCollection.all.toList
-  private lazy val promotionsByCode: Map[PromoCode, Promotion] =
-    allPromotions.iterator.map(promo => promo.promoCode -> promo).toMap
 
   def environment = if (config.tables.promotions.contains("PROD")) { "PROD" }
   else { "CODE" }
@@ -30,6 +28,7 @@ class PromotionService(config: PromotionsConfig, maybeCollection: Option[Promoti
 
   // promoCodes here is expected to be a small list of default promos plus one from the querystring
   def findPromotions(promoCodes: List[PromoCode]): List[PromotionWithCode] = {
+    val promotionsByCode = allPromotions.iterator.map(promo => promo.promoCode -> promo).toMap
     promoCodes.flatMap { promoCode =>
       promotionsByCode.get(promoCode).map(PromotionWithCode(promoCode, _))
     }


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This change uses iterator-based transformation before toMap to avoid creating an intermediate mapped collection.
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1213310019818834)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
Deployed to CODE env
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
