### PR TITLE
Checkouts: Email leading/trailing whitespace removal 

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
@@ -41,7 +41,7 @@ export function PersonalEmailFields({
 					optional={optional}
 					autoComplete="email"
 					onChange={(event) => {
-						setEmail(event.currentTarget.value);
+						setEmail(event.currentTarget.value.trim());
 					}}
 					onBlur={(event) => {
 						event.target.checkValidity();
@@ -77,7 +77,7 @@ export function PersonalEmailFields({
 							type="email"
 							autoComplete="email"
 							onChange={(event) => {
-								setConfirmedEmail(event.currentTarget.value);
+								setConfirmedEmail(event.currentTarget.value.trim());
 							}}
 							onBlur={(event) => {
 								// Delay to allow the state to update before checking validity.

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
@@ -40,8 +40,14 @@ export function PersonalEmailFields({
 					type="email"
 					optional={optional}
 					autoComplete="email"
+					onKeyDown={(event) => {
+						// removes the ability to enter spaces in the email field as these will be stripped out on change
+						if (event.key === ' ') {
+							event.preventDefault();
+						}
+					}}
 					onChange={(event) => {
-						setEmail(event.currentTarget.value.trim());
+						setEmail(event.currentTarget.value.replace(/\s/g, ''));
 					}}
 					onBlur={(event) => {
 						event.target.checkValidity();
@@ -76,8 +82,14 @@ export function PersonalEmailFields({
 							value={confirmedEmail}
 							type="email"
 							autoComplete="email"
+							onKeyDown={(event) => {
+								// removes the ability to enter spaces in the email field as these will be stripped out on change
+								if (event.key === ' ') {
+									event.preventDefault();
+								}
+							}}
 							onChange={(event) => {
-								setConfirmedEmail(event.currentTarget.value.trim());
+								setConfirmedEmail(event.currentTarget.value.replace(/\s/g, ''));
 							}}
 							onBlur={(event) => {
 								// Delay to allow the state to update before checking validity.

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
@@ -28,6 +28,7 @@ export function PersonalEmailFields({
 	const [confirmedEmailError, setConfirmedEmailError] = useState<string>();
 	const optional = endUser === 'recipient';
 	const emailNameId = endUser === 'recipient' ? 'recipientEmail' : 'email';
+	const regexLeadingTrailingSpace = /\s/g;
 	return (
 		<>
 			<div>
@@ -47,7 +48,9 @@ export function PersonalEmailFields({
 						}
 					}}
 					onChange={(event) => {
-						setEmail(event.currentTarget.value.replace(/\s/g, ''));
+						setEmail(
+							event.currentTarget.value.replace(regexLeadingTrailingSpace, ''),
+						);
 					}}
 					onBlur={(event) => {
 						event.target.checkValidity();

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/components/PersonalEmailFields.tsx
@@ -28,7 +28,7 @@ export function PersonalEmailFields({
 	const [confirmedEmailError, setConfirmedEmailError] = useState<string>();
 	const optional = endUser === 'recipient';
 	const emailNameId = endUser === 'recipient' ? 'recipientEmail' : 'email';
-	const regexLeadingTrailingSpace = /\s/g;
+	const regexLeadingTrailingSpacing = /\s/g;
 	return (
 		<>
 			<div>
@@ -49,7 +49,10 @@ export function PersonalEmailFields({
 					}}
 					onChange={(event) => {
 						setEmail(
-							event.currentTarget.value.replace(regexLeadingTrailingSpace, ''),
+							event.currentTarget.value.replace(
+								regexLeadingTrailingSpacing,
+								'',
+							),
 						);
 					}}
 					onBlur={(event) => {


### PR DESCRIPTION
## What are you doing in this PR?
Frontend change to prevent trailing/leading spaces entered into all email fields.
Currently, the input fields ValidityState does check for `type:email` which additionally removes spaces mid-string.  

Applies to:-
- (All Recurring) Checkouts
- OneTimeCheckout

## Why are you doing this?
To reduce incorrect email alarms

## How to test
https://support.thegulocal.com/uk/checkout?product=SupporterPlus&ratePlan=Monthly
Attempt to enter a space in either of the email input boxes.

## Screenshots

|before|after|
|----|----|
|<img width="610" height="632" alt="image" src="https://github.com/user-attachments/assets/d8330882-297f-4874-903f-95a877eb7248" />|<img width="610" height="632" alt="image" src="https://github.com/user-attachments/assets/9455ab78-5a1b-46c6-875f-23332aa72fc8" />|


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215009144633719


Error RaisingNotes (unused)
- Inverse pattern to detect spaces -> PersonalEmailsFields/ textInput.pattern={'^^\\S(.*\\S)?$'}
- Useful Regex->String Conversion Check Website : https://www.kloudbean.com/regex-to-string-converter

