### PR TITLE
Promotions service refactor

### DIFF
--- a/support-models/src/main/scala/com/gu/support/promotions/PromoError.scala
+++ b/support-models/src/main/scala/com/gu/support/promotions/PromoError.scala
@@ -20,10 +20,6 @@ case object NoSuchCode extends PromoError {
   override val msg = "Unknown or expired promo code"
 }
 
-case class DuplicateCode(debug: String) extends PromoError {
-  override val msg = s"Duplicate promo codes: $debug"
-}
-
 case object ExpiredPromotion extends PromoError {
   override val msg = "The promo code you supplied has expired"
 }

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionCache.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionCache.scala
@@ -14,7 +14,7 @@ class PromotionCache {
 
   def getMap: Option[Map[PromoCode, Promotion]] = promotionsRef.single().filter(_.isFresh).map(_.promotionsByCode)
 
-  def set(promotions: Iterable[Promotion], fetched: DateTime = DateTime.now): Unit = atomic { implicit txn =>
-    promotionsRef() = Some(PromotionCacheResponse(fetched, promotions.map(p => p.promoCode -> p).toMap))
+  def set(promotions: Map[PromoCode, Promotion], fetched: DateTime = DateTime.now): Unit = atomic { implicit txn =>
+    promotionsRef() = Some(PromotionCacheResponse(fetched, promotions))
   }
 }

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionCache.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionCache.scala
@@ -1,22 +1,20 @@
 package com.gu.support.promotions
 
-import com.gu.monitoring.SafeLogger
 import org.joda.time.{DateTime, Minutes}
 
 import scala.concurrent.stm.{Ref, atomic}
 
-case class PromotionCacheResponse(fetched: DateTime, promotions: Iterable[Promotion]) {
-  val maxAge = Minutes.ONE.toStandardDuration.getMillis
+case class PromotionCacheResponse(fetched: DateTime, promotionsByCode: Map[PromoCode, Promotion]) {
+  val maxAge: Long = Minutes.ONE.toStandardDuration.getMillis
   def isFresh: Boolean = DateTime.now.getMillis - fetched.getMillis < maxAge
 }
 
 class PromotionCache {
-  // this val contains the mutable cache contents
   val promotionsRef = Ref[Option[PromotionCacheResponse]](None)
 
-  def get: Option[Iterable[Promotion]] = promotionsRef.single().filter(_.isFresh).map(_.promotions)
+  def getMap: Option[Map[PromoCode, Promotion]] = promotionsRef.single().filter(_.isFresh).map(_.promotionsByCode)
 
   def set(promotions: Iterable[Promotion], fetched: DateTime = DateTime.now): Unit = atomic { implicit txn =>
-    promotionsRef() = Some(PromotionCacheResponse(fetched, promotions))
+    promotionsRef() = Some(PromotionCacheResponse(fetched, promotions.map(p => p.promoCode -> p).toMap))
   }
 }

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionCollection.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionCollection.scala
@@ -7,6 +7,7 @@ trait PromotionCollection {
   def allByCode: Map[PromoCode, Promotion]
 }
 
+// Used by the tests
 class SimplePromotionCollection(promotions: List[Promotion]) extends PromotionCollection {
   override def allByCode: Map[PromoCode, Promotion] = promotions.map(p => p.promoCode -> p).toMap
 }

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionCollection.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionCollection.scala
@@ -23,7 +23,7 @@ class CachedDynamoPromotionCollection(config: PromotionsTablesConfig) extends Dy
   override def allByCode: Map[PromoCode, Promotion] = cache.getMap.getOrElse(fetchAndCache)
 
   private def fetchAndCache: Map[PromoCode, Promotion] = {
-    val promotions = super.allByCode.values
+    val promotions = super.allByCode
     cache.set(promotions)
     cache.getMap.get
   }

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionCollection.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionCollection.scala
@@ -4,27 +4,27 @@ import com.gu.support.config.PromotionsTablesConfig
 import com.gu.support.promotions.dynamo.DynamoService
 
 trait PromotionCollection {
-  def all: Iterator[Promotion]
+  def allByCode: Map[PromoCode, Promotion]
 }
 
 class SimplePromotionCollection(promotions: List[Promotion]) extends PromotionCollection {
-  override def all: Iterator[Promotion] = promotions.iterator
+  override def allByCode: Map[PromoCode, Promotion] = promotions.map(p => p.promoCode -> p).toMap
 }
 
 class DynamoPromotionCollection(config: PromotionsTablesConfig)
     extends DynamoService[Promotion](config.promotions)
-    with PromotionCollection
-
-class CachedDynamoPromotionCollection(config: PromotionsTablesConfig)
-    extends DynamoPromotionCollection(config)
     with PromotionCollection {
+  override def allByCode: Map[PromoCode, Promotion] = all.map(p => p.promoCode -> p).toMap
+}
+
+class CachedDynamoPromotionCollection(config: PromotionsTablesConfig) extends DynamoPromotionCollection(config) {
 
   val cache = new PromotionCache
-  override def all: Iterator[Promotion] = cache.get.getOrElse(fetchAndCache).toIterator
+  override def allByCode: Map[PromoCode, Promotion] = cache.getMap.getOrElse(fetchAndCache)
 
-  private def fetchAndCache = {
-    val promotions = super.all.toList
+  private def fetchAndCache: Map[PromoCode, Promotion] = {
+    val promotions = super.allByCode.values
     cache.set(promotions)
-    promotions
+    cache.getMap.get
   }
 }

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
@@ -12,27 +12,19 @@ class PromotionService(config: PromotionsConfig, maybeCollection: Option[Promoti
     extends TouchpointService
     with LazyLogging {
   private val promotionCollection = maybeCollection.getOrElse(new CachedDynamoPromotionCollection(config.tables))
-  private def allPromotions = promotionCollection.all.toList
 
   def environment = if (config.tables.promotions.contains("PROD")) { "PROD" }
   else { "CODE" }
 
   def findPromotion(promoCode: PromoCode): Either[PromoError, PromotionWithCode] =
-    promotionCollection.all.toList
-      .filter(_.promoCode == promoCode)
-      .map(PromotionWithCode(promoCode, _)) match {
-      case Nil => Left(NoSuchCode)
-      case code :: Nil => Right(code)
-      case tooMany => Left(DuplicateCode(tooMany.mkString(", ")))
+    promotionCollection.allByCode.get(promoCode) match {
+      case Some(promotion) => Right(PromotionWithCode(promoCode, promotion))
+      case None => Left(NoSuchCode)
     }
 
   // promoCodes here is expected to be a small list of default promos plus one from the querystring
   def findPromotions(promoCodes: List[PromoCode]): List[PromotionWithCode] = {
-    val promosByCode: Map[PromoCode, Promotion] =
-      allPromotions
-        .map(promo => promo.promoCode -> promo)
-        .toMap
-
+    val promosByCode = promotionCollection.allByCode
     promoCodes.flatMap { promoCode =>
       promosByCode.get(promoCode).map(PromotionWithCode(promoCode, _))
     }

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionCacheSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionCacheSpec.scala
@@ -9,12 +9,12 @@ class PromotionCacheSpec extends AsyncFlatSpec with Matchers {
   "PromotionCache" should "return cached promotions when they are fresh" in {
     val cache = new PromotionCache
     cache.set(Nil)
-    cache.get shouldBe Some(Nil)
+    cache.getMap shouldBe Some(Map.empty)
   }
 
   it should "return None if they are stale" in {
     val cache = new PromotionCache
     cache.set(Nil, DateTime.now().minusSeconds(61))
-    cache.get shouldBe None
+    cache.getMap shouldBe None
   }
 }

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionCacheSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionCacheSpec.scala
@@ -8,13 +8,13 @@ class PromotionCacheSpec extends AsyncFlatSpec with Matchers {
 
   "PromotionCache" should "return cached promotions when they are fresh" in {
     val cache = new PromotionCache
-    cache.set(Nil)
+    cache.set(Map.empty)
     cache.getMap shouldBe Some(Map.empty)
   }
 
   it should "return None if they are stale" in {
     val cache = new PromotionCache
-    cache.set(Nil, DateTime.now().minusSeconds(61))
+    cache.set(Map.empty, DateTime.now().minusSeconds(61))
     cache.getMap shouldBe None
   }
 }

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceSpec.scala
@@ -16,15 +16,6 @@ class PromotionServiceSpec extends AsyncFlatSpec with Matchers {
   "PromotionService" should "find a PromoCode" in {
     serviceWithFixtures.findPromotion(freeTrialPromoCode) should be(Right(freeTrialWithCode))
     serviceWithFixtures.findPromotion(invalidPromoCode) should be(Left(NoSuchCode))
-    serviceWithFixtures
-      .findPromotion(duplicatedPromoCode)
-      .left
-      .map({
-        case code: DuplicateCode => code.copy(debug = "")
-        case _ => fail()
-      }) should be(
-      Left(DuplicateCode("")),
-    )
   }
 
   it should "find multiple promo codes, in correct order" in {
@@ -142,8 +133,6 @@ object PromotionServiceSpec {
           renewal.promotion,
           guardianWeeklyAnnual,
           freeTrial,
-          duplicate1,
-          duplicate2,
         ),
       ),
     ),

--- a/support-services/src/test/scala/com/gu/support/promotions/ServicesFixtures.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/ServicesFixtures.scala
@@ -18,7 +18,6 @@ object ServicesFixtures {
   val invalidPromoCode = "INVALID_CODE"
   val renewalPromoCode = "RENEWAL_CODE"
   val trackingPromoCode = "TRACKING_CODE"
-  val duplicatedPromoCode = "DUPLICATED_CODE"
   val tenAnnual = "10ANNUAL"
 
   val validProductRatePlanIds = Product.allProducts.flatMap(_.ratePlans(PROD).map(_.id))
@@ -59,8 +58,6 @@ object ServicesFixtures {
     ),
   )
   val guardianWeeklyWithCode = PromotionWithCode(tenAnnual, guardianWeeklyAnnual)
-  val duplicate1 = promotion(validProductRatePlanIds, duplicatedPromoCode, discountBenefit)
-  val duplicate2 = promotion(validProductRatePlanIds, duplicatedPromoCode, freeTrial = freeTrialBenefit)
 
   val now = LocalDate.now()
   val subscriptionData = SubscriptionData(


### PR DESCRIPTION
With @AnastasiiaBalenko 

A while back we migrated to a new promotions table. The data model is simpler and we now have one row per promo code.
[It was noted at the time](https://github.com/guardian/support-frontend/pull/7673/changes#r2685982340) of the migration that we could optimise how we cache the promotions in the backend.

Instead of caching the list of promo codes, we can instead cache it as a Map keyed by promo code. This saves `PromotionService` method calls from having to process the full list each time.

A consequence of this is that we no longer need to check for duplicate promo codes, since the table enforces this. The tests have been simplified as a result.

Tested by deploying to CODE and viewing promos on three-tier landing + checkout, and Guardian Weekly landing + checkout.