### PR TITLE
Rotate pm2 logs for support-backend

### DIFF
--- a/cdk/lib/__snapshots__/backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/backend.test.ts.snap
@@ -882,6 +882,22 @@ export STAGE=PROD
 mkdir /var/log/support-backend
 chown -R support-backend:support /var/log/support-backend
 
+cat << 'EOF' > /etc/logrotate.d/pm2
+/var/log/support-backend/*.log {
+	Hourly
+    rotate 5
+    missingok
+    notifempty
+    compress
+    delaycompress
+    sharedscripts
+    postrotate
+        # Forces PM2 to safely flush logs and open fresh file descriptors
+        /usr/local/node/pm2 reloadLogs > /dev/null 2>&1
+    endscript
+}
+EOF
+
 cd target
 /usr/local/node/pm2 start --uid support-backend --gid support --output /var/log/support-backend/application.log --error /var/log/support-backend/application.log server.js
 

--- a/cdk/lib/__snapshots__/backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/backend.test.ts.snap
@@ -884,7 +884,8 @@ chown -R support-backend:support /var/log/support-backend
 
 cat << 'EOF' > /etc/logrotate.d/pm2
 /var/log/support-backend/*.log {
-	Hourly
+	daily
+	maxsize 10M
     rotate 5
     missingok
     notifempty

--- a/cdk/lib/__snapshots__/backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/backend.test.ts.snap
@@ -884,8 +884,8 @@ chown -R support-backend:support /var/log/support-backend
 
 cat << 'EOF' > /etc/logrotate.d/pm2
 /var/log/support-backend/*.log {
-	daily
-	maxsize 10M
+    daily
+    maxsize 10M
     rotate 5
     missingok
     notifempty

--- a/cdk/lib/backend.ts
+++ b/cdk/lib/backend.ts
@@ -61,7 +61,8 @@ chown -R ${app}:support /var/log/${app}
 
 cat << 'EOF' > /etc/logrotate.d/pm2
 /var/log/support-backend/*.log {
-	Hourly
+	daily
+	maxsize 10M
     rotate 5
     missingok
     notifempty

--- a/cdk/lib/backend.ts
+++ b/cdk/lib/backend.ts
@@ -59,6 +59,22 @@ export STAGE=${this.stage}
 mkdir /var/log/${app}
 chown -R ${app}:support /var/log/${app}
 
+cat << 'EOF' > /etc/logrotate.d/pm2
+/var/log/support-backend/*.log {
+	Hourly
+    rotate 5
+    missingok
+    notifempty
+    compress
+    delaycompress
+    sharedscripts
+    postrotate
+        # Forces PM2 to safely flush logs and open fresh file descriptors
+        /usr/local/node/pm2 reloadLogs > /dev/null 2>&1
+    endscript
+}
+EOF
+
 cd target
 /usr/local/node/pm2 start --uid ${app} --gid support --output /var/log/${app}/application.log --error /var/log/${app}/application.log server.js
 

--- a/cdk/lib/backend.ts
+++ b/cdk/lib/backend.ts
@@ -61,8 +61,8 @@ chown -R ${app}:support /var/log/${app}
 
 cat << 'EOF' > /etc/logrotate.d/pm2
 /var/log/support-backend/*.log {
-	daily
-	maxsize 10M
+    daily
+    maxsize 10M
     rotate 5
     missingok
     notifempty

--- a/support-backend/src/handlers/postcodeLookup.ts
+++ b/support-backend/src/handlers/postcodeLookup.ts
@@ -8,6 +8,8 @@ export const buildPostcodeLookupHandler =
 	async (req, res) => {
 		const postcode = decodeURIComponent(req.params.postcode);
 
+		console.log(`Postcode lookup handler called with ${postcode}`);
+
 		if (postcode.length > 10) {
 			res.status(400).send();
 			return;


### PR DESCRIPTION
## What are you doing in this PR?

Rotate logs written by pm2 on the filesystem of support-backend EC2 instances. The logs are rotated daily, unless they reach 10M in size, in which case they'll be rotated at that point.

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1215060491531543)

## Why are you doing this?

So that it's not possible for a single log file to grow indefinitely causing performance issues.

## How to test

I've deployed this branch to CODE, SSH'd onto one of the instances and inspected the `logrotate.d` config under `/etc/logrotate.d/pm2`.

I did a dry run of the logrotation by running `sudo logrotate -d /etc/logrotate.d/pm2` on the instance which gave sensible looking output.

I forced a log rotation with `sudo logrotate -f /etc/logrotate.d/pm2`. This created a new log file under `/var/log/support-backend` and moved the existing file to `application.log.1`. A subsequent run of the same command resulted in the older log being compressed, as expected.

I verified that across rotations log messages were correctly showing up in Cloudwatch:

<img width="698" height="271" alt="Screenshot 2026-06-02 at 12 39 01" src="https://github.com/user-attachments/assets/af135415-7ae9-46a0-ab58-403b4e8be13e" />
