### PR TITLE
Payment-Api: Alarms rename & description extend

### DIFF
--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -1635,7 +1635,8 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "[CDK] payment-api PROD One or more requests have exceeded the rate limit for Stripe one-off contribution via the payment-api in the last 15 mins",
+        "AlarmDescription": "[CDK] payment-api PROD One or more requests have exceeded the rate limit for Stripe one-off contribution via the payment-api for 15 minutes",
+        "AlarmName": "[CDK] payment-api PROD One or more requests have exceeded the rate limit for Stripe one-off contribution via the payment-api for period",
         "ComparisonOperator": "GreaterThanThreshold",
         "Dimensions": [
           {

--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -947,7 +947,8 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "[CDK] payment-api PROD No successful paypal payments via payment-api for 1 hour 30 minutes",
+        "AlarmDescription": "No successful paypal payments via payment-api for 1 hour 30 minutes",
+        "AlarmName": "[CDK] payment-api PROD No successful paypal payments via payment-api for period",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -1131,7 +1132,8 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "[CDK] payment-api PROD No successful stripe payments via payment-api for an hour",
+        "AlarmDescription": "No successful stripe payments via payment-api for 1 hour",
+        "AlarmName": "[CDK] payment-api PROD No successful stripe payments via payment-api for period",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {

--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -1022,7 +1022,8 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "[CDK] payment-api PROD No successful stripe express payments via payment-api for 3 hours",
+        "AlarmDescription": "No successful stripe express payments via payment-api for 3 hours",
+        "AlarmName": "[CDK] payment-api PROD No successful stripe express payments via payment-api for period",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "EvaluationPeriods": 36,
         "Metrics": [

--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -599,7 +599,8 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "[CDK] High 5XX rate for payment-api in PROD",
+        "AlarmDescription": "[CDK] High 5XX rate for payment-api in PROD",
+        "AlarmName": "[CDK] High 5XX rate in PROD",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {

--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -947,7 +947,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "No successful paypal payments for 1 hour 30 minutes",
+        "AlarmDescription": "No successful paypal payments for 2 hours",
         "AlarmName": "[CDK] payment-api PROD No successful paypal payments for period",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
@@ -956,7 +956,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             "Value": "Paypal",
           },
         ],
-        "EvaluationPeriods": 18,
+        "EvaluationPeriods": 24,
         "MetricName": "payment-success",
         "Namespace": "support-payment-api-PROD",
         "OKActions": [
@@ -1023,10 +1023,10 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "No successful stripe express payments for 3 hours",
+        "AlarmDescription": "No successful stripe express payments for 4 hours",
         "AlarmName": "[CDK] payment-api PROD No successful stripe express payments for period",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "EvaluationPeriods": 36,
+        "EvaluationPeriods": 48,
         "Metrics": [
           {
             "Expression": "SUM(METRICS())",
@@ -1132,7 +1132,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "No successful stripe payments for 1 hour",
+        "AlarmDescription": "No successful stripe payments for 1 hour 30 minutes",
         "AlarmName": "[CDK] payment-api PROD No successful stripe payments for period",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
@@ -1141,7 +1141,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             "Value": "Stripe",
           },
         ],
-        "EvaluationPeriods": 12,
+        "EvaluationPeriods": 18,
         "MetricName": "payment-success",
         "Namespace": "support-payment-api-PROD",
         "OKActions": [

--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -599,8 +599,8 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "[CDK] High 5XX rate for payment-api in PROD",
-        "AlarmName": "[CDK] High 5XX rate in PROD",
+        "AlarmDescription": "[CDK]  payment-api PROD High 5XX rate",
+        "AlarmName": "[CDK] PROD High 5XX rate",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -878,8 +878,8 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "[CDK] No healthy instances for payment-api in PROD",
-        "AlarmName": "[CDK] No healthy instances in PROD",
+        "AlarmDescription": "[CDK] payment-api PROD No healthy instances",
+        "AlarmName": "[CDK] PROD No healthy instances",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -949,8 +949,8 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "No successful paypal payments via payment-api for 1 hour 30 minutes",
-        "AlarmName": "[CDK] payment-api PROD No successful paypal payments via payment-api for period",
+        "AlarmDescription": "[CDK] payment-api PROD No successful paypal payments via payment-api for 1 hour 30 minutes",
+        "AlarmName": "[CDK] PROD No successful paypal payments via payment-api for period",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -1025,8 +1025,8 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "No successful stripe express payments via payment-api for 3 hours",
-        "AlarmName": "[CDK] payment-api PROD No successful stripe express payments via payment-api for period",
+        "AlarmDescription": "[CDK] payment-api PROD No successful stripe express payments via payment-api for 3 hours",
+        "AlarmName": "[CDK] PROD No successful stripe express payments via payment-api for period",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "EvaluationPeriods": 36,
         "Metrics": [
@@ -1134,8 +1134,8 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "No successful stripe payments via payment-api for 1 hour",
-        "AlarmName": "[CDK] payment-api PROD No successful stripe payments via payment-api for period",
+        "AlarmDescription": "[CDK] payment-api PROD No successful stripe payments via payment-api for 1 hour",
+        "AlarmName": "[CDK] PROD No successful stripe payments via payment-api for period",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -1636,7 +1636,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
           },
         ],
         "AlarmDescription": "[CDK] payment-api PROD One or more requests have exceeded the rate limit for Stripe one-off contribution via the payment-api for 15 minutes",
-        "AlarmName": "[CDK] payment-api PROD One or more requests have exceeded the rate limit for Stripe one-off contribution via the payment-api for period",
+        "AlarmName": "[CDK] PROD One or more requests have exceeded the rate limit for Stripe one-off contribution via the payment-api for period",
         "ComparisonOperator": "GreaterThanThreshold",
         "Dimensions": [
           {

--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -877,7 +877,8 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "[CDK] No healthy instances for payment-api in PROD",
+        "AlarmDescription": "[CDK] No healthy instances for payment-api in PROD",
+        "AlarmName": "[CDK] No healthy instances in PROD",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {

--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -599,8 +599,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "[CDK]  payment-api PROD High 5XX rate",
-        "AlarmName": "[CDK] PROD High 5XX rate",
+        "AlarmName": "[CDK] payment-api PROD High 5XX rate",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -878,8 +877,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "[CDK] payment-api PROD No healthy instances",
-        "AlarmName": "[CDK] PROD No healthy instances",
+        "AlarmName": "[CDK] payment-api PROD No healthy instances",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -949,8 +947,8 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "[CDK] payment-api PROD No successful paypal payments via payment-api for 1 hour 30 minutes",
-        "AlarmName": "[CDK] PROD No successful paypal payments via payment-api for period",
+        "AlarmDescription": "No successful paypal payments for 1 hour 30 minutes",
+        "AlarmName": "[CDK] payment-api PROD No successful paypal payments for period",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -1025,8 +1023,8 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "[CDK] payment-api PROD No successful stripe express payments via payment-api for 3 hours",
-        "AlarmName": "[CDK] PROD No successful stripe express payments via payment-api for period",
+        "AlarmDescription": "No successful stripe express payments for 3 hours",
+        "AlarmName": "[CDK] payment-api PROD No successful stripe express payments for period",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "EvaluationPeriods": 36,
         "Metrics": [
@@ -1134,8 +1132,8 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "[CDK] payment-api PROD No successful stripe payments via payment-api for 1 hour",
-        "AlarmName": "[CDK] PROD No successful stripe payments via payment-api for period",
+        "AlarmDescription": "No successful stripe payments for 1 hour",
+        "AlarmName": "[CDK] payment-api PROD No successful stripe payments for period",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -1635,8 +1633,8 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmDescription": "[CDK] payment-api PROD One or more requests have exceeded the rate limit for Stripe one-off contribution via the payment-api for 15 minutes",
-        "AlarmName": "[CDK] PROD One or more requests have exceeded the rate limit for Stripe one-off contribution via the payment-api for period",
+        "AlarmDescription": "One or more requests have exceeded the rate limit for Stripe one-off contribution for 15 minutes",
+        "AlarmName": "[CDK] payment-api PROD One or more requests have exceeded the rate limit for Stripe one-off contribution for period",
         "ComparisonOperator": "GreaterThanThreshold",
         "Dimensions": [
           {

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -242,8 +242,8 @@ export class PaymentApi extends GuStack {
 		const noHealthyInstancesDescriptor = 'No healthy instances';
 		new GuAlarm(this, 'NoHealthyInstancesAlarm', {
 			app,
-			alarmName: `[CDK] ${noHealthyInstancesDescriptor} in ${this.stage}`,
-			alarmDescription: `[CDK] ${noHealthyInstancesDescriptor} for ${app} in ${this.stage}`,
+			alarmName: `[CDK] ${this.stage} ${noHealthyInstancesDescriptor}`,
+			alarmDescription: `[CDK] ${app} ${this.stage} ${noHealthyInstancesDescriptor}`,
 			actionsEnabled: props.stage === 'PROD',
 			threshold: 0.5,
 			evaluationPeriods: 2,
@@ -264,8 +264,8 @@ export class PaymentApi extends GuStack {
 		const high5XXRateDescriptor = 'High 5XX rate';
 		new GuAlarm(this, 'High5XXRateAlarm', {
 			app,
-			alarmName: `[CDK] ${high5XXRateDescriptor} in ${this.stage}`,
-			alarmDescription: `[CDK] ${high5XXRateDescriptor} for ${app} in ${this.stage}`,
+			alarmName: `[CDK] ${this.stage} ${high5XXRateDescriptor}`,
+			alarmDescription: `[CDK]  ${app} ${this.stage} ${high5XXRateDescriptor}`,
 			actionsEnabled: props.stage === 'PROD',
 			threshold: 3,
 			evaluationPeriods: 2,
@@ -292,8 +292,10 @@ export class PaymentApi extends GuStack {
 		);
 		new GuAlarm(this, 'NoPaypalPaymentsInPeriodAlarm', {
 			app,
-			alarmName: `[CDK] ${app} ${this.stage} ${paypalDescriptor} period`,
-			alarmDescription: `${paypalDescriptor} ${paypalAlarmPeriod.toHumanString()}`,
+			alarmName: `[CDK] ${this.stage} ${paypalDescriptor} period`,
+			alarmDescription: `[CDK] ${app} ${
+				this.stage
+			} ${paypalDescriptor} ${paypalAlarmPeriod.toHumanString()}`,
 			actionsEnabled: props.stage === 'PROD',
 			okAction: true,
 			threshold: 0,
@@ -322,8 +324,10 @@ export class PaymentApi extends GuStack {
 		);
 		new GuAlarm(this, 'NoStripePaymentsInOneHourAlarm', {
 			app,
-			alarmName: `[CDK] ${app} ${this.stage} ${stripePaymentsDescriptor} period`,
-			alarmDescription: `${stripePaymentsDescriptor} ${stripePaymentsAlarmPeriod.toHumanString()}`,
+			alarmName: `[CDK] ${this.stage} ${stripePaymentsDescriptor} period`,
+			alarmDescription: `[CDK] ${app} ${
+				this.stage
+			} ${stripePaymentsDescriptor} ${stripePaymentsAlarmPeriod.toHumanString()}`,
 			actionsEnabled: props.stage === 'PROD',
 			okAction: true,
 			threshold: 0,
@@ -374,8 +378,10 @@ export class PaymentApi extends GuStack {
 			});
 		new GuAlarm(this, 'NoStripeExpressPaymentsInOneHourAlarm', {
 			app,
-			alarmName: `[CDK] ${app} ${this.stage} ${stripeExpressAlarmDescriptor} period`,
-			alarmDescription: `${stripeExpressAlarmDescriptor} ${stripeExpressAlarmPeriod.toHumanString()}`,
+			alarmName: `[CDK] ${this.stage} ${stripeExpressAlarmDescriptor} period`,
+			alarmDescription: `[CDK] ${app} ${
+				this.stage
+			} ${stripeExpressAlarmDescriptor} ${stripeExpressAlarmPeriod.toHumanString()}`,
 			actionsEnabled: props.stage === 'PROD',
 			okAction: true,
 			threshold: 0,
@@ -391,7 +397,7 @@ export class PaymentApi extends GuStack {
 		const stripeRateLimitingMetricDuration = Duration.minutes(15);
 		new GuAlarm(this, 'StripeRateLimitingAlarm', {
 			app,
-			alarmName: `[CDK] ${app} ${this.stage} ${stripeRateLimitingDescriptor} period`,
+			alarmName: `[CDK] ${this.stage} ${stripeRateLimitingDescriptor} period`,
 			alarmDescription: `[CDK] ${app} ${
 				this.stage
 			} ${stripeRateLimitingDescriptor} ${stripeRateLimitingMetricDuration.toHumanString()}`,

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -357,10 +357,11 @@ export class PaymentApi extends GuStack {
 					m2: paymentRequestButtonSuccessMetric,
 				},
 			});
+		const stripeExpressAlarmDescriptor = `No successful stripe express payments via payment-api for`;
 		new GuAlarm(this, 'NoStripeExpressPaymentsInOneHourAlarm', {
 			app,
-			alarmName: `[CDK] ${app} ${this.stage} No successful stripe express payments via payment-api for period`,
-			alarmDescription: `No successful stripe express payments via payment-api for ${stripeExpressAlarmPeriod.toHumanString()}`,
+			alarmName: `[CDK] ${app} ${this.stage} ${stripeExpressAlarmDescriptor} period`,
+			alarmDescription: `${stripeExpressAlarmDescriptor} ${stripeExpressAlarmPeriod.toHumanString()}`,
 			actionsEnabled: props.stage === 'PROD',
 			okAction: true,
 			threshold: 0,

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -359,9 +359,8 @@ export class PaymentApi extends GuStack {
 			});
 		new GuAlarm(this, 'NoStripeExpressPaymentsInOneHourAlarm', {
 			app,
-			alarmName: `[CDK] ${app} ${
-				this.stage
-			} No successful stripe express payments via payment-api for ${stripeExpressAlarmPeriod.toHumanString()}`,
+			alarmName: `[CDK] ${app} ${this.stage} No successful stripe express payments via payment-api for period`,
+			alarmDescription: `No successful stripe express payments via payment-api for ${stripeExpressAlarmPeriod.toHumanString()}`,
 			actionsEnabled: props.stage === 'PROD',
 			okAction: true,
 			threshold: 0,

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -239,9 +239,11 @@ export class PaymentApi extends GuStack {
 
 		// ---- Alarms ---- //
 
+		const noHealthyInstancesDescriptor = 'No healthy instances';
 		new GuAlarm(this, 'NoHealthyInstancesAlarm', {
 			app,
-			alarmName: `[CDK] No healthy instances for ${app} in ${this.stage}`,
+			alarmName: `[CDK] ${noHealthyInstancesDescriptor} in ${this.stage}`,
+			alarmDescription: `[CDK] ${noHealthyInstancesDescriptor} for ${app} in ${this.stage}`,
 			actionsEnabled: props.stage === 'PROD',
 			threshold: 0.5,
 			evaluationPeriods: 2,

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -281,7 +281,7 @@ export class PaymentApi extends GuStack {
 
 		const paypalDescriptor = 'No successful paypal payments for';
 		const paypalMetricDuration = Duration.minutes(5);
-		const paypalEvaluationPeriods = 18; // The number of 5 minute periods in 90 minutes
+		const paypalEvaluationPeriods = 24; // The number of 5 minute periods in 120 minutes
 		const paypalAlarmPeriod = Duration.minutes(
 			paypalMetricDuration.toMinutes() * paypalEvaluationPeriods,
 		);
@@ -309,7 +309,7 @@ export class PaymentApi extends GuStack {
 
 		const stripePaymentsDescriptor = 'No successful stripe payments for';
 		const stripePaymentsMetricDuration = Duration.minutes(5);
-		const stripePaymentsEvaluationPeriods = 12; // The number of 5 minute periods in 1 hour
+		const stripePaymentsEvaluationPeriods = 18; // The number of 5 minute periods in 90mins
 		const stripePaymentsAlarmPeriod = Duration.minutes(
 			stripePaymentsMetricDuration.toMinutes() *
 				stripePaymentsEvaluationPeriods,
@@ -338,7 +338,7 @@ export class PaymentApi extends GuStack {
 
 		const stripeExpressAlarmDescriptor = `No successful stripe express payments for`;
 		const stripeExpressMetricDuration = Duration.minutes(5);
-		const stripeExpressEvaluationPeriods = 36; // The number of 5 minute periods in 3 hours
+		const stripeExpressEvaluationPeriods = 48; // The number of 5 minute periods in 4 hours
 		const stripeExpressAlarmPeriod = Duration.minutes(
 			stripeExpressMetricDuration.toMinutes() * stripeExpressEvaluationPeriods,
 		);

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -261,9 +261,11 @@ export class PaymentApi extends GuStack {
 			snsTopicName: `alarms-handler-topic-${this.stage}`,
 		});
 
+		const high5XXRateDescriptor = 'High 5XX rate';
 		new GuAlarm(this, 'High5XXRateAlarm', {
 			app,
-			alarmName: `[CDK] High 5XX rate for ${app} in ${this.stage}`,
+			alarmName: `[CDK] ${high5XXRateDescriptor} in ${this.stage}`,
+			alarmDescription: `[CDK] ${high5XXRateDescriptor} for ${app} in ${this.stage}`,
 			actionsEnabled: props.stage === 'PROD',
 			threshold: 3,
 			evaluationPeriods: 2,

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -239,11 +239,9 @@ export class PaymentApi extends GuStack {
 
 		// ---- Alarms ---- //
 
-		const noHealthyInstancesDescriptor = 'No healthy instances';
 		new GuAlarm(this, 'NoHealthyInstancesAlarm', {
 			app,
-			alarmName: `[CDK] ${this.stage} ${noHealthyInstancesDescriptor}`,
-			alarmDescription: `[CDK] ${app} ${this.stage} ${noHealthyInstancesDescriptor}`,
+			alarmName: `[CDK] ${app} ${this.stage} No healthy instances`,
 			actionsEnabled: props.stage === 'PROD',
 			threshold: 0.5,
 			evaluationPeriods: 2,
@@ -261,11 +259,9 @@ export class PaymentApi extends GuStack {
 			snsTopicName: `alarms-handler-topic-${this.stage}`,
 		});
 
-		const high5XXRateDescriptor = 'High 5XX rate';
 		new GuAlarm(this, 'High5XXRateAlarm', {
 			app,
-			alarmName: `[CDK] ${this.stage} ${high5XXRateDescriptor}`,
-			alarmDescription: `[CDK]  ${app} ${this.stage} ${high5XXRateDescriptor}`,
+			alarmName: `[CDK] ${app} ${this.stage} High 5XX rate`,
 			actionsEnabled: props.stage === 'PROD',
 			threshold: 3,
 			evaluationPeriods: 2,
@@ -283,8 +279,7 @@ export class PaymentApi extends GuStack {
 			snsTopicName: `alarms-handler-topic-${this.stage}`,
 		});
 
-		const paypalDescriptor =
-			'No successful paypal payments via payment-api for';
+		const paypalDescriptor = 'No successful paypal payments for';
 		const paypalMetricDuration = Duration.minutes(5);
 		const paypalEvaluationPeriods = 18; // The number of 5 minute periods in 90 minutes
 		const paypalAlarmPeriod = Duration.minutes(
@@ -292,10 +287,8 @@ export class PaymentApi extends GuStack {
 		);
 		new GuAlarm(this, 'NoPaypalPaymentsInPeriodAlarm', {
 			app,
-			alarmName: `[CDK] ${this.stage} ${paypalDescriptor} period`,
-			alarmDescription: `[CDK] ${app} ${
-				this.stage
-			} ${paypalDescriptor} ${paypalAlarmPeriod.toHumanString()}`,
+			alarmName: `[CDK] ${app} ${this.stage} ${paypalDescriptor} period`,
+			alarmDescription: `${paypalDescriptor} ${paypalAlarmPeriod.toHumanString()}`,
 			actionsEnabled: props.stage === 'PROD',
 			okAction: true,
 			threshold: 0,
@@ -314,8 +307,7 @@ export class PaymentApi extends GuStack {
 			snsTopicName: `alarms-handler-topic-${this.stage}`,
 		});
 
-		const stripePaymentsDescriptor =
-			'No successful stripe payments via payment-api for';
+		const stripePaymentsDescriptor = 'No successful stripe payments for';
 		const stripePaymentsMetricDuration = Duration.minutes(5);
 		const stripePaymentsEvaluationPeriods = 12; // The number of 5 minute periods in 1 hour
 		const stripePaymentsAlarmPeriod = Duration.minutes(
@@ -324,10 +316,8 @@ export class PaymentApi extends GuStack {
 		);
 		new GuAlarm(this, 'NoStripePaymentsInOneHourAlarm', {
 			app,
-			alarmName: `[CDK] ${this.stage} ${stripePaymentsDescriptor} period`,
-			alarmDescription: `[CDK] ${app} ${
-				this.stage
-			} ${stripePaymentsDescriptor} ${stripePaymentsAlarmPeriod.toHumanString()}`,
+			alarmName: `[CDK] ${app} ${this.stage} ${stripePaymentsDescriptor} period`,
+			alarmDescription: `${stripePaymentsDescriptor} ${stripePaymentsAlarmPeriod.toHumanString()}`,
 			actionsEnabled: props.stage === 'PROD',
 			okAction: true,
 			threshold: 0,
@@ -346,7 +336,7 @@ export class PaymentApi extends GuStack {
 			snsTopicName: `alarms-handler-topic-${this.stage}`,
 		});
 
-		const stripeExpressAlarmDescriptor = `No successful stripe express payments via payment-api for`;
+		const stripeExpressAlarmDescriptor = `No successful stripe express payments for`;
 		const stripeExpressMetricDuration = Duration.minutes(5);
 		const stripeExpressEvaluationPeriods = 36; // The number of 5 minute periods in 3 hours
 		const stripeExpressAlarmPeriod = Duration.minutes(
@@ -378,10 +368,8 @@ export class PaymentApi extends GuStack {
 			});
 		new GuAlarm(this, 'NoStripeExpressPaymentsInOneHourAlarm', {
 			app,
-			alarmName: `[CDK] ${this.stage} ${stripeExpressAlarmDescriptor} period`,
-			alarmDescription: `[CDK] ${app} ${
-				this.stage
-			} ${stripeExpressAlarmDescriptor} ${stripeExpressAlarmPeriod.toHumanString()}`,
+			alarmName: `[CDK] ${app} ${this.stage} ${stripeExpressAlarmDescriptor} period`,
+			alarmDescription: `${stripeExpressAlarmDescriptor} ${stripeExpressAlarmPeriod.toHumanString()}`,
 			actionsEnabled: props.stage === 'PROD',
 			okAction: true,
 			threshold: 0,
@@ -393,14 +381,12 @@ export class PaymentApi extends GuStack {
 		});
 
 		const stripeRateLimitingDescriptor =
-			'One or more requests have exceeded the rate limit for Stripe one-off contribution via the payment-api for';
+			'One or more requests have exceeded the rate limit for Stripe one-off contribution for';
 		const stripeRateLimitingMetricDuration = Duration.minutes(15);
 		new GuAlarm(this, 'StripeRateLimitingAlarm', {
 			app,
-			alarmName: `[CDK] ${this.stage} ${stripeRateLimitingDescriptor} period`,
-			alarmDescription: `[CDK] ${app} ${
-				this.stage
-			} ${stripeRateLimitingDescriptor} ${stripeRateLimitingMetricDuration.toHumanString()}`,
+			alarmName: `[CDK] ${app} ${this.stage} ${stripeRateLimitingDescriptor} period`,
+			alarmDescription: `${stripeRateLimitingDescriptor} ${stripeRateLimitingMetricDuration.toHumanString()}`,
 			actionsEnabled: props.stage === 'PROD',
 			threshold: 0,
 			evaluationPeriods: 1,

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -279,6 +279,8 @@ export class PaymentApi extends GuStack {
 			snsTopicName: `alarms-handler-topic-${this.stage}`,
 		});
 
+		const paypalDescriptor =
+			'No successful paypal payments via payment-api for';
 		const paypalMetricDuration = Duration.minutes(5);
 		const paypalEvaluationPeriods = 18; // The number of 5 minute periods in 90 minutes
 		const paypalAlarmPeriod = Duration.minutes(
@@ -286,9 +288,8 @@ export class PaymentApi extends GuStack {
 		);
 		new GuAlarm(this, 'NoPaypalPaymentsInPeriodAlarm', {
 			app,
-			alarmName: `[CDK] ${app} ${
-				this.stage
-			} No successful paypal payments via payment-api for ${paypalAlarmPeriod.toHumanString()}`,
+			alarmName: `[CDK] ${app} ${this.stage} ${paypalDescriptor} period`,
+			alarmDescription: `${paypalDescriptor} ${paypalAlarmPeriod.toHumanString()}`,
 			actionsEnabled: props.stage === 'PROD',
 			okAction: true,
 			threshold: 0,

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -386,6 +386,32 @@ export class PaymentApi extends GuStack {
 			snsTopicName: `alarms-handler-topic-${this.stage}`,
 		});
 
+		const stripeRateLimitingDescriptor =
+			'One or more requests have exceeded the rate limit for Stripe one-off contribution via the payment-api for';
+		const stripeRateLimitingMetricDuration = Duration.minutes(15);
+		new GuAlarm(this, 'StripeRateLimitingAlarm', {
+			app,
+			alarmName: `[CDK] ${app} ${this.stage} ${stripeRateLimitingDescriptor} period`,
+			alarmDescription: `[CDK] ${app} ${
+				this.stage
+			} ${stripeRateLimitingDescriptor} ${stripeRateLimitingMetricDuration.toHumanString()}`,
+			actionsEnabled: props.stage === 'PROD',
+			threshold: 0,
+			evaluationPeriods: 1,
+			comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+			metric: new Metric({
+				metricName: 'stripe-rate-limit-exceeded',
+				namespace: `support-payment-api-${this.stage}`,
+				dimensionsMap: {
+					'payment-provider': 'Stripe',
+				},
+				statistic: 'Sum',
+				period: stripeRateLimitingMetricDuration,
+			}),
+			treatMissingData: TreatMissingData.NOT_BREACHING,
+			snsTopicName: `alarms-handler-topic-${this.stage}`,
+		});
+
 		new GuAlarm(this, 'PaypalPaymentError', {
 			app,
 			alarmName: `[CDK] ${app} ${this.stage} Paypal payment error for one-off contribution via the payment-api`,
@@ -438,26 +464,6 @@ export class PaymentApi extends GuStack {
 				namespace: 'post-payment-tasks-error',
 				statistic: 'Sum',
 				period: Duration.seconds(60),
-			}),
-			treatMissingData: TreatMissingData.NOT_BREACHING,
-			snsTopicName: `alarms-handler-topic-${this.stage}`,
-		});
-
-		new GuAlarm(this, 'StripeRateLimitingAlarm', {
-			app,
-			alarmName: `[CDK] ${app} ${this.stage} One or more requests have exceeded the rate limit for Stripe one-off contribution via the payment-api in the last 15 mins`,
-			actionsEnabled: props.stage === 'PROD',
-			threshold: 0,
-			evaluationPeriods: 1,
-			comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
-			metric: new Metric({
-				metricName: 'stripe-rate-limit-exceeded',
-				namespace: `support-payment-api-${this.stage}`,
-				dimensionsMap: {
-					'payment-provider': 'Stripe',
-				},
-				statistic: 'Sum',
-				period: Duration.seconds(900),
 			}),
 			treatMissingData: TreatMissingData.NOT_BREACHING,
 			snsTopicName: `alarms-handler-topic-${this.stage}`,

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -307,13 +307,22 @@ export class PaymentApi extends GuStack {
 			snsTopicName: `alarms-handler-topic-${this.stage}`,
 		});
 
+		const stripePaymentsDescriptor =
+			'No successful stripe payments via payment-api for';
+		const stripePaymentsMetricDuration = Duration.minutes(5);
+		const stripePaymentsEvaluationPeriods = 12; // The number of 5 minute periods in 1 hour
+		const stripePaymentsAlarmPeriod = Duration.minutes(
+			stripePaymentsMetricDuration.toMinutes() *
+				stripePaymentsEvaluationPeriods,
+		);
 		new GuAlarm(this, 'NoStripePaymentsInOneHourAlarm', {
 			app,
-			alarmName: `[CDK] ${app} ${this.stage} No successful stripe payments via payment-api for an hour`,
+			alarmName: `[CDK] ${app} ${this.stage} ${stripePaymentsDescriptor} period`,
+			alarmDescription: `${stripePaymentsDescriptor} ${stripePaymentsAlarmPeriod.toHumanString()}`,
 			actionsEnabled: props.stage === 'PROD',
 			okAction: true,
 			threshold: 0,
-			evaluationPeriods: 12,
+			evaluationPeriods: stripePaymentsEvaluationPeriods,
 			comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
 			metric: new Metric({
 				metricName: 'payment-success',
@@ -322,12 +331,13 @@ export class PaymentApi extends GuStack {
 					'payment-provider': 'Stripe',
 				},
 				statistic: 'Sum',
-				period: Duration.seconds(300),
+				period: stripePaymentsMetricDuration,
 			}),
 			treatMissingData: TreatMissingData.BREACHING,
 			snsTopicName: `alarms-handler-topic-${this.stage}`,
 		});
 
+		const stripeExpressAlarmDescriptor = `No successful stripe express payments via payment-api for`;
 		const stripeExpressMetricDuration = Duration.minutes(5);
 		const stripeExpressEvaluationPeriods = 36; // The number of 5 minute periods in 3 hours
 		const stripeExpressAlarmPeriod = Duration.minutes(
@@ -357,7 +367,6 @@ export class PaymentApi extends GuStack {
 					m2: paymentRequestButtonSuccessMetric,
 				},
 			});
-		const stripeExpressAlarmDescriptor = `No successful stripe express payments via payment-api for`;
 		new GuAlarm(this, 'NoStripeExpressPaymentsInOneHourAlarm', {
 			app,
 			alarmName: `[CDK] ${app} ${this.stage} ${stripeExpressAlarmDescriptor} period`,


### PR DESCRIPTION
## What are you doing in this PR?
This changes the payment-api alarms (only NOT errors) to:-
- keep the alarm name consistant
- apply a duration to the alarm description

Alarm names modified (eg CODE):-
1. NoHealthyInstancesAlarm : `[CDK] payment-api CODE No healthy instances`
2. High5XXRateAlarm : `[CDK] payment-api CODE High 5XX rate`
3. NoPaypalPaymentsInPeriodAlarm: `[CDK] payment-api CODE No successful paypal payments for period`
4. NoStripePaymentsInOneHourAlarm: `[CDK] payment-api CODE No successful stripe payments for period`
5. NoStripeExpressPaymentsInOneHourAlarm: `[CDK] payment-api CODE No successful stripe express payments for period`
6. StripeRateLimitingAlarm: `[CDK] payment-api CODE One or more requests have exceeded the rate limit for Stripe one-off contribution for period`


## How to test
RiffRaff deploy payment alarm to CODE.
CmdLine : 
ALARM -> aws cloudwatch set-alarm-state --alarm-name "<GuAlarm.alarmName>" --state-value ALARM --state-reason "Testing"
ALARM OFF -> aws cloudwatch set-alarm-state --alarm-name "<GuAlarm.alarmName>" --state-value OK --state-reason "Testing"



|1|2|3|4|5|6|
|----|----|----|----|----|----|
|<img width="361" height="206" alt="image" src="https://github.com/user-attachments/assets/3b712471-48bd-458f-bde5-58deba719bdc" />|<img width="361" height="206" alt="image" src="https://github.com/user-attachments/assets/3707e1e2-c99e-4d2c-aaf0-817fd23f9ebb" />|<img width="515" height="384" alt="image" src="https://github.com/user-attachments/assets/77ba84ff-9b4e-49ad-beca-b59f8139efbf" />|<img width="515" height="384" alt="image" src="https://github.com/user-attachments/assets/efc776c4-d237-4735-afcd-190a032586c2" />|<img width="563" height="384" alt="image" src="https://github.com/user-attachments/assets/96e9f4b9-e552-4549-8f2a-1376ed110fcf" />|<img width="587" height="283" alt="image" src="https://github.com/user-attachments/assets/2a3c9808-3236-465b-9f4a-ec3db6aaa95b" />|

## Test Runs
aws cloudwatch set-alarm-state --alarm-name "[CDK] payment-api CODE No healthy instances" --state-value ALARM --state-reason "Testing"
aws cloudwatch set-alarm-state --alarm-name "[CDK] payment-api CODE No healthy instances" --state-value OK --state-reason "Testing"
aws cloudwatch set-alarm-state --alarm-name "[CDK] payment-api CODE High 5XX rate" --state-value ALARM --state-reason "Testing"
aws cloudwatch set-alarm-state --alarm-name "[CDK] payment-api CODE High 5XX rate" --state-value OK --state-reason "Testing"
aws cloudwatch set-alarm-state --alarm-name "[CDK] payment-api CODE No successful paypal payments for period" --state-value ALARM --state-reason "Testing"
aws cloudwatch set-alarm-state --alarm-name "[CDK] payment-api CODE No successful paypal payments for period" --state-value OK --state-reason "Testing"
aws cloudwatch set-alarm-state --alarm-name "[CDK] payment-api CODE No successful stripe payments for period" --state-value ALARM --state-reason "Testing"
aws cloudwatch set-alarm-state --alarm-name "[CDK] payment-api CODE No successful stripe payments for period" --state-value OK --state-reason "Testing"
aws cloudwatch set-alarm-state --alarm-name "[CDK] payment-api CODE No successful stripe express payments for period" --state-value ALARM --state-reason "Testing"
aws cloudwatch set-alarm-state --alarm-name "[CDK] payment-api CODE No successful stripe express payments for period" --state-value OK --state-reason "Testing"
aws cloudwatch set-alarm-state --alarm-name "[CDK] payment-api CODE One or more requests have exceeded the rate limit for Stripe one-off contribution for period" --state-value ALARM --state-reason "Testing"
aws cloudwatch set-alarm-state --alarm-name "[CDK] payment-api CODE One or more requests have exceeded the rate limit for Stripe one-off contribution for period" --state-value OK --state-reason "Testing"

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215338849731936