### PR TITLE
Payment-Api: Alarm timings extend

### DIFF
--- a/cdk/lib/__snapshots__/payment-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/payment-api.test.ts.snap
@@ -947,7 +947,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "[CDK] payment-api PROD No successful paypal payments via payment-api for 1 hour 30 minutes",
+        "AlarmName": "[CDK] payment-api PROD No successful paypal payments via payment-api for 2 hours",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -955,7 +955,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             "Value": "Paypal",
           },
         ],
-        "EvaluationPeriods": 18,
+        "EvaluationPeriods": 24,
         "MetricName": "payment-success",
         "Namespace": "support-payment-api-PROD",
         "OKActions": [
@@ -1022,9 +1022,9 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "[CDK] payment-api PROD No successful stripe express payments via payment-api for 3 hours",
+        "AlarmName": "[CDK] payment-api PROD No successful stripe express payments via payment-api for 4 hours",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "EvaluationPeriods": 36,
+        "EvaluationPeriods": 48,
         "Metrics": [
           {
             "Expression": "SUM(METRICS())",
@@ -1130,7 +1130,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "[CDK] payment-api PROD No successful stripe payments via payment-api for an hour",
+        "AlarmName": "[CDK] payment-api PROD No successful stripe payments via payment-api for 90mins",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
@@ -1138,7 +1138,7 @@ exports[`The Payment API stack matches the snapshot 1`] = `
             "Value": "Stripe",
           },
         ],
-        "EvaluationPeriods": 12,
+        "EvaluationPeriods": 18,
         "MetricName": "payment-success",
         "Namespace": "support-payment-api-PROD",
         "OKActions": [

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -309,11 +309,11 @@ export class PaymentApi extends GuStack {
 
 		new GuAlarm(this, 'NoStripePaymentsInOneHourAlarm', {
 			app,
-			alarmName: `[CDK] ${app} ${this.stage} No successful stripe payments via payment-api for an hour`,
+			alarmName: `[CDK] ${app} ${this.stage} No successful stripe payments via payment-api for 90mins`,
 			actionsEnabled: props.stage === 'PROD',
 			okAction: true,
 			threshold: 0,
-			evaluationPeriods: 12,
+			evaluationPeriods: 18,
 			comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
 			metric: new Metric({
 				metricName: 'payment-success',

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -280,7 +280,7 @@ export class PaymentApi extends GuStack {
 		});
 
 		const paypalMetricDuration = Duration.minutes(5);
-		const paypalEvaluationPeriods = 18; // The number of 5 minute periods in 90 minutes
+		const paypalEvaluationPeriods = 24; // The number of 5 minute periods in 120 minutes
 		const paypalAlarmPeriod = Duration.minutes(
 			paypalMetricDuration.toMinutes() * paypalEvaluationPeriods,
 		);

--- a/cdk/lib/payment-api.ts
+++ b/cdk/lib/payment-api.ts
@@ -329,7 +329,7 @@ export class PaymentApi extends GuStack {
 		});
 
 		const stripeExpressMetricDuration = Duration.minutes(5);
-		const stripeExpressEvaluationPeriods = 36; // The number of 5 minute periods in 3 hours
+		const stripeExpressEvaluationPeriods = 48; // The number of 5 minute periods in 4 hours
 		const stripeExpressAlarmPeriod = Duration.minutes(
 			stripeExpressMetricDuration.toMinutes() * stripeExpressEvaluationPeriods,
 		);


### PR DESCRIPTION
## What are you doing in this PR?
Widen alarm timing to reduce the `noise`

Timings to change are ->
1. : Single contribution PayPal from 1.5 hours to 2 hours
2. Single contribution Stripe from 1 hour to 1.5 hours
3. Single contribution Apple Pay + Google Pay combined from 3 hours to 4 hours

Note: Alarm names will be left untouched for future possible update


## How to test
RiffRaff deploy payment alarm to CODE.
CmdLine : 
ALARM -> aws cloudwatch set-alarm-state --alarm-name "<GuAlarm.alarmName>" --state-value ALARM --state-reason "Testing"
ALARM OFF -> aws cloudwatch set-alarm-state --alarm-name "<GuAlarm.alarmName>" --state-value OK --state-reason "Testing"



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215338849731936