### PR TITLE
Enable thank-you onboarding for Digital+

### DIFF
--- a/support-frontend/app/admin/settings/Settings.scala
+++ b/support-frontend/app/admin/settings/Settings.scala
@@ -16,7 +16,6 @@ import io.circe.{Decoder, Encoder}
 import scala.io.Source
 import scala.util.Try
 import com.gu.aws.AwsS3Client.S3Location
-import com.gu.support.workers.SupporterPlus
 
 case class AllSettings(
     switches: Switches,
@@ -26,15 +25,14 @@ case class AllSettings(
     checkoutNudgeTests: List[CheckoutNudgeTest],
     oneTimeCheckoutTests: List[OneTimeCheckoutTest],
     studentLandingPageTests: List[StudentLandingPageTest],
-    productsWithThankYouOnboarding: List[String] =
-      AllSettings.productsWithThankYouOnboarding.toList.map(_.getClass.getSimpleName.stripSuffix("$")),
+    productsWithThankYouOnboarding: List[String] = AllSettings.productsWithThankYouOnboarding,
 )
 
 object AllSettings {
   implicit val metricUrlEncoder: Encoder[MetricUrl] = Encoder.encodeString.contramap(_.value)
   implicit val metricUrlDecoder: Decoder[MetricUrl] = Decoder.decodeString.map(MetricUrl)
   implicit val allSettingsCodec: Codec[AllSettings] = deriveCodec[AllSettings]
-  val productsWithThankYouOnboarding: Set[SupporterPlus.type] = Set(SupporterPlus)
+  val productsWithThankYouOnboarding: List[String] = List("SupporterPlus", "DigitalSubscription")
 
 }
 

--- a/support-frontend/app/admin/settings/Switches.scala
+++ b/support-frontend/app/admin/settings/Switches.scala
@@ -26,6 +26,7 @@ case class FeatureSwitches(
     authenticateWithOkta: Option[SwitchState],
     enableCampaignCountdown: Option[SwitchState],
     enableThankYouOnboarding: Option[SwitchState],
+    enableDigitalPlusThankYouOnboarding: Option[SwitchState],
     enableCheckoutNudge: Option[SwitchState],
     enableMParticle: Option[SwitchState],
     enableTooledStudentLandingPage: Option[SwitchState],

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -51,6 +51,12 @@ object CreateSubscriptionController {
   private case class ServerError(message: String) extends CreateSubscriptionError
   private case class RequestValidationError(message: String) extends CreateSubscriptionError
 
+  private[controllers] def frontendProductKey(product: ProductType): String =
+    product match {
+      case _: DigitalPack => "DigitalSubscription"
+      case other => other.getClass.getSimpleName
+    }
+
 }
 
 sealed trait CreateResponse
@@ -299,7 +305,7 @@ class CreateSubscriptionController(
     val inOnboardingExperiment =
       settings.switches.featureSwitches.enableThankYouOnboarding.exists(_.isOn) &&
         settings.productsWithThankYouOnboarding.contains(
-          request.body.product.getClass.getSimpleName,
+          CreateSubscriptionController.frontendProductKey(request.body.product),
         )
 
     for {

--- a/support-frontend/app/controllers/CreateSubscriptionController.scala
+++ b/support-frontend/app/controllers/CreateSubscriptionController.scala
@@ -302,11 +302,14 @@ class CreateSubscriptionController(
 
     logDetailedMessage("createSubscription")
 
+    val onboardingProductKey = CreateSubscriptionController.frontendProductKey(request.body.product)
+    val digitalPlusGateOpen =
+      onboardingProductKey != "DigitalSubscription" ||
+        settings.switches.featureSwitches.enableDigitalPlusThankYouOnboarding.exists(_.isOn)
     val inOnboardingExperiment =
       settings.switches.featureSwitches.enableThankYouOnboarding.exists(_.isOn) &&
-        settings.productsWithThankYouOnboarding.contains(
-          CreateSubscriptionController.frontendProductKey(request.body.product),
-        )
+        settings.productsWithThankYouOnboarding.contains(onboardingProductKey) &&
+        digitalPlusGateOpen
 
     for {
       _ <- validate(request, settings.switches)

--- a/support-frontend/assets/__mocks__/settingsMock.ts
+++ b/support-frontend/assets/__mocks__/settingsMock.ts
@@ -74,7 +74,7 @@ const mockSettings = {
 	},
 	metricUrl:
 		'https://metric-push-api-code.support.guardianapis.com/metric-push-api',
-	productsWithThankYouOnboarding: ['SupporterPlus'],
+	productsWithThankYouOnboarding: ['SupporterPlus', 'DigitalSubscription'],
 } as AppConfig['settings'];
 
 window.guardian = { ...window.guardian, settings: mockSettings };

--- a/support-frontend/assets/helpers/globalsAndSwitches/window.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/window.ts
@@ -24,6 +24,7 @@ const featureSwitchesSchema = z.object({
 	authenticateWithOkta: z.optional(z.enum(['On', 'Off'])),
 	enableCampaignCountdown: z.optional(z.enum(['On', 'Off'])),
 	enableThankYouOnboarding: z.optional(z.enum(['On', 'Off'])),
+	enableDigitalPlusThankYouOnboarding: z.optional(z.enum(['On', 'Off'])),
 	enableCheckoutNudge: z.optional(z.enum(['On', 'Off'])),
 	enableMParticle: z.optional(z.enum(['On', 'Off'])),
 });

--- a/support-frontend/assets/pages/[countryGroupId]/components/onboardingComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/onboardingComponent.tsx
@@ -58,7 +58,10 @@ export type HandleStepNavigationFunction = (
 	targetStep: OnboardingSteps,
 ) => void;
 
-export type OnboardingProductKey = Extract<ActiveProductKey, 'SupporterPlus'>;
+export type OnboardingProductKey = Extract<
+	ActiveProductKey,
+	'SupporterPlus' | 'DigitalSubscription'
+>;
 
 export interface OnboardingProps {
 	supportRegionId: SupportRegionId;

--- a/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
@@ -41,7 +41,8 @@ export function ThankYou({
 }: ThankYouProps) {
 	const countryId = Country.detect();
 	const { currencyKey } = getSupportRegionIdConfig(supportRegionId);
-	const { enableThankYouOnboarding } = useFeatureSwitches();
+	const { enableThankYouOnboarding, enableDigitalPlusThankYouOnboarding } =
+		useFeatureSwitches();
 
 	const searchParams = new URLSearchParams(window.location.search);
 	const csrf = { token: window.guardian.csrf.token };
@@ -148,6 +149,8 @@ export function ThankYou({
 		enableThankYouOnboarding &&
 		productKey !== undefined &&
 		appConfig.settings.productsWithThankYouOnboarding.includes(productKey) &&
+		(productKey !== 'DigitalSubscription' ||
+			enableDigitalPlusThankYouOnboarding) &&
 		storage.session.get(SKIP_NEW_ONBOARDING_EXPERIENCE_KEY) !== 'true'
 	) {
 		return (

--- a/support-frontend/test/actions/ActionRefinerTest.scala
+++ b/support-frontend/test/actions/ActionRefinerTest.scala
@@ -30,6 +30,7 @@ class ActionRefinerTest extends AnyWordSpec with Matchers with TestCSRFComponent
       authenticateWithOkta = Some(Off),
       enableCampaignCountdown = Some(On),
       enableThankYouOnboarding = Some(On),
+      enableDigitalPlusThankYouOnboarding = Some(On),
       enableCheckoutNudge = Some(On),
       enableMParticle = Some(On),
       enableTooledStudentLandingPage = Some(On),

--- a/support-frontend/test/admin/settings/SwitchesSpec.scala
+++ b/support-frontend/test/admin/settings/SwitchesSpec.scala
@@ -104,6 +104,10 @@ class SwitchesSpec extends AnyWordSpec with Matchers {
           |        "description" : "Enables the new Thank You Onboarding flow",
           |        "state" : "Off"
           |      },
+          |      "enableDigitalPlusThankYouOnboarding" : {
+          |        "description" : "Enables the Thank You Onboarding flow for Digital+",
+          |        "state" : "On"
+          |      },
           |      "enableCheckoutNudge" : {
           |        "description" : "Enable checkout nudge",
           |        "state" : "On"
@@ -161,7 +165,7 @@ class SwitchesSpec extends AnyWordSpec with Matchers {
           ),
           subscriptionsSwitches = SubscriptionsSwitches(Some(On), Some(On), Some(On)),
           featureSwitches =
-            FeatureSwitches(Some(On), Some(On), Some(Off), Some(On), Some(Off), Some(On), Some(On), Some(On)),
+            FeatureSwitches(Some(On), Some(On), Some(Off), Some(On), Some(Off), Some(On), Some(On), Some(On), Some(On)),
           campaignSwitches = CampaignSwitches(Some(Off), Some(Off)),
           recaptchaSwitches = RecaptchaSwitches(Some(On), Some(On)),
         ),

--- a/support-frontend/test/controllers/ApplicationTest.scala
+++ b/support-frontend/test/controllers/ApplicationTest.scala
@@ -54,7 +54,8 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
     checkToken = csrfCheck,
     csrfConfig = csrfConfig,
     stage = stage,
-    featureSwitches = FeatureSwitches(Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On)),
+    featureSwitches =
+      FeatureSwitches(Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On)),
     testUsersService = TestUserService("secret"),
   )
 

--- a/support-frontend/test/controllers/CreateSubscriptionControllerTest.scala
+++ b/support-frontend/test/controllers/CreateSubscriptionControllerTest.scala
@@ -1,0 +1,36 @@
+package controllers
+
+import com.gu.i18n.Currency.GBP
+import com.gu.support.catalog.Domestic
+import com.gu.support.workers._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class CreateSubscriptionControllerTest extends AnyFlatSpec with Matchers {
+
+  "frontendProductKey" should "map DigitalPack to the catalog key DigitalSubscription" in {
+    CreateSubscriptionController.frontendProductKey(
+      DigitalPack(GBP, Monthly),
+    ) shouldBe "DigitalSubscription"
+  }
+
+  it should "leave SupporterPlus unchanged because its class name already matches the catalog key" in {
+    CreateSubscriptionController.frontendProductKey(
+      SupporterPlus(12, GBP, Monthly),
+    ) shouldBe "SupporterPlus"
+  }
+
+  it should "fall back to the simple class name for other products" in {
+    CreateSubscriptionController.frontendProductKey(
+      Contribution(5, GBP, Monthly),
+    ) shouldBe "Contribution"
+
+    CreateSubscriptionController.frontendProductKey(
+      GuardianWeekly(GBP, Annual, Domestic),
+    ) shouldBe "GuardianWeekly"
+
+    CreateSubscriptionController.frontendProductKey(
+      GuardianAdLite(GBP),
+    ) shouldBe "GuardianAdLite"
+  }
+}

--- a/support-frontend/test/controllers/SiteMapTest.scala
+++ b/support-frontend/test/controllers/SiteMapTest.scala
@@ -30,7 +30,8 @@ class SiteMapTest extends AnyWordSpec with Matchers with TestCSRFComponents {
     checkToken = csrfCheck,
     csrfConfig = csrfConfig,
     stage = stage,
-    featureSwitches = FeatureSwitches(Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On)),
+    featureSwitches =
+      FeatureSwitches(Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On)),
     testUsersService = TestUserService("secret"),
   )
 

--- a/support-frontend/test/fixtures/DisplayFormMocks.scala
+++ b/support-frontend/test/fixtures/DisplayFormMocks.scala
@@ -47,7 +47,8 @@ trait DisplayFormMocks extends TestCSRFComponents {
     checkToken = csrfCheck,
     csrfConfig = csrfConfig,
     stage = stage,
-    featureSwitches = FeatureSwitches(Some(On), Some(On), Some(Off), Some(On), Some(On), Some(On), Some(On), Some(On)),
+    featureSwitches =
+      FeatureSwitches(Some(On), Some(On), Some(Off), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On)),
     testUsersService = testUsers,
   )
 

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -814,7 +814,7 @@ object TestData {
     OneOffPaymentMethodSwitches(Some(On), Some(On), Some(On)),
     recurringPaymentMethodSwitches,
     SubscriptionsSwitches(Some(On), Some(On), Some(On)),
-    FeatureSwitches(Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On)),
+    FeatureSwitches(Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On), Some(On)),
     CampaignSwitches(Some(On), Some(On)),
     RecaptchaSwitches(Some(On), Some(On)),
   )


### PR DESCRIPTION
## What are you doing in this PR?

Enabling the thank-you onboarding experience for Digital+. Until now only Supporter Plus reached the onboarding flow after checkout — Digital+ purchasers dropped through to the legacy thank-you cards.

## Why are you doing this?

Digital+ should get the same post-purchase onboarding as Supporter Plus. The gate that decides whether to show onboarding compared the support-workers product name (`DigitalPack`) against a list of frontend catalog keys, so Digital+ never matched. This PR translates the workers product name to its catalog key (`DigitalSubscription`) server-side before the comparison, and adds the key to the onboarding list so the product is recognised.

## How to test

On this branch, buy a Digital+ subscription on `/uk` and land on the thank-you page: the onboarding experience now shows instead of the legacy cards. The product-key translation is covered by a new unit test (`CreateSubscriptionControllerTest`). Note the onboarding content comes from the landing-page settings (RRCP/DynamoDB); locally it can be previewed with `force-landing-page=AB_DIGITAL_PLUS_TEST:DP_TEST`.

## Have we considered potential risks?

Low risk. The behaviour stays gated behind the existing `enableThankYouOnboarding` switch. The only change is that Digital+ now matches the onboarding list — other products are unaffected, as the translation falls back to the simple class name for everything else.
