### PR TITLE
Add alarm config for support-backend GuEc2App

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -50,6 +50,7 @@ new Backend(app, 'Backend-PROD', {
 		minimumInstances: 1,
 		maximumInstances: 2,
 	},
+	shouldCreateAlarms: true,
 });
 
 new Backend(app, 'Backend-CODE', {
@@ -60,6 +61,7 @@ new Backend(app, 'Backend-CODE', {
 		minimumInstances: 1,
 		maximumInstances: 2,
 	},
+	shouldCreateAlarms: false,
 });
 
 new StripePatronsData(app, 'StripePatronsData-CODE', {

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -61,7 +61,7 @@ new Backend(app, 'Backend-CODE', {
 		minimumInstances: 1,
 		maximumInstances: 2,
 	},
-	shouldCreateAlarms: false,
+	shouldCreateAlarms: true,
 });
 
 new StripePatronsData(app, 'StripePatronsData-CODE', {

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -61,7 +61,7 @@ new Backend(app, 'Backend-CODE', {
 		minimumInstances: 1,
 		maximumInstances: 2,
 	},
-	shouldCreateAlarms: true,
+	shouldCreateAlarms: false,
 });
 
 new StripePatronsData(app, 'StripePatronsData-CODE', {

--- a/cdk/lib/__snapshots__/backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/backend.test.ts.snap
@@ -26,6 +26,8 @@ exports[`The Backend stack matches the snapshot 1`] = `
       "GuAccessLoggingBucketParameter",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
+      "GuAlb5xxPercentageAlarm",
+      "GuUnhealthyInstancesAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -398,6 +400,127 @@ exports[`The Backend stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "High5xxPercentageAlarmSupportbackendD49EEB40": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:eu-west-1:",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Some or all actions in support-backend are failing",
+        "AlarmName": "support-backend PROD is returning 5XX errors",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "100*(m1+m2)/m3",
+            "Id": "expr_1",
+            "Label": "% of 5XX responses served for support-backend (load balancer and instances combined)",
+            "ReturnData": true,
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "LoadBalancer",
+                    "Value": {
+                      "Fn::GetAtt": [
+                        "LoadBalancerSupportbackend1445ECB4",
+                        "LoadBalancerFullName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "HTTPCode_ELB_5XX_Count",
+                "Namespace": "AWS/ApplicationELB",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "LoadBalancer",
+                    "Value": {
+                      "Fn::GetAtt": [
+                        "LoadBalancerSupportbackend1445ECB4",
+                        "LoadBalancerFullName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "HTTPCode_Target_5XX_Count",
+                "Namespace": "AWS/ApplicationELB",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m3",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "LoadBalancer",
+                    "Value": {
+                      "Fn::GetAtt": [
+                        "LoadBalancerSupportbackend1445ECB4",
+                        "LoadBalancerFullName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "RequestCount",
+                "Namespace": "AWS/ApplicationELB",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 5,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "InstanceRoleSupportbackend25B34CE1": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -760,6 +883,121 @@ exports[`The Backend stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "UnhealthyInstancesAlarmSupportbackendF59534CB": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:eu-west-1:",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-PROD",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "support-backend's instances have failed healthchecks several times over the last 1 hour.
+      This typically results in the AutoScaling Group cycling instances and can lead to problems with deployment,
+      scaling or handling traffic spikes.
+
+      Check support-backend's application logs or ssh onto an unhealthy instance in order to debug these problems.",
+        "AlarmName": "Unhealthy instances for support-backend in PROD",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 30,
+        "Dimensions": [
+          {
+            "Name": "LoadBalancer",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Fn::Select": [
+                      1,
+                      {
+                        "Fn::Split": [
+                          "/",
+                          {
+                            "Ref": "ListenerSupportbackend28B0599A",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "/",
+                  {
+                    "Fn::Select": [
+                      2,
+                      {
+                        "Fn::Split": [
+                          "/",
+                          {
+                            "Ref": "ListenerSupportbackend28B0599A",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "/",
+                  {
+                    "Fn::Select": [
+                      3,
+                      {
+                        "Fn::Split": [
+                          "/",
+                          {
+                            "Ref": "ListenerSupportbackend28B0599A",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Name": "TargetGroup",
+            "Value": {
+              "Fn::GetAtt": [
+                "TargetGroupSupportbackendD03654E6",
+                "TargetGroupFullName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 60,
+        "MetricName": "UnHealthyHostCount",
+        "Namespace": "AWS/ApplicationELB",
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-frontend",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "supportPRODsupportbackend61AF342F": {
       "DependsOn": [

--- a/cdk/lib/backend.test.ts
+++ b/cdk/lib/backend.test.ts
@@ -13,6 +13,7 @@ describe('The Backend stack', () => {
 				minimumInstances: 1,
 				maximumInstances: 2,
 			},
+			shouldCreateAlarms: true,
 		});
 
 		const template = Template.fromStack(stack);

--- a/cdk/lib/backend.ts
+++ b/cdk/lib/backend.ts
@@ -22,11 +22,12 @@ import { ARecord, HostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53';
 interface BackendProps extends GuStackProps {
 	domainName: string;
 	scaling: GuAsgCapacity;
+	shouldCreateAlarms: boolean;
 }
 
 export class Backend extends GuStack {
 	constructor(scope: App, id: string, props: BackendProps) {
-		const { domainName, scaling } = props;
+		const { domainName, scaling, shouldCreateAlarms } = props;
 
 		super(scope, id, {
 			...props,
@@ -101,6 +102,16 @@ cd target
 			}),
 		];
 
+		const http5xxAlarm = shouldCreateAlarms
+			? {
+					alarmName: `support-backend ${this.stage} is returning 5XX errors`,
+					alarmDescription:
+						'Some or all actions in support-backend are failing',
+					actionsEnabled: shouldCreateAlarms,
+					tolerated5xxPercentage: 5,
+			  }
+			: false;
+
 		const ec2App = new GuEc2App(this, {
 			applicationPort: 3000,
 			app: app,
@@ -113,7 +124,11 @@ cd target
 				path: '/healthcheck-express',
 			},
 			instanceMetricGranularity: '5Minute',
-			monitoringConfiguration: { noMonitoring: true },
+			monitoringConfiguration: {
+				snsTopicName: `alarms-handler-topic-${this.stage}`,
+				http5xxAlarm: http5xxAlarm,
+				unhealthyInstancesAlarm: shouldCreateAlarms,
+			},
 			userData,
 			roleConfiguration: {
 				additionalPolicies: policies,


### PR DESCRIPTION
## What are you doing in this PR?

Adding standard alarm config for the support-backend `GuEc2App`.

## Why are you doing this?

So that we are notified if errors are being returned by support-backend.