### PR TITLE
Add a payment provider mapping for PayPalCompletePayments

### DIFF
--- a/support-workers/src/typescript/acquisitionData/acquisitionDataRowBuilder.ts
+++ b/support-workers/src/typescript/acquisitionData/acquisitionDataRowBuilder.ts
@@ -194,7 +194,8 @@ function paymentProviderFromPaymentMethod(
 	}
 	if (
 		paymentMethod.Type === 'PayPal' ||
-		paymentMethod.Type === 'PayPalCompletePaymentsWithBAID'
+		paymentMethod.Type === 'PayPalCompletePaymentsWithBAID' ||
+		paymentMethod.Type === 'PayPalCompletePayments'
 	) {
 		return 'PAYPAL';
 	}


### PR DESCRIPTION
## What are you doing in this PR?

In the support-workers sendAcquisitionEventLambda the payment method is mapped to a payment provider. There was no mapping for `PayPalCompletePayments` so it was falling through to the default of `GOCARDLESS`. This fixes things to map to `PAYPAL`. In future we should consider not having a default and handling a missing mapping differently.

## Why are you doing this?

So that data in the acquisition event table in BigQuery is correct.