### PR TITLE
Refactor `paymentProviderFromPaymentMethod` to remove default

### DIFF
--- a/support-workers/src/typescript/acquisitionData/acquisitionDataRowBuilder.ts
+++ b/support-workers/src/typescript/acquisitionData/acquisitionDataRowBuilder.ts
@@ -183,23 +183,22 @@ function paymentFrequencyFromBillingPeriod(
 function paymentProviderFromPaymentMethod(
 	paymentMethod: PaymentMethod,
 ): AcquisitionPaymentProvider {
-	if (paymentMethod.Type === 'CreditCardReferenceTransaction') {
-		if (paymentMethod.StripePaymentType === 'StripeApplePay') {
-			return 'STRIPE_APPLE_PAY';
-		}
-		if (paymentMethod.StripePaymentType === 'StripePaymentRequestButton') {
-			return 'STRIPE_PAYMENT_REQUEST_BUTTON';
-		}
-		return 'STRIPE';
+	switch (paymentMethod.Type) {
+		case 'CreditCardReferenceTransaction':
+			if (paymentMethod.StripePaymentType === 'StripeApplePay') {
+				return 'STRIPE_APPLE_PAY';
+			}
+			if (paymentMethod.StripePaymentType === 'StripePaymentRequestButton') {
+				return 'STRIPE_PAYMENT_REQUEST_BUTTON';
+			}
+			return 'STRIPE';
+		case 'PayPal':
+		case 'PayPalCompletePaymentsWithBAID':
+		case 'PayPalCompletePayments':
+			return 'PAYPAL';
+		case 'BankTransfer':
+			return 'GOCARDLESS';
 	}
-	if (
-		paymentMethod.Type === 'PayPal' ||
-		paymentMethod.Type === 'PayPalCompletePaymentsWithBAID' ||
-		paymentMethod.Type === 'PayPalCompletePayments'
-	) {
-		return 'PAYPAL';
-	}
-	return 'GOCARDLESS';
 }
 
 function getAbTests(data: AcquisitionData): AbTest[] {


### PR DESCRIPTION
## What are you doing in this PR?

Refactor `paymentProviderFromPaymentMethod` in support-workers, which maps a payment method to a payment provider for analytics, to use a switch statement and to remove the default. We know all of the possible inputs so there's no need for a default. 

## Why are you doing this?

This way if we ever add a new method and forget to add a mapping here, the TypeScript compiler will complain.