### PR TITLE
Switch off supporter-product-data

### DIFF
--- a/supporter-product-data/cloudformation/cfn.yaml
+++ b/supporter-product-data/cloudformation/cfn.yaml
@@ -327,7 +327,7 @@ Resources:
     Properties:
       Description: "Trigger regular data synchronisation from Zuora"
       ScheduleExpression: !FindInMap [StageVariables, !Ref Stage, scheduleRate]
-      State: "ENABLED"
+      State: "DISABLED"
       Targets:
         -
           Arn: !Ref SupporterProductData
@@ -361,6 +361,7 @@ Resources:
 
   SupporterProductDataDeadLetterQueue:
     Type: AWS::SQS::Queue
+    DeletionPolicy: Retain
     Properties:
       QueueName: !Sub dead-letters-supporter-product-data-${Stage}
       Tags:
@@ -369,6 +370,7 @@ Resources:
 
   SupporterProductDataQueue:
     Type: AWS::SQS::Queue
+    DeletionPolicy: Retain
     Properties:
       QueueName: !Sub supporter-product-data-${Stage}
       RedrivePolicy:
@@ -387,7 +389,7 @@ Resources:
     Properties:
       BatchSize: 10
       MaximumBatchingWindowInSeconds: 5
-      Enabled: true
+      Enabled: false
       EventSourceArn: !GetAtt SupporterProductDataQueue.Arn
       FunctionName: !Ref ProcessSupporterRatePlanItemLambda
     DependsOn:


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
https://github.com/guardian/support-service-lambdas/pull/3498 moves the supporter product data state machine and lambdas to the support-service-lambdas repo. 

Before we deploy that to code we want to disable the old version of the stack in this repo so that they don't interfere with each other.