### PR TITLE
Compressed size build action correction

### DIFF
--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -29,7 +29,7 @@ jobs:
         uses: preactjs/compressed-size-action@v3
         with:
           install-script: "pnpm install"
-          build-script: "--filter support-frontend build-github-action"
+          build-script: "pnpm --filter support-frontend build-github-action"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           pattern: "./support-frontend/public/compiled-assets/{javascripts,webpack}/**/*.js"
           minimum-change-threshold: 500


### PR DESCRIPTION
## What are you doing in this PR?
Corrects the compressed size failing github action.


Previously ->
`Unable to locate executable file: --filter. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`


<img width="1766" height="509" alt="image" src="https://github.com/user-attachments/assets/f9da4d3d-27ac-4524-af5c-86574f8497e0" />
