### PR TITLE
Revert compress-size-action to v2

### DIFF
--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -26,7 +26,7 @@ jobs:
           node-version-file: ".nvmrc"
 
       - name: Check compressed size of JS
-        uses: preactjs/compressed-size-action@v3
+        uses: preactjs/compressed-size-action@v2
         with:
           install-script: "pnpm install"
           build-script: "--filter support-frontend build-github-action"


### PR DESCRIPTION

## What are you doing in this PR?

This reverts #7886 where the version was bumped to v3.

## Why are you doing this?

It's turns out v3 is a branch not a tag, which isn't what we want as behaviour could change underneath us (and in fact this did cause an issue on a PR).