### PR TITLE
Detect if min-height is needed for desctop three tier cards

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -51,7 +51,7 @@ export type ThreeTierCardProps = {
 	currencyId: IsoCurrency;
 	billingPeriod: BillingPeriod;
 	showWeeklyPrice?: boolean;
-	forcePriceMinHeight?: boolean;
+	useLargePriceMinHeight?: boolean;
 };
 
 const container = (
@@ -92,13 +92,13 @@ const titleCss = css`
 	color: #606060;
 `;
 
-const priceCss = (useMinHeight: boolean) => css`
+const priceCss = (useLargeMinHeight: boolean) => css`
 	${textSansBold24};
 	position: relative;
 	margin-bottom: ${space[2]}px;
 
 	${from.desktop} {
-		min-height: ${useMinHeight ? `${space[16]}px` : `${space[12]}px`};
+		min-height: ${useLargeMinHeight ? `${space[16]}px` : `${space[12]}px`};
 	}
 `;
 
@@ -177,7 +177,7 @@ export function ThreeTierCard({
 	currencyId,
 	billingPeriod,
 	showWeeklyPrice = false,
-	forcePriceMinHeight = false,
+	useLargePriceMinHeight = false,
 }: ThreeTierCardProps): JSX.Element {
 	const {
 		title,
@@ -233,7 +233,7 @@ export function ThreeTierCard({
 				{titlePill && <BenefitPill copy={titlePill} />}
 				<h2 css={[titleCss, checkListTextItemCss]}>{title}</h2>
 			</div>
-			<div css={priceCss(forcePriceMinHeight)}>
+			<div css={priceCss(useLargePriceMinHeight)}>
 				{promotion && (
 					<>
 						<p>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -98,7 +98,7 @@ const priceCss = (useMinHeight: boolean) => css`
 	margin-bottom: ${space[2]}px;
 
 	${from.desktop} {
-		min-height: ${useMinHeight ? `${space[16]}px` : '0'};
+		min-height: ${useMinHeight ? `${space[16]}px` : `${space[12]}px`};
 	}
 `;
 

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -51,6 +51,7 @@ export type ThreeTierCardProps = {
 	currencyId: IsoCurrency;
 	billingPeriod: BillingPeriod;
 	showWeeklyPrice?: boolean;
+	forcePriceMinHeight?: boolean;
 };
 
 const container = (
@@ -91,13 +92,13 @@ const titleCss = css`
 	color: #606060;
 `;
 
-const priceCss = css`
+const priceCss = (useMinHeight: boolean) => css`
 	${textSansBold24};
 	position: relative;
 	margin-bottom: ${space[2]}px;
 
 	${from.desktop} {
-		min-height: ${space[16]}px;
+		min-height: ${useMinHeight ? `${space[16]}px` : '0'};
 	}
 `;
 
@@ -176,6 +177,7 @@ export function ThreeTierCard({
 	currencyId,
 	billingPeriod,
 	showWeeklyPrice = false,
+	forcePriceMinHeight = false,
 }: ThreeTierCardProps): JSX.Element {
 	const {
 		title,
@@ -231,7 +233,7 @@ export function ThreeTierCard({
 				{titlePill && <BenefitPill copy={titlePill} />}
 				<h2 css={[titleCss, checkListTextItemCss]}>{title}</h2>
 			</div>
-			<div css={priceCss}>
+			<div css={priceCss(forcePriceMinHeight)}>
 				{promotion && (
 					<>
 						<p>

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
@@ -50,6 +50,9 @@ export function ThreeTierCards({
 	billingPeriod,
 	showWeeklyPrice,
 }: ThreeTierCardsProps): JSX.Element {
+	const shouldForcePriceMinHeight =
+		!!showWeeklyPrice ||
+		cardsContent.some((card) => !!card.promotion || !!card.billingPeriodsCopy);
 	const haveLabelAndSelectedCards =
 		cardsContent.filter((card) => !!card.label || card.isUserSelected).length >
 		1;
@@ -75,6 +78,7 @@ export function ThreeTierCards({
 						currencyId={currencyId}
 						billingPeriod={billingPeriod}
 						showWeeklyPrice={showWeeklyPrice}
+						forcePriceMinHeight={shouldForcePriceMinHeight}
 					/>
 				);
 			})}

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
@@ -50,7 +50,7 @@ export function ThreeTierCards({
 	billingPeriod,
 	showWeeklyPrice,
 }: ThreeTierCardsProps): JSX.Element {
-	const shouldForcePriceMinHeight =
+	const shouldUseLargePriceMinHeight =
 		!!showWeeklyPrice ||
 		cardsContent.some((card) => !!card.promotion || !!card.billingPeriodsCopy);
 	const haveLabelAndSelectedCards =
@@ -78,7 +78,7 @@ export function ThreeTierCards({
 						currencyId={currencyId}
 						billingPeriod={billingPeriod}
 						showWeeklyPrice={showWeeklyPrice}
-						forcePriceMinHeight={shouldForcePriceMinHeight}
+						useLargePriceMinHeight={shouldUseLargePriceMinHeight}
 					/>
 				);
 			})}

--- a/support-frontend/stories/landingPage/ThreeTierCards.stories.tsx
+++ b/support-frontend/stories/landingPage/ThreeTierCards.stories.tsx
@@ -65,13 +65,6 @@ Default.args = {
 			price: 25,
 			product: 'DigitalSubscription',
 			...fallBackLandingPageSelection.products.DigitalSubscription,
-			promotion: {
-				discountedPrice: 16,
-				discount: {
-					amount: 16,
-					durationMonths: 12,
-				},
-			},
 		},
 	],
 	currencyId: 'GBP',


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR fixes vertical spacing between pricing text and "Support" button in Three Tier Card on Desktop
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1215660268224445)

## Why are you doing this?
After changes in this PR https://github.com/guardian/support-frontend/pull/7969/changes#diff-72802fe332ddbdf284b50f80ad3431b8d62941f8908a16ed02e82c1cfa667f87 the spacing between Price text and the "Support" button increased for all cases and we don't want it to happen for case without sub copy text under Price text(aka $4 / month)
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
Deployed on CODE env and verified for all cases:
- without promotion/weekly pricing/billing subcopy text
- with promotion on one of the cards
- with weekly pricing enabled
- with billing subcopy text
- with billing subcopy text + promotion
- with promotion + weekly pricing
- with promotion + weekly pricing + subcopy text
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
**Default Desktop**
<img width="1013" height="602" alt="Screenshot 2026-06-12 at 14 47 59" src="https://github.com/user-attachments/assets/b0a56042-0877-4a57-9ca4-ee0e397dca08" />


**Default Mobile**
<img width="779" height="615" alt="default-mobile" src="https://github.com/user-attachments/assets/b1749538-db2e-41eb-9310-b4c5646409e9" />

**Desktop promotion**
<img width="1096" height="569" alt="promoCode" src="https://github.com/user-attachments/assets/ea36c414-3916-481b-9bad-c66affb8b7f2" />

**Desktop billing subcopy**
<img width="1054" height="565" alt="billing-copy" src="https://github.com/user-attachments/assets/b634a43c-faf6-46b4-9954-8907972a9161" />

**Mobile billing subcopy**
<img width="309" height="242" alt="billing-copy-m" src="https://github.com/user-attachments/assets/938c46e0-f8c9-45bf-a877-5760a64f1d2d" />

**Desktop weekly price**
<img width="992" height="575" alt="weekly-pricing" src="https://github.com/user-attachments/assets/2012b68c-7d9e-4619-884d-157448c88aa4" />

**Mobile weekly price**
<img width="759" height="669" alt="weekly-pricing-mobile" src="https://github.com/user-attachments/assets/7a717056-3f71-4224-854b-21b6d6825578" />

**Desktop billing sub + weekly price + promotion**
<img width="1055" height="498" alt="promoCode+weekly" src="https://github.com/user-attachments/assets/d4007ead-553e-45cc-96e5-aac2698ddb9f" />
**Mobile billing sub + weekly price + promotion**
<img width="309" height="499" alt="promoCode+weekly-mobile" src="https://github.com/user-attachments/assets/936d3a9c-0c43-4568-9ba2-389b615aec93" />
