### PR TITLE
Changes to support tax exclusive rate plans

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ catalogs:
       specifier: ^2.1.5
       version: 2.1.5
     '@guardian/support-service-lambdas':
-      specifier: github:guardian/support-service-lambdas#1533432fc5bab3b75fb01765bc978ddce4934501
+      specifier: github:guardian/support-service-lambdas#916dc794742245307bfb53ed4f2212badedb6d5e
       version: 1.0.0
     '@types/jest':
       specifier: ^29.5.14
@@ -153,7 +153,7 @@ importers:
     devDependencies:
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1533432fc5bab3b75fb01765bc978ddce4934501
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/916dc794742245307bfb53ed4f2212badedb6d5e
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.0
@@ -272,7 +272,7 @@ importers:
         version: 18.1.1(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.5.4))(@guardian/source@10.2.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1533432fc5bab3b75fb01765bc978ddce4934501
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/916dc794742245307bfb53ed4f2212badedb6d5e
       '@guardian/tsconfig':
         specifier: ^0.2.0
         version: 0.2.0
@@ -574,7 +574,7 @@ importers:
         version: 3.995.0(@aws-sdk/client-dynamodb@3.1015.0)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1533432fc5bab3b75fb01765bc978ddce4934501
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/916dc794742245307bfb53ed4f2212badedb6d5e
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -2268,8 +2268,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1533432fc5bab3b75fb01765bc978ddce4934501':
-    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1533432fc5bab3b75fb01765bc978ddce4934501}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/916dc794742245307bfb53ed4f2212badedb6d5e':
+    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/916dc794742245307bfb53ed4f2212badedb6d5e}
     version: 1.0.0
 
   '@guardian/tsconfig@0.2.0':
@@ -10866,7 +10866,7 @@ snapshots:
       react: 18.2.0
       typescript: 5.5.4
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1533432fc5bab3b75fb01765bc978ddce4934501': {}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/916dc794742245307bfb53ed4f2212badedb6d5e': {}
 
   '@guardian/tsconfig@0.2.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ catalog:
   '@aws-sdk/credential-provider-node': 3.972.25
   '@aws-sdk/util-dynamodb': ^3.995.0
   '@guardian/prettier': ^2.1.5
-  '@guardian/support-service-lambdas': github:guardian/support-service-lambdas#1533432fc5bab3b75fb01765bc978ddce4934501
+  '@guardian/support-service-lambdas': github:guardian/support-service-lambdas#916dc794742245307bfb53ed4f2212badedb6d5e
   '@types/jest': ^29.5.14
   '@types/node': ^20.19.0
   esbuild: ^0.25.5

--- a/support-frontend/assets/helpers/productPrice/billingPeriods.ts
+++ b/support-frontend/assets/helpers/productPrice/billingPeriods.ts
@@ -53,6 +53,7 @@ export function ratePlanToBillingPeriod(
 ): BillingPeriod {
 	switch (ratePlanKey) {
 		case 'Annual':
+		case 'AnnualTaxExclusive':
 		case 'AnnualPlus':
 		case 'OneYearGift':
 		case 'OneYearStudent':
@@ -63,6 +64,7 @@ export function ratePlanToBillingPeriod(
 		case 'QuarterlyPlus':
 			return BillingPeriod.Quarterly;
 		case 'Monthly':
+		case 'MonthlyTaxExclusive':
 		case 'MonthlyPlus':
 		case 'Everyday':
 		case 'Sixday':


### PR DESCRIPTION
## What are you doing in this PR?

This PR adds the bare minimum of changes required to make it possible to put through a transaction for one of the new tax exclusive rate plans which are available for SupporterPlus and DigitalSubscription products.

Note: there is still a lot of work to do before we could show these to users, this simply makes it possible to put through a transaction. The supporting copy is incorrect in many cases.

## Why are you doing this?

This supports future PRs which will build on top of using these rate plans.

## How to test

- [x] Build checks
- [x] Smoke tests