### PR TITLE
refactor payment result

### DIFF
--- a/support-frontend/assets/helpers/forms/paymentIntegrations/oneOffContributions.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/oneOffContributions.ts
@@ -59,7 +59,7 @@ type PayPalApiError = {
 	message: string;
 };
 
-export type CreatePayPalPaymentResponse = PaymentApiResponse<
+type CreatePayPalPaymentResponse = PaymentApiResponse<
 	PayPalApiError,
 	CreatePayPalPaymentSuccess
 >;

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/oneOffContributions.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/oneOffContributions.ts
@@ -227,33 +227,29 @@ const processStripePaymentIntentRequestForPaypal = (
 					createIntentResponse as CreateIntentResponse;
 				if (_createIntentResponse.type === 'requiresconfirmation') {
 					try {
+						// Calling handleStripePaypal should trigger a redirect to Paypal confirmation page
 						const { error } = await handleStripePaypal(
 							_createIntentResponse.data.clientSecret,
 						);
 
 						// If we reach here, the redirect didn't happen — which means it failed
 						if (error) {
-							return {
-								type: 'error',
-								error: { failureReason: 'payment_provider_unavailable' },
-							};
+							logException(
+								`Error confirming Paypal Stripe payment: ${error.message}`,
+							);
 						}
 					} catch (error) {
-						return {
-							type: 'error',
-							error: { failureReason: 'payment_provider_unavailable' },
-						};
+						logException(
+							`Error confirming Paypal Stripe payment: ${String(error)}`,
+						);
 					}
-
-					// Shouldn't reach here in practice (successful confirmPayment redirects),
-					// but defend against it:
-					return {
-						type: 'error',
-						error: { failureReason: 'unknown' },
-					};
 				}
 
-				return _createIntentResponse;
+				// If for any reason the redirect to Paypal confirmation page did not happen then we show an error to the user
+				return {
+					type: 'error',
+					error: { failureReason: 'unknown' },
+				};
 			},
 		),
 	).then((result) => ({ type: 'stripe', result }));

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/oneOffContributions.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/oneOffContributions.ts
@@ -11,10 +11,15 @@ import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { addQueryParamsToURL } from 'helpers/urls/url';
 import { userTypeSchema } from 'helpers/user/userType';
 import { logException } from 'helpers/utilities/logger';
-import type { PaymentResult, StripePaymentMethod } from './readerRevenueApis';
+import type { StripePaymentMethod, StripePaymentResult } from './readerRevenueApis';
 import { PaymentSuccess } from './readerRevenueApis';
 
 // ----- Types ----- //
+type PaymentResult =
+	| { type: 'stripe'; result: StripePaymentResult }
+	| { type: 'stripe-paypal'; result: StripePaymentResult }
+	| { type: 'paypal'; result: CreatePayPalPaymentResponse };
+
 type UnexpectedError = {
 	type: 'unexpectedError';
 	error: string;
@@ -132,7 +137,7 @@ const responseSchema = z.discriminatedUnion('type', [
 
 function paymentResultFromObject(
 	json: Record<string, unknown>,
-): Promise<PaymentResult> {
+): Promise<StripePaymentResult> {
 	const response = responseSchema.parse(json);
 	if (response.type === 'error') {
 		const failureReason: ErrorReason = isErrorReason(
@@ -166,7 +171,7 @@ const postToPaymentApi = (
 // https://github.com/guardian/payment-api/blob/master/src/main/resources/routes#L17
 const handleOneOffExecution = (
 	result: Promise<Record<string, unknown>>,
-): Promise<PaymentResult> => logPromise(result).then(paymentResultFromObject);
+): Promise<StripePaymentResult> => logPromise(result).then(paymentResultFromObject);
 
 // Create a Stripe Payment Request, and if necessary perform 3DS auth and confirmation steps
 const processStripePaymentIntentRequest = (
@@ -205,46 +210,26 @@ const processStripePaymentIntentRequest = (
 				return _createIntentResponse;
 			},
 		),
-	);
+	).then(result => ({type: 'stripe', result }));
 
 // Create a Stripe Payment Intent Request for Paypal
 const processStripePaymentIntentRequestForPaypal = (
 	data: CreateStripePaymentIntentRequest,
-	handleStripePaypal: (clientSecret: string) => Promise<PaymentIntentResult>,
+	// handleStripePaypal: (clientSecret: string) => Promise<PaymentIntentResult>,
 ): Promise<PaymentResult> =>
 	handleOneOffExecution(
 		postToPaymentApi(data, '/contribute/one-off/stripe/create-payment').then(
 			(createIntentResponse) => {
 				const _createIntentResponse =
 					createIntentResponse as CreateIntentResponse;
+				// TODO - handle error here?
 				if (_createIntentResponse.type === 'requiresconfirmation') {
-					return handleStripePaypal(
-						_createIntentResponse.data.clientSecret,
-					).then((authResult: PaymentIntentResult) => {
-						if (authResult.error) {
-							trackComponentClick('stripe-paypal-failure');
-							console.log(authResult.error);
-							console.log('stripe-paypal-failure');
-							return {
-								type: 'error',
-								error: {
-									failureReason: 'card_authentication_error',
-								},
-							};
-						}
-
-						trackComponentClick('stripe-paypal-success');
-						return postToPaymentApi(
-							{ ...data, paymentIntentId: authResult.paymentIntent.id },
-							'/contribute/one-off/stripe/confirm-payment',
-						);
-					});
 				}
 
 				return _createIntentResponse;
 			},
 		),
-	);
+	).then((result) => ({ type: 'stripe', result }));
 
 // Object is expected to have structure:
 // { type: "error", error: PayPalApiError }, or
@@ -287,7 +272,7 @@ function createPayPalPaymentResponseFromObject(
 
 async function postOneOffPayPalCreatePaymentRequest(
 	data: CreatePaypalPaymentData,
-): Promise<CreatePayPalPaymentResponse> {
+): Promise<PaymentResult> {
 	try {
 		const res = await logPromise(
 			fetchJson(
@@ -295,9 +280,9 @@ async function postOneOffPayPalCreatePaymentRequest(
 				requestOptions(data, 'omit', 'POST', null),
 			),
 		);
-		return createPayPalPaymentResponseFromObject(res);
+		return { type: 'paypal', result: createPayPalPaymentResponseFromObject(res) };
 	} catch (err) {
-		return unexpectedError(`error creating a PayPal payment: ${err as string}`);
+		return { type: 'paypal', result: unexpectedError(`error creating a PayPal payment: ${err as string}`) };
 	}
 }
 
@@ -305,4 +290,5 @@ export {
 	postOneOffPayPalCreatePaymentRequest,
 	processStripePaymentIntentRequest,
 	processStripePaymentIntentRequestForPaypal,
+	type PaymentResult,
 };

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/oneOffContributions.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/oneOffContributions.ts
@@ -11,13 +11,15 @@ import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { addQueryParamsToURL } from 'helpers/urls/url';
 import { userTypeSchema } from 'helpers/user/userType';
 import { logException } from 'helpers/utilities/logger';
-import type { StripePaymentMethod, StripePaymentResult } from './readerRevenueApis';
+import type {
+	StripePaymentMethod,
+	StripePaymentResult,
+} from './readerRevenueApis';
 import { PaymentSuccess } from './readerRevenueApis';
 
 // ----- Types ----- //
 type PaymentResult =
 	| { type: 'stripe'; result: StripePaymentResult }
-	| { type: 'stripe-paypal'; result: StripePaymentResult }
 	| { type: 'paypal'; result: CreatePayPalPaymentResponse };
 
 type UnexpectedError = {
@@ -171,7 +173,8 @@ const postToPaymentApi = (
 // https://github.com/guardian/payment-api/blob/master/src/main/resources/routes#L17
 const handleOneOffExecution = (
 	result: Promise<Record<string, unknown>>,
-): Promise<StripePaymentResult> => logPromise(result).then(paymentResultFromObject);
+): Promise<StripePaymentResult> =>
+	logPromise(result).then(paymentResultFromObject);
 
 // Create a Stripe Payment Request, and if necessary perform 3DS auth and confirmation steps
 const processStripePaymentIntentRequest = (
@@ -210,20 +213,44 @@ const processStripePaymentIntentRequest = (
 				return _createIntentResponse;
 			},
 		),
-	).then(result => ({type: 'stripe', result }));
+	).then((result) => ({ type: 'stripe', result }));
 
 // Create a Stripe Payment Intent Request for Paypal
 const processStripePaymentIntentRequestForPaypal = (
 	data: CreateStripePaymentIntentRequest,
-	// handleStripePaypal: (clientSecret: string) => Promise<PaymentIntentResult>,
+	handleStripePaypal: (clientSecret: string) => Promise<PaymentIntentResult>,
 ): Promise<PaymentResult> =>
 	handleOneOffExecution(
 		postToPaymentApi(data, '/contribute/one-off/stripe/create-payment').then(
-			(createIntentResponse) => {
+			async (createIntentResponse) => {
 				const _createIntentResponse =
 					createIntentResponse as CreateIntentResponse;
-				// TODO - handle error here?
 				if (_createIntentResponse.type === 'requiresconfirmation') {
+					try {
+						const { error } = await handleStripePaypal(
+							_createIntentResponse.data.clientSecret,
+						);
+
+						// If we reach here, the redirect didn't happen — which means it failed
+						if (error) {
+							return {
+								type: 'error',
+								error: { failureReason: 'payment_provider_unavailable' },
+							};
+						}
+					} catch (error) {
+						return {
+							type: 'error',
+							error: { failureReason: 'payment_provider_unavailable' },
+						};
+					}
+
+					// Shouldn't reach here in practice (successful confirmPayment redirects),
+					// but defend against it:
+					return {
+						type: 'error',
+						error: { failureReason: 'unknown' },
+					};
 				}
 
 				return _createIntentResponse;
@@ -280,9 +307,17 @@ async function postOneOffPayPalCreatePaymentRequest(
 				requestOptions(data, 'omit', 'POST', null),
 			),
 		);
-		return { type: 'paypal', result: createPayPalPaymentResponseFromObject(res) };
+		return {
+			type: 'paypal',
+			result: createPayPalPaymentResponseFromObject(res),
+		};
 	} catch (err) {
-		return { type: 'paypal', result: unexpectedError(`error creating a PayPal payment: ${err as string}`) };
+		return {
+			type: 'paypal',
+			result: unexpectedError(
+				`error creating a PayPal payment: ${err as string}`,
+			),
+		};
 	}
 }
 

--- a/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
+++ b/support-frontend/assets/helpers/forms/paymentIntegrations/readerRevenueApis.ts
@@ -178,7 +178,7 @@ type Status = 'failure' | 'pending' | 'success';
 // standardised across payment methods & contribution types.
 // The only method/type combination which will not make use of this PayPal one-off,
 // because the end of that checkout happens on the backend after the user is redirected to our site.
-export type PaymentResult = {
+export type StripePaymentResult = {
 	paymentStatus: Status;
 	subscriptionCreationPending?: true;
 	error?: ErrorReason;
@@ -192,7 +192,7 @@ export type StatusResponse = {
 };
 
 // ----- Setup ----- //
-const PaymentSuccess: PaymentResult = {
+const PaymentSuccess: StripePaymentResult = {
 	paymentStatus: 'success',
 };
 

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -28,6 +28,7 @@ import { PaymentElement } from '@stripe/react-stripe-js';
 import type {
 	ExpressPaymentType,
 	PaymentMethodResult,
+	StripeError,
 } from '@stripe/stripe-js';
 import { useEffect, useRef, useState } from 'react';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
@@ -46,6 +47,7 @@ import { appropriateErrorMessage } from 'helpers/forms/errorReasons';
 import type {
 	CreatePayPalPaymentResponse,
 	CreateStripePaymentIntentRequest,
+	PaymentResult,
 } from 'helpers/forms/paymentIntegrations/oneOffContributions';
 import {
 	postOneOffPayPalCreatePaymentRequest,
@@ -53,7 +55,7 @@ import {
 	processStripePaymentIntentRequestForPaypal,
 } from 'helpers/forms/paymentIntegrations/oneOffContributions';
 import type {
-	PaymentResult,
+	StripePaymentResult,
 	StripePaymentMethod,
 } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
 import type { PaymentMethod as LegacyPaymentMethod } from 'helpers/forms/paymentMethods';
@@ -440,7 +442,7 @@ export function OneTimeCheckoutComponent({
 				setPaymentMethodError('Please select a payment method');
 			}
 
-			let paymentResult;
+			let paymentResult: PaymentResult | undefined;
 			if (paymentMethod === 'PayPal') {
 				paymentResult = await postOneOffPayPalCreatePaymentRequest({
 					currency: currencyKey,
@@ -526,7 +528,9 @@ export function OneTimeCheckoutComponent({
 					return stripe.handleCardAction(clientSecret);
 				};
 
-				const handlePaypal = (clientSecret: string) => {
+				const handlePaypal = (
+					clientSecret: string,
+				): Promise<{ error: StripeError }> => {
 					trackComponentLoad('stripe-Paypal');
 					return stripe.confirmPayment({
 						elements,
@@ -610,9 +614,10 @@ export function OneTimeCheckoutComponent({
 							status: 'success', // retry pending mechanism not applied to one-time payments
 						});
 
+						// do not call handlePaypal and do not redirect to paypal yet
 						paymentResult = await processStripePaymentIntentRequestForPaypal(
 							stripeData,
-							handlePaypal,
+							// handlePaypal,
 						);
 					} else {
 						paymentResult = await processStripePaymentIntentRequest(
@@ -623,6 +628,7 @@ export function OneTimeCheckoutComponent({
 				}
 			}
 
+			// paymentResult could be the result of Stripe or Paypal
 			if (paymentResult) {
 				setThankYouOrder({
 					firstName: '',
@@ -641,14 +647,17 @@ export function OneTimeCheckoutComponent({
 					thankYouUrlSearchParams,
 				);
 				if (nextStepRoute) {
+					// call the stripe paypal redirect function instead
 					window.location.href = nextStepRoute;
 				} else {
 					setErrorMessage('Sorry, something went wrong.');
 					if (
-						'paymentStatus' in paymentResult &&
-						paymentResult.paymentStatus === 'failure'
+						paymentResult.type === 'stripe' &&
+						paymentResult.result.paymentStatus === 'failure'
+						// 'paymentStatus' in paymentResult &&
+						// paymentResult.paymentStatus === 'failure'
 					) {
-						setErrorContext(appropriateErrorMessage(paymentResult.error ?? ''));
+						setErrorContext(appropriateErrorMessage(paymentResult.result.error ?? ''));
 					}
 					setIsProcessingPayment(false);
 				}
@@ -659,20 +668,28 @@ export function OneTimeCheckoutComponent({
 	};
 
 	function paymentResultThankyouRoute(
-		paymentResult: PaymentResult | CreatePayPalPaymentResponse | undefined,
+		paymentResult: PaymentResult,
+		// paymentResult: StripePaymentResult | CreatePayPalPaymentResponse | undefined,
 		supportRegionId: SupportRegionId,
 		thankYouUrlSearchParams: URLSearchParams,
 	): string | undefined {
-		if (paymentResult) {
-			if ('type' in paymentResult && paymentResult.type === 'success') {
-				return paymentResult.data.approvalUrl;
-			} else if (
-				'paymentStatus' in paymentResult &&
-				paymentResult.paymentStatus === 'success'
-			) {
-				return `/${supportRegionId}/thank-you?${thankYouUrlSearchParams.toString()}`;
-			}
+		if (paymentResult.type === 'paypal' && paymentResult.result.type === 'success') {
+			// redirect to paypal approval url
+			return paymentResult.result.data.approvalUrl;
+		} else if (paymentResult.type === 'stripe' && paymentResult.result.paymentStatus === 'success') {
+			return `/${supportRegionId}/thank-you?${thankYouUrlSearchParams.toString()}`;
 		}
+		// if (paymentResult) {
+			// if ('type' in paymentResult && paymentResult.type === 'success') {
+			// 	// Paypal redirect
+			// 	return paymentResult.data.approvalUrl;
+			// } else if (
+			// 	'paymentStatus' in paymentResult &&
+			// 	paymentResult.paymentStatus === 'success'
+			// ) {
+			// 	return `/${supportRegionId}/thank-you?${thankYouUrlSearchParams.toString()}`;
+			// }
+		// }
 
 		return;
 	}

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -45,7 +45,6 @@ import { config } from 'helpers/contributions';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import { appropriateErrorMessage } from 'helpers/forms/errorReasons';
 import type {
-	CreatePayPalPaymentResponse,
 	CreateStripePaymentIntentRequest,
 	PaymentResult,
 } from 'helpers/forms/paymentIntegrations/oneOffContributions';
@@ -54,10 +53,7 @@ import {
 	processStripePaymentIntentRequest,
 	processStripePaymentIntentRequestForPaypal,
 } from 'helpers/forms/paymentIntegrations/oneOffContributions';
-import type {
-	StripePaymentResult,
-	StripePaymentMethod,
-} from 'helpers/forms/paymentIntegrations/readerRevenueApis';
+import type { StripePaymentMethod } from 'helpers/forms/paymentIntegrations/readerRevenueApis';
 import type { PaymentMethod as LegacyPaymentMethod } from 'helpers/forms/paymentMethods';
 import {
 	isPaymentMethod,
@@ -614,10 +610,11 @@ export function OneTimeCheckoutComponent({
 							status: 'success', // retry pending mechanism not applied to one-time payments
 						});
 
-						// do not call handlePaypal and do not redirect to paypal yet
+						// If we successfully create a Payment Intent then this call will redirect to the paypal confirmation page
+						// In this case paymentResult will not be set
 						paymentResult = await processStripePaymentIntentRequestForPaypal(
 							stripeData,
-							// handlePaypal,
+							handlePaypal,
 						);
 					} else {
 						paymentResult = await processStripePaymentIntentRequest(
@@ -638,26 +635,28 @@ export function OneTimeCheckoutComponent({
 				});
 				const thankYouUrlSearchParams = new URLSearchParams();
 				thankYouUrlSearchParams.set('contribution', finalAmount.toString());
-				'userType' in paymentResult &&
-					paymentResult.userType &&
-					thankYouUrlSearchParams.set('userType', paymentResult.userType);
+				paymentResult.type === 'stripe' &&
+					paymentResult.result.userType &&
+					thankYouUrlSearchParams.set(
+						'userType',
+						paymentResult.result.userType,
+					);
 				const nextStepRoute = paymentResultThankyouRoute(
 					paymentResult,
 					supportRegionId,
 					thankYouUrlSearchParams,
 				);
 				if (nextStepRoute) {
-					// call the stripe paypal redirect function instead
 					window.location.href = nextStepRoute;
 				} else {
 					setErrorMessage('Sorry, something went wrong.');
 					if (
 						paymentResult.type === 'stripe' &&
 						paymentResult.result.paymentStatus === 'failure'
-						// 'paymentStatus' in paymentResult &&
-						// paymentResult.paymentStatus === 'failure'
 					) {
-						setErrorContext(appropriateErrorMessage(paymentResult.result.error ?? ''));
+						setErrorContext(
+							appropriateErrorMessage(paymentResult.result.error ?? ''),
+						);
 					}
 					setIsProcessingPayment(false);
 				}
@@ -669,29 +668,22 @@ export function OneTimeCheckoutComponent({
 
 	function paymentResultThankyouRoute(
 		paymentResult: PaymentResult,
-		// paymentResult: StripePaymentResult | CreatePayPalPaymentResponse | undefined,
 		supportRegionId: SupportRegionId,
 		thankYouUrlSearchParams: URLSearchParams,
 	): string | undefined {
-		if (paymentResult.type === 'paypal' && paymentResult.result.type === 'success') {
+		if (
+			paymentResult.type === 'paypal' &&
+			paymentResult.result.type === 'success'
+		) {
 			// redirect to paypal approval url
 			return paymentResult.result.data.approvalUrl;
-		} else if (paymentResult.type === 'stripe' && paymentResult.result.paymentStatus === 'success') {
+		} else if (
+			paymentResult.type === 'stripe' &&
+			paymentResult.result.paymentStatus === 'success'
+		) {
 			return `/${supportRegionId}/thank-you?${thankYouUrlSearchParams.toString()}`;
 		}
-		// if (paymentResult) {
-			// if ('type' in paymentResult && paymentResult.type === 'success') {
-			// 	// Paypal redirect
-			// 	return paymentResult.data.approvalUrl;
-			// } else if (
-			// 	'paymentStatus' in paymentResult &&
-			// 	paymentResult.paymentStatus === 'success'
-			// ) {
-			// 	return `/${supportRegionId}/thank-you?${thankYouUrlSearchParams.toString()}`;
-			// }
-		// }
-
-		return;
+		return undefined;
 	}
 
 	useAbandonedBasketCookie(

--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -610,8 +610,8 @@ export function OneTimeCheckoutComponent({
 							status: 'success', // retry pending mechanism not applied to one-time payments
 						});
 
-						// If we successfully create a Payment Intent then this call will redirect to the paypal confirmation page
-						// In this case paymentResult will not be set
+						// If we successfully create a Payment Intent then this call will redirect to the paypal confirmation page.
+						// In this case paymentResult will not be set and it will not continue past this point.
 						paymentResult = await processStripePaymentIntentRequestForPaypal(
 							stripeData,
 							handlePaypal,
@@ -625,7 +625,6 @@ export function OneTimeCheckoutComponent({
 				}
 			}
 
-			// paymentResult could be the result of Stripe or Paypal
 			if (paymentResult) {
 				setThankYouOrder({
 					firstName: '',


### PR DESCRIPTION
Models the results of the different payment methods more clearly by wrapping in a `PaymentResult` type, which has a type discriminator field. This makes it easier to see how we handle stripe vs paypal.

Improves error handling when calling `stripe.confirmPayment`, so that we display an error to the user if the redirect to paypal confirmation does not happen.