### PR TITLE
Enable VScode debug with Chrome

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "chrome",
+			"request": "launch",
+			"name": "Debug Frontend in Chrome",
+			"url": "https://support.thegulocal.com/contribute",
+			"webRoot": "${workspaceFolder}/support-frontend/assets",
+			"sourceMapPathOverrides": {
+				"webpack:///./~/*": "${workspaceFolder}/support-frontend/node_modules/*",
+				"webpack:///./*": "${workspaceFolder}/support-frontend/assets/*",
+				"webpack:///*": "*"
+			}
+		}
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,8 @@
 			"name": "Debug Frontend in Chrome",
 			"url": "https://support.thegulocal.com/contribute",
 			"webRoot": "${workspaceFolder}/support-frontend/assets",
+			"skipFiles": ["**/node_modules/**"],
 			"sourceMapPathOverrides": {
-				"webpack:///./~/*": "${workspaceFolder}/support-frontend/node_modules/*",
 				"webpack:///./*": "${workspaceFolder}/support-frontend/assets/*",
 				"webpack:///*": "*"
 			}

--- a/support-frontend/tsconfig.json
+++ b/support-frontend/tsconfig.json
@@ -12,6 +12,7 @@
 		"noFallthroughCasesInSwitch": true, // Report errors for fallthrough cases in switch statement
 		"noImplicitAny": true, // Enable error reporting for expressions and declarations with an implied any type
 		"baseUrl": "./assets", // The baseUrl to be used when resolving absolute module paths
+		"sourceMap": true,
 		"paths": {
 			"ophan": ["../node_modules/ophan-tracker-js/build/ophan.support"],
 			"@modules/internationalisation/*": [


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Enable VScode debug with Chrome

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


## Why are you doing this?
Sometimes is useful to debug using breakpoints and access all current state instead of adding logs everywhere.
<!--
Remember, PRs are documentation for future contributors.
-->

## How to use

1. run `support-frontend` as normal (running  `~./devrun` or `pnpm --filter support-frontend start` )
2. on VScode go to debugger panel on side bar
3. Select _Debug Frontend in Chrome_ and click the play icon

## Screenshot
<img width="583" height="629" alt="Screenshot 2026-06-18 at 12 09 29" src="https://github.com/user-attachments/assets/b5801700-0eff-4a71-b6ee-f03f83eb45ca" />
