### PR TITLE
Tax exclusive footer disclaimer

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -393,7 +393,7 @@ export function ThreeTierLanding({
 
 	const tier2Pricing = productCatalog.SupporterPlus?.ratePlans[
 		maybeTaxExclusiveRatePlanKey
-	].pricing[currencyId] as number;
+	]?.pricing[currencyId] as number;
 
 	const tier2Promotion = getPromotion(
 		allProductPrices.SupporterPlus,
@@ -453,7 +453,7 @@ export function ThreeTierLanding({
 	const tier3Product = 'DigitalSubscription';
 	const tier3Pricing = productCatalog[tier3Product]?.ratePlans[
 		maybeTaxExclusiveRatePlanKey
-	].pricing[currencyId] as number;
+	]?.pricing[currencyId] as number;
 
 	const { label: title, labelPill: titlePill } = getProductDescription(
 		'DigitalSubscription',

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -330,8 +330,8 @@ export function ThreeTierLanding({
 		setContributionType(paymentFrequencies[buttonIndex] as ContributionType);
 	};
 
-	const { maybeTaxExclusiveRatePlanKey, taxExclusionEnabled } =
-		useMaybeTaxExclusiveRatePlanKey(contributionType, supportRegionId);
+	const { ratePlanKey: maybeTaxExclusiveRatePlanKey, taxExclusionEnabled } =
+		useRatePlanKey(contributionType, supportRegionId);
 
 	const ratePlanKey = getRatePlanKey(contributionType);
 
@@ -393,7 +393,7 @@ export function ThreeTierLanding({
 
 	const tier2Pricing = productCatalog.SupporterPlus?.ratePlans[
 		maybeTaxExclusiveRatePlanKey
-	]?.pricing[currencyId] as number;
+	].pricing[currencyId] as number;
 
 	const tier2Promotion = getPromotion(
 		allProductPrices.SupporterPlus,
@@ -402,7 +402,7 @@ export function ThreeTierLanding({
 	);
 	const tier2CheckoutURL = buildCheckoutUrl(supportRegionId, {
 		product: 'SupporterPlus',
-		ratePlan: ratePlanKey,
+		ratePlan: maybeTaxExclusiveRatePlanKey,
 		promoCode: tier2Promotion?.promoCode,
 	});
 
@@ -453,7 +453,7 @@ export function ThreeTierLanding({
 	const tier3Product = 'DigitalSubscription';
 	const tier3Pricing = productCatalog[tier3Product]?.ratePlans[
 		maybeTaxExclusiveRatePlanKey
-	]?.pricing[currencyId] as number;
+	].pricing[currencyId] as number;
 
 	const { label: title, labelPill: titlePill } = getProductDescription(
 		'DigitalSubscription',
@@ -481,7 +481,7 @@ export function ThreeTierLanding({
 
 	const tier3CheckoutURL = buildCheckoutUrl(supportRegionId, {
 		product: tier3Product,
-		ratePlan: ratePlanKey,
+		ratePlan: maybeTaxExclusiveRatePlanKey,
 		promoCode: tier3Promotion?.promoCode,
 	});
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -171,6 +171,7 @@ const disclaimerContainer = css`
 const taxExclusionDisclaimer = css`
 	${textSans12};
 	color: ${palette.neutral[100]};
+	margin-bottom: ${space[2]}px;
 `;
 
 const links = [
@@ -540,6 +541,11 @@ export function ThreeTierLanding({
 						borderColor="rgba(170, 170, 180, 0.5)"
 						cssOverrides={disclaimerContainer}
 					>
+						{taxExclusionEnabled && (
+							<p css={taxExclusionDisclaimer}>
+								For All-access digital and Digital plus, taxes may apply.
+							</p>
+						)}
 						<ThreeTierTsAndCs
 							tsAndCsContent={[
 								{
@@ -577,11 +583,6 @@ export function ThreeTierLanding({
 							]}
 							currency={glyph(currencyId)}
 						></ThreeTierTsAndCs>
-						{taxExclusionEnabled && (
-							<p css={taxExclusionDisclaimer}>
-								For All-access digital and Digital plus, taxes may apply.
-							</p>
-						)}
 					</Container>
 					<FooterWithContents>
 						<FooterLinks links={links}></FooterLinks>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -4,6 +4,7 @@ import {
 	from,
 	palette,
 	space,
+	textSans12,
 	textSans17,
 	textSansBold20,
 } from '@guardian/source/foundations';
@@ -167,6 +168,11 @@ const disclaimerContainer = css`
 	}
 `;
 
+const taxExclusionDisclaimer = css`
+	${textSans12};
+	color: ${palette.neutral[100]};
+`;
+
 const links = [
 	{
 		href: 'https://www.theguardian.com/info/privacy',
@@ -323,10 +329,8 @@ export function ThreeTierLanding({
 		setContributionType(paymentFrequencies[buttonIndex] as ContributionType);
 	};
 
-	const maybeTaxExclusiveRatePlanKey = useRatePlanKey(
-		contributionType,
-		supportRegionId,
-	);
+	const { maybeTaxExclusiveRatePlanKey, taxExclusionEnabled } =
+		useMaybeTaxExclusiveRatePlanKey(contributionType, supportRegionId);
 
 	const ratePlanKey = getRatePlanKey(contributionType);
 
@@ -573,6 +577,11 @@ export function ThreeTierLanding({
 							]}
 							currency={glyph(currencyId)}
 						></ThreeTierTsAndCs>
+						{taxExclusionEnabled && (
+							<p css={taxExclusionDisclaimer}>
+								For All-access digital and Digital plus, taxes may apply.
+							</p>
+						)}
 					</Container>
 					<FooterWithContents>
 						<FooterLinks links={links}></FooterLinks>

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -24,6 +24,7 @@ import {
 	UnitedStates,
 } from '@modules/internationalisation/countryGroup';
 import type { BillingPeriod } from '@modules/product/billingPeriod';
+import type { ProductRatePlanKey } from '@modules/product-catalog/productCatalog';
 import { useState } from 'preact/hooks';
 import { BillingPeriodButtons } from 'components/billingPeriodButtons/billingPeriodButtons';
 import type { CountryGroupSwitcherProps } from 'components/countryGroupSwitcher/countryGroupSwitcher';
@@ -400,9 +401,11 @@ export function ThreeTierLanding({
 		countryId,
 		billingPeriod,
 	);
+
 	const tier2CheckoutURL = buildCheckoutUrl(supportRegionId, {
 		product: 'SupporterPlus',
-		ratePlan: maybeTaxExclusiveRatePlanKey,
+		ratePlan:
+			maybeTaxExclusiveRatePlanKey as ProductRatePlanKey<'SupporterPlus'>,
 		promoCode: tier2Promotion?.promoCode,
 	});
 
@@ -481,7 +484,8 @@ export function ThreeTierLanding({
 
 	const tier3CheckoutURL = buildCheckoutUrl(supportRegionId, {
 		product: tier3Product,
-		ratePlan: maybeTaxExclusiveRatePlanKey,
+		ratePlan:
+			maybeTaxExclusiveRatePlanKey as ProductRatePlanKey<'DigitalSubscription'>,
 		promoCode: tier3Promotion?.promoCode,
 	});
 

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/useRatePlanKey.test.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/useRatePlanKey.test.tsx
@@ -2,7 +2,7 @@ import { SupportRegionId } from '@modules/internationalisation/countryGroup';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useFeatureSwitches } from 'contexts/FeatureSwitchesContext';
 import type { ContributionType } from 'helpers/contributions';
-import { useRatePlanKey } from './useRatePlanKey';
+import { useMaybeTaxExclusiveRatePlanKey } from './useRatePlanKey';
 
 jest.mock('contexts/FeatureSwitchesContext', () => ({
 	useFeatureSwitches: jest.fn(),
@@ -31,28 +31,37 @@ describe('useRatePlanKey', () => {
 
 	it('returns the billing period key for non-Canada regions', () => {
 		const { result } = renderHook(() =>
-			useRatePlanKey('MONTHLY', SupportRegionId.UK),
+			useMaybeTaxExclusiveRatePlanKey('MONTHLY', SupportRegionId.UK),
 		);
 
-		expect(result.current).toBe('Monthly');
+		expect(result.current).toEqual({
+			maybeTaxExclusiveRatePlanKey: 'Monthly',
+			taxExclusionEnabled: false,
+		});
 	});
 
 	it('appends TaxExclusive for Canada when the switch is enabled', () => {
 		setCanadaTaxExclusionFlag(true);
 
 		const { result } = renderHook(() =>
-			useRatePlanKey('ANNUAL', SupportRegionId.CA),
+			useMaybeTaxExclusiveRatePlanKey('ANNUAL', SupportRegionId.CA),
 		);
 
-		expect(result.current).toBe('AnnualTaxExclusive');
+		expect(result.current).toEqual({
+			maybeTaxExclusiveRatePlanKey: 'AnnualTaxExclusive',
+			taxExclusionEnabled: true,
+		});
 	});
 
 	it('does not append TaxExclusive for Canada when the switch is disabled', () => {
 		const { result } = renderHook(() =>
-			useRatePlanKey('ANNUAL', SupportRegionId.CA),
+			useMaybeTaxExclusiveRatePlanKey('ANNUAL', SupportRegionId.CA),
 		);
 
-		expect(result.current).toBe('Annual');
+		expect(result.current).toEqual({
+			maybeTaxExclusiveRatePlanKey: 'Annual',
+			taxExclusionEnabled: false,
+		});
 	});
 
 	it('updates the key when contribution type changes', async () => {
@@ -60,7 +69,7 @@ describe('useRatePlanKey', () => {
 
 		const { result, rerender } = renderHook(
 			({ contributionType, supportRegionId }: HookProbeProps) =>
-				useRatePlanKey(contributionType, supportRegionId),
+				useMaybeTaxExclusiveRatePlanKey(contributionType, supportRegionId),
 			{
 				initialProps: {
 					contributionType: 'MONTHLY',
@@ -69,7 +78,10 @@ describe('useRatePlanKey', () => {
 			},
 		);
 
-		expect(result.current).toBe('MonthlyTaxExclusive');
+		expect(result.current).toEqual({
+			maybeTaxExclusiveRatePlanKey: 'MonthlyTaxExclusive',
+			taxExclusionEnabled: true,
+		});
 
 		rerender({
 			contributionType: 'ANNUAL',
@@ -77,7 +89,10 @@ describe('useRatePlanKey', () => {
 		});
 
 		await waitFor(() => {
-			expect(result.current).toBe('AnnualTaxExclusive');
+			expect(result.current).toEqual({
+				maybeTaxExclusiveRatePlanKey: 'AnnualTaxExclusive',
+				taxExclusionEnabled: true,
+			});
 		});
 	});
 });

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/useRatePlanKey.test.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/useRatePlanKey.test.tsx
@@ -2,7 +2,7 @@ import { SupportRegionId } from '@modules/internationalisation/countryGroup';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useFeatureSwitches } from 'contexts/FeatureSwitchesContext';
 import type { ContributionType } from 'helpers/contributions';
-import { useMaybeTaxExclusiveRatePlanKey } from './useRatePlanKey';
+import { useRatePlanKey } from './useRatePlanKey';
 
 jest.mock('contexts/FeatureSwitchesContext', () => ({
 	useFeatureSwitches: jest.fn(),
@@ -31,11 +31,11 @@ describe('useRatePlanKey', () => {
 
 	it('returns the billing period key for non-Canada regions', () => {
 		const { result } = renderHook(() =>
-			useMaybeTaxExclusiveRatePlanKey('MONTHLY', SupportRegionId.UK),
+			useRatePlanKey('MONTHLY', SupportRegionId.UK),
 		);
 
 		expect(result.current).toEqual({
-			maybeTaxExclusiveRatePlanKey: 'Monthly',
+			ratePlanKey: 'Monthly',
 			taxExclusionEnabled: false,
 		});
 	});
@@ -44,22 +44,22 @@ describe('useRatePlanKey', () => {
 		setCanadaTaxExclusionFlag(true);
 
 		const { result } = renderHook(() =>
-			useMaybeTaxExclusiveRatePlanKey('ANNUAL', SupportRegionId.CA),
+			useRatePlanKey('ANNUAL', SupportRegionId.CA),
 		);
 
 		expect(result.current).toEqual({
-			maybeTaxExclusiveRatePlanKey: 'AnnualTaxExclusive',
+			ratePlanKey: 'AnnualTaxExclusive',
 			taxExclusionEnabled: true,
 		});
 	});
 
 	it('does not append TaxExclusive for Canada when the switch is disabled', () => {
 		const { result } = renderHook(() =>
-			useMaybeTaxExclusiveRatePlanKey('ANNUAL', SupportRegionId.CA),
+			useRatePlanKey('ANNUAL', SupportRegionId.CA),
 		);
 
 		expect(result.current).toEqual({
-			maybeTaxExclusiveRatePlanKey: 'Annual',
+			ratePlanKey: 'Annual',
 			taxExclusionEnabled: false,
 		});
 	});
@@ -69,7 +69,7 @@ describe('useRatePlanKey', () => {
 
 		const { result, rerender } = renderHook(
 			({ contributionType, supportRegionId }: HookProbeProps) =>
-				useMaybeTaxExclusiveRatePlanKey(contributionType, supportRegionId),
+				useRatePlanKey(contributionType, supportRegionId),
 			{
 				initialProps: {
 					contributionType: 'MONTHLY',
@@ -79,7 +79,7 @@ describe('useRatePlanKey', () => {
 		);
 
 		expect(result.current).toEqual({
-			maybeTaxExclusiveRatePlanKey: 'MonthlyTaxExclusive',
+			ratePlanKey: 'MonthlyTaxExclusive',
 			taxExclusionEnabled: true,
 		});
 
@@ -90,7 +90,7 @@ describe('useRatePlanKey', () => {
 
 		await waitFor(() => {
 			expect(result.current).toEqual({
-				maybeTaxExclusiveRatePlanKey: 'AnnualTaxExclusive',
+				ratePlanKey: 'AnnualTaxExclusive',
 				taxExclusionEnabled: true,
 			});
 		});

--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/useRatePlanKey.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/useRatePlanKey.tsx
@@ -16,7 +16,7 @@ export function getRatePlanKey(contributionType: ContributionType) {
 export function useRatePlanKey(
 	contributionType: ContributionType,
 	supportRegionId: SupportRegionId,
-): ActiveRatePlanKey {
+): { ratePlanKey: ActiveRatePlanKey; taxExclusionEnabled: boolean } {
 	const [ratePlanKey, setRatePlanKey] = useState<ActiveRatePlanKey>(
 		getRatePlanKey(contributionType),
 	);
@@ -30,9 +30,13 @@ export function useRatePlanKey(
 	}, [contributionType]);
 
 	if (taxExclusionEnabled) {
-		return ratePlanKey === 'Monthly'
-			? 'MonthlyTaxExclusive'
-			: 'AnnualTaxExclusive';
+		return {
+			ratePlanKey:
+				ratePlanKey === 'Monthly'
+					? 'MonthlyTaxExclusive'
+					: 'AnnualTaxExclusive',
+			taxExclusionEnabled,
+		};
 	}
-	return ratePlanKey;
+	return { ratePlanKey, taxExclusionEnabled };
 }


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
display footer disclaimer when Tax exclusive rate plans are available.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[Landing page changes for CA tax](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1214265225282424?focus=true)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->
Required by legal and updated according to  Figma designs.
https://www.figma.com/design/bruXbfgh0XNSohIGB5v42c/Tax-exclusive-pricing?node-id=2724-63825&m=dev

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
ℹ️  Local feature switch override works via session storage, so you need to be within the same tab to see it working.
1. Enable `enableCanadaTaxExclusion` feature switch on https://support.thegulocal.com/switches
2. go to https://support.thegulocal.com/ca/contribute
3. see tax exclusive disclaimer displayed on the footer

## Screenshots
<img width="1121" height="1163" alt="Screenshot 2026-06-18 at 15 31 32" src="https://github.com/user-attachments/assets/65180eb3-1857-4c3d-8207-71fca44f0b4c" />
