### PR TITLE
Make Jest output in support-workers much quieter

### DIFF
--- a/support-workers/jest.config.js
+++ b/support-workers/jest.config.js
@@ -2,6 +2,7 @@
 module.exports = {
 	preset: 'ts-jest',
 	testEnvironment: 'node',
+	silent: true,
 	runner: 'groups',
 	testPathIgnorePatterns: ['/node_modules/', 'target'],
 	transformIgnorePatterns: ['/node_modules/\\.pnpm/(?!@guardian)'],

--- a/support-workers/src/typescript/test/createZuoraSubscriptionLambda.it.test.ts
+++ b/support-workers/src/typescript/test/createZuoraSubscriptionLambda.it.test.ts
@@ -29,7 +29,7 @@ describe('createZuoraSubscriptionLambda integration', () => {
 			} catch (error) {
 				if (error instanceof RetryError) {
 					expect(error.name).toBe(RetryErrorType.RetryNone);
-					expect(error.message).toContain('Ghostbusters!');
+					expect(error.message).toContain('Transaction declined');
 				} else {
 					fail('Error is not an instance of RetryError');
 				}

--- a/support-workers/src/typescript/test/createZuoraSubscriptionLambda.it.test.ts
+++ b/support-workers/src/typescript/test/createZuoraSubscriptionLambda.it.test.ts
@@ -29,7 +29,7 @@ describe('createZuoraSubscriptionLambda integration', () => {
 			} catch (error) {
 				if (error instanceof RetryError) {
 					expect(error.name).toBe(RetryErrorType.RetryNone);
-					expect(error.message).toContain('Transaction declined');
+					expect(error.message).toContain('Ghostbusters!');
 				} else {
 					fail('Error is not an instance of RetryError');
 				}

--- a/support-workers/src/typescript/test/test-setup.ts
+++ b/support-workers/src/typescript/test/test-setup.ts
@@ -1,3 +1,10 @@
 jest.mock('../model/stage', () => ({
 	stageFromEnvironment: jest.fn().mockReturnValue('CODE'),
 }));
+
+jest.mock('node:console', () => ({
+	log: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+}));


### PR DESCRIPTION
## What are you doing in this PR?

Make Jest output in support-workers much quieter.

## Why are you doing this?

It's quite hard to debug the tests, especially integration tests, because the output is very noisy. This commit changes two things:

* Adds the silent flag to jest config which suppresses console output (see https://jestjs.io/docs/cli#--silent)

* Mocks "node:console" which is used by Logger in support service lambdas. This isn't caught by the silent option so it's necessary to handle this separately. Edit: silent intercepts calls to console in the global namespace but not when imported explicitly.