### PR TITLE
Fix ratePlan query string arg in RC checkout link from 3 tier landing page

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/twoStepPages/threeTierLanding.tsx
@@ -349,7 +349,7 @@ export function ThreeTierLanding({
 		?.pricing[currencyId] as number;
 	const tier1UrlParams = new URLSearchParams({
 		product: 'Contribution',
-		ratePlanKey,
+		ratePlan: ratePlanKey,
 		contribution: tier1Pricing.toString(),
 	});
 	const tier1Url = `checkout?${tier1UrlParams.toString()}`;


### PR DESCRIPTION
## What are you doing in this PR?

Fix ratePlan query string arg in RC checkout link from 3 tier landing page.

## Why are you doing this?

This had been renamed to ratePlanKey which isn't what the checkout expects and was causing the checkout to error.