### PR TITLE
Simplify to only use the first methodology

### DIFF
--- a/support-frontend/app/admin/settings/Methodology.scala
+++ b/support-frontend/app/admin/settings/Methodology.scala
@@ -4,25 +4,20 @@ import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto._
 import io.circe.{Decoder, Encoder}
 
-sealed trait Methodology {
-  val testName: Option[String]
-}
+sealed trait Methodology
 
 case class ABTest(
     name: String = "ABTest",
-    testName: Option[String] = None,
 ) extends Methodology
 
 case class EpsilonGreedyBandit(
     name: String = "EpsilonGreedyBandit",
     epsilon: Double,
-    testName: Option[String] = None,
     sampleCount: Option[Int] = None,
 ) extends Methodology
 
 case class Roulette(
     name: String = "Roulette",
-    testName: Option[String] = None,
     sampleCount: Option[Int] = None,
 ) extends Methodology
 

--- a/support-frontend/app/services/BanditDataService.scala
+++ b/support-frontend/app/services/BanditDataService.scala
@@ -178,25 +178,24 @@ class BanditDataService(
     ),
   )
 
-  /** Extract bandit test configurations from landing page tests for each methodology */
+  /** Extract bandit test configurations from landing page tests using the first methodology. Only generates a config if
+    * the first methodology requires bandit data (EpsilonGreedyBandit or Roulette).
+    */
   def getBanditTestConfigs(tests: List[LandingPageTest]): List[BanditTestConfig] = {
     tests.flatMap { test =>
-      val banditMethodologies = test.methodologies.getOrElse(List.empty).filter {
-        case _: EpsilonGreedyBandit => true
-        case _: Roulette => true
-        case _ => false
-      }
-
-      banditMethodologies.map { methodology =>
-        BanditTestConfig(
-          testName = methodology.testName.getOrElse(test.name),
-          variantNames = test.variants.map(_.name),
-          sampleCount = methodology match {
-            case epsilon: EpsilonGreedyBandit => epsilon.sampleCount
-            case roulette: Roulette => roulette.sampleCount
-            case _ => None
-          },
-        )
+      test.methodologies.getOrElse(List.empty).headOption.collect {
+        case e: EpsilonGreedyBandit =>
+          BanditTestConfig(
+            testName = test.name,
+            variantNames = test.variants.map(_.name),
+            sampleCount = e.sampleCount,
+          )
+        case r: Roulette =>
+          BanditTestConfig(
+            testName = test.name,
+            variantNames = test.variants.map(_.name),
+            sampleCount = r.sampleCount,
+          )
       }
     }
   }

--- a/support-frontend/assets/helpers/abTests/__tests__/banditSelection.spec.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/banditSelection.spec.ts
@@ -63,8 +63,7 @@ describe('banditSelection', () => {
 
 			const result = selectVariantForTest(test, 0, [banditData]);
 
-			expect(result?.variant.name).toBe('v1');
-			expect(result?.trackingTestName).toBe('test-1');
+			expect(result?.name).toBe('v1');
 		});
 
 		it('selects random variant when exploring (epsilon probability)', () => {
@@ -92,8 +91,7 @@ describe('banditSelection', () => {
 
 			const result = selectVariantForTest(test, 0, [banditData]);
 
-			expect(result?.variant.name).toBe('v3');
-			expect(result?.trackingTestName).toBe('test-1');
+			expect(result?.name).toBe('v3');
 		});
 
 		it('selects randomly when all weights are zero', () => {
@@ -119,7 +117,7 @@ describe('banditSelection', () => {
 
 			const result = selectVariantForTest(test, 0, [banditData]);
 
-			expect(result?.variant.name).toBe('v2');
+			expect(result?.name).toBe('v2');
 		});
 
 		it('selects randomly when no bandit data available', () => {
@@ -137,7 +135,7 @@ describe('banditSelection', () => {
 
 			const result = selectVariantForTest(test, 0, []);
 
-			expect(result?.variant.name).toBe('v2');
+			expect(result?.name).toBe('v2');
 		});
 
 		it('randomly picks from tied best variants', () => {
@@ -166,7 +164,7 @@ describe('banditSelection', () => {
 
 			const result = selectVariantForTest(test, 0, [banditData]);
 
-			expect(result?.variant.name).toBe('v2');
+			expect(result?.name).toBe('v2');
 		});
 
 		it('ignores variants in bandit data that are not in test configuration', () => {
@@ -190,33 +188,7 @@ describe('banditSelection', () => {
 
 			const result = selectVariantForTest(test, 0, [banditData]);
 
-			expect(result?.variant.name).toBe('v1');
-		});
-
-		it('uses methodology testName override for tracking', () => {
-			const methodologyWithOverride: Methodology = {
-				name: 'EpsilonGreedyBandit',
-				epsilon: 0.1,
-				testName: 'LP_TEST_ABTest',
-			};
-
-			const test = createTest(
-				'LP_TEST',
-				[createTestVariant('v1', 'value-1')],
-				[methodologyWithOverride],
-			);
-
-			const banditData = createBanditData('LP_TEST_ABTest', [
-				{ name: 'v1', weight: 1.0 },
-			]);
-
-			// Mock Math.random to not explore
-			jest.spyOn(Math, 'random').mockReturnValue(0.5);
-
-			const result = selectVariantForTest(test, 0, [banditData]);
-
-			expect(result?.variant.name).toBe('v1');
-			expect(result?.trackingTestName).toBe('LP_TEST_ABTest');
+			expect(result?.name).toBe('v1');
 		});
 	});
 
@@ -244,19 +216,13 @@ describe('banditSelection', () => {
 			]);
 
 			jest.spyOn(Math, 'random').mockReturnValueOnce(0.15);
-			expect(selectVariantForTest(test, 0, [banditData])?.variant.name).toBe(
-				'v1',
-			);
+			expect(selectVariantForTest(test, 0, [banditData])?.name).toBe('v1');
 
 			jest.spyOn(Math, 'random').mockReturnValueOnce(0.49);
-			expect(selectVariantForTest(test, 0, [banditData])?.variant.name).toBe(
-				'v2',
-			);
+			expect(selectVariantForTest(test, 0, [banditData])?.name).toBe('v2');
 
 			jest.spyOn(Math, 'random').mockReturnValueOnce(0.5);
-			expect(selectVariantForTest(test, 0, [banditData])?.variant.name).toBe(
-				'v3',
-			);
+			expect(selectVariantForTest(test, 0, [banditData])?.name).toBe('v3');
 		});
 
 		it('applies minimum weight floor of 10%', () => {
@@ -282,19 +248,13 @@ describe('banditSelection', () => {
 			// v2≈0.0833, v3≈0.0833, v1≈0.8333
 			// Cumulative: v2≈0.0833, v3≈0.1666, v1=1.0
 			jest.spyOn(Math, 'random').mockReturnValueOnce(0.08);
-			expect(selectVariantForTest(test, 0, [banditData])?.variant.name).toBe(
-				'v2',
-			);
+			expect(selectVariantForTest(test, 0, [banditData])?.name).toBe('v2');
 
 			jest.spyOn(Math, 'random').mockReturnValueOnce(0.16);
-			expect(selectVariantForTest(test, 0, [banditData])?.variant.name).toBe(
-				'v3',
-			);
+			expect(selectVariantForTest(test, 0, [banditData])?.name).toBe('v3');
 
 			jest.spyOn(Math, 'random').mockReturnValueOnce(0.2);
-			expect(selectVariantForTest(test, 0, [banditData])?.variant.name).toBe(
-				'v1',
-			);
+			expect(selectVariantForTest(test, 0, [banditData])?.name).toBe('v1');
 		});
 
 		it('selects randomly when all weights are zero', () => {
@@ -318,7 +278,7 @@ describe('banditSelection', () => {
 
 			const result = selectVariantForTest(test, 0, [banditData]);
 
-			expect(result?.variant.name).toBe('v3');
+			expect(result?.name).toBe('v3');
 		});
 
 		it('selects randomly when no bandit data available', () => {
@@ -336,7 +296,7 @@ describe('banditSelection', () => {
 
 			const result = selectVariantForTest(test, 0, []);
 
-			expect(result?.variant.name).toBe('v3');
+			expect(result?.name).toBe('v3');
 		});
 
 		it('ignores variants in bandit data that are not in test configuration', () => {
@@ -356,29 +316,7 @@ describe('banditSelection', () => {
 
 			const result = selectVariantForTest(test, 0, [banditData]);
 
-			expect(result?.variant.name).toBe('v1');
-		});
-
-		it('uses methodology testName override for tracking', () => {
-			const methodologyWithOverride: Methodology = {
-				name: 'Roulette',
-				testName: 'LP_TEST_ABTest',
-			};
-
-			const test = createTest(
-				'LP_TEST',
-				[createTestVariant('v1', 'value-1')],
-				[methodologyWithOverride],
-			);
-
-			const banditData = createBanditData('LP_TEST_ABTest', [
-				{ name: 'v1', weight: 1.0 },
-			]);
-
-			const result = selectVariantForTest(test, 0, [banditData]);
-
-			expect(result?.variant.name).toBe('v1');
-			expect(result?.trackingTestName).toBe('LP_TEST_ABTest');
+			expect(result?.name).toBe('v1');
 		});
 
 		it('selects variants correctly with five weighted variants', () => {
@@ -405,24 +343,16 @@ describe('banditSelection', () => {
 			]);
 
 			jest.spyOn(Math, 'random').mockReturnValueOnce(0.15);
-			expect(selectVariantForTest(test, 0, [banditData])?.variant.name).toBe(
-				'v5',
-			);
+			expect(selectVariantForTest(test, 0, [banditData])?.name).toBe('v5');
 
 			jest.spyOn(Math, 'random').mockReturnValueOnce(0.25);
-			expect(selectVariantForTest(test, 0, [banditData])?.variant.name).toBe(
-				'v2',
-			);
+			expect(selectVariantForTest(test, 0, [banditData])?.name).toBe('v2');
 
 			jest.spyOn(Math, 'random').mockReturnValueOnce(0.9999);
-			expect(selectVariantForTest(test, 0, [banditData])?.variant.name).toBe(
-				'v4',
-			);
+			expect(selectVariantForTest(test, 0, [banditData])?.name).toBe('v4');
 
 			jest.spyOn(Math, 'random').mockReturnValueOnce(0.65);
-			expect(selectVariantForTest(test, 0, [banditData])?.variant.name).toBe(
-				'v3',
-			);
+			expect(selectVariantForTest(test, 0, [banditData])?.name).toBe('v3');
 		});
 	});
 
@@ -445,58 +375,40 @@ describe('banditSelection', () => {
 			const result2 = selectVariantForTest(test, 0, []);
 
 			// Same mvtId should produce same result
-			expect(result1?.variant.name).toBe(result2?.variant.name);
-		});
-
-		it('uses methodology testName override for tracking', () => {
-			const methodologyWithOverride: Methodology = {
-				name: 'ABTest',
-				testName: 'LP_TEST_ABTest',
-			};
-
-			const test = createTest(
-				'LP_TEST',
-				[createTestVariant('v1', 'value-1')],
-				[methodologyWithOverride],
-			);
-
-			const result = selectVariantForTest(test, 0, []);
-
-			expect(result?.variant.name).toBe('v1');
-			expect(result?.trackingTestName).toBe('LP_TEST_ABTest');
+			expect(result1?.name).toBe(result2?.name);
 		});
 	});
 
-	describe('selectVariantForTest - Multiple methodologies', () => {
-		const methodology1: Methodology = {
-			name: 'EpsilonGreedyBandit',
-			epsilon: 0.1,
-			testName: 'test-1-eg',
-		};
+	describe('selectVariantForTest - Multiple methodologies uses first', () => {
+		it('always uses the first methodology regardless of mvtId', () => {
+			const methodology1: Methodology = {
+				name: 'EpsilonGreedyBandit',
+				epsilon: 0.1,
+			};
 
-		const methodology2: Methodology = {
-			name: 'Roulette',
-			testName: 'test-1-roulette',
-		};
+			const methodology2: Methodology = {
+				name: 'Roulette',
+			};
 
-		it('picks methodology based on mvtId when multiple configured', () => {
 			const test = createTest(
 				'test-1',
 				[createTestVariant('v1', 'value-1')],
 				[methodology1, methodology2],
 			);
 
-			const banditData = createBanditData('test-1-eg', [
+			const banditData = createBanditData('test-1', [
 				{ name: 'v1', weight: 1.0 },
 			]);
+
+			// Mock Math.random to not explore
+			jest.spyOn(Math, 'random').mockReturnValue(0.5);
 
 			const result1 = selectVariantForTest(test, 0, [banditData]);
 			const result2 = selectVariantForTest(test, 1, [banditData]);
 
-			// These mvtIds are intentionally chosen because the deterministic hash maps
-			// them to different methodology indexes (using the seedrandom-based randomNumber).
-			expect(result1?.trackingTestName).toBe('test-1-roulette');
-			expect(result2?.trackingTestName).toBe('test-1-eg');
+			// Both should use the first methodology (EpsilonGreedyBandit) and return v1
+			expect(result1?.name).toBe('v1');
+			expect(result2?.name).toBe('v1');
 		});
 	});
 
@@ -509,8 +421,7 @@ describe('banditSelection', () => {
 
 			const result = selectVariantForTest(test, 0, []);
 
-			expect(result?.variant).toBeDefined();
-			expect(result?.trackingTestName).toBe('test-1');
+			expect(result).toBeDefined();
 		});
 	});
 

--- a/support-frontend/assets/helpers/abTests/__tests__/landingPageAbTests.spec.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/landingPageAbTests.spec.ts
@@ -174,7 +174,6 @@ describe('bandit selection integration', () => {
 				{
 					name: 'EpsilonGreedyBandit',
 					epsilon: 0.1,
-					testName: 'TEST_LP_ABTest',
 				},
 			],
 		};
@@ -183,7 +182,7 @@ describe('bandit selection integration', () => {
 			landingPageTests: [testWithMethodology],
 			banditData: [
 				{
-					testName: 'TEST_LP_ABTest',
+					testName: 'TEST_LP',
 					variants: [
 						{ name: 'VARIANT_A', weight: 0.7 },
 						{ name: 'VARIANT_B', weight: 0.3 },
@@ -201,8 +200,7 @@ describe('bandit selection integration', () => {
 		const result = config.selectVariant?.(testWithMethodology, 12345);
 
 		expect(result).toBeDefined();
-		expect(result?.variant).toBeDefined();
-		expect(result?.trackingTestName).toBe('TEST_LP_ABTest');
+		expect(result?.name).toBeDefined();
 	});
 
 	it('handles tests without banditData', () => {

--- a/support-frontend/assets/helpers/abTests/__tests__/pageParticipations.spec.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/pageParticipations.spec.ts
@@ -667,7 +667,7 @@ describe('getPageParticipations', () => {
 			expect(result.variant).toEqual(variant);
 		});
 
-		it('prunes participations that do not match methodology testName overrides', async () => {
+		it('prunes participations that do not match any test name', async () => {
 			const variant = createTestVariant('control', 'control-value');
 			const test = createPageTest('test-1', [variant], 'Live', [
 				'GBPCountries',
@@ -675,24 +675,23 @@ describe('getPageParticipations', () => {
 			test.methodologies = [
 				{
 					name: 'EpsilonGreedyBandit',
-					testName: 'test-1-ABTest',
 				},
 			];
 			const config = createConfig([test]);
 
 			mockLocation('/test/page');
-			// Session has participation for an old methodology that no longer exists
+			// Session has participation for an old test that no longer exists
 			mockGetSessionParticipations.mockReturnValue({
-				'test-1-old-methodology': 'variant-a',
-				'test-1-ABTest': 'control',
+				'test-1-old': 'variant-a',
+				'test-1': 'control',
 			});
 			mockCountryGroupMatches.mockReturnValue(true);
 			mockRandomNumber.mockReturnValue(0);
 
 			const result = await getPageParticipations(config);
 
-			// Should prune old methodology and keep current one
-			expect(result.participations).toEqual({ 'test-1-ABTest': 'control' });
+			// Should prune old test and keep current one
+			expect(result.participations).toEqual({ 'test-1': 'control' });
 			expect(result.variant).toEqual(variant);
 		});
 
@@ -723,26 +722,24 @@ describe('getPageParticipations', () => {
 			);
 		});
 
-		it('preserves methodology testName participations', async () => {
+		it('preserves participations keyed by test name', async () => {
 			const variant = createTestVariant('control', 'control-value');
 			const test = createPageTest('test-1', [variant], 'Live', [
 				'GBPCountries',
 			]);
-			test.methodologies = [
-				{ name: 'EpsilonGreedyBandit', testName: 'test-1-ABTest' },
-			];
+			test.methodologies = [{ name: 'EpsilonGreedyBandit' }];
 			const config = createConfig([test]);
 
 			mockLocation('/test/page');
 			mockGetSessionParticipations.mockReturnValue({
-				'test-1-ABTest': 'control',
+				'test-1': 'control',
 			});
 			mockCountryGroupMatches.mockReturnValue(true);
 
 			const result = await getPageParticipations(config);
 
-			// Should preserve participation keyed by methodology testName
-			expect(result.participations).toEqual({ 'test-1-ABTest': 'control' });
+			// Should preserve participation keyed by test name
+			expect(result.participations).toEqual({ 'test-1': 'control' });
 			expect(result.variant).toEqual(variant);
 		});
 	});
@@ -754,9 +751,7 @@ describe('getPageParticipations', () => {
 			const test = createPageTest('test-1', [variant1, variant2], 'Live', [
 				'GBPCountries',
 			]);
-			test.methodologies = [
-				{ name: 'EpsilonGreedyBandit', testName: 'test-1-ABTest' },
-			];
+			test.methodologies = [{ name: 'EpsilonGreedyBandit' }];
 			const config = createConfig([test], '^/.*/contribute(/.*)?$');
 
 			// Simulate landing page visit
@@ -789,9 +784,7 @@ describe('getPageParticipations', () => {
 			const test = createPageTest('test-1', [variant], 'Live', [
 				'GBPCountries',
 			]);
-			test.methodologies = [
-				{ name: 'EpsilonGreedyBandit', testName: 'test-1-ABTest' },
-			];
+			test.methodologies = [{ name: 'EpsilonGreedyBandit' }];
 			const config = createConfig([test], '^/.*/contribute(/.*)?$');
 
 			// Direct checkout entry (no session storage)

--- a/support-frontend/assets/helpers/abTests/banditSelection.ts
+++ b/support-frontend/assets/helpers/abTests/banditSelection.ts
@@ -137,62 +137,39 @@ function selectVariantUsingRoulette<VariantType extends { name: string }>(
 }
 
 /**
- * Select variant for a test with methodology picking
- * Returns both the variant and the effective test name for tracking
+ * Select variant for a test using its configured methodology.
+ * Always uses the first methodology if configured, otherwise defaults to AB test.
  */
 export function selectVariantForTest<VariantType extends { name: string }>(
 	test: {
 		name: string;
 		variants: VariantType[];
-		methodologies?: Array<{ name: string; testName?: string }>;
+		methodologies?: Array<{ name: string }>;
 	},
 	mvtId: number,
 	banditData: ClientBanditData[],
-): { variant: VariantType; trackingTestName: string } | undefined {
+): VariantType | undefined {
 	const methodologies = test.methodologies;
 
 	if (!methodologies || methodologies.length === 0) {
 		// No configured methodology, default to AB test
-		const variant = selectVariantUsingMVT(test, mvtId);
-		if (variant) {
-			return { variant, trackingTestName: test.name };
-		}
-		return;
+		return selectVariantUsingMVT(test, mvtId);
 	}
 
-	// Pick methodology (if multiple, use mvtId to select one deterministically)
-	const methodology =
-		methodologies.length === 1
-			? methodologies[0]!
-			: methodologies[randomNumber(mvtId, test.name) % methodologies.length];
+	// Always use the first methodology
+	const methodology = methodologies[0]!;
 
-	if (!methodology) {
-		return;
-	}
-
-	// Get effective test name with methodology override if specified
-	const trackingTestName = methodology.testName ?? test.name;
-
-	// Find bandit data for this test (using effective test name)
-	const testBanditData = banditData.find(
-		(bd) => bd.testName === trackingTestName,
-	);
+	// Find bandit data for this test
+	const testBanditData = banditData.find((bd) => bd.testName === test.name);
 
 	// Select variant based on methodology
-	let variant: VariantType | undefined;
 	if (methodology.name === 'EpsilonGreedyBandit') {
 		const epsilon = (methodology as { epsilon?: number }).epsilon ?? 0;
-		variant = selectVariantUsingEpsilonGreedy(test, epsilon, testBanditData);
+		return selectVariantUsingEpsilonGreedy(test, epsilon, testBanditData);
 	} else if (methodology.name === 'Roulette') {
-		variant = selectVariantUsingRoulette(test, testBanditData);
+		return selectVariantUsingRoulette(test, testBanditData);
 	} else {
 		// ABTest
-		variant = selectVariantUsingMVT(test, mvtId);
+		return selectVariantUsingMVT(test, mvtId);
 	}
-
-	if (variant) {
-		return { variant, trackingTestName };
-	}
-
-	return;
 }

--- a/support-frontend/assets/helpers/abTests/landingPageAbTests.ts
+++ b/support-frontend/assets/helpers/abTests/landingPageAbTests.ts
@@ -125,13 +125,9 @@ export function getLandingPageTestConfig(): PageParticipationsConfig<LandingPage
 			}
 
 			// Fallback to MVT-based selection
-			const variant =
-				test.variants[randomNumber(mvtId, test.name) % test.variants.length];
-			if (variant) {
-				return { variant, trackingTestName: test.name };
-			}
-
-			return;
+			return test.variants[
+				randomNumber(mvtId, test.name) % test.variants.length
+			];
 		},
 	};
 }

--- a/support-frontend/assets/helpers/abTests/models.ts
+++ b/support-frontend/assets/helpers/abTests/models.ts
@@ -79,7 +79,7 @@ interface PageTest<Variant> {
 	};
 	mParticleAudience?: number;
 	variants: Variant[];
-	methodologies?: Array<{ name: string; testName?: string }>;
+	methodologies?: Array<{ name: string }>;
 }
 interface PageParticipationsConfig<Variant> {
 	tests: Array<PageTest<Variant>>;
@@ -90,7 +90,7 @@ interface PageParticipationsConfig<Variant> {
 	selectVariant?: (
 		test: PageTest<Variant>,
 		mvtId: number,
-	) => { variant: Variant; trackingTestName: string } | undefined;
+	) => Variant | undefined;
 }
 
 export type {

--- a/support-frontend/assets/helpers/abTests/pageParticipations.ts
+++ b/support-frontend/assets/helpers/abTests/pageParticipations.ts
@@ -68,19 +68,7 @@ export async function getPageParticipations<Variant>(
 		testList: Array<PageTest<Variant>>,
 	): Variant | undefined => {
 		for (const test of testList) {
-			// Check test.name first
-			let variantName = participations[test.name];
-
-			// If not found, check methodology.testName overrides
-			if (!variantName && test.methodologies) {
-				for (const methodology of test.methodologies) {
-					const testName = methodology.testName;
-					if (testName && participations[testName]) {
-						variantName = participations[testName];
-						break;
-					}
-				}
-			}
+			const variantName = participations[test.name];
 
 			if (variantName) {
 				const variant = test.variants.find(
@@ -143,21 +131,11 @@ export async function getPageParticipations<Variant>(
 		Object.entries(sessionParticipations).length > 0
 	) {
 		// Validate and prune session participations: drop entries whose key
-		// matches no current test name or methodology testName override, or whose
-		// variant name does not exist in that test's variants.
+		// does not match any current test name, or whose variant name does not
+		// exist in that test's variants.
 		const validParticipations: Participations = {};
 		for (const [key, value] of Object.entries(sessionParticipations)) {
-			const matchingTest = tests.find((test) => {
-				// Check if key matches test.name
-				if (key === test.name) {
-					return true;
-				}
-				// Check if key matches any methodology.testName override
-				if (test.methodologies?.some((m) => m.testName === key)) {
-					return true;
-				}
-				return false;
-			});
+			const matchingTest = tests.find((test) => key === test.name);
 			if (matchingTest?.variants.some((v) => getVariantName(v) === value)) {
 				validParticipations[key] = value;
 			}
@@ -198,20 +176,17 @@ export async function getPageParticipations<Variant>(
 		? config.selectVariant(test, mvtId)
 		: undefined;
 
-	const variant = selectionResult?.variant
-		? selectionResult.variant
-		: test.variants[randomNumber(mvtId, test.name) % test.variants.length];
+	const variant =
+		selectionResult ??
+		test.variants[randomNumber(mvtId, test.name) % test.variants.length];
 
 	if (!variant) {
 		return makeFallbackResult();
 	}
 
-	// Use trackingTestName from selection result if available, otherwise use test.name
-	const trackingTestName: string =
-		selectionResult?.trackingTestName ?? test.name;
-	// Store only the fresh participation (no merge needed once every page runs identical selection)
+	// Store only the fresh participation
 	const participations: Participations = {
-		[trackingTestName]: getVariantName(variant),
+		[test.name]: getVariantName(variant),
 	};
 	// Record the participation in session storage so that we can track it from other pages
 	setSessionParticipations(participations, sessionStorageKey);

--- a/support-frontend/assets/helpers/globalsAndSwitches/landingPageSettings.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/landingPageSettings.ts
@@ -110,18 +110,15 @@ export type Methodology = ABTest | EpsilonGreedyBandit | Roulette;
 
 interface ABTest {
 	name: 'ABTest';
-	testName?: string;
 }
 
 interface EpsilonGreedyBandit {
 	name: 'EpsilonGreedyBandit';
 	epsilon: number;
-	testName?: string;
 	sampleCount?: number;
 }
 
 interface Roulette {
 	name: 'Roulette';
-	testName?: string;
 	sampleCount?: number;
 }

--- a/support-frontend/test/services/BanditDataServiceSpec.scala
+++ b/support-frontend/test/services/BanditDataServiceSpec.scala
@@ -148,8 +148,8 @@ class BanditDataServiceSpec extends AnyFlatSpec with Matchers {
         ),
         methodologies = Some(
           List(
-            EpsilonGreedyBandit(epsilon = 0.1, testName = Some("test-1-epsilon")),
-            Roulette(testName = Some("test-1-roulette")),
+            EpsilonGreedyBandit(epsilon = 0.1),
+            Roulette(),
           ),
         ),
       ),
@@ -171,7 +171,7 @@ class BanditDataServiceSpec extends AnyFlatSpec with Matchers {
         ),
         methodologies = Some(
           List(
-            ABTest(), // This should be filtered out
+            ABTest(), // First methodology is ABTest, so no bandit data needed for this test
             EpsilonGreedyBandit(epsilon = 0.2, sampleCount = Some(10)),
           ),
         ),
@@ -190,25 +190,17 @@ class BanditDataServiceSpec extends AnyFlatSpec with Matchers {
     // Test the methodology extraction
     val configs = service.getBanditTestConfigs(tests)
 
-    configs should have size 3 // 2 epsilon greedy + 1 roulette (ABTest filtered out)
+    configs should have size 1 // Only test-1 needs bandit data (first methodology is EpsilonGreedyBandit)
 
-    // First test - epsilon greedy with custom name
-    val epsilonConfig1 = configs.find(_.testName == "test-1-epsilon")
-    epsilonConfig1 should be(defined)
-    epsilonConfig1.get.variantNames shouldBe List("control", "variant-a")
-    epsilonConfig1.get.sampleCount shouldBe None
+    // First test - uses first bandit methodology (EpsilonGreedyBandit), testName is test.name
+    val config1 = configs.find(_.testName == "test-1")
+    config1 should be(defined)
+    config1.get.variantNames shouldBe List("control", "variant-a")
+    config1.get.sampleCount shouldBe None
 
-    // First test - roulette with custom name
-    val rouletteConfig = configs.find(_.testName == "test-1-roulette")
-    rouletteConfig should be(defined)
-    rouletteConfig.get.variantNames shouldBe List("control", "variant-a")
-    rouletteConfig.get.sampleCount shouldBe None
-
-    // Second test - epsilon greedy with default name and sample count
-    val epsilonConfig2 = configs.find(_.testName == "test-2")
-    epsilonConfig2 should be(defined)
-    epsilonConfig2.get.variantNames shouldBe List("control")
-    epsilonConfig2.get.sampleCount shouldBe Some(10)
+    // Second test - first methodology is ABTest, so no bandit data config is generated
+    val config2 = configs.find(_.testName == "test-2")
+    config2 should be(empty)
   }
 
   "getClientBanditData" should "normalise weights to sum to 1.0" in {


### PR DESCRIPTION
On the main website we can configure more than 1 methodology for a test. This enables us to AB test different methodologies against each other. It requires us to assign a different test name to each methodology, within a test.

This is a lot more complicated to achieve on the Support site because we have to persist test participations across page views and track them. I do not think that the complexity and risk is justifiable here.

This PR removes support for multiple methodologies.
The RRCP tools will need updating to only allow a single methodology.