### PR TITLE
Stop alarming on the PayPal "TRANSACTION_REFUSED" error

### DIFF
--- a/support-payment-api/src/main/scala/services/CloudWatchService.scala
+++ b/support-payment-api/src/main/scala/services/CloudWatchService.scala
@@ -63,13 +63,15 @@ class CloudWatchService(cloudWatchAsyncClient: CloudWatchAsyncClient, environmen
       case e: StripeApiError => !e.exceptionType.contains("CardException")
       case e: PaypalApiError =>
         e.errorName.getOrElse("") match {
-          case ("CREDIT_CARD_CVV_CHECK_FAILED") => false
-          case ("CREDIT_CARD_REFUSED") => false
-          case ("INSTRUMENT_DECLINED") => false
-          case ("INSUFFICIENT_FUNDS") => false
+          case "CREDIT_CARD_CVV_CHECK_FAILED" => false
+          case "CREDIT_CARD_REFUSED" => false
+          case "INSTRUMENT_DECLINED" => false
+          case "INSUFFICIENT_FUNDS" => false
+          // A new error we have been seeing since switching to the PayPal complete payments API
+          case "TRANSACTION_REFUSED" => false
           // PAYMENT_ALREADY_DONE is a valid error, but currently alerting too often and possibly masking other errors
           // Adding this error to the filter list until we can get it fixed.
-          case ("PAYMENT_ALREADY_DONE") => false
+          case "PAYMENT_ALREADY_DONE" => false
           case _ => true
         }
       case _ => true


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Since increasing the sensitivity of the payment-api 'payment failure' alarm, we have been getting a lot of alarms for a "TRANSACTION_REFUSED" error. This is not something we can resolve so should be added to the list of ignored failures.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214973184355176