### PR TITLE
Pin GitHub actions to specific version

### DIFF
--- a/.github/actions/setup-node-and-install/action.yml
+++ b/.github/actions/setup-node-and-install/action.yml
@@ -10,7 +10,7 @@ runs:
       shell: bash
 
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: ".nvmrc"
 

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -23,7 +23,7 @@ jobs:
         run: pnpm build-github-action
 
       - name: Run Bundle Analyser
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bundle-analyser-report
           path: support-frontend/public/compiled-assets/webpack-stats.html

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-node-and-install

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,7 +9,7 @@ jobs:
         working-directory: support-frontend
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -21,6 +21,6 @@ jobs:
           workingDir: support-frontend
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          buildScriptName: "build-storybook"
+          buildScriptName: 'build-storybook'
           exitOnceUploaded: true
-          onlyChanged: "!(main)" # only turbosnap on non-main branches
+          onlyChanged: '!(main)' # only turbosnap on non-main branches

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - run: npm install --global corepack@0.31.0
         shell: bash

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -21,7 +21,7 @@ jobs:
         shell: bash
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -22,7 +22,7 @@ jobs:
           JSON: ${{ toJSON(github) }}
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-node-and-install

--- a/.github/workflows/deploy-fastly-snippets.yaml
+++ b/.github/workflows/deploy-fastly-snippets.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 18
       - name: Deploy Fastly snippets

--- a/.github/workflows/deploy-fastly-snippets.yaml
+++ b/.github/workflows/deploy-fastly-snippets.yaml
@@ -28,7 +28,7 @@ jobs:
       LOCK_AND_ACTIVATE_SERVICE: ${{ github.event.inputs.lock-and-activate-service }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-node@v6
         with:
           node-version: 18

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-node-and-install

--- a/.github/workflows/payment-api-build.yml
+++ b/.github/workflows/payment-api-build.yml
@@ -28,7 +28,7 @@ jobs:
         run: env
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-node-and-install

--- a/.github/workflows/playwright-cron.yml
+++ b/.github/workflows/playwright-cron.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Run Playwright tests
       run: pnpm --filter support-e2e test-cron
 
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ !cancelled() }}
       with:
         name: playwright-report

--- a/.github/workflows/playwright-cron.yml
+++ b/.github/workflows/playwright-cron.yml
@@ -12,7 +12,7 @@ jobs:
       PAYPAL_TEST_PASSWORD: ${{ secrets.PAYPAL_TEST_PASSWORD }}
       GOOGLE_CHAT_WEB_HOOK: ${{ secrets.GOOGLE_CHAT_WEB_HOOK }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup Node and Install Dependencies
       uses: ./.github/actions/setup-node-and-install

--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run Playwright tests
         run: pnpm --filter support-e2e test-smoke
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       GOOGLE_CHAT_WEB_HOOK: ${{ secrets.GOOGLE_CHAT_WEB_HOOK }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-node-and-install

--- a/.github/workflows/stripe-patrons-data.yml
+++ b/.github/workflows/stripe-patrons-data.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-node-and-install

--- a/.github/workflows/support-e2e-build.yml
+++ b/.github/workflows/support-e2e-build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-node-and-install

--- a/.github/workflows/support-frontend-build.yml
+++ b/.github/workflows/support-frontend-build.yml
@@ -28,7 +28,7 @@ jobs:
         run: env
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-node-and-install

--- a/.github/workflows/support-frontend-eslint.yml
+++ b/.github/workflows/support-frontend-eslint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-node-and-install

--- a/.github/workflows/support-frontend-prettier.yml
+++ b/.github/workflows/support-frontend-prettier.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-node-and-install

--- a/.github/workflows/support-frontend-typescript.yml
+++ b/.github/workflows/support-frontend-typescript.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-node-and-install

--- a/.github/workflows/support-lambdas-build.yml
+++ b/.github/workflows/support-lambdas-build.yml
@@ -26,7 +26,7 @@ jobs:
         run: env
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-node-and-install
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-node-and-install

--- a/.github/workflows/support-workers-build.yml
+++ b/.github/workflows/support-workers-build.yml
@@ -26,7 +26,7 @@ jobs:
         run: env
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-node-and-install

--- a/.github/workflows/support-workers-it-tests.yml
+++ b/.github/workflows/support-workers-it-tests.yml
@@ -28,7 +28,7 @@ jobs:
         run: env
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-node-and-install

--- a/.github/workflows/supporter-product-data.yml
+++ b/.github/workflows/supporter-product-data.yml
@@ -26,7 +26,7 @@ jobs:
         run: env
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: sbt/setup-sbt@v1
 


### PR DESCRIPTION
## What are you doing in this PR?

Pin GitHub actions to a specific SHA.

## Why are you doing this?

It's the [recommendation](https://github.com/guardian/recommendations/blob/main/github-actions.md#specifying-versions-for-actions-you-use) because other identifiers can be mutable.

Dependabot will still be able to keep versions (and the comment) up to date for us. See: guardian/janus-app#876.