### PR TITLE
Upgrade Zod to version 4 and support-service-lambdas to latest

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ catalogs:
       specifier: ^2.1.5
       version: 2.1.5
     '@guardian/support-service-lambdas':
-      specifier: github:guardian/support-service-lambdas#916dc794742245307bfb53ed4f2212badedb6d5e
+      specifier: github:guardian/support-service-lambdas#73361af34a76149604a622e5513283f40ad355e6
       version: 1.0.0
     '@types/jest':
       specifier: ^29.5.14
@@ -67,8 +67,8 @@ catalogs:
       specifier: ^5.8.3
       version: 5.8.3
     zod:
-      specifier: ^3.25.30
-      version: 3.25.30
+      specifier: ^4.4.3
+      version: 4.4.3
 
 overrides:
   '@typescript-eslint/typescript-estree': ^8.46.2
@@ -149,11 +149,11 @@ importers:
     dependencies:
       zod:
         specifier: 'catalog:'
-        version: 3.25.30
+        version: 4.4.3
     devDependencies:
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/916dc794742245307bfb53ed4f2212badedb6d5e
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/73361af34a76149604a622e5513283f40ad355e6
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.0
@@ -171,7 +171,7 @@ importers:
         version: 5.2.1
       zod:
         specifier: 'catalog:'
-        version: 3.25.30
+        version: 4.4.3
     devDependencies:
       '@guardian/eslint-config':
         specifier: ^14.0.1
@@ -272,7 +272,7 @@ importers:
         version: 18.1.1(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.5.4))(@guardian/source@10.2.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/916dc794742245307bfb53ed4f2212badedb6d5e
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/73361af34a76149604a622e5513283f40ad355e6
       '@guardian/tsconfig':
         specifier: ^0.2.0
         version: 0.2.0
@@ -334,8 +334,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.1
       zod:
-        specifier: ^3.22.4
-        version: 3.25.30
+        specifier: 'catalog:'
+        version: 4.4.3
     devDependencies:
       '@axe-core/react':
         specifier: ^4.2.1
@@ -574,7 +574,7 @@ importers:
         version: 3.995.0(@aws-sdk/client-dynamodb@3.1015.0)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/916dc794742245307bfb53ed4f2212badedb6d5e
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/73361af34a76149604a622e5513283f40ad355e6
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -583,7 +583,7 @@ importers:
         version: 17.7.0
       zod:
         specifier: 'catalog:'
-        version: 3.25.30
+        version: 4.4.3
     devDependencies:
       '@aws-sdk/client-lambda':
         specifier: 'catalog:'
@@ -2428,8 +2428,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/916dc794742245307bfb53ed4f2212badedb6d5e':
-    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/916dc794742245307bfb53ed4f2212badedb6d5e}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/73361af34a76149604a622e5513283f40ad355e6':
+    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/73361af34a76149604a622e5513283f40ad355e6}
     version: 1.0.0
 
   '@guardian/tsconfig@0.2.0':
@@ -8630,6 +8630,9 @@ packages:
   zod@3.25.30:
     resolution: {integrity: sha512-VolhdEtu6TJr/fzGuHA/SZ5ixvXqA6ADOG9VRcQ3rdOKmF5hkmcJbyaQjUH5BgmpA9gej++zYRX7zjSmdReIwA==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@adobe/css-tools@4.4.3': {}
@@ -11231,7 +11234,7 @@ snapshots:
       react: 18.2.0
       typescript: 5.5.4
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/916dc794742245307bfb53ed4f2212badedb6d5e': {}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/73361af34a76149604a622e5513283f40ad355e6': {}
 
   '@guardian/tsconfig@0.2.0': {}
 
@@ -19003,3 +19006,5 @@ snapshots:
       zod: 3.25.30
 
   zod@3.25.30: {}
+
+  zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ catalog:
   '@aws-sdk/credential-provider-node': 3.972.25
   '@aws-sdk/util-dynamodb': ^3.995.0
   '@guardian/prettier': ^2.1.5
-  '@guardian/support-service-lambdas': github:guardian/support-service-lambdas#916dc794742245307bfb53ed4f2212badedb6d5e
+  '@guardian/support-service-lambdas': github:guardian/support-service-lambdas#73361af34a76149604a622e5513283f40ad355e6
   '@types/jest': ^29.5.14
   '@types/node': ^20.19.0
   esbuild: ^0.28.1
@@ -28,7 +28,7 @@ catalog:
   prettier: ^2.8.8
   ts-jest: ^29.3.4
   typescript: ^5.8.3
-  zod: ^3.25.30
+  zod: ^4.4.3
 
 onlyBuiltDependencies:
   - '@guardian/support-service-lambdas'

--- a/support-frontend/assets/helpers/globalsAndSwitches/window.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/window.ts
@@ -8,7 +8,6 @@ import { optional, z } from 'zod';
 import type { LegacyProductType } from 'helpers/legacyTypeConversions';
 import { legacyProductTypes } from 'helpers/legacyTypeConversions';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
-import type { ActiveProductKey } from '../productCatalog';
 import { isProductKey } from '../productCatalog';
 
 /**
@@ -150,9 +149,7 @@ const PaymentConfigSchema = z.object({
 			),
 		}),
 		metricUrl: z.string(),
-		productsWithThankYouOnboarding: z.array(
-			z.string().refine<ActiveProductKey>(isProductKey),
-		),
+		productsWithThankYouOnboarding: z.array(z.string().refine(isProductKey)),
 	}),
 	isObserverSubdomain: z.boolean(),
 });

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/stripeCheckoutSession.ts
@@ -29,7 +29,7 @@ const formDetailsSchema = z.object({
 			.optional(),
 	}),
 	deliveryInstructions: z.string().nullish(),
-	billingAddressMatchesDelivery: z.oboolean(),
+	billingAddressMatchesDelivery: z.boolean().optional(),
 });
 
 export type PersistableFormFields = z.infer<typeof formDetailsSchema>;

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -70,7 +70,7 @@
 		"snarkdown": "^2.0.0",
 		"tsx": "^4.19.2",
 		"uuid": "^9.0.0",
-		"zod": "^3.22.4"
+		"zod": "catalog:"
 	},
 	"devDependencies": {
 		"@axe-core/react": "^4.2.1",

--- a/support-workers/src/typescript/services/config.ts
+++ b/support-workers/src/typescript/services/config.ts
@@ -3,7 +3,7 @@ import { awsConfig } from '@modules/aws/config';
 import type { z } from 'zod';
 import type { Stage } from '../model/stage';
 
-export async function getConfig<I, O, T extends z.ZodType<O, z.ZodTypeDef, I>>(
+export async function getConfig<I, O, T extends z.ZodType<O, I>>(
 	stage: Stage,
 	configKeyName: string,
 	schema: T,

--- a/support-workers/src/typescript/services/salesforceClient.ts
+++ b/support-workers/src/typescript/services/salesforceClient.ts
@@ -37,7 +37,7 @@ export class SalesforceClient {
 	}
 	private authService: AuthService;
 
-	post = async <I, O, T extends z.ZodType<O, z.ZodTypeDef, I>>(
+	post = async <I, O, T extends z.ZodType<O, I>>(
 		path: string,
 		body: string,
 		schema: T,


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
https://github.com/guardian/support-service-lambdas/pull/3659 upgraded Zod in support-service-lambdas to version 4. 

This PR upgrades support-frontend to use Zod version 4 as well and the version of support-service-lambdas to go with it.

## Testing
I have tested support-workers and support-frontend in CODE with the end to end tests.