### PR TITLE
Only update tax rates using the sales-tax-api once a day

### DIFF
--- a/support-frontend/app/services/SalesTaxService.scala
+++ b/support-frontend/app/services/SalesTaxService.scala
@@ -120,9 +120,9 @@ class CachedSalesTaxService(
       throw SalesTaxServiceError(s"Failed to fetch tax rates on startup: ${e.getMessage}")
   }
 
-  // Subsequent refreshes happen in the background. The initial delay is 1 minute because the cache has
+  // Subsequent refreshes happen in the background. The initial delay is 1 day because the cache has
   // already been populated synchronously above.
-  system.scheduler.scheduleWithFixedDelay(1.minute, 10.minute) { () =>
+  system.scheduler.scheduleWithFixedDelay(1.day, 1.day) { () =>
     {
       updateAll()
     }


### PR DESCRIPTION
## What are you doing in this PR?

Only update tax rates using the sales-tax-api once a day

## Why are you doing this?

This data rarely changes so we don't need to be polling so often.