### PR TITLE
Fix the ProductPricesSchema by using partial records

### DIFF
--- a/support-frontend/assets/helpers/globalsAndSwitches/window.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/window.ts
@@ -213,15 +213,15 @@ export const ProductPricesSchema = z.object({
 	allProductPrices: z.record(
 		z.enum([...legacyProductTypes, 'GuardianWeeklyGift']),
 		optional(
-			z.record(
+			z.partialRecord(
 				countryKeySchema,
-				z.record(
+				z.partialRecord(
 					fulfilmentOptionsSchema,
-					z.record(
+					z.partialRecord(
 						productOptionsSchema,
-						z.record(
+						z.partialRecord(
 							billingPeriodSchema,
-							z.record(
+							z.partialRecord(
 								isoCurrencySchema,
 								z.object({
 									price: z.number(),


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
#8067 upgraded Zod to version 4 in which a record type [must be exhaustive to be valid](https://zod.dev/v4/changelog?id=improves-enum-support#improves-enum-support). 

This caused an issue because the product prices object on window.guardian uses record for objects which should really be partial records. This issue was not actually apparent in CODE and PROD because if Zod parsing fails there we just continue with the raw object, which was in the correct state. However it did show up in DEV.

This PR fixes the issue by using partial records.