### PR TITLE
Parse tax rates from the window

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ catalogs:
       specifier: ^2.1.5
       version: 2.1.5
     '@guardian/support-service-lambdas':
-      specifier: github:guardian/support-service-lambdas#fee1793663d1fcbf30bcac72914a9f7b865ee3cb
+      specifier: github:guardian/support-service-lambdas#168e05673883971b21c75cb04c778c6da56dbbca
       version: 1.0.0
     '@types/jest':
       specifier: ^29.5.14
@@ -153,7 +153,7 @@ importers:
     devDependencies:
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/fee1793663d1fcbf30bcac72914a9f7b865ee3cb
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/168e05673883971b21c75cb04c778c6da56dbbca
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.0
@@ -272,7 +272,7 @@ importers:
         version: 18.1.1(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.5.4))(@guardian/source@10.2.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/fee1793663d1fcbf30bcac72914a9f7b865ee3cb
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/168e05673883971b21c75cb04c778c6da56dbbca
       '@guardian/tsconfig':
         specifier: ^0.2.0
         version: 0.2.0
@@ -574,7 +574,7 @@ importers:
         version: 3.995.0(@aws-sdk/client-dynamodb@3.1015.0)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/fee1793663d1fcbf30bcac72914a9f7b865ee3cb
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/168e05673883971b21c75cb04c778c6da56dbbca
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -2428,8 +2428,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/fee1793663d1fcbf30bcac72914a9f7b865ee3cb':
-    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/fee1793663d1fcbf30bcac72914a9f7b865ee3cb}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/168e05673883971b21c75cb04c778c6da56dbbca':
+    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/168e05673883971b21c75cb04c778c6da56dbbca}
     version: 1.0.0
 
   '@guardian/tsconfig@0.2.0':
@@ -11234,7 +11234,7 @@ snapshots:
       react: 18.2.0
       typescript: 5.5.4
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/fee1793663d1fcbf30bcac72914a9f7b865ee3cb': {}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/168e05673883971b21c75cb04c778c6da56dbbca': {}
 
   '@guardian/tsconfig@0.2.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ catalog:
   '@aws-sdk/credential-provider-node': 3.972.25
   '@aws-sdk/util-dynamodb': ^3.995.0
   '@guardian/prettier': ^2.1.5
-  '@guardian/support-service-lambdas': github:guardian/support-service-lambdas#fee1793663d1fcbf30bcac72914a9f7b865ee3cb
+  '@guardian/support-service-lambdas': github:guardian/support-service-lambdas#168e05673883971b21c75cb04c778c6da56dbbca
   '@types/jest': ^29.5.14
   '@types/node': ^20.19.0
   esbuild: ^0.28.1

--- a/support-frontend/assets/helpers/globalsAndSwitches/window.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/window.ts
@@ -1,3 +1,4 @@
+import { caStateCodes } from '@modules/internationalisation/country';
 import { isoCurrencySchema } from '@modules/internationalisation/schemas';
 import {
 	billingPeriodSchema,
@@ -243,24 +244,7 @@ const TaxRatesSchema = z.object({
 	taxRates: z
 		.partialRecord(
 			z.enum(['SupporterPlus', 'DigitalSubscription']),
-			z.record(
-				z.enum([
-					'AB',
-					'BC',
-					'MB',
-					'NB',
-					'NL',
-					'NT',
-					'NS',
-					'NU',
-					'ON',
-					'PE',
-					'QC',
-					'SK',
-					'YT',
-				]),
-				z.number(),
-			),
+			z.record(z.enum(caStateCodes), z.number()),
 		)
 		.optional(), // This isn't made available on every page
 });

--- a/support-frontend/assets/helpers/globalsAndSwitches/window.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/window.ts
@@ -1,3 +1,4 @@
+import { caStateSchema } from '@modules/internationalisation/country';
 import { isoCurrencySchema } from '@modules/internationalisation/schemas';
 import {
 	billingPeriodSchema,
@@ -239,8 +240,18 @@ export const ProductPricesSchema = z.object({
 	),
 });
 
-const AppConfigSchema =
-	PaymentConfigSchema.merge(ProductCatalogSchema).merge(ProductPricesSchema);
+const TaxRatesSchema = z.object({
+	taxRates: z
+		.partialRecord(
+			z.enum(['SupporterPlus', 'DigitalSubscription']),
+			z.record(caStateSchema, z.number()),
+		)
+		.optional(), // This isn't made available on every page
+});
+
+const AppConfigSchema = PaymentConfigSchema.merge(ProductCatalogSchema)
+	.merge(ProductPricesSchema)
+	.merge(TaxRatesSchema);
 
 export type AppConfig = z.infer<typeof AppConfigSchema> & {
 	allProductPrices: Partial<

--- a/support-frontend/assets/helpers/globalsAndSwitches/window.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/window.ts
@@ -1,4 +1,3 @@
-import { caStateSchema } from '@modules/internationalisation/country';
 import { isoCurrencySchema } from '@modules/internationalisation/schemas';
 import {
 	billingPeriodSchema,
@@ -244,7 +243,24 @@ const TaxRatesSchema = z.object({
 	taxRates: z
 		.partialRecord(
 			z.enum(['SupporterPlus', 'DigitalSubscription']),
-			z.record(caStateSchema, z.number()),
+			z.record(
+				z.enum([
+					'AB',
+					'BC',
+					'MB',
+					'NB',
+					'NL',
+					'NT',
+					'NS',
+					'NU',
+					'ON',
+					'PE',
+					'QC',
+					'SK',
+					'YT',
+				]),
+				z.number(),
+			),
 		)
 		.optional(), // This isn't made available on every page
 });

--- a/support-frontend/assets/helpers/internationalisation/__tests__/countryTest.ts
+++ b/support-frontend/assets/helpers/internationalisation/__tests__/countryTest.ts
@@ -1,6 +1,5 @@
 // ----- Imports ----- //
 
-import type { IsoCountry } from '@modules/internationalisation/country';
 import {
 	AUDCountries,
 	EURCountries,
@@ -257,43 +256,5 @@ describe('find iso country', () => {
 
 	it('should return null for a country name as a string that is not in the list of countries', () => {
 		expect(Country.findIsoCountry('Simple And Coherent Land')).toBe(null);
-	});
-});
-
-describe('find a state for a given country using stateProvinceFromString', () => {
-	it('should return null if no country or state', () => {
-		expect(Country.stateProvinceFromString(null)).toBe(null);
-		expect(Country.stateProvinceFromString('US')).toBe(null);
-		expect(Country.stateProvinceFromString('US', '')).toBe(null);
-		expect(Country.stateProvinceFromString(null, 'NY')).toBe(null);
-		expect(Country.stateProvinceFromString('' as IsoCountry, 'NY')).toBe(null);
-	});
-
-	it("should return the StateCode that's within a given country's set", () => {
-		expect(Country.stateProvinceFromString('US', 'AL')).toBe('AL'); // Alabama
-
-		expect(Country.stateProvinceFromString('CA', 'AL')).toBe(null); // No state called 'AL' in Canada
-
-		expect(Country.stateProvinceFromString('AU', 'AL')).toBe(null); // No state called 'AL' in Australia
-
-		expect(Country.stateProvinceFromString('US', 'AB')).toBe(null); // No state called 'AB' in USA
-
-		expect(Country.stateProvinceFromString('CA', 'AB')).toBe('AB'); // Alberta
-
-		expect(Country.stateProvinceFromString('AU', 'AB')).toBe(null); // No state called 'AB' in Australia
-
-		expect(Country.stateProvinceFromString('US', 'NT')).toBe(null); // No state called 'NT' in USA
-
-		expect(Country.stateProvinceFromString('CA', 'NT')).toBe('NT'); // Northwest Territories
-
-		expect(Country.stateProvinceFromString('AU', 'NT')).toBe('NT'); // Northern Territory
-
-		expect(Country.stateProvinceFromString('CA', 'ON')).toBe('ON'); // Ontario
-
-		expect(Country.stateProvinceFromString('CA', 'Ontario')).toBe('ON'); // Ontario
-
-		expect(Country.stateProvinceFromString('CA', 'YT')).toBe('YT'); // Yukon does not start with 2 letter code
-
-		expect(Country.stateProvinceFromString('CA', 'Yukon')).toBe('YT');
 	});
 });

--- a/support-frontend/assets/helpers/internationalisation/classes/country.ts
+++ b/support-frontend/assets/helpers/internationalisation/classes/country.ts
@@ -1,17 +1,8 @@
-import type {
-	AuState,
-	CaState,
-	IsoCountry,
-	StateProvince,
-	UsState,
-} from '@modules/internationalisation/country';
+import type { IsoCountry } from '@modules/internationalisation/country';
 import {
-	auStates,
-	caStates,
 	countries,
 	isoCountries,
 	isoCountrySet,
-	usStates,
 } from '@modules/internationalisation/country';
 import {
 	AUDCountries,
@@ -35,78 +26,6 @@ type TargetCountryGroups =
 	| typeof AUDCountries;
 
 export class Country {
-	static stateProvinceFromMap(
-		search: string,
-		states: Record<string, string>,
-	): StateProvince | null | undefined {
-		const searchUppercase = search.toUpperCase();
-		return states[searchUppercase]
-			? searchUppercase
-			: Object.keys(states).find(
-					(key) =>
-						states[key]?.toUpperCase() === searchUppercase ||
-						(searchUppercase.length === 3 && searchUppercase.startsWith(key)),
-			  );
-	}
-
-	static usStateFromString(search: string): UsState | null {
-		return this.stateProvinceFromMap(search, usStates) ?? null;
-	}
-
-	static caStateFromString(search: string): CaState | null {
-		return this.stateProvinceFromMap(search, caStates) ?? null;
-	}
-
-	static auStateFromString(search: string): AuState | null {
-		return this.stateProvinceFromMap(search, auStates) ?? null;
-	}
-
-	static stateProvinceFieldFromString(
-		countryGroupId: CountryGroupId | null | undefined,
-		search?: string,
-	): StateProvince | null {
-		if (!search) {
-			return null;
-		}
-
-		switch (countryGroupId) {
-			case UnitedStates:
-				return this.usStateFromString(search);
-
-			case Canada:
-				return this.caStateFromString(search);
-
-			case AUDCountries:
-				return this.auStateFromString(search);
-
-			default:
-				return null;
-		}
-	}
-
-	static stateProvinceFromString(
-		country: IsoCountry | null,
-		search?: string,
-	): StateProvince | null {
-		if (!search) {
-			return null;
-		}
-
-		switch (country) {
-			case 'US':
-				return this.usStateFromString(search);
-
-			case 'CA':
-				return this.caStateFromString(search);
-
-			case 'AU':
-				return this.auStateFromString(search);
-
-			default:
-				return null;
-		}
-	}
-
 	static fromString(search: string): IsoCountry | null | undefined {
 		const candidateIso = search.toUpperCase();
 		if (candidateIso === 'UK') {

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -108,6 +108,8 @@ export function Checkout({
 	const { currencyKey } = getSupportRegionIdConfig(supportRegionId);
 	const urlSearchParams = new URLSearchParams(window.location.search);
 
+	console.log('taxRates', appConfig.taxRates);
+
 	/** 👇 a lot of this is copy/pasted into the thank you page */
 	/** Get and validate product */
 	const productParam = urlSearchParams.get('product');

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -108,8 +108,6 @@ export function Checkout({
 	const { currencyKey } = getSupportRegionIdConfig(supportRegionId);
 	const urlSearchParams = new URLSearchParams(window.location.search);
 
-	console.log('taxRates', appConfig.taxRates);
-
 	/** 👇 a lot of this is copy/pasted into the thank you page */
 	/** Get and validate product */
 	const productParam = urlSearchParams.get('product');


### PR DESCRIPTION
## What are you doing in this PR?

In #8050 tax rate data was added to the window for the checkout and thank you page. This PR extends the Zod schema we use to parse this data to pick up the new tax rate data.

Note I've updated `@guardian/support-service-lambdas` to pull in changes made in guardian/support-service-lambdas#3616 which broke some code in `country.ts` (`CaState` was a `string` but is now much narrower). This code turned out not to be used so I've removed it.

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1214265225282427)

## Why are you doing this?

So that the tax rate data is available to use by the client.