### PR TITLE
CA Tax:  e2e tests for tax exclusive rate plans

### DIFF
--- a/support-e2e/tests/smoke/three-tier-tax-exclusive.test.ts
+++ b/support-e2e/tests/smoke/three-tier-tax-exclusive.test.ts
@@ -1,0 +1,73 @@
+import test, { expect } from '@playwright/test';
+import { enableCanadaTaxExclusion } from '../utils/enableTaxExclusiveRatePlans';
+import { ProductTierLabel } from '../utils/products';
+import { visitLandingPageAndCompleteCheckout } from '../utils/visitLandingPageAndCompleteCheckout';
+
+const tests = [
+	{
+		productLabel: ProductTierLabel.TierTwo,
+		product: 'SupporterPlus',
+		billingFrequency: 'Monthly',
+		paymentType: 'Credit/Debit card',
+		internationalisationId: 'CA',
+	},
+	{
+		productLabel: ProductTierLabel.TierTwo,
+		product: 'SupporterPlus',
+		billingFrequency: 'Annual',
+		paymentType: 'Credit/Debit card',
+		internationalisationId: 'CA',
+	},
+	{
+		productLabel: ProductTierLabel.TierThree,
+		product: 'DigitalSubscription',
+		billingFrequency: 'Monthly',
+		paymentType: 'Credit/Debit card',
+		internationalisationId: 'CA',
+	},
+	{
+		productLabel: ProductTierLabel.TierThree,
+		product: 'DigitalSubscription',
+		billingFrequency: 'Annual',
+		paymentType: 'Credit/Debit card',
+		internationalisationId: 'CA',
+	},
+];
+
+test.describe('Three Tier Tax Exclusive Checkout', () =>
+	tests.map((testDetails) => {
+		const {
+			billingFrequency,
+			product,
+			paymentType,
+			internationalisationId,
+			productLabel,
+		} = testDetails;
+
+		test(`Three Tier - ${product} - ${billingFrequency} - ${paymentType} - ${internationalisationId}`, async ({
+			context,
+			baseURL,
+		}) => {
+			await enableCanadaTaxExclusion(context);
+			await visitLandingPageAndCompleteCheckout(
+				`/${internationalisationId.toLowerCase()}/contribute`,
+				{ context, baseURL, product, paymentType, internationalisationId },
+				async (page) => {
+					// 1. Select the billing frequency
+					await page.getByRole('tab', { name: billingFrequency }).click();
+
+					// 2. Make sure it links to a tax exclusive rae plan
+					const cta = page.getByRole('link', {
+						name: new RegExp(`^${productLabel},`),
+					});
+
+					expect(await cta.getAttribute('href')).toContain(
+						`ratePlan=${billingFrequency}TaxExclusive`,
+					);
+
+					// 2. Click through to the checkout (we use the aria-label to target the link)
+					await cta.click();
+				},
+			);
+		});
+	}));

--- a/support-e2e/tests/utils/enableTaxExclusiveRatePlans.ts
+++ b/support-e2e/tests/utils/enableTaxExclusiveRatePlans.ts
@@ -1,0 +1,11 @@
+import type { BrowserContext } from '@playwright/test';
+
+// Force skipping the new onboarding experience. This is WIP and we don't want
+// it to interfere with the Playwright tests
+export const enableCanadaTaxExclusion = async (context: BrowserContext) =>
+	await context.addInitScript(() => {
+		window.sessionStorage.setItem(
+			'enableCanadaTaxExclusion',
+			JSON.stringify({ value: 'On' }),
+		);
+	});

--- a/support-e2e/tests/utils/enableTaxExclusiveRatePlans.ts
+++ b/support-e2e/tests/utils/enableTaxExclusiveRatePlans.ts
@@ -1,7 +1,5 @@
 import type { BrowserContext } from '@playwright/test';
 
-// Force skipping the new onboarding experience. This is WIP and we don't want
-// it to interfere with the Playwright tests
 export const enableCanadaTaxExclusion = async (context: BrowserContext) =>
 	await context.addInitScript(() => {
 		window.sessionStorage.setItem(


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Add e2e test coverage for tax exclusive rate plans.
Currently only available for Canada with the feature flag enabled.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[Add e2e Smoke/Cron tests for CA tax exclusive journey (Playwright)](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1215868676558454?focus=true)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

Increase confidence in new releases and report on regression errors. 