### PR TITLE
Fix newspaper tab section image vertical stretch 

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/NewspaperTabHeroStyles.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/NewspaperTabHeroStyles.tsx
@@ -6,7 +6,6 @@ import {
 	space,
 	textSans17,
 	textSansBold17,
-	until,
 } from '@guardian/source/foundations';
 import { weeklyBenefitsPaperHeroBlue } from 'stylesheets/emotion/colours';
 
@@ -25,9 +24,9 @@ export const flexContainerOverride = css`
 	}
 
 	& img {
-		object-fit: fill;
-		${until.mobile} {
-			display: none;
+		justify-self: center;
+		${from.tablet} {
+			align-self: start;
 		}
 	}
 `;


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Make the images on the newspaper tab section maintain their original size and aspect ration when parent  container grows.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[Fix elastic man on newspaper collapsible panels ](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1216248756900247?focus=true)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->
The images on the newspaper tab section stretch vertical when the collapsible panels expand causing the container to grow.

## Screenshots

### Collect in Store 
| Mobile 📱 | Desktop 🖥️  |
| --- | --- |
|<img width="603" height="707" alt="Screenshot 2026-07-02 at 16 53 25" src="https://github.com/user-attachments/assets/b64877b7-6fb9-4243-af76-6da5a93511ed" />|<img width="994" height="489" alt="Screenshot 2026-07-02 at 16 52 57" src="https://github.com/user-attachments/assets/fbc36afd-3d07-4a90-a77c-8d347a36fe40" />|

### Collect in Store 
| Mobile 📱 | Desktop 🖥️  |
| --- | --- |
|<img width="602" height="536" alt="Screenshot 2026-07-02 at 16 53 16" src="https://github.com/user-attachments/assets/90e49162-2d25-4382-9d4d-955adb0c378e" />|<img width="992" height="317" alt="Screenshot 2026-07-02 at 16 53 07" src="https://github.com/user-attachments/assets/67bd8e7f-1a01-4c97-8ce8-bce6fe228c62" />|