### PR TITLE
Sales Tax Api : Retreive Tax Exclusive Promotions On Window.AllProductPrices

### DIFF
--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -380,7 +380,13 @@ export const productCatalogDescription: Record<
 			Monthly: {
 				billingPeriod: BillingPeriod.Monthly,
 			},
+			MonthlyTaxExclusive: {
+				billingPeriod: BillingPeriod.Monthly,
+			},
 			Annual: {
+				billingPeriod: BillingPeriod.Annual,
+			},
+			AnnualTaxExclusive: {
 				billingPeriod: BillingPeriod.Annual,
 			},
 			ThreeMonthGift: {
@@ -399,7 +405,13 @@ export const productCatalogDescription: Record<
 			Monthly: {
 				billingPeriod: BillingPeriod.Monthly,
 			},
+			MonthlyTaxExclusive: {
+				billingPeriod: BillingPeriod.Monthly,
+			},
 			Annual: {
+				billingPeriod: BillingPeriod.Annual,
+			},
+			AnnualTaxExclusive: {
 				billingPeriod: BillingPeriod.Annual,
 			},
 			OneYearStudent: {

--- a/support-models/src/main/scala/com/gu/support/workers/BillingPeriod.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/BillingPeriod.scala
@@ -9,7 +9,9 @@ sealed trait BillingPeriod {
 
 object BillingPeriod {
   def fromString(code: String): Option[BillingPeriod] = {
-    List(Monthly, Annual, Quarterly).find(_.getClass.getSimpleName == s"$code$$")
+    List(Monthly, MonthlyTaxExclusive, Annual, AnnualTaxExclusive, Quarterly).find(
+      _.getClass.getSimpleName == s"$code$$",
+    )
   }
 
   implicit val decodePeriod: Decoder[BillingPeriod] =
@@ -27,6 +29,11 @@ case object Monthly extends BillingPeriod {
   override val monthsInPeriod = 1
 }
 
+case object MonthlyTaxExclusive extends BillingPeriod {
+  override val noun = "month"
+  override val monthsInPeriod = 1
+}
+
 case object Quarterly extends BillingPeriod {
   override val noun = "quarter"
   override val monthsInPeriod = 3
@@ -35,4 +42,9 @@ case object Quarterly extends BillingPeriod {
 case object Annual extends BillingPeriod {
   override val noun = "year"
   override val monthsInPeriod = 12
+}
+
+case object AnnualTaxExclusive extends BillingPeriod {
+  override val noun = "month"
+  override val monthsInPeriod = 1
 }


### PR DESCRIPTION
## What are you doing in this PR?
Bring through romotions from the tax exclusive rates plans for Canada.

Requires [RRCP PromoTool TaxExclusive PR](https://github.com/guardian/support-admin-console/pull/1243)

How has this change been tested?

1. Build, deploy to CODE
2. Setup CANADIAN-ONLY Promotion on S+ & Digital+
https://support.code.dev-gutools.co.uk/switches
3. Add #promoCode=TAX_EXCLUSIVE_SP or #promoCode=TAX_EXCLUSIVE_DP
4. Open -> https://support.code.dev-theguardian.com/ca/checkout?promoCode=TAX_EXCLUSIVE_SP&product=SupporterPlus&ratePlan=MonthlyTaxExclusive
5. Check `window.guardian.allProductPrices` for `MonthlyTaxExclusive`/`AnnualTaxExclusive` RatePlans

## Screenshots
|before|after|
|----|----|
|<img width="1803" height="1261" alt="image" src="https://github.com/user-attachments/assets/57d48849-e52f-4ba8-9a08-4235c15c98fa" />||
