### PR TITLE
Remove Canada postal service industrial action notice

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
@@ -177,15 +177,6 @@ export default function CheckoutSummary({
 						/>
 					</div>
 				)}
-				{supportRegionId === SupportRegionId.CA &&
-					productKey === 'GuardianWeeklyDomestic' && (
-						<div role="alert" css={alertStyles}>
-							<InfoSummary
-								message="For Canadian residents only"
-								context="Please note that Canada Post is currently undergoing a period of industrial action. If you start a Guardian Weekly subscription today, the delivery of your copies may be subject to delays. We apologise for any inconvenience this may cause."
-							/>
-						</div>
-					)}
 				<ContributionsOrderSummary
 					productKey={productKey}
 					productLabel={productDescription.label}


### PR DESCRIPTION
## What are you doing in this PR?

Introduced in #7382.

This was previously shown to users in Canada taking out a GW subscription.

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1216212121250851)

## Why are you doing this?

The industrial action is no longer ongoing. The equivalent notice in MMA was removed some time ago: guardian/manage-frontend#1591.

## How to test

Visit the Canada checkout for Guardian Weekly Domestic and see that the notice does not appear.

## Images

### Before

<img width="512" height="293" alt="image" src="https://github.com/user-attachments/assets/b121b6ea-9fb2-49b2-b414-1ac872a754cd" />

### After

(Note the promo is different because this screenshot is from local and the above is from prod).

<img width="666" height="242" alt="Screenshot 2026-07-03 at 08 56 13" src="https://github.com/user-attachments/assets/faafd253-713e-4524-adce-c4e1f8cf229f" />
