### PR TITLE
Fix promotions on Thank-You Page

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -55,7 +55,7 @@ type Props = {
 
 const countryId: IsoCountry = Country.detect();
 
-const getPromotionFromProductPrices = (
+export const getPromotionFromProductPrices = (
 	appConfig: AppConfig,
 	productKey: ActiveProductKey,
 	ratePlanKey: ActiveRatePlanKey,

--- a/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/thankYou.tsx
@@ -11,7 +11,6 @@ import {
 } from 'helpers/productCatalog';
 import { toRegularBillingPeriod } from 'helpers/productPrice/billingPeriods';
 import type { Promotion } from 'helpers/productPrice/promotions';
-import { getPromotion } from 'helpers/productPrice/promotions';
 import type { UserType } from 'helpers/user/userType';
 import { logException } from 'helpers/utilities/logger';
 import { roundToDecimalPlaces } from 'helpers/utilities/utilities';
@@ -20,6 +19,7 @@ import { AnalyticsProfileCacheProvider } from '../../helpers/customHooks/analyti
 import type { LandingPageVariant } from '../../helpers/globalsAndSwitches/landingPageSettings';
 import { setHideSupportMessaginCookie } from '../../helpers/storage/contributionsCookies';
 import { getSupportRegionIdConfig } from '../supportRegionConfig';
+import { getPromotionFromProductPrices } from './checkout';
 import type { OnboardingProductKey } from './components/onboardingComponent';
 import OnboardingComponent from './components/onboardingComponent';
 import { ThankYouComponent } from './components/thankYouComponent';
@@ -86,11 +86,11 @@ export function ThankYou({
 		setHideSupportMessaginCookie();
 	} else {
 		/** Recurring product must have product & ratePlan */
-		if (!product) {
+		if (!productKey || !product) {
 			logException('Product not found');
 			return <div>Product not found</div>;
 		}
-		if (!ratePlan) {
+		if (!ratePlanKey || !ratePlan) {
 			logException('Rate plan not found');
 			return <div>Rate plan not found</div>;
 		}
@@ -113,22 +113,17 @@ export function ThankYou({
 				return <div>Price not found in product catalog</div>;
 			}
 
-			const productPrices =
-				productKey === 'SupporterPlus'
-					? appConfig.allProductPrices[productKey]
-					: undefined;
 			const billingPeriod =
 				toRegularBillingPeriod(ratePlan.billingPeriod) ?? BillingPeriod.Annual;
 
 			/** Get any promotions */
-			promotion = productPrices
-				? getPromotion(
-						productPrices,
-						countryId,
-						billingPeriod,
-						'NoFulfilmentOptions',
-				  )
-				: undefined;
+			promotion = getPromotionFromProductPrices(
+				appConfig,
+				productKey,
+				ratePlanKey,
+				countryId,
+				billingPeriod,
+			);
 
 			const discountedPrice = promotion?.discountedPrice ?? undefined;
 			const price = discountedPrice ?? productPrice;


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Reuse `getPromotionFromProductPrices` function from checkout to resolve promotions on the thank you page.
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Asana Card**](https://app.asana.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->
Currently the thank you page fetches promotions based only on the billing period, and wrongly applies discount for other rate plans that have that billing frequency.  

## Screenshots
### OneYearStudent
| New onboarding | legacy thank you page |
| --- | --- |
|<img width="640" height="455" alt="Screenshot 2026-07-03 at 16 20 17" src="https://github.com/user-attachments/assets/89bbfbb4-fb2b-4257-ad2c-7d815f8563e8" />|<img width="997" height="957" alt="Screenshot 2026-07-03 at 16 20 52" src="https://github.com/user-attachments/assets/fdd2044d-f8c1-4bab-bd70-cd3d1c379cbd" />|

### Regular rate plans with promotion
| Monthly | Annual |
| --- | --- |
|<img width="648" height="477" alt="Screenshot 2026-07-03 at 16 20 01" src="https://github.com/user-attachments/assets/554fe10c-f309-4c1e-8553-d09d83331bac" />|<img width="660" height="480" alt="Screenshot 2026-07-03 at 16 19 43" src="https://github.com/user-attachments/assets/975e045b-0284-4449-a61b-522491954c5b" />|

