### PR TITLE
Vulnerability Update: Jackson databind, removed Scala 3.0 cross compilation settings

### DIFF
--- a/support-internationalisation/build.sbt
+++ b/support-internationalisation/build.sbt
@@ -1,24 +1,3 @@
-import sbtrelease.ReleaseStateTransformations._
-
 name := "support-internationalisation"
 
-scalaVersion := "2.13.13"
-crossScalaVersions := Seq("2.13.13", "3.3.3")
-
 description := "Scala library to provide internationalisation classes to Guardian Membership/Subscriptions/support projects."
-
-releaseCrossBuild := true
-releaseProcess := Seq[ReleaseStep](
-  checkSnapshotDependencies,
-  inquireVersions,
-  runClean,
-  runTest,
-  setReleaseVersion,
-  commitReleaseVersion,
-  tagRelease,
-  ReleaseStep(action = Command.process("publishSigned", _), enableCrossBuild = true),
-  setNextVersion,
-  commitNextVersion,
-  ReleaseStep(action = Command.process("sonatypeReleaseAll", _), enableCrossBuild = true),
-  pushChanges,
-)


### PR DESCRIPTION
## What are you doing in this PR?
Jackson databind dependency Update requires removal of Scala 3.0 cross compilation setttings.




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216119704402995