### PR TITLE
Fix for 100%  discounts on the 3Tier price cards

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -204,9 +204,10 @@ export function ThreeTierCard({
 		: undefined;
 
 	const formattedMainPrice = simpleFormatAmount(currency, mainPrice);
-	const formattedMainDiscountedPrice = mainDiscountedPrice
-		? simpleFormatAmount(currency, mainDiscountedPrice)
-		: undefined;
+	const formattedMainDiscountedPrice =
+		mainDiscountedPrice !== undefined
+			? simpleFormatAmount(currency, mainDiscountedPrice)
+			: undefined;
 	const periodLabel = showWeeklyPrice ? 'week' : periodNoun;
 	const linkAriaLabel = `${title}, ${
 		formattedMainDiscountedPrice ?? formattedMainPrice


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Check discount prices agains undefined values as we allow 100% discounts and can have 0 as an amount.
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Asana Card**](https://app.asana.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

use a 100% discount promo code
1. https://support.code.dev-theguardian.com/nz/contribute?promoCode=NZ_STUDENT

## Screenshots

| Before | After |
| --- | --- |
|<img width="322" height="490" alt="Screenshot 2026-07-08 at 16 10 11" src="https://github.com/user-attachments/assets/e121df01-00af-4a55-a368-f1e004063aab" />|<img width="319" height="486" alt="Screenshot 2026-07-08 at 16 06 27" src="https://github.com/user-attachments/assets/35591bd2-83d0-465e-a5e3-0f92f35e443d" />|