### PR TITLE
Add missing rate plans to product catalog mappings

### DIFF
--- a/support-frontend/assets/helpers/productCatalog.ts
+++ b/support-frontend/assets/helpers/productCatalog.ts
@@ -380,7 +380,13 @@ export const productCatalogDescription: Record<
 			Monthly: {
 				billingPeriod: BillingPeriod.Monthly,
 			},
+			MonthlyTaxExclusive: {
+				billingPeriod: BillingPeriod.Monthly,
+			},
 			Annual: {
+				billingPeriod: BillingPeriod.Annual,
+			},
+			AnnualTaxExclusive: {
 				billingPeriod: BillingPeriod.Annual,
 			},
 			ThreeMonthGift: {
@@ -399,7 +405,13 @@ export const productCatalogDescription: Record<
 			Monthly: {
 				billingPeriod: BillingPeriod.Monthly,
 			},
+			MonthlyTaxExclusive: {
+				billingPeriod: BillingPeriod.Monthly,
+			},
 			Annual: {
+				billingPeriod: BillingPeriod.Annual,
+			},
+			AnnualTaxExclusive: {
 				billingPeriod: BillingPeriod.Annual,
 			},
 			OneYearStudent: {


### PR DESCRIPTION
## What are you doing in this PR?

Add missing tax exclusive rate plans to product catalog mappings.

## Why are you doing this?

This was causing us to incorrectly default to a billing period of monthly for the new tax exclusive rate plans, which weren't in this data structure until now. In future it'd be nice to remove the default as it feels a bit risky to silently default.

In future it'd be nice to get this data from the product catalog API, since it is available there. Hopefully this would remove the need to maintain a separate data structure manually and therefore no need to have a default.

## How to test

Visit the checkout for one of the new annual tax exclusive rate plans. Before, the summary at the top incorrectly specified that the payment was monthly while showing an annual price. Fortunately I think this only affects the new tax exclusive rate plans which aren't live yet so I don't think any real users would have run into this.