### PR TITLE
Set tax config on form submit and reuse calculator on TY page

### DIFF
--- a/support-frontend/assets/components/onboarding/sections/summaryHelpers.ts
+++ b/support-frontend/assets/components/onboarding/sections/summaryHelpers.ts
@@ -1,12 +1,15 @@
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { getCurrencyInfo } from '@modules/internationalisation/currency';
-import { simpleFormatAmount } from 'helpers/forms/checkouts';
-import type { OrderSchemaType } from 'pages/[countryGroupId]/checkout/helpers/sessionStorage';
+import {
+	simpleFormatAmount,
+	simpleFormatTaxAmount,
+} from 'helpers/forms/checkouts';
+import type { TaxRateConfig } from 'helpers/salesTax/getEstimatedSalesTaxConfig';
 
 export function getTodaysPaymentWithTaxExclusion(
 	finalAmount: number,
 	currencyKey: IsoCurrency,
-	taxConfig: OrderSchemaType['taxConfig'] | undefined,
+	taxConfig: TaxRateConfig | undefined,
 ): string | undefined {
 	if (!taxConfig || taxConfig.type !== 'tax_exclusive') {
 		return;
@@ -17,9 +20,10 @@ export function getTodaysPaymentWithTaxExclusion(
 		finalAmount,
 	);
 
-	const taxAmountWithCurrency = simpleFormatAmount(
+	const taxAmountWithCurrency = simpleFormatTaxAmount(
 		getCurrencyInfo(currencyKey),
-		finalAmount * taxConfig.rate,
+		finalAmount,
+		taxConfig.rate,
 	);
 
 	return `${finalAmountWithCurrency} + ${taxAmountWithCurrency} estimated tax`;

--- a/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/sessionStorage.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout/helpers/sessionStorage.ts
@@ -52,10 +52,13 @@ const OrderSchema = z.object({
 			z.object({
 				type: z.literal('tax_inclusive'),
 			}),
+			z.object({
+				type: z.literal('not_enough_information'),
+			}),
 		])
 		.optional(),
 });
-export type OrderSchemaType = z.infer<typeof OrderSchema>;
+type OrderSchemaType = z.infer<typeof OrderSchema>;
 export function setThankYouOrder(order: OrderSchemaType) {
 	storage.session.set(orderKey, order);
 }

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -625,6 +625,7 @@ export default function CheckoutForm({
 				abParticipations,
 				promotion,
 				contributionAmount,
+				taxRateConfig,
 				weeklyGiftDeliveryDate: isGuardianWeeklyGiftProduct(
 					productKey,
 					ratePlanKey,

--- a/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/components/formOnSubmit.ts
@@ -1,6 +1,7 @@
 import type { SupportRegionId } from '@modules/internationalisation/countryGroup';
 import type { ActivePaperProductOptions } from 'helpers/productCatalogToProductOption';
 import type { Promotion } from 'helpers/productPrice/promotions';
+import type { TaxRateConfig } from 'helpers/salesTax/getEstimatedSalesTaxConfig';
 import { formatMachineDate } from 'helpers/utilities/dateConversions';
 import type { Participations } from '../../../helpers/abTests/models';
 import { appropriateErrorMessage } from '../../../helpers/forms/errorReasons';
@@ -64,6 +65,7 @@ export const submitForm = async ({
 	abParticipations,
 	promotion,
 	contributionAmount,
+	taxRateConfig,
 	weeklyGiftDeliveryDate,
 }: {
 	supportRegionId: SupportRegionId;
@@ -77,6 +79,7 @@ export const submitForm = async ({
 	abParticipations: Participations;
 	promotion: Promotion | undefined;
 	contributionAmount: number | undefined;
+	taxRateConfig: TaxRateConfig;
 	weeklyGiftDeliveryDate?: Date;
 }): Promise<string> => {
 	const personalData = extractPersonalDataFromForm(formData);
@@ -178,6 +181,7 @@ export const submitForm = async ({
 			paymentRequest,
 			accountNumber: redactedAccountNumber,
 			weeklyGiftDeliveryDate,
+			taxRateConfig,
 		});
 
 		// If Stripe hosted checkout, delete previously persisted form details
@@ -213,6 +217,7 @@ const processSubscription = async ({
 	productKey,
 	ratePlanKey,
 	contributionAmount,
+	taxRateConfig,
 	paymentMethod,
 	supportRegionId,
 	paymentRequest,
@@ -224,6 +229,7 @@ const processSubscription = async ({
 	productKey: ActiveProductKey;
 	ratePlanKey: ActiveRatePlanKey;
 	contributionAmount: number | undefined;
+	taxRateConfig: TaxRateConfig;
 	paymentMethod: PaymentMethod;
 	supportRegionId: SupportRegionId;
 	paymentRequest: RegularPaymentRequest;
@@ -243,6 +249,7 @@ const processSubscription = async ({
 			appliedPromotion?.promoCode,
 			createSubscriptionResult.userType,
 			contributionAmount,
+			taxRateConfig,
 			personalData,
 			paymentMethod,
 			createSubscriptionResult.status,
@@ -270,6 +277,7 @@ const buildThankYouPageUrl = (
 	promoCode: string | undefined,
 	userType: UserType | undefined,
 	contributionAmount: number | undefined,
+	taxRateConfig: TaxRateConfig,
 	personalData: FormPersonalFields,
 	paymentMethod: PaymentMethod,
 	status: 'success' | 'pending',
@@ -284,6 +292,7 @@ const buildThankYouPageUrl = (
 		paymentMethod,
 		status,
 		deliveryDate: weeklyGiftDeliveryDate,
+		taxConfig: taxRateConfig,
 	};
 	setThankYouOrder(order);
 	const thankYouUrlSearchParams = new URLSearchParams();


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->
This branch carries the calculated tax configuration from checkout submission into Thank You page session data, then uses the same tax formatting helper used in checkout to display estimated tax consistently.

[Use tax Calculator on thankYou page](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1216211051658859?focus=true)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->
Previously, tax display formatting could differ between checkout and Thank You, and the tax config used for Thank You was not explicitly persisted from the submit flow. This change makes the amount and wording consistent across the user journey.

