### PR TITLE
Add preview-* URL parameters to bypass scheduler checks for AB test preview

### DIFF
--- a/support-frontend/assets/helpers/abTests/__tests__/checkoutNudgeAbTests.spec.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/checkoutNudgeAbTests.spec.ts
@@ -234,4 +234,55 @@ describe('getCheckoutNudgeParticipations', () => {
 		);
 		expect(result).toBeUndefined();
 	});
+
+	it('uses the preview-checkout-nudge url querystring parameter to force participation', () => {
+		const result = getCheckoutNudgeParticipations(
+			'GBPCountries',
+			'/uk/one-time-checkout',
+			tests,
+			0,
+			`preview-checkout-nudge=${oneTimeToRecurring__US.name}:control`,
+		);
+		expect(result).toEqual({
+			variant: oneTimeToRecurring__US.variants[0],
+			fromProduct: oneTimeToRecurring__US.nudgeFromProduct,
+			participations: { [oneTimeToRecurring__US.name]: 'control' },
+		});
+	});
+
+	it('bypasses scheduler check when using preview-checkout-nudge param', () => {
+		const expiredTest: CheckoutNudgeTest = {
+			...oneTimeToRecurring__US,
+			name: 'expiredTest',
+			scheduler: { end: '2020-01-01T00:00' },
+		};
+		const result = getCheckoutNudgeParticipations(
+			'GBPCountries',
+			'/uk/one-time-checkout',
+			[expiredTest],
+			0,
+			`preview-checkout-nudge=${expiredTest.name}:control`,
+		);
+		expect(result).toEqual({
+			variant: expiredTest.variants[0],
+			fromProduct: expiredTest.nudgeFromProduct,
+			participations: { [expiredTest.name]: 'control' },
+		});
+	});
+
+	it('does not bypass scheduler check when using force-checkout-nudge param with expired scheduler', () => {
+		const expiredTest: CheckoutNudgeTest = {
+			...oneTimeToRecurring__US,
+			name: 'expiredTest',
+			scheduler: { end: '2020-01-01T00:00' },
+		};
+		const result = getCheckoutNudgeParticipations(
+			'GBPCountries',
+			'/uk/one-time-checkout',
+			[expiredTest],
+			0,
+			`force-checkout-nudge=${expiredTest.name}:control`,
+		);
+		expect(result).toBeUndefined();
+	});
 });

--- a/support-frontend/assets/helpers/abTests/__tests__/pageParticipations.spec.ts
+++ b/support-frontend/assets/helpers/abTests/__tests__/pageParticipations.spec.ts
@@ -127,7 +127,7 @@ describe('getPageParticipations', () => {
 	});
 
 	afterEach(() => {
-		jest.clearAllMocks();
+		jest.resetAllMocks();
 	});
 
 	describe('URL query string forced participation', () => {
@@ -206,6 +206,126 @@ describe('getPageParticipations', () => {
 			expect(result).toEqual({
 				participations: {},
 				variant: undefined,
+			});
+		});
+	});
+
+	describe('URL query string preview participation (preview-* params)', () => {
+		it('returns preview participation from query string', async () => {
+			const variant1 = createTestVariant('control', 'control-value');
+			const test = createPageTest('test-1', [variant1]);
+			const config = createConfig([test]);
+
+			mockLocation('/test/page', '?preview-test=test-1:control');
+			mockGetParticipationFromQueryString
+				.mockReturnValueOnce(undefined) // force-* returns nothing
+				.mockReturnValueOnce({ 'test-1': 'control' }); // preview-* returns
+
+			const result = await getPageParticipations(config);
+
+			expect(result).toEqual({
+				participations: { 'test-1': 'control' },
+				variant: variant1,
+			});
+			expect(mockGetParticipationFromQueryString).toHaveBeenCalledWith(
+				'?preview-test=test-1:control',
+				'preview-test',
+			);
+		});
+
+		it('bypasses scheduler check for preview participations', async () => {
+			const variant = createTestVariant('control', 'control-value');
+			const test = createPageTest('test-1', [variant]);
+			const config = createConfig([test]);
+
+			mockLocation('/test/page', '?preview-test=test-1:control');
+			mockGetParticipationFromQueryString
+				.mockReturnValueOnce(undefined) // force-* returns nothing
+				.mockReturnValueOnce({ 'test-1': 'control' }); // preview-* returns
+			mockIsWithinSchedule.mockReturnValue(false); // scheduler says expired
+
+			const result = await getPageParticipations(config);
+
+			expect(result).toEqual({
+				participations: { 'test-1': 'control' },
+				variant: variant,
+			});
+		});
+
+		it('stores preview participation in session storage', async () => {
+			const variant = createTestVariant('control', 'control-value');
+			const test = createPageTest('test-1', [variant]);
+			const config = createConfig([test]);
+
+			mockLocation('/test/page', '?preview-test=test-1:control');
+			mockGetParticipationFromQueryString
+				.mockReturnValueOnce(undefined)
+				.mockReturnValueOnce({ 'test-1': 'control' });
+
+			await getPageParticipations(config);
+
+			expect(mockSetSessionParticipations).toHaveBeenCalledWith(
+				{ 'test-1': 'control' },
+				'landingPageParticipations',
+			);
+		});
+
+		it('returns fallback when preview participation test not found', async () => {
+			const test = createPageTest('test-1', [
+				createTestVariant('control', 'control-value'),
+			]);
+			const config = createConfig([test]);
+
+			mockLocation('/test/page', '?preview-test=test-2:control');
+			mockGetParticipationFromQueryString
+				.mockReturnValueOnce(undefined)
+				.mockReturnValueOnce({ 'test-2': 'control' });
+
+			const result = await getPageParticipations(config);
+
+			expect(result).toEqual({
+				participations: {},
+				variant: undefined,
+			});
+		});
+
+		it('returns fallback when preview variant name not found in test', async () => {
+			const variant = createTestVariant('control', 'control-value');
+			const test = createPageTest('test-1', [variant]);
+			const config = createConfig([test]);
+
+			mockLocation('/test/page', '?preview-test=test-1:variant-b');
+			mockGetParticipationFromQueryString
+				.mockReturnValueOnce(undefined)
+				.mockReturnValueOnce({ 'test-1': 'variant-b' });
+
+			const result = await getPageParticipations(config);
+
+			expect(result).toEqual({
+				participations: {},
+				variant: undefined,
+			});
+		});
+
+		it('prefers force-* over preview-* when both are present', async () => {
+			const variant1 = createTestVariant('control', 'control-value');
+			const variant2 = createTestVariant('variant-a', 'variant-a-value');
+			const test = createPageTest('test-1', [variant1, variant2]);
+			const config = createConfig([test]);
+
+			mockLocation(
+				'/test/page',
+				'?force-test=test-1:control&preview-test=test-1:variant-a',
+			);
+			mockGetParticipationFromQueryString
+				.mockReturnValueOnce({ 'test-1': 'control' }) // force-* matched first
+				.mockReturnValueOnce({ 'test-1': 'variant-a' }); // preview-* (should not be reached)
+
+			const result = await getPageParticipations(config);
+
+			expect(result).toEqual({
+				participations: { 'test-1': 'control' },
+				variant: variant1,
 			});
 		});
 	});

--- a/support-frontend/assets/helpers/abTests/checkoutNudgeAbTests.ts
+++ b/support-frontend/assets/helpers/abTests/checkoutNudgeAbTests.ts
@@ -76,6 +76,26 @@ export function getCheckoutNudgeParticipations(
 		}
 	}
 
+	// Is the participation requested via preview param? (bypass scheduler)
+	const previewParticipations = getParticipationFromQueryString(
+		queryString,
+		'preview-checkout-nudge',
+	);
+	if (previewParticipations) {
+		const variantData = getCheckoutTestVariant(
+			previewParticipations,
+			tests,
+			true,
+		);
+		if (variantData) {
+			return {
+				participations: previewParticipations,
+				fromProduct: variantData.test.nudgeFromProduct,
+				variant: variantData.variant,
+			};
+		}
+	}
+
 	// Is there already a participation in session storage?
 	const sessionParticipations = getSessionParticipations(
 		CHECKOUT_NUDGE_PARTICIPATIONS_KEY,
@@ -135,12 +155,13 @@ export function getCheckoutNudgeParticipations(
 function getCheckoutTestVariant(
 	participations: Participations,
 	checkoutNudgeTests: CheckoutNudgeTest[] = [],
+	bypassScheduler = false,
 ): { variant: CheckoutNudgeVariant; test: CheckoutNudgeTest } | undefined {
 	for (const test of checkoutNudgeTests) {
 		// Is the user in this test?
 		const variantName = participations[test.name];
 		if (variantName) {
-			if (!isWithinSchedule(test.scheduler)) {
+			if (!bypassScheduler && !isWithinSchedule(test.scheduler)) {
 				return undefined;
 			}
 			const variant = test.variants.find(

--- a/support-frontend/assets/helpers/abTests/pageParticipations.ts
+++ b/support-frontend/assets/helpers/abTests/pageParticipations.ts
@@ -66,11 +66,12 @@ export async function getPageParticipations<Variant>(
 	const getVariant = (
 		participations: Participations,
 		testList: Array<PageTest<Variant>>,
+		bypassScheduler = false,
 	): Variant | undefined => {
 		for (const test of testList) {
 			const variantName = participations[test.name];
 			if (variantName) {
-				if (!isWithinSchedule(test.scheduler)) {
+				if (!bypassScheduler && !isWithinSchedule(test.scheduler)) {
 					return undefined;
 				}
 				const variant = test.variants.find(
@@ -110,6 +111,8 @@ export async function getPageParticipations<Variant>(
 		};
 	};
 
+	const previewParamName = forceParamName.replace('force-', 'preview-');
+
 	// Is the participation forced in the url querystring? (bypass audience check)
 	const urlParticipations = getParticipationFromQueryString(
 		queryString,
@@ -124,6 +127,25 @@ export async function getPageParticipations<Variant>(
 		return {
 			participations: trackParticipation
 				? urlParticipations
+				: ({} as Participations),
+			variant,
+		};
+	}
+
+	// Is the participation requested via preview param? (bypass scheduler + audience check)
+	const previewParticipations = getParticipationFromQueryString(
+		queryString,
+		previewParamName,
+	);
+	if (previewParticipations) {
+		const variant = getVariant(previewParticipations, tests, true);
+		if (!variant) {
+			return makeFallbackResult();
+		}
+		setSessionParticipations(previewParticipations, sessionStorageKey);
+		return {
+			participations: trackParticipation
+				? previewParticipations
 				: ({} as Participations),
 			variant,
 		};


### PR DESCRIPTION
Introduces `preview-*` URL parameters (e.g., `preview-landing-page`, `preview-checkout-nudge`) that bypass scheduler checks, allowing preview of draft and expired tests. The existing `force-*` parameters remain unchanged and continue to respect scheduler constraints.