### PR TITLE
Sales Tax Api : Rounding to mimick Zuora Invoicing

### DIFF
--- a/support-e2e/tests/smoke/three-tier-tax-exclusive.test.ts
+++ b/support-e2e/tests/smoke/three-tier-tax-exclusive.test.ts
@@ -19,6 +19,15 @@ const tests = [
 		internationalisationId: 'CA',
 	},
 	{
+		productLabel: ProductTierLabel.TierTwo,
+		product: 'SupporterPlus',
+		billingFrequency: 'Monthly',
+		paymentType: 'Credit/Debit card',
+		internationalisationId: 'CA',
+		stateId: 'QC',
+		promoCode: 'TAX_EXCLUSIVE_SP',
+	},
+	{
 		productLabel: ProductTierLabel.TierThree,
 		product: 'DigitalSubscription',
 		billingFrequency: 'Monthly',
@@ -42,16 +51,28 @@ test.describe('Three Tier Tax Exclusive Checkout', () =>
 			paymentType,
 			internationalisationId,
 			productLabel,
+			stateId,
+			promoCode,
 		} = testDetails;
 
-		test(`Three Tier - ${product} - ${billingFrequency} - ${paymentType} - ${internationalisationId}`, async ({
+		const promoUrlParam = promoCode ? `?promoCode=${promoCode}` : '';
+		const promoCodeDescription = promoCode ? ` - ${promoCode}` : '';
+		const stateDescription = stateId ? `/${stateId}` : '';
+		test(`Three Tier - ${product} - ${billingFrequency} - ${paymentType}${promoCodeDescription} - ${internationalisationId}${stateDescription}`, async ({
 			context,
 			baseURL,
 		}) => {
 			await enableCanadaTaxExclusion(context);
 			await visitLandingPageAndCompleteCheckout(
-				`/${internationalisationId.toLowerCase()}/contribute`,
-				{ context, baseURL, product, paymentType, internationalisationId },
+				`/${internationalisationId.toLowerCase()}/contribute${promoUrlParam}`,
+				{
+					context,
+					baseURL,
+					product,
+					paymentType,
+					internationalisationId,
+					stateId,
+				},
 				async (page) => {
 					// 1. Select the billing frequency
 					await page.getByRole('tab', { name: billingFrequency }).click();

--- a/support-e2e/tests/utils/completeGenericCheckout.ts
+++ b/support-e2e/tests/utils/completeGenericCheckout.ts
@@ -11,6 +11,7 @@ type TestDetails = {
 	product: string;
 	paymentType: string;
 	internationalisationId: string;
+	stateId?: string;
 	postCode?: string;
 	ratePlan?: string;
 	billingCountry?: string;
@@ -32,6 +33,7 @@ export const completeGenericCheckout = async (
 	const {
 		product,
 		internationalisationId,
+		stateId,
 		postCode,
 		paymentType,
 		ratePlan,
@@ -41,7 +43,7 @@ export const completeGenericCheckout = async (
 		page,
 		product,
 		internationalisationId,
-		getUserFields(internationalisationId, postCode, billingCountry),
+		getUserFields(internationalisationId, stateId, postCode, billingCountry),
 		ratePlan,
 	);
 

--- a/support-e2e/tests/utils/userFields.ts
+++ b/support-e2e/tests/utils/userFields.ts
@@ -82,6 +82,17 @@ const userDetails: Record<string, TestFields> = {
 			},
 		],
 	},
+	CAQC: {
+		...userCoreFields,
+		addresses: [
+			{
+				postCode: 'QC G1R 4S9',
+				state: 'Quebec',
+				firstLine: '2 Rue des Jardins',
+				city: 'Quebec City',
+			},
+		],
+	},
 	AU: {
 		...userCoreFields,
 		addresses: [
@@ -130,16 +141,18 @@ const userDetails: Record<string, TestFields> = {
 
 export const getUserFields = (
 	country: string,
+	stateId?: string,
 	postCode?: string,
 	billingCountry?: string,
 ): TestFields => {
-	const countryUserDetails = userDetails[country];
+	const countryStateKey = stateId ? `${country}${stateId}` : country;
+	const countryUserDetails = userDetails[countryStateKey];
 	const validUserDetails = billingCountry
 		? countryUserDetails
 		: {
 				...countryUserDetails,
 				addresses: countryUserDetails.addresses?.slice(0, 1),
-			}; // Remove billing address if not specified
+		  }; // Remove billing address if not specified
 	const userDetailsCopy = structuredClone(validUserDetails); // Create a deep copy
 	if (
 		postCode &&

--- a/support-e2e/tests/utils/visitLandingPageAndCompleteCheckout.ts
+++ b/support-e2e/tests/utils/visitLandingPageAndCompleteCheckout.ts
@@ -9,6 +9,7 @@ type TestDetails = {
 	product: string;
 	paymentType: string;
 	internationalisationId: string;
+	stateId?: string;
 	postCode?: string;
 	ratePlan?: string;
 	billingCountry?: string;
@@ -25,6 +26,7 @@ export const visitLandingPageAndCompleteCheckout = async (
 		product,
 		paymentType,
 		internationalisationId,
+		stateId,
 		postCode,
 		ratePlan,
 		billingCountry,
@@ -36,7 +38,9 @@ export const visitLandingPageAndCompleteCheckout = async (
 	await landingPageToCheckoutFn(page);
 
 	// Wait for the checkout page to load
-	const title = `Your ${product === 'Contribution' ? 'support' : 'subscription'}`;
+	const title = `Your ${
+		product === 'Contribution' ? 'support' : 'subscription'
+	}`;
 	await expect(page.getByRole('heading', { name: title })).toBeVisible({
 		timeout: 100000,
 	});
@@ -45,6 +49,7 @@ export const visitLandingPageAndCompleteCheckout = async (
 		product,
 		paymentType,
 		internationalisationId,
+		stateId,
 		postCode,
 		ratePlan,
 		billingCountry,

--- a/support-frontend/assets/components/onboarding/sections/summary.tsx
+++ b/support-frontend/assets/components/onboarding/sections/summary.tsx
@@ -263,12 +263,7 @@ function OnboardingSummary({
 
 	const todaysPayment =
 		enableCanadaTaxExclusion &&
-		getTodaysPaymentWithTaxExclusion(
-			payment.originalAmount,
-			payment.finalAmount,
-			currencyKey,
-			order?.taxConfig,
-		);
+		getTodaysPaymentWithTaxExclusion(payment, currencyKey, order?.taxConfig);
 
 	const paymentMethodCopy = isDirectDebit
 		? 'Direct Debit'

--- a/support-frontend/assets/components/onboarding/sections/summary.tsx
+++ b/support-frontend/assets/components/onboarding/sections/summary.tsx
@@ -264,6 +264,7 @@ function OnboardingSummary({
 	const todaysPayment =
 		enableCanadaTaxExclusion &&
 		getTodaysPaymentWithTaxExclusion(
+			payment.originalAmount,
 			payment.finalAmount,
 			currencyKey,
 			order?.taxConfig,

--- a/support-frontend/assets/components/onboarding/sections/summaryHelpers.test.ts
+++ b/support-frontend/assets/components/onboarding/sections/summaryHelpers.test.ts
@@ -3,13 +3,13 @@ import { getTodaysPaymentWithTaxExclusion } from './summaryHelpers';
 describe('getTodaysPaymentWithTaxExclusion', () => {
 	it('returns undefined when taxConfig is undefined', () => {
 		expect(
-			getTodaysPaymentWithTaxExclusion(100, 'CAD', undefined),
+			getTodaysPaymentWithTaxExclusion(100, 100, 'CAD', undefined),
 		).toBeUndefined();
 	});
 
 	it('returns undefined when type is not tax_exclusive', () => {
 		expect(
-			getTodaysPaymentWithTaxExclusion(100, 'CAD', {
+			getTodaysPaymentWithTaxExclusion(100, 100, 'CAD', {
 				type: 'tax_inclusive',
 			}),
 		).toBeUndefined();
@@ -17,7 +17,7 @@ describe('getTodaysPaymentWithTaxExclusion', () => {
 
 	it('formats integer amounts correctly', () => {
 		expect(
-			getTodaysPaymentWithTaxExclusion(100, 'CAD', {
+			getTodaysPaymentWithTaxExclusion(100, 100, 'CAD', {
 				type: 'tax_exclusive',
 				rate: 0.13,
 			}),
@@ -26,10 +26,19 @@ describe('getTodaysPaymentWithTaxExclusion', () => {
 
 	it('formats decimal tax amounts correctly', () => {
 		expect(
-			getTodaysPaymentWithTaxExclusion(10, 'CAD', {
+			getTodaysPaymentWithTaxExclusion(10, 10, 'CAD', {
 				type: 'tax_exclusive',
 				rate: 0.05,
 			}),
 		).toBe('$10 + $0.50 estimated tax');
+	});
+
+	it('handles discounts correctly', () => {
+		expect(
+			getTodaysPaymentWithTaxExclusion(15, 12, 'CAD', {
+				type: 'tax_exclusive',
+				rate: 0.14975,
+			}),
+		).toBe('$12 + $1.80 estimated tax');
 	});
 });

--- a/support-frontend/assets/components/onboarding/sections/summaryHelpers.test.ts
+++ b/support-frontend/assets/components/onboarding/sections/summaryHelpers.test.ts
@@ -3,42 +3,62 @@ import { getTodaysPaymentWithTaxExclusion } from './summaryHelpers';
 describe('getTodaysPaymentWithTaxExclusion', () => {
 	it('returns undefined when taxConfig is undefined', () => {
 		expect(
-			getTodaysPaymentWithTaxExclusion(100, 100, 'CAD', undefined),
+			getTodaysPaymentWithTaxExclusion(
+				{ originalAmount: 100, finalAmount: 100 },
+				'CAD',
+				undefined,
+			),
 		).toBeUndefined();
 	});
 
 	it('returns undefined when type is not tax_exclusive', () => {
 		expect(
-			getTodaysPaymentWithTaxExclusion(100, 100, 'CAD', {
-				type: 'tax_inclusive',
-			}),
+			getTodaysPaymentWithTaxExclusion(
+				{ originalAmount: 100, finalAmount: 100 },
+				'CAD',
+				{
+					type: 'tax_inclusive',
+				},
+			),
 		).toBeUndefined();
 	});
 
 	it('formats integer amounts correctly', () => {
 		expect(
-			getTodaysPaymentWithTaxExclusion(100, 100, 'CAD', {
-				type: 'tax_exclusive',
-				rate: 0.13,
-			}),
+			getTodaysPaymentWithTaxExclusion(
+				{ originalAmount: 100, finalAmount: 100 },
+				'CAD',
+				{
+					type: 'tax_exclusive',
+					rate: 0.13,
+				},
+			),
 		).toBe('$100 + $13 estimated tax');
 	});
 
 	it('formats decimal tax amounts correctly', () => {
 		expect(
-			getTodaysPaymentWithTaxExclusion(10, 10, 'CAD', {
-				type: 'tax_exclusive',
-				rate: 0.05,
-			}),
+			getTodaysPaymentWithTaxExclusion(
+				{ originalAmount: 10, finalAmount: 10 },
+				'CAD',
+				{
+					type: 'tax_exclusive',
+					rate: 0.05,
+				},
+			),
 		).toBe('$10 + $0.50 estimated tax');
 	});
 
 	it('handles discounts correctly', () => {
 		expect(
-			getTodaysPaymentWithTaxExclusion(15, 12, 'CAD', {
-				type: 'tax_exclusive',
-				rate: 0.14975,
-			}),
+			getTodaysPaymentWithTaxExclusion(
+				{ originalAmount: 15, finalAmount: 12 },
+				'CAD',
+				{
+					type: 'tax_exclusive',
+					rate: 0.14975,
+				},
+			),
 		).toBe('$12 + $1.80 estimated tax');
 	});
 });

--- a/support-frontend/assets/components/onboarding/sections/summaryHelpers.ts
+++ b/support-frontend/assets/components/onboarding/sections/summaryHelpers.ts
@@ -7,6 +7,7 @@ import {
 import type { TaxRateConfig } from 'helpers/salesTax/getEstimatedSalesTaxConfig';
 
 export function getTodaysPaymentWithTaxExclusion(
+	originalAmount: number,
 	finalAmount: number,
 	currencyKey: IsoCurrency,
 	taxConfig: TaxRateConfig | undefined,
@@ -22,7 +23,7 @@ export function getTodaysPaymentWithTaxExclusion(
 
 	const taxAmountWithCurrency = simpleFormatTaxAmount(
 		getCurrencyInfo(currencyKey),
-		finalAmount, // TODO: this should be originalAmount
+		originalAmount,
 		finalAmount,
 		taxConfig.rate,
 	);

--- a/support-frontend/assets/components/onboarding/sections/summaryHelpers.ts
+++ b/support-frontend/assets/components/onboarding/sections/summaryHelpers.ts
@@ -22,6 +22,7 @@ export function getTodaysPaymentWithTaxExclusion(
 
 	const taxAmountWithCurrency = simpleFormatTaxAmount(
 		getCurrencyInfo(currencyKey),
+		finalAmount, // TODO: this should be originalAmount
 		finalAmount,
 		taxConfig.rate,
 	);

--- a/support-frontend/assets/components/onboarding/sections/summaryHelpers.ts
+++ b/support-frontend/assets/components/onboarding/sections/summaryHelpers.ts
@@ -1,5 +1,6 @@
 import type { IsoCurrency } from '@modules/internationalisation/currency';
 import { getCurrencyInfo } from '@modules/internationalisation/currency';
+import type { Payment } from 'helpers/forms/checkouts';
 import {
 	simpleFormatAmount,
 	simpleFormatTaxAmount,
@@ -7,14 +8,15 @@ import {
 import type { TaxRateConfig } from 'helpers/salesTax/getEstimatedSalesTaxConfig';
 
 export function getTodaysPaymentWithTaxExclusion(
-	originalAmount: number,
-	finalAmount: number,
+	payment: Payment,
 	currencyKey: IsoCurrency,
 	taxConfig: TaxRateConfig | undefined,
 ): string | undefined {
 	if (!taxConfig || taxConfig.type !== 'tax_exclusive') {
 		return;
 	}
+
+	const { finalAmount } = payment;
 
 	const finalAmountWithCurrency = simpleFormatAmount(
 		getCurrencyInfo(currencyKey),
@@ -23,8 +25,7 @@ export function getTodaysPaymentWithTaxExclusion(
 
 	const taxAmountWithCurrency = simpleFormatTaxAmount(
 		getCurrencyInfo(currencyKey),
-		originalAmount,
-		finalAmount,
+		payment,
 		taxConfig.rate,
 	);
 

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -200,7 +200,7 @@ export function ContributionsOrderSummary({
 	supportRegionId,
 	nudgeSettings,
 }: ContributionsOrderSummaryProps): JSX.Element {
-	const { originalAmount, finalAmount } = payment;
+	const { originalAmount } = payment;
 	const [showCheckList, setCheckList] = useState(false);
 	const isSundayOnlyNewspaperSubscription = isSundayOnlyNewspaperSub(
 		productKey,
@@ -318,8 +318,7 @@ export function ContributionsOrderSummary({
 				savingText={savingText}
 				isWeeklyGift={isWeeklyGift}
 				currency={currency}
-				originalAmount={originalAmount}
-				finalAmount={finalAmount}
+				payment={payment}
 				taxRateConfig={taxRateConfig}
 				studentDiscount={studentDiscount}
 				billingPeriod={billingPeriod}

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -161,7 +161,8 @@ export type ContributionsOrderSummaryProps = {
 	productKey: ActiveProductKey;
 	productLabel: string;
 	ratePlanKey: ActiveRatePlanKey;
-	amount: number;
+	originalAmount: number;
+	finalAmount: number;
 	currency: CurrencyInfo;
 	enableCheckList: boolean;
 	checkListData: BenefitsCheckListData[];
@@ -183,7 +184,8 @@ export function ContributionsOrderSummary({
 	productKey,
 	productLabel,
 	ratePlanKey,
-	amount,
+	originalAmount,
+	finalAmount,
 	currency,
 	enableCheckList,
 	checkListData,
@@ -216,10 +218,10 @@ export function ContributionsOrderSummary({
 
 	const fullPrice =
 		studentDiscount?.fullPriceWithCurrency ??
-		simpleFormatAmount(currency, amount);
+		simpleFormatAmount(currency, originalAmount);
 	const promoDiscountPrice =
 		promotion &&
-		simpleFormatAmount(currency, promotion.discountedPrice ?? amount);
+		simpleFormatAmount(currency, promotion.discountedPrice ?? originalAmount);
 	const discountPrice =
 		studentDiscount?.discountPriceWithCurrency ?? promoDiscountPrice;
 	const title = `Your ${
@@ -261,7 +263,7 @@ export function ContributionsOrderSummary({
 			? simpleFormatAmount(
 					currency,
 					calculateWeeklyPrice(
-						promotion?.discountedPrice ?? amount,
+						promotion?.discountedPrice ?? originalAmount,
 						billingPeriodObj,
 					),
 			  )
@@ -317,7 +319,8 @@ export function ContributionsOrderSummary({
 				savingText={savingText}
 				isWeeklyGift={isWeeklyGift}
 				currency={currency}
-				amount={promotion?.discountedPrice ?? amount}
+				originalAmount={originalAmount}
+				finalAmount={finalAmount}
 				taxRateConfig={taxRateConfig}
 				studentDiscount={studentDiscount}
 				billingPeriod={billingPeriod}

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -22,7 +22,7 @@ import {
 	type BenefitsCheckListData,
 } from 'components/checkoutBenefits/benefitsCheckList';
 import { CheckoutNudgeSelector } from 'components/checkoutNudge/checkoutNudge';
-import { simpleFormatAmount } from 'helpers/forms/checkouts';
+import { type Payment, simpleFormatAmount } from 'helpers/forms/checkouts';
 import type {
 	ActiveProductKey,
 	ActiveRatePlanKey,
@@ -161,8 +161,7 @@ export type ContributionsOrderSummaryProps = {
 	productKey: ActiveProductKey;
 	productLabel: string;
 	ratePlanKey: ActiveRatePlanKey;
-	originalAmount: number;
-	finalAmount: number;
+	payment: Payment;
 	currency: CurrencyInfo;
 	enableCheckList: boolean;
 	checkListData: BenefitsCheckListData[];
@@ -184,8 +183,7 @@ export function ContributionsOrderSummary({
 	productKey,
 	productLabel,
 	ratePlanKey,
-	originalAmount,
-	finalAmount,
+	payment,
 	currency,
 	enableCheckList,
 	checkListData,
@@ -202,6 +200,7 @@ export function ContributionsOrderSummary({
 	supportRegionId,
 	nudgeSettings,
 }: ContributionsOrderSummaryProps): JSX.Element {
+	const { originalAmount, finalAmount } = payment;
 	const [showCheckList, setCheckList] = useState(false);
 	const isSundayOnlyNewspaperSubscription = isSundayOnlyNewspaperSub(
 		productKey,

--- a/support-frontend/assets/components/orderSummary/priceBreakdown.tsx
+++ b/support-frontend/assets/components/orderSummary/priceBreakdown.tsx
@@ -66,7 +66,8 @@ type PriceBreakdownProps = {
 	savingText: string | null;
 	isWeeklyGift: boolean;
 	currency: CurrencyInfo;
-	amount: number;
+	finalAmount: number;
+	originalAmount: number;
 	taxRateConfig: TaxRateConfig;
 	studentDiscount?: StudentDiscount;
 	billingPeriod: BillingPeriod;
@@ -79,7 +80,8 @@ export function PriceBreakdown({
 	savingText,
 	isWeeklyGift,
 	currency,
-	amount,
+	finalAmount,
+	originalAmount,
 	taxRateConfig,
 	billingPeriod,
 	studentDiscount,
@@ -133,7 +135,8 @@ export function PriceBreakdown({
 					// when a promotion applies, otherwise the full amount. This doesn't handle
 					// student discounts currently because they're never tax exclusive, but if
 					// this changes we'll need to revisit this amount prop.
-					amount={amount}
+					finalAmount={finalAmount}
+					originalAmount={originalAmount}
 					taxRateConfig={taxRateConfig}
 				>
 					<TaxTsAndCs />

--- a/support-frontend/assets/components/orderSummary/priceBreakdown.tsx
+++ b/support-frontend/assets/components/orderSummary/priceBreakdown.tsx
@@ -4,6 +4,7 @@ import type { CurrencyInfo } from '@guardian/support-service-lambdas/modules/int
 import type { BillingPeriod } from '@modules/product/billingPeriod';
 import { PriceSummary } from 'components/priceSummary/priceSummary';
 import { MaybeEstimatedTax } from 'components/salesTax/maybeEstimatedTax';
+import type { Payment } from 'helpers/forms/checkouts';
 import { getBillingPeriodNoun } from 'helpers/productPrice/billingPeriods';
 import type { TaxRateConfig } from 'helpers/salesTax/getEstimatedSalesTaxConfig';
 import type { StudentDiscount } from 'pages/[countryGroupId]/student/helpers/discountDetails';
@@ -66,8 +67,7 @@ type PriceBreakdownProps = {
 	savingText: string | null;
 	isWeeklyGift: boolean;
 	currency: CurrencyInfo;
-	finalAmount: number;
-	originalAmount: number;
+	payment: Payment;
 	taxRateConfig: TaxRateConfig;
 	studentDiscount?: StudentDiscount;
 	billingPeriod: BillingPeriod;
@@ -80,8 +80,7 @@ export function PriceBreakdown({
 	savingText,
 	isWeeklyGift,
 	currency,
-	finalAmount,
-	originalAmount,
+	payment,
 	taxRateConfig,
 	billingPeriod,
 	studentDiscount,
@@ -131,12 +130,10 @@ export function PriceBreakdown({
 				</div>
 				<MaybeEstimatedTax
 					currency={currency}
-					// The amount to use for tax calculations. This is the discounted price
-					// when a promotion applies, otherwise the full amount. This doesn't handle
-					// student discounts currently because they're never tax exclusive, but if
-					// this changes we'll need to revisit this amount prop.
-					finalAmount={finalAmount}
-					originalAmount={originalAmount}
+					// This doesn't handle student discounts currently because
+					// they're never tax exclusive, but if this changes we'll
+					// need to revisit this payment prop.
+					payment={payment}
 					taxRateConfig={taxRateConfig}
 				>
 					<TaxTsAndCs />

--- a/support-frontend/assets/components/salesTax/maybeEstimatedTax.tsx
+++ b/support-frontend/assets/components/salesTax/maybeEstimatedTax.tsx
@@ -1,12 +1,12 @@
 import { css } from '@emotion/react';
 import type { CurrencyInfo } from '@modules/internationalisation/currency';
 import type { ReactNode } from 'react';
+import type { Payment } from 'helpers/forms/checkouts';
 import { simpleFormatTaxAmount } from 'helpers/forms/checkouts';
 import type { TaxRateConfig } from 'helpers/salesTax/getEstimatedSalesTaxConfig';
 
 type Props = {
-	finalAmount: number;
-	originalAmount: number;
+	payment: Payment;
 	taxRateConfig: TaxRateConfig;
 	currency: CurrencyInfo;
 	children?: ReactNode;
@@ -19,12 +19,13 @@ const rowContainer = css`
 `;
 
 export function MaybeEstimatedTax({
+	payment,
 	currency,
-	originalAmount,
-	finalAmount,
 	taxRateConfig,
 	children,
 }: Props) {
+	const { originalAmount, finalAmount } = payment;
+
 	switch (taxRateConfig.type) {
 		case 'tax_inclusive':
 			return null;

--- a/support-frontend/assets/components/salesTax/maybeEstimatedTax.tsx
+++ b/support-frontend/assets/components/salesTax/maybeEstimatedTax.tsx
@@ -24,8 +24,6 @@ export function MaybeEstimatedTax({
 	taxRateConfig,
 	children,
 }: Props) {
-	const { originalAmount, finalAmount } = payment;
-
 	switch (taxRateConfig.type) {
 		case 'tax_inclusive':
 			return null;
@@ -45,12 +43,7 @@ export function MaybeEstimatedTax({
 					<div css={rowContainer}>
 						<p>Estimated tax</p>
 						<p>
-							{simpleFormatTaxAmount(
-								currency,
-								originalAmount,
-								finalAmount,
-								taxRateConfig.rate,
-							)}
+							{simpleFormatTaxAmount(currency, payment, taxRateConfig.rate)}
 						</p>
 					</div>
 					{children}

--- a/support-frontend/assets/components/salesTax/maybeEstimatedTax.tsx
+++ b/support-frontend/assets/components/salesTax/maybeEstimatedTax.tsx
@@ -5,7 +5,8 @@ import { simpleFormatTaxAmount } from 'helpers/forms/checkouts';
 import type { TaxRateConfig } from 'helpers/salesTax/getEstimatedSalesTaxConfig';
 
 type Props = {
-	amount: number;
+	finalAmount: number;
+	originalAmount: number;
 	taxRateConfig: TaxRateConfig;
 	currency: CurrencyInfo;
 	children?: ReactNode;
@@ -19,7 +20,8 @@ const rowContainer = css`
 
 export function MaybeEstimatedTax({
 	currency,
-	amount,
+	originalAmount,
+	finalAmount,
 	taxRateConfig,
 	children,
 }: Props) {
@@ -41,7 +43,14 @@ export function MaybeEstimatedTax({
 				<>
 					<div css={rowContainer}>
 						<p>Estimated tax</p>
-						<p>{simpleFormatTaxAmount(currency, amount, taxRateConfig.rate)}</p>
+						<p>
+							{simpleFormatTaxAmount(
+								currency,
+								originalAmount,
+								finalAmount,
+								taxRateConfig.rate,
+							)}
+						</p>
 					</div>
 					{children}
 				</>

--- a/support-frontend/assets/components/salesTax/maybeEstimatedTaxSummary.tsx
+++ b/support-frontend/assets/components/salesTax/maybeEstimatedTaxSummary.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { from, space, textSans17 } from '@guardian/source/foundations';
 import type { CurrencyInfo } from '@modules/internationalisation/currency';
 import type { BillingPeriod } from '@modules/product/billingPeriod';
+import type { Payment } from 'helpers/forms/checkouts';
 import { calculateAndFormatTotal } from 'helpers/forms/checkouts';
 import { getBillingPeriodNoun } from 'helpers/productPrice/billingPeriods';
 import type { TaxRateConfig } from 'helpers/salesTax/getEstimatedSalesTaxConfig';
@@ -32,8 +33,7 @@ const boldText = css`
 `;
 
 export type Props = {
-	finalAmount: number;
-	originalAmount: number;
+	payment: Payment;
 	taxRateConfig: TaxRateConfig;
 	currency: CurrencyInfo;
 	billingPeriod: BillingPeriod;
@@ -43,8 +43,7 @@ export type Props = {
 
 export function MaybeEstimatedTaxSummary({
 	currency,
-	finalAmount,
-	originalAmount,
+	payment,
 	taxRateConfig,
 	billingPeriod,
 	fullPrice,
@@ -52,6 +51,7 @@ export function MaybeEstimatedTaxSummary({
 }: Props) {
 	// Note: we'll have to revisit this if weekly gift is ever tax exclusive
 	const isWeeklyGift = false;
+	const { originalAmount, finalAmount } = payment;
 
 	switch (taxRateConfig.type) {
 		case 'tax_inclusive':
@@ -76,8 +76,7 @@ export function MaybeEstimatedTaxSummary({
 						/>
 					</div>
 					<MaybeEstimatedTax
-						finalAmount={finalAmount}
-						originalAmount={originalAmount}
+						payment={payment}
 						taxRateConfig={taxRateConfig}
 						currency={currency}
 					/>

--- a/support-frontend/assets/components/salesTax/maybeEstimatedTaxSummary.tsx
+++ b/support-frontend/assets/components/salesTax/maybeEstimatedTaxSummary.tsx
@@ -51,7 +51,6 @@ export function MaybeEstimatedTaxSummary({
 }: Props) {
 	// Note: we'll have to revisit this if weekly gift is ever tax exclusive
 	const isWeeklyGift = false;
-	const { originalAmount, finalAmount } = payment;
 
 	switch (taxRateConfig.type) {
 		case 'tax_inclusive':
@@ -82,14 +81,7 @@ export function MaybeEstimatedTaxSummary({
 					/>
 					<div css={[summaryRow, boldText]}>
 						<p>Due today</p>
-						<p>
-							{calculateAndFormatTotal(
-								taxRateConfig,
-								currency,
-								originalAmount,
-								finalAmount,
-							)}
-						</p>
+						<p>{calculateAndFormatTotal(taxRateConfig, currency, payment)}</p>
 					</div>
 				</div>
 			);

--- a/support-frontend/assets/components/salesTax/maybeEstimatedTaxSummary.tsx
+++ b/support-frontend/assets/components/salesTax/maybeEstimatedTaxSummary.tsx
@@ -33,6 +33,7 @@ const boldText = css`
 
 export type Props = {
 	amount: number;
+	amountExclDiscount?: number;
 	taxRateConfig: TaxRateConfig;
 	currency: CurrencyInfo;
 	billingPeriod: BillingPeriod;
@@ -43,6 +44,7 @@ export type Props = {
 export function MaybeEstimatedTaxSummary({
 	currency,
 	amount,
+	amountExclDiscount,
 	taxRateConfig,
 	billingPeriod,
 	fullPrice,
@@ -80,7 +82,14 @@ export function MaybeEstimatedTaxSummary({
 					/>
 					<div css={[summaryRow, boldText]}>
 						<p>Due today</p>
-						<p>{calculateAndFormatTotal(taxRateConfig, currency, amount)}</p>
+						<p>
+							{calculateAndFormatTotal(
+								taxRateConfig,
+								currency,
+								amount,
+								amountExclDiscount,
+							)}
+						</p>
 					</div>
 				</div>
 			);

--- a/support-frontend/assets/components/salesTax/maybeEstimatedTaxSummary.tsx
+++ b/support-frontend/assets/components/salesTax/maybeEstimatedTaxSummary.tsx
@@ -32,8 +32,8 @@ const boldText = css`
 `;
 
 export type Props = {
-	amount: number;
-	amountExclDiscount: number;
+	finalAmount: number;
+	originalAmount: number;
 	taxRateConfig: TaxRateConfig;
 	currency: CurrencyInfo;
 	billingPeriod: BillingPeriod;
@@ -43,8 +43,8 @@ export type Props = {
 
 export function MaybeEstimatedTaxSummary({
 	currency,
-	amount,
-	amountExclDiscount,
+	finalAmount,
+	originalAmount,
 	taxRateConfig,
 	billingPeriod,
 	fullPrice,
@@ -76,7 +76,8 @@ export function MaybeEstimatedTaxSummary({
 						/>
 					</div>
 					<MaybeEstimatedTax
-						amount={amount}
+						finalAmount={finalAmount}
+						originalAmount={originalAmount}
 						taxRateConfig={taxRateConfig}
 						currency={currency}
 					/>
@@ -86,8 +87,8 @@ export function MaybeEstimatedTaxSummary({
 							{calculateAndFormatTotal(
 								taxRateConfig,
 								currency,
-								amount,
-								amountExclDiscount,
+								finalAmount,
+								originalAmount,
 							)}
 						</p>
 					</div>

--- a/support-frontend/assets/components/salesTax/maybeEstimatedTaxSummary.tsx
+++ b/support-frontend/assets/components/salesTax/maybeEstimatedTaxSummary.tsx
@@ -33,7 +33,7 @@ const boldText = css`
 
 export type Props = {
 	amount: number;
-	amountExclDiscount?: number;
+	amountExclDiscount: number;
 	taxRateConfig: TaxRateConfig;
 	currency: CurrencyInfo;
 	billingPeriod: BillingPeriod;

--- a/support-frontend/assets/components/salesTax/maybeEstimatedTaxSummary.tsx
+++ b/support-frontend/assets/components/salesTax/maybeEstimatedTaxSummary.tsx
@@ -87,8 +87,8 @@ export function MaybeEstimatedTaxSummary({
 							{calculateAndFormatTotal(
 								taxRateConfig,
 								currency,
-								finalAmount,
 								originalAmount,
+								finalAmount,
 							)}
 						</p>
 					</div>

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
@@ -49,11 +49,13 @@ describe('calculateAndFormatTotal', () => {
 			{ type: 'tax_exclusive', rate: 0.05 } as const,
 			getCurrencyInfo('CAD'),
 			15,
+			15,
 			'$15.75',
 		],
 		[
 			{ type: 'tax_exclusive', rate: 0.12 } as const,
 			getCurrencyInfo('CAD'),
+			30,
 			30,
 			'$33.60',
 		],
@@ -61,11 +63,13 @@ describe('calculateAndFormatTotal', () => {
 			{ type: 'tax_exclusive', rate: 0.15 } as const,
 			getCurrencyInfo('CAD'),
 			150,
+			150,
 			'$172.50',
 		],
 		[
 			{ type: 'tax_exclusive', rate: 0.14975 } as const,
 			getCurrencyInfo('CAD'),
+			300,
 			300,
 			'$344.93',
 		],
@@ -73,14 +77,15 @@ describe('calculateAndFormatTotal', () => {
 			{ type: 'tax_exclusive', rate: 0.14975 } as const,
 			getCurrencyInfo('CAD'),
 			15,
+			15,
 			'$17.25',
 		],
 	])(
 		`%s / Amount: %i / Tax Rate: %d should return %s`,
-		(taxRateConfig, currency, amount, expected) => {
-			expect(calculateAndFormatTotal(taxRateConfig, currency, amount)).toBe(
-				expected,
-			);
+		(taxRateConfig, currency, amount, fullAmount, expected) => {
+			expect(
+				calculateAndFormatTotal(taxRateConfig, currency, amount, fullAmount),
+			).toBe(expected);
 		},
 	);
 
@@ -89,7 +94,7 @@ describe('calculateAndFormatTotal', () => {
 		const currency = getCurrencyInfo('CAD');
 		const amount = 15;
 
-		const result = calculateAndFormatTotal(taxConfig, currency, amount);
+		const result = calculateAndFormatTotal(taxConfig, currency, amount, amount);
 
 		expect(result).toEqual('$15');
 	});
@@ -99,7 +104,7 @@ describe('calculateAndFormatTotal', () => {
 		const currency = getCurrencyInfo('CAD');
 		const amount = 15;
 
-		const result = calculateAndFormatTotal(taxConfig, currency, amount);
+		const result = calculateAndFormatTotal(taxConfig, currency, amount, amount);
 
 		expect(result).toEqual('$15');
 	});

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
@@ -61,9 +61,11 @@ describe('calculateAndRoundTax', () => {
 	it.each([
 		[{ originalAmount: 30, finalAmount: 30 }, 0.12, 3.6],
 		[{ originalAmount: 30, finalAmount: 15 }, 0.14975, 2.24],
+		[{ originalAmount: 30, finalAmount: 15 }, 0.12, 1.8],
 		[{ originalAmount: 15, finalAmount: 15 }, 0.14975, 2.25],
 		[{ originalAmount: 15, finalAmount: 12 }, 0.14975, 1.8],
 		[{ originalAmount: 15, finalAmount: 7.5 }, 0.14975, 1.13],
+		[{ originalAmount: 15, finalAmount: 15 }, 0.05, 0.75],
 	])(
 		`Payment: %s / Tax rate: %d should return %d`,
 		(payment, taxRate, expected) => {
@@ -117,6 +119,12 @@ describe('calculateAndFormatTotal', () => {
 			getCurrencyInfo('CAD'),
 			{ originalAmount: 15, finalAmount: 7.5 },
 			'$8.63',
+		],
+		[
+			{ type: 'tax_exclusive', rate: 0.12 } as const,
+			getCurrencyInfo('CAD'),
+			{ originalAmount: 30, finalAmount: 15 },
+			'$16.80',
 		],
 	])(
 		`%s / Currency %s / Payment: %s should return %s`,

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
@@ -1,7 +1,7 @@
 import { getCurrencyInfo } from '@modules/internationalisation/currency';
 import {
 	calculateAndFormatTotal,
-	calculateTax,
+	calculateAndRoundTax,
 	simpleFormatAmount,
 	simpleFormatTaxAmount,
 } from '../forms/checkouts';
@@ -34,13 +34,17 @@ describe('simpleFormatTaxAmount', () => {
 	);
 });
 
-describe('calculateTax', () => {
+describe('calculateAndRoundTax', () => {
 	it('calculates tax based on a rate and an amount', () => {
 		const originalAmount = 30;
 		const finalAmount = 30;
 		const taxRate = 0.12;
 
-		const taxAmount = calculateTax(originalAmount, finalAmount, taxRate);
+		const taxAmount = calculateAndRoundTax(
+			originalAmount,
+			finalAmount,
+			taxRate,
+		);
 
 		expect(taxAmount).toEqual(3.6);
 	});
@@ -50,7 +54,11 @@ describe('calculateTax', () => {
 		const finalAmount = 12;
 		const taxRate = 0.14975;
 
-		const taxAmount = calculateTax(originalAmount, finalAmount, taxRate);
+		const taxAmount = calculateAndRoundTax(
+			originalAmount,
+			finalAmount,
+			taxRate,
+		);
 
 		expect(taxAmount).toEqual(1.8);
 	});
@@ -60,7 +68,11 @@ describe('calculateTax', () => {
 		const finalAmount = 7.5;
 		const taxRate = 0.14975;
 
-		const taxAmount = calculateTax(originalAmount, finalAmount, taxRate);
+		const taxAmount = calculateAndRoundTax(
+			originalAmount,
+			finalAmount,
+			taxRate,
+		);
 
 		expect(taxAmount).toEqual(1.13);
 	});

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
@@ -60,6 +60,7 @@ describe('simpleFormatTaxAmount', () => {
 describe('calculateAndRoundTax', () => {
 	it.each([
 		[{ originalAmount: 30, finalAmount: 30 }, 0.12, 3.6],
+		[{ originalAmount: 30, finalAmount: 15 }, 0.14975, 2.24],
 		[{ originalAmount: 15, finalAmount: 15 }, 0.14975, 2.25],
 		[{ originalAmount: 15, finalAmount: 12 }, 0.14975, 1.8],
 		[{ originalAmount: 15, finalAmount: 7.5 }, 0.14975, 1.13],

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
@@ -44,6 +44,26 @@ describe('calculateTax', () => {
 
 		expect(taxAmount).toEqual(3.6);
 	});
+
+	it('calculates tax when there is a discount', () => {
+		const originalAmount = 15;
+		const finalAmount = 12;
+		const taxRate = 0.14975;
+
+		const taxAmount = calculateTax(originalAmount, finalAmount, taxRate);
+
+		expect(taxAmount).toEqual(1.8);
+	});
+
+	it('calculates tax when there is a different discount', () => {
+		const originalAmount = 15;
+		const finalAmount = 7.5;
+		const taxRate = 0.14975;
+
+		const taxAmount = calculateTax(originalAmount, finalAmount, taxRate);
+
+		expect(taxAmount).toEqual(1.13);
+	});
 });
 
 describe('calculateAndFormatTotal', () => {

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
@@ -106,19 +106,19 @@ describe('calculateAndFormatTotal', () => {
 		[
 			{ type: 'tax_exclusive', rate: 0.14975 } as const,
 			getCurrencyInfo('CAD'),
-			12, // This has a discount applied
 			15, // This is the full amount
+			12, // This has a discount applied
 			'$13.80',
 		],
 		[
 			{ type: 'tax_exclusive', rate: 0.14975 } as const,
 			getCurrencyInfo('CAD'),
-			7.5, // This has a discount applied
 			15, // This is the full amount
+			7.5, // This has a discount applied
 			'$8.63',
 		],
 	])(
-		`%s / Amount: %i / Tax Rate: %d should return %s`,
+		`%s / Currency %s / Original amount: %i / Final amount: %i should return %s`,
 		(taxRateConfig, currency, originalAmount, finalAmount, expected) => {
 			expect(
 				calculateAndFormatTotal(

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
@@ -35,47 +35,22 @@ describe('simpleFormatTaxAmount', () => {
 });
 
 describe('calculateAndRoundTax', () => {
-	it('calculates tax based on a rate and an amount', () => {
-		const originalAmount = 30;
-		const finalAmount = 30;
-		const taxRate = 0.12;
+	it.each([
+		[30, 30, 0.12, 3.6],
+		[15, 12, 0.14975, 1.8],
+		[15, 7.5, 0.14975, 1.13],
+	])(
+		`Original amount: %d / Final amount: %d / Tax rate: %d should return %d`,
+		(originalAmount, finalAmount, taxRate, expected) => {
+			const taxAmount = calculateAndRoundTax(
+				originalAmount,
+				finalAmount,
+				taxRate,
+			);
 
-		const taxAmount = calculateAndRoundTax(
-			originalAmount,
-			finalAmount,
-			taxRate,
-		);
-
-		expect(taxAmount).toEqual(3.6);
-	});
-
-	it('calculates tax when there is a discount', () => {
-		const originalAmount = 15;
-		const finalAmount = 12;
-		const taxRate = 0.14975;
-
-		const taxAmount = calculateAndRoundTax(
-			originalAmount,
-			finalAmount,
-			taxRate,
-		);
-
-		expect(taxAmount).toEqual(1.8);
-	});
-
-	it('calculates tax when there is a different discount', () => {
-		const originalAmount = 15;
-		const finalAmount = 7.5;
-		const taxRate = 0.14975;
-
-		const taxAmount = calculateAndRoundTax(
-			originalAmount,
-			finalAmount,
-			taxRate,
-		);
-
-		expect(taxAmount).toEqual(1.13);
-	});
+			expect(taxAmount).toEqual(expected);
+		},
+	);
 });
 
 describe('calculateAndFormatTotal', () => {

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
@@ -37,6 +37,7 @@ describe('simpleFormatTaxAmount', () => {
 describe('calculateAndRoundTax', () => {
 	it.each([
 		[30, 30, 0.12, 3.6],
+		[15, 15, 0.14975, 2.25],
 		[15, 12, 0.14975, 1.8],
 		[15, 7.5, 0.14975, 1.13],
 	])(

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
@@ -2,7 +2,6 @@ import { getCurrencyInfo } from '@modules/internationalisation/currency';
 import {
 	calculateAndFormatTotal,
 	calculateTax,
-	roundTaxAmount,
 	simpleFormatAmount,
 	simpleFormatTaxAmount,
 } from '../forms/checkouts';
@@ -31,16 +30,6 @@ describe('simpleFormatTaxAmount', () => {
 			expect(simpleFormatTaxAmount(currency, amount, taxRate)).toBe(expected);
 		},
 	);
-});
-
-describe('roundTaxAmount', () => {
-	it('rounds down to 2 decimal places', () => {
-		const taxAmount = 44.929;
-
-		const roundedTaxAmount = roundTaxAmount(taxAmount);
-
-		expect(roundedTaxAmount).toEqual(44.93);
-	});
 });
 
 describe('calculateTax', () => {

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
@@ -23,8 +23,8 @@ describe('simpleFormatTaxAmount', () => {
 		[getCurrencyInfo('CAD'), 15, 0.05, '$0.75'],
 		[getCurrencyInfo('CAD'), 30, 0.12, '$3.60'],
 		[getCurrencyInfo('CAD'), 150, 0.15, '$22.50'],
-		[getCurrencyInfo('CAD'), 300, 0.14975, '$44.92'],
-		[getCurrencyInfo('CAD'), 15, 0.14975, '$2.24'],
+		[getCurrencyInfo('CAD'), 300, 0.14975, '$44.93'],
+		[getCurrencyInfo('CAD'), 15, 0.14975, '$2.25'],
 	])(
 		`%s / Amount: %i / Tax Rate: %d should format as %s`,
 		(currency, amount, taxRate, expected) => {
@@ -39,7 +39,7 @@ describe('roundTaxAmount', () => {
 
 		const roundedTaxAmount = roundTaxAmount(taxAmount);
 
-		expect(roundedTaxAmount).toEqual(44.92);
+		expect(roundedTaxAmount).toEqual(44.93);
 	});
 });
 
@@ -78,13 +78,13 @@ describe('calculateAndFormatTotal', () => {
 			{ type: 'tax_exclusive', rate: 0.14975 } as const,
 			getCurrencyInfo('CAD'),
 			300,
-			'$344.92',
+			'$344.93',
 		],
 		[
 			{ type: 'tax_exclusive', rate: 0.14975 } as const,
 			getCurrencyInfo('CAD'),
 			15,
-			'$17.24',
+			'$17.25',
 		],
 	])(
 		`%s / Amount: %i / Tax Rate: %d should return %s`,

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
@@ -19,35 +19,54 @@ describe('simpleFormatAmount', () => {
 
 describe('simpleFormatTaxAmount', () => {
 	it.each([
-		[getCurrencyInfo('CAD'), 15, 15, 0.05, '$0.75'],
-		[getCurrencyInfo('CAD'), 30, 30, 0.12, '$3.60'],
-		[getCurrencyInfo('CAD'), 150, 150, 0.15, '$22.50'],
-		[getCurrencyInfo('CAD'), 300, 300, 0.14975, '$44.93'],
-		[getCurrencyInfo('CAD'), 15, 15, 0.14975, '$2.25'],
+		[
+			getCurrencyInfo('CAD'),
+			{ originalAmount: 15, finalAmount: 15 },
+			0.05,
+			'$0.75',
+		],
+		[
+			getCurrencyInfo('CAD'),
+			{ originalAmount: 30, finalAmount: 30 },
+			0.12,
+			'$3.60',
+		],
+		[
+			getCurrencyInfo('CAD'),
+			{ originalAmount: 150, finalAmount: 150 },
+			0.15,
+			'$22.50',
+		],
+		[
+			getCurrencyInfo('CAD'),
+			{ originalAmount: 300, finalAmount: 300 },
+			0.14975,
+			'$44.93',
+		],
+		[
+			getCurrencyInfo('CAD'),
+			{ originalAmount: 15, finalAmount: 15 },
+			0.14975,
+			'$2.25',
+		],
 	])(
-		`%s / Amount: %i / Tax Rate: %d should format as %s`,
-		(currency, originalAmount, finalAmount, taxRate, expected) => {
-			expect(
-				simpleFormatTaxAmount(currency, originalAmount, finalAmount, taxRate),
-			).toBe(expected);
+		`Currenct: %s / Payment: %s / Tax Rate: %d should format as %s`,
+		(currency, payment, taxRate, expected) => {
+			expect(simpleFormatTaxAmount(currency, payment, taxRate)).toBe(expected);
 		},
 	);
 });
 
 describe('calculateAndRoundTax', () => {
 	it.each([
-		[30, 30, 0.12, 3.6],
-		[15, 15, 0.14975, 2.25],
-		[15, 12, 0.14975, 1.8],
-		[15, 7.5, 0.14975, 1.13],
+		[{ originalAmount: 30, finalAmount: 30 }, 0.12, 3.6],
+		[{ originalAmount: 15, finalAmount: 15 }, 0.14975, 2.25],
+		[{ originalAmount: 15, finalAmount: 12 }, 0.14975, 1.8],
+		[{ originalAmount: 15, finalAmount: 7.5 }, 0.14975, 1.13],
 	])(
-		`Original amount: %d / Final amount: %d / Tax rate: %d should return %d`,
-		(originalAmount, finalAmount, taxRate, expected) => {
-			const taxAmount = calculateAndRoundTax(
-				originalAmount,
-				finalAmount,
-				taxRate,
-			);
+		`Payment: %s / Tax rate: %d should return %d`,
+		(payment, taxRate, expected) => {
+			const taxAmount = calculateAndRoundTax(payment, taxRate);
 
 			expect(taxAmount).toEqual(expected);
 		},
@@ -59,72 +78,60 @@ describe('calculateAndFormatTotal', () => {
 		[
 			{ type: 'tax_exclusive', rate: 0.05 } as const,
 			getCurrencyInfo('CAD'),
-			15,
-			15,
+			{ originalAmount: 15, finalAmount: 15 },
 			'$15.75',
 		],
 		[
 			{ type: 'tax_exclusive', rate: 0.12 } as const,
 			getCurrencyInfo('CAD'),
-			30,
-			30,
+			{ originalAmount: 30, finalAmount: 30 },
 			'$33.60',
 		],
 		[
 			{ type: 'tax_exclusive', rate: 0.15 } as const,
 			getCurrencyInfo('CAD'),
-			150,
-			150,
+			{ originalAmount: 150, finalAmount: 150 },
 			'$172.50',
 		],
 		[
 			{ type: 'tax_exclusive', rate: 0.14975 } as const,
 			getCurrencyInfo('CAD'),
-			300,
-			300,
+			{ originalAmount: 300, finalAmount: 300 },
 			'$344.93',
 		],
 		[
 			{ type: 'tax_exclusive', rate: 0.14975 } as const,
 			getCurrencyInfo('CAD'),
-			15,
-			15,
+			{ originalAmount: 15, finalAmount: 15 },
 			'$17.25',
 		],
 		[
 			{ type: 'tax_exclusive', rate: 0.14975 } as const,
 			getCurrencyInfo('CAD'),
-			15, // This is the full amount
-			12, // This has a discount applied
+			{ originalAmount: 15, finalAmount: 12 },
 			'$13.80',
 		],
 		[
 			{ type: 'tax_exclusive', rate: 0.14975 } as const,
 			getCurrencyInfo('CAD'),
-			15, // This is the full amount
-			7.5, // This has a discount applied
+			{ originalAmount: 15, finalAmount: 7.5 },
 			'$8.63',
 		],
 	])(
-		`%s / Currency %s / Original amount: %i / Final amount: %i should return %s`,
-		(taxRateConfig, currency, originalAmount, finalAmount, expected) => {
-			expect(
-				calculateAndFormatTotal(
-					taxRateConfig,
-					currency,
-					originalAmount,
-					finalAmount,
-				),
-			).toBe(expected);
+		`%s / Currency %s / Payment: %s should return %s`,
+		(taxRateConfig, currency, payment, expected) => {
+			expect(calculateAndFormatTotal(taxRateConfig, currency, payment)).toBe(
+				expected,
+			);
 		},
 	);
 
 	it('returns the total when the tax config is not_enough_information', () => {
 		const taxConfig = { type: 'not_enough_information' } as const;
 		const currency = getCurrencyInfo('CAD');
-		const amount = 15;
+		const payment = { originalAmount: 15, finalAmount: 15 };
 
-		const result = calculateAndFormatTotal(taxConfig, currency, amount, amount);
+		const result = calculateAndFormatTotal(taxConfig, currency, payment);
 
 		expect(result).toEqual('$15');
 	});
@@ -132,9 +139,9 @@ describe('calculateAndFormatTotal', () => {
 	it('returns the total when the tax config is tax_inclusive', () => {
 		const taxConfig = { type: 'tax_inclusive' } as const;
 		const currency = getCurrencyInfo('CAD');
-		const amount = 15;
+		const payment = { originalAmount: 15, finalAmount: 15 };
 
-		const result = calculateAndFormatTotal(taxConfig, currency, amount, amount);
+		const result = calculateAndFormatTotal(taxConfig, currency, payment);
 
 		expect(result).toEqual('$15');
 	});

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
@@ -80,6 +80,20 @@ describe('calculateAndFormatTotal', () => {
 			15,
 			'$17.25',
 		],
+		[
+			{ type: 'tax_exclusive', rate: 0.14975 } as const,
+			getCurrencyInfo('CAD'),
+			12, // This has a discount applied
+			15, // This is the full amount
+			'$13.80',
+		],
+		[
+			{ type: 'tax_exclusive', rate: 0.14975 } as const,
+			getCurrencyInfo('CAD'),
+			7.5, // This has a discount applied
+			15, // This is the full amount
+			'$8.63',
+		],
 	])(
 		`%s / Amount: %i / Tax Rate: %d should return %s`,
 		(taxRateConfig, currency, amount, fullAmount, expected) => {

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.ts
@@ -19,25 +19,28 @@ describe('simpleFormatAmount', () => {
 
 describe('simpleFormatTaxAmount', () => {
 	it.each([
-		[getCurrencyInfo('CAD'), 15, 0.05, '$0.75'],
-		[getCurrencyInfo('CAD'), 30, 0.12, '$3.60'],
-		[getCurrencyInfo('CAD'), 150, 0.15, '$22.50'],
-		[getCurrencyInfo('CAD'), 300, 0.14975, '$44.93'],
-		[getCurrencyInfo('CAD'), 15, 0.14975, '$2.25'],
+		[getCurrencyInfo('CAD'), 15, 15, 0.05, '$0.75'],
+		[getCurrencyInfo('CAD'), 30, 30, 0.12, '$3.60'],
+		[getCurrencyInfo('CAD'), 150, 150, 0.15, '$22.50'],
+		[getCurrencyInfo('CAD'), 300, 300, 0.14975, '$44.93'],
+		[getCurrencyInfo('CAD'), 15, 15, 0.14975, '$2.25'],
 	])(
 		`%s / Amount: %i / Tax Rate: %d should format as %s`,
-		(currency, amount, taxRate, expected) => {
-			expect(simpleFormatTaxAmount(currency, amount, taxRate)).toBe(expected);
+		(currency, originalAmount, finalAmount, taxRate, expected) => {
+			expect(
+				simpleFormatTaxAmount(currency, originalAmount, finalAmount, taxRate),
+			).toBe(expected);
 		},
 	);
 });
 
 describe('calculateTax', () => {
 	it('calculates tax based on a rate and an amount', () => {
-		const amount = 30;
+		const originalAmount = 30;
+		const finalAmount = 30;
 		const taxRate = 0.12;
 
-		const taxAmount = calculateTax(amount, taxRate);
+		const taxAmount = calculateTax(originalAmount, finalAmount, taxRate);
 
 		expect(taxAmount).toEqual(3.6);
 	});
@@ -96,9 +99,14 @@ describe('calculateAndFormatTotal', () => {
 		],
 	])(
 		`%s / Amount: %i / Tax Rate: %d should return %s`,
-		(taxRateConfig, currency, amount, fullAmount, expected) => {
+		(taxRateConfig, currency, originalAmount, finalAmount, expected) => {
 			expect(
-				calculateAndFormatTotal(taxRateConfig, currency, amount, fullAmount),
+				calculateAndFormatTotal(
+					taxRateConfig,
+					currency,
+					originalAmount,
+					finalAmount,
+				),
 			).toBe(expected);
 		},
 	);

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -83,28 +83,6 @@ function calculateAndFormatTotal(
 			);
 
 			return simpleFormatAmount(currency, roundedTotal + tax);
-			// const roundedDownTaxAmount = roundAmount(
-			// 	calculateTax(originalAmount, finalAmount, taxRateConfig.rate),
-			// );
-			// const totalWithTax = roundedTotal + roundedDownTaxAmount;
-
-			// if (originalAmount === finalAmount) {
-			// 	return simpleFormatAmount(currency, totalWithTax);
-			// } else {
-			// 	const roundedExclDiscountTotal = roundAmount(originalAmount);
-			// 	const roundedDownTaxExclDiscountAmount = roundAmount(
-			// 		calculateTax(originalAmount, finalAmount, taxRateConfig.rate),
-			// 	);
-			// 	const totalExclDiscountWithTax =
-			// 		roundedExclDiscountTotal + roundedDownTaxExclDiscountAmount;
-
-			// 	// This reflects the Zuora invoice calculation
-			// 	// Due Today = Total Excl Discount With Tax - Total Incl Discount With Tax
-			// 	return simpleFormatAmount(
-			// 		currency,
-			// 		totalExclDiscountWithTax - totalWithTax,
-			// 	);
-			// }
 		}
 	}
 }

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -27,7 +27,7 @@ const simpleFormatAmount = (currency: CurrencyInfo, amount: number): string => {
 	return `${currency.glyph}${amountText}`.trim();
 };
 
-function calculateTax(
+function calculateAndRoundTax(
 	originalAmount: number,
 	finalAmount: number,
 	taxRate: number,
@@ -56,7 +56,7 @@ function simpleFormatTaxAmount(
 	finalAmount: number,
 	taxRate: number, // A decimal, e.g. 0.15
 ): string {
-	const taxAmount = calculateTax(originalAmount, finalAmount, taxRate);
+	const taxAmount = calculateAndRoundTax(originalAmount, finalAmount, taxRate);
 	return simpleFormatAmount(currency, taxAmount);
 }
 
@@ -76,7 +76,11 @@ function calculateAndFormatTotal(
 			// Amounts are rounded the usual way:
 			const roundedTotal = roundAmount(finalAmount);
 
-			const tax = calculateTax(originalAmount, finalAmount, taxRateConfig.rate);
+			const tax = calculateAndRoundTax(
+				originalAmount,
+				finalAmount,
+				taxRateConfig.rate,
+			);
 
 			return simpleFormatAmount(currency, roundedTotal + tax);
 			// const roundedDownTaxAmount = roundAmount(
@@ -109,6 +113,6 @@ function calculateAndFormatTotal(
 export {
 	simpleFormatAmount,
 	simpleFormatTaxAmount,
-	calculateTax,
+	calculateAndRoundTax,
 	calculateAndFormatTotal,
 };

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -48,10 +48,8 @@ function calculateAndRoundTax(payment: Payment, taxRate: number): number {
 		(originalAmount * (taxRate * 100000)) / 100000,
 	);
 
-	if (originalAmount === finalAmount) {
-		return taxOnOriginalAmount;
-	}
-
+	// If originalAmount and finalAmount are the same (no discount) then this
+	// will result in a taxOnDiscountAmount of zero - so no affect.
 	const discountAmount = originalAmount - finalAmount;
 	const taxOnDiscountAmount = roundAmount(
 		(discountAmount * (taxRate * 100000)) / 100000,

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -27,47 +27,56 @@ const simpleFormatAmount = (currency: CurrencyInfo, amount: number): string => {
 	return `${currency.glyph}${amountText}`.trim();
 };
 
-function calculateTax(amount: number, taxRate: number): number {
+function calculateTax(
+	originalAmount: number,
+	finalAmount: number,
+	taxRate: number,
+): number {
 	// Multiply to avoid floating point precision issues. Should we be using a
 	// library for this?
-	return (amount * (taxRate * 100000)) / 100000;
+	if (originalAmount === finalAmount) {
+		return (finalAmount * (taxRate * 100000)) / 100000;
+	}
+
+	throw new Error('not implemented yet');
 }
 
 function simpleFormatTaxAmount(
 	currency: CurrencyInfo,
-	amount: number,
+	originalAmount: number,
+	finalAmount: number,
 	taxRate: number, // A decimal, e.g. 0.15
 ): string {
-	const taxAmount = calculateTax(amount, taxRate);
+	const taxAmount = calculateTax(originalAmount, finalAmount, taxRate);
 	return simpleFormatAmount(currency, taxAmount);
 }
 
 function calculateAndFormatTotal(
 	taxRateConfig: TaxRateConfig,
 	currency: CurrencyInfo,
-	amount: number,
-	amountExclDiscount: number,
+	originalAmount: number,
+	finalAmount: number,
 ): string {
 	switch (taxRateConfig.type) {
 		case 'tax_inclusive':
 		case 'not_enough_information':
-			return simpleFormatAmount(currency, amount);
+			return simpleFormatAmount(currency, finalAmount);
 		case 'tax_exclusive': {
 			// It's important that the rounding here reflects the individual amounts
 			// otherwise we may show the user a calculation which doesn't add up:
 			// Amounts are rounded the usual way:
-			const roundedTotal = roundAmount(amount);
+			const roundedTotal = roundAmount(finalAmount);
 			const roundedDownTaxAmount = roundAmount(
-				calculateTax(amount, taxRateConfig.rate),
+				calculateTax(originalAmount, finalAmount, taxRateConfig.rate),
 			);
 			const totalWithTax = roundedTotal + roundedDownTaxAmount;
 
-			if (amountExclDiscount === amount) {
+			if (originalAmount === finalAmount) {
 				return simpleFormatAmount(currency, totalWithTax);
 			} else {
-				const roundedExclDiscountTotal = roundAmount(amountExclDiscount);
+				const roundedExclDiscountTotal = roundAmount(originalAmount);
 				const roundedDownTaxExclDiscountAmount = roundAmount(
-					calculateTax(amountExclDiscount, taxRateConfig.rate),
+					calculateTax(originalAmount, finalAmount, taxRateConfig.rate),
 				);
 				const totalExclDiscountWithTax =
 					roundedExclDiscountTotal + roundedDownTaxExclDiscountAmount;

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -34,11 +34,20 @@ function calculateTax(
 ): number {
 	// Multiply to avoid floating point precision issues. Should we be using a
 	// library for this?
+	const taxOnOriginalAmount = roundAmount(
+		(originalAmount * (taxRate * 100000)) / 100000,
+	);
+
 	if (originalAmount === finalAmount) {
-		return (finalAmount * (taxRate * 100000)) / 100000;
+		return taxOnOriginalAmount;
 	}
 
-	throw new Error('not implemented yet');
+	const discountAmount = originalAmount - finalAmount;
+	const taxOnDiscountAmount = roundAmount(
+		(discountAmount * (taxRate * 100000)) / 100000,
+	);
+
+	return taxOnOriginalAmount - taxOnDiscountAmount;
 }
 
 function simpleFormatTaxAmount(

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -19,7 +19,7 @@ function roundTaxAmount(amount: number) {
 	 * `Number.toFixed` returns a string which is not useful for calculations
 	 * and would need unnecessary type conversions
 	 */
-	return Math.floor(amount * 1e2) / 1e2;
+	return Math.round(amount * 1e2) / 1e2;
 }
 
 const simpleFormatAmount = (

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -2,6 +2,18 @@
 import type { CurrencyInfo } from '@guardian/support-service-lambdas/modules/internationalisation/src/currency';
 import type { TaxRateConfig } from 'helpers/salesTax/getEstimatedSalesTaxConfig';
 
+/**
+ * - `originalAmount` the amount pre any discounts or contributions
+ * - `discountedAmount` the amount with a discountApplied
+ * - `finalAmount` is the amount a person will pay
+ */
+export type Payment = {
+	originalAmount: number;
+	discountedAmount?: number;
+	contributionAmount?: number;
+	finalAmount: number;
+};
+
 function roundAmount(amount: number) {
 	/**
 	 * This rounds a `number` to the second decimal.

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -60,6 +60,7 @@ function calculateAndFormatTotal(
 	taxRateConfig: TaxRateConfig,
 	currency: CurrencyInfo,
 	amount: number,
+	amountExclDiscount?: number,
 ): string {
 	switch (taxRateConfig.type) {
 		case 'tax_inclusive':
@@ -70,13 +71,28 @@ function calculateAndFormatTotal(
 			// otherwise we may show the user a calculation which doesn't add up:
 			// Amounts are rounded the usual way:
 			const roundedTotal = roundAmount(amount);
-
-			// Tax amounts are rounded down:
 			const roundedDownTaxAmount = roundTaxAmount(
 				calculateTax(amount, taxRateConfig.rate),
 			);
+			const totalWithTax = roundedTotal + roundedDownTaxAmount;
 
-			return simpleFormatAmount(currency, roundedTotal + roundedDownTaxAmount);
+			if (amountExclDiscount === undefined || amountExclDiscount === amount) {
+				return simpleFormatAmount(currency, totalWithTax);
+			} else {
+				const roundedExclDiscountTotal = roundAmount(amountExclDiscount);
+				const roundedDownTaxExclDiscountAmount = roundTaxAmount(
+					calculateTax(amountExclDiscount, taxRateConfig.rate),
+				);
+				const totalExclDiscountWithTax =
+					roundedExclDiscountTotal + roundedDownTaxExclDiscountAmount;
+
+				// This reflects the Zuora invoice calculation
+				// Due Today = Total Excl Discount With Tax - Total Incl Discount With Tax
+				return simpleFormatAmount(
+					currency,
+					totalExclDiscountWithTax - totalWithTax,
+				);
+			}
 		}
 	}
 }

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -84,9 +84,9 @@ function calculateAndFormatTotal(
 			// Amounts are rounded the usual way:
 			const roundedTotal = roundAmount(finalAmount);
 
-			const tax = calculateAndRoundTax(payment, taxRateConfig.rate);
+			const roundedTax = calculateAndRoundTax(payment, taxRateConfig.rate);
 
-			return simpleFormatAmount(currency, roundedTotal + tax);
+			return simpleFormatAmount(currency, roundedTotal + roundedTax);
 		}
 	}
 }

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -46,7 +46,7 @@ function calculateAndFormatTotal(
 	taxRateConfig: TaxRateConfig,
 	currency: CurrencyInfo,
 	amount: number,
-	amountExclDiscount?: number,
+	amountExclDiscount: number,
 ): string {
 	switch (taxRateConfig.type) {
 		case 'tax_inclusive':
@@ -62,7 +62,7 @@ function calculateAndFormatTotal(
 			);
 			const totalWithTax = roundedTotal + roundedDownTaxAmount;
 
-			if (amountExclDiscount === undefined || amountExclDiscount === amount) {
+			if (amountExclDiscount === amount) {
 				return simpleFormatAmount(currency, totalWithTax);
 			} else {
 				const roundedExclDiscountTotal = roundAmount(amountExclDiscount);

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -12,26 +12,12 @@ function roundAmount(amount: number) {
 	return Math.round(amount * 1e2) / 1e2;
 }
 
-function roundTaxAmount(amount: number) {
-	/**
-	 * This rounds a `number` down to the second decimal.
-	 *
-	 * `Number.toFixed` returns a string which is not useful for calculations
-	 * and would need unnecessary type conversions
-	 */
-	return Math.round(amount * 1e2) / 1e2;
-}
-
-const simpleFormatAmount = (
-	currency: CurrencyInfo,
-	amount: number,
-	roundFn: (value: number) => number = roundAmount,
-): string => {
+const simpleFormatAmount = (currency: CurrencyInfo, amount: number): string => {
 	/**
 	 * We need to round the amount before checking if it is an Int for the edge case of something like 12.0001
 	 * which would not be an int, but then format as 12.00, whereas we'd like 12.
 	 */
-	const roundedAmount = roundFn(amount);
+	const roundedAmount = roundAmount(amount);
 	const isInt = roundedAmount % 1 === 0;
 	/** only add the percentile amount if it's not a round integer */
 	const amountText = isInt
@@ -53,7 +39,7 @@ function simpleFormatTaxAmount(
 	taxRate: number, // A decimal, e.g. 0.15
 ): string {
 	const taxAmount = calculateTax(amount, taxRate);
-	return simpleFormatAmount(currency, taxAmount, roundTaxAmount);
+	return simpleFormatAmount(currency, taxAmount);
 }
 
 function calculateAndFormatTotal(
@@ -71,7 +57,7 @@ function calculateAndFormatTotal(
 			// otherwise we may show the user a calculation which doesn't add up:
 			// Amounts are rounded the usual way:
 			const roundedTotal = roundAmount(amount);
-			const roundedDownTaxAmount = roundTaxAmount(
+			const roundedDownTaxAmount = roundAmount(
 				calculateTax(amount, taxRateConfig.rate),
 			);
 			const totalWithTax = roundedTotal + roundedDownTaxAmount;
@@ -80,7 +66,7 @@ function calculateAndFormatTotal(
 				return simpleFormatAmount(currency, totalWithTax);
 			} else {
 				const roundedExclDiscountTotal = roundAmount(amountExclDiscount);
-				const roundedDownTaxExclDiscountAmount = roundTaxAmount(
+				const roundedDownTaxExclDiscountAmount = roundAmount(
 					calculateTax(amountExclDiscount, taxRateConfig.rate),
 				);
 				const totalExclDiscountWithTax =
@@ -101,7 +87,6 @@ function calculateAndFormatTotal(
 export {
 	simpleFormatAmount,
 	simpleFormatTaxAmount,
-	roundTaxAmount,
 	calculateTax,
 	calculateAndFormatTotal,
 };

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -75,28 +75,32 @@ function calculateAndFormatTotal(
 			// otherwise we may show the user a calculation which doesn't add up:
 			// Amounts are rounded the usual way:
 			const roundedTotal = roundAmount(finalAmount);
-			const roundedDownTaxAmount = roundAmount(
-				calculateTax(originalAmount, finalAmount, taxRateConfig.rate),
-			);
-			const totalWithTax = roundedTotal + roundedDownTaxAmount;
 
-			if (originalAmount === finalAmount) {
-				return simpleFormatAmount(currency, totalWithTax);
-			} else {
-				const roundedExclDiscountTotal = roundAmount(originalAmount);
-				const roundedDownTaxExclDiscountAmount = roundAmount(
-					calculateTax(originalAmount, finalAmount, taxRateConfig.rate),
-				);
-				const totalExclDiscountWithTax =
-					roundedExclDiscountTotal + roundedDownTaxExclDiscountAmount;
+			const tax = calculateTax(originalAmount, finalAmount, taxRateConfig.rate);
 
-				// This reflects the Zuora invoice calculation
-				// Due Today = Total Excl Discount With Tax - Total Incl Discount With Tax
-				return simpleFormatAmount(
-					currency,
-					totalExclDiscountWithTax - totalWithTax,
-				);
-			}
+			return simpleFormatAmount(currency, roundedTotal + tax);
+			// const roundedDownTaxAmount = roundAmount(
+			// 	calculateTax(originalAmount, finalAmount, taxRateConfig.rate),
+			// );
+			// const totalWithTax = roundedTotal + roundedDownTaxAmount;
+
+			// if (originalAmount === finalAmount) {
+			// 	return simpleFormatAmount(currency, totalWithTax);
+			// } else {
+			// 	const roundedExclDiscountTotal = roundAmount(originalAmount);
+			// 	const roundedDownTaxExclDiscountAmount = roundAmount(
+			// 		calculateTax(originalAmount, finalAmount, taxRateConfig.rate),
+			// 	);
+			// 	const totalExclDiscountWithTax =
+			// 		roundedExclDiscountTotal + roundedDownTaxExclDiscountAmount;
+
+			// 	// This reflects the Zuora invoice calculation
+			// 	// Due Today = Total Excl Discount With Tax - Total Incl Discount With Tax
+			// 	return simpleFormatAmount(
+			// 		currency,
+			// 		totalExclDiscountWithTax - totalWithTax,
+			// 	);
+			// }
 		}
 	}
 }

--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -39,11 +39,9 @@ const simpleFormatAmount = (currency: CurrencyInfo, amount: number): string => {
 	return `${currency.glyph}${amountText}`.trim();
 };
 
-function calculateAndRoundTax(
-	originalAmount: number,
-	finalAmount: number,
-	taxRate: number,
-): number {
+function calculateAndRoundTax(payment: Payment, taxRate: number): number {
+	const { originalAmount, finalAmount } = payment;
+
 	// Multiply to avoid floating point precision issues. Should we be using a
 	// library for this?
 	const taxOnOriginalAmount = roundAmount(
@@ -64,20 +62,20 @@ function calculateAndRoundTax(
 
 function simpleFormatTaxAmount(
 	currency: CurrencyInfo,
-	originalAmount: number,
-	finalAmount: number,
+	payment: Payment,
 	taxRate: number, // A decimal, e.g. 0.15
 ): string {
-	const taxAmount = calculateAndRoundTax(originalAmount, finalAmount, taxRate);
+	const taxAmount = calculateAndRoundTax(payment, taxRate);
 	return simpleFormatAmount(currency, taxAmount);
 }
 
 function calculateAndFormatTotal(
 	taxRateConfig: TaxRateConfig,
 	currency: CurrencyInfo,
-	originalAmount: number,
-	finalAmount: number,
+	payment: Payment,
 ): string {
+	const { finalAmount } = payment;
+
 	switch (taxRateConfig.type) {
 		case 'tax_inclusive':
 		case 'not_enough_information':
@@ -88,11 +86,7 @@ function calculateAndFormatTotal(
 			// Amounts are rounded the usual way:
 			const roundedTotal = roundAmount(finalAmount);
 
-			const tax = calculateAndRoundTax(
-				originalAmount,
-				finalAmount,
-				taxRateConfig.rate,
-			);
+			const tax = calculateAndRoundTax(payment, taxRateConfig.rate);
 
 			return simpleFormatAmount(currency, roundedTotal + tax);
 		}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -351,6 +351,7 @@ export function Checkout({
 						ratePlanKey={ratePlanKey}
 						promotion={promotion}
 						originalAmount={payment.originalAmount}
+						finalAmount={payment.finalAmount}
 						countryId={countryId}
 						forcedCountry={forcedCountry}
 						abParticipations={abParticipations}

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -8,6 +8,7 @@ import { loadStripe } from '@stripe/stripe-js';
 import { useEffect, useState } from 'react';
 import ObserverPageLayout from 'components/observer-layout/ObserverPageLayout';
 import { observerThemeButton } from 'components/observer-layout/styles';
+import type { Payment } from 'helpers/forms/checkouts';
 import { getPaypalClientId } from 'helpers/forms/payPal';
 import {
 	getStripeKeyForCountry,
@@ -143,17 +144,7 @@ export function Checkout({
 	 * - any contributions made
 	 */
 
-	/**
-	 * - `originalAmount` the amount pre any discounts or contributions
-	 * - `discountedAmount` the amount with a discountApplied
-	 * - `finalAmount` is the amount a person will pay
-	 */
-	let payment: {
-		originalAmount: number;
-		discountedAmount?: number;
-		contributionAmount?: number;
-		finalAmount: number;
-	};
+	let payment: Payment;
 
 	const contributionParam = urlSearchParams.get('contribution');
 	const contributionAmount = contributionParam

--- a/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/checkout.tsx
@@ -341,8 +341,7 @@ export function Checkout({
 						productKey={productKey}
 						ratePlanKey={ratePlanKey}
 						promotion={promotion}
-						originalAmount={payment.originalAmount}
-						finalAmount={payment.finalAmount}
+						payment={payment}
 						countryId={countryId}
 						forcedCountry={forcedCountry}
 						abParticipations={abParticipations}
@@ -364,9 +363,7 @@ export function Checkout({
 						productKey={productKey}
 						ratePlanKey={ratePlanKey}
 						promotion={promotion}
-						originalAmount={payment.originalAmount}
-						contributionAmount={payment.contributionAmount}
-						finalAmount={payment.finalAmount}
+						payment={payment}
 						useStripeExpressCheckout={useStripeExpressCheckout}
 						countryId={countryId}
 						abParticipations={abParticipations}

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -32,7 +32,11 @@ import type { AddressFormFieldError } from 'components/subscriptionCheckouts/add
 import type { Participations } from 'helpers/abTests/models';
 import { isContributionsOnlyCountry } from 'helpers/contributions';
 import useEmailMarketingUtmSession from 'helpers/customHooks/useEmailMarketingUtmSession';
-import { calculateTax, simpleFormatAmount } from 'helpers/forms/checkouts';
+import {
+	calculateAndRoundTax,
+	type Payment,
+	simpleFormatAmount,
+} from 'helpers/forms/checkouts';
 import { loadPayPalRecurring } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 import {
 	isPaymentMethod,
@@ -139,8 +143,7 @@ type CheckoutFormProps = {
 	isTestUser: boolean;
 	productKey: ActiveProductKey;
 	ratePlanKey: ActiveRatePlanKey;
-	originalAmount: number;
-	finalAmount: number;
+	payment: Payment;
 	useStripeExpressCheckout: boolean;
 	countryId: CountryCode;
 	abParticipations: Participations;
@@ -149,7 +152,6 @@ type CheckoutFormProps = {
 	weeklyDeliveryDate: Date;
 	setWeeklyDeliveryDate: (value: Date) => void;
 	thresholdAmount: number;
-	contributionAmount?: number;
 	promotion?: Promotion;
 	checkoutSession?: CheckoutSession;
 	studentDiscount?: StudentDiscount;
@@ -166,8 +168,7 @@ export default function CheckoutForm({
 	isTestUser,
 	productKey,
 	ratePlanKey,
-	originalAmount,
-	finalAmount,
+	payment,
 	useStripeExpressCheckout,
 	countryId,
 	abParticipations,
@@ -175,7 +176,6 @@ export default function CheckoutForm({
 	weeklyDeliveryDate,
 	setWeeklyDeliveryDate,
 	thresholdAmount,
-	contributionAmount,
 	promotion,
 	checkoutSession,
 	studentDiscount,
@@ -184,6 +184,7 @@ export default function CheckoutForm({
 	setBillingState,
 	taxRateConfig,
 }: CheckoutFormProps) {
+	const { originalAmount, finalAmount, contributionAmount } = payment;
 	const csrf: CsrfState = appConfig.csrf;
 	const user = appConfig.user;
 	const isSignedIn = !!user?.email;
@@ -824,7 +825,11 @@ export default function CheckoutForm({
 
 											const taxAmount =
 												updatedTaxConfig.type === 'tax_exclusive'
-													? calculateTax(finalAmount, updatedTaxConfig.rate)
+													? calculateAndRoundTax(
+															originalAmount,
+															finalAmount,
+															updatedTaxConfig.rate,
+													  )
 													: 0;
 
 											const totalWithTax = finalAmount + taxAmount;

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -1248,8 +1248,8 @@ export default function CheckoutForm({
 							amount={originalAmount}
 						/>
 						<MaybeEstimatedTaxSummary
-							amount={finalAmount}
-							amountExclDiscount={originalAmount}
+							finalAmount={finalAmount}
+							originalAmount={originalAmount}
 							taxRateConfig={taxRateConfig}
 							currency={currency}
 							billingPeriod={billingPeriod}

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -1253,8 +1253,7 @@ export default function CheckoutForm({
 							amount={originalAmount}
 						/>
 						<MaybeEstimatedTaxSummary
-							finalAmount={finalAmount}
-							originalAmount={originalAmount}
+							payment={payment}
 							taxRateConfig={taxRateConfig}
 							currency={currency}
 							billingPeriod={billingPeriod}

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -825,11 +825,7 @@ export default function CheckoutForm({
 
 											const taxAmount =
 												updatedTaxConfig.type === 'tax_exclusive'
-													? calculateAndRoundTax(
-															originalAmount,
-															finalAmount,
-															updatedTaxConfig.rate,
-													  )
+													? calculateAndRoundTax(payment, updatedTaxConfig.rate)
 													: 0;
 
 											const totalWithTax = finalAmount + taxAmount;

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -1249,6 +1249,7 @@ export default function CheckoutForm({
 						/>
 						<MaybeEstimatedTaxSummary
 							amount={finalAmount}
+							amountExclDiscount={originalAmount}
 							taxRateConfig={taxRateConfig}
 							currency={currency}
 							billingPeriod={billingPeriod}

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
@@ -47,6 +47,7 @@ type CheckoutSummaryProps = {
 	productKey: ActiveProductKey;
 	ratePlanKey: ActiveRatePlanKey;
 	originalAmount: number;
+	finalAmount: number;
 	countryId: CountryCode;
 	abParticipations: Participations;
 	landingPageSettings: LandingPageVariant;
@@ -67,6 +68,7 @@ export default function CheckoutSummary({
 	productKey,
 	ratePlanKey,
 	originalAmount,
+	finalAmount,
 	countryId,
 	abParticipations,
 	landingPageSettings,
@@ -186,7 +188,8 @@ export default function CheckoutSummary({
 					ratePlanLabel={ratePlanDetail.displayName ?? ratePlanDetail.label}
 					taxRateConfig={taxRateConfig}
 					billingPeriod={ratePlanDetail.billingPeriod}
-					amount={originalAmount}
+					originalAmount={originalAmount}
+					finalAmount={finalAmount}
 					promotion={promotion}
 					currency={currency}
 					checkListData={benefitsCheckListData}

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
@@ -11,6 +11,7 @@ import { OrderSummaryStartDate } from 'components/orderSummary/orderSummaryStart
 import { OrderSummaryTsAndCs } from 'components/orderSummary/orderSummaryTsAndCs';
 import type { Participations } from 'helpers/abTests/models';
 import { isContributionsOnlyCountry } from 'helpers/contributions';
+import type { Payment } from 'helpers/forms/checkouts';
 import type { AppConfig } from 'helpers/globalsAndSwitches/window';
 import {
 	type ActiveProductKey,
@@ -46,8 +47,7 @@ type CheckoutSummaryProps = {
 	appConfig: AppConfig;
 	productKey: ActiveProductKey;
 	ratePlanKey: ActiveRatePlanKey;
-	originalAmount: number;
-	finalAmount: number;
+	payment: Payment;
 	countryId: CountryCode;
 	abParticipations: Participations;
 	landingPageSettings: LandingPageVariant;
@@ -67,8 +67,7 @@ export default function CheckoutSummary({
 	appConfig,
 	productKey,
 	ratePlanKey,
-	originalAmount,
-	finalAmount,
+	payment,
 	countryId,
 	abParticipations,
 	landingPageSettings,
@@ -82,6 +81,7 @@ export default function CheckoutSummary({
 	studentDiscount,
 	nudgeSettings,
 }: CheckoutSummaryProps) {
+	const { originalAmount, finalAmount } = payment;
 	const urlParams = new URLSearchParams(window.location.search);
 	const showBackButton = urlParams.get('backButton') !== 'false';
 	const productCatalog = appConfig.productCatalog;

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutSummary.tsx
@@ -81,7 +81,7 @@ export default function CheckoutSummary({
 	studentDiscount,
 	nudgeSettings,
 }: CheckoutSummaryProps) {
-	const { originalAmount, finalAmount } = payment;
+	const { originalAmount } = payment;
 	const urlParams = new URLSearchParams(window.location.search);
 	const showBackButton = urlParams.get('backButton') !== 'false';
 	const productCatalog = appConfig.productCatalog;
@@ -188,8 +188,7 @@ export default function CheckoutSummary({
 					ratePlanLabel={ratePlanDetail.displayName ?? ratePlanDetail.label}
 					taxRateConfig={taxRateConfig}
 					billingPeriod={ratePlanDetail.billingPeriod}
-					originalAmount={originalAmount}
-					finalAmount={finalAmount}
+					payment={payment}
 					promotion={promotion}
 					currency={currency}
 					checkListData={benefitsCheckListData}

--- a/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
@@ -116,8 +116,7 @@ Default.args = {
 	productLabel: 'Monthly support',
 	billingPeriod: BillingPeriod.Monthly,
 	enableCheckList: true,
-	originalAmount: 10,
-	finalAmount: 10,
+	payment: { originalAmount: 10, finalAmount: 10 },
 	currency: {
 		glyph: '£',
 		extendedGlyph: '£',
@@ -151,8 +150,7 @@ RecurringContribution.args = {
 	productLabel: getProductLabel(ProductKeys.Contribution),
 	billingPeriod: BillingPeriod.Monthly,
 	enableCheckList: true,
-	originalAmount: 3,
-	finalAmount: 3,
+	payment: { originalAmount: 3, finalAmount: 3 },
 	currency: {
 		glyph: '£',
 		extendedGlyph: '£',
@@ -189,8 +187,7 @@ SupporterPlus.args = {
 	billingPeriod: BillingPeriod.Monthly,
 	productLabel: getProductLabel(ProductKeys.SupporterPlusKey),
 	enableCheckList: true,
-	originalAmount: 12,
-	finalAmount: 12,
+	payment: { originalAmount: 12, finalAmount: 12 },
 	currency: {
 		glyph: '£',
 		extendedGlyph: '£',
@@ -228,8 +225,7 @@ SupporterPlusWithTax.args = {
 	billingPeriod: BillingPeriod.Monthly,
 	productLabel: getProductLabel(ProductKeys.SupporterPlusKey),
 	enableCheckList: true,
-	originalAmount: 15,
-	finalAmount: 15,
+	payment: { originalAmount: 15, finalAmount: 15 },
 	currency: {
 		glyph: '$',
 		extendedGlyph: 'CA$',
@@ -267,8 +263,7 @@ DigitalPlusWithTaxAndDiscount.args = {
 	billingPeriod: BillingPeriod.Monthly,
 	productLabel: getProductLabel(ProductKeys.DigitalSubscription),
 	enableCheckList: true,
-	finalAmount: 15,
-	originalAmount: 30,
+	payment: { finalAmount: 15, originalAmount: 30 },
 	currency: {
 		glyph: '$',
 		extendedGlyph: 'CA$',
@@ -317,8 +312,7 @@ DigitalSubscription.args = {
 	billingPeriod: BillingPeriod.Monthly,
 	productLabel: getProductLabel(ProductKeys.DigitalSubscription),
 	enableCheckList: true,
-	originalAmount: 27,
-	finalAmount: 27,
+	payment: { originalAmount: 27, finalAmount: 27 },
 	currency: {
 		glyph: '£',
 		extendedGlyph: '£',
@@ -364,8 +358,7 @@ StudentOneYear.args = {
 	productLabel: getProductLabel(ProductKeys.SupporterPlusKey),
 	billingPeriod: BillingPeriod.Annual,
 	enableCheckList: true,
-	originalAmount: 9,
-	finalAmount: 9,
+	payment: { originalAmount: 9, finalAmount: 9 },
 	currency: {
 		glyph: '£',
 		extendedGlyph: '£',
@@ -404,8 +397,7 @@ WeeklyPricing.args = {
 	productLabel: getProductLabel(ProductKeys.SupporterPlusKey),
 	billingPeriod: BillingPeriod.Monthly,
 	enableCheckList: true,
-	originalAmount: 12,
-	finalAmount: 12,
+	payment: { originalAmount: 12, finalAmount: 12 },
 	currency: {
 		glyph: '£',
 		extendedGlyph: '£',
@@ -443,8 +435,7 @@ WeeklyPricingWithPromotion.args = {
 	productLabel: getProductLabel(ProductKeys.SupporterPlusKey),
 	billingPeriod: BillingPeriod.Monthly,
 	enableCheckList: true,
-	originalAmount: 12,
-	finalAmount: 8,
+	payment: { originalAmount: 12, finalAmount: 8 },
 	currency: {
 		glyph: '£',
 		extendedGlyph: '£',

--- a/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
@@ -116,7 +116,8 @@ Default.args = {
 	productLabel: 'Monthly support',
 	billingPeriod: BillingPeriod.Monthly,
 	enableCheckList: true,
-	amount: 10,
+	originalAmount: 10,
+	finalAmount: 10,
 	currency: {
 		glyph: '£',
 		extendedGlyph: '£',
@@ -150,7 +151,8 @@ RecurringContribution.args = {
 	productLabel: getProductLabel(ProductKeys.Contribution),
 	billingPeriod: BillingPeriod.Monthly,
 	enableCheckList: true,
-	amount: 3,
+	originalAmount: 3,
+	finalAmount: 3,
 	currency: {
 		glyph: '£',
 		extendedGlyph: '£',
@@ -187,7 +189,8 @@ SupporterPlus.args = {
 	billingPeriod: BillingPeriod.Monthly,
 	productLabel: getProductLabel(ProductKeys.SupporterPlusKey),
 	enableCheckList: true,
-	amount: 12,
+	originalAmount: 12,
+	finalAmount: 12,
 	currency: {
 		glyph: '£',
 		extendedGlyph: '£',
@@ -225,7 +228,8 @@ SupporterPlusWithTax.args = {
 	billingPeriod: BillingPeriod.Monthly,
 	productLabel: getProductLabel(ProductKeys.SupporterPlusKey),
 	enableCheckList: true,
-	amount: 15,
+	originalAmount: 15,
+	finalAmount: 15,
 	currency: {
 		glyph: '$',
 		extendedGlyph: 'CA$',
@@ -263,7 +267,8 @@ DigitalPlusWithTaxAndDiscount.args = {
 	billingPeriod: BillingPeriod.Monthly,
 	productLabel: getProductLabel(ProductKeys.DigitalSubscription),
 	enableCheckList: true,
-	amount: 30,
+	finalAmount: 15,
+	originalAmount: 30,
 	currency: {
 		glyph: '$',
 		extendedGlyph: 'CA$',
@@ -312,7 +317,8 @@ DigitalSubscription.args = {
 	billingPeriod: BillingPeriod.Monthly,
 	productLabel: getProductLabel(ProductKeys.DigitalSubscription),
 	enableCheckList: true,
-	amount: 27,
+	originalAmount: 27,
+	finalAmount: 27,
 	currency: {
 		glyph: '£',
 		extendedGlyph: '£',
@@ -358,7 +364,8 @@ StudentOneYear.args = {
 	productLabel: getProductLabel(ProductKeys.SupporterPlusKey),
 	billingPeriod: BillingPeriod.Annual,
 	enableCheckList: true,
-	amount: 120,
+	originalAmount: 9,
+	finalAmount: 9,
 	currency: {
 		glyph: '£',
 		extendedGlyph: '£',
@@ -397,7 +404,8 @@ WeeklyPricing.args = {
 	productLabel: getProductLabel(ProductKeys.SupporterPlusKey),
 	billingPeriod: BillingPeriod.Monthly,
 	enableCheckList: true,
-	amount: 12,
+	originalAmount: 12,
+	finalAmount: 12,
 	currency: {
 		glyph: '£',
 		extendedGlyph: '£',
@@ -435,7 +443,8 @@ WeeklyPricingWithPromotion.args = {
 	productLabel: getProductLabel(ProductKeys.SupporterPlusKey),
 	billingPeriod: BillingPeriod.Monthly,
 	enableCheckList: true,
-	amount: 12,
+	originalAmount: 12,
+	finalAmount: 8,
 	currency: {
 		glyph: '£',
 		extendedGlyph: '£',

--- a/support-frontend/stories/checkouts/MaybeEstimatedTaxSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/MaybeEstimatedTaxSummary.stories.tsx
@@ -38,7 +38,8 @@ Template.args = {} as MaybeEstimatedTaxSummaryProps;
 export const TaxExclusive = Template.bind({});
 TaxExclusive.args = {
 	currency: getCurrencyInfo('CAD'),
-	amount: 120,
+	finalAmount: 120,
+	originalAmount: 120,
 	taxRateConfig: {
 		type: 'tax_exclusive',
 		rate: 0.13,
@@ -51,7 +52,8 @@ TaxExclusive.args = {
 export const NotEnoughInformation = Template.bind({});
 NotEnoughInformation.args = {
 	currency: getCurrencyInfo('CAD'),
-	amount: 20,
+	finalAmount: 20,
+	originalAmount: 20,
 	taxRateConfig: {
 		type: 'not_enough_information',
 	},
@@ -63,7 +65,8 @@ NotEnoughInformation.args = {
 export const WithDiscount = Template.bind({});
 WithDiscount.args = {
 	currency: getCurrencyInfo('CAD'),
-	amount: 60,
+	finalAmount: 60,
+	originalAmount: 60,
 	taxRateConfig: {
 		type: 'tax_exclusive',
 		rate: 0.13,

--- a/support-frontend/stories/checkouts/MaybeEstimatedTaxSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/MaybeEstimatedTaxSummary.stories.tsx
@@ -70,8 +70,8 @@ export const WithDiscount = Template.bind({});
 WithDiscount.args = {
 	currency: getCurrencyInfo('CAD'),
 	payment: {
+		originalAmount: 120,
 		finalAmount: 60,
-		originalAmount: 60,
 	},
 	taxRateConfig: {
 		type: 'tax_exclusive',

--- a/support-frontend/stories/checkouts/MaybeEstimatedTaxSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/MaybeEstimatedTaxSummary.stories.tsx
@@ -38,8 +38,10 @@ Template.args = {} as MaybeEstimatedTaxSummaryProps;
 export const TaxExclusive = Template.bind({});
 TaxExclusive.args = {
 	currency: getCurrencyInfo('CAD'),
-	finalAmount: 120,
-	originalAmount: 120,
+	payment: {
+		finalAmount: 120,
+		originalAmount: 120,
+	},
 	taxRateConfig: {
 		type: 'tax_exclusive',
 		rate: 0.13,
@@ -52,8 +54,10 @@ TaxExclusive.args = {
 export const NotEnoughInformation = Template.bind({});
 NotEnoughInformation.args = {
 	currency: getCurrencyInfo('CAD'),
-	finalAmount: 20,
-	originalAmount: 20,
+	payment: {
+		finalAmount: 20,
+		originalAmount: 20,
+	},
 	taxRateConfig: {
 		type: 'not_enough_information',
 	},
@@ -65,8 +69,10 @@ NotEnoughInformation.args = {
 export const WithDiscount = Template.bind({});
 WithDiscount.args = {
 	currency: getCurrencyInfo('CAD'),
-	finalAmount: 60,
-	originalAmount: 60,
+	payment: {
+		finalAmount: 60,
+		originalAmount: 60,
+	},
 	taxRateConfig: {
 		type: 'tax_exclusive',
 		rate: 0.13,


### PR DESCRIPTION
## What are you doing in this PR?
Rounding in Zuora is not lining up with rounding down within the checkout.

To correct this, the PR does:-
1. Tax Due = TotalInclDiscountPlusTax - TotalExcludingDiscountPlusTax
2. Rounds instead of Flooring tax amounts

[**Asana Card**](https://app.asana.com)

## Why are you doing this?
Mismatch between Zuora and the tax amounts shown in checkout.


## How to test

Goto ->
https://support.thegulocal.com/ca/checkout?product=SupporterPlus&ratePlan=MonthlyTaxExclusive&promoCode=TAX_EXCLUSIVE_SP
Select Qubec as province


## Screenshots


|before|after|
|----|----|
|<img width="876" height="812" alt="image" src="https://github.com/user-attachments/assets/007f3b3b-1405-40e5-9763-0a905d86cb2d" />|<img width="876" height="884" alt="image" src="https://github.com/user-attachments/assets/286cb803-8de5-4a78-a987-d981546feae5" />|

Updated screenshot, after changes to make the estimated tax + monthly price match the total:

<img width="610" height="190" alt="Screenshot 2026-07-14 at 13 10 37" src="https://github.com/user-attachments/assets/df50dad3-a80b-4ad8-819b-20e62123873b" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216432898293678