### PR TITLE
Show tax payable amount in Google / Apple Pay

### DIFF
--- a/support-frontend/assets/helpers/salesTax/getEstimatedSalesTaxConfig.ts
+++ b/support-frontend/assets/helpers/salesTax/getEstimatedSalesTaxConfig.ts
@@ -22,7 +22,7 @@ export type TaxRateConfig =
 			type: 'tax_inclusive';
 	  };
 
-function isCaState(value: string): value is CaStateCode {
+export function isCaState(value: string): value is CaStateCode {
 	return caStateCodes.includes(value as CaStateCode);
 }
 

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -774,6 +774,9 @@ export default function CheckoutForm({
 											options.shippingRates = [
 												{ id: 'free', displayName: 'Free', amount: 0 },
 											];
+											// The breakdown of pricing shown in the payment dialog
+											// Until the user selects a shipping address the tax
+											// shows as 'to be calculated'
 											options.lineItems = [
 												{
 													name: 'Subtotal (excl. tax)',
@@ -808,6 +811,8 @@ export default function CheckoutForm({
 											}
 
 											setBillingState(address.state);
+
+											// Get the correct tax config now that we have a province to calculate tax with
 											const updatedTaxConfig = getEstimatedSalesTaxConfig(
 												productCatalog,
 												appConfig.taxRates,
@@ -819,10 +824,10 @@ export default function CheckoutForm({
 
 											const taxAmount =
 												updatedTaxConfig.type === 'tax_exclusive'
-													? calculateTax(originalAmount, updatedTaxConfig.rate)
+													? calculateTax(finalAmount, updatedTaxConfig.rate)
 													: 0;
 
-											const totalWithTax = originalAmount + taxAmount;
+											const totalWithTax = finalAmount + taxAmount;
 
 											// Update the Elements amount so the sheet total reflects tax
 											void elements?.update({
@@ -830,10 +835,12 @@ export default function CheckoutForm({
 											});
 
 											resolve({
+												// Now that we have a tax amount we can
+												// show the correct pricing information
 												lineItems: [
 													{
 														name: 'Subtotal (excl. tax)',
-														amount: Math.round(originalAmount * 100),
+														amount: Math.round(finalAmount * 100),
 													},
 													{
 														name: 'Estimated tax',

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -6,7 +6,7 @@ import {
 	ErrorSummary,
 } from '@guardian/source-development-kitchen/react-components';
 import type { CountryCode } from '@modules/internationalisation/country';
-import type { SupportRegionId } from '@modules/internationalisation/countryGroup';
+import { SupportRegionId } from '@modules/internationalisation/countryGroup';
 import { BillingPeriod } from '@modules/product/billingPeriod';
 import {
 	ExpressCheckoutElement,
@@ -32,7 +32,7 @@ import type { AddressFormFieldError } from 'components/subscriptionCheckouts/add
 import type { Participations } from 'helpers/abTests/models';
 import { isContributionsOnlyCountry } from 'helpers/contributions';
 import useEmailMarketingUtmSession from 'helpers/customHooks/useEmailMarketingUtmSession';
-import { simpleFormatAmount } from 'helpers/forms/checkouts';
+import { calculateTax, simpleFormatAmount } from 'helpers/forms/checkouts';
 import { loadPayPalRecurring } from 'helpers/forms/paymentIntegrations/payPalRecurringCheckout';
 import {
 	isPaymentMethod,
@@ -51,6 +51,7 @@ import {
 import { getBillingPeriodNoun } from 'helpers/productPrice/billingPeriods';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import type { TaxRateConfig } from 'helpers/salesTax/getEstimatedSalesTaxConfig';
+import { getEstimatedSalesTaxConfig } from 'helpers/salesTax/getEstimatedSalesTaxConfig';
 import { useAbandonedBasketCookie } from 'helpers/storage/abandonedBasketCookies';
 import { sendEventPaymentMethodSelected } from 'helpers/tracking/quantumMetric';
 import type { CsrfState } from 'helpers/types/csrf';
@@ -751,9 +752,45 @@ export default function CheckoutForm({
 									}}
 									onClick={({ resolve }) => {
 										/** @see https://docs.stripe.com/elements/express-checkout-element/accept-a-payment?locale=en-GB#handle-click-event */
-										const options = {
-											emailRequired: true,
-										};
+										const isTaxExclusive =
+											taxRateConfig.type === 'tax_exclusive' ||
+											taxRateConfig.type === 'not_enough_information';
+
+										const options: NonNullable<Parameters<typeof resolve>[0]> =
+											{
+												emailRequired: true,
+											};
+
+										/**
+										 * For Canadian users, request an address inside the
+										 * payment sheet so we can calculate tax dynamically
+										 * via onShippingAddressChange before confirmation.
+										 * shippingRates is required by Stripe whenever
+										 * shippingAddressRequired is true.
+										 */
+										if (supportRegionId === SupportRegionId.CA) {
+											options.shippingAddressRequired = true;
+											options.shippingRates = [
+												{ id: 'free', displayName: 'Free', amount: 0 },
+											];
+										}
+
+										/**
+										 * When pricing is tax-exclusive (and we don't yet know
+										 * the province), show placeholder line items.
+										 */
+										if (isTaxExclusive) {
+											options.lineItems = [
+												{
+													name: 'Subtotal (excl. tax)',
+													amount: Math.round(finalAmount * 100),
+												},
+												{
+													name: 'Tax (to be calculated)',
+													amount: 0,
+												},
+											];
+										}
 
 										// Track payment method selection with QM
 										sendEventPaymentMethodSelected(
@@ -761,6 +798,51 @@ export default function CheckoutForm({
 										);
 
 										resolve(options);
+									}}
+									onShippingAddressChange={({ address, resolve, reject }) => {
+										/**
+										 * The "shipping" address is being used here as a proxy
+										 * for billing address, solely to obtain the Canadian
+										 * province before confirmation so that we can calculate
+										 * the tax and update the payment sheet total in real time.
+										 */
+										try {
+											const updatedTaxConfig = getEstimatedSalesTaxConfig(
+												productCatalog,
+												appConfig.taxRates,
+												productKey,
+												ratePlanKey,
+												address.state,
+												supportRegionId,
+											);
+
+											const taxAmount =
+												updatedTaxConfig.type === 'tax_exclusive'
+													? calculateTax(originalAmount, updatedTaxConfig.rate)
+													: 0;
+
+											const totalWithTax = originalAmount + taxAmount;
+
+											// Update the Elements amount so the sheet total reflects tax
+											void elements?.update({
+												amount: Math.round(totalWithTax * 100),
+											});
+
+											resolve({
+												lineItems: [
+													{
+														name: 'Subtotal (excl. tax)',
+														amount: Math.round(originalAmount * 100),
+													},
+													{
+														name: 'Estimated tax',
+														amount: Math.round(taxAmount * 100),
+													},
+												],
+											});
+										} catch {
+											reject();
+										}
 									}}
 									onConfirm={async (event) => {
 										if (!(stripe && elements)) {

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -682,19 +682,21 @@ export default function CheckoutForm({
 		? `for${isWeeklyGift ? '' : ' a'}`
 		: 'per';
 
+	const taxExclusive =
+		taxRateConfig.type === 'tax_exclusive' ||
+		taxRateConfig.type === 'not_enough_information';
+
 	// When pricing is tax exclusive the button copy is simply "Pay now" because
 	// there's a summary of the price just above.
-	const buttonText =
-		taxRateConfig.type === 'tax_exclusive' ||
-		taxRateConfig.type === 'not_enough_information'
-			? 'Pay now'
-			: `Pay ${simpleFormatAmount(
-					currency,
-					finalAmount,
-			  )} ${billingPreposition} ${getBillingPeriodNoun(
-					billingPeriod,
-					isWeeklyGift,
-			  )}`;
+	const buttonText = taxExclusive
+		? 'Pay now'
+		: `Pay ${simpleFormatAmount(
+				currency,
+				finalAmount,
+		  )} ${billingPreposition} ${getBillingPeriodNoun(
+				billingPeriod,
+				isWeeklyGift,
+		  )}`;
 
 	const useExpressPostcodeLookup =
 		abParticipations.postCodeLookupExpress === 'variant';
@@ -755,10 +757,6 @@ export default function CheckoutForm({
 									}}
 									onClick={({ resolve }) => {
 										/** @see https://docs.stripe.com/elements/express-checkout-element/accept-a-payment?locale=en-GB#handle-click-event */
-										const taxExclusive =
-											taxRateConfig.type === 'tax_exclusive' ||
-											taxRateConfig.type === 'not_enough_information';
-
 										const options: NonNullable<Parameters<typeof resolve>[0]> =
 											{
 												emailRequired: true,

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -6,7 +6,7 @@ import {
 	ErrorSummary,
 } from '@guardian/source-development-kitchen/react-components';
 import type { CountryCode } from '@modules/internationalisation/country';
-import { SupportRegionId } from '@modules/internationalisation/countryGroup';
+import type { SupportRegionId } from '@modules/internationalisation/countryGroup';
 import { BillingPeriod } from '@modules/product/billingPeriod';
 import {
 	ExpressCheckoutElement,
@@ -51,7 +51,10 @@ import {
 import { getBillingPeriodNoun } from 'helpers/productPrice/billingPeriods';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import type { TaxRateConfig } from 'helpers/salesTax/getEstimatedSalesTaxConfig';
-import { getEstimatedSalesTaxConfig } from 'helpers/salesTax/getEstimatedSalesTaxConfig';
+import {
+	getEstimatedSalesTaxConfig,
+	isCaState,
+} from 'helpers/salesTax/getEstimatedSalesTaxConfig';
 import { useAbandonedBasketCookie } from 'helpers/storage/abandonedBasketCookies';
 import { sendEventPaymentMethodSelected } from 'helpers/tracking/quantumMetric';
 import type { CsrfState } from 'helpers/types/csrf';
@@ -752,7 +755,7 @@ export default function CheckoutForm({
 									}}
 									onClick={({ resolve }) => {
 										/** @see https://docs.stripe.com/elements/express-checkout-element/accept-a-payment?locale=en-GB#handle-click-event */
-										const isTaxExclusive =
+										const taxExclusive =
 											taxRateConfig.type === 'tax_exclusive' ||
 											taxRateConfig.type === 'not_enough_information';
 
@@ -762,24 +765,17 @@ export default function CheckoutForm({
 											};
 
 										/**
-										 * For Canadian users, request an address inside the
+										 * For tax exclusive rate plans, request an address inside the
 										 * payment sheet so we can calculate tax dynamically
 										 * via onShippingAddressChange before confirmation.
 										 * shippingRates is required by Stripe whenever
 										 * shippingAddressRequired is true.
 										 */
-										if (supportRegionId === SupportRegionId.CA) {
+										if (taxExclusive) {
 											options.shippingAddressRequired = true;
 											options.shippingRates = [
 												{ id: 'free', displayName: 'Free', amount: 0 },
 											];
-										}
-
-										/**
-										 * When pricing is tax-exclusive (and we don't yet know
-										 * the province), show placeholder line items.
-										 */
-										if (isTaxExclusive) {
 											options.lineItems = [
 												{
 													name: 'Subtotal (excl. tax)',
@@ -804,9 +800,16 @@ export default function CheckoutForm({
 										 * The "shipping" address is being used here as a proxy
 										 * for billing address, solely to obtain the Canadian
 										 * province before confirmation so that we can calculate
-										 * the tax and update the payment sheet total in real time.
+										 * the tax and update the payment total in real time.
 										 */
 										try {
+											// Currently this will only work for Canada because of a
+											// similar check in getEstimatedSalesTaxConfig
+											if (!isCaState(address.state)) {
+												return;
+											}
+
+											setBillingState(address.state);
 											const updatedTaxConfig = getEstimatedSalesTaxConfig(
 												productCatalog,
 												appConfig.taxRates,
@@ -872,13 +875,13 @@ export default function CheckoutForm({
 										setFirstName(firstName);
 										setLastName(lastName);
 
-										event.billingDetails?.address.postal_code &&
+										event.shippingAddress?.address.postal_code &&
 											setBillingPostcode(
-												event.billingDetails.address.postal_code,
+												event.shippingAddress.address.postal_code,
 											);
 
 										if (
-											!event.billingDetails?.address.state &&
+											!event.shippingAddress?.address.state &&
 											countriesRequiringBillingState.includes(countryId)
 										) {
 											logException(
@@ -886,8 +889,8 @@ export default function CheckoutForm({
 												{ supportRegionId, countryGroupId, countryId },
 											);
 										}
-										event.billingDetails?.address.state &&
-											setBillingState(event.billingDetails.address.state);
+										event.shippingAddress?.address.state &&
+											setBillingState(event.shippingAddress.address.state);
 
 										event.billingDetails?.email &&
 											setEmail(event.billingDetails.email);


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
The Apple / Google pay button on the checkout is before the address fields. If a user selects it they will never get to the address fields because the form auto submits once the payment button modal is completed.

#### Apple Pay button on the checkout:
<img width="640" height="510" alt="image" src="https://github.com/user-attachments/assets/0d603a8a-65e2-44be-bdc5-8e0c5c49b02a" />

This flow causes problems in Canada because we need to know the province of the user to calculate the tax that they should pay and to communicate this amount on the payment button modal.

To fix this we can make the payment method require a shipping address and then listen for a shipping address change event. When we receive that event we can then set the state in the checkout form, calculate the tax and update the payment modal.

### Paying with Apple Pay
#### The payment modal now requires a shipping address:
<img width="320" alt="image" src="https://github.com/user-attachments/assets/b48d07b0-a83a-4ef6-a932-c0680f403062" />


#### When it is set we can update the amount to include tax:
<img width="320" alt="image" src="https://github.com/user-attachments/assets/b0815eba-83b7-4cb5-b567-2ea16837f362" />




[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1216401012799457)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
- Deploy to CODE - Google Pay works locally but Apple Pay doesn't because it will only work on a publicly accessible a whitelisted URL
- Go to [non-promo-url](https://support.code.dev-theguardian.com/ca/checkout?product=SupporterPlus&ratePlan=MonthlyTaxExclusive) / [promo url](https://support.code.dev-theguardian.com/ca/checkout?product=SupporterPlus&ratePlan=MonthlyTaxExclusive&promoCode=TAX_EXCLUSIVE_SP)) using one of the following browser configurations:
    - Chrome with Google Pay enabled on your signed in account (this will need to be a non-guardian gmail account)
    - Safari with Apple Pay enabled on your signed in account.

By signed in here I mean the account / profile your browser is using, NOT an identity sign in on the support site 