### PR TITLE
Show estimated tax alongside weekly pricing

### DIFF
--- a/support-frontend/assets/components/orderSummary/priceBreakdown.tsx
+++ b/support-frontend/assets/components/orderSummary/priceBreakdown.tsx
@@ -88,9 +88,12 @@ export function PriceBreakdown({
 	const paymentFrequency = getBillingPeriodNoun(billingPeriod, isWeeklyGift);
 	const period = studentDiscount?.periodNoun ?? paymentFrequency;
 
-	// Ignore tax calculation for weekly pricing, we'll revisit this if
-	// we want to show weekly prices for tax exclusive rate plans in Canada
 	if (weeklyPrice) {
+		const billingPeriodLabel =
+			taxRateConfig.type === 'tax_inclusive'
+				? `Total due every ${period}`
+				: `Billed each ${period}`;
+
 		return (
 			<div css={weeklyPricingSummary}>
 				<div css={summaryRow}>
@@ -98,9 +101,19 @@ export function PriceBreakdown({
 					<p>{weeklyPrice}</p>
 				</div>
 				<div css={[summaryRow, boldText]}>
-					<p>Total due every {period}</p>
+					<p>{billingPeriodLabel}</p>
 					<p>{discountPrice ?? fullPrice}</p>
 				</div>
+				<MaybeEstimatedTax
+					currency={currency}
+					// This doesn't handle student discounts currently because
+					// they're never tax exclusive, but if this changes we'll
+					// need to revisit this payment prop.
+					payment={payment}
+					taxRateConfig={taxRateConfig}
+				>
+					<TaxTsAndCs />
+				</MaybeEstimatedTax>
 				{savingText && (
 					<div>
 						<hr css={hrCss} />

--- a/support-frontend/assets/components/orderSummary/taxTsAndCs.tsx
+++ b/support-frontend/assets/components/orderSummary/taxTsAndCs.tsx
@@ -2,7 +2,9 @@ import { css } from '@emotion/react';
 import { neutral, space, textSans12 } from '@guardian/source/foundations';
 
 const tsAndCsContainer = css`
-	padding: ${space[2]}px 0 0 0;
+	// In the weekly pricing context, child divs are given a padding of 0, we
+	// need to override that here.
+	padding: ${space[2]}px 0 0 0 !important;
 `;
 
 const tsAndCsText = css`

--- a/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
@@ -475,3 +475,41 @@ WeeklyPricingWithPromotion.args = {
 	landingPageSettings: weeklyPricingLandingPageSettings,
 	taxRateConfig: { type: 'tax_inclusive' },
 };
+
+export const WeeklyPricingWithTax = Template.bind({});
+WeeklyPricingWithTax.args = {
+	productKey: ProductKeys.SupporterPlusKey,
+	ratePlanKey: 'Monthly',
+	productLabel: getProductLabel(ProductKeys.SupporterPlusKey),
+	billingPeriod: BillingPeriod.Monthly,
+	enableCheckList: true,
+	payment: { originalAmount: 15, finalAmount: 15 },
+	currency: {
+		glyph: '$',
+		extendedGlyph: 'CA$',
+		spokenCurrency: 'dollar',
+	},
+	checkListData: [
+		...productCatalogDescription.SupporterPlus.benefits.map((benefit) => ({
+			isChecked: true,
+			text: benefit.copy,
+		})),
+	],
+	tsAndCs: (
+		<OrderSummaryTsAndCs
+			productKey={'SupporterPlus'}
+			ratePlanKey={'Monthly'}
+			countryGroupId={Canada}
+			thresholdAmount={15}
+		/>
+	),
+	startDate: null,
+	headerButton: (
+		<Button priority="tertiary" size="xsmall">
+			Change
+		</Button>
+	),
+	supportRegionId: SupportRegionId.CA,
+	landingPageSettings: weeklyPricingLandingPageSettings,
+	taxRateConfig: { type: 'tax_exclusive', rate: 0.15 },
+};


### PR DESCRIPTION
## What are you doing in this PR?

Show estimated tax on the checkout alongside weekly pricing.

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1216358146004940)

## Why are you doing this?

In previous PRs we didn't think we'd be showing tax exclusive rate plans in combination with showing weekly pricing, but this is required.

## How to test

Visit the checkout with a tax exclusive rate plan and force weekly pricing to display (this can be achieved by adding `force-weekly=true` to the query string).

## Screenshots

<img width="614" height="375" alt="Screenshot 2026-07-15 at 12 04 08" src="https://github.com/user-attachments/assets/26e39184-69a4-4494-9495-52fcefafc072" />

<img width="610" height="353" alt="Screenshot 2026-07-15 at 12 17 08" src="https://github.com/user-attachments/assets/a11c5f16-fde6-4334-9563-4dd15f31eb94" />
