### PR TITLE
Checkout: Stripe Card Complete Checks

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -1130,10 +1130,12 @@ export default function CheckoutForm({
 																cardNumber: event.complete,
 															}));
 
-															// Clear errors when the field changes, we'll (re) show errors, if any, on submit
+															// Clear errors when the field changes and complete, we'll (re) show errors, if any, on submit
 															setStripeFieldError((prevState) => ({
 																...prevState,
-																cardNumber: undefined,
+																cardNumber: event.complete
+																	? undefined
+																	: prevState.cardNumber,
 															}));
 														}}
 														onExpiryChange={(
@@ -1148,10 +1150,12 @@ export default function CheckoutForm({
 																expiry: event.complete,
 															}));
 
-															// Clear errors when the field changes, we'll (re) show errors, if any, on submit
+															// Clear errors when the field changes and complete, we'll (re) show errors, if any, on submit
 															setStripeFieldError((prevState) => ({
 																...prevState,
-																expiry: undefined,
+																expiry: event.complete
+																	? undefined
+																	: prevState.expiry,
 															}));
 														}}
 														onCvcChange={(
@@ -1166,10 +1170,10 @@ export default function CheckoutForm({
 																cvc: event.complete,
 															}));
 
-															// Clear errors when the field changes, we'll (re) show errors, if any, on submit
+															// Clear errors when the field changes and complete, we'll (re) show errors, if any, on submit
 															setStripeFieldError((prevState) => ({
 																...prevState,
-																cvc: undefined,
+																cvc: event.complete ? undefined : prevState.cvc,
 															}));
 														}}
 														errors={{

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -1128,7 +1128,7 @@ export default function CheckoutForm({
 																cardNumber: event.complete,
 															}));
 
-															// Clear errors when the field changes and is complete; we'll (re) show errors, if any, on submit
+															// Clear errors when the field changes and is complete, we'll (re) show errors, if any, on submit
 															setStripeFieldError((prevState) => ({
 																...prevState,
 																cardNumber: event.complete
@@ -1148,7 +1148,7 @@ export default function CheckoutForm({
 																expiry: event.complete,
 															}));
 
-															// Clear errors when the field changes and is complete; we'll (re) show errors, if any, on submit
+															// Clear errors when the field changes and is complete, we'll (re) show errors, if any, on submit
 															setStripeFieldError((prevState) => ({
 																...prevState,
 																expiry: event.complete
@@ -1168,7 +1168,7 @@ export default function CheckoutForm({
 																cvc: event.complete,
 															}));
 
-															// Clear errors when the field changes and is complete; we'll (re) show errors, if any, on submit
+															// Clear errors when the field changes and is complete, we'll (re) show errors, if any, on submit
 															setStripeFieldError((prevState) => ({
 																...prevState,
 																cvc: event.complete ? undefined : prevState.cvc,

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -1019,9 +1019,11 @@ export default function CheckoutForm({
 														onCardNumberChange={(
 															event: StripeCardNumberElementChangeEvent,
 														) => {
+															const isNotEmptyAndComplete =
+																!event.empty && event.complete;
 															setStripeFieldsAreEmpty((prevState) => ({
 																...prevState,
-																cardNumber: event.empty,
+																cardNumber: !isNotEmptyAndComplete,
 															}));
 
 															// Clear errors when the field changes, we'll (re) show errors, if any, on submit
@@ -1033,9 +1035,11 @@ export default function CheckoutForm({
 														onExpiryChange={(
 															event: StripeCardExpiryElementChangeEvent,
 														) => {
+															const isNotEmptyAndComplete =
+																!event.empty && event.complete;
 															setStripeFieldsAreEmpty((prevState) => ({
 																...prevState,
-																expiry: event.empty,
+																expiry: !isNotEmptyAndComplete,
 															}));
 
 															// Clear errors when the field changes, we'll (re) show errors, if any, on submit
@@ -1047,9 +1051,11 @@ export default function CheckoutForm({
 														onCvcChange={(
 															event: StripeCardCvcElementChangeEvent,
 														) => {
+															const isNotEmptyAndComplete =
+																!event.empty && event.complete;
 															setStripeFieldsAreEmpty((prevState) => ({
 																...prevState,
-																cvc: event.empty,
+																cvc: !isNotEmptyAndComplete,
 															}));
 
 															// Clear errors when the field changes, we'll (re) show errors, if any, on submit

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -279,9 +279,9 @@ export default function CheckoutForm({
 	const [stripeFieldsAreEmpty, setStripeFieldsAreEmpty] = useState<
 		Record<StripeOnlyField, boolean>
 	>({ cardNumber: true, expiry: true, cvc: true });
-const [stripeFieldsAreComplete, setStripeFieldsAreComplete] = useState<
-	Record<StripeOnlyField, boolean>
->({ cardNumber: false, expiry: false, cvc: false });
+	const [stripeFieldsAreComplete, setStripeFieldsAreComplete] = useState<
+		Record<StripeOnlyField, boolean>
+	>({ cardNumber: false, expiry: false, cvc: false });
 	type StripeField = StripeOnlyField | 'recaptcha';
 	const [stripeFieldError, setStripeFieldError] = useState<
 		Partial<Record<StripeField, string>>
@@ -1128,7 +1128,7 @@ const [stripeFieldsAreComplete, setStripeFieldsAreComplete] = useState<
 																cardNumber: event.complete,
 															}));
 
-// Clear errors when the field changes and is complete; we'll (re) show errors, if any, on submit
+															// Clear errors when the field changes and is complete; we'll (re) show errors, if any, on submit
 															setStripeFieldError((prevState) => ({
 																...prevState,
 																cardNumber: event.complete
@@ -1148,7 +1148,7 @@ const [stripeFieldsAreComplete, setStripeFieldsAreComplete] = useState<
 																expiry: event.complete,
 															}));
 
-// Clear errors when the field changes and is complete; we'll (re) show errors, if any, on submit
+															// Clear errors when the field changes and is complete; we'll (re) show errors, if any, on submit
 															setStripeFieldError((prevState) => ({
 																...prevState,
 																expiry: event.complete
@@ -1168,7 +1168,7 @@ const [stripeFieldsAreComplete, setStripeFieldsAreComplete] = useState<
 																cvc: event.complete,
 															}));
 
-// Clear errors when the field changes and is complete; we'll (re) show errors, if any, on submit
+															// Clear errors when the field changes and is complete; we'll (re) show errors, if any, on submit
 															setStripeFieldError((prevState) => ({
 																...prevState,
 																cvc: event.complete ? undefined : prevState.cvc,

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -279,9 +279,9 @@ export default function CheckoutForm({
 	const [stripeFieldsAreEmpty, setStripeFieldsAreEmpty] = useState<
 		Record<StripeOnlyField, boolean>
 	>({ cardNumber: true, expiry: true, cvc: true });
-	const [stripeFieldsAreComplete, setStripeFieldsAreComplete] = useState<
+	const [stripeFieldsAreIncomplete, setStripeFieldsAreIncomplete] = useState<
 		Record<StripeOnlyField, boolean>
-	>({ cardNumber: false, expiry: false, cvc: false });
+	>({ cardNumber: true, expiry: true, cvc: true });
 	type StripeField = StripeOnlyField | 'recaptcha';
 	const [stripeFieldError, setStripeFieldError] = useState<
 		Partial<Record<StripeField, string>>

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -1168,7 +1168,7 @@ const [stripeFieldsAreComplete, setStripeFieldsAreComplete] = useState<
 																cvc: event.complete,
 															}));
 
-															// Clear errors when the field changes and complete, we'll (re) show errors, if any, on submit
+// Clear errors when the field changes and is complete; we'll (re) show errors, if any, on submit
 															setStripeFieldError((prevState) => ({
 																...prevState,
 																cvc: event.complete ? undefined : prevState.cvc,

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -279,9 +279,9 @@ export default function CheckoutForm({
 	const [stripeFieldsAreEmpty, setStripeFieldsAreEmpty] = useState<
 		Record<StripeOnlyField, boolean>
 	>({ cardNumber: true, expiry: true, cvc: true });
-	const [stripeFieldsAreComplete, setStripeFieldsAreComplete] = useState<
-		Record<StripeOnlyField, boolean>
-	>({ cardNumber: true, expiry: true, cvc: true });
+const [stripeFieldsAreComplete, setStripeFieldsAreComplete] = useState<
+	Record<StripeOnlyField, boolean>
+>({ cardNumber: false, expiry: false, cvc: false });
 	type StripeField = StripeOnlyField | 'recaptcha';
 	const [stripeFieldError, setStripeFieldError] = useState<
 		Partial<Record<StripeField, string>>

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -1128,7 +1128,7 @@ const [stripeFieldsAreComplete, setStripeFieldsAreComplete] = useState<
 																cardNumber: event.complete,
 															}));
 
-															// Clear errors when the field changes and complete, we'll (re) show errors, if any, on submit
+// Clear errors when the field changes and is complete; we'll (re) show errors, if any, on submit
 															setStripeFieldError((prevState) => ({
 																...prevState,
 																cardNumber: event.complete

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -570,12 +570,10 @@ export default function CheckoutForm({
 				// Recaptcha works slightly differently because we own the state
 				...(!recaptchaToken && { recaptcha: 'Please complete security check' }),
 			};
-			console.log('*** newStripeFieldError', newStripeFieldError);
 
 			// Don't go any further if there are errors for any Stripe fields
 			if (Object.values(newStripeFieldError).some((value) => value)) {
 				setStripeFieldError(newStripeFieldError);
-				console.log('*** stripeFieldError set to ', stripeFieldError);
 				paymentMethodRef.current?.scrollIntoView({ behavior: 'smooth' });
 				return false;
 			}

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -1148,7 +1148,7 @@ const [stripeFieldsAreComplete, setStripeFieldsAreComplete] = useState<
 																expiry: event.complete,
 															}));
 
-															// Clear errors when the field changes and complete, we'll (re) show errors, if any, on submit
+// Clear errors when the field changes and is complete; we'll (re) show errors, if any, on submit
 															setStripeFieldError((prevState) => ({
 																...prevState,
 																expiry: event.complete

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -553,19 +553,21 @@ export default function CheckoutForm({
 		if (paymentMethod === 'Stripe') {
 			const newStripeFieldError: Partial<Record<StripeField, string>> = {
 				...((stripeFieldsAreEmpty.cardNumber ||
-					!stripeFieldsAreComplete.cardNumber) && {
+					stripeFieldsAreIncomplete.cardNumber) && {
 					cardNumber: `Please enter ${
-						!stripeFieldsAreEmpty.cardNumber ? 'a valid ' : ''
+						stripeFieldsAreIncomplete.cardNumber ? 'a valid ' : ''
 					}card number`,
 				}),
 				...((stripeFieldsAreEmpty.expiry ||
-					!stripeFieldsAreComplete.expiry) && {
+					stripeFieldsAreIncomplete.expiry) && {
 					expiry: `Please enter ${
-						!stripeFieldsAreEmpty.expiry ? 'a valid ' : ''
+						stripeFieldsAreIncomplete.expiry ? 'a valid ' : ''
 					}expiry`,
 				}),
-				...((stripeFieldsAreEmpty.cvc || !stripeFieldsAreComplete.cvc) && {
-					cvc: `Please enter ${!stripeFieldsAreEmpty.cvc ? 'a valid ' : ''}CVC`,
+				...((stripeFieldsAreEmpty.cvc || stripeFieldsAreIncomplete.cvc) && {
+					cvc: `Please enter ${
+						stripeFieldsAreIncomplete.cvc ? 'a valid ' : ''
+					}CVC`,
 				}),
 				// Recaptcha works slightly differently because we own the state
 				...(!recaptchaToken && { recaptcha: 'Please complete security check' }),
@@ -1123,9 +1125,9 @@ export default function CheckoutForm({
 																...prevState,
 																cardNumber: event.empty,
 															}));
-															setStripeFieldsAreComplete((prevState) => ({
+															setStripeFieldsAreIncomplete((prevState) => ({
 																...prevState,
-																cardNumber: event.complete,
+																cardNumber: !event.complete,
 															}));
 
 															// Clear errors when the field changes and is complete, we'll (re) show errors, if any, on submit
@@ -1143,9 +1145,9 @@ export default function CheckoutForm({
 																...prevState,
 																expiry: event.empty,
 															}));
-															setStripeFieldsAreComplete((prevState) => ({
+															setStripeFieldsAreIncomplete((prevState) => ({
 																...prevState,
-																expiry: event.complete,
+																expiry: !event.complete,
 															}));
 
 															// Clear errors when the field changes and is complete, we'll (re) show errors, if any, on submit
@@ -1163,9 +1165,9 @@ export default function CheckoutForm({
 																...prevState,
 																cvc: event.empty,
 															}));
-															setStripeFieldsAreComplete((prevState) => ({
+															setStripeFieldsAreIncomplete((prevState) => ({
 																...prevState,
-																cvc: event.complete,
+																cvc: !event.complete,
 															}));
 
 															// Clear errors when the field changes and is complete, we'll (re) show errors, if any, on submit

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -551,23 +551,20 @@ export default function CheckoutForm({
 		}
 
 		if (paymentMethod === 'Stripe') {
+			const stripeErrorMessageStart = `Please enter ${
+				stripeFieldsAreIncomplete.cardNumber ? 'a valid ' : ''
+			}`;
 			const newStripeFieldError: Partial<Record<StripeField, string>> = {
 				...((stripeFieldsAreEmpty.cardNumber ||
 					stripeFieldsAreIncomplete.cardNumber) && {
-					cardNumber: `Please enter ${
-						stripeFieldsAreIncomplete.cardNumber ? 'a valid ' : ''
-					}card number`,
+					cardNumber: `${stripeErrorMessageStart}card number`,
 				}),
 				...((stripeFieldsAreEmpty.expiry ||
 					stripeFieldsAreIncomplete.expiry) && {
-					expiry: `Please enter ${
-						stripeFieldsAreIncomplete.expiry ? 'a valid ' : ''
-					}expiry`,
+					expiry: `${stripeErrorMessageStart}expiry`,
 				}),
 				...((stripeFieldsAreEmpty.cvc || stripeFieldsAreIncomplete.cvc) && {
-					cvc: `Please enter ${
-						stripeFieldsAreIncomplete.cvc ? 'a valid ' : ''
-					}CVC`,
+					cvc: `${stripeErrorMessageStart}CVC`,
 				}),
 				// Recaptcha works slightly differently because we own the state
 				...(!recaptchaToken && { recaptcha: 'Please complete security check' }),

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -279,6 +279,9 @@ export default function CheckoutForm({
 	const [stripeFieldsAreEmpty, setStripeFieldsAreEmpty] = useState<
 		Record<StripeOnlyField, boolean>
 	>({ cardNumber: true, expiry: true, cvc: true });
+	const [stripeFieldsAreComplete, setStripeFieldsAreComplete] = useState<
+		Record<StripeOnlyField, boolean>
+	>({ cardNumber: true, expiry: true, cvc: true });
 	type StripeField = StripeOnlyField | 'recaptcha';
 	const [stripeFieldError, setStripeFieldError] = useState<
 		Partial<Record<StripeField, string>>
@@ -548,23 +551,31 @@ export default function CheckoutForm({
 		}
 
 		if (paymentMethod === 'Stripe') {
-			const newStripeFieldError = {
-				...(stripeFieldsAreEmpty.cardNumber && {
-					cardNumber: 'Please enter card number',
+			const newStripeFieldError: Partial<Record<StripeField, string>> = {
+				...((stripeFieldsAreEmpty.cardNumber ||
+					!stripeFieldsAreComplete.cardNumber) && {
+					cardNumber: `Please enter ${
+						!stripeFieldsAreEmpty.cardNumber ? 'a valid ' : ''
+					}card number`,
 				}),
-				...(stripeFieldsAreEmpty.expiry && {
-					expiry: 'Please enter expiry',
+				...((stripeFieldsAreEmpty.expiry ||
+					!stripeFieldsAreComplete.expiry) && {
+					expiry: `Please enter ${
+						!stripeFieldsAreEmpty.expiry ? 'a valid ' : ''
+					}expiry`,
 				}),
-				...(stripeFieldsAreEmpty.cvc && {
-					cvc: 'Please enter CVC',
+				...((stripeFieldsAreEmpty.cvc || !stripeFieldsAreComplete.cvc) && {
+					cvc: `Please enter ${!stripeFieldsAreEmpty.cvc ? 'a valid ' : ''}CVC`,
 				}),
 				// Recaptcha works slightly differently because we own the state
 				...(!recaptchaToken && { recaptcha: 'Please complete security check' }),
 			};
+			console.log('*** newStripeFieldError', newStripeFieldError);
 
 			// Don't go any further if there are errors for any Stripe fields
 			if (Object.values(newStripeFieldError).some((value) => value)) {
 				setStripeFieldError(newStripeFieldError);
+				console.log('*** stripeFieldError set to ', stripeFieldError);
 				paymentMethodRef.current?.scrollIntoView({ behavior: 'smooth' });
 				return false;
 			}
@@ -1110,11 +1121,13 @@ export default function CheckoutForm({
 														onCardNumberChange={(
 															event: StripeCardNumberElementChangeEvent,
 														) => {
-															const isNotEmptyAndComplete =
-																!event.empty && event.complete;
 															setStripeFieldsAreEmpty((prevState) => ({
 																...prevState,
-																cardNumber: !isNotEmptyAndComplete,
+																cardNumber: event.empty,
+															}));
+															setStripeFieldsAreComplete((prevState) => ({
+																...prevState,
+																cardNumber: event.complete,
 															}));
 
 															// Clear errors when the field changes, we'll (re) show errors, if any, on submit
@@ -1126,11 +1139,13 @@ export default function CheckoutForm({
 														onExpiryChange={(
 															event: StripeCardExpiryElementChangeEvent,
 														) => {
-															const isNotEmptyAndComplete =
-																!event.empty && event.complete;
 															setStripeFieldsAreEmpty((prevState) => ({
 																...prevState,
-																expiry: !isNotEmptyAndComplete,
+																expiry: event.empty,
+															}));
+															setStripeFieldsAreComplete((prevState) => ({
+																...prevState,
+																expiry: event.complete,
 															}));
 
 															// Clear errors when the field changes, we'll (re) show errors, if any, on submit
@@ -1142,11 +1157,13 @@ export default function CheckoutForm({
 														onCvcChange={(
 															event: StripeCardCvcElementChangeEvent,
 														) => {
-															const isNotEmptyAndComplete =
-																!event.empty && event.complete;
 															setStripeFieldsAreEmpty((prevState) => ({
 																...prevState,
-																cvc: !isNotEmptyAndComplete,
+																cvc: event.empty,
+															}));
+															setStripeFieldsAreComplete((prevState) => ({
+																...prevState,
+																cvc: event.complete,
 															}));
 
 															// Clear errors when the field changes, we'll (re) show errors, if any, on submit


### PR DESCRIPTION
## What are you doing in this PR?
Adds Stripe Complete checks to creditCard->
- Number
- Expiry
- CVID
These checks will fire before the card details are processed. `Valid` inserted in error messages.


## How to test

1.  Goto https://support.thegulocal.com/uk/checkout?product=SupporterPlus&ratePlan=Monthly
2. Enter 1 into CardNumber/Expiry/CVID
3. Submit 'Pay' CTA

Processing Items now will not come up efore the validation is shown, `valid` has been inserted in error messages.

## Screenshots
|empty errors (both)|incomplete errors(current)|incomplete errors (new)|
|----|----|----|
|<img width="617" height="442" alt="image" src="https://github.com/user-attachments/assets/7e3cc989-9e04-4129-b102-bd3e3f9df401" />|<img width="617" height="382" alt="image" src="https://github.com/user-attachments/assets/8bf5eabb-0e29-4300-a6fd-8f7ab08154b3" />|<img width="617" height="442" alt="image" src="https://github.com/user-attachments/assets/f22555aa-8fc9-4bc8-8a9b-6cdb44828702" />|




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215932237102220