### PR TITLE
Update support-service-lambdas

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ catalogs:
       specifier: ^2.1.5
       version: 2.1.5
     '@guardian/support-service-lambdas':
-      specifier: github:guardian/support-service-lambdas#1152744344505d8612ae5fa436c2b3e5bf2bf4e6
+      specifier: github:guardian/support-service-lambdas#05e69bdc42ab1c95a6573d58068c5a2753d013cb
       version: 1.0.0
     '@types/jest':
       specifier: ^29.5.14
@@ -153,7 +153,7 @@ importers:
     devDependencies:
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1152744344505d8612ae5fa436c2b3e5bf2bf4e6
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/05e69bdc42ab1c95a6573d58068c5a2753d013cb
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.0
@@ -272,7 +272,7 @@ importers:
         version: 18.1.1(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.5.4))(@guardian/source@10.2.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1152744344505d8612ae5fa436c2b3e5bf2bf4e6
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/05e69bdc42ab1c95a6573d58068c5a2753d013cb
       '@guardian/tsconfig':
         specifier: ^0.2.0
         version: 0.2.0
@@ -513,7 +513,7 @@ importers:
         version: 8.1.1
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1152744344505d8612ae5fa436c2b3e5bf2bf4e6
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/05e69bdc42ab1c95a6573d58068c5a2753d013cb
       aws-lambda:
         specifier: ^1.0.7
         version: 1.0.7
@@ -580,7 +580,7 @@ importers:
         version: 3.995.0(@aws-sdk/client-dynamodb@3.1015.0)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1152744344505d8612ae5fa436c2b3e5bf2bf4e6
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/05e69bdc42ab1c95a6573d58068c5a2753d013cb
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -2434,8 +2434,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1152744344505d8612ae5fa436c2b3e5bf2bf4e6':
-    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1152744344505d8612ae5fa436c2b3e5bf2bf4e6}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/05e69bdc42ab1c95a6573d58068c5a2753d013cb':
+    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/05e69bdc42ab1c95a6573d58068c5a2753d013cb}
     version: 1.0.0
 
   '@guardian/tsconfig@0.2.0':
@@ -11240,7 +11240,7 @@ snapshots:
       react: 18.2.0
       typescript: 5.5.4
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1152744344505d8612ae5fa436c2b3e5bf2bf4e6': {}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/05e69bdc42ab1c95a6573d58068c5a2753d013cb': {}
 
   '@guardian/tsconfig@0.2.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ catalog:
   '@aws-sdk/credential-provider-node': 3.972.25
   '@aws-sdk/util-dynamodb': ^3.995.0
   '@guardian/prettier': ^2.1.5
-  '@guardian/support-service-lambdas': github:guardian/support-service-lambdas#1152744344505d8612ae5fa436c2b3e5bf2bf4e6
+  '@guardian/support-service-lambdas': github:guardian/support-service-lambdas#05e69bdc42ab1c95a6573d58068c5a2753d013cb
   '@types/jest': ^29.5.14
   '@types/node': ^20.19.0
   esbuild: ^0.28.1


### PR DESCRIPTION
This version removes the grace period from digisubs (for testing).

<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Asana Card**](https://app.asana.com)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
