### PR TITLE
Display tax amount correctly in classic PayPal UI

### DIFF
--- a/support-frontend/assets/helpers/forms/checkouts.ts
+++ b/support-frontend/assets/helpers/forms/checkouts.ts
@@ -67,17 +67,16 @@ function simpleFormatTaxAmount(
 	return simpleFormatAmount(currency, taxAmount);
 }
 
-function calculateAndFormatTotal(
+function calculateTotal(
 	taxRateConfig: TaxRateConfig,
-	currency: CurrencyInfo,
 	payment: Payment,
-): string {
+): number {
 	const { finalAmount } = payment;
 
 	switch (taxRateConfig.type) {
 		case 'tax_inclusive':
 		case 'not_enough_information':
-			return simpleFormatAmount(currency, finalAmount);
+			return finalAmount;
 		case 'tax_exclusive': {
 			// It's important that the rounding here reflects the individual amounts
 			// otherwise we may show the user a calculation which doesn't add up:
@@ -86,9 +85,17 @@ function calculateAndFormatTotal(
 
 			const roundedTax = calculateAndRoundTax(payment, taxRateConfig.rate);
 
-			return simpleFormatAmount(currency, roundedTotal + roundedTax);
+			return roundedTotal + roundedTax;
 		}
 	}
+}
+
+function calculateAndFormatTotal(
+	taxRateConfig: TaxRateConfig,
+	currency: CurrencyInfo,
+	payment: Payment,
+): string {
+	return simpleFormatAmount(currency, calculateTotal(taxRateConfig, payment));
 }
 
 // ----- Exports ----- //
@@ -96,5 +103,6 @@ export {
 	simpleFormatAmount,
 	simpleFormatTaxAmount,
 	calculateAndRoundTax,
+	calculateTotal,
 	calculateAndFormatTotal,
 };

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -1275,7 +1275,8 @@ export default function CheckoutForm({
 								setPayPalPaymentToken={setPayPalPaymentToken}
 								formRef={formRef}
 								isTestUser={isTestUser}
-								finalAmount={finalAmount}
+								payment={payment}
+								taxRateConfig={taxRateConfig}
 								currencyKey={currencyKey}
 								billingPeriod={billingPeriod}
 								csrf={csrf.token ?? ''}

--- a/support-frontend/assets/pages/[countryGroupId]/components/submitButton.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/submitButton.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import { DefaultPaymentButton } from 'components/paymentButton/defaultPaymentButton';
 import { PayPalButton } from 'components/payPalPaymentButton/payPalButton';
 import type { Payment } from 'helpers/forms/checkouts';
-import { calculateAndRoundTax } from 'helpers/forms/checkouts';
+import { calculateTotal } from 'helpers/forms/checkouts';
 import type { TaxRateConfig } from 'helpers/salesTax/getEstimatedSalesTaxConfig';
 import { isProd } from 'helpers/urls/url';
 import {
@@ -175,13 +175,9 @@ export function SubmitButton({
 						}}
 						/** the order is Button.payment(opens PayPal window).then(Button.onAuthorize) */
 						payment={(resolve, reject) => {
-							const taxAmount =
-								taxRateConfig.type === 'tax_exclusive'
-									? calculateAndRoundTax(payment, taxRateConfig.rate)
-									: 0;
-
+							const totalPaymentAmount = calculateTotal(taxRateConfig, payment);
 							setupPayPalPayment(
-								payment.finalAmount + taxAmount,
+								totalPaymentAmount,
 								currencyKey,
 								billingPeriod,
 								csrf,

--- a/support-frontend/assets/pages/[countryGroupId]/components/submitButton.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/submitButton.tsx
@@ -4,6 +4,9 @@ import { PayPalButtons, PayPalScriptProvider } from '@paypal/react-paypal-js';
 import { useEffect, useState } from 'react';
 import { DefaultPaymentButton } from 'components/paymentButton/defaultPaymentButton';
 import { PayPalButton } from 'components/payPalPaymentButton/payPalButton';
+import type { Payment } from 'helpers/forms/checkouts';
+import { calculateAndRoundTax } from 'helpers/forms/checkouts';
+import type { TaxRateConfig } from 'helpers/salesTax/getEstimatedSalesTaxConfig';
 import { isProd } from 'helpers/urls/url';
 import {
 	paypalOneClickCheckout,
@@ -14,8 +17,10 @@ import {
 	createSetupToken,
 	exchangeSetupTokenForPaymentToken,
 } from '../checkout/helpers/paypalCompletePayments';
-import { getPayPalEnv } from '../checkout/helpers/payPalSdkOptions';
-import { paypalSdkFundingBlocklist } from '../checkout/helpers/payPalSdkOptions';
+import {
+	getPayPalEnv,
+	paypalSdkFundingBlocklist,
+} from '../checkout/helpers/payPalSdkOptions';
 import type { PaymentMethod } from './paymentFields';
 
 type ApprovedSetupToken = {
@@ -31,7 +36,8 @@ type SubmitButtonProps = {
 	payPalPaymentToken: PaymentToken | undefined;
 	setPayPalPaymentToken: (paymentToken: PaymentToken) => void;
 	isTestUser: boolean;
-	finalAmount: number;
+	payment: Payment;
+	taxRateConfig: TaxRateConfig;
 	currencyKey: IsoCurrency;
 	billingPeriod: BillingPeriod;
 	csrf: string;
@@ -97,7 +103,8 @@ export function SubmitButton({
 	setPayPalPaymentToken,
 	formRef,
 	isTestUser,
-	finalAmount,
+	payment,
+	taxRateConfig,
 	currencyKey,
 	billingPeriod,
 	csrf,
@@ -168,7 +175,17 @@ export function SubmitButton({
 						}}
 						/** the order is Button.payment(opens PayPal window).then(Button.onAuthorize) */
 						payment={(resolve, reject) => {
-							setupPayPalPayment(finalAmount, currencyKey, billingPeriod, csrf)
+							const taxAmount =
+								taxRateConfig.type === 'tax_exclusive'
+									? calculateAndRoundTax(payment, taxRateConfig.rate)
+									: 0;
+
+							setupPayPalPayment(
+								payment.finalAmount + taxAmount,
+								currencyKey,
+								billingPeriod,
+								csrf,
+							)
 								.then((token) => {
 									resolve(token);
 								})


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Previously the classic PayPal UI (not the new 'complete payments' one) was showing an incorrect amount for tax exclusive rate plans (it was showing the amount without tax. This PR changes the behaviour so that it shows the correct amount 
[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1216567976906094)

## Screenshots

### The price breakdown on the checkout
<img width="617" height="321" alt="image" src="https://github.com/user-attachments/assets/35f4a74a-875b-4172-85f0-3bac98654afe" />

### Before (price without tax)
Note that the price in the middle of the screen is a conversion to USD the CAD price is top right
<img width="612" height="770" alt="image" src="https://github.com/user-attachments/assets/ad2565ec-3ceb-464e-80f8-47232858273a" />

### After (prices with tax)
Note that the price in the middle of the screen is a conversion to USD the CAD price is top right
<img width="612" height="770" alt="image" src="https://github.com/user-attachments/assets/12fca8c7-d8a9-479e-bf56-de5d0e7d00fb" />

