### PR TITLE
Add `taxAmount` and `amountWithoutTax` to the payment schedule from the create Zuora subscription lambda

### DIFF
--- a/support-workers/src/typescript/model/paymentSchedule.ts
+++ b/support-workers/src/typescript/model/paymentSchedule.ts
@@ -10,8 +10,8 @@ export type InvoiceItem = {
 const paymentSchema = z.object({
 	date: dateOrDateStringSchema,
 	amount: z.number(),
-	amountWithoutTax: z.number().nullish(),
-	taxAmount: z.number().nullish(),
+	amountWithoutTax: z.number().optional(),
+	taxAmount: z.number().optional(),
 });
 export type Payment = z.infer<typeof paymentSchema>;
 

--- a/support-workers/src/typescript/model/paymentSchedule.ts
+++ b/support-workers/src/typescript/model/paymentSchedule.ts
@@ -10,6 +10,8 @@ export type InvoiceItem = {
 const paymentSchema = z.object({
 	date: dateOrDateStringSchema,
 	amount: z.number(),
+	amountWithoutTax: z.number().nullish(),
+	taxAmount: z.number().nullish(),
 });
 export type Payment = z.infer<typeof paymentSchema>;
 
@@ -26,22 +28,30 @@ export const buildPaymentSchedule = (
 	if (invoiceItems.length == 0) {
 		throw new Error('No invoice items provided to buildPaymentSchedule');
 	}
-	const paymentMap = new Map<string, number>();
+	const paymentMap = new Map<
+		string,
+		{ amountWithoutTax: number; taxAmount: number }
+	>();
 
 	for (const charge of invoiceItems) {
 		const dateKey = charge.serviceStartDate.toISOString();
-		const currentAmount = paymentMap.get(dateKey) ?? 0;
-		paymentMap.set(
-			dateKey,
-			currentAmount + charge.amountWithoutTax + charge.taxAmount,
-		);
+		const current = paymentMap.get(dateKey) ?? {
+			amountWithoutTax: 0,
+			taxAmount: 0,
+		};
+		paymentMap.set(dateKey, {
+			amountWithoutTax: current.amountWithoutTax + charge.amountWithoutTax,
+			taxAmount: current.taxAmount + charge.taxAmount,
+		});
 	}
 
 	const payments: Payment[] = [];
-	for (const [dateKey, amount] of paymentMap) {
+	for (const [dateKey, { amountWithoutTax, taxAmount }] of paymentMap) {
 		payments.push({
 			date: new Date(dateKey),
-			amount: round(amount),
+			amount: round(amountWithoutTax + taxAmount),
+			amountWithoutTax: amountWithoutTax,
+			taxAmount: taxAmount,
 		});
 	}
 

--- a/support-workers/src/typescript/test/paymentSchedule.test.ts
+++ b/support-workers/src/typescript/test/paymentSchedule.test.ts
@@ -24,6 +24,8 @@ describe('buildPaymentSchedule', () => {
 				{
 					date: new Date('2025-01-01'),
 					amount: 12.0,
+					amountWithoutTax: 10.0,
+					taxAmount: 2.0,
 				},
 			],
 		});
@@ -50,6 +52,8 @@ describe('buildPaymentSchedule', () => {
 				{
 					date: new Date('2025-01-01'),
 					amount: 18.0,
+					amountWithoutTax: 15.0,
+					taxAmount: 3.0,
 				},
 			],
 		});
@@ -76,10 +80,14 @@ describe('buildPaymentSchedule', () => {
 				{
 					date: new Date('2025-01-01'),
 					amount: 12.0,
+					amountWithoutTax: 10.0,
+					taxAmount: 2.0,
 				},
 				{
 					date: new Date('2025-02-01'),
 					amount: 18.0,
+					amountWithoutTax: 15.0,
+					taxAmount: 3.0,
 				},
 			],
 		});
@@ -110,19 +118,25 @@ describe('buildPaymentSchedule', () => {
 			{
 				date: new Date('2025-01-01'),
 				amount: 12.0,
+				amountWithoutTax: 10.0,
+				taxAmount: 2.0,
 			},
 			{
 				date: new Date('2025-02-01'),
 				amount: 18.0,
+				amountWithoutTax: 15.0,
+				taxAmount: 3.0,
 			},
 			{
 				date: new Date('2025-03-01'),
 				amount: 24.0,
+				amountWithoutTax: 20.0,
+				taxAmount: 4.0,
 			},
 		]);
 	});
 
-	test('should round amounts to 2 decimal places', () => {
+	test('should round the total amount to 2 decimal places', () => {
 		const invoiceItems: InvoiceItem[] = [
 			{
 				serviceStartDate: new Date('2025-01-01'),
@@ -138,6 +152,8 @@ describe('buildPaymentSchedule', () => {
 				{
 					date: new Date('2025-01-01'),
 					amount: 13.0,
+					amountWithoutTax: 10.333,
+					taxAmount: 2.666,
 				},
 			],
 		});
@@ -159,6 +175,8 @@ describe('buildPaymentSchedule', () => {
 				{
 					date: new Date('2025-01-01'),
 					amount: 0,
+					amountWithoutTax: 0,
+					taxAmount: 0,
 				},
 			],
 		});

--- a/support-workers/src/typescript/test/paymentSchedule.test.ts
+++ b/support-workers/src/typescript/test/paymentSchedule.test.ts
@@ -1,5 +1,8 @@
 import type { InvoiceItem } from '../model/paymentSchedule';
-import { buildPaymentSchedule } from '../model/paymentSchedule';
+import {
+	buildPaymentSchedule,
+	paymentScheduleSchema,
+} from '../model/paymentSchedule';
 
 describe('buildPaymentSchedule', () => {
 	test('should throw if we have no invoice items', () => {
@@ -180,5 +183,26 @@ describe('buildPaymentSchedule', () => {
 				},
 			],
 		});
+	});
+});
+
+describe('paymentScheduleSchema', () => {
+	it("ignores fields it doesn't know about", () => {
+		const payments = {
+			payments: [
+				{
+					date: new Date('2025-01-01'),
+					amount: 10.0,
+					amountWithoutTax: 8.0,
+					taxAmount: 2.0,
+					unexpectedField: 'hi',
+				},
+			],
+		};
+
+		const result = paymentScheduleSchema.safeParse(payments);
+
+		expect(result.success).toEqual(true);
+		console.log(result.error);
 	});
 });

--- a/support-workers/src/typescript/test/paymentSchedule.test.ts
+++ b/support-workers/src/typescript/test/paymentSchedule.test.ts
@@ -203,6 +203,5 @@ describe('paymentScheduleSchema', () => {
 		const result = paymentScheduleSchema.safeParse(payments);
 
 		expect(result.success).toEqual(true);
-		console.log(result.error);
 	});
 });


### PR DESCRIPTION
## What are you doing in this PR?

Adding two new fields, `taxAmount` and `amountWithoutTax`, to the payment schedule returned by the create Zuora subscription lambda. These are optional for now, but will later become non-optional and we'll remove the total amount field.

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1216530799713756)

## Why are you doing this?

For tax exclusive rate plans we want the amount without tax in the day 0 email, for tax inclusive rate plans we want them combined. So we need more granular information than we currently have.

In a future PR, we'll start using these new fields in the send thank you email lambda.