### PR TITLE
Add isIntroductoryPricing flag to promotion

### DIFF
--- a/support-frontend/app/services/pricing/PriceSummary.scala
+++ b/support-frontend/app/services/pricing/PriceSummary.scala
@@ -25,6 +25,7 @@ case class PromotionSummary(
     landingPage: Option[PromotionCopy] = None,
     starts: DateTime,
     expires: Option[DateTime],
+    isIntroductoryPricing: Boolean,
 )
 
 import com.gu.support.encoding.Codec

--- a/support-frontend/app/services/pricing/PriceSummaryService.scala
+++ b/support-frontend/app/services/pricing/PriceSummaryService.scala
@@ -111,6 +111,7 @@ class PriceSummaryService(
       landingPage = promotion.landingPage,
       starts = promotion.starts,
       expires = promotion.expires,
+      isIntroductoryPricing = promotion.isIntroductoryPricing.getOrElse(false),
     )
   }
 

--- a/support-frontend/assets/__mocks__/productInfoMocks.ts
+++ b/support-frontend/assets/__mocks__/productInfoMocks.ts
@@ -238,6 +238,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -273,6 +274,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -318,6 +320,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -353,6 +356,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -406,6 +410,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -441,6 +446,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -486,6 +492,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -521,6 +528,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -566,6 +574,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -601,6 +610,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -654,6 +664,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -689,6 +700,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -746,6 +758,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -767,6 +780,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -808,6 +822,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -829,6 +844,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -322,6 +322,7 @@ export function ContributionsOrderSummary({
 				taxRateConfig={taxRateConfig}
 				studentDiscount={studentDiscount}
 				billingPeriod={billingPeriod}
+				isIntroductoryPricing={promotion?.isIntroductoryPricing ?? false}
 			/>
 			{!!tsAndCs && <div css={termsAndConditions}>{tsAndCs}</div>}
 			{isWeeklyDigital && (

--- a/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.test.tsx
+++ b/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.test.tsx
@@ -23,6 +23,7 @@ describe('orderSummaryTs&Cs Snapshot comparison', () => {
 		promoCode: 'GUARDIAN_WEEKLY_DIGITAL_USA_QUARTERLY',
 		numberOfDiscountedPeriods: 3,
 		discountedPrice: 54,
+		isIntroductoryPricing: false,
 	};
 
 	type OrderSummaryTestParams = [

--- a/support-frontend/assets/components/orderSummary/priceBreakdown.tsx
+++ b/support-frontend/assets/components/orderSummary/priceBreakdown.tsx
@@ -71,6 +71,7 @@ type PriceBreakdownProps = {
 	taxRateConfig: TaxRateConfig;
 	studentDiscount?: StudentDiscount;
 	billingPeriod: BillingPeriod;
+	isIntroductoryPricing: boolean;
 };
 
 export function PriceBreakdown({
@@ -84,6 +85,7 @@ export function PriceBreakdown({
 	taxRateConfig,
 	billingPeriod,
 	studentDiscount,
+	isIntroductoryPricing,
 }: PriceBreakdownProps): JSX.Element {
 	const paymentFrequency = getBillingPeriodNoun(billingPeriod, isWeeklyGift);
 	const period = studentDiscount?.periodNoun ?? paymentFrequency;
@@ -126,6 +128,7 @@ export function PriceBreakdown({
 						discountPrice={discountPrice}
 						isWeeklyGift={isWeeklyGift}
 						showPeriod={taxRateConfig.type === 'tax_inclusive'}
+						isIntroductoryPricing={isIntroductoryPricing}
 					/>
 				</div>
 				<MaybeEstimatedTax

--- a/support-frontend/assets/components/priceSummary/priceSummary.tsx
+++ b/support-frontend/assets/components/priceSummary/priceSummary.tsx
@@ -25,6 +25,7 @@ type PriceSummaryProps = {
 	discountPrice?: string;
 	isWeeklyGift?: boolean;
 	showPeriod: boolean;
+	isIntroductoryPricing?: boolean;
 };
 
 export function PriceSummary({
@@ -33,17 +34,20 @@ export function PriceSummary({
 	discountPrice,
 	isWeeklyGift,
 	showPeriod,
+	isIntroductoryPricing,
 }: PriceSummaryProps): JSX.Element {
 	const divider = isWeeklyGift ? ' for ' : '/';
 
 	if (discountPrice) {
 		return (
 			<p>
-				<span css={originalPriceStrikeThrough}>
-					<span css={visuallyHiddenCss}>Was </span>
-					{fullPrice}
-					<span css={visuallyHiddenCss}>, now</span>
-				</span>{' '}
+				{!isIntroductoryPricing && (
+					<span css={originalPriceStrikeThrough}>
+						<span css={visuallyHiddenCss}>Was </span>
+						{fullPrice}
+						<span css={visuallyHiddenCss}>, now</span>
+					</span>
+				)}{' '}
 				{displayPeriod(discountPrice, divider, period, showPeriod)}
 			</p>
 		);

--- a/support-frontend/assets/helpers/globalsAndSwitches/window.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/window.ts
@@ -209,6 +209,7 @@ const promotionSchema = z.object({
 	),
 	starts: dateTimeSchema,
 	expires: dateTimeSchema.optional(),
+	isIntroductoryPricing: z.boolean(),
 });
 
 export const ProductPricesSchema = z.object({

--- a/support-frontend/assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts
+++ b/support-frontend/assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts
@@ -34,6 +34,7 @@ describe('getPriceDescription', () => {
 						amount: 10,
 						durationMonths: 12,
 					},
+					isIntroductoryPricing: false,
 				},
 			],
 			fixedTerm: false,
@@ -78,6 +79,7 @@ describe('getPriceDescription', () => {
 						amount: 15,
 						durationMonths: 3,
 					},
+					isIntroductoryPricing: false,
 				},
 			],
 			fixedTerm: false,
@@ -111,6 +113,7 @@ describe('getSimplifiedPriceDescription', () => {
 					amount: 50,
 					durationMonths: 3,
 				},
+				isIntroductoryPricing: false,
 			},
 		],
 	};

--- a/support-frontend/assets/helpers/productPrice/__tests__/promotionsTests.ts
+++ b/support-frontend/assets/helpers/productPrice/__tests__/promotionsTests.ts
@@ -91,6 +91,7 @@ describe('applyDiscount', () => {
 				description: '25% off',
 				promoCode: 'GH86H9J',
 				discountedPrice: 8.99,
+				isIntroductoryPricing: false,
 			},
 		],
 	};
@@ -111,6 +112,7 @@ describe('applyDiscount', () => {
 					description: '25% off',
 					promoCode: 'GH86H9J',
 					discountedPrice: 8.99,
+					isIntroductoryPricing: false,
 				},
 			],
 		});

--- a/support-frontend/assets/helpers/productPrice/promotions.tsx
+++ b/support-frontend/assets/helpers/productPrice/promotions.tsx
@@ -40,6 +40,7 @@ export type Promotion = {
 	name: string;
 	description: string;
 	promoCode: string;
+	isIntroductoryPricing: boolean;
 	discountedPrice?: number;
 	numberOfDiscountedPeriods?: number;
 	discount?: DiscountBenefit;

--- a/support-frontend/assets/helpers/tracking/__tests__/quantumMetricHelpersTest.ts
+++ b/support-frontend/assets/helpers/tracking/__tests__/quantumMetricHelpersTest.ts
@@ -16,6 +16,7 @@ describe('Quantum Metric Helpers', () => {
 					discountedPrice: 5.99,
 					numberOfDiscountedPeriods: 3,
 					discount: { amount: 50, durationMonths: 3 },
+					isIntroductoryPricing: false,
 				},
 			],
 		};
@@ -46,6 +47,7 @@ describe('Quantum Metric Helpers', () => {
 					discountedPrice: 99,
 					numberOfDiscountedPeriods: 1,
 					discount: { amount: 16.81, durationMonths: 12 },
+					isIntroductoryPricing: false,
 				},
 			],
 		};

--- a/support-frontend/assets/pages/[countryGroupId]/student/helpers/discountDetails.test.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/student/helpers/discountDetails.test.ts
@@ -137,6 +137,7 @@ describe('Discount Details', () => {
 				discount: { amount: 100, durationMonths: 24 },
 				discountedPrice: 0,
 				numberOfDiscountedPeriods: 24,
+				isIntroductoryPricing: false,
 			};
 
 			const result = getStudentDiscount(

--- a/support-frontend/assets/pages/paper-subscription-landing/helpers/__fixtures__/productPrices.fixtures.ts
+++ b/support-frontend/assets/pages/paper-subscription-landing/helpers/__fixtures__/productPrices.fixtures.ts
@@ -7,12 +7,14 @@ export const baseHomeDeliveryPromotion = {
 	name: 'Home delivery promo',
 	promoCode: 'PROMO10',
 	description: '10% off',
+	isIntroductoryPricing: false,
 };
 
 export const baseCollectionPromotion = {
 	name: 'Collection promo',
 	promoCode: 'PROMO20',
 	description: '20% off',
+	isIntroductoryPricing: false,
 };
 
 const baseProductOption: Omit<ProductPrice, 'promotions'> = {
@@ -49,6 +51,7 @@ export const productPrices: ProductPrices = {
 								name: 'First promo',
 								promoCode: 'FIRST',
 								description: 'First promo',
+								isIntroductoryPricing: false,
 							},
 							baseHomeDeliveryPromotion,
 						],

--- a/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.test.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.test.tsx
@@ -26,6 +26,7 @@ describe('Payment Ts&Cs Snapshot comparison', () => {
 		promoCode: 'ANNUAL10',
 		numberOfDiscountedPeriods: 12,
 		discountedPrice: 324,
+		isIntroductoryPricing: false,
 	};
 
 	type PaymentProductTestParams = {

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -238,7 +238,13 @@ export function ThreeTierCard({
 				{promotion && (
 					<>
 						<p>
-							<span css={previousPriceStrikeThrough}>{formattedMainPrice}</span>{' '}
+							{!promotion.isIntroductoryPricing && (
+								<>
+									<span css={previousPriceStrikeThrough}>
+										{formattedMainPrice}
+									</span>{' '}
+								</>
+							)}
 							{`${formattedMainDiscountedPrice}/${periodLabel}`}
 						</p>
 						<p>

--- a/support-frontend/assets/pages/weekly-subscription-landing/helpers/getSavingsText.test.ts
+++ b/support-frontend/assets/pages/weekly-subscription-landing/helpers/getSavingsText.test.ts
@@ -16,6 +16,7 @@ const makePromotion = (overrides: Partial<Promotion> = {}): Promotion => ({
 	name: 'Test Promo',
 	description: 'Test promo description',
 	promoCode: 'TESTPROMO',
+	isIntroductoryPricing: false,
 	...overrides,
 });
 

--- a/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
@@ -278,6 +278,7 @@ DigitalPlusWithTaxAndDiscount.args = {
 			amount: 50,
 			durationMonths: 6,
 		},
+		isIntroductoryPricing: false,
 	},
 	checkListData: [
 		...productCatalogDescription.DigitalSubscription.benefits.map(
@@ -456,6 +457,7 @@ WeeklyPricingWithPromotion.args = {
 			amount: 33,
 			durationMonths: 6,
 		},
+		isIntroductoryPricing: false,
 	},
 	tsAndCs: (
 		<OrderSummaryTsAndCs

--- a/support-frontend/stories/checkouts/checkoutNudge.stories.tsx
+++ b/support-frontend/stories/checkouts/checkoutNudge.stories.tsx
@@ -102,6 +102,7 @@ WithPromotion.args = {
 			description: 'Save 25% for your first 3 months',
 			roundel: '25% off',
 		},
+		isIntroductoryPricing: false,
 	},
 	benefits: {
 		label: 'Your all-access benefits:',
@@ -136,5 +137,6 @@ WithPromotionAnnual.args = {
 			description: 'Save 30% on your annual subscription',
 			roundel: '30% off',
 		},
+		isIntroductoryPricing: false,
 	},
 };

--- a/support-frontend/stories/checkouts/orderSummaryTsAndCs.stories.tsx
+++ b/support-frontend/stories/checkouts/orderSummaryTsAndCs.stories.tsx
@@ -48,6 +48,7 @@ WeeklyDigital.args = {
 		promoCode: 'GUARDIAN_WEEKLY_DIGITAL_USA_QUARTERLY',
 		numberOfDiscountedPeriods: 3,
 		discountedPrice: 54,
+		isIntroductoryPricing: false,
 	},
 };
 

--- a/support-frontend/stories/checkouts/paymentTsAndCs.stories.tsx
+++ b/support-frontend/stories/checkouts/paymentTsAndCs.stories.tsx
@@ -132,5 +132,6 @@ WeeklyDigitalRestOfWorldInclPromo.args = {
 		promoCode: 'ANNUAL10',
 		numberOfDiscountedPeriods: 12,
 		discountedPrice: 324,
+		isIntroductoryPricing: false,
 	},
 };

--- a/support-frontend/stories/landingPage/ThreeTierCard.stories.tsx
+++ b/support-frontend/stories/landingPage/ThreeTierCard.stories.tsx
@@ -92,6 +92,24 @@ Promotion.args = {
 	},
 };
 
+export const IntroductoryPromotion = Template.bind({});
+
+IntroductoryPromotion.args = {
+	isSubdued: false,
+	currencyId: 'EUR',
+	paymentFrequency: 'MONTHLY',
+	cardTier: 3,
+	cardContent: {
+		...fallBackLandingPageSelection.products.DigitalSubscription,
+		product: 'DigitalSubscription',
+		isUserSelected: false,
+		price: 38.5,
+		cta: { copy: 'Support' },
+		label: { copy: 'Highest impact' },
+		promotion: { ...promotionEURCountries, isIntroductoryPricing: true },
+	},
+};
+
 export const BillingPeriodsCopy = Template.bind({});
 BillingPeriodsCopy.args = {
 	isSubdued: false,

--- a/support-frontend/test/controllers/PricesControllerSerialisationTest.scala
+++ b/support-frontend/test/controllers/PricesControllerSerialisationTest.scala
@@ -33,7 +33,7 @@ class PricesControllerSerialisationTest extends AnyFlatSpec with Matchers {
       None,
       new DateTime("2020-01-01"),
       None,
-      None,
+      false,
     )
     val priceSummary = PriceSummary(BigDecimal(1.2), Some(50), Currency.GBP, false, List(promotionSummary))
     val ratePlanPriceData = RatePlanPriceData("pr", "cur", Some(priceSummary))

--- a/support-frontend/test/controllers/PricesControllerSerialisationTest.scala
+++ b/support-frontend/test/controllers/PricesControllerSerialisationTest.scala
@@ -33,6 +33,7 @@ class PricesControllerSerialisationTest extends AnyFlatSpec with Matchers {
       None,
       new DateTime("2020-01-01"),
       None,
+      false,
     )
     val priceSummary = PriceSummary(BigDecimal(1.2), Some(50), Currency.GBP, false, List(promotionSummary))
     val ratePlanPriceData = RatePlanPriceData("pr", "cur", Some(priceSummary))

--- a/support-frontend/test/controllers/PricesControllerSerialisationTest.scala
+++ b/support-frontend/test/controllers/PricesControllerSerialisationTest.scala
@@ -33,7 +33,7 @@ class PricesControllerSerialisationTest extends AnyFlatSpec with Matchers {
       None,
       new DateTime("2020-01-01"),
       None,
-      false,
+      None,
     )
     val priceSummary = PriceSummary(BigDecimal(1.2), Some(50), Currency.GBP, false, List(promotionSummary))
     val ratePlanPriceData = RatePlanPriceData("pr", "cur", Some(priceSummary))

--- a/support-frontend/test/controllers/PricesControllerTest.scala
+++ b/support-frontend/test/controllers/PricesControllerTest.scala
@@ -47,7 +47,7 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
                           ),
                           new DateTime("2020-01-01"),
                           None,
-                          false,
+                          None,
                         ),
                       ),
                     ),
@@ -134,7 +134,7 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
                   None, // no landing page text
                   new DateTime("2020-01-01"),
                   None,
-                  false,
+                  None,
                 ),
               ),
             ),
@@ -163,7 +163,7 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
                   None, // no landing page text
                   new DateTime("2020-01-01"),
                   None,
-                  false,
+                  None,
                 ),
               ),
             ),

--- a/support-frontend/test/controllers/PricesControllerTest.scala
+++ b/support-frontend/test/controllers/PricesControllerTest.scala
@@ -47,6 +47,7 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
                           ),
                           new DateTime("2020-01-01"),
                           None,
+                          false,
                         ),
                       ),
                     ),
@@ -72,6 +73,7 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
                           Some(PromotionCopy(None, None, Some("Subscribe for 12 months and save 10%"))),
                           new DateTime("2020-01-01"),
                           None,
+                          false,
                         ),
                       ),
                     ),
@@ -132,6 +134,7 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
                   None, // no landing page text
                   new DateTime("2020-01-01"),
                   None,
+                  false,
                 ),
               ),
             ),
@@ -160,6 +163,7 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
                   None, // no landing page text
                   new DateTime("2020-01-01"),
                   None,
+                  false,
                 ),
               ),
             ),

--- a/support-frontend/test/controllers/PricesControllerTest.scala
+++ b/support-frontend/test/controllers/PricesControllerTest.scala
@@ -47,7 +47,7 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
                           ),
                           new DateTime("2020-01-01"),
                           None,
-                          None,
+                          false,
                         ),
                       ),
                     ),
@@ -134,7 +134,7 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
                   None, // no landing page text
                   new DateTime("2020-01-01"),
                   None,
-                  None,
+                  false,
                 ),
               ),
             ),
@@ -163,7 +163,7 @@ class PricesControllerTest extends AnyWordSpec with Matchers {
                   None, // no landing page text
                   new DateTime("2020-01-01"),
                   None,
-                  None,
+                  false,
                 ),
               ),
             ),

--- a/support-models/src/main/scala/com/gu/support/promotions/Promotion.scala
+++ b/support-models/src/main/scala/com/gu/support/promotions/Promotion.scala
@@ -21,6 +21,7 @@ case class Promotion(
     renewalOnly: Boolean = false,
     tracking: Boolean = false,
     landingPage: Option[PromotionCopy] = None,
+    isIntroductoryPricing: Option[Boolean] = Some(false),
 )
 
 object Promotion {

--- a/support-models/src/main/scala/com/gu/support/promotions/Promotion.scala
+++ b/support-models/src/main/scala/com/gu/support/promotions/Promotion.scala
@@ -21,7 +21,7 @@ case class Promotion(
     renewalOnly: Boolean = false,
     tracking: Boolean = false,
     landingPage: Option[PromotionCopy] = None,
-    isIntroductoryPricing: Option[Boolean] = Some(false),
+    isIntroductoryPricing: Option[Boolean] = None,
 )
 
 object Promotion {


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Exposes whether a promotion is introductory pricing as a first-class field in the PromotionSummary API response, so consumers (e.g. front-end checkout) can distinguish introductory-price promotions from standard ones.
This is available in the promotion object in window.guardian under the allProductPrices.
Defaults to false if no data for `isIntroductoryPricing` exist in dynamoDB entry.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[S+: Update promotion object in window.guardian](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1216530672278111?focus=true)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

The isIntroductoryPricing flag already exists on the underlying Promotion model in DynamoDB, but was not being surfaced in the pricing API response. Without it, clients have no reliable way to detect introductory pricing promotions.

## Returned promotion object
```json
{
    "name": "PROMO_1",
    "description": "",
    "promoCode": "PROMO_1",
    "discountedPrice": 2.4,
    "numberOfDiscountedPeriods": 12,
    "discount": {
        "amount": 80,
        "durationMonths": 12
    },
    "starts": "2026-02-26T13:55:20.255Z",
    "expires": "2027-11-15T10:38:00.000Z",
    "isIntroductoryPricing": true
}
```
