### PR TITLE
Landing Page: Introductory Pricing apply to Tier Cards

### DIFF
--- a/support-frontend/assets/__mocks__/productInfoMocks.ts
+++ b/support-frontend/assets/__mocks__/productInfoMocks.ts
@@ -238,6 +238,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -273,6 +274,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -318,6 +320,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -353,6 +356,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -406,6 +410,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -441,6 +446,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -486,6 +492,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -521,6 +528,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -566,6 +574,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -601,6 +610,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -654,6 +664,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -689,6 +700,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -746,6 +758,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -767,6 +780,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -808,6 +822,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},
@@ -829,6 +844,7 @@ export const weeklyProducts: ProductPrices = {
 								landingPage: {
 									roundel: 'Subscribe for 12 months and save 10%',
 								},
+								isIntroductoryPricing: false,
 							},
 						],
 					},

--- a/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
+++ b/support-frontend/assets/components/orderSummary/contributionsOrderSummary.tsx
@@ -322,6 +322,7 @@ export function ContributionsOrderSummary({
 				taxRateConfig={taxRateConfig}
 				studentDiscount={studentDiscount}
 				billingPeriod={billingPeriod}
+				isIntroductoryPricing={promotion?.isIntroductoryPricing ?? false}
 			/>
 			{!!tsAndCs && <div css={termsAndConditions}>{tsAndCs}</div>}
 			{isWeeklyDigital && (

--- a/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.test.tsx
+++ b/support-frontend/assets/components/orderSummary/orderSummaryTsAndCs.test.tsx
@@ -23,6 +23,7 @@ describe('orderSummaryTs&Cs Snapshot comparison', () => {
 		promoCode: 'GUARDIAN_WEEKLY_DIGITAL_USA_QUARTERLY',
 		numberOfDiscountedPeriods: 3,
 		discountedPrice: 54,
+		isIntroductoryPricing: false,
 	};
 
 	type OrderSummaryTestParams = [

--- a/support-frontend/assets/components/orderSummary/priceBreakdown.tsx
+++ b/support-frontend/assets/components/orderSummary/priceBreakdown.tsx
@@ -71,6 +71,7 @@ type PriceBreakdownProps = {
 	taxRateConfig: TaxRateConfig;
 	studentDiscount?: StudentDiscount;
 	billingPeriod: BillingPeriod;
+	isIntroductoryPricing: boolean;
 };
 
 export function PriceBreakdown({
@@ -84,6 +85,7 @@ export function PriceBreakdown({
 	taxRateConfig,
 	billingPeriod,
 	studentDiscount,
+	isIntroductoryPricing,
 }: PriceBreakdownProps): JSX.Element {
 	const paymentFrequency = getBillingPeriodNoun(billingPeriod, isWeeklyGift);
 	const period = studentDiscount?.periodNoun ?? paymentFrequency;
@@ -126,6 +128,7 @@ export function PriceBreakdown({
 						discountPrice={discountPrice}
 						isWeeklyGift={isWeeklyGift}
 						showPeriod={taxRateConfig.type === 'tax_inclusive'}
+						isIntroductoryPricing={isIntroductoryPricing}
 					/>
 				</div>
 				<MaybeEstimatedTax

--- a/support-frontend/assets/components/priceSummary/priceSummary.tsx
+++ b/support-frontend/assets/components/priceSummary/priceSummary.tsx
@@ -25,6 +25,7 @@ type PriceSummaryProps = {
 	discountPrice?: string;
 	isWeeklyGift?: boolean;
 	showPeriod: boolean;
+	isIntroductoryPricing?: boolean;
 };
 
 export function PriceSummary({
@@ -33,17 +34,20 @@ export function PriceSummary({
 	discountPrice,
 	isWeeklyGift,
 	showPeriod,
+	isIntroductoryPricing,
 }: PriceSummaryProps): JSX.Element {
 	const divider = isWeeklyGift ? ' for ' : '/';
 
 	if (discountPrice) {
 		return (
 			<p>
-				<span css={originalPriceStrikeThrough}>
-					<span css={visuallyHiddenCss}>Was </span>
-					{fullPrice}
-					<span css={visuallyHiddenCss}>, now</span>
-				</span>{' '}
+				{!isIntroductoryPricing && (
+					<span css={originalPriceStrikeThrough}>
+						<span css={visuallyHiddenCss}>Was </span>
+						{fullPrice}
+						<span css={visuallyHiddenCss}>, now</span>
+					</span>
+				)}{' '}
 				{displayPeriod(discountPrice, divider, period, showPeriod)}
 			</p>
 		);

--- a/support-frontend/assets/helpers/globalsAndSwitches/window.ts
+++ b/support-frontend/assets/helpers/globalsAndSwitches/window.ts
@@ -209,6 +209,7 @@ const promotionSchema = z.object({
 	),
 	starts: dateTimeSchema,
 	expires: dateTimeSchema.optional(),
+	isIntroductoryPricing: z.boolean(),
 });
 
 export const ProductPricesSchema = z.object({

--- a/support-frontend/assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts
+++ b/support-frontend/assets/helpers/productPrice/__tests__/priceDescriptionsTests.ts
@@ -34,6 +34,7 @@ describe('getPriceDescription', () => {
 						amount: 10,
 						durationMonths: 12,
 					},
+					isIntroductoryPricing: false,
 				},
 			],
 			fixedTerm: false,
@@ -78,6 +79,7 @@ describe('getPriceDescription', () => {
 						amount: 15,
 						durationMonths: 3,
 					},
+					isIntroductoryPricing: false,
 				},
 			],
 			fixedTerm: false,
@@ -111,6 +113,7 @@ describe('getSimplifiedPriceDescription', () => {
 					amount: 50,
 					durationMonths: 3,
 				},
+				isIntroductoryPricing: false,
 			},
 		],
 	};

--- a/support-frontend/assets/helpers/productPrice/__tests__/promotionsTests.ts
+++ b/support-frontend/assets/helpers/productPrice/__tests__/promotionsTests.ts
@@ -91,6 +91,7 @@ describe('applyDiscount', () => {
 				description: '25% off',
 				promoCode: 'GH86H9J',
 				discountedPrice: 8.99,
+				isIntroductoryPricing: false,
 			},
 		],
 	};

--- a/support-frontend/assets/helpers/productPrice/__tests__/promotionsTests.ts
+++ b/support-frontend/assets/helpers/productPrice/__tests__/promotionsTests.ts
@@ -112,6 +112,7 @@ describe('applyDiscount', () => {
 					description: '25% off',
 					promoCode: 'GH86H9J',
 					discountedPrice: 8.99,
+					isIntroductoryPricing: false,
 				},
 			],
 		});

--- a/support-frontend/assets/helpers/productPrice/promotions.tsx
+++ b/support-frontend/assets/helpers/productPrice/promotions.tsx
@@ -40,13 +40,13 @@ export type Promotion = {
 	name: string;
 	description: string;
 	promoCode: string;
+	isIntroductoryPricing: boolean;
 	discountedPrice?: number;
 	numberOfDiscountedPeriods?: number;
 	discount?: DiscountBenefit;
 	landingPage?: PromotionCopy;
 	starts?: string;
 	expires?: string;
-	isIntroductoryPricing?: boolean;
 	roundelText?: string;
 	hasPriority?: boolean;
 };

--- a/support-frontend/assets/helpers/productPrice/promotions.tsx
+++ b/support-frontend/assets/helpers/productPrice/promotions.tsx
@@ -46,6 +46,7 @@ export type Promotion = {
 	landingPage?: PromotionCopy;
 	starts?: string;
 	expires?: string;
+	isIntroductoryPricing?: boolean;
 	roundelText?: string;
 	hasPriority?: boolean;
 };

--- a/support-frontend/assets/helpers/tracking/__tests__/quantumMetricHelpersTest.ts
+++ b/support-frontend/assets/helpers/tracking/__tests__/quantumMetricHelpersTest.ts
@@ -16,6 +16,7 @@ describe('Quantum Metric Helpers', () => {
 					discountedPrice: 5.99,
 					numberOfDiscountedPeriods: 3,
 					discount: { amount: 50, durationMonths: 3 },
+					isIntroductoryPricing: false,
 				},
 			],
 		};
@@ -46,6 +47,7 @@ describe('Quantum Metric Helpers', () => {
 					discountedPrice: 99,
 					numberOfDiscountedPeriods: 1,
 					discount: { amount: 16.81, durationMonths: 12 },
+					isIntroductoryPricing: false,
 				},
 			],
 		};

--- a/support-frontend/assets/pages/[countryGroupId]/student/helpers/discountDetails.test.ts
+++ b/support-frontend/assets/pages/[countryGroupId]/student/helpers/discountDetails.test.ts
@@ -137,6 +137,7 @@ describe('Discount Details', () => {
 				discount: { amount: 100, durationMonths: 24 },
 				discountedPrice: 0,
 				numberOfDiscountedPeriods: 24,
+				isIntroductoryPricing: false,
 			};
 
 			const result = getStudentDiscount(

--- a/support-frontend/assets/pages/paper-subscription-landing/helpers/__fixtures__/productPrices.fixtures.ts
+++ b/support-frontend/assets/pages/paper-subscription-landing/helpers/__fixtures__/productPrices.fixtures.ts
@@ -7,12 +7,14 @@ export const baseHomeDeliveryPromotion = {
 	name: 'Home delivery promo',
 	promoCode: 'PROMO10',
 	description: '10% off',
+	isIntroductoryPricing: false,
 };
 
 export const baseCollectionPromotion = {
 	name: 'Collection promo',
 	promoCode: 'PROMO20',
 	description: '20% off',
+	isIntroductoryPricing: false,
 };
 
 const baseProductOption: Omit<ProductPrice, 'promotions'> = {
@@ -49,6 +51,7 @@ export const productPrices: ProductPrices = {
 								name: 'First promo',
 								promoCode: 'FIRST',
 								description: 'First promo',
+								isIntroductoryPricing: false,
 							},
 							baseHomeDeliveryPromotion,
 						],

--- a/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.test.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/paymentTsAndCs.test.tsx
@@ -26,6 +26,7 @@ describe('Payment Ts&Cs Snapshot comparison', () => {
 		promoCode: 'ANNUAL10',
 		numberOfDiscountedPeriods: 12,
 		discountedPrice: 324,
+		isIntroductoryPricing: false,
 	};
 
 	type PaymentProductTestParams = {

--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCard.tsx
@@ -238,7 +238,13 @@ export function ThreeTierCard({
 				{promotion && (
 					<>
 						<p>
-							<span css={previousPriceStrikeThrough}>{formattedMainPrice}</span>{' '}
+							{!promotion.isIntroductoryPricing && (
+								<>
+									<span css={previousPriceStrikeThrough}>
+										{formattedMainPrice}
+									</span>{' '}
+								</>
+							)}
 							{`${formattedMainDiscountedPrice}/${periodLabel}`}
 						</p>
 						<p>

--- a/support-frontend/assets/pages/weekly-subscription-landing/helpers/getSavingsText.test.ts
+++ b/support-frontend/assets/pages/weekly-subscription-landing/helpers/getSavingsText.test.ts
@@ -16,6 +16,7 @@ const makePromotion = (overrides: Partial<Promotion> = {}): Promotion => ({
 	name: 'Test Promo',
 	description: 'Test promo description',
 	promoCode: 'TESTPROMO',
+	isIntroductoryPricing: false,
 	...overrides,
 });
 

--- a/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
+++ b/support-frontend/stories/checkouts/ContributionsOrderSummary.stories.tsx
@@ -278,6 +278,7 @@ DigitalPlusWithTaxAndDiscount.args = {
 			amount: 50,
 			durationMonths: 6,
 		},
+		isIntroductoryPricing: false,
 	},
 	checkListData: [
 		...productCatalogDescription.DigitalSubscription.benefits.map(
@@ -456,6 +457,7 @@ WeeklyPricingWithPromotion.args = {
 			amount: 33,
 			durationMonths: 6,
 		},
+		isIntroductoryPricing: false,
 	},
 	tsAndCs: (
 		<OrderSummaryTsAndCs

--- a/support-frontend/stories/checkouts/checkoutNudge.stories.tsx
+++ b/support-frontend/stories/checkouts/checkoutNudge.stories.tsx
@@ -102,6 +102,7 @@ WithPromotion.args = {
 			description: 'Save 25% for your first 3 months',
 			roundel: '25% off',
 		},
+		isIntroductoryPricing: false,
 	},
 	benefits: {
 		label: 'Your all-access benefits:',
@@ -136,5 +137,6 @@ WithPromotionAnnual.args = {
 			description: 'Save 30% on your annual subscription',
 			roundel: '30% off',
 		},
+		isIntroductoryPricing: false,
 	},
 };

--- a/support-frontend/stories/checkouts/orderSummaryTsAndCs.stories.tsx
+++ b/support-frontend/stories/checkouts/orderSummaryTsAndCs.stories.tsx
@@ -48,6 +48,7 @@ WeeklyDigital.args = {
 		promoCode: 'GUARDIAN_WEEKLY_DIGITAL_USA_QUARTERLY',
 		numberOfDiscountedPeriods: 3,
 		discountedPrice: 54,
+		isIntroductoryPricing: false,
 	},
 };
 

--- a/support-frontend/stories/checkouts/paymentTsAndCs.stories.tsx
+++ b/support-frontend/stories/checkouts/paymentTsAndCs.stories.tsx
@@ -132,5 +132,6 @@ WeeklyDigitalRestOfWorldInclPromo.args = {
 		promoCode: 'ANNUAL10',
 		numberOfDiscountedPeriods: 12,
 		discountedPrice: 324,
+		isIntroductoryPricing: false,
 	},
 };

--- a/support-frontend/stories/landingPage/ThreeTierCard.stories.tsx
+++ b/support-frontend/stories/landingPage/ThreeTierCard.stories.tsx
@@ -92,6 +92,24 @@ Promotion.args = {
 	},
 };
 
+export const IntroductoryPromotion = Template.bind({});
+
+IntroductoryPromotion.args = {
+	isSubdued: false,
+	currencyId: 'EUR',
+	paymentFrequency: 'MONTHLY',
+	cardTier: 3,
+	cardContent: {
+		...fallBackLandingPageSelection.products.DigitalSubscription,
+		product: 'DigitalSubscription',
+		isUserSelected: false,
+		price: 38.5,
+		cta: { copy: 'Support' },
+		label: { copy: 'Highest impact' },
+		promotion: { ...promotionEURCountries, isIntroductoryPricing: true },
+	},
+};
+
 export const BillingPeriodsCopy = Template.bind({});
 BillingPeriodsCopy.args = {
 	isSubdued: false,


### PR DESCRIPTION
## What are you doing in this PR?

Built upon https://github.com/guardian/support-frontend/pull/8105

Should a Promotion contain `isIntroductoryPricing=true` field, hide the strikethrough amount in the product card.

[**Asana Card**](https://app.asana.com)

## Why are you doing this?
Enable visual representation of introductory prices in the product cards on the landing page

## How to test
https://support.thegulocal.com/uk/contribute?promoCode=PROMO_1OMO_1)

## Screenshots

|before|after|
|----|----|
|<img width="323" height="473" alt="image" src="https://github.com/user-attachments/assets/13708fc8-66af-4d59-9441-7c32c6f6f566" />|<img width="323" height="473" alt="image" src="https://github.com/user-attachments/assets/791145c4-e60a-432f-9293-70be847877db" />|