### PR TITLE
In day 0 emails for tax exclusive rate plans show amount without tax

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ catalogs:
       specifier: ^2.1.5
       version: 2.1.5
     '@guardian/support-service-lambdas':
-      specifier: github:guardian/support-service-lambdas#1152744344505d8612ae5fa436c2b3e5bf2bf4e6
+      specifier: github:guardian/support-service-lambdas#1ad597bde8efc83f125b4804399468ac15a7e9bd
       version: 1.0.0
     '@types/jest':
       specifier: ^29.5.14
@@ -153,7 +153,7 @@ importers:
     devDependencies:
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1152744344505d8612ae5fa436c2b3e5bf2bf4e6
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1ad597bde8efc83f125b4804399468ac15a7e9bd
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.0
@@ -272,7 +272,7 @@ importers:
         version: 18.1.1(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.5.4))(@guardian/source@10.2.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1152744344505d8612ae5fa436c2b3e5bf2bf4e6
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1ad597bde8efc83f125b4804399468ac15a7e9bd
       '@guardian/tsconfig':
         specifier: ^0.2.0
         version: 0.2.0
@@ -513,7 +513,7 @@ importers:
         version: 8.1.1
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1152744344505d8612ae5fa436c2b3e5bf2bf4e6
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1ad597bde8efc83f125b4804399468ac15a7e9bd
       aws-lambda:
         specifier: ^1.0.7
         version: 1.0.7
@@ -580,7 +580,7 @@ importers:
         version: 3.995.0(@aws-sdk/client-dynamodb@3.1015.0)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1152744344505d8612ae5fa436c2b3e5bf2bf4e6
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1ad597bde8efc83f125b4804399468ac15a7e9bd
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -2434,8 +2434,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1152744344505d8612ae5fa436c2b3e5bf2bf4e6':
-    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1152744344505d8612ae5fa436c2b3e5bf2bf4e6}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1ad597bde8efc83f125b4804399468ac15a7e9bd':
+    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1ad597bde8efc83f125b4804399468ac15a7e9bd}
     version: 1.0.0
 
   '@guardian/tsconfig@0.2.0':
@@ -11240,7 +11240,7 @@ snapshots:
       react: 18.2.0
       typescript: 5.5.4
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1152744344505d8612ae5fa436c2b3e5bf2bf4e6': {}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1ad597bde8efc83f125b4804399468ac15a7e9bd': {}
 
   '@guardian/tsconfig@0.2.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ catalogs:
       specifier: ^2.1.5
       version: 2.1.5
     '@guardian/support-service-lambdas':
-      specifier: github:guardian/support-service-lambdas#1ad597bde8efc83f125b4804399468ac15a7e9bd
+      specifier: github:guardian/support-service-lambdas#0c4dec1f4142fce673dbd5216d9afbfa7c66ab9f
       version: 1.0.0
     '@types/jest':
       specifier: ^29.5.14
@@ -153,7 +153,7 @@ importers:
     devDependencies:
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1ad597bde8efc83f125b4804399468ac15a7e9bd
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/0c4dec1f4142fce673dbd5216d9afbfa7c66ab9f
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.0
@@ -272,7 +272,7 @@ importers:
         version: 18.1.1(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.5.4))(@guardian/source@10.2.0(@emotion/react@11.14.0(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4))(@types/react@18.2.0)(react@18.2.0)(tslib@2.8.1)(typescript@5.5.4)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1ad597bde8efc83f125b4804399468ac15a7e9bd
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/0c4dec1f4142fce673dbd5216d9afbfa7c66ab9f
       '@guardian/tsconfig':
         specifier: ^0.2.0
         version: 0.2.0
@@ -513,7 +513,7 @@ importers:
         version: 8.1.1
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1ad597bde8efc83f125b4804399468ac15a7e9bd
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/0c4dec1f4142fce673dbd5216d9afbfa7c66ab9f
       aws-lambda:
         specifier: ^1.0.7
         version: 1.0.7
@@ -580,7 +580,7 @@ importers:
         version: 3.995.0(@aws-sdk/client-dynamodb@3.1015.0)
       '@guardian/support-service-lambdas':
         specifier: 'catalog:'
-        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1ad597bde8efc83f125b4804399468ac15a7e9bd
+        version: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/0c4dec1f4142fce673dbd5216d9afbfa7c66ab9f
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -2434,8 +2434,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1ad597bde8efc83f125b4804399468ac15a7e9bd':
-    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1ad597bde8efc83f125b4804399468ac15a7e9bd}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/0c4dec1f4142fce673dbd5216d9afbfa7c66ab9f':
+    resolution: {tarball: https://codeload.github.com/guardian/support-service-lambdas/tar.gz/0c4dec1f4142fce673dbd5216d9afbfa7c66ab9f}
     version: 1.0.0
 
   '@guardian/tsconfig@0.2.0':
@@ -11240,7 +11240,7 @@ snapshots:
       react: 18.2.0
       typescript: 5.5.4
 
-  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/1ad597bde8efc83f125b4804399468ac15a7e9bd': {}
+  '@guardian/support-service-lambdas@https://codeload.github.com/guardian/support-service-lambdas/tar.gz/0c4dec1f4142fce673dbd5216d9afbfa7c66ab9f': {}
 
   '@guardian/tsconfig@0.2.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ catalog:
   '@aws-sdk/credential-provider-node': 3.972.25
   '@aws-sdk/util-dynamodb': ^3.995.0
   '@guardian/prettier': ^2.1.5
-  '@guardian/support-service-lambdas': github:guardian/support-service-lambdas#1152744344505d8612ae5fa436c2b3e5bf2bf4e6
+  '@guardian/support-service-lambdas': github:guardian/support-service-lambdas#1ad597bde8efc83f125b4804399468ac15a7e9bd
   '@types/jest': ^29.5.14
   '@types/node': ^20.19.0
   esbuild: ^0.28.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ catalog:
   '@aws-sdk/credential-provider-node': 3.972.25
   '@aws-sdk/util-dynamodb': ^3.995.0
   '@guardian/prettier': ^2.1.5
-  '@guardian/support-service-lambdas': github:guardian/support-service-lambdas#1ad597bde8efc83f125b4804399468ac15a7e9bd
+  '@guardian/support-service-lambdas': github:guardian/support-service-lambdas#0c4dec1f4142fce673dbd5216d9afbfa7c66ab9f
   '@types/jest': ^29.5.14
   '@types/node': ^20.19.0
   esbuild: ^0.28.1

--- a/support-workers/src/typescript/lambdas/sendThankYouEmailLambda.ts
+++ b/support-workers/src/typescript/lambdas/sendThankYouEmailLambda.ts
@@ -73,12 +73,19 @@ function toEmailPaymentMethod(
 async function getFieldsFromState(
 	sendThankYouEmailState: SendThankYouEmailState,
 ) {
-	const fixedTerm = isFixedTerm(
+	const productCatalog: ProductCatalog =
 		await productCatalogProvider.getServiceForUser(
 			sendThankYouEmailState.user.isTestUser,
-		),
+		);
+	const fixedTerm = isFixedTerm(
+		productCatalog,
 		sendThankYouEmailState.productInformation,
 	);
+	const taxMode = getTaxMode(
+		productCatalog,
+		sendThankYouEmailState.productInformation,
+	);
+
 	return {
 		today: dayjs(),
 		user: sendThankYouEmailState.user,
@@ -93,6 +100,7 @@ async function getFieldsFromState(
 			sendThankYouEmailState.accountNumber,
 		),
 		isFixedTerm: fixedTerm,
+		taxMode,
 	};
 }
 
@@ -253,6 +261,17 @@ function isFixedTerm(
 		productInformation,
 	);
 	return productRatePlan.termType === 'FixedTerm';
+}
+
+function getTaxMode(
+	productCatalog: ProductCatalog,
+	productInformation: ProductPurchase,
+) {
+	const productRatePlan = getProductRatePlan(
+		productCatalog,
+		productInformation,
+	);
+	return productRatePlan.taxMode;
 }
 
 export function getBillingPeriod(productType: ProductType): EmailBillingPeriod {

--- a/support-workers/src/typescript/model/paymentSchedule.ts
+++ b/support-workers/src/typescript/model/paymentSchedule.ts
@@ -10,8 +10,8 @@ export type InvoiceItem = {
 const paymentSchema = z.object({
 	date: dateOrDateStringSchema,
 	amount: z.number(),
-	amountWithoutTax: z.number().optional(),
-	taxAmount: z.number().optional(),
+	amountWithoutTax: z.number(),
+	taxAmount: z.number(),
 });
 export type Payment = z.infer<typeof paymentSchema>;
 

--- a/support-workers/src/typescript/test/createZuoraSubscriptionLambda.test.ts
+++ b/support-workers/src/typescript/test/createZuoraSubscriptionLambda.test.ts
@@ -19,6 +19,8 @@ const paymentSchedule = {
 		{
 			date: new Date(),
 			amount: 49.99,
+			amountWithoutTax: 45,
+			taxAmount: 4.99,
 		},
 	],
 };

--- a/support-workers/src/typescript/test/fixtures/sendThankYouEmail/contributionState.json
+++ b/support-workers/src/typescript/test/fixtures/sendThankYouEmail/contributionState.json
@@ -52,7 +52,9 @@
         "payments": [
           {
             "date": "2025-12-05",
-            "amount": 412.8
+            "amount": 412.8,
+            "amountWithoutTax": 412.8,
+            "taxAmount": 0
           }
         ]
       },

--- a/support-workers/src/typescript/test/fixtures/sendThankYouEmail/digitalSubscriptionState.json
+++ b/support-workers/src/typescript/test/fixtures/sendThankYouEmail/digitalSubscriptionState.json
@@ -45,7 +45,9 @@
         "payments": [
           {
             "date": "2025-12-24",
-            "amount": 191.23
+            "amount": 191.23,
+            "amountWithoutTax": 170,
+            "taxAmount": 21.23
           }
         ]
       },

--- a/support-workers/src/typescript/test/fixtures/sendThankYouEmail/guardianAdLiteState.json
+++ b/support-workers/src/typescript/test/fixtures/sendThankYouEmail/guardianAdLiteState.json
@@ -44,51 +44,75 @@
         "payments": [
           {
             "date": "2025-11-29",
-            "amount": 5
+            "amount": 5,
+            "amountWithoutTax": 4.5,
+            "taxAmount": 0.5
           },
           {
             "date": "2025-12-29",
-            "amount": 5
+            "amount": 5,
+            "amountWithoutTax": 4.5,
+            "taxAmount": 0.5
           },
           {
             "date": "2026-01-29",
-            "amount": 5
+            "amount": 5,
+            "amountWithoutTax": 4.5,
+            "taxAmount": 0.5
           },
           {
             "date": "2026-02-28",
-            "amount": 5
+            "amount": 5,
+            "amountWithoutTax": 4.5,
+            "taxAmount": 0.5
           },
           {
             "date": "2026-03-29",
-            "amount": 5
+            "amount": 5,
+            "amountWithoutTax": 4.5,
+            "taxAmount": 0.5
           },
           {
             "date": "2026-04-29",
-            "amount": 5
+            "amount": 5,
+            "amountWithoutTax": 4.5,
+            "taxAmount": 0.5
           },
           {
             "date": "2026-05-29",
-            "amount": 5
+            "amount": 5,
+            "amountWithoutTax": 4.5,
+            "taxAmount": 0.5
           },
           {
             "date": "2026-06-29",
-            "amount": 5
+            "amount": 5,
+            "amountWithoutTax": 4.5,
+            "taxAmount": 0.5
           },
           {
             "date": "2026-07-29",
-            "amount": 5
+            "amount": 5,
+            "amountWithoutTax": 4.5,
+            "taxAmount": 0.5
           },
           {
             "date": "2026-08-29",
-            "amount": 5
+            "amount": 5,
+            "amountWithoutTax": 4.5,
+            "taxAmount": 0.5
           },
           {
             "date": "2026-09-29",
-            "amount": 5
+            "amount": 5,
+            "amountWithoutTax": 4.5,
+            "taxAmount": 0.5
           },
           {
             "date": "2026-10-29",
-            "amount": 2.58
+            "amount": 2.58,
+            "amountWithoutTax": 2,
+            "taxAmount": 0.58
           }
         ]
       },

--- a/support-workers/src/typescript/test/fixtures/sendThankYouEmail/guardianWeeklyState.json
+++ b/support-workers/src/typescript/test/fixtures/sendThankYouEmail/guardianWeeklyState.json
@@ -69,55 +69,81 @@
         "payments": [
           {
             "date": "2025-11-28",
-            "amount": 14.85
+            "amount": 14.85,
+            "amountWithoutTax": 14,
+            "taxAmount": 0.85
           },
           {
             "date": "2025-12-28",
-            "amount": 14.85
+            "amount": 14.85,
+            "amountWithoutTax": 14,
+            "taxAmount": 0.85
           },
           {
             "date": "2026-01-28",
-            "amount": 14.85
+            "amount": 14.85,
+            "amountWithoutTax": 14,
+            "taxAmount": 0.85
           },
           {
             "date": "2026-02-28",
-            "amount": 14.85
+            "amount": 14.85,
+            "amountWithoutTax": 14,
+            "taxAmount": 0.85
           },
           {
             "date": "2026-03-28",
-            "amount": 14.85
+            "amount": 14.85,
+            "amountWithoutTax": 14,
+            "taxAmount": 0.85
           },
           {
             "date": "2026-04-28",
-            "amount": 14.85
+            "amount": 14.85,
+            "amountWithoutTax": 14,
+            "taxAmount": 0.85
           },
           {
             "date": "2026-05-28",
-            "amount": 14.85
+            "amount": 14.85,
+            "amountWithoutTax": 14,
+            "taxAmount": 0.85
           },
           {
             "date": "2026-06-28",
-            "amount": 14.85
+            "amount": 14.85,
+            "amountWithoutTax": 14,
+            "taxAmount": 0.85
           },
           {
             "date": "2026-07-28",
-            "amount": 14.85
+            "amount": 14.85,
+            "amountWithoutTax": 14,
+            "taxAmount": 0.85
           },
           {
             "date": "2026-08-28",
-            "amount": 14.85
+            "amount": 14.85,
+            "amountWithoutTax": 14,
+            "taxAmount": 0.85
           },
           {
             "date": "2026-09-28",
-            "amount": 14.85
+            "amount": 14.85,
+            "amountWithoutTax": 14,
+            "taxAmount": 0.85
           },
           {
             "date": "2026-10-28",
-            "amount": 14.85
+            "amount": 14.85,
+            "amountWithoutTax": 14,
+            "taxAmount": 0.85
           },
           {
             "date": "2026-11-28",
-            "amount": 16.5
+            "amount": 16.5,
+            "amountWithoutTax": 15,
+            "taxAmount": 1.5 
           }
         ]
       },

--- a/support-workers/src/typescript/test/fixtures/sendThankYouEmail/supporterPlusState.json
+++ b/support-workers/src/typescript/test/fixtures/sendThankYouEmail/supporterPlusState.json
@@ -32,59 +32,87 @@
         "payments": [
           {
             "date": "2026-01-20",
-            "amount": 12
+            "amount": 12,
+            "amountWithoutTax": 10,
+            "taxAmount": 2
           },
           {
             "date": "2026-02-20",
-            "amount": 12
+            "amount": 12,
+            "amountWithoutTax": 10,
+            "taxAmount": 2
           },
           {
             "date": "2026-03-20",
-            "amount": 12
+            "amount": 12,
+            "amountWithoutTax": 10,
+            "taxAmount": 2
           },
           {
             "date": "2026-04-20",
-            "amount": 12
+            "amount": 12,
+            "amountWithoutTax": 10,
+            "taxAmount": 2
           },
           {
             "date": "2026-05-20",
-            "amount": 12
+            "amount": 12,
+            "amountWithoutTax": 10,
+            "taxAmount": 2
           },
           {
             "date": "2026-06-20",
-            "amount": 12
+            "amount": 12,
+            "amountWithoutTax": 10,
+            "taxAmount": 2
           },
           {
             "date": "2026-07-20",
-            "amount": 12
+            "amount": 12,
+            "amountWithoutTax": 10,
+            "taxAmount": 2
           },
           {
             "date": "2026-08-20",
-            "amount": 12
+            "amount": 12,
+            "amountWithoutTax": 10,
+            "taxAmount": 2
           },
           {
             "date": "2026-09-20",
-            "amount": 12
+            "amount": 12,
+            "amountWithoutTax": 10,
+            "taxAmount": 2
           },
           {
             "date": "2026-10-20",
-            "amount": 12
+            "amount": 12,
+            "amountWithoutTax": 10,
+            "taxAmount": 2
           },
           {
             "date": "2026-11-20",
-            "amount": 12
+            "amount": 12,
+            "amountWithoutTax": 10,
+            "taxAmount": 2
           },
           {
             "date": "2026-12-20",
-            "amount": 12
+            "amount": 12,
+            "amountWithoutTax": 10,
+            "taxAmount": 2
           },
           {
             "date": "2027-01-20",
-            "amount": 12
+            "amount": 12,
+            "amountWithoutTax": 10,
+            "taxAmount": 2
           },
           {
             "date": "2027-02-20",
-            "amount": 12
+            "amount": 12,
+            "amountWithoutTax": 10,
+            "taxAmount": 2
           }
         ]
       },

--- a/support-workers/src/typescript/test/fixtures/sendThankYouEmail/tierThreeState.json
+++ b/support-workers/src/typescript/test/fixtures/sendThankYouEmail/tierThreeState.json
@@ -66,7 +66,9 @@
         "payments": [
           {
             "date": "2025-12-05",
-            "amount": 412.8
+            "amount": 412.8,
+            "amountWithoutTax": 380,
+            "taxAmount": 32.8
           }
         ]
       },


### PR DESCRIPTION
## What are you doing in this PR?

In the day 0 email for rate plans which are tax exclusive we want to show subscription amounts without tax. This builds on #8104 where we added the amount without tax and the tax amount to the payment schedule passed to the send thank you email lambda.

Note: most of the changes to support this are in code we include from `@guardian/support-service-lambdas`. These changes are in this PR: guardian/support-service-lambdas#3716.

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1216530799713756)

## Why are you doing this?

In the day 0 email for rate plans which are tax exclusive we want to show subscription amounts without tax.

## How to test

Take out a subscription for a tax exclusive rate plan and see that the base amount without tax is shown in the email.

### Supporter Plus monthly tax exclusive (no discount)

<img width="553" height="259" alt="Screenshot 2026-07-20 at 14 41 55" src="https://github.com/user-attachments/assets/2e74cae9-1f07-4c4a-b073-c2adb3531a07" />

### Digital Plus annual tax exclusive (with discount)

<img width="556" height="248" alt="Screenshot 2026-07-20 at 14 52 31" src="https://github.com/user-attachments/assets/8d92fb86-ccea-4acd-8962-6fe696f1294b" />

### Supporter Plus tax inclusive (to illustrate nothing broken in tax inclusive cases!)

<img width="560" height="261" alt="Screenshot 2026-07-20 at 14 55 06" src="https://github.com/user-attachments/assets/0a67e7b8-7cd5-405c-9fd7-f01b0823ad97" />
