### PR TITLE
sales tax api : row spacing adjustments

### DIFF
--- a/support-frontend/assets/components/orderSummary/priceBreakdown.tsx
+++ b/support-frontend/assets/components/orderSummary/priceBreakdown.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, palette, space, textSans17 } from '@guardian/source/foundations';
+import { palette, space, textSans17 } from '@guardian/source/foundations';
 import type { CurrencyInfo } from '@guardian/support-service-lambdas/modules/internationalisation/src/currency';
 import type { BillingPeriod } from '@modules/product/billingPeriod';
 import { PriceSummary } from 'components/priceSummary/priceSummary';
@@ -16,18 +16,14 @@ const summaryRow = css`
 	align-items: baseline;
 `;
 
-const rowSpacing = (isTaxInclusive: boolean) => css`
+const rowSpacing = css`
 	display: flex;
 	flex-direction: column;
 	gap: ${space[1]}px;
 	margin-top: ${space[1]}px;
 
 	&:not(:last-child) {
-		margin-bottom: ${space[6]}px;
-
-		${from.desktop} {
-			margin-bottom: ${space[isTaxInclusive ? 8 : 6]}px;
-		}
+		margin-bottom: ${space[8]}px;
 	}
 `;
 
@@ -132,7 +128,7 @@ export function PriceBreakdown({
 
 	return (
 		<>
-			<div css={rowSpacing(isTaxInclusive)}>
+			<div css={rowSpacing}>
 				<div css={[summaryRow, boldText]}>
 					<p>{priceLabel}</p>
 					<PriceSummary

--- a/support-frontend/assets/components/orderSummary/priceBreakdown.tsx
+++ b/support-frontend/assets/components/orderSummary/priceBreakdown.tsx
@@ -16,7 +16,7 @@ const summaryRow = css`
 	align-items: baseline;
 `;
 
-const rowSpacing = css`
+const rowSpacing = (isTaxInclusive: boolean) => css`
 	display: flex;
 	flex-direction: column;
 	gap: ${space[1]}px;
@@ -26,7 +26,7 @@ const rowSpacing = css`
 		margin-bottom: ${space[6]}px;
 
 		${from.desktop} {
-			margin-bottom: ${space[8]}px;
+			margin-bottom: ${space[isTaxInclusive ? 8 : 6]}px;
 		}
 	}
 `;
@@ -127,12 +127,12 @@ export function PriceBreakdown({
 	}
 
 	// When the tax is shown separately the label is e.g. "Monthly price"
-	const priceLabel =
-		taxRateConfig.type === 'tax_inclusive' ? 'Total' : `${billingPeriod} price`;
+	const isTaxInclusive = taxRateConfig.type === 'tax_inclusive';
+	const priceLabel = isTaxInclusive ? 'Total' : `${billingPeriod} price`;
 
 	return (
 		<>
-			<div css={[rowSpacing]}>
+			<div css={rowSpacing(isTaxInclusive)}>
 				<div css={[summaryRow, boldText]}>
 					<p>{priceLabel}</p>
 					<PriceSummary
@@ -140,7 +140,7 @@ export function PriceBreakdown({
 						period={period}
 						discountPrice={discountPrice}
 						isWeeklyGift={isWeeklyGift}
-						showPeriod={taxRateConfig.type === 'tax_inclusive'}
+						showPeriod={isTaxInclusive}
 						isIntroductoryPricing={isIntroductoryPricing}
 					/>
 				</div>

--- a/support-frontend/assets/components/orderSummary/taxTsAndCs.tsx
+++ b/support-frontend/assets/components/orderSummary/taxTsAndCs.tsx
@@ -4,7 +4,7 @@ import { neutral, space, textSans12 } from '@guardian/source/foundations';
 const tsAndCsContainer = css`
 	// In the weekly pricing context, child divs are given a padding of 0, we
 	// need to override that here.
-	padding: ${space[2]}px 0 0 0 !important;
+	padding: ${space[3]}px 0 0 0 !important;
 `;
 
 const tsAndCsText = css`

--- a/support-frontend/assets/components/salesTax/maybeEstimatedTaxSummary.tsx
+++ b/support-frontend/assets/components/salesTax/maybeEstimatedTaxSummary.tsx
@@ -24,6 +24,7 @@ const taxSummaryContainer = css`
 	margin-bottom: ${space[5]}px;
 
 	${from.desktop} {
+		margin-top: ${space[8]}px;
 		margin-bottom: ${space[6]}px;
 	}
 `;

--- a/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/checkoutForm.tsx
@@ -1262,7 +1262,7 @@ export default function CheckoutForm({
 						/>
 						<div
 							css={css`
-								margin: ${space[8]}px 0;
+								margin: ${space[taxExclusive ? 0 : 8]}px 0 ${space[8]}px;
 							`}
 						>
 							<SubmitButton

--- a/support-workers/src/typescript/test/createZuoraSubscriptionLambda.it.test.ts
+++ b/support-workers/src/typescript/test/createZuoraSubscriptionLambda.it.test.ts
@@ -28,7 +28,7 @@ describe('createZuoraSubscriptionLambda integration', () => {
 				fail('Expected handler to throw');
 			} catch (error) {
 				if (error instanceof RetryError) {
-					expect(error.name).toBe(RetryErrorType.RetryLimited);
+					expect(error.name).toBe(RetryErrorType.RetryNone);
 					expect(error.message).toContain('Transaction declined');
 				} else {
 					fail('Error is not an instance of RetryError');

--- a/support-workers/src/typescript/test/createZuoraSubscriptionLambda.it.test.ts
+++ b/support-workers/src/typescript/test/createZuoraSubscriptionLambda.it.test.ts
@@ -28,7 +28,7 @@ describe('createZuoraSubscriptionLambda integration', () => {
 				fail('Expected handler to throw');
 			} catch (error) {
 				if (error instanceof RetryError) {
-					expect(error.name).toBe(RetryErrorType.RetryNone);
+					expect(error.name).toBe(RetryErrorType.RetryLimited);
 					expect(error.message).toContain('Transaction declined');
 				} else {
 					fail('Error is not an instance of RetryError');


### PR DESCRIPTION
## What are you doing in this PR?
Row spacing overrides for taxExclusive components->

1. price summary breakdown, Margin bottom 24px (only taxExclusive)
2. price checkout estimated tax summary, margin top widened to 32pt, margin removed checkout summary (only taxExclusive)
3. TaxTs&Cs container spacing widened from 8pt to 12pt (all) 

## Screenshots

|1|2|
|-----|-----|
|<img width="1285" height="619" alt="image" src="https://github.com/user-attachments/assets/b4d482da-806e-4599-98cf-1edf84eddcd7" />|<img width="1214" height="470" alt="image" src="https://github.com/user-attachments/assets/3a23381d-80c2-451f-a147-b56f9764e89d" />|


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216640069286825