### PR TITLE
Test createZuoraSubscriptionLambda transactionDeclined updated with S+ CODE prices

### DIFF
--- a/support-workers/src/typescript/test/fixtures/createZuoraSubscription/transactionDeclinedInput.json
+++ b/support-workers/src/typescript/test/fixtures/createZuoraSubscription/transactionDeclinedInput.json
@@ -4,7 +4,7 @@
       "productType": "SupporterPlus",
       "billingCountry": "GB",
       "product": {
-        "amount": 12,
+        "amount": 14,
         "currency": "GBP",
         "billingPeriod": "Monthly",
         "productType": "SupporterPlus"
@@ -12,7 +12,7 @@
       "productInformation": {
         "product": "SupporterPlus",
         "ratePlan": "Monthly",
-        "amount": 12
+        "amount": 14
       },
       "paymentMethod": {
         "TokenId": "pm_0S1SrNItVxyc3Q6ntB3yRwJ9",
@@ -54,7 +54,7 @@
     },
     "giftRecipient": null,
     "product": {
-      "amount": 12,
+      "amount": 14,
       "currency": "GBP",
       "billingPeriod": "Monthly",
       "productType": "SupporterPlus"
@@ -62,7 +62,7 @@
     "productInformation": {
       "product": "SupporterPlus",
       "ratePlan": "Monthly",
-      "amount": 12
+      "amount": 14
     },
     "analyticsInfo": {
       "isGiftPurchase": false,


### PR DESCRIPTION
## What are you doing in this PR?

After a S+ price update in CODE the createZuoraSubscriptionLambda/transactionDeclined error reflects a negative contribution amount unless the `transactionDeclinedError.json` is updated to reflect the new price 

## How to test

`pnpm --filter support-workers it-test`