### PR TITLE
S+ Pricing Update - Playwright  Test Updates

### DIFF
--- a/support-e2e/tests/smoke/promo-codes.test.ts
+++ b/support-e2e/tests/smoke/promo-codes.test.ts
@@ -19,8 +19,8 @@ import { email, firstName, lastName } from '../utils/users';
 		expectedCardHeading: ProductTierLabel.TierTwo,
 		expectedPromoText:
 			/£(\d|\.)+\/month for (\d|\.) months, then £(\d|\.)+\/month/,
-		expectedCheckoutTotalText: 'Was £12, now £9.60/month',
-		expectedPaymentButtonText: 'Pay £9.60 per month',
+		expectedCheckoutTotalText: 'Was £14, now £11.20/month',
+		expectedPaymentButtonText: 'Pay £11.20 per month',
 		expectedThankYouText:
 			/You'll pay £(\d|\.)+\/month for the first (\d|\.)+ months, then £(\d|\.)+\/month afterwards unless you cancel\./,
 		accessibleCtaText: ProductTierLabel.TierTwo,

--- a/support-e2e/tests/smoke/promo-codes.test.ts
+++ b/support-e2e/tests/smoke/promo-codes.test.ts
@@ -19,8 +19,8 @@ import { email, firstName, lastName } from '../utils/users';
 		expectedCardHeading: ProductTierLabel.TierTwo,
 		expectedPromoText:
 			/£(\d|\.)+\/month for (\d|\.) months, then £(\d|\.)+\/month/,
-		expectedCheckoutTotalText: 'Was £14, now £11.20/month',
-		expectedPaymentButtonText: 'Pay £11.20 per month',
+		expectedCheckoutTotalText: /Was £(\d|\.)+, now £(\d|\.)+\/month/i,
+		expectedPaymentButtonText: /Pay £(\d|\.)+ per month/i,
 		expectedThankYouText:
 			/You'll pay £(\d|\.)+\/month for the first (\d|\.)+ months, then £(\d|\.)+\/month afterwards unless you cancel\./,
 		accessibleCtaText: ProductTierLabel.TierTwo,

--- a/support-e2e/tests/smoke/student-au.test.ts
+++ b/support-e2e/tests/smoke/student-au.test.ts
@@ -12,11 +12,11 @@ import { email, firstName, lastName } from '../utils/users';
 		frequency: 'Monthly',
 		promoCode: 'UTS_STUDENT',
 		expectedCardHeading: ProductTierLabel.TierTwo,
-		expectedPromoText: '$0/month for two years, then $25/month',
-		expectedCheckoutTotalText: 'Was $25, now $0/month',
+		expectedPromoText: /[$]0\/month for two years, then [$](\d|\.)+\/month/,
+		expectedCheckoutTotalText: /Was [$](\d|\.)+, now [$]0\/month/i,
 		accessibleCtaText: 'Sign up for free',
 		expectedThankYouText:
-			"You'll pay $0/month for the first 24 months, then $25/month afterwards unless you cancel",
+			/You'll pay [$]0\/month for the first 24 months, then [$](\d|\.)+\/month afterwards unless you cancel\./,
 	},
 ].forEach((testDetails) => {
 	test(`${testDetails.expectedCardHeading} ${testDetails.frequency} ${testDetails.promoCode} Promo`, async ({

--- a/support-e2e/tests/smoke/student-au.test.ts
+++ b/support-e2e/tests/smoke/student-au.test.ts
@@ -12,11 +12,11 @@ import { email, firstName, lastName } from '../utils/users';
 		frequency: 'Monthly',
 		promoCode: 'UTS_STUDENT',
 		expectedCardHeading: ProductTierLabel.TierTwo,
-		expectedPromoText: '$0/month for two years, then $20/month',
-		expectedCheckoutTotalText: 'Was $20, now $0/month',
+		expectedPromoText: '$0/month for two years, then $25/month',
+		expectedCheckoutTotalText: 'Was $25, now $0/month',
 		accessibleCtaText: 'Sign up for free',
 		expectedThankYouText:
-			"You'll pay $0/month for the first 24 months, then $20/month afterwards unless you cancel",
+			"You'll pay $0/month for the first 24 months, then $25/month afterwards unless you cancel",
 	},
 ].forEach((testDetails) => {
 	test(`${testDetails.expectedCardHeading} ${testDetails.frequency} ${testDetails.promoCode} Promo`, async ({


### PR DESCRIPTION
## What are you doing in this PR?
Price Update S+ has cause 2 test failures shown below
<img width="800" height="153" alt="image" src="https://github.com/user-attachments/assets/52f429c8-0167-4817-b9bd-074dd0af8e5d" />

Update amounts to reflect S+ test totals are correct
Make tests independent of price updates

## How to test

`cd support-e2e`
`pnpm test-smoke-dev`
