### PR TITLE
Update Collection product info with expanded retailer list and wording changes

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/helpers/newsPaperTabHeroData.tsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/helpers/newsPaperTabHeroData.tsx
@@ -48,14 +48,14 @@ const heroContent: Record<PaperFulfilmentOptions, HeroContent> = {
 		],
 	},
 	Collection: {
-		productInfo: `Use your Guardian subscription card to pick up your paper in over 40,000 UK shops with news kiosks, including Co-op, McColl's, One Stop, and select SPAR stores. Or use your card to arrange your own delivery through a local newsagent.`,
+		productInfo: `Use your Guardian subscription card to pick up your paper in over 45,000 UK shops with news kiosks, including Waitrose, WH Smith, Co-op, Morrisons Daily, TGJones, One Stop, and select SPAR stores. Or use your card to arrange your own delivery through a local newsagent.`,
 		deliveries: [
 			{
 				deliveryTitle: 'How to collect in store',
 				deliveryInfo: (
 					<>
 						<p>
-							To pick up your paper from multiple newsagents, present your
+							To pick up your paper from your local retailer, present your
 							Guardian subscription card each time – they’ll scan it and be
 							reimbursed automatically.
 						</p>


### PR DESCRIPTION
Updates the hardcoded copy on the paper subscription landing page (`/uk/subscribe/paper#Collection`) to support the Newspaper Pre-summer sale and Waitrose partnership.

- Store count: 40,000 → 45,000
- Retailer list: added Waitrose, WH Smith, Morrisons Daily, TGJones; removed McColl's
- "How to collect in store": "multiple newsagents" → "your local retailer"

### Screenshot

<img width="1200" height="897" alt="image" src="https://github.com/user-attachments/assets/4a3ad94f-b406-4d3f-8eb8-543ced466751" />
