### PR TITLE
Exclude http4s-blaze-server

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -52,6 +52,11 @@ excludeDependencies ++= Seq(
   // This exclusion is needed until we upgrade identity-auth-play to a version which doesn't pull in an older play and
   // therefore an older version of lz4. The later version of lz4 pulled in by Play 3.0.10 will be used instead.
   ExclusionRule("org.lz4"),
+  // Exclude http4s-blaze-server due to CVEs GHSA-mhvj-jhpq-885v and GHSA-7ppr-r889-mcf2 (HIGH severity).
+  // Brought in transitively via com.gu.identity:identity-auth-core which uses http4s only as an HTTP client;
+  // the server JAR is not needed in this Play application. A fix requires upgrading to 0.23.x which is a
+  // Cats Effect 3 migration incompatible with the CE2-based identity-auth-core 7.0.0.
+  ExclusionRule("org.http4s", "http4s-blaze-server_2.13"),
 )
 
 ThisBuild / libraryDependencySchemes ++= Seq(


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
org.http4s:http4s-blaze-server_2.13 0.22.15 is pulled in as a transitive dependency via com.gu.identity:identity-auth-core 7.0.0 (itself a dependency of identity-auth-play 7.0.0). It has two HIGH-severity CVEs:
- GHSA-mhvj-jhpq-885v — HTTP/1.1 request-smuggling via blaze's server-side wire parser
- GHSA-7ppr-r889-mcf2 — Unbounded WebSocket message aggregation leading to OOM/DoS

A version override won't work for these vulnerabilities because the fix requires upgrading to 0.23.x, but that series uses Cats Effect 3, whereas identity-auth-core 7.0.0 was compiled against CE2 (0.22.x). Forcing 0.23.x would cause binary incompatibilities at runtime.

As a fix I have added an ExclusionRule("org.http4s", "http4s-blaze-server_2.13") to support-frontend/build.sbt. This is safe because support-frontend is a Play application, http4s is only used here as an HTTP client (to call the Guardian identity API). BlazeServerBuilder is never started — the app uses Play's own Netty-based server. The http4s-blaze-client JAR (needed for the client calls) is unaffected and remains on the classpath.