### PR TITLE
pass implicit fulfilmentOption and productOption based on the product

### DIFF
--- a/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
@@ -16,11 +16,14 @@ import {
 } from '@guardian/source/react-components';
 import type { SupportRegionId } from '@modules/internationalisation/countryGroup';
 import { BillingPeriod } from '@modules/product/billingPeriod';
+import type { ProductOptions } from '@modules/product/productOptions';
 import { useEffect } from 'react';
 import { Box, BoxContents } from 'components/checkoutBox/checkoutBox';
 import { simpleFormatAmount } from 'helpers/forms/checkouts';
 import { Country } from 'helpers/internationalisation/classes/country';
 import { getLegacyProductType } from 'helpers/legacyTypeConversions';
+import { getFulfilmentOptionFromProductKey } from 'helpers/productCatalogToFulfilmentOption';
+import { getProductOptionFromProductAndRatePlan } from 'helpers/productCatalogToProductOption';
 import {
 	allCheckoutNudgeProductPrices,
 	getProductPrice,
@@ -44,6 +47,7 @@ import {
 	BenefitsCheckList,
 	type BenefitsCheckListData,
 } from '../checkoutBenefits/benefitsCheckList';
+
 
 const nudgeBoxOverrides = css`
 	border: none;
@@ -346,11 +350,19 @@ function getNudgePromotion(
 		return undefined;
 	}
 
+	const fulfilmentOption = getFulfilmentOptionFromProductKey(legacyProductKey);
+	const productOptions: ProductOptions = getProductOptionFromProductAndRatePlan(
+		legacyProductKey,
+		ratePlan as ActiveRatePlanKey,
+	);
+
 	try {
 		const productPrice = getProductPrice(
 			productPrices,
 			Country.detect(),
 			billingPeriod,
+			fulfilmentOption,
+			productOptions,
 		);
 		return productPrice.promotions?.find((p) =>
 			promoCodes.includes(p.promoCode),

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
@@ -48,7 +48,6 @@ import {
 	type BenefitsCheckListData,
 } from '../checkoutBenefits/benefitsCheckList';
 
-
 const nudgeBoxOverrides = css`
 	border: none;
 	margin-top: ${space[3]}px;


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR fixes checkout nudge CTA text if promotion is applied. Previously getProductPrice function did not received explicit fulfilmentOption and productOptions and used default values, but after productPrices schema changed it stopped working. Now getProductPrice receives explicit fulfilmentOption and productOptions based on the product and rate plan
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1216899290142678)

## Why are you doing this?
There was a bug in checkout nudge where promotion was applied - CTA did not show the promotion
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test
Deploy to CODE env, verify that for checkout nudge with promotion it is shown up in CTA
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
<img width="675" height="423" alt="Screenshot 2026-07-28 at 09 48 35" src="https://github.com/user-attachments/assets/c026dca5-c37e-44fc-b372-c4208ffe4c07" />
