### PR TITLE
Use Mise & `.tool-versions` to manage Node version

### DIFF
--- a/.github/actions/setup-node-and-install/action.yml
+++ b/.github/actions/setup-node-and-install/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version-file: ".nvmrc"
+        node-version-file: ".tool-versions"
 
     - name: Install
       run: pnpm install

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: ".tool-versions"
 
       - name: Check compressed size of JS
         uses: preactjs/compressed-size-action@v2

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,3 @@
+# Node version management is moving to Mise/.tool-versions.
+# This file will be deleted in a future PR.
 24.14.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 java corretto-21
+node 24


### PR DESCRIPTION
## What are you doing in this PR?

Switch to using Mise and the `.tool-versions` file to manage Node.

## Why are you doing this?

We already use Mise and `.tool-versions` to manage Java versions. As we start using devcontainers we'll also be using Mise and `.tool-versions` to manage the version of `guardian/devenv`. I think it makes sense to move Node into this world as well so all versions are specified in a single place and we don't have an exception for the tool used to manage Node.

For the time being I've left the `.nvmrc` file in place to ease the transition for developers. This will be deleted in a future PR.

## How to test

Locally verify that the correct Node version is picked up.

In CI I can see that version 24 is picked up from the `.tool-versions` file successfully:

<img width="494" height="62" alt="Screenshot 2026-07-28 at 09 57 16" src="https://github.com/user-attachments/assets/994612c6-6765-4fdb-abc0-d39d911c7307" />
