### PR TITLE
use activeproduct key

### DIFF
--- a/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
@@ -331,10 +331,7 @@ function getNudgePromotion(
 	product: ActiveProductKey,
 	ratePlan: ActiveRatePlanKey,
 ): Promotion | undefined {
-	const legacyProductKey = getLegacyProductType(
-		product,
-		ratePlan,
-	);
+	const legacyProductKey = getLegacyProductType(product, ratePlan);
 	if (
 		!promoCodes?.length ||
 		!isValidCheckoutNudgeProductKey(legacyProductKey) ||

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
@@ -48,7 +48,6 @@ import {
 	type BenefitsCheckListData,
 } from '../checkoutBenefits/benefitsCheckList';
 
-
 const nudgeBoxOverrides = css`
 	border: none;
 	margin-top: ${space[3]}px;

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
@@ -328,12 +328,12 @@ function isValidCheckoutNudgeProductKey(
  */
 function getNudgePromotion(
 	promoCodes: string[] | undefined,
-	product: string,
-	ratePlan: string,
+	product: ActiveProductKey,
+	ratePlan: ActiveRatePlanKey,
 ): Promotion | undefined {
 	const legacyProductKey = getLegacyProductType(
-		product as ActiveProductKey,
-		ratePlan as ActiveRatePlanKey,
+		product,
+		ratePlan,
 	);
 	if (
 		!promoCodes?.length ||
@@ -344,15 +344,15 @@ function getNudgePromotion(
 	}
 
 	const productPrices = allCheckoutNudgeProductPrices[legacyProductKey];
-	const billingPeriod = ratePlanToBillingPeriod[ratePlan as ActiveRatePlanKey];
+	const billingPeriod = ratePlanToBillingPeriod[ratePlan];
 	if (!billingPeriod) {
 		return undefined;
 	}
 
-	const fulfilmentOption = getFulfilmentOptionFromProductKey(legacyProductKey);
+	const fulfilmentOption = getFulfilmentOptionFromProductKey(product);
 	const productOptions: ProductOptions = getProductOptionFromProductAndRatePlan(
-		legacyProductKey,
-		ratePlan as ActiveRatePlanKey,
+		product,
+		ratePlan,
 	);
 
 	try {

--- a/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
+++ b/support-frontend/assets/components/checkoutNudge/checkoutNudge.tsx
@@ -48,6 +48,7 @@ import {
 	type BenefitsCheckListData,
 } from '../checkoutBenefits/benefitsCheckList';
 
+
 const nudgeBoxOverrides = css`
 	border: none;
 	margin-top: ${space[3]}px;


### PR DESCRIPTION
<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR updates Checkout Nudge getFulfilmentOptionFromProductKey and getProductOptionFromProductAndRatePlan to use active product key instead of legacy product key
<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1216899290142678)

## Why are you doing this?
For product DigitalSubscription the legacy key was DigitalPack and getProductOptionFromProductAndRatePlan did not map it correctly to DigitalSubscription.
<!--
Remember, PRs are documentation for future contributors.
-->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Accessibility test checklist

-  [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-  [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-  [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-  [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

## Screenshots
<img width="686" height="534" alt="Screenshot 2026-07-28 at 11 23 13" src="https://github.com/user-attachments/assets/cf0e2670-ae15-4d23-8097-1bc406204cdb" />
