### PR TITLE
Fix currency type in routes.ts

### DIFF
--- a/support-frontend/assets/helpers/urls/routes.ts
+++ b/support-frontend/assets/helpers/urls/routes.ts
@@ -1,7 +1,7 @@
 // ----- Routes ----- //
 import type { CountryGroupId } from '@modules/internationalisation/countryGroup';
 import { countryGroups } from '@modules/internationalisation/countryGroup';
-import type { IsoCurrency } from '@modules/internationalisation/currency';
+import type { CurrencyCode } from '@modules/internationalisation/currency';
 import type { BillingPeriod } from '@modules/product/billingPeriod';
 import type {
 	FulfilmentOptions,
@@ -199,7 +199,7 @@ function stripePayPalReturnUrl(
 	cgId: CountryGroupId,
 	email: string,
 	stripePublicKey: string,
-	currency: IsoCurrency,
+	currency: CurrencyCode,
 	amount: number,
 ): string {
 	return `${getOrigin()}/${countryPath(


### PR DESCRIPTION
## What are you doing in this PR?

Updating a broken type reference in `routes.ts`. I think this slipped through the cracks because the reference to `IsoCurrency` was added in #8011, but this didn't exist when the PR which renamed the currency types was opened (#8117).

## Why are you doing this?

The typescript check is currently broken on main.