### PR TITLE
In the Fastly snippets workflow don't hardcode the Node version

### DIFF
--- a/.github/workflows/deploy-fastly-snippets.yaml
+++ b/.github/workflows/deploy-fastly-snippets.yaml
@@ -31,6 +31,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 18
+          node-version-file: ".tool-versions"
       - name: Deploy Fastly snippets
         run: node .github/workflows/deploy-fastly-snippets.js


### PR DESCRIPTION
## What are you doing in this PR?

I noticed that in the Fastly snippets workflow we hardcode the Node version to 18, which is no longer supported. Instead get the Node version from `.tool-versions` like we do everywhere else.

## How to test

I ran the [Fastly deploy snippets workflow](https://github.com/guardian/support-frontend/actions/runs/30444698831) from this branch.