### PR TITLE
Update support-backend SSM paths to use conventional pattern

### DIFF
--- a/cdk/lib/__snapshots__/backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/backend.test.ts.snap
@@ -774,18 +774,32 @@ exports[`The Backend stack matches the snapshot 1`] = `
             {
               "Action": "ssm:GetParameter",
               "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:eu-west-1:",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/support/support-backend/PROD/*",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:eu-west-1:",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/support/support-backend/PROD/*",
+                    ],
                   ],
-                ],
-              },
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:ssm:eu-west-1:",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/PROD/support-backend/support/*",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/__snapshots__/backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/backend.test.ts.snap
@@ -774,32 +774,18 @@ exports[`The Backend stack matches the snapshot 1`] = `
             {
               "Action": "ssm:GetParameter",
               "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:aws:ssm:eu-west-1:",
-                      {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":parameter/support/support-backend/PROD/*",
-                    ],
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/support/support-backend/PROD/*",
                   ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:aws:ssm:eu-west-1:",
-                      {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":parameter/PROD/support-backend/support/*",
-                    ],
-                  ],
-                },
-              ],
+                ],
+              },
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/backend.ts
+++ b/cdk/lib/backend.ts
@@ -88,7 +88,9 @@ cd target
 			new GuAllowPolicy(this, 'SSMGet', {
 				actions: ['ssm:GetParameter'],
 				resources: [
+					// TODO: remove this entry once we've migrated to the version with stage first:
 					`arn:aws:ssm:${this.region}:${this.account}:parameter/${this.stack}/${app}/${this.stage}/*`,
+					`arn:aws:ssm:${this.region}:${this.account}:parameter/${this.stage}/${app}/${this.stack}/*`,
 				],
 			}),
 			new GuAllowPolicy(this, 'CloudwatchMetrics', {

--- a/cdk/lib/backend.ts
+++ b/cdk/lib/backend.ts
@@ -90,7 +90,6 @@ cd target
 				resources: [
 					// TODO: remove this entry once we've migrated to the version with stage first:
 					`arn:aws:ssm:${this.region}:${this.account}:parameter/${this.stack}/${app}/${this.stage}/*`,
-					`arn:aws:ssm:${this.region}:${this.account}:parameter/${this.stage}/${app}/${this.stack}/*`,
 				],
 			}),
 			new GuAllowPolicy(this, 'CloudwatchMetrics', {

--- a/support-backend/src/routers/apiRouter.ts
+++ b/support-backend/src/routers/apiRouter.ts
@@ -10,7 +10,7 @@ async function getIdealPostcodeApiKey(): Promise<string> {
 		region: 'eu-west-1',
 	});
 	const command = new GetParameterCommand({
-		Name: `/support/support-backend/${stage}/ideal-postcodes-api.key`,
+		Name: `/${stage}/support/support-backend/ideal-postcodes-api.key`,
 		WithDecryption: true,
 	});
 	const response = await ssmClient.send(command);


### PR DESCRIPTION
## What are you doing in this PR?

This updates support-backend to use a more conventional SSM path convention where the stage comes first.

I'm doing this in two steps to avoid temporary errors where the CDK has updated but the application hasn't yet. I've added the new entries to parameter store and currently both paths exist in the CDK. Once this PR is merged I'll go back and clean up the CDK and remove the old parameter store entries themselves.

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1216857703906213)

## Why are you doing this?

This change means it'll be possible to run support-backend locally with the new Janus Local Development policy without having to add exceptions to the policy..

## How to test

I've run support-backend locally and in CODE and verified the postcode lookup endpoint works successfully (it needs to read the API key from parameter store).