### PR TITLE
Exclude io.appium:java-client from support-frontend and payment-api

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -57,6 +57,9 @@ excludeDependencies ++= Seq(
   // the server JAR is not needed in this Play application. A fix requires upgrading to 0.23.x which is a
   // Cats Effect 3 migration incompatible with the CE2-based identity-auth-core 7.0.0.
   ExclusionRule("org.http4s", "http4s-blaze-server_2.13"),
+  // Exclude io.appium:java-client due to a high severity vulnerability. It's pulled in via org.playframework:play-test
+  // > io.fluentlenium:fluentlenium-core, but I don't think it's used/needed.
+  ExclusionRule("io.appium", "java-client"),
 )
 
 ThisBuild / libraryDependencySchemes ++= Seq(

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -70,6 +70,9 @@ excludeDependencies ++= Seq(
   // newer version by specifying it in the dependencies.
   ExclusionRule("net.sourceforge.htmlunit", "htmlunit"),
   ExclusionRule("commons-beanutils", "commons-beanutils"), // Also exclude commons-beanutils due to a vulnerability
+  // Exclude io.appium:java-client due to a high severity vulnerability. It's pulled in via org.playframework:play-test
+  // > io.fluentlenium:fluentlenium-core, but I don't think it's used/needed.
+  ExclusionRule("io.appium", "java-client"),
 )
 
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion


### PR DESCRIPTION
## What are you doing in this PR?

Exclude `io.appium:java-client` from support-frontend and payment-api.

[**Asana Card**](https://app.asana.com)

## Why are you doing this?

Depandabot has reported a high severity vulnerability for `io.appium:java-client`. To move to a non vulnerable version would require a bump of several major versions. It's brought in via `org.playframework:play-test` > `io.fluentlenium:fluentlenium-core`, but I don't think it's used/needed.

## How to test

This is a dev/test dependency, so if the build is green I think all's well.