### PR TITLE
Remove unneeded support-backend SSM read permission from CDK

### DIFF
--- a/cdk/lib/__snapshots__/backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/backend.test.ts.snap
@@ -6,7 +6,6 @@ exports[`The Backend stack matches the snapshot 1`] = `
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
       "GuAllowPolicy",
-      "GuAllowPolicy",
       "GuVpcParameter",
       "GuSubnetListParameter",
       "GuSubnetListParameter",
@@ -759,38 +758,6 @@ exports[`The Backend stack matches the snapshot 1`] = `
           "Version": "2012-10-17",
         },
         "PolicyName": "parameter-store-read-policy",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleSupportbackend25B34CE1",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "SSMGetF4C837D5": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "ssm:GetParameter",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:eu-west-1:",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/support/support-backend/PROD/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "SSMGetF4C837D5",
         "Roles": [
           {
             "Ref": "InstanceRoleSupportbackend25B34CE1",

--- a/cdk/lib/backend.ts
+++ b/cdk/lib/backend.ts
@@ -85,13 +85,6 @@ cd target
 		} ${app} /var/log/${app}/application.log`);
 
 		const policies = [
-			new GuAllowPolicy(this, 'SSMGet', {
-				actions: ['ssm:GetParameter'],
-				resources: [
-					// TODO: remove this entry once we've migrated to the version with stage first:
-					`arn:aws:ssm:${this.region}:${this.account}:parameter/${this.stack}/${app}/${this.stage}/*`,
-				],
-			}),
 			new GuAllowPolicy(this, 'CloudwatchMetrics', {
 				actions: [
 					'logs:CreateLogGroup',


### PR DESCRIPTION
## What are you doing in this PR?

Removing an unneeded support-backend SSM read permission from CDK.

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1216857703906213)

## Why are you doing this?

We've updated support-backend to use a more conventional path, and we get this read policy for free, so this old permission can be removed.

## How to test

Verify that support-backend can still read from SSM to get the postcode search API key ✅ 