### PR TITLE
Update alarms to cover PayPalCompletePayments

### DIFF
--- a/cdk/lib/__snapshots__/support-workers.test.ts.snap
+++ b/cdk/lib/__snapshots__/support-workers.test.ts.snap
@@ -1155,7 +1155,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "EvaluationPeriods": 144,
         "Metrics": [
           {
-            "Expression": "SUM([FILL(m0,0),FILL(m1,0),FILL(m2,0),FILL(m3,0),FILL(m4,0),FILL(m5,0)])",
+            "Expression": "SUM([FILL(m0,0),FILL(m1,0),FILL(m2,0),FILL(m3,0),FILL(m4,0),FILL(m5,0),FILL(m6,0)])",
             "Id": "expr_1",
             "Label": "AllGuardianAdLiteConversions",
             "ReturnData": true,
@@ -1245,7 +1245,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
                 "Dimensions": [
                   {
                     "Name": "PaymentProvider",
-                    "Value": "StripeApplePay",
+                    "Value": "PayPalCompletePayments",
                   },
                   {
                     "Name": "ProductType",
@@ -1271,7 +1271,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
                 "Dimensions": [
                   {
                     "Name": "PaymentProvider",
-                    "Value": "StripePaymentRequestButton",
+                    "Value": "StripeApplePay",
                   },
                   {
                     "Name": "ProductType",
@@ -1292,6 +1292,32 @@ exports[`The support-workers stack matches the snapshot 1`] = `
           },
           {
             "Id": "m5",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "StripePaymentRequestButton",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "GuardianAdLite",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m6",
             "MetricStat": {
               "Metric": {
                 "Dimensions": [
@@ -2033,7 +2059,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "EvaluationPeriods": 288,
         "Metrics": [
           {
-            "Expression": "SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0)])",
+            "Expression": "SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0),FILL(m4,0)])",
             "Id": "expr_1",
             "Label": "AllPaperConversions",
             "ReturnData": true,
@@ -2098,6 +2124,32 @@ exports[`The support-workers stack matches the snapshot 1`] = `
                   {
                     "Name": "PaymentProvider",
                     "Value": "PayPal",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "Paper",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m4",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "PayPalCompletePayments",
                   },
                   {
                     "Name": "ProductType",
@@ -2246,7 +2298,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "NoPayPalContributionsAlarm3674D829": {
+    "NoPayPalCompletePaymentsContributionsAlarmB8EA2E8E": {
       "DependsOn": [
         "SupportWorkersPROD",
         "SupportWorkersRoleDefaultPolicyCB757939",
@@ -2272,12 +2324,12 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "support-workers PROD No successful recurring PayPal contributions recently.",
+        "AlarmName": "support-workers PROD No successful recurring PayPalCompletePayments contributions recently.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
             "Name": "PaymentProvider",
-            "Value": "PayPal",
+            "Value": "PayPalCompletePayments",
           },
           {
             "Name": "ProductType",
@@ -2334,7 +2386,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "NoPayPalSupporterPlusAlarm3A1EEE12": {
+    "NoPayPalCompletePaymentsSupporterPlusAlarmF51DC546": {
       "DependsOn": [
         "SupportWorkersPROD",
         "SupportWorkersRoleDefaultPolicyCB757939",
@@ -2360,12 +2412,12 @@ exports[`The support-workers stack matches the snapshot 1`] = `
             ],
           },
         ],
-        "AlarmName": "support-workers PROD No successful PayPal supporter plus subscriptions recently.",
+        "AlarmName": "support-workers PROD No successful PayPalCompletePayments supporter plus subscriptions recently.",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
             "Name": "PaymentProvider",
-            "Value": "PayPal",
+            "Value": "PayPalCompletePayments",
           },
           {
             "Name": "ProductType",
@@ -2981,7 +3033,7 @@ exports[`The support-workers stack matches the snapshot 1`] = `
         "EvaluationPeriods": 144,
         "Metrics": [
           {
-            "Expression": "SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0)])",
+            "Expression": "SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0),FILL(m4,0)])",
             "Id": "expr_1",
             "Label": "AllWeeklyConversions",
             "ReturnData": true,
@@ -3046,6 +3098,32 @@ exports[`The support-workers stack matches the snapshot 1`] = `
                   {
                     "Name": "PaymentProvider",
                     "Value": "PayPal",
+                  },
+                  {
+                    "Name": "ProductType",
+                    "Value": "GuardianWeekly",
+                  },
+                  {
+                    "Name": "Stage",
+                    "Value": "PROD",
+                  },
+                ],
+                "MetricName": "PaymentSuccess",
+                "Namespace": "support-frontend",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m4",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "PaymentProvider",
+                    "Value": "PayPalCompletePayments",
                   },
                   {
                     "Name": "ProductType",

--- a/cdk/lib/support-workers.ts
+++ b/cdk/lib/support-workers.ts
@@ -46,6 +46,7 @@ const PaymentProviders = {
 	Stripe: 'Stripe',
 	DirectDebit: 'DirectDebit',
 	PayPal: 'PayPal',
+	PayPalCompletePayments: 'PayPalCompletePayments',
 	StripeApplePay: 'StripeApplePay',
 	StripePaymentRequestButton: 'StripePaymentRequestButton',
 	StripeHostedCheckout: 'StripeHostedCheckout',
@@ -384,7 +385,7 @@ export class SupportWorkers extends GuStack {
 			periodDuration: Duration;
 		}> = [
 			{
-				paymentProvider: PaymentProviders.PayPal,
+				paymentProvider: PaymentProviders.PayPalCompletePayments,
 				evaluationPeriods: 4,
 				periodDuration: Duration.seconds(3600),
 			},
@@ -440,7 +441,7 @@ export class SupportWorkers extends GuStack {
 			periodDuration: Duration;
 		}> = [
 			{
-				paymentProvider: PaymentProviders.PayPal,
+				paymentProvider: PaymentProviders.PayPalCompletePayments,
 				evaluationPeriods: 6,
 				periodDuration: Duration.seconds(3600),
 			},
@@ -575,7 +576,7 @@ export class SupportWorkers extends GuStack {
 			snsTopicName: `alarms-handler-topic-${this.stage}`,
 			alarmName: `URGENT 9-5 - ${this.stage} support-workers No successful paper checkouts in 24h.`,
 			metric: new MathExpression({
-				expression: 'SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0)])',
+				expression: 'SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0),FILL(m4,0)])',
 				label: 'AllPaperConversions',
 				period: Duration.minutes(5),
 				usingMetrics: {
@@ -589,6 +590,10 @@ export class SupportWorkers extends GuStack {
 					),
 					m3: this.buildPaymentSuccessMetric(
 						PaymentProviders.PayPal,
+						ProductTypes.Paper,
+					),
+					m4: this.buildPaymentSuccessMetric(
+						PaymentProviders.PayPalCompletePayments,
 						ProductTypes.Paper,
 					),
 				},
@@ -641,7 +646,7 @@ export class SupportWorkers extends GuStack {
 			} support-workers No successful guardian weekly checkouts in ${weeklyAlarmPeriod.toHumanString()}.`,
 			metric: new MathExpression({
 				label: 'AllWeeklyConversions',
-				expression: 'SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0)])',
+				expression: 'SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0),FILL(m4,0)])',
 				period: weeklyMetricDuration,
 				usingMetrics: {
 					m1: this.buildPaymentSuccessMetric(
@@ -654,6 +659,10 @@ export class SupportWorkers extends GuStack {
 					),
 					m3: this.buildPaymentSuccessMetric(
 						PaymentProviders.PayPal,
+						ProductTypes.GuardianWeekly,
+					),
+					m4: this.buildPaymentSuccessMetric(
+						PaymentProviders.PayPalCompletePayments,
 						ProductTypes.GuardianWeekly,
 					),
 				},


### PR DESCRIPTION

<!-- Note: Please label your PR with one of "Feature", "Change failure fix" or "Maintenance"! -->

<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Now that we've fully migrated over to `PayPalCompletePayments` we need to factor these into our alarms. The strategy I've taken is:

* For alarms which use a composite metric by summing together `PaymentSuccess` across different `PaymentProvider` dimensions, I've added `PayPalCompletePayments` alongside `PayPal` so that these are combined together. We can remove `PayPal` in future.

* For alarms which are for a specific payment provider dimension I've switched `PayPal` over to `PayPalCompletePayments`.

[**Asana Card**](https://app.asana.com/1/1210045093164357/project/1213112839739792/task/1216857703906186)

## Why are you doing this?

So that we don't get false alarms.