### PR TITLE
Add contribution message description to receipt

### DIFF
--- a/support-payment-api/src/main/scala/services/StripeService.scala
+++ b/support-payment-api/src/main/scala/services/StripeService.scala
@@ -67,6 +67,7 @@ class SingleAccountStripeService(config: StripeAccountConfig)(implicit pool: Str
               val params = PaymentIntentCreateParams.builder
                 .addPaymentMethodType("paypal")
                 .setPaymentMethod(data.paymentMethodId)
+                .setDescription("Contribution to the Guardian")
                 .setAmount((data.paymentData.amount * 100).toLong) // Stripe amount must be in pence
                 .setCurrency(data.paymentData.currency.entryName)
                 .setReceiptEmail(data.paymentData.email.value)


### PR DESCRIPTION
## What are you doing in this PR?

Adding the "Contribution to the Guardian" message to guardian receipts.

## How to test

In PROD, create a test payment and verify that the receipt shows the "Contribution to the Guardian" message.
