### PR TITLE
Set stripe payment element ab test to active

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.ts
@@ -97,7 +97,7 @@ export const tests: Tests = {
 				size: 1,
 			},
 		},
-		isActive: false,
+		isActive: true,
 		referrerControlled: false, // ab-test name not needed to be in paramURL
 		seed: 4,
 		targetPage: pageUrlRegexes.oneTimeCheckoutOnly,


### PR DESCRIPTION

## What are you doing in this PR?

Changing the stripe payment element A/B test boolean, isActive, to true.

## Why are you doing this?

This sets the test to active exposing it to users, to either the control or variant one time checkout.