### PR TITLE
LandingPage: TierCard incorrectly subdued when empty label copy supplied

### DIFF
--- a/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
+++ b/support-frontend/assets/pages/supporter-plus-landing/components/threeTierCards.tsx
@@ -54,8 +54,8 @@ export function ThreeTierCards({
 		!!showWeeklyPrice ||
 		cardsContent.some((card) => !!card.promotion || !!card.billingPeriodsCopy);
 	const haveLabelAndSelectedCards =
-		cardsContent.filter((card) => !!card.label || card.isUserSelected).length >
-		1;
+		cardsContent.filter((card) => !!card.label?.copy || card.isUserSelected)
+			.length > 1;
 	let promoCount = 0;
 	return (
 		<div


### PR DESCRIPTION
## What are you doing in this PR?
Code that sets a card to subdued coloring differs between RRCP Production and Code with the same LandingPage settings. This is caused by incorrectly subduing when an empty label `copy` is supplied

## Why are you doing this?
Align's TierCard colouring between Production and Code.

## How to test
Currently:-
1. RRCP CODE/LandingPage/LP_DEFAULT_US, Preview
2. RRCP PROD/LandingPage/LP_DEFAULT_US, Preview

## Screenshots
Before->
<img width="3299" height="1074" alt="image" src="https://github.com/user-attachments/assets/4dcac893-af11-4ef4-807d-c065d30b99a0" />

After -> 
<img width="2006" height="911" alt="image" src="https://github.com/user-attachments/assets/8827b6e6-6ddd-4ea9-94be-0224562bb024" />

