### PR TITLE
Update Stripe Payment Element payment method order

### DIFF
--- a/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
+++ b/support-frontend/assets/pages/[countryGroupId]/components/oneTimeCheckoutComponent.tsx
@@ -1048,6 +1048,7 @@ export function OneTimeCheckoutComponent({
 												wallets: {
 													link: 'never',
 												},
+												paymentMethodOrder: ['card', 'paypal'],
 											}}
 											onFocus={() => {
 												setPaymentMethod(Stripe);


### PR DESCRIPTION
## What are you doing in this PR?

Adds paymentMethodOrder to the payment element configuration to control the order the payment methods are displayed.

## Why are you doing this?

Stripe dynamically orders payment methods based on the user's location and other factors. Paypal was being displayed as the first payment method in the payment element. This change displays card first, providing the expected payment method ordering.

## How to test

The change can be tested locally by changing the payment order to display PayPal first and verifying that the payment element reflects the configured order. The order can then be changed back to display card first and verify again.

Without setting paymentMethodOrder, Stripe dynamically orders the payment method, so it's difficult to reproduce in CODE.