### PR TITLE
Set Cache-Control header on Express endpoint

### DIFF
--- a/support-backend/src/routers/apiRouter.test.ts
+++ b/support-backend/src/routers/apiRouter.test.ts
@@ -37,6 +37,7 @@ describe('GET /postcode-lookup/:postcode', () => {
 				country: 'UK',
 			},
 		]);
+		expect(response.headers['cache-control']).toBe('no-cache, private');
 		expect(findSpy).toHaveBeenCalledWith('N1 9GU');
 	});
 

--- a/support-backend/src/routers/apiRouter.ts
+++ b/support-backend/src/routers/apiRouter.ts
@@ -34,6 +34,10 @@ export const buildApiRouter = (idealPostcodeService: IdealPostcodeService) => {
 
 	apiRouter.get(
 		'/postcode-lookup/:postcode',
+		(req, res, next) => {
+			res.set('Cache-Control', 'no-cache, private');
+			next();
+		},
 		buildPostcodeLookupHandler(idealPostcodeService),
 	);
 


### PR DESCRIPTION
## What are you doing in this PR?

Set the `Cache-Control` header on the existing Express endpoint to `no-cache, private`.

## Why are you doing this?

This mirrors the behaviour of the Scala endpoint.

## How to test

Make a request to the endpoint and verify the header is set.
